### PR TITLE
Cache common JsValue allocations

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -45,22 +45,22 @@ namespace Jint
 
         internal static Dictionary<Type, Func<Engine, object, JsValue>> TypeMappers = new Dictionary<Type, Func<Engine, object, JsValue>>()
         {
-            { typeof(bool), (Engine engine, object v) => new JsValue((bool)v) },
-            { typeof(byte), (Engine engine, object v) => new JsValue((byte)v) },
-            { typeof(char), (Engine engine, object v) => new JsValue((char)v) },
+            { typeof(bool), (Engine engine, object v) => (bool) v ? JsValue.True : JsValue.False },
+            { typeof(byte), (Engine engine, object v) => JsValue.FromInt((byte)v) },
+            { typeof(char), (Engine engine, object v) => JsValue.FromChar((char)v) },
             { typeof(DateTime), (Engine engine, object v) => engine.Date.Construct((DateTime)v) },
             { typeof(DateTimeOffset), (Engine engine, object v) => engine.Date.Construct((DateTimeOffset)v) },
-            { typeof(decimal), (Engine engine, object v) => new JsValue((double)(decimal)v) },
-            { typeof(double), (Engine engine, object v) => new JsValue((double)v) },
-            { typeof(Int16), (Engine engine, object v) => new JsValue((Int16)v) },
-            { typeof(Int32), (Engine engine, object v) => new JsValue((Int32)v) },
-            { typeof(Int64), (Engine engine, object v) => new JsValue((Int64)v) },
-            { typeof(SByte), (Engine engine, object v) => new JsValue((SByte)v) },
-            { typeof(Single), (Engine engine, object v) => new JsValue((Single)v) },
-            { typeof(string), (Engine engine, object v) => new JsValue((string)v) },
-            { typeof(UInt16), (Engine engine, object v) => new JsValue((UInt16)v) },
-            { typeof(UInt32), (Engine engine, object v) => new JsValue((UInt32)v) },
-            { typeof(UInt64), (Engine engine, object v) => new JsValue((UInt64)v) },
+            { typeof(decimal), (Engine engine, object v) => (JsValue) (double)(decimal)v },
+            { typeof(double), (Engine engine, object v) => (JsValue)(double)v },
+            { typeof(Int16), (Engine engine, object v) => JsValue.FromInt((Int16)v) },
+            { typeof(Int32), (Engine engine, object v) => JsValue.FromInt((Int32)v) },
+            { typeof(Int64), (Engine engine, object v) => (JsValue)(Int64)v },
+            { typeof(SByte), (Engine engine, object v) => JsValue.FromInt((SByte)v) },
+            { typeof(Single), (Engine engine, object v) => (JsValue)(Single)v },
+            { typeof(string), (Engine engine, object v) => (JsValue) (string)v },
+            { typeof(UInt16), (Engine engine, object v) => JsValue.FromInt((UInt16)v) },
+            { typeof(UInt32), (Engine engine, object v) => JsValue.FromInt((UInt32)v) },
+            { typeof(UInt64), (Engine engine, object v) => JsValue.FromInt((UInt64)v) },
             { typeof(JsValue), (Engine engine, object v) => (JsValue)v },
             { typeof(System.Text.RegularExpressions.Regex), (Engine engine, object v) => engine.RegExp.Construct((System.Text.RegularExpressions.Regex)v, "") }
         };
@@ -257,9 +257,14 @@ namespace Jint
             return SetValue(name, new JsValue(value));
         }
 
+        public Engine SetValue(string name, int value)
+        {
+            return SetValue(name, JsValue.FromInt(value));
+        }
+
         public Engine SetValue(string name, bool value)
         {
-            return SetValue(name, new JsValue(value));
+            return SetValue(name, value ? JsValue.True : JsValue.False);
         }
 
         public Engine SetValue(string name, JsValue value)
@@ -539,7 +544,7 @@ namespace Jint
                 {
                     return baseValue;
                 }
-                
+
                 if (reference.HasPrimitiveBase() == false)
                 {
                     var o = TypeConverter.ToObject(this, baseValue);

--- a/Jint/Native/Argument/ArgumentsInstance.cs
+++ b/Jint/Native/Argument/ArgumentsInstance.cs
@@ -163,7 +163,7 @@ namespace Jint.Native.Argument
             if (desc.IsAccessorDescriptor())
             {
                 var setter = desc.Set.TryCast<ICallable>();
-                setter.Call(new JsValue(this), new[] { value });
+                setter.Call(JsValue, new[] { value });
             }
             else
             {

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -52,7 +52,7 @@ namespace Jint.Native.Array
             if (desc.IsAccessorDescriptor())
             {
                 var setter = desc.Set.TryCast<ICallable>();
-                setter.Call(new JsValue(this), new[] { value });
+                setter.Call(JsValue, new[] { value });
             }
             else
             {
@@ -128,7 +128,7 @@ namespace Jint.Native.Array
                             var deleteSucceeded = Delete(TypeConverter.ToString(keyIndex), false);
                             if (!deleteSucceeded)
                             {
-                                newLenDesc.Value = new JsValue(keyIndex + 1);
+                                newLenDesc.Value = JsValue.FromInt(keyIndex + 1);
                                 if (!newWritable)
                                 {
                                     newLenDesc.Writable = false;

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -30,7 +30,7 @@ namespace Jint.Native.Function
             Extensible = true;
             Prototype = engine.Function.PrototypeObject;
 
-            DefineOwnProperty("length", new PropertyDescriptor(new JsValue(FormalParameters.Length), false, false, false ), false);
+            DefineOwnProperty("length", new PropertyDescriptor(JsValue.FromInt(FormalParameters.Length), false, false, false ), false);
 
             var proto = engine.Object.Construct(Arguments.Empty);
             proto.DefineOwnProperty("constructor", new PropertyDescriptor(this, true, false, true), false);

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -787,7 +787,7 @@ namespace Jint.Native.Json
                     var v = Lex().Value;
                     return Null.Instance;
                 case Tokens.BooleanLiteral:
-                    return new JsValue((bool)Lex().Value);
+                    return (bool) Lex().Value ? JsValue.True : JsValue.False;
                 case Tokens.String:
                     return new JsValue((string)Lex().Value);
                 case Tokens.Number:

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -8,6 +8,7 @@ namespace Jint.Native.Object
 {
     public class ObjectInstance
     {
+        private JsValue _jsValue;
         private Dictionary<string, PropertyDescriptor> _intrinsicProperties;
 
         public ObjectInstance(Engine engine)
@@ -19,6 +20,14 @@ namespace Jint.Native.Object
         public Engine Engine { get; set; }
 
         protected IDictionary<string, PropertyDescriptor> Properties { get; private set; }
+
+        /// <summary>
+        /// Caches the constructed JS.
+        /// </summary>
+        internal JsValue JsValue
+        {
+            get { return _jsValue = _jsValue ?? new JsValue(this); }
+        }
 
         protected bool TryGetIntrinsicValue(JsSymbol symbol, out JsValue value)
         {
@@ -228,7 +237,7 @@ namespace Jint.Native.Object
             if (desc.IsAccessorDescriptor())
             {
                 var setter = desc.Set.TryCast<ICallable>();
-                setter.Call(new JsValue(this), new [] {value});
+                setter.Call(JsValue, new [] {value});
             }
             else
             {
@@ -356,7 +365,7 @@ namespace Jint.Native.Object
                 var toString = Get("toString").TryCast<ICallable>();
                 if (toString != null)
                 {
-                    var str = toString.Call(new JsValue(this), Arguments.Empty);
+                    var str = toString.Call(JsValue, Arguments.Empty);
                     if (str.IsPrimitive())
                     {
                         return str;
@@ -366,7 +375,7 @@ namespace Jint.Native.Object
                 var valueOf = Get("valueOf").TryCast<ICallable>();
                 if (valueOf != null)
                 {
-                    var val = valueOf.Call(new JsValue(this), Arguments.Empty);
+                    var val = valueOf.Call(JsValue, Arguments.Empty);
                     if (val.IsPrimitive())
                     {
                         return val;
@@ -381,7 +390,7 @@ namespace Jint.Native.Object
                 var valueOf = Get("valueOf").TryCast<ICallable>();
                 if (valueOf != null)
                 {
-                    var val = valueOf.Call(new JsValue(this), Arguments.Empty);
+                    var val = valueOf.Call(JsValue, Arguments.Empty);
                     if (val.IsPrimitive())
                     {
                         return val;
@@ -391,7 +400,7 @@ namespace Jint.Native.Object
                 var toString = Get("toString").TryCast<ICallable>();
                 if (toString != null)
                 {
-                    var str = toString.Call(new JsValue(this), Arguments.Empty);
+                    var str = toString.Call(JsValue, Arguments.Empty);
                     if (str.IsPrimitive())
                     {
                         return str;

--- a/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
@@ -68,7 +68,7 @@ namespace Jint.Runtime.Environments
         {
             if (_provideThis)
             {
-                return new JsValue(_bindingObject);
+                return _bindingObject.JsValue;
             }
 
             return Undefined.Instance;

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -5,7 +5,6 @@ using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Native.Number;
-using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interop;
@@ -610,20 +609,17 @@ namespace Jint.Runtime
 
         public JsValue EvaluateLiteral(Literal literal)
         {
-            if (literal.Cached)
+            switch (literal.TokenType)
             {
-                switch (literal.TokenType)
-                {
-                    case TokenType.BooleanLiteral:
-                        return literal.BooleanValue ? JsValue.True : JsValue.False;
-                    case TokenType.NullLiteral:
-                        return JsValue.Null;
-                    case TokenType.NumericLiteral:
-                        // implicit conversion operator goes through caching
-                        return literal.NumericValue;
-                    case TokenType.StringLiteral:
-                        return new JsValue(literal.StringValue);
-                }
+                case TokenType.BooleanLiteral:
+                    return literal.BooleanValue ? JsValue.True : JsValue.False;
+                case TokenType.NullLiteral:
+                    return JsValue.Null;
+                case TokenType.NumericLiteral:
+                    // implicit conversion operator goes through caching
+                    return literal.NumericValue;
+                case TokenType.StringLiteral:
+                    return new JsValue(literal.StringValue);
             }
 
             if (literal.RegexValue != null) //(literal.Type == Nodes.RegularExpressionLiteral)

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -615,11 +615,12 @@ namespace Jint.Runtime
                 switch (literal.TokenType)
                 {
                     case TokenType.BooleanLiteral:
-                        return new JsValue(literal.BooleanValue);
+                        return literal.BooleanValue ? JsValue.True : JsValue.False;
                     case TokenType.NullLiteral:
                         return JsValue.Null;
                     case TokenType.NumericLiteral:
-                        return new JsValue(literal.NumericValue);
+                        // implicit conversion operator goes through caching
+                        return literal.NumericValue;
                     case TokenType.StringLiteral:
                         return new JsValue(literal.StringValue);
                 }

--- a/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
@@ -129,7 +129,7 @@ namespace Jint.Runtime.Interop
                 var jsArray = Engine.Array.Construct(Arguments.Empty);
                 Engine.Array.PrototypeObject.Push(jsArray, argsToTransform.ToArray());
 
-                newArgumentsCollection.Add(new JsValue(jsArray));
+                newArgumentsCollection.Add(jsArray.JsValue);
                 return newArgumentsCollection.ToArray();
             }
 


### PR DESCRIPTION
Here we get a really nice reduction of allocations and a speed boost by catching all sorts of implicit JsValue allocations. I generally don't like implicit operators but it was quite easy to redirect them to use caching. 

As JsValue is immutable and attached to certain object, we can easily pair them lazily and reuse. Also caching common int, double and char maps.

## UncacheableExpressionsBenchmark

### Before 

|    Method |   N |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|---------- |---- |--------:|---------:|---------:|------------:|-----------:|----------:|
| Benchmark | 500 | 1.214 s | 0.0755 s | 0.1083 s | 202687.5000 | 55312.5000 |  903.2 MB |

### After

|    Method |   N |    Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|---------- |---- |--------:|---------:|---------:|------------:|-----------:|----------:|
| Benchmark | 500 | 1.131 s | 0.0086 s | 0.0123 s | 189937.5000 | 54187.5000 |  817.6 MB |

