### PR TITLE
Fix build on clean environment

### DIFF
--- a/Jint/Directory.Build.props
+++ b/Jint/Directory.Build.props
@@ -4,6 +4,7 @@
     <PackageId>Jint</PackageId>
     <AssemblyTitle>Jint</AssemblyTitle>
     <Description>Javascript interpreter for .NET which provides full ECMA 5.1 compliance.</Description>
+    <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>
     <VersionPrefix>2.11.$(BuildNumber)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageId>Jint</PackageId>


### PR DESCRIPTION
Dependency on BuildNumber is not documented so we should set up some working defaults. Build on environment where BuildNumber variable is defined should work as before.