### PR TITLE
Reduce memory allocations

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -444,7 +444,7 @@ namespace Jint
             }
         }
 
-        public object EvaluateExpression(Expression expression)
+        public object EvaluateExpression(INode expression)
         {
             _lastSyntaxNode = expression;
 
@@ -679,7 +679,8 @@ namespace Jint
         /// <summary>
         /// Invoke the current value as function.
         /// </summary>
-        /// <param name="propertyName">The arguments of the function call.</param>
+        /// <param name="propertyName">The name of the function to call.</param>
+        /// <param name="arguments">The arguments of the function call.</param>
         /// <returns>The value returned by the function call.</returns>
         public JsValue Invoke(string propertyName, params object[] arguments)
         {
@@ -868,7 +869,7 @@ namespace Jint
             for (var i = 0; i < variableDeclarations.Count; i++)
             {
                 var variableDeclaration = variableDeclarations[i];
-                var declarations  = (List<VariableDeclarator>) variableDeclaration.Declarations;
+                var declarations  = variableDeclaration.Declarations;
                 foreach (var d in declarations)
                 {
                     var dn = d.Id.As<Identifier>().Name;

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <NeutralLanguage>en-US</NeutralLanguage>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyOriginatorKeyFile>Jint.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Esprima" Version="1.0.0-beta-1000" /> 
+    <PackageReference Include="Esprima" Version="1.0.0-beta-1022" />
   </ItemGroup>
 </Project>

--- a/Jint/Native/Function/FunctionConstructor.cs
+++ b/Jint/Native/Function/FunctionConstructor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Esprima;
 using Esprima.Ast;

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -52,7 +51,7 @@ namespace Jint.Native.Function
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static string[] GetParameterNames(IFunction functionDeclaration)
         {
-            var list = (List<INode>) functionDeclaration.Params;
+            var list = functionDeclaration.Params;
             var count = list.Count;
             var names = new string[count];
             for (var i = 0; i < count; ++i)

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -1,5 +1,4 @@
-﻿using Esprima;
-using Jint.Native.Object;
+﻿using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
 

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -196,7 +196,7 @@ namespace Jint.Native.String
             var len = s.Length;
             var intStart = ToIntegerSupportInfinity(start);
 
-            var intEnd = arguments.At(1) == Undefined.Instance ? len : (int)ToIntegerSupportInfinity(end);
+            var intEnd = arguments.At(1) == Undefined.Instance ? len : ToIntegerSupportInfinity(end);
             var finalStart = System.Math.Min(len, System.Math.Max(intStart, 0));
             var finalEnd = System.Math.Min(len, System.Math.Max(intEnd, 0));
             // Swap value if finalStart < finalEnd

--- a/Jint/Native/Symbol/SymbolConstructor.cs
+++ b/Jint/Native/Symbol/SymbolConstructor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Jint.Native.Function;
+﻿using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Interop;

--- a/Jint/Native/Symbol/SymbolPrototype.cs
+++ b/Jint/Native/Symbol/SymbolPrototype.cs
@@ -1,19 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Jint.Native.Array;
-using Jint.Native.Function;
-using Jint.Native.Object;
-using Jint.Native.RegExp;
+﻿using Jint.Native.Object;
 using Jint.Runtime;
-using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.Symbol
 {
-
-
     /// <summary>
     /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.5.4
     /// </summary>

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using Jint.Native;
 using Jint.Runtime.Interop;
 
 namespace Jint
@@ -16,7 +17,7 @@ namespace Jint
         private bool _allowClr;
         private readonly List<IObjectConverter> _objectConverters = new List<IObjectConverter>();
         private int _maxStatements;
-        private int _maxRecursionDepth = -1; 
+        private int _maxRecursionDepth = -1;
         private TimeSpan _timeoutInterval;
         private CultureInfo _culture = CultureInfo.CurrentCulture;
         private TimeZoneInfo _localTimeZone = TimeZoneInfo.Local;
@@ -47,7 +48,7 @@ namespace Jint
         /// Allow the <code>debugger</code> statement to be called in a script.
         /// </summary>
         /// <remarks>
-        /// Because the <code>debugger</code> statement can start the 
+        /// Because the <code>debugger</code> statement can start the
         /// Visual Studio debugger, is it disabled by default
         /// </remarks>
         public Options AllowDebuggerStatement(bool allowDebuggerStatement = true)
@@ -112,7 +113,7 @@ namespace Jint
             _maxStatements = maxStatements;
             return this;
         }
-        
+
         public Options TimeoutInterval(TimeSpan timeoutInterval)
         {
             _timeoutInterval = timeoutInterval;

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -985,7 +985,7 @@ namespace Jint.Runtime
 
         public JsValue EvaluateArrayExpression(ArrayExpression arrayExpression)
         {
-            var elements = (List<ArrayExpressionElement>) arrayExpression.Elements;
+            var elements = arrayExpression.Elements;
             var count = elements.Count;
             var a = _engine.Array.Construct(new JsValue[] { count });
             for (var n = 0; n < count; n++)


### PR DESCRIPTION
This time around again trying to reduce memory allocations to give virtual machine some breathing room. Most of the changes should have positive changes all around.

* remove LINQ from hot paths
* use List<T> where possible to get rid of memory allocations when using foreach
* cache empty completions

Next I'm going to tackle generally ObjectInstance and it's memory usage, trying to optimize MruPropertyCache2 etc.

## UncacheableExpressionsBenchmark

### Before (dev branch)

|    Method |   N |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|---------- |---- |--------:|---------:|---------:|------------:|-----------:|----------:|
| Benchmark | 500 | 1.094 s | 0.0049 s | 0.0071 s | 243554.1667 | 15075.0000 | 997.15 MB |

### After (this pull request)

|    Method |   N |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|---------- |---- |--------:|---------:|---------:|------------:|-----------:|----------:|
| Benchmark | 500 | 1.057 s | 0.0070 s | 0.0105 s | 204179.1667 | 50595.8333 | 905.73 MB |

## ArrayStressBenchmark

### Before

| Method |  N |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 |      Gen 2 | Allocated |
|------- |--- |--------:|---------:|---------:|------------:|-----------:|-----------:|----------:|
|   Jint | 20 | 2.656 s | 0.1310 s | 0.0074 s | 244000.0000 | 20250.0000 | 10000.0000 |   1.04 GB |

### After

| Method |  N |    Mean |   Error |   StdDev |       Gen 0 |      Gen 1 |      Gen 2 | Allocated |
|------- |--- |--------:|--------:|---------:|------------:|-----------:|-----------:|----------:|
|   Jint | 20 | 2.588 s | 3.788 s | 0.2140 s | 217750.0000 | 21000.0000 | 10250.0000 | 956.95 MB |