### PR TITLE
fix array sort method

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1194,5 +1194,23 @@ namespace Jint.Tests.Runtime
 
             Assert.Equal(value, result);
         }
+
+
+
+        [Fact]
+        public void ShouldSortArrayWhenCompareFunctionReturnsFloatingPointNumber()
+        {
+            RunTest(@"
+                var nums = [1, 1.1, 1.2, 2, 2, 2.1, 2.2];
+                nums.sort(function(a,b){return b-a;});
+                assert(nums[0] === 2.2);
+                assert(nums[1] === 2.1);
+                assert(nums[2] === 2);
+                assert(nums[3] === 2);
+                assert(nums[4] === 1.2);
+                assert(nums[5] === 1.1);
+                assert(nums[6] === 1);
+            ");
+        }
     }
 }

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -518,8 +518,16 @@ namespace Jint.Native.Array
 
                     if (compareFn != null)
                     {
-                        var s = (int) TypeConverter.ToUint32(compareFn.Call(Undefined.Instance, new[] {x, y}));
-                        return s;
+                        var s = TypeConverter.ToNumber(compareFn.Call(Undefined.Instance, new[] {x, y}));
+                        if (s < 0)
+                        {
+                            return -1;
+                        }
+                        if (s > 0)
+                        {
+                            return 1;
+                        }
+                        return 0;
                     }
 
                     var xString = TypeConverter.ToString(x);


### PR DESCRIPTION
fix array sort method to allow floating point numbers to be returned from the compare function