### PR TITLE
New import* keyword

### DIFF
--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Parser\ParserExtensions.cs" />
     <Compile Include="Parser\ParserOptions.cs" />
     <Compile Include="Parser\Position.cs" />
+    <Compile Include="Parser\SourceReader.cs" />
     <Compile Include="Parser\State.cs" />
     <Compile Include="Parser\Token.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -26,7 +26,7 @@ namespace Jint.Native.Json
         private int _lineStart;
         private Location _location;
         private Token _lookahead;
-        private string _source;
+        private SourceReader _source;
 
         private State _state;
 
@@ -797,11 +797,11 @@ namespace Jint.Native.Json
 
         public JsValue Parse(string code, ParserOptions options)
         {
-            _source = code;
+            _source = new SourceReader(code);
             _index = 0;
-            _lineNumber = (_source.Length > 0) ? 1 : 0;
+            _lineNumber = (code.Length > 0) ? 1 : 0;
             _lineStart = 0;
-            _length = _source.Length;
+            _length = code.Length;
             _lookahead = null;
             _state = new State
                 {

--- a/Jint/Parser/JavascriptParser.cs
+++ b/Jint/Parser/JavascriptParser.cs
@@ -312,7 +312,7 @@ namespace Jint.Parser
                     _lineStart = _index;
                     if (_index >= _length)
                     {
-                        ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+                        ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
                     }
                 }
                 else if (ch == 42)
@@ -342,7 +342,7 @@ namespace Jint.Parser
                 }
             }
 
-            ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+            ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
         }
 
         private void SkipComment()
@@ -430,13 +430,13 @@ namespace Jint.Parser
             {
                 if (_source.CharCodeAt(_index) != 117)
                 {
-                    ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+                    ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
                 }
                 ++_index;
 
                 if (!ScanHexEscape('u', out ch) || ch == '\\' || !IsIdentifierStart(ch))
                 {
-                    ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+                    ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
                 }
                 id = new StringBuilder(ch.ToString());
             }
@@ -456,13 +456,13 @@ namespace Jint.Parser
                 {
                     if (_source.CharCodeAt(_index) != 117)
                     {
-                        ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+                        ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
                     }
                     ++_index;
 
                     if (!ScanHexEscape('u', out ch) || ch == '\\' || !IsIdentifierPart(ch))
                     {
-                        ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+                        ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
                     }
                     id.Append(ch);
                 }
@@ -537,7 +537,8 @@ namespace Jint.Parser
                     Value = id,
                     LineNumber = _lineNumber,
                     LineStart = _lineStart,
-                    Range = new[] {start, _index}
+                    Start = start,
+                    End = _index
                 };
         }
 
@@ -573,14 +574,15 @@ namespace Jint.Parser
                             Value = code.ToString(),
                             LineNumber = _lineNumber,
                             LineStart = _lineStart,
-                            Range = new[] {start, _index}
+                            Start = start,
+                            End = _index
                         };
 
                 default:
                     char code2 = _source.CharCodeAt(_index + 1);
 
                     // '=' (char #61) marks an assignment or comparison operator.
-                    if (code2 == 61)
+                    if (code2 == 0x3D)
                     {
                         switch ((int) code)
                         {
@@ -598,12 +600,11 @@ namespace Jint.Parser
                                 return new Token
                                     {
                                         Type = Tokens.Punctuator,
-                                        Value =
-                                            code.ToString() +
-                                            code2.ToString(),
+                                        Value = code + code2,
                                         LineNumber = _lineNumber,
                                         LineStart = _lineStart,
-                                        Range = new[] {start, _index}
+                                        Start = start,
+                                        End = _index
                                     };
 
                             case 33: // !
@@ -621,7 +622,8 @@ namespace Jint.Parser
                                         Value = _source.Slice(start, _index),
                                         LineNumber = _lineNumber,
                                         LineStart = _lineStart,
-                                        Range = new[] {start, _index}
+                                        Start = start,
+                                        End = _index
                                     };
                         }
                     }
@@ -647,7 +649,8 @@ namespace Jint.Parser
                             Value = ">>>=",
                             LineNumber = _lineNumber,
                             LineStart = _lineStart,
-                            Range = new[] {start, _index}
+                            Start = start,
+                            End = _index
                         };
                 }
             }
@@ -663,7 +666,8 @@ namespace Jint.Parser
                         Value = ">>>",
                         LineNumber = _lineNumber,
                         LineStart = _lineStart,
-                        Range = new[] {start, _index}
+                        Start = start,
+                        End = _index
                     };
             }
 
@@ -676,7 +680,8 @@ namespace Jint.Parser
                         Value = "<<=",
                         LineNumber = _lineNumber,
                         LineStart = _lineStart,
-                        Range = new[] {start, _index}
+                        Start = start,
+                        End = _index
                     };
             }
 
@@ -689,7 +694,8 @@ namespace Jint.Parser
                         Value = ">>=",
                         LineNumber = _lineNumber,
                         LineStart = _lineStart,
-                        Range = new[] {start, _index}
+                        Start = start,
+                        End = _index
                     };
             }
 
@@ -704,7 +710,8 @@ namespace Jint.Parser
                         Value = ch1.ToString() + ch2.ToString(),
                         LineNumber = _lineNumber,
                         LineStart = _lineStart,
-                        Range = new[] {start, _index}
+                        Start = start,
+                        End = _index
                     };
             }
 
@@ -717,13 +724,14 @@ namespace Jint.Parser
                         Value = ch1.ToString(),
                         LineNumber = _lineNumber,
                         LineStart = _lineStart,
-                        Range = new[] {start, _index}
+                        Start = start,
+                        End = _index
                     };
             }
 
-            ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+            ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
 
-            return null;
+            return Token.Empty;
         }
 
         // 7.8.3 Numeric Literals
@@ -743,12 +751,12 @@ namespace Jint.Parser
 
             if (number.Length == 0)
             {
-                ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+                ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
             }
 
             if (IsIdentifierStart(_source.CharCodeAt(_index)))
             {
-                ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+                ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
             }
 
             return new Token
@@ -757,7 +765,8 @@ namespace Jint.Parser
                     Value = Convert.ToInt64(number, 16),
                     LineNumber = _lineNumber,
                     LineStart = _lineStart,
-                    Range = new[] {start, _index}
+                    Start = start,
+                    End = _index
                 };
         }
 
@@ -775,7 +784,7 @@ namespace Jint.Parser
 
             if (IsIdentifierStart(_source.CharCodeAt(_index)) || IsDecimalDigit(_source.CharCodeAt(_index)))
             {
-                ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+                ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
             }
 
             return new Token
@@ -785,7 +794,8 @@ namespace Jint.Parser
                     Octal = true,
                     LineNumber = _lineNumber,
                     LineStart = _lineStart,
-                    Range = new[] {start, _index}
+                    Start = start,
+                    End = _index
                 };
         }
 
@@ -817,7 +827,7 @@ namespace Jint.Parser
                     // decimal number starts with '0' such as '09' is illegal.
                     if (ch > 0 && IsDecimalDigit(ch))
                     {
-                        ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+                        ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
                     }
                 }
 
@@ -856,13 +866,13 @@ namespace Jint.Parser
                 }
                 else
                 {
-                    ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+                    ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
                 }
             }
 
             if (IsIdentifierStart(_source.CharCodeAt(_index)))
             {
-                ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+                ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
             }
 
             double n;
@@ -894,7 +904,8 @@ namespace Jint.Parser
                     Value = n,
                     LineNumber = _lineNumber,
                     LineStart = _lineStart,
-                    Range = new[] {start, _index}
+                    Start = start,
+                    End = _index
                 };
         }
 
@@ -1015,7 +1026,7 @@ namespace Jint.Parser
 
             if (quote != 0)
             {
-                ThrowError(null, Messages.UnexpectedToken, "ILLEGAL");
+                ThrowError(Token.Empty, Messages.UnexpectedToken, "ILLEGAL");
             }
 
             return new Token
@@ -1025,7 +1036,8 @@ namespace Jint.Parser
                     Octal = octal,
                     LineNumber = _lineNumber,
                     LineStart = _lineStart,
-                    Range = new[] {start, _index}
+                    Start = start,
+                    End = _index
                 };
         }
 
@@ -1052,13 +1064,13 @@ namespace Jint.Parser
                     // ECMA-262 7.8.5
                     if (IsLineTerminator(ch))
                     {
-                        ThrowError(null, Messages.UnterminatedRegExp);
+                        ThrowError(Token.Empty, Messages.UnterminatedRegExp);
                     }
                     str.Append(ch);
                 }
                 else if (IsLineTerminator(ch))
                 {
-                    ThrowError(null, Messages.UnterminatedRegExp);
+                    ThrowError(Token.Empty, Messages.UnterminatedRegExp);
                 }
                 else if (classMarker)
                 {
@@ -1084,7 +1096,7 @@ namespace Jint.Parser
 
             if (!terminated)
             {
-                ThrowError(null, Messages.UnterminatedRegExp);
+                ThrowError(Token.Empty, Messages.UnterminatedRegExp);
             }
 
             // Exclude leading and trailing slash.
@@ -1141,7 +1153,8 @@ namespace Jint.Parser
                     Type = Tokens.RegularExpression,
                     Literal = str.ToString(),
                     Value = pattern + flags,
-                    Range = new[] {start, _index}
+                    Start = start,
+                    End = _index
                 };
         }
 
@@ -1170,7 +1183,7 @@ namespace Jint.Parser
             if (_extra.Tokens != null)
             {
                 Token token = _extra.Tokens[_extra.Tokens.Count - 1];
-                if (token.Range[0] == pos && token.Type == Tokens.Punctuator)
+                if (token.Start == pos && token.Type == Tokens.Punctuator)
                 {
                     if ("/".Equals(token.Value) || "/=".Equals(token.Value))
                     {
@@ -1182,7 +1195,8 @@ namespace Jint.Parser
                 {
                     Type = Tokens.RegularExpression,
                     Value = regex.Literal,
-                    Range = new[] { pos, _index },
+                    Start = pos,
+                    End = _index,
                     Location = loc
                 });
             }
@@ -1209,7 +1223,8 @@ namespace Jint.Parser
                         Type = Tokens.EOF,
                         LineNumber = _lineNumber,
                         LineStart = _lineStart,
-                        Range = new[] {_index, _index}
+                        Start = _index,
+                        End = _index
                     };
             }
 
@@ -1272,13 +1287,13 @@ namespace Jint.Parser
 
             if (token.Type != Tokens.EOF)
             {
-                var range = new[] {token.Range[0], token.Range[1]};
-                string value = _source.Slice(token.Range[0], token.Range[1]);
+                string value = _source.Slice(token.Start, token.End);
                 _extra.Tokens.Add(new Token
                     {
                         Type = token.Type,
                         Value = value,
-                        Range = range,
+                        Start = token.Start,
+                        End = token.End,
                         Location = _location
                     });
             }
@@ -1289,13 +1304,13 @@ namespace Jint.Parser
         private Token Lex()
         {
             Token token = _lookahead;
-            _index = token.Range[1];
+            _index = token.End;
             _lineNumber = token.LineNumber.HasValue ? token.LineNumber.Value : 0;
             _lineStart = token.LineStart;
 
             _lookahead = (_extra.Tokens != null) ? CollectToken() : Advance();
 
-            _index = token.Range[1];
+            _index = token.End;
             _lineNumber = token.LineNumber.HasValue ? token.LineNumber.Value : 0;
             _lineStart = token.LineStart;
 
@@ -1621,7 +1636,7 @@ namespace Jint.Parser
                 {
                     Type = SyntaxNodes.RegularExpressionLiteral,
                     Value = token.Value,
-                    Raw = _source.Slice(token.Range[0], token.Range[1])
+                    Raw = _source.Slice(token.Start, token.End)
                 };
             }
 
@@ -1629,7 +1644,7 @@ namespace Jint.Parser
                 {
                     Type = SyntaxNodes.Literal,
                     Value = token.Value,
-                    Raw = _source.Slice(token.Range[0], token.Range[1])
+                    Raw = _source.Slice(token.Start, token.End)
                 };
         }
 
@@ -1855,13 +1870,13 @@ namespace Jint.Parser
             ParserError error;
             string msg = String.Format(messageFormat, arguments);
 
-            if (token != null && token.LineNumber.HasValue)
+            if (token != Token.Empty && token.LineNumber.HasValue)
             {
                 error = new ParserError("Line " + token.LineNumber + ": " + msg)
                     {
-                        Index = token.Range[0],
+                        Index = token.Start,
                         LineNumber = token.LineNumber.Value,
-                        Column = token.Range[0] - _lineStart + 1
+                        Column = token.Start - _lineStart + 1
                     };
             }
             else
@@ -2068,7 +2083,7 @@ namespace Jint.Parser
 
         // 11.1.5 Object Initialiser
 
-        private FunctionExpression ParsePropertyFunction(Identifier[] parameters, Token first = null)
+        private FunctionExpression ParsePropertyFunction(Identifier[] parameters, Token first)
         {
             EnterVariableScope();
             EnterFunctionScope();
@@ -2076,7 +2091,7 @@ namespace Jint.Parser
             bool previousStrict = _strict;
             MarkStart();
             Statement body = ParseFunctionSourceElements();
-            if (first != null && _strict && IsRestrictedWord(parameters[0].Name))
+            if (first != Token.Empty && _strict && IsRestrictedWord(parameters[0].Name))
             {
                 ThrowErrorTolerant(first, Messages.StrictParamName);
             }
@@ -2123,7 +2138,7 @@ namespace Jint.Parser
                     var key = ParseObjectPropertyKey();
                     Expect("(");
                     Expect(")");
-                    value = ParsePropertyFunction(new Identifier[0]);
+                    value = ParsePropertyFunction(new Identifier[0], Token.Empty);
                     return MarkEnd(CreateProperty(PropertyKind.Get, key, value));
                 }
                 if ("set".Equals(token.Value) && !Match(":"))
@@ -2135,7 +2150,7 @@ namespace Jint.Parser
                     {
                         Expect(")");
                         ThrowErrorTolerant(token, Messages.UnexpectedToken, (string) token.Value);
-                        value = ParsePropertyFunction(new Identifier[0]);
+                        value = ParsePropertyFunction(new Identifier[0], Token.Empty);
                     }
                     else
                     {
@@ -2527,7 +2542,7 @@ namespace Jint.Parser
             return MarkEndIf(expr);
         }
 
-        private int binaryPrecedence(Token token, bool allowIn)
+        private int BinaryPrecedence(Token token, bool allowIn)
         {
             int prec = 0;
 
@@ -2614,7 +2629,7 @@ namespace Jint.Parser
             Expression left = ParseUnaryExpression();
 
             Token token = _lookahead;
-            int prec = binaryPrecedence(token, _state.AllowIn);
+            int prec = BinaryPrecedence(token, _state.AllowIn);
             if (prec == 0)
             {
                 return left;
@@ -2627,7 +2642,7 @@ namespace Jint.Parser
 
             var stack = new List<object>( new object[] {left, token, right});
 
-            while ((prec = binaryPrecedence(_lookahead, _state.AllowIn)) > 0)
+            while ((prec = BinaryPrecedence(_lookahead, _state.AllowIn)) > 0)
             {
                 // Reduce: make a binary expression from the three topmost entries.
                 while ((stack.Count > 2) && (prec <= ((Token) stack[stack.Count - 2]).Precedence))
@@ -3516,7 +3531,7 @@ namespace Jint.Parser
                     // this is not directive
                     break;
                 }
-                string directive = _source.Slice(token.Range[0] + 1, token.Range[1] - 1);
+                string directive = _source.Slice(token.Start + 1, token.End - 1);
                 if (directive == "use strict")
                 {
                     _strict = true;
@@ -3825,7 +3840,7 @@ namespace Jint.Parser
                     // this is not directive
                     break;
                 }
-                string directive = _source.Slice(token.Range[0] + 1, token.Range[1] - 1);
+                string directive = _source.Slice(token.Start + 1, token.End - 1);
                 if (directive == "use strict")
                 {
                     _strict = true;
@@ -3892,7 +3907,7 @@ namespace Jint.Parser
             _lineNumber = (code.Length > 0) ? 1 : 0;
             _lineStart = 0;
             _length = code.Length;
-            _lookahead = null;
+            _lookahead = Token.Empty;
             _state = new State
             {
                 AllowIn = true,
@@ -3968,7 +3983,7 @@ namespace Jint.Parser
             _lineNumber = (functionExpression.Length > 0) ? 1 : 0;
             _lineStart = 0;
             _length = functionExpression.Length;
-            _lookahead = null;
+            _lookahead = Token.Empty;
             _state = new State
             {
                 AllowIn = true,

--- a/Jint/Parser/JavascriptParser.cs
+++ b/Jint/Parser/JavascriptParser.cs
@@ -63,7 +63,7 @@ namespace Jint.Parser
         static JavaScriptParser()
         {
             WhiteSpaceMap = new BitArray(0xFEFF+1);
-
+            #region WhiteSpaceMap
             WhiteSpaceMap[9] = true;
             WhiteSpaceMap[32] = true;
             WhiteSpaceMap[0xB] = true;
@@ -71,15 +71,30 @@ namespace Jint.Parser
             WhiteSpaceMap[0xA0] = true;
             WhiteSpaceMap[0x1680] = true;
             WhiteSpaceMap[0x180E] = true;
-            for (var i = 0x2000; i <= 0x200A; i++)
-            {
-                WhiteSpaceMap[i] = true;
-            }
+            WhiteSpaceMap[0x2000] = true;
+            WhiteSpaceMap[0x2001] = true;
+            WhiteSpaceMap[0x2002] = true;
+            WhiteSpaceMap[0x2003] = true;
+            WhiteSpaceMap[0x2004] = true;
+            WhiteSpaceMap[0x2005] = true;
+            WhiteSpaceMap[0x2006] = true;
+            WhiteSpaceMap[0x2007] = true;
+            WhiteSpaceMap[0x2008] = true;
+            WhiteSpaceMap[0x2009] = true;
+            WhiteSpaceMap[0x200A] = true;
             WhiteSpaceMap[0x202F] = true;
             WhiteSpaceMap[0x205F] = true;
             WhiteSpaceMap[0x3000] = true;
             WhiteSpaceMap[0xFEFF] = true;
+            #endregion
 
+            LineTerminatorMap = new BitArray(0x2029+1);
+            #region LineTerminatorMap
+            LineTerminatorMap[10] = true;
+            LineTerminatorMap[13] = true;
+            LineTerminatorMap[0x2028] = true;
+            LineTerminatorMap[0x2029] = true;
+            #endregion 
         }
 
         public JavaScriptParser()
@@ -115,16 +130,17 @@ namespace Jint.Parser
         // 7.2 White Space
         private static readonly BitArray WhiteSpaceMap;
 
+        public static bool IsWhiteSpace(char ch)
+        {
+            return ch <= 0xFEFF && WhiteSpaceMap[ch];
+        }
 
         // 7.3 Line Terminators
-
+        private static readonly BitArray LineTerminatorMap;
         private static bool IsLineTerminator(char ch)
         {
-            return (ch == 10) 
-                || (ch == 13) 
-                || (ch == 0x2028) // line separator
-                || (ch == 0x2029) // paragraph separator
-                ;
+            // todo: original method seems to be faster 
+            return ch <= 0x2029 && LineTerminatorMap[ch];
         }
 
         // 7.6 Identifier Names and Identifiers

--- a/Jint/Parser/ParserExtensions.cs
+++ b/Jint/Parser/ParserExtensions.cs
@@ -4,22 +4,6 @@ namespace Jint.Parser
 {
     public static class ParserExtensions
     {
-        public static string Slice(this string source, int start, int end)
-        {
-            return source.Substring(start, end - start);
-        }
-
-        public static char CharCodeAt(this string source, int index)
-        {
-            if (index < 0 || index > source.Length - 1)
-            {
-                // char.MinValue is used as the null value
-                return char.MinValue;
-            }
-
-            return source[index];
-        }
-
         public static T Pop<T>(this List<T> list)
         {
             var lastIndex = list.Count - 1;

--- a/Jint/Parser/SourceReader.cs
+++ b/Jint/Parser/SourceReader.cs
@@ -1,0 +1,25 @@
+﻿namespace Jint.Parser
+{
+    public class SourceReader
+    {
+        private readonly string _source;
+        private readonly char[] _reader;
+
+        public SourceReader(string source)
+        {
+            _source = source;
+            _reader = source.ToCharArray();
+        }
+
+        public char CharCodeAt(int index)
+        {
+            return _reader[index];
+        }
+
+        public string Slice(int start, int end)
+        {
+            return _source.Substring(start, end - start);
+        }
+
+    }
+}

--- a/Jint/Parser/Token.cs
+++ b/Jint/Parser/Token.cs
@@ -13,18 +13,61 @@
         RegularExpression = 9
     };
 
-    public class Token
+    public struct Token
     {
         public static Token Empty = new Token();
 
         public Tokens Type;
         public string Literal;
         public object Value;
-        public int[] Range;
+        public int Start;
+        public int End;
         public int? LineNumber;
         public int LineStart;
         public bool Octal;
         public Location Location;
         public int Precedence;
+
+        public int StartLineNumber;
+        public int StartLineStart;
+
+        public override bool Equals(object obj)
+        {
+            return base.Equals(obj);
+        }
+
+        public bool Equals(Token other)
+        {
+            return Type == other.Type && string.Equals(Literal, other.Literal) && Equals(Value, other.Value) && Start == other.Start && End == other.End && LineNumber == other.LineNumber && LineStart == other.LineStart && Octal.Equals(other.Octal) && Equals(Location, other.Location) && Precedence == other.Precedence;
+        }
+
+        public static bool operator ==(Token lhs, Token rhs)
+        {
+            return lhs.Equals(rhs);
+        }
+
+        public static bool operator !=(Token lhs, Token rhs)
+        {
+            return !lhs.Equals(rhs);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (int)Type;
+                hashCode = (hashCode * 397) ^ (Literal != null ? Literal.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Value != null ? Value.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ Start;
+                hashCode = (hashCode * 397) ^ End;
+                hashCode = (hashCode * 397) ^ LineNumber.GetHashCode();
+                hashCode = (hashCode * 397) ^ LineStart;
+                hashCode = (hashCode * 397) ^ Octal.GetHashCode();
+                hashCode = (hashCode * 397) ^ (Location != null ? Location.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ Precedence;
+                return hashCode;
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Hi Sebastienros,

Thanks for this great scripting tool! There's the new **"import"** keyword in the new JavaScript standard which can be really great and handy if you actually translate it to Jint. The **"import"** keyword can be implemented as a scripting library importer (for importing external scripts to the currently edited script) like in html pages:

```
script src="mylibrary.js"
```
translated to Jint: 
```
import "mylibrary.js" ,"tools.js";

//import function myFunction() from external JS script
import "myFunction()" from "mylibrary.js";
```
...or as an array representation:
```
import ["mylibrary.js", "tools.js"];
```

It can also be used as a *Class* importer keyword to help in reducing multiple code reuses while calling internally-defined functions in C#/VB, just like the ```using``` keyword in C# or the ```imports``` keyword in VB.NET. All this is so as to help in building large and highly scalable external scripts. Will be really grateful!