### PR TITLE
Optimize EvaluateMemberExpression when targeting static member

### DIFF
--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -747,19 +747,21 @@ namespace Jint.Runtime
         {
             var baseReference = EvaluateExpression(memberExpression.Object);
             var baseValue = _engine.GetValue(baseReference);
-            Expression expression = memberExpression.Property;
 
-
+            string propertyNameString;
             if (!memberExpression.Computed) // index accessor ?
             {
-                var name = memberExpression.Property.As<Identifier>().Name;
-                expression = new Literal(name, name);
+                // we can take fast path without querying the engine again
+                propertyNameString = memberExpression.Property.As<Identifier>().Name;
+            }
+            else
+            {
+                var propertyNameReference = EvaluateExpression(memberExpression.Property);
+                var propertyNameValue = _engine.GetValue(propertyNameReference);
+                propertyNameString = TypeConverter.ToString(propertyNameValue);
             }
 
-            var propertyNameReference = EvaluateExpression(expression);
-            var propertyNameValue = _engine.GetValue(propertyNameReference);
             TypeConverter.CheckObjectCoercible(_engine, baseValue, memberExpression, baseReference);
-            var propertyNameString = TypeConverter.ToString(propertyNameValue);
 
             return new Reference(baseValue, propertyNameString, StrictModeScope.IsStrictModeCode);
         }


### PR DESCRIPTION
Member expression invocation is on hot path with static object properties and allocates a lot of literals, we can simplify it to work without literal expression evaluation.

## UncacheableExpressionsBenchmark

### Before (dev branch)

|    Method |   N |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|---------- |---- |--------:|---------:|---------:|------------:|-----------:|----------:|
| Benchmark | 500 | 1.094 s | 0.0049 s | 0.0071 s | 243554.1667 | 15075.0000 | 997.15 MB |

### After (this pull request)

|    Method |   N |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|---------- |---- |--------:|---------:|---------:|------------:|-----------:|----------:|
| Benchmark | 500 | 1.081 s | 0.0112 s | 0.0167 s | 202687.5000 | 55312.5000 |  903.2 MB |


