### PR TITLE
Optimize array access and add ability to hint array size

### DIFF
--- a/Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj
+++ b/Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Jint.Tests.CommonScripts</AssemblyName>
@@ -14,21 +13,18 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
   </PropertyGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="Scripts\*.*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="xunit.analyzers" Version="0.7.0" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
-
 </Project>

--- a/Jint.Tests.Ecma/Jint.Tests.Ecma.csproj
+++ b/Jint.Tests.Ecma/Jint.Tests.Ecma.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>Jint.Tests.Ecma</AssemblyName>
@@ -15,21 +14,19 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit.analyzers" Version="0.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
 </Project>

--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -22,8 +22,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="xunit.analyzers" Version="0.7.0" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 </Project>

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -311,6 +311,28 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
+        public void DenseArrayTurnsToSparseArrayWhenSizeGrowsTooMuch()
+        {
+            RunTest(@"
+                var n = 1024*10+2;
+                var o = Array(n);
+                for (var i = 0; i < n; i++) o[i] = i;
+                assert(o[0] == 0);
+                assert(o[n - 1] == n -1);
+            ");
+        }
+
+        [Fact]
+        public void DenseArrayTurnsToSparseArrayWhenSparseIndexed()
+        {
+            RunTest(@"
+                var o = Array();
+                o[100] = 1;
+                assert(o[100] == 1);
+            ");
+        }
+
+        [Fact]
         public void ArrayPopShouldDecrementLength()
         {
             RunTest(@"
@@ -1893,7 +1915,7 @@ namespace Jint.Tests.Runtime
 
             Assert.True(val.AsString() == "53.6841659");
         }
-		
+
         [Theory]
         [InlineData("", "escape('')")]
         [InlineData("%u0100%u0101%u0102", "escape('\u0100\u0101\u0102')")]

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <NeutralLanguage>en-US</NeutralLanguage>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyOriginatorKeyFile>Jint.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Esprima" Version="1.0.0-beta-1000" /> 
+    <PackageReference Include="Esprima" Version="1.0.0-beta-1011" />
   </ItemGroup>
 </Project>

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -56,7 +56,17 @@ namespace Jint.Native.Array
 
         public ObjectInstance Construct(JsValue[] arguments)
         {
-            return Construct(arguments, 0);
+            // check if we can figure out good size
+            var capacity = arguments.Length > 0 ? (uint) arguments.Length : 0;
+            if (arguments.Length == 1 && arguments[0].Type == Types.Number)
+            {
+                var number = arguments[0].AsNumber();
+                if (number > 0)
+                {
+                    capacity = (uint) number;
+                }
+            }
+            return Construct(arguments, capacity);
         }
 
         public ArrayInstance Construct(int capacity)

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -37,7 +37,7 @@ namespace Jint.Native.Array
             FastAddProperty("isArray", new ClrFunctionInstance(Engine, IsArray, 1), true, false, true);
         }
 
-        private JsValue IsArray(JsValue thisObj, JsValue[] arguments)
+        private static JsValue IsArray(JsValue thisObj, JsValue[] arguments)
         {
             if (arguments.Length == 0)
             {
@@ -59,7 +59,7 @@ namespace Jint.Native.Array
             return Construct(arguments, 0);
         }
 
-        public ObjectInstance Construct(int capacity)
+        public ArrayInstance Construct(int capacity)
         {
             if (capacity < 0)
             {
@@ -68,12 +68,12 @@ namespace Jint.Native.Array
             return Construct(System.Array.Empty<JsValue>(), (uint) capacity);
         }
 
-        public ObjectInstance Construct(uint capacity)
+        public ArrayInstance Construct(uint capacity)
         {
             return Construct(System.Array.Empty<JsValue>(), capacity);
         }
 
-        public ObjectInstance Construct(JsValue[] arguments, uint capacity)
+        public ArrayInstance Construct(JsValue[] arguments, uint capacity)
         {
             var instance = new ArrayInstance(Engine, capacity);
             instance.Prototype = PrototypeObject;
@@ -95,7 +95,7 @@ namespace Jint.Native.Array
 
                 if (enumerable != null)
                 {
-                    var jsArray = Engine.Array.Construct(Arguments.Empty);
+                    var jsArray = (ArrayInstance) Engine.Array.Construct(Arguments.Empty);
                     foreach (var item in enumerable)
                     {
                         var jsItem = JsValue.FromObject(Engine, item);

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -19,7 +20,7 @@ namespace Jint.Native.Array
             var obj = new ArrayConstructor(engine);
             obj.Extensible = true;
 
-            // The value of the [[Prototype]] internal property of the Array constructor is the Function prototype object 
+            // The value of the [[Prototype]] internal property of the Array constructor is the Function prototype object
             obj.Prototype = engine.Function.PrototypeObject;
             obj.PrototypeObject = ArrayPrototype.CreatePrototypeObject(engine, obj);
 
@@ -55,7 +56,26 @@ namespace Jint.Native.Array
 
         public ObjectInstance Construct(JsValue[] arguments)
         {
-            var instance = new ArrayInstance(Engine);
+            return Construct(arguments, 0);
+        }
+
+        public ObjectInstance Construct(int capacity)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentException("invalid array length", nameof(capacity));
+            }
+            return Construct(System.Array.Empty<JsValue>(), (uint) capacity);
+        }
+
+        public ObjectInstance Construct(uint capacity)
+        {
+            return Construct(System.Array.Empty<JsValue>(), capacity);
+        }
+
+        public ObjectInstance Construct(JsValue[] arguments, uint capacity)
+        {
+            var instance = new ArrayInstance(Engine, capacity);
             instance.Prototype = PrototypeObject;
             instance.Extensible = true;
 
@@ -66,7 +86,7 @@ namespace Jint.Native.Array
                 {
                     throw new JavaScriptException(Engine.RangeError, "Invalid array length");
                 }
-                
+
                 instance.FastAddProperty("length", length, true, false, false);
             }
             else if (arguments.Length == 1 && arguments.At(0).IsObject() && arguments.At(0).As<ObjectWrapper>() != null )

--- a/Jint/Native/Array/ArrayExecutionContext.cs
+++ b/Jint/Native/Array/ArrayExecutionContext.cs
@@ -16,7 +16,10 @@ namespace Jint.Native.Array
         }
 
         public List<uint> KeyCache = new List<uint>();
+
+        public JsValue[] CallArray1 = new JsValue[1];
         public JsValue[] CallArray3 = new JsValue[3];
+        public JsValue[] CallArray4 = new JsValue[4];
 
         public static ArrayExecutionContext Current => _executionContext.Value;
     }

--- a/Jint/Native/Array/ArrayExecutionContext.cs
+++ b/Jint/Native/Array/ArrayExecutionContext.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+
+namespace Jint.Native.Array
+{
+    /// <summary>
+    /// Helper to cache common data structures needed in array access on a per thread basis.
+    /// </summary>
+    internal class ArrayExecutionContext
+    {
+        // cache key container for array iteration for less allocations
+        private static readonly ThreadLocal<ArrayExecutionContext> _executionContext = new ThreadLocal<ArrayExecutionContext>(() => new ArrayExecutionContext());
+
+        private ArrayExecutionContext()
+        {
+        }
+
+        public List<uint> KeyCache = new List<uint>();
+        public JsValue[] CallArray3 = new JsValue[3];
+
+        public static ArrayExecutionContext Current => _executionContext.Value;
+    }
+}

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -12,12 +12,13 @@ namespace Jint.Native.Array
         private static readonly ThreadLocal<List<uint>> keyCache = new ThreadLocal<List<uint>>(() => new List<uint>());
 
         private readonly Engine _engine;
-        private readonly Dictionary<uint, PropertyDescriptor> _array = new Dictionary<uint, PropertyDescriptor>();
+        private readonly Dictionary<uint, PropertyDescriptor> _array;
         private PropertyDescriptor _length;
 
-        public ArrayInstance(Engine engine) : base(engine)
+        public ArrayInstance(Engine engine, uint size = 0) : base(engine)
         {
             _engine = engine;
+            _array = new Dictionary<uint, PropertyDescriptor>((int) (size < int.MaxValue ? size : int.MaxValue));
         }
 
         public override string Class => "Array";

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -8,9 +8,6 @@ namespace Jint.Native.Array
 {
     public class ArrayInstance : ObjectInstance
     {
-        // cache key container for array iteration for less allocations
-        private static readonly ThreadLocal<List<uint>> keyCache = new ThreadLocal<List<uint>>(() => new List<uint>());
-
         private readonly Engine _engine;
         private readonly Dictionary<uint, PropertyDescriptor> _array;
         private PropertyDescriptor _length;
@@ -18,7 +15,7 @@ namespace Jint.Native.Array
         public ArrayInstance(Engine engine, uint size = 0) : base(engine)
         {
             _engine = engine;
-            _array = new Dictionary<uint, PropertyDescriptor>((int) (size < int.MaxValue ? size : int.MaxValue));
+            _array = new Dictionary<uint, PropertyDescriptor>((int) (size <= 1024 ? size : 1024));
         }
 
         public override string Class => "Array";
@@ -118,7 +115,7 @@ namespace Jint.Native.Array
 
                 if (_array.Count < oldLen - newLen)
                 {
-                    var keys = keyCache.Value;
+                    var keys = ArrayExecutionContext.Current.KeyCache;
                     keys.Clear();
                     keys.AddRange(_array.Keys);
                     foreach (var keyIndex in keys)

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -19,10 +19,10 @@ namespace Jint.Native.Array
         public static ArrayPrototype CreatePrototypeObject(Engine engine, ArrayConstructor arrayConstructor)
         {
             var obj = new ArrayPrototype(engine)
-                {
-                    Extensible = true,
-                    Prototype = engine.Object.PrototypeObject
-                };
+            {
+                Extensible = true,
+                Prototype = engine.Object.PrototypeObject
+            };
 
             obj.FastAddProperty("length", 0, true, false, false);
             obj.FastAddProperty("constructor", arrayConstructor, true, false, true);
@@ -57,37 +57,48 @@ namespace Jint.Native.Array
 
         private JsValue LastIndexOf(JsValue thisObj, JsValue[] arguments)
         {
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenValue = o.Get("length");
-            var len = TypeConverter.ToUint32(lenValue);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
             if (len == 0)
             {
                 return -1;
             }
 
-            var n = arguments.Length > 1 ? (uint) TypeConverter.ToInteger(arguments[1]) : len - 1;
-            uint k;
+            var n = arguments.Length > 1 ? TypeConverter.ToInteger(arguments[1]) : len - 1;
+            double k;
             if (n >= 0)
             {
                 k = System.Math.Min(n, len - 1); // min
             }
             else
             {
-                k = len - (uint) System.Math.Abs(n);
+                k = len - System.Math.Abs(n);
             }
-            var searchElement = arguments.At(0);
-            for (; k >= 0; k--)
+
+            if (k < 0 || k > uint.MaxValue)
             {
-                var kString = TypeConverter.ToString(k);
-                if (o.TryGetValue(kString, out var value))
+                return -1;
+            }
+
+            var searchElement = arguments.At(0);
+            var i = (uint) k;
+            for (;; i--)
+            {
+                if (o.TryGetValue(i, out var value))
                 {
                     var same = ExpressionInterpreter.StrictlyEqual(value, searchElement);
                     if (same)
                     {
-                        return k;
+                        return i;
                     }
                 }
+
+                if (i == 0)
+                {
+                    break;
+                }
             }
+
             return -1;
         }
 
@@ -96,14 +107,10 @@ namespace Jint.Native.Array
             var callbackfn = arguments.At(0);
             var initialValue = arguments.At(1);
 
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenValue = o.Get("length");
-            var len = TypeConverter.ToUint32(lenValue);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
 
-            var callable = callbackfn.TryCast<ICallable>(x =>
-            {
-                throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
-            });
+            var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
 
             if (len == 0 && arguments.Length < 2)
             {
@@ -121,26 +128,34 @@ namespace Jint.Native.Array
                 var kPresent = false;
                 while (kPresent == false && k < len)
                 {
-                    var pk = TypeConverter.ToString(k);
-                    if (kPresent = o.TryGetValue(pk, out var temp))
+                    if (kPresent = o.TryGetValue((uint) k, out var temp))
                     {
                         accumulator = temp;
                     }
+
                     k++;
                 }
+
                 if (kPresent == false)
                 {
                     throw new JavaScriptException(Engine.TypeError);
                 }
             }
 
-            while(k < len)
+
+            var args = ArrayExecutionContext.Current.CallArray4;
+            while (k < len)
             {
-                var pk = TypeConverter.ToString(k);
-                if (o.TryGetValue(pk, out var kvalue))
+                var i = (uint) k;
+                if (o.TryGetValue(i, out var kvalue))
                 {
-                    accumulator = callable.Call(Undefined.Instance, new [] { accumulator, kvalue, k, o });
+                    args[0] = accumulator;
+                    args[1] = kvalue;
+                    args[2] = i;
+                    args[3] = o.Target;
+                    accumulator = callable.Call(Undefined.Instance, args);
                 }
+
                 k++;
             }
 
@@ -152,32 +167,26 @@ namespace Jint.Native.Array
             var callbackfn = arguments.At(0);
             var thisArg = arguments.At(1);
 
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenValue = o.Get("length");
-            var len = TypeConverter.ToUint32(lenValue);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
 
-            var callable = callbackfn.TryCast<ICallable>(x =>
-            {
-                throw new JavaScriptException(Engine.TypeError,
-                    "Argument must be callable");
-            });
+            var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
 
-            var a = (ArrayInstance)Engine.Array.Construct(Arguments.Empty);
+            var a = (ArrayInstance) Engine.Array.Construct(Arguments.Empty);
 
-            var to = 0;
+            uint to = 0;
             var jsValues = ArrayExecutionContext.Current.CallArray3;
-            for (var k = 0; k < len; k++)
+            for (uint k = 0; k < len; k++)
             {
-                var pk = TypeConverter.ToString(k);
-                if (o.TryGetValue(pk, out var kvalue))
+                if (o.TryGetValue(k, out var kvalue))
                 {
                     jsValues[0] = kvalue;
                     jsValues[1] = k;
-                    jsValues[2] = o;
+                    jsValues[2] = o.Target;
                     var selected = callable.Call(thisArg, jsValues);
                     if (TypeConverter.ToBoolean(selected))
                     {
-                        a.DefineOwnProperty(TypeConverter.ToString(to), new PropertyDescriptor(kvalue, true, true, true), false);
+                        a.SetIndexValue(to, kvalue, throwOnError: false);
                         to++;
                     }
                 }
@@ -191,27 +200,24 @@ namespace Jint.Native.Array
             var callbackfn = arguments.At(0);
             var thisArg = arguments.At(1);
 
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenValue = o.Get("length");
-            var len = TypeConverter.ToUint32(lenValue);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
 
-            var callable = callbackfn.TryCast<ICallable>(x =>
-            {
-                throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
-            });
+            var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
 
-            var a = Engine.Array.Construct(new JsValue[] {len}, len);
+            var args = ArrayExecutionContext.Current.CallArray1;
+            args[0] = len;
+            var a = Engine.Array.Construct(args, len);
             var jsValues = ArrayExecutionContext.Current.CallArray3;
-            for (var k = 0; k < len; k++)
+            for (uint k = 0; k < len; k++)
             {
-                var pk = TypeConverter.ToString(k);
-                if (o.TryGetValue(pk, out var kvalue))
+                if (o.TryGetValue(k, out var kvalue))
                 {
                     jsValues[0] = kvalue;
                     jsValues[1] = k;
-                    jsValues[2] = o;
+                    jsValues[2] = o.Target;
                     var mappedValue = callable.Call(thisArg, jsValues);
-                    a.DefineOwnProperty(pk, new PropertyDescriptor(mappedValue, true, true, true), false);
+                    a.SetIndexValue(k, mappedValue, throwOnError: false);
                 }
             }
 
@@ -223,24 +229,19 @@ namespace Jint.Native.Array
             var callbackfn = arguments.At(0);
             var thisArg = arguments.At(1);
 
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenValue = o.Get("length");
-            var len = TypeConverter.ToUint32(lenValue);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
 
-            var callable = callbackfn.TryCast<ICallable>(x =>
-            {
-                throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
-            });
+            var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
 
             var jsValues = ArrayExecutionContext.Current.CallArray3;
-            for (var k = 0; k < len; k++)
+            for (uint k = 0; k < len; k++)
             {
-                var pk = TypeConverter.ToString(k);
-                if (o.TryGetValue(pk, out var kvalue))
+                if (o.TryGetValue(k, out var kvalue))
                 {
                     jsValues[0] = kvalue;
                     jsValues[1] = k;
-                    jsValues[2] = o;
+                    jsValues[2] = o.Target;
                     callable.Call(thisArg, jsValues);
                 }
             }
@@ -253,24 +254,19 @@ namespace Jint.Native.Array
             var callbackfn = arguments.At(0);
             var thisArg = arguments.At(1);
 
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenValue = o.Get("length");
-            var len = TypeConverter.ToUint32(lenValue);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
 
-            var callable = callbackfn.TryCast<ICallable>(x =>
-            {
-                throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
-            });
+            var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
 
             var jsValues = ArrayExecutionContext.Current.CallArray3;
-            for (var k = 0; k < len; k++)
+            for (uint k = 0; k < len; k++)
             {
-                var pk = TypeConverter.ToString(k);
-                if (o.TryGetValue(pk, out var kvalue))
+                if (o.TryGetValue(k, out var kvalue))
                 {
                     jsValues[0] = kvalue;
                     jsValues[1] = k;
-                    jsValues[2] = o;
+                    jsValues[2] = o.Target;
                     var testResult = callable.Call(thisArg, jsValues);
                     if (TypeConverter.ToBoolean(testResult))
                     {
@@ -287,24 +283,19 @@ namespace Jint.Native.Array
             var callbackfn = arguments.At(0);
             var thisArg = arguments.At(1);
 
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenValue = o.Get("length");
-            var len = TypeConverter.ToUint32(lenValue);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
 
-            var callable = callbackfn.TryCast<ICallable>(x =>
-            {
-                throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
-            });
+            var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
 
             var jsValues = ArrayExecutionContext.Current.CallArray3;
-            for (var k = 0; k < len; k++)
+            for (uint k = 0; k < len; k++)
             {
-                var pk = TypeConverter.ToString(k);
-                if (o.TryGetValue(pk, out var kvalue))
+                if (o.TryGetValue(k, out var kvalue))
                 {
                     jsValues[0] = kvalue;
                     jsValues[1] = k;
-                    jsValues[2] = o;
+                    jsValues[2] = o.Target;
                     var testResult = callable.Call(thisArg, jsValues);
                     if (false == TypeConverter.ToBoolean(testResult))
                     {
@@ -318,37 +309,52 @@ namespace Jint.Native.Array
 
         private JsValue IndexOf(JsValue thisObj, JsValue[] arguments)
         {
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenValue = o.Get("length");
-            var len = TypeConverter.ToUint32(lenValue);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
             if (len == 0)
             {
                 return -1;
             }
 
-            var n = arguments.Length > 1 ? (uint) TypeConverter.ToInteger(arguments[1]) : 0;
-            if (n >= len)
+            var startIndex = arguments.Length > 1 ? TypeConverter.ToInteger(arguments[1]) : 0;
+
+            if (startIndex > uint.MaxValue)
             {
                 return -1;
             }
+
             uint k;
-            if (n >= 0)
+            if (startIndex < 0)
             {
-                k = n;
+                var abs = System.Math.Abs(startIndex);
+                long temp = len - (uint) abs;
+                if (abs > len || temp < 0)
+                {
+                    temp = 0;
+                }
+
+                k = (uint) temp;
             }
             else
             {
-                k = len - (uint) System.Math.Abs(n);
-                if (k < 0)
-                {
-                    k = 0;
-                }
+                k = (uint) startIndex;
             }
+
+            if (k >= len)
+            {
+                return -1;
+            }
+
+            uint smallestIndex = o.GetSmallestIndex();
+            if (smallestIndex > k)
+            {
+                k = smallestIndex;
+            }
+
             var searchElement = arguments.At(0);
             for (; k < len; k++)
             {
-                var kString = TypeConverter.ToString(k);
-                if (o.TryGetValue(kString, out var elementK))
+                if (o.TryGetValue(k, out var elementK))
                 {
                     var same = ExpressionInterpreter.StrictlyEqual(elementK, searchElement);
                     if (same)
@@ -357,6 +363,7 @@ namespace Jint.Native.Array
                     }
                 }
             }
+
             return -1;
         }
 
@@ -365,29 +372,27 @@ namespace Jint.Native.Array
             var start = arguments.At(0);
             var deleteCount = arguments.At(1);
 
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var a = Engine.Array.Construct(Arguments.Empty);
-            var lenVal = o.Get("length");
-            var len = TypeConverter.ToUint32(lenVal);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var a = (ArrayInstance) Engine.Array.Construct(Arguments.Empty);
+            var len = o.GetLength();
             var relativeStart = TypeConverter.ToInteger(start);
 
             uint actualStart;
             if (relativeStart < 0)
             {
-                actualStart = (uint)System.Math.Max(len + relativeStart, 0);
+                actualStart = (uint) System.Math.Max(len + relativeStart, 0);
             }
             else
             {
-                actualStart = (uint)System.Math.Min(relativeStart, len);
+                actualStart = (uint) System.Math.Min(relativeStart, len);
             }
 
-            var actualDeleteCount = System.Math.Min(System.Math.Max(TypeConverter.ToInteger(deleteCount), 0), len - actualStart);
-            for (var k = 0; k < actualDeleteCount; k++)
+            var actualDeleteCount = (uint) System.Math.Min(System.Math.Max(TypeConverter.ToInteger(deleteCount), 0), len - actualStart);
+            for (uint k = 0; k < actualDeleteCount; k++)
             {
-                var from = TypeConverter.ToString(actualStart + k);
-                if (o.TryGetValue(from, out var fromValue))
+                if (o.TryGetValue(actualStart + k, out var fromValue))
                 {
-                    a.DefineOwnProperty(TypeConverter.ToString(k), new PropertyDescriptor(fromValue, true, true, true), false);
+                    a.SetIndexValue(k, fromValue, throwOnError: false);
                 }
             }
 
@@ -397,77 +402,80 @@ namespace Jint.Native.Array
                 items = new JsValue[arguments.Length - 2];
                 System.Array.Copy(arguments, 2, items, 0, items.Length);
             }
+
             if (items.Length < actualDeleteCount)
             {
-                for (var k = actualStart; k < len - actualDeleteCount; k++)
+                for (uint k = actualStart; k < len - actualDeleteCount; k++)
                 {
-                    var from = TypeConverter.ToString(k + actualDeleteCount);
-                    var to = TypeConverter.ToString(k + items.Length);
+                    var from = k + actualDeleteCount;
+                    var to = (uint) (k + items.Length);
                     if (o.TryGetValue(from, out var fromValue))
                     {
                         o.Put(to, fromValue, true);
                     }
                     else
                     {
-                        o.Delete(to, true);
+                        o.DeleteAt(to);
                     }
                 }
-                for (var k = len; k > len - actualDeleteCount + items.Length; k-- )
+
+                for (var k = len; k > len - actualDeleteCount + items.Length; k--)
                 {
-                    o.Delete(TypeConverter.ToString(k - 1), true);
+                    o.DeleteAt(k - 1);
                 }
             }
             else if (items.Length > actualDeleteCount)
             {
                 for (var k = len - actualDeleteCount; k > actualStart; k--)
                 {
-                    var from = TypeConverter.ToString(k + actualDeleteCount - 1);
-                    var to = TypeConverter.ToString(k + items.Length - 1);
+                    var from = k + actualDeleteCount - 1;
+                    uint to = (uint) (k + items.Length - 1);
                     if (o.TryGetValue(from, out var fromValue))
                     {
                         o.Put(to, fromValue, true);
                     }
                     else
                     {
-                        o.Delete(to, true);
+                        o.DeleteAt(to);
                     }
                 }
             }
 
-            for(var k = 0; k< items.Length; k++)
+            for (uint k = 0; k < items.Length; k++)
             {
                 var e = items[k];
-                o.Put(TypeConverter.ToString(k+actualStart), e, true);
+                o.Put(k + actualStart, e, true);
             }
 
-            o.Put("length", len - actualDeleteCount + items.Length, true);
+            o.SetLength(len - actualDeleteCount + (uint) items.Length);
             return a;
         }
 
         private JsValue Unshift(JsValue thisObj, JsValue[] arguments)
         {
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenVal = o.Get("length");
-            var len = TypeConverter.ToUint32(lenVal);
-            var argCount = (uint)arguments.Length;
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
+            var argCount = (uint) arguments.Length;
             for (var k = len; k > 0; k--)
             {
-                var from = TypeConverter.ToString(k - 1);
-                var to = TypeConverter.ToString(k + argCount - 1);
+                var from = k - 1;
+                var to = k + argCount - 1;
                 if (o.TryGetValue(from, out var fromValue))
                 {
                     o.Put(to, fromValue, true);
                 }
                 else
                 {
-                    o.Delete(to, true);
+                    o.DeleteAt(to);
                 }
             }
-            for (var j = 0; j < argCount; j++)
+
+            for (uint j = 0; j < argCount; j++)
             {
-                o.Put(TypeConverter.ToString(j), arguments[j], true);
+                o.Put(j, arguments[j], true);
             }
-            o.Put("length", len + argCount, true);
+
+            o.SetLength(len + argCount);
             return len + argCount;
         }
 
@@ -478,23 +486,19 @@ namespace Jint.Native.Array
                 throw new JavaScriptException(Engine.TypeError, "Array.prorotype.sort can only be applied on objects");
             }
 
-            var obj = thisObj.AsObject();
+            var obj = ArrayOperations.For(thisObj.AsObject());
 
-            var len = obj.Get("length");
-            var lenVal = TypeConverter.ToInt32(len);
-            if (lenVal <= 1)
+            var len = obj.GetLength();
+            if (len <= 1)
             {
-                return obj;
+                return obj.Target;
             }
 
             var compareArg = arguments.At(0);
             ICallable compareFn = null;
             if (compareArg != Undefined.Instance)
             {
-                compareFn = compareArg.TryCast<ICallable>(x =>
-                {
-                    throw new JavaScriptException(Engine.TypeError, "The sort argument must be a function");
-                });
+                compareFn = compareArg.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "The sort argument must be a function"));
             }
 
             int Comparer(JsValue x, JsValue y)
@@ -537,10 +541,10 @@ namespace Jint.Native.Array
                 return r;
             }
 
-            var array = new JsValue[lenVal];
-            for (int i = 0; i < lenVal; ++i)
+            var array = new JsValue[len];
+            for (uint i = 0; i < len; ++i)
             {
-                array[i] = obj.Get(TypeConverter.ToString(i));
+                array[i] = obj.Get(i);
             }
 
             // don't eat inner exceptions
@@ -553,12 +557,12 @@ namespace Jint.Native.Array
                 throw e.InnerException;
             }
 
-            for (var i = 0; i < lenVal; ++i)
+            for (uint i = 0; i < len; ++i)
             {
-                obj.Put(TypeConverter.ToString(i), array[i], false);
+                obj.Put(i, array[i], false);
             }
 
-            return obj;
+            return obj.Target;
         }
 
         private JsValue Slice(JsValue thisObj, JsValue[] arguments)
@@ -566,19 +570,18 @@ namespace Jint.Native.Array
             var start = arguments.At(0);
             var end = arguments.At(1);
 
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenVal = o.Get("length");
-            var len = TypeConverter.ToUint32(lenVal);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
 
             var relativeStart = TypeConverter.ToInteger(start);
             uint k;
             if (relativeStart < 0)
             {
-                k = (uint)System.Math.Max(len + relativeStart, 0);
+                k = (uint) System.Math.Max(len + relativeStart, 0);
             }
             else
             {
-                k = (uint)System.Math.Min(TypeConverter.ToInteger(start), len);
+                k = (uint) System.Math.Min(TypeConverter.ToInteger(start), len);
             }
 
             uint final;
@@ -591,24 +594,23 @@ namespace Jint.Native.Array
                 double relativeEnd = TypeConverter.ToInteger(end);
                 if (relativeEnd < 0)
                 {
-                    final = (uint)System.Math.Max(len + relativeEnd, 0);
+                    final = (uint) System.Math.Max(len + relativeEnd, 0);
                 }
                 else
                 {
-                    final = (uint)System.Math.Min(TypeConverter.ToInteger(relativeEnd), len);
+                    final = (uint) System.Math.Min(TypeConverter.ToInteger(relativeEnd), len);
                 }
             }
 
             var a = Engine.Array.Construct(final - k);
-            var n = 0;
+            uint n = 0;
             for (; k < final; k++)
             {
-                var pk = TypeConverter.ToString(k);
-                if (o.TryGetValue(pk, out var kValue))
+                if (o.TryGetValue(k, out var kValue))
                 {
-                    a.DefineOwnProperty(TypeConverter.ToString(n),
-                                        new PropertyDescriptor(kValue, true, true, true), false);
+                    a.SetIndexValue(n, kValue, throwOnError: false);
                 }
+
                 n++;
             }
 
@@ -617,80 +619,79 @@ namespace Jint.Native.Array
 
         private JsValue Shift(JsValue thisObj, JsValue[] arg2)
         {
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenVal = o.Get("length");
-            var len = TypeConverter.ToUint32(lenVal);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
             if (len == 0)
             {
-                o.Put("length", 0, true);
+                o.SetLength(0);
                 return Undefined.Instance;
             }
-            var first = o.Get("0");
-            for (var k = 1; k < len; k++)
+
+            var first = o.Get(0);
+            for (uint k = 1; k < len; k++)
             {
-                var from = TypeConverter.ToString(k);
-                var to = TypeConverter.ToString(k - 1);
-                if (o.TryGetValue(from, out var fromVal))
+                var to = k - 1;
+                if (o.TryGetValue(k, out var fromVal))
                 {
                     o.Put(to, fromVal, true);
                 }
                 else
                 {
-                    o.Delete(to, true);
+                    o.DeleteAt(to);
                 }
             }
-            o.Delete(TypeConverter.ToString(len - 1), true);
-            o.Put("length", len-1, true);
+
+            o.DeleteAt(len - 1);
+            o.SetLength(len - 1);
 
             return first;
         }
 
         private JsValue Reverse(JsValue thisObj, JsValue[] arguments)
         {
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenVal = o.Get("length");
-            var len = TypeConverter.ToUint32(lenVal);
-            var middle = (uint)System.Math.Floor(len/2.0);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
+            var middle = (uint) System.Math.Floor(len / 2.0);
             uint lower = 0;
             while (lower != middle)
             {
                 var upper = len - lower - 1;
-                var upperP = TypeConverter.ToString(upper);
-                var lowerP = TypeConverter.ToString(lower);
-                var lowerExists = o.TryGetValue(lowerP, out var lowerValue);
-                var upperExists = o.TryGetValue(upperP, out var upperValue);
+                var lowerExists = o.TryGetValue(lower, out var lowerValue);
+                var upperExists = o.TryGetValue(upper, out var upperValue);
                 if (lowerExists && upperExists)
                 {
-                    o.Put(lowerP, upperValue, true);
-                    o.Put(upperP, lowerValue, true);
+                    o.Put(lower, upperValue, true);
+                    o.Put(upper, lowerValue, true);
                 }
+
                 if (!lowerExists && upperExists)
                 {
-                    o.Put(lowerP, upperValue, true);
-                    o.Delete(upperP, true);
+                    o.Put(lower, upperValue, true);
+                    o.DeleteAt(upper);
                 }
+
                 if (lowerExists && !upperExists)
                 {
-                    o.Delete(lowerP, true);
-                    o.Put(upperP, lowerValue, true);
+                    o.DeleteAt(lower);
+                    o.Put(upper, lowerValue, true);
                 }
 
                 lower++;
             }
 
-            return o;
+            return o.Target;
         }
 
         private JsValue Join(JsValue thisObj, JsValue[] arguments)
         {
             var separator = arguments.At(0);
-            var o = TypeConverter.ToObject(Engine, thisObj);
-            var lenVal = o.Get("length");
-            var len = TypeConverter.ToUint32(lenVal);
+            var o = ArrayOperations.For(Engine, thisObj);
+            var len = o.GetLength();
             if (separator == Undefined.Instance)
             {
                 separator = ",";
             }
+
             var sep = TypeConverter.ToString(separator);
 
             // as per the spec, this has to be called after ToString(separator)
@@ -699,77 +700,71 @@ namespace Jint.Native.Array
                 return "";
             }
 
-            var element0 = o.Get("0");
+            var element0 = o.Get(0);
             string r = element0 == Undefined.Instance || element0 == Null.Instance
-                                  ? ""
-                                  : TypeConverter.ToString(element0);
-            for (var k = 1; k < len; k++)
+                ? ""
+                : TypeConverter.ToString(element0);
+            for (uint k = 1; k < len; k++)
             {
                 var s = r + sep;
-                var element = o.Get(TypeConverter.ToString(k));
+                var element = o.Get(k);
                 string next = element == Undefined.Instance || element == Null.Instance
-                                  ? ""
-                                  : TypeConverter.ToString(element);
+                    ? ""
+                    : TypeConverter.ToString(element);
                 r = s + next;
             }
+
             return r;
         }
 
         private JsValue ToLocaleString(JsValue thisObj, JsValue[] arguments)
         {
-            var array = TypeConverter.ToObject(Engine, thisObj);
-            var arrayLen = array.Get("length");
-            var len = TypeConverter.ToUint32(arrayLen);
+            var array = ArrayOperations.For(Engine, thisObj);
+            var len = array.GetLength();
             const string separator = ",";
             if (len == 0)
             {
                 return "";
             }
+
             JsValue r;
-            var firstElement = array.Get("0");
-            if (firstElement == Null.Instance || firstElement == Undefined.Instance)
+            if (!array.TryGetValue(0, out var firstElement) || firstElement == Null.Instance || firstElement == Undefined.Instance)
             {
                 r = "";
             }
             else
             {
                 var elementObj = TypeConverter.ToObject(Engine, firstElement);
-                var func = elementObj.Get("toLocaleString").TryCast<ICallable>(x =>
-                {
-                    throw new JavaScriptException(Engine.TypeError);
-                });
+                var func = elementObj.Get("toLocaleString").TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError));
 
                 r = func.Call(elementObj, Arguments.Empty);
             }
-            for (var k = 1; k < len; k++)
+
+            for (uint k = 1; k < len; k++)
             {
                 string s = r + separator;
-                var nextElement = array.Get(TypeConverter.ToString(k));
-                if (nextElement == Undefined.Instance || nextElement == Null.Instance)
+                if (array.TryGetValue(k, out var nextElement) == Undefined.Instance || nextElement == Null.Instance)
                 {
                     r = "";
                 }
                 else
                 {
                     var elementObj = TypeConverter.ToObject(Engine, nextElement);
-                    var func = elementObj.Get("toLocaleString").TryCast<ICallable>(x =>
-                    {
-                        throw new JavaScriptException(Engine.TypeError);
-                    });
+                    var func = elementObj.Get("toLocaleString").TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError));
                     r = func.Call(elementObj, Arguments.Empty);
                 }
+
                 r = s + r;
             }
 
             return r;
-
         }
 
         private JsValue Concat(JsValue thisObj, JsValue[] arguments)
         {
             var o = TypeConverter.ToObject(Engine, thisObj);
-            var a = Engine.Array.Construct(Arguments.Empty);
-            var n = 0;
+            var a = (ArrayInstance) Engine.Array.Construct(Arguments.Empty);
+            uint n = 0;
             var items = new List<JsValue>(arguments.Length + 1) {o};
             items.AddRange(arguments);
 
@@ -778,20 +773,20 @@ namespace Jint.Native.Array
                 var eArray = e.TryCast<ArrayInstance>();
                 if (eArray != null)
                 {
-                    var len =  TypeConverter.ToUint32(eArray.Get("length"));
-                    for (var k = 0; k < len; k++)
+                    var len = eArray.GetLength();
+                    for (uint k = 0; k < len; k++)
                     {
-                        var p = TypeConverter.ToString(k);
-                        if (eArray.TryGetValue(p, out var subElement))
+                        if (eArray.TryGetValue(k, out var subElement))
                         {
-                            a.DefineOwnProperty(TypeConverter.ToString(n), new PropertyDescriptor(subElement, true, true, true), false);
+                            a.SetIndexValue(n, subElement, throwOnError: false);
                         }
+
                         n++;
                     }
                 }
                 else
                 {
-                    a.DefineOwnProperty(TypeConverter.ToString(n), new PropertyDescriptor(e, true, true, true ), false);
+                    a.SetIndexValue(n, e, throwOnError: false);
                     n++;
                 }
             }
@@ -807,13 +802,7 @@ namespace Jint.Native.Array
         {
             var array = TypeConverter.ToObject(Engine, thisObj);
             ICallable func;
-            func = array.Get("join").TryCast<ICallable>(x =>
-            {
-                func = Engine.Object.PrototypeObject.Get("toString").TryCast<ICallable>(y =>
-                {
-                    throw new ArgumentException();
-                });
-            });
+            func = array.Get("join").TryCast<ICallable>(x => { func = Engine.Object.PrototypeObject.Get("toString").TryCast<ICallable>(y => throw new ArgumentException()); });
 
             return func.Call(array, Arguments.Empty);
         }
@@ -827,17 +816,14 @@ namespace Jint.Native.Array
             var lenValue = o.Get("length");
             var len = TypeConverter.ToUint32(lenValue);
 
-            var callable = callbackfn.TryCast<ICallable>(x =>
-            {
-                throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
-            });
+            var callable = callbackfn.TryCast<ICallable>(x => { throw new JavaScriptException(Engine.TypeError, "Argument must be callable"); });
 
             if (len == 0 && arguments.Length < 2)
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
 
-            int k = (int)len - 1;
+            int k = (int) len - 1;
             JsValue accumulator = Undefined.Instance;
             if (arguments.Length > 1)
             {
@@ -849,13 +835,15 @@ namespace Jint.Native.Array
                 while (kPresent == false && k >= 0)
                 {
                     var pk = TypeConverter.ToString(k);
-                    kPresent = o.TryGetValue(pk, out var temp);
+                    kPresent = o.HasProperty(pk);
                     if (kPresent)
                     {
-                        accumulator = temp;
+                        accumulator = o.Get(pk);
                     }
+
                     k--;
                 }
+
                 if (kPresent == false)
                 {
                     throw new JavaScriptException(Engine.TypeError);
@@ -865,9 +853,11 @@ namespace Jint.Native.Array
             for (; k >= 0; k--)
             {
                 var pk = TypeConverter.ToString(k);
-                if (o.TryGetValue(pk, out var kvalue))
+                var kPresent = o.HasProperty(pk);
+                if (kPresent)
                 {
-                    accumulator = callable.Call(Undefined.Instance, new [] { accumulator, kvalue, k, o });
+                    var kvalue = o.Get(pk);
+                    accumulator = callable.Call(Undefined.Instance, new[] {accumulator, kvalue, k, o});
                 }
             }
 
@@ -876,42 +866,157 @@ namespace Jint.Native.Array
 
         public JsValue Push(JsValue thisObject, JsValue[] arguments)
         {
-            ObjectInstance o = TypeConverter.ToObject(Engine, thisObject);
-            var lenVal = TypeConverter.ToNumber(o.Get("length"));
+            var o = ArrayOperations.For(Engine, thisObject);
+            var lenVal = TypeConverter.ToNumber(o.Target.Get("length"));
 
             // cast to double as we need to prevent an overflow
             double n = TypeConverter.ToUint32(lenVal);
             for (var i = 0; i < arguments.Length; i++)
             {
                 JsValue e = arguments[i];
-                o.Put(TypeConverter.ToString(n), e, true);
+                o.Target.Put(TypeConverter.ToString(n), e, true);
                 n++;
             }
 
-            o.Put("length", n, true);
+            o.Target.Put("length", n, true);
 
             return n;
         }
 
         public JsValue Pop(JsValue thisObject, JsValue[] arguments)
         {
-            ObjectInstance o = TypeConverter.ToObject(Engine, thisObject);
-            var lenVal = TypeConverter.ToNumber(o.Get("length"));
+            var o = ArrayOperations.For(Engine, thisObject);
+            var lenVal = TypeConverter.ToNumber(o.Target.Get("length"));
 
             uint len = TypeConverter.ToUint32(lenVal);
             if (len == 0)
             {
-                o.Put("length", 0, true);
+                o.SetLength(0);
                 return Undefined.Instance;
             }
-            else
+
+            len = len - 1;
+            string indx = TypeConverter.ToString(len);
+            JsValue element = o.Target.Get(indx);
+            o.Target.Delete(indx, true);
+            o.Target.Put("length", len, true);
+            return element;
+        }
+
+        /// <summary>
+        /// Adapter to use optimized array operations when possible.
+        /// Gaps the difference between ArgumensInstance and ArrayInstance.
+        /// </summary>
+        private abstract class ArrayOperations
+        {
+            public abstract ObjectInstance Target { get; }
+
+            public virtual uint GetSmallestIndex() => 0;
+
+            public abstract uint GetLength();
+
+            public abstract void SetLength(uint length);
+
+            public abstract JsValue Get(uint index);
+
+            public abstract bool TryGetValue(uint index, out JsValue value);
+
+            public abstract void Put(uint index, JsValue value, bool throwOnError);
+
+            public abstract void DeleteAt(uint index);
+
+            public static ArrayOperations For(Engine engine, JsValue thisObj)
             {
-                len = len - 1;
-                string indx = TypeConverter.ToString(len);
-                JsValue element = o.Get(indx);
-                o.Delete(indx, true);
-                o.Put("length", len, true);
-                return element;
+                var instance = TypeConverter.ToObject(engine, thisObj);
+                return For(instance);
+            }
+
+            public static ArrayOperations For(ObjectInstance instance)
+            {
+                if (instance is ArrayInstance arrayInstance)
+                {
+                    return new ArrayInstanceOperations(arrayInstance);
+                }
+
+                return new ObjectInstanceOperations(instance);
+            }
+
+            private class ObjectInstanceOperations : ArrayOperations
+            {
+                private readonly ObjectInstance _instance;
+
+                public ObjectInstanceOperations(ObjectInstance instance)
+                {
+                    _instance = instance;
+                }
+
+                public override ObjectInstance Target => _instance;
+
+                public override uint GetLength()
+                {
+                    var desc = _instance.GetProperty("length");
+                    if (desc.IsDataDescriptor() && desc.Value != null)
+                    {
+                        return TypeConverter.ToUint32(desc.Value);
+                    }
+
+                    var getter = desc.Get != null ? desc.Get : Undefined.Instance;
+
+                    if (getter.IsUndefined())
+                    {
+                        return 0;
+                    }
+
+                    // if getter is not undefined it must be ICallable
+                    var callable = getter.TryCast<ICallable>();
+                    var value = callable.Call(_instance, Arguments.Empty);
+                    return TypeConverter.ToUint32(value);
+                }
+
+                public override void SetLength(uint length) => _instance.Put("length", length, true);
+
+                public override JsValue Get(uint index) => _instance.Get(TypeConverter.ToString(index));
+
+                public override bool TryGetValue(uint index, out JsValue value)
+                {
+                    var property = TypeConverter.ToString(index);
+                    var kPresent = _instance.HasProperty(property);
+                    value = kPresent ? _instance.Get(property) : JsValue.Undefined;
+                    return kPresent;
+                }
+
+                public override void Put(uint index, JsValue value, bool throwOnError) => _instance.Put(TypeConverter.ToString(index), value, throwOnError);
+
+                public override void DeleteAt(uint index) => _instance.Delete(TypeConverter.ToString(index), true);
+            }
+
+            private class ArrayInstanceOperations : ArrayOperations
+            {
+                private readonly ArrayInstance _array;
+
+                public ArrayInstanceOperations(ArrayInstance array)
+                {
+                    _array = array;
+                }
+
+                public override ObjectInstance Target => _array;
+
+                public override uint GetSmallestIndex() => _array.GetSmallestIndex();
+
+                public override uint GetLength() => _array.GetLength();
+
+                public override void SetLength(uint length) => _array.Put("length", length, true);
+
+                public override bool TryGetValue(uint index, out JsValue value)
+                {
+                    return _array.TryGetValue(index, out value);
+                }
+
+                public override JsValue Get(uint index) => _array.Get(TypeConverter.ToString(index));
+
+                public override void DeleteAt(uint index) => _array.DeleteAt(index);
+
+                public override void Put(uint index, JsValue value, bool throwOnError) => _array.SetIndexValue(index, value, throwOnError);
             }
         }
     }

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -79,11 +79,9 @@ namespace Jint.Native.Array
             for (; k >= 0; k--)
             {
                 var kString = k.ToString();
-                var kPresent = o.HasProperty(kString);
-                if (kPresent)
+                if (o.TryGetValue(kString, out var value))
                 {
-                    var elementK = o.Get(kString);
-                    var same = ExpressionInterpreter.StrictlyEqual(elementK, searchElement);
+                    var same = ExpressionInterpreter.StrictlyEqual(value, searchElement);
                     if (same)
                     {
                         return k;
@@ -124,10 +122,9 @@ namespace Jint.Native.Array
                 while (kPresent == false && k < len)
                 {
                     var pk = TypeConverter.ToString(k);
-                    kPresent = o.HasProperty(pk);
-                    if (kPresent)
+                    if (kPresent = o.TryGetValue(pk, out var temp))
                     {
-                        accumulator = o.Get(pk);
+                        accumulator = temp;
                     }
                     k++;
                 }
@@ -140,10 +137,8 @@ namespace Jint.Native.Array
             while(k < len)
             {
                 var pk = TypeConverter.ToString(k);
-                var kPresent = o.HasProperty(pk);
-                if (kPresent)
+                if (o.TryGetValue(pk, out var kvalue))
                 {
-                    var kvalue = o.Get(pk);
                     accumulator = callable.Call(Undefined.Instance, new [] { accumulator, kvalue, k, o });
                 }
                 k++;
@@ -170,14 +165,16 @@ namespace Jint.Native.Array
             var a = (ArrayInstance)Engine.Array.Construct(Arguments.Empty);
 
             var to = 0;
+            var jsValues = new JsValue[3];
             for (var k = 0; k < len; k++)
             {
                 var pk = TypeConverter.ToString(k);
-                var kpresent = o.HasProperty(pk);
-                if (kpresent)
+                if (o.TryGetValue(pk, out var kvalue))
                 {
-                    var kvalue = o.Get(pk);
-                    var selected = callable.Call(thisArg, new [] { kvalue, k, o });
+                    jsValues[0] = kvalue;
+                    jsValues[1] = k;
+                    jsValues[2] = o;
+                    var selected = callable.Call(thisArg, jsValues);
                     if (TypeConverter.ToBoolean(selected))
                     {
                         a.DefineOwnProperty(TypeConverter.ToString(to), new PropertyDescriptor(kvalue, true, true, true), false);
@@ -203,16 +200,17 @@ namespace Jint.Native.Array
                 throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
             });
 
-            var a = Engine.Array.Construct(new JsValue[] {len});
-
+            var a = Engine.Array.Construct(new JsValue[] {len}, len);
+            var jsValues = new JsValue[3];
             for (var k = 0; k < len; k++)
             {
                 var pk = TypeConverter.ToString(k);
-                var kpresent = o.HasProperty(pk);
-                if (kpresent)
+                if (o.TryGetValue(pk, out var kvalue))
                 {
-                    var kvalue = o.Get(pk);
-                    var mappedValue = callable.Call(thisArg, new [] { kvalue, k, o });
+                    jsValues[0] = kvalue;
+                    jsValues[1] = k;
+                    jsValues[2] = o;
+                    var mappedValue = callable.Call(thisArg, jsValues);
                     a.DefineOwnProperty(pk, new PropertyDescriptor(mappedValue, true, true, true), false);
                 }
             }
@@ -234,14 +232,16 @@ namespace Jint.Native.Array
                 throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
             });
 
+            var jsValues = new JsValue[3];
             for (var k = 0; k < len; k++)
             {
                 var pk = TypeConverter.ToString(k);
-                var kpresent = o.HasProperty(pk);
-                if (kpresent)
+                if (o.TryGetValue(pk, out var kvalue))
                 {
-                    var kvalue = o.Get(pk);
-                    callable.Call(thisArg, new [] { kvalue, k, o });
+                    jsValues[0] = kvalue;
+                    jsValues[1] = k;
+                    jsValues[2] = o;
+                    callable.Call(thisArg, jsValues);
                 }
             }
 
@@ -262,14 +262,16 @@ namespace Jint.Native.Array
                 throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
             });
 
+            var jsValues = new JsValue[3];
             for (var k = 0; k < len; k++)
             {
                 var pk = TypeConverter.ToString(k);
-                var kpresent = o.HasProperty(pk);
-                if (kpresent)
+                if (o.TryGetValue(pk, out var kvalue))
                 {
-                    var kvalue = o.Get(pk);
-                    var testResult = callable.Call(thisArg, new [] { kvalue, k, o });
+                    jsValues[0] = kvalue;
+                    jsValues[1] = k;
+                    jsValues[2] = o;
+                    var testResult = callable.Call(thisArg, jsValues);
                     if (TypeConverter.ToBoolean(testResult))
                     {
                         return true;
@@ -294,14 +296,16 @@ namespace Jint.Native.Array
                 throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
             });
 
+            var jsValues = new JsValue[3];
             for (var k = 0; k < len; k++)
             {
                 var pk = TypeConverter.ToString(k);
-                var kpresent = o.HasProperty(pk);
-                if (kpresent)
+                if (o.TryGetValue(pk, out var kvalue))
                 {
-                    var kvalue = o.Get(pk);
-                    var testResult = callable.Call(thisArg, new [] { kvalue, k, o });
+                    jsValues[0] = kvalue;
+                    jsValues[1] = k;
+                    jsValues[2] = o;
+                    var testResult = callable.Call(thisArg, jsValues);
                     if (false == TypeConverter.ToBoolean(testResult))
                     {
                         return JsValue.False;
@@ -344,10 +348,8 @@ namespace Jint.Native.Array
             for (; k < len; k++)
             {
                 var kString = k.ToString();
-                var kPresent = o.HasProperty(kString);
-                if (kPresent)
+                if (o.TryGetValue(kString, out var elementK))
                 {
-                    var elementK = o.Get(kString);
                     var same = ExpressionInterpreter.StrictlyEqual(elementK, searchElement);
                     if (same)
                     {
@@ -383,10 +385,8 @@ namespace Jint.Native.Array
             for (var k = 0; k < actualDeleteCount; k++)
             {
                 var from = TypeConverter.ToString(actualStart + k);
-                var fromPresent = o.HasProperty(from);
-                if (fromPresent)
+                if (o.TryGetValue(from, out var fromValue))
                 {
-                    var fromValue = o.Get(from);
                     a.DefineOwnProperty(TypeConverter.ToString(k), new PropertyDescriptor(fromValue, true, true, true), false);
                 }
             }
@@ -403,10 +403,8 @@ namespace Jint.Native.Array
                 {
                     var from = TypeConverter.ToString(k + actualDeleteCount);
                     var to = TypeConverter.ToString(k + items.Length);
-                    var fromPresent = o.HasProperty(from);
-                    if (fromPresent)
+                    if (o.TryGetValue(from, out var fromValue))
                     {
-                        var fromValue = o.Get(from);
                         o.Put(to, fromValue, true);
                     }
                     else
@@ -425,10 +423,8 @@ namespace Jint.Native.Array
                 {
                     var from = TypeConverter.ToString(k + actualDeleteCount - 1);
                     var to = TypeConverter.ToString(k + items.Length - 1);
-                    var fromPresent = o.HasProperty(from);
-                    if (fromPresent)
+                    if (o.TryGetValue(from, out var fromValue))
                     {
-                        var fromValue = o.Get(from);
                         o.Put(to, fromValue, true);
                     }
                     else
@@ -458,10 +454,8 @@ namespace Jint.Native.Array
             {
                 var from = TypeConverter.ToString(k - 1);
                 var to = TypeConverter.ToString(k + argCount - 1);
-                var fromPresent = o.HasProperty(from);
-                if (fromPresent)
+                if (o.TryGetValue(from, out var fromValue))
                 {
-                    var fromValue = o.Get(from);
                     o.Put(to, fromValue, true);
                 }
                 else
@@ -503,43 +497,45 @@ namespace Jint.Native.Array
                 });
             }
 
-            Comparison<JsValue> comparer = (x, y) =>
+            int Comparer(JsValue x, JsValue y)
+            {
+                if (x == Undefined.Instance && y == Undefined.Instance)
                 {
-                    if (x == Undefined.Instance && y == Undefined.Instance)
-                    {
-                        return 0;
-                    }
+                    return 0;
+                }
 
-                    if (x == Undefined.Instance)
-                    {
-                        return 1;
-                    }
+                if (x == Undefined.Instance)
+                {
+                    return 1;
+                }
 
-                    if (y == Undefined.Instance)
+                if (y == Undefined.Instance)
+                {
+                    return -1;
+                }
+
+                if (compareFn != null)
+                {
+                    var s = TypeConverter.ToNumber(compareFn.Call(Undefined.Instance, new[] {x, y}));
+                    if (s < 0)
                     {
                         return -1;
                     }
 
-                    if (compareFn != null)
+                    if (s > 0)
                     {
-                        var s = TypeConverter.ToNumber(compareFn.Call(Undefined.Instance, new[] {x, y}));
-                        if (s < 0)
-                        {
-                            return -1;
-                        }
-                        if (s > 0)
-                        {
-                            return 1;
-                        }
-                        return 0;
+                        return 1;
                     }
 
-                    var xString = TypeConverter.ToString(x);
-                    var yString = TypeConverter.ToString(y);
+                    return 0;
+                }
 
-                    var r = System.String.CompareOrdinal(xString, yString);
-                    return r;
-                };
+                var xString = TypeConverter.ToString(x);
+                var yString = TypeConverter.ToString(y);
+
+                var r = System.String.CompareOrdinal(xString, yString);
+                return r;
+            }
 
             var array = new JsValue[lenVal];
             for (int i = 0; i < lenVal; ++i)
@@ -550,7 +546,7 @@ namespace Jint.Native.Array
             // don't eat inner exceptions
             try
             {
-                System.Array.Sort(array, comparer);
+                System.Array.Sort(array, Comparer);
             }
             catch (InvalidOperationException e)
             {
@@ -571,7 +567,6 @@ namespace Jint.Native.Array
             var end = arguments.At(1);
 
             var o = TypeConverter.ToObject(Engine, thisObj);
-            var a = Engine.Array.Construct(Arguments.Empty);
             var lenVal = o.Get("length");
             var len = TypeConverter.ToUint32(lenVal);
 
@@ -604,14 +599,13 @@ namespace Jint.Native.Array
                 }
             }
 
+            var a = Engine.Array.Construct(final - k);
             var n = 0;
             for (; k < final; k++)
             {
                 var pk = TypeConverter.ToString(k);
-                var kPresent = o.HasProperty(pk);
-                if (kPresent)
+                if (o.TryGetValue(pk, out var kValue))
                 {
-                    var kValue = o.Get(pk);
                     a.DefineOwnProperty(TypeConverter.ToString(n),
                                         new PropertyDescriptor(kValue, true, true, true), false);
                 }
@@ -636,10 +630,8 @@ namespace Jint.Native.Array
             {
                 var from = TypeConverter.ToString(k);
                 var to = TypeConverter.ToString(k - 1);
-                var fromPresent = o.HasProperty(from);
-                if (fromPresent)
+                if (o.TryGetValue(from, out var fromVal))
                 {
-                    var fromVal = o.Get(from);
                     o.Put(to, fromVal, true);
                 }
                 else
@@ -665,10 +657,8 @@ namespace Jint.Native.Array
                 var upper = len - lower - 1;
                 var upperP = TypeConverter.ToString(upper);
                 var lowerP = TypeConverter.ToString(lower);
-                var lowerValue = o.Get(lowerP);
-                var upperValue = o.Get(upperP);
-                var lowerExists = o.HasProperty(lowerP);
-                var upperExists = o.HasProperty(upperP);
+                var lowerExists = o.TryGetValue(lowerP, out var lowerValue);
+                var upperExists = o.TryGetValue(upperP, out var upperValue);
                 if (lowerExists && upperExists)
                 {
                     o.Put(lowerP, upperValue, true);
@@ -780,7 +770,7 @@ namespace Jint.Native.Array
             var o = TypeConverter.ToObject(Engine, thisObj);
             var a = Engine.Array.Construct(Arguments.Empty);
             var n = 0;
-            var items = new List<JsValue> {o};
+            var items = new List<JsValue>(arguments.Length + 1) {o};
             items.AddRange(arguments);
 
             foreach (var e in items)
@@ -792,10 +782,8 @@ namespace Jint.Native.Array
                     for (var k = 0; k < len; k++)
                     {
                         var p = TypeConverter.ToString(k);
-                        var exists = eArray.HasProperty(p);
-                        if (exists)
+                        if (eArray.TryGetValue(p, out var subElement))
                         {
-                            var subElement = eArray.Get(p);
                             a.DefineOwnProperty(TypeConverter.ToString(n), new PropertyDescriptor(subElement, true, true, true), false);
                         }
                         n++;
@@ -861,10 +849,10 @@ namespace Jint.Native.Array
                 while (kPresent == false && k >= 0)
                 {
                     var pk = TypeConverter.ToString(k);
-                    kPresent = o.HasProperty(pk);
+                    kPresent = o.TryGetValue(pk, out var temp);
                     if (kPresent)
                     {
-                        accumulator = o.Get(pk);
+                        accumulator = temp;
                     }
                     k--;
                 }
@@ -877,10 +865,8 @@ namespace Jint.Native.Array
             for (; k >= 0; k--)
             {
                 var pk = TypeConverter.ToString(k);
-                var kPresent = o.HasProperty(pk);
-                if (kPresent)
+                if (o.TryGetValue(pk, out var kvalue))
                 {
-                    var kvalue = o.Get(pk);
                     accumulator = callable.Call(Undefined.Instance, new [] { accumulator, kvalue, k, o });
                 }
             }
@@ -895,8 +881,9 @@ namespace Jint.Native.Array
 
             // cast to double as we need to prevent an overflow
             double n = TypeConverter.ToUint32(lenVal);
-            foreach (JsValue e in arguments)
+            for (var i = 0; i < arguments.Length; i++)
             {
+                JsValue e = arguments[i];
                 o.Put(TypeConverter.ToString(n), e, true);
                 n++;
             }

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -65,20 +65,20 @@ namespace Jint.Native.Array
                 return -1;
             }
 
-            var n = arguments.Length > 1 ? TypeConverter.ToInteger(arguments[1]) : len - 1;
-            double k;
+            var n = arguments.Length > 1 ? (uint) TypeConverter.ToInteger(arguments[1]) : len - 1;
+            uint k;
             if (n >= 0)
             {
                 k = System.Math.Min(n, len - 1); // min
             }
             else
             {
-                k = len - System.Math.Abs(n);
+                k = len - (uint) System.Math.Abs(n);
             }
             var searchElement = arguments.At(0);
             for (; k >= 0; k--)
             {
-                var kString = k.ToString();
+                var kString = TypeConverter.ToString(k);
                 if (o.TryGetValue(kString, out var value))
                 {
                     var same = ExpressionInterpreter.StrictlyEqual(value, searchElement);
@@ -165,7 +165,7 @@ namespace Jint.Native.Array
             var a = (ArrayInstance)Engine.Array.Construct(Arguments.Empty);
 
             var to = 0;
-            var jsValues = new JsValue[3];
+            var jsValues = ArrayExecutionContext.Current.CallArray3;
             for (var k = 0; k < len; k++)
             {
                 var pk = TypeConverter.ToString(k);
@@ -201,7 +201,7 @@ namespace Jint.Native.Array
             });
 
             var a = Engine.Array.Construct(new JsValue[] {len}, len);
-            var jsValues = new JsValue[3];
+            var jsValues = ArrayExecutionContext.Current.CallArray3;
             for (var k = 0; k < len; k++)
             {
                 var pk = TypeConverter.ToString(k);
@@ -232,7 +232,7 @@ namespace Jint.Native.Array
                 throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
             });
 
-            var jsValues = new JsValue[3];
+            var jsValues = ArrayExecutionContext.Current.CallArray3;
             for (var k = 0; k < len; k++)
             {
                 var pk = TypeConverter.ToString(k);
@@ -262,7 +262,7 @@ namespace Jint.Native.Array
                 throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
             });
 
-            var jsValues = new JsValue[3];
+            var jsValues = ArrayExecutionContext.Current.CallArray3;
             for (var k = 0; k < len; k++)
             {
                 var pk = TypeConverter.ToString(k);
@@ -296,7 +296,7 @@ namespace Jint.Native.Array
                 throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
             });
 
-            var jsValues = new JsValue[3];
+            var jsValues = ArrayExecutionContext.Current.CallArray3;
             for (var k = 0; k < len; k++)
             {
                 var pk = TypeConverter.ToString(k);
@@ -326,19 +326,19 @@ namespace Jint.Native.Array
                 return -1;
             }
 
-            var n = arguments.Length > 1 ? TypeConverter.ToInteger(arguments[1]) : 0;
+            var n = arguments.Length > 1 ? (uint) TypeConverter.ToInteger(arguments[1]) : 0;
             if (n >= len)
             {
                 return -1;
             }
-            double k;
+            uint k;
             if (n >= 0)
             {
                 k = n;
             }
             else
             {
-                k = len - System.Math.Abs(n);
+                k = len - (uint) System.Math.Abs(n);
                 if (k < 0)
                 {
                     k = 0;
@@ -347,7 +347,7 @@ namespace Jint.Native.Array
             var searchElement = arguments.At(0);
             for (; k < len; k++)
             {
-                var kString = k.ToString();
+                var kString = TypeConverter.ToString(k);
                 if (o.TryGetValue(kString, out var elementK))
                 {
                     var same = ExpressionInterpreter.StrictlyEqual(elementK, searchElement);

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -355,6 +355,9 @@ namespace Jint.Native.Global
             '~', '*', '\'', '(', ')'
         };
 
+        private static readonly char[] UnescapedUriSet = UriReserved.Concat(UriUnescaped).Concat(new[] { '#' }).ToArray();
+        private static readonly char[] ReservedUriSet = UriReserved.Concat(new[] { '#' }).ToArray();
+
         private const string HexaMap = "0123456789ABCDEF";
 
         private static bool IsValidHexaChar(char c)
@@ -373,9 +376,8 @@ namespace Jint.Native.Global
         public JsValue EncodeUri(JsValue thisObject, JsValue[] arguments)
         {
             var uriString = TypeConverter.ToString(arguments.At(0));
-            var unescapedUriSet = UriReserved.Concat(UriUnescaped).Concat(new[] { '#' }).ToArray();
 
-            return Encode(uriString, unescapedUriSet);
+            return Encode(uriString, UnescapedUriSet);
         }
 
 
@@ -498,9 +500,8 @@ namespace Jint.Native.Global
         public JsValue DecodeUri(JsValue thisObject, JsValue[] arguments)
         {
             var uriString = TypeConverter.ToString(arguments.At(0));
-            var reservedUriSet = UriReserved.Concat(new[] { '#' }).ToArray();
 
-            return Decode(uriString, reservedUriSet);
+            return Decode(uriString, ReservedUriSet);
         }
 
         public JsValue DecodeUriComponent(JsValue thisObject, JsValue[] arguments)

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -478,7 +478,7 @@ namespace Jint.Native
                 {
                     var array = (System.Array)v;
 
-                    var jsArray = engine.Array.Construct(Arguments.Empty);
+                    var jsArray = engine.Array.Construct(a.Length);
                     foreach (var item in array)
                     {
                         var jsItem = JsValue.FromObject(engine, item);

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -614,8 +614,9 @@ namespace Jint.Native.Json
 
         public ObjectInstance CreateArrayInstance(IEnumerable<JsValue> values)
         {
-            var jsArray = _engine.Array.Construct(Arguments.Empty);
-            _engine.Array.PrototypeObject.Push(jsArray, values.ToArray());
+            var jsValues = values.ToArray();
+            var jsArray = _engine.Array.Construct(jsValues.Length);
+            _engine.Array.PrototypeObject.Push(jsArray, jsValues);
             return jsArray;
         }
 

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -140,20 +140,23 @@ namespace Jint.Native.Object
                 throw new JavaScriptException(Engine.TypeError);
             }
 
-            var array = Engine.Array.Construct(Arguments.Empty);
             var n = 0;
 
-            var s = o as StringInstance;
-            if (s != null)
+            ObjectInstance array = null;
+            var ownProperties = o.GetOwnProperties().ToList();
+            if (o is StringInstance s)
             {
-                for (var i = 0; i < s.PrimitiveValue.AsString().Length; i++)
+                var length = s.PrimitiveValue.AsString().Length;
+                array = Engine.Array.Construct(ownProperties.Count + length);
+                for (var i = 0; i < length; i++)
                 {
                     array.DefineOwnProperty(TypeConverter.ToString(n), new PropertyDescriptor(TypeConverter.ToString(i), true, true, true), false);
                     n++;
                 }
             }
 
-            foreach (var p in o.GetOwnProperties())
+            array = array ?? Engine.Array.Construct(ownProperties.Count);
+            foreach (var p in ownProperties)
             {
                 array.DefineOwnProperty(TypeConverter.ToString(n), new PropertyDescriptor(p.Key, true, true, true), false);
                 n++;
@@ -387,7 +390,7 @@ namespace Jint.Native.Object
                 .Where(x => x.Value.Enumerable.HasValue && x.Value.Enumerable.Value)
                 .ToArray();
             var n = enumerableProperties.Length;
-            var array = Engine.Array.Construct(new JsValue[] {n});
+            var array = Engine.Array.Construct(new JsValue[] {n}, (uint) n);
             var index = 0;
             foreach (var prop in enumerableProperties)
             {

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -92,7 +92,7 @@ namespace Jint.Native.Object
             if (_prototype != null)
             {
                 yield return new KeyValuePair<string, PropertyDescriptor>(PropertyNamePrototype, _prototype);
-            }
+        }
             if (_constructor != null)
             {
                 yield return new KeyValuePair<string, PropertyDescriptor>(PropertyNameConstructor, _constructor);
@@ -103,7 +103,7 @@ namespace Jint.Native.Object
             }
 
             if (_properties != null)
-            {
+        {
                 foreach (var pair in _properties.GetEnumerator())
                 {
                     yield return pair;
@@ -171,7 +171,7 @@ namespace Jint.Native.Object
             if (propertyName == PropertyNamePrototype)
             {
                 return _prototype != null;
-            }
+        }
             if (propertyName == PropertyNameConstructor)
             {
                 return _constructor != null;
@@ -191,7 +191,7 @@ namespace Jint.Native.Object
             if (propertyName == PropertyNamePrototype)
             {
                 _prototype = null;
-            }
+        }
             if (propertyName == PropertyNameConstructor)
             {
                 _constructor = null;
@@ -254,13 +254,13 @@ namespace Jint.Native.Object
                 return _prototype ?? PropertyDescriptor.Undefined;
             }
             if (propertyName == PropertyNameConstructor)
-            {
+                {
                 return _constructor ?? PropertyDescriptor.Undefined;
-            }
+                }
             if (propertyName == PropertyNameLength)
-            {
+                {
                 return _length ?? PropertyDescriptor.Undefined;
-            }
+                }
 
             PropertyDescriptor x;
             if (_properties != null && _properties.TryGetValue(propertyName, out x))
@@ -279,7 +279,7 @@ namespace Jint.Native.Object
             {
                 _prototype = desc;
                 return;
-            }
+        }
             if (propertyName == PropertyNameConstructor)
             {
                 _constructor = desc;
@@ -319,6 +319,45 @@ namespace Jint.Native.Object
             }
 
             return Prototype.GetProperty(propertyName);
+        }
+
+        public bool TryGetValue(string propertyName, out JsValue value)
+        {
+            value = JsValue.Undefined;
+            var desc = GetOwnProperty(propertyName);
+            if (desc != null && desc != PropertyDescriptor.Undefined)
+            {
+                if (desc == PropertyDescriptor.Undefined)
+                {
+                    return false;
+                }
+
+                if (desc.IsDataDescriptor() && desc.Value != null)
+                {
+                    value = desc.Value;
+                    return true;
+                }
+
+                var getter = desc.Get != null ? desc.Get : Undefined.Instance;
+
+                if (getter.IsUndefined())
+                {
+                    value = Undefined.Instance;
+                    return false;
+                }
+
+                // if getter is not undefined it must be ICallable
+                var callable = getter.TryCast<ICallable>();
+                value = callable.Call(this, Arguments.Empty);
+                return true;
+            }
+
+            if(Prototype == null)
+            {
+                return false;
+            }
+
+            return Prototype.TryGetValue(propertyName, out value);
         }
 
         /// <summary>

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using Jint.Native.Array;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
@@ -80,7 +81,7 @@ namespace Jint.Native.RegExp
             if (R.Source == "(?:)")  // Reg Exp is really ""
             {
                 // "aaa".match() => [ '', index: 0, input: 'aaa' ]
-                var aa = InitReturnValueArray(Engine.Array.Construct(Arguments.Empty), s, 1, 0);
+                var aa = InitReturnValueArray((ArrayInstance) Engine.Array.Construct(Arguments.Empty), s, 1, 0);
                 aa.DefineOwnProperty("0", new PropertyDescriptor("", true, true, true), true);
                 return aa;
             }
@@ -109,19 +110,19 @@ namespace Jint.Native.RegExp
             var n = r.Groups.Count;
             var matchIndex = r.Index;
 
-            var a = InitReturnValueArray(Engine.Array.Construct(Arguments.Empty), s, n, matchIndex);
+            var a = InitReturnValueArray((ArrayInstance) Engine.Array.Construct(Arguments.Empty), s, n, matchIndex);
 
-            for (var k = 0; k < n; k++)
+            for (uint k = 0; k < n; k++)
             {
-                var group = r.Groups[k];
+                var group = r.Groups[(int) k];
                 var value = group.Success ? group.Value : Undefined.Instance;
-                a.DefineOwnProperty(TypeConverter.ToString(k), new PropertyDescriptor(value, true, true, true), true);
+                a.SetIndexValue(k, value, throwOnError: true);
             }
 
             return a;
         }
 
-        private static Object.ObjectInstance InitReturnValueArray(Object.ObjectInstance array, string inputValue, int lengthValue, int indexValue)
+        private static ArrayInstance InitReturnValueArray(ArrayInstance array, string inputValue, int lengthValue, int indexValue)
         {
             array.DefineOwnProperty("index", new PropertyDescriptor(indexValue, writable: true, enumerable: true, configurable: true), true);
             array.DefineOwnProperty("input", new PropertyDescriptor(inputValue, writable: true, enumerable: true, configurable: true), true);

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -269,12 +269,12 @@ namespace Jint.Native.String
 
                 if (!match.Success) // No match at all return the string in an array
                 {
-                    a.DefineOwnProperty("0", new PropertyDescriptor(s, true, true, true), false);
+                    a.SetIndexValue(0, s, throwOnError: false);
                     return a;
                 }
 
                 int lastIndex = 0;
-                int index = 0;
+                uint index = 0;
                 while (match.Success && index < limit)
                 {
                     if (match.Length == 0 && (match.Index == 0 || match.Index == len || match.Index == lastIndex))
@@ -284,7 +284,7 @@ namespace Jint.Native.String
                     }
 
                     // Add the match results to the array.
-                    a.DefineOwnProperty(TypeConverter.ToString(index++), new PropertyDescriptor(s.Substring(lastIndex, match.Index - lastIndex), true, true, true), false);
+                    a.SetIndexValue(index++, s.Substring(lastIndex, match.Index - lastIndex), throwOnError: false);
 
                     if (index >= limit)
                     {
@@ -301,7 +301,7 @@ namespace Jint.Native.String
                             item = match.Groups[i].Value;
                         }
 
-                        a.DefineOwnProperty(TypeConverter.ToString(index++), new PropertyDescriptor(item, true, true, true ), false);
+                        a.SetIndexValue(index++, item, throwOnError: false);
 
                         if (index >= limit)
                         {
@@ -312,7 +312,7 @@ namespace Jint.Native.String
                     match = match.NextMatch();
                     if (!match.Success) // Add the last part of the split
                     {
-                        a.DefineOwnProperty(TypeConverter.ToString(index++), new PropertyDescriptor(s.Substring(lastIndex), true, true, true), false);
+                        a.SetIndexValue(index++, s.Substring(lastIndex), throwOnError: false);
                     }
                 }
 
@@ -338,7 +338,7 @@ namespace Jint.Native.String
 
                 for (int i = 0; i < segments.Count && i < limit; i++)
                 {
-                    a.DefineOwnProperty(TypeConverter.ToString(i), new PropertyDescriptor(segments[i], true, true, true), false);
+                    a.SetIndexValue((uint) i, segments[i], throwOnError: false);
                 }
 
                 return a;
@@ -578,9 +578,9 @@ namespace Jint.Native.String
             else
             {
                 rx.Put("lastIndex", 0, false);
-                var a = Engine.Array.Construct(Arguments.Empty);
+                var a = (ArrayInstance) Engine.Array.Construct(Arguments.Empty);
                 double previousLastIndex = 0;
-                var n = 0;
+                uint n = 0;
                 var lastMatch = true;
                 while (lastMatch)
                 {
@@ -599,7 +599,7 @@ namespace Jint.Native.String
                         }
 
                         var matchStr = result.Get("0");
-                        a.DefineOwnProperty(TypeConverter.ToString(n), new PropertyDescriptor(matchStr, true, true, true), false);
+                        a.SetIndexValue(n, matchStr, throwOnError: false);
                         n++;
                     }
                 }

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -186,5 +186,35 @@ namespace Jint.Runtime.Descriptors
 
             return obj;
         }
+
+        internal bool TryGetValue(ObjectInstance thisArg, out JsValue value)
+        {
+            value = JsValue.Undefined;
+
+            if (this == Undefined)
+            {
+                value = JsValue.Undefined;
+                return false;
+            }
+
+            if (IsDataDescriptor())
+            {
+                var val = Value;
+                if (val != null)
+                {
+                    value = val;
+                    return true;
+                }
+            }
+
+            if (Get != null && !Get.IsUndefined())
+            {
+                // if getter is not undefined it must be ICallable
+                var callable = Get.TryCast<ICallable>();
+                value = callable.Call(thisArg, Arguments.Empty);
+            }
+
+            return true;
+        }
     }
 }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 using Esprima;
 using Esprima.Ast;
 using Jint.Native;
-using Jint.Native.Array;
 using Jint.Native.Function;
 using Jint.Native.Number;
 using Jint.Runtime.Descriptors;
@@ -611,18 +610,18 @@ namespace Jint.Runtime
 
         public JsValue EvaluateLiteral(Literal literal)
         {
-                switch (literal.TokenType)
-                {
-                    case TokenType.BooleanLiteral:
+            switch (literal.TokenType)
+            {
+                case TokenType.BooleanLiteral:
                     return literal.BooleanValue ? JsValue.True : JsValue.False;
-                    case TokenType.NullLiteral:
-                        return JsValue.Null;
-                    case TokenType.NumericLiteral:
+                case TokenType.NullLiteral:
+                    return JsValue.Null;
+                case TokenType.NumericLiteral:
                     // implicit conversion operator goes through caching
                     return literal.NumericValue;
-                    case TokenType.StringLiteral:
-                        return new JsValue(literal.StringValue);
-                }
+                case TokenType.StringLiteral:
+                    return new JsValue(literal.StringValue);
+            }
 
             if (literal.RegexValue != null) //(literal.Type == Nodes.RegularExpressionLiteral)
             {
@@ -1099,7 +1098,7 @@ namespace Jint.Runtime
                 var argument = (Expression) expressionArguments[i];
                 arguments[i] = _engine.GetValue(EvaluateExpression(argument));
                 allLiteral &= argument is Literal;
-    }
+            }
 
             return arguments;
         }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 using Esprima;
 using Esprima.Ast;
 using Jint.Native;
-using Jint.Native.Array;
 using Jint.Native.Function;
 using Jint.Native.Number;
 using Jint.Runtime.Descriptors;
@@ -986,7 +985,8 @@ namespace Jint.Runtime
 
         public JsValue EvaluateArrayExpression(ArrayExpression arrayExpression)
         {
-            var a = (ArrayInstance) _engine.Array.Construct(new JsValue[] { arrayExpression.Elements.Count });
+            var count = (uint) arrayExpression.Elements.Count;
+            var a = _engine.Array.Construct(new JsValue[] { count }, count);
             uint n = 0;
             foreach (var expr in arrayExpression.Elements)
             {

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using Esprima;
 using Esprima.Ast;
 using Jint.Native;
+using Jint.Native.Array;
 using Jint.Native.Function;
 using Jint.Native.Number;
 using Jint.Runtime.Descriptors;
@@ -985,15 +986,16 @@ namespace Jint.Runtime
 
         public JsValue EvaluateArrayExpression(ArrayExpression arrayExpression)
         {
-            var count = (uint) arrayExpression.Elements.Count;
-            var a = _engine.Array.Construct(new JsValue[] { count }, count);
-            uint n = 0;
-            foreach (var expr in arrayExpression.Elements)
+            var elements = arrayExpression.Elements;
+            var count = elements.Count;
+            var a = _engine.Array.Construct(new JsValue[] {count}, (uint) count);
+            for (var n = 0; n < count; n++)
             {
+                var expr = elements[n];
                 if (expr != null)
                 {
                     var value = _engine.GetValue(EvaluateExpression(expr.As<Expression>()));
-                    a.SetIndexValue(n, value, throwOnError: false);
+                    a.SetIndexValue((uint) n, value, throwOnError: false);
                 }
             }
 

--- a/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
@@ -48,14 +48,10 @@ namespace Jint.Runtime.Interop
                         var arrayInstance = arguments[i].AsArray();
                         var len = TypeConverter.ToInt32(arrayInstance.Get("length"));
                         var result = new JsValue[len];
-                        for (var k = 0; k < len; k++)
+                        for (uint k = 0; k < len; k++)
                         {
-                            var pk = TypeConverter.ToString(k);
-                            result[k] = arrayInstance.HasProperty(pk)
-                                ? arrayInstance.Get(pk)
-                                : JsValue.Undefined;
+                            result[k] = arrayInstance.TryGetValue(k, out var value) ? value : JsValue.Undefined;
                         }
-
                         parameters[i] = result;
                     }
                     else

--- a/Jint/Runtime/MruPropertyCache.cs
+++ b/Jint/Runtime/MruPropertyCache.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Jint.Runtime
 {
-    public class MruPropertyCache<TKey, TValue> : IDictionary<TKey, TValue>
+    internal class MruPropertyCache<TKey, TValue> : IDictionary<TKey, TValue>
     {
         private IDictionary<TKey, TValue> _dictionary = new Dictionary<TKey, TValue>();
         private LinkedList<KeyValuePair<TKey, TValue>> _list;

--- a/Jint/Runtime/MruPropertyCache2.cs
+++ b/Jint/Runtime/MruPropertyCache2.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace Jint.Runtime
 {
-    public class MruPropertyCache2<TKey, TValue> where TKey : class where TValue : class
+    internal class MruPropertyCache2<TKey, TValue> where TKey : class where TValue : class
     {
         private Dictionary<TKey, TValue> _dictionary;
         private bool _set;

--- a/Jint/Runtime/MruPropertyCache2.cs
+++ b/Jint/Runtime/MruPropertyCache2.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace Jint.Runtime
 {
-    internal class MruPropertyCache2<TKey, TValue> where TValue : class
+    public class MruPropertyCache2<TKey, TValue> where TKey : class where TValue : class
     {
         private Dictionary<TKey, TValue> _dictionary;
         private bool _set;


### PR DESCRIPTION
* Made it possible to hint about wanted array size
* Support for dense arrays
* MruPropertyCache is lazy

## ArrayBenchmark

### Baseline

|             Method |   N |       Mean |     Error |    StdDev |     Gen 0 | Allocated |
|------------------- |---- |-----------:|----------:|----------:|----------:|----------:|
|              Slice | 100 |   2.606 ms | 0.0555 ms | 0.0519 ms |  546.8750 |    2.2 MB |
|             Concat | 100 |   2.758 ms | 0.0231 ms | 0.0205 ms |  593.7500 |   2.38 MB |
|            Unshift | 100 | 107.151 ms | 0.3361 ms | 0.2807 ms | 8250.0000 |  33.16 MB |
|               Push | 100 |  33.993 ms | 0.6668 ms | 0.7134 ms | 4000.0000 |  16.13 MB |
|              Index | 100 |  26.968 ms | 0.0660 ms | 0.0585 ms | 2750.0000 |  11.07 MB |
|                Map | 100 |  12.291 ms | 0.0380 ms | 0.0356 ms | 3546.8750 |  14.23 MB |
|              Apply | 100 |   5.936 ms | 0.0071 ms | 0.0063 ms |  742.1875 |   2.97 MB |
| JsonStringifyParse | 100 |  11.847 ms | 0.0464 ms | 0.0434 ms | 2046.8750 |   8.22 MB |

### After sparse array optimization

|             Method |   N |      Mean |     Error |    StdDev |     Gen 0 | Allocated |
|------------------- |---- |----------:|----------:|----------:|----------:|----------:|
|              Slice | 100 |  1.149 ms | 0.0152 ms | 0.0134 ms |  382.8125 |   1.53 MB |
|             Concat | 100 |  1.305 ms | 0.0027 ms | 0.0022 ms |  457.0313 |   1.83 MB |
|            Unshift | 100 | 46.830 ms | 0.0509 ms | 0.0451 ms | 8125.0000 |  32.51 MB |
|               Push | 100 | 33.087 ms | 0.1223 ms | 0.1144 ms | 3937.5000 |  15.81 MB |
|              Index | 100 | 26.781 ms | 0.0412 ms | 0.0344 ms | 2593.7500 |  10.45 MB |
|                Map | 100 |  8.557 ms | 0.0126 ms | 0.0105 ms | 2953.1250 |  11.87 MB |
|              Apply | 100 |  5.607 ms | 0.0047 ms | 0.0037 ms |  718.7500 |    2.9 MB |
| JsonStringifyParse | 100 | 11.445 ms | 0.0234 ms | 0.0219 ms | 1984.3750 |   7.95 MB |

### After introducing dense array

|             Method |   N |        Mean |      Error |     StdDev |     Gen 0 | Allocated |
|------------------- |---- |------------:|-----------:|-----------:|----------:|----------:|
|              Slice | 100 |    935.5 us |   3.443 us |   3.052 us |  336.9141 |   1.35 MB |
|             Concat | 100 |  1,068.9 us |   2.023 us |   1.892 us |  361.3281 |   1.45 MB |
|            Unshift | 100 | 41,124.9 us | 116.609 us | 103.371 us | 8687.5000 |  34.79 MB |
|               Push | 100 | 28,129.1 us |  77.340 us |  72.344 us | 3625.0000 |  14.53 MB |
|              Index | 100 | 25,813.5 us |  84.770 us |  79.294 us | 2500.0000 |  10.07 MB |
|                Map | 100 |  8,320.5 us |  33.465 us |  27.945 us | 2906.2500 |  11.68 MB |
|              Apply | 100 |  1,160.1 us |  11.889 us |  11.121 us |  369.1406 |   1.48 MB |
| JsonStringifyParse | 100 |  6,885.8 us |  18.351 us |  17.166 us | 1671.8750 |   6.71 MB |

## ArrayStressBenchmark

### Baseline

| Method |  N |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 |      Gen 2 | Allocated |
|------- |--- |--------:|---------:|---------:|------------:|-----------:|-----------:|----------:|
|   Jint | 20 | 2.520 s | 0.0885 s | 0.0050 s | 223750.0000 | 23250.0000 | 11500.0000 | 979.52 MB |

### After sparse array optimization

| Method |  N |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|------- |--- |--------:|---------:|---------:|------------:|-----------:|----------:|----------:|
|   Jint | 20 | 1.492 s | 0.0479 s | 0.0027 s | 180000.0000 | 20000.0000 | 9750.0000 | 805.61 MB |

### After introducing dense array

| Method |  N |    Mean |    Error |   StdDev |       Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|------- |--- |--------:|---------:|---------:|------------:|----------:|----------:|----------:|
|   Jint | 20 | 2.096 s | 0.0750 s | 0.0042 s | 198416.6667 | 8833.3333 | 3833.3333 | 873.57 MB |

## UncacheableExpressionsBenchmark

### Baseline

|    Method |   N |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|---------- |---- |--------:|---------:|---------:|------------:|-----------:|----------:|
| Benchmark | 500 | 1.062 s | 0.0289 s | 0.0406 s | 202687.5000 | 55312.5000 |  903.2 MB |

### After sparse array optimization

|    Method |   N |     Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|---------- |---- |---------:|---------:|---------:|------------:|-----------:|----------:|
| Benchmark | 500 | 845.1 ms | 3.704 ms | 5.430 ms | 178058.3333 | 45079.1667 | 783.57 MB |

### After introducing dense array

|    Method |   N |     Mean |    Error |   StdDev |       Gen 0 |     Gen 1 | Allocated |
|---------- |---- |---------:|---------:|---------:|------------:|----------:|----------:|
| Benchmark | 500 | 797.6 ms | 2.303 ms | 3.447 ms | 189070.8333 | 2366.6667 | 761.26 MB |