### PR TITLE
Reduce string operations memory allocations

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -248,7 +248,7 @@ namespace Jint
 
         public Engine SetValue(string name, string value)
         {
-            return SetValue(name, new JsValue(value));
+            return SetValue(name, (JsValue) value);
         }
 
         public Engine SetValue(string name, double value)

--- a/Jint/Native/Array/ArrayExecutionContext.cs
+++ b/Jint/Native/Array/ArrayExecutionContext.cs
@@ -11,15 +11,20 @@ namespace Jint.Native.Array
         // cache key container for array iteration for less allocations
         private static readonly ThreadLocal<ArrayExecutionContext> _executionContext = new ThreadLocal<ArrayExecutionContext>(() => new ArrayExecutionContext());
 
+        private List<uint> _keyCache;
+        private JsValue[] _callArray1;
+        private JsValue[] _callArray3;
+        private JsValue[] _callArray4;
+
         private ArrayExecutionContext()
         {
         }
 
-        public List<uint> KeyCache = new List<uint>();
+        public List<uint> KeyCache => _keyCache = _keyCache ?? new List<uint>();
 
-        public JsValue[] CallArray1 = new JsValue[1];
-        public JsValue[] CallArray3 = new JsValue[3];
-        public JsValue[] CallArray4 = new JsValue[4];
+        public JsValue[] CallArray1 => _callArray1 = _callArray1 ?? new JsValue[1];
+        public JsValue[] CallArray3 => _callArray3 = _callArray3 ?? new JsValue[3];
+        public JsValue[] CallArray4 => _callArray4 = _callArray4 ?? new JsValue[4];
 
         public static ArrayExecutionContext Current => _executionContext.Value;
     }

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -156,7 +156,7 @@ namespace Jint.Native.Array
                                 var deleteSucceeded = Delete(TypeConverter.ToString(keyIndex), false);
                                 if (!deleteSucceeded)
                                 {
-                                    newLenDesc.Value = new JsValue(keyIndex + 1);
+                                    newLenDesc.Value = keyIndex + 1;
                                     if (!newWritable)
                                     {
                                         newLenDesc.Writable = false;

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -788,9 +788,11 @@ namespace Jint.Native.Json
                     var v = Lex().Value;
                     return Null.Instance;
                 case Tokens.BooleanLiteral:
+                    // implicit conversion operator goes through caching
                     return (bool) Lex().Value ? JsValue.True : JsValue.False;
                 case Tokens.String:
-                    return new JsValue((string)Lex().Value);
+                    // implicit conversion operator goes through caching
+                    return (string) Lex().Value;
                 case Tokens.Number:
                     return new JsValue((double)Lex().Value);
             }

--- a/Jint/Native/Null.cs
+++ b/Jint/Native/Null.cs
@@ -2,7 +2,7 @@
 {
     public static class Null
     {
-        public readonly static JsValue Instance = JsValue.Null;
-        public readonly static string Text = "null";
+        public static readonly JsValue Instance = JsValue.Null;
+        public const string Text = "null";
     }
 }

--- a/Jint/Native/String/StringExecutionContext.cs
+++ b/Jint/Native/String/StringExecutionContext.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Jint.Native.String
+{
+    /// <summary>
+    /// Helper to cache common data structures when manipulating strings.
+    /// </summary>
+    internal class StringExecutionContext
+    {
+        private static readonly ThreadLocal<StringExecutionContext> _executionContext = new ThreadLocal<StringExecutionContext>(() => new StringExecutionContext());
+
+        private StringBuilder _stringBuilder;
+        private List<string> _splitSegmentList;
+        private string[] _splitArray1;
+        private JsValue[] _callArray3;
+
+        private StringExecutionContext()
+        {
+        }
+
+        public StringBuilder GetStringBuilder(int capacity)
+        {
+            if (_stringBuilder == null)
+            {
+                _stringBuilder = new StringBuilder(capacity);
+            }
+            else
+            {
+                _stringBuilder.EnsureCapacity(capacity);
+            }
+
+            return _stringBuilder;
+        }
+
+        public List<string> SplitSegmentList => _splitSegmentList = _splitSegmentList ?? new List<string>();
+        public string[] SplitArray1 => _splitArray1 = _splitArray1 ?? new string[1];
+        public JsValue[] CallArray3 => _callArray3 = _callArray3 ?? new JsValue[3];
+
+        public static StringExecutionContext Current => _executionContext.Value;
+    }
+}

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -11,23 +11,11 @@ namespace Jint.Native.String
         {
         }
 
-        public override string Class
-        {
-            get
-            {
-                return "String";
-            }
-        }
+        public override string Class => "String";
 
-        Types IPrimitiveInstance.Type
-        {
-            get { return Types.String; }
-        }
+        Types IPrimitiveInstance.Type => Types.String;
 
-        JsValue IPrimitiveInstance.PrimitiveValue
-        {
-            get { return PrimitiveValue; }
-        }
+        JsValue IPrimitiveInstance.PrimitiveValue => PrimitiveValue;
 
         public JsValue PrimitiveValue { get; set; }
 
@@ -35,17 +23,19 @@ namespace Jint.Native.String
         {
             if (d >= long.MinValue && d <= long.MaxValue)
             {
-                var l = (long)d;
+                var l = (long) d;
                 return l >= int.MinValue && l <= int.MaxValue;
             }
-            else 
-                return false;
+
+            return false;
         }
 
         public override PropertyDescriptor GetOwnProperty(string propertyName)
         {
-            if(propertyName == "Infinity")
+            if (propertyName == "Infinity")
+            {
                 return PropertyDescriptor.Undefined;
+            }
 
             var desc = base.GetOwnProperty(propertyName);
             if (desc != PropertyDescriptor.Undefined)
@@ -53,24 +43,26 @@ namespace Jint.Native.String
                 return desc;
             }
 
-            if (propertyName != System.Math.Abs(TypeConverter.ToInteger(propertyName)).ToString())
+            var integer = TypeConverter.ToInteger(propertyName);
+            if (integer == 0 && propertyName != "0" || propertyName != System.Math.Abs(integer).ToString())
             {
                 return PropertyDescriptor.Undefined;
             }
 
             var str = PrimitiveValue;
-            var dIndex = TypeConverter.ToInteger(propertyName);
-            if(!IsInt(dIndex))
+            var dIndex = integer;
+            if (!IsInt(dIndex))
                 return PropertyDescriptor.Undefined;
 
-            var index = (int)dIndex;
+            var index = (int) dIndex;
             var len = str.AsString().Length;
             if (len <= index || index < 0)
             {
                 return PropertyDescriptor.Undefined;
             }
-            var resultStr = str.AsString()[index].ToString();
-            return new PropertyDescriptor(new JsValue(resultStr), false, true, false);
+
+            var resultStr = TypeConverter.ToString(str.AsString()[index]);
+            return new PropertyDescriptor(resultStr, false, true, false);
         }
     }
 }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -620,7 +620,8 @@ namespace Jint.Runtime
                     // implicit conversion operator goes through caching
                     return literal.NumericValue;
                 case TokenType.StringLiteral:
-                    return new JsValue(literal.StringValue);
+                    // implicit conversion operator goes through caching
+                    return literal.StringValue;
             }
 
             if (literal.RegexValue != null) //(literal.Type == Nodes.RegularExpressionLiteral)


### PR DESCRIPTION
I tracked unnecessary string->JsValue conversions and tried to minimize unneeded allocations. Also found couple shortcuts from hot paths. This time my baseline benchmark was SunSpider.

One particularly nasty surprise code was StringInstance.GetOwnProperty that called TypeConverter.ToInteger(propertyName), this did implicit JsValue conversion always for things like replace,split etc. I overloaded to create direct string support + shortcut when letter is detected at start, no need to trim etc.

I dropped char and string lookup array to first 128 ASCII characters as beyond that the chars are not.. so common.

### Before

| Method |                 FileName |       Mean |      Error |     StdDev |        Gen 0 |        Gen 1 |        Gen 2 |  Allocated |
|------- |------------------------- |-----------:|-----------:|-----------:|-------------:|-------------:|-------------:|-----------:|
|    **Run** |                  **3d-cube** | **1,157.0 ms** |  **34.807 ms** |  **1.9666 ms** |  **143500.0000** |     **250.0000** |            **-** |  **576.99 MB** |
|    **Run** |                 **3d-morph** | **1,272.3 ms** |  **24.111 ms** |  **1.3623 ms** |  **139000.0000** |   **40500.0000** |    **7250.0000** |   **549.1 MB** |
|    **Run** |              **3d-raytrace** |   **935.5 ms** |  **19.710 ms** |  **1.1136 ms** |  **118500.0000** |    **1500.0000** |     **250.0000** |  **478.32 MB** |
|    **Run** |      **access-binary-trees** |   **431.9 ms** |  **85.608 ms** |  **4.8370 ms** |   **76000.0000** |    **1250.0000** |            **-** |  **306.72 MB** |
|    **Run** |          **access-fannkuch** | **3,569.1 ms** | **327.645 ms** | **18.5125 ms** |  **432000.0000** |     **250.0000** |            **-** | **1728.41 MB** |
|    **Run** |             **access-nbody** |   **909.7 ms** |  **48.298 ms** |  **2.7289 ms** |  **104500.0000** |            **-** |            **-** |  **418.97 MB** |
|    **Run** |            **access-nsieve** | **1,748.6 ms** | **249.244 ms** | **14.0827 ms** |  **124500.0000** |   **35750.0000** |    **7750.0000** |  **576.05 MB** |
|    **Run** | **bitops-3bit-bits-in-byte** |   **872.3 ms** | **189.684 ms** | **10.7175 ms** |  **167500.0000** |            **-** |            **-** |  **670.44 MB** |
|    **Run** |      **bitops-bits-in-byte** | **1,375.7 ms** | **603.920 ms** | **34.1226 ms** |  **240500.0000** |            **-** |            **-** |  **962.87 MB** |
|    **Run** |       **bitops-bitwise-and** |   **867.3 ms** | **196.875 ms** | **11.1238 ms** |  **101750.0000** |            **-** |            **-** |  **407.43 MB** |
|    **Run** |       **bitops-nsieve-bits** | **1,542.5 ms** | **206.758 ms** | **11.6822 ms** |  **184000.0000** |   **17000.0000** |    **1250.0000** |  **739.74 MB** |
|    **Run** |    **controlflow-recursive** |   **769.8 ms** |  **91.531 ms** |  **5.1717 ms** |  **147833.3333** |    **2916.6667** |            **-** |  **599.25 MB** |
|    **Run** |               **crypto-aes** | **1,054.1 ms** | **109.615 ms** |  **6.1934 ms** |  **116500.0000** |     **250.0000** |            **-** |  **469.64 MB** |
|    **Run** |               **crypto-md5** |   **644.8 ms** | **128.021 ms** |  **7.2334 ms** |  **115250.0000** |    **2250.0000** |     **500.0000** |  **463.99 MB** |
|    **Run** |              **crypto-sha1** |   **691.3 ms** | **212.719 ms** | **12.0190 ms** |  **112500.0000** |    **1000.0000** |     **250.0000** |  **451.88 MB** |
|    **Run** |        **date-format-tofte** |   **735.4 ms** |  **62.694 ms** |  **3.5423 ms** |   **93750.0000** |     **250.0000** |            **-** |  **376.67 MB** |
|    **Run** |        **date-format-xparb** |   **512.1 ms** |  **35.518 ms** |  **2.0068 ms** |   **38250.0000** |     **250.0000** |            **-** |  **154.77 MB** |
|    **Run** |              **math-cordic** | **1,778.6 ms** |  **77.312 ms** |  **4.3683 ms** |  **258000.0000** |            **-** |            **-** | **1032.25 MB** |
|    **Run** |        **math-partial-sums** |   **555.6 ms** |   **3.106 ms** |  **0.1755 ms** |   **65750.0000** |            **-** |            **-** |  **263.64 MB** |
|    **Run** |       **math-spectral-norm** |   **796.2 ms** | **185.938 ms** | **10.5059 ms** |  **117500.0000** |            **-** |            **-** |  **470.42 MB** |
|    **Run** |               **regexp-dna** |   **339.3 ms** |  **46.155 ms** |  **2.6078 ms** |    **2750.0000** |    **2000.0000** |    **1750.0000** |   **21.22 MB** |
|    **Run** |            **string-base64** |   **765.4 ms** |  **42.651 ms** |  **2.4099 ms** |  **328500.0000** |     **250.0000** |            **-** |  **1317.4 MB** |
|    **Run** |             **string-fasta** |   **966.2 ms** | **104.991 ms** |  **5.9322 ms** |  **149000.0000** |            **-** |            **-** |  **596.38 MB** |
|    **Run** |          **string-tagcloud** |   **813.3 ms** |  **47.667 ms** |  **2.6933 ms** |  **179333.3333** |  **119833.3333** |  **112833.3333** | **1014.04 MB** |
|    **Run** |       **string-unpack-code** |   **336.6 ms** |  **18.341 ms** |  **1.0363 ms** |   **57000.0000** |    **4000.0000** |    **1250.0000** |  **243.54 MB** |
|    **Run** |    **string-validate-input** | **2,828.3 ms** | **198.416 ms** | **11.2109 ms** | **1614333.3333** | **1545666.6667** | **1544583.3333** |  **6402.7 MB** |

### After

| Method |                 FileName |       Mean |      Error |     StdDev |        Gen 0 |        Gen 1 |        Gen 2 |  Allocated |
|------- |------------------------- |-----------:|-----------:|-----------:|-------------:|-------------:|-------------:|-----------:|
|    **Run** |                  **3d-cube** | **1,062.4 ms** | **179.688 ms** | **10.1527 ms** |   **75750.0000** |     **250.0000** |            **-** |  **305.51 MB** |
|    **Run** |                 **3d-morph** | **1,196.4 ms** | **130.698 ms** |  **7.3847 ms** |   **50500.0000** |    **7750.0000** |    **2500.0000** |   **246.2 MB** |
|    **Run** |              **3d-raytrace** |   **856.7 ms** | **208.057 ms** | **11.7556 ms** |   **67000.0000** |     **500.0000** |            **-** |  **271.42 MB** |
|    **Run** |      **access-binary-trees** |   **343.4 ms** |  **53.036 ms** |  **2.9966 ms** |   **47000.0000** |     **750.0000** |            **-** |  **188.86 MB** |
|    **Run** |          **access-fannkuch** | **3,437.5 ms** | **281.443 ms** | **15.9021 ms** |  **210500.0000** |     **250.0000** |            **-** |  **842.64 MB** |
|    **Run** |             **access-nbody** |   **933.7 ms** | **198.781 ms** | **11.2315 ms** |   **64000.0000** |            **-** |            **-** |  **256.46 MB** |
|    **Run** |            **access-nsieve** | **1,195.2 ms** | **134.386 ms** |  **7.5931 ms** |   **69583.3333** |    **9416.6667** |    **3083.3333** |     **304 MB** |
|    **Run** | **bitops-3bit-bits-in-byte** |   **675.5 ms** | **122.599 ms** |  **6.9271 ms** |   **67250.0000** |            **-** |            **-** |  **269.31 MB** |
|    **Run** |      **bitops-bits-in-byte** | **1,115.0 ms** |  **67.698 ms** |  **3.8251 ms** |   **89750.0000** |            **-** |            **-** |  **359.68 MB** |
|    **Run** |       **bitops-bitwise-and** |   **892.1 ms** |  **35.886 ms** |  **2.0276 ms** |   **52500.0000** |            **-** |            **-** |  **210.51 MB** |
|    **Run** |       **bitops-nsieve-bits** | **1,336.5 ms** |  **85.963 ms** |  **4.8570 ms** |   **84500.0000** |    **8000.0000** |     **750.0000** |  **341.35 MB** |
|    **Run** |    **controlflow-recursive** |   **496.3 ms** |  **57.192 ms** |  **3.2315 ms** |   **72500.0000** |            **-** |            **-** |  **290.09 MB** |
|    **Run** |               **crypto-aes** |   **968.3 ms** | **477.793 ms** | **26.9962 ms** |   **56500.0000** |     **250.0000** |            **-** |  **228.93 MB** |
|    **Run** |               **crypto-md5** |   **488.9 ms** |  **48.741 ms** |  **2.7539 ms** |   **60750.0000** |     **250.0000** |            **-** |  **247.02 MB** |
|    **Run** |              **crypto-sha1** |   **510.2 ms** | **204.550 ms** | **11.5574 ms** |   **56000.0000** |     **500.0000** |            **-** |  **225.31 MB** |
|    **Run** |        **date-format-tofte** |   **600.5 ms** |  **80.538 ms** |  **4.5505 ms** |   **46000.0000** |     **250.0000** |            **-** |  **185.25 MB** |
|    **Run** |        **date-format-xparb** |   **435.0 ms** |  **75.241 ms** |  **4.2512 ms** |   **20500.0000** |     **250.0000** |            **-** |    **83.3 MB** |
|    **Run** |              **math-cordic** | **1,565.9 ms** | **351.841 ms** | **19.8797 ms** |  **130750.0000** |            **-** |            **-** |   **523.4 MB** |
|    **Run** |        **math-partial-sums** |   **511.8 ms** |   **8.807 ms** |  **0.4976 ms** |   **31750.0000** |            **-** |            **-** |  **127.57 MB** |
|    **Run** |       **math-spectral-norm** |   **649.1 ms** | **293.084 ms** | **16.5598 ms** |   **55500.0000** |            **-** |            **-** |  **222.33 MB** |
|    **Run** |               **regexp-dna** |   **355.9 ms** |  **96.932 ms** |  **5.4768 ms** |    **1833.3333** |    **1333.3333** |    **1083.3333** |   **13.76 MB** |
|    **Run** |            **string-base64** |   **552.0 ms** |  **98.430 ms** |  **5.5615 ms** |  **269750.0000** |     **250.0000** |            **-** | **1082.25 MB** |
|    **Run** |             **string-fasta** |   **828.5 ms** | **217.661 ms** | **12.2982 ms** |   **77250.0000** |            **-** |            **-** |  **309.22 MB** |
|    **Run** |          **string-tagcloud** |   **689.4 ms** | **110.243 ms** |  **6.2289 ms** |  **127083.3333** |   **95083.3333** |   **93166.6667** |  **880.64 MB** |
|    **Run** |       **string-unpack-code** |   **266.1 ms** |  **83.057 ms** |  **4.6929 ms** |   **35250.0000** |    **8250.0000** |    **2250.0000** |  **153.89 MB** |
|    **Run** |    **string-validate-input** | **2,785.1 ms** |  **77.768 ms** |  **4.3940 ms** | **1535250.0000** | **1502083.3333** | **1500500.0000** | **6262.53 MB** |