### PR TITLE
Fixed examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can also directly pass POCOs or anonymous objects and use them from JavaScri
 You can invoke JavaScript function reference
 ```c#
     var add = new Engine()
-        .Execute("function add(a, b) { return a + b; }");
+        .Execute("function add(a, b) { return a + b; }")
         .GetValue("add")
         ;
 
@@ -72,7 +72,7 @@ You can allow an engine to access any .NET class by configuring the engine insta
 ```
 Then you have access to the `System` namespace as a global value. Here is how it's used in the context on the command line utility:
 ```javascript
-    jint> var file = new System.IO.File('log.txt');
+    jint> var file = new System.IO.StreamWriter('log.txt');
     jint> file.WriteLine('Hello World !');
     jint> file.Dispose();
 ```


### PR DESCRIPTION
Changed: var file = new System.IO.File('log.txt');
To: var file = new System.IO.StreamWriter('log.txt');
Because: System.IO.File is a static C# class.

Also: Removed incorrect semicolon in middle of method chaining.