### PR TITLE
Convert Jint.Benchmark to use BenchmarkDotNet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ Jint.sln.ide/*
 .vs
 project.lock.json
 .build
+
+.idea
+BenchmarkDotNet.Artifacts

--- a/Jint.Benchmark/EvaluationBenchmark.cs
+++ b/Jint.Benchmark/EvaluationBenchmark.cs
@@ -1,0 +1,64 @@
+﻿using BenchmarkDotNet.Attributes;
+using Jurassic;
+
+namespace Jint.Benchmark
+{
+    [MemoryDiagnoser]
+    public class EvaluationBenchmark
+    {
+        private Engine sharedJint;
+        private ScriptEngine sharedJurassic;
+
+        private const string Script = @"
+            var o = {};
+            o.Foo = 'bar';
+            o.Baz = 42.0001;
+            o.Blah = o.Foo + o.Baz;
+
+            if(o.Blah != 'bar42.0001') throw TypeError;
+
+            function fib(n){
+                if(n<2) {
+                    return n;
+                }
+
+                return fib(n-1) + fib(n-2);
+            }
+
+            if(fib(3) != 2) throw TypeError;
+        ";
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            sharedJint = new Engine();
+            sharedJurassic = new ScriptEngine();
+        }
+
+        [Params(10, 20)]
+        public int Iterations { get; set; }
+
+        [Params(true, false)]
+        public bool ReuseEngine { get; set; }
+
+        [Benchmark]
+        public void Jint()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                var jint = ReuseEngine ? sharedJint : new Engine();
+                jint.Execute(Script);
+            }
+        }
+
+        [Benchmark]
+        public void Jurassic()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                var jurassic = ReuseEngine ? sharedJurassic : new ScriptEngine();
+                jurassic.Execute(Script);
+            }
+        }
+    }
+}

--- a/Jint.Benchmark/Jint.Benchmark.csproj
+++ b/Jint.Benchmark/Jint.Benchmark.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>Jint.Benchmark</AssemblyName>
@@ -14,10 +13,9 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.11" />
     <PackageReference Include="Jurassic" Version="3.0.0-alpha2" />
   </ItemGroup>
-
 </Project>

--- a/Jint.Benchmark/Program.cs
+++ b/Jint.Benchmark/Program.cs
@@ -1,99 +1,13 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Reflection;
+using BenchmarkDotNet.Running;
 
 namespace Jint.Benchmark
 {
-    class Program
+    public static class Program
     {
-        private const string Script = @"
-            var o = {};
-            o.Foo = 'bar';
-            o.Baz = 42.0001;
-            o.Blah = o.Foo + o.Baz;
-
-            if(o.Blah != 'bar42.0001') throw TypeError;
-
-            function fib(n){
-                if(n<2) {
-                    return n;
-                }
-
-                return fib(n-1) + fib(n-2);
-            }
-
-            if(fib(3) != 2) throw TypeError;
-        ";
-
-        static void Main()
+        public static void Main(string[] args)
         {
-            //const bool runIronJs = true;
-            const bool runJint = true;
-            const bool runJurassic = true;
-
-            const int iterations = 1000;
-            const bool reuseEngine = false;
-
-            var watch = new Stopwatch();
-
-
-            //if (runIronJs)
-            //{
-            //    IronJS.Hosting.CSharp.Context ironjs;
-            //    ironjs = new IronJS.Hosting.CSharp.Context();
-            //    ironjs.Execute(Script);
-            //    watch.Restart();
-            //    for (var i = 0; i < iterations; i++)
-            //    {
-            //        if (!reuseEngine)
-            //        {
-            //            ironjs = new IronJS.Hosting.CSharp.Context();
-            //        }
-
-            //        ironjs.Execute(Script);
-            //    }
-
-            //    Console.WriteLine("IronJs: {0} iterations in {1} ms", iterations, watch.ElapsedMilliseconds);
-            //}
-
-            if (runJint)
-            {
-                Engine jint;
-                jint = new Engine();
-                jint.Execute(Script);
-
-                watch.Restart();
-                for (var i = 0; i < iterations; i++)
-                {
-                    if (!reuseEngine)
-                    {
-                        jint = new Jint.Engine();
-                    }
-
-                    jint.Execute(Script);
-                }
-
-                Console.WriteLine("Jint: {0} iterations in {1} ms", iterations, watch.ElapsedMilliseconds);
-            }
-
-            if (runJurassic)
-            {
-                Jurassic.ScriptEngine jurassic;
-                jurassic = new Jurassic.ScriptEngine();
-                jurassic.Execute(Script);
-
-                watch.Restart();
-                for (var i = 0; i < iterations; i++)
-                {
-                    if (!reuseEngine)
-                    {
-                        jurassic = new Jurassic.ScriptEngine();
-                    }
-
-                    jurassic.Execute(Script);
-                }
-
-                Console.WriteLine("Jurassic: {0} iterations in {1} ms", iterations, watch.ElapsedMilliseconds);
-            }
+            BenchmarkSwitcher.FromAssembly(typeof(Program).GetTypeInfo().Assembly).Run(args);
         }
     }
 }


### PR DESCRIPTION
While discussing a [performance problem](http://issues.hibernatingrhinos.com/issue/RavenDB-9718) when using RavenDB I also checked some Jint code. There might be possibilities for performance optimizations but there should be solid numbers if changes are made. So I converted the current benchmark project to use [BenchmarkDotNet](http://benchmarkdotnet.org/).

Now we can get better numbers and memory allocations from running the Jurassic vs Jint performance test in GitHub pasteable format by running `dotnet run -c Release` in benchmark project directory: 

``` ini

BenchmarkDotNet=v0.10.11, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.98)
Processor=Intel Core i7-6820HQ CPU 2.70GHz (Skylake), ProcessorCount=8
Frequency=2648437 Hz, Resolution=377.5812 ns, Timer=TSC
.NET Core SDK=2.1.2
  [Host]     : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT


```
|   Method | Iterations | ReuseEngine |         Mean |        Error |       StdDev |     Gen 0 |    Gen 1 |   Allocated |
|--------- |----------- |------------ |-------------:|-------------:|-------------:|----------:|---------:|------------:|
|     **Jint** |         **10** |       **False** |   **1,766.2 us** |     **8.986 us** |     **7.504 us** |  **453.1250** |   **5.8594** |  **1858.52 KB** |
| Jurassic |         10 |       False |  51,225.1 us |   647.867 us |   574.317 us | 1062.5000 | 375.0000 |     6057 KB |
|     **Jint** |         **10** |        **True** |     **960.7 us** |    **14.484 us** |    **13.548 us** |  **125.9766** |        **-** |   **519.06 KB** |
| Jurassic |         10 |        True |  49,007.5 us | 1,217.638 us | 2,132.596 us |   62.5000 |        - |   450.25 KB |
|     **Jint** |         **20** |       **False** |   **3,647.4 us** |    **43.487 us** |    **38.550 us** |  **906.2500** |  **11.7188** |  **3717.03 KB** |
| Jurassic |         20 |       False | 103,830.2 us | 1,997.076 us | 2,927.289 us | 2187.5000 | 750.0000 | 12113.99 KB |
|     **Jint** |         **20** |        **True** |   **1,920.6 us** |    **37.992 us** |    **58.017 us** |  **251.9531** |        **-** |  **1038.13 KB** |
| Jurassic |         20 |        True | 109,151.1 us | 2,157.805 us | 5,043.800 us |  187.5000 |  62.5000 |   900.53 KB |
