### PR TITLE
Tweak hot paths

### DIFF
--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -64,6 +64,11 @@ namespace Jint.Native
             return new ConcatenatedString(_value, capacity);
         }
 
+        internal virtual bool IsNullOrEmpty()
+        {
+            return string.IsNullOrEmpty(_value);
+        }
+
         internal static JsString Create(string value)
         {
             if (value.Length <= 1)
@@ -181,6 +186,12 @@ namespace Jint.Native
             {
                 _stringBuilder.EnsureCapacity(capacity);
                 return this;
+            }
+
+            internal override bool IsNullOrEmpty()
+            {
+                return _stringBuilder == null && string.IsNullOrEmpty(_value)
+                    || _stringBuilder != null && _stringBuilder.Length == 0;
             }
 
             public override bool Equals(JsValue other)

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -18,7 +18,7 @@ namespace Jint.Native.Object
 {
     public class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     {
-        private Dictionary<string, PropertyDescriptor> _intrinsicProperties;
+        private MruPropertyCache2<PropertyDescriptor> _intrinsicProperties;
         private MruPropertyCache2<PropertyDescriptor> _properties;
 
         public ObjectInstance(Engine engine) : base(Types.Object)
@@ -54,7 +54,7 @@ namespace Jint.Native.Object
         {
             if (_intrinsicProperties == null)
             {
-                _intrinsicProperties = new Dictionary<string, PropertyDescriptor>();
+                _intrinsicProperties = new MruPropertyCache2<PropertyDescriptor>();
             }
 
             _intrinsicProperties[symbol.AsSymbol()] = new PropertyDescriptor(value, writable, enumerable, configurable);

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -56,8 +56,8 @@ namespace Jint.Runtime
             if (assignmentExpression.Operator == AssignmentOperator.Assign) // "="
             {
 
-                if(lref.IsStrict() 
-                   && !ReferenceEquals(lref.GetBase().TryCast<EnvironmentRecord>(), null) 
+                if(lref.IsStrict()
+                   && lref.GetBase() is EnvironmentRecord
                    && (lref.GetReferencedName() == "eval" || lref.GetReferencedName() == "arguments"))
                 {
                     throw new JavaScriptException(_engine.SyntaxError);
@@ -967,7 +967,7 @@ namespace Jint.Runtime
                     r = value as Reference;
                     if (r != null
                         && r.IsStrict()
-                        && (!ReferenceEquals(r.GetBase().TryCast<EnvironmentRecord>(), null))
+                        && r.GetBase() is EnvironmentRecord
                         && ("eval" == r.GetReferencedName() || "arguments" == r.GetReferencedName()))
                     {
                         throw new JavaScriptException(_engine.SyntaxError);
@@ -984,7 +984,7 @@ namespace Jint.Runtime
                     r = value as Reference;
                     if (r != null
                         && r.IsStrict()
-                        && (!ReferenceEquals(r.GetBase().TryCast<EnvironmentRecord>(), null))
+                        && r.GetBase() is EnvironmentRecord
                         && ("eval" == r.GetReferencedName() || "arguments" == r.GetReferencedName()))
                     {
                         throw new JavaScriptException(_engine.SyntaxError);

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -539,8 +539,8 @@ namespace Jint.Runtime
                         throw new ArgumentException();
                     }
 
-                    if (lhs.IsStrict() 
-                        && !ReferenceEquals(lhs.GetBase().TryCast<EnvironmentRecord>(), null) 
+                    if (lhs.IsStrict()
+                        && lhs.GetBase() is EnvironmentRecord
                         && (lhs.GetReferencedName() == "eval" || lhs.GetReferencedName() == "arguments"))
                     {
                         throw new JavaScriptException(_engine.SyntaxError);

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -106,13 +106,7 @@ namespace Jint.Runtime
 
             if (type == Types.String)
             {
-                var s = o.AsString();
-                if (string.IsNullOrEmpty(s))
-                {
-                    return false;
-                }
-
-                return true;
+                return !((JsString) o).IsNullOrEmpty();
             }
 
             return true;


### PR DESCRIPTION
## ArrayBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Slice|100|512.2 us|161.1328|660.16 KB|
| **New** |	|	| **506.9 us (-1%)** | **161.1328 (0%)** | **660.16 KB (0%)** |
| Old |Concat|100|607.1 us|175.7813|720.31 KB|
| **New** |	|	| **584.0 us (-4%)** | **175.7813 (0%)** | **720.31 KB (0%)** |
| Old |Unshift|100|20,136.0 us|3562.5000|14672.66 KB|
| **New** |	|	| **20,528.9 us (+2%)** | **3562.5000 (0%)** | **14672.66 KB (0%)** |
| Old |Push|100|13,198.6 us|515.6250|2134.38 KB|
| **New** |	|	| **13,058.4 us (-1%)** | **515.6250 (0%)** | **2134.38 KB (0%)** |
| Old |Index|100|12,839.2 us|390.6250|1637.5 KB|
| **New** |	|	| **12,663.2 us (-1%)** | **390.6250 (0%)** | **1637.5 KB (0%)** |
| Old |Map|100|3,683.2 us|765.6250|3151.56 KB|
| **New** |	|	| **3,768.9 us (+2%)** | **765.6250 (0%)** | **3151.56 KB (0%)** |
| Old |Apply|100|707.6 us|190.4297|782.81 KB|
| **New** |	|	| **715.6 us (+1%)** | **190.4297 (0%)** | **782.81 KB (0%)** |
| Old |JsonStringifyParse|100|4,687.4 us|1273.4375|5233.59 KB|
| **New** |	|	| **4,657.6 us (-1%)** | **1273.4375 (0%)** | **5233.59 KB (0%)** |


## ArrayStressBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|20|696.1 ms|60000.0000|8312.5000|256.64 MB|
| **New** |	|	| **678.8 ms (-2%)** | **60000.0000 (0%)** | **8312.5000 (0%)** | **256.64 MB (0%)** |


## DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|dromaeo-3d-cube|81.43 ms|1437.5000|500.0000|-|7749.97 KB|
| **New** |	|	| **81.55 ms (0%)** | **1437.5000 (0%)** | **500.0000 (0%)** | **-** | **7749.97 KB (0%)** |
| Old |Run|dromaeo-core-eval|23.91 ms|62.5000|-|-|299.02 KB|
| **New** |	|	| **19.33 ms (-19%)** | **62.5000 (0%)** | **-** | **-** | **299.02 KB (0%)** |
| Old |Run|dromaeo-object-array|197.28 ms|43312.5000|2000.0000|1000.0000|181953.89 KB|
| **New** |	|	| **182.82 ms (-7%)** | **43312.5000 (0%)** | **2000.0000 (0%)** | **1000.0000 (0%)** | **181953.56 KB (0%)** |
| Old |Run|dromaeo-object-regexp|1,093.45 ms|61750.0000|33000.0000|22500.0000|466736.45 KB|
| **New** |	|	| **1,089.88 ms (0%)** | **62125.0000 (+1%)** | **32812.5000 (-1%)** | **22562.5000 (0%)** | **466863.07 KB (0%)** |
| Old |Run|dromaeo-object-string|1,245.35 ms|220000.0000|176500.0000|173000.0000|1403845.43 KB|
| **New** |	|	| **1,236.08 ms (-1%)** | **221125.0000 (+1%)** | **177125.0000 (0%)** | **174000.0000 (+1%)** | **1403487.19 KB (0%)** |
| Old |Run|dromaeo-string-base64|184.81 ms|6062.5000|437.5000|-|26624.45 KB|
| **New** |	|	| **184.44 ms (0%)** | **6062.5000 (0%)** | **437.5000 (0%)** | **-** | **26624.45 KB (0%)** |


## EvaluationBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Jint|20|702.0 us|120.1172|492.5 KB|
| **New** |	|	| **695.0 us (-1%)** | **120.1172 (0%)** | **492.5 KB (0%)** |


## LinqJsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|10|73.84 ms|5062.5000|2500.0000|30.56 MB|
| **New** |	|	| **71.13 ms (-4%)** | **5062.5000 (0%)** | **2500.0000 (0%)** | **30.56 MB (0%)** |


## MinimalScriptBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Jint|10|18.97 us|8.1482|33.44 KB|
| **New** |	|	| **19.76 us (+4%)** | **8.1482 (0%)** | **33.44 KB (0%)** |


## SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|3d-cube|651.2 ms|12000.0000|312.5000|-|50.06 MB|
| **New** |	|	| **651.4 ms (0%)** | **12000.0000 (0%)** | **312.5000 (0%)** | **-** | **50.06 MB (0%)** |
| Old |Run|3d-morph|605.4 ms|11812.5000|2500.0000|1062.5000|68.03 MB|
| **New** |	|	| **603.9 ms (0%)** | **11812.5000 (0%)** | **2500.0000 (0%)** | **1062.5000 (0%)** | **68.03 MB (0%)** |
| Old |Run|3d-raytrace|567.9 ms|22562.5000|750.0000|125.0000|92.34 MB|
| **New** |	|	| **508.7 ms (-10%)** | **22562.5000 (0%)** | **625.0000 (-17%)** | **62.5000 (-50%)** | **92.34 MB (0%)** |
| Old |Run|access-binary-trees|213.8 ms|17625.0000|312.5000|62.5000|73 MB|
| **New** |	|	| **214.9 ms (+1%)** | **17625.0000 (0%)** | **312.5000 (0%)** | **62.5000 (0%)** | **73 MB (0%)** |
| Old |Run|access-fannkuch|1,973.5 ms|9437.5000|187.5000|-|37.87 MB|
| **New** |	|	| **1,960.2 ms (-1%)** | **9437.5000 (0%)** | **187.5000 (0%)** | **-** | **37.87 MB (0%)** |
| Old |Run|access-nbody|589.8 ms|13125.0000|-|-|52.6 MB|
| **New** |	|	| **594.2 ms (+1%)** | **13125.0000 (0%)** | **-** | **-** | **52.6 MB (0%)** |
| Old |Run|access-nsieve|745.1 ms|15312.5000|3937.5000|1875.0000|73.09 MB|
| **New** |	|	| **746.3 ms (0%)** | **15375.0000 (0%)** | **3937.5000 (0%)** | **1875.0000 (0%)** | **73.1 MB (0%)** |
| Old |Run|bitops-3bit-bits-in-byte|452.4 ms|19750.0000|-|-|79.06 MB|
| **New** |	|	| **456.2 ms (+1%)** | **19750.0000 (0%)** | **-** | **-** | **79.06 MB (0%)** |
| Old |Run|bitops-bits-in-byte|769.0 ms|12437.5000|62.5000|-|49.86 MB|
| **New** |	|	| **776.5 ms (+1%)** | **12437.5000 (0%)** | **62.5000 (0%)** | **-** | **49.86 MB (0%)** |
| Old |Run|bitops-bitwise-and|454.4 ms|13562.5000|-|-|54.32 MB|
| **New** |	|	| **455.3 ms (0%)** | **13562.5000 (0%)** | **-** | **-** | **54.32 MB (0%)** |
| Old |Run|bitops-nsieve-bits|761.4 ms|21625.0000|250.0000|62.5000|88.65 MB|
| **New** |	|	| **764.0 ms (0%)** | **21625.0000 (0%)** | **250.0000 (0%)** | **62.5000 (0%)** | **88.65 MB (0%)** |
| Old |Run|controlflow-recursive|302.3 ms|25937.5000|62.5000|-|103.78 MB|
| **New** |	|	| **306.8 ms (+1%)** | **25937.5000 (0%)** | **62.5000 (0%)** | **-** | **103.78 MB (0%)** |
| Old |Run|crypto-aes|489.4 ms|5625.0000|250.0000|-|24.49 MB|
| **New** |	|	| **477.4 ms (-2%)** | **5625.0000 (0%)** | **250.0000 (0%)** | **-** | **24.5 MB (0%)** |
| Old |Run|crypto-md5|349.4 ms|30562.5000|187.5000|-|124.99 MB|
| **New** |	|	| **347.0 ms (-1%)** | **30562.5000 (0%)** | **187.5000 (0%)** | **-** | **124.99 MB (0%)** |
| Old |Run|crypto-sha1|344.9 ms|24875.0000|312.5000|-|101.48 MB|
| **New** |	|	| **336.5 ms (-2%)** | **24875.0000 (0%)** | **312.5000 (0%)** | **-** | **101.48 MB (0%)** |
| Old |Run|date-format-tofte|340.7 ms|12625.0000|-|-|50.73 MB|
| **New** |	|	| **338.4 ms (-1%)** | **12625.0000 (0%)** | **-** | **-** | **50.73 MB (0%)** |
| Old |Run|date-format-xparb|335.6 ms|10375.0000|250.0000|-|42.27 MB|
| **New** |	|	| **334.6 ms (0%)** | **10375.0000 (0%)** | **250.0000 (0%)** | **-** | **42.27 MB (0%)** |
| Old |Run|math-cordic|990.1 ms|22562.5000|62.5000|-|90.25 MB|
| **New** |	|	| **985.6 ms (0%)** | **22562.5000 (0%)** | **62.5000 (0%)** | **-** | **90.25 MB (0%)** |
| Old |Run|math-partial-sums|312.5 ms|7250.0000|-|-|29.04 MB|
| **New** |	|	| **314.1 ms (+1%)** | **7250.0000 (0%)** | **-** | **-** | **29.04 MB (0%)** |
| Old |Run|math-spectral-norm|369.2 ms|18062.5000|-|-|72.31 MB|
| **New** |	|	| **371.1 ms (+1%)** | **18062.5000 (0%)** | **-** | **-** | **72.31 MB (0%)** |
| Old |Run|regexp-dna|341.6 ms|2250.0000|1812.5000|1500.0000|13.55 MB|
| **New** |	|	| **341.3 ms (0%)** | **2250.0000 (0%)** | **1812.5000 (0%)** | **1500.0000 (0%)** | **13.55 MB (0%)** |
| Old |Run|string-base64|278.0 ms|8875.0000|500.0000|-|37.16 MB|
| **New** |	|	| **277.0 ms (0%)** | **8875.0000 (0%)** | **500.0000 (0%)** | **-** | **37.16 MB (0%)** |
| Old |Run|string-fasta|478.5 ms|27125.0000|62.5000|-|108.53 MB|
| **New** |	|	| **464.1 ms (-3%)** | **27125.0000 (0%)** | **62.5000 (0%)** | **-** | **108.53 MB (0%)** |
| Old |Run|string-tagcloud|219.3 ms|14687.5000|1750.0000|687.5000|67.2 MB|
| **New** |	|	| **217.0 ms (-1%)** | **14625.0000 (0%)** | **1687.5000 (-4%)** | **687.5000 (0%)** | **67.2 MB (0%)** |
| Old |Run|string-unpack-code|170.7 ms|14062.5000|3937.5000|937.5000|68.64 MB|
| **New** |	|	| **169.3 ms (-1%)** | **14062.5000 (0%)** | **3937.5000 (0%)** | **937.5000 (0%)** | **68.64 MB (0%)** |
| Old |Run|string-validate-input|189.6 ms|7312.5000|312.5000|62.5000|34.26 MB|
| **New** |	|	| **188.4 ms (-1%)** | **7312.5000 (0%)** | **312.5000 (0%)** | **62.5000 (0%)** | **34.27 MB (0%)** |


## UncacheableExpressionsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Benchmark|500|389.6 ms|50187.5000|10000.0000|211.26 MB|
| **New** |	|	| **379.4 ms (-3%)** | **50187.5000 (0%)** | **10000.0000 (0%)** | **211.26 MB (0%)** |


