### PR TITLE
Implementing StringInstance.GetOwnProperties()

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -464,6 +464,16 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
+        public void ForInStatementEnumeratesKeys()
+        {
+            RunTest(@"
+                for(var i in 'abc');
+				log(i);
+                assert(i === '2');
+            ");
+        }
+
+        [Fact]
         public void WithStatement()
         {
             RunTest(@"
@@ -1013,7 +1023,7 @@ namespace Jint.Tests.Runtime
                 Assert.Equal("jQuery.js", e.Source);
             }
         }
-#region DateParsingAndStrings
+        #region DateParsingAndStrings
         [Fact]
         public void ParseShouldReturnNumber()
         {
@@ -1056,7 +1066,7 @@ namespace Jint.Tests.Runtime
             const string customName = "Custom Time";
             var customTimeZone = TimeZoneInfo.CreateCustomTimeZone(customName, new TimeSpan(0, 11, 0), customName, customName, customName, null, false);
 #else
-        var customTimeZone = TimeZoneInfo.Utc;
+            var customTimeZone = TimeZoneInfo.Utc;
 #endif
 
             var engine = new Engine(cfg => cfg.LocalTimeZone(customTimeZone));
@@ -1142,7 +1152,7 @@ namespace Jint.Tests.Runtime
             const string customName = "Custom Time";
             var customTimeZone = TimeZoneInfo.CreateCustomTimeZone(customName, new TimeSpan(0, timespanMinutes, 0), customName, customName, customName, null, false);
 #else
-    var customTimeZone = TimeZoneInfo.Utc;
+            var customTimeZone = TimeZoneInfo.Utc;
 #endif
             var engine = new Engine(cfg => cfg.LocalTimeZone(customTimeZone)).SetValue("d", date);
 
@@ -1192,7 +1202,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(expected, actual);
         }
 
-#endregion
+        #endregion
 
         //DateParsingAndStrings
         [Fact]
@@ -1848,10 +1858,10 @@ namespace Jint.Tests.Runtime
             }
         }
 
-		[Fact]
-		public void GlobalRegexLiteralShouldNotKeepState()
-		{
-			RunTest(@"
+        [Fact]
+        public void GlobalRegexLiteralShouldNotKeepState()
+        {
+            RunTest(@"
 				var url = 'https://www.example.com';
 
 				assert(isAbsolutePath(url));
@@ -1862,7 +1872,7 @@ namespace Jint.Tests.Runtime
 					return /\.+/g.test(path);
 				}
             ");
-		}
+        }
 
         [Fact]
         public void ShouldCompareInnerValueOfClrInstances()
@@ -1876,20 +1886,20 @@ namespace Jint.Tests.Runtime
             engine.SetValue("guid1", guid1);
             engine.SetValue("guid2", guid2);
 
-			var result = engine.Execute("guid1 == guid2").GetCompletionValue().AsBoolean();
+            var result = engine.Execute("guid1 == guid2").GetCompletionValue().AsBoolean();
 
-			Assert.True(result);
+            Assert.True(result);
         }
-	
+
         [Fact]
         public void ShouldStringifyNumWithoutV8DToA()
         {
-	    // 53.6841659 cannot be converted by V8's DToA => "old" DToA code will be used.
-	
+            // 53.6841659 cannot be converted by V8's DToA => "old" DToA code will be used.
+
             var engine = new Engine();
             Native.JsValue val = engine.Execute("JSON.stringify(53.6841659)").GetCompletionValue();
 
             Assert.True(val.AsString() == "53.6841659");
         }
-	}
+    }
 }

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -210,7 +210,7 @@ namespace Jint.Native.Array
             return base.DefineOwnProperty(propertyName, desc, throwOnError);
         }
 
-        private uint GetLength()
+        public uint GetLength()
         {
             return TypeConverter.ToUint32(_length.Value);
         }

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Jint.Native.Object;
+﻿using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
@@ -39,39 +38,13 @@ namespace Jint.Native.String
                 var l = (long)d;
                 return l >= int.MinValue && l <= int.MaxValue;
             }
-            else
+            else 
                 return false;
-        }
-
-        public override bool HasOwnProperty(string propertyName)
-        {
-            var desc = this.GetOwnProperty(propertyName);
-            if (desc != PropertyDescriptor.Undefined)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        public override IEnumerable<KeyValuePair<string, PropertyDescriptor>> GetOwnProperties()
-        {
-            var str = PrimitiveValue.AsString();
-
-            for (var i = 0; i < str.Length; i++)
-            {
-                yield return new KeyValuePair<string, PropertyDescriptor>(i.ToString(), new PropertyDescriptor(str[i], true, true, false));
-            }
-
-            foreach (var entry in base.GetOwnProperties())
-            {
-                yield return entry;
-            }
         }
 
         public override PropertyDescriptor GetOwnProperty(string propertyName)
         {
-            if (propertyName == "Infinity")
+            if(propertyName == "Infinity")
                 return PropertyDescriptor.Undefined;
 
             var desc = base.GetOwnProperty(propertyName);
@@ -87,7 +60,7 @@ namespace Jint.Native.String
 
             var str = PrimitiveValue;
             var dIndex = TypeConverter.ToInteger(propertyName);
-            if (!IsInt(dIndex))
+            if(!IsInt(dIndex))
                 return PropertyDescriptor.Undefined;
 
             var index = (int)dIndex;

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -1,4 +1,5 @@
-﻿using Jint.Native.Object;
+﻿using System.Collections.Generic;
+using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
@@ -38,13 +39,39 @@ namespace Jint.Native.String
                 var l = (long)d;
                 return l >= int.MinValue && l <= int.MaxValue;
             }
-            else 
+            else
                 return false;
+        }
+
+        public override bool HasOwnProperty(string propertyName)
+        {
+            var desc = this.GetOwnProperty(propertyName);
+            if (desc != PropertyDescriptor.Undefined)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public override IEnumerable<KeyValuePair<string, PropertyDescriptor>> GetOwnProperties()
+        {
+            var str = PrimitiveValue.AsString();
+
+            for (var i = 0; i < str.Length; i++)
+            {
+                yield return new KeyValuePair<string, PropertyDescriptor>(i.ToString(), new PropertyDescriptor(str[i], true, true, false));
+            }
+
+            foreach (var entry in base.GetOwnProperties())
+            {
+                yield return entry;
+            }
         }
 
         public override PropertyDescriptor GetOwnProperty(string propertyName)
         {
-            if(propertyName == "Infinity")
+            if (propertyName == "Infinity")
                 return PropertyDescriptor.Undefined;
 
             var desc = base.GetOwnProperty(propertyName);
@@ -60,7 +87,7 @@ namespace Jint.Native.String
 
             var str = PrimitiveValue;
             var dIndex = TypeConverter.ToInteger(propertyName);
-            if(!IsInt(dIndex))
+            if (!IsInt(dIndex))
                 return PropertyDescriptor.Undefined;
 
             var index = (int)dIndex;


### PR DESCRIPTION
The for-in statement on strings should return the list of keys of the string.
However the specification doesn't mention this. To be verified.

Fixes #371