### PR TITLE
Handle escaped slashes in regular expressions

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -641,6 +641,16 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
+        public void ShouldHandleEscapedSlashesInRegex()
+        {
+            RunTest(@"
+                var regex = /[a-z]\/[a-z]/;
+                assert(regex.test('a/b') === true);
+                assert(regex.test('a\\/b') === false);
+            ");
+      }
+
+        [Fact]
         public void ShouldComputeFractionInBase()
         {
             Assert.Equal("011", NumberPrototype.ToFractionBase(0.375, 2));

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -48,7 +48,8 @@ namespace Jint.Native.RegExp
         }
 
         /// <summary>
-        /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.7.2.1
+        /// http://www.ecma-international.org/ecma-262/5.1/#sec-7.8.5
+        /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.10.4
         /// </summary>
         /// <param name="arguments"></param>
         /// <returns></returns>
@@ -124,11 +125,15 @@ namespace Jint.Native.RegExp
             var r = new RegExpInstance(Engine);
             r.Prototype = PrototypeObject;
             r.Extensible = true;
-
-            var segments = regExp.Split('/');
-
-            var pattern = segments[1];
-            var flags = segments[2];
+ 
+            if (regExp[0] != '/')
+            {
+                throw new JavaScriptException(Engine.SyntaxError, "Regexp should start with slash");
+            }
+            var lastSlash = regExp.LastIndexOf('/');
+            // Unescape escaped forward slashes (\/)
+            var pattern = regExp.Substring(1, lastSlash - 1).Replace("\\/", "/");
+            var flags = regExp.Substring(lastSlash + 1);
 
             var options = ParseOptions(r, flags);
             try


### PR DESCRIPTION
Escaped slashes in regular expressions were not being recognised. `/[A-Z]\/[A-Z]/` should match `A/B`.
