### PR TITLE
Allow return statements without a function body (with setting)

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -31,10 +31,9 @@ namespace Jint.Tests.Runtime
         {
         }
 
-
-        private void RunTest(string source)
+        private void RunTest(string source, ParserOptions options = null)
         {
-            _engine.Execute(source);
+            _engine.Execute(source, options);
         }
 
         [Theory]
@@ -1637,6 +1636,19 @@ namespace Jint.Tests.Runtime
                 var b = new Date(a);
                 assert(String(a) === String(b));
             ");
+        }
+
+        [Fact]
+        public void ShouldDisallowNonEmptyReturnWithoutFunctionBody()
+        {
+            Assert.Throws<ParserException>(() => RunTest(@"return 'hello';"));
+        }
+
+        [Fact]
+        public void ShouldAllowNonEmptyReturnWithoutFunctionBody()
+        {
+            RunTest(@"return 'hello';", new ParserOptions { Flags = ParserOptionFlags.SuppressIllegalReturn });
+            Assert.Equal("hello", _engine.GetCompletionValue().ToObject());
         }
     }
 }

--- a/Jint/Parser/Ast/Program.cs
+++ b/Jint/Parser/Ast/Program.cs
@@ -13,6 +13,8 @@ namespace Jint.Parser.Ast
         public List<Comment> Comments;
         public List<Token> Tokens;
         public List<ParserException> Errors;
+        public ParserOptionFlags Flags { get; set; }
+
         public bool Strict;
 
         public IList<VariableDeclaration> VariableDeclarations { get; set; }

--- a/Jint/Parser/JavascriptParser.cs
+++ b/Jint/Parser/JavascriptParser.cs
@@ -3201,7 +3201,7 @@ namespace Jint.Parser
 
             ExpectKeyword("return");
 
-            if (!_state.InFunctionBody)
+            if (!_state.InFunctionBody && ((_extra.Flags & ParserOptionFlags.SuppressIllegalReturn) != ParserOptionFlags.SuppressIllegalReturn))
             {
                 ThrowErrorTolerant(Token.Empty, Messages.IllegalReturn);
             }
@@ -3948,6 +3948,8 @@ namespace Jint.Parser
                 {
                     _extra.Errors = new List<ParserException>();
                 }
+
+                _extra.Flags = options.Flags;
             }
 
             try
@@ -3968,6 +3970,8 @@ namespace Jint.Parser
                 {
                     program.Errors = _extra.Errors;
                 }
+
+                program.Flags = _extra.Flags;
             }
             finally
             {
@@ -4017,6 +4021,8 @@ namespace Jint.Parser
             public List<Comment> Comments;
             public List<Token> Tokens;
             public List<ParserException> Errors;
+
+            public ParserOptionFlags Flags;
         }
 
         private class LocationMarker

--- a/Jint/Parser/ParserOptions.cs
+++ b/Jint/Parser/ParserOptions.cs
@@ -1,10 +1,20 @@
-﻿namespace Jint.Parser
+﻿using System;
+
+namespace Jint.Parser
 {
+    [Flags]
+    public enum ParserOptionFlags
+    {
+        SuppressIllegalReturn = 0x1
+    }
+
     public class ParserOptions
     {
         public string Source { get; set; }
         public bool Tokens { get; set; }
         public bool Comment { get; set; }
         public bool Tolerant { get; set; }
+
+        public ParserOptionFlags Flags { get; set; }
     }
 }


### PR DESCRIPTION
Allows for better backward compatibility with Jint v1
Note since return; is allowed we break some of the ECMA spec tests (when the parser setting is used)