### PR TITLE
Line/column for exceptions in nested functions weren't correct

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -617,7 +617,7 @@ namespace Jint.Tests.Runtime
                 () => new Engine(cfg => cfg.MaxStatements(100)).Execute("while(true);")
             );
         }
-        
+
         [Fact]
         public void ShouldThrowTimeout()
         {
@@ -1259,7 +1259,7 @@ namespace Jint.Tests.Runtime
             var engine = new Engine(options => options.DebugMode());
 
             engine.Step += EngineStep;
-            
+
             engine.Execute(@"var local = true;
                 var creatingSomeOtherLine = 0;
                 var lastOneIPromise = true");
@@ -1287,7 +1287,7 @@ namespace Jint.Tests.Runtime
 
             Assert.Equal(1, countBreak);
         }
-        
+
         private StepMode EngineStep(object sender, DebugInformation debugInfo)
         {
             Assert.NotNull(sender);
@@ -1337,7 +1337,7 @@ namespace Jint.Tests.Runtime
             Assert.Contains(debugInfo.Globals, kvp => kvp.Key.Equals("local", StringComparison.Ordinal) && kvp.Value.AsBoolean() == false);
             Assert.Contains(debugInfo.Locals, kvp => kvp.Key.Equals("local", StringComparison.Ordinal) && kvp.Value.AsBoolean() == false);
             Assert.DoesNotContain(debugInfo.Locals, kvp => kvp.Key.Equals("global", StringComparison.Ordinal));
-            
+
             countBreak++;
             return stepMode;
         }
@@ -1395,7 +1395,7 @@ namespace Jint.Tests.Runtime
         public void ShouldNotStepInIfRequiredToStepOut()
         {
             countBreak = 0;
-            
+
             var engine = new Engine(options => options.DebugMode());
 
             engine.Step += EngineStepOutWhenInsideFunction;
@@ -1422,7 +1422,7 @@ namespace Jint.Tests.Runtime
             countBreak++;
             if (debugInfo.CallStack.Count > 0)
                 return StepMode.Out;
-            
+
             return StepMode.Into;
         }
 
@@ -1453,7 +1453,7 @@ namespace Jint.Tests.Runtime
         public void ShouldNotStepInsideIfRequiredToStepOver()
         {
             countBreak = 0;
-            
+
             var engine = new Engine(options => options.DebugMode());
 
             stepMode = StepMode.Over;
@@ -1637,6 +1637,25 @@ namespace Jint.Tests.Runtime
                 var b = new Date(a);
                 assert(String(a) === String(b));
             ");
+        }
+
+        [Fact]
+        public void ExceptionShouldHaveLocationOfInnerFunction()
+        {
+            try
+            {
+                new Engine()
+                    .Execute(@"
+                    function test(s) {
+                        o.boom();
+                    }
+                    test('arg');
+                ");
+            }
+            catch (JavaScriptException ex)
+            {
+                Assert.Equal(3, ex.LineNumber);
+            }
         }
     }
 }

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -60,7 +60,7 @@ namespace Jint.Runtime
             var result = ExecuteStatement(labelledStatement.Body);
             if (result.Type == Completion.Break && result.Identifier == labelledStatement.Label.Name)
             {
-                return new Completion(Completion.Normal, result.Value, null);    
+                return new Completion(Completion.Normal, result.Value, null);
             }
 
             return result;
@@ -110,7 +110,7 @@ namespace Jint.Runtime
         /// <returns></returns>
         public Completion ExecuteWhileStatement(WhileStatement whileStatement)
         {
-            JsValue v = Undefined.Instance; 
+            JsValue v = Undefined.Instance;
             while (true)
             {
                 var exprRef = _engine.EvaluateExpression(whileStatement.Test);
@@ -149,7 +149,7 @@ namespace Jint.Runtime
         /// <returns></returns>
         public Completion ExecuteForStatement(ForStatement forStatement)
         {
-            
+
             if (forStatement.Init != null)
             {
                 if (forStatement.Init.Type == SyntaxNodes.VariableDeclaration)
@@ -205,8 +205,8 @@ namespace Jint.Runtime
         /// <returns></returns>
         public Completion ExecuteForInStatement(ForInStatement forInStatement)
         {
-            Identifier identifier = forInStatement.Left.Type == SyntaxNodes.VariableDeclaration 
-                                        ? forInStatement.Left.As<VariableDeclaration>().Declarations.First().Id 
+            Identifier identifier = forInStatement.Left.Type == SyntaxNodes.VariableDeclaration
+                                        ? forInStatement.Left.As<VariableDeclaration>().Declarations.First().Id
                                         : forInStatement.Left.As<Identifier>();
 
             var varRef = _engine.EvaluateExpression(identifier) as Reference;
@@ -220,7 +220,7 @@ namespace Jint.Runtime
 
             var obj = TypeConverter.ToObject(_engine, experValue);
             JsValue v = Null.Instance;
-            
+
             // keys are constructed using the prototype chain
             var cursor = obj;
             var processedKeys = new HashSet<string>();
@@ -236,8 +236,8 @@ namespace Jint.Runtime
                     }
 
                     processedKeys.Add(p);
-                    
-                    // collection might be modified by inner statement 
+
+                    // collection might be modified by inner statement
                     if (!cursor.HasOwnProperty(p))
                     {
                         continue;
@@ -306,8 +306,8 @@ namespace Jint.Runtime
             {
                 return new Completion(Completion.Return, Undefined.Instance, null);
             }
-            
-            var exprRef = _engine.EvaluateExpression(statement.Argument);    
+
+            var exprRef = _engine.EvaluateExpression(statement.Argument);
             return new Completion(Completion.Return, _engine.GetValue(exprRef), null);
         }
 
@@ -385,7 +385,7 @@ namespace Jint.Runtime
                     {
                         return r;
                     }
-                    
+
                     v = r.Value.HasValue ? r.Value.Value : Undefined.Instance;
                 }
 
@@ -432,7 +432,7 @@ namespace Jint.Runtime
             catch(JavaScriptException v)
             {
                 c = new Completion(Completion.Throw, v.Error, null);
-                c.Location = s.Location;
+                c.Location = v.Location ?? s.Location;
                 return c;
             }
 
@@ -486,7 +486,7 @@ namespace Jint.Runtime
                 {
                     return b;
                 }
-            
+
                 return f;
             }
 


### PR DESCRIPTION
Given the following script:

``` JS
function test() {
    o.boom();
}
test();
```

Previously the exception would indicate the error was on the `test();` line rather than the `o.boom();` line.
