### PR TITLE
bugfix: be able to pass single number as params array

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -1060,6 +1060,7 @@ namespace Jint.Tests.Runtime
             RunTest(@"
                 assert(a.Call13('1','2','3') === '1,2,3');
                 assert(a.Call13('1') === '1');
+                assert(a.Call13(1) === '1');
                 assert(a.Call13() === '');
 
                 assert(a.Call14('a','1','2','3') === 'a:1,2,3');

--- a/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
@@ -91,8 +91,10 @@ namespace Jint.Runtime.Interop
                 if (argsToTransform.Count == 1 && argsToTransform.FirstOrDefault().IsArray())
                     continue;
 
-                var arrayInstance = ArrayConstructor.CreateArrayConstructor(Engine).Construct(argsToTransform.ToArray());
-                newArgumentsCollection.Add(new JsValue(arrayInstance));
+                var jsArray = Engine.Array.Construct(Arguments.Empty);
+                Engine.Array.PrototypeObject.Push(jsArray, argsToTransform.ToArray());
+
+                newArgumentsCollection.Add(new JsValue(jsArray));
                 return newArgumentsCollection.ToArray();
             }
 


### PR DESCRIPTION
**Bug**: Cannot pass single number to the .NET method as params object[] argument.
**Reason**: ArrayConstructor has JS behaviour for array construction: if there is only one argument and it's number, then it's length of array (not an array with one element)
**Solution**: Replace ArrayContructor with low level JS array creation in params resolution resolver method.

_Please update NuGet version with this fix._