### PR TITLE
Introduce IPropertyDescriptor and specialized descriptors

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -157,7 +157,7 @@ namespace Jint
                 options(Options);
             }
 
-            Eval = new EvalFunctionInstance(this, new string[0], LexicalEnvironment.NewDeclarativeEnvironment(this, ExecutionContext.LexicalEnvironment), StrictModeScope.IsStrictModeCode);
+            Eval = new EvalFunctionInstance(this, System.Array.Empty<string>(), LexicalEnvironment.NewDeclarativeEnvironment(this, ExecutionContext.LexicalEnvironment), StrictModeScope.IsStrictModeCode);
             Global.FastAddProperty("eval", Eval, true, false, true);
 
             _statements = new StatementInterpreter(this);

--- a/Jint/Native/Argument/ArgumentsInstance.cs
+++ b/Jint/Native/Argument/ArgumentsInstance.cs
@@ -42,7 +42,7 @@ namespace Jint.Native.Argument
             var obj = new ArgumentsInstance(engine, self =>
             {
                 var len = args.Length;
-                self.FastAddProperty("length", len, true, false, true);
+                self.SetOwnProperty("length", new NonEnumerablePropertyDescriptor(len));
                 var map = engine.Object.Construct(Arguments.Empty);
                 var mappedNamed = new List<string>();
                 var indx = 0;
@@ -50,7 +50,7 @@ namespace Jint.Native.Argument
                 {
                     var indxStr = TypeConverter.ToString(indx);
                     var val = args[indx];
-                    self.FastAddProperty(indxStr, val, true, true, true);
+                    self.SetOwnProperty(indxStr, new ConfigurableEnumerableWritablePropertyDescriptor(val));
                     if (indx < names.Length)
                     {
                         var name = names[indx];
@@ -60,7 +60,7 @@ namespace Jint.Native.Argument
                             Func<JsValue, JsValue> g = n => env.GetBindingValue(name, false);
                             var p = new Action<JsValue, JsValue>((n, o) => env.SetMutableBinding(name, o, true));
 
-                            map.DefineOwnProperty(indxStr, new ClrAccessDescriptor(engine, g, p) { Configurable = true }, false);
+                            map.SetOwnProperty(indxStr, new ClrAccessDescriptor(engine, g, p) { Configurable = true });
                         }
                     }
                     indx++;
@@ -75,7 +75,7 @@ namespace Jint.Native.Argument
                 // step 13
                 if (!strict)
                 {
-                    self.FastAddProperty("callee", func, true, false, true);
+                    self.SetOwnProperty("callee", new NonEnumerablePropertyDescriptor(func));
                 }
                 // step 14
                 else
@@ -107,7 +107,7 @@ namespace Jint.Native.Argument
         }
 
 
-        public override PropertyDescriptor GetOwnProperty(string propertyName)
+        public override IPropertyDescriptor GetOwnProperty(string propertyName)
         {
             EnsureInitialized();
 
@@ -152,7 +152,7 @@ namespace Jint.Native.Argument
 
             if (ownDesc.IsDataDescriptor())
             {
-                var valueDesc = new PropertyDescriptor(value: value, writable: null, enumerable: null, configurable: null);
+                var valueDesc = new NullConfigurationPropertyDescriptor(value);
                 DefineOwnProperty(propertyName, valueDesc, throwOnError);
                 return;
             }
@@ -167,12 +167,12 @@ namespace Jint.Native.Argument
             }
             else
             {
-                var newDesc = new PropertyDescriptor(value, true, true, true);
+                var newDesc = new ConfigurableEnumerableWritablePropertyDescriptor(value);
                 DefineOwnProperty(propertyName, newDesc, throwOnError);
             }
         }
 
-        public override bool DefineOwnProperty(string propertyName, PropertyDescriptor desc, bool throwOnError)
+        public override bool DefineOwnProperty(string propertyName, IPropertyDescriptor desc, bool throwOnError)
         {
             EnsureInitialized();
 

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.Array
@@ -25,7 +26,7 @@ namespace Jint.Native.Array
             };
 
             obj.FastAddProperty("length", 0, true, false, false);
-            obj.FastAddProperty("constructor", arrayConstructor, true, false, true);
+            obj.SetOwnProperty("constructor", new NonEnumerablePropertyDescriptor(arrayConstructor));
 
             return obj;
         }
@@ -804,7 +805,7 @@ namespace Jint.Native.Array
 
             // this is not in the specs, but is necessary in case the last element of the last
             // array doesn't exist, and thus the length would not be incremented
-            a.DefineOwnProperty("length", new PropertyDescriptor(n, null, null, null), false);
+            a.DefineOwnProperty("length", new NullConfigurationPropertyDescriptor(n), false);
 
             return a;
         }

--- a/Jint/Native/Boolean/BooleanConstructor.cs
+++ b/Jint/Native/Boolean/BooleanConstructor.cs
@@ -1,6 +1,7 @@
 ﻿using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Native.Boolean
 {
@@ -15,14 +16,14 @@ namespace Jint.Native.Boolean
             var obj = new BooleanConstructor(engine);
             obj.Extensible = true;
 
-            // The value of the [[Prototype]] internal property of the Boolean constructor is the Function prototype object 
+            // The value of the [[Prototype]] internal property of the Boolean constructor is the Function prototype object
             obj.Prototype = engine.Function.PrototypeObject;
             obj.PrototypeObject = BooleanPrototype.CreatePrototypeObject(engine, obj);
 
-            obj.FastAddProperty("length", 1, false, false, false);
+            obj.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(1));
 
             // The initial value of Boolean.prototype is the Boolean prototype object
-            obj.FastAddProperty("prototype", obj.PrototypeObject, false, false, false);
+            obj.SetOwnProperty("prototype", new AllForbiddenPropertyDescriptor(obj.PrototypeObject));
 
             return obj;
         }

--- a/Jint/Native/Boolean/BooleanPrototype.cs
+++ b/Jint/Native/Boolean/BooleanPrototype.cs
@@ -1,4 +1,5 @@
 ﻿using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.Boolean
@@ -19,7 +20,7 @@ namespace Jint.Native.Boolean
             obj.PrimitiveValue = false;
             obj.Extensible = true;
 
-            obj.FastAddProperty("constructor", booleanConstructor, true, false, true);
+            obj.SetOwnProperty("constructor", new NonEnumerablePropertyDescriptor(booleanConstructor));
 
             return obj;
         }

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.Date
@@ -20,14 +21,14 @@ namespace Jint.Native.Date
             var obj = new DateConstructor(engine);
             obj.Extensible = true;
 
-            // The value of the [[Prototype]] internal property of the Date constructor is the Function prototype object 
+            // The value of the [[Prototype]] internal property of the Date constructor is the Function prototype object
             obj.Prototype = engine.Function.PrototypeObject;
             obj.PrototypeObject = DatePrototype.CreatePrototypeObject(engine, obj);
 
-            obj.FastAddProperty("length", 7, false, false, false);
+            obj.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(7));
 
             // The initial value of Date.prototype is the Date prototype object
-            obj.FastAddProperty("prototype", obj.PrototypeObject, false, false, false);
+            obj.SetOwnProperty("prototype", new AllForbiddenPropertyDescriptor(obj.PrototypeObject));
 
             return obj;
         }

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.Date
@@ -24,7 +25,7 @@ namespace Jint.Native.Date
                 PrimitiveValue = double.NaN
             };
 
-            obj.FastAddProperty("constructor", dateConstructor, true, false, true);
+            obj.SetOwnProperty("constructor", new NonEnumerablePropertyDescriptor(dateConstructor));
 
             return obj;
         }

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -1,6 +1,7 @@
 ﻿using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Native.Error
 {
@@ -22,17 +23,17 @@ namespace Jint.Native.Error
             obj.Prototype = engine.Function.PrototypeObject;
             obj.PrototypeObject = ErrorPrototype.CreatePrototypeObject(engine, obj, name);
 
-            obj.FastAddProperty("length", 1, false, false, false);
+            obj.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(1));
 
             // The initial value of Error.prototype is the Error prototype object
-            obj.FastAddProperty("prototype", obj.PrototypeObject, false, false, false);
+            obj.SetOwnProperty("prototype", new AllForbiddenPropertyDescriptor(obj.PrototypeObject));
 
             return obj;
         }
 
         public void Configure()
         {
-            
+
         }
 
         public override JsValue Call(JsValue thisObject, JsValue[] arguments)

--- a/Jint/Native/Error/ErrorPrototype.cs
+++ b/Jint/Native/Error/ErrorPrototype.cs
@@ -1,5 +1,6 @@
 ﻿using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.Error
@@ -17,7 +18,7 @@ namespace Jint.Native.Error
         public static ErrorPrototype CreatePrototypeObject(Engine engine, ErrorConstructor errorConstructor, string name)
         {
             var obj = new ErrorPrototype(engine, name) { Extensible = true };
-            obj.FastAddProperty("constructor", errorConstructor, true, false, true);
+            obj.SetOwnProperty("constructor", new NonEnumerablePropertyDescriptor(errorConstructor));
             obj.FastAddProperty("message", "", true, false, true);
 
             if (name != "Error")

--- a/Jint/Native/Function/BindFunctionInstance.cs
+++ b/Jint/Native/Function/BindFunctionInstance.cs
@@ -6,7 +6,7 @@ namespace Jint.Native.Function
 {
     public class BindFunctionInstance : FunctionInstance, IConstructor
     {
-        public BindFunctionInstance(Engine engine) : base(engine, new string[0], null, false)
+        public BindFunctionInstance(Engine engine) : base(engine, System.Array.Empty<string>(), null, false)
         {
         }
 
@@ -42,7 +42,7 @@ namespace Jint.Native.Function
             {
                 throw new JavaScriptException(Engine.TypeError);
             });
-              
+
             return f.HasInstance(v);
         }
     }

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -1,5 +1,6 @@
 ﻿using Esprima;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Environments;
 
 namespace Jint.Native.Function
@@ -14,7 +15,7 @@ namespace Jint.Native.Function
         {
             _engine = engine;
             Prototype = Engine.Function.PrototypeObject;
-            FastAddProperty("length", 1, false, false, false);
+            SetOwnProperty("length", new AllForbiddenPropertyDescriptor(1));
         }
 
         public override JsValue Call(JsValue thisObject, JsValue[] arguments)

--- a/Jint/Native/Function/FunctionConstructor.cs
+++ b/Jint/Native/Function/FunctionConstructor.cs
@@ -5,6 +5,7 @@ using Esprima.Ast;
 using Jint.Native.Object;
 using Jint.Native.String;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Environments;
 
 namespace Jint.Native.Function
@@ -28,9 +29,8 @@ namespace Jint.Native.Function
             // The value of the [[Prototype]] internal property of the Function constructor is the standard built-in Function prototype object
             obj.Prototype = obj.PrototypeObject;
 
-            obj.FastAddProperty("prototype", obj.PrototypeObject, false, false, false);
-
-            obj.FastAddProperty("length", 1, false, false, false);
+            obj.SetOwnProperty("prototype", new AllForbiddenPropertyDescriptor(obj.PrototypeObject));
+            obj.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(1));
 
             return obj;
         }
@@ -49,7 +49,12 @@ namespace Jint.Native.Function
 
         private string[] ParseArgumentNames(string parameterDeclaration)
         {
-            string[] values = parameterDeclaration.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            if (string.IsNullOrWhiteSpace(parameterDeclaration))
+            {
+                return System.Array.Empty<string>();
+            }
+
+            string[] values = parameterDeclaration.Split(ArgumentNameSeparator, StringSplitOptions.RemoveEmptyEntries);
 
             var newValues = new string[values.Length];
             for (var i = 0; i < values.Length; i++)
@@ -124,6 +129,7 @@ namespace Jint.Native.Function
         }
 
         private FunctionInstance _throwTypeError;
+        private static readonly char[] ArgumentNameSeparator = new[] { ',' };
 
         public FunctionInstance ThrowTypeError
         {

--- a/Jint/Native/Function/FunctionPrototype.cs
+++ b/Jint/Native/Function/FunctionPrototype.cs
@@ -1,6 +1,7 @@
 ﻿using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.Function
@@ -22,14 +23,14 @@ namespace Jint.Native.Function
             // The value of the [[Prototype]] internal property of the Function prototype object is the standard built-in Object prototype object
             obj.Prototype = engine.Object.PrototypeObject;
 
-            obj.FastAddProperty("length", 0, false, false, false);
+            obj.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(0));
 
             return obj;
         }
 
         public void Configure()
         {
-            FastAddProperty("constructor", Engine.Function, true, false, true);
+            SetOwnProperty("constructor", new NonEnumerablePropertyDescriptor(Engine.Function));
             FastAddProperty("toString", new ClrFunctionInstance(Engine, ToString), true, false, true);
             FastAddProperty("apply", new ClrFunctionInstance(Engine, Apply, 2), true, false, true);
             FastAddProperty("call", new ClrFunctionInstance(Engine, CallImpl, 1), true, false, true);
@@ -54,11 +55,11 @@ namespace Jint.Native.Function
             if (o != null)
             {
                 var l = TypeConverter.ToNumber(o.Get("length")) - (arguments.Length - 1);
-                f.FastAddProperty("length", System.Math.Max(l, 0), false, false, false);
+                f.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(System.Math.Max(l, 0)));
             }
             else
             {
-                f.FastAddProperty("length", 0, false, false, false);
+                f.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(0));
             }
 
 

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -3,6 +3,7 @@ using Esprima.Ast;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Environments;
 
 namespace Jint.Native.Function
@@ -30,14 +31,14 @@ namespace Jint.Native.Function
             Extensible = true;
             Prototype = engine.Function.PrototypeObject;
 
-            DefineOwnProperty("length", new PropertyDescriptor(JsValue.FromInt(FormalParameters.Length), false, false, false ), false);
+            DefineOwnProperty("length", new AllForbiddenPropertyDescriptor(JsValue.FromInt(FormalParameters.Length)), false);
 
             var proto = engine.Object.Construct(Arguments.Empty);
-            proto.DefineOwnProperty("constructor", new PropertyDescriptor(this, true, false, true), false);
-            DefineOwnProperty("prototype", new PropertyDescriptor(proto, true, false, false ), false);
+            proto.SetOwnProperty("constructor", new NonEnumerablePropertyDescriptor(this));
+            SetOwnProperty("prototype", new WritablePropertyDescriptor(proto));
             if (_functionDeclaration.Id != null)
             {
-                DefineOwnProperty("name", new PropertyDescriptor(_functionDeclaration.Id.Name, null, null, null), false);
+                DefineOwnProperty("name", new NullConfigurationPropertyDescriptor(_functionDeclaration.Id.Name), false);
             }
 
             if (strict)
@@ -53,6 +54,12 @@ namespace Jint.Native.Function
         {
             var list = functionDeclaration.Params;
             var count = list.Count;
+
+            if (count == 0)
+            {
+                return System.Array.Empty<string>();
+            }
+
             var names = new string[count];
             for (var i = 0; i < count; ++i)
             {

--- a/Jint/Native/Function/ThrowTypeError.cs
+++ b/Jint/Native/Function/ThrowTypeError.cs
@@ -1,5 +1,5 @@
 ﻿using Jint.Runtime;
-using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Native.Function
 {
@@ -7,10 +7,10 @@ namespace Jint.Native.Function
     {
         private readonly Engine _engine;
 
-        public ThrowTypeError(Engine engine): base(engine, new string[0], engine.GlobalEnvironment, false)
+        public ThrowTypeError(Engine engine): base(engine, System.Array.Empty<string>(), engine.GlobalEnvironment, false)
         {
             _engine = engine;
-            DefineOwnProperty("length", new PropertyDescriptor(0, false, false, false), false);
+            DefineOwnProperty("length", new AllForbiddenPropertyDescriptor(0), false);
             Extensible = false;
         }
 

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -5,7 +5,7 @@ using Jint.Native.Array;
 using Jint.Native.Global;
 using Jint.Native.Object;
 using Jint.Runtime;
-using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Native.Json
 {
@@ -29,7 +29,7 @@ namespace Jint.Native.Json
 
             // for JSON.stringify(), any function passed as the first argument will return undefined
             // if the replacer is not defined. The function is not called either.
-            if (value.Is<ICallable>() && replacer == Undefined.Instance) 
+            if (value.Is<ICallable>() && replacer == Undefined.Instance)
             {
                 return Undefined.Instance;
             }
@@ -97,7 +97,7 @@ namespace Jint.Native.Json
                 if (space.AsNumber() > 0) {
                     _gap = new System.String(' ', (int)System.Math.Min(10, space.AsNumber()));
                 }
-                else 
+                else
                 {
                     _gap = string.Empty;
                 }
@@ -113,14 +113,14 @@ namespace Jint.Native.Json
             }
 
             var wrapper = _engine.Object.Construct(Arguments.Empty);
-            wrapper.DefineOwnProperty("", new PropertyDescriptor(value, true, true, true), false);
+            wrapper.DefineOwnProperty("", new ConfigurableEnumerableWritablePropertyDescriptor(value), false);
 
             return Str("", wrapper);
         }
 
         private JsValue Str(string key, ObjectInstance holder)
         {
-            
+
             var value = holder.Get(key);
             if (value.IsObject())
             {
@@ -134,14 +134,14 @@ namespace Jint.Native.Json
                     }
                 }
             }
-            
+
             if (_replacerFunction != Undefined.Instance)
             {
                 var replacerFunctionCallable = (ICallable)_replacerFunction.AsObject();
                 value = replacerFunctionCallable.Call(holder, Arguments.From(key, value));
             }
 
-            
+
             if (value.IsObject())
             {
                 var valueObj = value.AsObject();
@@ -156,7 +156,7 @@ namespace Jint.Native.Json
                     case "Boolean":
                         value = TypeConverter.ToPrimitive(value);
                         break;
-                    case "Array": 
+                    case "Array":
                         value = SerializeArray(value.As<ArrayInstance>());
                         return value;
                     case "Object":
@@ -164,7 +164,7 @@ namespace Jint.Native.Json
                         return value;
                 }
             }
-           
+
             if (value == Null.Instance)
             {
                 return "null";
@@ -191,7 +191,7 @@ namespace Jint.Native.Json
                 {
                     return TypeConverter.ToString(value);
                 }
-                
+
                 return "null";
             }
 
@@ -288,7 +288,7 @@ namespace Jint.Native.Json
                 var properties = System.String.Join(separator, partial.ToArray());
                 final = "[\n" + _indent + properties + "\n" + stepback + "]";
             }
-            
+
             _stack.Pop();
             _indent = stepback;
             return final;
@@ -315,7 +315,7 @@ namespace Jint.Native.Json
             _stack.Push(value);
             var stepback = _indent;
             _indent += _gap;
-            
+
             var k = _propertyList ?? value.GetOwnProperties()
                 .Where(x => x.Value.Enumerable.HasValue && x.Value.Enumerable.Value == true)
                 .Select(x => x.Key)
@@ -353,7 +353,7 @@ namespace Jint.Native.Json
                     var separator = ",\n" + _indent;
                     var properties = System.String.Join(separator, partial.ToArray());
                     final = "{\n" + _indent + properties + "\n" + stepback + "}";
-                }                
+                }
             }
             _stack.Pop();
             _indent = stepback;

--- a/Jint/Native/Number/NumberConstructor.cs
+++ b/Jint/Native/Number/NumberConstructor.cs
@@ -1,6 +1,7 @@
 ﻿using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Native.Number
 {
@@ -9,7 +10,7 @@ namespace Jint.Native.Number
         public NumberConstructor(Engine engine)
             : base(engine, null, null, false)
         {
-            
+
         }
 
         public static NumberConstructor CreateNumberConstructor(Engine engine)
@@ -17,25 +18,25 @@ namespace Jint.Native.Number
             var obj = new NumberConstructor(engine);
             obj.Extensible = true;
 
-            // The value of the [[Prototype]] internal property of the Number constructor is the Function prototype object 
+            // The value of the [[Prototype]] internal property of the Number constructor is the Function prototype object
             obj.Prototype = engine.Function.PrototypeObject;
             obj.PrototypeObject = NumberPrototype.CreatePrototypeObject(engine, obj);
 
-            obj.FastAddProperty("length", 1, false, false, false);
+            obj.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(1));
 
             // The initial value of Number.prototype is the Number prototype object
-            obj.FastAddProperty("prototype", obj.PrototypeObject, false, false, false);
+            obj.SetOwnProperty("prototype", new AllForbiddenPropertyDescriptor(obj.PrototypeObject));
 
             return obj;
         }
 
         public void Configure()
         {
-            FastAddProperty("MAX_VALUE", double.MaxValue, false, false, false);
-            FastAddProperty("MIN_VALUE", double.Epsilon, false, false, false);
-            FastAddProperty("NaN", double.NaN, false, false, false);
-            FastAddProperty("NEGATIVE_INFINITY", double.NegativeInfinity, false, false, false);
-            FastAddProperty("POSITIVE_INFINITY", double.PositiveInfinity, false, false, false);
+            SetOwnProperty("MAX_VALUE", new AllForbiddenPropertyDescriptor(double.MaxValue));
+            SetOwnProperty("MIN_VALUE", new AllForbiddenPropertyDescriptor(double.Epsilon));
+            SetOwnProperty("NaN", new AllForbiddenPropertyDescriptor(double.NaN));
+            SetOwnProperty("NEGATIVE_INFINITY", new AllForbiddenPropertyDescriptor(double.NegativeInfinity));
+            SetOwnProperty("POSITIVE_INFINITY", new AllForbiddenPropertyDescriptor(double.PositiveInfinity));
         }
 
         public override JsValue Call(JsValue thisObject, JsValue[] arguments)

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -4,6 +4,7 @@ using Esprima;
 using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Native.RegExp
 {
@@ -23,10 +24,10 @@ namespace Jint.Native.RegExp
             obj.Prototype = engine.Function.PrototypeObject;
             obj.PrototypeObject = RegExpPrototype.CreatePrototypeObject(engine, obj);
 
-            obj.FastAddProperty("length", 2, false, false, false);
+            obj.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(2));
 
             // The initial value of RegExp.prototype is the RegExp prototype object
-            obj.FastAddProperty("prototype", obj.PrototypeObject, false, false, false);
+            obj.SetOwnProperty("prototype", new AllForbiddenPropertyDescriptor(obj.PrototypeObject));
 
             return obj;
         }
@@ -112,11 +113,7 @@ namespace Jint.Native.RegExp
             r.Source = s;
             AssignFlags(r, f);
 
-            r.FastAddProperty("global", r.Global, false, false, false);
-            r.FastAddProperty("ignoreCase", r.IgnoreCase, false, false, false);
-            r.FastAddProperty("multiline", r.Multiline, false, false, false);
-            r.FastAddProperty("source", r.Source, false, false, false);
-            r.FastAddProperty("lastIndex", 0, true, false, false);
+            SetRegexProperties(r);
 
             return r;
         }
@@ -136,11 +133,7 @@ namespace Jint.Native.RegExp
             AssignFlags(r, flags);
             r.Source = System.String.IsNullOrEmpty(body) ? "(?:)" : body;
 
-            r.FastAddProperty("global", r.Global, false, false, false);
-            r.FastAddProperty("ignoreCase", r.IgnoreCase, false, false, false);
-            r.FastAddProperty("multiline", r.Multiline, false, false, false);
-            r.FastAddProperty("source", r.Source, false, false, false);
-            r.FastAddProperty("lastIndex", 0, true, false, false);
+            SetRegexProperties(r);
 
             return r;
         }
@@ -157,13 +150,18 @@ namespace Jint.Native.RegExp
             r.Source = regExp.ToString();
             r.Value = regExp;
 
-            r.FastAddProperty("global", r.Global, false, false, false);
-            r.FastAddProperty("ignoreCase", r.IgnoreCase, false, false, false);
-            r.FastAddProperty("multiline", r.Multiline, false, false, false);
-            r.FastAddProperty("source", r.Source, false, false, false);
-            r.FastAddProperty("lastIndex", 0, true, false, false);
+            SetRegexProperties(r);
 
             return r;
+        }
+
+        private static void SetRegexProperties(RegExpInstance r)
+        {
+            r.SetOwnProperty("global", new AllForbiddenPropertyDescriptor(r.Global));
+            r.SetOwnProperty("ignoreCase", new AllForbiddenPropertyDescriptor(r.IgnoreCase));
+            r.SetOwnProperty("multiline", new AllForbiddenPropertyDescriptor(r.Multiline));
+            r.SetOwnProperty("source", new AllForbiddenPropertyDescriptor(r.Source));
+            r.SetOwnProperty("lastIndex", new WritablePropertyDescriptor(0));
         }
 
         private void AssignFlags(RegExpInstance r, string flags)

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -2,6 +2,7 @@
 using Jint.Native.Array;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.RegExp
@@ -124,9 +125,9 @@ namespace Jint.Native.RegExp
 
         private static ArrayInstance InitReturnValueArray(ArrayInstance array, string inputValue, int lengthValue, int indexValue)
         {
-            array.DefineOwnProperty("index", new PropertyDescriptor(indexValue, writable: true, enumerable: true, configurable: true), true);
-            array.DefineOwnProperty("input", new PropertyDescriptor(inputValue, writable: true, enumerable: true, configurable: true), true);
-            array.DefineOwnProperty("length", new PropertyDescriptor(value: lengthValue, writable: true, enumerable: false, configurable: false), true);
+            array.SetOwnProperty("index", new ConfigurableEnumerableWritablePropertyDescriptor(indexValue));
+            array.SetOwnProperty("input", new ConfigurableEnumerableWritablePropertyDescriptor(inputValue));
+            array.SetOwnProperty("length", new WritablePropertyDescriptor(lengthValue));
             return array;
         }
     }

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -1,6 +1,7 @@
 ﻿using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.String
@@ -17,21 +18,21 @@ namespace Jint.Native.String
             var obj = new StringConstructor(engine);
             obj.Extensible = true;
 
-            // The value of the [[Prototype]] internal property of the String constructor is the Function prototype object 
+            // The value of the [[Prototype]] internal property of the String constructor is the Function prototype object
             obj.Prototype = engine.Function.PrototypeObject;
             obj.PrototypeObject = StringPrototype.CreatePrototypeObject(engine, obj);
 
-            obj.FastAddProperty("length", 1, false, false, false);
+            obj.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(1));
 
             // The initial value of String.prototype is the String prototype object
-            obj.FastAddProperty("prototype", obj.PrototypeObject, false, false, false);
+            obj.SetOwnProperty("prototype", new AllForbiddenPropertyDescriptor(obj.PrototypeObject));
 
             return obj;
         }
 
         public void Configure()
         {
-            FastAddProperty("fromCharCode", new ClrFunctionInstance(Engine, FromCharCode, 1), true, false, true);
+            SetOwnProperty("fromCharCode", new NonEnumerablePropertyDescriptor(new ClrFunctionInstance(Engine, FromCharCode, 1)));
         }
 
         private static JsValue FromCharCode(JsValue thisObj, JsValue[] arguments)
@@ -41,7 +42,7 @@ namespace Jint.Native.String
             {
                 chars[i] = (char)TypeConverter.ToUint16(arguments[i]);
             }
-            
+
             return new System.String(chars);
         }
 
@@ -74,7 +75,7 @@ namespace Jint.Native.String
             instance.PrimitiveValue = value;
             instance.Extensible = true;
 
-            instance.FastAddProperty("length", value.Length, false, false, false);
+            instance.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(value.Length));
 
             return instance;
         }

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -1,6 +1,7 @@
 ﻿using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Native.String
 {
@@ -30,7 +31,7 @@ namespace Jint.Native.String
             return false;
         }
 
-        public override PropertyDescriptor GetOwnProperty(string propertyName)
+        public override IPropertyDescriptor GetOwnProperty(string propertyName)
         {
             if (propertyName == "Infinity")
             {
@@ -62,7 +63,7 @@ namespace Jint.Native.String
             }
 
             var resultStr = TypeConverter.ToString(str.AsString()[index]);
-            return new PropertyDescriptor(resultStr, false, true, false);
+            return new EnumerablePropertyDescriptor(resultStr);
         }
     }
 }

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -7,6 +7,7 @@ using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Native.RegExp;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.String
@@ -27,8 +28,8 @@ namespace Jint.Native.String
             obj.Prototype = engine.Object.PrototypeObject;
             obj.PrimitiveValue = "";
             obj.Extensible = true;
-            obj.FastAddProperty("length", 0, false, false, false);
-            obj.FastAddProperty("constructor", stringConstructor, true, false, true);
+            obj.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(0));
+            obj.SetOwnProperty("constructor", new NonEnumerablePropertyDescriptor(stringConstructor));
 
             return obj;
         }

--- a/Jint/Native/Symbol/SymbolConstructor.cs
+++ b/Jint/Native/Symbol/SymbolConstructor.cs
@@ -1,6 +1,7 @@
 ﻿using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.Symbol
@@ -25,10 +26,10 @@ namespace Jint.Native.Symbol
             obj.Prototype = engine.Function.PrototypeObject;
             obj.PrototypeObject = SymbolPrototype.CreatePrototypeObject(engine, obj);
 
-            obj.FastAddProperty("length", 0, false, false, false);
+            obj.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(0));
 
             // The initial value of String.prototype is the String prototype object
-            obj.FastAddProperty("prototype", obj.PrototypeObject, false, false, false);
+            obj.SetOwnProperty("prototype", new AllForbiddenPropertyDescriptor(obj.PrototypeObject));
 
 
             return obj;

--- a/Jint/Native/Symbol/SymbolPrototype.cs
+++ b/Jint/Native/Symbol/SymbolPrototype.cs
@@ -1,5 +1,6 @@
 ﻿using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.Symbol
@@ -19,7 +20,7 @@ namespace Jint.Native.Symbol
             var obj = new SymbolPrototype(engine);
             obj.Prototype = engine.Object.PrototypeObject;
             obj.Extensible = true;
-            obj.FastAddProperty("length", 0, false, false, false);
+            obj.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(0));
             obj.FastAddProperty("constructor", symbolConstructor, true, false, true);
 
             return obj;

--- a/Jint/Runtime/Descriptors/IPropertyDescriptor .cs
+++ b/Jint/Runtime/Descriptors/IPropertyDescriptor .cs
@@ -1,0 +1,16 @@
+﻿using Jint.Native;
+
+namespace Jint.Runtime.Descriptors
+{
+    public interface IPropertyDescriptor
+    {
+        JsValue Get { get; }
+        JsValue Set { get; }
+
+        bool? Enumerable { get; }
+        bool? Writable { get; }
+        bool? Configurable { get; }
+
+        JsValue Value { get; set; }
+    }
+}

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -1,13 +1,14 @@
 ﻿using Jint.Native;
 using Jint.Native.Object;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Runtime.Descriptors
 {
-    public class PropertyDescriptor
+    public class PropertyDescriptor : IPropertyDescriptor
     {
-        public static PropertyDescriptor Undefined = new PropertyDescriptor();
+        public static readonly IPropertyDescriptor Undefined = new PropertyDescriptor();
 
-        public PropertyDescriptor()
+        protected PropertyDescriptor()
         {
         }
 
@@ -47,7 +48,7 @@ namespace Jint.Runtime.Descriptors
             }
         }
 
-        public PropertyDescriptor(PropertyDescriptor descriptor)
+        public PropertyDescriptor(IPropertyDescriptor descriptor)
         {
             Get = descriptor.Get;
             Set = descriptor.Set;
@@ -63,35 +64,6 @@ namespace Jint.Runtime.Descriptors
         public bool? Writable { get; set; }
         public bool? Configurable { get; set; }
         public virtual JsValue Value { get; set; }
-
-        public bool IsAccessorDescriptor()
-        {
-            if (Get ==null && Set == null)
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        public bool IsDataDescriptor()
-        {
-            if (!Writable.HasValue && Value == null)
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// http://www.ecma-international.org/ecma-262/5.1/#sec-8.10.3
-        /// </summary>
-        /// <returns></returns>
-        public bool IsGenericDescriptor()
-        {
-            return !IsDataDescriptor() && !IsAccessorDescriptor();
-        }
 
         public static PropertyDescriptor ToPropertyDescriptor(Engine engine, JsValue o)
         {
@@ -161,7 +133,7 @@ namespace Jint.Runtime.Descriptors
             return desc;
         }
 
-        public static JsValue FromPropertyDescriptor(Engine engine, PropertyDescriptor desc)
+        public static JsValue FromPropertyDescriptor(Engine engine, IPropertyDescriptor desc)
         {
             if (desc == Undefined)
             {
@@ -172,49 +144,19 @@ namespace Jint.Runtime.Descriptors
 
             if (desc.IsDataDescriptor())
             {
-                obj.DefineOwnProperty("value", new PropertyDescriptor(value: desc.Value != null ? desc.Value : Native.Undefined.Instance, writable: true, enumerable: true, configurable: true ), false);
-                obj.DefineOwnProperty("writable", new PropertyDescriptor(value: desc.Writable.HasValue && desc.Writable.Value, writable: true, enumerable: true, configurable: true), false);
+                obj.SetOwnProperty("value", new ConfigurableEnumerableWritablePropertyDescriptor(desc.Value != null ? desc.Value : Native.Undefined.Instance));
+                obj.SetOwnProperty("writable", new ConfigurableEnumerableWritablePropertyDescriptor(desc.Writable.HasValue && desc.Writable.Value));
             }
             else
             {
-                obj.DefineOwnProperty("get", new PropertyDescriptor(desc.Get ?? Native.Undefined.Instance, writable: true, enumerable: true, configurable: true ), false);
-                obj.DefineOwnProperty("set", new PropertyDescriptor(desc.Set ?? Native.Undefined.Instance, writable: true, enumerable: true, configurable: true), false);
+                obj.SetOwnProperty("get", new ConfigurableEnumerableWritablePropertyDescriptor(desc.Get ?? Native.Undefined.Instance));
+                obj.SetOwnProperty("set", new ConfigurableEnumerableWritablePropertyDescriptor(desc.Set ?? Native.Undefined.Instance));
             }
 
-            obj.DefineOwnProperty("enumerable", new PropertyDescriptor(value: desc.Enumerable.HasValue && desc.Enumerable.Value, writable: true, enumerable: true, configurable: true), false);
-            obj.DefineOwnProperty("configurable", new PropertyDescriptor(value: desc.Configurable.HasValue && desc.Configurable.Value, writable: true, enumerable: true, configurable: true), false);
+            obj.SetOwnProperty("enumerable", new ConfigurableEnumerableWritablePropertyDescriptor(desc.Enumerable.HasValue && desc.Enumerable.Value));
+            obj.SetOwnProperty("configurable", new ConfigurableEnumerableWritablePropertyDescriptor(desc.Configurable.HasValue && desc.Configurable.Value));
 
             return obj;
-        }
-
-        internal bool TryGetValue(ObjectInstance thisArg, out JsValue value)
-        {
-            value = JsValue.Undefined;
-
-            if (this == Undefined)
-            {
-                value = JsValue.Undefined;
-                return false;
-            }
-
-            if (IsDataDescriptor())
-            {
-                var val = Value;
-                if (val != null)
-                {
-                    value = val;
-                    return true;
-                }
-            }
-
-            if (Get != null && !Get.IsUndefined())
-            {
-                // if getter is not undefined it must be ICallable
-                var callable = Get.TryCast<ICallable>();
-                value = callable.Call(thisArg, Arguments.Empty);
-            }
-
-            return true;
         }
     }
 }

--- a/Jint/Runtime/Descriptors/PropertyDescriptorExtensions.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptorExtensions.cs
@@ -1,0 +1,62 @@
+﻿using System.Runtime.CompilerServices;
+using Jint.Native;
+using Jint.Native.Object;
+
+namespace Jint.Runtime.Descriptors
+{
+    public static class PropertyDescriptorExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsAccessorDescriptor(this IPropertyDescriptor descriptor)
+        {
+            return descriptor.Get != null || descriptor.Set != null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsDataDescriptor(this IPropertyDescriptor descriptor)
+        {
+            return descriptor.Writable.HasValue || descriptor.Value != null;
+        }
+
+        /// <summary>
+        /// http://www.ecma-international.org/ecma-262/5.1/#sec-8.10.3
+        /// </summary>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsGenericDescriptor(this IPropertyDescriptor descriptor)
+        {
+            return !descriptor.IsDataDescriptor() && !descriptor.IsAccessorDescriptor();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool TryGetValue(this IPropertyDescriptor descriptor, ObjectInstance thisArg, out JsValue value)
+        {
+            value = JsValue.Undefined;
+
+            if (descriptor == PropertyDescriptor.Undefined)
+            {
+                value = JsValue.Undefined;
+                return false;
+            }
+
+            if (descriptor.IsDataDescriptor())
+            {
+                var val = descriptor.Value;
+                if (val != null)
+                {
+                    value = val;
+                    return true;
+                }
+            }
+
+            if (descriptor.Get != null && !descriptor.Get.IsUndefined())
+            {
+                // if getter is not undefined it must be ICallable
+                var callable = descriptor.Get.TryCast<ICallable>();
+                value = callable.Call(thisArg, Arguments.Empty);
+            }
+
+            return true;
+        }
+    }
+}

--- a/Jint/Runtime/Descriptors/Specialized/AllForbiddenPropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/AllForbiddenPropertyDescriptor.cs
@@ -1,0 +1,24 @@
+﻿using Jint.Native;
+
+namespace Jint.Runtime.Descriptors.Specialized
+{
+    /// <summary>
+    /// configurable = false, enumerable = false, writable = false.
+    /// </summary>
+    internal sealed class AllForbiddenPropertyDescriptor : IPropertyDescriptor
+    {
+        public AllForbiddenPropertyDescriptor(JsValue value)
+        {
+            Value = value;
+        }
+
+        public JsValue Get => null;
+        public JsValue Set => null;
+
+        public bool? Enumerable => false;
+        public bool? Writable => false;
+        public bool? Configurable => false;
+
+        public JsValue Value { get; set; }
+    }
+}

--- a/Jint/Runtime/Descriptors/Specialized/ClrAccessDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/ClrAccessDescriptor.cs
@@ -4,19 +4,21 @@ using Jint.Runtime.Interop;
 
 namespace Jint.Runtime.Descriptors.Specialized
 {
-    public sealed class ClrAccessDescriptor : PropertyDescriptor
+    public sealed class ClrAccessDescriptor : IPropertyDescriptor
     {
-        public ClrAccessDescriptor(Engine engine, Func<JsValue, JsValue> get)
-            : this(engine, get, null)
+        public ClrAccessDescriptor(Engine engine, Func<JsValue, JsValue> get, Action<JsValue, JsValue> set = null)
         {
+            Get = new GetterFunctionInstance(engine, get);
+            Set = set == null ? Undefined.Instance : new SetterFunctionInstance(engine, set);
         }
 
-        public ClrAccessDescriptor(Engine engine, Func<JsValue, JsValue> get, Action<JsValue, JsValue> set)
-            : base(
-                get: new GetterFunctionInstance(engine, get),
-                set: set == null ? Native.Undefined.Instance : new SetterFunctionInstance(engine, set)
-                )
-        {
-        }
+        public JsValue Get { get; }
+        public JsValue Set { get; }
+
+        public bool? Enumerable => null;
+        public bool? Writable => null;
+        public bool? Configurable { get; set; }
+
+        public JsValue Value { get; set; }
     }
 }

--- a/Jint/Runtime/Descriptors/Specialized/ClrAccessDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/ClrAccessDescriptor.cs
@@ -1,24 +1,45 @@
-﻿using System;
-using Jint.Native;
+﻿using Jint.Native;
+using Jint.Runtime.Environments;
 using Jint.Runtime.Interop;
 
 namespace Jint.Runtime.Descriptors.Specialized
 {
-    public sealed class ClrAccessDescriptor : IPropertyDescriptor
+    internal sealed class ClrAccessDescriptor : IPropertyDescriptor
     {
-        public ClrAccessDescriptor(Engine engine, Func<JsValue, JsValue> get, Action<JsValue, JsValue> set = null)
+        private readonly EnvironmentRecord _env;
+        private readonly Engine _engine;
+        private readonly string _name;
+
+        private GetterFunctionInstance _get;
+        private SetterFunctionInstance _set;
+
+        public ClrAccessDescriptor(
+            EnvironmentRecord env,
+            Engine engine,
+            string name)
         {
-            Get = new GetterFunctionInstance(engine, get);
-            Set = set == null ? Undefined.Instance : new SetterFunctionInstance(engine, set);
+            _env = env;
+            _engine = engine;
+            _name = name;
         }
 
-        public JsValue Get { get; }
-        public JsValue Set { get; }
+        public JsValue Get => _get = _get ?? new GetterFunctionInstance(_engine, DoGet);
+        public JsValue Set => _set = _set ?? new SetterFunctionInstance(_engine, DoSet);
 
         public bool? Enumerable => null;
         public bool? Writable => null;
-        public bool? Configurable { get; set; }
+        public bool? Configurable => true;
 
         public JsValue Value { get; set; }
+
+        private JsValue DoGet(JsValue n)
+        {
+            return _env.GetBindingValue(_name, false);
+        }
+
+        private void DoSet(JsValue n, JsValue o)
+        {
+            _env.SetMutableBinding(_name, o, true);
+        }
     }
 }

--- a/Jint/Runtime/Descriptors/Specialized/ConfigurableEnumerableWritablePropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/ConfigurableEnumerableWritablePropertyDescriptor.cs
@@ -1,0 +1,24 @@
+﻿using Jint.Native;
+
+namespace Jint.Runtime.Descriptors.Specialized
+{
+    /// <summary>
+    /// configurable = true, enumerable = true, writable = true.
+    /// </summary>
+    internal sealed class ConfigurableEnumerableWritablePropertyDescriptor : IPropertyDescriptor
+    {
+        public ConfigurableEnumerableWritablePropertyDescriptor(JsValue value)
+        {
+            Value = value;
+        }
+
+        public JsValue Get => null;
+        public JsValue Set => null;
+
+        public bool? Enumerable => true;
+        public bool? Writable => true;
+        public bool? Configurable => true;
+
+        public JsValue Value { get; set; }
+    }
+}

--- a/Jint/Runtime/Descriptors/Specialized/EnumerablePropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/EnumerablePropertyDescriptor.cs
@@ -1,0 +1,24 @@
+﻿using Jint.Native;
+
+namespace Jint.Runtime.Descriptors.Specialized
+{
+    /// <summary>
+    /// configurable = true, enumerable = true, writable = true.
+    /// </summary>
+    internal sealed class EnumerablePropertyDescriptor : IPropertyDescriptor
+    {
+        public EnumerablePropertyDescriptor(JsValue value)
+        {
+            Value = value;
+        }
+
+        public JsValue Get => null;
+        public JsValue Set => null;
+
+        public bool? Enumerable => true;
+        public bool? Writable => false;
+        public bool? Configurable => false;
+
+        public JsValue Value { get; set; }
+    }
+}

--- a/Jint/Runtime/Descriptors/Specialized/NonConfigurablePropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/NonConfigurablePropertyDescriptor.cs
@@ -1,0 +1,24 @@
+﻿using Jint.Native;
+
+namespace Jint.Runtime.Descriptors.Specialized
+{
+    /// <summary>
+    /// configurable = false, enumerable = true, writable = true.
+    /// </summary>
+    internal sealed class NonConfigurablePropertyDescriptor : IPropertyDescriptor
+    {
+        public NonConfigurablePropertyDescriptor(JsValue value)
+        {
+            Value = value;
+        }
+
+        public JsValue Get => null;
+        public JsValue Set => null;
+
+        public bool? Enumerable => true;
+        public bool? Writable => true;
+        public bool? Configurable => false;
+
+        public JsValue Value { get; set; }
+    }
+}

--- a/Jint/Runtime/Descriptors/Specialized/NonEnumerablePropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/NonEnumerablePropertyDescriptor.cs
@@ -1,0 +1,24 @@
+﻿using Jint.Native;
+
+namespace Jint.Runtime.Descriptors.Specialized
+{
+    /// <summary>
+    /// configurable = true, enumerable = false, writable  = true.
+    /// </summary>
+    internal sealed class NonEnumerablePropertyDescriptor : IPropertyDescriptor
+    {
+        public NonEnumerablePropertyDescriptor(JsValue value)
+        {
+            Value = value;
+        }
+
+        public JsValue Get => null;
+        public JsValue Set => null;
+
+        public bool? Enumerable => false;
+        public bool? Writable => true;
+        public bool? Configurable => true;
+
+        public JsValue Value { get; set; }
+    }
+}

--- a/Jint/Runtime/Descriptors/Specialized/NullConfigurationPropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/NullConfigurationPropertyDescriptor.cs
@@ -1,0 +1,24 @@
+﻿using Jint.Native;
+
+namespace Jint.Runtime.Descriptors.Specialized
+{
+    /// <summary>
+    /// configurable = null, enumerable = null, writable = null.
+    /// </summary>
+    internal sealed class NullConfigurationPropertyDescriptor : IPropertyDescriptor
+    {
+        public NullConfigurationPropertyDescriptor(JsValue value)
+        {
+            Value = value;
+        }
+
+        public JsValue Get => null;
+        public JsValue Set => null;
+
+        public bool? Enumerable => null;
+        public bool? Writable => null;
+        public bool? Configurable => null;
+
+        public JsValue Value { get; set; }
+    }
+}

--- a/Jint/Runtime/Descriptors/Specialized/WritablePropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/WritablePropertyDescriptor.cs
@@ -1,0 +1,24 @@
+﻿using Jint.Native;
+
+namespace Jint.Runtime.Descriptors.Specialized
+{
+    /// <summary>
+    /// configurable = false, enumerable = false, writable  = true.
+    /// </summary>
+    internal sealed class WritablePropertyDescriptor : IPropertyDescriptor
+    {
+        public WritablePropertyDescriptor(JsValue value)
+        {
+            Value = value;
+        }
+
+        public JsValue Get => null;
+        public JsValue Set => null;
+
+        public bool? Enumerable => false;
+        public bool? Writable => true;
+        public bool? Configurable => false;
+
+        public JsValue Value { get; set; }
+    }
+}

--- a/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
@@ -1,7 +1,9 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Runtime.Environments
 {
@@ -34,7 +36,11 @@ namespace Jint.Runtime.Environments
         /// <param name="configurable"></param>
         public override void CreateMutableBinding(string name, bool configurable = true)
         {
-            _bindingObject.DefineOwnProperty(name, new PropertyDescriptor(Undefined.Instance, true, true, configurable), true);
+            var propertyDescriptor = configurable
+                ? (IPropertyDescriptor) new ConfigurableEnumerableWritablePropertyDescriptor(Undefined.Instance)
+                : new NonConfigurablePropertyDescriptor(Undefined.Instance);
+
+            _bindingObject.SetOwnProperty(name, propertyDescriptor);
         }
 
         public override void SetMutableBinding(string name, JsValue value, bool strict)
@@ -81,7 +87,7 @@ namespace Jint.Runtime.Environments
                 return _bindingObject.GetOwnProperties().Select( x=> x.Key).ToArray();
             }
 
-            return new string[0];
+            return Array.Empty<string>();
         }
     }
 }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -7,6 +7,7 @@ using Jint.Native;
 using Jint.Native.Function;
 using Jint.Native.Number;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interop;
 using Jint.Runtime.References;
@@ -641,7 +642,7 @@ namespace Jint.Runtime
             {
                 var propName = property.Key.GetKey();
                 var previous = obj.GetOwnProperty(propName);
-                PropertyDescriptor propDesc;
+                IPropertyDescriptor propDesc;
 
                 switch (property.Kind)
                 {
@@ -649,7 +650,7 @@ namespace Jint.Runtime
                     case PropertyKind.Data:
                         var exprValue = _engine.EvaluateExpression(property.Value.As<Expression>());
                         var propValue = _engine.GetValue(exprValue);
-                        propDesc = new PropertyDescriptor(propValue, true, true, true);
+                        propDesc = new ConfigurableEnumerableWritablePropertyDescriptor(propValue);
                         break;
 
                     case PropertyKind.Get:

--- a/Jint/Runtime/Interop/ClrFunctionInstance.cs
+++ b/Jint/Runtime/Interop/ClrFunctionInstance.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Jint.Native;
 using Jint.Native.Function;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Runtime.Interop
 {
@@ -16,7 +17,7 @@ namespace Jint.Runtime.Interop
         {
             _func = func;
             Prototype = engine.Function.PrototypeObject;
-            FastAddProperty("length", length, false, false, false);
+            SetOwnProperty("length", new AllForbiddenPropertyDescriptor(length));
             Extensible = true;
         }
 

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -23,7 +23,7 @@ namespace Jint.Runtime.Interop
             _path = path;
         }
 
-        public override bool DefineOwnProperty(string propertyName, PropertyDescriptor desc, bool throwOnError)
+        public override bool DefineOwnProperty(string propertyName, IPropertyDescriptor desc, bool throwOnError)
         {
             if (throwOnError)
             {
@@ -98,13 +98,13 @@ namespace Jint.Runtime.Interop
                 return TypeReference.CreateTypeReference(Engine, type);
             }
 
-            // in CoreCLR, for example, classes that used to be in 
+            // in CoreCLR, for example, classes that used to be in
             // mscorlib were moved away, and only stubs remained, because
             // of that, we do the search on the lookup assemblies first,
             // and only then in mscorlib. Probelm usage: System.IO.File.CreateText
-            
+
             // search in loaded assemblies
-            var lookupAssemblies = new[] { Assembly.GetCallingAssembly(), Assembly.GetExecutingAssembly() };
+            var lookupAssemblies = new[] {Assembly.GetCallingAssembly(), Assembly.GetExecutingAssembly()};
 
             foreach (var assembly in lookupAssemblies)
             {
@@ -130,14 +130,14 @@ namespace Jint.Runtime.Interop
                 var trimPath = path.Substring(0, lastPeriodPos);
                 type = GetType(assembly, trimPath);
                 if (type != null)
-                  foreach (Type nType in GetAllNestedTypes(type))
-                  {
-                    if (nType.FullName.Replace("+", ".").Equals(path.Replace("+", ".")))
+                    foreach (Type nType in GetAllNestedTypes(type))
                     {
-                      Engine.TypeCache.Add(path.Replace("+", "."), nType);
-                      return TypeReference.CreateTypeReference(Engine, nType);
+                        if (nType.FullName.Replace("+", ".").Equals(path.Replace("+", ".")))
+                        {
+                            Engine.TypeCache.Add(path.Replace("+", "."), nType);
+                            return TypeReference.CreateTypeReference(Engine, nType);
+                        }
                     }
-                  }
             }
 
             // search for type in mscorlib
@@ -160,7 +160,6 @@ namespace Jint.Runtime.Interop
         /// <param name="typeName"> Name of the type. </param>
         ///
         /// <returns>   The type. </returns>
-
         private static Type GetType(Assembly assembly, string typeName)
         {
             Type[] types = assembly.GetTypes();
@@ -171,27 +170,28 @@ namespace Jint.Runtime.Interop
                     return t;
                 }
             }
+
             return null;
         }
 
         private static IEnumerable<Type> GetAllNestedTypes(Type type)
         {
-          var types = new List<Type>();
-          AddNestedTypesRecursively(types, type);
-          return types.ToArray();
+            var types = new List<Type>();
+            AddNestedTypesRecursively(types, type);
+            return types.ToArray();
         }
 
         private static void AddNestedTypesRecursively(List<Type> types, Type type)
         {
-          Type[] nestedTypes = type.GetNestedTypes(BindingFlags.Public);
-          foreach (Type nestedType in nestedTypes)
-          {
-            types.Add(nestedType);
-            AddNestedTypesRecursively(types, nestedType);
-          }
+            Type[] nestedTypes = type.GetNestedTypes(BindingFlags.Public);
+            foreach (Type nestedType in nestedTypes)
+            {
+                types.Add(nestedType);
+                AddNestedTypesRecursively(types, nestedType);
+            }
         }
 
-      public override PropertyDescriptor GetOwnProperty(string propertyName)
+        public override IPropertyDescriptor GetOwnProperty(string propertyName)
         {
             return PropertyDescriptor.Undefined;
         }

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -50,10 +50,9 @@ namespace Jint.Runtime.Interop
             ownDesc.Value = value;
         }
 
-        public override PropertyDescriptor GetOwnProperty(string propertyName)
+        public override IPropertyDescriptor GetOwnProperty(string propertyName)
         {
-            PropertyDescriptor x;
-            if (TryGetProperty(propertyName, out x))
+            if (TryGetProperty(propertyName, out var x))
                 return x;
 
             var type = Target.GetType();
@@ -87,7 +86,7 @@ namespace Jint.Runtime.Interop
 
             if (methods.Any())
             {
-                var descriptor = new PropertyDescriptor(new MethodInfoFunctionInstance(Engine, methods), false, true, false);
+                var descriptor = new EnumerablePropertyDescriptor(new MethodInfoFunctionInstance(Engine, methods));
                 AddProperty(propertyName, descriptor);
                 return descriptor;
             }
@@ -121,7 +120,7 @@ namespace Jint.Runtime.Interop
 
             if (explicitMethods.Length > 0)
             {
-                var descriptor = new PropertyDescriptor(new MethodInfoFunctionInstance(Engine, explicitMethods), false, true, false);
+                var descriptor = new EnumerablePropertyDescriptor(new MethodInfoFunctionInstance(Engine, explicitMethods));
                 AddProperty(propertyName, descriptor);
                 return descriptor;
             }

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -28,10 +28,10 @@ namespace Jint.Runtime.Interop
             // The value of the [[Prototype]] internal property of the TypeReference constructor is the Function prototype object
             obj.Prototype = engine.Function.PrototypeObject;
 
-            obj.FastAddProperty("length", 0, false, false, false);
+            obj.SetOwnProperty("length", new AllForbiddenPropertyDescriptor(0));
 
             // The initial value of Boolean.prototype is the Boolean prototype object
-            obj.FastAddProperty("prototype", engine.Object.PrototypeObject, false, false, false);
+            obj.SetOwnProperty("prototype", new AllForbiddenPropertyDescriptor(engine.Object.PrototypeObject));
 
             return obj;
         }
@@ -108,7 +108,7 @@ namespace Jint.Runtime.Interop
             return wrapper.Target.GetType() == this.Type;
         }
 
-        public override bool DefineOwnProperty(string propertyName, PropertyDescriptor desc, bool throwOnError)
+        public override bool DefineOwnProperty(string propertyName, IPropertyDescriptor desc, bool throwOnError)
         {
             if (throwOnError)
             {
@@ -157,7 +157,7 @@ namespace Jint.Runtime.Interop
             ownDesc.Value = value;
         }
 
-        public override PropertyDescriptor GetOwnProperty(string propertyName)
+        public override IPropertyDescriptor GetOwnProperty(string propertyName)
         {
             // todo: cache members locally
 
@@ -170,7 +170,7 @@ namespace Jint.Runtime.Interop
                 {
                     if (enumNames.GetValue(i) as string == propertyName)
                     {
-                        return new PropertyDescriptor((int)enumValues.GetValue(i), false, false, false);
+                        return new AllForbiddenPropertyDescriptor((int) enumValues.GetValue(i));
                     }
                 }
                 return PropertyDescriptor.Undefined;
@@ -198,7 +198,7 @@ namespace Jint.Runtime.Interop
                 return PropertyDescriptor.Undefined;
             }
 
-            return new PropertyDescriptor(new MethodInfoFunctionInstance(Engine, methodInfo), false, false, false);
+            return new AllForbiddenPropertyDescriptor(new MethodInfoFunctionInstance(Engine, methodInfo));
         }
 
         public object Target


### PR DESCRIPTION
This PR changes PropertyDescriptor usage to happen through IPropertyDescriptor interface. This allows specialized descritors that don't hold other instance fields other than the actual JsValue. This benefits especially arrays where descriptor stays quite constant. Array heave operators seem to get around 10% allocation reduction.

ObjectInstance converts to more memory hungry full PropertyDescriptor when changes are requested. I've kept new specialized versions as internal. This change affects memory usage and should not have much positive or negative impact on speed. Virtual dispatch is already happening with PropertyDescriptor.Value as it's virtual.

## Before

|             Method |   N |        Mean |      Error |     StdDev |     Gen 0 |   Allocated |
|------------------- |---- |------------:|-----------:|-----------:|----------:|------------:|
|              Slice | 100 |    877.4 us |   7.603 us |   7.112 us |  239.2578 |   982.81 KB |
|             Concat | 100 |    991.0 us |   1.550 us |   1.210 us |  257.8125 |   1062.5 KB |
|            Unshift | 100 | 36,026.6 us | 182.054 us | 152.023 us | 7000.0000 | 28785.16 KB |
|               Push | 100 | 23,722.6 us | 439.804 us | 411.393 us | 1625.0000 |   6762.5 KB |
|              Index | 100 | 25,124.1 us |  59.588 us |  49.759 us | 1531.2500 |  6333.59 KB |
|                Map | 100 |  4,644.9 us |  15.578 us |  13.810 us | 1804.6875 |  7420.31 KB |
|              Apply | 100 |  1,040.4 us |   5.970 us |   5.584 us |  267.5781 |  1098.44 KB |
| JsonStringifyParse | 100 |  6,641.6 us |  26.941 us |  25.200 us | 1476.5625 |  6068.75 KB |

|    Method |   N |     Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|---------- |---- |---------:|---------:|---------:|------------:|-----------:|----------:|
| UncacheableExpressionsBenchmark| 500 | 572.1 ms | 82.07 ms | 4.637 ms | 114750.0000 | 33562.5000 | 494.73 MB |
  
## After

|             Method |   N |        Mean |      Error |     StdDev |     Gen 0 |   Allocated |
|------------------- |---- |------------:|-----------:|-----------:|----------:|------------:|
|              Slice | 100 |    839.7 us |   6.128 us |   5.432 us |  154.2969 |   635.94 KB |
|             Concat | 100 |    947.8 us |  11.131 us |  10.412 us |  171.8750 |   707.81 KB |
|            Unshift | 100 | 37,094.3 us | 278.159 us | 260.190 us | 3750.0000 | 15492.19 KB |
|               Push | 100 | 25,588.8 us |  30.847 us |  27.345 us | 1468.7500 |  6125.78 KB |
|              Index | 100 | 26,047.0 us | 102.136 us |  90.541 us | 1375.0000 |  5696.88 KB |
|                Map | 100 |  4,650.9 us |   9.938 us |   9.296 us | 1718.7500 |  7071.88 KB |
|              Apply | 100 |  1,038.3 us |   3.905 us |   3.653 us |  187.5000 |   774.22 KB |
| JsonStringifyParse | 100 |  6,671.2 us |   6.482 us |   6.063 us | 1390.6250 |  5710.16 KB |


|    Method |   N |     Mean |    Error |   StdDev |       Gen 0 |      Gen 1 | Allocated |
|---------- |---- |---------:|---------:|---------:|------------:|-----------:|----------:|
| UncacheableExpressionsBenchmark| 500 | 592.7 ms | 22.18 ms | 1.253 ms | 100104.1667 | 29541.6667 | 446.99 MB |
