### PR TITLE
Fix a error that occurs when creating an instance of value type without parameters

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -818,13 +818,22 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
-        public void ShouldConstructWithParameters()
+        public void ShouldConstructReferenceTypeWithParameters()
         {
             RunTest(@"
                 var Shapes = importNamespace('Shapes');
                 var circle = new Shapes.Circle(1);
                 assert(circle.Radius === 1);
                 assert(circle.Perimeter() === Math.PI);
+            ");
+        }
+
+        [Fact]
+        public void ShouldConstructValueTypeWithoutParameters()
+        {
+            RunTest(@"
+                var guid = new System.Guid();
+                assert('00000000-0000-0000-0000-000000000000' === guid.ToString());
             ");
         }
 

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -44,6 +44,14 @@ namespace Jint.Runtime.Interop
 
         public ObjectInstance Construct(JsValue[] arguments)
         {
+            if (arguments.Length == 0 && Type.IsValueType)
+            {
+                var instance = Activator.CreateInstance(Type);
+                var result = TypeConverter.ToObject(Engine, JsValue.FromObject(Engine, instance));
+
+                return result;
+            }
+
             var constructors = Type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
             
             var methods = TypeConverter.FindBestMatch(Engine, constructors, arguments).ToList();
@@ -71,7 +79,8 @@ namespace Jint.Runtime.Interop
                     }
 
                     var constructor = (ConstructorInfo)method;
-                    var result = TypeConverter.ToObject(Engine, JsValue.FromObject(Engine, constructor.Invoke(parameters.ToArray())));
+                    var instance = constructor.Invoke(parameters.ToArray());
+                    var result = TypeConverter.ToObject(Engine, JsValue.FromObject(Engine, instance));
 
                     // todo: cache method info
 


### PR DESCRIPTION
When creating an instance of value type without parameters the following error occurs:

	No public methods with the specified arguments were found.