### PR TITLE
Call object instance methods directly from an object

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -852,6 +852,32 @@ namespace Jint.Tests.Runtime
             Assert.Throws<ArgumentException>(() => x.Invoke(1, 2));
         }
 
+        [Fact]
+        public void ShouldInvokeAFunctionValueThatBelongsToAnObject()
+        {
+            RunTest(@"
+                var obj = { foo: 5, getFoo: function (bar) { return 'foo is ' + this.foo + ', bar is ' + bar; } };
+            ");
+
+            var obj = _engine.GetValue("obj").AsObject();
+            var getFoo = obj.Get("getFoo");
+
+            Assert.Equal("foo is 5, bar is 7", _engine.Invoke(getFoo, obj, new object[] { 7 }).AsString());
+        }
+
+        [Fact]
+        public void ShouldNotInvokeNonFunctionValueThatBelongsToAnObject()
+        {
+            RunTest(@"
+                var obj = { foo: 2 };
+            ");
+
+            var obj = _engine.GetValue("obj").AsObject();
+            var foo = obj.Get("foo");
+
+            Assert.Throws<ArgumentException>(() => _engine.Invoke(foo, obj, new object[] { }));
+        }
+
         [Theory]
         [InlineData("0", 0, 16)]
         [InlineData("1", 1, 16)]

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -877,25 +877,25 @@ namespace Jint.Tests.Runtime
             ");
         }
 
-		[Fact]
-		public void JsonParserShouldUseToString()
-		{
-			RunTest(@"
+        [Fact]
+        public void JsonParserShouldUseToString()
+        {
+            RunTest(@"
                 var a = JSON.parse(null); // Equivalent to JSON.parse('null')
                 assert(a === null);
             ");
 
-			RunTest(@"
+            RunTest(@"
                 var a = JSON.parse(true); // Equivalent to JSON.parse('true')
                 assert(a === true);
             ");
 
-			RunTest(@"
+            RunTest(@"
                 var a = JSON.parse(false); // Equivalent to JSON.parse('false')
                 assert(a === false);
             ");
 
-			RunTest(@"
+            RunTest(@"
                 try {
                     JSON.parse(undefined); // Equivalent to JSON.parse('undefined')
                     assert(false);
@@ -903,9 +903,9 @@ namespace Jint.Tests.Runtime
                 catch(ex) {
                     assert(ex instanceof SyntaxError);
                 }
-			");
+            ");
 
-			RunTest(@"
+            RunTest(@"
                 try {
                     JSON.parse({}); // Equivalent to JSON.parse('[object Object]')
                     assert(false);
@@ -913,9 +913,9 @@ namespace Jint.Tests.Runtime
                 catch(ex) {
                     assert(ex instanceof SyntaxError);
                 }
-			");
+            ");
 
-			RunTest(@"
+            RunTest(@"
                 try {
                     JSON.parse(function() { }); // Equivalent to JSON.parse('function () {}')
                     assert(false);
@@ -923,10 +923,10 @@ namespace Jint.Tests.Runtime
                 catch(ex) {
                     assert(ex instanceof SyntaxError);
                 }
-			");
-		}
+            ");
+        }
 
-		[Fact]
+        [Fact]
         public void JsonParserShouldDetectInvalidNegativeNumberSyntax()
         {
             RunTest(@"

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -672,6 +672,30 @@ namespace Jint
         public JsValue Invoke(string propertyName, object thisObj, object[] arguments)
         {
             var value = GetValue(propertyName);
+
+            return Invoke(value, thisObj, arguments);
+        }
+
+        /// <summary>
+        /// Invoke the current value as function.
+        /// </summary>
+        /// <param name="value">The function to call.</param>
+        /// <param name="arguments">The arguments of the function call.</param>
+        /// <returns>The value returned by the function call.</returns>
+        public JsValue Invoke(JsValue value, params object[] arguments)
+        {
+            return Invoke(value, null, arguments);
+        }
+
+        /// <summary>
+        /// Invoke the current value as function.
+        /// </summary>
+        /// <param name="value">The function to call.</param>
+        /// <param name="thisObj">The this value inside the function call.</param>
+        /// <param name="arguments">The arguments of the function call.</param>
+        /// <returns>The value returned by the function call.</returns>
+        public JsValue Invoke(JsValue value, object thisObj, object[] arguments)
+        {
             var callable = value.TryCast<ICallable>();
 
             if (callable == null)


### PR DESCRIPTION
Suppose that you've executed the following script and you want to call `obj.getFoo` passing some POCOs.

```js
var obj = {
    foo: 5,
    getFoo: function (someDotNetObject, someOtherObject) {
        var foo = this.foo;
        // do something with foo, someDotNetObject and someOtherObject
        var result = foo;

        return result;
    }
};
```

We want to call `getFoo`

```cs
var obj = Engine.GetValue("obj").AsObject();
var getFoo = obj.Get("getFoo");
```

If the type of the passed value was `int`, `double`, `string` or some `ObjectInstance`; we could've simply done this:

```cs
var arguments = new JsValue[] { 3, "bar" };
var result = getFoo.Invoke(obj, arguments);
```

But we want to pass some .NET objects so we have to do this:

```cs
var arguments = new object[] { someDotNetObject, someOtherObject };
var result = getFoo.Invoke(obj, arguments.Select(x => JsValue.FromObject(Engine, x)).ToArray());
```

It would be much better if we could call `getFoo` directly from `obj`:

```cs
var result = obj.CallMethod("getFoo", arguments);
```