### PR TITLE
Don't cast from long to int when converting base.

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -696,5 +696,18 @@ namespace Jint.Tests.Runtime
 
             Assert.Throws<ArgumentException>(() => x.Invoke(1, 2));
         }
+
+        [Theory]
+        [InlineData("0", 0, 16)]
+        [InlineData("1", 1, 16)]
+        [InlineData("100", 100, 10)]
+        [InlineData("1100100", 100, 2)]
+        [InlineData("2s", 100, 36)]
+        [InlineData("2qgpckvng1s", 10000000000000000L, 36)]
+        public void ShouldConvertNumbersToDifferentBase(string expected, long number, int radix)
+        {
+          var result = NumberPrototype.ToBase(number, radix);
+          Assert.Equal(expected, result);
+        }
     }
 }

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -235,7 +235,7 @@ namespace Jint.Native.Number
             var result = new StringBuilder();
             while (n > 0)
             {
-                var digit = (int)n % radix;
+                var digit = (int)(n % radix);
                 n = n / radix;
                 result.Insert(0, digits[digit].ToString());
             }


### PR DESCRIPTION
`NumberPrototype.ToBase` was casting from `long` to `int`, causing it to overflow for large numbers.
