### PR TITLE
Allow non-empty return statements without a function body

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1183,5 +1183,18 @@ namespace Jint.Tests.Runtime
 
             Assert.Equal(value, result);
         }
+
+        [Fact]
+        public void ShouldAllowNonEmptyReturnWithoutFunctionBody()
+        {
+            RunTest(@"return 'hello';");
+            Assert.Equal("hello", _engine.GetCompletionValue().ToObject());
+        }
+
+        [Fact]
+        public void ShouldThrowParserExceptionWhenEptyReturnWithoutFunctionBody()
+        {
+            Assert.Throws<ParserException>(() => RunTest(@"return;"));
+        }
     }
 }

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1192,9 +1192,15 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
-        public void ShouldThrowParserExceptionWhenEptyReturnWithoutFunctionBody()
+        public void ShouldThrowParserExceptionWhenEmptyReturnWithoutFunctionBody()
         {
             Assert.Throws<ParserException>(() => RunTest(@"return;"));
+        }
+
+        [Fact]
+        public void ShouldThrowParserExceptionWhenEmptyReturnWithoutFunctionBody2()
+        {
+            Assert.Throws<ParserException>(() => RunTest(@"return ;"));
         }
     }
 }

--- a/Jint/Parser/JavascriptParser.cs
+++ b/Jint/Parser/JavascriptParser.cs
@@ -3200,7 +3200,7 @@ namespace Jint.Parser
 
             ExpectKeyword("return");
 
-            if (!_state.InFunctionBody && _source.CharCodeAt(_index) == ';')
+            if (!_state.InFunctionBody && Equals(_lookahead.Value, ";"))
             {
                 ThrowErrorTolerant(Token.Empty, Messages.IllegalReturn);
             }

--- a/Jint/Parser/JavascriptParser.cs
+++ b/Jint/Parser/JavascriptParser.cs
@@ -3200,7 +3200,7 @@ namespace Jint.Parser
 
             ExpectKeyword("return");
 
-            if (!_state.InFunctionBody)
+            if (!_state.InFunctionBody && _source.CharCodeAt(_index) == ';')
             {
                 ThrowErrorTolerant(Token.Empty, Messages.IllegalReturn);
             }


### PR DESCRIPTION
Allows for better backward compatibility with Jint v1 (and seems like it should be valid?)
return; is still disallowed to keep inline with the ECMA spec tests