### PR TITLE
FieldOffset fix to avoid TypeLoad exception in partial trust IIS level

### DIFF
--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -85,7 +85,7 @@ namespace Jint.Native
         [FieldOffset(8)]
         private readonly ObjectInstance _object;
 
-        [FieldOffset(8)]
+        [FieldOffset(12)]
         private readonly string _string;
 
         [FieldOffset(16)]


### PR DESCRIPTION
Bugfix for #139: set +4 field offset to avoid overlapping