### PR TITLE
CLR instances should compare on their inner value

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1863,5 +1863,22 @@ namespace Jint.Tests.Runtime
 				}
             ");
 		}
+
+        [Fact]
+        public void ShouldCompareInnerValueOfClrInstances()
+        {
+            var engine = new Engine();
+
+            // Create two separate Guid with identical inner values.
+            var guid1 = new Guid("f541f5bf-0fad-44fa-952d-a35c3282f9ef");
+            var guid2 = new Guid("f541f5bf-0fad-44fa-952d-a35c3282f9ef");
+
+            engine.SetValue("guid1", guid1);
+            engine.SetValue("guid2", guid1);
+
+            var result = engine.Execute("guid1 == guid2").GetCompletionValue();
+
+            Assert.True(result.AsBoolean());
+        }
     }
 }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -414,6 +414,15 @@ namespace Jint.Runtime
                     return x.AsBoolean() == y.AsBoolean();
                 }
 
+                if (typex == Types.Object)
+                {
+                    var xObject = x.AsObject();
+                    var yObject = x.AsObject();
+
+                    // How do I check if these are CLR instances? And if so, how do I consistently get the "inner value"?
+                    return xObject == yObject;
+                }
+
                 return x == y;
             }
 


### PR DESCRIPTION
Case: When comparing two Guids, they should be considered equal if there are indeed equal. However, they are being treated as two separate objects (which they are) and so they are not considered equal.

The issue with this is the developer would expect them to be equal. The solution proposed is to check if they are CLR instances and then check on their inner value.

This commit includes a unit test that covers the test scenario. The changes in ExpressionInterpreter.Equal do not solve this problem.

Attempts at solving the problem (such as calling ToString) has resulted in multiple EcmaTests to fail. I need help.