### PR TITLE
Generate xml documentation file on build

### DIFF
--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Jint.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,6 +37,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Jint.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
I've realized that there's no `Jint.xml` file within the nuget package so I've configured the project to generate one during the build process. Now we can see method, class, etc. comments in IntelliSense while using the api.

But, configuring the project to generate the documentation xml file generates lots of "Hey, this class/method/etc. does not have any comments!" warnings. We can suppress those warnings by adding `1591` into the `Suppress compiler warnings` field. I didn't do that, in case someone might volunteer to add those missing comments.
