### PR TITLE
Using StringBuilder to improve perf when handling long strings

### DIFF
--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -290,7 +290,7 @@ namespace Jint.Native.Json
 
         private Token ScanStringLiteral()
         {
-            string str = "";
+            var sb = new System.Text.StringBuilder();
 
             char quote = _source.CharCodeAt(_index);
 
@@ -321,13 +321,13 @@ namespace Jint.Native.Json
                         switch (ch)
                         {
                             case 'n':
-                                str += '\n';
+                                sb.Append('\n');
                                 break;
                             case 'r':
-                                str += '\r';
+                                sb.Append('\r');
                                 break;
                             case 't':
-                                str += '\t';
+                                sb.Append('\t');
                                 break;
                             case 'u':
                             case 'x':
@@ -335,22 +335,22 @@ namespace Jint.Native.Json
                                 char unescaped = ScanHexEscape(ch);
                                 if (unescaped > 0)
                                 {
-                                    str += unescaped.ToString();
+                                    sb.Append(unescaped.ToString());
                                 }
                                 else
                                 {
                                     _index = restore;
-                                    str += ch.ToString();
+                                    sb.Append(ch.ToString());
                                 }
                                 break;
                             case 'b':
-                                str += "\b";
+                                sb.Append("\b");
                                 break;
                             case 'f':
-                                str += "\f";
+                                sb.Append("\f");
                                 break;
                             case 'v':
-                                str += "\x0B";
+                                sb.Append("\x0B");
                                 break;
 
                             default:
@@ -371,11 +371,11 @@ namespace Jint.Native.Json
                                             code = code * 8 + "01234567".IndexOf(_source.CharCodeAt(_index++));
                                         }
                                     }
-                                    str += ((char)code).ToString();
+                                    sb.Append(((char)code).ToString());
                                 }
                                 else
                                 {
-                                    str += ch.ToString();
+                                    sb.Append(ch.ToString());
                                 }
                                 break;
                         }
@@ -395,7 +395,7 @@ namespace Jint.Native.Json
                 }
                 else
                 {
-                    str += ch.ToString();
+                    sb.Append(ch.ToString());
                 }
             }
 
@@ -407,7 +407,7 @@ namespace Jint.Native.Json
             return new Token
                 {
                     Type = Tokens.String,
-                    Value = str,
+                    Value = sb.ToString(),
                     LineNumber = _lineNumber,
                     LineStart = _lineStart,
                     Range = new[] {start, _index}

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -212,47 +212,47 @@ namespace Jint.Native.Json
 
         private string Quote(string value)
         {
-            var product = "\"";
+            var sb = new System.Text.StringBuilder("\"");
 
             foreach (char c in value)
             {
                 switch (c)
                 {
                     case '\"':
-                        product += "\\\"";
+                        sb.Append("\\\"");
                         break;
                     case '\\':
-                        product += "\\\\";
+                        sb.Append("\\\\");
                         break;
                     case '\b':
-                        product += "\\b";
+                        sb.Append("\\b");
                         break;
                     case '\f':
-                        product += "\\f";
+                        sb.Append("\\f");
                         break;
                     case '\n':
-                        product += "\\n";
+                        sb.Append("\\n");
                         break;
                     case '\r':
-                        product += "\\r";
+                        sb.Append("\\r");
                         break;
                     case '\t':
-                        product += "\\t";
+                        sb.Append("\\t");
                         break;
                     default:
                         if (c < 0x20)
                         {
-                            product += "\\u";
-                            product += ((int) c).ToString("x4");
+                            sb.Append("\\u");
+                            sb.Append(((int) c).ToString("x4"));
                         }
                         else
-                            product += c;
+                            sb.Append(c);
                         break;
                 }
             }
 
-            product += "\"";
-            return product;
+            sb.Append("\"");
+            return sb.ToString();
         }
 
         private string SerializeArray(ArrayInstance value)


### PR DESCRIPTION
@sebastienros Please take a look.

## Goal
JSON.parse and JSON.stringify slow down a lot when handling long strings, #357 
Using StringBuilder.Append improves the performance a lot.

## Benchmark
|String.Length|Before(ms) |  After(ms) |
|---|---|---|
|10|0 |0 |
|100|0 |0 |
|1,000|1 |0 |
|10,000|22 |1 |
|100,000|2166 |7 |
|1,000,000|(too long) |74 |
### Test Code
```

namespace ConsoleApp1
{
    using Jint;
    using System;
    using System.Diagnostics;
    using System.Linq;

    public class Program
    {
        static void Main(string[] args)
        {
            var repeatCount = 1;
            Parse(repeatCount);
            if (args.Length > 0)
            {
                repeatCount = int.Parse(args[0]);
            }
            Stopwatch sw = new Stopwatch();
            sw.Start();
            Parse(repeatCount);
            sw.Stop();
            Console.WriteLine(repeatCount + " times stringify takes: " + sw.ElapsedMilliseconds + " milliseconds.");
        }

        private static void Stringify(int repeatCount)
        {
            Engine engine = new Engine();
            var data = GetTestData(repeatCount);
            engine.SetValue("a", data);
            engine.Execute("JSON.stringify(a)");
            var k = engine.GetCompletionValue();
        }

        private static void Parse(int repeatCount)
        {
            Engine engine = new Engine();
            var data = GetTestData(repeatCount);
            var stringified = "{ \"s\": \"" + data + "\"}";
            engine.SetValue("a", stringified);
            engine.Execute("JSON.parse(a)");
            var k = engine.GetCompletionValue();
        }

        private static string GetTestData(int repeatCount)
        {
            const string data = @"0123456789";
            return string.Concat(Enumerable.Repeat(data, repeatCount));
        }
    }
}

```