### PR TITLE
Sign an Jint version 2.10 with a Strong Name

### DIFF
--- a/Jint/project.json
+++ b/Jint/project.json
@@ -13,6 +13,9 @@
       "url": "git://github.com/sebastienros/jint"
     }
   },
+  "buildOptions": {
+    "keyFile": "Jint.snk"
+  },
   "frameworks": {
     "net45": {
       "dependencies": {
@@ -20,10 +23,10 @@
       }
     },
     ".NETPortable,Version=v4.0,Profile=Profile328": {
-     "buildOptions": {
-       "define": [
-         "PORTABLE"
-       ]
+      "buildOptions": {
+        "define": [
+          "PORTABLE"
+        ]
      },
      "frameworkAssemblies": {
        "mscorlib": "",


### PR DESCRIPTION
`Jint.dll` in the Jint version 2.10 package not signed with strong name.