### PR TITLE
JsString multiple concatination fails

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2384,5 +2384,21 @@ namespace Jint.Tests.Runtime
             var actualValue = engine.Execute(actual).GetCompletionValue().ToObject();
             Assert.Equal(expectedValue, actualValue);
         }
+	
+	[Fact]
+        public void ShouldReturnCorrectConcatenatedStrings()
+        {
+            RunTest(@"
+                function concat(x, a, b) { 
+                    x += a;
+                    x += b;
+                    return x; 
+                }");
+
+            var concat = _engine.GetValue("concat");
+            var result = concat.Invoke("concat", "well", "done").ToObject() as string;
+            Assert.Equal("concatwelldone", result);
+        }
+
     }
 }

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -164,6 +164,17 @@ namespace Jint.Native
 
                 return _value;
             }
+            
+            [Pure]
+            public override object ToObject()
+            {
+                if (_dirty)
+                {
+                    _value = _stringBuilder.ToString();
+                    _dirty = false;
+                }
+                return _value;
+            }
 
             public override JsString Append(JsValue jsValue)
             {

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -168,12 +168,7 @@ namespace Jint.Native
             [Pure]
             public override object ToObject()
             {
-                if (_dirty)
-                {
-                    _value = _stringBuilder.ToString();
-                    _dirty = false;
-                }
-                return _value;
+                return AsString();
             }
 
             public override JsString Append(JsValue jsValue)


### PR DESCRIPTION
If you concatenate strings more than once JSString (ConcatenatedString) delivers a wrong value, just the first concatenation works, overwriting ToObject in ConcatenatedString resolves this issue