### PR TITLE
#451 optimize evaluation performance

### DIFF
--- a/Jint.Benchmark/Jint.Benchmark.csproj
+++ b/Jint.Benchmark/Jint.Benchmark.csproj
@@ -12,13 +12,14 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include=".\Scripts\**" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\Jint.Tests.CommonScripts\Scripts\**" CopyToOutputDirectory="PreserveNewest" LinkBase="SunSpider" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.12" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
     <ProjectReference Include="..\Jint\Jint.csproj" />
     <PackageReference Include="Jurassic" Version="3.0.0-alpha2" />
     <PackageReference Include="NiL.JS.NetCore" Version="2.5.1200" />

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyOriginatorKeyFile>Jint.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Esprima" Version="1.0.0-beta-1026" />

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -105,14 +105,14 @@ namespace Jint.Native.Array
                 if (objectWrapper.Target is IEnumerable enumerable)
                 {
                     var jsArray = (ArrayInstance) Engine.Array.Construct(Arguments.Empty);
-                    var tempArray = new JsValue[1];
+                    var tempArray = Engine.JsValueArrayPool.RentArray(1);
                     foreach (var item in enumerable)
                     {
                         var jsItem = FromObject(Engine, item);
                         tempArray[0] = jsItem;
                         Engine.Array.PrototypeObject.Push(jsArray, tempArray);
                     }
-
+                    Engine.JsValueArrayPool.ReturnArray(tempArray);
                     return jsArray;
                 }
             }

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -14,6 +14,8 @@ namespace Jint.Native.Array
         private readonly Engine _engine;
 
         private const string PropertyNameLength = "length";
+        private const int PropertyNameLengthLength = 6;
+
         private IPropertyDescriptor _length;
 
         private const int MaxDenseArrayLength = 1024 * 10;
@@ -81,7 +83,7 @@ namespace Jint.Native.Array
             var oldLenDesc = _length;
             var oldLen = (uint) TypeConverter.ToNumber(oldLenDesc.Value);
 
-            if (propertyName == "length")
+            if (propertyName.Length == 6 && propertyName == "length")
             {
                 if (desc.Value == null)
                 {
@@ -290,7 +292,7 @@ namespace Jint.Native.Array
 
         protected override void AddProperty(string propertyName, IPropertyDescriptor descriptor)
         {
-            if (propertyName == PropertyNameLength)
+            if (propertyName.Length == PropertyNameLengthLength && propertyName == PropertyNameLength)
             {
                 _length = descriptor;
                 return;
@@ -300,7 +302,7 @@ namespace Jint.Native.Array
 
         protected override bool TryGetProperty(string propertyName, out IPropertyDescriptor descriptor)
         {
-            if (propertyName == PropertyNameLength)
+            if (propertyName.Length == PropertyNameLengthLength && propertyName == PropertyNameLength)
             {
                 descriptor = _length;
                 return _length != null;
@@ -351,7 +353,7 @@ namespace Jint.Native.Array
                 return PropertyDescriptor.Undefined;
             }
 
-            if (propertyName == PropertyNameLength)
+            if (propertyName.Length == PropertyNameLengthLength && propertyName == PropertyNameLength)
             {
                 return _length ?? PropertyDescriptor.Undefined;
             }
@@ -365,7 +367,7 @@ namespace Jint.Native.Array
             {
                 WriteArrayValue(index, desc);
             }
-            else if (propertyName == PropertyNameLength)
+            else if (propertyName.Length == PropertyNameLengthLength && propertyName == PropertyNameLength)
             {
                 _length = desc;
             }

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -175,7 +175,7 @@ namespace Jint.Native.Array
             var a = (ArrayInstance) Engine.Array.Construct(Arguments.Empty);
 
             uint to = 0;
-            var args = new JsValue[3];
+            var args = Engine.JsValueArrayPool.RentArray(3);
             for (uint k = 0; k < len; k++)
             {
                 if (o.TryGetValue(k, out var kvalue))
@@ -191,6 +191,7 @@ namespace Jint.Native.Array
                     }
                 }
             }
+            Engine.JsValueArrayPool.ReturnArray(args);
 
             return a;
         }
@@ -205,8 +206,12 @@ namespace Jint.Native.Array
 
             var callable = GetCallable(callbackfn);
 
-            var a = Engine.Array.Construct(new JsValue[] {len}, len);
-            var args = new JsValue[3];
+            var jsValues = Engine.JsValueArrayPool.RentArray(1);
+            jsValues[0] = len;
+            var a = Engine.Array.Construct(jsValues, len);
+            Engine.JsValueArrayPool.ReturnArray(jsValues);
+            
+            var args = Engine.JsValueArrayPool.RentArray(3);
             for (uint k = 0; k < len; k++)
             {
                 if (o.TryGetValue(k, out var kvalue))
@@ -218,6 +223,8 @@ namespace Jint.Native.Array
                     a.SetIndexValue(k, mappedValue, throwOnError: false);
                 }
             }
+
+            Engine.JsValueArrayPool.ReturnArray(args);
 
             return a;
         }
@@ -232,7 +239,7 @@ namespace Jint.Native.Array
 
             var callable = GetCallable(callbackfn);
 
-            var args = new JsValue[3];
+            var args = Engine.JsValueArrayPool.RentArray(3);
             for (uint k = 0; k < len; k++)
             {
                 if (o.TryGetValue(k, out var kvalue))
@@ -243,6 +250,7 @@ namespace Jint.Native.Array
                     callable.Call(thisArg, args);
                 }
             }
+            Engine.JsValueArrayPool.ReturnArray(args);
 
             return Undefined;
         }
@@ -257,7 +265,7 @@ namespace Jint.Native.Array
 
             var callable = GetCallable(callbackfn);
 
-            var args = new JsValue[3];
+            var args = Engine.JsValueArrayPool.RentArray(3);
             for (uint k = 0; k < len; k++)
             {
                 if (o.TryGetValue(k, out var kvalue))
@@ -272,6 +280,7 @@ namespace Jint.Native.Array
                     }
                 }
             }
+            Engine.JsValueArrayPool.ReturnArray(args);
 
             return false;
         }
@@ -286,7 +295,7 @@ namespace Jint.Native.Array
 
             var callable = GetCallable(callbackfn);
 
-            var args = new JsValue[3];
+            var args = Engine.JsValueArrayPool.RentArray(3);
             for (uint k = 0; k < len; k++)
             {
                 if (o.TryGetValue(k, out var kvalue))
@@ -301,6 +310,7 @@ namespace Jint.Native.Array
                     }
                 }
             }
+            Engine.JsValueArrayPool.ReturnArray(args);
 
             return JsBoolean.True;
         }

--- a/Jint/Native/Function/FunctionInstance.cs
+++ b/Jint/Native/Function/FunctionInstance.cs
@@ -9,8 +9,11 @@ namespace Jint.Native.Function
     public abstract class FunctionInstance : ObjectInstance, ICallable
     {
         private const string PropertyNamePrototype = "prototype";
+        private const int PropertyNamePrototypeLength = 9;
         private IPropertyDescriptor _prototype;
+
         private const string PropertyNameLength = "length";
+        private const int PropertyNameLengthLength = 6;
         private IPropertyDescriptor _length;
 
         private readonly Engine _engine;
@@ -84,8 +87,9 @@ namespace Jint.Native.Function
         {
             var v = base.Get(propertyName);
 
-            var f = v.As<FunctionInstance>();
-            if (propertyName == "caller" && f != null && f.Strict)
+            if (propertyName.Length == 6
+                && propertyName == "caller"
+                && ((v.As<FunctionInstance>()?.Strict).GetValueOrDefault()))
             {
                 throw new JavaScriptException(_engine.TypeError);
             }
@@ -112,11 +116,11 @@ namespace Jint.Native.Function
 
         public override IPropertyDescriptor GetOwnProperty(string propertyName)
         {
-            if (propertyName == PropertyNamePrototype)
+            if (propertyName.Length == PropertyNamePrototypeLength && propertyName == PropertyNamePrototype)
             {
                 return _prototype ?? PropertyDescriptor.Undefined;
             }
-            if (propertyName == PropertyNameLength)
+            if (propertyName.Length == PropertyNameLengthLength && propertyName == PropertyNameLength)
             {
                 return _length ?? PropertyDescriptor.Undefined;
             }
@@ -126,11 +130,11 @@ namespace Jint.Native.Function
 
         protected internal override void SetOwnProperty(string propertyName, IPropertyDescriptor desc)
         {
-            if (propertyName == PropertyNamePrototype)
+            if (propertyName.Length == PropertyNamePrototypeLength && propertyName == PropertyNamePrototype)
             {
                 _prototype = desc;
             }
-            else if (propertyName == PropertyNameLength)
+            else if (propertyName.Length == PropertyNameLengthLength && propertyName == PropertyNameLength)
             {
                 _length = desc;
             }
@@ -142,11 +146,11 @@ namespace Jint.Native.Function
 
         public override bool HasOwnProperty(string propertyName)
         {
-            if (propertyName == PropertyNamePrototype)
+            if (propertyName.Length == PropertyNamePrototypeLength && propertyName == PropertyNamePrototype)
             {
                 return _prototype != null;
             }
-            if (propertyName == PropertyNameLength)
+            if (propertyName.Length == PropertyNameLengthLength && propertyName == PropertyNameLength)
             {
                 return _length != null;
             }
@@ -156,11 +160,11 @@ namespace Jint.Native.Function
 
         public override void RemoveOwnProperty(string propertyName)
         {
-            if (propertyName == PropertyNamePrototype)
+            if (propertyName.Length == PropertyNamePrototypeLength && propertyName == PropertyNamePrototype)
             {
                 _prototype = null;
             }
-            if (propertyName == PropertyNameLength)
+            if (propertyName.Length == PropertyNameLengthLength && propertyName == PropertyNameLength)
             {
                 _prototype = null;
             }

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -16,6 +16,7 @@ namespace Jint.Native.Function
     public sealed class ScriptFunctionInstance : FunctionInstance, IConstructor
     {
         private const string PropertyNameName = "name";
+        private const int PropertyNameNameLength = 4;
 
         private IPropertyDescriptor _name;
 
@@ -74,7 +75,7 @@ namespace Jint.Native.Function
 
         public override IPropertyDescriptor GetOwnProperty(string propertyName)
         {
-            if (propertyName == PropertyNameName)
+            if (propertyName.Length == PropertyNameNameLength && propertyName == PropertyNameName)
             {
                 return _name ?? PropertyDescriptor.Undefined;
             }
@@ -84,7 +85,7 @@ namespace Jint.Native.Function
 
         protected internal override void SetOwnProperty(string propertyName, IPropertyDescriptor desc)
         {
-            if (propertyName == PropertyNameName)
+            if (propertyName.Length == PropertyNameNameLength && propertyName == PropertyNameName)
             {
                 _name = desc;
             }
@@ -96,7 +97,7 @@ namespace Jint.Native.Function
 
         public override bool HasOwnProperty(string propertyName)
         {
-            if (propertyName == PropertyNameName)
+            if (propertyName.Length == PropertyNameNameLength && propertyName == PropertyNameName)
             {
                 return _name != null;
             }
@@ -106,7 +107,7 @@ namespace Jint.Native.Function
 
         public override void RemoveOwnProperty(string propertyName)
         {
-            if (propertyName == PropertyNameName)
+            if (propertyName.Length == PropertyNameNameLength && propertyName == PropertyNameName)
             {
                 _name = null;
             }
@@ -236,6 +237,7 @@ namespace Jint.Native.Function
         private class ObjectInstanceWithConstructor : ObjectInstance
         {
             private const string PropertyNameConstructor = "constructor";
+            private const int PropertyNameConstructorLength = 11;
             private IPropertyDescriptor _constructor;
 
             public ObjectInstanceWithConstructor(Engine engine, ObjectInstance thisObj) : base(engine)
@@ -258,7 +260,7 @@ namespace Jint.Native.Function
 
             public override IPropertyDescriptor GetOwnProperty(string propertyName)
             {
-                if (propertyName == PropertyNameConstructor)
+                if (propertyName.Length == PropertyNameConstructorLength && propertyName == PropertyNameConstructor)
                 {
                     return _constructor ?? PropertyDescriptor.Undefined;
                 }
@@ -268,7 +270,7 @@ namespace Jint.Native.Function
 
             protected internal override void SetOwnProperty(string propertyName, IPropertyDescriptor desc)
             {
-                if (propertyName == PropertyNameConstructor)
+                if (propertyName.Length == PropertyNameConstructorLength && propertyName == PropertyNameConstructor)
                 {
                     _constructor = desc;
                 }
@@ -280,7 +282,7 @@ namespace Jint.Native.Function
 
             public override bool HasOwnProperty(string propertyName)
             {
-                if (propertyName == PropertyNameConstructor)
+                if (propertyName.Length == PropertyNameConstructorLength && propertyName == PropertyNameConstructor)
                 {
                     return _constructor != null;
                 }
@@ -290,7 +292,7 @@ namespace Jint.Native.Function
 
             public override void RemoveOwnProperty(string propertyName)
             {
-                if (propertyName == PropertyNameConstructor)
+                if (propertyName.Length == PropertyNameConstructorLength && propertyName == PropertyNameConstructor)
                 {
                     _constructor = null;
                 }

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -401,7 +401,12 @@ namespace Jint.Native.Object
                 .Where(x => x.Value.Enumerable.HasValue && x.Value.Enumerable.Value)
                 .ToArray();
             var n = enumerableProperties.Length;
-            var array = Engine.Array.Construct(new JsValue[] {n}, (uint) n);
+
+            var args = _engine.JsValueArrayPool.RentArray(1);
+            args[0] = n;
+            var array = Engine.Array.Construct(args, (uint) n);
+            _engine.JsValueArrayPool.ReturnArray(args);
+
             uint index = 0;
             foreach (var prop in enumerableProperties)
             {

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -9,6 +9,8 @@ namespace Jint.Native.String
     public class StringInstance : ObjectInstance, IPrimitiveInstance
     {
         private const string PropertyNameLength = "length";
+        private const int PropertyNameLengthLength = 6;
+
         private IPropertyDescriptor _length;
 
         public StringInstance(Engine engine)
@@ -37,12 +39,12 @@ namespace Jint.Native.String
 
         public override IPropertyDescriptor GetOwnProperty(string propertyName)
         {
-            if (propertyName == "Infinity")
+            if (propertyName.Length == 8 && propertyName == "Infinity")
             {
                 return PropertyDescriptor.Undefined;
             }
 
-            if (propertyName == PropertyNameLength)
+            if (propertyName.Length == PropertyNameLengthLength && propertyName == PropertyNameLength)
             {
                 return _length ?? PropertyDescriptor.Undefined;
             }
@@ -90,7 +92,7 @@ namespace Jint.Native.String
 
         protected internal override void SetOwnProperty(string propertyName, IPropertyDescriptor desc)
         {
-            if (propertyName == PropertyNameLength)
+            if (propertyName.Length == PropertyNameLengthLength && propertyName == PropertyNameLength)
             {
                 _length = desc;
             }
@@ -102,7 +104,7 @@ namespace Jint.Native.String
 
         public override bool HasOwnProperty(string propertyName)
         {
-            if (propertyName == PropertyNameLength)
+            if (propertyName.Length == PropertyNameLengthLength && propertyName == PropertyNameLength)
             {
                 return _length != null;
             }
@@ -112,7 +114,7 @@ namespace Jint.Native.String
 
         public override void RemoveOwnProperty(string propertyName)
         {
-            if (propertyName == PropertyNameLength)
+            if (propertyName.Length == PropertyNameLengthLength && propertyName == PropertyNameLength)
             {
                 _length = null;
             }

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -268,7 +268,11 @@ namespace Jint.Native.String
             }
             else if (ReferenceEquals(separator, Undefined))
             {
-                return (ArrayInstance)Engine.Array.Construct(Arguments.From(s));
+                var jsValues = Engine.JsValueArrayPool.RentArray(1);
+                jsValues[0] = s;
+                var arrayInstance = (ArrayInstance)Engine.Array.Construct(jsValues);
+                Engine.JsValueArrayPool.ReturnArray(jsValues);
+                return arrayInstance;
             }
             else
             {
@@ -581,12 +585,14 @@ namespace Jint.Native.String
                     return thisString;
                 int end = start + substr.Length;
 
-                var args = new JsValue[3];
+                var args = Engine.JsValueArrayPool.RentArray(3);
                 args[0] = substr;
                 args[1] = start;
                 args[2] = thisString;
 
                 var replaceString = TypeConverter.ToString(replaceFunction.Call(Undefined, args));
+                
+                Engine.JsValueArrayPool.ReturnArray(args);
 
                 // Replace only the first match.
                 var result = StringExecutionContext.Current.GetStringBuilder(thisString.Length + (substr.Length - substr.Length));

--- a/Jint/Pooling/JsValueArrayPool.cs
+++ b/Jint/Pooling/JsValueArrayPool.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Jint.Native;
+
+namespace Jint.Pooling
+{
+    /// <summary>
+    /// Cache reusable <see cref="JsValue" /> array instances as we allocate them a lot.
+    /// </summary>
+    internal sealed class JsValueArrayPool
+    {
+        private const int PoolSize = 15;
+        private readonly ObjectPool<JsValue[]> _poolArray1;
+        private readonly ObjectPool<JsValue[]> _poolArray2;
+        private readonly ObjectPool<JsValue[]> _poolArray3;
+
+        public JsValueArrayPool()
+        {
+            _poolArray1 = new ObjectPool<JsValue[]>(Factory1, PoolSize);
+            _poolArray2 = new ObjectPool<JsValue[]>(Factory2, PoolSize);
+            _poolArray3 = new ObjectPool<JsValue[]>(Factory3, PoolSize);
+        }
+
+        private static JsValue[] Factory1()
+        {
+            return new JsValue[1];
+        }
+
+        private static JsValue[] Factory2()
+        {
+            return new JsValue[2];
+        }
+
+        private static JsValue[] Factory3()
+        {
+            return new JsValue[3];
+        }
+
+        public JsValue[] RentArray(int size)
+        {
+            switch (size)
+            {
+                case 0:
+                    return Array.Empty<JsValue>();
+                case 1:
+                    return _poolArray1.Allocate();
+                case 2:
+                    return _poolArray2.Allocate();
+                case 3:
+                    return _poolArray3.Allocate();
+            }
+
+            return new JsValue[size];
+        }
+
+        public void ReturnArray(JsValue[] array)
+        {
+            switch (array.Length)
+            {
+                case 1:
+                    _poolArray1.Free(array);
+                    break;
+                case 2:
+                    _poolArray2.Free(array);
+                    break;
+                case 3:
+                    _poolArray3.Free(array);
+                    break;
+            }
+        }
+    }
+}

--- a/Jint/Runtime/Arguments.cs
+++ b/Jint/Runtime/Arguments.cs
@@ -6,7 +6,7 @@ namespace Jint.Runtime
 {
     public static class Arguments
     {
-        public static JsValue[] Empty = new JsValue[0];
+        public static readonly JsValue[] Empty = Array.Empty<JsValue>();
 
         public static JsValue[] From(params JsValue[] o)
         {

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -148,7 +148,7 @@ namespace Jint.Runtime.Debugger
         {
             var info = new DebugInformation { CurrentStatement = statement, CallStack = _debugCallStack };
 
-            if (_engine.ExecutionContext != null && _engine.ExecutionContext.LexicalEnvironment != null)
+            if (_engine.ExecutionContext?.LexicalEnvironment != null)
             {
                 var lexicalEnvironment = _engine.ExecutionContext.LexicalEnvironment;
                 info.Locals = GetLocalVariables(lexicalEnvironment);

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -24,7 +24,7 @@ namespace Jint.Runtime.Environments
 
         public override bool HasBinding(string name)
         {
-            if (name == BindingNameArguments)
+            if (name.Length == 9 && name == BindingNameArguments)
             {
                 return _argumentsBinding != null;
             }

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -139,7 +139,7 @@ namespace Jint.Runtime.Interop
                 {
                     if (type == typeof(Action))
                     {
-                        return (Action)(() => function(JsValue.Undefined, new JsValue[0]));
+                        return (Action)(() => function(JsValue.Undefined, Array.Empty<JsValue>()));
                     }
                     else if (typeof(MulticastDelegate).IsAssignableFrom(type))
                     {

--- a/Jint/StrictModeScope.cs
+++ b/Jint/StrictModeScope.cs
@@ -2,7 +2,7 @@
 
 namespace Jint
 {
-    public class StrictModeScope : IDisposable
+    public readonly struct StrictModeScope : IDisposable
     {
         private readonly bool _strict;
         private readonly bool _force;
@@ -21,12 +21,15 @@ namespace Jint
                 _forcedRefCount = _refCount;
                 _refCount = 0;
             }
+            else
+            {
+                _forcedRefCount = 0;
+            }
 
             if (_strict)
             {
                 _refCount++;
             }
-
         }
 
         public void Dispose()
@@ -42,21 +45,6 @@ namespace Jint
             } 
         }
 
-        public static bool IsStrictModeCode
-        {
-            get { return _refCount > 0; }
-        }
-
-        public static int RefCount
-        {
-            get
-            {
-                return _refCount;
-            }
-            set
-            {
-                _refCount = value;
-            }
-        }
+        public static bool IsStrictModeCode => _refCount > 0;
     }
 }


### PR DESCRIPTION
* make StrictModeScope a struct
* prioritize statement branching
* reuse JsValue array instances
* check string length before equality (can save some 20% if less likely to hit)


## Esprima.Benchmark.DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|dromaeo-3d-cube|103.35 ms|1312.5000|250.0000|-|7107.59 KB|
| **New** |	|	| **101.68 ms (-2%)** | **1250.0000 (-5%)** | **312.5000 (+25%)** | **-** | **6812.54 KB (-4%)** |
| Old |Run|dromaeo-core-eval|24.70 ms|62.5000|-|-|298.95 KB|
| **New** |	|	| **23.89 ms (-3%)** | **62.5000 (0%)** | **-** | **-** | **298.55 KB (0%)** |
| Old |Run|dromaeo-object-array|259.58 ms|39500.0000|2000.0000|1000.0000|166027.24 KB|
| **New** |	|	| **255.24 ms (-2%)** | **39125.0000 (-1%)** | **2000.0000 (0%)** | **1000.0000 (0%)** | **164345.05 KB (-1%)** |
| Old |Run|dromaeo-object-regexp|1,142.73 ms|57750.0000|34750.0000|22125.0000|433170.74 KB|
| **New** |	|	| **1,158.63 ms (+1%)** | **56437.5000 (-2%)** | **34687.5000 (0%)** | **21812.5000 (-1%)** | **430615.03 KB (-1%)** |
| Old |Run|dromaeo-object-string|1,359.54 ms|220812.5000|178437.5000|175812.5000|1392803.07 KB|
| **New** |	|	| **1,360.40 ms (0%)** | **218375.0000 (-1%)** | **177000.0000 (-1%)** | **174187.5000 (-1%)** | **1390250.42 KB (0%)** |
| Old |Run|dromaeo-string-base64|234.61 ms|6187.5000|187.5000|-|26458.12 KB|
| **New** |	|	| **229.69 ms (-2%)** | **5437.5000 (-12%)** | **437.5000 (+133%)** | **-** | **23300.13 KB (-12%)** |


## Jint.Benchmark.ArrayBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Slice|100|671.5 us|145.5078|598.44 KB|
| **New** |	|	| **666.6 us (-1%)** | **145.5078 (0%)** | **596.09 KB (0%)** |
| Old |Concat|100|797.6 us|162.1094|666.41 KB|
| **New** |	|	| **787.3 us (-1%)** | **160.1563 (-1%)** | **657.81 KB (-1%)** |
| Old |Unshift|100|30,480.2 us|3031.2500|12525.78 KB|
| **New** |	|	| **30,568.4 us (0%)** | **2968.7500 (-2%)** | **12267.19 KB (-2%)** |
| Old |Push|100|17,942.4 us|593.7500|2518.75 KB|
| **New** |	|	| **17,673.1 us (-2%)** | **531.2500 (-11%)** | **2260.16 KB (-10%)** |
| Old |Index|100|16,595.0 us|343.7500|1515.63 KB|
| **New** |	|	| **16,299.8 us (-2%)** | **343.7500 (0%)** | **1510.16 KB (0%)** |
| Old |Map|100|4,150.7 us|796.8750|3286.72 KB|
| **New** |	|	| **4,050.0 us (-2%)** | **750.0000 (-6%)** | **3083.59 KB (-6%)** |
| Old |Apply|100|933.3 us|176.7578|727.34 KB|
| **New** |	|	| **941.8 us (+1%)** | **175.7813 (-1%)** | **721.09 KB (-1%)** |
| Old |JsonStringifyParse|100|5,289.6 us|1242.1875|5111.72 KB|
| **New** |	|	| **5,127.9 us (-3%)** | **1242.1875 (0%)** | **5103.13 KB (0%)** |


## Jint.Benchmark.ArrayStressBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|20|1.646 s|60000.0000|5000.0000|249.81 MB|
| **New** |	|	| **1.510 s (-8%)** | **59937.5000 (0%)** | **1062.5000 (-79%)** | **241.6 MB (-3%)** |


## Jint.Benchmark.UncacheableExpressionsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Benchmark|500|461.2 ms|52812.5000|62.5000|211.35 MB|
| **New** |	|	| **464.0 ms (+1%)** | **50375.0000 (-5%)** | **375.0000 (+500%)** | **201.85 MB (-4%)** |


