### PR TITLE
Make ObjectInstance MruPropertyCache2 dictionary lazy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,4 +160,4 @@ project.lock.json
 .build
 
 .idea
-BenchmarkDotNet.Artifacts
+BenchmarkDotNet.Artifacts*

--- a/Jint/Native/Function/FunctionPrototype.cs
+++ b/Jint/Native/Function/FunctionPrototype.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Jint.Native.Object;
+﻿using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
@@ -49,7 +47,7 @@ namespace Jint.Native.Function
             var f = new BindFunctionInstance(Engine) {Extensible = true};
             f.TargetFunction = thisObj;
             f.BoundThis = thisArg;
-            f.BoundArgs = arguments.Skip(1).ToArray();
+            f.BoundArgs = arguments.Skip(1);
             f.Prototype = Engine.Function.PrototypeObject;
 
             var o = target as FunctionInstance;
@@ -126,7 +124,7 @@ namespace Jint.Native.Function
                 throw new JavaScriptException(Engine.TypeError);
             }
 
-            return func.Call(arguments.At(0), arguments.Length == 0 ? arguments : arguments.Skip(1).ToArray());
+            return func.Call(arguments.At(0), arguments.Length == 0 ? arguments : arguments.Skip(1));
         }
 
         public override JsValue Call(JsValue thisObject, JsValue[] arguments)

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -22,7 +23,7 @@ namespace Jint.Native.Function
         /// <param name="scope"></param>
         /// <param name="strict"></param>
         public ScriptFunctionInstance(Engine engine, IFunction functionDeclaration, LexicalEnvironment scope, bool strict)
-            : base(engine, functionDeclaration.Params.Select(x => x.As<Identifier>().Name).ToArray(), scope, strict)
+            : base(engine, GetParameterNames(functionDeclaration), scope, strict)
         {
             _functionDeclaration = functionDeclaration;
 
@@ -46,6 +47,20 @@ namespace Jint.Native.Function
                 DefineOwnProperty("caller", new PropertyDescriptor(thrower, thrower, false, false), false);
                 DefineOwnProperty("arguments", new PropertyDescriptor(thrower, thrower, false, false), false);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string[] GetParameterNames(IFunction functionDeclaration)
+        {
+            var list = (List<INode>) functionDeclaration.Params;
+            var count = list.Count;
+            var names = new string[count];
+            for (var i = 0; i < count; ++i)
+            {
+                names[i] = ((Identifier) list[i]).Name;
+            }
+
+            return names;
         }
 
         /// <summary>

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -12,6 +12,8 @@ namespace Jint.Native.Number
     /// </summary>
     public sealed class NumberPrototype : NumberInstance
     {
+        private static readonly char[] _numberSeparators = {'.', 'e'};
+
         private NumberPrototype(Engine engine)
             : base(engine)
         {
@@ -154,7 +156,7 @@ namespace Jint.Native.Number
 
             // Get the number of decimals
             string str = x.ToString("e23", CultureInfo.InvariantCulture);
-            int decimals = str.IndexOfAny(new [] { '.', 'e' });
+            int decimals = str.IndexOfAny(_numberSeparators);
             decimals = decimals == -1 ? str.Length : decimals;
 
             p -= decimals;

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -8,6 +8,7 @@ namespace Jint.Native.Object
     {
         private const string PropertyNamePrototype = "prototype";
         private const string PropertyNameConstructor = "constructor";
+        private const string PropertyNameLength = "length";
 
         private JsValue _jsValue;
 
@@ -16,6 +17,7 @@ namespace Jint.Native.Object
 
         private PropertyDescriptor _prototype;
         private PropertyDescriptor _constructor;
+        private PropertyDescriptor _length;
 
         public ObjectInstance(Engine engine)
         {
@@ -95,6 +97,10 @@ namespace Jint.Native.Object
             {
                 yield return new KeyValuePair<string, PropertyDescriptor>(PropertyNameConstructor, _constructor);
             }
+            if (_length != null)
+            {
+                yield return new KeyValuePair<string, PropertyDescriptor>(PropertyNameLength, _length);
+            }
 
             if (_properties != null)
             {
@@ -117,6 +123,11 @@ namespace Jint.Native.Object
                 _constructor = descriptor;
                 return;
             }
+            if (propertyName == PropertyNameLength)
+            {
+                _length = descriptor;
+                return;
+            }
 
             if (_properties == null)
             {
@@ -133,11 +144,15 @@ namespace Jint.Native.Object
                 descriptor = _prototype;
                 return _prototype != null;
             }
-
             if (propertyName == PropertyNameConstructor)
             {
                 descriptor = _constructor;
                 return _constructor != null;
+            }
+            if (propertyName == PropertyNameLength)
+            {
+                descriptor = _length;
+                return _length != null;
             }
 
             if (_properties == null)
@@ -161,6 +176,10 @@ namespace Jint.Native.Object
             {
                 return _constructor != null;
             }
+            if (propertyName == PropertyNameLength)
+            {
+                return _length != null;
+            }
 
             return _properties?.ContainsKey(propertyName) ?? false;
         }
@@ -176,6 +195,10 @@ namespace Jint.Native.Object
             if (propertyName == PropertyNameConstructor)
             {
                 _constructor = null;
+            }
+            if (propertyName == PropertyNameLength)
+            {
+                _length = null;
             }
 
             _properties?.Remove(propertyName);
@@ -234,6 +257,10 @@ namespace Jint.Native.Object
             {
                 return _constructor ?? PropertyDescriptor.Undefined;
             }
+            if (propertyName == PropertyNameLength)
+            {
+                return _length ?? PropertyDescriptor.Undefined;
+            }
 
             PropertyDescriptor x;
             if (_properties != null && _properties.TryGetValue(propertyName, out x))
@@ -256,6 +283,11 @@ namespace Jint.Native.Object
             if (propertyName == PropertyNameConstructor)
             {
                 _constructor = desc;
+                return;
+            }
+            if (propertyName == PropertyNameLength)
+            {
+                _length = desc;
                 return;
             }
 
@@ -753,5 +785,7 @@ namespace Jint.Native.Object
         {
             return TypeConverter.ToString(this);
         }
+
+        protected uint GetLengthValue() => TypeConverter.ToUint32(_length.Value);
     }
 }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using System;
-using System.Collections.Specialized;
 
 namespace Jint.Native.Object
 {

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -320,19 +320,20 @@ namespace Jint.Native.String
             }
             else
             {
-                var segments = new List<string>();
+                List<string> segments;
                 var sep = TypeConverter.ToString(separator);
 
                 if (sep == string.Empty || (rx != null && rx.Source == regExpForMatchingAllCharactere)) // for s.split(new RegExp)
                 {
+                    segments = new List<string>(s.Length);
                     foreach (var c in s)
                     {
-                        segments.Add(c.ToString());
+                        segments.Add(TypeConverter.ToString(c));
                     }
                 }
                 else
                 {
-                    segments = s.Split(new[] {sep}, StringSplitOptions.None).ToList();
+                    segments = new List<string>(s.Split(new[] {sep}, StringSplitOptions.None));
                 }
 
                 for (int i = 0; i < segments.Count && i < limit; i++)
@@ -731,7 +732,7 @@ namespace Jint.Native.String
             {
                 return "";
             }
-            return s[(int) position].ToString();
+            return TypeConverter.ToString(s[(int) position]);
 
         }
 

--- a/Jint/Runtime/Arguments.cs
+++ b/Jint/Runtime/Arguments.cs
@@ -1,4 +1,6 @@
-﻿using Jint.Native;
+﻿using System;
+using System.Runtime.CompilerServices;
+using Jint.Native;
 
 namespace Jint.Runtime
 {
@@ -18,14 +20,30 @@ namespace Jint.Runtime
         /// <param name="index">The index of the parameter to return</param>
         /// <param name="undefinedValue">The value to return is the parameter is not provided</param>
         /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static JsValue At(this JsValue[] args, int index, JsValue undefinedValue)
         {
             return args.Length > index ? args[index] : undefinedValue;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static JsValue At(this JsValue[] args, int index)
         {
             return At(args, index, Undefined.Instance);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static JsValue[] Skip(this JsValue[] args, int count)
+        {
+            var newLength = args.Length - count;
+            if (newLength <= 0)
+            {
+                return Array.Empty<JsValue>();
+            }
+
+            var array = new JsValue[newLength];
+            Array.Copy(args, count, array, 0, newLength);
+            return array;
         }
     }
 }

--- a/Jint/Runtime/Completion.cs
+++ b/Jint/Runtime/Completion.cs
@@ -8,11 +8,14 @@ namespace Jint.Runtime
     /// </summary>
     public class Completion
     {
-        public static string Normal = "normal";
-        public static string Break = "break";
-        public static string Continue = "continue";
-        public static string Return = "return";
-        public static string Throw = "throw";
+        public const string Normal = "normal";
+        public const string Break = "break";
+        public const string Continue = "continue";
+        public const string Return = "return";
+        public const string Throw = "throw";
+
+        public static readonly Completion Empty = new Completion(Normal, null, null);
+        public static readonly Completion EmptyUndefined = new Completion(Normal, Undefined.Instance, null);
 
         public Completion(string type, JsValue value, string identifier)
         {
@@ -21,9 +24,9 @@ namespace Jint.Runtime
             Identifier = identifier;
         }
 
-        public string Type { get; private set; }
-        public JsValue Value { get; private set; }
-        public string Identifier { get; private set; }
+        public string Type { get; }
+        public JsValue Value { get; }
+        public string Identifier { get; }
 
         public JsValue GetValueOrDefault()
         {

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -11,7 +11,7 @@ namespace Jint.Runtime.Environments
     public sealed class DeclarativeEnvironmentRecord : EnvironmentRecord
     {
         private readonly Engine _engine;
-        private readonly IDictionary<string, Binding> _bindings = new Dictionary<string, Binding>();
+        private readonly Dictionary<string, Binding> _bindings = new Dictionary<string, Binding>();
 
         public DeclarativeEnvironmentRecord(Engine engine) : base(engine)
         {
@@ -27,7 +27,7 @@ namespace Jint.Runtime.Environments
         {
             _bindings.Add(name, new Binding
                 {
-                    Value = Undefined.Instance, 
+                    Value = Undefined.Instance,
                     CanBeDeleted =  canBeDeleted,
                     Mutable = true
                 });
@@ -80,7 +80,7 @@ namespace Jint.Runtime.Environments
             }
 
             _bindings.Remove(name);
-            
+
             return true;
         }
 

--- a/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Jint.Native;
-using Jint.Native.Array;
 using Jint.Native.Function;
 
 namespace Jint.Runtime.Interop
@@ -29,10 +26,9 @@ namespace Jint.Runtime.Interop
         public JsValue Invoke(MethodInfo[] methodInfos, JsValue thisObject, JsValue[] jsArguments)
         {
             var arguments = ProcessParamsArrays(jsArguments, methodInfos);
-            var methods = TypeConverter.FindBestMatch(Engine, methodInfos, arguments).ToList();
             var converter = Engine.ClrTypeConverter;
 
-            foreach (var method in methods)
+            foreach (var method in TypeConverter.FindBestMatch(Engine, methodInfos, arguments))
             {
                 var parameters = new object[arguments.Length];
                 var argumentsMatch = true;
@@ -86,7 +82,7 @@ namespace Jint.Runtime.Interop
                 // todo: cache method info
                 try
                 {
-                    return JsValue.FromObject(Engine, method.Invoke(thisObject.ToObject(), parameters.ToArray()));
+                    return JsValue.FromObject(Engine, method.Invoke(thisObject.ToObject(), parameters));
                 }
                 catch (TargetInvocationException exception)
                 {
@@ -108,29 +104,45 @@ namespace Jint.Runtime.Interop
         /// <summary>
         /// Reduces a flat list of parameters to a params array
         /// </summary>
-        private JsValue[] ProcessParamsArrays(JsValue[] jsArguments, IEnumerable<MethodInfo> methodInfos)
+        private JsValue[] ProcessParamsArrays(JsValue[] jsArguments, MethodInfo[] methodInfos)
         {
-            foreach (var methodInfo in methodInfos)
+            for (var i = 0; i < methodInfos.Length; i++)
             {
+                var methodInfo = methodInfos[i];
                 var parameters = methodInfo.GetParameters();
-                if (!parameters.Any(p => p.HasAttribute<ParamArrayAttribute>()))
+
+                bool hasParamArrayAttribute = false;
+                for (int j = 0; j < parameters.Length; ++j)
+                {
+                    if (parameters[j].HasAttribute<ParamArrayAttribute>())
+                    {
+                        hasParamArrayAttribute = true;
+                        break;
+                    }
+                }
+                if (!hasParamArrayAttribute)
                     continue;
 
                 var nonParamsArgumentsCount = parameters.Length - 1;
                 if (jsArguments.Length < nonParamsArgumentsCount)
                     continue;
 
-                var newArgumentsCollection = jsArguments.Take(nonParamsArgumentsCount).ToList();
-                var argsToTransform = jsArguments.Skip(nonParamsArgumentsCount).ToList();
+                var argsToTransform = jsArguments.Skip(nonParamsArgumentsCount);
 
-                if (argsToTransform.Count == 1 && argsToTransform.FirstOrDefault().IsArray())
+                if (argsToTransform.Length == 1 && argsToTransform[0].IsArray())
                     continue;
 
                 var jsArray = Engine.Array.Construct(Arguments.Empty);
-                Engine.Array.PrototypeObject.Push(jsArray, argsToTransform.ToArray());
+                Engine.Array.PrototypeObject.Push(jsArray, argsToTransform);
 
-                newArgumentsCollection.Add(jsArray.JsValue);
-                return newArgumentsCollection.ToArray();
+                var newArgumentsCollection = new JsValue[nonParamsArgumentsCount + 1];
+                for (var j = 0; j < nonParamsArgumentsCount; ++j)
+                {
+                    newArgumentsCollection[j] = jsArguments[j];
+                }
+
+                newArgumentsCollection[nonParamsArgumentsCount] = new JsValue(jsArray);
+                return newArgumentsCollection;
             }
 
             return jsArguments;

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -53,7 +53,7 @@ namespace Jint.Runtime.Interop
         public override PropertyDescriptor GetOwnProperty(string propertyName)
         {
             PropertyDescriptor x;
-            if (Properties.TryGetValue(propertyName, out x))
+            if (TryGetProperty(propertyName, out x))
                 return x;
 
             var type = Target.GetType();
@@ -65,7 +65,7 @@ namespace Jint.Runtime.Interop
             if (property != null)
             {
                 var descriptor = new PropertyInfoDescriptor(Engine, property, Target);
-                Properties.Add(propertyName, descriptor);
+                AddProperty(propertyName, descriptor);
                 return descriptor;
             }
 
@@ -76,11 +76,11 @@ namespace Jint.Runtime.Interop
             if (field != null)
             {
                 var descriptor = new FieldInfoDescriptor(Engine, field, Target);
-                Properties.Add(propertyName, descriptor);
+                AddProperty(propertyName, descriptor);
                 return descriptor;
             }
 
-            // if no properties were found then look for a method 
+            // if no properties were found then look for a method
             var methods = type.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public)
                 .Where(m => EqualsIgnoreCasing(m.Name, propertyName))
                 .ToArray();
@@ -88,7 +88,7 @@ namespace Jint.Runtime.Interop
             if (methods.Any())
             {
                 var descriptor = new PropertyDescriptor(new MethodInfoFunctionInstance(Engine, methods), false, true, false);
-                Properties.Add(propertyName, descriptor);
+                AddProperty(propertyName, descriptor);
                 return descriptor;
             }
 
@@ -109,7 +109,7 @@ namespace Jint.Runtime.Interop
             if (explicitProperties.Length == 1)
             {
                 var descriptor = new PropertyInfoDescriptor(Engine, explicitProperties[0], Target);
-                Properties.Add(propertyName, descriptor);
+                AddProperty(propertyName, descriptor);
                 return descriptor;
             }
 
@@ -122,7 +122,7 @@ namespace Jint.Runtime.Interop
             if (explicitMethods.Length > 0)
             {
                 var descriptor = new PropertyDescriptor(new MethodInfoFunctionInstance(Engine, explicitMethods), false, true, false);
-                Properties.Add(propertyName, descriptor);
+                AddProperty(propertyName, descriptor);
                 return descriptor;
             }
 
@@ -146,11 +146,11 @@ namespace Jint.Runtime.Interop
             bool equals = false;
             if (s1.Length == s2.Length)
             {
-                if (s1.Length > 0 && s2.Length > 0) 
+                if (s1.Length > 0 && s2.Length > 0)
                 {
                     equals = (s1.ToLower()[0] == s2.ToLower()[0]);
                 }
-                if (s1.Length > 1 && s2.Length > 1) 
+                if (s1.Length > 1 && s2.Length > 1)
                 {
                     equals = equals && (s1.Substring(1) == s2.Substring(1));
                 }

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -25,7 +25,7 @@ namespace Jint.Runtime
 
         public Completion ExecuteEmptyStatement(EmptyStatement emptyStatement)
         {
-            return new Completion(Completion.Normal, null, null);
+            return Completion.Empty;
         }
 
         public Completion ExecuteExpressionStatement(ExpressionStatement expressionStatement)
@@ -49,7 +49,7 @@ namespace Jint.Runtime
             }
             else
             {
-                return new Completion(Completion.Normal, null, null);
+                return Completion.Empty;
             }
 
             return result;
@@ -217,7 +217,7 @@ namespace Jint.Runtime
             var experValue = _engine.GetValue(exprRef);
             if (experValue == Undefined.Instance || experValue == Null.Instance)
             {
-                return new Completion(Completion.Normal, null, null);
+                return Completion.Empty;
             }
 
 
@@ -415,13 +415,15 @@ namespace Jint.Runtime
 
         public Completion ExecuteStatementList(IEnumerable<StatementListItem> statementList)
         {
-            var c = new Completion(Completion.Normal, null, null);
+            var c = Completion.Empty;
             Completion sl = c;
             Statement s = null;
 
+            var list = (List<StatementListItem>) statementList;
+
             try
             {
-                foreach (var statement in statementList)
+                foreach (var statement in list)
                 {
                     s = statement.As<Statement>();
                     c = ExecuteStatement(s);
@@ -528,7 +530,7 @@ namespace Jint.Runtime
                 }
             }
 
-            return new Completion(Completion.Normal, Undefined.Instance, null);
+            return Completion.EmptyUndefined;
         }
 
         public Completion ExecuteBlockStatement(BlockStatement blockStatement)
@@ -548,7 +550,7 @@ namespace Jint.Runtime
                 System.Diagnostics.Debugger.Break();
             }
 
-            return new Completion(Completion.Normal, null, null);
+            return Completion.Empty;
         }
     }
 }

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -440,7 +440,7 @@ namespace Jint.Runtime
         public static IEnumerable<MethodBase> FindBestMatch(Engine engine, MethodBase[] methods, JsValue[] arguments)
         {
             methods = methods
-                .Where(m => m.GetParameters().Count() == arguments.Length)
+                .Where(m => m.GetParameters().Length == arguments.Length)
                 .ToArray();
 
             if (methods.Length == 1 && !methods[0].GetParameters().Any())


### PR DESCRIPTION
This change add commonly accessed prototype and constructor fields directly to ObjectInstance. Dictionary is initialized if these two fields are not enough to describe the object. On top of memory usage changes so that PR needs to be addressed first.