### PR TITLE
Replace `dependencies` section by `frameworkAssemblies` in `net45` target

### DIFF
--- a/Jint/project.json
+++ b/Jint/project.json
@@ -20,8 +20,8 @@
   },
   "frameworks": {
     "net45": {
-      "dependencies": {
-        "System.Diagnostics.Contracts": "4.0.0"
+      "frameworkAssemblies": {
+        "System.Diagnostics.Contracts": "4.0.0.0"
       }
     },
     ".NETPortable,Version=v4.0,Profile=Profile328": {


### PR DESCRIPTION
Jint version 2.10.1 package is not compatible with older versions of the NuGet Package Manager (for example, version 2.12.0.817), i.e. cannot be used in the Visual Studio 2013. An error occurs when installing this version of Jint:

```
Attempting to resolve dependency 'System.Diagnostics.Contracts (? 4.0.0)'.

The 'System.Diagnostics.Contracts 4.0.0' package requires NuGet client version '3.0' or above, but the current NuGet version is '2.12.0.817'.
```

To resolve this error need to replace `dependencies` section by `frameworkAssemblies` in `net45` target.