### PR TITLE
Feature/ignore method casing

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -126,6 +126,21 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
+        public void CanInvokeObjectMethodsWithPascalCase()
+        {
+            var p = new Person
+            {
+                Name = "Mickey Mouse"
+            };
+
+            _engine.SetValue("p", p);
+
+            RunTest(@"
+                assert(p.toString() === 'Mickey Mouse');
+            ");
+        }
+
+        [Fact]
         public void CanSetObjectProperties()
         {
             var p = new Person

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -178,21 +178,24 @@ namespace Jint.Runtime.Interop
             bool canConvert;
             var key = value == null ? String.Format("Null->{0}", type) : String.Format("{0}->{1}", value.GetType(), type);
 
-            lock (_lockObject)
+            if (!_knownConversions.TryGetValue(key, out canConvert))
             {
-                if (!_knownConversions.TryGetValue(key, out canConvert))
+                lock (_lockObject)
                 {
-                    try
+                    if (!_knownConversions.TryGetValue(key, out canConvert))
                     {
-                        converted = Convert(value, type, formatProvider);
-                        _knownConversions.Add(key, true);
-                        return true;
-                    }
-                    catch
-                    {
-                        converted = null;
-                        _knownConversions.Add(key, false);
-                        return false;
+                        try
+                        {
+                            converted = Convert(value, type, formatProvider);
+                            _knownConversions.Add(key, true);
+                            return true;
+                        }
+                        catch
+                        {
+                            converted = null;
+                            _knownConversions.Add(key, false);
+                            return false;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I updated the ObjectWrapper so PascalCased .NET methods can be called from JavaScript using camelCase. This can be really useful, to avoid conflicts caused by the different naming conventions.