### PR TITLE
Support for DBNull Type

### DIFF
--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -280,6 +280,11 @@ namespace Jint.Native
                 return Null;
             }
 
+            if (value == DBNull.Value)
+            {
+                return Null;
+            }
+
             foreach(var converter in engine.Options.GetObjectConverters())
             {
                 JsValue result;


### PR DESCRIPTION
Direct database integration.
This bug should throw a ArgumentOutOfRangeException if is not fixed.

My first pull has compilation error by team city because i used: TypeCode.DBNull

Best Regards,
Igor Quirino
