### PR TITLE
Provide stack traces for error objects

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1160,6 +1160,28 @@ namespace Jint.Tests.Runtime
             RunTest(@"
                 assert(true === isNaN());
             ");
-        }    
+        }
+
+        [Theory]
+        [InlineData(4d, 0, "4")]
+        [InlineData(4d, 1, "4.0")]
+        [InlineData(4d, 2, "4.00")]
+        [InlineData(28.995, 2, "29.00")]
+        [InlineData(-28.995, 2, "-29.00")]
+        [InlineData(-28.495, 2, "-28.50")]
+        [InlineData(-28.445, 2, "-28.45")]
+        [InlineData(28.445, 2, "28.45")]
+        [InlineData(10.995, 0, "11")]
+        public void ShouldRoundToFixedDecimal(double number, int fractionDigits, string result)
+        {
+            var engine = new Engine();
+            var value = engine.Execute(
+                String.Format("new Number({0}).toFixed({1})",
+                    number.ToString(CultureInfo.InvariantCulture),
+                    fractionDigits.ToString(CultureInfo.InvariantCulture)))
+                .GetCompletionValue().ToObject();
+
+            Assert.Equal(value, result);
+        }
     }
 }

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -534,6 +534,37 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
+        public void ErrorHasCorrectStack()
+        {
+            RunTest(@"try { throw new Error(); } catch (x) { assert(!x.stack); }");
+
+            var engine = new Engine()
+                .SetValue("assert", new Action<bool>(Assert.True));
+            engine.ShouldCreateStackTrace = true;
+            engine.Execute(@"try { throw new Error(); } catch (x) { assert(x.stack != null); }");
+
+            _engine.ShouldCreateStackTrace = true;
+            RunTest(@"function a() {
+b();
+}
+
+function b() {
+c();
+}
+
+function c() {
+throw new Error('foo');
+}
+
+try {
+a();
+} catch (x) {
+    log(x.stack);
+  assert(x.stack === 'Error: foo\n	at c (unknown:10:10)\n	at b (unknown:6:0)\n	at a (unknown:2:0)\n	at <global> (unknown:14:0)\n');
+}");
+        }
+
+        [Fact]
         public void TryCatchBlockStatement()
         {
             RunTest(@"

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -65,6 +65,12 @@ namespace Jint.Native.Error
                 Engine.AppendStack(builder);
                 instance.Put("stack", builder.ToString(), false);
             }
+            else if (arguments.At(0) != Undefined.Instance)
+            {
+                var message = TypeConverter.ToString(arguments.At(0));
+                instance.Put("message", message, false);
+            }
+
 
             return instance;
         }

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -1,6 +1,7 @@
 ﻿using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
+using System.Text;
 
 namespace Jint.Native.Error
 {
@@ -46,14 +47,28 @@ namespace Jint.Native.Error
             instance.Prototype = PrototypeObject;
             instance.Extensible = true;
 
-            if (arguments.At(0) != Undefined.Instance)
+            if (Engine.ShouldCreateStackTrace)
             {
-                instance.Put("message", TypeConverter.ToString(arguments.At(0)), false);
+                StringBuilder builder = new StringBuilder();
+                builder.Append(this._name);
+
+                if (arguments.At(0) != Undefined.Instance)
+                {
+                    var message = TypeConverter.ToString(arguments.At(0));
+                    builder.Append(": ").Append(message).Append('\n');
+                    instance.Put("message", message, false);
+                }
+                else
+                {
+                    builder.AppendLine();
+                }
+                Engine.AppendStack(builder);
+                instance.Put("stack", builder.ToString(), false);
             }
 
             return instance;
         }
 
-        public ErrorPrototype PrototypeObject { get; private set; }
+        public ErrorPrototype PrototypeObject { get; private set; }        
     }
 }

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -71,7 +71,6 @@ namespace Jint.Native.Error
                 instance.Put("message", message, false);
             }
 
-
             return instance;
         }
 

--- a/Jint/Native/Error/ErrorPrototype.cs
+++ b/Jint/Native/Error/ErrorPrototype.cs
@@ -19,6 +19,7 @@ namespace Jint.Native.Error
             var obj = new ErrorPrototype(engine, name) { Extensible = true };
             obj.FastAddProperty("constructor", errorConstructor, true, false, true);
             obj.FastAddProperty("message", "", true, false, true);
+            obj.FastAddProperty("stack", "", true, true, true);
 
             if (name != "Error")
             {

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -43,13 +43,13 @@ namespace Jint.Native.Function
                         {
                             if (!directCall)
                             {
-                                Engine.EnterExecutionContext(Engine.GlobalEnvironment, Engine.GlobalEnvironment, Engine.Global);
+                                Engine.EnterExecutionContext(Engine.GlobalEnvironment, Engine.GlobalEnvironment, Engine.Global, "eval");
                             }
 
                             if (StrictModeScope.IsStrictModeCode)
                             {
                                 strictVarEnv = LexicalEnvironment.NewDeclarativeEnvironment(Engine, Engine.ExecutionContext.LexicalEnvironment);
-                                Engine.EnterExecutionContext(strictVarEnv, strictVarEnv, Engine.ExecutionContext.ThisBinding);
+                                Engine.EnterExecutionContext(strictVarEnv, strictVarEnv, Engine.ExecutionContext.ThisBinding, "eval");
                             }
 
                             Engine.DeclarationBindingInstantiation(DeclarationBindingType.EvalCode, program.FunctionDeclarations, program.VariableDeclarations, this, arguments);

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -79,7 +79,8 @@ namespace Jint.Native.Function
 
                 var localEnv = LexicalEnvironment.NewDeclarativeEnvironment(Engine, Scope);
 
-                Engine.EnterExecutionContext(localEnv, localEnv, thisBinding);
+                var envName = _functionDeclaration.Id != null ? _functionDeclaration.Id.Name : "<anonymous>";
+                Engine.EnterExecutionContext(localEnv, localEnv, thisBinding, envName);
 
                 try
                 {

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -108,16 +108,8 @@ namespace Jint.Native.Number
             {
                 return ToNumberString(x);
             }
-    
-            var l = (long) x; // extract integer part
 
-            if (f == 0)
-            {
-                return l.ToString(CultureInfo.InvariantCulture);
-            }
-
-            var d = x - l;
-            return l.ToString(CultureInfo.InvariantCulture) + d.ToString("." + new string('0', f), CultureInfo.InvariantCulture);
+            return x.ToString("f" + f, CultureInfo.InvariantCulture);
         }
 
         private JsValue ToExponential(JsValue thisObj, JsValue[] arguments)

--- a/Jint/Runtime/Environments/ExecutionContext.cs
+++ b/Jint/Runtime/Environments/ExecutionContext.cs
@@ -4,6 +4,18 @@ namespace Jint.Runtime.Environments
 {
     public sealed class ExecutionContext
     {
+        public ExecutionContext(Engine engine, string name)
+        {
+            this.Name = name;
+            var lastNode = engine.GetLastSyntaxNode();
+            if (lastNode != null)
+            {
+                this.Location = lastNode.Location;
+            }
+        }
+
+        public string Name { get; set; }
+        public Parser.Location Location { get; set; }
         public LexicalEnvironment LexicalEnvironment { get; set; }
         public LexicalEnvironment VariableEnvironment { get; set; }
         public JsValue ThisBinding { get; set; }


### PR DESCRIPTION
Optional - disabled by default. Includes a test.

Depends on the uint/int merge being merged first just because I don't have the cycles to manage the potential conflicts of multiple branches. Apologies.

#293 