### PR TITLE
Add function prototype to DelegateWrapper

### DIFF
--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -17,6 +17,7 @@ namespace Jint.Runtime.Interop
         public DelegateWrapper(Engine engine, Delegate d) : base(engine, null, null, false)
         {
             _d = d;
+	        Prototype = engine.Function.PrototypeObject;
         }
 
         public override JsValue Call(JsValue thisObject, JsValue[] jsArguments)

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -17,7 +17,7 @@ namespace Jint.Runtime.Interop
         public DelegateWrapper(Engine engine, Delegate d) : base(engine, null, null, false)
         {
             _d = d;
-	        Prototype = engine.Function.PrototypeObject;
+            Prototype = engine.Function.PrototypeObject;
         }
 
         public override JsValue Call(JsValue thisObject, JsValue[] jsArguments)


### PR DESCRIPTION
Add the Engine.Function.PrototypeObject prototype to DelegateWrapper so it is populated with standard properties such as `call(...)`, `apply(...)`, and `bind(...)`. This allows for things such as currying of C# functions just as is possible with JS functions, or passing them as callbacks with the parameters already supplied.

My own tests did not reveal any breaking characteristics of this change but if necessary I can write unit tests