### PR TITLE
JSON.parse() does not parse negative number

### DIFF
--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -161,9 +161,17 @@ namespace Jint.Native.Json
 
             int start = _index;
             string number = "";
+            
+            // Number start with a -
+            if (ch == '-')
+            {
+                number += _source.CharCodeAt(_index++).ToString();
+                ch = _source.CharCodeAt(_index);
+            }
+
             if (ch != '.')
             {
-                number = _source.CharCodeAt(_index++).ToString();
+                number += _source.CharCodeAt(_index++).ToString();
                 ch = _source.CharCodeAt(_index);
 
                 // Hex number starts with '0x'.
@@ -219,7 +227,7 @@ namespace Jint.Native.Json
             return new Token
                 {
                     Type = Tokens.Number,
-                    Value = Double.Parse(number, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture),
+                    Value = Double.Parse(number, NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture),
                     LineNumber = _lineNumber,
                     LineStart = _lineStart,
                     Range = new[] {start, _index}
@@ -439,6 +447,15 @@ namespace Jint.Native.Json
             // Dot (.) char #46 can also start a floating-point number, hence the need
             // to check the next character.
             if (ch == 46)
+            {
+                if (IsDecimalDigit(_source.CharCodeAt(_index + 1)))
+                {
+                    return ScanNumericLiteral();
+                }
+                return ScanPunctuator();
+            }
+
+            if (ch == '-') // Negative Number
             {
                 if (IsDecimalDigit(_source.CharCodeAt(_index + 1)))
                 {


### PR DESCRIPTION
Sebastien, I am not sure how to include the unit test that goes with the change.
Here is the JavaScript unit test

function testcase() {

```
if(JSON.parse('{ "x":-1 }').x !== -1) return false;
if(JSON.parse('{ "x": -1 }').x !== -1) return false;
try {
    JSON.parse('{ "x": -.1 }'); // Not allowed
    return false;
}
catch(ex) {}

return true;
```

 }
runTestCase(testcase);
