### PR TITLE
Adding AST Walker

### DIFF
--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Runtime\SamplesTests.cs" />
     <Compile Include="Runtime\InteropTests.cs" />
     <Compile Include="Runtime\EngineTests.cs" />
+    <Compile Include="WalkerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Parser\Scripts\jQuery.js" />

--- a/Jint.Tests/WalkerTests.cs
+++ b/Jint.Tests/WalkerTests.cs
@@ -1,0 +1,990 @@
+﻿using System.Collections.Generic;
+using Jint.Parser;
+using Jint.Parser.Ast;
+using Jint.Walker;
+using Xunit;
+
+namespace Jint.Tests
+{
+    public class WalkerTests
+    {
+        private string _prgText = "";
+        private int _idCnt;
+        private int _ifCnt;
+        private int _forCnt;
+        private int _funCnt;
+        private int _varDeclCnt;
+        
+        private void DoWalkerTestEvents(string script)
+        {
+            _funCnt = 0;
+            _varDeclCnt = 0;
+            var w = new JintWalker();
+            w.ExpressionWalkEvent += DoExpressionWalkEvent;
+            w.StatementWalkEvent += DoStatementWalkEvent;
+            var prg = Engine.Compile(script, new ParserOptions { Source = "script" });
+            w.WalkStatement(prg);
+        }
+        private void DoWalkerTest(string script)
+        {
+            var prg = Engine.Compile(script, new ParserOptions { Source = "script" });
+            _prgText += JintWalker.GetStatementAsString(prg, true);
+        }
+
+        void DoStatementWalkEvent(object sender, StatementWalkEventDelegateArgs args)
+        {
+            var s = args.Stmt;
+            if (s is FunctionDeclaration)
+            {
+                ++_funCnt;
+            }
+            if (s is ForStatement)
+            {
+                ++_forCnt;
+            }
+            if (s is IfStatement)
+            {
+                ++_ifCnt;
+            }
+            //Console.WriteLine(JintWalker.GetStatementAsString(s, true));
+            //Console.WriteLine(s);
+        }
+
+        void DoExpressionWalkEvent(object sender, ExpressionWalkEventDelegateArgs args)
+        {
+            var e = args.Expr;
+            if (e is FunctionExpression)
+            {
+                ++_funCnt;
+            }
+            if (e is VariableDeclarator)
+            {
+                ++_varDeclCnt;
+            }
+            if (e is Identifier)
+            {
+                ++_idCnt;
+                //Console.WriteLine((e as Identifier).Name);
+            }
+            //Console.WriteLine(JintWalker.GetExprAsString(e));
+            //Console.WriteLine(e);
+        }
+
+
+        [Fact]
+        public void WalkVarDeclLit()
+        {
+            const string script = @"
+var a = 123;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarDeclVar()
+        {
+            const string script = @"
+var a = 123;
+var b = a;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarDeclStmt()
+        {
+            const string script = @"
+var a = 123;
+var b = a + 10;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarDeclExpr2()
+        {
+            const string script = @"
+var a = 123;
+var b = a + (10 * a);
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarDeclMultiple()
+        {
+            const string script = @"
+var a = 123, b, c = 456;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarDeclString()
+        {
+            const string script = @"
+var a = 'hello';
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarDeclNewArray()
+        {
+            const string script = @"
+var a = new Array();
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarDeclNewObjectWithArgs()
+        {
+            const string script = @"
+var a = new MyObject(a, b, c + 10);
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarDeclNewArray2()
+        {
+            const string script = @"
+var a = [];
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkAssignExpr()
+        {
+            const string script = @"
+a = 123;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkAssignExprUnary()
+        {
+            const string script = @"
+a = -123;
+a = ++b;
+a = b++;
+a = !c;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+        [Fact]
+        public void WalkAssignExprLogical()
+        {
+            const string script = @"
+a = true || c;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+
+        [Fact]
+        public void WalkAssignExpr2()
+        {
+          const string script = @"
+a = 123 + (b / c);
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkAssignExpr3()
+        {
+          const string script = @"
+a = (123 + b) / c;
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkAssignExpr4()
+        {
+          const string script = @"
+a = (((123 + b) / c) + (x / y)) + 55;
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkDeclFunction()
+        {
+          const string script = @"
+function test()
+{
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkDeclFunctionWithReturn()
+        {
+          const string script = @"
+function test()
+{
+return 'test';
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkCallFunction()
+        {
+            const string script = @"
+test(a, b);
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkMemeberExpr()
+        {
+            const string script = @"
+a = c.b + 3;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkThisExpr()
+        {
+            const string script = @"
+a = this.b + 3;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkSequenceExpr()
+        {
+            const string script = @"
+a = bar(), foo();
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarRegEx()
+        {
+            const string script = @"
+var re = /[.*+?^${}()|[\]\\]/g;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarCondExpr()
+        {
+            const string script = @"
+var re = a >= b ? 1 : 2;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarFuncExpr()
+        {
+            const string script = @"
+var re = function () { };
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarObjectExpr()
+        {
+            const string script = @"
+var o = { a: 'foo', b: 42, c: {  } };
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarObjectExpr2()
+        {
+            const string script = @"
+var o = { c: {  } };
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarPostfixUpdate()
+        {
+            const string script = @"
+var o = a++;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarPrefixUpdate()
+        {
+            const string script = @"
+var o = ++a;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkVarDeclExpr()
+        {
+            const string script = @"
+o = 1;
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkIfStmt()
+        {
+            const string script = @"
+if(a > 10)
+{
+var b = 30;
+}
+else
+{
+var c = 10;
+}
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkIfStmt2()
+        {
+            const string script = @"
+if(a > 10)
+{
+var b = 30;
+}
+else
+{
+if(d > 5)
+{
+var c = 10;
+}
+}
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkForStmt()
+        {
+            const string script = @"
+for(var i = 0;i < 10;i++)
+{
+var a = 0;
+}
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkForInStmt()
+        {
+            const string script = @"
+var obj = { a: 1, b: 2, c: 3 };
+for(var prop in obj)
+{
+console.log((('o.' + prop) + ' = ') + obj[prop]);
+}
+";
+            _prgText = "\r\n";
+            DoWalkerTest(script);
+            Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkSetDecl()
+        {
+          const string script = @"
+var o = { 
+  set current(str) 
+  { 
+    this.log[this.log.length] = str;
+  }, log: [] 
+};
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkGetDecl()
+        {
+          const string script = @"
+var log = ['test'];
+var obj = {
+  get latest () {
+    if (log.length == 0) 
+    {
+      return undefined;
+    }
+    return log[log.length - 1];
+  }
+};
+console.log (obj.latest);
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkDeletePropety()
+        {
+          const string script = @"
+delete obj.latest;
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkWhileStmt()
+        {
+          const string script = @"
+var n = 0;
+var x = 0;
+
+while (n < 3) {
+  n++;
+  x += n;
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkWithStmt()
+        {
+          const string script = @"
+function f(x, o) {
+  with (o) { print(x); }
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkWithStmt2()
+        {
+          const string script = @"
+var a, x, y;
+var r = 10;
+
+with (Math) {
+  a = (PI * r) * r;
+  x = r * cos(PI);
+  y = r * sin(PI / 2);
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkWhileStmtWhithBreak()
+        {
+          const string script = @"
+var n = 0;
+var x = 0;
+
+while (n < 3) {
+  n++;
+  x += n;
+  break;
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkWhileStmtWhithBreakLabel()
+        {
+          const string script = @"
+outer_block: {
+  inner_block: {
+    console.log('1');
+    break outer_block;
+    console.log(':-(');
+  }
+  console.log('2');
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkDoWhileStmt()
+        {
+          const string script = @"
+var i = 0;
+do {
+   i += 1;
+   console.log(i);
+} while (i < 5);
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkContinueStmt()
+        {
+          const string script = @"
+var i = 0;
+var n = 0;
+
+while (i < 5) {
+  i++;
+
+  if (i === 3) {
+    continue;
+  }
+
+  n += i;
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkContinueStmtWithLabel()
+        {
+          const string script = @"
+var i = 0;
+var j = 8;
+
+checkiandj: { while (i < 4) {
+  console.log('i: ' + i);
+  i += 1;
+
+  checkj: { while (j > 4) {
+    console.log('j: '+ j);
+    j -= 1;
+
+    if ((j % 2) == 0) {
+      continue checkj;
+    }
+    console.log(j + ' is odd.');
+    }
+  }
+  }
+  console.log('i = ' + i);
+  console.log('j = ' + j);
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkDebuggerStmt()
+        {
+          const string script = @"
+function potentiallyBuggyCode() {
+    debugger;
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkEmptyForStmt()
+        {
+          const string script = @"
+for (i = 0; i < arr.length; arr[i++] = 0);
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkComplexIfStmt()
+        {
+          const string script = @"
+if(one){doOne();}else{if(two){doTwo();}else{if(three){doThree();}else{if(four){doFour();}else{launchRocket();}}}}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkEmptyIfStmt()
+        {
+          const string script = @"
+ if(one){doOne();}else{if(two){doTwo();}else{if(three);else{if(four){doFour();}else{launchRocket();}}}}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkSwitchStmt()
+        {
+          const string script = @"
+switch (expr) {
+  case 'Oranges':
+    console.log('Oranges are $0.59 a pound.');
+    break;
+  case 'Apples':
+    console.log('Apples are $0.32 a pound.');
+    break;
+  case 'Bananas':
+    console.log('Bananas are $0.48 a pound.');
+    break;
+  case 'Cherries':
+    console.log('Cherries are $3.00 a pound.');
+    break;
+  case 'Mangoes':
+  case 'Papayas':
+    console.log('Mangoes and papayas are $2.79 a pound.');
+    break;
+  default:
+    console.log(('Sorry, we are out of ' + expr) + '.');
+}
+
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkThrowStmt()
+        {
+          const string script = @"
+throw 'Error2';
+throw 42;
+throw true;
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkTryCatchStmt()
+        {
+          const string script = @"
+try {
+   throw 'myException';
+}
+catch (e) {
+   logMyErrors(e);
+}
+  ";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkTryFinallyStmt()
+        {
+          const string script = @"
+openMyFile();
+try {
+   writeMyFile(theData);
+}
+finally {
+   closeMyFile();
+}  ";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkFunDeclWithVarDecl()
+        {
+          const string script = @"
+function test()
+{
+var i = 0;
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script, _prgText);
+        }
+
+        [Fact]
+        public void WalkAccessNsieve()
+        {
+          const string script = @"
+function pad(number,width){
+   var s = number.toString();
+   var prefixWidth = width - s.length;
+   if (prefixWidth>0){
+      for (var i=1; i<=prefixWidth; i++) { s = ' ' + s; }
+   }
+   return s;
+}
+
+function nsieve(m, isPrime){
+   var i, k, count;
+
+   for (i=2; i<=m; i++) { isPrime[i] = true; }
+   count = 0;
+
+   for (i=2; i<=m; i++){
+      if (isPrime[i]) {
+         for (k=i+i; k<=m; k+=i) { isPrime[k] = false; }
+         count++;
+      }
+   }
+   return count;
+}
+
+function sieve() {
+    var sum = 0;
+    for (var i = 1; i <= 3; i++ ) {
+        var m = (1<<i)*10000;
+        var flags = Array(m+1);
+        sum += nsieve(m, flags);
+    }
+    return sum;
+}
+
+var result = sieve();
+
+var expected = 14302;
+if (result != expected)
+{
+    throw (('ERROR: bad result: expected ' + expected) + ' but got ') + result;
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkControlFlowRecursive()
+        {
+          const string script = @"
+function ack(m,n){
+   if (m==0) { return n+1; }
+   if (n==0) { return ack(m-1,1); }
+   return ack(m-1, ack(m,n-1) );
+}
+
+function fib(n) {
+    if (n < 2){ return 1; }
+    return fib(n-2) + fib(n-1);
+}
+
+function tak(x,y,z) {
+    if (y >= x) {return z;}
+    return tak(tak(x-1,y,z), tak(y-1,z,x), tak(z-1,x,y));
+}
+
+var result = 0;
+
+for ( var i = 3; i <= 5; i++ ) {
+    result += ack(3,i);
+    result += fib(17.0+i);
+    result += tak((3*i)+3,(2*i)+2,i+1);
+}
+
+var expected = 57775;
+if (result != expected)
+{
+    throw (('ERROR: bad result: expected ' + expected) + ' but got ') + result;
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTest(script);
+          Assert.Equal(script.RemoveWhitespace(), _prgText.RemoveWhitespace());
+        }
+
+        [Fact]
+        public void WalkControlFlowRecursiveEvents()
+        {
+          const string script = @"
+function ack(m,n){
+   if (m==0) { return n+1; }
+   if (n==0) { return ack(m-1,1); }
+   return ack(m-1, ack(m,n-1) );
+}
+
+function fib(n) {
+    if (n < 2){ return 1; }
+    return fib(n-2) + fib(n-1);
+}
+
+function tak(x,y,z) {
+    if (y >= x) {return z;}
+    return tak(tak(x-1,y,z), tak(y-1,z,x), tak(z-1,x,y));
+}
+
+var result = 0;
+
+for ( var i = 3; i <= 5; i++ ) {
+    result += ack(3,i);
+    result += fib(17.0+i);
+    result += tak((3*i)+3,(2*i)+2,i+1);
+}
+
+var expected = 57775;
+if (result != expected)
+{
+    throw (('ERROR: bad result: expected ' + expected) + ' but got ') + result;
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTestEvents(script);
+          Assert.Equal(3,_funCnt);
+          Assert.Equal(3, _varDeclCnt);
+          Assert.Equal(1, _forCnt);
+          Assert.Equal(5, _ifCnt);
+          Assert.Equal(51, _idCnt);
+
+        }
+
+// would pass if we allow return in non function
+//        [Fact]
+//        public void WalkIdsInIfEvents()
+//        {
+//            const string script = @"
+//   if (m==0) { return n+1; }
+//";
+//            _prgText = "\r\n";
+//            DoWalkerTestEvents(script);
+//            Assert.Equal(2, _idCnt);
+//            Assert.Equal(1, _ifCnt);
+
+//        }
+
+        [Fact]
+        public void WalkIdsInForEvents()
+        {
+          const string script = @"
+for ( var i = 3; i <= 5; i++ ) {
+    result += ack(3,i);
+    result += fib(17.0+i);
+    result += tak((3*i)+3,(2*i)+2,i+1);
+}
+";
+          _prgText = "\r\n";
+          DoWalkerTestEvents(script);
+          Assert.Equal(14, _idCnt);
+          Assert.Equal(1, _forCnt);
+
+        }
+        [Fact]
+        public void TestGetAstFromOffset()
+        {
+          const string script = @"
+var aaa = 1.01;
+var bbb = 2.01;
+aaa = bbb + 2;
+";
+          var w = new JintWalker();
+          var prg = Engine.Compile(script, new ParserOptions { Source = "script" });
+          Identifier astNode = w.GetAstIdentifierAt(prg, 4, 1);
+          Assert.Equal(astNode != null, true);
+          Assert.Equal(astNode.Name, "aaa");
+          astNode = w.GetAstIdentifierAt(prg, 4, 8);
+          Assert.Equal(astNode != null, true);
+          Assert.Equal(astNode.Name, "bbb");
+        }
+    }
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -269,6 +269,12 @@ namespace Jint
             CallStack.Clear();
         }
 
+        public static Program Compile(string source, ParserOptions options)
+        {
+            var parser = new JavaScriptParser();
+            return parser.Parse(source, options);
+        }
+
         public Engine Execute(string source)
         {
             var parser = new JavaScriptParser();

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -201,6 +201,9 @@
     <Compile Include="Runtime\StatementsCountOverflowException.cs" />
     <Compile Include="Runtime\TypeConverter.cs" />
     <Compile Include="StrictModeScope.cs" />
+    <Compile Include="Walker\ExpressionWalker.cs" />
+    <Compile Include="Walker\JintWalker.cs" />
+    <Compile Include="Walker\StatementWalker.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Jint.nuspec" />

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -14,6 +14,11 @@ namespace Jint.Native.Function
     {
         private readonly IFunctionDeclaration _functionDeclaration;
 
+        public IFunctionDeclaration FunctionDeclaration
+        {
+            get { return _functionDeclaration; }
+        }
+
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-13.2
         /// </summary>

--- a/Jint/Parser/Ast/AssignmentExpression.cs
+++ b/Jint/Parser/Ast/AssignmentExpression.cs
@@ -57,5 +57,38 @@ namespace Jint.Parser.Ast
                     throw new ArgumentOutOfRangeException("Invalid assignment operator: " + op);
             }
         }
+
+        public static string GetAssignOperatorAsString(AssignmentOperator op)
+        {
+            switch (op)
+            {
+                case AssignmentOperator.Assign:
+                    return "=";
+                case AssignmentOperator.PlusAssign:
+                    return "+=";
+                case AssignmentOperator.MinusAssign:
+                    return "-=";
+                case AssignmentOperator.TimesAssign:
+                    return "*=";
+                case AssignmentOperator.DivideAssign:
+                    return "/=";
+                case AssignmentOperator.ModuloAssign:
+                    return "%=";
+                case AssignmentOperator.BitwiseAndAssign:
+                    return "&=";
+                case AssignmentOperator.BitwiseOrAssign:
+                    return "|=";
+                case AssignmentOperator.BitwiseXOrAssign:
+                    return "^=";
+                case AssignmentOperator.LeftShiftAssign:
+                    return "<<=";
+                case AssignmentOperator.RightShiftAssign:
+                    return ">>=";
+                case AssignmentOperator.UnsignedRightShiftAssign:
+                    return ">>>=";
+
+            }
+            return null;
+        }
     }
 }

--- a/Jint/Parser/Ast/BinaryExpression.cs
+++ b/Jint/Parser/Ast/BinaryExpression.cs
@@ -84,5 +84,56 @@ namespace Jint.Parser.Ast
                     throw new ArgumentOutOfRangeException("Invalid binary operator: " + op);
             }
         }
+
+        public static string GetBinaryOperatorAsString(BinaryOperator op)
+        {
+            switch (op)
+            {
+                case BinaryOperator.Plus:
+                    return "+";
+                case BinaryOperator.Minus:
+                    return "-";
+                case BinaryOperator.Times:
+                    return "*";
+                case BinaryOperator.Divide:
+                    return "/";
+                case BinaryOperator.Modulo:
+                    return "%";
+                case BinaryOperator.Equal:
+                    return "==";
+                case BinaryOperator.NotEqual:
+                    return "!=";
+                case BinaryOperator.Greater:
+                    return ">";
+                case BinaryOperator.GreaterOrEqual:
+                    return ">=";
+                case BinaryOperator.Less:
+                    return "<";
+                case BinaryOperator.LessOrEqual:
+                    return "<=";
+                case BinaryOperator.StrictlyEqual:
+                    return "===";
+                case BinaryOperator.StricltyNotEqual:
+                    return "!==";
+                case BinaryOperator.BitwiseAnd:
+                    return "&";
+                case BinaryOperator.BitwiseOr:
+                    return "|";
+                case BinaryOperator.BitwiseXOr:
+                    return "^";
+                case BinaryOperator.LeftShift:
+                    return "<<";
+                case BinaryOperator.RightShift:
+                    return ">>";
+                case BinaryOperator.UnsignedRightShift:
+                    return ">>>";
+                case BinaryOperator.InstanceOf:
+                    return "instanceof";
+                case BinaryOperator.In:
+                    return "in";
+
+            }
+            return null;
+        }
     }
 }

--- a/Jint/Parser/Ast/LogicalExpression.cs
+++ b/Jint/Parser/Ast/LogicalExpression.cs
@@ -27,5 +27,17 @@ namespace Jint.Parser.Ast
                     throw new ArgumentOutOfRangeException("Invalid binary operator: " + op);
             }
         }
+
+        public static string GetLogicalOperatorAsString(LogicalOperator op)
+        {
+            switch (op)
+            {
+                case LogicalOperator.LogicalAnd:
+                    return "&&";
+                case LogicalOperator.LogicalOr:
+                    return "||";
+            }
+            return null;
+        }
     }
 }

--- a/Jint/Parser/Ast/UnaryExpression.cs
+++ b/Jint/Parser/Ast/UnaryExpression.cs
@@ -49,5 +49,31 @@ namespace Jint.Parser.Ast
 
             }
         }
+
+        public static string GetUnaryOperatorAsString(UnaryOperator op)
+        {
+            switch (op)
+            {
+                case UnaryOperator.Plus:
+                    return "+";
+                case UnaryOperator.Minus:
+                    return "-";
+                case UnaryOperator.Increment:
+                    return "++";
+                case UnaryOperator.Decrement:
+                    return "--";
+                case UnaryOperator.BitwiseNot:
+                    return "~";
+                case UnaryOperator.LogicalNot:
+                    return "!";
+                case UnaryOperator.Delete:
+                    return "delete";
+                case UnaryOperator.Void:
+                    return "void";
+                case UnaryOperator.TypeOf:
+                    return "typeof";
+            }
+            return null;
+        }
     }
 }

--- a/Jint/Parser/ParserExtensions.cs
+++ b/Jint/Parser/ParserExtensions.cs
@@ -1,10 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Jint.Parser
 {
     public static class ParserExtensions
     {
+        public static string RemoveWhitespace(this string input)
+        {
+          return new string(input.ToCharArray()
+              .Where(c => !Char.IsWhiteSpace(c))
+              .ToArray());
+        }
+
         public static string Slice(this string source, int start, int end)
         {
             return source.Substring(start, Math.Min(source.Length, end) - start);

--- a/Jint/Runtime/Interop/ClrFunctionInstance.cs
+++ b/Jint/Runtime/Interop/ClrFunctionInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using Jint.Native;
 using Jint.Native.Function;
 
@@ -25,6 +26,8 @@ namespace Jint.Runtime.Interop
         {
         }
 
+      public string JsFunName { get; set; }
+
         public override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             try
@@ -37,5 +40,12 @@ namespace Jint.Runtime.Interop
                 throw new JavaScriptException(Engine.TypeError);
             }
         }
+
+      public MethodInfo GetMethodInfo()
+      {
+        if (_func != null) 
+          return _func.Method;
+        return null;
+      }
     }
 }

--- a/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Jint.Native;
 using Jint.Native.Array;
 using Jint.Native.Function;
+using Jint.Parser.Ast;
 
 namespace Jint.Runtime.Interop
 {

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -7,6 +7,8 @@ using Jint.Native;
 using Jint.Native.Number;
 using Jint.Native.Object;
 using Jint.Native.String;
+using Jint.Parser.Ast;
+using Jint.Runtime.References;
 
 namespace Jint.Runtime
 {

--- a/Jint/Walker/ExpressionWalker.cs
+++ b/Jint/Walker/ExpressionWalker.cs
@@ -1,0 +1,136 @@
+using System;
+using Jint.Parser.Ast;
+
+namespace Jint.Walker
+{
+    public class ExpressionWalker
+    {
+        private readonly JintWalker _jintWalker;
+
+        internal ExpressionWalker(JintWalker jintWalker)
+        {
+            _jintWalker = jintWalker;
+        }
+
+        internal void WalkArrayExpression(ArrayExpression arrayExpression)
+        {
+            foreach (Expression expr in arrayExpression.Elements)
+            {
+                _jintWalker.WalkExpression(expr);
+            }
+        }
+
+        internal void WalkBinaryExpression(BinaryExpression expression)
+        {
+            _jintWalker.WalkExpression(expression.Left);
+            _jintWalker.WalkExpression(expression.Right);
+        }
+
+        internal void WalkCallExpression(CallExpression callExpression)
+        {
+            _jintWalker.WalkExpression(callExpression.Callee);
+            foreach (Expression arg in callExpression.Arguments)
+            {
+                _jintWalker.WalkExpression(arg);
+            }
+        }
+
+        internal void WalkConditionalExpression(ConditionalExpression conditionalExpression)
+        {
+            _jintWalker.WalkExpression(conditionalExpression.Test);
+            _jintWalker.WalkExpression(conditionalExpression.Consequent);
+            _jintWalker.WalkExpression(conditionalExpression.Alternate);
+        }
+
+        internal void WalkFunctionExpression(FunctionExpression functionExpression)
+        {
+            if (functionExpression.Id != null) 
+                _jintWalker.WalkExpression(functionExpression.Id);
+
+            foreach (var p in functionExpression.Parameters)
+            {
+                _jintWalker.WalkExpression(p);
+            }
+            _jintWalker.WalkStatement(functionExpression.Body);
+        }
+
+        internal void WalkIdentifier(Identifier identifier)
+        {
+        }
+
+        internal void WalkLiteral(Literal literal)
+        {
+        }
+
+        internal void WalkLogicalExpression(LogicalExpression logicalExpression)
+        {
+            _jintWalker.WalkExpression(logicalExpression.Left);
+            _jintWalker.WalkExpression(logicalExpression.Right);
+        }
+
+        internal void WalkMemberExpression(MemberExpression memberExpression)
+        {
+            _jintWalker.WalkExpression(memberExpression.Object);
+            _jintWalker.WalkExpression(memberExpression.Property);
+        }
+
+        internal void WalkNewExpression(NewExpression newExpression)
+        {
+            _jintWalker.WalkExpression(newExpression.Callee);
+            foreach (Expression exp in newExpression.Arguments)
+            {
+                _jintWalker.WalkExpression(exp);
+            }
+        }
+
+        internal void WalkObjectExpression(ObjectExpression objectExpression)
+        {
+            foreach (Property property in objectExpression.Properties)
+            {
+                _jintWalker.WalkExpression(property.Value);
+            }
+        }
+
+        internal void WalkSequenceExpression(SequenceExpression sequenceExpression)
+        {
+            foreach (Expression expression in sequenceExpression.Expressions)
+            {
+                _jintWalker.WalkExpression(expression);
+            }
+        }
+
+        internal void WalkThisExpression(ThisExpression thisExpression)
+        {
+        }
+
+        internal void WalkUpdateExpression(UpdateExpression updateExpression)
+        {
+            _jintWalker.WalkExpression(updateExpression.Argument);
+        }
+
+        internal void WalkUnaryExpression(UnaryExpression unaryExpression)
+        {
+            _jintWalker.WalkExpression(unaryExpression.Argument);
+        }
+
+        internal void WalkAssignmentExpression(AssignmentExpression assignmentExpression)
+        {
+            _jintWalker.WalkExpression(assignmentExpression.Left);
+            _jintWalker.WalkExpression(assignmentExpression.Right);
+        }
+
+        public void WalkVariableDeclaratorExpression(VariableDeclarator variableDeclarator)
+        {
+            _jintWalker.WalkExpression(variableDeclarator.Id);
+            _jintWalker.WalkExpression(variableDeclarator.Init);
+        }
+
+        public void WalkVariableDeclarationExpression(VariableDeclaration variableDeclaration)
+        {
+            foreach (VariableDeclarator v in variableDeclaration.Declarations)
+            {
+                _jintWalker.WalkExpression(v);
+            }
+        }
+    }
+}

--- a/Jint/Walker/JintWalker.cs
+++ b/Jint/Walker/JintWalker.cs
@@ -1,0 +1,808 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jint.Parser.Ast;
+
+namespace Jint.Walker
+{
+    public class JintWalker
+    {
+        private readonly ExpressionWalker _expressionWalker;
+        private readonly StatementWalker _statementWalker;
+        private static bool _isSet;
+      private static bool _isGet;
+      private List<SyntaxNode> _astList;
+
+      public JintWalker()
+        {
+            _statementWalker = new StatementWalker(this);
+            _expressionWalker = new ExpressionWalker(this);
+        }
+
+        public ExpressionWalker ExpressionWalker
+        {
+            get { return _expressionWalker; }
+        }
+
+        public event StatementWalkEventDelegate StatementWalkEvent;
+
+        protected virtual void OnStatementWalkEvent(StatementWalkEventDelegateArgs args)
+        {
+            StatementWalkEventDelegate handler = StatementWalkEvent;
+            if (handler != null) handler(this, args);
+        }
+
+        public event ExpressionWalkEventDelegate ExpressionWalkEvent;
+
+        protected virtual void OnExpressionWalkEvent(ExpressionWalkEventDelegateArgs args)
+        {
+            ExpressionWalkEventDelegate handler = ExpressionWalkEvent;
+            if (handler != null) handler(this, args);
+        }
+
+        public void WalkExpression(Expression expression)
+        {
+            if (expression == null)
+                return;
+
+            OnExpressionWalkEvent(new ExpressionWalkEventDelegateArgs { Expr = expression });
+
+            switch (expression.Type)
+            {
+                case SyntaxNodes.AssignmentExpression:
+                    ExpressionWalker.WalkAssignmentExpression(expression.As<AssignmentExpression>());
+                    break;
+                case SyntaxNodes.ArrayExpression:
+                    ExpressionWalker.WalkArrayExpression(expression.As<ArrayExpression>());
+                    break;
+                case SyntaxNodes.BinaryExpression:
+                    ExpressionWalker.WalkBinaryExpression(expression.As<BinaryExpression>());
+                    break;
+
+                case SyntaxNodes.CallExpression:
+                    ExpressionWalker.WalkCallExpression(expression.As<CallExpression>());
+                    break;
+
+                case SyntaxNodes.ConditionalExpression:
+                    ExpressionWalker.WalkConditionalExpression(expression.As<ConditionalExpression>());
+                    break;
+
+                case SyntaxNodes.FunctionExpression:
+                    ExpressionWalker.WalkFunctionExpression(expression.As<FunctionExpression>());
+                    break;
+
+                case SyntaxNodes.Identifier:
+                    ExpressionWalker.WalkIdentifier(expression.As<Identifier>());
+                    break;
+
+                case SyntaxNodes.Literal:
+                    ExpressionWalker.WalkLiteral(expression.As<Literal>());
+                    break;
+
+                case SyntaxNodes.RegularExpressionLiteral:
+                    ExpressionWalker.WalkLiteral(expression.As<Literal>());
+                    break;
+
+                case SyntaxNodes.LogicalExpression:
+                    ExpressionWalker.WalkLogicalExpression(expression.As<LogicalExpression>());
+                    break;
+
+                case SyntaxNodes.MemberExpression:
+                    ExpressionWalker.WalkMemberExpression(expression.As<MemberExpression>());
+                    break;
+
+                case SyntaxNodes.NewExpression:
+                    ExpressionWalker.WalkNewExpression(expression.As<NewExpression>());
+                    break;
+
+                case SyntaxNodes.ObjectExpression:
+                    ExpressionWalker.WalkObjectExpression(expression.As<ObjectExpression>());
+                    break;
+
+                case SyntaxNodes.SequenceExpression:
+                    ExpressionWalker.WalkSequenceExpression(expression.As<SequenceExpression>());
+                    break;
+
+                case SyntaxNodes.ThisExpression:
+                    ExpressionWalker.WalkThisExpression(expression.As<ThisExpression>());
+                    break;
+
+                case SyntaxNodes.UpdateExpression:
+                    ExpressionWalker.WalkUpdateExpression(expression.As<UpdateExpression>());
+                    break;
+
+                case SyntaxNodes.UnaryExpression:
+                    ExpressionWalker.WalkUnaryExpression(expression.As<UnaryExpression>());
+                    break;
+
+                case SyntaxNodes.VariableDeclarator:
+                    ExpressionWalker.WalkVariableDeclaratorExpression(expression.As<VariableDeclarator>());
+                    break;
+
+                case SyntaxNodes.VariableDeclaration:
+                    ExpressionWalker.WalkVariableDeclarationExpression(expression.As<VariableDeclaration>());
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public void WalkStatement(Statement statement)
+        {
+            if (statement == null)
+              return;
+
+            OnStatementWalkEvent(new StatementWalkEventDelegateArgs { Stmt = statement });
+
+            switch (statement.Type)
+            {
+                case SyntaxNodes.BlockStatement:
+                    _statementWalker.WalkBlockStatement(statement.As<BlockStatement>());
+                    break;
+
+                case SyntaxNodes.BreakStatement:
+                    _statementWalker.WalkBreakStatement(statement.As<BreakStatement>());
+                    break;
+
+                case SyntaxNodes.ContinueStatement:
+                    _statementWalker.WalkContinueStatement(statement.As<ContinueStatement>());
+                    break;
+
+                case SyntaxNodes.DoWhileStatement:
+                    _statementWalker.WalkDoWhileStatement(statement.As<DoWhileStatement>());
+                    break;
+
+                case SyntaxNodes.DebuggerStatement:
+                    _statementWalker.WalkDebuggerStatement(statement.As<DebuggerStatement>());
+                    break;
+
+                case SyntaxNodes.EmptyStatement:
+                    _statementWalker.WalkEmptyStatement(statement.As<EmptyStatement>());
+                    break;
+
+                case SyntaxNodes.ExpressionStatement:
+                    _statementWalker.WalkExpressionStatement(statement.As<ExpressionStatement>());
+                    break;
+
+                case SyntaxNodes.ForStatement:
+                    _statementWalker.WalkForStatement(statement.As<ForStatement>());
+                    break;
+
+                case SyntaxNodes.ForInStatement:
+                    _statementWalker.WalkForInStatement(statement.As<ForInStatement>());
+                    break;
+
+                case SyntaxNodes.FunctionDeclaration:
+                    _statementWalker.WalkFunctionDeclaration(statement.As<FunctionDeclaration>());
+                    break;
+
+                case SyntaxNodes.IfStatement:
+                    _statementWalker.WalkIfStatement(statement.As<IfStatement>());
+                    break;
+
+                case SyntaxNodes.LabeledStatement:
+                    _statementWalker.WalkLabelledStatement(statement.As<LabelledStatement>());
+                    break;
+
+                case SyntaxNodes.ReturnStatement:
+                    _statementWalker.WalkReturnStatement(statement.As<ReturnStatement>());
+                    break;
+
+                case SyntaxNodes.SwitchStatement:
+                    _statementWalker.WalkSwitchStatement(statement.As<SwitchStatement>());
+                    break;
+
+                case SyntaxNodes.ThrowStatement:
+                    _statementWalker.WalkThrowStatement(statement.As<ThrowStatement>());
+                    break;
+
+                case SyntaxNodes.TryStatement:
+                    _statementWalker.WalkTryStatement(statement.As<TryStatement>());
+                    break;
+
+                case SyntaxNodes.VariableDeclaration:
+                    _statementWalker.WalkVariableDeclaration(statement.As<VariableDeclaration>());
+                    break;
+
+                case SyntaxNodes.WhileStatement:
+                    _statementWalker.WalkWhileStatement(statement.As<WhileStatement>());
+                    break;
+
+                case SyntaxNodes.WithStatement:
+                    _statementWalker.WalkWithStatement(statement.As<WithStatement>());
+                    break;
+
+                case SyntaxNodes.Program:
+                    _statementWalker.WalkProgram(statement.As<Program>());
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+        public static string GetExprAsString(Expression expr)
+        {
+            if (expr is ArrayExpression)
+            {
+                var exp = expr as ArrayExpression;
+                return "[" + GetExprAsString(exp.Elements) + "]";
+            }
+            if (expr is AssignmentExpression)
+            {
+                var exp = expr as AssignmentExpression;
+                return GetExprAsString(exp.Left) + " " + AssignmentExpression.GetAssignOperatorAsString(exp.Operator) + " " + GetExprAsString(exp.Right);
+            }
+            if (expr is BinaryExpression)
+            {
+                var exp = expr as BinaryExpression;
+                bool leftIsExpr = exp.Left is BinaryExpression;
+                bool rightIsExpr = exp.Right is BinaryExpression;
+                var res = "";
+                res += (leftIsExpr ?"(":"")
+                  + GetExprAsString(exp.Left) 
+                  + (leftIsExpr?") ":" ");
+                res += BinaryExpression.GetBinaryOperatorAsString(exp.Operator);
+                res += (rightIsExpr?" (":" " )
+                    + GetExprAsString(exp.Right) 
+                    + (rightIsExpr?")":"");
+                return res;
+            }
+            if (expr is CallExpression)
+            {
+                var exp = expr as CallExpression;
+                return GetExprAsString(exp.Callee) + "(" + GetExprAsString(exp.Arguments) + ")";
+            }
+            if (expr is ConditionalExpression)
+            {
+                var exp = expr as ConditionalExpression;
+                return GetExprAsString(exp.Test) + " ? " + GetExprAsString(exp.Consequent) + " : " + GetExprAsString(exp.Alternate);
+            }
+            if (expr is FunctionExpression)
+            {
+                string res = "";
+                var exp = expr as FunctionExpression;
+                if (exp.Id != null)
+                {
+                  res += "function ";
+                  res += GetExprAsString(exp.Id);
+                  res += "(";
+                  res += GetExprAsString(exp.Parameters);
+                  res += ") ";
+                  res += "{ ";
+                  res += GetStatementAsString(exp.Body, true);
+                  res += "}";
+                }
+                else
+                {
+                  res += (_isSet || _isGet ? "" : "function ");
+                  res += "(";
+                  res += GetExprAsString(exp.Parameters);
+                  res += ") ";
+                  res += "{ ";
+                  res += GetStatementAsString(exp.Body, true);
+                  res += "}";
+                }
+                //foreach (FunctionDeclaration d in exp.FunctionDeclarations)
+                //{
+                //    res += GetStatementAsString(d,true);
+                //}
+                //foreach (VariableDeclaration d in exp.VariableDeclarations)
+                //{
+                //    res += GetStatementAsString(d,true);
+                //}
+                return res;
+            }
+            if (expr is Identifier)
+            {
+                var exp = expr as Identifier;
+                return exp.Name;
+            }
+            if (expr is Literal)
+            {
+                var exp = expr as Literal;
+                return exp.Raw;
+            }
+            if (expr is LogicalExpression)
+            {
+                var exp = expr as LogicalExpression;
+                return GetExprAsString(exp.Left) + " " + LogicalExpression.GetLogicalOperatorAsString(exp.Operator) + " " + GetExprAsString(exp.Right);
+            }
+            if (expr is MemberExpression)
+            {
+                var exp = expr as MemberExpression;
+                if (exp.Computed)
+                {
+                    return GetExprAsString(exp.Object) + "[" + GetExprAsString(exp.Property) +"]";
+                }
+                else
+                {
+                    return GetExprAsString(exp.Object) + "." + GetExprAsString(exp.Property);
+                }
+
+            }
+            if (expr is NewExpression)
+            {
+                var exp = expr as NewExpression;
+                return "new " + GetExprAsString(exp.Callee) + "(" + GetExprAsString(exp.Arguments) + ")";
+            }
+            if (expr is ObjectExpression)
+            {
+                var res = "{ ";
+                var exp = expr as ObjectExpression;
+                decimal index = 1;
+                var props = exp.Properties;
+                if (props != null)
+                {
+                    var cnt = props.Count();
+                    foreach (Property p in props)
+                    {
+                        res += GetExprAsString(p) + (cnt > 1 && index < cnt ? ", " : "");
+                        ++index;
+                    }
+                }
+                return res + " }";
+            }
+            if (expr is Property)
+            {
+                var exp = expr as Property;
+                switch (exp.Kind)
+                {
+                    case PropertyKind.Set:
+                        {
+                            _isSet = true;
+                            var res = "set " + GetExprAsString(exp.Key as Expression) + GetExprAsString(exp.Value);
+                            _isSet = false;
+                            return res;
+
+                        }
+                    case PropertyKind.Get:
+                        {
+                            _isGet = true;
+                            var res = "get " + GetExprAsString(exp.Key as Expression) + GetExprAsString(exp.Value);
+                            _isGet = false;
+                            return res;
+                        }
+                    case PropertyKind.Data:
+                        return GetExprAsString(exp.Key as Expression) + ": " + GetExprAsString(exp.Value);
+                }
+            }
+            if (expr is RegExpLiteral)
+            {
+                var exp = expr as RegExpLiteral;
+                throw new NotImplementedException();
+            }
+            if (expr is SequenceExpression)
+            {
+                string res = "";
+                var exp = expr as SequenceExpression;
+                decimal index = 1;
+                foreach (Expression e in exp.Expressions)
+                {
+                    res += GetExprAsString(e) + (exp.Expressions.Count > 1 && index < exp.Expressions.Count ? ", " : "");
+                    ++index;
+                }
+                return res;
+            }
+            if (expr is ThisExpression)
+            {
+                return "this";
+            }
+            if (expr is UnaryExpression)
+            {
+                if (expr is UpdateExpression)
+                {
+                    var exp = expr as UpdateExpression;
+                    if (exp.Prefix)
+                    {
+                        return UnaryExpression.GetUnaryOperatorAsString(exp.Operator) + GetExprAsString(exp.Argument);
+                    }
+                    return GetExprAsString(exp.Argument) + UnaryExpression.GetUnaryOperatorAsString(exp.Operator);
+                }
+                else
+                {
+                    var exp = expr as UnaryExpression;
+                    return UnaryExpression.GetUnaryOperatorAsString(exp.Operator) + GetExprAsString(exp.Argument);
+                }
+            }
+            if (expr is VariableDeclarator)
+            {
+                string res = "";
+                var exp = expr as VariableDeclarator;
+                if (exp.Init != null)
+                {
+                    res = GetExprAsString(exp.Id) + " = " + GetExprAsString(exp.Init);
+                }
+                else
+                {
+                    res = GetExprAsString(exp.Id);
+                }
+                return res;
+            }
+            return "";
+        }
+        public static string GetExprAsString(IEnumerable<Expression> arguments)
+        {
+            if (arguments != null)
+            {
+                var cnt = arguments.Count();
+                if (cnt == 0)
+                {
+                    return "";
+                }
+                var res = "";
+                decimal index = 1;
+                foreach (Expression argument in arguments)
+                {
+                    res += GetExprAsString(argument) + (cnt > 1 && index < cnt ? ", " : "");
+                    ++index;
+                }
+                return res;
+            }
+            return "";
+        }
+
+        private static string GetExprAsString(IEnumerable<Identifier> arguments)
+        {
+            if (arguments != null)
+            {
+                var cnt = arguments.Count();
+
+                if (cnt == 0)
+                {
+                    return "";
+                }
+                var res = "";
+                decimal index = 1;
+                foreach (Identifier argument in arguments)
+                {
+                    res += GetExprAsString(argument) + (cnt > 1 && index < cnt ? ", " : "");
+                    ++index;
+                }
+                return res;
+            }
+            return "";
+        }
+
+        public static string GetStatementAsString(Statement s, bool termWithSemiColon)
+        {
+            string res = "";
+            if (s is TryStatement)
+            {
+              var stmt = s as TryStatement;
+              res += "try ";
+              res += "{\r\n";
+              res += GetStatementAsString(stmt.Block, termWithSemiColon);
+              res += "}\r\n";
+              //foreach (Statement g in b.GuardedHandlers)
+              //{
+              //  res += GetStatementAsString(g,termWithSemiColon);
+              //}
+              foreach (CatchClause c in stmt.Handlers)
+              {
+                res += "catch ";
+                res += "(";
+                res += GetExprAsString(c.Param);
+                res += ")";
+                res += "{\r\n";
+                res += GetStatementAsString(c.Body, termWithSemiColon);
+                res += "}\r\n";
+              }
+              if (stmt.Finalizer != null)
+              {
+                res += "finally ";
+                res += "{\r\n";
+                res += GetStatementAsString(stmt.Finalizer, termWithSemiColon);
+                res += "}\r\n";
+              }
+              return res;
+            }
+            if (s is ThrowStatement)
+            {
+              var stmt = s as ThrowStatement;
+              res += "throw ";
+              res += GetExprAsString(stmt.Argument);
+              res += ";\r\n";
+              return res;
+            }
+            if (s is SwitchStatement)
+            {
+              var stmt = s as SwitchStatement;
+              res += "switch (";
+              res += GetExprAsString(stmt.Discriminant);
+              res += ")\r\n";
+              res += "{\r\n";
+              foreach (SwitchCase c in stmt.Cases)
+              {
+                if (c.Test == null)
+                {
+                  res += "default:";
+                }
+                else
+                {
+                  res += "case " + GetExprAsString(c.Test) + ":\r\n";
+                }
+                res += GetStatementAsString(c.Consequent, termWithSemiColon);
+              }
+              res += "}\r\n";
+              return res;
+            }
+            if (s is EmptyStatement)
+            {
+              var stmt = s as EmptyStatement;
+              res += ";\r\n";
+              return res;
+            }
+            if (s is DebuggerStatement)
+            {
+              res += "debugger";
+              var stmt = s as DebuggerStatement;
+              res += ";\r\n";
+              return res;
+            }
+            if (s is ContinueStatement)
+            {
+              res += "continue ";
+              var stmt = s as ContinueStatement;
+              res += GetExprAsString(stmt.Label);
+              res += ";\r\n";
+              return res;
+            }
+            if (s is LabelledStatement)
+            {
+              var stmt = s as LabelledStatement;
+              res += GetExprAsString(stmt.Label);
+              res += ": {\r\n";
+              res += GetStatementAsString(stmt.Body, termWithSemiColon);
+              res += "}\r\n";
+              return res;
+            }
+            if (s is BreakStatement)
+            {
+              res += "break ";
+              var stmt = s as BreakStatement;
+              res += GetExprAsString(stmt.Label);
+              res += ";\r\n";
+              return res;
+            }
+            if (s is DoWhileStatement)
+            {
+              res += "do";
+              var stmt = s as DoWhileStatement;
+              var bodyIsEmpty = stmt.Body is EmptyStatement;
+              res += (bodyIsEmpty?"":"\r\n{");
+              res += GetStatementAsString(stmt.Body, termWithSemiColon);
+              res += (bodyIsEmpty?"\r\n":"}\r\n");
+              res += "while(";
+              res += GetExprAsString(stmt.Test);
+              res += ");\r\n";
+              return res;
+            }
+            if (s is WithStatement)
+            {
+              res += "with(";
+              var stmt = s as WithStatement;
+              res += GetExprAsString(stmt.Object);
+              res += ")\r\n";
+              var bodyIsEmpty = stmt.Body is EmptyStatement;
+              res += (bodyIsEmpty ? "" : "{\r\n");
+              res += GetStatementAsString(stmt.Body, termWithSemiColon);
+              res += (bodyIsEmpty ? "\r\n" : "}\r\n");
+              return res;
+            }
+            if (s is WhileStatement)
+            {
+              res += "while(";
+              var stmt = s as WhileStatement;
+              res += GetExprAsString(stmt.Test);
+              var bodyIsEmpty = stmt.Body is EmptyStatement;
+              res += ")\r\n";
+              res += (bodyIsEmpty ? "" : "{\r\n");
+              res += GetStatementAsString(stmt.Body, termWithSemiColon);
+              res += (bodyIsEmpty ? "\r\n" : "}\r\n");
+              return res;
+            }
+            if (s is ReturnStatement)
+            {
+              res += "return ";
+              var stmt = s as ReturnStatement;
+              res += GetExprAsString(stmt.Argument);
+              res += ";\r\n";
+              return res;
+            }
+            if (s is ForInStatement)
+            {
+              res += "for(";
+              var stmt = s as ForInStatement;
+              res += GetSyntaxNodeAsString(stmt.Left, false);
+              res += " in ";
+              res += GetExprAsString(stmt.Right);
+              var bodyIsEmpty = stmt.Body is EmptyStatement;
+              res += ")\r\n";
+              res += (bodyIsEmpty ? "" : "{\r\n");
+              res += GetStatementAsString(stmt.Body, termWithSemiColon);
+              res += (bodyIsEmpty ? "\r\n" : "}\r\n");
+              return res;
+            }
+            if (s is ForStatement)
+            {
+                res += "for(";
+                var stmt = s as ForStatement;
+                res += GetSyntaxNodeAsString(stmt.Init, false);
+                res += ";";
+                res += GetExprAsString(stmt.Test);
+                res += ";";
+                res += GetExprAsString(stmt.Update);
+                var bodyIsEmpty = stmt.Body is EmptyStatement;
+                res += ")\r\n";
+                res += (bodyIsEmpty?"":"{\r\n");
+                res += GetStatementAsString(stmt.Body, termWithSemiColon);
+                res += (bodyIsEmpty?"\r\n":"}\r\n");
+                return res;
+            }
+            if (s is IfStatement)
+            {
+                res += "if(";
+                var stmt = s as IfStatement;
+                res += GetExprAsString(stmt.Test);
+                var consequentIsEmpty = stmt.Consequent is EmptyStatement;
+                res += ")\r\n";
+                res+= consequentIsEmpty?"\r\n":"{\r\n";
+                res += GetStatementAsString(stmt.Consequent, termWithSemiColon);
+                res += consequentIsEmpty ? "\r\n" : "}\r\n";
+                if (stmt.Alternate != null)
+                {
+                  var alternateIsEmpty = stmt.Alternate is EmptyStatement;
+                  res += "else\r\n";
+                  res += alternateIsEmpty?"\r\n":"{\r\n";
+                  res += GetStatementAsString(stmt.Alternate, termWithSemiColon);
+                  res += alternateIsEmpty?"\r\n":"}\r\n";
+                }
+                return res;
+            }
+            if (s is BlockStatement)
+            {
+                var stmt = s as BlockStatement;
+                res += GetStatementAsString(stmt.Body, termWithSemiColon);
+                return res;
+            }
+            if (s is FunctionDeclaration)
+            {
+                var stmt = s as FunctionDeclaration;
+                res += "function ";
+                res += GetExprAsString(stmt.Id);
+                res += "(";
+                res += GetExprAsString(stmt.Parameters);
+                res += ")\r\n";
+                res += "{\r\n";
+                res += GetStatementAsString(stmt.Body, termWithSemiColon);
+                res += "}\r\n";
+                //foreach (FunctionDeclaration d in v.FunctionDeclarations)
+                //{
+                //    res += GetStatementAsString(d, termWithSemiColon);
+                //}
+                //foreach (VariableDeclaration d in v.VariableDeclarations)
+                //{
+                //    res += GetStatementAsString(d, termWithSemiColon);
+                //}
+                return res;
+
+            }
+            if (s is VariableDeclaration)
+            {
+                var stmt = s as VariableDeclaration;
+                decimal index = 1;
+                var decls = stmt.Declarations as List<VariableDeclarator>;
+                if (decls != null)
+                {
+                    res = "var ";
+                    foreach (VariableDeclarator d in decls)
+                    {
+                        res += GetExprAsString(d) + (decls.Count > 1 && index < decls.Count ? ", " : "");
+                        ++index;
+                    }
+                    return res + (termWithSemiColon ? ";\r\n" : "");
+                }
+            }
+            if (s is ExpressionStatement)
+            {
+                var stmt = s as ExpressionStatement;
+                return GetExprAsString(stmt.Expression) + (termWithSemiColon ? ";\r\n" : "");
+            }
+            if (s is Program)
+            {
+                var stmt = s as Program;
+                foreach (Statement prgStmt in stmt.Body)
+                {
+                    res += GetStatementAsString(prgStmt, termWithSemiColon);
+                }
+                return res;
+            }
+            return null;
+        }
+
+        private static string GetSyntaxNodeAsString(SyntaxNode node, bool termWithSemiColon)
+        {
+            if (node is Expression)
+            {
+                return GetExprAsString(node as Expression);
+            }
+            if (node is Statement)
+            {
+                return GetStatementAsString(node as Statement, termWithSemiColon);
+            }
+            return "";
+        }
+
+        private static string GetStatementAsString(IEnumerable<Statement> body, bool termWithSemiColon)
+        {
+            string res = "";
+            if (body != null)
+            {
+                foreach (Statement statement in body)
+                {
+                    res += GetStatementAsString(statement, termWithSemiColon);
+                }
+            }
+            return res;
+        }
+
+      public List<SyntaxNode> GetAstList(Program prg)
+      {
+        _astList = new List<SyntaxNode>();
+        this.ExpressionWalkEvent += GetExpressionListEvent;
+        this.StatementWalkEvent += GetStatementListEvent;
+        WalkStatement(prg);
+        this.ExpressionWalkEvent -= GetExpressionListEvent;
+        this.StatementWalkEvent -= GetStatementListEvent;
+
+        return _astList;
+      }
+
+      private void GetStatementListEvent(object sender, StatementWalkEventDelegateArgs args)
+      {
+        _astList.Add(args.Stmt);
+      }
+
+      private void GetExpressionListEvent(object sender, ExpressionWalkEventDelegateArgs args)
+      {
+        _astList.Add(args.Expr);
+      }
+
+      public Identifier GetAstIdentifierAt(Program prg, int line, int column)
+      {
+        if (prg == null)
+        {
+          return null;
+        }
+        var astList = GetAstList(prg);
+        foreach (var syntaxNode in astList)
+        {
+          if (syntaxNode.Location.Start.Column <= column
+            && syntaxNode.Location.End.Column >= column
+            && syntaxNode.Location.Start.Line <= line
+            && syntaxNode.Location.End.Line >= line
+            && syntaxNode is Identifier
+            )
+          {
+            return syntaxNode as Identifier;
+          }
+        }
+        return null;
+      }
+    }
+
+    public delegate void ExpressionWalkEventDelegate(object sender, ExpressionWalkEventDelegateArgs args);
+
+    public class ExpressionWalkEventDelegateArgs
+    {
+        public Expression Expr { get; set; }
+    }
+
+    public delegate void StatementWalkEventDelegate(object sender, StatementWalkEventDelegateArgs args);
+
+    public class StatementWalkEventDelegateArgs
+    {
+        public Statement Stmt { get; set; }
+    }
+}

--- a/Jint/Walker/StatementWalker.cs
+++ b/Jint/Walker/StatementWalker.cs
@@ -1,0 +1,180 @@
+using System.Collections.Generic;
+using System.Linq;
+using Jint.Parser.Ast;
+
+namespace Jint.Walker
+{
+    internal class StatementWalker
+    {
+        private readonly JintWalker _jintWalker;
+
+        internal StatementWalker(JintWalker jintWalker)
+        {
+            _jintWalker = jintWalker;
+        }
+
+        internal void WalkFunctionDeclaration(FunctionDeclaration functionDeclaration)
+        {
+            _jintWalker.ExpressionWalker.WalkIdentifier(functionDeclaration.Id);
+            foreach (Identifier param in functionDeclaration.Parameters)
+            {
+                _jintWalker.ExpressionWalker.WalkIdentifier(param);
+            }
+            _jintWalker.WalkStatement(functionDeclaration.Body);
+        }
+
+        internal void WalkForStatement(ForStatement forStatement)
+        {
+            if (forStatement.Init != null)
+            {
+                if (forStatement.Init.Type == SyntaxNodes.VariableDeclaration)
+                {
+                    _jintWalker.WalkStatement(forStatement.Init.As<Statement>());
+                }
+                else
+                {
+                    _jintWalker.WalkExpression(forStatement.Init.As<Expression>());
+                }
+            }
+            _jintWalker.WalkExpression(forStatement.Test);
+            _jintWalker.WalkExpression(forStatement.Update);
+            _jintWalker.WalkStatement(forStatement.Body);
+        }
+
+        internal void WalkExpressionStatement(ExpressionStatement stmt)
+        {
+            _jintWalker.WalkExpression(stmt.Expression);
+        }
+
+        internal void WalkEmptyStatement(EmptyStatement stmt)
+        {
+        }
+
+        internal void WalkDebuggerStatement(DebuggerStatement stmt)
+        {
+        }
+
+        internal void WalkDoWhileStatement(DoWhileStatement stmt)
+        {
+            _jintWalker.WalkStatement(stmt.Body);
+            _jintWalker.WalkExpression(stmt.Test);
+        }
+
+        internal void WalkContinueStatement(ContinueStatement stmt)
+        {
+        }
+
+        internal void WalkBreakStatement(BreakStatement stmt)
+        {
+        }
+
+        internal void WalkForInStatement(ForInStatement forInStatement)
+        {
+            Identifier identifier = forInStatement.Left.Type == SyntaxNodes.VariableDeclaration
+              ? forInStatement.Left.As<VariableDeclaration>().Declarations.First().Id
+              : forInStatement.Left.As<Identifier>();
+
+            _jintWalker.WalkExpression(identifier);
+            _jintWalker.WalkExpression(forInStatement.Right);
+            _jintWalker.WalkStatement(forInStatement.Body);
+        }
+
+        internal void WalkIfStatement(IfStatement stmt)
+        {
+            _jintWalker.WalkExpression(stmt.Test);
+            _jintWalker.WalkStatement(stmt.Consequent);
+            if (stmt.Alternate != null)
+            {
+                _jintWalker.WalkStatement(stmt.Alternate);
+            }
+        }
+
+        internal void WalkLabelledStatement(LabelledStatement stmt)
+        {
+            _jintWalker.WalkStatement(stmt.Body);
+        }
+
+        internal void WalkReturnStatement(ReturnStatement stmt)
+        {
+            _jintWalker.WalkExpression(stmt.Argument);
+        }
+
+        internal void WalkSwitchStatement(SwitchStatement stmt)
+        {
+            _jintWalker.WalkExpression(stmt.Discriminant);
+            foreach (SwitchCase c in stmt.Cases)
+            {
+                _jintWalker.WalkExpression(c.Test);
+                WalkStatementList(c.Consequent);
+            }
+        }
+
+        internal void WalkThrowStatement(ThrowStatement stmt)
+        {
+            _jintWalker.WalkExpression(stmt.Argument);
+        }
+
+        internal void WalkTryStatement(TryStatement stmt)
+        {
+            _jintWalker.WalkStatement(stmt.Block);
+            if (stmt.Handlers.Any())
+            {
+                foreach (CatchClause catchClause in stmt.Handlers)
+                {
+                    _jintWalker.WalkStatement(catchClause.Body);
+                }
+            }
+            _jintWalker.WalkStatement(stmt.Finalizer);
+        }
+
+        internal void WalkVariableDeclaration(VariableDeclaration stmt)
+        {
+            foreach (VariableDeclarator declaration in stmt.Declarations)
+            {
+                _jintWalker.WalkExpression(declaration);
+            }
+        }
+
+        internal void WalkInSightTagDeclaration(VariableDeclaration stmt)
+        {
+            foreach (VariableDeclarator declaration in stmt.Declarations)
+            {
+                _jintWalker.WalkExpression(declaration.Id);
+                if (declaration.Init != null)
+                {
+                    _jintWalker.WalkExpression(declaration.Init);
+                }
+            }
+        }
+
+        internal void WalkWhileStatement(WhileStatement whileStatement)
+        {
+            _jintWalker.WalkExpression(whileStatement.Test);
+            _jintWalker.WalkStatement(whileStatement.Body);
+        }
+
+        internal void WalkWithStatement(WithStatement withStatement)
+        {
+            _jintWalker.WalkExpression(withStatement.Object);
+            _jintWalker.WalkStatement(withStatement.Body);
+        }
+
+        internal void WalkProgram(Program stmt)
+        {
+            WalkStatementList(stmt.Body);
+        }
+
+        internal void WalkBlockStatement(BlockStatement stmt)
+        {
+            WalkStatementList(stmt.Body);
+        }
+
+        private void WalkStatementList(IEnumerable<Statement> body)
+        {
+            foreach (Statement statement in body)
+            {
+                _jintWalker.WalkStatement(statement);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds ability to walk the ast produced by the parser.  This can be useful to extract certain structural data from the js code enabling building tools to aid during script editing and analysis.

As an example a toString on a function will print the function...

function test(a,b)
{
  return a + b;
}

print(test.toString());

--------output---------
function test(a, b) 
{ 
return a + b; 
} 