### PR TITLE
Reduce virtual calls and optimize JsValue equality checks

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -206,7 +206,7 @@ namespace Jint
 
         public GlobalSymbolRegistry GlobalSymbolRegistry { get; }
 
-        internal Options Options { get; }
+        internal Options Options { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         internal ReferencePool ReferencePool { get; }
         internal CompletionPool CompletionPool { get; }
@@ -520,7 +520,7 @@ namespace Jint
         internal JsValue GetValue(object value, bool returnReferenceToPool)
         {
             var jsValue = value as JsValue;
-            if (jsValue != null)
+            if (!ReferenceEquals(jsValue, null))
             {
                 return jsValue;
             }
@@ -591,7 +591,7 @@ namespace Jint
             }
 
             var record = (EnvironmentRecord) baseValue;
-            if (record == null)
+            if (ReferenceEquals(record, null))
             {
                 throw new ArgumentException();
             }
@@ -639,7 +639,7 @@ namespace Jint
                 var baseValue = reference.GetBase();
                 var record = baseValue as EnvironmentRecord;
 
-                if (record == null)
+                if (ReferenceEquals(record, null))
                 {
                     throw new ArgumentNullException();
                 }
@@ -838,7 +838,7 @@ namespace Jint
                 }
                 else
                 {
-                    if (env == GlobalEnvironment.Record)
+                    if (ReferenceEquals(env, GlobalEnvironment.Record))
                     {
                         var go = Global;
                         var existingProp = go.GetProperty(fn);
@@ -876,7 +876,7 @@ namespace Jint
                 {
                     var declEnv = env as DeclarativeEnvironmentRecord;
 
-                    if (declEnv == null)
+                    if (ReferenceEquals(declEnv, null))
                     {
                         throw new ArgumentException();
                     }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -382,64 +382,64 @@ namespace Jint
             switch (statement.Type)
             {
                 case Nodes.BlockStatement:
-                    return _statements.ExecuteBlockStatement(statement.As<BlockStatement>());
+                    return _statements.ExecuteBlockStatement((BlockStatement) statement);
 
                 case Nodes.ReturnStatement:
-                    return _statements.ExecuteReturnStatement(statement.As<ReturnStatement>());
+                    return _statements.ExecuteReturnStatement((ReturnStatement) statement);
 
                 case Nodes.VariableDeclaration:
-                    return _statements.ExecuteVariableDeclaration(statement.As<VariableDeclaration>());
+                    return _statements.ExecuteVariableDeclaration((VariableDeclaration) statement);
 
                 case Nodes.BreakStatement:
-                    return _statements.ExecuteBreakStatement(statement.As<BreakStatement>());
+                    return _statements.ExecuteBreakStatement((BreakStatement) statement);
 
                 case Nodes.ContinueStatement:
-                    return _statements.ExecuteContinueStatement(statement.As<ContinueStatement>());
+                    return _statements.ExecuteContinueStatement((ContinueStatement) statement);
 
                 case Nodes.DoWhileStatement:
-                    return _statements.ExecuteDoWhileStatement(statement.As<DoWhileStatement>());
+                    return _statements.ExecuteDoWhileStatement((DoWhileStatement) statement);
 
                 case Nodes.EmptyStatement:
-                    return _statements.ExecuteEmptyStatement(statement.As<EmptyStatement>());
+                    return _statements.ExecuteEmptyStatement((EmptyStatement) statement);
 
                 case Nodes.ExpressionStatement:
-                    return _statements.ExecuteExpressionStatement(statement.As<ExpressionStatement>());
+                    return _statements.ExecuteExpressionStatement((ExpressionStatement) statement);
 
                 case Nodes.ForStatement:
-                    return _statements.ExecuteForStatement(statement.As<ForStatement>());
+                    return _statements.ExecuteForStatement((ForStatement) statement);
 
                 case Nodes.ForInStatement:
-                    return _statements.ExecuteForInStatement(statement.As<ForInStatement>());
+                    return _statements.ExecuteForInStatement((ForInStatement) statement);
 
                 case Nodes.IfStatement:
-                    return _statements.ExecuteIfStatement(statement.As<IfStatement>());
+                    return _statements.ExecuteIfStatement((IfStatement) statement);
 
                 case Nodes.LabeledStatement:
-                    return _statements.ExecuteLabeledStatement(statement.As<LabeledStatement>());
+                    return _statements.ExecuteLabeledStatement((LabeledStatement) statement);
 
                 case Nodes.SwitchStatement:
-                    return _statements.ExecuteSwitchStatement(statement.As<SwitchStatement>());
+                    return _statements.ExecuteSwitchStatement((SwitchStatement) statement);
 
                 case Nodes.FunctionDeclaration:
                     return Completion.Empty;
 
                 case Nodes.ThrowStatement:
-                    return _statements.ExecuteThrowStatement(statement.As<ThrowStatement>());
+                    return _statements.ExecuteThrowStatement((ThrowStatement) statement);
 
                 case Nodes.TryStatement:
-                    return _statements.ExecuteTryStatement(statement.As<TryStatement>());
+                    return _statements.ExecuteTryStatement((TryStatement) statement);
 
                 case Nodes.WhileStatement:
-                    return _statements.ExecuteWhileStatement(statement.As<WhileStatement>());
+                    return _statements.ExecuteWhileStatement((WhileStatement) statement);
 
                 case Nodes.WithStatement:
-                    return _statements.ExecuteWithStatement(statement.As<WithStatement>());
+                    return _statements.ExecuteWithStatement((WithStatement) statement);
 
                 case Nodes.DebuggerStatement:
-                    return _statements.ExecuteDebuggerStatement(statement.As<DebuggerStatement>());
+                    return _statements.ExecuteDebuggerStatement((DebuggerStatement) statement);
 
                 case Nodes.Program:
-                    return _statements.ExecuteProgram(statement.As<Program>());
+                    return _statements.ExecuteProgram((Program) statement);
 
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -453,52 +453,52 @@ namespace Jint
             switch (expression.Type)
             {
                 case Nodes.AssignmentExpression:
-                    return _expressions.EvaluateAssignmentExpression(expression.As<AssignmentExpression>());
+                    return _expressions.EvaluateAssignmentExpression((AssignmentExpression) expression);
 
                 case Nodes.ArrayExpression:
-                    return _expressions.EvaluateArrayExpression(expression.As<ArrayExpression>());
+                    return _expressions.EvaluateArrayExpression((ArrayExpression) expression);
 
                 case Nodes.BinaryExpression:
-                    return _expressions.EvaluateBinaryExpression(expression.As<BinaryExpression>());
+                    return _expressions.EvaluateBinaryExpression((BinaryExpression) expression);
 
                 case Nodes.CallExpression:
-                    return _expressions.EvaluateCallExpression(expression.As<CallExpression>());
+                    return _expressions.EvaluateCallExpression((CallExpression) expression);
 
                 case Nodes.ConditionalExpression:
-                    return _expressions.EvaluateConditionalExpression(expression.As<ConditionalExpression>());
+                    return _expressions.EvaluateConditionalExpression((ConditionalExpression) expression);
 
                 case Nodes.FunctionExpression:
-                    return _expressions.EvaluateFunctionExpression(expression.As<IFunction>());
+                    return _expressions.EvaluateFunctionExpression((IFunction) expression);
 
                 case Nodes.Identifier:
-                    return _expressions.EvaluateIdentifier(expression.As<Identifier>());
+                    return _expressions.EvaluateIdentifier((Identifier) expression);
 
                 case Nodes.Literal:
-                    return _expressions.EvaluateLiteral(expression.As<Literal>());
+                    return _expressions.EvaluateLiteral((Literal) expression);
 
                 case Nodes.LogicalExpression:
-                    return _expressions.EvaluateLogicalExpression(expression.As<BinaryExpression>());
+                    return _expressions.EvaluateLogicalExpression((BinaryExpression) expression);
 
                 case Nodes.MemberExpression:
-                    return _expressions.EvaluateMemberExpression(expression.As<MemberExpression>());
+                    return _expressions.EvaluateMemberExpression((MemberExpression) expression);
 
                 case Nodes.NewExpression:
-                    return _expressions.EvaluateNewExpression(expression.As<NewExpression>());
+                    return _expressions.EvaluateNewExpression((NewExpression) expression);
 
                 case Nodes.ObjectExpression:
-                    return _expressions.EvaluateObjectExpression(expression.As<ObjectExpression>());
+                    return _expressions.EvaluateObjectExpression((ObjectExpression) expression);
 
                 case Nodes.SequenceExpression:
-                    return _expressions.EvaluateSequenceExpression(expression.As<SequenceExpression>());
+                    return _expressions.EvaluateSequenceExpression((SequenceExpression) expression);
 
                 case Nodes.ThisExpression:
-                    return _expressions.EvaluateThisExpression(expression.As<ThisExpression>());
+                    return _expressions.EvaluateThisExpression((ThisExpression) expression);
 
                 case Nodes.UpdateExpression:
-                    return _expressions.EvaluateUpdateExpression(expression.As<UpdateExpression>());
+                    return _expressions.EvaluateUpdateExpression((UpdateExpression) expression);
 
                 case Nodes.UnaryExpression:
-                    return _expressions.EvaluateUnaryExpression(expression.As<UnaryExpression>());
+                    return _expressions.EvaluateUnaryExpression((UnaryExpression) expression);
 
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -519,7 +519,8 @@ namespace Jint
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal JsValue GetValue(object value, bool returnReferenceToPool)
         {
-            if (value is JsValue jsValue)
+            var jsValue = value as JsValue;
+            if (jsValue != null)
             {
                 return jsValue;
             }
@@ -843,13 +844,14 @@ namespace Jint
                         var existingProp = go.GetProperty(fn);
                         if (existingProp.Configurable)
                         {
-                            go.DefineOwnProperty(fn,
-                                new PropertyDescriptor(
-                                    value: Undefined.Instance,
-                                    writable: true,
-                                    enumerable: true,
-                                    configurable: configurableBindings
-                                ), true);
+                            var flags = PropertyFlag.Writable | PropertyFlag.Enumerable;
+                            if (configurableBindings)
+                            {
+                                flags |= PropertyFlag.Configurable;
+                            }
+
+                            var descriptor = new PropertyDescriptor(Undefined.Instance, flags);
+                            go.DefineOwnProperty(fn, descriptor, true);
                         }
                         else
                         {
@@ -896,7 +898,7 @@ namespace Jint
                 for (var j = 0; j < declarationsCount; j++)
                 {
                     var d = variableDeclaration.Declarations[j];
-                    var dn = d.Id.As<Identifier>().Name;
+                    var dn = ((Identifier) d.Id).Name;
                     var varAlreadyDeclared = env.HasBinding(dn);
                     if (!varAlreadyDeclared)
                     {

--- a/Jint/Native/Argument/ArgumentsInstance.cs
+++ b/Jint/Native/Argument/ArgumentsInstance.cs
@@ -107,7 +107,7 @@ namespace Jint.Native.Argument
         {
             EnsureInitialized();
 
-            if (!Strict && ParameterMap != null)
+            if (!Strict && !ReferenceEquals(ParameterMap, null))
             {
                 var desc = base.GetOwnProperty(propertyName);
                 if (desc == PropertyDescriptor.Undefined)
@@ -172,7 +172,7 @@ namespace Jint.Native.Argument
         {
             EnsureInitialized();
 
-            if (!Strict && ParameterMap != null)
+            if (!Strict && !ReferenceEquals(ParameterMap, null))
             {
                 var map = ParameterMap;
                 var isMapped = map.GetOwnProperty(propertyName);
@@ -193,9 +193,10 @@ namespace Jint.Native.Argument
                     }
                     else
                     {
-                        if (desc.Value != null && desc.Value != Undefined)
+                        var descValue = desc.Value;
+                        if (!ReferenceEquals(descValue, null) && !ReferenceEquals(descValue, Undefined))
                         {
-                            map.Put(propertyName, desc.Value, throwOnError);
+                            map.Put(propertyName, descValue, throwOnError);
                         }
 
                         if (desc.WritableSet && !desc.Writable)
@@ -215,7 +216,7 @@ namespace Jint.Native.Argument
         {
             EnsureInitialized();
 
-            if (!Strict && ParameterMap != null)
+            if (!Strict && !ReferenceEquals(ParameterMap, null))
             {
                 var map = ParameterMap;
                 var isMapped = map.GetOwnProperty(propertyName);

--- a/Jint/Native/Argument/ArgumentsInstance.cs
+++ b/Jint/Native/Argument/ArgumentsInstance.cs
@@ -93,8 +93,9 @@ namespace Jint.Native.Argument
             else
             {
                 var thrower = Engine.Function.ThrowTypeError;
-                self.DefineOwnProperty("caller", new GetSetPropertyDescriptor(get: thrower, set: thrower, enumerable: false, configurable: false), false);
-                self.DefineOwnProperty("callee", new GetSetPropertyDescriptor(get: thrower, set: thrower, enumerable: false, configurable: false), false);
+                const PropertyFlag flags = PropertyFlag.EnumerableSet | PropertyFlag.ConfigurableSet;
+                self.DefineOwnProperty("caller", new GetSetPropertyDescriptor(get: thrower, set: thrower, flags), false);
+                self.DefineOwnProperty("callee", new GetSetPropertyDescriptor(get: thrower, set: thrower, flags), false);
             }
         }
 

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -232,7 +232,7 @@ namespace Jint.Native.Array
 
                 if (!newWritable)
                 {
-                    DefineOwnProperty("length", new PropertyDescriptor(value: null, writable: false, enumerable: null, configurable: null), false);
+                    DefineOwnProperty("length", new PropertyDescriptor(value: null, PropertyFlag.WritableSet), false);
                 }
 
                 return true;

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -87,14 +87,15 @@ namespace Jint.Native.Array
 
             if (propertyName.Length == 6 && propertyName == "length")
             {
-                if (desc.Value == null)
+                var value = desc.Value;
+                if (ReferenceEquals(value, null))
                 {
                     return base.DefineOwnProperty("length", desc, throwOnError);
                 }
 
                 var newLenDesc = new PropertyDescriptor(desc);
-                uint newLen = TypeConverter.ToUint32(desc.Value);
-                if (newLen != TypeConverter.ToNumber(desc.Value))
+                uint newLen = TypeConverter.ToUint32(value);
+                if (newLen != TypeConverter.ToNumber(value))
                 {
                     throw new JavaScriptException(_engine.RangeError);
                 }
@@ -490,7 +491,7 @@ namespace Jint.Native.Array
             if (!TryGetDescriptor(index, out var desc)
                 || desc == null
                 || desc == PropertyDescriptor.Undefined
-                || (desc.Value == null && desc.Get == null))
+                || (ReferenceEquals(desc.Value, null) && ReferenceEquals(desc.Get, null)))
             {
                 desc = GetProperty(TypeConverter.ToString(index));
             }

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -506,7 +506,7 @@ namespace Jint.Native.Array
 
             var compareArg = arguments.At(0);
             ICallable compareFn = null;
-            if (compareArg != Undefined)
+            if (!ReferenceEquals(compareArg, Undefined))
             {
                 compareFn = compareArg.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "The sort argument must be a function"));
             }
@@ -797,7 +797,7 @@ namespace Jint.Native.Array
             foreach (var e in items)
             {
                 var eArray = e.TryCast<ArrayInstance>();
-                if (eArray != null)
+                if (!ReferenceEquals(eArray, null))
                 {
                     var len = eArray.GetLength();
                     for (uint k = 0; k < len; k++)
@@ -901,7 +901,7 @@ namespace Jint.Native.Array
             for (var i = 0; i < arguments.Length; i++)
             {
                 JsValue e = arguments[i];
-                if (arrayInstance != null && n >= 0 && n < uint.MaxValue)
+                if (!ReferenceEquals(arrayInstance, null) && n >= 0 && n < uint.MaxValue)
                 {
                     // try to optimize a bit
                     arrayInstance.SetIndexValue((uint) n, e, true);
@@ -1004,13 +1004,13 @@ namespace Jint.Native.Array
                 public override uint GetLength()
                 {
                     var desc = _instance.GetProperty("length");
-                    if (desc.IsDataDescriptor() && desc.Value != null)
+                    var descValue = desc.Value;
+                    if (desc.IsDataDescriptor() && !ReferenceEquals(descValue, null))
                     {
-                        return TypeConverter.ToUint32(desc.Value);
+                        return TypeConverter.ToUint32(descValue);
                     }
 
-                    var getter = desc.Get != null ? desc.Get : Undefined;
-
+                    var getter = desc.Get ?? Undefined;
                     if (getter.IsUndefined())
                     {
                         return 0;

--- a/Jint/Native/Boolean/BooleanInstance.cs
+++ b/Jint/Native/Boolean/BooleanInstance.cs
@@ -10,23 +10,11 @@ namespace Jint.Native.Boolean
         {
         }
 
-        public override string Class
-        {
-            get
-            {
-                return "Boolean";
-            }
-        }
+        public override string Class => "Boolean";
 
-        Types IPrimitiveInstance.Type
-        {
-            get { return Types.Boolean; }
-        }
+        Types IPrimitiveInstance.Type => Types.Boolean;
 
-        JsValue IPrimitiveInstance.PrimitiveValue
-        {
-            get { return PrimitiveValue; }
-        }
+        JsValue IPrimitiveInstance.PrimitiveValue => PrimitiveValue;
 
         public JsValue PrimitiveValue { get; set; }
     }

--- a/Jint/Native/Boolean/BooleanPrototype.cs
+++ b/Jint/Native/Boolean/BooleanPrototype.cs
@@ -38,18 +38,14 @@ namespace Jint.Native.Boolean
             {
                 return B;
             }
-            else
+
+            var o = B.TryCast<BooleanInstance>();
+            if (!ReferenceEquals(o, null))
             {
-                var o = B.TryCast<BooleanInstance>();
-                if (o != null)
-                {
-                    return o.PrimitiveValue;
-                }
-                else
-                {
-                    throw new JavaScriptException(Engine.TypeError);
-                }
+                return o.PrimitiveValue;
             }
+
+            throw new JavaScriptException(Engine.TypeError);
         }
 
         private JsValue ToBooleanString(JsValue thisObj, JsValue[] arguments)

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -47,7 +47,7 @@ namespace Jint.Native.Error
             instance.Prototype = PrototypeObject;
             instance.Extensible = true;
 
-            if (arguments.At(0) != Undefined)
+            if (!ReferenceEquals(arguments.At(0), Undefined))
             {
                 instance.Put("message", TypeConverter.ToString(arguments.At(0)), false);
             }

--- a/Jint/Native/Error/ErrorPrototype.cs
+++ b/Jint/Native/Error/ErrorPrototype.cs
@@ -42,7 +42,7 @@ namespace Jint.Native.Error
         public JsValue ToString(JsValue thisObject, JsValue[] arguments)
         {
             var o = thisObject.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }

--- a/Jint/Native/Function/FunctionConstructor.cs
+++ b/Jint/Native/Function/FunctionConstructor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Esprima;
 using Esprima.Ast;
 using Jint.Native.Object;
@@ -74,7 +73,7 @@ namespace Jint.Native.Function
             {
                 var functionExpression = "function f(" + p + ") { " + body + "}";
                 var parser = new JavaScriptParser(functionExpression, ParserOptions);
-                function = parser.ParseProgram().Body.First().As<IFunction>();
+                function = (IFunction) parser.ParseProgram().Body[0];
             }
             catch (ParserException)
             {

--- a/Jint/Native/Function/FunctionConstructor.cs
+++ b/Jint/Native/Function/FunctionConstructor.cs
@@ -115,7 +115,7 @@ namespace Jint.Native.Function
         {
             get
             {
-                if (_throwTypeError != null)
+                if (!ReferenceEquals(_throwTypeError, null))
                 {
                     return _throwTypeError;
                 }
@@ -147,7 +147,7 @@ namespace Jint.Native.Function
             }
 
             var argArrayObj = argArray.TryCast<ObjectInstance>();
-            if (argArrayObj == null)
+            if (ReferenceEquals(argArrayObj, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }

--- a/Jint/Native/Function/FunctionInstance.cs
+++ b/Jint/Native/Function/FunctionInstance.cs
@@ -42,7 +42,7 @@ namespace Jint.Native.Function
         public virtual bool HasInstance(JsValue v)
         {
             var vObj = v.TryCast<ObjectInstance>();
-            if (vObj == null)
+            if (ReferenceEquals(vObj, null))
             {
                 return false;
             }
@@ -50,12 +50,12 @@ namespace Jint.Native.Function
             var po = Get("prototype");
             if (!po.IsObject())
             {
-                throw new JavaScriptException(_engine.TypeError, string.Format("Function has non-object prototype '{0}' in instanceof check", TypeConverter.ToString(po)));
+                throw new JavaScriptException(_engine.TypeError, $"Function has non-object prototype '{TypeConverter.ToString(po)}' in instanceof check");
             }
 
             var o = po.AsObject();
 
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(_engine.TypeError);
             }
@@ -64,7 +64,7 @@ namespace Jint.Native.Function
             {
                 vObj = vObj.Prototype;
 
-                if (vObj == null)
+                if (ReferenceEquals(vObj, null))
                 {
                     return false;
                 }

--- a/Jint/Native/Function/FunctionPrototype.cs
+++ b/Jint/Native/Function/FunctionPrototype.cs
@@ -52,7 +52,7 @@ namespace Jint.Native.Function
             f.Prototype = Engine.Function.PrototypeObject;
 
             var o = target as FunctionInstance;
-            if (o != null)
+            if (!ReferenceEquals(o, null))
             {
                 var l = TypeConverter.ToNumber(o.Get("length")) - (arguments.Length - 1);
                 f.SetOwnProperty("length", new PropertyDescriptor(System.Math.Max(l, 0), PropertyFlag.AllForbidden));
@@ -75,7 +75,7 @@ namespace Jint.Native.Function
         {
             var func = thisObj.TryCast<FunctionInstance>();
 
-            if (func == null)
+            if (ReferenceEquals(func, null))
             {
                 throw new JavaScriptException(Engine.TypeError, "Function object expected.");
             }
@@ -100,7 +100,7 @@ namespace Jint.Native.Function
             }
 
             var argArrayObj = argArray.TryCast<ObjectInstance>();
-            if (argArrayObj == null)
+            if (ReferenceEquals(argArrayObj, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }

--- a/Jint/Native/Function/FunctionPrototype.cs
+++ b/Jint/Native/Function/FunctionPrototype.cs
@@ -64,9 +64,9 @@ namespace Jint.Native.Function
 
 
             var thrower = Engine.Function.ThrowTypeError;
-            f.DefineOwnProperty("caller", new GetSetPropertyDescriptor(thrower, thrower, false, false), false);
-            f.DefineOwnProperty("arguments", new GetSetPropertyDescriptor(thrower, thrower, false, false), false);
-
+            const PropertyFlag flags = PropertyFlag.EnumerableSet | PropertyFlag.ConfigurableSet;
+            f.DefineOwnProperty("caller", new GetSetPropertyDescriptor(thrower, thrower, flags), false);
+            f.DefineOwnProperty("arguments", new GetSetPropertyDescriptor(thrower, thrower, flags), false);
 
             return f;
         }

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -55,8 +55,9 @@ namespace Jint.Native.Function
             if (strict)
             {
                 var thrower = engine.Function.ThrowTypeError;
-                DefineOwnProperty("caller", new GetSetPropertyDescriptor(thrower, thrower, false, false), false);
-                DefineOwnProperty("arguments", new GetSetPropertyDescriptor(thrower, thrower, false, false), false);
+                const PropertyFlag flags = PropertyFlag.EnumerableSet | PropertyFlag.ConfigurableSet;
+                DefineOwnProperty("caller", new GetSetPropertyDescriptor(thrower, thrower, flags), false);
+                DefineOwnProperty("arguments", new GetSetPropertyDescriptor(thrower, thrower, flags), false);
             }
         }
 

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -227,7 +227,7 @@ namespace Jint.Native.Function
             };
 
             var result = Call(obj, arguments).TryCast<ObjectInstance>();
-            if (result != null)
+            if (!ReferenceEquals(result, null))
             {
                 return result;
             }

--- a/Jint/Native/JsBoolean.cs
+++ b/Jint/Native/JsBoolean.cs
@@ -6,17 +6,18 @@ namespace Jint.Native
 {
     public sealed class JsBoolean : JsValue, IEquatable<JsBoolean>
     {
-        private readonly bool _value;
-
         public static readonly JsValue False = new JsBoolean(false);
         public static readonly JsValue True = new JsBoolean(true);
 
-        public JsBoolean(bool value)
+        internal static readonly object BoxedTrue = true;
+        internal static readonly object BoxedFalse = false;
+
+        internal readonly bool _value;
+
+        public JsBoolean(bool value) : base(Types.Boolean)
         {
             _value = value;
         }
-
-        public override Types Type => Types.Boolean;
 
         [Pure]
         public override bool AsBoolean()
@@ -26,7 +27,7 @@ namespace Jint.Native
 
         public override object ToObject()
         {
-            return _value;
+            return _value ? BoxedTrue : BoxedFalse;
         }
 
         public override string ToString()

--- a/Jint/Native/JsNull.cs
+++ b/Jint/Native/JsNull.cs
@@ -5,11 +5,9 @@ namespace Jint.Native
 {
     public sealed class JsNull : JsValue, IEquatable<JsNull>
     {
-        internal JsNull()
+        internal JsNull() : base(Types.Null)
         {
         }
-
-        public override Types Type => Types.Null;
 
         public override object ToObject()
         {

--- a/Jint/Native/JsNumber.cs
+++ b/Jint/Native/JsNumber.cs
@@ -34,22 +34,20 @@ namespace Jint.Native
             }
         }
 
-        public JsNumber(double value)
+        public JsNumber(double value) : base(Types.Number)
         {
             _value = value;
         }
 
-        public JsNumber(int value)
+        public JsNumber(int value) : base(Types.Number)
         {
             _value = value;
         }
 
-        public JsNumber(uint value)
+        public JsNumber(uint value) : base(Types.Number)
         {
             _value = value;
         }
-
-        public override Types Type => Types.Number;
 
         [Pure]
         public override double AsNumber()

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -28,7 +28,7 @@ namespace Jint.Native
             }
         }
 
-        public JsString(string value)
+        public JsString(string value) : base(Types.String)
         {
             _value = value;
         }
@@ -38,12 +38,10 @@ namespace Jint.Native
             return _value;
         }
 
-        public JsString(char value)
+        public JsString(char value) : base(Types.String)
         {
             _value = value.ToString();
         }
-
-        public override Types Type => Types.String;
 
         [Pure]
         public override string AsString()

--- a/Jint/Native/JsSymbol.cs
+++ b/Jint/Native/JsSymbol.cs
@@ -10,12 +10,10 @@ namespace Jint.Native
     {
         private readonly string _value;
 
-        public JsSymbol(string value)
+        public JsSymbol(string value) : base(Types.Symbol)
         {
             _value = value;
         }
-
-        public override Types Type => Types.Symbol;
 
         public override object ToObject()
         {

--- a/Jint/Native/JsUndefined.cs
+++ b/Jint/Native/JsUndefined.cs
@@ -5,11 +5,9 @@ namespace Jint.Native
 {
     public sealed class JsUndefined : JsValue, IEquatable<JsUndefined>
     {
-        internal JsUndefined()
+        internal JsUndefined() : base(Types.Undefined)
         {
         }
-
-        public override Types Type => Types.Undefined;
 
         public override object ToObject()
         {

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -64,9 +64,7 @@ namespace Jint.Native.Json
                                 new PropertyDescriptor
                                 (
                                     value: newValue,
-                                    writable: true,
-                                    enumerable: true,
-                                    configurable: true
+                                    PropertyFlag.ConfigurableEnumerableWritable
                                 ),
                                 false
                             );
@@ -91,9 +89,7 @@ namespace Jint.Native.Json
                                 new PropertyDescriptor
                                 (
                                     value: newElement,
-                                    writable: true,
-                                    enumerable: true,
-                                    configurable: true
+                                    PropertyFlag.ConfigurableEnumerableWritable
                                 ),
                                 false
                             );
@@ -116,9 +112,7 @@ namespace Jint.Native.Json
                     "",
                     new PropertyDescriptor(
                         value: res,
-                        writable: true,
-                        enumerable: true,
-                        configurable: true
+                        PropertyFlag.ConfigurableEnumerableWritable
                     ),
                     false
                 );

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -135,7 +135,7 @@ namespace Jint.Native.Json
                 }
             }
 
-            if (_replacerFunction != Undefined.Instance)
+            if (!ReferenceEquals(_replacerFunction, Undefined.Instance))
             {
                 var replacerFunctionCallable = (ICallable)_replacerFunction.AsObject();
                 value = replacerFunctionCallable.Call(holder, Arguments.From(key, value));
@@ -266,7 +266,7 @@ namespace Jint.Native.Json
             for (int i = 0; i < len; i++)
             {
                 var strP = Str(TypeConverter.ToString(i), value);
-                if (strP == JsValue.Undefined)
+                if (ReferenceEquals(strP, JsValue.Undefined))
                     strP = "null";
                 partial.Add(strP.AsString());
             }
@@ -325,7 +325,7 @@ namespace Jint.Native.Json
             foreach (var p in k)
             {
                 var strP = Str(p, value);
-                if (strP != JsValue.Undefined)
+                if (!ReferenceEquals(strP, JsValue.Undefined))
                 {
                     var member = Quote(p) + ":";
                     if (_gap != "")

--- a/Jint/Native/Number/NumberInstance.cs
+++ b/Jint/Native/Number/NumberInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Jint.Native.Object;
 using Jint.Runtime;
 
@@ -13,35 +14,24 @@ namespace Jint.Native.Number
         {
         }
 
-        public override string Class
-        {
-            get
-            {
-                return "Number";
-            }
-        }
+        public override string Class => "Number";
 
-        Types IPrimitiveInstance.Type
-        {
-            get { return Types.Number; }
-        }
+        Types IPrimitiveInstance.Type => Types.Number;
 
-        JsValue IPrimitiveInstance.PrimitiveValue
-        {
-            get { return NumberData; }
-        }
+        JsValue IPrimitiveInstance.PrimitiveValue => NumberData;
 
         public JsValue NumberData { get; set; }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsNegativeZero(double x)
         {
             return x == 0 && BitConverter.DoubleToInt64Bits(x) == NegativeZeroBits;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsPositiveZero(double x)
         {
             return x == 0 && BitConverter.DoubleToInt64Bits(x) != NegativeZeroBits;
         }
-
     }
 }

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -43,7 +43,7 @@ namespace Jint.Native.Number
 
         private JsValue ToLocaleString(JsValue thisObject, JsValue[] arguments)
         {
-            if (!thisObject.IsNumber() && (thisObject.TryCast<NumberInstance>() == null))
+            if (!thisObject.IsNumber() && ReferenceEquals(thisObject.TryCast<NumberInstance>(), null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -81,7 +81,7 @@ namespace Jint.Native.Number
         private JsValue ValueOf(JsValue thisObj, JsValue[] arguments)
         {
             var number = thisObj.TryCast<NumberInstance>();
-            if (number == null)
+            if (ReferenceEquals(number, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -167,12 +167,14 @@ namespace Jint.Native.Number
 
         private JsValue ToNumberString(JsValue thisObject, JsValue[] arguments)
         {
-            if (!thisObject.IsNumber() && (thisObject.TryCast<NumberInstance>() == null))
+            if (!thisObject.IsNumber() && (ReferenceEquals(thisObject.TryCast<NumberInstance>(), null)))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
 
-            var radix = arguments.At(0) == JsValue.Undefined ? 10 : (int) TypeConverter.ToInteger(arguments.At(0));
+            var radix = ReferenceEquals(arguments.At(0), Undefined) 
+                ? 10 
+                : (int) TypeConverter.ToInteger(arguments.At(0));
 
             if (radix < 2 || radix > 36)
             {

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -84,7 +84,7 @@ namespace Jint.Native.Object
             {
                 var value = arguments[0];
                 var valueObj = value.TryCast<ObjectInstance>();
-                if (valueObj != null)
+                if (!ReferenceEquals(valueObj, null))
                 {
                     return valueObj;
                 }
@@ -108,7 +108,7 @@ namespace Jint.Native.Object
         {
             var oArg = arguments.At(0);
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -120,7 +120,7 @@ namespace Jint.Native.Object
         {
             var oArg = arguments.At(0);
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -136,7 +136,7 @@ namespace Jint.Native.Object
         {
             var oArg = arguments.At(0);
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -171,7 +171,7 @@ namespace Jint.Native.Object
             var oArg = arguments.At(0);
 
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null && oArg != Null)
+            if (ReferenceEquals(o, null) && !ReferenceEquals(oArg, Null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -180,7 +180,7 @@ namespace Jint.Native.Object
             obj.Prototype = o;
 
             var properties = arguments.At(1);
-            if (properties != Undefined)
+            if (!ReferenceEquals(properties, Undefined))
             {
                 DefineProperties(thisObject, new [] {obj, properties});
             }
@@ -192,7 +192,7 @@ namespace Jint.Native.Object
         {
             var oArg = arguments.At(0);
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -211,7 +211,7 @@ namespace Jint.Native.Object
         {
             var oArg = arguments.At(0);
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -242,7 +242,7 @@ namespace Jint.Native.Object
         {
             var oArg = arguments.At(0);
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -269,7 +269,7 @@ namespace Jint.Native.Object
         {
             var oArg = arguments.At(0);
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -305,7 +305,7 @@ namespace Jint.Native.Object
         {
             var oArg = arguments.At(0);
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -319,7 +319,7 @@ namespace Jint.Native.Object
         {
             var oArg = arguments.At(0);
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -344,7 +344,7 @@ namespace Jint.Native.Object
         {
             var oArg = arguments.At(0);
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -377,7 +377,7 @@ namespace Jint.Native.Object
         {
             var oArg = arguments.At(0);
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -389,7 +389,7 @@ namespace Jint.Native.Object
         {
             var oArg = arguments.At(0);
             var o = oArg.TryCast<ObjectInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }

--- a/Jint/Native/Object/ObjectPrototype.cs
+++ b/Jint/Native/Object/ObjectPrototype.cs
@@ -62,7 +62,7 @@ namespace Jint.Native.Object
             {
                 v = v.Prototype;
 
-                if (v == null)
+                if (ReferenceEquals(v, null))
                 {
                     return false;
                 }

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -66,27 +66,26 @@ namespace Jint.Native.RegExp
             var flags = arguments.At(1);
 
             var r = pattern.TryCast<RegExpInstance>();
-            if (ReferenceEquals(flags, Undefined) && r != null)
+            if (ReferenceEquals(flags, Undefined) && !ReferenceEquals(r, null))
             {
                 return r;
             }
-            else if (flags != Undefined && r != null)
+
+            if (!ReferenceEquals(flags, Undefined) && !ReferenceEquals(r, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
+
+            if (ReferenceEquals(pattern, Undefined))
+            {
+                p = "";
+            }
             else
             {
-                if (ReferenceEquals(pattern, Undefined))
-                {
-                    p = "";
-                }
-                else
-                {
-                    p = TypeConverter.ToString(pattern);
-                }
-
-                f = !ReferenceEquals(flags, Undefined) ? TypeConverter.ToString(flags) : "";
+                p = TypeConverter.ToString(pattern);
             }
+
+            f = !ReferenceEquals(flags, Undefined) ? TypeConverter.ToString(flags) : "";
 
             r = new RegExpInstance(Engine);
             r.Prototype = PrototypeObject;
@@ -105,7 +104,7 @@ namespace Jint.Native.RegExp
             string s;
             s = p;
 
-            if (System.String.IsNullOrEmpty(s))
+            if (string.IsNullOrEmpty(s))
             {
                 s = "(?:)";
             }

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -56,13 +56,13 @@ namespace Jint.Native.RegExp
             }
 
             var match = Exec(r, arguments);
-            return match != Null;
+            return !ReferenceEquals(match, Null);
         }
 
         internal JsValue Exec(JsValue thisObj, JsValue[] arguments)
         {
             var R = TypeConverter.ToObject(Engine, thisObj) as RegExpInstance;
-            if (R == null)
+            if (ReferenceEquals(R, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -82,7 +82,7 @@ namespace Jint.Native.RegExp
             {
                 // "aaa".match() => [ '', index: 0, input: 'aaa' ]
                 var aa = InitReturnValueArray((ArrayInstance) Engine.Array.Construct(Arguments.Empty), s, 1, 0);
-                aa.DefineOwnProperty("0", new PropertyDescriptor("", true, true, true), true);
+                aa.DefineOwnProperty("0", new PropertyDescriptor("", PropertyFlag.ConfigurableEnumerableWritable), true);
                 return aa;
             }
 

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -63,7 +63,7 @@ namespace Jint.Native.String
         private JsValue ToStringString(JsValue thisObj, JsValue[] arguments)
         {
             var s = TypeConverter.ToObject(Engine, thisObj) as StringInstance;
-            if (s == null)
+            if (ReferenceEquals(s, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -229,7 +229,7 @@ namespace Jint.Native.String
         {
             var s = TypeConverter.ToString(thisObj);
             var start = TypeConverter.ToInteger(arguments.At(0));
-            var length = arguments.At(1) == JsValue.Undefined
+            var length = ReferenceEquals(arguments.At(1), Undefined)
                 ? double.PositiveInfinity
                 : TypeConverter.ToInteger(arguments.At(1));
 
@@ -290,7 +290,7 @@ namespace Jint.Native.String
 
             const string regExpForMatchingAllCharactere = "(?:)";
 
-            if (rx != null &&
+            if (!ReferenceEquals(rx, null) &&
                 rx.Source != regExpForMatchingAllCharactere // We need pattern to be defined -> for s.split(new RegExp)
                 )
             {
@@ -354,7 +354,7 @@ namespace Jint.Native.String
                 segments.Clear();
                 var sep = TypeConverter.ToString(separator);
 
-                if (sep == string.Empty || (rx != null && rx.Source == regExpForMatchingAllCharactere)) // for s.split(new RegExp)
+                if (sep == string.Empty || (!ReferenceEquals(rx, null) && rx.Source == regExpForMatchingAllCharactere)) // for s.split(new RegExp)
                 {
                     if (s.Length > segments.Capacity)
                     {
@@ -460,7 +460,7 @@ namespace Jint.Native.String
 
             // If the second parameter is not a function we create one
             var replaceFunction = replaceValue.TryCast<FunctionInstance>();
-            if (replaceFunction == null)
+            if (ReferenceEquals(replaceFunction, null))
             {
                 replaceFunction = new ClrFunctionInstance(Engine, (self, args) =>
                 {
@@ -552,7 +552,7 @@ namespace Jint.Native.String
             }
 
             var rx = TypeConverter.ToObject(Engine, searchValue) as RegExpInstance;
-            if (rx != null)
+            if (!ReferenceEquals(rx, null))
             {
                 // Replace the input string with replaceText, recording the last match found.
                 string result = rx.Value.Replace(thisString, match =>
@@ -634,7 +634,7 @@ namespace Jint.Native.String
                 while (lastMatch)
                 {
                     var result = Engine.RegExp.PrototypeObject.Exec(rx, Arguments.From(s)).TryCast<ObjectInstance>();
-                    if (result == null)
+                    if (ReferenceEquals(result, null))
                     {
                         lastMatch = false;
                     }
@@ -678,7 +678,7 @@ namespace Jint.Native.String
             var s = TypeConverter.ToString(thisObj);
             var searchStr = TypeConverter.ToString(arguments.At(0));
             double numPos = double.NaN;
-            if (arguments.Length > 1 && arguments[1] != Undefined)
+            if (arguments.Length > 1 && !ReferenceEquals(arguments[1], Undefined))
             {
                 numPos = TypeConverter.ToNumber(arguments[1]);
             }
@@ -725,7 +725,7 @@ namespace Jint.Native.String
             var s = TypeConverter.ToString(thisObj);
             var searchStr = TypeConverter.ToString(arguments.At(0));
             double pos = 0;
-            if (arguments.Length > 1 && arguments[1] != Undefined)
+            if (arguments.Length > 1 && !ReferenceEquals(arguments[1], Undefined))
             {
                 pos = TypeConverter.ToInteger(arguments[1]);
             }
@@ -807,7 +807,7 @@ namespace Jint.Native.String
         private JsValue ValueOf(JsValue thisObj, JsValue[] arguments)
         {
             var s = thisObj.TryCast<StringInstance>();
-            if (s == null)
+            if (ReferenceEquals(s, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -77,7 +77,7 @@ namespace Jint.Native.String
         const char MONGOLIAN_VOWEL_SEPARATOR = '\u180E';
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsWhiteSpaceEx(char c)
+        internal static bool IsWhiteSpaceEx(char c)
         {
             return
                 char.IsWhiteSpace(c) ||
@@ -86,6 +86,7 @@ namespace Jint.Native.String
                 c == MONGOLIAN_VOWEL_SEPARATOR;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string TrimEndEx(string s)
         {
             if (s.Length == 0)
@@ -108,6 +109,7 @@ namespace Jint.Native.String
                 return string.Empty;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string TrimStartEx(string s)
         {
             if (s.Length == 0)
@@ -130,11 +132,13 @@ namespace Jint.Native.String
                 return s.Substring(i);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string TrimEx(string s)
         {
             return TrimEndEx(TrimStartEx(s));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private JsValue Trim(JsValue thisObj, JsValue[] arguments)
         {
             TypeConverter.CheckObjectCoercible(Engine, thisObj);

--- a/Jint/Native/Symbol/SymbolInstance.cs
+++ b/Jint/Native/Symbol/SymbolInstance.cs
@@ -10,23 +10,11 @@ namespace Jint.Native.Symbol
         {
         }
 
-        public override string Class
-        {
-            get
-            {
-                return "Symbol";
-            }
-        }
+        public override string Class => "Symbol";
 
-        Types IPrimitiveInstance.Type
-        {
-            get { return Types.Symbol; }
-        }
+        Types IPrimitiveInstance.Type => Types.Symbol;
 
-        JsValue IPrimitiveInstance.PrimitiveValue
-        {
-            get { return SymbolData; }
-        }
+        JsValue IPrimitiveInstance.PrimitiveValue => SymbolData;
 
         public JsSymbol SymbolData { get; set; }
     }

--- a/Jint/Native/Symbol/SymbolPrototype.cs
+++ b/Jint/Native/Symbol/SymbolPrototype.cs
@@ -54,7 +54,7 @@ namespace Jint.Native.Symbol
         private JsValue ValueOf(JsValue thisObject, JsValue[] arguments)
         {
             var sym = thisObject.TryCast<SymbolInstance>();
-            if (sym == null)
+            if (ReferenceEquals(sym, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -71,7 +71,7 @@ namespace Jint.Native.Symbol
 
             // Steps 3. and 4.
             var o = thisObject.AsInstance<SymbolInstance>();
-            if (o == null)
+            if (ReferenceEquals(o, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Runtime.Interop;
 
@@ -155,11 +156,19 @@ namespace Jint
 
         internal bool _IsGlobalDiscarded => _discardGlobal;
 
-        internal bool _IsStrict => _strict;
+        internal bool _IsStrict
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return _strict; }
+        }
 
         internal bool _IsDebuggerStatementAllowed => _allowDebuggerStatement;
 
-        internal bool _IsDebugMode => _debugMode;
+        internal bool _IsDebugMode
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return _debugMode; }
+        }
 
         internal bool _IsClrAllowed => _allowClr;
 
@@ -169,7 +178,11 @@ namespace Jint
 
         internal List<IObjectConverter> _ObjectConverters => _objectConverters;
 
-        internal int _MaxStatements => _maxStatements;
+        internal int _MaxStatements
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return _maxStatements; }
+        }
 
         internal int _MaxRecursionDepth => _maxRecursionDepth;
 

--- a/Jint/Pooling/ArgumentsInstancePool.cs
+++ b/Jint/Pooling/ArgumentsInstancePool.cs
@@ -47,7 +47,7 @@ namespace Jint.Pooling
 
         public void Return(ArgumentsInstance instance)
         {
-            if (instance == null)
+            if (ReferenceEquals(instance, null))
             {
                 return;
             }

--- a/Jint/Runtime/Completion.cs
+++ b/Jint/Runtime/Completion.cs
@@ -53,7 +53,7 @@ namespace Jint.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JsValue GetValueOrDefault()
         {
-            return Value != null ? Value : Undefined.Instance;
+            return Value ?? Undefined.Instance;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Runtime/Completion.cs
+++ b/Jint/Runtime/Completion.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Esprima;
 using Jint.Native;
 
@@ -28,15 +29,34 @@ namespace Jint.Runtime
             Location = location;
         }
 
-        public string Type { get; private set; }
-        public JsValue Value { get; private set; }
-        public string Identifier { get; private set; }
+        public string Type
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get;
+            private set;
+        }
 
+        public JsValue Value
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get; 
+            private set;
+        }
+
+        public string Identifier
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get; 
+            private set;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JsValue GetValueOrDefault()
         {
             return Value != null ? Value : Undefined.Instance;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsAbrupt()
         {
             return Type != Normal;

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -161,7 +161,7 @@ namespace Jint.Runtime.Debugger
         private static Dictionary<string, JsValue> GetLocalVariables(LexicalEnvironment lex)
         {
             Dictionary<string, JsValue> locals = new Dictionary<string, JsValue>();
-            if (lex != null && lex.Record != null)
+            if (!ReferenceEquals(lex?.Record, null))
             {
                 AddRecordsFromEnvironment(lex, locals);
             }
@@ -173,7 +173,7 @@ namespace Jint.Runtime.Debugger
             Dictionary<string, JsValue> globals = new Dictionary<string, JsValue>();
             LexicalEnvironment tempLex = lex;
 
-            while (tempLex != null && tempLex.Record != null)
+            while (tempLex != null && !ReferenceEquals(tempLex.Record, null))
             {
                 AddRecordsFromEnvironment(tempLex, globals);
                 tempLex = tempLex.Outer;

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -213,7 +213,7 @@ namespace Jint.Runtime.Descriptors
         public static PropertyDescriptor ToPropertyDescriptor(Engine engine, JsValue o)
         {
             var obj = o.TryCast<ObjectInstance>();
-            if (obj == null)
+            if (ReferenceEquals(obj, null))
             {
                 throw new JavaScriptException(engine.TypeError);
             }
@@ -263,7 +263,7 @@ namespace Jint.Runtime.Descriptors
             if (hasGetProperty)
             {
                 var getter = obj.UnwrapJsValue(getProperty);
-                if (getter != JsValue.Undefined && getter.TryCast<ICallable>() == null)
+                if (!ReferenceEquals(getter, JsValue.Undefined) && getter.TryCast<ICallable>() == null)
                 {
                     throw new JavaScriptException(engine.TypeError);
                 }
@@ -274,7 +274,7 @@ namespace Jint.Runtime.Descriptors
             if (hasSetProperty)
             {
                 var setter = obj.UnwrapJsValue(setProperty);
-                if (setter != Native.Undefined.Instance && setter.TryCast<ICallable>() == null)
+                if (!ReferenceEquals(setter, JsValue.Undefined) && setter.TryCast<ICallable>() == null)
                 {
                     throw new JavaScriptException(engine.TypeError);
                 }
@@ -282,9 +282,9 @@ namespace Jint.Runtime.Descriptors
                 ((GetSetPropertyDescriptor) desc).SetSet(setter);
             }
 
-            if (desc.Get != null || desc.Get != null)
+            if (!ReferenceEquals(desc.Get, null) || !ReferenceEquals(desc.Get, null))
             {
-                if (desc.Value != null || desc.WritableSet)
+                if (!ReferenceEquals(desc.Value, null) || desc.WritableSet)
                 {
                     throw new JavaScriptException(engine.TypeError);
                 }
@@ -304,7 +304,7 @@ namespace Jint.Runtime.Descriptors
 
             if (desc.IsDataDescriptor())
             {
-                obj.SetOwnProperty("value", new PropertyDescriptor(desc.Value != null ? desc.Value : Native.Undefined.Instance, PropertyFlag.ConfigurableEnumerableWritable));
+                obj.SetOwnProperty("value", new PropertyDescriptor(desc.Value ?? Native.Undefined.Instance, PropertyFlag.ConfigurableEnumerableWritable));
                 obj.SetOwnProperty("writable", new PropertyDescriptor(desc.Writable, PropertyFlag.ConfigurableEnumerableWritable));
             }
             else
@@ -322,13 +322,13 @@ namespace Jint.Runtime.Descriptors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsAccessorDescriptor()
         {
-            return Get != null || Set != null;
+            return !ReferenceEquals(Get, null) || !ReferenceEquals(Set, null);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsDataDescriptor()
         {
-            return WritableSet || Value != null;
+            return WritableSet || !ReferenceEquals(Value, null);
         }
 
         /// <summary>
@@ -355,17 +355,18 @@ namespace Jint.Runtime.Descriptors
             if (IsDataDescriptor())
             {
                 var val = Value;
-                if (val != null)
+                if (!ReferenceEquals(val, null))
                 {
                     value = val;
                     return true;
                 }
             }
 
-            if (Get != null && !Get.IsUndefined())
+            var getter = Get;
+            if (!ReferenceEquals(getter, null) && !getter.IsUndefined())
             {
                 // if getter is not undefined it must be ICallable
-                var callable = Get.TryCast<ICallable>();
+                var callable = getter.TryCast<ICallable>();
                 value = callable.Call(thisArg, Arguments.Empty);
             }
 

--- a/Jint/Runtime/Descriptors/PropertyFlag.cs
+++ b/Jint/Runtime/Descriptors/PropertyFlag.cs
@@ -3,7 +3,7 @@
 namespace Jint.Runtime.Descriptors
 {
     [Flags]
-    internal enum PropertyFlag
+    public enum PropertyFlag
     {
         None = 0,
         Enumerable = 1,
@@ -12,6 +12,8 @@ namespace Jint.Runtime.Descriptors
         WritableSet = 8,
         Configurable = 16,
         ConfigurableSet = 32,
+        
+        CustomJsValue = 256,
         
         // common helpers
         AllForbidden = ConfigurableSet | EnumerableSet | WritableSet,

--- a/Jint/Runtime/Descriptors/Specialized/ClrAccessDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/ClrAccessDescriptor.cs
@@ -17,7 +17,7 @@ namespace Jint.Runtime.Descriptors.Specialized
             EnvironmentRecord env,
             Engine engine,
             string name)
-            : base(value: null, writable: null, enumerable: null, configurable: true)
+            : base(value: null, PropertyFlag.Configurable)
         {
             _env = env;
             _engine = engine;

--- a/Jint/Runtime/Descriptors/Specialized/FieldInfoDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/FieldInfoDescriptor.cs
@@ -10,7 +10,7 @@ namespace Jint.Runtime.Descriptors.Specialized
         private readonly FieldInfo _fieldInfo;
         private readonly object _item;
 
-        public FieldInfoDescriptor(Engine engine, FieldInfo fieldInfo, object item)
+        public FieldInfoDescriptor(Engine engine, FieldInfo fieldInfo, object item) : base(PropertyFlag.CustomJsValue)
         {
             _engine = engine;
             _fieldInfo = fieldInfo;
@@ -19,13 +19,9 @@ namespace Jint.Runtime.Descriptors.Specialized
             Writable = !fieldInfo.Attributes.HasFlag(FieldAttributes.InitOnly); // don't write to fields marked as readonly
         }
 
-        public override JsValue Value
+        protected override JsValue CustomValue
         {
-            get
-            {
-                return JsValue.FromObject(_engine, _fieldInfo.GetValue(_item));
-            }
-
+            get => JsValue.FromObject(_engine, _fieldInfo.GetValue(_item));
             set
             {
                 var currentValue = value;

--- a/Jint/Runtime/Descriptors/Specialized/GetSetPropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/GetSetPropertyDescriptor.cs
@@ -14,6 +14,13 @@ namespace Jint.Runtime.Descriptors.Specialized
             _set = set;
         }
 
+        internal GetSetPropertyDescriptor(JsValue get, JsValue set, PropertyFlag flags)
+            : base(null, flags)
+        {
+            _get = get;
+            _set = set;
+        }
+
         public GetSetPropertyDescriptor(PropertyDescriptor descriptor) : base(descriptor)
         {
             _get = descriptor.Get;

--- a/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
@@ -92,7 +92,7 @@ namespace Jint.Runtime.Descriptors.Specialized
                     throw new InvalidOperationException("Indexer has no public setter.");
                 }
 
-                object[] parameters = {_key, value != null ? value.ToObject() : null};
+                object[] parameters = {_key, value?.ToObject()};
                 setter.Invoke(_item, parameters);
             }
         }

--- a/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
@@ -13,7 +13,7 @@ namespace Jint.Runtime.Descriptors.Specialized
         private readonly PropertyInfo _indexer;
         private readonly MethodInfo _containsKey;
 
-        public IndexDescriptor(Engine engine, Type targetType, string key, object item)
+        public IndexDescriptor(Engine engine, Type targetType, string key, object item) : base(PropertyFlag.CustomJsValue)
         {
             _engine = engine;
             _item = item;
@@ -33,9 +33,8 @@ namespace Jint.Runtime.Descriptors.Specialized
                     {
                         _indexer = indexer;
                         // get contains key method to avoid index exception being thrown in dictionaries
-                        _containsKey = targetType.GetMethod("ContainsKey", new Type[] { paramType });
+                        _containsKey = targetType.GetMethod("ContainsKey", new Type[] {paramType});
                         break;
-
                     }
                 }
             }
@@ -54,7 +53,7 @@ namespace Jint.Runtime.Descriptors.Specialized
         {
         }
 
-        public override JsValue Value
+        protected override JsValue CustomValue
         {
             get
             {
@@ -65,7 +64,7 @@ namespace Jint.Runtime.Descriptors.Specialized
                     throw new InvalidOperationException("Indexer has no public getter.");
                 }
 
-                object[] parameters = { _key };
+                object[] parameters = {_key};
 
                 if (_containsKey != null)
                 {
@@ -93,7 +92,7 @@ namespace Jint.Runtime.Descriptors.Specialized
                     throw new InvalidOperationException("Indexer has no public setter.");
                 }
 
-                object[] parameters = { _key, value != null ? value.ToObject() : null };
+                object[] parameters = {_key, value != null ? value.ToObject() : null};
                 setter.Invoke(_item, parameters);
             }
         }

--- a/Jint/Runtime/Descriptors/Specialized/PropertyInfoDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/PropertyInfoDescriptor.cs
@@ -10,7 +10,7 @@ namespace Jint.Runtime.Descriptors.Specialized
         private readonly PropertyInfo _propertyInfo;
         private readonly object _item;
 
-        public PropertyInfoDescriptor(Engine engine, PropertyInfo propertyInfo, object item)
+        public PropertyInfoDescriptor(Engine engine, PropertyInfo propertyInfo, object item) : base(PropertyFlag.CustomJsValue)
         {
             _engine = engine;
             _propertyInfo = propertyInfo;
@@ -19,13 +19,9 @@ namespace Jint.Runtime.Descriptors.Specialized
             Writable = propertyInfo.CanWrite;
         }
 
-        public override JsValue Value
+        protected override JsValue CustomValue
         {
-            get
-            {
-                return JsValue.FromObject(_engine, _propertyInfo.GetValue(_item, null));
-            }
-
+            get => JsValue.FromObject(_engine, _propertyInfo.GetValue(_item, null));
             set
             {
                 var currentValue = value;

--- a/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
@@ -73,7 +73,7 @@ namespace Jint.Runtime.Environments
 
         public override string[] GetAllBindingNames()
         {
-            if (_bindingObject != null)
+            if (!ReferenceEquals(_bindingObject, null))
             {
                 return _bindingObject.GetOwnProperties().Select( x=> x.Key).ToArray();
             }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -45,7 +45,7 @@ namespace Jint.Runtime
 
         public JsValue EvaluateAssignmentExpression(AssignmentExpression assignmentExpression)
         {
-            var lref = EvaluateExpression(assignmentExpression.Left.As<Expression>()) as Reference;
+            var lref = EvaluateExpression((Expression) assignmentExpression.Left) as Reference;
             JsValue rval = _engine.GetValue(EvaluateExpression(assignmentExpression.Right), true);
 
             if (lref == null)
@@ -208,7 +208,7 @@ namespace Jint.Runtime
             JsValue left;
             if (expression.Left.Type == Nodes.Literal)
             {
-                left = EvaluateLiteral(expression.Left.As<Literal>());
+                left = EvaluateLiteral((Literal) expression.Left);
             }
             else
             {
@@ -218,7 +218,7 @@ namespace Jint.Runtime
             JsValue right;
             if (expression.Right.Type == Nodes.Literal)
             {
-                right = EvaluateLiteral(expression.Right.As<Literal>());
+                right = EvaluateLiteral((Literal) expression.Right);
             }
             else
             {
@@ -666,11 +666,13 @@ namespace Jint.Runtime
                 var previous = obj.GetOwnProperty(propName);
                 PropertyDescriptor propDesc;
 
+                const PropertyFlag enumerableConfigurable = PropertyFlag.Enumerable | PropertyFlag.Configurable;
+                
                 switch (property.Kind)
                 {
                     case PropertyKind.Init:
                     case PropertyKind.Data:
-                        var exprValue = _engine.EvaluateExpression(property.Value.As<Expression>());
+                        var exprValue = _engine.EvaluateExpression(property.Value);
                         var propValue = _engine.GetValue(exprValue, true);
                         propDesc = new PropertyDescriptor(propValue, PropertyFlag.ConfigurableEnumerableWritable);
                         break;
@@ -694,7 +696,7 @@ namespace Jint.Runtime
                             );
                         }
 
-                        propDesc = new GetSetPropertyDescriptor(get: get, set: null, enumerable: true, configurable: true);
+                        propDesc = new GetSetPropertyDescriptor(get: get, set: null, enumerableConfigurable);
                         break;
 
                     case PropertyKind.Set:
@@ -716,7 +718,7 @@ namespace Jint.Runtime
                             );
                         }
 
-                        propDesc = new GetSetPropertyDescriptor(get: null, set: set, enumerable: true, configurable: true);
+                        propDesc = new GetSetPropertyDescriptor(get: null, set: set, enumerableConfigurable);
                         break;
 
                     default:
@@ -948,7 +950,7 @@ namespace Jint.Runtime
             for (var i = 0; i < expressionsCount; i++)
             {
                 var expression = sequenceExpression.Expressions[i];
-                result = _engine.GetValue(_engine.EvaluateExpression(expression.As<Expression>()), true);
+                result = _engine.GetValue(_engine.EvaluateExpression(expression), true);
             }
 
             return result;
@@ -1041,7 +1043,7 @@ namespace Jint.Runtime
                 var expr = elements[n];
                 if (expr != null)
                 {
-                    var value = _engine.GetValue(EvaluateExpression(expr.As<Expression>()), true);
+                    var value = _engine.GetValue(EvaluateExpression((Expression) expr), true);
                     a.SetIndexValue((uint) n, value, throwOnError: false);
                 }
             }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -56,7 +56,9 @@ namespace Jint.Runtime
             if (assignmentExpression.Operator == AssignmentOperator.Assign) // "="
             {
 
-                if(lref.IsStrict() && lref.GetBase().TryCast<EnvironmentRecord>() != null && (lref.GetReferencedName() == "eval" || lref.GetReferencedName() == "arguments"))
+                if(lref.IsStrict() 
+                   && !ReferenceEquals(lref.GetBase().TryCast<EnvironmentRecord>(), null) 
+                   && (lref.GetReferencedName() == "eval" || lref.GetReferencedName() == "arguments"))
                 {
                     throw new JavaScriptException(_engine.SyntaxError);
                 }
@@ -76,7 +78,7 @@ namespace Jint.Runtime
                     if (lprim.IsString() || rprim.IsString())
                     {
                         var jsString = lprim as JsString;
-                        if (jsString == null)
+                        if (ReferenceEquals(jsString, null))
                         {
                             jsString = new JsString.ConcatenatedString(TypeConverter.ToString(lprim));
                         }
@@ -346,12 +348,10 @@ namespace Jint.Runtime
 
                 case BinaryOperator.InstanceOf:
                     var f = right.TryCast<FunctionInstance>();
-
-                    if (f == null)
+                    if (ReferenceEquals(f, null))
                     {
                         throw new JavaScriptException(_engine.TypeError, "instanceof can only be used with a function object");
                     }
-
                     value = f.HasInstance(left);
                     break;
 
@@ -744,12 +744,12 @@ namespace Jint.Runtime
 
                     if (previous.IsAccessorDescriptor() && propDesc.IsAccessorDescriptor())
                     {
-                        if (propDesc.Set != null && previous.Set != null)
+                        if (!ReferenceEquals(propDesc.Set, null) && !ReferenceEquals(previous.Set, null))
                         {
                             throw new JavaScriptException(_engine.SyntaxError);
                         }
 
-                        if (propDesc.Get != null && previous.Get != null)
+                        if (!ReferenceEquals(propDesc.Get, null) && !ReferenceEquals(previous.Get, null))
                         {
                             throw new JavaScriptException(_engine.SyntaxError);
                         }
@@ -967,7 +967,7 @@ namespace Jint.Runtime
                     r = value as Reference;
                     if (r != null
                         && r.IsStrict()
-                        && (r.GetBase().TryCast<EnvironmentRecord>() != null)
+                        && (!ReferenceEquals(r.GetBase().TryCast<EnvironmentRecord>(), null))
                         && ("eval" == r.GetReferencedName() || "arguments" == r.GetReferencedName()))
                     {
                         throw new JavaScriptException(_engine.SyntaxError);
@@ -984,7 +984,7 @@ namespace Jint.Runtime
                     r = value as Reference;
                     if (r != null
                         && r.IsStrict()
-                        && (r.GetBase().TryCast<EnvironmentRecord>() != null)
+                        && (!ReferenceEquals(r.GetBase().TryCast<EnvironmentRecord>(), null))
                         && ("eval" == r.GetReferencedName() || "arguments" == r.GetReferencedName()))
                     {
                         throw new JavaScriptException(_engine.SyntaxError);

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -62,7 +62,7 @@ namespace Jint.Runtime.Interop
 
             var typeReference = GetPath(_path + "`" + arguments.Length.ToString(CultureInfo.InvariantCulture)).As<TypeReference>();
 
-            if (typeReference == null)
+            if (ReferenceEquals(typeReference, null))
             {
                 return Undefined;
             }

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -100,7 +100,7 @@ namespace Jint.Runtime.Interop
         {
             ObjectWrapper wrapper = v.As<ObjectWrapper>();
 
-            if (wrapper == null)
+            if (ReferenceEquals(wrapper, null))
             {
                 return base.HasInstance(v);
             }

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -95,12 +95,12 @@ namespace Jint.Runtime
             {
                 if (_callStack != null)
                     return _callStack;
-                if (Error == null)
+                if (ReferenceEquals(Error, null))
                     return null;
                 if (Error.IsObject() == false)
                     return null;
                 var callstack = Error.AsObject().Get("callstack");
-                if (callstack == JsValue.Undefined)
+                if (ReferenceEquals(callstack, JsValue.Undefined))
                     return null;
                 return callstack.AsString();
             }

--- a/Jint/Runtime/References/Reference.cs
+++ b/Jint/Runtime/References/Reference.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Runtime.Environments;
 
@@ -20,35 +21,41 @@ namespace Jint.Runtime.References
             _name = name;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JsValue GetBase()
         {
             return _baseValue;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string GetReferencedName()
         {
             return _name;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsStrict()
         {
             return _strict;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool HasPrimitiveBase()
         {
             return _baseValue.IsPrimitive();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsUnresolvableReference()
         {
             return _baseValue.IsUndefined();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsPropertyReference()
         {
             // http://www.ecma-international.org/ecma-262/5.1/#sec-8.7
-            return HasPrimitiveBase() || (_baseValue.IsObject() && !(_baseValue is EnvironmentRecord));
+            return _baseValue.IsPrimitive() || (_baseValue.IsObject() && !(_baseValue is EnvironmentRecord));
         }
 
         internal Reference Reassign(JsValue baseValue, string name, bool strict)

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.Descriptors;
@@ -162,13 +161,13 @@ namespace Jint.Runtime
             {
                 if (forStatement.Init.Type == Nodes.VariableDeclaration)
                 {
-                    var c = ExecuteStatement(forStatement.Init.As<Statement>());
+                    var c = ExecuteStatement((Statement) forStatement.Init);
                     _engine.CompletionPool.Return(c);
 
                 }
                 else
                 {
-                    _engine.GetValue(_engine.EvaluateExpression(forStatement.Init.As<Expression>()), true);
+                    _engine.GetValue(_engine.EvaluateExpression(forStatement.Init), true);
                 }
             }
 
@@ -216,9 +215,9 @@ namespace Jint.Runtime
         /// <returns></returns>
         public Completion ExecuteForInStatement(ForInStatement forInStatement)
         {
-            Identifier identifier = forInStatement.Left.Type == Nodes.VariableDeclaration
-                                        ? forInStatement.Left.As<VariableDeclaration>().Declarations.First().Id.As<Identifier>()
-                                        : forInStatement.Left.As<Identifier>();
+            var identifier = forInStatement.Left.Type == Nodes.VariableDeclaration
+                ? (Identifier) ((VariableDeclaration) forInStatement.Left).Declarations[0].Id
+                : (Identifier) forInStatement.Left;
 
             var varRef = _engine.EvaluateExpression(identifier) as Reference;
             var experValue = _engine.GetValue(_engine.EvaluateExpression(forInStatement.Right), true);
@@ -439,8 +438,7 @@ namespace Jint.Runtime
                 var statementListCount = statementList.Count;
                 for (var i = 0; i < statementListCount; i++)
                 {
-                    var statement = statementList[i];
-                    s = statement.As<Statement>();
+                    s = (Statement) statementList[i];
                     c = ExecuteStatement(s);
                     if (c.Type != Completion.Normal)
                     {
@@ -502,7 +500,7 @@ namespace Jint.Runtime
                     var c = _engine.GetValue(b);
                     var oldEnv = _engine.ExecutionContext.LexicalEnvironment;
                     var catchEnv = LexicalEnvironment.NewDeclarativeEnvironment(_engine, oldEnv);
-                    catchEnv.Record.CreateMutableBinding(catchClause.Param.As<Identifier>().Name, c);
+                    catchEnv.Record.CreateMutableBinding(((Identifier) catchClause.Param).Name, c);
                     _engine.ExecutionContext.LexicalEnvironment = catchEnv;
                     b = ExecuteStatement(catchClause.Body);
                     _engine.ExecutionContext.LexicalEnvironment = oldEnv;
@@ -536,7 +534,7 @@ namespace Jint.Runtime
                 var declaration = statement.Declarations[i];
                 if (declaration.Init != null)
                 {
-                    if (!(_engine.EvaluateExpression(declaration.Id.As<Identifier>()) is Reference lhs))
+                    if (!(_engine.EvaluateExpression(declaration.Id) is Reference lhs))
                     {
                         throw new ArgumentException();
                     }

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -81,7 +81,7 @@ namespace Jint.Runtime
             do
             {
                 var stmt = ExecuteStatement(doWhileStatement.Body);
-                if (stmt.Value != null)
+                if (!ReferenceEquals(stmt.Value, null))
                 {
                     v = stmt.Value;
                 }
@@ -126,7 +126,7 @@ namespace Jint.Runtime
 
                 var stmt = ExecuteStatement(whileStatement.Body);
 
-                if (stmt.Value != null)
+                if (!ReferenceEquals(stmt.Value, null))
                 {
                     v = stmt.Value;
                 }
@@ -156,18 +156,18 @@ namespace Jint.Runtime
         /// <returns></returns>
         public Completion ExecuteForStatement(ForStatement forStatement)
         {
-
-            if (forStatement.Init != null)
+            var init = forStatement.Init;
+            if (init != null)
             {
-                if (forStatement.Init.Type == Nodes.VariableDeclaration)
+                if (init.Type == Nodes.VariableDeclaration)
                 {
-                    var c = ExecuteStatement((Statement) forStatement.Init);
+                    var c = ExecuteStatement((Statement) init);
                     _engine.CompletionPool.Return(c);
 
                 }
                 else
                 {
-                    _engine.GetValue(_engine.EvaluateExpression(forStatement.Init), true);
+                    _engine.GetValue(_engine.EvaluateExpression(init), true);
                 }
             }
 
@@ -184,7 +184,7 @@ namespace Jint.Runtime
                 }
 
                 var stmt = ExecuteStatement(forStatement.Body);
-                if (stmt.Value != null)
+                if (!ReferenceEquals(stmt.Value, null))
                 {
                     v = stmt.Value;
                 }
@@ -233,7 +233,7 @@ namespace Jint.Runtime
             var cursor = obj;
             var processedKeys = new HashSet<string>();
 
-            while (cursor != null)
+            while (!ReferenceEquals(cursor, null))
             {
                 var keys = _engine.Object.GetOwnPropertyNames(Undefined.Instance, Arguments.From(cursor)).AsArray();
 
@@ -264,7 +264,7 @@ namespace Jint.Runtime
                     _engine.PutValue(varRef, p);
 
                     var stmt = ExecuteStatement(forInStatement.Body);
-                    if (stmt.Value != null)
+                    if (!ReferenceEquals(stmt.Value, null))
                     {
                         v = stmt.Value;
                     }
@@ -408,7 +408,7 @@ namespace Jint.Runtime
                         return r;
                     }
 
-                    v = r.Value != null ? r.Value : Undefined.Instance;
+                    v = r.Value ?? Undefined.Instance;
                 }
             }
 
@@ -421,7 +421,7 @@ namespace Jint.Runtime
                     return r;
                 }
 
-                v = r.Value != null ? r.Value : Undefined.Instance;
+                v = r.Value ?? Undefined.Instance;
             }
 
             return _engine.CompletionPool.Rent(Completion.Normal, v, null);
@@ -444,7 +444,7 @@ namespace Jint.Runtime
                     {
                         var executeStatementList = _engine.CompletionPool.Rent(
                             c.Type,
-                            c.Value != null ? c.Value : sl.Value,
+                            c.Value ?? sl.Value,
                             c.Identifier,
                             c.Location);
 
@@ -539,8 +539,9 @@ namespace Jint.Runtime
                         throw new ArgumentException();
                     }
 
-                    if (lhs.IsStrict() && lhs.GetBase().TryCast<EnvironmentRecord>() != null &&
-                        (lhs.GetReferencedName() == "eval" || lhs.GetReferencedName() == "arguments"))
+                    if (lhs.IsStrict() 
+                        && !ReferenceEquals(lhs.GetBase().TryCast<EnvironmentRecord>(), null) 
+                        && (lhs.GetReferencedName() == "eval" || lhs.GetReferencedName() == "arguments"))
                     {
                         throw new JavaScriptException(_engine.SyntaxError);
                     }

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -74,18 +74,18 @@ namespace Jint.Runtime
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-9.2
         /// </summary>
-        /// <param name="o"></param>
-        /// <returns></returns>
         public static bool ToBoolean(JsValue o)
         {
-            if (o.IsObject())
+            var type = o.Type;
+
+            if (type == Types.Object)
             {
                 return true;
             }
 
-            if (o.IsBoolean())
+            if (type == Types.Boolean)
             {
-                return o.AsBoolean();
+                return ((JsBoolean) o)._value;
             }
 
             if (ReferenceEquals(o, Undefined.Instance) || ReferenceEquals(o, Null.Instance))
@@ -93,9 +93,9 @@ namespace Jint.Runtime
                 return false;
             }
 
-            if (o.IsNumber())
+            if (type == Types.Number)
             {
-                var n = o.AsNumber();
+                var n = ((JsNumber) o)._value;
                 if (n.Equals(0) || double.IsNaN(n))
                 {
                     return false;
@@ -104,10 +104,10 @@ namespace Jint.Runtime
                 return true;
             }
 
-            if (o.IsString())
+            if (type == Types.String)
             {
                 var s = o.AsString();
-                if (String.IsNullOrEmpty(s))
+                if (string.IsNullOrEmpty(s))
                 {
                     return false;
                 }
@@ -126,15 +126,15 @@ namespace Jint.Runtime
         public static double ToNumber(JsValue o)
         {
             // check number first as this is what is usually expected
-            if (o.IsNumber())
+            var type = o.Type;
+            if (type == Types.Number)
             {
-                return o.AsNumber();
+                return ((JsNumber) o)._value;
             }
 
-            if (o.IsObject())
+            if (type == Types.Object)
             {
-                var p = o.AsObject() as IPrimitiveInstance;
-                if (p != null)
+                if (o is IPrimitiveInstance p)
                 {
                     o = p.PrimitiveValue;
                 }
@@ -150,12 +150,12 @@ namespace Jint.Runtime
                 return 0;
             }
 
-            if (o.IsBoolean())
+            if (type == Types.Boolean)
             {
-                return o.AsBoolean() ? 1 : 0;
+                return ((JsBoolean) o)._value ? 1 : 0;
             }
 
-            if (o.IsString())
+            if (type == Types.String)
             {
                 return ToNumber(o.AsString());
             }
@@ -171,7 +171,9 @@ namespace Jint.Runtime
                 return 0;
             }
 
-            var s = StringPrototype.TrimEx(input);
+            var s = StringPrototype.IsWhiteSpaceEx(input[0]) || StringPrototype.IsWhiteSpaceEx(input[input.Length - 1])
+                ? StringPrototype.TrimEx(input)
+                : input;
 
             if (string.IsNullOrEmpty(s))
             {

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -363,7 +363,7 @@ namespace Jint.Runtime
                 else
                 {
                     var s = o.AsInstance<SymbolInstance>();
-                    if (s != null)
+                    if (!ReferenceEquals(s, null))
                     {
                         // TODO: throw a TypeError
                         // NB: But it requires an Engine reference
@@ -456,10 +456,13 @@ namespace Jint.Runtime
             return value.Type;
         }
 
-        public static void CheckObjectCoercible(Engine engine, JsValue o, MemberExpression expression,
+        public static void CheckObjectCoercible(
+            Engine engine,
+            JsValue o,
+            MemberExpression expression,
             object baseReference)
         {
-            if (o != Undefined.Instance && o != Null.Instance)
+            if (!ReferenceEquals(o, Undefined.Instance) && !ReferenceEquals(o, Null.Instance))
             {
                 return;
             }


### PR DESCRIPTION
* JsValue virtual methods converted to non-virtual where possible
* PropertyDescriptor Value changed to non-virtual, customization allowed via CustomValue
* changed to use ReferenceEqual instead of sneaky inefficient equality operator for basic null/undefined etc checks

## ArrayBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Slice|100|589.6 us|161.1328|660.16 KB|
| **New** |	|	| **503.0 us (-15%)** | **161.1328 (0%)** | **660.16 KB (0%)** |
| Old |Concat|100|691.7 us|175.7813|720.31 KB|
| **New** |	|	| **605.4 us (-12%)** | **175.7813 (0%)** | **720.31 KB (0%)** |
| Old |Unshift|100|24,614.2 us|3562.5000|14672.66 KB|
| **New** |	|	| **20,565.8 us (-16%)** | **3562.5000 (0%)** | **14672.66 KB (0%)** |
| Old |Push|100|15,500.2 us|515.6250|2134.38 KB|
| **New** |	|	| **13,610.1 us (-12%)** | **515.6250 (0%)** | **2134.38 KB (0%)** |
| Old |Index|100|14,841.0 us|390.6250|1637.5 KB|
| **New** |	|	| **12,966.3 us (-13%)** | **390.6250 (0%)** | **1637.5 KB (0%)** |
| Old |Map|100|4,051.0 us|765.6250|3150.78 KB|
| **New** |	|	| **3,748.1 us (-7%)** | **765.6250 (0%)** | **3151.56 KB (0%)** |
| Old |Apply|100|786.8 us|190.4297|782.81 KB|
| **New** |	|	| **730.5 us (-7%)** | **190.4297 (0%)** | **782.81 KB (0%)** |
| Old |JsonStringifyParse|100|5,130.9 us|1257.8125|5166.41 KB|
| **New** |	|	| **4,851.7 us (-5%)** | **1273.4375 (+1%)** | **5233.59 KB (+1%)** |


## ArrayStressBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|20|806.8 ms|60000.0000|8312.5000|256.64 MB|
| **New** |	|	| **717.8 ms (-11%)** | **60000.0000 (0%)** | **8312.5000 (0%)** | **256.64 MB (0%)** |


## DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|dromaeo-3d-cube|98.72 ms|1312.5000|312.5000|-|7054.55 KB|
| **New** |	|	| **83.14 ms (-16%)** | **1437.5000 (+10%)** | **500.0000 (+60%)** | **-** | **7749.97 KB (+10%)** |
| Old |Run|dromaeo-core-eval|22.80 ms|62.5000|-|-|298.69 KB|
| **New** |	|	| **19.60 ms (-14%)** | **62.5000 (0%)** | **-** | **-** | **299.02 KB (0%)** |
| Old |Run|dromaeo-object-array|219.61 ms|42875.0000|2000.0000|1000.0000|179714.35 KB|
| **New** |	|	| **197.04 ms (-10%)** | **43312.5000 (+1%)** | **2000.0000 (0%)** | **1000.0000 (0%)** | **181953.41 KB (+1%)** |
| Old |Run|dromaeo-object-regexp|1,150.99 ms|59437.5000|33500.0000|23437.5000|448378.36 KB|
| **New** |	|	| **1,099.41 ms (-4%)** | **62062.5000 (+4%)** | **32687.5000 (-2%)** | **22562.5000 (-4%)** | **468560.36 KB (+5%)** |
| Old |Run|dromaeo-object-string|1,372.11 ms|220250.0000|178312.5000|175500.0000|1391975.63 KB|
| **New** |	|	| **1,310.23 ms (-5%)** | **220437.5000 (0%)** | **176375.0000 (-1%)** | **173187.5000 (-1%)** | **1403414.96 KB (+1%)** |
| Old |Run|dromaeo-string-base64|224.99 ms|5625.0000|312.5000|-|24517.42 KB|
| **New** |	|	| **194.00 ms (-14%)** | **6062.5000 (+8%)** | **437.5000 (+40%)** | **-** | **26624.45 KB (+9%)** |


## UncacheableExpressionsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Benchmark|500|449.3 ms|50000.0000|8500.0000|211.22 MB|
| **New** |	|	| **403.1 ms (-10%)** | **50187.5000 (0%)** | **10000.0000 (+18%)** | **211.26 MB (0%)** |


