### PR TITLE
Introduce object pooling

### DIFF
--- a/Jint.Benchmark/ArrayStressBenchmark.cs
+++ b/Jint.Benchmark/ArrayStressBenchmark.cs
@@ -1,9 +1,21 @@
 ﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
 
 namespace Jint.Benchmark
 {
+    [Config(typeof(Config))]
     public class ArrayStressBenchmark : SingleScriptBenchmark
     {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                Add(Job.ShortRun);
+                Add(MemoryDiagnoser.Default);
+            }
+        }
         protected override string Script => "var ret=[],tmp,num=100,i=256;for(var j1=0;j1<i*15;j1++){ret=[];ret.length=i}for(var j2=0;j2<i*10;j2++){ret=new Array(i)}ret=[];for(var j3=0;j3<i;j3++){ret.unshift(j3)}ret=[];for(var j4=0;j4<i;j4++){ret.splice(0,0,j4)}var a=ret.slice();for(var j5=0;j5<i;j5++){tmp=a.shift()}var b=ret.slice();for(var j6=0;j6<i;j6++){tmp=b.splice(0,1)}ret=[];for(var j7=0;j7<i*25;j7++){ret.push(j7)}var c=ret.slice();for(var j8=0;j8<i*25;j8++){tmp=c.pop()}var done = true;";
 
         [Params(20)]

--- a/Jint.Benchmark/DromaeoBenchmark.cs
+++ b/Jint.Benchmark/DromaeoBenchmark.cs
@@ -3,13 +3,25 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
 using Jint;
 
 namespace Esprima.Benchmark
 {
-    [MemoryDiagnoser]
+    [Config(typeof(Config))]
     public class DromaeoBenchmark
     {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                Add(Job.MediumRun.WithLaunchCount(1));
+                Add(MemoryDiagnoser.Default);
+            }
+        }
+        
         private static readonly Dictionary<string, string> files = new Dictionary<string, string>
         {
             {"dromaeo-3d-cube", null},

--- a/Jint.Benchmark/Program.cs
+++ b/Jint.Benchmark/Program.cs
@@ -7,7 +7,8 @@ namespace Jint.Benchmark
     {
         public static void Main(string[] args)
         {
-            BenchmarkSwitcher.FromAssembly(typeof(Program).GetTypeInfo().Assembly).Run(args);
+            BenchmarkRunner.Run<UncacheableExpressionsBenchmark>();
+            //BenchmarkSwitcher.FromAssembly(typeof(Program).GetTypeInfo().Assembly).RunAll();
         }
     }
 }

--- a/Jint.Benchmark/Program.cs
+++ b/Jint.Benchmark/Program.cs
@@ -7,8 +7,7 @@ namespace Jint.Benchmark
     {
         public static void Main(string[] args)
         {
-            BenchmarkRunner.Run<UncacheableExpressionsBenchmark>();
-            //BenchmarkSwitcher.FromAssembly(typeof(Program).GetTypeInfo().Assembly).RunAll();
+            BenchmarkSwitcher.FromAssembly(typeof(Program).GetTypeInfo().Assembly).Run(args);
         }
     }
 }

--- a/Jint.Benchmark/StopwatchBenchmark.cs
+++ b/Jint.Benchmark/StopwatchBenchmark.cs
@@ -1,9 +1,22 @@
 ﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
 
 namespace Jint.Benchmark
 {
+    [Config(typeof(Config))]
     public class StopwatchBenchmark : SingleScriptBenchmark
     {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                Add(Job.ShortRun);
+                Add(MemoryDiagnoser.Default);
+            }
+        }
+ 
         [Params(1)]
         public override int N { get; set; }
 

--- a/Jint.Benchmark/SunSpiderBenchmark.cs
+++ b/Jint.Benchmark/SunSpiderBenchmark.cs
@@ -3,13 +3,25 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
 using Jint;
 
 namespace Esprima.Benchmark
 {
-    [MemoryDiagnoser]
+    [Config(typeof(Config))]
     public class SunSpiderBenchmark
     {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                Add(Job.ShortRun.WithLaunchCount(1));
+                Add(MemoryDiagnoser.Default);
+            }
+        }
+        
         private static readonly Dictionary<string, string> files = new Dictionary<string, string>
         {
             {"3d-cube", null},

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -157,7 +157,6 @@ namespace Jint
 
             ReferencePool = new ReferencePool();
             CompletionPool = new CompletionPool();
-            DeclarativeEnvironmentRecordPool = new DeclarativeEnvironmentRecordPool(this);
 
             Eval = new EvalFunctionInstance(this, System.Array.Empty<string>(), LexicalEnvironment.NewDeclarativeEnvironment(this, ExecutionContext.LexicalEnvironment), StrictModeScope.IsStrictModeCode);
             Global.FastAddProperty("eval", Eval, true, false, true);
@@ -210,7 +209,6 @@ namespace Jint
 
         internal ReferencePool ReferencePool { get; }
         internal CompletionPool CompletionPool { get; }
-        internal DeclarativeEnvironmentRecordPool DeclarativeEnvironmentRecordPool { get; }
 
         #region Debugger
         public delegate StepMode DebugStepDelegate(object sender, DebugInformation e);

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -158,6 +158,7 @@ namespace Jint
             }
 
             ReferencePool = new ReferencePool();
+            CompletionPool = new CompletionPool();
 
             Eval = new EvalFunctionInstance(this, System.Array.Empty<string>(), LexicalEnvironment.NewDeclarativeEnvironment(this, ExecutionContext.LexicalEnvironment), StrictModeScope.IsStrictModeCode);
             Global.FastAddProperty("eval", Eval, true, false, true);
@@ -209,6 +210,7 @@ namespace Jint
         internal Options Options { get; private set; }
 
         internal ReferencePool ReferencePool { get; }
+        internal CompletionPool CompletionPool { get; }
 
         #region Debugger
         public delegate StepMode DebugStepDelegate(object sender, DebugInformation e);
@@ -339,11 +341,13 @@ namespace Jint
                 var result = _statements.ExecuteProgram(program);
                 if (result.Type == Completion.Throw)
                 {
-                    throw new JavaScriptException(result.GetValueOrDefault())
-                        .SetCallstack(this, result.Location);
+                    var ex = new JavaScriptException(result.GetValueOrDefault()).SetCallstack(this, result.Location);
+                    CompletionPool.Return(result);
+                    throw ex;
                 }
 
                 _completionValue = result.GetValueOrDefault();
+                CompletionPool.Return(result);
             }
 
             return this;
@@ -905,49 +909,6 @@ namespace Jint
                     }
                 }
             }
-        }
-    }
-
-    /// <summary>
-    /// Cache reusable Reference instances as we allocate them a lot.
-    /// </summary>
-    internal sealed class ReferencePool
-    {
-        private const int PoolSize = 10;
-        private readonly Reference[] _pool;
-        private int _currentSize;
-
-        public ReferencePool()
-        {
-            // pre-allocate so we don't show up in benchmarks
-            _pool = new Reference[PoolSize];
-            for (var i = 0; i < PoolSize; ++i)
-            {
-                _pool[i] = new Reference(JsValue.Undefined, string.Empty, false);
-            }
-
-            _currentSize = PoolSize;
-        }
-
-        public Reference Rent(JsValue baseValue, string name, bool strict)
-        {
-            if (_currentSize > 0)
-            {
-                _currentSize--;
-                var reference = _pool[_currentSize];
-                return reference.Reassign(baseValue, name, strict);
-            }
-            return new Reference(baseValue, name, strict);
-        }
-
-        public void Return(Reference reference)
-        {
-            if (reference == null || _currentSize >= PoolSize)
-            {
-                return;
-            }
-            _pool[_currentSize] = reference;
-            _currentSize++;
         }
     }
 }

--- a/Jint/Native/Argument/ArgumentsInstance.cs
+++ b/Jint/Native/Argument/ArgumentsInstance.cs
@@ -17,27 +17,29 @@ namespace Jint.Native.Argument
         // cache key container for array iteration for less allocations
         private static readonly ThreadLocal<HashSet<string>> _mappedNamed = new ThreadLocal<HashSet<string>>(() => new HashSet<string>());
 
-        private readonly FunctionInstance _func;
-        private readonly string[] _names;
-        private readonly JsValue[] _args;
-        private readonly EnvironmentRecord _env;
-        private readonly bool _strict;
+        private FunctionInstance _func;
+        private string[] _names;
+        private JsValue[] _args;
+        private EnvironmentRecord _env;
+        private bool _strict;
 
         private bool _initialized;
 
-        private ArgumentsInstance(
-            Engine engine, 
-            FunctionInstance func,
-            string[] names,
-            JsValue[] args, 
-            EnvironmentRecord env,
-            bool strict) : base(engine)
+        internal ArgumentsInstance(Engine engine) : base(engine)
         {
+        }
+
+        internal void Prepare(FunctionInstance func, string[] names, JsValue[] args, EnvironmentRecord env, bool strict)
+        {
+            Clear();
+
             _func = func;
             _names = names;
             _args = args;
             _env = env;
             _strict = strict;
+
+            _initialized = false;
         }
 
         public bool Strict { get; set; }
@@ -94,25 +96,6 @@ namespace Jint.Native.Argument
                 self.DefineOwnProperty("caller", new PropertyDescriptor(get: thrower, set: thrower, enumerable: false, configurable: false), false);
                 self.DefineOwnProperty("callee", new PropertyDescriptor(get: thrower, set: thrower, enumerable: false, configurable: false), false);
             }
-        }
-
-        public static ArgumentsInstance CreateArgumentsObject(
-            Engine engine, 
-            FunctionInstance func, 
-            string[] names, 
-            JsValue[] args, 
-            EnvironmentRecord env, 
-            bool strict)
-        {
-            var obj = new ArgumentsInstance(engine, func, names, args, env, strict);
-
-            // These properties are pre-initialized as their don't trigger
-            // the EnsureInitialized() event and are cheap
-            obj.Prototype = engine.Object.PrototypeObject;
-            obj.Extensible = true;
-            obj.Strict = strict;
-
-            return obj;
         }
 
         public ObjectInstance ParameterMap { get; set; }

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -111,7 +111,7 @@ namespace Jint.Native.Array
             var o = ArrayOperations.For(Engine, thisObj);
             var len = o.GetLength();
 
-            var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
+            var callable = GetCallable(callbackfn);
 
             if (len == 0 && arguments.Length < 2)
             {
@@ -170,7 +170,7 @@ namespace Jint.Native.Array
             var o = ArrayOperations.For(Engine, thisObj);
             var len = o.GetLength();
 
-            var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
+            var callable = GetCallable(callbackfn);
 
             var a = (ArrayInstance) Engine.Array.Construct(Arguments.Empty);
 
@@ -203,7 +203,7 @@ namespace Jint.Native.Array
             var o = ArrayOperations.For(Engine, thisObj);
             var len = o.GetLength();
 
-            var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
+            var callable = GetCallable(callbackfn);
 
             var a = Engine.Array.Construct(new JsValue[] {len}, len);
             var args = new JsValue[3];
@@ -230,7 +230,7 @@ namespace Jint.Native.Array
             var o = ArrayOperations.For(Engine, thisObj);
             var len = o.GetLength();
 
-            var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
+            var callable = GetCallable(callbackfn);
 
             var args = new JsValue[3];
             for (uint k = 0; k < len; k++)
@@ -255,7 +255,7 @@ namespace Jint.Native.Array
             var o = ArrayOperations.For(Engine, thisObj);
             var len = o.GetLength();
 
-            var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
+            var callable = GetCallable(callbackfn);
 
             var args = new JsValue[3];
             for (uint k = 0; k < len; k++)
@@ -284,7 +284,7 @@ namespace Jint.Native.Array
             var o = ArrayOperations.For(Engine, thisObj);
             var len = o.GetLength();
 
-            var callable = callbackfn.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "Argument must be callable"));
+            var callable = GetCallable(callbackfn);
 
             var args = new JsValue[3];
             for (uint k = 0; k < len; k++)
@@ -833,7 +833,7 @@ namespace Jint.Native.Array
             var lenValue = o.Get("length");
             var len = TypeConverter.ToUint32(lenValue);
 
-            var callable = callbackfn.TryCast<ICallable>(x => { throw new JavaScriptException(Engine.TypeError, "Argument must be callable"); });
+            var callable = GetCallable(callbackfn);
 
             if (len == 0 && arguments.Length < 2)
             {
@@ -928,6 +928,16 @@ namespace Jint.Native.Array
             o.Target.Put("length", len, true);
             return element;
         }
+        
+        private ICallable GetCallable(JsValue source)
+        {
+            if (source is ICallable callable)
+            {
+                return callable;
+            }
+
+            throw new JavaScriptException(Engine.TypeError, "Argument must be callable");
+        }
 
         /// <summary>
         /// Adapter to use optimized array operations when possible.
@@ -998,7 +1008,7 @@ namespace Jint.Native.Array
                     }
 
                     // if getter is not undefined it must be ICallable
-                    var callable = getter.TryCast<ICallable>();
+                    var callable = (ICallable) getter;
                     var value = callable.Call(_instance, Arguments.Empty);
                     return TypeConverter.ToUint32(value);
                 }

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -58,15 +58,18 @@ namespace Jint.Native.Function
                             Engine.DeclarationBindingInstantiation(DeclarationBindingType.EvalCode, program.HoistingScope.FunctionDeclarations, program.HoistingScope.VariableDeclarations, this, arguments);
 
                             var result = _engine.ExecuteStatement(program);
+                            var value = result.GetValueOrDefault();
 
                             if (result.Type == Completion.Throw)
                             {
-                                throw new JavaScriptException(result.GetValueOrDefault())
-                                    .SetCallstack(_engine, result.Location);
+                                var ex = new JavaScriptException(value).SetCallstack(_engine, result.Location);
+                                _engine.CompletionPool.Return(result);
+                                throw ex;
                             }
                             else
                             {
-                                return result.GetValueOrDefault();
+                                _engine.CompletionPool.Return(result);
+                                return value;
                             }
                         }
                         finally

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -166,6 +166,7 @@ namespace Jint.Native.Function
 
                 Engine.EnterExecutionContext(localEnv, localEnv, thisBinding);
 
+                Completion result = null;
                 try
                 {
                     Engine.DeclarationBindingInstantiation(
@@ -175,22 +176,22 @@ namespace Jint.Native.Function
                         this,
                         arguments);
 
-                    var result = Engine.ExecuteStatement(_functionDeclaration.Body);
-
+                    result = Engine.ExecuteStatement(_functionDeclaration.Body);
+                    var value = result.GetValueOrDefault();
                     if (result.Type == Completion.Throw)
                     {
-                        JavaScriptException ex = new JavaScriptException(result.GetValueOrDefault())
-                            .SetCallstack(Engine, result.Location);
+                        var ex = new JavaScriptException(value).SetCallstack(Engine, result.Location);
                         throw ex;
                     }
 
                     if (result.Type == Completion.Return)
                     {
-                        return result.GetValueOrDefault();
+                        return value;
                     }
                 }
                 finally
                 {
+                    Engine.CompletionPool.Return(result);
                     Engine.LeaveExecutionContext();
                 }
 

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -959,5 +959,11 @@ namespace Jint.Native.Object
 
             return false;
         }
+
+        internal virtual void Clear()
+        {
+            _intrinsicProperties?.Clear();
+            _properties?.Clear();
+        }
     }
 }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -960,7 +960,7 @@ namespace Jint.Native.Object
             return false;
         }
 
-        internal virtual void Clear()
+        internal void Clear()
         {
             _intrinsicProperties?.Clear();
             _properties?.Clear();

--- a/Jint/Pooling/ArgumentsInstancePool.cs
+++ b/Jint/Pooling/ArgumentsInstancePool.cs
@@ -1,0 +1,57 @@
+﻿using Jint.Native;
+using Jint.Native.Argument;
+using Jint.Native.Function;
+using Jint.Runtime.Environments;
+using Jint.Runtime.References;
+
+namespace Jint.Pooling
+{
+    /// <summary>
+    /// Cache reusable <see cref="Reference" /> instances as we allocate them a lot.
+    /// </summary>
+    internal sealed class ArgumentsInstancePool
+    {
+        private const int PoolSize = 10;
+        private readonly Engine _engine;
+        private readonly ObjectPool<ArgumentsInstance> _pool;
+
+        public ArgumentsInstancePool(Engine engine)
+        {
+            _engine = engine;
+            _pool = new ObjectPool<ArgumentsInstance>(Factory, PoolSize);
+        }
+
+        private ArgumentsInstance Factory()
+        {
+            return new ArgumentsInstance(_engine);
+        }
+
+        public ArgumentsInstance Rent(
+            FunctionInstance func, 
+            string[] names, 
+            JsValue[] args, 
+            EnvironmentRecord env, 
+            bool strict)
+        {
+            var obj = _pool.Allocate();
+            obj.Prepare(func, names, args, env, strict);
+
+            // These properties are pre-initialized as their don't trigger
+            // the EnsureInitialized() event and are cheap
+            obj.Prototype = _engine.Object.PrototypeObject;
+            obj.Extensible = true;
+            obj.Strict = strict;
+
+            return obj;
+        }
+
+        public void Return(ArgumentsInstance instance)
+        {
+            if (instance == null)
+            {
+                return;
+            }
+            _pool.Free(instance);;
+        }
+    }
+}

--- a/Jint/Pooling/CompletionPool.cs
+++ b/Jint/Pooling/CompletionPool.cs
@@ -24,22 +24,6 @@ namespace Jint.Pooling
         
         public Completion Rent(string type, JsValue value, string identifier, Location location = null)
         {
-            if (type == Completion.Normal)
-            {
-                if (identifier == null)
-                {
-                    if (value == null)
-                    {
-                        return Completion.Empty;
-                    }
-
-                    if (ReferenceEquals(value, Undefined.Instance))
-                    {
-                        return Completion.EmptyUndefined;
-                    }
-                }
-            }
-
             return _pool.Allocate().Reassign(type, value, identifier, location);
         }
 

--- a/Jint/Pooling/CompletionPool.cs
+++ b/Jint/Pooling/CompletionPool.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Esprima;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint
+{
+    /// <summary>
+    /// Cache reusable <see cref="Completion" /> instances as we allocate them a lot.
+    /// </summary>
+    internal sealed class CompletionPool
+    {
+        private const int PoolSize = 15;
+        private readonly Completion[] _pool;
+        private int _currentSize;
+
+        public CompletionPool()
+        {
+            // pre-allocate so we don't show up in benchmarks
+            _pool = new Completion[PoolSize];
+            for (var i = 0; i < PoolSize; ++i)
+            {
+                _pool[i] = new Completion(string.Empty, JsValue.Undefined, string.Empty);
+            }
+
+            _currentSize = PoolSize;
+        }
+
+        public Completion Rent(string type, JsValue value, string identifier, Location location = null)
+        {
+            if (type == Completion.Normal)
+            {
+                if (identifier == null)
+                {
+                    if (value == null)
+                    {
+                        return Completion.Empty;
+                    }
+
+                    if (ReferenceEquals(value, Undefined.Instance))
+                    {
+                        return Completion.EmptyUndefined;
+                    }
+                }
+            }
+
+            if (_currentSize > 0)
+            {
+                _currentSize--;
+                var completion = _pool[_currentSize];
+                return completion.Reassign(type, value, identifier, location);
+            }
+
+            return new Completion(type, value, identifier, location);
+        }
+
+        public void Return(Completion completion)
+        {
+            if (completion == null
+                || _currentSize >= PoolSize
+                || ReferenceEquals(completion, Completion.Empty)
+                || ReferenceEquals(completion, Completion.EmptyUndefined))
+            {
+                return;
+            }
+            _pool[_currentSize] = completion;
+            _currentSize++;
+        }
+    }
+}

--- a/Jint/Pooling/ObjectPool.cs
+++ b/Jint/Pooling/ObjectPool.cs
@@ -1,0 +1,279 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+ 
+// define TRACE_LEAKS to get additional diagnostics that can lead to the leak sources. note: it will
+// make everything about 2-3x slower
+// 
+// #define TRACE_LEAKS
+ 
+// define DETECT_LEAKS to detect possible leaks
+// #if DEBUG
+// #define DETECT_LEAKS  //for now always enable DETECT_LEAKS in debug.
+// #endif
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+#if DETECT_LEAKS
+using System.Runtime.CompilerServices;
+ 
+#endif
+namespace Jint.Pooling
+{
+    /// <summary>
+    /// Generic implementation of object pooling pattern with predefined pool size limit. The main
+    /// purpose is that limited number of frequently used objects can be kept in the pool for
+    /// further recycling.
+    /// 
+    /// Notes: 
+    /// 1) it is not the goal to keep all returned objects. Pool is not meant for storage. If there
+    ///    is no space in the pool, extra returned objects will be dropped.
+    /// 
+    /// 2) it is implied that if object was obtained from a pool, the caller will return it back in
+    ///    a relatively short time. Keeping checked out objects for long durations is ok, but 
+    ///    reduces usefulness of pooling. Just new up your own.
+    /// 
+    /// Not returning objects to the pool in not detrimental to the pool's work, but is a bad practice. 
+    /// Rationale: 
+    ///    If there is no intent for reusing the object, do not use pool - just use "new". 
+    /// </summary>
+    internal class ObjectPool<T> where T : class
+    {
+        [DebuggerDisplay("{Value,nq}")]
+        private struct Element
+        {
+            internal T Value;
+        }
+ 
+        /// <remarks>
+        /// Not using System.Func{T} because this file is linked into the (debugger) Formatter,
+        /// which does not have that type (since it compiles against .NET 2.0).
+        /// </remarks>
+        internal delegate T Factory();
+ 
+        // Storage for the pool objects. The first item is stored in a dedicated field because we
+        // expect to be able to satisfy most requests from it.
+        private T _firstItem;
+        private readonly Element[] _items;
+ 
+        // factory is stored for the lifetime of the pool. We will call this only when pool needs to
+        // expand. compared to "new T()", Func gives more flexibility to implementers and faster
+        // than "new T()".
+        private readonly Factory _factory;
+ 
+#if DETECT_LEAKS
+        private static readonly ConditionalWeakTable<T, LeakTracker> leakTrackers = new ConditionalWeakTable<T, LeakTracker>();
+ 
+        private class LeakTracker : IDisposable
+        {
+            private volatile bool disposed;
+ 
+#if TRACE_LEAKS
+            internal volatile object Trace = null;
+#endif
+
+            public void Dispose()
+            {
+                disposed = true;
+                GC.SuppressFinalize(this);
+            }
+ 
+            private string GetTrace()
+            {
+#if TRACE_LEAKS
+                return Trace == null ? "" : Trace.ToString();
+#else
+                return "Leak tracing information is disabled. Define TRACE_LEAKS on ObjectPool`1.cs to get more info \n";
+#endif
+            }
+ 
+            ~LeakTracker()
+            {
+                if (!this.disposed && !Environment.HasShutdownStarted)
+                {
+                    var trace = GetTrace();
+ 
+                    // If you are seeing this message it means that object has been allocated from the pool 
+                    // and has not been returned back. This is not critical, but turns pool into rather 
+                    // inefficient kind of "new".
+                    Debug.WriteLine($"TRACEOBJECTPOOLLEAKS_BEGIN\nPool detected potential leaking of {typeof(T)}. \n Location of the leak: \n {GetTrace()} TRACEOBJECTPOOLLEAKS_END");
+                }
+            }
+        }
+#endif      
+ 
+        internal ObjectPool(Factory factory)
+            : this(factory, Environment.ProcessorCount * 2)
+        { }
+ 
+        internal ObjectPool(Factory factory, int size)
+        {
+            Debug.Assert(size >= 1);
+            _factory = factory;
+            _items = new Element[size - 1];
+        }
+ 
+        private T CreateInstance()
+        {
+            var inst = _factory();
+            return inst;
+        }
+ 
+        /// <summary>
+        /// Produces an instance.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically 
+        /// reducing how far we will typically search.
+        /// </remarks>
+        internal T Allocate()
+        {
+            // PERF: Examine the first element. If that fails, AllocateSlow will look at the remaining elements.
+            // Note that the initial read is optimistically not synchronized. That is intentional. 
+            // We will interlock only when we have a candidate. in a worst case we may miss some
+            // recently returned objects. Not a big deal.
+            T inst = _firstItem;
+            if (inst == null || inst != Interlocked.CompareExchange(ref _firstItem, null, inst))
+            {
+                inst = AllocateSlow();
+            }
+ 
+#if DETECT_LEAKS
+            var tracker = new LeakTracker();
+            leakTrackers.Add(inst, tracker);
+ 
+#if TRACE_LEAKS
+            var frame = CaptureStackTrace();
+            tracker.Trace = frame;
+#endif
+#endif
+            return inst;
+        }
+ 
+        private T AllocateSlow()
+        {
+            var items = _items;
+ 
+            for (int i = 0; i < items.Length; i++)
+            {
+                // Note that the initial read is optimistically not synchronized. That is intentional. 
+                // We will interlock only when we have a candidate. in a worst case we may miss some
+                // recently returned objects. Not a big deal.
+                T inst = items[i].Value;
+                if (inst != null)
+                {
+                    if (inst == Interlocked.CompareExchange(ref items[i].Value, null, inst))
+                    {
+                        return inst;
+                    }
+                }
+            }
+ 
+            return CreateInstance();
+        }
+ 
+        /// <summary>
+        /// Returns objects to the pool.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically 
+        /// reducing how far we will typically search in Allocate.
+        /// </remarks>
+        internal void Free(T obj)
+        {
+            Validate(obj);
+            ForgetTrackedObject(obj);
+ 
+            if (_firstItem == null)
+            {
+                // Intentionally not using interlocked here. 
+                // In a worst case scenario two objects may be stored into same slot.
+                // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                _firstItem = obj;
+            }
+            else
+            {
+                FreeSlow(obj);
+            }
+        }
+ 
+        private void FreeSlow(T obj)
+        {
+            var items = _items;
+            for (int i = 0; i < items.Length; i++)
+            {
+                if (items[i].Value == null)
+                {
+                    // Intentionally not using interlocked here. 
+                    // In a worst case scenario two objects may be stored into same slot.
+                    // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                    items[i].Value = obj;
+                    break;
+                }
+            }
+        }
+ 
+        /// <summary>
+        /// Removes an object from leak tracking.  
+        /// 
+        /// This is called when an object is returned to the pool.  It may also be explicitly 
+        /// called if an object allocated from the pool is intentionally not being returned
+        /// to the pool.  This can be of use with pooled arrays if the consumer wants to 
+        /// return a larger array to the pool than was originally allocated.
+        /// </summary>
+        [Conditional("DEBUG")]
+        internal void ForgetTrackedObject(T old, T replacement = null)
+        {
+#if DETECT_LEAKS
+            LeakTracker tracker;
+            if (leakTrackers.TryGetValue(old, out tracker))
+            {
+                tracker.Dispose();
+                leakTrackers.Remove(old);
+            }
+            else
+            {
+                var trace = CaptureStackTrace();
+                Debug.WriteLine($"TRACEOBJECTPOOLLEAKS_BEGIN\nObject of type {typeof(T)} was freed, but was not from pool. \n Callstack: \n {trace} TRACEOBJECTPOOLLEAKS_END");
+            }
+ 
+            if (replacement != null)
+            {
+                tracker = new LeakTracker();
+                leakTrackers.Add(replacement, tracker);
+            }
+#endif
+        }
+ 
+#if DETECT_LEAKS
+        private static Lazy<Type> _stackTraceType = new Lazy<Type>(() => Type.GetType("System.Diagnostics.StackTrace"));
+ 
+        private static object CaptureStackTrace()
+        {
+            return Activator.CreateInstance(_stackTraceType.Value);
+        }
+#endif
+ 
+        [Conditional("DEBUG")]
+        private void Validate(object obj)
+        {
+            Debug.Assert(obj != null, "freeing null?");
+ 
+            Debug.Assert(_firstItem != obj, "freeing twice?");
+ 
+            var items = _items;
+            for (int i = 0; i < items.Length; i++)
+            {
+                var value = items[i].Value;
+                if (value == null)
+                {
+                    return;
+                }
+ 
+                Debug.Assert(value != obj, "freeing twice?");
+            }
+        }
+    }
+}

--- a/Jint/Pooling/ReferencePool.cs
+++ b/Jint/Pooling/ReferencePool.cs
@@ -1,0 +1,49 @@
+﻿using Jint.Native;
+using Jint.Runtime.References;
+
+namespace Jint
+{
+    /// <summary>
+    /// Cache reusable <see cref="Reference" /> instances as we allocate them a lot.
+    /// </summary>
+    internal sealed class ReferencePool
+    {
+        private const int PoolSize = 10;
+        private readonly Reference[] _pool;
+        private int _currentSize;
+
+        public ReferencePool()
+        {
+            // pre-allocate so we don't show up in benchmarks
+            _pool = new Reference[PoolSize];
+            for (var i = 0; i < PoolSize; ++i)
+            {
+                _pool[i] = new Reference(JsValue.Undefined, string.Empty, false);
+            }
+
+            _currentSize = PoolSize;
+        }
+
+        public Reference Rent(JsValue baseValue, string name, bool strict)
+        {
+            if (_currentSize > 0)
+            {
+                _currentSize--;
+                var reference = _pool[_currentSize];
+                return reference.Reassign(baseValue, name, strict);
+            }
+
+            return new Reference(baseValue, name, strict);
+        }
+
+        public void Return(Reference reference)
+        {
+            if (reference == null || _currentSize >= PoolSize)
+            {
+                return;
+            }
+            _pool[_currentSize] = reference;
+            _currentSize++;
+        }
+    }
+}

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -31,11 +31,11 @@ namespace Jint.Runtime.Environments
             return _bindings?.ContainsKey(name) == true;
         }
 
-        public override void CreateMutableBinding(string name, bool canBeDeleted = false)
+        public override void CreateMutableBinding(string name, JsValue value, bool canBeDeleted = false)
         {
             var binding = new Binding
             {
-                Value = Undefined,
+                Value = value,
                 CanBeDeleted =  canBeDeleted,
                 Mutable = true
             };
@@ -132,14 +132,15 @@ namespace Jint.Runtime.Environments
         }
 
         /// <summary>
-        /// Creates a new but uninitialised immutable binding in an environment record.
+        /// Creates a new immutable binding in an environment record.
         /// </summary>
         /// <param name="name">The identifier of the binding.</param>
-        public void CreateImmutableBinding(string name)
+        /// <param name="value">The value  of the binding.</param>
+        public void CreateImmutableBinding(string name, JsValue value)
         {
             var binding = new Binding
             {
-                Value = Undefined,
+                Value = value,
                 Mutable = false,
                 CanBeDeleted = false
             };
@@ -159,23 +160,19 @@ namespace Jint.Runtime.Environments
         }
 
         /// <summary>
-        /// Sets the value of an already existing but uninitialised immutable binding in an environment record.
-        /// </summary>
-        /// <param name="name">The identifier of the binding.</param>
-        /// <param name="value">The value of the binding.</param>
-        public void InitializeImmutableBinding(string name, JsValue value)
-        {
-            var binding = name == BindingNameArguments ? _argumentsBinding : _bindings[name];
-            binding.Value = value;
-        }
-
-        /// <summary>
         /// Returns an array of all the defined binding names
         /// </summary>
         /// <returns>The array of all defined bindings</returns>
         public override string[] GetAllBindingNames()
         {
             return _bindings?.GetKeys() ?? Array.Empty<string>();
+        }
+
+        internal override void Clear()
+        {
+            base.Clear();
+            _argumentsBinding = null;
+            _bindings?.Clear();
         }
     }
 }

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Jint.Native;
+using Jint.Native.Argument;
 
 namespace Jint.Runtime.Environments
 {
@@ -168,11 +169,13 @@ namespace Jint.Runtime.Environments
             return _bindings?.GetKeys() ?? Array.Empty<string>();
         }
 
-        internal override void Clear()
+        internal void ReleaseArguments()
         {
-            base.Clear();
-            _argumentsBinding = null;
-            _bindings?.Clear();
+            if (_argumentsBinding?.Value is ArgumentsInstance instance)
+            {
+                _engine.ArgumentsInstancePool.Return(instance);
+                _argumentsBinding = null;
+            }
         }
     }
 }

--- a/Jint/Runtime/Environments/EnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/EnvironmentRecord.cs
@@ -24,8 +24,9 @@ namespace Jint.Runtime.Environments
         /// Creates a new mutable binding in an environment record.
         /// </summary>
         /// <param name="name">The identifier of the binding.</param>
+        /// <param name="value">The value of the binding.</param>
         /// <param name="canBeDeleted"><c>true</c> if the binding may be subsequently deleted.</param>
-        public abstract void CreateMutableBinding(string name, bool canBeDeleted = false);
+        public abstract void CreateMutableBinding(string name, JsValue value, bool canBeDeleted = false);
 
         /// <summary>
         /// Sets the value of an already existing mutable binding in an environment record. 

--- a/Jint/Runtime/Environments/LexicalEnvironment.cs
+++ b/Jint/Runtime/Environments/LexicalEnvironment.cs
@@ -11,24 +11,20 @@ namespace Jint.Runtime.Environments
     /// </summary>
     public sealed class LexicalEnvironment
     {
+        private readonly Engine _engine;
         private readonly EnvironmentRecord _record;
         private readonly LexicalEnvironment _outer;
 
-        public LexicalEnvironment(EnvironmentRecord record, LexicalEnvironment outer)
+        public LexicalEnvironment(Engine engine, EnvironmentRecord record, LexicalEnvironment outer)
         {
+            _engine = engine;
             _record = record;
             _outer = outer;
         }
 
-        public EnvironmentRecord Record
-        {
-            get { return _record; }
-        }
+        public EnvironmentRecord Record => _record;
 
-        public LexicalEnvironment Outer
-        {
-            get { return _outer; }
-        }
+        public LexicalEnvironment Outer => _outer;
 
         public static Reference GetIdentifierReference(LexicalEnvironment lex, string name, bool strict)
         {
@@ -41,12 +37,12 @@ namespace Jint.Runtime.Environments
 
                 if (lex.Record.HasBinding(name))
                 {
-                    return new Reference(lex.Record, name, strict);
+                    return lex._engine.ReferencePool.Rent(lex.Record, name, strict);
                 }
 
                 if (lex.Outer == null)
                 {
-                    return new Reference(Undefined.Instance, name, strict);
+                    return lex._engine.ReferencePool.Rent(Undefined.Instance, name, strict);
                 }
 
                 lex = lex.Outer;
@@ -55,14 +51,12 @@ namespace Jint.Runtime.Environments
 
         public static LexicalEnvironment NewDeclarativeEnvironment(Engine engine, LexicalEnvironment outer = null)
         {
-            return new LexicalEnvironment(new DeclarativeEnvironmentRecord(engine), outer);
+            return new LexicalEnvironment(engine, new DeclarativeEnvironmentRecord(engine), outer);
         }
 
         public static LexicalEnvironment NewObjectEnvironment(Engine engine, ObjectInstance objectInstance, LexicalEnvironment outer, bool provideThis)
         {
-            return new LexicalEnvironment(new ObjectEnvironmentRecord(engine, objectInstance, provideThis), outer);
+            return new LexicalEnvironment(engine, new ObjectEnvironmentRecord(engine, objectInstance, provideThis), outer);
         }
     }
-
-    
 }

--- a/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
@@ -32,13 +32,11 @@ namespace Jint.Runtime.Environments
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-10.2.1.2.2
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="configurable"></param>
-        public override void CreateMutableBinding(string name, bool configurable = true)
+        public override void CreateMutableBinding(string name, JsValue value, bool configurable = true)
         {
             var propertyDescriptor = configurable
-                ? (IPropertyDescriptor) new ConfigurableEnumerableWritablePropertyDescriptor(Undefined)
-                : new NonConfigurablePropertyDescriptor(Undefined);
+                ? (IPropertyDescriptor) new ConfigurableEnumerableWritablePropertyDescriptor(value)
+                : new NonConfigurablePropertyDescriptor(value);
 
             _bindingObject.SetOwnProperty(name, propertyDescriptor);
         }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -31,22 +31,22 @@ namespace Jint.Runtime
         public JsValue EvaluateConditionalExpression(ConditionalExpression conditionalExpression)
         {
             var lref = _engine.EvaluateExpression(conditionalExpression.Test);
-            if (TypeConverter.ToBoolean(_engine.GetValue(lref)))
+            if (TypeConverter.ToBoolean(_engine.GetValue(lref, true)))
             {
                 var trueRef = _engine.EvaluateExpression(conditionalExpression.Consequent);
-                return _engine.GetValue(trueRef);
+                return _engine.GetValue(trueRef, true);
             }
             else
             {
                 var falseRef = _engine.EvaluateExpression(conditionalExpression.Alternate);
-                return _engine.GetValue(falseRef);
+                return _engine.GetValue(falseRef, true);
             }
         }
 
         public JsValue EvaluateAssignmentExpression(AssignmentExpression assignmentExpression)
         {
             var lref = EvaluateExpression(assignmentExpression.Left.As<Expression>()) as Reference;
-            JsValue rval = _engine.GetValue(EvaluateExpression(assignmentExpression.Right));
+            JsValue rval = _engine.GetValue(EvaluateExpression(assignmentExpression.Right), true);
 
             if (lref == null)
             {
@@ -62,6 +62,7 @@ namespace Jint.Runtime
                 }
 
                 _engine.PutValue(lref, rval);
+                _engine.ReferencePool.Return(lref);
                 return rval;
             }
 
@@ -148,6 +149,7 @@ namespace Jint.Runtime
 
             _engine.PutValue(lref, lval);
 
+            _engine.ReferencePool.Return(lref);
             return lval;
         }
 
@@ -210,8 +212,7 @@ namespace Jint.Runtime
             }
             else
             {
-                var leftExpression = EvaluateExpression(expression.Left);
-                left = _engine.GetValue(leftExpression);
+                left = _engine.GetValue(EvaluateExpression(expression.Left), true);
             }
 
             JsValue right;
@@ -221,8 +222,7 @@ namespace Jint.Runtime
             }
             else
             {
-                var rightExpression = EvaluateExpression(expression.Right);
-                right = _engine.GetValue(rightExpression);
+                right = _engine.GetValue(EvaluateExpression(expression.Right), true);
             }
 
             JsValue value;
@@ -373,7 +373,7 @@ namespace Jint.Runtime
 
         public JsValue EvaluateLogicalExpression(BinaryExpression binaryExpression)
         {
-            var left = _engine.GetValue(EvaluateExpression(binaryExpression.Left));
+            var left = _engine.GetValue(EvaluateExpression(binaryExpression.Left), true);
 
             switch (binaryExpression.Operator)
             {
@@ -384,7 +384,7 @@ namespace Jint.Runtime
                         return left;
                     }
 
-                    return _engine.GetValue(EvaluateExpression(binaryExpression.Right));
+                    return _engine.GetValue(EvaluateExpression(binaryExpression.Right), true);
 
                 case BinaryOperator.LogicalOr:
                     if (TypeConverter.ToBoolean(left))
@@ -392,7 +392,7 @@ namespace Jint.Runtime
                         return left;
                     }
 
-                    return _engine.GetValue(EvaluateExpression(binaryExpression.Right));
+                    return _engine.GetValue(EvaluateExpression(binaryExpression.Right), true);
 
                 default:
                     throw new NotImplementedException();
@@ -669,7 +669,7 @@ namespace Jint.Runtime
                     case PropertyKind.Init:
                     case PropertyKind.Data:
                         var exprValue = _engine.EvaluateExpression(property.Value.As<Expression>());
-                        var propValue = _engine.GetValue(exprValue);
+                        var propValue = _engine.GetValue(exprValue, true);
                         propDesc = new ConfigurableEnumerableWritablePropertyDescriptor(propValue);
                         break;
 
@@ -777,13 +777,17 @@ namespace Jint.Runtime
             else
             {
                 var propertyNameReference = EvaluateExpression(memberExpression.Property);
-                var propertyNameValue = _engine.GetValue(propertyNameReference);
+                var propertyNameValue = _engine.GetValue(propertyNameReference, true);
                 propertyNameString = TypeConverter.ToString(propertyNameValue);
             }
 
             TypeConverter.CheckObjectCoercible(_engine, baseValue, memberExpression, baseReference);
 
-            return new Reference(baseValue, propertyNameString, StrictModeScope.IsStrictModeCode);
+            if (baseReference is Reference r)
+            {
+                _engine.ReferencePool.Return(r);
+            }
+            return _engine.ReferencePool.Rent(baseValue, propertyNameString, StrictModeScope.IsStrictModeCode);
         }
 
         public JsValue EvaluateFunctionExpression(IFunction functionExpression)
@@ -791,7 +795,7 @@ namespace Jint.Runtime
             var funcEnv = LexicalEnvironment.NewDeclarativeEnvironment(_engine, _engine.ExecutionContext.LexicalEnvironment);
             var envRec = (DeclarativeEnvironmentRecord)funcEnv.Record;
 
-            if (functionExpression.Id != null && !String.IsNullOrEmpty(functionExpression.Id.Name))
+            if (functionExpression.Id != null && !string.IsNullOrEmpty(functionExpression.Id.Name))
             {
                 envRec.CreateMutableBinding(functionExpression.Id.Name);
             }
@@ -924,6 +928,7 @@ namespace Jint.Runtime
                 _engine.CallStack.Pop();
             }
 
+            _engine.ReferencePool.Return(r);
             return result;
         }
 
@@ -932,7 +937,7 @@ namespace Jint.Runtime
             var result = Undefined.Instance;
             foreach (var expression in sequenceExpression.Expressions)
             {
-                result = _engine.GetValue(_engine.EvaluateExpression(expression.As<Expression>()));
+                result = _engine.GetValue(_engine.EvaluateExpression(expression.As<Expression>()), true);
             }
 
             return result;
@@ -959,6 +964,7 @@ namespace Jint.Runtime
                     var newValue = oldValue + 1;
                     _engine.PutValue(r, newValue);
 
+                    _engine.ReferencePool.Return(r);
                     return updateExpression.Prefix ? newValue : oldValue;
 
                 case UnaryOperator.Decrement:
@@ -992,7 +998,7 @@ namespace Jint.Runtime
             var arguments = BuildArguments(newExpression.Arguments, out bool _);
 
             // todo: optimize by defining a common abstract class or interface
-            var callee = _engine.GetValue(EvaluateExpression(newExpression.Callee)).TryCast<IConstructor>();
+            var callee = _engine.GetValue(EvaluateExpression(newExpression.Callee), true).TryCast<IConstructor>();
 
             if (callee == null)
             {
@@ -1015,7 +1021,7 @@ namespace Jint.Runtime
                 var expr = elements[n];
                 if (expr != null)
                 {
-                    var value = _engine.GetValue(EvaluateExpression(expr.As<Expression>()));
+                    var value = _engine.GetValue(EvaluateExpression(expr.As<Expression>()), true);
                     a.SetIndexValue((uint) n, value, throwOnError: false);
                 }
             }
@@ -1026,25 +1032,24 @@ namespace Jint.Runtime
         public JsValue EvaluateUnaryExpression(UnaryExpression unaryExpression)
         {
             var value = _engine.EvaluateExpression(unaryExpression.Argument);
-            Reference r;
 
             switch (unaryExpression.Operator)
             {
                 case UnaryOperator.Plus:
-                    return TypeConverter.ToNumber(_engine.GetValue(value));
+                    return TypeConverter.ToNumber(_engine.GetValue(value, true));
 
                 case UnaryOperator.Minus:
-                    var n = TypeConverter.ToNumber(_engine.GetValue(value));
+                    var n = TypeConverter.ToNumber(_engine.GetValue(value, true));
                     return double.IsNaN(n) ? double.NaN : n*-1;
 
                 case UnaryOperator.BitwiseNot:
-                    return ~TypeConverter.ToInt32(_engine.GetValue(value));
+                    return ~TypeConverter.ToInt32(_engine.GetValue(value, true));
 
                 case UnaryOperator.LogicalNot:
-                    return !TypeConverter.ToBoolean(_engine.GetValue(value));
+                    return !TypeConverter.ToBoolean(_engine.GetValue(value, true));
 
                 case UnaryOperator.Delete:
-                    r = value as Reference;
+                    var r = value as Reference;
                     if (r == null)
                     {
                         return true;
@@ -1056,19 +1061,26 @@ namespace Jint.Runtime
                             throw new JavaScriptException(_engine.SyntaxError);
                         }
 
+                        _engine.ReferencePool.Return(r);
                         return true;
                     }
                     if (r.IsPropertyReference())
                     {
                         var o = TypeConverter.ToObject(_engine, r.GetBase());
-                        return o.Delete(r.GetReferencedName(), r.IsStrict());
+                        var jsValue = o.Delete(r.GetReferencedName(), r.IsStrict());
+                        _engine.ReferencePool.Return(r);
+                        return jsValue;
                     }
                     if (r.IsStrict())
                     {
                         throw new JavaScriptException(_engine.SyntaxError);
                     }
+
                     var bindings = r.GetBase().TryCast<EnvironmentRecord>();
-                    return bindings.DeleteBinding(r.GetReferencedName());
+                    var referencedName = r.GetReferencedName();
+                    _engine.ReferencePool.Return(r);
+
+                    return bindings.DeleteBinding(referencedName);
 
                 case UnaryOperator.Void:
                     _engine.GetValue(value);
@@ -1080,10 +1092,13 @@ namespace Jint.Runtime
                     {
                         if (r.IsUnresolvableReference())
                         {
+                            _engine.ReferencePool.Return(r);
                             return "undefined";
                         }
                     }
-                    var v = _engine.GetValue(value);
+
+                    var v = _engine.GetValue(value, true);
+
                     if (ReferenceEquals(v, Undefined.Instance))
                     {
                         return "undefined";
@@ -1124,7 +1139,7 @@ namespace Jint.Runtime
             for (var i = 0; i < count; i++)
             {
                 var argument = (Expression) expressionArguments[i];
-                arguments[i] = _engine.GetValue(EvaluateExpression(argument));
+                arguments[i] = _engine.GetValue(EvaluateExpression(argument), true);
                 allLiteral &= argument is Literal;
             }
 

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -913,7 +913,9 @@ namespace Jint.Runtime
             // is it a direct call to eval ? http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.1.1
             if (r != null && r.GetReferencedName() == "eval" && callable is EvalFunctionInstance)
             {
-                return ((EvalFunctionInstance) callable).Call(thisObject, arguments, true);
+                var value = ((EvalFunctionInstance) callable).Call(thisObject, arguments, true);
+                _engine.ReferencePool.Return(r);
+                return value;
             }
 
             var result = callable.Call(thisObject, arguments);
@@ -979,7 +981,9 @@ namespace Jint.Runtime
 
                     oldValue = TypeConverter.ToNumber(_engine.GetValue(value));
                     newValue = oldValue - 1;
+
                     _engine.PutValue(r, newValue);
+                    _engine.ReferencePool.Return(r);
 
                     return updateExpression.Prefix ? newValue : oldValue;
                 default:

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -795,11 +795,6 @@ namespace Jint.Runtime
             var funcEnv = LexicalEnvironment.NewDeclarativeEnvironment(_engine, _engine.ExecutionContext.LexicalEnvironment);
             var envRec = (DeclarativeEnvironmentRecord)funcEnv.Record;
 
-            if (functionExpression.Id != null && !string.IsNullOrEmpty(functionExpression.Id.Name))
-            {
-                envRec.CreateMutableBinding(functionExpression.Id.Name);
-            }
-
             var closure = new ScriptFunctionInstance(
                 _engine,
                 functionExpression,
@@ -807,9 +802,9 @@ namespace Jint.Runtime
                 functionExpression.Strict
                 );
 
-            if (functionExpression.Id != null && !String.IsNullOrEmpty(functionExpression.Id.Name))
+            if (!string.IsNullOrEmpty(functionExpression.Id?.Name))
             {
-                envRec.InitializeImmutableBinding(functionExpression.Id.Name, closure);
+                envRec.CreateMutableBinding(functionExpression.Id.Name, closure);
             }
 
             return closure;

--- a/Jint/Runtime/References/Reference.cs
+++ b/Jint/Runtime/References/Reference.cs
@@ -1,4 +1,6 @@
-﻿using Jint.Native;
+﻿using System;
+using System.Threading;
+using Jint.Native;
 using Jint.Runtime.Environments;
 
 namespace Jint.Runtime.References
@@ -9,9 +11,9 @@ namespace Jint.Runtime.References
     /// </summary>
     public class Reference
     {
-        private readonly JsValue _baseValue;
-        private readonly string _name;
-        private readonly bool _strict;
+        private JsValue _baseValue;
+        private string _name;
+        private bool _strict;
 
         public Reference(JsValue baseValue, string name, bool strict)
         {
@@ -49,6 +51,14 @@ namespace Jint.Runtime.References
         {
             // http://www.ecma-international.org/ecma-262/5.1/#sec-8.7
             return HasPrimitiveBase() || (_baseValue.IsObject() && !(_baseValue is EnvironmentRecord));
+        }
+
+        internal Reference Reassign(JsValue baseValue, string name, bool strict)
+        {
+            _baseValue = baseValue;
+            _name = name;
+            _strict = strict;
+            return this;
         }
     }
 }

--- a/Jint/Runtime/References/Reference.cs
+++ b/Jint/Runtime/References/Reference.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using Jint.Native;
 using Jint.Runtime.Environments;
 
@@ -9,7 +8,7 @@ namespace Jint.Runtime.References
     /// Represents the Reference Specification Type
     /// http://www.ecma-international.org/ecma-262/5.1/#sec-8.7
     /// </summary>
-    public class Reference
+    public sealed class Reference
     {
         private JsValue _baseValue;
         private string _name;
@@ -19,7 +18,6 @@ namespace Jint.Runtime.References
         {
             _baseValue = baseValue;
             _name = name;
-            _strict = strict;
         }
 
         public JsValue GetBase()
@@ -58,6 +56,7 @@ namespace Jint.Runtime.References
             _baseValue = baseValue;
             _name = name;
             _strict = strict;
+
             return this;
         }
     }

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -451,7 +451,7 @@ namespace Jint.Runtime
                         return executeStatementList;
                     }
 
-                    if (sl != null)
+                    if (sl != c)
                     {
                         _engine.CompletionPool.Return(sl);
                     }
@@ -463,11 +463,6 @@ namespace Jint.Runtime
             {
                 var completion = _engine.CompletionPool.Rent(Completion.Throw, v.Error, null, v.Location ?? s.Location);
                 return completion;
-            }
-            finally
-            {
-                _engine.CompletionPool.Return(sl);
-                _engine.CompletionPool.Return(c);
             }
 
             var rent = _engine.CompletionPool.Rent(c.Type, c.GetValueOrDefault(), c.Identifier);
@@ -503,8 +498,7 @@ namespace Jint.Runtime
                     var c = _engine.GetValue(b);
                     var oldEnv = _engine.ExecutionContext.LexicalEnvironment;
                     var catchEnv = LexicalEnvironment.NewDeclarativeEnvironment(_engine, oldEnv);
-                    catchEnv.Record.CreateMutableBinding(catchClause.Param.As<Identifier>().Name);
-                    catchEnv.Record.SetMutableBinding(catchClause.Param.As<Identifier>().Name, c, false);
+                    catchEnv.Record.CreateMutableBinding(catchClause.Param.As<Identifier>().Name, c);
                     _engine.ExecutionContext.LexicalEnvironment = catchEnv;
                     b = ExecuteStatement(catchClause.Body);
                     _engine.ExecutionContext.LexicalEnvironment = oldEnv;


### PR DESCRIPTION
This PR introduces object pooling for top memory pressure creators: 

* Reference
* Completion 
* ArgumentsInstance

With this change they practically disappear from performance report. The approach is opportunistic/best effort. When we are in code path that no longer needs the deep-acquire object we release it, unfortunately using pattern cannot be used.

## Esprima.Benchmark.DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|dromaeo-3d-cube|107.09 ms|7437.5000|250.0000|-|31.67 MB|
| **New** |	|	| **107.96 ms (+1%)** | **1312.5000 (-82%)** | **250.0000 (0%)** | **-** | **7107.59 KB (-78%)** |
| Old |Run|dromaeo-core-eval|25.92 ms|1718.7500|-|-|6.9 MB|
| **New** |	|	| **24.98 ms (-4%)** | **62.5000 (-96%)** | **-** | **-** | **298.95 KB (-96%)** |
| Old |Run|dromaeo-object-array|270.44 ms|45125.0000|2062.5000|1000.0000|186.35 MB|
| **New** |	|	| **262.77 ms (-3%)** | **39500.0000 (-12%)** | **2000.0000 (-3%)** | **1000.0000 (0%)** | **166027.07 KB (-11%)** |
| Old |Run|dromaeo-object-regexp|1,168.48 ms|71812.5000|35312.5000|22250.0000|479.86 MB|
| **New** |	|	| **1,141.61 ms (-2%)** | **57562.5000 (-20%)** | **35062.5000 (-1%)** | **22000.0000 (-1%)** | **434680.59 KB (-9%)** |
| Old |Run|dromaeo-object-string|1,584.29 ms|249500.0000|183437.5000|179187.5000|1457.82 MB|
| **New** |	|	| **1,524.09 ms (-4%)** | **226687.5000 (-9%)** | **184625.0000 (+1%)** | **181687.5000 (+1%)** | **1393645.01 KB (-4%)** |
| Old |Run|dromaeo-string-base64|236.82 ms|16062.5000|375.0000|-|65.37 MB|
| **New** |	|	| **236.61 ms (0%)** | **6187.5000 (-61%)** | **187.5000 (-50%)** | **-** | **26458.12 KB (-60%)** |


## Esprima.Benchmark.SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|3d-cube|848.7 ms|63687.5000|312.5000|62.5000|256.97 MB|
| **New** |	|	| **826.2 ms (-3%)** | **10250.0000 (-84%)** | **312.5000 (0%)** | **62.5000 (0%)** | **42.9 MB (-83%)** |
| Old |Run|3d-morph|796.1 ms|41937.5000|5875.0000|1812.5000|193.86 MB|
| **New** |	|	| **759.8 ms (-5%)** | **10875.0000 (-74%)** | **2312.5000 (-61%)** | **1000.0000 (-45%)** | **61.05 MB (-69%)** |
| Old |Run|3d-raytrace|648.6 ms|53562.5000|1000.0000|125.0000|216.57 MB|
| **New** |	|	| **648.5 ms (0%)** | **21937.5000 (-59%)** | **500.0000 (-50%)** | **62.5000 (-50%)** | **90.1 MB (-58%)** |
| Old |Run|access-binary-trees|260.5 ms|36125.0000|437.5000|-|145.24 MB|
| **New** |	|	| **259.5 ms (0%)** | **19187.5000 (-47%)** | **250.0000 (-43%)** | **-** | **77.08 MB (-47%)** |
| Old |Run|access-fannkuch|2,707.8 ms|172437.5000|250.0000|-|689.76 MB|
| **New** |	|	| **2,656.7 ms (-2%)** | **7062.5000 (-96%)** | **250.0000 (0%)** | **-** | **28.43 MB (-96%)** |
| Old |Run|access-nbody|764.4 ms|57500.0000|62.5000|-|230.06 MB|
| **New** |	|	| **745.0 ms (-3%)** | **10625.0000 (-82%)** | **62.5000 (0%)** | **-** | **42.73 MB (-81%)** |
| Old |Run|access-nsieve|980.3 ms|62937.5000|7937.5000|2937.5000|260.87 MB|
| **New** |	|	| **948.8 ms (-3%)** | **12812.5000 (-80%)** | **3875.0000 (-51%)** | **1812.5000 (-38%)** | **62.71 MB (-76%)** |
| Old |Run|bitops-3bit-bits-in-byte|560.9 ms|54937.5000|-|-|219.81 MB|
| **New** |	|	| **544.9 ms (-3%)** | **20687.5000 (-62%)** | **-** | **-** | **82.99 MB (-62%)** |
| Old |Run|bitops-bits-in-byte|965.9 ms|80625.0000|62.5000|-|322.7 MB|
| **New** |	|	| **947.1 ms (-2%)** | **13437.5000 (-83%)** | **62.5000 (0%)** | **-** | **53.98 MB (-83%)** |
| Old |Run|bitops-bitwise-and|653.2 ms|45625.0000|62.5000|-|182.65 MB|
| **New** |	|	| **600.7 ms (-8%)** | **10125.0000 (-78%)** | **-** | **-** | **40.74 MB (-78%)** |
| Old |Run|bitops-nsieve-bits|1,047.0 ms|66750.0000|4375.0000|375.0000|269.04 MB|
| **New** |	|	| **1,010.6 ms (-3%)** | **17250.0000 (-74%)** | **250.0000 (-94%)** | **62.5000 (-83%)** | **71.02 MB (-74%)** |
| Old |Run|controlflow-recursive|357.1 ms|55687.5000|-|-|222.91 MB|
| **New** |	|	| **358.6 ms (0%)** | **29062.5000 (-48%)** | **62.5000** | **-** | **116.32 MB (-48%)** |
| Old |Run|crypto-aes|643.3 ms|44250.0000|312.5000|62.5000|179.2 MB|
| **New** |	|	| **645.4 ms (0%)** | **5250.0000 (-88%)** | **250.0000 (-20%)** | **-** | **23.11 MB (-87%)** |
| Old |Run|crypto-md5|421.5 ms|51250.0000|312.5000|62.5000|207.1 MB|
| **New** |	|	| **409.2 ms (-3%)** | **30187.5000 (-41%)** | **312.5000 (0%)** | **62.5000 (0%)** | **123.04 MB (-41%)** |
| Old |Run|crypto-sha1|417.5 ms|47687.5000|312.5000|62.5000|192.39 MB|
| **New** |	|	| **404.7 ms (-3%)** | **24875.0000 (-48%)** | **187.5000 (-40%)** | **-** | **101.27 MB (-47%)** |
| Old |Run|date-format-tofte|433.6 ms|36062.5000|-|-|144.36 MB|
| **New** |	|	| **425.1 ms (-2%)** | **12187.5000 (-66%)** | **62.5000** | **-** | **49.05 MB (-66%)** |
| Old |Run|date-format-xparb|373.4 ms|18062.5000|250.0000|-|72.86 MB|
| **New** |	|	| **372.6 ms (0%)** | **10750.0000 (-40%)** | **250.0000 (0%)** | **-** | **43.57 MB (-40%)** |
| Old |Run|math-cordic|1,253.7 ms|110000.0000|125.0000|-|440.03 MB|
| **New** |	|	| **1,220.4 ms (-3%)** | **21562.5000 (-80%)** | **62.5000 (-50%)** | **-** | **86.4 MB (-80%)** |
| Old |Run|math-partial-sums|401.5 ms|26812.5000|-|-|107.29 MB|
| **New** |	|	| **390.7 ms (-3%)** | **6500.0000 (-76%)** | **-** | **-** | **26.15 MB (-76%)** |
| Old |Run|math-spectral-norm|475.1 ms|48312.5000|-|-|193.43 MB|
| **New** |	|	| **458.3 ms (-4%)** | **19187.5000 (-60%)** | **-** | **-** | **76.96 MB (-60%)** |
| Old |Run|regexp-dna|343.3 ms|2000.0000|1687.5000|1375.0000|13.46 MB|
| **New** |	|	| **343.7 ms (0%)** | **2250.0000 (+13%)** | **1937.5000 (+15%)** | **1562.5000 (+14%)** | **13.45 MB (0%)** |
| Old |Run|string-base64|350.1 ms|23812.5000|250.0000|-|96.61 MB|
| **New** |	|	| **351.1 ms (0%)** | **8812.5000 (-63%)** | **437.5000 (+75%)** | **-** | **36.92 MB (-62%)** |
| Old |Run|string-fasta|601.0 ms|57875.0000|-|-|231.69 MB|
| **New** |	|	| **596.6 ms (-1%)** | **25625.0000 (-56%)** | **-** | **-** | **102.6 MB (-56%)** |
| Old |Run|string-tagcloud|257.0 ms|26187.5000|2125.0000|750.0000|113.18 MB|
| **New** |	|	| **250.7 ms (-2%)** | **14875.0000 (-43%)** | **1687.5000 (-21%)** | **625.0000 (-17%)** | **68.05 MB (-40%)** |
| Old |Run|string-unpack-code|202.0 ms|27187.5000|6250.0000|1375.0000|118.12 MB|
| **New** |	|	| **197.2 ms (-2%)** | **14625.0000 (-46%)** | **4625.0000 (-26%)** | **1187.5000 (-14%)** | **70.22 MB (-41%)** |
| Old |Run|string-validate-input|241.7 ms|20375.0000|375.0000|62.5000|84.8 MB|
| **New** |	|	| **236.3 ms (-2%)** | **7500.0000 (-63%)** | **250.0000 (-33%)** | **62.5000 (0%)** | **35.24 MB (-58%)** |


## Jint.Benchmark.ArrayBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Slice|100|672.9 us|149.4141|615.63 KB|
| **New** |	|	| **685.5 us (+2%)** | **145.5078 (-3%)** | **598.44 KB (-3%)** |
| Old |Concat|100|827.7 us|166.0156|683.59 KB|
| **New** |	|	| **791.7 us (-4%)** | **162.1094 (-2%)** | **666.41 KB (-3%)** |
| Old |Unshift|100|30,986.7 us|3687.5000|15212.5 KB|
| **New** |	|	| **31,235.1 us (+1%)** | **3031.2500 (-18%)** | **12525.78 KB (-18%)** |
| Old |Push|100|17,942.8 us|1406.2500|5846.09 KB|
| **New** |	|	| **18,001.2 us (0%)** | **593.7500 (-58%)** | **2518.75 KB (-57%)** |
| Old |Index|100|16,693.3 us|1250.0000|5171.09 KB|
| **New** |	|	| **16,898.0 us (+1%)** | **343.7500 (-73%)** | **1515.63 KB (-71%)** |
| Old |Map|100|4,334.2 us|1437.5000|5903.13 KB|
| **New** |	|	| **4,324.5 us (0%)** | **796.8750 (-45%)** | **3286.72 KB (-44%)** |
| Old |Apply|100|942.3 us|183.5938|752.34 KB|
| **New** |	|	| **960.3 us (+2%)** | **176.7578 (-4%)** | **727.34 KB (-3%)** |
| Old |JsonStringifyParse|100|5,271.2 us|1250.0000|5140.63 KB|
| **New** |	|	| **5,371.5 us (+2%)** | **1242.1875 (-1%)** | **5111.72 KB (-1%)** |


## Jint.Benchmark.ArrayStressBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|20|1.706 s|92437.5000|12562.5000|385.91 MB|
| **New** |	|	| **1.643 s (-4%)** | **60000.0000 (-35%)** | **5000.0000 (-60%)** | **249.81 MB (-35%)** |


## Jint.Benchmark.EvaluationBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Jint|20|765.5 us|134.7656|554.69 KB|
| **New** |	|	| **743.9 us (-3%)** | **120.1172 (-11%)** | **495.16 KB (-11%)** |


## Jint.Benchmark.LinqJsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Jint|10|76.41 ms|5187.5000|2500.0000|187.5000|30.71 MB|
| **New** |	|	| **71.07 ms (-7%)** | **5062.5000 (-2%)** | **2500.0000 (0%)** | **-** | **30.47 MB (-1%)** |


## Jint.Benchmark.MinimalScriptBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Jint|10|23.65 us|8.5144|34.92 KB|
| **New** |	|	| **22.37 us (-5%)** | **8.2092 (-4%)** | **33.67 KB (-4%)** |


## Jint.Benchmark.StopwatchBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|1|1.598 s|118562.5000|125.0000|474.43 MB|
| **New** |	|	| **1.535 s (-4%)** | **18875.0000 (-84%)** | **125.0000 (0%)** | **75.75 MB (-84%)** |


## Jint.Benchmark.UncacheableExpressionsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Benchmark|500|481.7 ms|94187.5000|250.0000|377.11 MB|
| **New** |	|	| **475.6 ms (-1%)** | **52812.5000 (-44%)** | **62.5000 (-75%)** | **211.35 MB (-44%)** |


