### PR TITLE
Add Chrome debug protocol implementation

### DIFF
--- a/Jint.DebugAgent/ChromeDebugProtocolServer.cs
+++ b/Jint.DebugAgent/ChromeDebugProtocolServer.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jint.DebugAgent.Domains;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Jint.DebugAgent
+{
+    /// <summary>
+    /// Implements the messaging for the chrome debug protocol. The commands are implemented (by domain) in the ...Domain classes
+    /// </summary>
+    internal class ChromeDebugProtocolServer
+    {
+        private readonly IProtocolServerOwner owner;
+        private readonly DomainBase[] domains;
+        private int count;
+        private CancellationToken cancellationToken;
+        private WebSocket webSocket;
+        private readonly object webSocketLock = new object();
+        private readonly object sendLock = new object();
+
+
+        /// <summary/>
+        public ChromeDebugProtocolServer(IProtocolServerOwner owner, params DomainBase[] domains)
+        {
+            this.owner = owner;
+            this.domains = domains;
+        }
+
+        /// <summary>
+        /// Starts the server. This method only returns when the cancellation token is set to cancelled
+        /// </summary>
+        public async Task Start(CancellationToken cancellationToken, params string[] listenerPrefix)
+        {
+            this.cancellationToken = cancellationToken;
+            HttpListener Listener = new HttpListener();
+            Array.ForEach(listenerPrefix, _ => Listener.Prefixes.Add(_));
+            Listener.Start();
+            Debug.WriteLine("Listening...");
+
+            while (this.cancellationToken.IsCancellationRequested == false)
+            {
+                HttpListenerContext ListenerContext = await Listener.GetContextAsync();
+                if (ListenerContext.Request.IsWebSocketRequest)
+                {
+                    ProcessRequest(ListenerContext);
+                }
+                else
+                {
+                    ListenerContext.Response.StatusCode = 400;
+                    ListenerContext.Response.Close();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sends debug protocol messages throught the websocket
+        /// </summary>
+         public async void Transmit(string domain, string method, JObject parameter)
+        {
+            await this.SendMessage(new JObject(
+                new JProperty("method", string.Join(".", domain, method)),
+                new JProperty("params", parameter)
+                ));
+        }
+
+        /// <summary>
+        /// Processes a debug method request by forwarding ti to the corresponding domain implementation
+        /// </summary>
+        private async void ProcessRequest(HttpListenerContext listenerContext)
+        {
+
+            WebSocketContext WebSocketContext;
+            try
+            {
+                WebSocketContext = await listenerContext.AcceptWebSocketAsync(null);
+                Interlocked.Increment(ref count);
+                Debug.WriteLine("Processed: {0}", count);
+            }
+            catch (Exception Exception)
+            {
+                listenerContext.Response.StatusCode = 500;
+                listenerContext.Response.Close();
+                Debug.WriteLine("Exception: {0}", Exception);
+                return;
+            }
+            lock (this.webSocketLock)
+            {
+                this.webSocket = WebSocketContext.WebSocket;
+            }
+            this.owner.NotifyConnected();
+            try
+            {
+                byte[] ReceiveBuffer = new byte[1024];
+
+                while (this.webSocket?.State == WebSocketState.Open && cancellationToken.IsCancellationRequested == false)
+                {
+                    WebSocketReceiveResult ReceiveResult = await webSocket.ReceiveAsync(new ArraySegment<byte>(ReceiveBuffer), this.cancellationToken);
+
+                    if (ReceiveResult.MessageType == WebSocketMessageType.Close)
+                    {
+                        await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", this.cancellationToken);
+                    }
+                    else if (ReceiveResult.MessageType == WebSocketMessageType.Text)
+                    {
+                        //Revceive message, decode it and forward it to the correspoinding domain implementation. If the method exists, send back 
+                        //the result value or only an acknowledge of the mesage in case no return value is specified
+                        string MessageText = Encoding.UTF8.GetString(ReceiveBuffer, 0, ReceiveResult.Count);
+                        Debug.WriteLine($">> {MessageText}");
+
+                        JObject Message = JsonConvert.DeserializeObject<JObject>(MessageText);
+                        int MessageId = Message["id"].Value<int>();
+                        string[] Method = Message["method"].Value<string>().Split('.');
+                        JObject Parameter = Message["params"]?.Value<JObject>();
+                        try
+                        {
+                            JObject Result = await this.ProcessMessageAsync(Method[0], Method[1], Parameter);
+                            if (Result != null && this.webSocket != null)
+                            {
+                                JProperty IdProperty = new JProperty("id", MessageId);
+                                JProperty ResultProperty = Result.HasValues ? new JProperty("result", Result) : null;
+                                JObject Response = ResultProperty != null
+                                    ? new JObject(IdProperty, ResultProperty)
+                                    : new JObject(IdProperty);
+                                try
+                                {
+                                    Monitor.Enter(this.sendLock);
+                                    await SendMessage(Response);
+                                }
+                                finally
+                                {
+                                    Monitor.Exit(this.sendLock);
+                                }
+                            }
+                            else
+                            {
+                                //Ignore error or null results
+                            }
+                        }
+                        catch
+                        {
+                            //Ignore
+                        }
+                    }
+                }
+            }
+            catch (Exception Exception)
+            {
+                Debug.WriteLine("Exception: {0}", Exception);
+            }
+            finally
+            {
+                this.owner.NotifyDisconnected();
+                lock (this.webSocketLock)
+                {
+                    // Clean up by disposing the WebSocket once it is closed/aborted.
+                    this.webSocket?.Dispose();
+                    this.webSocket = null;
+                }
+            }
+        }
+
+        private async Task SendMessage(JObject message)
+        {
+            try
+            {
+                Monitor.Enter(this.sendLock);
+                string ResponseText = JsonConvert.SerializeObject(message);
+                Debug.WriteLine($"<< {ResponseText}");
+                await this.webSocket.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes(ResponseText)), WebSocketMessageType.Text, true, this.cancellationToken);
+            }
+            catch
+            {
+                Debug.WriteLine("<< SEND FAILED");
+                //Ignore. Send was not successful
+            }
+            finally
+            {
+                Monitor.Exit(this.sendLock);
+            }
+        }
+
+        private async Task<JObject> ProcessMessageAsync(string domain, string method, JObject parameter)
+        {
+            DomainBase Domain = this.domains.FirstOrDefault(_ => _.Name == domain);
+            if (Domain != null)
+            {
+                return await Domain.ProcessMessageAsync(method, parameter);
+            }
+            else
+            {
+                //Domain not supported; ignore
+                return null;
+            }
+        }
+    }
+}

--- a/Jint.DebugAgent/DebugAgentServer.cs
+++ b/Jint.DebugAgent/DebugAgentServer.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Jint.DebugAgent.Domains;
+using Jint.Runtime.Debugger;
+using Newtonsoft.Json.Linq;
+
+namespace Jint.DebugAgent
+{
+    /// <summary>
+    /// The Debug Agent Server provides a CHrome Debug Protocol Server for one or more Jint engines.
+    /// The code loaded into the registered engines will be transmitted to the debugging tools and allow setting breakpoints and stepping through code.
+    /// To stop the server, dispose the instance.
+    /// </summary>
+    /// <remarks>
+    /// Because of the asynchronous nature o the debugging protocol, it may happen that pre-set breakpoints are transmitted by the debugger
+    /// after the code has already been run; in this case either delay the execution or use the <c>debugger</c> statement to force breaking into the debugger
+    /// </remarks>
+    public class DebugAgentServer : IDisposable, IDebugAgent, IProtocolServerOwner
+    {
+        [Flags]
+        public enum Options
+        {
+            None=0x00,
+            /// <summary>
+            /// wait for debugger to connect before executing the first statement
+            /// </summary>
+            WaitForDebuggerOnFirstStatement=0x01,
+            /// <summary>
+            /// Halts on the first executed statement, with or without est breakpoint
+            /// </summary>
+            HaltOnFirstStatement=0x02,
+            /// <summary>
+            /// If Debugger gets disconnected, wait on next breakpoint or step for debugger to reconnect again. 
+            /// If not set, execution is continued while debugger is not connected. If reconnect happens, break is done on next breakpoint or debugger statement.
+            /// </summary>
+            WaitForDebuggerReconnect=0x04,
+        }
+
+        private readonly List<WeakReference<Engine>> engines = new List<WeakReference<Engine>>();
+        private readonly CancellationTokenSource serverCancellation;
+        private ChromeDebugProtocolServer debuggingServer;
+        private readonly DebuggerDomain debuggerDomain;
+        private readonly RuntimeDomain runtimeDomain;
+
+        /// <summary>
+        /// Create the server and expose the engines registered. Additional engines may be added afterwards.
+        /// </summary>
+        /// <remarks>
+        /// The default port is 9222.
+        /// To attach the chrome debugger, use the following URL to start the dev tools and connect to the server:
+        /// "chrome-devtools://devtools/bundled/inspector.html?ws=localhost:9222"
+        /// </remarks>
+        public DebugAgentServer(Options options = Options.None, params Engine[] engines) : this(options, 9222, engines) { }
+        /// <summary>
+        /// Create the server and expose the engines registered. Additional engines may be added afterwards.
+        /// </summary>
+        /// <remarks>
+        /// The default port is 9222.
+        /// To attach the chrome debugger, use the following URL to start the dev tools and connect to the server:
+        /// "chrome-devtools://devtools/bundled/inspector.html?ws=localhost:9222"
+        /// </remarks>
+        public DebugAgentServer(Options options = Options.None, int port = 9222, params Engine[] engines)
+        {
+            this.runtimeDomain = new RuntimeDomain(this, options.HasFlag(Options.WaitForDebuggerOnFirstStatement));
+            this.debuggerDomain = new DebuggerDomain(this, options.HasFlag(Options.HaltOnFirstStatement), options.HasFlag(Options.WaitForDebuggerReconnect), this.runtimeDomain);
+
+            Array.ForEach(engines, this.AddEngine);
+
+            //Start the chrome debug protocol server
+            this.serverCancellation = new CancellationTokenSource();
+            Task.Run(async () =>
+            {
+                this.debuggingServer = new ChromeDebugProtocolServer(this, this.debuggerDomain, this.runtimeDomain);
+                await debuggingServer.Start(this.serverCancellation.Token, $"http://localhost:{port}/", $"http://127.0.0.1:{port}/");
+            }).ContinueWith(_ =>
+            {
+                if (_.IsFaulted)
+                {
+                    Debug.Fail(_.Exception?.Flatten().InnerExceptions.FirstOrDefault()?.Message);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Register an additional Jint engine for debugging
+        /// </summary>
+        [PublicAPI]
+        public void AddEngine(Engine engine)
+        {
+            this.engines.Add(new WeakReference<Engine>(engine));
+            engine.Step += Engine_Step;
+            engine.Break += Engine_Break;
+            engine.ExceptionThrown += Engine_ExceptionThrown;
+            engine.Parse += Engine_Parse;
+        }
+
+        public void Dispose()
+        {
+            this.serverCancellation.Cancel();
+        }
+
+        private StepMode Engine_ExceptionThrown(object sender, DebugInformation e)
+        {
+            return this.debuggerDomain.NotifyExceptionThrown(e);
+        }
+
+        private void Engine_Parse(object sender, SourceInformation e)
+        {
+            this.debuggerDomain.NotifyParse((Engine) sender, e);
+        }
+
+        private StepMode Engine_Step(object sender, DebugInformation e)
+        {
+            this.runtimeDomain.NotifyStep();
+            return this.debuggerDomain.NotifyStep(e);
+        }
+
+        private StepMode Engine_Break(object sender, DebugInformation e)
+        {
+            return this.debuggerDomain.NotifyBreak(e);
+        }
+
+        public void Transmit(string domain, string method, object parameter )
+        {
+            this.debuggingServer.Transmit(domain, method, JObject.FromObject(parameter));
+        }
+
+        public Engine GetEngine(int engineId)
+        {
+            return this.GetEngines().FirstOrDefault(_ => _.GetHashCode() == engineId);
+        }
+
+        public IEnumerable<Engine> GetEngines()
+        {
+            foreach (WeakReference<Engine> EngineReference in this.engines.ToArray())
+            {
+                Engine Engine;
+                if (EngineReference.TryGetTarget(out Engine))
+                {
+                    yield return Engine;
+                }
+                else
+                {
+                    this.engines.Remove(EngineReference);
+                }
+            }
+        }
+
+        public void NotifyConnected()
+        {
+        }
+
+        public void NotifyDisconnected()
+        {
+            this.runtimeDomain.NotifyDisconnected();
+            this.debuggerDomain.NotifyDisconnected();
+        }
+    }
+}

--- a/Jint.DebugAgent/Domains/DebuggerDomain.cs
+++ b/Jint.DebugAgent/Domains/DebuggerDomain.cs
@@ -1,0 +1,613 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using JetBrains.Annotations;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Parser;
+using Jint.Parser.Ast;
+using Jint.Runtime;
+using Jint.Runtime.Debugger;
+using ExecutionContext = Jint.Runtime.Environments.ExecutionContext;
+using StackFrame = Jint.Runtime.Debugger.StackFrame;
+
+namespace Jint.DebugAgent.Domains
+{
+    /// <summary>
+    /// Implements commands from the 'Debugger' Domain
+    /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/
+    /// </summary>
+    internal class DebuggerDomain : DomainBase
+    {
+        private class SourceData
+        {
+            private readonly WeakReference<string> source;
+            public int EngineId { get; }
+            public Statement[] Statements { get; }
+
+            public string Source
+            {
+                get
+                {
+                    string Source;
+                    return this.source.TryGetTarget(out Source) ? Source : null;
+                }
+            }
+
+            public bool IsGarbageCollected
+            {
+                get
+                {
+                    string Source;
+                    return this.source.TryGetTarget(out Source)==false;
+                }
+            }
+
+            public SourceData(int engineId, string source, Statement[] statements)
+            {
+                this.source = new WeakReference<string>(source);
+                EngineId = engineId;
+                Statements = statements;
+            }
+        }
+
+        private readonly Dictionary<string, SourceData> sources = new Dictionary<string, SourceData>();
+        private readonly AutoResetEvent continueExecutionEvent = new AutoResetEvent(true);
+        private StepMode nextStepMode = StepMode.None;
+        private readonly RuntimeDomain runtimeDomain;
+        private DebugInformation currentDebugInformation;
+        private DebuggerDomainProtocol.PauseOnExceptionMode pauseOnExceptionMode;
+        private bool skipAllPauses;
+        private bool deactivateBreakpoints;
+        private bool isDebuggerConnected;
+        private readonly object debuggerLock=new object();
+        private readonly bool waitForDebuggerReconnect;
+
+        public DebuggerDomain(IDebugAgent debugAgent, bool haltOnFirstStatement, bool waitForDebuggerReconnect, RuntimeDomain runtimeDomain) : base("Debugger", debugAgent)
+        {
+            this.runtimeDomain = runtimeDomain;
+            this.waitForDebuggerReconnect = waitForDebuggerReconnect;
+            if (haltOnFirstStatement)
+            {
+                this.continueExecutionEvent.Reset();
+            }
+        }
+
+        public void NotifyDisconnected()
+        {
+            lock (this.debuggerLock)
+            {
+                this.isDebuggerConnected = false;
+                if (this.waitForDebuggerReconnect == false)
+                {
+                    this.SetNextStepModeAndContinueExecution(StepMode.None);
+                }
+            }
+        }
+
+        public StepMode NotifyBreak(DebugInformation debugInformation)
+        {
+            if (this.skipAllPauses || this.deactivateBreakpoints || this.isDebuggerConnected==false)
+            {
+                return debugInformation.StepMode;
+            }
+            else
+            {
+                this.continueExecutionEvent.Reset();
+
+                SendPausedEvent("debugCommand", debugInformation);
+                this.currentDebugInformation = debugInformation;
+
+                this.continueExecutionEvent.WaitOne();
+
+                this.currentDebugInformation = null;
+                SendResumedEvent();
+                return this.nextStepMode;
+            }
+        }
+
+        public StepMode NotifyStep(DebugInformation debugInformation)
+        {
+            if (this.isDebuggerConnected == false)
+            {
+                this.currentDebugInformation = debugInformation;
+                //the event is reset if wait for debugger is enabled
+                this.continueExecutionEvent.WaitOne();
+                this.currentDebugInformation = null;
+
+                return StepMode.None;
+            }
+            else
+            {
+                SendPausedEvent("debugCommand", debugInformation);
+                this.currentDebugInformation = debugInformation;
+
+                if (debugInformation.Engine.BreakPoints?.Any(_ => BreakpointMatchesStatement(_, debugInformation.CurrentStatement, debugInformation.Engine)) == true)
+                {
+                    //if breakpoint was just set during the execution, still halt now
+                    this.continueExecutionEvent.Reset();
+                }
+
+                this.continueExecutionEvent.WaitOne();
+
+                this.currentDebugInformation = null;
+                SendResumedEvent();
+                return this.nextStepMode;
+            }
+        }
+
+        public StepMode NotifyExceptionThrown(DebugInformation debugInformation)
+        {
+            if (this.skipAllPauses || this.isDebuggerConnected == false)
+            {
+                return debugInformation.StepMode;
+            }
+            else
+            {
+                if (this.pauseOnExceptionMode == DebuggerDomainProtocol.PauseOnExceptionMode.All ||
+                    (this.pauseOnExceptionMode == DebuggerDomainProtocol.PauseOnExceptionMode.Uncaught && debugInformation.UncaughtException))
+                {
+                    this.continueExecutionEvent.Reset();
+
+                    SendPausedEvent("exception", debugInformation);
+                    this.currentDebugInformation = debugInformation;
+
+                    this.continueExecutionEvent.WaitOne();
+
+                    this.currentDebugInformation = null;
+                    SendResumedEvent();
+                    return this.nextStepMode;
+                }
+                else
+                {
+                    return debugInformation.StepMode;
+                }
+            }
+        }
+
+        public void NotifyParse(Engine engine, SourceInformation sourceInformation)
+        {
+            lock (this.debuggerLock)
+            {
+                string Source = sourceInformation.Source;
+                this.sources.Add(sourceInformation.Name, new SourceData(engine.GetHashCode(), Source, sourceInformation.Statements));
+                if (this.isDebuggerConnected)
+                {
+                    SendScriptParsedEvent(engine.GetHashCode(), sourceInformation.Name, Source);
+                }
+            }
+        }
+
+        private bool BreakpointMatchesStatement(BreakPoint breakpoint, Statement statement, Engine engine)
+        {
+            if (breakpoint.Statement == statement)
+            {
+                return string.IsNullOrEmpty(breakpoint.Condition) || engine.ExecuteWithoutDebugging(breakpoint.Condition).GetCompletionValue().AsBoolean();
+            }
+            else
+            {
+                return false;
+            }
+        }
+        #region Domain Events
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#event-paused
+        /// </summary>
+        private void SendPausedEvent(string reason, DebugInformation debugInformation)
+        {
+            this.Transmit("paused", new DebuggerDomainProtocol.PausedEventParameters
+            {
+                callFrames=CreateCallFrames(debugInformation.Engine, debugInformation.CallStack, debugInformation.CurrentStatement),
+                reason= reason,
+                hitBreakpoints=debugInformation.BreakPoint != null ? new[] {GetIdFromHash(debugInformation.BreakPoint) } : null,
+                data = CreateExceptionAuxData(debugInformation.Exception)
+            });
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#event-resumed
+        /// </summary>
+        private void SendResumedEvent()
+        {
+            this.Transmit("resumed", new Dictionary<string, object>());
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#event-scriptParsed
+        /// </summary>
+        private void SendScriptParsedEvent(int engineId, string name, string source)
+        {
+            string[] SourceLines = source.Split('\n', '\r');
+
+            this.Transmit("scriptParsed", new DebuggerDomainProtocol.ScriptParsedEventParameter 
+            {
+                url=name,
+                scriptId=name,
+                startLine=0,
+                startColumn=0,
+                endLine=SourceLines.Length,
+                endColumn=SourceLines.Last().Length,
+                executionContextId=engineId,
+                hash=GetIdFromHash(source)
+            });
+        }
+
+        #endregion
+
+        #region Domain Methods
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-stepOver
+        /// </summary>
+        [UsedImplicitly]
+        private void StepOver()
+        {
+            SetNextStepModeAndContinueExecution(StepMode.Over);
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-stepInto
+        /// </summary>
+        [UsedImplicitly]
+        private void StepInto()
+        {
+            SetNextStepModeAndContinueExecution(StepMode.Into);
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-stepOut
+        /// </summary>
+        [UsedImplicitly]
+        private void StepOut()
+        {
+            SetNextStepModeAndContinueExecution(StepMode.Out);
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-pause
+        /// </summary>
+        [UsedImplicitly]
+        private void Pause()
+        {
+            this.continueExecutionEvent.Reset();
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-resume
+        /// </summary>
+        [UsedImplicitly]
+        private void Resume()
+        {
+            SetNextStepModeAndContinueExecution(StepMode.None);
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-enable
+        /// </summary>
+        [UsedImplicitly]
+        private void Enable()
+        {
+            lock (this.debuggerLock)
+            {
+                this.isDebuggerConnected = true;
+
+                foreach (KeyValuePair<string, SourceData> Source in this.GetScripts())
+                {
+                    this.SendScriptParsedEvent(Source.Value.EngineId, Source.Key, Source.Value.Source);
+                }
+                if (this.currentDebugInformation != null)
+                {
+                    this.SendPausedEvent("debugCommand",this.currentDebugInformation);
+                }
+            }
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-getScriptSource
+        /// </summary>
+        [UsedImplicitly]
+        private DebuggerDomainProtocol.GetScriptSourceResult GetScriptSource(string scriptId)
+        {
+            string Source = this.GetScript(scriptId)?.Source ?? "<unloaded>";
+            return new DebuggerDomainProtocol.GetScriptSourceResult  {scriptSource= Source};
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-setBreakpointByUrl
+        /// </summary>
+        [UsedImplicitly]
+        private DebuggerDomainProtocol.SetBreakpointResult SetBreakpointByUrl(string url, int lineNumber, int columnNumber)
+        {
+            SourceData SourceData = this.GetScript(url);
+            int EngineId = SourceData.EngineId;
+            Engine Engine = this.GetEngine(EngineId);
+            Statement NearestStatement = null;
+            string BreakPointId = null;
+            if (Engine != null)
+            {
+                IEnumerable<Statement> FlattenedStatements = GetFlattenedStatements(SourceData.Statements)
+                    .OrderByDescending(_ => _.Location.Start.Line).ThenByDescending(_ => _.Location.Start.Column);
+                //Get statement nearest to the requested position. Careful: Parser line numbers are 1 based, not 0 based!
+                NearestStatement = FlattenedStatements.FirstOrDefault(_ => lineNumber >= _.Location.Start.Line-1) ??FlattenedStatements.Last();
+
+                if (NearestStatement != null)
+                {
+                    BreakPoint BreakPoint = new BreakPoint(NearestStatement);
+                    Engine.BreakPoints.Add(BreakPoint);
+                    BreakPointId = GetIdFromHash(BreakPoint);
+                }
+            }
+            if (NearestStatement != null)
+            {
+                return new DebuggerDomainProtocol.SetBreakpointResult
+                {
+                    breakpointId= BreakPointId,
+                    locations= new[] {this.CreateLocation(NearestStatement.Location.Start, this.GetScriptId(NearestStatement.Location.Source)) }
+                    
+                };
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-removeBreakpoint
+        /// </summary>
+        [UsedImplicitly]
+        private void RemoveBreakpoint(string breakpointId)
+        {
+            Tuple<Engine, BreakPoint> BreakPointInfo = (from Engine in this.GetEngines()
+                from BreakPoint in Engine.BreakPoints
+                where GetIdFromHash(BreakPoint) == breakpointId
+                select new Tuple<Engine, BreakPoint>(Engine, BreakPoint)).FirstOrDefault();
+            BreakPointInfo?.Item1.BreakPoints.Remove(BreakPointInfo.Item2);
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/tot/Debugger/#method-setBreakpointsActive
+        /// </summary>
+        [UsedImplicitly]
+        private void SetBreakpointsActive(bool active)
+        {
+            this.deactivateBreakpoints = !active;
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-setPauseOnExceptions
+        /// </summary>
+        [UsedImplicitly]
+        private void SetPauseOnExceptions(string state)
+        {
+            this.pauseOnExceptionMode = (DebuggerDomainProtocol.PauseOnExceptionMode)Enum.Parse(typeof(DebuggerDomainProtocol.PauseOnExceptionMode),state,true);
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/tot/Debugger/#method-setSkipAllPauses
+        /// </summary>
+        [UsedImplicitly]
+        private void SetSkipAllPauses(bool skip)
+        {
+            this.skipAllPauses = skip;
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-evaluateOnCallFrame
+        /// </summary>
+        [UsedImplicitly]
+        private DebuggerDomainProtocol.EvaluateOnCallFrameResult EvaluateOnCallFrame( string callFrameId, string expression )
+        {
+            int FrameNumber = int.Parse(callFrameId);
+            if (FrameNumber == 0)
+            {
+                try
+                {
+                    JsValue Result = this.currentDebugInformation.Engine.ExecuteWithoutDebugging(expression).GetCompletionValue();
+                    return new DebuggerDomainProtocol.EvaluateOnCallFrameResult
+                    {
+                        result = this.runtimeDomain.GetRemoteObject(Result)
+                    };
+                }
+                catch (JavaScriptException Exception)
+                {
+                    /*return new DebuggerDomainProtocol.EvaluateOnCallFrameResult
+                    {
+                        exceptionDetails = new RuntimeDomainProtocol.ExceptionDetails {exception =}
+                    }*/
+                    return new DebuggerDomainProtocol.EvaluateOnCallFrameResult
+                    {
+                        result = this.runtimeDomain.GetRemoteObject(JsValue.FromObject(this.currentDebugInformation.Engine, $"<{Exception.Error.AsObject().GetProperty("message").Value}>"))
+                    };
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+            else
+            {
+                return new DebuggerDomainProtocol.EvaluateOnCallFrameResult
+                {
+                    result = this.runtimeDomain.GetRemoteObject(JsValue.FromObject(this.currentDebugInformation.Engine,"<Evaluation is only supported on the top stack frame>"))
+                };
+            }
+        }
+
+        private void SetNextStepModeAndContinueExecution(StepMode mode)
+        {
+            this.nextStepMode = mode;
+            this.continueExecutionEvent.Set();
+        }
+        #endregion
+
+        private IEnumerable<DebuggerDomainProtocol.CallFrame> CreateCallFrames(Engine engine, StackFrame[] callStack, Statement currentStatement)
+        {
+            Statement CurrentStatement = currentStatement;
+            int Index = 0;
+
+            //frame Execution context is the one of the calling method. engine execution context is the current one
+            ExecutionContext Context= engine.ExecutionContext;
+            foreach (StackFrame Frame in callStack)
+            {
+                yield return CreateCallFrame(engine, Index++, Frame.ToString(), CurrentStatement, Context);
+                Context = Frame.ExecutionContext;
+            }
+            yield return CreateCallFrame(engine, Index, "<entry>", CurrentStatement, Context);
+        }
+
+        private DebuggerDomainProtocol.CallFrame CreateCallFrame(Engine engine, int index, string frameName, Statement currentStatement, ExecutionContext executionContext)
+        {
+            return new DebuggerDomainProtocol.CallFrame
+            {
+                callFrameId= index.ToString(),
+                functionName= frameName,
+                location= this.CreateLocation(currentStatement.Location.Start,this.GetScriptId(currentStatement.Location.Source)),
+                scopeChain= new[] {
+                    this.CreateScope(true, engine.GlobalEnvironment.Record, "Global scope"),
+                    executionContext.LexicalEnvironment.Outer!=null
+                    ?this.CreateScope(false, executionContext.LexicalEnvironment.Record, "Local scope"):null
+                }.Where(_=>_!=null).ToArray() ,
+                @this= this.runtimeDomain.GetRemoteObject(executionContext.ThisBinding)
+            };
+        }
+
+        private DebuggerDomainProtocol.Scope CreateScope(bool global, ObjectInstance value, string description)
+        {
+            return new DebuggerDomainProtocol.Scope
+            {
+                type= global ? "global":"local" , /*global, local, with, closure, catch, block, script.*/
+                @object= this.runtimeDomain.GetRemoteObject(value,description),
+            };
+        }
+
+
+
+        private DebuggerDomainProtocol.Location CreateLocation(Position position, string scriptId)
+        {
+            return
+                new
+                    DebuggerDomainProtocol.Location
+                {
+                    scriptId = scriptId,
+                    lineNumber = position.Line - 1,
+                    columnNumber =position.Column
+                };
+        }
+
+        private DebuggerDomainProtocol.AuxData CreateExceptionAuxData(JavaScriptException exception)
+        {
+            if (exception != null)
+            {
+                return new DebuggerDomainProtocol.AuxData
+                {
+                    description = exception.Message
+                };
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private IEnumerable<Statement> GetFlattenedStatements(IEnumerable<Statement> statements)
+        {
+            foreach (Statement Statement in statements)
+            {
+                yield return Statement;
+                IEnumerable<Statement> InnerStatements;
+
+                if (Statement is BlockStatement)
+                {
+                    InnerStatements = ((BlockStatement) Statement).Body;
+                }
+                else if (Statement is CatchClause )
+                {
+                    InnerStatements = new[] {((CatchClause) Statement).Body};
+                }
+                else if (Statement is DoWhileStatement)
+                {
+                    InnerStatements = new[] {((DoWhileStatement) Statement).Body};
+                }
+                else if (Statement is ForInStatement)
+                {
+                    InnerStatements = new[] {((ForInStatement) Statement).Body};
+                }
+                else if (Statement is ForStatement)
+                {
+                    InnerStatements = new[] {((ForStatement) Statement).Body};
+                }
+                else if (Statement is FunctionDeclaration)
+                {
+                    InnerStatements = new[] {((FunctionDeclaration) Statement).Body};
+                }
+                else if (Statement is IfStatement)
+                {
+                    InnerStatements = new[] {((IfStatement) Statement).Consequent,((IfStatement) Statement).Alternate};
+                }
+                else if (Statement is LabelledStatement)
+                {
+                    InnerStatements = new[] {((LabelledStatement) Statement).Body};
+                }
+                else if (Statement is Program)
+                {
+                    InnerStatements = ((Program) Statement).Body;
+                }
+                else if (Statement is VariableDeclaration)
+                {
+                    InnerStatements = ((VariableDeclaration) Statement).Declarations.Select(_=>(_.Init as FunctionExpression)?.Body).Where(_=>_!=null);
+                }
+                else if (Statement is TryStatement)
+                {
+                    InnerStatements = new[] { ((TryStatement)Statement).Block, ((TryStatement)Statement).Finalizer};
+                }
+                else if (Statement is WhileStatement)
+                {
+                    InnerStatements = new[] { ((WhileStatement)Statement).Body};
+                }
+                else if (Statement is WithStatement)
+                {
+                    InnerStatements = new[] {((WithStatement) Statement).Body};
+                }
+                else
+                {
+                    InnerStatements = null;
+                }
+
+
+                if (InnerStatements != null)
+                {
+                    foreach (Statement InnerStatement in GetFlattenedStatements(InnerStatements))
+                    {
+                        yield return InnerStatement;
+                    }
+                }
+            } 
+        }
+
+        private string GetScriptId(string source)
+        {
+            return this.GetScripts().Where(_ => _.Value.Source == source).Select(_ => _.Key).FirstOrDefault();
+        }
+
+        private SourceData GetScript(string scriptId)
+        {
+            return this.GetScripts().Where(_=>_.Key==scriptId).Select(_=>_.Value).FirstOrDefault();
+        }
+
+        private IEnumerable<KeyValuePair<string, SourceData>> GetScripts()
+        {
+            foreach (KeyValuePair<string, SourceData> Script in this.sources.ToArray())
+            {
+                if (Script.Value.IsGarbageCollected)
+                {
+                    this.sources.Remove(Script.Key);
+                }
+                else
+                {
+                    yield return Script;
+                }
+            }
+        }
+    }
+}

--- a/Jint.DebugAgent/Domains/DebuggerDomainProtocol.cs
+++ b/Jint.DebugAgent/Domains/DebuggerDomainProtocol.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+// ReSharper disable InconsistentNaming
+#pragma warning disable 414
+
+namespace Jint.DebugAgent.Domains
+{
+    /// <summary>
+    /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/
+    /// </summary>
+    internal static class DebuggerDomainProtocol
+    {
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#event-scriptParsed
+        /// </summary>
+        public class ScriptParsedEventParameter
+        {
+            public string url;
+            public string scriptId;
+            public int startLine;
+            public int startColumn;
+            public int endLine;
+            public int endColumn;
+            public int executionContextId;
+            public string hash;
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#event-paused
+        /// </summary>
+        public class PausedEventParameters
+        {
+            public IEnumerable<CallFrame> callFrames;
+            public string reason;
+            public string[] hitBreakpoints;
+            public AuxData data; //Object containing break-specific auxiliary properties. 
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-getScriptSource
+        /// </summary>
+        public class GetScriptSourceResult
+        {
+            public string scriptSource;
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-evaluateOnCallFrame
+        /// </summary>
+        public class EvaluateOnCallFrameResult
+        {
+            public RuntimeDomainProtocol.RemoteObject result; // Object wrapper for the evaluation result.
+            public RuntimeDomainProtocol.ExceptionDetails exceptionDetails; //optional Exception details.
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#method-setBreakpoint
+        /// </summary>
+        public class SetBreakpointResult
+        {
+            public string breakpointId;
+            public Location[] locations;
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#type-CallFrame
+        /// </summary>
+        public class CallFrame
+        {
+            public string callFrameId;
+            public string functionName;
+            public Location location;
+            public Scope[] scopeChain;
+            public RuntimeDomainProtocol.RemoteObject @this;
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#type-Scope
+        /// </summary>
+        public class Scope
+        {
+            public string type;
+            public RuntimeDomainProtocol.RemoteObject @object;
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Debugger/#type-Location
+        /// </summary>
+        public class Location
+        {
+            public string scriptId;
+            public int lineNumber;
+            public int columnNumber;
+        }
+
+        public class AuxData
+        {
+            public string description;
+        }
+
+        public enum PauseOnExceptionMode
+        {
+            None,
+            Uncaught,
+            All
+        }
+    }
+}

--- a/Jint.DebugAgent/Domains/DomainBase.cs
+++ b/Jint.DebugAgent/Domains/DomainBase.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace Jint.DebugAgent.Domains
+{
+    /// <summary>
+    /// Implements base functionality for the domain implementations. Most of all this is a reflections-based
+    /// Dispatching of debugger methods and results
+    /// </summary>
+    internal abstract class DomainBase
+    {
+        private readonly IDebugAgent debugAgent;
+        public string Name { get; }
+
+        protected DomainBase(string name, IDebugAgent debugAgent)
+        {
+            this.debugAgent = debugAgent;
+            Name = name;
+        }
+
+        /// <summary>
+        /// Process debugger emthods.
+        /// The methods are named as specified int he debugger protocol (case insensitive) and may have an 'Async' postfix.
+        /// If the return value is given, it is sent back to the debugger. If the result value is a task type, then an 'await' async
+        /// call is made.
+        /// </summary>
+        public async Task<JObject> ProcessMessageAsync(string method, JObject parameter)
+        {
+            try
+            {
+                //Get class method for the message. Prefer Async implementations
+                MethodInfo Method = this.GetType().GetMethod($"{method}Async", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase) ?? this.GetType().GetMethod($"{method}", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (Method != null)
+                {
+                    ParameterInfo[] Parameters = Method.GetParameters();
+                    object[] Arguments = new object[Parameters.Length];
+                    for (int Index = 0; Index < Parameters.Length; Index++)
+                    {
+                        JToken Value=null;
+                        if (parameter?.TryGetValue(Parameters[Index].Name, StringComparison.InvariantCultureIgnoreCase, out Value)==true)
+                        {
+                            Arguments[Index] = Value.ToObject(Parameters[Index].ParameterType);
+                        }
+                        else
+                        {
+                            //parameter value not found in message, maybe its optional. use default(T)
+                        }
+
+                        //Set default if not set before
+                        Arguments[Index] = Arguments[Index] ?? (Parameters[Index].ParameterType.IsValueType ? Activator.CreateInstance(Parameters[Index].ParameterType) : null);
+                    }
+
+                    //Call method in a typed manner
+                    object Result = Method.Invoke(this, Arguments);
+
+                    if (Method.ReturnType == typeof (void))
+                    {
+                        // there is no return value
+                    }
+                    else if (Method.ReturnType.IsGenericType)
+                    {
+                        if (Method.ReturnType.BaseType == typeof (Task))
+                        {
+                            //Result is a Task<T>. Await its content
+                            Result = await (dynamic) Result;
+                        }
+                        else
+                        {
+                            //Leave Result
+                        }
+                    }
+                    else
+                    {
+                        if (Method.ReturnType == typeof (Task))
+                        {
+                            await (Task) Result;
+                            //there is no real return type, only a Task that was awaited before continuation
+                        }
+                        else
+                        {
+                            //Leave Result
+                        }
+                    }
+
+                    //Null means, response must be sent but no content. Use empty JObject for that. Otherwise create Json from result
+                    return Result != null ? JObject.FromObject(Result) : new JObject();
+                }
+                else
+                {
+                    //Method no found, ignore
+                    return null;
+                }
+            }
+            catch (Exception Exception)
+            {
+                Debug.WriteLine($"Exception calling {method}:{Exception.Message}");
+                return null;
+            }
+        }
+
+        protected void Transmit(string method, object parameters)
+        {
+           this.debugAgent.Transmit(this.Name, method, parameters);
+        }
+
+        protected Engine GetEngine(int engineId)
+        {
+            return this.debugAgent.GetEngine(engineId);
+        }
+
+        protected IEnumerable<Engine> GetEngines()
+        {
+            return this.debugAgent.GetEngines();
+        }
+
+        protected static string GetIdFromHash(object value)
+        {
+            return value.GetHashCode().ToString("X8");
+        }
+    }
+}

--- a/Jint.DebugAgent/Domains/RuntimeDomain.cs
+++ b/Jint.DebugAgent/Domains/RuntimeDomain.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using JetBrains.Annotations;
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Environments;
+using ExecutionContext = Jint.Runtime.Environments.ExecutionContext;
+
+namespace Jint.DebugAgent.Domains
+{
+    /// <summary>
+    /// Implements commands from the 'Debugger' Domain
+    /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/
+    /// </summary>
+    internal class RuntimeDomain : DomainBase
+    {
+        private readonly ManualResetEvent continueExecutionEvent = new ManualResetEvent(true);
+        private readonly Dictionary<string,WeakReference<ObjectInstance>> runtimeValues= new Dictionary<string, WeakReference<ObjectInstance>>();
+
+        public RuntimeDomain(IDebugAgent debugAgent, bool waitForDebugger) : base("Runtime", debugAgent)
+        {
+            if (waitForDebugger)
+            {
+                this.continueExecutionEvent.Reset();
+            }
+        }
+
+        public void NotifyDisconnected()
+        {
+            this.continueExecutionEvent.Set();
+        }
+
+        public void NotifyStep()
+        {
+            //Wait for debugger to connect (if opted for this)
+            this.continueExecutionEvent.WaitOne();
+        }
+
+        #region Domain Methods
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#method-enable
+        /// </summary>
+        [UsedImplicitly]
+        private void Enable()
+        {
+            //this method is defined to signal the debugger that it is understood
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#method-runIfWaitingForDebugger
+        /// </summary>
+        [UsedImplicitly]
+        private void RunIfWaitingForDebugger()
+        {
+            this.continueExecutionEvent.Set();
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#method-getProperties
+        /// </summary>
+        /// <param name="objectId"></param>
+        /// <returns></returns>
+        [UsedImplicitly]
+        private RuntimeDomainProtocol.GetPropertiesResult GetProperties(string objectId)
+        {
+            ObjectInstance Value;
+            WeakReference<ObjectInstance> ValueReference = this.runtimeValues.Where(_ => _.Key == objectId).Select(_=>_.Value).FirstOrDefault();
+            if (ValueReference != null && ValueReference.TryGetTarget(out Value))
+            {
+
+                IEnumerable<KeyValuePair<string, JsValue>> KeyValuePairs;
+                if (Value is EnvironmentRecord)
+                {
+                    KeyValuePairs = ((EnvironmentRecord) Value).GetAllBindingNames().Select(_ => new KeyValuePair<string, JsValue>(_, ((EnvironmentRecord)Value).GetBindingValue(_,false)));
+                }
+                else
+                {
+                    KeyValuePairs = Value.GetOwnProperties().Select(_=> new KeyValuePair<string, JsValue>(_.Key,_.Value.Value));
+                }
+                return new RuntimeDomainProtocol.GetPropertiesResult
+                {
+                    result = KeyValuePairs.Select(property => new RuntimeDomainProtocol.PropertyDescriptor
+                    {
+                        isOwn = true,configurable = false, name = property.Key, writable = false,value=GetRemoteObject(property.Value)
+                    }).ToArray()
+                };
+            }
+            else
+            {
+                return null;
+            }
+        }
+        #endregion
+        #region Domain events
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#event-executionContextCreated
+        /// </summary>
+        /// <param name="executionContext"></param>
+        [UsedImplicitly]
+        private void SendExecutionContextCreatedEvent(ExecutionContext executionContext)
+        {
+            this.Transmit("executionContextCreated", new RuntimeDomainProtocol.ExecutionContextCreatedEvent
+            {
+                context = new RuntimeDomainProtocol.ExecutionContextDescription
+                {
+                    id = GetIdFromHash(executionContext),
+                    origin = "",
+                    name = ""
+                }
+            });
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#event-executionContextDestroyed
+        /// </summary>
+        /// <param name="executionContext"></param>
+        [UsedImplicitly]
+        private void SendExecutionContextDestroyedEvent(ExecutionContext executionContext)
+        {
+            this.Transmit("executionContextDestroyed", new RuntimeDomainProtocol.ExecutionContextDestroyedEvent
+            {
+                executionContextId= GetIdFromHash(executionContext)
+            });
+        }
+        #endregion
+
+        public RuntimeDomainProtocol.RemoteObject GetRemoteObject(ObjectInstance value, string description=null)
+        {
+            string ObjectId = GetIdFromHash(value);
+            if (this.runtimeValues.ContainsKey(ObjectId) == false)
+            {
+                this.runtimeValues.Add(ObjectId, new WeakReference<ObjectInstance>(value));
+            }
+
+            return new RuntimeDomainProtocol.RemoteObject
+            {
+                type=GetObjectType(value),
+                value=GetValue(value),
+                description = description??value.ToString(),
+                objectId=ObjectId,
+            };
+        }
+
+        public RuntimeDomainProtocol.RemoteObject GetRemoteObject(JsValue value)
+        {
+            if (value.IsObject())
+            {
+                return this.GetRemoteObject(value.AsObject());
+            }
+            else
+            {
+                return new RuntimeDomainProtocol.RemoteObject
+                {
+                    type = GetObjectType(value),
+                    value = GetValue(value),
+                    description = value.ToString(),
+                    objectId = GetIdFromHash(value),
+                };
+            }
+        }
+
+        private static string GetValue(JsValue value)
+        {
+            switch (value.Type)
+            {
+                case Types.None:
+                    return "<none>";
+                case Types.Undefined:
+                    return "<undefined>";
+                case Types.Null:
+                    return "<null>";
+                case Types.Boolean:
+                    return value.AsBoolean().ToString();
+                case Types.String:
+                    return value.AsString();
+                case Types.Number:
+                    return value.AsNumber().ToString(CultureInfo.InvariantCulture);
+                case Types.Object:
+                    return null;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private static string GetObjectType(JsValue value)
+        {
+            /*typestring  Object type. Allowed values: object, function, undefined, string, number, boolean, symbol. */
+            switch (value.Type)
+            {
+                case Types.Undefined:
+                    return "undefined";
+                case Types.Null:
+                    return "object";
+                case Types.Boolean:
+                    return "boolean";
+                case Types.String:
+                    return "string";
+                case Types.Number:
+                    return "number";
+                case Types.Object:
+                    if (value.AsObject() is FunctionInstance)
+                    {
+                        return "function";
+                    }
+                    else
+                    {
+                        return "object";
+                    }
+                //case Types.None:
+                default:
+                    return "symbol";
+            }
+        }
+    }
+}

--- a/Jint.DebugAgent/Domains/RuntimeDomainProtocol.cs
+++ b/Jint.DebugAgent/Domains/RuntimeDomainProtocol.cs
@@ -1,0 +1,111 @@
+// ReSharper disable InconsistentNaming
+#pragma warning disable 414
+
+namespace Jint.DebugAgent.Domains
+{
+    /// <summary>
+    /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/
+    /// </summary>
+    internal static class RuntimeDomainProtocol
+    {
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#method-getProperties
+        /// </summary>
+        public class GetPropertiesResult
+        {
+            public PropertyDescriptor[] result;
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#type-RemoteObject
+        /// </summary>
+        public class RemoteObject
+        {
+            public string type;
+            public string value;
+            public string description;
+            public string objectId;
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#type-PropertyDescriptor
+        /// </summary>
+        public class PropertyDescriptor
+        {
+            public string name; //Property name or symbol description.
+            public RemoteObject value; //optionalRemoteObject  The value associated with the property.  
+            public bool writable; //optional True if the value associated with the property may be changed (data descriptors only).  
+            //public RemoteObject get;//optional A function which serves as a getter for the property, or undefined if there is no getter(accessor descriptors only).  
+            //public RemoteObject set;//optional A function which serves as a setter for the property, or undefined if there is no setter(accessor descriptors only).  
+            public bool configurable; //boolean True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object.  
+            public bool enumerable; //True if this property shows up during enumeration of the properties on the corresponding object.  
+            public bool wasThrown; //optionalTrue if the result was thrown during the evaluation.
+            public bool isOwn; //optional True if the property is owned for the object.  
+            public RemoteObject symbol; //optional Property symbol object, if the property is of the symbol type. 
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#type-ExceptionDetails
+        /// </summary>
+        public class ExceptionDetails
+        {
+            public int exceptionId;//Exception id.
+            public string text;// Exception text, which should be used together with exception object when available.
+            public int lineNumber;// Line number of the exception location(0-based).  
+            public int columnNumber;//Column number of the exception location(0-based).  
+            public string scriptId;//Script ID of the exception location.
+            public string url;//URL of the exception location, to be used when the script was not reported.
+            public StackTrace stackTrace;//optional JavaScript stack trace if available.
+            public RemoteObject exception;//optional Exception object if available.
+            public string executionContextId;//Identifier of the context where exception happened. 
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#type-StackTrace
+        /// </summary>
+        public class StackTrace
+        {
+            public string description;//optional String label of this stack trace.For async traces this may be a name of the function that initiated the async call.  
+            public CallFrame[] callFrames;//JavaScript function name.  
+            public StackTrace parent;//optional Asynchronous JavaScript stack trace that preceded this stack, if available.
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#type-CallFrame
+        /// </summary>
+        public class CallFrame
+        {
+            public string functionName; //JavaScript function name.
+            public string scriptId; //JavaScript script id.
+            public string url; //JavaScript script name or url.  
+            public int lineNumber; //JavaScript script line number (0-based).  
+            public int columnNumber; //JavaScript script column number(0-based). 
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#event-executionContextCreated
+        /// </summary>
+        public class ExecutionContextCreatedEvent
+        {
+            public ExecutionContextDescription context;
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#type-ExecutionContextDescription
+        /// </summary>
+        public class ExecutionContextDescription
+        {
+            public string id;
+            public string origin;
+            public string name;
+        }
+
+        /// <summary>
+        /// https://chromedevtools.github.io/debugger-protocol-viewer/1-2/Runtime/#event-executionContextDestroyed
+        /// </summary>
+        public class ExecutionContextDestroyedEvent
+        {
+            public string executionContextId;
+        }
+    }
+}

--- a/Jint.DebugAgent/IDebugAgent.cs
+++ b/Jint.DebugAgent/IDebugAgent.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace Jint.DebugAgent
+{
+    /// <summary>
+    /// Methods provided to the domain implementations from the debugger agent
+    /// </summary>
+    internal interface IDebugAgent
+    {
+        /// <summary>
+        /// Transmit a debugger message through the websocket
+        /// </summary>
+        void Transmit(string domain, string method, object parameter);
+        /// <summary>
+        /// Gets the engine by its ID transferred to the debugger
+        /// </summary>
+        Engine GetEngine(int engineId);
+        /// <summary>
+        /// Get all engines registered
+        /// </summary>
+        IEnumerable<Engine> GetEngines();
+    }
+}

--- a/Jint.DebugAgent/IProtocolServerOwner.cs
+++ b/Jint.DebugAgent/IProtocolServerOwner.cs
@@ -1,0 +1,17 @@
+namespace Jint.DebugAgent
+{
+    /// <summary>
+    /// Methods called from the websocket debug protocol handler
+    /// </summary>
+    internal interface IProtocolServerOwner
+    {
+        /// <summary>
+        /// Notifies that a debugger has connected to the websocket
+        /// </summary>
+        void NotifyConnected();
+        /// <summary>
+        /// Notifies that a debugger has disconnected from the websocket
+        /// </summary>
+        void NotifyDisconnected();
+    }
+}

--- a/Jint.DebugAgent/Jint.DebugAgent.csproj
+++ b/Jint.DebugAgent/Jint.DebugAgent.csproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C0006571-0D49-40B0-A3ED-B073FFD91AA5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Jint.DebugAgent</RootNamespace>
+    <AssemblyName>JintDebugAgent</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=10.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\..\..\Visual Studio 2015\Projects\JintDebugAgent\packages\JetBrains.Annotations.10.2.1\lib\net\JetBrains.Annotations.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\Visual Studio 2015\Projects\JintDebugAgent\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.WebSockets, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\Visual Studio 2015\Projects\JintDebugAgent\packages\System.Net.WebSockets.4.0.0\lib\net46\System.Net.WebSockets.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ChromeDebugProtocolServer.cs" />
+    <Compile Include="DebugAgentServer.cs" />
+    <Compile Include="Domains\DebuggerDomain.cs" />
+    <Compile Include="Domains\DebuggerDomainProtocol.cs" />
+    <Compile Include="Domains\DomainBase.cs" />
+    <Compile Include="Domains\RuntimeDomainProtocol.cs" />
+    <Compile Include="IDebugAgent.cs" />
+    <Compile Include="IProtocolServerOwner.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Domains\RuntimeDomain.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\jint\Jint\Jint.csproj">
+      <Project>{678738DA-F723-4920-B9E5-CAD667104BDA}</Project>
+      <Name>Jint</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Jint.DebugAgent/Properties/AssemblyInfo.cs
+++ b/Jint.DebugAgent/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("jintDebugAgent")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("jintDebugAgent")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c0006571-0d49-40b0-a3ed-b073ffd91aa5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Jint.DebugAgent/packages.config
+++ b/Jint.DebugAgent/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="JetBrains.Annotations" version="10.2.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="System.Net.WebSockets" version="4.0.0" targetFramework="net461" />
+</packages>

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -26,9 +26,14 @@ namespace Jint.Tests.Runtime
                 .SetValue("assert", new Action<bool>(Assert.True))
                 .SetValue("equal", new Action<object, object>(Assert.Equal))
                 ;
+#if NET451
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en");
+#else
+            CultureInfo.CurrentCulture = new CultureInfo("en");
+#endif
         }
 
-        void IDisposable.Dispose()
+            void IDisposable.Dispose()
         {
         }
 
@@ -1469,8 +1474,8 @@ namespace Jint.Tests.Runtime
             Assert.NotNull(debugInfo.CurrentStatement);
             Assert.NotNull(debugInfo.Locals);
 
-            Assert.Equal(1, debugInfo.CallStack.Count);
-            Assert.Equal("func1()", debugInfo.CallStack.Peek());
+            Assert.Equal(1, debugInfo.CallStack.Length);
+            Assert.Equal("func1()", debugInfo.CallStack[0]);
             Assert.Contains(debugInfo.Globals, kvp => kvp.Key.Equals("global", StringComparison.Ordinal) && kvp.Value.AsBoolean() == true);
             Assert.Contains(debugInfo.Globals, kvp => kvp.Key.Equals("local", StringComparison.Ordinal) && kvp.Value.AsBoolean() == false);
             Assert.Contains(debugInfo.Locals, kvp => kvp.Key.Equals("local", StringComparison.Ordinal) && kvp.Value.AsBoolean() == false);
@@ -1558,7 +1563,7 @@ namespace Jint.Tests.Runtime
             Assert.NotNull(debugInfo);
 
             countBreak++;
-            if (debugInfo.CallStack.Count > 0)
+            if (debugInfo.CallStack.Length > 0)
                 return StepMode.Out;
 
             return StepMode.Into;

--- a/Jint.sln
+++ b/Jint.sln
@@ -22,6 +22,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Jint.Tests.Ecma", "Jint.Tes
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Jint.Tests.CommonScripts", "Jint.Tests.CommonScripts\Jint.Tests.CommonScripts.xproj", "{B815F239-6409-4BA7-9461-18317AA2DBED}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jint.DebugAgent", "Jint.DebugAgent\Jint.DebugAgent.csproj", "{C0006571-0D49-40B0-A3ED-B073FFD91AA5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,6 +54,10 @@ Global
 		{B815F239-6409-4BA7-9461-18317AA2DBED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B815F239-6409-4BA7-9461-18317AA2DBED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B815F239-6409-4BA7-9461-18317AA2DBED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0006571-0D49-40B0-A3ED-B073FFD91AA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0006571-0D49-40B0-A3ED-B073FFD91AA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0006571-0D49-40B0-A3ED-B073FFD91AA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0006571-0D49-40B0-A3ED-B073FFD91AA5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Parser\State.cs" />
     <Compile Include="Parser\Token.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReflectionExtensions.cs" />
     <Compile Include="Runtime\Arguments.cs" />
     <Compile Include="Runtime\CallStack\JintCallStack.cs" />
     <Compile Include="Runtime\CallStack\CallStackElementComparer.cs" />
@@ -166,6 +167,9 @@
     <Compile Include="Runtime\Debugger\BreakPoint.cs" />
     <Compile Include="Runtime\Debugger\DebugHandler.cs" />
     <Compile Include="Runtime\Debugger\DebugInformation.cs" />
+    <Compile Include="Runtime\Debugger\ExecutionContextInformation.cs" />
+    <Compile Include="Runtime\Debugger\SourceInformation.cs" />
+    <Compile Include="Runtime\Debugger\StackFrame.cs" />
     <Compile Include="Runtime\Debugger\StepMode.cs" />
     <Compile Include="Runtime\Descriptors\PropertyDescriptor.cs" />
     <Compile Include="Runtime\Descriptors\Specialized\FieldInfoDescriptor.cs" />

--- a/Jint/Jint.nuget.targets
+++ b/Jint/Jint.nuget.targets
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="EmitMSBuildWarning" BeforeTargets="Build">
+    <Warning Text="Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored." />
+  </Target>
+</Project>

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -58,7 +58,8 @@ namespace Jint.Native.Function
 
                             if (result.Type == Completion.Throw)
                             {
-                                throw new JavaScriptException(result.GetValueOrDefault());
+                                JavaScriptException JavaScriptException = new JavaScriptException(result.GetValueOrDefault());
+                                throw JavaScriptException;
                             }
                             else
                             {

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -490,7 +490,8 @@ namespace Jint.Native.Json
                         {
                             Line = _lineNumber,
                             Column = _index - _lineStart
-                        }
+                        },
+                    Source = _source
                 };
 
             Token token = Advance();

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using Jint.Native;
 using Jint.Runtime.Interop;
 
 namespace Jint
@@ -11,7 +12,7 @@ namespace Jint
     {
         private bool _discardGlobal;
         private bool _strict;
-        private bool _allowDebuggerStatement;
+        private bool _debuggerStatementBreaksIntoNetDebugger;
         private bool _debugMode;
         private bool _allowClr;
         private readonly List<IObjectConverter> _objectConverters = new List<IObjectConverter>();
@@ -42,15 +43,16 @@ namespace Jint
         }
 
         /// <summary>
-        /// Allow the <code>debugger</code> statement to be called in a script.
+        /// If enabled, <code>debugger</code> statement breaks into the .Net debugger.
+        /// If disabled, it is forwarded to the Break event of the engine
         /// </summary>
         /// <remarks>
         /// Because the <code>debugger</code> statement can start the 
         /// Visual Studio debugger, is it disabled by default
         /// </remarks>
-        public Options AllowDebuggerStatement(bool allowDebuggerStatement = true)
+        public Options DebuggerStatementBreaksIntoNetDebugger(bool debuggerStatementBreaksIntoNetDebugger = true)
         {
-            _allowDebuggerStatement = allowDebuggerStatement;
+            _debuggerStatementBreaksIntoNetDebugger = debuggerStatementBreaksIntoNetDebugger;
             return this;
         }
 
@@ -126,7 +128,7 @@ namespace Jint
 
         internal bool _IsStrict => _strict;
 
-        internal bool _IsDebuggerStatementAllowed => _allowDebuggerStatement;
+        internal bool _DebuggerStatementBreaksIntoNetDebugger => _debuggerStatementBreaksIntoNetDebugger;
 
         internal bool _IsDebugMode => _debugMode;
 

--- a/Jint/Parser/JavascriptParser.cs
+++ b/Jint/Parser/JavascriptParser.cs
@@ -217,8 +217,9 @@ namespace Jint.Parser
                         {
                             Line = _lineNumber,
                             Column = _index - _lineStart - offset
-                    }
-                };
+                    },
+                Source = _source
+            };
 
             while (_index < _length)
             {
@@ -272,8 +273,9 @@ namespace Jint.Parser
                             {
                                 Line = _lineNumber,
                                 Column = _index - _lineStart - 2
-                            }
-                    };
+                            },
+                    Source = _source
+                };
             }
 
             while (_index < _length)
@@ -1167,8 +1169,9 @@ namespace Jint.Parser
                         {
                             Line = _lineNumber,
                             Column = _index - _lineStart
-                        }
-                };
+                        },
+                Source = _source
+            };
 
             Token regex = ScanRegExp();
             loc.End = new Position
@@ -1271,8 +1274,9 @@ namespace Jint.Parser
                         {
                             Line = _lineNumber,
                             Column = _index - _lineStart
-                        }
-                };
+                        },
+                Source = _source
+            };
 
             Token token = Advance();
             _location.End = new Position
@@ -1357,8 +1361,9 @@ namespace Jint.Parser
                             {
                                 Line = _lineNumber,
                                 Column = _index - _lineStart
-                            }
-                    };
+                            },
+                    Source = _source
+                };
                 PostProcess(node);
             }
             return node;
@@ -3891,7 +3896,7 @@ namespace Jint.Parser
 
             SkipComment();
 
-            return new LocationMarker(_index, _lineNumber, _lineStart);
+            return new LocationMarker(_index, _lineNumber, _lineStart,_source);
         }
 
         public Program Parse(string code)
@@ -4022,10 +4027,12 @@ namespace Jint.Parser
         private class LocationMarker
         {
             private readonly int[] _marker;
+            private string _source;
 
-            public LocationMarker(int index, int lineNumber, int lineStart)
+            public LocationMarker(int index, int lineNumber, int lineStart, string source)
             {
                 _marker = new[] {index, lineNumber, index - lineStart, 0, 0, 0};
+                _source = source;
             }
 
             public void End(int index, int lineNumber, int lineStart)
@@ -4054,8 +4061,9 @@ namespace Jint.Parser
                                 {
                                     Line = _marker[4],
                                     Column = _marker[5]
-                                }
-                        };
+                                },
+                        Source = _source
+                    };
                 }
 
                 node = postProcess(node);

--- a/Jint/Parser/ParserException.cs
+++ b/Jint/Parser/ParserException.cs
@@ -8,10 +8,7 @@ namespace Jint.Parser
         public string Description;
         public int Index;
         public int LineNumber;
-
-#if PORTABLE
         public string Source;
-#endif
 
         public ParserException(string message) : base(message)
         {

--- a/Jint/Runtime/Debugger/BreakPoint.cs
+++ b/Jint/Runtime/Debugger/BreakPoint.cs
@@ -1,21 +1,27 @@
-﻿namespace Jint.Runtime.Debugger
+﻿using Jint.Parser.Ast;
+
+namespace Jint.Runtime.Debugger
 {
     public class BreakPoint
     {
-        public int Line { get; set; }
-        public int Char { get; set; }
-        public string Condition { get; set; }
+        public int Line { get; }
+        public int Char { get; }
+        public string Condition { get; }
+        public Statement Statement { get; }
 
-        public BreakPoint(int line, int character)
+        public BreakPoint(int line, int character, string condition=null)
         {
             Line = line;
             Char = character;
+            Condition = condition;
         }
 
-        public BreakPoint(int line, int character, string condition)
-            : this(line, character)
+        public BreakPoint(Statement statement, string condition = null)
         {
-            Condition = condition;
+            this.Statement = statement;
+            this.Line = statement.Location.Start.Line;
+            this.Char = statement.Location.Start.Column;
+            this.Condition = condition;
         }
     }
 }

--- a/Jint/Runtime/Debugger/DebugInformation.cs
+++ b/Jint/Runtime/Debugger/DebugInformation.cs
@@ -8,9 +8,29 @@ namespace Jint.Runtime.Debugger
 {
     public class DebugInformation : EventArgs
     {
-        public Stack<String> CallStack { get; set; }
-        public Statement CurrentStatement { get; set; }
-        public Dictionary<string, JsValue> Locals { get; set; }
-        public Dictionary<string, JsValue> Globals { get; set; }
+        public DebugInformation(StackFrame[] callStack, Statement currentStatement, Dictionary<string, JsValue> locals, Dictionary<string, JsValue> globals, BreakPoint breakPoint, Engine engine, Program program, JavaScriptException exception, bool uncaughtException, StepMode stepMode)
+        {
+            CallStack = callStack;
+            CurrentStatement = currentStatement;
+            Locals = locals;
+            Globals = globals;
+            BreakPoint = breakPoint;
+            Engine = engine;
+            Program = program;
+            Exception = exception;
+            UncaughtException = uncaughtException;
+            StepMode = stepMode;
+        }
+
+        public StackFrame[] CallStack { get; }
+        public Statement CurrentStatement { get; }
+        public Dictionary<string, JsValue> Locals { get; }
+        public Dictionary<string, JsValue> Globals { get; }
+        public BreakPoint BreakPoint { get; }
+        public Engine Engine { get; }
+        public Program Program { get; }
+        public JavaScriptException Exception { get; }
+        public bool UncaughtException { get; }
+        public StepMode StepMode { get; }
     }
 }

--- a/Jint/Runtime/Debugger/ExecutionContextInformation.cs
+++ b/Jint/Runtime/Debugger/ExecutionContextInformation.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Jint.Runtime.Environments;
+
+namespace Jint.Runtime.Debugger
+{
+    public class ExecutionContextInformation : EventArgs
+    {
+        public ExecutionContext ExecutionContext { get; }
+
+        public ExecutionContextInformation(ExecutionContext executionContext)
+        {
+            ExecutionContext = executionContext;
+        }
+    }
+}

--- a/Jint/Runtime/Debugger/SourceInformation.cs
+++ b/Jint/Runtime/Debugger/SourceInformation.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Jint.Parser.Ast;
+
+namespace Jint.Runtime.Debugger
+{
+    public class SourceInformation : EventArgs
+    {
+        public string Name { get; }
+        public string Source { get; }
+        public Statement[] Statements { get; }
+
+        public SourceInformation(string name, string source, Statement[] statements)
+        {
+            Name = name?? $"<Unnamed> ({source.GetHashCode():X8})";
+            Source = source;
+            Statements = statements;
+        }
+    }
+}

--- a/Jint/Runtime/Debugger/StackFrame.cs
+++ b/Jint/Runtime/Debugger/StackFrame.cs
@@ -1,0 +1,31 @@
+using Jint.Parser.Ast;
+using Jint.Runtime.Environments;
+
+namespace Jint.Runtime.Debugger
+{
+    public class StackFrame
+    {
+        private readonly string value;
+        public Statement CallStatement { get; }
+        public CallExpression CallExpression { get; }
+        public ExecutionContext ExecutionContext { get; }
+
+        public StackFrame(string value, Statement callStatement, CallExpression callExpression, ExecutionContext executionContext)
+        {
+            this.value = value;
+            CallStatement = callStatement;
+            CallExpression = callExpression;
+            ExecutionContext = executionContext;
+        }
+
+        public override string ToString()
+        {
+            return this.value;
+        }
+
+        public static implicit operator string(StackFrame frame)
+        {
+            return frame.ToString();
+        }
+    }
+}

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -797,13 +797,13 @@ namespace Jint.Runtime
             return closure;
         }
 
-        public JsValue EvaluateCallExpression(CallExpression callExpression)
+        public JsValue EvaluateCallExpression(CallExpression callExpression, Statement statement)
         {
             var callee = EvaluateExpression(callExpression.Callee);
 
             if (_engine.Options._IsDebugMode)
             {
-                _engine.DebugHandler.AddToDebugCallStack(callExpression);
+                _engine.DebugHandler.AddToDebugCallStack(callExpression,statement);
             }
 
             JsValue thisObject;

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -29,13 +29,13 @@ namespace Jint.Runtime
 
         public Completion ExecuteExpressionStatement(ExpressionStatement expressionStatement)
         {
-            var exprRef = _engine.EvaluateExpression(expressionStatement.Expression);
+            var exprRef = _engine.EvaluateExpression(expressionStatement.Expression, expressionStatement);
             return new Completion(Completion.Normal, _engine.GetValue(exprRef), null);
         }
 
         public Completion ExecuteIfStatement(IfStatement ifStatement)
         {
-            var exprRef = _engine.EvaluateExpression(ifStatement.Test);
+            var exprRef = _engine.EvaluateExpression(ifStatement.Test, ifStatement);
             Completion result;
 
             if (TypeConverter.ToBoolean(_engine.GetValue(exprRef)))
@@ -95,7 +95,7 @@ namespace Jint.Runtime
                         return stmt;
                     }
                 }
-                var exprRef = _engine.EvaluateExpression(doWhileStatement.Test);
+                var exprRef = _engine.EvaluateExpression(doWhileStatement.Test, doWhileStatement);
                 iterating = TypeConverter.ToBoolean(_engine.GetValue(exprRef));
 
             } while (iterating);
@@ -113,7 +113,7 @@ namespace Jint.Runtime
             JsValue v = Undefined.Instance;
             while (true)
             {
-                var exprRef = _engine.EvaluateExpression(whileStatement.Test);
+                var exprRef = _engine.EvaluateExpression(whileStatement.Test, whileStatement);
 
                 if (!TypeConverter.ToBoolean(_engine.GetValue(exprRef)))
                 {
@@ -158,7 +158,7 @@ namespace Jint.Runtime
                 }
                 else
                 {
-                    _engine.GetValue(_engine.EvaluateExpression(forStatement.Init.As<Expression>()));
+                    _engine.GetValue(_engine.EvaluateExpression(forStatement.Init.As<Expression>(), forStatement));
                 }
             }
 
@@ -167,7 +167,7 @@ namespace Jint.Runtime
             {
                 if (forStatement.Test != null)
                 {
-                    var testExprRef = _engine.EvaluateExpression(forStatement.Test);
+                    var testExprRef = _engine.EvaluateExpression(forStatement.Test, forStatement);
                     if (!TypeConverter.ToBoolean(_engine.GetValue(testExprRef)))
                     {
                         return new Completion(Completion.Normal, v, null);
@@ -192,7 +192,7 @@ namespace Jint.Runtime
                 }
                 if (forStatement.Update != null)
                 {
-                    var incExprRef = _engine.EvaluateExpression(forStatement.Update);
+                    var incExprRef = _engine.EvaluateExpression(forStatement.Update, forStatement);
                     _engine.GetValue(incExprRef);
                 }
             }
@@ -209,8 +209,8 @@ namespace Jint.Runtime
                                         ? forInStatement.Left.As<VariableDeclaration>().Declarations.First().Id
                                         : forInStatement.Left.As<Identifier>();
 
-            var varRef = _engine.EvaluateExpression(identifier) as Reference;
-            var exprRef = _engine.EvaluateExpression(forInStatement.Right);
+            var varRef = _engine.EvaluateExpression(identifier, forInStatement) as Reference;
+            var exprRef = _engine.EvaluateExpression(forInStatement.Right, forInStatement);
             var experValue = _engine.GetValue(exprRef);
             if (experValue == Undefined.Instance || experValue == Null.Instance)
             {
@@ -307,7 +307,7 @@ namespace Jint.Runtime
                 return new Completion(Completion.Return, Undefined.Instance, null);
             }
 
-            var exprRef = _engine.EvaluateExpression(statement.Argument);
+            var exprRef = _engine.EvaluateExpression(statement.Argument, statement);
             return new Completion(Completion.Return, _engine.GetValue(exprRef), null);
         }
 
@@ -318,7 +318,7 @@ namespace Jint.Runtime
         /// <returns></returns>
         public Completion ExecuteWithStatement(WithStatement withStatement)
         {
-            var val = _engine.EvaluateExpression(withStatement.Object);
+            var val = _engine.EvaluateExpression(withStatement.Object, withStatement);
             var obj = TypeConverter.ToObject(_engine, _engine.GetValue(val));
             var oldEnv = _engine.ExecutionContext.LexicalEnvironment;
             var newEnv = LexicalEnvironment.NewObjectEnvironment(_engine, obj, oldEnv, true);
@@ -333,6 +333,7 @@ namespace Jint.Runtime
             {
                 c = new Completion(Completion.Throw, e.Error, null);
                 c.Location = withStatement.Location;
+                _engine.DebugHandler.OnExceptionThrown(withStatement.Body, new JavaScriptException(c.GetValueOrDefault()));
             }
             finally
             {
@@ -349,7 +350,7 @@ namespace Jint.Runtime
         /// <returns></returns>
         public Completion ExecuteSwitchStatement(SwitchStatement switchStatement)
         {
-            var exprRef = _engine.EvaluateExpression(switchStatement.Discriminant);
+            var exprRef = _engine.EvaluateExpression(switchStatement.Discriminant, switchStatement);
             var r = ExecuteSwitchBlock(switchStatement.Cases, _engine.GetValue(exprRef));
             if (r.Type == Completion.Break && r.Identifier == switchStatement.LabelSet)
             {
@@ -417,7 +418,15 @@ namespace Jint.Runtime
                 foreach (var statement in statementList)
                 {
                     s = statement;
-                    c = ExecuteStatement(statement);
+                    try
+                    {
+                        c = ExecuteStatement(statement);
+                    }
+                    catch (JavaScriptException exception)
+                    {
+                        _engine.DebugHandler.OnExceptionThrown(statement, new JavaScriptException(exception.Error));
+                        throw exception;
+                    }
                     if (c.Type != Completion.Normal)
                     {
                         return new Completion(c.Type, c.Value != null ? c.Value : sl.Value, c.Identifier)
@@ -446,7 +455,7 @@ namespace Jint.Runtime
         /// <returns></returns>
         public Completion ExecuteThrowStatement(ThrowStatement throwStatement)
         {
-            var exprRef = _engine.EvaluateExpression(throwStatement.Argument);
+            var exprRef = _engine.EvaluateExpression(throwStatement.Argument, throwStatement);
             Completion c = new Completion(Completion.Throw, _engine.GetValue(exprRef), null);
             c.Location = throwStatement.Location;
             return c;
@@ -459,7 +468,15 @@ namespace Jint.Runtime
         /// <returns></returns>
         public Completion ExecuteTryStatement(TryStatement tryStatement)
         {
+            if( tryStatement.Handlers.Any())
+            {
+                _engine.DebugHandler.OnCatchableTryBlockEntered();
+            }
             var b = ExecuteStatement(tryStatement.Block);
+            if (tryStatement.Handlers.Any())
+            {
+                _engine.DebugHandler.OnCatchableTryBlockLeft();
+            }
             if (b.Type == Completion.Throw)
             {
                 // execute catch
@@ -504,7 +521,7 @@ namespace Jint.Runtime
             {
                 if (declaration.Init != null)
                 {
-                    var lhs = _engine.EvaluateExpression(declaration.Id) as Reference;
+                    var lhs = _engine.EvaluateExpression(declaration.Id, statement) as Reference;
 
                     if (lhs == null)
                     {
@@ -518,7 +535,7 @@ namespace Jint.Runtime
                     }
 
                     lhs.GetReferencedName();
-                    var value = _engine.GetValue(_engine.EvaluateExpression(declaration.Init));
+                    var value = _engine.GetValue(_engine.EvaluateExpression(declaration.Init, statement));
                     _engine.PutValue(lhs, value);
                 }
             }
@@ -533,7 +550,7 @@ namespace Jint.Runtime
 
         public Completion ExecuteDebuggerStatement(DebuggerStatement debuggerStatement)
         {
-            if (_engine.Options._IsDebuggerStatementAllowed)
+            if (_engine.Options._DebuggerStatementBreaksIntoNetDebugger)
             {
                 if (!System.Diagnostics.Debugger.IsAttached)
                 {
@@ -541,6 +558,10 @@ namespace Jint.Runtime
                 }
 
                 System.Diagnostics.Debugger.Break();
+            }
+            else
+            {
+                _engine.DebugHandler.BreakOnDebugStatement(debuggerStatement);
             }
 
             return new Completion(Completion.Normal, null, null);

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Jint is a __Javascript interpreter__ for .NET which provides full __ECMA 5.1__ c
 - Full support for ECMAScript 5.1 - http://www.ecma-international.org/ecma-262/5.1/
 - .NET Portable Class Library - http://msdn.microsoft.com/en-us/library/gg597391(v=vs.110).aspx
 - .NET Interoperability 
+- Debugging using Chrome Debugging Protocol
 
 > ECMAScript 6.0 currently being implemeted, see https://github.com/sebastienros/jint/issues/343
 
@@ -153,5 +154,41 @@ This example is using French as the default culture.
   - Regex -> RegExp
   - Function -> Delegate
 
+## Debugging JavaScript code running in Jint
+
+Visual debugging is implemented on top of the engines built-in debug callbacks.
+You can enable it by instanciating the DebugAgentServer and attaching one or more engines to it.
+All engines attached can run scripts under debug mode using an external debugger.
+
+The DebugAgent is implemented in the assembly 'Jint.DebugAgent' which is currently only available on Windows.
+
+As the DebugAgentServer implements the Chrome debugging protocol, you can use a compatible application to debug your
+javascript code, e.g. the Chrome built in dev tools.
+
+Example:
+```c#
+	var Engine = new Jint.Engine(_=>_.DebugMode());
+	DebugAgentServer Server = new DebugAgentServer(DebugAgentServer.Options.WaitForDebuggerOnFirstStatement, Engine);
+	Engine.Execute(@"<your javascript code here>", "<name of your script for display in the debugger>");
+	Server.Dispose();
+```
+
+This code will instanciate an engine in debug mode. The it creates a debug server and attaches the engine to it. 
+Because of the debug agent options, the agent will wait on the first statement for the debugger to connect.
+If you like to use Chrome as debugger, open chrome an connect to the server: 
+```
+	chrome-devtools://devtools/bundled/inspector.html?ws=localhost:9222
+```
+
+Features supported:
+- Breakpoints
+- Step in/out/over
+- Break on exceptions (handled/unhandled)
+- Callstack with local/global scope
+- Watches (only on top stack frame)
+  
+  
+  
+  
 Continuous Integration kindly provided by  [AppVeyor](https://www.appveyor.com)
 


### PR DESCRIPTION
Hello,
I really like the Jint project because it enables me to include a javascript engine into my own projects.
What I wanted to achieve is, that I wanted to debug the code in an easy way.
Because of that, I implemented a chrome debugging protocol compliant debug websocket server, that allows to use the chrome dev tools on Jint engines.
To enable that, I had to slightly change the debugger implementation, mostly to get more information, hook into additional events (parsing scripts, exceptions) and enable expression execution without debugging (to allow watches while breaking in an breakpoint).
For details please see the modified readme.md (on the bottom)
What is not done so far are unit tests. I want to do them as well, but wanted to give you the option to give your comments to this addition.
It would really be great if you would like to add this implementation to the 'official' Jint package.
best regards and keen about responses or questions
Michael
PS: one unit test fails on my PC, with the original master code as well as with my changes (3D raytrace test)