### PR TITLE
 Catching CLR exceptions in JavaScript code

### DIFF
--- a/Jint.Tests/CatchingClrExceptionsTest.cs
+++ b/Jint.Tests/CatchingClrExceptionsTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jint.Tests
+{
+    public class CatchingClrExceptionsTest
+    {
+        [Fact]
+        public void ItShouldBePossibleToCatchClrExceptionsInJavaScript()
+        {
+            var engine = new Engine();
+            engine.SetValue("error", new Action(() => { throw new ArgumentOutOfRangeException("x"); }));
+
+            engine.Execute(@"
+function run(){
+    try {
+        error();
+        return false;
+    } 
+    catch(e) {
+        return true;
+    }
+}
+");
+
+            var result = engine.Invoke("run");
+
+            Assert.Equal(result.AsBoolean(), true);
+        }
+    }
+}

--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -59,6 +59,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CatchingClrExceptionsTest.cs" />
     <Compile Include="Parser\JavascriptParserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Runtime\Converters\NegateBoolConverter.cs" />

--- a/Jint/ExceptionExtensions.cs
+++ b/Jint/ExceptionExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace Jint
+{
+    static class ExceptionExtensions
+    {
+        public static void Rethrow(this Exception @this)
+        {
+            UseExceptionDispatchInfo(@this);
+
+            var internalPreserveStackTrace = typeof(Exception).GetMethod("InternalPreserveStackTrace", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            if (internalPreserveStackTrace != null)
+            {
+                internalPreserveStackTrace.Invoke(@this, new object[0]);
+                throw @this;
+            }
+
+            throw @this;
+        }
+
+        private static void UseExceptionDispatchInfo(Exception @this)
+        {
+            var type = Type.GetType("System.Runtime.ExceptionServices.ExceptionDispatchInfo, mscorlib");
+
+            if (type != null)
+            {
+                var info = type.GetMethod("Capture").Invoke(null, new object[] { @this });
+                var throwMethod = type.GetMethod("Throw");
+                //var call = Expression.Call(Expression.Constant(info), throwMethod);
+                //Expression.Lambda<Action>()
+                var action = (Action)Delegate.CreateDelegate(typeof(Action), info, type.GetMethod("Throw"));
+                action();
+                //info.Throw();
+            }
+        }
+    }
+}

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Runtime\Interop\TypeReference.cs" />
     <Compile Include="Runtime\Interop\TypeReferencePrototype.cs" />
     <Compile Include="Runtime\JavaScriptException.cs" />
+    <Compile Include="Runtime\JintException.cs" />
     <Compile Include="Runtime\MruPropertyCache2.cs" />
     <Compile Include="Runtime\MruPropertyCache.cs" />
     <Compile Include="Runtime\RecursionDepthOverflowException.cs" />

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -47,6 +47,7 @@
     <Compile Include="DeclarationBindingType.cs" />
     <Compile Include="EvalCodeScope.cs" />
     <Compile Include="Engine.cs" />
+    <Compile Include="ExceptionExtensions.cs" />
     <Compile Include="Native\Array\ArrayConstructor.cs" />
     <Compile Include="Native\Array\ArrayInstance.cs" />
     <Compile Include="Native\Array\ArrayPrototype.cs" />

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Jint.Native.Object;
 using Jint.Parser;
 using Jint.Runtime;
@@ -94,6 +95,16 @@ namespace Jint.Native.Function
 
                     if (result.Type == Completion.Throw)
                     {
+                        if (result.Value.HasValue && result.Value.Value.IsObject())
+                        {
+                            var e = result.Value.Value.ToObject() as Exception;
+                            if (e != null)
+                            {
+                                e.Rethrow();
+                                throw new InvalidOperationException("Clr is not working");
+                           }
+                        }
+
                         JavaScriptException ex = new JavaScriptException(result.GetValueOrDefault());
                         ex.Location = result.Location;
                         throw ex;

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -4,7 +4,7 @@ using Jint.Native.Error;
 
 namespace Jint.Runtime
 {
-    public class JavaScriptException : Exception
+    public class JavaScriptException : JintException
     {
         private readonly JsValue _errorObject;
 

--- a/Jint/Runtime/JintException.cs
+++ b/Jint/Runtime/JintException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Jint.Runtime
+{
+    public abstract class JintException : Exception
+    {
+        public JintException()
+        {
+        }
+
+        public JintException(string message)
+            : base(message)
+        {
+
+        }
+    }
+}

--- a/Jint/Runtime/RecursionDepthOverflowException.cs
+++ b/Jint/Runtime/RecursionDepthOverflowException.cs
@@ -9,7 +9,7 @@ namespace Jint.Runtime
 {
     using Jint.Runtime.CallStack;
 
-    public class RecursionDepthOverflowException : Exception
+    public class RecursionDepthOverflowException : JintException
     {
         public string CallChain { get; private set; }
 

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -19,7 +19,30 @@ namespace Jint.Runtime
 
         private Completion ExecuteStatement(Statement statement)
         {
-            return _engine.ExecuteStatement(statement);
+            try
+            {
+                return _engine.ExecuteStatement(statement);
+            }
+            catch(JavaScriptException)
+            {
+                throw;
+            }
+            catch (RecursionDepthOverflowException)
+            {
+                throw;
+            }
+            catch (StatementsCountOverflowException)
+            {
+                throw;
+            }
+            catch (TimeoutException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {                
+                return new Completion(Completion.Throw, JsValue.FromObject(_engine, e.InnerException), null);
+            }
         }
 
         public Completion ExecuteEmptyStatement(EmptyStatement emptyStatement)

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -23,18 +23,10 @@ namespace Jint.Runtime
             {
                 return _engine.ExecuteStatement(statement);
             }
-            catch(JavaScriptException)
+            catch(JintException)
             {
                 throw;
-            }
-            catch (RecursionDepthOverflowException)
-            {
-                throw;
-            }
-            catch (StatementsCountOverflowException)
-            {
-                throw;
-            }
+            }           
             catch (TimeoutException)
             {
                 throw;

--- a/Jint/Runtime/StatementsCountOverflowException.cs
+++ b/Jint/Runtime/StatementsCountOverflowException.cs
@@ -2,7 +2,7 @@
 
 namespace Jint.Runtime
 {
-    public class StatementsCountOverflowException : Exception 
+    public class StatementsCountOverflowException : JintException 
     {
         public StatementsCountOverflowException() : base("The maximum number of statements executed have been reached.")
         {


### PR DESCRIPTION
Now it is possible for JavaScript code to catch exceptions thrown by CLR methods.
