### PR TITLE
 Implement TypeReference.HasInstance

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -862,6 +862,16 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
+        public void ShouldBeInstanceOfTypeReferenceType()
+        {
+            _engine.SetValue("A", typeof(A));
+            RunTest(@"
+                var a = new A();
+                assert(a instanceof A);
+            ");
+        }
+
+        [Fact]
         public void ShouldImportNamespace()
         {
             RunTest(@"

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -63,7 +63,7 @@ namespace Jint.Runtime.Interop
                 {
                     for (var i = 0; i < arguments.Length; i++)
                     {
-                        var parameterType =  method.GetParameters()[i].ParameterType;
+                        var parameterType = method.GetParameters()[i].ParameterType;
 
                         if (parameterType == typeof(JsValue))
                         {
@@ -94,6 +94,18 @@ namespace Jint.Runtime.Interop
 
             throw new JavaScriptException(Engine.TypeError, "No public methods with the specified arguments were found.");
 
+        }
+
+        public override bool HasInstance(JsValue v)
+        {
+            ObjectWrapper wrapper = v.As<ObjectWrapper>();
+
+            if (wrapper == null)
+            {
+                return base.HasInstance(v);
+            }
+
+            return wrapper.Target.GetType() == this.Type;
         }
 
         public override bool DefineOwnProperty(string propertyName, PropertyDescriptor desc, bool throwOnError)


### PR DESCRIPTION
 This patch introduces support for `instanceof` operator on engine symbols which are created from a `TypeReference`.  Instances constructed from a `TypeReference` should be an instance of that CLR type.

Traditionally, ObjectWrapper instances have no prototype, so FunctionInstance.HasInstance will always throw an error.

 Tests included in InteropTests assembly. Fixes #421.