### PR TITLE
Add debug support

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1320,10 +1320,11 @@ namespace Jint.Tests.Runtime
 
             Assert.Equal(1, debugInfo.CallStack.Count);
             Assert.Equal("func1()", debugInfo.CallStack.Peek());
-            Assert.Contains(debugInfo.Locals, kvp => kvp.Key.Equals("global", StringComparison.Ordinal) && kvp.Value.AsBoolean() == true);
+            Assert.Contains(debugInfo.Globals, kvp => kvp.Key.Equals("global", StringComparison.Ordinal) && kvp.Value.AsBoolean() == true);
+            Assert.Contains(debugInfo.Globals, kvp => kvp.Key.Equals("local", StringComparison.Ordinal) && kvp.Value.AsBoolean() == false);
             Assert.Contains(debugInfo.Locals, kvp => kvp.Key.Equals("local", StringComparison.Ordinal) && kvp.Value.AsBoolean() == false);
-
-
+            Assert.DoesNotContain(debugInfo.Locals, kvp => kvp.Key.Equals("global", StringComparison.Ordinal));
+            
             countBreak++;
             return stepMode;
         }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -18,6 +18,7 @@ using Jint.Native.String;
 using Jint.Parser;
 using Jint.Parser.Ast;
 using Jint.Runtime;
+using Jint.Runtime.Debugger;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interop;
@@ -138,6 +139,8 @@ namespace Jint
             }
 
             ClrTypeConverter = new DefaultTypeConverter(this);
+            BreakPoints = new List<BreakPoint>();
+            DebugHandler = new DebugHandler(this);
         }
 
         public LexicalEnvironment GlobalEnvironment;
@@ -166,6 +169,33 @@ namespace Jint
         public ExecutionContext ExecutionContext { get { return _executionContexts.Peek(); } }
 
         internal Options Options { get; private set; }
+        
+        #region Debugger
+        public delegate StepMode DebugStepDelegate(object sender, DebugInformation e);
+        public delegate StepMode BreakDelegate(object sender, DebugInformation e);
+        public event DebugStepDelegate Step;
+        public event BreakDelegate Break;
+        internal DebugHandler DebugHandler { get; private set; }
+        public List<BreakPoint> BreakPoints { get; private set; }
+
+        internal StepMode? InvokeStepEvent(DebugInformation info)
+        {
+            if (Step != null)
+            {
+                return Step(this, info);
+            }
+            return null;
+        }
+
+        internal StepMode? InvokeBreakEvent(DebugInformation info)
+        {
+            if (Break != null)
+            {
+                return Break(this, info);
+            }
+            return null;
+        }
+        #endregion
 
         public ExecutionContext EnterExecutionContext(LexicalEnvironment lexicalEnvironment, LexicalEnvironment variableEnvironment, JsValue thisBinding)
         {
@@ -301,6 +331,11 @@ namespace Jint
             }
 
             _lastSyntaxNode = statement;
+            
+            if (Options.IsDebugMode())
+            {
+                DebugHandler.OnStep(statement);
+            }
 
             switch (statement.Type)
             {
@@ -368,10 +403,10 @@ namespace Jint
                     throw new ArgumentOutOfRangeException();
             }
         }
-
+        
         public object EvaluateExpression(Expression expression)
         {
-            _lastSyntaxNode = expression;
+			_lastSyntaxNode = expression;
 
             switch (expression.Type)
             {

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -403,10 +403,10 @@ namespace Jint
                     throw new ArgumentOutOfRangeException();
             }
         }
-        
+
         public object EvaluateExpression(Expression expression)
         {
-			_lastSyntaxNode = expression;
+            _lastSyntaxNode = expression;
 
             switch (expression.Type)
             {

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -163,6 +163,10 @@
     <Compile Include="Runtime\CallStack\CallStackElementComparer.cs" />
     <Compile Include="Runtime\CallStack\CallStackElement.cs" />
     <Compile Include="Runtime\Completion.cs" />
+    <Compile Include="Runtime\Debugger\BreakPoint.cs" />
+    <Compile Include="Runtime\Debugger\DebugHandler.cs" />
+    <Compile Include="Runtime\Debugger\DebugInformation.cs" />
+    <Compile Include="Runtime\Debugger\StepMode.cs" />
     <Compile Include="Runtime\Descriptors\PropertyDescriptor.cs" />
     <Compile Include="Runtime\Descriptors\Specialized\FieldInfoDescriptor.cs" />
     <Compile Include="Runtime\Descriptors\Specialized\IndexDescriptor.cs" />

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -13,6 +13,7 @@ namespace Jint
         private bool _discardGlobal;
         private bool _strict;
         private bool _allowDebuggerStatement;
+        private bool _debugMode;
         private bool _allowClr;
         private readonly List<IObjectConverter> _objectConverters = new List<IObjectConverter>();
         private int _maxStatements;
@@ -51,6 +52,15 @@ namespace Jint
         public Options AllowDebuggerStatement(bool allowDebuggerStatement = true)
         {
             _allowDebuggerStatement = allowDebuggerStatement;
+            return this;
+        }
+
+        /// <summary>
+        /// Allow to run the script in debug mode.
+        /// </summary>
+        public Options DebugMode(bool debugMode = true)
+        {
+            _debugMode = debugMode;
             return this;
         }
 
@@ -126,6 +136,11 @@ namespace Jint
         internal bool IsDebuggerStatementAllowed()
         {
             return _allowDebuggerStatement;
+        }
+
+        internal bool IsDebugMode()
+        {
+            return _debugMode;
         }
 
         internal bool IsClrAllowed()

--- a/Jint/Runtime/Debugger/BreakPoint.cs
+++ b/Jint/Runtime/Debugger/BreakPoint.cs
@@ -1,0 +1,21 @@
+﻿namespace Jint.Runtime.Debugger
+{
+    public class BreakPoint
+    {
+        public int Line { get; set; }
+        public int Char { get; set; }
+        public string Condition { get; set; }
+
+        public BreakPoint(int line, int character)
+        {
+            Line = line;
+            Char = character;
+        }
+
+        public BreakPoint(int line, int character, string condition)
+            : this(line, character)
+        {
+            Condition = condition;
+        }
+    }
+}

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jint.Native;
+using Jint.Parser.Ast;
+using Jint.Runtime.Environments;
+using Jint.Runtime.References;
+
+namespace Jint.Runtime.Debugger
+{
+    internal class DebugHandler
+    {
+        private readonly Stack<string> _debugCallStack;
+        private StepMode _stepMode;
+        private int _callBackStepOverDepth;
+        private readonly Engine _engine;
+
+        public DebugHandler(Engine engine)
+        {
+            _engine = engine;
+            _debugCallStack = new Stack<string>();
+            _stepMode = StepMode.Into;
+        }
+
+        internal void PopDebugCallStack()
+        {
+            if (_debugCallStack.Count > 0)
+            {
+                _debugCallStack.Pop();
+            }
+            if (_stepMode == StepMode.Over && _debugCallStack.Count <= _callBackStepOverDepth)
+            {
+                _callBackStepOverDepth = _debugCallStack.Count;
+                _stepMode = StepMode.Into;
+            }
+        }
+
+        internal void AddToDebugCallStack(CallExpression callExpression)
+        {
+            var identifier = callExpression.Callee as Identifier;
+            if (identifier != null)
+            {
+                var stack = identifier.Name + "(";
+                var paramStrings = new List<string>();
+
+                foreach (var argument in callExpression.Arguments)
+                {
+                    if (argument != null)
+                    {
+                        var argIdentifier = argument as Identifier;
+                        paramStrings.Add(argIdentifier != null ? argIdentifier.Name : "null");
+                    }
+                    else
+                    {
+                        paramStrings.Add("null");
+                    }
+                }
+
+                stack += string.Join(", ", paramStrings);
+                stack += ")";
+                _debugCallStack.Push(stack);
+            }
+        }
+
+        internal void OnStep(Statement statement)
+        {
+            var old = _stepMode;
+            if (statement == null)
+            {
+                return;
+            }
+
+            
+            
+            BreakPoint breakpoint = _engine.BreakPoints.FirstOrDefault(breakPoint => BpTest(statement, breakPoint));
+            bool breakpointFound = false;
+
+            if (breakpoint != null)
+            {
+                DebugInformation info = CreateDebugInformation(statement);
+                var result = _engine.InvokeBreakEvent(info);
+                if (result.HasValue)
+                {
+                    _stepMode = result.Value;
+                    breakpointFound = true;
+                }
+            }
+
+            if (breakpointFound == false && _stepMode == StepMode.Into)
+            {
+                DebugInformation info = CreateDebugInformation(statement);
+                var result = _engine.InvokeStepEvent(info);
+                if (result.HasValue)
+                {
+                    _stepMode = result.Value;
+                }
+            }
+
+            if (old == StepMode.Into && _stepMode == StepMode.Over)
+            {
+                _callBackStepOverDepth = _debugCallStack.Count;
+            }
+        }
+
+        private bool BpTest(Statement statement, BreakPoint breakpoint)
+        {
+            bool afterStart, beforeEnd;
+
+            afterStart = (breakpoint.Line == statement.Location.Start.Line &&
+                          breakpoint.Char >= statement.Location.Start.Column);
+
+            if (!afterStart)
+            {
+                return false;
+            }
+
+            beforeEnd = (breakpoint.Line == statement.Location.End.Line &&
+                         breakpoint.Char <= statement.Location.End.Column);
+
+            if (!beforeEnd)
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(breakpoint.Condition))
+            {
+                return _engine.Execute(breakpoint.Condition).GetCompletionValue().AsBoolean();
+            }
+
+            return true;
+        }
+
+        private DebugInformation CreateDebugInformation(Statement statement)
+        {
+            var info = new DebugInformation { CurrentStatement = statement, CallStack = _debugCallStack };
+
+            if (_engine.ExecutionContext != null && _engine.ExecutionContext.LexicalEnvironment != null)
+            {
+                info.Locals = GetIdentifierReference(_engine.ExecutionContext.LexicalEnvironment);
+            }
+
+            return info;
+        }
+
+        public static Dictionary<string, JsValue> GetIdentifierReference(LexicalEnvironment lex)
+        {
+            Dictionary<string, JsValue> locals = new Dictionary<string, JsValue>();
+            LexicalEnvironment tempLex = lex;
+
+            while (tempLex != null && tempLex.Record != null)
+            {
+                var bindings = tempLex.Record.GetAllBindingNames();
+                foreach (var binding in bindings)
+                {
+                    if (locals.ContainsKey(binding) == false)
+                    {
+                        var jsValue = tempLex.Record.GetBindingValue(binding, false);
+                        if (jsValue.TryCast<ICallable>() == null)
+                        {
+                            locals.Add(binding, jsValue);
+                        }
+                    }
+                }
+                tempLex = tempLex.Outer;
+            }
+            return locals;
+        }
+    }
+}

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -28,7 +28,7 @@ namespace Jint.Runtime.Debugger
             {
                 _debugCallStack.Pop();
             }
-            if (_stepMode == StepMode.Over && _debugCallStack.Count <= _callBackStepOverDepth)
+            if (_stepMode == StepMode.Over && _debugCallStack.Count < _callBackStepOverDepth)
             {
                 _callBackStepOverDepth = _debugCallStack.Count;
                 _stepMode = StepMode.Into;
@@ -69,8 +69,6 @@ namespace Jint.Runtime.Debugger
             {
                 return;
             }
-
-            
             
             BreakPoint breakpoint = _engine.BreakPoints.FirstOrDefault(breakPoint => BpTest(statement, breakPoint));
             bool breakpointFound = false;
@@ -107,15 +105,16 @@ namespace Jint.Runtime.Debugger
             bool afterStart, beforeEnd;
 
             afterStart = (breakpoint.Line == statement.Location.Start.Line &&
-                          breakpoint.Char >= statement.Location.Start.Column);
+                             breakpoint.Char >= statement.Location.Start.Column);
 
             if (!afterStart)
             {
                 return false;
             }
 
-            beforeEnd = (breakpoint.Line == statement.Location.End.Line &&
-                         breakpoint.Char <= statement.Location.End.Column);
+            beforeEnd = breakpoint.Line < statement.Location.End.Line
+                        || (breakpoint.Line == statement.Location.End.Line &&
+                            breakpoint.Char <= statement.Location.End.Column);
 
             if (!beforeEnd)
             {

--- a/Jint/Runtime/Debugger/DebugInformation.cs
+++ b/Jint/Runtime/Debugger/DebugInformation.cs
@@ -11,5 +11,6 @@ namespace Jint.Runtime.Debugger
         public Stack<String> CallStack { get; set; }
         public Statement CurrentStatement { get; set; }
         public Dictionary<string, JsValue> Locals { get; set; }
+        public Dictionary<string, JsValue> Globals { get; set; }
     }
 }

--- a/Jint/Runtime/Debugger/DebugInformation.cs
+++ b/Jint/Runtime/Debugger/DebugInformation.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using Jint.Native;
+using Jint.Parser.Ast;
+using Jint.Runtime.Environments;
+
+namespace Jint.Runtime.Debugger
+{
+    public class DebugInformation : EventArgs
+    {
+        public Stack<String> CallStack { get; set; }
+        public Statement CurrentStatement { get; set; }
+        public Dictionary<string, JsValue> Locals { get; set; }
+    }
+}

--- a/Jint/Runtime/Debugger/StepMode.cs
+++ b/Jint/Runtime/Debugger/StepMode.cs
@@ -1,0 +1,9 @@
+﻿namespace Jint.Runtime.Debugger
+{
+    public enum StepMode
+    {
+        None,
+        Over,
+        Into
+    }
+}

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Jint.Native;
 
 namespace Jint.Runtime.Environments
@@ -111,6 +112,15 @@ namespace Jint.Runtime.Environments
         {
             var binding = _bindings[name];
             binding.Value = value;
+        }
+
+        /// <summary>
+        /// Returns an array of all the defined binding names
+        /// </summary>
+        /// <returns>The array of all defined bindings</returns>
+        public override string[] GetAllBindingNames()
+        {
+            return _bindings.Keys.ToArray();
         }
     }
 }

--- a/Jint/Runtime/Environments/EnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/EnvironmentRecord.cs
@@ -56,6 +56,10 @@ namespace Jint.Runtime.Environments
         /// <returns>The value to use as <c>this</c>.</returns>
         public abstract JsValue ImplicitThisValue();
 
-
+        /// <summary>
+        /// Returns an array of all the defined binding names
+        /// </summary>
+        /// <returns>The array of all defined bindings</returns>
+        public abstract string[] GetAllBindingNames();
     }
 }

--- a/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
@@ -1,4 +1,5 @@
-﻿using Jint.Native;
+﻿using System.Linq;
+using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
 
@@ -71,6 +72,15 @@ namespace Jint.Runtime.Environments
             }
 
             return Undefined.Instance;
+        }
+
+        public override string[] GetAllBindingNames()
+        {
+            if (_bindingObject != null && _bindingObject.Properties != null)
+            {
+                return _bindingObject.Properties.Keys.ToArray();
+            }
+            return new string[0];
         }
     }
 }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -789,6 +789,11 @@ namespace Jint.Runtime
         {
             var callee = EvaluateExpression(callExpression.Callee);
 
+            if (_engine.Options.IsDebugMode())
+            {
+                _engine.DebugHandler.AddToDebugCallStack(callExpression);
+            }
+
             JsValue thisObject;
 
             // todo: implement as in http://www.ecma-international.org/ecma-262/5.1/#sec-11.2.4
@@ -852,6 +857,11 @@ namespace Jint.Runtime
             }
             
             var result = callable.Call(thisObject, arguments);
+
+            if (_engine.Options.IsDebugMode())
+            {
+                _engine.DebugHandler.PopDebugCallStack();
+            }
 
             if (isRecursionHandled)
             {


### PR DESCRIPTION
As requested in Issue #25, I have implemented a first and basic support for debugging.
I started from fvaneijk implementation, found here:
https://github.com/fvaneijk/jint/tree/addDebugger

Debugging is enabled with a new parameter in Options, called DebugMode.
There are two new events, for being notified of step and breakpoint (Step and Break respectively).
Both events allow to return the behavior for following steps (Into, Over or None)
The events provide a DebugInformation instance, which contains the statement, a simple callstack and dictionaries of local and global variables.

I've written some unit tests for covering most of the use cases:

ShouldBreakWhenBreakpointIsReached
ShouldExecuteStepByStep
ShouldNotBreakTwiceIfSteppingOverBreakpoint
ShouldShowProperDebugInformation
ShouldBreakWhenConditionIsMatched
ShouldNotStepInSameLevelStatementsWhenStepOver
ShouldNotStepInIfRequiredToStepOver
ShouldBreakWhenStatementIsMultiLine

Let me known if this solution can be further improved.