### PR TITLE
#451 string comparison related performance improvements

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -510,18 +510,18 @@ namespace Jint
         /// <returns></returns>
         public JsValue GetValue(object value)
         {
-            var reference = value as Reference;
+            if (value is JsValue jsValue)
+            {
+                return jsValue;
+            }
 
+            var reference = value as Reference;
             if (reference == null)
             {
-                var completion = value as Completion;
-
-                if (completion != null)
+                if (value is Completion completion)
                 {
                     return GetValue(completion.Value);
                 }
-
-                return (JsValue)value;
             }
 
             if (reference.IsUnresolvableReference())

--- a/Jint/Native/Function/FunctionConstructor.cs
+++ b/Jint/Native/Function/FunctionConstructor.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Esprima;
 using Esprima.Ast;
 using Jint.Native.Object;
-using Jint.Native.String;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Environments;
@@ -47,23 +46,6 @@ namespace Jint.Native.Function
             return Construct(arguments);
         }
 
-        private string[] ParseArgumentNames(string parameterDeclaration)
-        {
-            if (string.IsNullOrWhiteSpace(parameterDeclaration))
-            {
-                return System.Array.Empty<string>();
-            }
-
-            string[] values = parameterDeclaration.Split(ArgumentNameSeparator, StringSplitOptions.RemoveEmptyEntries);
-
-            var newValues = new string[values.Length];
-            for (var i = 0; i < values.Length; i++)
-            {
-                newValues[i] = StringPrototype.TrimEx(values[i]);
-            }
-            return newValues;
-        }
-
         public ObjectInstance Construct(JsValue[] arguments)
         {
             var argCount = arguments.Length;
@@ -87,7 +69,6 @@ namespace Jint.Native.Function
                 body = TypeConverter.ToString(arguments[argCount-1]);
             }
 
-            var parameters = this.ParseArgumentNames(p);
             IFunction function;
             try
             {

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
 using Jint.Native.Object;
 using Jint.Native.String;

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -1,4 +1,5 @@
-﻿using Jint.Native.Object;
+﻿using System.Collections.Generic;
+using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Descriptors.Specialized;
@@ -7,6 +8,9 @@ namespace Jint.Native.String
 {
     public class StringInstance : ObjectInstance, IPrimitiveInstance
     {
+        private const string PropertyNameLength = "length";
+        private IPropertyDescriptor _length;
+
         public StringInstance(Engine engine)
             : base(engine)
         {
@@ -38,6 +42,11 @@ namespace Jint.Native.String
                 return PropertyDescriptor.Undefined;
             }
 
+            if (propertyName == PropertyNameLength)
+            {
+                return _length ?? PropertyDescriptor.Undefined;
+            }
+
             var desc = base.GetOwnProperty(propertyName);
             if (desc != PropertyDescriptor.Undefined)
             {
@@ -64,6 +73,51 @@ namespace Jint.Native.String
 
             var resultStr = TypeConverter.ToString(str.AsString()[index]);
             return new EnumerablePropertyDescriptor(resultStr);
+        }
+
+        public override IEnumerable<KeyValuePair<string, IPropertyDescriptor>> GetOwnProperties()
+        {
+            if (_length != null)
+            {
+                yield return new KeyValuePair<string, IPropertyDescriptor>(PropertyNameLength, _length);
+            }
+
+            foreach (var entry in base.GetOwnProperties())
+            {
+                yield return entry;
+            }
+        }
+
+        protected internal override void SetOwnProperty(string propertyName, IPropertyDescriptor desc)
+        {
+            if (propertyName == PropertyNameLength)
+            {
+                _length = desc;
+            }
+            else
+            {
+                base.SetOwnProperty(propertyName, desc);
+            }
+        }
+
+        public override bool HasOwnProperty(string propertyName)
+        {
+            if (propertyName == PropertyNameLength)
+            {
+                return _length != null;
+            }
+
+            return base.HasOwnProperty(propertyName);
+        }
+
+        public override void RemoveOwnProperty(string propertyName)
+        {
+            if (propertyName == PropertyNameLength)
+            {
+                _length = null;
+            }
+
+            base.RemoveOwnProperty(propertyName);
         }
     }
 }

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -13,7 +13,7 @@ namespace Jint.Runtime.Environments
         private const string BindingNameArguments = "arguments";
         private Binding _argumentsBinding;
 
-        private readonly MruPropertyCache2<string, Binding> _bindings = new MruPropertyCache2<string, Binding>();
+        private readonly MruPropertyCache2<Binding> _bindings = new MruPropertyCache2<Binding>();
 
         public DeclarativeEnvironmentRecord(Engine engine) : base(engine)
         {

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -203,11 +203,27 @@ namespace Jint.Runtime
 
         public JsValue EvaluateBinaryExpression(BinaryExpression expression)
         {
-            var leftExpression = EvaluateExpression(expression.Left);
-            JsValue left = _engine.GetValue(leftExpression);
+            JsValue left;
+            if (expression.Left.Type == Nodes.Literal)
+            {
+                left = EvaluateLiteral(expression.Left.As<Literal>());
+            }
+            else
+            {
+                var leftExpression = EvaluateExpression(expression.Left);
+                left = _engine.GetValue(leftExpression);
+            }
 
-            var rightExpression = EvaluateExpression(expression.Right);
-            JsValue right = _engine.GetValue(rightExpression);
+            JsValue right;
+            if (expression.Right.Type == Nodes.Literal)
+            {
+                right = EvaluateLiteral(expression.Right.As<Literal>());
+            }
+            else
+            {
+                var rightExpression = EvaluateExpression(expression.Right);
+                right = _engine.GetValue(rightExpression);
+            }
 
             JsValue value;
 
@@ -451,11 +467,6 @@ namespace Jint.Runtime
                 return true;
             }
 
-            if (typea == Types.None)
-            {
-                return true;
-            }
-
             if (typea == Types.Number)
             {
                 var nx = x.AsNumber();
@@ -486,14 +497,17 @@ namespace Jint.Runtime
 
 			if (typea == Types.Object)
 			{
-				var xw = x.AsObject() as IObjectWrapper;
-
-				if (xw != null)
+			    if (x.AsObject() is IObjectWrapper xw)
 				{
 					var yw = y.AsObject() as IObjectWrapper;
-					return Object.Equals(xw.Target, yw.Target);
+					return Equals(xw.Target, yw.Target);
 				}
 			}
+
+            if (typea == Types.None)
+            {
+                return true;
+            }
 
             return x == y;
         }
@@ -614,6 +628,7 @@ namespace Jint.Runtime
             return LexicalEnvironment.GetIdentifierReference(env, identifier.Name, strict);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JsValue EvaluateLiteral(Literal literal)
         {
             switch (literal.TokenType)

--- a/Jint/Runtime/MruPropertyCache2.cs
+++ b/Jint/Runtime/MruPropertyCache2.cs
@@ -3,18 +3,17 @@ using System.Runtime.CompilerServices;
 
 namespace Jint.Runtime
 {
-    internal class MruPropertyCache2<TKey, TValue> where TKey : class where TValue : class
+    internal class MruPropertyCache2<TValue> where TValue : class
     {
-        private Dictionary<TKey, TValue> _dictionary;
-        private bool _set;
-        private TKey _key;
+        private Dictionary<string, TValue> _dictionary;
+        private string _key;
         private TValue _value;
 
-        public TValue this[TKey key]
+        public TValue this[string key]
         {
             get
             {
-                if (_set && key.Equals(_key))
+                if (_key != null && _key == key)
                 {
                     return _value;
                 }
@@ -25,7 +24,6 @@ namespace Jint.Runtime
             set
             {
                 EnsureInitialized(key);
-                _set = true;
                 _key = key;
                 _value = value;
 
@@ -40,7 +38,7 @@ namespace Jint.Runtime
         {
             get
             {
-                int count = _set ? 1 : 0;
+                int count = _key != null ? 1 : 0;
                 if (_dictionary != null)
                 {
                     count += _dictionary.Count;
@@ -50,10 +48,9 @@ namespace Jint.Runtime
             }
         }
 
-        public void Add(TKey key, TValue value)
+        public void Add(string key, TValue value)
         {
             EnsureInitialized(key);
-            _set = true;
             _key = key;
             _value = value;
 
@@ -65,16 +62,15 @@ namespace Jint.Runtime
 
         public void Clear()
         {
-            _set = false;
-            _key = default(TKey);
+            _key = default(string);
             _value = null;
 
             _dictionary?.Clear();
         }
 
-        public bool ContainsKey(TKey key)
+        public bool ContainsKey(string key)
         {
-            if (_set && key.Equals(_key))
+            if (_key != null && _key == key)
             {
                 return true;
             }
@@ -82,13 +78,13 @@ namespace Jint.Runtime
             return _dictionary != null && _dictionary.ContainsKey(key);
         }
 
-        public IEnumerable<KeyValuePair<TKey, TValue>> GetEnumerator()
+        public IEnumerable<KeyValuePair<string, TValue>> GetEnumerator()
         {
             if (_dictionary == null)
             {
-                if (_set)
+                if (_key != null)
                 {
-                    yield return new KeyValuePair<TKey, TValue>(_key, _value);
+                    yield return new KeyValuePair<string, TValue>(_key, _value);
                 }
 
                 yield break;
@@ -100,24 +96,23 @@ namespace Jint.Runtime
             }
         }
 
-        public bool Remove(TKey key)
+        public bool Remove(string key)
         {
             bool removed = false;
-            if (_set && key.Equals(_key))
+            if (_key != null && _key == key)
             {
-                _set = false;
-                _key = default(TKey);
+                _key = null;
                 _value = null;
                 removed = true;
             }
 
-            _dictionary?.Remove(key);
+            removed |= _dictionary?.Remove(key) ?? false;
             return removed;
         }
 
-        public bool TryGetValue(TKey key, out TValue value)
+        public bool TryGetValue(string key, out TValue value)
         {
-            if (_set && _key.Equals(key))
+            if (_key != null && _key == key)
             {
                 value = _value;
                 return true;
@@ -129,33 +124,40 @@ namespace Jint.Runtime
                 return false;
             }
 
-            return _dictionary.TryGetValue(key, out value);
+            if (_dictionary.TryGetValue(key, out value))
+            {
+                _key = key;
+                _value = value;
+                return true;
+            }
+
+            return false;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void EnsureInitialized(TKey key)
+        private void EnsureInitialized(string key)
         {
-            if (_set && !Equals(_key, key))
+            if (_key != null && _key != key)
             {
                 if (_dictionary == null)
                 {
-                    _dictionary = new Dictionary<TKey, TValue>();
+                    _dictionary = new Dictionary<string, TValue>();
                 }
                 _dictionary[_key] = _value;
             }
         }
 
-        public TKey[] GetKeys()
+        public string[] GetKeys()
         {
-            int size = _set ? 1 : 0;
+            int size = _key != null ? 1 : 0;
             if (_dictionary != null)
             {
                 size += _dictionary.Count;
             }
 
-            var keys = new TKey[size];
+            var keys = new string[size];
             int n = 0;
-            if (_set)
+            if (_key != null)
             {
                 keys[n++] = _key;
             }


### PR DESCRIPTION
* change MruPropertyCache2 to have string key
* remove shared string property checks from ObjectInstance
* check length in array instance
* move prototype and constructor to ScriptFunctionInstance, specialize ObjectInstanceWithConstructor

# Numbers for old (current dev) against new (this branch)

## Esprima.Benchmark.DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|dromaeo-3d-cube|108.23 ms|7500.0000|250.0000|-|31.85 MB|
| **New** |	|	| **106.64 ms (-1%)** | **7375.0000 (-2%)** | **250.0000 (0%)** | **-** | **31.65 MB (-1%)** |
| Old |Run|dromaeo-core-eval|26.65 ms|1718.7500|-|-|6.9 MB|
| **New** |	|	| **25.88 ms (-3%)** | **1718.7500 (0%)** | **-** | **-** | **6.9 MB (0%)** |
| Old |Run|dromaeo-object-array|293.76 ms|45187.5000|2000.0000|1000.0000|186.78 MB|
| **New** |	|	| **273.48 ms (-7%)** | **45125.0000 (0%)** | **2062.5000 (+3%)** | **1000.0000 (0%)** | **186.35 MB (0%)** |
| Old |Run|dromaeo-object-regexp|1,278.51 ms|72562.5000|36000.0000|21937.5000|482.68 MB|
| **New** |	|	| **1,153.38 ms (-10%)** | **71625.0000 (-1%)** | **34875.0000 (-3%)** | **22062.5000 (+1%)** | **478.25 MB (-1%)** |
| Old |Run|dromaeo-object-string|1,746.72 ms|251375.0000|184687.5000|180250.0000|1461.29 MB|
| **New** |	|	| **1,576.93 ms (-10%)** | **249812.5000 (-1%)** | **183937.5000 (0%)** | **179500.0000 (0%)** | **1457.99 MB (0%)** |
| Old |Run|dromaeo-string-base64|276.92 ms|16687.5000|187.5000|-|67.54 MB|
| **New** |	|	| **233.35 ms (-16%)** | **16062.5000 (-4%)** | **375.0000 (+100%)** | **-** | **65.37 MB (-3%)** |


## Esprima.Benchmark.SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|3d-cube|861.9 ms|63937.5000|312.5000|62.5000|257.9 MB|
| **New** |	|	| **846.0 ms (-2%)** | **63687.5000 (0%)** | **312.5000 (0%)** | **62.5000 (0%)** | **256.87 MB (0%)** |
| Old |Run|3d-morph|968.3 ms|41937.5000|5875.0000|1812.5000|193.86 MB|
| **New** |	|	| **781.1 ms (-19%)** | **41937.5000 (0%)** | **5875.0000 (0%)** | **1812.5000 (0%)** | **193.86 MB (0%)** |
| Old |Run|3d-raytrace|731.6 ms|54250.0000|1000.0000|187.5000|219.33 MB|
| **New** |	|	| **652.6 ms (-11%)** | **53437.5000 (-1%)** | **937.5000 (-6%)** | **125.0000 (-33%)** | **216.14 MB (-1%)** |
| Old |Run|access-binary-trees|312.8 ms|37937.5000|125.0000|-|151.98 MB|
| **New** |	|	| **269.1 ms (-14%)** | **35937.5000 (-5%)** | **125.0000 (0%)** | **-** | **143.95 MB (-5%)** |
| Old |Run|access-fannkuch|2,916.6 ms|172437.5000|250.0000|-|689.77 MB|
| **New** |	|	| **2,629.4 ms (-10%)** | **172437.5000 (0%)** | **250.0000 (0%)** | **-** | **689.76 MB (0%)** |
| Old |Run|access-nbody|837.3 ms|57562.5000|62.5000|-|230.27 MB|
| **New** |	|	| **765.6 ms (-9%)** | **57500.0000 (0%)** | **62.5000 (0%)** | **-** | **230.02 MB (0%)** |
| Old |Run|access-nsieve|1,091.0 ms|62937.5000|7937.5000|2937.5000|260.87 MB|
| **New** |	|	| **966.6 ms (-11%)** | **62937.5000 (0%)** | **7937.5000 (0%)** | **2937.5000 (0%)** | **260.87 MB (0%)** |
| Old |Run|bitops-3bit-bits-in-byte|597.6 ms|56375.0000|-|-|225.67 MB|
| **New** |	|	| **552.9 ms (-7%)** | **54687.5000 (-3%)** | **-** | **-** | **218.83 MB (-3%)** |
| Old |Run|bitops-bits-in-byte|972.4 ms|81687.5000|62.5000|-|326.8 MB|
| **New** |	|	| **952.1 ms (-2%)** | **80500.0000 (-1%)** | **62.5000 (0%)** | **-** | **322.02 MB (-1%)** |
| Old |Run|bitops-bitwise-and|812.0 ms|45625.0000|62.5000|-|182.65 MB|
| **New** |	|	| **701.7 ms (-14%)** | **45625.0000 (0%)** | **62.5000 (0%)** | **-** | **182.65 MB (0%)** |
| Old |Run|bitops-nsieve-bits|1,197.1 ms|66812.5000|4000.0000|375.0000|269.04 MB|
| **New** |	|	| **1,051.0 ms (-12%)** | **66750.0000 (0%)** | **4375.0000 (+9%)** | **375.0000 (0%)** | **269.04 MB (0%)** |
| Old |Run|controlflow-recursive|421.9 ms|58500.0000|-|-|234.15 MB|
| **New** |	|	| **352.8 ms (-16%)** | **55250.0000 (-6%)** | **-** | **-** | **221.03 MB (-6%)** |
| Old |Run|crypto-aes|714.4 ms|44500.0000|312.5000|62.5000|180.09 MB|
| **New** |	|	| **663.2 ms (-7%)** | **44250.0000 (-1%)** | **312.5000 (0%)** | **62.5000 (0%)** | **179.14 MB (-1%)** |
| Old |Run|crypto-md5|482.3 ms|52625.0000|312.5000|62.5000|212.71 MB|
| **New** |	|	| **411.3 ms (-15%)** | **51000.0000 (-3%)** | **312.5000 (0%)** | **62.5000 (0%)** | **206.24 MB (-3%)** |
| Old |Run|crypto-sha1|475.3 ms|49062.5000|250.0000|-|197.82 MB|
| **New** |	|	| **419.0 ms (-12%)** | **47500.0000 (-3%)** | **312.5000 (+25%)** | **62.5000** | **191.53 MB (-3%)** |
| Old |Run|date-format-tofte|492.1 ms|37375.0000|-|-|149.63 MB|
| **New** |	|	| **435.2 ms (-12%)** | **36312.5000 (-3%)** | **62.5000** | **-** | **145.3 MB (-3%)** |
| Old |Run|date-format-xparb|415.1 ms|18562.5000|250.0000|-|74.92 MB|
| **New** |	|	| **379.2 ms (-9%)** | **18000.0000 (-3%)** | **250.0000 (0%)** | **-** | **72.58 MB (-3%)** |
| Old |Run|math-cordic|1,414.5 ms|111437.5000|125.0000|-|445.75 MB|
| **New** |	|	| **1,234.4 ms (-13%)** | **109750.0000 (-2%)** | **62.5000 (-50%)** | **-** | **439.08 MB (-1%)** |
| Old |Run|math-partial-sums|495.0 ms|26812.5000|-|-|107.29 MB|
| **New** |	|	| **401.6 ms (-19%)** | **26812.5000 (0%)** | **-** | **-** | **107.29 MB (0%)** |
| Old |Run|math-spectral-norm|538.1 ms|49750.0000|-|-|199.04 MB|
| **New** |	|	| **470.3 ms (-13%)** | **48062.5000 (-3%)** | **-** | **-** | **192.49 MB (-3%)** |
| Old |Run|regexp-dna|370.1 ms|2187.5000|1937.5000|1562.5000|13.46 MB|
| **New** |	|	| **343.6 ms (-7%)** | **2250.0000 (+3%)** | **1937.5000 (0%)** | **1562.5000 (0%)** | **13.46 MB (0%)** |
| Old |Run|string-base64|413.4 ms|24562.5000|312.5000|-|99.86 MB|
| **New** |	|	| **354.8 ms (-14%)** | **23750.0000 (-3%)** | **250.0000 (-20%)** | **-** | **96.61 MB (-3%)** |
| Old |Run|string-fasta|714.1 ms|59062.5000|62.5000|-|236.34 MB|
| **New** |	|	| **594.3 ms (-17%)** | **57812.5000 (-2%)** | **-** | **-** | **231.27 MB (-2%)** |
| Old |Run|string-tagcloud|282.7 ms|26687.5000|1875.0000|625.0000|115.39 MB|
| **New** |	|	| **247.7 ms (-12%)** | **25750.0000 (-4%)** | **2062.5000 (+10%)** | **625.0000 (0%)** | **111.67 MB (-3%)** |
| Old |Run|string-unpack-code|226.9 ms|28312.5000|7687.5000|1437.5000|123.15 MB|
| **New** |	|	| **197.4 ms (-13%)** | **27375.0000 (-3%)** | **7375.0000 (-4%)** | **1687.5000 (+17%)** | **117.34 MB (-5%)** |
| Old |Run|string-validate-input|282.9 ms|20750.0000|312.5000|62.5000|86.94 MB|
| **New** |	|	| **238.4 ms (-16%)** | **20250.0000 (-2%)** | **312.5000 (0%)** | **62.5000 (0%)** | **84.6 MB (-3%)** |


## Jint.Benchmark.ArrayBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Slice|100|881.9 us|150.3906|617.19 KB|
| **New** |	|	| **685.7 us (-22%)** | **149.4141 (-1%)** | **615.63 KB (0%)** |
| Old |Concat|100|1,014.1 us|166.9922|686.72 KB|
| **New** |	|	| **836.1 us (-18%)** | **166.0156 (-1%)** | **683.59 KB (0%)** |
| Old |Unshift|100|36,593.7 us|3687.5000|15214.06 KB|
| **New** |	|	| **31,734.4 us (-13%)** | **3687.5000 (0%)** | **15212.5 KB (0%)** |
| Old |Push|100|24,325.2 us|1406.2500|5847.66 KB|
| **New** |	|	| **17,903.8 us (-26%)** | **1406.2500 (0%)** | **5846.09 KB (0%)** |
| Old |Index|100|22,525.8 us|1250.0000|5172.66 KB|
| **New** |	|	| **16,333.6 us (-27%)** | **1250.0000 (0%)** | **5171.09 KB (0%)** |
| Old |Map|100|4,680.0 us|1531.2500|6285.16 KB|
| **New** |	|	| **4,295.7 us (-8%)** | **1421.8750 (-7%)** | **5835.94 KB (-7%)** |
| Old |Apply|100|1,207.0 us|183.5938|753.91 KB|
| **New** |	|	| **957.6 us (-21%)** | **183.5938 (0%)** | **752.34 KB (0%)** |
| Old |JsonStringifyParse|100|5,876.6 us|1250.0000|5144.53 KB|
| **New** |	|	| **5,367.4 us (-9%)** | **1250.0000 (0%)** | **5139.84 KB (0%)** |


## Jint.Benchmark.ArrayStressBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|20|2.022 s|93312.5000|13250.0000|388.02 MB|
| **New** |	|	| **1.672 s (-17%)** | **92437.5000 (-1%)** | **12562.5000 (-5%)** | **385.91 MB (-1%)** |


## Jint.Benchmark.EvaluationBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Jint|20|848.1 us|136.7188|562.97 KB|
| **New** |	|	| **764.3 us (-10%)** | **134.7656 (-1%)** | **554.53 KB (-1%)** |


## Jint.Benchmark.LinqJsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|10|79.58 ms|5125.0000|2562.5000|30.86 MB|
| **New** |	|	| **73.91 ms (-7%)** | **5125.0000 (0%)** | **2562.5000 (0%)** | **30.78 MB (0%)** |


## Jint.Benchmark.MinimalScriptBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Jint|10|25.94 us|8.5144|34.92 KB|
| **New** |	|	| **23.31 us (-10%)** | **8.5144 (0%)** | **34.92 KB (0%)** |


## Jint.Benchmark.StopwatchBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|1|2.133 s|123187.5000|187.5000|492.84 MB|
| **New** |	|	| **1.582 s (-26%)** | **118000.0000 (-4%)** | **125.0000 (-33%)** | **472.01 MB (-4%)** |


## Jint.Benchmark.UncacheableExpressionsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Benchmark|500|555.4 ms|100000.0000|1312.5000|400.31 MB|
| **New** |	|	| **477.7 ms (-14%)** | **93062.5000 (-7%)** | **-** | **372.45 MB (-7%)** |



