### PR TITLE
Bug: string.replace using regex and function as paramters

### DIFF
--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -506,8 +506,7 @@ namespace Jint.Native.String
                     for (var k = 0; k < match.Groups.Count; k++)
                     {
                         var group = match.Groups[k];
-                        if (group.Success)
-                            args.Add(group.Value);
+                        args.Add(group.Value);
                     }
                     
                     args.Add(match.Index);


### PR DESCRIPTION
Bug: string.replace using regex and function as paramters #141 