### PR TITLE
Added engine parameter to IObjectConverter.TryConvert for context

### DIFF
--- a/Jint.Tests/Runtime/Converters/EnumsToStringConverter.cs
+++ b/Jint.Tests/Runtime/Converters/EnumsToStringConverter.cs
@@ -6,7 +6,7 @@ namespace Jint.Tests.Runtime.Converters
 {
     public class EnumsToStringConverter : IObjectConverter
     {
-        public bool TryConvert(object value, out JsValue result)
+        public bool TryConvert(Engine engine, object value, out JsValue result)
         {
             if (value is Enum)
             {

--- a/Jint.Tests/Runtime/Converters/NegateBoolConverter.cs
+++ b/Jint.Tests/Runtime/Converters/NegateBoolConverter.cs
@@ -5,11 +5,11 @@ namespace Jint.Tests.Runtime.Converters
 {
     public class NegateBoolConverter : IObjectConverter
     {
-        public bool TryConvert(object value, out JsValue result)
+        public bool TryConvert(Engine engine, object value, out JsValue result)
         {
-            if (value is bool)
+            if (value is bool b)
             {
-                result = !(bool) value;
+                result = !b;
                 return true;
             }
 

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -290,7 +290,7 @@ namespace Jint.Native
             for (var i = 0; i < convertersCount; i++)
             {
                 var converter = converters[i];
-                if (converter.TryConvert(value, out var result))
+                if (converter.TryConvert(engine, value, out var result))
                 {
                     return result;
                 }

--- a/Jint/Runtime/Interop/IObjectConverter.cs
+++ b/Jint/Runtime/Interop/IObjectConverter.cs
@@ -7,6 +7,6 @@ namespace Jint.Runtime.Interop
     /// </summary>
     public interface IObjectConverter
     {
-        bool TryConvert(object value, out JsValue result);
+        bool TryConvert(Engine engine, object value, out JsValue result);
     }
 }


### PR DESCRIPTION
I had a need to create an ObjectConverter which called JsValue.FromObject inside it, but I had no reference to the current engine so I extended the TryConvert method to pass in the current engine.
