### PR TITLE
Fixes Multiple Indexer and DefaultTypeConverter TryConvert

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -279,6 +279,32 @@ namespace Jint.Tests.Runtime
             Assert.Equal("Donald Duck", dictionary[2]);
         }
 
+        private class DoubleIndexedClass
+        {
+            public int this[int index]
+            {
+                get { return index; }
+            }
+
+            public string this[string index]
+            {
+                get { return index; }
+            }
+        }
+
+        [Fact]
+        public void CanGetIndexUsingBothIntAndStringIndex()
+        {
+            var dictionary = new DoubleIndexedClass();
+
+            _engine.SetValue("dictionary", dictionary);
+
+            RunTest(@"
+                assert(dictionary[1] === 1);
+                assert(dictionary['test'] === 'test');
+            ");
+        }
+
         [Fact]
         public void CanUseGenericMethods()
         {

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -222,8 +222,16 @@ namespace Jint.Runtime.Interop
 
             if (canConvert)
             {
-                converted = Convert(value, type, formatProvider);
-                return true;
+                try
+                {
+                    converted = Convert(value, type, formatProvider);
+                    return true;
+                }
+                catch
+                {
+                    converted = null;
+                    return false;
+                }
             }
 
             converted = null;


### PR DESCRIPTION
Hello,

Jint crashes if used in combination with a mixed type indexed class.

The bug is inside DefaultTypeConverter: it should not crash inside the "TryConvert" method.

Thank you