### PR TITLE
Changed namespace of WithStatement to Jint.Parser.Ast

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+﻿# EditorConfig is awesome: http://EditorConfig.org
+# Visual Studio extension: https://visualstudiogallery.msdn.microsoft.com/c8bccfe2-650c-4b42-bc5c-845e21f96328
+
+# 4 space indentation
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,0 @@
-﻿# EditorConfig is awesome: http://EditorConfig.org
-# Visual Studio extension: https://visualstudiogallery.msdn.microsoft.com/c8bccfe2-650c-4b42-bc5c-845e21f96328
-
-# 4 space indentation
-[*.cs]
-indent_style = space
-indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ $RECYCLE.BIN/
 # Mac crap
 .DS_Store
 Jint.sln.ide/*
+/Jint.sln.GhostDoc.xml

--- a/Jint/Parser/Ast/WithStatement.cs
+++ b/Jint/Parser/Ast/WithStatement.cs
@@ -1,6 +1,4 @@
-using Jint.Parser.Ast;
-
-namespace Jint
+namespace Jint.Parser.Ast
 {
     public class WithStatement : Statement
     {


### PR DESCRIPTION
All Ast node classes reside in Jint.Parser.Ast namespace, except of WithStatement node.