### PR TITLE
Support local date time on native clr

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -1420,6 +1420,47 @@ namespace Jint.Tests.Runtime
             Assert.Equal(Nested.ClassWithStaticFields.Setter, "hello");
         }
 
+        private class DateClass
+        {
+            public DateTime MyDate { get; set; }
+        }
+
+        [Fact]
+        public void ShouldSetLocalDateTime()
+        {
+            var localTimeEngine = new Engine(cfg => cfg
+                    .ClrSetLocalDateTimeKind(true)
+                    .LocalTimeZone(TimeZoneInfo.Local))
+                ;
+            var dt = new DateTime(2017, 1, 1, 0, 0, 0);
+
+            var dc = new DateClass();
+
+            localTimeEngine.SetValue("dc", dc);
+
+            localTimeEngine.Execute(@"dc.MyDate = new Date(2017, 0, 1, 0, 0, 0, 0);");
+
+            Assert.Equal(dt, dc.MyDate);
+        }
+
+        [Fact]
+        public void ShouldSetUtcDateTime()
+        {
+            var localTimeEngine = new Engine(cfg => cfg
+                    .ClrSetLocalDateTimeKind(false)
+                    .LocalTimeZone(TimeZoneInfo.Local))
+                ;
+            var dt = new DateTime(2017, 1, 1, 0, 0, 0);
+
+            var dc = new DateClass();
+
+            localTimeEngine.SetValue("dc", dc);
+
+            localTimeEngine.Execute(@"dc.MyDate = new Date(2017, 0, 1, 0, 0, 0, 0);");
+
+            Assert.Equal(dt.ToUniversalTime(), dc.MyDate);
+        }
+
         [Fact]
         public void CantSetStaticNestedReadonly()
         {

--- a/Jint/Native/Date/DateInstance.cs
+++ b/Jint/Native/Date/DateInstance.cs
@@ -33,7 +33,15 @@ namespace Jint.Native.Date
             }
             else
             {
-                return DateConstructor.Epoch.AddMilliseconds(PrimitiveValue);
+                DateTime dt = DateConstructor.Epoch.AddMilliseconds(PrimitiveValue);
+
+                if (Engine.Options._ClrSetLocalDateTimeKind)
+                {
+                    var dto = new DateTimeOffset(TimeZoneInfo.ConvertTime(dt, Engine.Options._LocalTimeZone), Engine.Options._LocalTimeZone.GetUtcOffset(dt));
+                    dt = dto.DateTime;
+                }
+
+                return dt;
             }
         }
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -14,6 +14,7 @@ namespace Jint
         private bool _allowDebuggerStatement;
         private bool _debugMode;
         private bool _allowClr;
+        private bool _clrSetLocalDateTimeKind;
         private readonly List<IObjectConverter> _objectConverters = new List<IObjectConverter>();
         private int _maxStatements;
         private int _maxRecursionDepth = -1; 
@@ -39,6 +40,17 @@ namespace Jint
         public Options Strict(bool strict = true)
         {
             _strict = strict;
+            return this;
+        }
+
+        /// <summary>
+        /// Uses DateTimeKind.Local when updating native value
+        /// </summary>
+        /// <param name="clrSetLocalDateTimeKind"></param>
+        /// <returns></returns>
+        public Options ClrSetLocalDateTimeKind(bool clrSetLocalDateTimeKind = true)
+        {
+            _clrSetLocalDateTimeKind = clrSetLocalDateTimeKind;
             return this;
         }
 
@@ -154,6 +166,8 @@ namespace Jint
         internal bool _IsDebugMode => _debugMode;
 
         internal bool _IsClrAllowed => _allowClr;
+
+        internal bool _ClrSetLocalDateTimeKind => _clrSetLocalDateTimeKind;
 
         internal Predicate<Exception> _ClrExceptionsHandler => _clrExceptionsHandler;
 


### PR DESCRIPTION
Hi,

when working with DateTime, we may expect in output a DateTime with DateTimeKind.Local.

Actually the Engine always returns a DateTimeKind.Utc.

I added an option to change the behaviour.

Thanks