### PR TITLE
#451 prefer for over foreach when iterating Lists

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -883,12 +883,14 @@ namespace Jint
             }
 
             // process all variable declarations in the current parser scope
-            for (var i = 0; i < variableDeclarations.Count; i++)
+            var variableDeclarationsCount = variableDeclarations.Count;
+            for (var i = 0; i < variableDeclarationsCount; i++)
             {
                 var variableDeclaration = variableDeclarations[i];
-                var declarations  = variableDeclaration.Declarations;
-                foreach (var d in declarations)
+                var declarationsCount = variableDeclaration.Declarations.Count;
+                for (var j = 0; j < declarationsCount; j++)
                 {
+                    var d = variableDeclaration.Declarations[j];
                     var dn = d.Id.As<Identifier>().Name;
                     var varAlreadyDeclared = env.HasBinding(dn);
                     if (!varAlreadyDeclared)

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -100,15 +100,17 @@ namespace Jint.Native.Array
 
                 instance.SetOwnProperty("length", new WritablePropertyDescriptor(length));
             }
-            else if (arguments.Length == 1 && arguments.At(0).IsObject() && arguments.At(0).As<ObjectWrapper>() != null )
+            else if (arguments.Length == 1 && arguments[0] is ObjectWrapper objectWrapper)
             {
-                if (arguments.At(0).As<ObjectWrapper>().Target is IEnumerable enumerable)
+                if (objectWrapper.Target is IEnumerable enumerable)
                 {
                     var jsArray = (ArrayInstance) Engine.Array.Construct(Arguments.Empty);
+                    var tempArray = new JsValue[1];
                     foreach (var item in enumerable)
                     {
-                        var jsItem = JsValue.FromObject(Engine, item);
-                        Engine.Array.PrototypeObject.Push(jsArray, Arguments.From(jsItem));
+                        var jsItem = FromObject(Engine, item);
+                        tempArray[0] = jsItem;
+                        Engine.Array.PrototypeObject.Push(jsArray, tempArray);
                     }
 
                     return jsArray;

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -188,7 +188,8 @@ namespace Jint.Native.Array
                         for (var i = 0; i < keysCount; i++)
                         {
                             var keyIndex = keys[i];
-// is it the index of the array
+                            
+                            // is it the index of the array
                             if (keyIndex >= newLen && keyIndex < oldLen)
                             {
                                 var deleteSucceeded = Delete(TypeConverter.ToString(keyIndex), false);

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -184,9 +184,11 @@ namespace Jint.Native.Array
                         // in the case of sparse arrays, treat each concrete element instead of
                         // iterating over all indexes
                         var keys = new List<uint>(_sparse.Keys);
-                        foreach (var keyIndex in keys)
+                        var keysCount = keys.Count;
+                        for (var i = 0; i < keysCount; i++)
                         {
-                            // is it the index of the array
+                            var keyIndex = keys[i];
+// is it the index of the array
                             if (keyIndex >= newLen && keyIndex < oldLen)
                             {
                                 var deleteSucceeded = Delete(TypeConverter.ToString(keyIndex), false);
@@ -542,7 +544,7 @@ namespace Jint.Native.Array
             return _sparse.TryGetValue(index, out descriptor);
         }
 
-        private void WriteArrayValue(uint index, IPropertyDescriptor desc)
+        internal void WriteArrayValue(uint index, IPropertyDescriptor desc)
         {
             // calculate eagerly so we know if we outgrow
             var newSize = _dense != null && index >= _dense.Length

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -352,9 +352,10 @@ namespace Jint.Native.String
                     {
                         segments.Capacity = s.Length;
                     }
-                    foreach (var c in s)
+
+                    for (var i = 0; i < s.Length; i++)
                     {
-                        segments.Add(TypeConverter.ToString(c));
+                        segments.Add(TypeConverter.ToString(s[i]));
                     }
                 }
                 else

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -165,9 +165,9 @@ namespace Jint
 
         internal Predicate<Exception> _ClrExceptionsHandler => _clrExceptionsHandler;
 
-        internal IList<Assembly> _LookupAssemblies => _lookupAssemblies;
+        internal List<Assembly> _LookupAssemblies => _lookupAssemblies;
 
-        internal IEnumerable<IObjectConverter> _ObjectConverters => _objectConverters;
+        internal List<IObjectConverter> _ObjectConverters => _objectConverters;
 
         internal int _MaxStatements => _maxStatements;
 

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -658,8 +658,10 @@ namespace Jint.Runtime
             // http://www.ecma-international.org/ecma-262/5.1/#sec-11.1.5
 
             var obj = _engine.Object.Construct(Arguments.Empty);
-            foreach (var property in objectExpression.Properties)
+            var propertiesCount = objectExpression.Properties.Count;
+            for (var i = 0; i < propertiesCount; i++)
             {
+                var property = objectExpression.Properties[i];
                 var propName = property.Key.GetKey();
                 var previous = obj.GetOwnProperty(propName);
                 IPropertyDescriptor propDesc;
@@ -692,7 +694,7 @@ namespace Jint.Runtime
                             );
                         }
 
-                        propDesc = new PropertyDescriptor(get: get, set: null, enumerable: true, configurable:true);
+                        propDesc = new PropertyDescriptor(get: get, set: null, enumerable: true, configurable: true);
                         break;
 
                     case PropertyKind.Set:
@@ -706,15 +708,15 @@ namespace Jint.Runtime
                         ScriptFunctionInstance set;
                         using (new StrictModeScope(setter.Strict))
                         {
-
                             set = new ScriptFunctionInstance(
                                 _engine,
                                 setter,
                                 _engine.ExecutionContext.LexicalEnvironment,
                                 StrictModeScope.IsStrictModeCode
-                                );
+                            );
                         }
-                        propDesc = new PropertyDescriptor(get:null, set: set, enumerable: true, configurable: true);
+
+                        propDesc = new PropertyDescriptor(get: null, set: set, enumerable: true, configurable: true);
                         break;
 
                     default:
@@ -932,8 +934,10 @@ namespace Jint.Runtime
         public JsValue EvaluateSequenceExpression(SequenceExpression sequenceExpression)
         {
             var result = Undefined.Instance;
-            foreach (var expression in sequenceExpression.Expressions)
+            var expressionsCount = sequenceExpression.Expressions.Count;
+            for (var i = 0; i < expressionsCount; i++)
             {
+                var expression = sequenceExpression.Expressions[i];
                 result = _engine.GetValue(_engine.EvaluateExpression(expression.As<Expression>()), true);
             }
 

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -88,9 +88,7 @@ namespace Jint.Runtime.Interop
 
         public JsValue GetPath(string path)
         {
-            Type type;
-
-            if (Engine.TypeCache.TryGetValue(path, out type))
+            if (Engine.TypeCache.TryGetValue(path, out var type))
             {
                 if (type == null)
                 {
@@ -108,8 +106,10 @@ namespace Jint.Runtime.Interop
             // search in loaded assemblies
             var lookupAssemblies = new[] {Assembly.GetCallingAssembly(), Assembly.GetExecutingAssembly()};
 
-            foreach (var assembly in lookupAssemblies)
+            var lookupAssembliesLength = lookupAssemblies.Length;
+            for (var i = 0; i < lookupAssembliesLength; i++)
             {
+                var assembly = lookupAssemblies[i];
                 type = assembly.GetType(path);
                 if (type != null)
                 {

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -383,8 +383,11 @@ namespace Jint.Runtime
             JsValue v = Undefined.Instance;
             SwitchCase defaultCase = null;
             bool hit = false;
-            foreach (var clause in switchBlock)
+
+            var switchBlockCount = switchBlock.Count;
+            for (var i = 0; i < switchBlockCount; i++)
             {
+                var clause = switchBlock[i];
                 if (clause.Test == null)
                 {
                     defaultCase = clause;
@@ -408,7 +411,6 @@ namespace Jint.Runtime
 
                     v = r.Value != null ? r.Value : Undefined.Instance;
                 }
-
             }
 
             // do we need to execute the default case ?
@@ -434,8 +436,10 @@ namespace Jint.Runtime
 
             try
             {
-                foreach (var statement in statementList)
+                var statementListCount = statementList.Count;
+                for (var i = 0; i < statementListCount; i++)
                 {
+                    var statement = statementList[i];
                     s = statement.As<Statement>();
                     c = ExecuteStatement(s);
                     if (c.Type != Completion.Normal)
@@ -526,8 +530,10 @@ namespace Jint.Runtime
 
         public Completion ExecuteVariableDeclaration(VariableDeclaration statement)
         {
-            foreach (var declaration in statement.Declarations)
+            var declarationsCount = statement.Declarations.Count;
+            for (var i = 0; i < declarationsCount; i++)
             {
+                var declaration = statement.Declarations[i];
                 if (declaration.Init != null)
                 {
                     if (!(_engine.EvaluateExpression(declaration.Id.As<Identifier>()) is Reference lhs))


### PR DESCRIPTION
* As `for` is faster for `List`, now using it - `foreach` for normal array is the same speed as for
* RavenDB for one does a lot of conversions for arrays, so optimized array conversion array handling to go as near bare metal as possible, this will also reduce memory usage quite lot as `Arguments.From` was removed from inside the loop that always allocated new array - testing again RavenDB code base gave about roughly 4-5% improvement, memory usage reduction was harder to test

