### PR TITLE
Implement object.setPrototypeOf to allow inheritance to work properly

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1160,6 +1160,28 @@ namespace Jint.Tests.Runtime
             RunTest(@"
                 assert(true === isNaN());
             ");
-        }    
+        }
+
+        [Theory]
+        [InlineData(4d, 0, "4")]
+        [InlineData(4d, 1, "4.0")]
+        [InlineData(4d, 2, "4.00")]
+        [InlineData(28.995, 2, "29.00")]
+        [InlineData(-28.995, 2, "-29.00")]
+        [InlineData(-28.495, 2, "-28.50")]
+        [InlineData(-28.445, 2, "-28.45")]
+        [InlineData(28.445, 2, "28.45")]
+        [InlineData(10.995, 0, "11")]
+        public void ShouldRoundToFixedDecimal(double number, int fractionDigits, string result)
+        {
+            var engine = new Engine();
+            var value = engine.Execute(
+                String.Format("new Number({0}).toFixed({1})",
+                    number.ToString(CultureInfo.InvariantCulture),
+                    fractionDigits.ToString(CultureInfo.InvariantCulture)))
+                .GetCompletionValue().ToObject();
+
+            Assert.Equal(value, result);
+        }
     }
 }

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -1,6 +1,7 @@
 ﻿using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
+using System.Text;
 
 namespace Jint.Native.Error
 {
@@ -46,14 +47,28 @@ namespace Jint.Native.Error
             instance.Prototype = PrototypeObject;
             instance.Extensible = true;
 
-            if (arguments.At(0) != Undefined.Instance)
+            if (Engine.ShouldCreateStackTrace)
             {
-                instance.Put("message", TypeConverter.ToString(arguments.At(0)), false);
+                StringBuilder builder = new StringBuilder();
+                builder.Append(this._name);
+
+                if (arguments.At(0) != Undefined.Instance)
+                {
+                    var message = TypeConverter.ToString(arguments.At(0));
+                    builder.Append(": ").Append(message).Append('\n');
+                    instance.Put("message", message, false);
+                }
+                else
+                {
+                    builder.AppendLine();
+                }
+                Engine.AppendStack(builder);
+                instance.Put("stack", builder.ToString(), false);
             }
 
             return instance;
         }
 
-        public ErrorPrototype PrototypeObject { get; private set; }
+        public ErrorPrototype PrototypeObject { get; private set; }        
     }
 }

--- a/Jint/Native/Error/ErrorPrototype.cs
+++ b/Jint/Native/Error/ErrorPrototype.cs
@@ -19,6 +19,7 @@ namespace Jint.Native.Error
             var obj = new ErrorPrototype(engine, name) { Extensible = true };
             obj.FastAddProperty("constructor", errorConstructor, true, false, true);
             obj.FastAddProperty("message", "", true, false, true);
+            obj.FastAddProperty("stack", "", true, true, true);
 
             if (name != "Error")
             {

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -43,13 +43,13 @@ namespace Jint.Native.Function
                         {
                             if (!directCall)
                             {
-                                Engine.EnterExecutionContext(Engine.GlobalEnvironment, Engine.GlobalEnvironment, Engine.Global);
+                                Engine.EnterExecutionContext(Engine.GlobalEnvironment, Engine.GlobalEnvironment, Engine.Global, "eval");
                             }
 
                             if (StrictModeScope.IsStrictModeCode)
                             {
                                 strictVarEnv = LexicalEnvironment.NewDeclarativeEnvironment(Engine, Engine.ExecutionContext.LexicalEnvironment);
-                                Engine.EnterExecutionContext(strictVarEnv, strictVarEnv, Engine.ExecutionContext.ThisBinding);
+                                Engine.EnterExecutionContext(strictVarEnv, strictVarEnv, Engine.ExecutionContext.ThisBinding, "eval");
                             }
 
                             Engine.DeclarationBindingInstantiation(DeclarationBindingType.EvalCode, program.FunctionDeclarations, program.VariableDeclarations, this, arguments);

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -79,7 +79,8 @@ namespace Jint.Native.Function
 
                 var localEnv = LexicalEnvironment.NewDeclarativeEnvironment(Engine, Scope);
 
-                Engine.EnterExecutionContext(localEnv, localEnv, thisBinding);
+                var envName = _functionDeclaration.Id != null ? _functionDeclaration.Id.Name : "<anonymous>";
+                Engine.EnterExecutionContext(localEnv, localEnv, thisBinding, envName);
 
                 try
                 {

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -108,16 +108,8 @@ namespace Jint.Native.Number
             {
                 return ToNumberString(x);
             }
-    
-            var l = (long) x; // extract integer part
 
-            if (f == 0)
-            {
-                return l.ToString(CultureInfo.InvariantCulture);
-            }
-
-            var d = x - l;
-            return l.ToString(CultureInfo.InvariantCulture) + d.ToString("." + new string('0', f), CultureInfo.InvariantCulture);
+            return x.ToString("f" + f, CultureInfo.InvariantCulture);
         }
 
         private JsValue ToExponential(JsValue thisObj, JsValue[] arguments)

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -73,7 +73,7 @@ namespace Jint.Native.Object
         }
 
         /// <summary>
-        /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.2.1
+        /// http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-setprototypeof-v
         /// </summary>
         /// <param name="arguments"></param>
         /// <returns></returns>

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -414,7 +414,7 @@ namespace Jint.Native.Object
                     // c. Else,
                     //    i. If the[[GetPrototypeOf]] internal method of p is not
                     //       the ordinary object internal method defined in 9.1.1, let done be true.
-                    if (!(p is ObjectInstance)) {
+                    if (!p.IsObject()) {
                         // I don't think this is possible in Jint right now because
                         // we don't have proxies/modules, but implementing the logic anyways
                         done = true;

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -420,12 +420,19 @@ namespace Jint.Native.Object
                         done = true;
                     } else {
                         //   ii. Else, let p be the value of p’s[[Prototype]] internal slot.
-                        p = p.AsObject().Prototype;
+                        var protoChild = p.AsObject().Prototype;
+                        if (protoChild != null)
+                        {
+                            p = protoChild;
+                        } else
+                        {
+                            p = JsValue.Null;
+                        }
                     }
                 }
             }
             // 9. Set the value of the[[Prototype]] internal slot of O to V.
-            this.Prototype = prototype.IsNull() ? null : p.AsObject();
+            this.Prototype = prototype.IsNull() ? null : prototype.AsObject();
             // 10. Return true.
             return JsValue.True;
         }

--- a/Jint/Runtime/Environments/ExecutionContext.cs
+++ b/Jint/Runtime/Environments/ExecutionContext.cs
@@ -4,6 +4,18 @@ namespace Jint.Runtime.Environments
 {
     public sealed class ExecutionContext
     {
+        public ExecutionContext(Engine engine, string name)
+        {
+            this.Name = name;
+            var lastNode = engine.GetLastSyntaxNode();
+            if (lastNode != null)
+            {
+                this.Location = lastNode.Location;
+            }
+        }
+
+        public string Name { get; set; }
+        public Parser.Location Location { get; set; }
         public LexicalEnvironment LexicalEnvironment { get; set; }
         public LexicalEnvironment VariableEnvironment { get; set; }
         public JsValue ThisBinding { get; set; }


### PR DESCRIPTION
Without this, babel transpiles will not work. I'm sure you'll want tests - I'm a little unclear how to add them. Is there a version of ECMA tests you originally used updated for ES6? All I found was this, which is a very different format:

https://github.com/tc39/test262