### PR TITLE
Properly compile Lambdas when the target method is looking for a Delegate

### DIFF
--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Linq.Expressions;
 using Jint.Native;
 using Jint.Native.Function;
 
@@ -47,7 +48,13 @@ namespace Jint.Runtime.Interop
                         jsArguments[i].ToObject(),
                         parameterType,
                         CultureInfo.InvariantCulture);
-                }
+
+					if ( typeof( Delegate ).IsAssignableFrom( parameterType ) &&
+						parameters[ i ] is LambdaExpression )
+					{
+						parameters[ i ] = ( (LambdaExpression) parameters[ i ] ).Compile();
+					}
+				}
             }
 
             // assign null to parameters not provided
@@ -86,7 +93,13 @@ namespace Jint.Runtime.Interop
                             jsArguments[i].ToObject(),
                             paramsParameterType,
                             CultureInfo.InvariantCulture);
-                    }                    
+
+						if ( typeof( Delegate ).IsAssignableFrom( paramsParameterType ) &&
+						parameters[ i ] is LambdaExpression )
+						{
+							parameters[ i ] = ( (LambdaExpression) parameters[ i ] ).Compile();
+						}
+					}                    
                 }
                 parameters[paramsArgumentIndex] = paramsParameter;
             }

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -49,12 +49,12 @@ namespace Jint.Runtime.Interop
                         parameterType,
                         CultureInfo.InvariantCulture);
 
-					if ( typeof( Delegate ).IsAssignableFrom( parameterType ) &&
-						parameters[ i ] is LambdaExpression )
-					{
-						parameters[ i ] = ( (LambdaExpression) parameters[ i ] ).Compile();
-					}
-				}
+                    if (typeof(Delegate).IsAssignableFrom(parameterType) &&
+                        parameters[i] is LambdaExpression)
+                    {
+                        parameters[i] = ((LambdaExpression) parameters[i]).Compile();
+                    }
+                }
             }
 
             // assign null to parameters not provided
@@ -94,12 +94,12 @@ namespace Jint.Runtime.Interop
                             paramsParameterType,
                             CultureInfo.InvariantCulture);
 
-						if ( typeof( Delegate ).IsAssignableFrom( paramsParameterType ) &&
-						parameters[ i ] is LambdaExpression )
-						{
-							parameters[ i ] = ( (LambdaExpression) parameters[ i ] ).Compile();
-						}
-					}                    
+                        if (typeof(Delegate).IsAssignableFrom(paramsParameterType) &&
+                            parameters[i] is LambdaExpression)
+                        {
+                            parameters[i] = ((LambdaExpression) parameters[i]).Compile();
+                        }
+                    }                    
                 }
                 parameters[paramsArgumentIndex] = paramsParameter;
             }


### PR DESCRIPTION
If a Delegate is passed as a function to JavaScript, and that Delegate requires another Delegate (callback) as a parameter, Jint will try to pass the JS callback function to the Delegate as a LambdaExpression instead of compiling it to a Delegate, causing an Exception to be thrown. This checks to see if the target method wants a Delegate type instead of a Lambda, and compiles the Lambda to a Delegate if so.