### PR TITLE
Debugger improvements

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -937,7 +937,7 @@ namespace Jint.Tests.Runtime
             {
                 Assert.Equal(1, e.LineNumber);
                 Assert.Equal(9, e.Column);
-                Assert.Equal("jQuery.js", e.Source);
+                Assert.Equal("jQuery.js", e.Source.Source);
             }
         }
 
@@ -1239,7 +1239,10 @@ namespace Jint.Tests.Runtime
 
             engine.Break += EngineStep;
 
-            engine.BreakPoints.Add(new BreakPoint(1, 1));
+            engine.SourceLoaded += (s, e) =>
+            {
+                engine.BreakPoints.Add(new BreakPoint(e.Source, 1, 1));
+            };
 
             engine.Execute(@"var local = true;
                 if (local === true)
@@ -1276,7 +1279,12 @@ namespace Jint.Tests.Runtime
             stepMode = StepMode.Into;
 
             var engine = new Engine(options => options.DebugMode());
-            engine.BreakPoints.Add(new BreakPoint(1, 1));
+
+            engine.SourceLoaded += (s, e) =>
+            {
+                engine.BreakPoints.Add(new BreakPoint(e.Source, 1, 1));
+            };
+
             engine.Step += EngineStep;
             engine.Break += EngineStep;
 
@@ -1305,8 +1313,12 @@ namespace Jint.Tests.Runtime
             stepMode = StepMode.None;
 
             var engine = new Engine(options => options.DebugMode());
-            engine.BreakPoints.Add(new BreakPoint(5, 0));
             engine.Break += EngineStepVerifyDebugInfo;
+
+            engine.SourceLoaded += (s, e) =>
+            {
+                engine.BreakPoints.Add(new BreakPoint(e.Source, 5, 0));
+            };
 
             engine.Execute(@"var global = true;
                             function func1()
@@ -1352,8 +1364,18 @@ namespace Jint.Tests.Runtime
 
             engine.Break += EngineStep;
 
-            engine.BreakPoints.Add(new BreakPoint(5, 16, "condition === true"));
-            engine.BreakPoints.Add(new BreakPoint(6, 16, "condition === false"));
+            bool loaded = false;
+
+            engine.SourceLoaded += (s, e) =>
+            {
+                if (loaded)
+                    return;
+
+                loaded = true;
+
+                engine.BreakPoints.Add(new BreakPoint(e.Source, 5, 16, "condition === true"));
+                engine.BreakPoints.Add(new BreakPoint(e.Source, 6, 16, "condition === false"));
+            };
 
             engine.Execute(@"var local = true;
                 var condition = true;
@@ -1433,7 +1455,12 @@ namespace Jint.Tests.Runtime
             stepMode = StepMode.None;
 
             var engine = new Engine(options => options.DebugMode());
-            engine.BreakPoints.Add(new BreakPoint(4, 33));
+
+            engine.SourceLoaded += (s, e) =>
+            {
+                engine.BreakPoints.Add(new BreakPoint(e.Source, 4, 33));
+            };
+
             engine.Break += EngineStep;
 
             engine.Execute(@"var global = true;

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -305,9 +305,10 @@ namespace Jint
                 var result = _statements.ExecuteProgram(program);
                 if (result.Type == Completion.Throw)
                 {
-                    throw new JavaScriptException(result.GetValueOrDefault())
+                    throw new JavaScriptException(result.GetValueOrDefault(), result.Exception)
                     {
-                        Location = result.Location
+                        Location = result.Location,
+                        DebugInformation = result.DebugInformation
                     };
                 }
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -175,6 +175,7 @@ namespace Jint
         public delegate StepMode BreakDelegate(object sender, DebugInformation e);
         public event DebugStepDelegate Step;
         public event BreakDelegate Break;
+        public event SourceLoadedEventHandler SourceLoaded;
         internal DebugHandler DebugHandler { get; private set; }
         public List<BreakPoint> BreakPoints { get; private set; }
 
@@ -195,6 +196,15 @@ namespace Jint
             }
             return null;
         }
+
+        internal void InvokeSourceLoaded(Script script)
+        {
+            if (SourceLoaded != null)
+            {
+                SourceLoaded(this, new SourceLoadedEventArgs(script));
+            }
+        }
+
         #endregion
 
         public ExecutionContext EnterExecutionContext(LexicalEnvironment lexicalEnvironment, LexicalEnvironment variableEnvironment, JsValue thisBinding)
@@ -271,13 +281,13 @@ namespace Jint
 
         public Engine Execute(string source)
         {
-            var parser = new JavaScriptParser();
+            var parser = new JavaScriptParser(this);
             return Execute(parser.Parse(source));
         }
 
         public Engine Execute(string source, ParserOptions parserOptions)
         {
-            var parser = new JavaScriptParser();
+            var parser = new JavaScriptParser(this);
             return Execute(parser.Parse(source, parserOptions));
         }
 

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Parser\ParserExtensions.cs" />
     <Compile Include="Parser\ParserOptions.cs" />
     <Compile Include="Parser\Position.cs" />
+    <Compile Include="Parser\Script.cs" />
     <Compile Include="Parser\State.cs" />
     <Compile Include="Parser\Token.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -200,6 +201,7 @@
     <Compile Include="Runtime\StatementInterpreter.cs" />
     <Compile Include="Runtime\StatementsCountOverflowException.cs" />
     <Compile Include="Runtime\TypeConverter.cs" />
+    <Compile Include="SourceLoadedEventArgs.cs" />
     <Compile Include="StrictModeScope.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -58,7 +58,10 @@ namespace Jint.Native.Function
 
                             if (result.Type == Completion.Throw)
                             {
-                                throw new JavaScriptException(result.GetValueOrDefault());
+                                JavaScriptException exception = new JavaScriptException(result.GetValueOrDefault(), result.Exception);
+                                exception.Location = result.Location;
+                                exception.DebugInformation = result.DebugInformation;
+                                throw exception;
                             }
                             else
                             {

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -31,7 +31,7 @@ namespace Jint.Native.Function
 
             try
             {
-                var parser = new JavaScriptParser(StrictModeScope.IsStrictModeCode);
+                var parser = new JavaScriptParser(Engine, StrictModeScope.IsStrictModeCode);
                 var program = parser.Parse(code);
                 using (new StrictModeScope(program.Strict))
                 {

--- a/Jint/Native/Function/FunctionConstructor.cs
+++ b/Jint/Native/Function/FunctionConstructor.cs
@@ -82,7 +82,7 @@ namespace Jint.Native.Function
             }
             
             var parameters = this.ParseArgumentNames(p);
-            var parser = new JavaScriptParser();
+            var parser = new JavaScriptParser(Engine);
             FunctionExpression function;
             try
             {

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -94,8 +94,9 @@ namespace Jint.Native.Function
 
                     if (result.Type == Completion.Throw)
                     {
-                        JavaScriptException ex = new JavaScriptException(result.GetValueOrDefault());
+                        JavaScriptException ex = new JavaScriptException(result.GetValueOrDefault(), result.Exception);
                         ex.Location = result.Location;
+                        ex.DebugInformation = result.DebugInformation;
                         throw ex;
                     }
 

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -837,16 +837,13 @@ namespace Jint.Native.Json
                 {
                     Range = new int[0], 
                     Loc = 0,
-
+                    Source = new Script(options?.Source, code)
                 };
+
+            _engine.InvokeSourceLoaded(_extra.Source);
 
             if (options != null)
             {
-                if (!System.String.IsNullOrEmpty(options.Source))
-                {
-                    _extra.Source = options.Source;
-                }
-
                 if (options.Tokens)
                 {
                     _extra.Tokens = new List<Token>();
@@ -879,7 +876,7 @@ namespace Jint.Native.Json
         {
             public int? Loc;
             public int[] Range;
-            public string Source;
+            public Script Source;
 
             public List<Token> Tokens;
         }

--- a/Jint/Parser/JavascriptParser.cs
+++ b/Jint/Parser/JavascriptParser.cs
@@ -54,6 +54,7 @@ namespace Jint.Parser
         private Token _lookahead;
         private string _source;
 
+        private Engine _engine;
         private State _state;
         private bool _strict;
 
@@ -61,12 +62,13 @@ namespace Jint.Parser
         private readonly Stack<IFunctionScope> _functionScopes = new Stack<IFunctionScope>();
 
 
-        public JavaScriptParser()
+        public JavaScriptParser(Engine engine)
         {
-            
+            _engine = engine;
         }
 
-        public JavaScriptParser(bool strict)
+        public JavaScriptParser(Engine engine, bool strict)
+            : this(engine)
         {
             _strict = strict;
         }
@@ -3924,16 +3926,13 @@ namespace Jint.Parser
             {
                 Range = new int[0],
                 Loc = 0,
-
+                Source = new Script(options?.Source, code)
             };
+
+            _engine.InvokeSourceLoaded(_extra.Source);
 
             if (options != null)
             {
-                if (!String.IsNullOrEmpty(options.Source))
-                {
-                    _extra.Source = options.Source;
-                }
-
                 if (options.Tokens)
                 {
                     _extra.Tokens = new List<Token>();
@@ -4000,8 +3999,10 @@ namespace Jint.Parser
             {
                 Range = new int[0],
                 Loc = 0,
-
+                Source = new Script(null, functionExpression)
             };
+
+            _engine.InvokeSourceLoaded(_extra.Source);
 
             _strict = false;
             Peek();
@@ -4012,7 +4013,7 @@ namespace Jint.Parser
         {
             public int? Loc;
             public int[] Range;
-            public string Source;
+            public Script Source;
 
             public List<Comment> Comments;
             public List<Token> Tokens;

--- a/Jint/Parser/JavascriptParser.cs
+++ b/Jint/Parser/JavascriptParser.cs
@@ -62,6 +62,11 @@ namespace Jint.Parser
         private readonly Stack<IFunctionScope> _functionScopes = new Stack<IFunctionScope>();
 
 
+        public JavaScriptParser()
+            : this(null)
+        {
+        }
+
         public JavaScriptParser(Engine engine)
         {
             _engine = engine;
@@ -3929,7 +3934,8 @@ namespace Jint.Parser
                 Source = new Script(options?.Source, code)
             };
 
-            _engine.InvokeSourceLoaded(_extra.Source);
+            if (_engine != null)
+                _engine.InvokeSourceLoaded(_extra.Source);
 
             if (options != null)
             {
@@ -4002,7 +4008,8 @@ namespace Jint.Parser
                 Source = new Script(null, functionExpression)
             };
 
-            _engine.InvokeSourceLoaded(_extra.Source);
+            if (_engine != null)
+                _engine.InvokeSourceLoaded(_extra.Source);
 
             _strict = false;
             Peek();

--- a/Jint/Parser/Loc.cs
+++ b/Jint/Parser/Loc.cs
@@ -4,6 +4,6 @@
     {
         public Position Start;
         public Position End;
-        public string Source;
+        public Script Source;
     }
 }

--- a/Jint/Parser/ParserException.cs
+++ b/Jint/Parser/ParserException.cs
@@ -8,7 +8,7 @@ namespace Jint.Parser
         public string Description;
         public int Index;
         public int LineNumber;
-        public string Source;
+        public Script Source;
 
         public ParserException(string message) : base(message)
         {

--- a/Jint/Parser/Script.cs
+++ b/Jint/Parser/Script.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Jint.Parser
+{
+    public class Script
+    {
+        public string Source { get; }
+        public string Code { get; }
+
+        public Script(string source, string code)
+        {
+            Source = source;
+            Code = code;
+        }
+    }
+}

--- a/Jint/Runtime/Completion.cs
+++ b/Jint/Runtime/Completion.cs
@@ -1,4 +1,5 @@
-﻿using Jint.Native;
+﻿using System;
+using Jint.Native;
 
 namespace Jint.Runtime
 {
@@ -14,15 +15,22 @@ namespace Jint.Runtime
         public static string Throw = "throw";
 
         public Completion(string type, JsValue? value, string identifier)
+            : this(type, value, identifier, null)
+        {
+        }
+
+        public Completion(string type, JsValue? value, string identifier, Exception exception)
         {
             Type = type;
             Value = value;
             Identifier = identifier;
+            Exception = exception;
         }
 
         public string Type { get; private set; }
         public JsValue? Value { get; private set; }
         public string Identifier { get; private set; }
+        public Exception Exception { get; private set; }
 
         public JsValue GetValueOrDefault()
         {
@@ -30,5 +38,7 @@ namespace Jint.Runtime
         }
 
         public Jint.Parser.Location Location { get; set; }
+
+        public Jint.Runtime.Debugger.DebugInformation DebugInformation { get; set; }
     }
 }

--- a/Jint/Runtime/Debugger/BreakPoint.cs
+++ b/Jint/Runtime/Debugger/BreakPoint.cs
@@ -1,19 +1,23 @@
-﻿namespace Jint.Runtime.Debugger
+﻿using Jint.Parser;
+
+namespace Jint.Runtime.Debugger
 {
     public class BreakPoint
     {
+        public Script Source { get; set; }
         public int Line { get; set; }
         public int Char { get; set; }
         public string Condition { get; set; }
 
-        public BreakPoint(int line, int character)
+        public BreakPoint(Script source, int line, int character)
         {
+            Source = source;
             Line = line;
             Char = character;
         }
 
-        public BreakPoint(int line, int character, string condition)
-            : this(line, character)
+        public BreakPoint(Script source, int line, int character, string condition)
+            : this(source, line, character)
         {
             Condition = condition;
         }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -797,11 +797,10 @@ namespace Jint.Runtime
         public JsValue EvaluateCallExpression(CallExpression callExpression)
         {
             var callee = EvaluateExpression(callExpression.Callee);
-            bool shouldDebugPop = false;
 
             if (_engine.Options._IsDebugMode)
             {
-                shouldDebugPop = _engine.DebugHandler.AddToDebugCallStack(callExpression, callee);
+                _engine.DebugHandler.AddToDebugCallStack(callExpression, callee);
             }
 
             JsValue thisObject;
@@ -892,7 +891,7 @@ namespace Jint.Runtime
             
             var result = callable.Call(thisObject, arguments);
 
-            if (shouldDebugPop)
+            if (_engine.Options._IsDebugMode)
             {
                 _engine.DebugHandler.PopDebugCallStack();
             }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -797,10 +797,11 @@ namespace Jint.Runtime
         public JsValue EvaluateCallExpression(CallExpression callExpression)
         {
             var callee = EvaluateExpression(callExpression.Callee);
+            bool shouldDebugPop = false;
 
             if (_engine.Options._IsDebugMode)
             {
-                _engine.DebugHandler.AddToDebugCallStack(callExpression);
+                shouldDebugPop = _engine.DebugHandler.AddToDebugCallStack(callExpression, callee);
             }
 
             JsValue thisObject;
@@ -891,7 +892,7 @@ namespace Jint.Runtime
             
             var result = callable.Call(thisObject, arguments);
 
-            if (_engine.Options._IsDebugMode)
+            if (shouldDebugPop)
             {
                 _engine.DebugHandler.PopDebugCallStack();
             }

--- a/Jint/Runtime/Interop/ClrFunctionInstance.cs
+++ b/Jint/Runtime/Interop/ClrFunctionInstance.cs
@@ -36,6 +36,14 @@ namespace Jint.Runtime.Interop
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
+            catch (JavaScriptException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new JavaScriptException(ex.Message, ex);
+            }
         }
     }
 }

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -96,7 +96,7 @@ namespace Jint.Runtime.Interop
             {
                 return JsValue.FromObject(Engine, _d.DynamicInvoke(parameters));
             }
-            catch (TargetInvocationException ex)
+            catch (TargetInvocationException ex) when (ex.InnerException != null)
             {
                 throw ex.InnerException;
             }

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using Jint.Native;
 using Jint.Native.Function;
 
@@ -91,7 +92,14 @@ namespace Jint.Runtime.Interop
                 parameters[paramsArgumentIndex] = paramsParameter;
             }
 
-            return JsValue.FromObject(Engine, _d.DynamicInvoke(parameters));
+            try
+            {
+                return JsValue.FromObject(Engine, _d.DynamicInvoke(parameters));
+            }
+            catch (TargetInvocationException ex)
+            {
+                throw ex.InnerException;
+            }
         }
     }
 }

--- a/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
@@ -98,6 +98,16 @@ namespace Jint.Runtime.Interop
             foreach (var methodInfo in methodInfos)
             {
                 var parameters = methodInfo.GetParameters();
+                if (parameters.Any(p => Attribute.IsDefined(p, typeof(ParamArrayAttribute))))
+                    continue;
+
+                if (parameters.Length == jsArguments.Length)
+                    return jsArguments;
+            }
+
+            foreach (var methodInfo in methodInfos)
+            {
+                var parameters = methodInfo.GetParameters();
                 if (!parameters.Any(p => Attribute.IsDefined(p, typeof(ParamArrayAttribute))))
                     continue;
 

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Jint.Native;
 using Jint.Native.Error;
+using Jint.Runtime.Debugger;
 
 namespace Jint.Runtime
 {
@@ -21,6 +22,12 @@ namespace Jint.Runtime
 
         public JavaScriptException(JsValue error)
             : base(GetErrorMessage(error))
+        {
+            _errorObject = error;
+        }
+
+        public JavaScriptException(JsValue error, Exception innerException)
+            : base(GetErrorMessage(error), innerException)
         {
             _errorObject = error;
         }
@@ -49,5 +56,7 @@ namespace Jint.Runtime
         public int LineNumber { get { return null == Location ? 0 : Location.Start.Line; } }
 
         public int Column { get { return null == Location ? 0 : Location.Start.Column; } }
+
+        public DebugInformation DebugInformation { get; set; }
     }
 }

--- a/Jint/SourceLoadedEventArgs.cs
+++ b/Jint/SourceLoadedEventArgs.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Jint.Parser;
+
+namespace Jint
+{
+    public class SourceLoadedEventArgs : EventArgs
+    {
+        public Script Source { get; }
+
+        public SourceLoadedEventArgs(Script source)
+        {
+            Source = source;
+        }
+    }
+
+    public delegate void SourceLoadedEventHandler(object sender, SourceLoadedEventArgs e);
+}


### PR DESCRIPTION
This pull request contains a number of improvements to better support debugging. An example of a project that uses these changes can be found at https://github.com/pvginkel/JintDebugger.

Besides a few bug fixes, the largest change is that sources can now be identified. Every time a source is loaded, a new instance of the `Script` class is created. The purpose of this class is to uniquely identify a source file (or eval or function). This is then used by the debugger to show the source to the user. Also, before, breakpoints were not tied to a specific source. The `Breakpoint` class now also has a property for the `Script` instance to ensure that the breakpoint is actually of the correct file.
