### PR TITLE
Fix toInt32 and toUint32

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1160,6 +1160,28 @@ namespace Jint.Tests.Runtime
             RunTest(@"
                 assert(true === isNaN());
             ");
-        }    
+        }
+
+        [Theory]
+        [InlineData(4d, 0, "4")]
+        [InlineData(4d, 1, "4.0")]
+        [InlineData(4d, 2, "4.00")]
+        [InlineData(28.995, 2, "29.00")]
+        [InlineData(-28.995, 2, "-29.00")]
+        [InlineData(-28.495, 2, "-28.50")]
+        [InlineData(-28.445, 2, "-28.45")]
+        [InlineData(28.445, 2, "28.45")]
+        [InlineData(10.995, 0, "11")]
+        public void ShouldRoundToFixedDecimal(double number, int fractionDigits, string result)
+        {
+            var engine = new Engine();
+            var value = engine.Execute(
+                String.Format("new Number({0}).toFixed({1})",
+                    number.ToString(CultureInfo.InvariantCulture),
+                    fractionDigits.ToString(CultureInfo.InvariantCulture)))
+                .GetCompletionValue().ToObject();
+
+            Assert.Equal(value, result);
+        }
     }
 }

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -106,6 +106,27 @@ namespace Jint.Tests.Runtime
             var result = engine.Execute(source).GetCompletionValue().ToObject();
 
             Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(-59, "~58")]
+        [InlineData(58, "~~58")]
+        public void ShouldInterpretUnaryExpressionToInt(object expected, string source)
+        {
+            var engine = new Engine();
+            var result = engine.Execute(source).GetCompletionValue();
+
+            Assert.Equal(expected, TypeConverter.ToInt32(result));
+        }
+
+        [Theory]
+        [InlineData(58U, "~~58")]
+        public void ShouldInterpretUnaryExpressionToUInt(object expected, string source)
+        {
+            var engine = new Engine();
+            var result = engine.Execute(source).GetCompletionValue();
+
+            Assert.Equal(expected, TypeConverter.ToUint32(result));
         }
 
         [Fact]

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -108,16 +108,8 @@ namespace Jint.Native.Number
             {
                 return ToNumberString(x);
             }
-    
-            var l = (long) x; // extract integer part
 
-            if (f == 0)
-            {
-                return l.ToString(CultureInfo.InvariantCulture);
-            }
-
-            var d = x - l;
-            return l.ToString(CultureInfo.InvariantCulture) + d.ToString("." + new string('0', f), CultureInfo.InvariantCulture);
+            return x.ToString("f" + f, CultureInfo.InvariantCulture);
         }
 
         private JsValue ToExponential(JsValue thisObj, JsValue[] arguments)


### PR DESCRIPTION
I feel like I've made this PR before, but according to github it seems I haven't, and it doesn't seem master has these updates. I can barely remember what it's fixing, but the money commit is "Fix implementation of ToInt32 and ToUInt32 to match ECMA-262 9.5 and 9.6"