### PR TITLE
Fix bug in number to string conversion.

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1880,5 +1880,16 @@ namespace Jint.Tests.Runtime
 
 			Assert.True(result);
         }
+	
+        [Fact]
+        public void ShouldStringifyNumWithoutV8DToA()
+        {
+	    // 53.6841659 cannot be converted by V8's DToA => "old" DToA code will be used.
+	
+            var engine = new Engine();
+            Native.JsValue val = engine.Execute("JSON.stringify(53.6841659)").GetCompletionValue();
+
+            Assert.True(val.AsString() == "53.6841659");
+        }
 	}
 }

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -295,7 +295,7 @@ namespace Jint.Native.Number
             // 123.4 s=1234, k=4, n=3
             // 1234000 s = 1234, k=4, n=7
             string s = null;
-            var rFormat = m.ToString("r");
+            var rFormat = m.ToString("r", CultureInfo.InvariantCulture);
             if (rFormat.IndexOf("e", StringComparison.OrdinalIgnoreCase) == -1)
             {
                 s = rFormat.Replace(".", "").TrimStart('0').TrimEnd('0');


### PR DESCRIPTION
If V8 FastDtoa cannot convert a number, the "old" DToA implementation can fail, if the system Jint is running on does not use "." (dot) as separator between integer and fractional part of the number.