### PR TITLE
handle the common string to int conversion 

### DIFF
--- a/Jint.Tests/Runtime/Domain/DataRow.cs
+++ b/Jint.Tests/Runtime/Domain/DataRow.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Jint.Tests.Runtime.Domain
+{
+    public class DataRow
+    {
+        private Int32 _columnIndex = 0;
+        private string _columnName = "MrColumn";
+        private object _column = "Column Data";
+
+        public DataRow()
+        {
+
+        }
+
+        public object this[int columnIndex]
+        {
+            get
+            {
+                if (columnIndex == _columnIndex) return _column;
+                else return null;
+            }
+            set
+            {
+            }
+        }
+
+        public object this[string columnName]
+        {
+            get
+            {
+                if (columnName == (string)_columnName) return _column;
+                else return null;
+            }
+            set
+            {
+            }
+        }
+
+    }
+}

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -230,6 +230,21 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
+        public void CanGetOverloadedIndexUsingStringKey()
+        {
+            var dataRow = new DataRow();
+
+            _engine.SetValue("dataRow", dataRow);
+
+            RunTest(@"
+                assert(dataRow[0] === 'Column Data');
+                assert(dataRow[1] === null);
+                assert(dataRow['MrColumn'] === 'Column Data');
+                assert(dataRow['Noone'] === null);
+            ");
+        }
+
+        [Fact]
         public void CanSetIndexUsingStringKey()
         {
             var dictionary = new Dictionary<string, Person>();

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -222,8 +222,23 @@ namespace Jint.Runtime.Interop
 
             if (canConvert)
             {
-                converted = Convert(value, type, formatProvider);
-                return true;
+                //handle the common string to int conversion that otherwise removes the possibility to have overloaded indexers with both int and string 
+                var isStringValue = value is string;
+                if (isStringValue && type == typeof(Int32))
+                {
+                    Int32 outInt;
+                    var success = Int32.TryParse(value as string, out outInt);
+                    if (success)
+                    {
+                        converted = outInt;
+                        return success;
+                    }
+                }
+                else
+                {
+                    converted = Convert(value, type, formatProvider);
+                    return true;
+                }
             }
 
             converted = null;


### PR DESCRIPTION
that otherwise removes the possibility to have overloaded indexers with both int and string