### PR TITLE
feature: CLR array converter

### DIFF
--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Runtime\Converters\NegateBoolConverter.cs" />
     <Compile Include="Runtime\Domain\A.cs" />
+    <Compile Include="Runtime\Domain\ArrayConverterTestClass.cs" />
     <Compile Include="Runtime\Domain\ClassWithField.cs" />
     <Compile Include="Runtime\Domain\ClassWithStaticFields.cs" />
     <Compile Include="Runtime\Domain\Colors.cs" />

--- a/Jint.Tests/Runtime/Domain/ArrayConverterTestClass.cs
+++ b/Jint.Tests/Runtime/Domain/ArrayConverterTestClass.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Jint.Tests.Runtime.Domain
+{
+    public class ArrayConverterTestClass
+    {
+        public string MethodAcceptsArrayOfStrings(string[] arrayOfStrings)
+        {
+            return SerializeToString(arrayOfStrings);
+        }
+
+        public string MethodAcceptsArrayOfInt(int[] arrayOfInt)
+        {
+            return SerializeToString(arrayOfInt);
+        }
+
+        public string MethodAcceptsArrayOfBool(int[] arrayOfBool)
+        {
+            return SerializeToString(arrayOfBool);
+        }
+
+        private static string SerializeToString<T>(IEnumerable<T> array)
+        {
+            return String.Join(",", array);
+        }
+    }
+
+    public class ArrayConverterItem : IConvertible
+    {
+        private readonly int _value;
+
+        public ArrayConverterItem(int value)
+        {
+            _value = value;
+        }
+
+        public override string ToString()
+        {
+            return ToString(CultureInfo.InvariantCulture);
+        }
+
+        public string ToString(IFormatProvider provider)
+        {
+            return _value.ToString(provider);
+        }
+
+        public int ToInt32(IFormatProvider provider)
+        {
+            return Convert.ToInt32(_value, provider);
+        }
+
+        #region NotImplemented
+        public TypeCode GetTypeCode()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool ToBoolean(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public char ToChar(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public sbyte ToSByte(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public byte ToByte(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public short ToInt16(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ushort ToUInt16(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public uint ToUInt32(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public long ToInt64(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ulong ToUInt64(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public float ToSingle(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public double ToDouble(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public decimal ToDecimal(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public DateTime ToDateTime(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object ToType(Type conversionType, IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+        #endregion
+
+
+    }
+}

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -1125,5 +1125,23 @@ namespace Jint.Tests.Runtime
                 assert(!ud.undefinedProperty);
             ");
         }
+
+        [Fact]
+        public void ShouldAutomaticallyConvertArraysToFindBestInteropResulution()
+        {
+            _engine.SetValue("a", new ArrayConverterTestClass());
+            _engine.SetValue("item1", new ArrayConverterItem(1));
+            _engine.SetValue("item2", new ArrayConverterItem(2));
+
+            RunTest(@"
+                assert(a.MethodAcceptsArrayOfInt([false, '1', 2]) === a.MethodAcceptsArrayOfInt([0, 1, 2]));
+                assert(a.MethodAcceptsArrayOfStrings(['1', 2]) === a.MethodAcceptsArrayOfStrings([1, 2]));
+                assert(a.MethodAcceptsArrayOfBool(['1', 0]) === a.MethodAcceptsArrayOfBool([true, false]));
+
+                assert(a.MethodAcceptsArrayOfStrings([item1, item2]) === a.MethodAcceptsArrayOfStrings(['1', '2']));
+                assert(a.MethodAcceptsArrayOfInt([item1, item2]) === a.MethodAcceptsArrayOfInt([1, 2]));
+            ");
+        }
+
     }
 }

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -157,6 +157,19 @@ namespace Jint.Runtime.Interop
 
             }
 
+            if (type.IsArray)
+            {
+                var source = value as object[];
+                if (source == null)
+                    throw new ArgumentException(String.Format("Value of object[] type is expected, but actual type is {0}.", value.GetType()));
+
+                var targetElementType = type.GetElementType();
+                var itemsConverted = source.Select(o => Convert(o, targetElementType, formatProvider)).ToArray();
+                var result = Array.CreateInstance(targetElementType, source.Length);
+                itemsConverted.CopyTo(result, 0);
+                return result;
+            }
+
             return System.Convert.ChangeType(value, type, formatProvider);
         }
 


### PR DESCRIPTION
Usually i start using Jint with custom ArrayConverter derived from DefaultTypeConverter. What about to add it to the Jint core?

In current Jint this case works _(integer automatically converted to string)_:

    public void Method(string args) { }
    engine.Execute("a.Method(1)");
   
But this one doesn't _(array of integers cannot be converted to array of strings)_:

    public void Method(string[] args) { }
    engine.Execute("a.Method([1,2])");

My Pull Request adds an array converter for interop operations.