### PR TITLE
Implement Jint.Runtime.NamespaceCache*

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -1247,5 +1247,19 @@ namespace Jint.Tests.Runtime
             Assert.Equal(Nested.ClassWithStaticFields.Readonly, "Readonly");
         }
 
+        [Fact]
+        public void ShouldThrowRelevantExceptionOnUndefinedNamespace()
+        {
+            RunTest(@"
+                try {
+                    var Jint = importNamespace('Jint');
+                    Jint.Tests.Runtime.Domain.NonexistantNamespace.NonexistantType.NonexistantMethod(1);
+                    assert(false);
+                } catch (e) {
+                    assert(e.message == 'Jint.Tests.Runtime.Domain.NonexistantNamespace is not defined');
+                }
+            ");
+        }
+
     }
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -42,6 +42,9 @@ namespace Jint
         // cache of types used when resolving CLR type names
         internal Dictionary<string, Type> TypeCache = new Dictionary<string, Type>();
 
+        // cache of namespaces available to aid in accurate type/generic resolution
+        internal NamespaceCacheRoot NamespaceCache = null;
+
         internal JintCallStack CallStack = new JintCallStack();
 
         public Engine() : this(null)

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Runtime\Interop\TypeReference.cs" />
     <Compile Include="Runtime\Interop\TypeReferencePrototype.cs" />
     <Compile Include="Runtime\JavaScriptException.cs" />
+    <Compile Include="Runtime\NamespaceCache.cs" />
     <Compile Include="Runtime\RecursionDepthOverflowException.cs" />
     <Compile Include="Runtime\References\Reference.cs" />
     <Compile Include="Runtime\StatementInterpreter.cs" />

--- a/Jint/Runtime/NamespaceCache.cs
+++ b/Jint/Runtime/NamespaceCache.cs
@@ -1,0 +1,189 @@
+using System;
+using Generic = System.Collections.Generic;
+using System.Linq;
+
+namespace Jint.Runtime
+{
+    public class NamespaceCacheElement
+    {
+        #region "Instance"
+        // Fields
+        String _name;
+        NamespaceCacheElement _parent;
+
+        Generic.Dictionary<String, NamespaceCacheElement> _ncChildren = null;
+
+        // Properties
+        public String Name {
+            get { return _name;  }
+        }
+
+        public String AbsoluteName {
+            get { return assembleAbsoluleName(this);  }
+        }
+
+        public NamespaceCacheRoot Global {
+            get { return traverseToRoot(this); }
+        }
+
+        public NamespaceCacheElement Parent
+        {
+            get { return _parent; }
+        }
+
+        public NamespaceCacheElement[] Ancestors
+        {
+            get { return enumerateAncestors(this); }
+        }
+        
+        public NamespaceCacheElement[] Children {
+            get {
+                if (_ncChildren == null) return new NamespaceCacheElement[0];
+                return _ncChildren.Values.ToArray();
+            }
+        }
+
+        // Gah, why doesn't C# support indexed properties yet >:(
+        /*public NamespaceCacheElement Children[String ns] {
+            get { return _children[ns]; }
+        }*/
+
+        // Constructor (public construction not allowed)
+        protected NamespaceCacheElement(NamespaceCacheElement parent, String name) {
+            _parent = parent;
+            _name = name;
+        }
+
+        // Instance Indexer
+        public NamespaceCacheElement this[String ns] {
+            get { return findDescendent(this, ns, true); }
+        }
+
+        // Methods
+        public bool ContainsNamespace(NamespaceCacheElement ncElem) {
+            return _ncChildren != null && _ncChildren.ContainsKey(ncElem.Name);
+        }
+
+        public bool ContainsNamespace(String ns) {
+            return findDescendent(this, ns) != null;
+        }
+       
+        #endregion
+
+        #region "Static"
+        protected static NamespaceCacheRoot traverseToRoot(NamespaceCacheElement ncElem) {
+            if (ncElem is NamespaceCacheRoot) return (NamespaceCacheRoot)ncElem;
+
+            NamespaceCacheElement ncOldestAncestor = enumerateAncestors(ncElem).DefaultIfEmpty(null).First();
+            if (ncOldestAncestor == null || !(ncOldestAncestor is NamespaceCacheRoot)) return null;
+
+            return (NamespaceCacheRoot)ncOldestAncestor;
+        }
+
+        protected static NamespaceCacheElement[] enumerateAncestors(NamespaceCacheElement ncElem) {
+            return enumerateAncestors(ncElem, false);
+        }
+
+        protected static NamespaceCacheElement[] enumerateAncestors(NamespaceCacheElement ncElem, bool includeSelf) {
+            Generic.List<NamespaceCacheElement> ncAncestors = new Generic.List<NamespaceCacheElement>();
+
+            if (includeSelf) ncAncestors.Insert(0, ncElem);
+
+            while (ncElem.Parent != null) {
+                ncElem = ncElem.Parent;
+                ncAncestors.Insert(0, ncElem);
+            }
+
+            return ncAncestors.ToArray();
+        }
+
+        protected static String assembleAbsoluleName(NamespaceCacheElement ncElem) {
+            if (ncElem is NamespaceCacheRoot) return "[Global]";
+            NamespaceCacheElement[] ncAncestors = enumerateAncestors(ncElem, true);
+
+            if (ncAncestors.First() is NamespaceCacheRoot)
+                return String.Join(".", ncAncestors.Skip(1).Select(x => x.Name).ToArray());
+
+            throw new Exception("Orphan namespace, cannot resolve full path");
+        }
+
+        protected static NamespaceCacheElement findDescendent(NamespaceCacheElement ncElem, String ns) {
+            return findDescendent(ncElem, ns, false);
+        }
+
+        protected static NamespaceCacheElement findDescendent(NamespaceCacheElement ncElem, String ns, bool throwOnNamespaceNotFound) {
+            if (String.IsNullOrEmpty(ns.Trim())) throw new ArgumentException("Invalid argument: namespace");
+
+            String[] nsParts = ns.Split('.');
+
+            for (int i = 0; i < nsParts.Length; i++) {
+                String nsPart = nsParts[i];
+
+                if (ncElem._ncChildren == null || !ncElem._ncChildren.ContainsKey(nsPart)) {
+                    ncElem = null;
+                    break;
+                }
+
+                ncElem = ncElem._ncChildren[nsPart];
+            }
+
+            if (throwOnNamespaceNotFound && ncElem == null)
+                throw new System.Collections.Generic.KeyNotFoundException();
+
+            return ncElem;
+        }
+
+        protected static NamespaceCacheElement AppendNamespaceElement(NamespaceCacheElement ncParent, string name) {
+            if (ncParent == null) throw new ArgumentException("Invalid argument: parent");
+            if (String.IsNullOrWhiteSpace(name) || name.Contains(".")) new ArgumentException("Invalid argument: name");
+
+            NamespaceCacheElement ncChild = findDescendent(ncParent, name, false);
+
+            if (ncChild == null)
+            {
+                ncChild = new NamespaceCacheElement(ncParent, name);
+                if (ncParent._ncChildren == null) ncParent._ncChildren = new Generic.Dictionary<String, NamespaceCacheElement>(StringComparer.OrdinalIgnoreCase);
+                ncParent._ncChildren[name] = ncChild;
+            }
+
+            return ncChild;
+        }
+        #endregion
+
+        public override String ToString() {
+            return String.Format("{0}  -  ({1})", _name, AbsoluteName);
+        }
+
+    }
+
+    public class NamespaceCacheRoot : NamespaceCacheElement {
+        public NamespaceCacheRoot() : base(null, "[Global]") {
+        }
+
+        public void populate(params System.Reflection.Assembly[] assemblies) {
+            String[] namespaces = (from System.Reflection.Assembly assembly in assemblies.Distinct()
+                                   from System.Type type in assembly.GetTypes()
+                                   where !System.String.IsNullOrEmpty(type.Namespace)
+                                   orderby type.Namespace
+                                   select type.Namespace).Distinct().ToArray();
+            populate(this, namespaces);
+        }
+
+        private static void populate(NamespaceCacheRoot ncRoot, String[] namespaces) {
+            foreach (String ns in namespaces)
+                populate(ncRoot, ns);
+        }
+
+        private static void populate(NamespaceCacheRoot ncRoot, String ns) { 
+            String[] nsParts = ns.Split('.');
+
+            NamespaceCacheElement ncElem = ncRoot;
+            foreach (String nsPart in nsParts)
+                ncElem = AppendNamespaceElement(ncElem, nsPart);
+        }
+
+        public override String ToString() {
+            return "[Global Scope]";
+        }
+    }
+}

--- a/Jint/Runtime/NamespaceCache.cs
+++ b/Jint/Runtime/NamespaceCache.cs
@@ -26,13 +26,11 @@ namespace Jint.Runtime
             get { return traverseToRoot(this); }
         }
 
-        public NamespaceCacheElement Parent
-        {
+        public NamespaceCacheElement Parent {
             get { return _parent; }
         }
 
-        public NamespaceCacheElement[] Ancestors
-        {
+        public NamespaceCacheElement[] Ancestors {
             get { return enumerateAncestors(this); }
         }
         
@@ -112,7 +110,7 @@ namespace Jint.Runtime
         }
 
         protected static NamespaceCacheElement findDescendent(NamespaceCacheElement ncElem, String ns, bool throwOnNamespaceNotFound) {
-            if (String.IsNullOrEmpty(ns.Trim())) throw new ArgumentException("Invalid argument: namespace");
+            if (String.IsNullOrWhiteSpace(ns)) throw new ArgumentException("Invalid argument: namespace");
 
             String[] nsParts = ns.Split('.');
 
@@ -135,7 +133,7 @@ namespace Jint.Runtime
 
         protected static NamespaceCacheElement AppendNamespaceElement(NamespaceCacheElement ncParent, string name) {
             if (ncParent == null) throw new ArgumentException("Invalid argument: parent");
-            if (String.IsNullOrWhiteSpace(name) || name.Contains(".")) new ArgumentException("Invalid argument: name");
+            if (String.IsNullOrWhiteSpace(name) || name.Contains(".")) throw new ArgumentException("Invalid argument: name");
 
             NamespaceCacheElement ncChild = findDescendent(ncParent, name, false);
 


### PR DESCRIPTION
Class to help cache known namespaces, removing some assumptions Jint.Runtime.Interop.NamespaceReference has to make about type information.

Also helps provide more specific exceptions in certain situations; for example, with this change it becomes obvious fairly quickly if you are missing an assembly in your ClrSecurity setup - whereas before it was giving errors about generics, and you really had no idea why.