### PR TITLE
Revert back to MruPropertyCache2 with _set field

### DIFF
--- a/Jint/Native/Array/ArrayExecutionContext.cs
+++ b/Jint/Native/Array/ArrayExecutionContext.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Text;
+﻿using System.Text;
 using System.Threading;
 
 namespace Jint.Native.Array
@@ -12,23 +11,11 @@ namespace Jint.Native.Array
         // cache key container for array iteration for less allocations
         private static readonly ThreadLocal<ArrayExecutionContext> _executionContext = new ThreadLocal<ArrayExecutionContext>(() => new ArrayExecutionContext());
 
-        private List<uint> _keyCache;
-        private JsValue[] _callArray1;
-        private JsValue[] _callArray2;
-        private JsValue[] _callArray3;
-        private JsValue[] _callArray4;
         private StringBuilder _stringBuilder;
 
         private ArrayExecutionContext()
         {
         }
-
-        public List<uint> KeyCache => _keyCache = _keyCache ?? new List<uint>();
-
-        public JsValue[] CallArray1 => _callArray1 = _callArray1 ?? new JsValue[1];
-        public JsValue[] CallArray2 => _callArray2 = _callArray2 ?? new JsValue[2];
-        public JsValue[] CallArray3 => _callArray3 = _callArray3 ?? new JsValue[3];
-        public JsValue[] CallArray4 => _callArray4 = _callArray4 ?? new JsValue[4];
 
         public StringBuilder StringBuilder => _stringBuilder = _stringBuilder ?? new StringBuilder();
 

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -183,10 +183,7 @@ namespace Jint.Native.Array
                     {
                         // in the case of sparse arrays, treat each concrete element instead of
                         // iterating over all indexes
-
-                        var keys = ArrayExecutionContext.Current.KeyCache;
-                        keys.Clear();
-                        keys.AddRange(_sparse.Keys);
+                        var keys = new List<uint>(_sparse.Keys);
                         foreach (var keyIndex in keys)
                         {
                             // is it the index of the array

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -143,8 +143,7 @@ namespace Jint.Native.Array
                 }
             }
 
-
-            var args = ArrayExecutionContext.Current.CallArray4;
+            var args = new JsValue[4];
             while (k < len)
             {
                 var i = (uint) k;
@@ -176,15 +175,15 @@ namespace Jint.Native.Array
             var a = (ArrayInstance) Engine.Array.Construct(Arguments.Empty);
 
             uint to = 0;
-            var jsValues = ArrayExecutionContext.Current.CallArray3;
+            var args = new JsValue[3];
             for (uint k = 0; k < len; k++)
             {
                 if (o.TryGetValue(k, out var kvalue))
                 {
-                    jsValues[0] = kvalue;
-                    jsValues[1] = k;
-                    jsValues[2] = o.Target;
-                    var selected = callable.Call(thisArg, jsValues);
+                    args[0] = kvalue;
+                    args[1] = k;
+                    args[2] = o.Target;
+                    var selected = callable.Call(thisArg, args);
                     if (TypeConverter.ToBoolean(selected))
                     {
                         a.SetIndexValue(to, kvalue, throwOnError: false);
@@ -206,18 +205,16 @@ namespace Jint.Native.Array
 
             var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
 
-            var args = ArrayExecutionContext.Current.CallArray1;
-            args[0] = len;
-            var a = Engine.Array.Construct(args, len);
-            var jsValues =ArrayExecutionContext.Current.CallArray3;
+            var a = Engine.Array.Construct(new JsValue[] {len}, len);
+            var args = new JsValue[3];
             for (uint k = 0; k < len; k++)
             {
                 if (o.TryGetValue(k, out var kvalue))
                 {
-                    jsValues[0] = kvalue;
-                    jsValues[1] = k;
-                    jsValues[2] = o.Target;
-                    var mappedValue = callable.Call(thisArg, jsValues);
+                    args[0] = kvalue;
+                    args[1] = k;
+                    args[2] = o.Target;
+                    var mappedValue = callable.Call(thisArg, args);
                     a.SetIndexValue(k, mappedValue, throwOnError: false);
                 }
             }
@@ -235,15 +232,15 @@ namespace Jint.Native.Array
 
             var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
 
-            var jsValues = ArrayExecutionContext.Current.CallArray3;
+            var args = new JsValue[3];
             for (uint k = 0; k < len; k++)
             {
                 if (o.TryGetValue(k, out var kvalue))
                 {
-                    jsValues[0] = kvalue;
-                    jsValues[1] = k;
-                    jsValues[2] = o.Target;
-                    callable.Call(thisArg, jsValues);
+                    args[0] = kvalue;
+                    args[1] = k;
+                    args[2] = o.Target;
+                    callable.Call(thisArg, args);
                 }
             }
 
@@ -260,15 +257,15 @@ namespace Jint.Native.Array
 
             var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
 
-            var jsValues = ArrayExecutionContext.Current.CallArray3;
+            var args = new JsValue[3];
             for (uint k = 0; k < len; k++)
             {
                 if (o.TryGetValue(k, out var kvalue))
                 {
-                    jsValues[0] = kvalue;
-                    jsValues[1] = k;
-                    jsValues[2] = o.Target;
-                    var testResult = callable.Call(thisArg, jsValues);
+                    args[0] = kvalue;
+                    args[1] = k;
+                    args[2] = o.Target;
+                    var testResult = callable.Call(thisArg, args);
                     if (TypeConverter.ToBoolean(testResult))
                     {
                         return true;
@@ -289,15 +286,15 @@ namespace Jint.Native.Array
 
             var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
 
-            var jsValues = ArrayExecutionContext.Current.CallArray3;
+            var args = new JsValue[3];
             for (uint k = 0; k < len; k++)
             {
                 if (o.TryGetValue(k, out var kvalue))
                 {
-                    jsValues[0] = kvalue;
-                    jsValues[1] = k;
-                    jsValues[2] = o.Target;
-                    var testResult = callable.Call(thisArg, jsValues);
+                    args[0] = kvalue;
+                    args[1] = k;
+                    args[2] = o.Target;
+                    var testResult = callable.Call(thisArg, args);
                     if (false == TypeConverter.ToBoolean(testResult))
                     {
                         return JsBoolean.False;
@@ -524,10 +521,7 @@ namespace Jint.Native.Array
 
                 if (compareFn != null)
                 {
-                    var args = ArrayExecutionContext.Current.CallArray2;
-                    args[0] = x;
-                    args[1] = y;
-                    var s = TypeConverter.ToNumber(compareFn.Call(Undefined, args));
+                    var s = TypeConverter.ToNumber(compareFn.Call(Undefined, new[] {x, y}));
                     if (s < 0)
                     {
                         return -1;

--- a/Jint/Native/String/StringExecutionContext.cs
+++ b/Jint/Native/String/StringExecutionContext.cs
@@ -14,7 +14,6 @@ namespace Jint.Native.String
         private StringBuilder _stringBuilder;
         private List<string> _splitSegmentList;
         private string[] _splitArray1;
-        private JsValue[] _callArray3;
 
         private StringExecutionContext()
         {
@@ -36,7 +35,6 @@ namespace Jint.Native.String
 
         public List<string> SplitSegmentList => _splitSegmentList = _splitSegmentList ?? new List<string>();
         public string[] SplitArray1 => _splitArray1 = _splitArray1 ?? new string[1];
-        public JsValue[] CallArray3 => _callArray3 = _callArray3 ?? new JsValue[3];
 
         public static StringExecutionContext Current => _executionContext.Value;
     }

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -580,7 +580,7 @@ namespace Jint.Native.String
                     return thisString;
                 int end = start + substr.Length;
 
-                var args = StringExecutionContext.Current.CallArray3;
+                var args = new JsValue[3];
                 args[0] = substr;
                 args[1] = start;
                 args[2] = thisString;


### PR DESCRIPTION
The optimization caused some condition that was hard to debug and find, with reverting back to _set logic we get a working version at least for now.