### PR TITLE
#451 remove tail recursion and faster environment records

### DIFF
--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Dynamic;
+using System.Runtime.CompilerServices;
 using Jint.Native.Array;
 using Jint.Native.Boolean;
 using Jint.Native.Date;
@@ -136,7 +137,12 @@ namespace Jint.Native.Object
         public virtual JsValue Get(string propertyName)
         {
             var desc = GetProperty(propertyName);
+            return UnwrapJsValue(desc);
+        }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal JsValue UnwrapJsValue(IPropertyDescriptor desc)
+        {
             if (desc == PropertyDescriptor.Undefined)
             {
                 return Undefined;
@@ -145,11 +151,10 @@ namespace Jint.Native.Object
             if (desc.IsDataDescriptor())
             {
                 var val = desc.Value;
-                return val != null ? val : Undefined;
+                return !ReferenceEquals(val, null) ? val : Undefined;
             }
 
-            var getter = desc.Get != null ? desc.Get : Undefined;
-
+            var getter = !ReferenceEquals(desc.Get, null) ? desc.Get : Undefined;
             if (getter.IsUndefined())
             {
                 return Undefined;
@@ -197,6 +202,7 @@ namespace Jint.Native.Object
         /// </summary>
         /// <param name="propertyName"></param>
         /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IPropertyDescriptor GetProperty(string propertyName)
         {
             var prop = GetOwnProperty(propertyName);
@@ -367,6 +373,7 @@ namespace Jint.Native.Object
         /// </summary>
         /// <param name="propertyName"></param>
         /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool HasProperty(string propertyName)
         {
             return GetProperty(propertyName) != PropertyDescriptor.Undefined;

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -1,4 +1,5 @@
-﻿using Jint.Native;
+﻿using System;
+using Jint.Native;
 
 namespace Jint.Runtime.Environments
 {
@@ -13,7 +14,7 @@ namespace Jint.Runtime.Environments
         private const string BindingNameArguments = "arguments";
         private Binding _argumentsBinding;
 
-        private readonly MruPropertyCache2<Binding> _bindings = new MruPropertyCache2<Binding>();
+        private MruPropertyCache2<Binding> _bindings;
 
         public DeclarativeEnvironmentRecord(Engine engine) : base(engine)
         {
@@ -27,7 +28,7 @@ namespace Jint.Runtime.Environments
                 return _argumentsBinding != null;
             }
 
-            return _bindings.ContainsKey(name);
+            return _bindings?.ContainsKey(name) == true;
         }
 
         public override void CreateMutableBinding(string name, bool canBeDeleted = false)
@@ -45,12 +46,21 @@ namespace Jint.Runtime.Environments
             }
             else
             {
+                if (_bindings == null)
+                {
+                    _bindings = new MruPropertyCache2<Binding>();
+                }
                 _bindings.Add(name, binding);
             }
         }
 
         public override void SetMutableBinding(string name, JsValue value, bool strict)
         {
+            if (_bindings == null)
+            {
+                _bindings = new MruPropertyCache2<Binding>();
+            }
+
             var binding = name == BindingNameArguments ? _argumentsBinding : _bindings[name];
             if (binding.Mutable)
             {
@@ -84,14 +94,14 @@ namespace Jint.Runtime.Environments
 
         public override bool DeleteBinding(string name)
         {
-            Binding binding;
+            Binding binding = null;
             if (name == BindingNameArguments)
             {
                 binding = _argumentsBinding;
             }
             else
             {
-                _bindings.TryGetValue(name, out binding);
+                _bindings?.TryGetValue(name, out binding);
             }
 
             if (binding == null)
@@ -140,6 +150,10 @@ namespace Jint.Runtime.Environments
             }
             else
             {
+                if (_bindings == null)
+                {
+                    _bindings = new MruPropertyCache2<Binding>();
+                }
                 _bindings.Add(name, binding);
             }
         }
@@ -161,7 +175,7 @@ namespace Jint.Runtime.Environments
         /// <returns>The array of all defined bindings</returns>
         public override string[] GetAllBindingNames()
         {
-            return _bindings.GetKeys();
+            return _bindings?.GetKeys() ?? Array.Empty<string>();
         }
     }
 }

--- a/Jint/Runtime/Environments/LexicalEnvironment.cs
+++ b/Jint/Runtime/Environments/LexicalEnvironment.cs
@@ -32,22 +32,25 @@ namespace Jint.Runtime.Environments
 
         public static Reference GetIdentifierReference(LexicalEnvironment lex, string name, bool strict)
         {
-            if (lex == null)
+            while (true)
             {
-                return new Reference(Undefined.Instance, name, strict);
-            }
+                if (lex == null)
+                {
+                    return new Reference(Undefined.Instance, name, strict);
+                }
 
-            if (lex.Record.HasBinding(name))
-            {
-                return new Reference(lex.Record, name, strict);
-            }
+                if (lex.Record.HasBinding(name))
+                {
+                    return new Reference(lex.Record, name, strict);
+                }
 
-            if (lex.Outer == null)
-            {
-                return new Reference(Undefined.Instance, name, strict);    
-            }
+                if (lex.Outer == null)
+                {
+                    return new Reference(Undefined.Instance, name, strict);
+                }
 
-            return GetIdentifierReference(lex.Outer, name, strict);
+                lex = lex.Outer;
+            }
         }
 
         public static LexicalEnvironment NewDeclarativeEnvironment(Engine engine, LexicalEnvironment outer = null)

--- a/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
@@ -50,19 +50,13 @@ namespace Jint.Runtime.Environments
 
         public override JsValue GetBindingValue(string name, bool strict)
         {
-            // todo: can be optimized
-
-            if (!_bindingObject.HasProperty(name))
+            var desc = _bindingObject.GetProperty(name);
+            if (strict && desc == PropertyDescriptor.Undefined)
             {
-                if(!strict)
-                {
-                    return Undefined;
-                }
-
                 throw new JavaScriptException(_engine.ReferenceError);
             }
 
-            return _bindingObject.Get(name);
+            return UnwrapJsValue(desc);
         }
 
         public override bool DeleteBinding(string name)


### PR DESCRIPTION
* make DeclarativeEnvironmentRecord dictionary lazy
* explicit tail recursion to iteration so that don't need to rely on x64 JIT

## Esprima.Benchmark.DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|dromaeo-3d-cube|106.64 ms|7375.0000|250.0000|-|31.65 MB|
| **New** |	|	| **105.62 ms (-1%)** | **7375.0000 (0%)** | **250.0000 (0%)** | **-** | **31.65 MB (0%)** |
| Old |Run|dromaeo-core-eval|25.88 ms|1718.7500|-|-|6.9 MB|
| **New** |	|	| **26.67 ms (+3%)** | **1718.7500 (0%)** | **-** | **-** | **6.9 MB (0%)** |
| Old |Run|dromaeo-object-array|273.48 ms|45125.0000|2062.5000|1000.0000|186.35 MB|
| **New** |	|	| **262.58 ms (-4%)** | **45125.0000 (0%)** | **2062.5000 (0%)** | **1000.0000 (0%)** | **186.35 MB (0%)** |
| Old |Run|dromaeo-object-regexp|1,153.38 ms|71625.0000|34875.0000|22062.5000|478.25 MB|
| **New** |	|	| **1,206.38 ms (+5%)** | **71062.5000 (-1%)** | **35625.0000 (+2%)** | **22000.0000 (0%)** | **478.13 MB (0%)** |
| Old |Run|dromaeo-object-string|1,576.93 ms|249812.5000|183937.5000|179500.0000|1457.99 MB|
| **New** |	|	| **1,638.59 ms (+4%)** | **248625.0000 (0%)** | **182375.0000 (-1%)** | **178125.0000 (-1%)** | **1458.04 MB (0%)** |
| Old |Run|dromaeo-string-base64|233.35 ms|16062.5000|375.0000|-|65.37 MB|
| **New** |	|	| **249.20 ms (+7%)** | **16062.5000 (0%)** | **375.0000 (0%)** | **-** | **65.37 MB (0%)** |


## Esprima.Benchmark.SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|3d-cube|846.0 ms|63687.5000|312.5000|62.5000|256.87 MB|
| **New** |	|	| **843.8 ms (0%)** | **63687.5000 (0%)** | **312.5000 (0%)** | **62.5000 (0%)** | **256.87 MB (0%)** |
| Old |Run|3d-morph|781.1 ms|41937.5000|5875.0000|1812.5000|193.86 MB|
| **New** |	|	| **761.8 ms (-2%)** | **41937.5000 (0%)** | **5875.0000 (0%)** | **1812.5000 (0%)** | **193.86 MB (0%)** |
| Old |Run|3d-raytrace|652.6 ms|53437.5000|937.5000|125.0000|216.14 MB|
| **New** |	|	| **647.0 ms (-1%)** | **53437.5000 (0%)** | **937.5000 (0%)** | **125.0000 (0%)** | **216.14 MB (0%)** |
| Old |Run|access-binary-trees|269.1 ms|35937.5000|125.0000|-|143.95 MB|
| **New** |	|	| **257.7 ms (-4%)** | **35937.5000 (0%)** | **125.0000 (0%)** | **-** | **143.95 MB (0%)** |
| Old |Run|access-fannkuch|2,629.4 ms|172437.5000|250.0000|-|689.76 MB|
| **New** |	|	| **2,666.6 ms (+1%)** | **172437.5000 (0%)** | **250.0000 (0%)** | **-** | **689.76 MB (0%)** |
| Old |Run|access-nbody|765.6 ms|57500.0000|62.5000|-|230.02 MB|
| **New** |	|	| **742.4 ms (-3%)** | **57500.0000 (0%)** | **62.5000 (0%)** | **-** | **230.02 MB (0%)** |
| Old |Run|access-nsieve|966.6 ms|62937.5000|7937.5000|2937.5000|260.87 MB|
| **New** |	|	| **974.8 ms (+1%)** | **62937.5000 (0%)** | **7937.5000 (0%)** | **2937.5000 (0%)** | **260.87 MB (0%)** |
| Old |Run|bitops-3bit-bits-in-byte|552.9 ms|54687.5000|-|-|218.83 MB|
| **New** |	|	| **549.7 ms (-1%)** | **54687.5000 (0%)** | **-** | **-** | **218.83 MB (0%)** |
| Old |Run|bitops-bits-in-byte|952.1 ms|80500.0000|62.5000|-|322.02 MB|
| **New** |	|	| **948.8 ms (0%)** | **80500.0000 (0%)** | **62.5000 (0%)** | **-** | **322.02 MB (0%)** |
| Old |Run|bitops-bitwise-and|701.7 ms|45625.0000|62.5000|-|182.65 MB|
| **New** |	|	| **595.6 ms (-15%)** | **45625.0000 (0%)** | **-** | **-** | **182.65 MB (0%)** |
| Old |Run|bitops-nsieve-bits|1,051.0 ms|66750.0000|4375.0000|375.0000|269.04 MB|
| **New** |	|	| **1,050.4 ms (0%)** | **66750.0000 (0%)** | **4375.0000 (0%)** | **375.0000 (0%)** | **269.04 MB (0%)** |
| Old |Run|controlflow-recursive|352.8 ms|55250.0000|-|-|221.03 MB|
| **New** |	|	| **342.0 ms (-3%)** | **55250.0000 (0%)** | **-** | **-** | **221.03 MB (0%)** |
| Old |Run|crypto-aes|663.2 ms|44250.0000|312.5000|62.5000|179.14 MB|
| **New** |	|	| **639.7 ms (-4%)** | **44250.0000 (0%)** | **312.5000 (0%)** | **62.5000 (0%)** | **179.13 MB (0%)** |
| Old |Run|crypto-md5|411.3 ms|51000.0000|312.5000|62.5000|206.24 MB|
| **New** |	|	| **407.3 ms (-1%)** | **51000.0000 (0%)** | **312.5000 (0%)** | **62.5000 (0%)** | **206.24 MB (0%)** |
| Old |Run|crypto-sha1|419.0 ms|47500.0000|312.5000|62.5000|191.53 MB|
| **New** |	|	| **401.6 ms (-4%)** | **47500.0000 (0%)** | **312.5000 (0%)** | **62.5000 (0%)** | **191.53 MB (0%)** |
| Old |Run|date-format-tofte|435.2 ms|36312.5000|62.5000|-|145.3 MB|
| **New** |	|	| **445.5 ms (+2%)** | **36000.0000 (-1%)** | **-** | **-** | **144.23 MB (-1%)** |
| Old |Run|date-format-xparb|379.2 ms|18000.0000|250.0000|-|72.58 MB|
| **New** |	|	| **374.1 ms (-1%)** | **18000.0000 (0%)** | **250.0000 (0%)** | **-** | **72.58 MB (0%)** |
| Old |Run|math-cordic|1,234.4 ms|109750.0000|62.5000|-|439.08 MB|
| **New** |	|	| **1,225.0 ms (-1%)** | **109750.0000 (0%)** | **62.5000 (0%)** | **-** | **439.08 MB (0%)** |
| Old |Run|math-partial-sums|401.6 ms|26812.5000|-|-|107.29 MB|
| **New** |	|	| **383.4 ms (-5%)** | **26812.5000 (0%)** | **-** | **-** | **107.29 MB (0%)** |
| Old |Run|math-spectral-norm|470.3 ms|48062.5000|-|-|192.49 MB|
| **New** |	|	| **466.8 ms (-1%)** | **48062.5000 (0%)** | **-** | **-** | **192.49 MB (0%)** |
| Old |Run|regexp-dna|343.6 ms|2250.0000|1937.5000|1562.5000|13.46 MB|
| **New** |	|	| **343.6 ms (0%)** | **2250.0000 (0%)** | **1937.5000 (0%)** | **1562.5000 (0%)** | **13.46 MB (0%)** |
| Old |Run|string-base64|354.8 ms|23750.0000|250.0000|-|96.61 MB|
| **New** |	|	| **339.6 ms (-4%)** | **23812.5000 (0%)** | **250.0000 (0%)** | **-** | **96.61 MB (0%)** |
| Old |Run|string-fasta|594.3 ms|57812.5000|-|-|231.27 MB|
| **New** |	|	| **581.4 ms (-2%)** | **57812.5000 (0%)** | **-** | **-** | **231.27 MB (0%)** |
| Old |Run|string-tagcloud|247.7 ms|25750.0000|2062.5000|625.0000|111.67 MB|
| **New** |	|	| **244.6 ms (-1%)** | **25750.0000 (0%)** | **2187.5000 (+6%)** | **625.0000 (0%)** | **111.67 MB (0%)** |
| Old |Run|string-unpack-code|197.4 ms|27375.0000|7375.0000|1687.5000|117.34 MB|
| **New** |	|	| **198.1 ms (0%)** | **27375.0000 (0%)** | **7375.0000 (0%)** | **1687.5000 (0%)** | **117.34 MB (0%)** |
| Old |Run|string-validate-input|238.4 ms|20250.0000|312.5000|62.5000|84.6 MB|
| **New** |	|	| **234.6 ms (-2%)** | **20250.0000 (0%)** | **312.5000 (0%)** | **62.5000 (0%)** | **84.6 MB (0%)** |


## Jint.Benchmark.ArrayBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Slice|100|685.7 us|149.4141|615.63 KB|
| **New** |	|	| **655.7 us (-4%)** | **149.4141 (0%)** | **615.63 KB (0%)** |
| Old |Concat|100|836.1 us|166.0156|683.59 KB|
| **New** |	|	| **795.1 us (-5%)** | **166.0156 (0%)** | **683.59 KB (0%)** |
| Old |Unshift|100|31,734.4 us|3687.5000|15212.5 KB|
| **New** |	|	| **30,489.0 us (-4%)** | **3687.5000 (0%)** | **15212.5 KB (0%)** |
| Old |Push|100|17,903.8 us|1406.2500|5846.09 KB|
| **New** |	|	| **16,376.5 us (-9%)** | **1406.2500 (0%)** | **5846.09 KB (0%)** |
| Old |Index|100|16,333.6 us|1250.0000|5171.09 KB|
| **New** |	|	| **14,891.0 us (-9%)** | **1250.0000 (0%)** | **5171.09 KB (0%)** |
| Old |Map|100|4,295.7 us|1421.8750|5835.94 KB|
| **New** |	|	| **4,229.2 us (-2%)** | **1421.8750 (0%)** | **5832.03 KB (0%)** |
| Old |Apply|100|957.6 us|183.5938|752.34 KB|
| **New** |	|	| **916.0 us (-4%)** | **183.5938 (0%)** | **752.34 KB (0%)** |
| Old |JsonStringifyParse|100|5,367.4 us|1250.0000|5139.84 KB|
| **New** |	|	| **5,302.2 us (-1%)** | **1250.0000 (0%)** | **5139.84 KB (0%)** |


## Jint.Benchmark.ArrayStressBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|20|1.672 s|92437.5000|12562.5000|385.91 MB|
| **New** |	|	| **1.476 s (-12%)** | **92437.5000 (0%)** | **12562.5000 (0%)** | **385.91 MB (0%)** |


## Jint.Benchmark.EvaluationBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Jint|20|764.3 us|134.7656|554.53 KB|
| **New** |	|	| **744.5 us (-3%)** | **134.7656 (0%)** | **553.75 KB (0%)** |


## Jint.Benchmark.LinqJsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Jint|10|73.91 ms|5125.0000|2562.5000|-|30.78 MB|
| **New** |	|	| **74.61 ms (+1%)** | **5187.5000 (+1%)** | **2500.0000 (-2%)** | **125.0000** | **30.71 MB (0%)** |


## Jint.Benchmark.MinimalScriptBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Jint|10|23.31 us|8.5144|34.92 KB|
| **New** |	|	| **22.80 us (-2%)** | **8.5144 (0%)** | **34.92 KB (0%)** |


## Jint.Benchmark.StopwatchBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|1|1.582 s|118000.0000|125.0000|472.01 MB|
| **New** |	|	| **1.484 s (-6%)** | **118000.0000 (0%)** | **125.0000 (0%)** | **472.01 MB (0%)** |


## Jint.Benchmark.UncacheableExpressionsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Benchmark|500|477.7 ms|93062.5000|372.45 MB|
| **New** |	|	| **458.3 ms (-4%)** | **93062.5000 (0%)** | **372.33 MB (0%)** |


