### PR TITLE
fix for issue #351

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1976,6 +1976,45 @@ namespace Jint.Tests.Runtime
             Assert.True(val.AsString() == "53.6841659");
         }
 
+        [Fact]
+        public void ShouldStringifyObjectWithPropertiesToSameRef()
+        {
+            var engine = new Engine();
+            var res = engine.Execute(@"
+                var obj = {
+                    a : [],
+                    a1 : ['str'],
+                    a2 : {},
+                    a3 : { 'prop' : 'val' }
+                };
+                obj.b = obj.a;
+                obj.b1 = obj.a1;
+                JSON.stringify(obj);
+            ").GetCompletionValue();
+
+            Assert.True(res == "{\"a\":[],\"a1\":[\"str\"],\"a2\":{},\"a3\":{\"prop\":\"val\"},\"b\":[],\"b1\":[\"str\"]}");
+        }
+
+        [Fact]
+        public void ShouldThrowOnSerializingCyclicRefObject()
+        {
+            var engine = new Engine();
+            var res = engine.Execute(@"
+                (function(){
+                    try{
+                        a = [];
+                        a[0] = a;
+                        my_text = JSON.stringify(a);
+                    }
+                    catch(ex){
+                        return ex.message;
+                    }
+                })();
+            ").GetCompletionValue();
+
+            Assert.True(res == "Cyclic reference detected.");
+        }
+
         [Theory]
         [InlineData("", "escape('')")]
         [InlineData("%u0100%u0101%u0102", "escape('\u0100\u0101\u0102')")]

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -51,20 +51,37 @@ namespace Jint.Native.Json
                     var arrLen = valAsArray.GetLength();
                     while (i < arrLen)
                     {
+<<<<<<< HEAD
                         var newValue = AbstractWalkOperation(valAsArray, TypeConverter.ToString(i));
                         if (newValue.IsUndefined())
                         {
                             valAsArray.Delete(TypeConverter.ToString(i), false);
+=======
+                        var newValue = AbstractWalkOperation(valAsArray, i.ToString());
+                        if (newValue.IsUndefined())
+                        {
+                            valAsArray.Delete(i.ToString(), false);
+>>>>>>> fixed bug #436
                         }
                         else
                         {
                             valAsArray.DefineOwnProperty
                             (
+<<<<<<< HEAD
                                 TypeConverter.ToString(i),
                                 new PropertyDescriptor
                                 (
                                     value: newValue,
                                     PropertyFlag.ConfigurableEnumerableWritable
+=======
+                                i.ToString(),
+                                new PropertyDescriptor
+                                (
+                                    value: newValue,
+                                    writable: true,
+                                    enumerable: true,
+                                    configurable: true
+>>>>>>> fixed bug #436
                                 ),
                                 false
                             );
@@ -89,7 +106,13 @@ namespace Jint.Native.Json
                                 new PropertyDescriptor
                                 (
                                     value: newElement,
+<<<<<<< HEAD
                                     PropertyFlag.ConfigurableEnumerableWritable
+=======
+                                    writable: true,
+                                    enumerable: true,
+                                    configurable: true
+>>>>>>> fixed bug #436
                                 ),
                                 false
                             );
@@ -112,7 +135,13 @@ namespace Jint.Native.Json
                     "",
                     new PropertyDescriptor(
                         value: res,
+<<<<<<< HEAD
                         PropertyFlag.ConfigurableEnumerableWritable
+=======
+                        writable: true,
+                        enumerable: true,
+                        configurable: true
+>>>>>>> fixed bug #436
                     ),
                     false
                 );

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -51,37 +51,20 @@ namespace Jint.Native.Json
                     var arrLen = valAsArray.GetLength();
                     while (i < arrLen)
                     {
-<<<<<<< HEAD
                         var newValue = AbstractWalkOperation(valAsArray, TypeConverter.ToString(i));
                         if (newValue.IsUndefined())
                         {
                             valAsArray.Delete(TypeConverter.ToString(i), false);
-=======
-                        var newValue = AbstractWalkOperation(valAsArray, i.ToString());
-                        if (newValue.IsUndefined())
-                        {
-                            valAsArray.Delete(i.ToString(), false);
->>>>>>> fixed bug #436
                         }
                         else
                         {
                             valAsArray.DefineOwnProperty
                             (
-<<<<<<< HEAD
                                 TypeConverter.ToString(i),
                                 new PropertyDescriptor
                                 (
                                     value: newValue,
                                     PropertyFlag.ConfigurableEnumerableWritable
-=======
-                                i.ToString(),
-                                new PropertyDescriptor
-                                (
-                                    value: newValue,
-                                    writable: true,
-                                    enumerable: true,
-                                    configurable: true
->>>>>>> fixed bug #436
                                 ),
                                 false
                             );
@@ -106,13 +89,7 @@ namespace Jint.Native.Json
                                 new PropertyDescriptor
                                 (
                                     value: newElement,
-<<<<<<< HEAD
                                     PropertyFlag.ConfigurableEnumerableWritable
-=======
-                                    writable: true,
-                                    enumerable: true,
-                                    configurable: true
->>>>>>> fixed bug #436
                                 ),
                                 false
                             );
@@ -135,13 +112,7 @@ namespace Jint.Native.Json
                     "",
                     new PropertyDescriptor(
                         value: res,
-<<<<<<< HEAD
                         PropertyFlag.ConfigurableEnumerableWritable
-=======
-                        writable: true,
-                        enumerable: true,
-                        configurable: true
->>>>>>> fixed bug #436
                     ),
                     false
                 );

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -272,6 +272,7 @@ namespace Jint.Native.Json
             }
             if (partial.Count == 0)
             {
+                _stack.Pop();
                 return "[]";
             }
 


### PR DESCRIPTION
fix for the following issue in JSON serialization.

when two properties of an object are referenced to same object(an empty array) error is thrown.