### PR TITLE
Use struct for DiyFp

### DIFF
--- a/Jint/Native/Number/Dtoa/CachePowers.cs
+++ b/Jint/Native/Number/Dtoa/CachePowers.cs
@@ -32,8 +32,7 @@ using System.Diagnostics;
 
 namespace Jint.Native.Number.Dtoa
 {
-
-    public class CachedPowers
+    internal class CachedPowers
     {
         private const double Kd1Log210 = 0.30102999566398114; //  1 / lg(10)
 
@@ -52,17 +51,16 @@ namespace Jint.Native.Number.Dtoa
         }
 
 
-        internal static int GetCachedPower(int e, int alpha, int gamma, DiyFp cMk)
+        internal static (short, DiyFp) GetCachedPower(int e, int alpha, int gamma)
         {
             const int kQ = DiyFp.KSignificandSize;
-            double k = System.Math.Ceiling((alpha - e + kQ - 1)*Kd1Log210);
-            int index = (GrisuCacheOffset + (int) k - 1)/CachedPowersSpacing + 1;
+            double k = System.Math.Ceiling((alpha - e + kQ - 1) * Kd1Log210);
+            int index = (GrisuCacheOffset + (int) k - 1) / CachedPowersSpacing + 1;
             CachedPower cachedPower = CACHED_POWERS[index];
 
-            cMk.F = cachedPower.Significand;
-            cMk.E = cachedPower.BinaryExponent;
+            var cMk = new DiyFp(cachedPower.Significand, cachedPower.BinaryExponent);
             Debug.Assert((alpha <= cMk.E + e) && (cMk.E + e <= gamma));
-            return cachedPower.DecimalExponent;
+            return (cachedPower.DecimalExponent, cMk);
         }
 
         // Code below is converted from GRISU_CACHE_NAME(8) in file "powers-ten.h"
@@ -159,7 +157,5 @@ namespace Jint.Native.Number.Dtoa
         };
 
         private const int GrisuCacheOffset = 308;
-
-
     }
 }

--- a/Jint/Native/Number/Dtoa/FastDtoaBuilder.cs
+++ b/Jint/Native/Number/Dtoa/FastDtoaBuilder.cs
@@ -2,14 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+using System.Runtime.CompilerServices;
+
 namespace Jint.Native.Number.Dtoa
 {
-    public class FastDtoaBuilder
+    internal class FastDtoaBuilder
     {
 
         // allocate buffer for generated digits + extra notation + padding zeroes
         private readonly char[] _chars = new char[FastDtoa.KFastDtoaMaximalLength + 8];
-        internal int End = 0;
+        internal int End;
         internal int Point;
         private bool _formatted;
 
@@ -25,16 +27,18 @@ namespace Jint.Native.Number.Dtoa
 
         public void Reset()
         {
+            Point = 0;
             End = 0;
             _formatted = false;
+            System.Array.Clear(_chars, 0, _chars.Length);
         }
 
         public override string ToString()
         {
-            return "[chars:" + new System.String(_chars, 0, End) + ", point:" + Point + "]";
+            return "[chars:" + new string(_chars, 0, End) + ", point:" + Point + "]";
         }
 
-        public System.String Format()
+        public string Format()
         {
             if (!_formatted)
             {
@@ -51,7 +55,7 @@ namespace Jint.Native.Number.Dtoa
                 }
                 _formatted = true;
             }
-            return new System.String(_chars, 0, End);
+            return new string(_chars, 0, End);
 
         }
 
@@ -127,6 +131,7 @@ namespace Jint.Native.Number.Dtoa
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'
         };
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Fill<T>(T[] array, int fromIndex, int toIndex, T val)
         {
             for (int i = fromIndex; i < toIndex; i++)

--- a/Jint/Native/Number/Dtoa/NumberExtensions.cs
+++ b/Jint/Native/Number/Dtoa/NumberExtensions.cs
@@ -1,7 +1,10 @@
-﻿namespace Jint.Native.Number.Dtoa
+﻿using System.Runtime.CompilerServices;
+
+namespace Jint.Native.Number.Dtoa
 {
-    public static class NumberExtensions
+    internal static class NumberExtensions
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long UnsignedShift(this long l, int shift)
         {
             return (long) ((ulong) l >> shift);


### PR DESCRIPTION
By converting DiyFp to struct we can lower memory traffic by  about 30% with small performance gain. I'm using the array test again here.

I have also internalized the Dtoa bits so that no poor soul takes dependency on them, I believe they are not something that library should offer as part of the API.

/cc @sebastienros @ayende 

### Before

| Method |  N | ReuseEngine |    Mean |   Error |   StdDev |       Gen 0 |      Gen 1 |      Gen 2 | Allocated |
|------- |--- |------------ |--------:|--------:|---------:|------------:|-----------:|-----------:|----------:|
|   **Jint** | **20** |       **False** | **4.169 s** | **2.139 s** | **0.1209 s** | **784750.0000** | **40500.0000** | **17500.0000** |   **3.18 GB** |
|   **Jint** | **20** |        **True** | **4.090 s** | **1.327 s** | **0.0750 s** | **786750.0000** | **40250.0000** | **18500.0000** |   **3.17 GB** |

### After

| Method |  N | ReuseEngine |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 |      Gen 2 | Allocated |
|------- |--- |------------ |--------:|---------:|---------:|------------:|-----------:|-----------:|----------:|
|   **Jint** | **20** |       **False** | **4.006 s** | **0.9027 s** | **0.0510 s** | **537000.0000** | **36750.0000** | **17000.0000** |   **2.19 GB** |
|   **Jint** | **20** |        **True** | **3.987 s** | **0.1880 s** | **0.0106 s** | **539500.0000** | **40250.0000** | **18500.0000** |   **2.19 GB** |


