### PR TITLE
Fix for JSON.parse handling non-string values

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -876,7 +876,56 @@ namespace Jint.Tests.Runtime
             ");
         }
 
-        [Fact]
+		[Fact]
+		public void JsonParserShouldUseToString()
+		{
+			RunTest(@"
+                var a = JSON.parse(null); // Equivalent to JSON.parse('null')
+                assert(a === null);
+            ");
+
+			RunTest(@"
+                var a = JSON.parse(true); // Equivalent to JSON.parse('true')
+                assert(a === true);
+            ");
+
+			RunTest(@"
+                var a = JSON.parse(false); // Equivalent to JSON.parse('false')
+                assert(a === false);
+            ");
+
+			RunTest(@"
+                try {
+                    JSON.parse(undefined); // Equivalent to JSON.parse('undefined')
+                    assert(false);
+                }
+                catch(ex) {
+                    assert(ex instanceof SyntaxError);
+                }
+			");
+
+			RunTest(@"
+                try {
+                    JSON.parse({}); // Equivalent to JSON.parse('[object Object]')
+                    assert(false);
+                }
+                catch(ex) {
+                    assert(ex instanceof SyntaxError);
+                }
+			");
+
+			RunTest(@"
+                try {
+                    JSON.parse(function() { }); // Equivalent to JSON.parse('function () {}')
+                    assert(false);
+                }
+                catch(ex) {
+                    assert(ex instanceof SyntaxError);
+                }
+			");
+		}
+
+		[Fact]
         public void JsonParserShouldDetectInvalidNegativeNumberSyntax()
         {
             RunTest(@"

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -1,4 +1,5 @@
 ﻿using Jint.Native.Object;
+using Jint.Runtime;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.Json
@@ -39,7 +40,7 @@ namespace Jint.Native.Json
         {
             var parser = new JsonParser(_engine);
 
-            return parser.Parse(arguments[0].ToString());
+            return parser.Parse(TypeConverter.ToString(arguments[0]));
         }
 
         public JsValue Stringify(JsValue thisObject, JsValue[] arguments)

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -39,7 +39,7 @@ namespace Jint.Native.Json
         {
             var parser = new JsonParser(_engine);
 
-            return parser.Parse(arguments[0].AsString());
+            return parser.Parse(arguments[0].ToString());
         }
 
         public JsValue Stringify(JsValue thisObject, JsValue[] arguments)


### PR DESCRIPTION
According to [the spec](http://www.ecma-international.org/ecma-262/5.1/#sec-15.12.2), JSON.parse(text) should use ToString(text) to get the string value. The previous implementation would throw an error when JSON.parse was called with a non-string value.