### PR TITLE
Optimize DeclarativeEnvironmentRecord

### DIFF
--- a/Jint.Benchmark/UncacheableExpressionsBenchmark.cs
+++ b/Jint.Benchmark/UncacheableExpressionsBenchmark.cs
@@ -23,7 +23,7 @@ namespace Jint.Benchmark
         {
             public Config()
             {
-                Add(Job.MediumRun);
+                Add(Job.ShortRun);
                 Add(MemoryDiagnoser.Default);
             }
         }

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -137,19 +137,19 @@ namespace Jint.Native
         [Pure]
         public bool IsArray()
         {
-            return IsObject() && AsObject() is ArrayInstance;
+            return _type == Types.Object && _object is ArrayInstance;
         }
 
         [Pure]
         public bool IsDate()
         {
-            return IsObject() && AsObject() is DateInstance;
+            return _type == Types.Object && _object is DateInstance;
         }
 
         [Pure]
         public bool IsRegExp()
         {
-            return IsObject() && AsObject() is RegExpInstance;
+            return _type == Types.Object && _object is RegExpInstance;
         }
 
         [Pure]
@@ -283,7 +283,7 @@ namespace Jint.Native
 
         public bool Is<T>()
         {
-            return IsObject() && AsObject() is T;
+            return _type == Types.Object && _object is T;
         }
 
         public T As<T>() where T : ObjectInstance
@@ -741,7 +741,17 @@ namespace Jint.Native
             return !a.Equals(b);
         }
 
+        static public implicit operator JsValue(char value)
+        {
+            return FromChar(value);
+        }
+
         static public implicit operator JsValue(int value)
+        {
+            return FromInt(value);
+        }
+
+        static public implicit operator JsValue(uint value)
         {
             return FromInt(value);
         }

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -719,7 +719,7 @@ namespace Jint.Native.String
             {
                 return double.NaN;
             }
-            return s[position];
+            return (double) s[position];
         }
 
         private JsValue CharAt(JsValue thisObj, JsValue[] arguments)

--- a/Jint/Runtime/MruPropertyCache2.cs
+++ b/Jint/Runtime/MruPropertyCache2.cs
@@ -40,12 +40,13 @@ namespace Jint.Runtime
         {
             get
             {
+                int count = _set ? 1 : 0;
                 if (_dictionary != null)
                 {
-                    return _dictionary.Count;
+                    count += _dictionary.Count;
                 }
 
-                return _set ? 1 : 0;
+                return count;
             }
         }
 
@@ -142,6 +143,31 @@ namespace Jint.Runtime
                 }
                 _dictionary[_key] = _value;
             }
+        }
+
+        public TKey[] GetKeys()
+        {
+            int size = _set ? 1 : 0;
+            if (_dictionary != null)
+            {
+                size += _dictionary.Count;
+            }
+
+            var keys = new TKey[size];
+            int n = 0;
+            if (_set)
+            {
+                keys[n++] = _key;
+            }
+            if (_dictionary != null)
+            {
+                foreach (var key in _dictionary.Keys)
+                {
+                    keys[n++] = key;
+                }
+            }
+
+            return keys;
         }
     }
 }

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -365,7 +365,7 @@ namespace Jint.Runtime
             return r;
         }
 
-        public Completion ExecuteSwitchBlock(IEnumerable<SwitchCase> switchBlock, JsValue input)
+        public Completion ExecuteSwitchBlock(List<SwitchCase> switchBlock, JsValue input)
         {
             JsValue v = Undefined.Instance;
             SwitchCase defaultCase = null;
@@ -413,17 +413,15 @@ namespace Jint.Runtime
             return new Completion(Completion.Normal, v, null);
         }
 
-        public Completion ExecuteStatementList(IEnumerable<StatementListItem> statementList)
+        public Completion ExecuteStatementList(List<StatementListItem> statementList)
         {
             var c = Completion.Empty;
             Completion sl = c;
             Statement s = null;
 
-            var list = (List<StatementListItem>) statementList;
-
             try
             {
-                foreach (var statement in list)
+                foreach (var statement in statementList)
                 {
                     s = statement.As<Statement>();
                     c = ExecuteStatement(s);


### PR DESCRIPTION
Now improving performance of my pet peeve UncacheableExpressionsBenchmark.

* use MruPropertyCache2 and common parameter "arguments" as stored field, now dictionary won't be created for common arguments + single extra parameter
* add missing implicit JsValue operators for uint and char, used sub-optimal double path
* simplify often called JsValue Is* As* methods that have unnecessary nesting and logic

UncacheableExpressionsBenchmark execution time went down 22%, Map time went down 37%. 10% reduction in UncacheableExpressionsBenchmark memory usage.

### Before (dev)

|             Method |   N |      Mean |     Error |    StdDev |     Gen 0 |   Allocated |
|------------------- |---- |----------:|----------:|----------:|----------:|------------:|
|              Slice | 100 |  1.199 ms | 0.0249 ms | 0.0233 ms |  240.2344 |   986.72 KB |
|             Concat | 100 |  1.289 ms | 0.0132 ms | 0.0117 ms |  259.7656 |  1070.31 KB |
|            Unshift | 100 | 38.819 ms | 0.2905 ms | 0.2718 ms | 7000.0000 | 28789.06 KB |
|               Push | 100 | 25.200 ms | 0.1081 ms | 0.1011 ms | 1625.0000 |  6766.41 KB |
|              Index | 100 | 26.802 ms | 0.2575 ms | 0.2409 ms | 1531.2500 |  6333.59 KB |
|                Map | 100 |  7.339 ms | 0.1466 ms | 0.1299 ms | 2109.3750 |  8692.19 KB |
|              Apply | 100 |  1.255 ms | 0.0013 ms | 0.0010 ms |  267.5781 |  1098.44 KB |
| JsonStringifyParse | 100 |  6.944 ms | 0.0086 ms | 0.0067 ms | 1484.3750 |  6103.91 KB |

|    Method |   N |     Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|---------- |---- |---------:|---------:|---------:|------------:|-----------:|----------:|
| UncacheableExpressionsBenchmark| 500 | 740.1 ms | 78.08 ms | 4.412 ms | 129750.0000 | 36562.5000 |  556.2 MB |

### After (this branch)

|             Method |   N |        Mean |     Error |    StdDev |     Gen 0 |   Allocated |
|------------------- |---- |------------:|----------:|----------:|----------:|------------:|
|              Slice | 100 |    910.4 us |  6.458 us |  5.725 us |  239.2578 |   982.81 KB |
|             Concat | 100 |  1,007.7 us |  2.083 us |  1.847 us |  258.7891 |   1062.5 KB |
|            Unshift | 100 | 36,668.5 us | 86.661 us | 81.063 us | 7000.0000 | 28785.16 KB |
|               Push | 100 | 24,286.9 us | 30.631 us | 28.653 us | 1625.0000 |   6762.5 KB |
|              Index | 100 | 25,788.4 us | 19.635 us | 16.396 us | 1531.2500 |  6333.59 KB |
|                Map | 100 |  4,607.4 us | 10.529 us |  9.333 us | 1804.6875 |  7420.31 KB |
|              Apply | 100 |  1,023.9 us |  3.040 us |  2.843 us |  267.5781 |  1098.44 KB |
| JsonStringifyParse | 100 |  6,671.7 us | 11.872 us | 11.105 us | 1484.3750 |     6100 KB |

|    Method |   N |     Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|---------- |---- |---------:|---------:|---------:|------------:|-----------:|----------:|
| UncacheableExpressionsBenchmark| 500 | 578.6 ms | 29.91 ms | 1.690 ms | 114937.5000 | 32791.6667 | 494.71 MB |
