### PR TITLE
A number of interop related performance optimizations

### DIFF
--- a/Jint.Tests/Runtime/Domain/A.cs
+++ b/Jint.Tests/Runtime/Domain/A.cs
@@ -92,7 +92,7 @@ namespace Jint.Tests.Runtime.Domain
         }
         public string Call16(params JsValue[] values)
         {
-            return String.Join(",", values);
+            return String.Join(",", (System.Collections.Generic.IEnumerable<JsValue>)values);
         }
 
         public int Call17(Func<int, int> callback)

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Runtime\Descriptors\PropertyDescriptor.cs" />
     <Compile Include="Runtime\Descriptors\Specialized\FieldInfoDescriptor.cs" />
     <Compile Include="Runtime\Descriptors\Specialized\IndexDescriptor.cs" />
+    <Compile Include="Runtime\Descriptors\Specialized\ISharedDescriptor.cs" />
     <Compile Include="Runtime\Descriptors\Specialized\PropertyInfoDescriptor.cs" />
     <Compile Include="Runtime\Descriptors\Specialized\ClrAccessDescriptor.cs" />
     <Compile Include="Runtime\Environments\Binding.cs" />
@@ -183,13 +184,18 @@
     <Compile Include="Runtime\Interop\IObjectWrapper.cs" />
     <Compile Include="Runtime\Interop\IObjectConverter.cs" />
     <Compile Include="Runtime\Interop\ITypeConverter.cs" />
+    <Compile Include="Runtime\Interop\MethodGroup.cs" />
     <Compile Include="Runtime\Interop\MethodInfoFunctionInstance.cs" />
     <Compile Include="Runtime\Interop\ClrFunctionInstance.cs" />
+    <Compile Include="Runtime\Interop\MethodProxy.cs" />
     <Compile Include="Runtime\Interop\NamespaceReference.cs" />
     <Compile Include="Runtime\Interop\ObjectWrapper.cs" />
+    <Compile Include="Runtime\Interop\FieldProxy.cs" />
+    <Compile Include="Runtime\Interop\PropertyProxy.cs" />
     <Compile Include="Runtime\Interop\SetterFunctionInstance.cs" />
     <Compile Include="Runtime\Interop\GetterFunctionInstance.cs" />
     <Compile Include="Runtime\Interop\DelegateWrapper.cs" />
+    <Compile Include="Runtime\Interop\TypeInteropDescriptor.cs" />
     <Compile Include="Runtime\Interop\TypeReference.cs" />
     <Compile Include="Runtime\Interop\TypeReferencePrototype.cs" />
     <Compile Include="Runtime\JavaScriptException.cs" />

--- a/Jint/Native/Argument/ArgumentsInstance.cs
+++ b/Jint/Native/Argument/ArgumentsInstance.cs
@@ -162,7 +162,7 @@ namespace Jint.Native.Argument
 
             if (desc.IsAccessorDescriptor())
             {
-                var setter = desc.Set.Value.TryCast<ICallable>();
+                var setter = desc.Set.TryCast<ICallable>();
                 setter.Call(new JsValue(this), new[] { value });
             }
             else
@@ -196,9 +196,9 @@ namespace Jint.Native.Argument
                     }
                     else
                     {
-                        if (desc.Value.HasValue && desc.Value.Value != Undefined.Instance)
+                        if (desc.Value != null && desc.Value != Undefined.Instance)
                         {
-                            map.Put(propertyName, desc.Value.Value, throwOnError);
+                            map.Put(propertyName, desc.Value, throwOnError);
                         }
 
                         if (desc.Writable.HasValue && desc.Writable.Value == false)

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -54,7 +54,7 @@ namespace Jint.Native.Array
 
             if (desc.IsAccessorDescriptor())
             {
-                var setter = desc.Set.Value.TryCast<ICallable>();
+                var setter = desc.Set.TryCast<ICallable>();
                 setter.Call(new JsValue(this), new[] { value });
             }
             else
@@ -67,19 +67,19 @@ namespace Jint.Native.Array
         public override bool DefineOwnProperty(string propertyName, PropertyDescriptor desc, bool throwOnError)
         {
             var oldLenDesc = GetOwnProperty("length");
-            var oldLen = (uint)TypeConverter.ToNumber(oldLenDesc.Value.Value);
+            var oldLen = (uint)TypeConverter.ToNumber(oldLenDesc.Value);
             uint index;
 
             if (propertyName == "length")
             {
-                if (!desc.Value.HasValue)
+                if (desc.Value == null)
                 {
                     return base.DefineOwnProperty("length", desc, throwOnError);
                 }
 
                 var newLenDesc = new PropertyDescriptor(desc);
-                uint newLen = TypeConverter.ToUint32(desc.Value.Value);
-                if (newLen != TypeConverter.ToNumber(desc.Value.Value))
+                uint newLen = TypeConverter.ToUint32(desc.Value);
+                if (newLen != TypeConverter.ToNumber(desc.Value))
                 {
                     throw new JavaScriptException(_engine.RangeError);
                 }
@@ -212,7 +212,7 @@ namespace Jint.Native.Array
 
         private uint GetLength()
         {
-            return TypeConverter.ToUint32(_length.Value.Value);
+            return TypeConverter.ToUint32(_length.Value);
         }
 
         public override IEnumerable<KeyValuePair<string, PropertyDescriptor>> GetOwnProperties()

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -17,7 +17,7 @@ using Jint.Runtime.Interop;
 namespace Jint.Native
 {
     [DebuggerTypeProxy(typeof(JsValueDebugView))]
-    public struct JsValue : IEquatable<JsValue>
+    public class JsValue : IEquatable<JsValue>
     {
         public readonly static JsValue Undefined = new JsValue(Types.Undefined);
         public readonly static JsValue Null = new JsValue(Types.Null);
@@ -242,6 +242,11 @@ namespace Jint.Native
 
         public bool Equals(JsValue other)
         {
+            if ((object)other == null)
+            {
+                return false;
+            }
+
             if (_type != other._type)
             {
                 return false;
@@ -271,7 +276,7 @@ namespace Jint.Native
             get { return _type; }
         }
 
-        /// <summary>
+		/// <summary>
         /// Creates a valid <see cref="JsValue"/> instance from any <see cref="Object"/> instance
         /// </summary>
         /// <param name="engine"></param>
@@ -284,106 +289,75 @@ namespace Jint.Native
                 return Null;
             }
 
-            foreach (var converter in engine.Options._ObjectConverters)
+            if (engine.Options.HasObjectConverters)
             {
-                JsValue result;
-                if (converter.TryConvert(value, out result))
+                foreach (var converter in engine.Options._ObjectConverters)
                 {
-                    return result;
+                    JsValue result;
+                    if (converter.TryConvert(value, out result))
+                    {
+                        return result;
+                    }
                 }
             }
 
-            var typeCode = System.Type.GetTypeCode(value.GetType());
-            switch (typeCode)
-            {
-                case TypeCode.Boolean:
-                    return new JsValue((bool)value);
-                case TypeCode.Byte:
-                    return new JsValue((byte)value);
-                case TypeCode.Char:
-                    return new JsValue(value.ToString());
-                case TypeCode.DateTime:
-                    return engine.Date.Construct((DateTime)value);
-                case TypeCode.Decimal:
-                    return new JsValue((double)(decimal)value);
-                case TypeCode.Double:
-                    return new JsValue((double)value);
-                case TypeCode.Int16:
-                    return new JsValue((Int16)value);
-                case TypeCode.Int32:
-                    return new JsValue((Int32)value);
-                case TypeCode.Int64:
-                    return new JsValue((Int64)value);
-                case TypeCode.SByte:
-                    return new JsValue((SByte)value);
-                case TypeCode.Single:
-                    return new JsValue((Single)value);
-                case TypeCode.String:
-                    return new JsValue((string)value);
-                case TypeCode.UInt16:
-                    return new JsValue((UInt16)value);
-                case TypeCode.UInt32:
-                    return new JsValue((UInt32)value);
-                case TypeCode.UInt64:
-                    return new JsValue((UInt64)value);
-                case TypeCode.Object:
-                    break;
-                case TypeCode.Empty:
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+            var valueType = value.GetType();
 
-            if (value is DateTimeOffset)
+            var typeMappers = engine.TypeMappers;
+
+            Func<Engine, object, JsValue> typeMapper;
+            if (typeMappers.TryGetValue(valueType, out typeMapper))
             {
-                return engine.Date.Construct((DateTimeOffset)value);
+                return typeMapper(engine, value);
             }
 
             // if an ObjectInstance is passed directly, use it as is
             var instance = value as ObjectInstance;
             if (instance != null)
             {
+                // Learn conversion.
+                typeMappers.Add(valueType, (Engine e, object v) => new JsValue((ObjectInstance)v));
                 return new JsValue(instance);
             }
 
-            // if a JsValue is passed directly, use it as is
-            if (value is JsValue)
+            var a = value as System.Array;
+            if (a != null)
             {
-                return (JsValue)value;
-            }
-
-            var array = value as System.Array;
-            if (array != null)
-            {
-                var jsArray = engine.Array.Construct(Arguments.Empty);
-                foreach (var item in array)
+                Func<Engine, object, JsValue> convert = (Engine e, object v) =>
                 {
-                    var jsItem = FromObject(engine, item);
-                    engine.Array.PrototypeObject.Push(jsArray, Arguments.From(jsItem));
-                }
+                    var array = (System.Array)v;
 
-                return jsArray;
-            }
+                    var jsArray = engine.Array.Construct(Arguments.Empty);
+                    foreach (var item in array)
+                    {
+                        var jsItem = JsValue.FromObject(engine, item);
+                        engine.Array.PrototypeObject.Push(jsArray, Arguments.From(jsItem));
+                    }
 
-            var regex = value as System.Text.RegularExpressions.Regex;
-            if (regex != null)
-            {
-                var jsRegex = engine.RegExp.Construct(regex.ToString().Trim('/'));
-                return jsRegex;
+                    return jsArray;
+                };
+                typeMappers.Add(valueType, convert);
+                return convert(engine, a);
             }
 
             var d = value as Delegate;
             if (d != null)
             {
+                // Learn conversion.
+                typeMappers.Add(value.GetType(), (Engine e, object v) => new DelegateWrapper(e, (Delegate)v));
                 return new DelegateWrapper(engine, d);
             }
 
             if (value.GetType().IsEnum)
             {
+                // Learn conversion.
+                typeMappers.Add(value.GetType(), (Engine e, object v) => new JsValue((Int32)v));
                 return new JsValue((Int32)value);
             }
 
             // if no known type could be guessed, wrap it as an ObjectInstance
+            // Learn conversion.
+            typeMappers.Add(value.GetType(), (Engine e, object v) => new ObjectWrapper(e, v));
             return new ObjectWrapper(engine, value);
         }
 
@@ -572,11 +546,35 @@ namespace Jint.Native
 
         public static bool operator ==(JsValue a, JsValue b)
         {
+            if ((object)a == null)
+            {
+                if ((object)b == null)
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
             return a.Equals(b);
         }
 
         public static bool operator !=(JsValue a, JsValue b)
         {
+            if ((object)a == null)
+            {
+                if ((object)b == null)
+                {
+                    return false;
+                }
+                else
+                {
+                    return true;
+                }
+            }
+
             return !a.Equals(b);
         }
 

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -50,7 +50,7 @@ namespace Jint.Native.Json
 
                     foreach (var property in replacerObj.GetOwnProperties().Select(x => x.Value))
                     {
-                        JsValue v = _engine.GetValue(property);
+                        JsValue v = _engine.GetValue((JsValue)(object)property);
                         string item = null;
                         if (v.IsString())
                         {

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -73,10 +73,10 @@ namespace Jint.Native.Object
             if (desc.IsDataDescriptor())
             {
                 var val = desc.Value;
-                return val.HasValue ? val.Value : Undefined.Instance;
+                return val != null ? val : Undefined.Instance;
             }
 
-            var getter = desc.Get.HasValue ? desc.Get.Value : Undefined.Instance;
+            var getter = desc.Get != null ? desc.Get : Undefined.Instance;
 
             if (getter.IsUndefined())
             {
@@ -190,7 +190,7 @@ namespace Jint.Native.Object
 
             if (desc.IsAccessorDescriptor())
             {
-                var setter = desc.Set.Value.TryCast<ICallable>();
+                var setter = desc.Set.TryCast<ICallable>();
                 setter.Call(new JsValue(this), new [] {value});
             }
             else
@@ -216,7 +216,7 @@ namespace Jint.Native.Object
             {
                 if (desc.IsAccessorDescriptor())
                 {
-                    if (!desc.Set.HasValue || desc.Set.Value.IsUndefined())
+                    if (desc.Set == null || desc.Set.IsUndefined())
                     {
                         return false;
                     }
@@ -241,7 +241,7 @@ namespace Jint.Native.Object
 
             if (inherited.IsAccessorDescriptor())
             {
-                if (!inherited.Set.HasValue || inherited.Set.Value.IsUndefined())
+                if (inherited.Set == null || inherited.Set.IsUndefined())
                 {
                     return false;
                 }
@@ -401,7 +401,7 @@ namespace Jint.Native.Object
                     {
                         SetOwnProperty(propertyName, new PropertyDescriptor(desc)
                         {
-                            Value = desc.Value.HasValue ? desc.Value : JsValue.Undefined,
+                            Value = desc.Value != null ? desc.Value : JsValue.Undefined,
                             Writable = desc.Writable.HasValue ? desc.Writable.Value : false,
                             Enumerable = desc.Enumerable.HasValue ? desc.Enumerable.Value : false,
                             Configurable = desc.Configurable.HasValue ? desc.Configurable.Value : false
@@ -426,9 +426,9 @@ namespace Jint.Native.Object
             if (!current.Configurable.HasValue && 
                 !current.Enumerable.HasValue &&
                 !current.Writable.HasValue &&
-                !current.Get.HasValue &&
-                !current.Set.HasValue &&
-                !current.Value.HasValue)
+                current.Get == null &&
+                current.Set == null &&
+                current.Value == null)
             {
 
                 return true;
@@ -440,9 +440,9 @@ namespace Jint.Native.Object
                 current.Writable == desc.Writable &&
                 current.Enumerable == desc.Enumerable &&
 
-                ((!current.Get.HasValue && !desc.Get.HasValue) || (current.Get.HasValue && desc.Get.HasValue && ExpressionInterpreter.SameValue(current.Get.Value, desc.Get.Value))) &&
-                ((!current.Set.HasValue && !desc.Set.HasValue) || (current.Set.HasValue && desc.Set.HasValue && ExpressionInterpreter.SameValue(current.Set.Value, desc.Set.Value))) &&
-                ((!current.Value.HasValue && !desc.Value.HasValue) || (current.Value.HasValue && desc.Value.HasValue && ExpressionInterpreter.StrictlyEqual(current.Value.Value, desc.Value.Value)))
+                ((current.Get == null && desc.Get == null) || (current.Get != null && desc.Get != null && ExpressionInterpreter.SameValue(current.Get, desc.Get))) &&
+                ((current.Set == null && desc.Set == null) || (current.Set != null && desc.Set != null && ExpressionInterpreter.SameValue(current.Set, desc.Set))) &&
+                ((current.Value == null && desc.Value == null) || (current.Value != null && desc.Value != null && ExpressionInterpreter.StrictlyEqual(current.Value, desc.Value)))
             ) {
                 return true;
             }
@@ -520,7 +520,7 @@ namespace Jint.Native.Object
 
                         if (!current.Writable.Value)
                         {
-                            if (desc.Value.HasValue && !ExpressionInterpreter.SameValue(desc.Value.Value, current.Value.Value))
+                            if (desc.Value != null && !ExpressionInterpreter.SameValue(desc.Value, current.Value))
                             {
                                 if (throwOnError)
                                 {
@@ -536,9 +536,9 @@ namespace Jint.Native.Object
                 {
                     if (!current.Configurable.HasValue || !current.Configurable.Value)
                     {
-                        if ((desc.Set.HasValue && !ExpressionInterpreter.SameValue(desc.Set.Value, current.Set.HasValue ? current.Set.Value : Undefined.Instance))
+                        if ((desc.Set != null && !ExpressionInterpreter.SameValue(desc.Set, current.Set != null ? current.Set : Undefined.Instance))
                             ||
-                            (desc.Get.HasValue && !ExpressionInterpreter.SameValue(desc.Get.Value, current.Get.HasValue ? current.Get.Value : Undefined.Instance)))
+                            (desc.Get != null && !ExpressionInterpreter.SameValue(desc.Get, current.Get != null ? current.Get : Undefined.Instance)))
                         {
                             if (throwOnError)
                             {
@@ -551,7 +551,7 @@ namespace Jint.Native.Object
                 }
             }
 
-            if (desc.Value.HasValue)
+            if (desc.Value != null)
             {
                 current.Value = desc.Value;
             }
@@ -571,12 +571,12 @@ namespace Jint.Native.Object
                 current.Configurable = desc.Configurable;
             }
 
-            if (desc.Get.HasValue)
+            if (desc.Get != null)
             {
                 current.Get = desc.Get;
             }
 
-            if (desc.Set.HasValue)
+            if (desc.Set != null)
             {
                 current.Set = desc.Set;
             }

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -72,6 +72,11 @@ namespace Jint
             return this;
         }
 
+		internal bool HasObjectConverters
+		{
+			get { return _objectConverters.Count > 0; }
+		}
+
         /// <summary>
         /// Allows scripts to call CLR types directly like <example>System.IO.File</example>
         /// </summary>

--- a/Jint/Runtime/Completion.cs
+++ b/Jint/Runtime/Completion.cs
@@ -13,7 +13,7 @@ namespace Jint.Runtime
         public static string Return = "return";
         public static string Throw = "throw";
 
-        public Completion(string type, JsValue? value, string identifier)
+        public Completion(string type, JsValue value, string identifier)
         {
             Type = type;
             Value = value;
@@ -21,12 +21,12 @@ namespace Jint.Runtime
         }
 
         public string Type { get; private set; }
-        public JsValue? Value { get; private set; }
+        public JsValue Value { get; private set; }
         public string Identifier { get; private set; }
 
         public JsValue GetValueOrDefault()
         {
-            return Value.HasValue ? Value.Value : Undefined.Instance;
+            return Value != null ? Value : Undefined.Instance;
         }
 
         public Jint.Parser.Location Location { get; set; }

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -11,7 +11,7 @@ namespace Jint.Runtime.Descriptors
         {
         }
 
-        public PropertyDescriptor(JsValue? value, bool? writable, bool? enumerable, bool? configurable)
+        public PropertyDescriptor(JsValue value, bool? writable, bool? enumerable, bool? configurable)
         {
             Value = value;
 
@@ -31,7 +31,7 @@ namespace Jint.Runtime.Descriptors
             }
         }
 
-        public PropertyDescriptor(JsValue? get, JsValue? set, bool? enumerable = null, bool? configurable = null)
+        public PropertyDescriptor(JsValue get, JsValue set, bool? enumerable = null, bool? configurable = null)
         {
             Get = get;
             Set = set;
@@ -57,16 +57,16 @@ namespace Jint.Runtime.Descriptors
             Writable = descriptor.Writable;
         }
 
-        public JsValue? Get { get; set; }
-        public JsValue? Set { get; set; }
+        public JsValue Get { get; set; }
+        public JsValue Set { get; set; }
         public bool? Enumerable { get; set; }
         public bool? Writable { get; set; }
         public bool? Configurable { get; set; }
-        public virtual JsValue? Value { get; set; }
+        public virtual JsValue Value { get; set; }
         
         public bool IsAccessorDescriptor()
         {
-            if (!Get.HasValue && !Set.HasValue)
+            if (Get == null && Set == null)
             {
                 return false;
             }
@@ -76,7 +76,7 @@ namespace Jint.Runtime.Descriptors
 
         public bool IsDataDescriptor()
         {
-            if (!Writable.HasValue && !Value.HasValue)
+            if (!Writable.HasValue && Value == null)
             {
                 return false;
             }
@@ -150,9 +150,9 @@ namespace Jint.Runtime.Descriptors
                 desc.Set = setter;
             }
 
-            if (desc.Get.HasValue || desc.Get.HasValue)
+            if (desc.Get != null || desc.Get != null)
             {
-                if (desc.Value.HasValue || desc.Writable.HasValue)
+                if (desc.Value != null || desc.Writable.HasValue)
                 {
                     throw new JavaScriptException(engine.TypeError);
                 }
@@ -172,7 +172,7 @@ namespace Jint.Runtime.Descriptors
 
             if (desc.IsDataDescriptor())
             {
-                obj.DefineOwnProperty("value", new PropertyDescriptor(value: desc.Value.HasValue ? desc.Value : Native.Undefined.Instance, writable: true, enumerable: true, configurable: true ), false);
+                obj.DefineOwnProperty("value", new PropertyDescriptor(value: desc.Value != null ? desc.Value : Native.Undefined.Instance, writable: true, enumerable: true, configurable: true ), false);
                 obj.DefineOwnProperty("writable", new PropertyDescriptor(value: desc.Writable.HasValue && desc.Writable.Value, writable: true, enumerable: true, configurable: true), false);
             }
             else

--- a/Jint/Runtime/Descriptors/Specialized/ISharedDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/ISharedDescriptor.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Jint.Runtime.Descriptors.Specialized
+{
+    public interface ISharedDescriptor
+    {
+        void SetTarget(object target);
+    }
+}

--- a/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
@@ -6,19 +6,18 @@ using Jint.Native;
 
 namespace Jint.Runtime.Descriptors.Specialized
 {
-    public sealed class IndexDescriptor : PropertyDescriptor
+    public sealed class IndexDescriptor : PropertyDescriptor, ISharedDescriptor
     {
         private readonly Engine _engine;
         private readonly object _key;
-        private readonly object _item;
+        private object _item;
         private readonly PropertyInfo _indexer;
         private readonly MethodInfo _containsKey;
 
-        public IndexDescriptor(Engine engine, Type targetType, string key, object item)
+        public IndexDescriptor(Engine engine, Type targetType, string key)
         {
             _engine = engine;
-            _item = item;
-
+            
             // get all instance indexers with exactly 1 argument
             var indexers = targetType
                 .GetProperties(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
@@ -52,12 +51,7 @@ namespace Jint.Runtime.Descriptors.Specialized
         }
 
 
-        public IndexDescriptor(Engine engine, string key, object item)
-            : this(engine, item.GetType(), key, item)
-        {
-        }
-
-        public override JsValue? Value
+        public override JsValue Value
         {
             get
             {
@@ -96,9 +90,14 @@ namespace Jint.Runtime.Descriptors.Specialized
                     throw new InvalidOperationException("Indexer has no public setter.");
                 }
 
-                object[] parameters = { _key, value.HasValue ? value.Value.ToObject() : null };
+                object[] parameters = { _key, value != null ? value.ToObject() : null };
                 setter.Invoke(_item, parameters);
             }
+        }
+
+        public void SetTarget(object target)
+        {
+            _item = target;
         }
     }
 }

--- a/Jint/Runtime/Interop/FieldProxy.cs
+++ b/Jint/Runtime/Interop/FieldProxy.cs
@@ -1,0 +1,113 @@
+﻿using Jint.Native;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace Jint.Runtime.Interop
+{
+    public class FieldProxy
+    {
+        private FieldInfo _fieldInfo;
+        private Func<object, object> _getterProxy;
+        private Action<object, object> _setterProxy;
+
+        public FieldProxy(FieldInfo fieldInfo)
+        {
+            _fieldInfo = fieldInfo;
+        }
+
+        public string Name
+        {
+            get
+            {
+                return _fieldInfo.Name;
+            }
+        }
+
+        public Type FieldType
+        {
+            get
+            {
+                return _fieldInfo.FieldType;
+            }
+        }
+
+        public bool CanWrite
+        {
+            get
+            {
+                // don't write to fields marked as readonly
+                return !_fieldInfo.Attributes.HasFlag(FieldAttributes.InitOnly);
+            }
+        }
+
+        public JsValue GetValue(Engine engine, object item)
+        {
+#if __IOS__
+            // Avoid slower, "interpreted Expression", path on iOS/Xamarin.
+            return JsValue.FromObject(engine, _fieldInfo.GetValue(item));
+#else
+            if (_getterProxy == null)
+            {
+                var selfArgument = Expression.Parameter(typeof(object), "self");
+
+                if (_fieldInfo.IsStatic)
+                {
+                    _getterProxy = Expression.Lambda<Func<object, object>>(
+                        Expression.Convert(
+                            Expression.Field(
+                                null, _fieldInfo),
+                        typeof(object)), selfArgument).Compile();
+                }
+                else
+                {
+                    _getterProxy = Expression.Lambda<Func<object, object>>(
+                        Expression.Convert(
+                            Expression.Field(
+                                Expression.Convert(selfArgument, _fieldInfo.DeclaringType), _fieldInfo),
+                        typeof(object)), selfArgument).Compile();
+                }
+            }
+
+            return JsValue.FromObject(engine, _getterProxy(item));
+#endif
+        }
+
+        public void SetValue(Engine engine, object item, object value)
+        {
+#if __IOS__
+            _fieldInfo.SetValue(item, value);
+#else
+            if (_setterProxy == null)
+            {
+                var selfArgument = Expression.Parameter(typeof(object), "self");
+                var valueArgument = Expression.Parameter(typeof(object), "value");
+
+                if (_fieldInfo.IsStatic)
+                {
+                    _setterProxy = Expression.Lambda<Action<object, object>>(
+                        Expression.Assign(
+                            Expression.Field(
+                                null, _fieldInfo),
+                            Expression.Convert(valueArgument, _fieldInfo.FieldType)
+                        ), selfArgument, valueArgument).Compile();
+                }
+                else
+                {
+                    _setterProxy = Expression.Lambda<Action<object, object>>(
+                        Expression.Assign(
+                            Expression.Field(
+                                Expression.Convert(selfArgument, _fieldInfo.DeclaringType), _fieldInfo),
+                            Expression.Convert(valueArgument, _fieldInfo.FieldType)
+                        ), selfArgument, valueArgument).Compile();
+                }
+            }
+
+            _setterProxy(item, value);
+#endif
+        }
+    }
+}

--- a/Jint/Runtime/Interop/MethodGroup.cs
+++ b/Jint/Runtime/Interop/MethodGroup.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Jint.Runtime.Interop
+{
+	public class MethodGroup
+	{
+		public static readonly MethodGroupMethodInfo[] Empty = new MethodGroupMethodInfo[0];
+
+		public readonly MethodBase[] Methods;
+		public readonly bool HasVariableParameters;
+		public readonly Dictionary<int, MethodGroupMethodInfo[]> ByParameterCount;
+		
+		public MethodGroup(MethodBase[] methods)
+		{
+			Methods = methods;
+
+			// Micro-optimization: If there are no methods taking variable number of arguments in this method group,
+			// there is no point in calling ProcessParamsArrays at later time.
+			HasVariableParameters = CheckVariableParameters(methods);
+			
+            // Group methods by number of parameters.
+			ByParameterCount = methods
+				.Select(method => new { Parameters = method.GetParameters().Count(), Method = method })
+				.GroupBy(methodInfo => methodInfo.Parameters)
+				.ToDictionary(methodInfo => methodInfo.Key, methodInfo => methodInfo.Select(
+                    m => new MethodGroupMethodInfo()
+                    {
+                        Method = new MethodProxy(m.Method),
+                        Parameters = m.Method.GetParameters()
+                    }).ToArray());
+		}
+
+		public MethodGroupMethodInfo[] WithParameterCount(int count)
+		{
+			MethodGroupMethodInfo[] methods;
+			if (ByParameterCount.TryGetValue(count, out methods))
+			{
+				return methods;
+			}
+			return Empty;
+		}
+			
+		private bool CheckVariableParameters(MethodBase[] methods)
+		{
+			foreach (var methodInfo in methods)
+			{
+				var parameters = methodInfo.GetParameters();
+				if (parameters.Any(p => Attribute.IsDefined(p, typeof(ParamArrayAttribute))))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+	}
+
+	public class MethodGroupMethodInfo
+	{
+		public MethodProxy Method;
+		public ParameterInfo[] Parameters;
+	}
+}

--- a/Jint/Runtime/Interop/MethodProxy.cs
+++ b/Jint/Runtime/Interop/MethodProxy.cs
@@ -1,0 +1,80 @@
+﻿using Jint.Native;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace Jint.Runtime.Interop
+{
+    public class MethodProxy
+    {
+        private MethodBase _methodBase;
+        private Func<object, object[], object> _methodProxy;
+
+        public MethodBase UnderlyingMethod
+        {
+            get { return _methodBase; }
+        }
+
+        public MethodProxy(MethodBase methodBase)
+        {
+            _methodBase = methodBase;
+        }
+
+        public JsValue Invoke(Engine engine, object self, object[] parameters)
+        {
+#if __IOS__
+            return JsValue.FromObject(engine, _methodBase.Invoke(self, parameters));
+#else
+            if (_methodProxy == null)
+            {
+                var methodInfo = _methodBase as MethodInfo;
+                if (methodInfo == null)
+                {
+                    // If it is not a method, it is probably a constructor. If so, why are we here?
+                    throw new InvalidOperationException("Cannot invoke constructor directly");
+                }
+
+                var selfArgument = Expression.Parameter(typeof(object));
+                var argumentsArgument = Expression.Parameter(typeof(object[]));
+
+                var arguments = methodInfo.GetParameters().Select((parameter, index) =>
+                {
+                    return Expression.Convert(
+                        Expression.ArrayAccess(argumentsArgument, Expression.Constant(index)),
+                        parameter.ParameterType);
+                });
+
+                Expression body;
+
+                if (methodInfo.IsStatic)
+                {
+                    body = Expression.Call(
+                        methodInfo,
+                        arguments);
+                }
+                else
+                {
+                    body = Expression.Call(
+                        Expression.Convert(selfArgument, methodInfo.DeclaringType),
+                        methodInfo,
+                        arguments);
+                }
+
+                if (methodInfo.ReturnType == typeof(void))
+                {
+                    body = Expression.Block(body, Expression.Constant(null));
+                }
+
+                body = Expression.Convert(body, typeof(object));
+
+                _methodProxy = Expression.Lambda<Func<object, object[], object>>(body, selfArgument, argumentsArgument).Compile();
+            }
+
+            return JsValue.FromObject(engine, _methodProxy(self, parameters));
+#endif
+        }
+    }
+}

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -16,10 +16,14 @@ namespace Jint.Runtime.Interop
     {
         public Object Target { get; set; }
 
+        internal TypeInteropDescriptor TypeDescriptor { get; set; }
+
         public ObjectWrapper(Engine engine, Object obj)
             : base(engine)
         {
             Target = obj;
+
+            TypeDescriptor = obj != null ? engine.GetTypeInteropDescriptor(obj.GetType()) : null;
         }
 
         public override void Put(string propertyName, JsValue value, bool throwOnError)
@@ -53,110 +57,15 @@ namespace Jint.Runtime.Interop
 
         public override PropertyDescriptor GetOwnProperty(string propertyName)
         {
-            PropertyDescriptor x;
-            if (Properties.TryGetValue(propertyName, out x))
-                return x;
+            var descriptor = TypeDescriptor.GetProperty(Engine, propertyName);
 
-            var type = Target.GetType();
-
-            // look for a property
-            var property = type.GetProperties(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public)
-                .Where(p => EqualsIgnoreCasing(p.Name, propertyName))
-                .FirstOrDefault();
-            if (property != null)
+            var sharedDescriptor = descriptor as ISharedDescriptor;
+            if (sharedDescriptor != null)
             {
-                var descriptor = new PropertyInfoDescriptor(Engine, property, Target);
-                Properties.Add(propertyName, descriptor);
-                return descriptor;
+                sharedDescriptor.SetTarget(Target);
             }
 
-            // look for a field
-            var field = type.GetFields(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public)
-                .Where(f => EqualsIgnoreCasing(f.Name, propertyName))
-                .FirstOrDefault();
-            if (field != null)
-            {
-                var descriptor = new FieldInfoDescriptor(Engine, field, Target);
-                Properties.Add(propertyName, descriptor);
-                return descriptor;
-            }
-
-            // if no properties were found then look for a method 
-            var methods = type.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public)
-                .Where(m => EqualsIgnoreCasing(m.Name, propertyName))
-                .ToArray();
-
-            if (methods.Any())
-            {
-                var descriptor = new PropertyDescriptor(new MethodInfoFunctionInstance(Engine, methods), false, true, false);
-                Properties.Add(propertyName, descriptor);
-                return descriptor;
-            }
-
-            // if no methods are found check if target implemented indexing
-            if (type.GetProperties().Where(p => p.GetIndexParameters().Length != 0).FirstOrDefault() != null)
-            {
-                return new IndexDescriptor(Engine, propertyName, Target);
-            }
-
-            var interfaces = type.GetInterfaces();
-
-            // try to find a single explicit property implementation
-            var explicitProperties = (from iface in interfaces
-                                      from iprop in iface.GetProperties()
-                                      where EqualsIgnoreCasing(iprop.Name, propertyName)
-                                      select iprop).ToArray();
-
-            if (explicitProperties.Length == 1)
-            {
-                var descriptor = new PropertyInfoDescriptor(Engine, explicitProperties[0], Target);
-                Properties.Add(propertyName, descriptor);
-                return descriptor;
-            }
-
-            // try to find explicit method implementations
-            var explicitMethods = (from iface in interfaces
-                                   from imethod in iface.GetMethods()
-                                   where EqualsIgnoreCasing(imethod.Name, propertyName)
-                                   select imethod).ToArray();
-
-            if (explicitMethods.Length > 0)
-            {
-                var descriptor = new PropertyDescriptor(new MethodInfoFunctionInstance(Engine, explicitMethods), false, true, false);
-                Properties.Add(propertyName, descriptor);
-                return descriptor;
-            }
-
-            // try to find explicit indexer implementations
-            var explicitIndexers =
-                (from iface in interfaces
-                 from iprop in iface.GetProperties()
-                 where iprop.GetIndexParameters().Length != 0
-                 select iprop).ToArray();
-
-            if (explicitIndexers.Length == 1)
-            {
-                return new IndexDescriptor(Engine, explicitIndexers[0].DeclaringType, propertyName, Target);
-            }
-
-            return PropertyDescriptor.Undefined;
-        }
-
-        private bool EqualsIgnoreCasing(string s1, string s2)
-        {
-            bool equals = false;
-            if (s1.Length == s2.Length)
-            {
-                if (s1.Length > 0 && s2.Length > 0) 
-                {
-                    equals = (s1.ToLower()[0] == s2.ToLower()[0]);
-                }
-                if (s1.Length > 1 && s2.Length > 1) 
-                {
-                    equals = equals && (s1.Substring(1) == s2.Substring(1));
-                }
-            }
-            return equals;
+            return descriptor;
         }
     }
 }

--- a/Jint/Runtime/Interop/PropertyProxy.cs
+++ b/Jint/Runtime/Interop/PropertyProxy.cs
@@ -1,0 +1,126 @@
+﻿using Jint.Native;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace Jint.Runtime.Interop
+{
+    public class PropertyProxy
+    {
+        private PropertyInfo _propertyInfo;
+        private MethodInfo _getter;
+        private MethodInfo _setter;
+        private Func<object, object> _getterProxy;
+        private Action<object, object> _setterProxy;
+
+        public PropertyProxy(PropertyInfo propertyInfo, MethodInfo getter, MethodInfo setter)
+        {
+            _propertyInfo = propertyInfo;
+            _getter = getter;
+            _setter = setter;
+        }
+
+        public string Name
+        {
+            get
+            {
+                return _propertyInfo.Name;
+            }
+        }
+
+        public Type PropertyType
+        {
+            get
+            {
+                return _propertyInfo.PropertyType;
+            }
+        }
+
+        public bool CanWrite
+        {
+            get
+            {
+                return _propertyInfo.CanWrite;
+            }
+        }
+
+        public bool HasIndexParameters
+        {
+            get
+            {
+                return _propertyInfo.GetIndexParameters().Length != 0;
+            }
+        }
+
+        public JsValue GetValue(Engine engine, object item)
+        {
+#if __IOS__
+            // Avoid slower, "interpreted Expression", path on iOS/Xamarin.
+            return JsValue.FromObject(engine, _propertyInfo.GetValue(item, null));
+#else
+            if (_getterProxy == null)
+            {
+                var selfArgument = Expression.Parameter(typeof(object), "self");
+
+                if (_getter.IsStatic)
+                {
+                    _getterProxy = Expression.Lambda<Func<object, object>>(
+                        Expression.Convert(
+                            Expression.Call(
+                                _getter
+                            ),
+                        typeof(object)), selfArgument).Compile();
+                }
+                else
+                {
+                    _getterProxy = Expression.Lambda<Func<object, object>>(
+                        Expression.Convert(
+                            Expression.Call(
+                                Expression.Convert(selfArgument, _propertyInfo.DeclaringType),
+                                _getter
+                            ),
+                        typeof(object)), selfArgument).Compile();
+                }
+            }
+
+            return JsValue.FromObject(engine, _getterProxy(item));
+#endif
+        }
+
+        public void SetValue(Engine engine, object item, object value)
+        {
+#if __IOS__
+            _propertyInfo.SetValue(item, value, null);
+#else
+            if (_setterProxy == null)
+            {
+                var selfArgument = Expression.Parameter(typeof(object), "self");
+                var valueArgument = Expression.Parameter(typeof(object), "value");
+
+                if (_setter.IsStatic)
+                {
+                    _setterProxy = Expression.Lambda<Action<object, object>>(
+                        Expression.Call(
+                            _setter,
+                            Expression.Convert(valueArgument, _propertyInfo.PropertyType)
+                        ), selfArgument, valueArgument).Compile();
+                }
+                else
+                {
+                    _setterProxy = Expression.Lambda<Action<object, object>>(
+                        Expression.Call(
+                            Expression.Convert(selfArgument, _propertyInfo.DeclaringType),
+                            _setter,
+                            Expression.Convert(valueArgument, _propertyInfo.PropertyType)
+                        ), selfArgument, valueArgument).Compile();                    
+                }
+            }
+
+            _setterProxy(item, value);
+#endif
+        }
+    }
+}

--- a/Jint/Runtime/Interop/TypeInteropDescriptor.cs
+++ b/Jint/Runtime/Interop/TypeInteropDescriptor.cs
@@ -1,0 +1,245 @@
+﻿using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Jint.Runtime.Interop
+{
+    internal class TypeInteropDescriptor
+    {
+        public Type WrappedType;
+
+        public PropertyProxy[] TypeProperties;
+        public FieldInfo[] TypeFields;
+        public MethodInfo[] TypeMethods;
+        public Type[] TypeInterfaces;
+
+        public IDictionary<string, MatchedMember> MatchedMembersCache = new Dictionary<string, MatchedMember>();
+        public IDictionary<string, PropertyDescriptor> Properties = new Dictionary<string, PropertyDescriptor>();
+
+        public TypeInteropDescriptor(Type type)
+        {
+            WrappedType = type;
+
+            CacheProperties();
+        }
+
+        public PropertyDescriptor GetProperty(Engine engine, string propertyName)
+        {
+            PropertyDescriptor x;
+            if (Properties.TryGetValue(propertyName, out x))
+                return x;
+
+            var member = FindMember(propertyName);
+
+            switch (member.Type)
+            {
+                case MatchedMemberType.Property:
+                    {
+                        var descriptor = new PropertyInfoDescriptor(engine, member.Property);
+                        Properties.Add(propertyName, descriptor);
+                        return descriptor;
+                    }
+
+                case MatchedMemberType.Field:
+                    {
+                        var descriptor = new FieldInfoDescriptor(engine, member.Field);
+                        Properties.Add(propertyName, descriptor);
+                        return descriptor;
+                    }
+
+                case MatchedMemberType.Method:
+                    {
+                        var descriptor = new PropertyDescriptor(new MethodInfoFunctionInstance(engine, member.Methods), false, true, false);
+                        Properties.Add(propertyName, descriptor);
+                        return descriptor;
+                    }
+
+                case MatchedMemberType.Indexer:
+                    {
+                        if (member.IndexerType != null)
+                        {
+                            return new IndexDescriptor(engine, member.IndexerType, propertyName);
+                        }
+                        else
+                        {
+                            return new IndexDescriptor(engine, WrappedType, propertyName);
+                        }
+                    }
+            }
+
+            return PropertyDescriptor.Undefined;
+        }
+
+        public MatchedMember FindMember(string propertyName)
+        {
+            MatchedMember member;
+            if (MatchedMembersCache.TryGetValue(propertyName, out member))
+            {
+                return member;
+            }
+            
+            // look for a property
+            var property = TypeProperties
+                .Where(p => EqualsIgnoreCasing(p.Name, propertyName))
+                .FirstOrDefault();
+            if (property != null)
+            {
+                MatchedMembersCache[propertyName] = (member = new MatchedMember()
+                {
+                    Type = MatchedMemberType.Property,
+                    Property = property
+                });
+                return member;
+            }
+
+            // look for a field
+            var field = TypeFields
+                .Where(f => EqualsIgnoreCasing(f.Name, propertyName))
+                .FirstOrDefault();
+            if (field != null)
+            {
+                MatchedMembersCache[propertyName] = (member = new MatchedMember()
+                {
+                    Type = MatchedMemberType.Field,
+                    Field = new FieldProxy(field)
+                });
+                return member;
+            }
+
+            // if no properties were found then look for a method 
+            var methods = TypeMethods
+                .Where(m => EqualsIgnoreCasing(m.Name, propertyName))
+                .ToArray();
+
+            if (methods.Any())
+            {
+                MatchedMembersCache[propertyName] = (member = new MatchedMember()
+                {
+                    Type = MatchedMemberType.Method,
+                    Methods = new MethodGroup(methods)
+                });
+                return member;
+            }
+
+            // if no methods are found check if target implemented indexing
+            if (TypeProperties.Where(p => p.HasIndexParameters).FirstOrDefault() != null)
+            {
+                MatchedMembersCache[propertyName] = (member = new MatchedMember()
+                {
+                    Type = MatchedMemberType.Indexer
+                });
+                return member;
+            }
+
+            // try to find a single explicit property implementation
+            var explicitProperties = 
+                (from iface in TypeInterfaces
+                from iprop in iface.GetProperties()
+                where EqualsIgnoreCasing(iprop.Name, propertyName)
+                select iprop).ToArray();
+
+            if (explicitProperties.Length == 1)
+            {
+                MatchedMembersCache[propertyName] = (member = new MatchedMember()
+                {
+                    Type = MatchedMemberType.Property,
+                    Property = new PropertyProxy(explicitProperties[0], explicitProperties[0].GetGetMethod(), explicitProperties[0].GetSetMethod())
+                });
+               
+                return member;
+            }
+
+            // try to find explicit method implementations
+            var explicitMethods = 
+                (from iface in TypeInterfaces
+                from imethod in iface.GetMethods()
+                where EqualsIgnoreCasing(imethod.Name, propertyName)
+                select imethod).ToArray();
+
+            if (explicitMethods.Length > 0)
+            {
+                MatchedMembersCache[propertyName] = (member = new MatchedMember()
+                {
+                    Type = MatchedMemberType.Method,
+                    Methods = new MethodGroup(explicitMethods)
+                });
+                return member;
+            }
+
+            // try to find explicit indexer implementations
+            var explicitIndexers =
+                (from iface in TypeInterfaces
+                from iprop in iface.GetProperties()
+                where iprop.GetIndexParameters().Length != 0
+                select iprop).ToArray();
+
+            if (explicitIndexers.Length == 1)
+            {
+                MatchedMembersCache[propertyName] = (member = new MatchedMember()
+                {
+                    Type = MatchedMemberType.Indexer,
+                    IndexerType = explicitIndexers[0].DeclaringType
+
+                });
+                return member;
+            }
+
+            return new MatchedMember()
+            {
+                Type = MatchedMemberType.NotFound
+            };
+        }
+
+        private void CacheProperties()
+        {
+            TypeProperties =
+                WrappedType.GetProperties(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public).
+                Select(property => new PropertyProxy(property, property.GetGetMethod(), property.GetSetMethod())).ToArray();
+            TypeFields = WrappedType.GetFields(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
+            TypeMethods = WrappedType.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
+
+            TypeInterfaces = WrappedType.GetInterfaces();
+        }
+
+        private bool EqualsIgnoreCasing(string s1, string s2)
+        {
+            bool equals = false;
+
+            if (s1.Length == s2.Length)
+            {
+                if (s1.Length > 0 && s2.Length > 0)
+                {
+                    equals = (Char.ToLowerInvariant(s1[0]) == Char.ToLowerInvariant(s2[0]));
+                }
+                if (s1.Length > 1 && s2.Length > 1)
+                {
+                    equals = equals && (s1.Substring(1) == s2.Substring(1));
+                }
+            }
+            return equals;
+        }
+    }
+
+    internal enum MatchedMemberType
+    {
+        Property,
+        Field,
+        Method,
+        Indexer,
+        NotFound	
+    }
+
+    internal class MatchedMember
+    {
+        public MatchedMemberType Type;
+
+        public PropertyProxy Property;
+        public FieldProxy Field;
+        public MethodGroup Methods;
+        public Type IndexerType;
+    }
+}

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -79,9 +79,9 @@ namespace Jint.Runtime
             do
             {
                 var stmt = ExecuteStatement(doWhileStatement.Body);
-                if (stmt.Value.HasValue)
+                if (stmt.Value != null)
                 {
-                    v = stmt.Value.Value;
+                    v = stmt.Value;
                 }
                 if (stmt.Type != Completion.Continue || stmt.Identifier != doWhileStatement.LabelSet)
                 {
@@ -122,9 +122,9 @@ namespace Jint.Runtime
 
                 var stmt = ExecuteStatement(whileStatement.Body);
 
-                if (stmt.Value.HasValue)
+                if (stmt.Value != null)
                 {
-                    v = stmt.Value.Value;
+                    v = stmt.Value;
                 }
 
                 if (stmt.Type != Completion.Continue || stmt.Identifier != whileStatement.LabelSet)
@@ -175,9 +175,9 @@ namespace Jint.Runtime
                 }
 
                 var stmt = ExecuteStatement(forStatement.Body);
-                if (stmt.Value.HasValue)
+				if (stmt.Value != null)
                 {
-                    v = stmt.Value.Value;
+					v = stmt.Value;
                 }
                 if (stmt.Type == Completion.Break && (stmt.Identifier == null || stmt.Identifier == forStatement.LabelSet))
                 {
@@ -252,9 +252,9 @@ namespace Jint.Runtime
                     _engine.PutValue(varRef, p);
 
                     var stmt = ExecuteStatement(forInStatement.Body);
-                    if (stmt.Value.HasValue)
+                    if (stmt.Value != null)
                     {
-                        v = stmt.Value.Value;
+                        v = stmt.Value;
                     }
                     if (stmt.Type == Completion.Break)
                     {
@@ -386,7 +386,7 @@ namespace Jint.Runtime
                         return r;
                     }
                     
-                    v = r.Value.HasValue ? r.Value.Value : Undefined.Instance;
+                    v = r.Value != null ? r.Value : Undefined.Instance;
                 }
 
             }
@@ -400,7 +400,7 @@ namespace Jint.Runtime
                     return r;
                 }
 
-                v = r.Value.HasValue ? r.Value.Value : Undefined.Instance;
+                v = r.Value != null ? r.Value : Undefined.Instance;
             }
 
             return new Completion(Completion.Normal, v, null);
@@ -420,7 +420,7 @@ namespace Jint.Runtime
                     c = ExecuteStatement(statement);
                     if (c.Type != Completion.Normal)
                     {
-                        return new Completion(c.Type, c.Value.HasValue ? c.Value : sl.Value, c.Identifier)
+                        return new Completion(c.Type, c.Value != null ? c.Value : sl.Value, c.Identifier)
                         {
                             Location = c.Location
                         };

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -7,6 +7,7 @@ using Jint.Native;
 using Jint.Native.Number;
 using Jint.Native.Object;
 using Jint.Native.String;
+using Jint.Runtime.Interop;
 
 namespace Jint.Runtime
 {
@@ -18,7 +19,7 @@ namespace Jint.Runtime
         Boolean,
         String,
         Number,
-        Object
+        Object		
     }
 
     public class TypeConverter
@@ -347,26 +348,23 @@ namespace Jint.Runtime
             }
         }
 
-        public static IEnumerable<MethodBase> FindBestMatch(Engine engine, MethodBase[] methods, JsValue[] arguments)
+        public static IEnumerable<MethodGroupMethodInfo> FindBestMatch(Engine engine, MethodGroup methodGroup, JsValue[] arguments)
         {
-            methods = methods
-                .Where(m => m.GetParameters().Count() == arguments.Length)
-                .ToArray();
+			var methods = methodGroup.WithParameterCount(arguments.Length);			
 
-            if (methods.Length == 1 && !methods[0].GetParameters().Any())
+            if (methods.Length == 1 && methods[0].Parameters.Length == 0)
             {
                 yield return methods[0];
                 yield break;
             }
 
-            var objectArguments = arguments.Select(x => x.ToObject()).ToArray();
             foreach (var method in methods)
             {
                 var perfectMatch = true;
-                var parameters = method.GetParameters();
+				var parameters = method.Parameters;
                 for (var i = 0; i < arguments.Length; i++)
                 {
-                    var arg = objectArguments[i];
+					var arg = arguments[i].ToObject();
                     var paramType = parameters[i].ParameterType;
                     
                     if (arg == null)
@@ -393,7 +391,7 @@ namespace Jint.Runtime
 
             foreach (var method in methods)
             {
-                yield return method;
+				yield return method;
             }
         }
 


### PR DESCRIPTION
Hey, 

A project that I'm working on uses Jint to let users write their own business rules to extend functionality. Rules tend to be pretty light on the actual javascript beyond simple math or comparisons with a string manipulation sprinkled around, but instead spend most of the time calling various .NET objects. We've been running into some heavy server load recently, so we took a look if there are any quick wins anywhere, and Jint's interop was the one taking the huge chunk of the time.

I've spent a couple of days optimizing a few things here and there, taking a rather conservative approach without changing significantly the way Jint work. So far I've got interop speed boost of 4-6 times depending on the script. Jint.Benchmark runs about 15% faster, mostly due to conversion of JsValue to ref type. All tests appear to be passing, and we've been using optimized branch in production as well...

Summary of changes:

**[Potentially Breaking?]** JsValue as reference type - removes some excess allocations related to boxing and unboxing, saves a bit of time on reducing copy-by-value penalty
JsValue.FromObject - replaces a cascade of checks with a direct type lookup. Good when you have a lot of different native .NET types which used to always hit worse case scenario of not matching any other type
FieldInfoDescriptor, PropertyInfoDescriptor - **a bit of ugly temporary solution**: fields and property accessors could technically be shared among all instances of the same .NET type. However PropertyDescriptor “owns" the final value, and has to provide it without knowing the object instance that it belongs to. Thus both of these objects used to store Target object reference, thus preventing their reuse. Removed the Target and replaced with ISharedDescriptor workaround… I might revisit this later.

Interop… this is where the biggest chunk of changes is...

DefaultTypeConverter - learns and remembers type->type conversion methods for faster lookups.
**[Potentially Breaking - Portability issues?]** FieldProxy/MethodProxy/PropertyProxy - replaces reflection based accessors with expressions emit-based generated proxies. I think this is quite portable, with exception of iOS /Xamarin (handled as a special case in proxies), but untested
MethodGroup - encapsulates overloaded method resolution
**[Potentially Breaking - see Object.hasOwnProperty note]** TypeInteropDescriptor - works as a pseudo-prototype for .NET types and caches a lot of the information that was otherwise replicated with each ObjectWrapper. Needs to be revisited so it could work as a true prototype. One of the consequences of caching member info separately from ObjectWrapper instances is that Object.hasOwnProperty doesn’t work anymore...

A few optimizations in random places that shaved off a bit of time each or removed chunks of memory allocations (e.g. s1.ToLower()[0] == s2.ToLower()[0] in ObjectWrapper.EqualsIgnoreString)
