### PR TITLE
Make execution context struct and other performance tweaks

### DIFF
--- a/Jint.Benchmark/UncacheableExpressionsBenchmark.cs
+++ b/Jint.Benchmark/UncacheableExpressionsBenchmark.cs
@@ -23,7 +23,7 @@ namespace Jint.Benchmark
         {
             public Config()
             {
-                Add(Job.ShortRun);
+                Add(Job.MediumRun.WithLaunchCount(1));
                 Add(MemoryDiagnoser.Default);
             }
         }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -538,8 +538,7 @@ namespace Jint
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal JsValue GetValue(object value, bool returnReferenceToPool)
         {
-            var jsValue = value as JsValue;
-            if (!ReferenceEquals(jsValue, null))
+            if (value is JsValue jsValue)
             {
                 return jsValue;
             }
@@ -599,7 +598,7 @@ namespace Jint
                     }
 
                     var getter = desc.Get;
-                    if (ReferenceEquals(getter, Undefined.Instance))
+                    if (getter.IsUndefined())
                     {
                         return Undefined.Instance;
                     }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -376,7 +376,6 @@ namespace Jint
             return _completionValue;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Completion ExecuteStatement(Statement statement)
         {
             if (_maxStatements > 0 && _statementsCount++ > _maxStatements)
@@ -464,7 +463,6 @@ namespace Jint
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object EvaluateExpression(INode expression)
         {
             _lastSyntaxNode = expression;
@@ -528,11 +526,27 @@ namespace Jint
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-8.7.1
         /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JsValue GetValue(object value)
         {
-            return GetValue(value, false);
+            if (value is JsValue jsValue)
+            {
+                return jsValue;
+            }
+
+            return GetValueFromReference(value, false);
+        }
+        
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal JsValue GetValue(in Completion completion)
+        {
+            var value = completion.Value;
+            if (value is JsValue jsValue)
+            {
+                return jsValue;
+            }
+            return GetValueFromReference(completion.Value, false);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -543,6 +557,11 @@ namespace Jint
                 return jsValue;
             }
 
+            return GetValueFromReference(value, returnReferenceToPool);
+        }
+       
+        internal JsValue GetValueFromReference(object value, bool returnReferenceToPool)
+        {
             var reference = value as Reference;
             if (reference == null)
             {
@@ -629,7 +648,6 @@ namespace Jint
         /// </summary>
         /// <param name="reference"></param>
         /// <param name="value"></param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void PutValue(Reference reference, JsValue value)
         {
             if (reference.IsUnresolvableReference())
@@ -794,7 +812,6 @@ namespace Jint
         /// </summary>
         /// <param name="scope">The scope to get the property from.</param>
         /// <param name="propertyName">The name of the property to return.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JsValue GetValue(JsValue scope, string propertyName)
         {
             AssertNotNullOrEmpty(nameof(propertyName), propertyName);
@@ -919,6 +936,7 @@ namespace Jint
             return canReleaseArgumentsInstance;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void UpdateLexicalEnvironment(LexicalEnvironment newEnv)
         {
             _executionContexts.ReplaceTopLexicalEnvironment(newEnv);
@@ -961,6 +979,5 @@ namespace Jint
         {
             throw new JavaScriptException(TypeError);
         }
-
     }
 }

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint
+{
+    public static class JsValueExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool AsBoolean(this JsValue value)
+        {
+            if (value._type != Types.Boolean)
+            {
+                ThrowWrongTypeException("The value is not a boolean");
+            }
+
+            return ((JsBoolean) value)._value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double AsNumber(this JsValue value)
+        {
+            if (value._type != Types.Number)
+            {
+                ThrowWrongTypeException("The value is not a number");
+            }
+
+            return ((JsNumber) value)._value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string AsString(this JsValue value)
+        {
+            if (value._type != Types.String)
+            {
+                ThrowWrongTypeException("The value is not a string");
+            }
+
+            return AsStringWithoutTypeCheck(value);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static string AsStringWithoutTypeCheck(this JsValue value)
+        {
+            return value.ToString();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string AsSymbol(this JsValue value)
+        {
+            if (value._type != Types.Symbol)
+            {
+                ThrowWrongTypeException("The value is not a symbol");
+            }
+
+            return ((JsSymbol) value)._value;
+        }
+        
+        private static void ThrowWrongTypeException(string message)
+        {
+            throw new ArgumentException(message);
+        }
+    }
+}

--- a/Jint/Native/Argument/ArgumentsInstance.cs
+++ b/Jint/Native/Argument/ArgumentsInstance.cs
@@ -25,7 +25,7 @@ namespace Jint.Native.Argument
 
         private bool _initialized;
 
-        internal ArgumentsInstance(Engine engine) : base(engine)
+        internal ArgumentsInstance(Engine engine) : base(engine, objectClass: "Arguments")
         {
         }
 
@@ -100,8 +100,6 @@ namespace Jint.Native.Argument
         }
 
         public ObjectInstance ParameterMap { get; set; }
-
-        public override string Class => "Arguments";
 
         public override PropertyDescriptor GetOwnProperty(string propertyName)
         {
@@ -194,7 +192,7 @@ namespace Jint.Native.Argument
                     else
                     {
                         var descValue = desc.Value;
-                        if (!ReferenceEquals(descValue, null) && !ReferenceEquals(descValue, Undefined))
+                        if (!ReferenceEquals(descValue, null) && !descValue.IsUndefined())
                         {
                             map.Put(propertyName, descValue, throwOnError);
                         }

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -61,7 +61,7 @@ namespace Jint.Native.Array
             var capacity = arguments.Length > 0 ? (uint) arguments.Length : 0;
             if (arguments.Length == 1 && arguments[0].Type == Types.Number)
             {
-                var number = arguments[0].AsNumber();
+                var number = ((JsNumber) arguments[0])._value;
                 if (number > 0)
                 {
                     capacity = (uint) number;

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -24,7 +24,7 @@ namespace Jint.Native.Array
         private PropertyDescriptor[] _dense;
         private Dictionary<uint, PropertyDescriptor> _sparse;
 
-        public ArrayInstance(Engine engine, uint capacity = 0) : base(engine)
+        public ArrayInstance(Engine engine, uint capacity = 0) : base(engine, objectClass: "Array")
         {
             if (capacity < MaxDenseArrayLength)
             {
@@ -36,7 +36,7 @@ namespace Jint.Native.Array
             }
         }
 
-        public ArrayInstance(Engine engine, PropertyDescriptor[] items) : base(engine)
+        public ArrayInstance(Engine engine, PropertyDescriptor[] items) : base(engine, objectClass: "Array")
         {
             int length = 0;
             if (items == null || items.Length == 0)
@@ -53,14 +53,12 @@ namespace Jint.Native.Array
             _length = new PropertyDescriptor(length, PropertyFlag.OnlyWritable);
         }
 
-        public ArrayInstance(Engine engine, Dictionary<uint, PropertyDescriptor> items) : base(engine)
+        public ArrayInstance(Engine engine, Dictionary<uint, PropertyDescriptor> items) : base(engine, objectClass: "Array")
         {
             _sparse = items;
             var length = items?.Count ?? 0;
             _length = new PropertyDescriptor(length, PropertyFlag.OnlyWritable);
         }
-
-        public override string Class => "Array";
 
         /// Implementation from ObjectInstance official specs as the one
         /// in ObjectInstance is optimized for the general case and wouldn't work

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -450,8 +450,17 @@ namespace Jint.Native.Array
                 return uint.MaxValue;
             }
 
-            ulong result = (uint) d;
+            if (p.Length > 1)
+            {
+                return StringAsIndex(d, p);
+            }
+            
+            return (uint) d;
+        }
 
+        private static uint StringAsIndex(int d, string p)
+        {
+            ulong result = (uint) d;
             for (int i = 1; i < p.Length; i++)
             {
                 d = p[i] - '0';

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -13,8 +13,6 @@ namespace Jint.Native.Array
 {
     public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
     {
-        private readonly Engine _engine;
-
         private const string PropertyNameLength = "length";
         private const int PropertyNameLengthLength = 6;
 
@@ -28,7 +26,6 @@ namespace Jint.Native.Array
 
         public ArrayInstance(Engine engine, uint capacity = 0) : base(engine)
         {
-            _engine = engine;
             if (capacity < MaxDenseArrayLength)
             {
                 _dense = capacity > 0 ? new PropertyDescriptor[capacity] : System.Array.Empty<PropertyDescriptor>();
@@ -41,7 +38,6 @@ namespace Jint.Native.Array
 
         public ArrayInstance(Engine engine, PropertyDescriptor[] items) : base(engine)
         {
-            _engine = engine;
             int length = 0;
             if (items == null || items.Length == 0)
             {
@@ -59,7 +55,6 @@ namespace Jint.Native.Array
 
         public ArrayInstance(Engine engine, Dictionary<uint, PropertyDescriptor> items) : base(engine)
         {
-            _engine = engine;
             _sparse = items;
             var length = items?.Count ?? 0;
             _length = new PropertyDescriptor(length, PropertyFlag.OnlyWritable);

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -509,24 +509,26 @@ namespace Jint.Native.Array
 
             var compareArg = arguments.At(0);
             ICallable compareFn = null;
-            if (!ReferenceEquals(compareArg, Undefined))
+            if (!compareArg.IsUndefined())
             {
                 compareFn = compareArg.TryCast<ICallable>(x => throw new JavaScriptException(Engine.TypeError, "The sort argument must be a function"));
             }
 
             int Comparer(JsValue x, JsValue y)
             {
-                if (ReferenceEquals(x, Undefined) && ReferenceEquals(y, Undefined))
+                var xUndefined = x.IsUndefined();
+                var yUndefined = y.IsUndefined();
+                if (xUndefined && yUndefined)
                 {
                     return 0;
                 }
 
-                if (ReferenceEquals(x, Undefined))
+                if (xUndefined)
                 {
                     return 1;
                 }
 
-                if (ReferenceEquals(y, Undefined))
+                if (yUndefined)
                 {
                     return -1;
                 }
@@ -598,7 +600,7 @@ namespace Jint.Native.Array
             }
 
             uint final;
-            if (ReferenceEquals(end, Undefined))
+            if (end.IsUndefined())
             {
                 final = TypeConverter.ToUint32(len);
             }
@@ -700,7 +702,7 @@ namespace Jint.Native.Array
             var separator = arguments.At(0);
             var o = ArrayOperations.For(Engine, thisObj);
             var len = o.GetLength();
-            if (ReferenceEquals(separator, Undefined))
+            if (separator.IsUndefined())
             {
                 separator = ",";
             }
@@ -715,7 +717,7 @@ namespace Jint.Native.Array
 
             string StringFromJsValue(JsValue value)
             {
-                return ReferenceEquals(value, Undefined) || ReferenceEquals(value, Null)
+                return value.IsUndefined() || value.IsNull()
                     ? ""
                     : TypeConverter.ToString(value);
             }
@@ -749,7 +751,7 @@ namespace Jint.Native.Array
             }
 
             JsValue r;
-            if (!array.TryGetValue(0, out var firstElement) || ReferenceEquals(firstElement, Null) || ReferenceEquals(firstElement, Undefined))
+            if (!array.TryGetValue(0, out var firstElement) || firstElement.IsNull() || firstElement.IsUndefined())
             {
                 r = "";
             }
@@ -764,7 +766,7 @@ namespace Jint.Native.Array
             for (uint k = 1; k < len; k++)
             {
                 string s = r + separator;
-                if (!array.TryGetValue(k, out var nextElement) || ReferenceEquals(nextElement, Null))
+                if (!array.TryGetValue(k, out var nextElement) || nextElement.IsNull())
                 {
                     r = "";
                 }

--- a/Jint/Native/Boolean/BooleanInstance.cs
+++ b/Jint/Native/Boolean/BooleanInstance.cs
@@ -6,11 +6,9 @@ namespace Jint.Native.Boolean
     public class BooleanInstance : ObjectInstance, IPrimitiveInstance
     {
         public BooleanInstance(Engine engine)
-            : base(engine)
+            : base(engine, objectClass: "Boolean")
         {
         }
-
-        public override string Class => "Boolean";
 
         Types IPrimitiveInstance.Type => Types.Boolean;
 

--- a/Jint/Native/Boolean/BooleanPrototype.cs
+++ b/Jint/Native/Boolean/BooleanPrototype.cs
@@ -51,7 +51,7 @@ namespace Jint.Native.Boolean
         private JsValue ToBooleanString(JsValue thisObj, JsValue[] arguments)
         {
             var b = ValueOf(thisObj, Arguments.Empty);
-            return b.AsBoolean() ? "true" : "false";
+            return ((JsBoolean) b)._value ? "true" : "false";
         }
     }
 }

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -105,7 +105,7 @@ namespace Jint.Native.Date
             return TimeClip(ConstructTimeValue(arguments, useUtc: true));
         }
 
-        private JsValue Now(JsValue thisObj, JsValue[] arguments)
+        private static JsValue Now(JsValue thisObj, JsValue[] arguments)
         {
             return System.Math.Floor((DateTime.UtcNow - Epoch).TotalMilliseconds);
         }

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -131,7 +131,7 @@ namespace Jint.Native.Date
                 var v = TypeConverter.ToPrimitive(arguments[0]);
                 if (v.IsString())
                 {
-                    return Construct(Parse(Undefined, Arguments.From(v)).AsNumber());
+                    return Construct(((JsNumber) Parse(Undefined, Arguments.From(v)))._value);
                 }
 
                 return Construct(TypeConverter.ToNumber(v));

--- a/Jint/Native/Date/DateInstance.cs
+++ b/Jint/Native/Date/DateInstance.cs
@@ -13,16 +13,8 @@ namespace Jint.Native.Date
         internal static readonly double Min = -(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc) - DateTime.MinValue).TotalMilliseconds;
 
         public DateInstance(Engine engine)
-            : base(engine)
+            : base(engine, objectClass: "Date")
         {
-        }
-
-        public override string Class
-        {
-            get
-            {
-                return "Date";
-            }
         }
 
         public DateTime ToDateTime()

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -562,9 +562,9 @@ namespace Jint.Native.Date
         {
             var o = TypeConverter.ToObject(Engine, thisObj);
             var tv = TypeConverter.ToPrimitive(o, Types.Number);
-            if (tv.IsNumber() && double.IsInfinity(tv.AsNumber()))
+            if (tv.IsNumber() && double.IsInfinity(((JsNumber) tv)._value))
             {
-                return JsValue.Null;
+                return Null;
             }
 
             var toIso = o.Get("toISOString");

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -47,9 +47,10 @@ namespace Jint.Native.Error
             instance.Prototype = PrototypeObject;
             instance.Extensible = true;
 
-            if (!ReferenceEquals(arguments.At(0), Undefined))
+            var jsValue = arguments.At(0);
+            if (!jsValue.IsUndefined())
             {
-                instance.Put("message", TypeConverter.ToString(arguments.At(0)), false);
+                instance.Put("message", TypeConverter.ToString(jsValue), false);
             }
 
             return instance;

--- a/Jint/Native/Error/ErrorInstance.cs
+++ b/Jint/Native/Error/ErrorInstance.cs
@@ -6,17 +6,9 @@ namespace Jint.Native.Error
     public class ErrorInstance : ObjectInstance
     {
         public ErrorInstance(Engine engine, string name)
-            : base(engine)
+            : base(engine, objectClass: "Error")
         {
             FastAddProperty("name", name, true, false, true);
-        }
-
-        public override string Class
-        {
-            get
-            {
-                return "Error";
-            }
         }
 
         public override string ToString()

--- a/Jint/Native/Error/ErrorPrototype.cs
+++ b/Jint/Native/Error/ErrorPrototype.cs
@@ -51,7 +51,7 @@ namespace Jint.Native.Error
 
             var msgProp = o.Get("message");
             string msg;
-            if (ReferenceEquals(msgProp, Undefined))
+            if (msgProp.IsUndefined())
             {
                 msg = "";
             }

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -10,11 +10,8 @@ namespace Jint.Native.Function
     {
         private static readonly ParserOptions ParserOptions = new ParserOptions { AdaptRegexp = true, Tolerant = false };
 
-        private readonly Engine _engine;
-
         public EvalFunctionInstance(Engine engine, string[] parameters, LexicalEnvironment scope, bool strict) : base(engine, parameters, scope, strict)
         {
-            _engine = engine;
             Prototype = Engine.Function.PrototypeObject;
             SetOwnProperty("length", new PropertyDescriptor(1, PropertyFlag.AllForbidden));
         }

--- a/Jint/Native/Function/FunctionConstructor.cs
+++ b/Jint/Native/Function/FunctionConstructor.cs
@@ -141,7 +141,7 @@ namespace Jint.Native.Function
                 throw new JavaScriptException(Engine.TypeError);
             }
 
-            if (ReferenceEquals(argArray, Undefined) || ReferenceEquals(argArray, Undefined))
+            if (argArray.IsNull() || argArray.IsUndefined())
             {
                 return func.Call(thisArg, Arguments.Empty);
             }

--- a/Jint/Native/Function/FunctionInstance.cs
+++ b/Jint/Native/Function/FunctionInstance.cs
@@ -15,8 +15,19 @@ namespace Jint.Native.Function
         private const string PropertyNameLength = "length";
         private const int PropertyNameLengthLength = 6;
         private PropertyDescriptor _length;
+        
+        protected FunctionInstance(Engine engine, string[] parameters, LexicalEnvironment scope, bool strict)
+            : this(engine, parameters, scope, strict, objectClass: "Function")
+        {
+        }
 
-        protected FunctionInstance(Engine engine, string[] parameters, LexicalEnvironment scope, bool strict) : base(engine)
+        protected FunctionInstance(
+            Engine engine, 
+            string[] parameters, 
+            LexicalEnvironment scope, 
+            bool strict, 
+            in string objectClass)
+            : base(engine, objectClass)
         {
             FormalParameters = parameters;
             Scope = scope;
@@ -72,8 +83,6 @@ namespace Jint.Native.Function
                 }
             }
         }
-
-        public override string Class => "Function";
 
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.3.5.4

--- a/Jint/Native/Function/FunctionInstance.cs
+++ b/Jint/Native/Function/FunctionInstance.cs
@@ -16,11 +16,8 @@ namespace Jint.Native.Function
         private const int PropertyNameLengthLength = 6;
         private PropertyDescriptor _length;
 
-        private readonly Engine _engine;
-
         protected FunctionInstance(Engine engine, string[] parameters, LexicalEnvironment scope, bool strict) : base(engine)
         {
-            _engine = engine;
             FormalParameters = parameters;
             Scope = scope;
             Strict = strict;

--- a/Jint/Native/Function/FunctionPrototype.cs
+++ b/Jint/Native/Function/FunctionPrototype.cs
@@ -94,7 +94,7 @@ namespace Jint.Native.Function
                 throw new JavaScriptException(Engine.TypeError);
             }
 
-            if (ReferenceEquals(argArray, Null) || ReferenceEquals(argArray, Undefined))
+            if (argArray.IsNull() || argArray.IsUndefined())
             {
                 return func.Call(thisArg, Arguments.Empty);
             }

--- a/Jint/Native/Function/FunctionPrototype.cs
+++ b/Jint/Native/Function/FunctionPrototype.cs
@@ -105,7 +105,7 @@ namespace Jint.Native.Function
                 throw new JavaScriptException(Engine.TypeError);
             }
 
-            var len = argArrayObj.Get("length").AsNumber();
+            var len = ((JsNumber) argArrayObj.Get("length"))._value;
             uint n = TypeConverter.ToUint32(len);
 
             var argList = n < 10 

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -116,7 +116,6 @@ namespace Jint.Native.Function
             base.RemoveOwnProperty(propertyName);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static string[] GetParameterNames(IFunction functionDeclaration)
         {
             var list = functionDeclaration.Params;

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -152,7 +152,7 @@ namespace Jint.Native.Function
                 {
                     thisBinding = thisArg;
                 }
-                else if (ReferenceEquals(thisArg, Undefined) || ReferenceEquals(thisArg, Null))
+                else if (thisArg.IsUndefined() || thisArg.IsNull())
                 {
                     thisBinding = _engine.Global;
                 }

--- a/Jint/Native/Function/ThrowTypeError.cs
+++ b/Jint/Native/Function/ThrowTypeError.cs
@@ -5,11 +5,8 @@ namespace Jint.Native.Function
 {
     public sealed class ThrowTypeError : FunctionInstance
     {
-        private readonly Engine _engine;
-
         public ThrowTypeError(Engine engine): base(engine, System.Array.Empty<string>(), engine.GlobalEnvironment, false)
         {
-            _engine = engine;
             DefineOwnProperty("length", new PropertyDescriptor(0, PropertyFlag.AllForbidden), false);
             Extensible = false;
         }

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -120,7 +120,7 @@ namespace Jint.Native.Global
 
             try
             {
-                return sign * Parse(s, radix).AsNumber();
+                return sign * Parse(s, radix);
             }
             catch
             {
@@ -129,7 +129,7 @@ namespace Jint.Native.Global
 
         }
 
-        private static JsValue Parse(string number, int radix)
+        private static double Parse(string number, int radix)
         {
             if (number == "")
             {

--- a/Jint/Native/JsBoolean.cs
+++ b/Jint/Native/JsBoolean.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.Contracts;
 using Jint.Runtime;
 
 namespace Jint.Native
@@ -17,12 +16,6 @@ namespace Jint.Native
         public JsBoolean(bool value) : base(Types.Boolean)
         {
             _value = value;
-        }
-
-        [Pure]
-        public override bool AsBoolean()
-        {
-            return _value;
         }
 
         public override object ToObject()

--- a/Jint/Native/JsNumber.cs
+++ b/Jint/Native/JsNumber.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.Contracts;
 using Jint.Runtime;
 
 namespace Jint.Native
@@ -47,12 +46,6 @@ namespace Jint.Native
         public JsNumber(uint value) : base(Types.Number)
         {
             _value = value;
-        }
-
-        [Pure]
-        public override double AsNumber()
-        {
-            return _value;
         }
 
         public override object ToObject()

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.Contracts;
 using System.Text;
 using Jint.Runtime;
 
@@ -14,7 +13,7 @@ namespace Jint.Native
         private static readonly JsString Empty = new JsString("");
         private static readonly JsString NullString = new JsString("null");
 
-        private string _value;
+        internal string _value;
 
         static JsString()
         {
@@ -41,17 +40,6 @@ namespace Jint.Native
         public JsString(char value) : base(Types.String)
         {
             _value = value.ToString();
-        }
-
-        [Pure]
-        public override string AsString()
-        {
-            if (_value == null)
-            {
-                throw new ArgumentException("The value is not defined");
-            }
-
-            return _value;
         }
 
         public virtual JsString Append(JsValue jsValue)
@@ -156,8 +144,7 @@ namespace Jint.Native
                 }
             }
 
-            [Pure]
-            public override string AsString()
+            public override string ToString()
             {
                 if (_dirty)
                 {
@@ -203,13 +190,13 @@ namespace Jint.Native
 
                 if (other.Type == Types.String)
                 {
-                    var otherString = other.AsString();
+                    var otherString = other.AsStringWithoutTypeCheck();
                     if (otherString.Length != _stringBuilder.Length)
                     {
                         return false;
                     }
 
-                    return AsString().Equals(otherString);
+                    return ToString().Equals(otherString);
                 }
 
                 return base.Equals(other);

--- a/Jint/Native/JsSymbol.cs
+++ b/Jint/Native/JsSymbol.cs
@@ -8,7 +8,7 @@ namespace Jint.Native
     /// </summary>
     public sealed class JsSymbol : JsValue, IEquatable<JsSymbol>
     {
-        private readonly string _value;
+        internal readonly string _value;
 
         public JsSymbol(string value) : base(Types.Symbol)
         {
@@ -17,16 +17,6 @@ namespace Jint.Native
 
         public override object ToObject()
         {
-            return _value;
-        }
-
-        public override string AsSymbol()
-        {
-            if (_value == null)
-            {
-                throw new ArgumentException("The value is not defined");
-            }
-
             return _value;
         }
 

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -19,7 +19,7 @@ namespace Jint.Native
     {
         public static readonly JsValue Undefined = new JsUndefined();
         public static readonly JsValue Null = new JsNull();
-        private readonly Types _type;
+        internal readonly Types _type;
 
         protected JsValue(Types type)
         {
@@ -211,30 +211,6 @@ namespace Jint.Native
                 return this as T;
             }
             return null;
-        }
-
-        [Pure]
-        public virtual bool AsBoolean()
-        {
-            throw new ArgumentException("The value is not a boolean");
-        }
-
-        [Pure]
-        public virtual string AsString()
-        {
-            throw new ArgumentException("The value is not a string");
-        }
-
-        [Pure]
-        public virtual string AsSymbol()
-        {
-            throw new ArgumentException("The value is not a symbol");
-        }
-
-        [Pure]
-        public virtual double AsNumber()
-        {
-            throw new ArgumentException("The value is not a number");
         }
 
         // ReSharper disable once ConvertToAutoPropertyWhenPossible // PERF
@@ -511,13 +487,13 @@ namespace Jint.Native
                         Value = "null";
                         break;
                     case Types.Boolean:
-                        Value = value.AsBoolean() + " (bool)";
+                        Value = ((JsBoolean) value)._value + " (bool)";
                         break;
                     case Types.String:
-                        Value = value.AsString() + " (string)";
+                        Value = value.AsStringWithoutTypeCheck() + " (string)";
                         break;
                     case Types.Number:
-                        Value = value.AsNumber() + " (number)";
+                        Value = ((JsNumber) value)._value + " (number)";
                         break;
                     case Types.Object:
                         Value = value.AsObject().GetType().Name;

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -30,7 +30,7 @@ namespace Jint.Native
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsPrimitive()
         {
-            return _type != Types.Object && Type != Types.None;
+            return _type != Types.Object && _type != Types.None;
         }
 
         [Pure]
@@ -174,7 +174,7 @@ namespace Jint.Native
             }
 
             // TODO not implemented
-            return Completion.EmptyUndefined;
+            return new Completion(CompletionType.Normal, Native.Undefined.Instance, null);
         }
 
         [Pure]

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -183,8 +183,7 @@ namespace Jint.Native
         {
             if (IsObject())
             {
-                var o = this as T;
-                if (o != null)
+                if (this is T o)
                 {
                     return o;
                 }

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -10,17 +10,9 @@ namespace Jint.Native.Json
         private JsValue _reviver;
 
         private JsonInstance(Engine engine)
-            : base(engine)
+            : base(engine, objectClass: "JSON")
         {
             Extensible = true;
-        }
-
-        public override string Class
-        {
-            get
-            {
-                return "JSON";
-            }
         }
 
         public static JsonInstance CreateJsonObject(Engine engine)
@@ -142,7 +134,7 @@ namespace Jint.Native.Json
             }
 
             var serializer = new JsonSerializer(_engine);
-            if (ReferenceEquals(value, Undefined) && ReferenceEquals(replacer, Undefined)) {
+            if (value.IsUndefined() && replacer.IsUndefined()) {
                 return Undefined;
             }
 

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -7,13 +7,11 @@ namespace Jint.Native.Json
 {
     public sealed class JsonInstance : ObjectInstance
     {
-        private readonly Engine _engine;
         private JsValue _reviver;
 
         private JsonInstance(Engine engine)
             : base(engine)
         {
-            _engine = engine;
             Extensible = true;
         }
 

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -757,7 +757,7 @@ namespace Jint.Native.Json
             return obj;
         }
 
-        private bool PropertyNameContainsInvalidChar0To31(string s)
+        private static bool PropertyNameContainsInvalidChar0To31(string s)
         {
             const int max = 31;
 

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -54,7 +54,7 @@ namespace Jint.Native.Json
                         string item = null;
                         if (v.IsString())
                         {
-                            item = v.AsString();
+                            item = v.AsStringWithoutTypeCheck();
                         }
                         else if (v.IsNumber())
                         {
@@ -94,8 +94,10 @@ namespace Jint.Native.Json
             // defining the gap
             if (space.IsNumber())
             {
-                if (space.AsNumber() > 0) {
-                    _gap = new System.String(' ', (int)System.Math.Min(10, space.AsNumber()));
+                var number = ((JsNumber) space)._value;
+                if (number > 0)
+                {
+                    _gap = new string(' ', (int) System.Math.Min(10, number));
                 }
                 else
                 {
@@ -104,7 +106,7 @@ namespace Jint.Native.Json
             }
             else if (space.IsString())
             {
-                var stringSpace = space.AsString();
+                var stringSpace = space.AsStringWithoutTypeCheck();
                 _gap = stringSpace.Length <= 10 ? stringSpace : stringSpace.Substring(0, 10);
             }
             else
@@ -170,24 +172,20 @@ namespace Jint.Native.Json
                 return "null";
             }
 
-            if (value.IsBoolean() && value.AsBoolean())
+            if (value.IsBoolean())
             {
-                return "true";
-            }
-
-            if (value.IsBoolean() && !value.AsBoolean())
-            {
-                return "false";
+                return ((JsBoolean) value)._value ? "true" : "false";
             }
 
             if (value.IsString())
             {
-                return Quote(value.AsString());
+                return Quote(value.AsStringWithoutTypeCheck());
             }
 
             if (value.IsNumber())
             {
-                if (GlobalObject.IsFinite(Undefined.Instance, Arguments.From(value)).AsBoolean())
+                var isFinite = GlobalObject.IsFinite(Undefined.Instance, Arguments.From(value));
+                if (((JsBoolean) isFinite)._value)
                 {
                     return TypeConverter.ToString(value);
                 }
@@ -268,7 +266,7 @@ namespace Jint.Native.Json
                 var strP = Str(TypeConverter.ToString(i), value);
                 if (ReferenceEquals(strP, JsValue.Undefined))
                     strP = "null";
-                partial.Add(strP.AsString());
+                partial.Add(strP.AsStringWithoutTypeCheck());
             }
             if (partial.Count == 0)
             {

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -208,7 +208,7 @@ namespace Jint.Native.Json
             return JsValue.Undefined;
         }
 
-        private string Quote(string value)
+        private static string Quote(string value)
         {
             var sb = new System.Text.StringBuilder("\"");
 

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -264,7 +264,7 @@ namespace Jint.Native.Json
             for (int i = 0; i < len; i++)
             {
                 var strP = Str(TypeConverter.ToString(i), value);
-                if (ReferenceEquals(strP, JsValue.Undefined))
+                if (strP.IsUndefined())
                     strP = "null";
                 partial.Add(strP.AsStringWithoutTypeCheck());
             }
@@ -324,7 +324,7 @@ namespace Jint.Native.Json
             foreach (var p in k)
             {
                 var strP = Str(p, value);
-                if (!ReferenceEquals(strP, JsValue.Undefined))
+                if (!strP.IsUndefined())
                 {
                     var member = Quote(p) + ":";
                     if (_gap != "")

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -8,18 +8,10 @@ namespace Jint.Native.Math
 {
     public sealed class MathInstance : ObjectInstance
     {
-        private static Random _random = new Random();
-        
-        private MathInstance(Engine engine):base(engine)
-        {
-        }
+        private static readonly Random _random = new Random();
 
-        public override string Class
+        private MathInstance(Engine engine) : base(engine, "Math")
         {
-            get
-            {
-                return "Math";
-            }
         }
 
         public static MathInstance CreateMathObject(Engine engine)

--- a/Jint/Native/Number/Dtoa/FastDtoaBuilder.cs
+++ b/Jint/Native/Number/Dtoa/FastDtoaBuilder.cs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-using System.Runtime.CompilerServices;
-
 namespace Jint.Native.Number.Dtoa
 {
     internal class FastDtoaBuilder
@@ -131,8 +129,7 @@ namespace Jint.Native.Number.Dtoa
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'
         };
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void Fill<T>(T[] array, int fromIndex, int toIndex, T val)
+        private static void Fill(char[] array, int fromIndex, int toIndex, char val)
         {
             for (int i = fromIndex; i < toIndex; i++)
             {

--- a/Jint/Native/Number/NumberInstance.cs
+++ b/Jint/Native/Number/NumberInstance.cs
@@ -10,11 +10,9 @@ namespace Jint.Native.Number
         private static readonly long NegativeZeroBits = BitConverter.DoubleToInt64Bits(-0.0);
 
         public NumberInstance(Engine engine)
-            : base(engine)
+            : base(engine, "Number")
         {
         }
-
-        public override string Class => "Number";
 
         Types IPrimitiveInstance.Type => Types.Number;
 

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -137,7 +137,7 @@ namespace Jint.Native.Number
         {
             var x = TypeConverter.ToNumber(thisObj);
 
-            if (ReferenceEquals(arguments.At(0), Undefined))
+            if (arguments.At(0).IsUndefined())
             {
                 return TypeConverter.ToString(x);
             }
@@ -172,7 +172,7 @@ namespace Jint.Native.Number
                 throw new JavaScriptException(Engine.TypeError);
             }
 
-            var radix = ReferenceEquals(arguments.At(0), Undefined) 
+            var radix = arguments.At(0).IsUndefined() 
                 ? 10 
                 : (int) TypeConverter.ToInteger(arguments.At(0));
 

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -11,11 +11,8 @@ namespace Jint.Native.Object
 {
     public sealed class ObjectConstructor : FunctionInstance, IConstructor
     {
-        private readonly Engine _engine;
-
         private ObjectConstructor(Engine engine) : base(engine, null, null, false)
         {
-            _engine = engine;
         }
 
         public static ObjectConstructor CreateObjectConstructor(Engine engine)

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -147,7 +147,7 @@ namespace Jint.Native.Object
             var ownProperties = o.GetOwnProperties().ToList();
             if (o is StringInstance s)
             {
-                var length = s.PrimitiveValue.AsString().Length;
+                var length = s.PrimitiveValue.AsStringWithoutTypeCheck().Length;
                 array = Engine.Array.Construct(ownProperties.Count + length);
                 for (var i = 0; i < length; i++)
                 {

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -62,7 +62,7 @@ namespace Jint.Native.Object
                 return Construct(arguments);
             }
 
-            if(ReferenceEquals(arguments[0], Null) || ReferenceEquals(arguments[0], Undefined))
+            if(arguments[0].IsNull() || arguments[0].IsUndefined())
             {
                 return Construct(arguments);
             }
@@ -170,7 +170,7 @@ namespace Jint.Native.Object
             var oArg = arguments.At(0);
 
             var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null) && !ReferenceEquals(oArg, Null))
+            if (ReferenceEquals(o, null) && !oArg.IsNull())
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
@@ -179,7 +179,7 @@ namespace Jint.Native.Object
             obj.Prototype = o;
 
             var properties = arguments.At(1);
-            if (!ReferenceEquals(properties, Undefined))
+            if (!properties.IsUndefined())
             {
                 DefineProperties(thisObject, new [] {obj, properties});
             }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -777,7 +777,7 @@ namespace Jint.Native.Object
                 case "String":
                     if (this is StringInstance stringInstance)
                     {
-                        return stringInstance.PrimitiveValue.AsString();
+                        return stringInstance.PrimitiveValue.AsStringWithoutTypeCheck();
                     }
 
                     break;
@@ -793,7 +793,7 @@ namespace Jint.Native.Object
                 case "Boolean":
                     if (this is BooleanInstance booleanInstance)
                     {
-                        return booleanInstance.PrimitiveValue.AsBoolean()
+                        return ((JsBoolean) booleanInstance.PrimitiveValue)._value
                              ? JsBoolean.BoxedTrue
                              : JsBoolean.BoxedFalse;
                     }
@@ -811,7 +811,7 @@ namespace Jint.Native.Object
                 case "Number":
                     if (this is NumberInstance numberInstance)
                     {
-                        return numberInstance.NumberData.AsNumber();
+                        return ((JsNumber) numberInstance.NumberData)._value;
                     }
 
                     break;

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -20,13 +20,14 @@ namespace Jint.Native.Object
     {
         private MruPropertyCache2<PropertyDescriptor> _intrinsicProperties;
         private MruPropertyCache2<PropertyDescriptor> _properties;
+        protected Engine _engine;
 
         public ObjectInstance(Engine engine) : base(Types.Object)
         {
-            Engine = engine;
+            _engine = engine;
         }
 
-        public Engine Engine { get; }
+        public Engine Engine => _engine;
 
         protected bool TryGetIntrinsicValue(JsSymbol symbol, out JsValue value)
         {

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -157,10 +157,10 @@ namespace Jint.Native.Object
             if (desc.IsDataDescriptor())
             {
                 var val = desc.Value;
-                return !ReferenceEquals(val, null) ? val : Undefined;
+                return val ?? Undefined;
             }
 
-            var getter = !ReferenceEquals(desc.Get, null) ? desc.Get : Undefined;
+            var getter = desc.Get ?? Undefined;
             if (getter.IsUndefined())
             {
                 return Undefined;

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -20,11 +20,19 @@ namespace Jint.Native.Object
     {
         private MruPropertyCache2<PropertyDescriptor> _intrinsicProperties;
         private MruPropertyCache2<PropertyDescriptor> _properties;
-        protected Engine _engine;
-
-        public ObjectInstance(Engine engine) : base(Types.Object)
+        
+        private readonly string _class;
+        protected readonly Engine _engine;
+        
+        public ObjectInstance(Engine engine) : this(engine, "Object")
         {
             _engine = engine;
+        }
+        
+        protected ObjectInstance(Engine engine, in string objectClass) : base(Types.Object)
+        {
+            _engine = engine;
+            _class = objectClass;
         }
 
         public Engine Engine => _engine;
@@ -76,7 +84,7 @@ namespace Jint.Native.Object
         /// A String value indicating a specification defined
         /// classification of objects.
         /// </summary>
-        public virtual string Class => "Object";
+        public ref readonly string Class => ref _class;
 
         public virtual IEnumerable<KeyValuePair<string, PropertyDescriptor>> GetOwnProperties()
         {

--- a/Jint/Native/Object/ObjectPrototype.cs
+++ b/Jint/Native/Object/ObjectPrototype.cs
@@ -94,12 +94,12 @@ namespace Jint.Native.Object
         /// <returns></returns>
         public JsValue ToObjectString(JsValue thisObject, JsValue[] arguments)
         {
-            if (ReferenceEquals(thisObject, Undefined))
+            if (thisObject.IsUndefined())
             {
                 return "[object Undefined]";
             }
 
-            if (ReferenceEquals(thisObject, Null))
+            if (thisObject.IsNull())
             {
                 return "[object Null]";
             }

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -41,8 +41,8 @@ namespace Jint.Native.RegExp
             var pattern = arguments.At(0);
             var flags = arguments.At(1);
 
-            if (!ReferenceEquals(pattern, Undefined)
-                && ReferenceEquals(flags, Undefined)
+            if (!pattern.IsUndefined()
+                && flags.IsUndefined()
                 && TypeConverter.ToObject(Engine, pattern).Class == "Regex")
             {
                 return pattern;
@@ -66,17 +66,17 @@ namespace Jint.Native.RegExp
             var flags = arguments.At(1);
 
             var r = pattern.TryCast<RegExpInstance>();
-            if (ReferenceEquals(flags, Undefined) && !ReferenceEquals(r, null))
+            if (flags.IsUndefined() && !ReferenceEquals(r, null))
             {
                 return r;
             }
 
-            if (!ReferenceEquals(flags, Undefined) && !ReferenceEquals(r, null))
+            if (!flags.IsUndefined() && !ReferenceEquals(r, null))
             {
                 throw new JavaScriptException(Engine.TypeError);
             }
 
-            if (ReferenceEquals(pattern, Undefined))
+            if (pattern.IsUndefined())
             {
                 p = "";
             }
@@ -85,7 +85,7 @@ namespace Jint.Native.RegExp
                 p = TypeConverter.ToString(pattern);
             }
 
-            f = !ReferenceEquals(flags, Undefined) ? TypeConverter.ToString(flags) : "";
+            f = !flags.IsUndefined() ? TypeConverter.ToString(flags) : "";
 
             r = new RegExpInstance(Engine);
             r.Prototype = PrototypeObject;

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -164,7 +164,7 @@ namespace Jint.Native.RegExp
             r.SetOwnProperty("lastIndex", new PropertyDescriptor(0, PropertyFlag.OnlyWritable));
         }
 
-        private void AssignFlags(RegExpInstance r, string flags)
+        private static void AssignFlags(RegExpInstance r, string flags)
         {
             for(var i=0; i < flags.Length; i++)
             {

--- a/Jint/Native/RegExp/RegExpInstance.cs
+++ b/Jint/Native/RegExp/RegExpInstance.cs
@@ -6,20 +6,11 @@ namespace Jint.Native.RegExp
     public class RegExpInstance : ObjectInstance
     {
         public RegExpInstance(Engine engine)
-            : base(engine)
+            : base(engine, objectClass: "RegExp")
         {
-        }
-
-        public override string Class
-        {
-            get
-            {
-                return "RegExp";
-            }
         }
 
         public Regex Value { get; set; }
-        //public string Pattern { get; set; }
         public string Source { get; set; }
         public string Flags { get; set; }
         public bool Global { get; set; }

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -56,7 +56,7 @@ namespace Jint.Native.RegExp
             }
 
             var match = Exec(r, arguments);
-            return !ReferenceEquals(match, Null);
+            return !match.IsNull();
         }
 
         internal JsValue Exec(JsValue thisObj, JsValue[] arguments)

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -36,7 +36,7 @@ namespace Jint.Native.RegExp
             FastAddProperty("lastIndex", 0, true, false, false);
         }
 
-        private JsValue ToRegExpString(JsValue thisObj, JsValue[] arguments)
+        private static JsValue ToRegExpString(JsValue thisObj, JsValue[] arguments)
         {
             var regExp = thisObj.TryCast<RegExpInstance>();
 

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -13,11 +13,9 @@ namespace Jint.Native.String
         private PropertyDescriptor _length;
 
         public StringInstance(Engine engine)
-            : base(engine)
+            : base(engine, objectClass: "String")
         {
         }
-
-        public override string Class => "String";
 
         Types IPrimitiveInstance.Type => Types.String;
 

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -66,13 +66,13 @@ namespace Jint.Native.String
                 return PropertyDescriptor.Undefined;
 
             var index = (int) dIndex;
-            var len = str.AsString().Length;
+            var len = str.AsStringWithoutTypeCheck().Length;
             if (len <= index || index < 0)
             {
                 return PropertyDescriptor.Undefined;
             }
 
-            var resultStr = TypeConverter.ToString(str.AsString()[index]);
+            var resultStr = TypeConverter.ToString(str.AsStringWithoutTypeCheck()[index]);
             return new PropertyDescriptor(resultStr, PropertyFlag.OnlyEnumerable);
         }
 

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -621,7 +621,7 @@ namespace Jint.Native.String
 
             rx = rx ?? (RegExpInstance) Engine.RegExp.Construct(new[] {regex});
 
-            var global = rx.Get("global").AsBoolean();
+            var global = ((JsBoolean) rx.Get("global"))._value;
             if (!global)
             {
                 return Engine.RegExp.PrototypeObject.Exec(rx, Arguments.From(s));
@@ -642,7 +642,7 @@ namespace Jint.Native.String
                     }
                     else
                     {
-                        var thisIndex = rx.Get("lastIndex").AsNumber();
+                        var thisIndex = ((JsNumber) rx.Get("lastIndex"))._value;
                         if (thisIndex == previousLastIndex)
                         {
                             rx.Put("lastIndex", thisIndex + 1, false);
@@ -756,7 +756,7 @@ namespace Jint.Native.String
             {
                 if (arguments[i].Type == Types.String)
                 {
-                    capacity += arguments[i].AsString().Length;
+                    capacity += arguments[i].AsStringWithoutTypeCheck().Length;
                 }
             }
 

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -95,6 +95,11 @@ namespace Jint.Native.String
             if (!IsWhiteSpaceEx(s[s.Length - 1]))
                 return s;
 
+            return TrimEnd(s);
+        }
+
+        private static string TrimEnd(string s)
+        {
             var i = s.Length - 1;
             while (i >= 0)
             {
@@ -103,10 +108,8 @@ namespace Jint.Native.String
                 else
                     break;
             }
-            if (i >= 0)
-                return s.Substring(0, i + 1);
-            else
-                return string.Empty;
+
+            return i >= 0 ? s.Substring(0, i + 1) : string.Empty;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -118,6 +121,11 @@ namespace Jint.Native.String
             if (!IsWhiteSpaceEx(s[0]))
                 return s;
 
+            return TrimStart(s);
+        }
+
+        private static string TrimStart(string s)
+        {
             var i = 0;
             while (i < s.Length)
             {
@@ -126,10 +134,8 @@ namespace Jint.Native.String
                 else
                     break;
             }
-            if (i >= s.Length)
-                return string.Empty;
-            else
-                return s.Substring(i);
+
+            return i >= s.Length ? string.Empty : s.Substring(i);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -225,7 +231,7 @@ namespace Jint.Native.String
             return s.Substring(from, length);
         }
 
-        private JsValue Substr(JsValue thisObj, JsValue[] arguments)
+        private static JsValue Substr(JsValue thisObj, JsValue[] arguments)
         {
             var s = TypeConverter.ToString(thisObj);
             var start = TypeConverter.ToInteger(arguments.At(0));

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -204,7 +204,7 @@ namespace Jint.Native.String
             var len = s.Length;
             var intStart = ToIntegerSupportInfinity(start);
 
-            var intEnd = ReferenceEquals(arguments.At(1), Undefined) ? len : ToIntegerSupportInfinity(end);
+            var intEnd = arguments.At(1).IsUndefined() ? len : ToIntegerSupportInfinity(end);
             var finalStart = System.Math.Min(len, System.Math.Max(intStart, 0));
             var finalEnd = System.Math.Min(len, System.Math.Max(intEnd, 0));
             // Swap value if finalStart < finalEnd
@@ -229,7 +229,7 @@ namespace Jint.Native.String
         {
             var s = TypeConverter.ToString(thisObj);
             var start = TypeConverter.ToInteger(arguments.At(0));
-            var length = ReferenceEquals(arguments.At(1), Undefined)
+            var length = arguments.At(1).IsUndefined()
                 ? double.PositiveInfinity
                 : TypeConverter.ToInteger(arguments.At(1));
 
@@ -258,7 +258,7 @@ namespace Jint.Native.String
 
             // Coerce into a number, true will become 1
             var l = arguments.At(1);
-            var limit = ReferenceEquals(l, Undefined) ? uint.MaxValue : TypeConverter.ToUint32(l);
+            var limit = l.IsUndefined() ? uint.MaxValue : TypeConverter.ToUint32(l);
             var len = s.Length;
 
             if (limit == 0)
@@ -266,11 +266,11 @@ namespace Jint.Native.String
                 return Engine.Array.Construct(Arguments.Empty);
             }
 
-            if (ReferenceEquals(separator, Null))
+            if (separator.IsNull())
             {
                 separator = Native.Null.Text;
             }
-            else if (ReferenceEquals(separator, Undefined))
+            else if (separator.IsUndefined())
             {
                 var jsValues = Engine.JsValueArrayPool.RentArray(1);
                 jsValues[0] = s;
@@ -407,7 +407,7 @@ namespace Jint.Native.String
 
             var len = s.Length;
             var intStart = (int)TypeConverter.ToInteger(start);
-            var intEnd = ReferenceEquals(arguments.At(1), Undefined) ? len : (int)TypeConverter.ToInteger(end);
+            var intEnd = arguments.At(1).IsUndefined() ? len : (int)TypeConverter.ToInteger(end);
             var from = intStart < 0 ? System.Math.Max(len + intStart, 0) : System.Math.Min(intStart, len);
             var to = intEnd < 0 ? System.Math.Max(len + intEnd, 0) : System.Math.Min(intEnd, len);
             var span = System.Math.Max(to - from, 0);
@@ -681,7 +681,7 @@ namespace Jint.Native.String
             var s = TypeConverter.ToString(thisObj);
             var searchStr = TypeConverter.ToString(arguments.At(0));
             double numPos = double.NaN;
-            if (arguments.Length > 1 && !ReferenceEquals(arguments[1], Undefined))
+            if (arguments.Length > 1 && !arguments[1].IsUndefined())
             {
                 numPos = TypeConverter.ToNumber(arguments[1]);
             }
@@ -728,7 +728,7 @@ namespace Jint.Native.String
             var s = TypeConverter.ToString(thisObj);
             var searchStr = TypeConverter.ToString(arguments.At(0));
             double pos = 0;
-            if (arguments.Length > 1 && !ReferenceEquals(arguments[1], Undefined))
+            if (arguments.Length > 1 && !arguments[1].IsUndefined())
             {
                 pos = TypeConverter.ToInteger(arguments[1]);
             }

--- a/Jint/Native/Symbol/SymbolConstructor.cs
+++ b/Jint/Native/Symbol/SymbolConstructor.cs
@@ -60,7 +60,7 @@ namespace Jint.Native.Symbol
         public override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             var description = arguments.At(0);
-            var descString = ReferenceEquals(description, Undefined)
+            var descString = description.IsUndefined()
                 ? Undefined
                 : TypeConverter.ToString(description);
 
@@ -80,8 +80,7 @@ namespace Jint.Native.Symbol
 
             // 2. ReturnIfAbrupt(stringKey).
 
-            JsSymbol symbol;
-            if (!Engine.GlobalSymbolRegistry.TryGetValue(stringKey, out symbol))
+            if (!Engine.GlobalSymbolRegistry.TryGetValue(stringKey, out var symbol))
             {
                 symbol = new JsSymbol(stringKey);
                 Engine.GlobalSymbolRegistry.Add(stringKey, symbol);

--- a/Jint/Native/Symbol/SymbolInstance.cs
+++ b/Jint/Native/Symbol/SymbolInstance.cs
@@ -6,11 +6,9 @@ namespace Jint.Native.Symbol
     public class SymbolInstance : ObjectInstance, IPrimitiveInstance
     {
         public SymbolInstance(Engine engine)
-            : base(engine)
+            : base(engine, objectClass: "Symbol")
         {
         }
-
-        public override string Class => "Symbol";
 
         Types IPrimitiveInstance.Type => Types.Symbol;
 

--- a/Jint/Pooling/JsValueArrayPool.cs
+++ b/Jint/Pooling/JsValueArrayPool.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Jint.Native;
 
 namespace Jint.Pooling
@@ -35,36 +36,43 @@ namespace Jint.Pooling
             return new JsValue[3];
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JsValue[] RentArray(int size)
         {
-            switch (size)
+            if (size == 0)
             {
-                case 0:
-                    return Array.Empty<JsValue>();
-                case 1:
-                    return _poolArray1.Allocate();
-                case 2:
-                    return _poolArray2.Allocate();
-                case 3:
-                    return _poolArray3.Allocate();
+                return Array.Empty<JsValue>();
+            }
+            if (size == 1)
+            {
+                return _poolArray1.Allocate();
+            }
+            if (size == 2)
+            {
+                return _poolArray2.Allocate();
+            }
+            if (size == 3)
+            {
+                return _poolArray3.Allocate();
             }
 
             return new JsValue[size];
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ReturnArray(JsValue[] array)
         {
-            switch (array.Length)
+            if (array.Length == 1)
             {
-                case 1:
-                    _poolArray1.Free(array);
-                    break;
-                case 2:
-                    _poolArray2.Free(array);
-                    break;
-                case 3:
-                    _poolArray3.Free(array);
-                    break;
+                _poolArray1.Free(array);
+            }
+            else if (array.Length == 2)
+            {
+                _poolArray2.Free(array);
+            }
+            else if (array.Length == 3)
+            {
+                _poolArray3.Free(array);
             }
         }
     }

--- a/Jint/Runtime/Completion.cs
+++ b/Jint/Runtime/Completion.cs
@@ -18,9 +18,6 @@ namespace Jint.Runtime
     /// </summary>
     public readonly struct Completion
     {
-        internal static readonly Completion Empty = new Completion(CompletionType.Normal, null, null);
-        internal static readonly Completion EmptyUndefined = new Completion(CompletionType.Normal, Undefined.Instance, null);
-
         public Completion(CompletionType type, JsValue value, string identifier, Location location = null)
         {
             Type = type;
@@ -30,10 +27,9 @@ namespace Jint.Runtime
         }
 
         public readonly CompletionType Type;
-
         public readonly JsValue Value;
-
         public readonly string Identifier;
+        public readonly Location Location;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JsValue GetValueOrDefault()
@@ -46,7 +42,5 @@ namespace Jint.Runtime
         {
             return Type != CompletionType.Normal;
         }
-
-        public readonly Location Location;
     }
 }

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -149,7 +149,7 @@ namespace Jint.Runtime.Debugger
         {
             var info = new DebugInformation { CurrentStatement = statement, CallStack = _debugCallStack };
 
-            if (_engine.ExecutionContext?.LexicalEnvironment != null)
+            if (_engine.ExecutionContext.LexicalEnvironment != null)
             {
                 var lexicalEnvironment = _engine.ExecutionContext.LexicalEnvironment;
                 info.Locals = GetLocalVariables(lexicalEnvironment);

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -138,7 +138,8 @@ namespace Jint.Runtime.Debugger
 
             if (!string.IsNullOrEmpty(breakpoint.Condition))
             {
-                return _engine.Execute(breakpoint.Condition).GetCompletionValue().AsBoolean();
+                var completionValue = _engine.Execute(breakpoint.Condition).GetCompletionValue();
+                return ((JsBoolean) completionValue)._value;
             }
 
             return true;

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -282,7 +282,7 @@ namespace Jint.Runtime.Descriptors
                 ((GetSetPropertyDescriptor) desc).SetSet(setter);
             }
 
-            if (!ReferenceEquals(desc.Get, null) || !ReferenceEquals(desc.Get, null))
+            if (!ReferenceEquals(desc.Get, null))
             {
                 if (!ReferenceEquals(desc.Value, null) || desc.WritableSet)
                 {
@@ -295,6 +295,11 @@ namespace Jint.Runtime.Descriptors
 
         public static JsValue FromPropertyDescriptor(Engine engine, PropertyDescriptor desc)
         {
+            if (ReferenceEquals(desc, Undefined))
+            {
+                return Native.Undefined.Instance;
+            }
+            
             var obj = engine.Object.Construct(Arguments.Empty);
 
             if (desc.IsDataDescriptor())

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -263,7 +263,7 @@ namespace Jint.Runtime.Descriptors
             if (hasGetProperty)
             {
                 var getter = obj.UnwrapJsValue(getProperty);
-                if (!ReferenceEquals(getter, JsValue.Undefined) && getter.TryCast<ICallable>() == null)
+                if (!getter.IsUndefined() && getter.TryCast<ICallable>() == null)
                 {
                     throw new JavaScriptException(engine.TypeError);
                 }
@@ -274,7 +274,7 @@ namespace Jint.Runtime.Descriptors
             if (hasSetProperty)
             {
                 var setter = obj.UnwrapJsValue(setProperty);
-                if (!ReferenceEquals(setter, JsValue.Undefined) && setter.TryCast<ICallable>() == null)
+                if (!setter.IsUndefined() && setter.TryCast<ICallable>() == null)
                 {
                     throw new JavaScriptException(engine.TypeError);
                 }
@@ -295,11 +295,6 @@ namespace Jint.Runtime.Descriptors
 
         public static JsValue FromPropertyDescriptor(Engine engine, PropertyDescriptor desc)
         {
-            if (ReferenceEquals(desc, Undefined))
-            {
-                return Native.Undefined.Instance;
-            }
-
             var obj = engine.Object.Construct(Arguments.Empty);
 
             if (desc.IsDataDescriptor())

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -21,9 +21,9 @@ namespace Jint.Runtime.Environments
 
         public override bool HasBinding(string name)
         {
-            if (name.Length == 9 && name == BindingNameArguments)
+            if (_argumentsBinding != null && name.Length == 9 && name == BindingNameArguments)
             {
-                return _argumentsBinding != null;
+                return true;
             }
 
             return _bindings?.ContainsKey(name) == true;

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -10,8 +10,6 @@ namespace Jint.Runtime.Environments
     /// </summary>
     public sealed class DeclarativeEnvironmentRecord : EnvironmentRecord
     {
-        private readonly Engine _engine;
-
         private const string BindingNameArguments = "arguments";
         private Binding _argumentsBinding;
 
@@ -19,7 +17,6 @@ namespace Jint.Runtime.Environments
 
         public DeclarativeEnvironmentRecord(Engine engine) : base(engine)
         {
-            _engine = engine;
         }
 
         public override bool HasBinding(string name)

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -77,7 +77,7 @@ namespace Jint.Runtime.Environments
         {
             var binding = name == BindingNameArguments ? _argumentsBinding : _bindings[name];
 
-            if (!binding.Mutable && ReferenceEquals(binding.Value, Undefined))
+            if (!binding.Mutable && binding.Value.IsUndefined())
             {
                 if (strict)
                 {

--- a/Jint/Runtime/Environments/ExecutionContext.cs
+++ b/Jint/Runtime/Environments/ExecutionContext.cs
@@ -2,11 +2,22 @@
 
 namespace Jint.Runtime.Environments
 {
-    public sealed class ExecutionContext
+    public readonly struct ExecutionContext
     {
-        public LexicalEnvironment LexicalEnvironment { get; set; }
-        public LexicalEnvironment VariableEnvironment { get; set; }
-        public JsValue ThisBinding { get; set; }
+        public ExecutionContext(LexicalEnvironment lexicalEnvironment, LexicalEnvironment variableEnvironment, JsValue thisBinding)
+        {
+            LexicalEnvironment = lexicalEnvironment;
+            VariableEnvironment = variableEnvironment;
+            ThisBinding = thisBinding;
+        }
 
+        public readonly LexicalEnvironment LexicalEnvironment;
+        public readonly LexicalEnvironment VariableEnvironment;
+        public readonly JsValue ThisBinding;
+
+        public ExecutionContext UpdateLexicalEnvironment(LexicalEnvironment newEnv)
+        {
+            return new ExecutionContext(newEnv, VariableEnvironment, ThisBinding);
+        }
     }
 }

--- a/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
@@ -12,13 +12,11 @@ namespace Jint.Runtime.Environments
     /// </summary>
     public sealed class ObjectEnvironmentRecord : EnvironmentRecord
     {
-        private readonly Engine _engine;
         private readonly ObjectInstance _bindingObject;
         private readonly bool _provideThis;
 
         public ObjectEnvironmentRecord(Engine engine, ObjectInstance bindingObject, bool provideThis) : base(engine)
         {
-            _engine = engine;
             _bindingObject = bindingObject;
             _provideThis = provideThis;
         }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -635,7 +635,6 @@ namespace Jint.Runtime
             return LexicalEnvironment.GetIdentifierReference(env, identifier.Name, strict);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JsValue EvaluateLiteral(Literal literal)
         {
             switch (literal.TokenType)
@@ -1150,7 +1149,6 @@ namespace Jint.Runtime
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void BuildArguments(
             List<ArgumentListElement> expressionArguments, 
             JsValue[] targetArray,

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -85,8 +85,7 @@ namespace Jint.Runtime
                     var rprim = TypeConverter.ToPrimitive(rval);
                     if (lprim.IsString() || rprim.IsString())
                     {
-                        var jsString = lprim as JsString;
-                        if (ReferenceEquals(jsString, null))
+                        if (!(lprim is JsString jsString))
                         {
                             jsString = new JsString.ConcatenatedString(TypeConverter.ToString(lprim));
                         }
@@ -103,7 +102,7 @@ namespace Jint.Runtime
                     break;
 
                 case AssignmentOperator.TimesAssign:
-                    if (ReferenceEquals(lval, Undefined.Instance) || ReferenceEquals(rval, Undefined.Instance))
+                    if (lval.IsUndefined() || rval.IsUndefined())
                     {
                         lval = Undefined.Instance;
                     }
@@ -118,7 +117,7 @@ namespace Jint.Runtime
                     break;
 
                 case AssignmentOperator.ModuloAssign:
-                    if (ReferenceEquals(lval, Undefined.Instance) || ReferenceEquals(rval, Undefined.Instance))
+                    if (lval.IsUndefined() || rval.IsUndefined())
                     {
                         lval = Undefined.Instance;
                     }
@@ -165,7 +164,7 @@ namespace Jint.Runtime
 
         private JsValue Divide(JsValue lval, JsValue rval)
         {
-            if (ReferenceEquals(lval, Undefined.Instance) || ReferenceEquals(rval, Undefined.Instance))
+            if (lval.IsUndefined() || rval.IsUndefined())
             {
                 return Undefined.Instance;
             }
@@ -257,7 +256,7 @@ namespace Jint.Runtime
                     break;
 
                 case BinaryOperator.Times:
-                    if (ReferenceEquals(left, Undefined.Instance) || ReferenceEquals(right, Undefined.Instance))
+                    if (left.IsUndefined() || right.IsUndefined())
                     {
                         value = Undefined.Instance;
                     }
@@ -272,7 +271,7 @@ namespace Jint.Runtime
                     break;
 
                 case BinaryOperator.Modulo:
-                    if (ReferenceEquals(left, Undefined.Instance) || ReferenceEquals(right, Undefined.Instance))
+                    if (left.IsUndefined() || right.IsUndefined())
                     {
                         value = Undefined.Instance;
                     }
@@ -292,7 +291,7 @@ namespace Jint.Runtime
 
                 case BinaryOperator.Greater:
                     value = Compare(right, left, false);
-                    if (ReferenceEquals(value, Undefined.Instance))
+                    if (value.IsUndefined())
                     {
                         value = false;
                     }
@@ -300,7 +299,7 @@ namespace Jint.Runtime
 
                 case BinaryOperator.GreaterOrEqual:
                     value = Compare(left, right);
-                    if (ReferenceEquals(value, Undefined.Instance) || ((JsBoolean) value)._value)
+                    if (value.IsUndefined() || ((JsBoolean) value)._value)
                     {
                         value = false;
                     }
@@ -312,7 +311,7 @@ namespace Jint.Runtime
 
                 case BinaryOperator.Less:
                     value = Compare(left, right);
-                    if (ReferenceEquals(value, Undefined.Instance))
+                    if (value.IsUndefined())
                     {
                         value = false;
                     }
@@ -320,7 +319,7 @@ namespace Jint.Runtime
 
                 case BinaryOperator.LessOrEqual:
                     value = Compare(right, left, false);
-                    if (ReferenceEquals(value, Undefined.Instance) || ((JsBoolean) value)._value)
+                    if (value.IsUndefined() || ((JsBoolean) value)._value)
                     {
                         value = false;
                     }
@@ -417,12 +416,12 @@ namespace Jint.Runtime
 				return StrictlyEqual(x, y);
             }
 
-            if (ReferenceEquals(x, Null.Instance) && ReferenceEquals(y, Undefined.Instance))
+            if (x.IsNull() && y.IsUndefined())
             {
                 return true;
             }
 
-            if (ReferenceEquals(x, Undefined.Instance) && ReferenceEquals(y, Null.Instance))
+            if (x.IsUndefined() && y.IsNull())
             {
                 return true;
             }
@@ -880,7 +879,7 @@ namespace Jint.Runtime
                 }
             }
 
-            if (ReferenceEquals(func, Undefined.Instance))
+            if (func.IsUndefined())
             {
                 throw new JavaScriptException(_engine.TypeError, r == null ? "" : string.Format("Object has no method '{0}'", r.GetReferencedName()));
             }
@@ -1126,11 +1125,11 @@ namespace Jint.Runtime
 
                     var v = _engine.GetValue(value, true);
 
-                    if (ReferenceEquals(v, Undefined.Instance))
+                    if (v.IsUndefined())
                     {
                         return "undefined";
                     }
-                    if (ReferenceEquals(v, Null.Instance))
+                    if (v.IsNull())
                     {
                         return "object";
                     }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -300,7 +300,7 @@ namespace Jint.Runtime
 
                 case BinaryOperator.GreaterOrEqual:
                     value = Compare(left, right);
-                    if (ReferenceEquals(value, Undefined.Instance) || value.AsBoolean())
+                    if (ReferenceEquals(value, Undefined.Instance) || ((JsBoolean) value)._value)
                     {
                         value = false;
                     }
@@ -320,7 +320,7 @@ namespace Jint.Runtime
 
                 case BinaryOperator.LessOrEqual:
                     value = Compare(right, left, false);
-                    if (ReferenceEquals(value, Undefined.Instance) || value.AsBoolean())
+                    if (ReferenceEquals(value, Undefined.Instance) || ((JsBoolean) value)._value)
                     {
                         value = false;
                     }
@@ -477,8 +477,8 @@ namespace Jint.Runtime
 
             if (typea == Types.Number)
             {
-                var nx = x.AsNumber();
-                var ny = y.AsNumber();
+                var nx = ((JsNumber) x)._value;
+                var ny = ((JsNumber) y)._value;
 
                 if (double.IsNaN(nx) || double.IsNaN(ny))
                 {
@@ -495,12 +495,12 @@ namespace Jint.Runtime
 
             if (typea == Types.String)
             {
-                return x.AsString() == y.AsString();
+                return x.AsStringWithoutTypeCheck() == y.AsStringWithoutTypeCheck();
             }
 
             if (typea == Types.Boolean)
             {
-                return x.AsBoolean() == y.AsBoolean();
+                return ((JsBoolean) x)._value == ((JsBoolean) y)._value;
             }
 
 			if (typea == Types.Object)

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -50,7 +50,7 @@ namespace Jint.Runtime.Interop
             for (int i = 0; i < arguments.Length; i++)
             {
                 var genericTypeReference = arguments.At(i);
-                if (ReferenceEquals(genericTypeReference, Undefined)
+                if (genericTypeReference.IsUndefined()
                     || !genericTypeReference.IsObject() 
                     || genericTypeReference.AsObject().Class != "TypeReference")
                 {

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -140,7 +140,7 @@ namespace Jint.Runtime.Interop
             return PropertyDescriptor.Undefined;
         }
 
-        private bool EqualsIgnoreCasing(string s1, string s2)
+        private static bool EqualsIgnoreCasing(string s1, string s2)
         {
             bool equals = false;
             if (s1.Length == s2.Length)

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -13,7 +13,7 @@ namespace Jint.Runtime.Interop
     public class TypeReference : FunctionInstance, IConstructor, IObjectWrapper
     {
         private TypeReference(Engine engine)
-            : base(engine, null, null, false)
+            : base(engine, null, null, false, "TypeReference")
         {
         }
 
@@ -202,7 +202,5 @@ namespace Jint.Runtime.Interop
         }
 
         public object Target => ReferenceType;
-
-        public override string Class => "TypeReference";
     }
 }

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -77,7 +77,7 @@ namespace Jint.Runtime
                 return message;
             }
             if (error.IsString())
-                return error.AsString();
+                return error.AsStringWithoutTypeCheck();
 
             return error.ToString();
         }

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -100,7 +100,7 @@ namespace Jint.Runtime
                 if (Error.IsObject() == false)
                     return null;
                 var callstack = Error.AsObject().Get("callstack");
-                if (ReferenceEquals(callstack, JsValue.Undefined))
+                if (callstack.IsUndefined())
                     return null;
                 return callstack.AsString();
             }
@@ -117,8 +117,8 @@ namespace Jint.Runtime
 
         public Location Location { get; set; }
 
-        public int LineNumber { get { return null == Location ? 0 : Location.Start.Line; } }
+        public int LineNumber => Location?.Start.Line ?? 0;
 
-        public int Column { get { return null == Location ? 0 : Location.Start.Column; } }
+        public int Column => Location?.Start.Column ?? 0;
     }
 }

--- a/Jint/Runtime/RefStack.cs
+++ b/Jint/Runtime/RefStack.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Jint.Runtime.Environments;
+
+namespace Jint.Runtime
+{
+    internal sealed class ExecutionContextStack
+    {
+        private ExecutionContext[] _array;
+        private int _size;
+
+        private const int DefaultCapacity = 4;
+
+        public ExecutionContextStack()
+        {
+            _array = new ExecutionContext[4];
+            _size = 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ref readonly ExecutionContext Peek()
+        {
+            if (_size == 0)
+            {
+                ThrowEmptyStackException();
+            }
+            return ref _array[_size - 1];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Pop()
+        {
+            if (_size == 0)
+            {
+                ThrowEmptyStackException();
+            }
+            _size--;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Push(in ExecutionContext item)
+        {
+            if (_size == _array.Length)
+            {
+                var newSize = 2 * _array.Length;
+                var newArray = new ExecutionContext[newSize];
+                Array.Copy(_array, 0, newArray, 0, _size);
+                _array = newArray;
+            }
+
+            _array[_size++] = item;
+        }
+
+        private static void ThrowEmptyStackException()
+        {
+            throw new InvalidOperationException("stack is empty");
+        }
+
+        public void ReplaceTopLexicalEnvironment(LexicalEnvironment newEnv)
+        {
+            _array[_size - 1] = _array[_size - 1].UpdateLexicalEnvironment(newEnv);
+        }
+    }
+}

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -218,7 +218,7 @@ namespace Jint.Runtime
 
             var varRef = _engine.EvaluateExpression(identifier) as Reference;
             var experValue = _engine.GetValue(_engine.EvaluateExpression(forInStatement.Right), true);
-            if (ReferenceEquals(experValue, Undefined.Instance) || ReferenceEquals(experValue,  Null.Instance))
+            if (experValue.IsUndefined() || experValue.IsNull())
             {
                 return new Completion(CompletionType.Normal, null, null);
             }

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -232,7 +232,7 @@ namespace Jint.Runtime
 
                 for (var i = 0; i < keys.GetLength(); i++)
                 {
-                    var p = keys.GetOwnProperty(TypeConverter.ToString(i)).Value.AsString();
+                    var p = keys.GetOwnProperty(TypeConverter.ToString(i)).Value.AsStringWithoutTypeCheck();
 
                     if (processedKeys.Contains(p))
                     {
@@ -246,7 +246,6 @@ namespace Jint.Runtime
                     {
                         continue;
                     }
-
 
                     var value = cursor.GetOwnProperty(p);
                     if (!value.Enumerable)

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -18,19 +18,16 @@ namespace Jint.Runtime
             _engine = engine;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private Completion ExecuteStatement(Statement statement)
         {
             return _engine.ExecuteStatement(statement);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Completion ExecuteEmptyStatement(EmptyStatement emptyStatement)
         {
             return new Completion(CompletionType.Normal, null, null);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Completion ExecuteExpressionStatement(ExpressionStatement expressionStatement)
         {
             var exprRef = _engine.EvaluateExpression(expressionStatement.Expression);
@@ -288,7 +285,6 @@ namespace Jint.Runtime
         /// </summary>
         /// <param name="continueStatement"></param>
         /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Completion ExecuteContinueStatement(ContinueStatement continueStatement)
         {
             return new Completion(
@@ -302,7 +298,6 @@ namespace Jint.Runtime
         /// </summary>
         /// <param name="breakStatement"></param>
         /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Completion ExecuteBreakStatement(BreakStatement breakStatement)
         {
             return new Completion(
@@ -316,7 +311,6 @@ namespace Jint.Runtime
         /// </summary>
         /// <param name="statement"></param>
         /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Completion ExecuteReturnStatement(ReturnStatement statement)
         {
             if (statement.Argument == null)
@@ -363,7 +357,6 @@ namespace Jint.Runtime
         /// </summary>
         /// <param name="switchStatement"></param>
         /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Completion ExecuteSwitchStatement(SwitchStatement switchStatement)
         {
             var jsValue = _engine.GetValue(_engine.EvaluateExpression(switchStatement.Discriminant), true);
@@ -545,7 +538,6 @@ namespace Jint.Runtime
             return new Completion(CompletionType.Normal, Undefined.Instance, null);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Completion ExecuteBlockStatement(BlockStatement blockStatement)
         {
             return ExecuteStatementList(blockStatement.Body);

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -393,21 +393,17 @@ namespace Jint.Runtime
             return ToString(ToPrimitive(o, Types.String));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ObjectInstance ToObject(Engine engine, JsValue value)
         {
             if (value.IsObject())
             {
-                return value.AsObject();
+                return (ObjectInstance) value;
             }
 
-            if (ReferenceEquals(value, Undefined.Instance))
+            if (ReferenceEquals(value, Undefined.Instance) ||ReferenceEquals(value, Null.Instance))
             {
-                throw new JavaScriptException(engine.TypeError);
-            }
-
-            if (ReferenceEquals(value, Null.Instance))
-            {
-                throw new JavaScriptException(engine.TypeError);
+                ThrowTypeError(engine);
             }
 
             if (value.IsBoolean())
@@ -430,6 +426,12 @@ namespace Jint.Runtime
                 return engine.Symbol.Construct(value.AsSymbol());
             }
 
+            ThrowTypeError(engine);
+            return null;
+        }
+
+        private static void ThrowTypeError(Engine engine)
+        {
             throw new JavaScriptException(engine.TypeError);
         }
 

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -151,7 +151,7 @@ namespace Jint.Runtime
 
             if (type == Types.String)
             {
-                return ToNumber(o.AsString());
+                return ToNumber(o.AsStringWithoutTypeCheck());
             }
 
             return ToNumber(ToPrimitive(o, Types.Number));
@@ -344,13 +344,12 @@ namespace Jint.Runtime
         {
             if (o.IsString())
             {
-                return o.AsString();
+                return o.AsStringWithoutTypeCheck();
             }
 
             if (o.IsObject())
             {
-                var p = o.AsObject() as IPrimitiveInstance;
-                if (p != null)
+                if (o.AsObject() is IPrimitiveInstance p)
                 {
                     o = p.PrimitiveValue;
                 }
@@ -378,12 +377,12 @@ namespace Jint.Runtime
 
             if (o.IsBoolean())
             {
-                return o.AsBoolean() ? "true" : "false";
+                return ((JsBoolean) o)._value ? "true" : "false";
             }
 
             if (o.IsNumber())
             {
-                return ToString(o.AsNumber());
+                return ToString(((JsNumber) o)._value);
             }
 
             if (o.IsSymbol())
@@ -413,17 +412,17 @@ namespace Jint.Runtime
 
             if (value.IsBoolean())
             {
-                return engine.Boolean.Construct(value.AsBoolean());
+                return engine.Boolean.Construct(((JsBoolean) value)._value);
             }
 
             if (value.IsNumber())
             {
-                return engine.Number.Construct(value.AsNumber());
+                return engine.Number.Construct(((JsNumber) value)._value);
             }
 
             if (value.IsString())
             {
-                return engine.String.Construct(value.AsString());
+                return engine.String.Construct(value.AsStringWithoutTypeCheck());
             }
 
             if (value.IsSymbol())


### PR DESCRIPTION
This is a kind of a collection of different tweaks as I was going through performance profiling, so sorry for the big PR. Main idea is to reduce allocations with ExecutionContext being a struct and then various tweaks like accessing fieds instead of properties when possible. Benchmark also showed that using type field check for null and undefined is faster than ReferenceEquals calls.

* ensure method bodies are inline friendly
* remove virtual calls from AsNumber, AsString and AsSymbol
  * direct field access when possible
  * offer migration path via extension methods
* use IsUndefined & IsNull which are faster than ReferenceEquals


## ArrayBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Slice|100|436.2 us|161.1328|660.16 KB|
| **New** |	|	| **432.7 us (-1%)** | **161.1328 (0%)** | **660.16 KB (0%)** |
| Old |Concat|100|468.4 us|175.7813|720.31 KB|
| **New** |	|	| **454.0 us (-3%)** | **175.7813 (0%)** | **720.31 KB (0%)** |
| Old |Unshift|100|17,912.2 us|3562.5000|14672.66 KB|
| **New** |	|	| **18,052.9 us (+1%)** | **3562.5000 (0%)** | **14672.66 KB (0%)** |
| Old |Push|100|10,861.8 us|343.7500|1438.28 KB|
| **New** |	|	| **10,491.0 us (-3%)** | **343.7500 (0%)** | **1438.28 KB (0%)** |
| Old |Index|100|12,106.5 us|390.6250|1637.5 KB|
| **New** |	|	| **11,950.4 us (-1%)** | **390.6250 (0%)** | **1637.5 KB (0%)** |
| Old |Map|100|3,382.7 us|765.6250|3149.22 KB|
| **New** |	|	| **3,143.6 us (-7%)** | **691.4063 (-10%)** | **2833.59 KB (-10%)** |
| Old |Apply|100|569.2 us|188.4766|774.22 KB|
| **New** |	|	| **564.2 us (-1%)** | **188.4766 (0%)** | **774.22 KB (0%)** |
| Old |JsonStringifyParse|100|4,523.7 us|1273.4375|5225 KB|
| **New** |	|	| **4,489.3 us (-1%)** | **1273.4375 (0%)** | **5225.78 KB (0%)** |


## ArrayStressBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|20|608.7 ms|60000.0000|2937.5000|245.9 MB|
| **New** |	|	| **585.3 ms (-4%)** | **60000.0000 (0%)** | **2937.5000 (0%)** | **245.9 MB (0%)** |


## DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|dromaeo-3d-cube|78.48 ms|1500.0000|500.0000|-|7747.67 KB|
| **New** |	|	| **75.73 ms (-4%)** | **1375.0000 (-8%)** | **250.0000 (-50%)** | **-** | **7662.21 KB (-1%)** |
| Old |Run|dromaeo-core-eval|18.03 ms|62.5000|-|-|299.02 KB|
| **New** |	|	| **16.32 ms (-9%)** | **62.5000 (0%)** | **-** | **-** | **298.7 KB (0%)** |
| Old |Run|dromaeo-object-array|163.17 ms|42562.5000|2000.0000|1000.0000|178312.87 KB|
| **New** |	|	| **158.04 ms (-3%)** | **42437.5000 (0%)** | **1937.5000 (-3%)** | **937.5000 (-6%)** | **178314.09 KB (0%)** |
| Old |Run|dromaeo-object-regexp|892.92 ms|52812.5000|31375.0000|21250.0000|413157.83 KB|
| **New** |	|	| **882.55 ms (-1%)** | **54687.5000 (+4%)** | **33500.0000 (+7%)** | **22750.0000 (+7%)** | **417652.55 KB (+1%)** |
| Old |Run|dromaeo-object-string|1,214.16 ms|219375.0000|176187.5000|173375.0000|1393091.9 KB|
| **New** |	|	| **1,194.33 ms (-2%)** | **219437.5000 (0%)** | **176125.0000 (0%)** | **173625.0000 (0%)** | **1394577.96 KB (0%)** |
| Old |Run|dromaeo-string-base64|179.78 ms|6125.0000|312.5000|-|26272.45 KB|
| **New** |	|	| **175.07 ms (-3%)** | **6375.0000 (+4%)** | **312.5000 (0%)** | **-** | **27381.53 KB (+4%)** |


## EvaluationBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Jint|20|710.5 us|120.1172|492.5 KB|
| **New** |	|	| **686.9 us (-3%)** | **119.1406 (-1%)** | **488.91 KB (-1%)** |


## LinqJsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Jint|10|69.97 ms|5062.5000|2500.0000|-|30.56 MB|
| **New** |	|	| **71.57 ms (+2%)** | **5125.0000 (+1%)** | **2500.0000 (0%)** | **125.0000** | **30.57 MB (0%)** |


## MinimalScriptBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Jint|10|19.10 us|8.1482|33.44 KB|
| **New** |	|	| **19.47 us (+2%)** | **8.1482 (0%)** | **33.44 KB (0%)** |


## StopwatchBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|1|1.213 s|17125.0000|62.5000|68.5 MB|
| **New** |	|	| **1.169 s (-4%)** | **14375.0000 (-16%)** | **62.5000 (0%)** | **57.73 MB (-16%)** |


## SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|3d-cube|620.7 ms|12000.0000|312.5000|-|50.05 MB|
| **New** |	|	| **601.3 ms (-3%)** | **11875.0000 (-1%)** | **312.5000 (0%)** | **-** | **49.56 MB (-1%)** |
| Old |Run|3d-morph|588.6 ms|11812.5000|2500.0000|1062.5000|68.03 MB|
| **New** |	|	| **581.5 ms (-1%)** | **11812.5000 (0%)** | **2500.0000 (0%)** | **1062.5000 (0%)** | **68.03 MB (0%)** |
| Old |Run|3d-raytrace|503.0 ms|22500.0000|625.0000|62.5000|92.11 MB|
| **New** |	|	| **485.4 ms (-3%)** | **21875.0000 (-3%)** | **750.0000 (+20%)** | **125.0000 (+100%)** | **89.96 MB (-2%)** |
| Old |Run|access-binary-trees|207.1 ms|17687.5000|375.0000|62.5000|73 MB|
| **New** |	|	| **204.7 ms (-1%)** | **16500.0000 (-7%)** | **437.5000 (+17%)** | **62.5000 (0%)** | **68.51 MB (-6%)** |
| Old |Run|access-fannkuch|1,916.6 ms|9437.5000|187.5000|-|37.87 MB|
| **New** |	|	| **1,880.4 ms (-2%)** | **9437.5000 (0%)** | **125.0000 (-33%)** | **-** | **37.87 MB (0%)** |
| Old |Run|access-nbody|598.4 ms|13125.0000|-|-|52.6 MB|
| **New** |	|	| **556.6 ms (-7%)** | **13062.5000 (0%)** | **-** | **-** | **52.42 MB (0%)** |
| Old |Run|access-nsieve|738.8 ms|15375.0000|3937.5000|1875.0000|73.09 MB|
| **New** |	|	| **704.6 ms (-5%)** | **15375.0000 (0%)** | **3937.5000 (0%)** | **1875.0000 (0%)** | **73.09 MB (0%)** |
| Old |Run|bitops-3bit-bits-in-byte|437.9 ms|19750.0000|-|-|79.06 MB|
| **New** |	|	| **418.3 ms (-4%)** | **18500.0000 (-6%)** | **-** | **-** | **74.18 MB (-6%)** |
| Old |Run|bitops-bits-in-byte|730.5 ms|12437.5000|62.5000|-|49.86 MB|
| **New** |	|	| **690.4 ms (-5%)** | **11562.5000 (-7%)** | **62.5000 (0%)** | **-** | **46.44 MB (-7%)** |
| Old |Run|bitops-bitwise-and|438.7 ms|13562.5000|-|-|54.32 MB|
| **New** |	|	| **422.5 ms (-4%)** | **13562.5000 (0%)** | **-** | **-** | **54.32 MB (0%)** |
| Old |Run|bitops-nsieve-bits|761.7 ms|21625.0000|250.0000|62.5000|88.65 MB|
| **New** |	|	| **724.2 ms (-5%)** | **21625.0000 (0%)** | **250.0000 (0%)** | **62.5000 (0%)** | **88.65 MB (0%)** |
| Old |Run|controlflow-recursive|297.1 ms|25937.5000|62.5000|-|103.78 MB|
| **New** |	|	| **293.4 ms (-1%)** | **23625.0000 (-9%)** | **-** | **-** | **94.61 MB (-9%)** |
| Old |Run|crypto-aes|461.1 ms|5625.0000|250.0000|-|24.51 MB|
| **New** |	|	| **445.5 ms (-3%)** | **5500.0000 (-2%)** | **312.5000 (+25%)** | **62.5000** | **24.16 MB (-1%)** |
| Old |Run|crypto-md5|340.7 ms|30562.5000|187.5000|-|124.99 MB|
| **New** |	|	| **330.7 ms (-3%)** | **29500.0000 (-3%)** | **312.5000 (+67%)** | **62.5000** | **120.95 MB (-3%)** |
| Old |Run|crypto-sha1|328.2 ms|24875.0000|312.5000|-|101.48 MB|
| **New** |	|	| **322.6 ms (-2%)** | **23875.0000 (-4%)** | **187.5000 (-40%)** | **-** | **97.36 MB (-4%)** |
| Old |Run|date-format-tofte|353.3 ms|12625.0000|-|-|50.73 MB|
| **New** |	|	| **327.6 ms (-7%)** | **12500.0000 (-1%)** | **62.5000** | **-** | **50.32 MB (-1%)** |
| Old |Run|date-format-xparb|336.1 ms|10375.0000|250.0000|-|42.27 MB|
| **New** |	|	| **329.4 ms (-2%)** | **10062.5000 (-3%)** | **250.0000 (0%)** | **-** | **41.1 MB (-3%)** |
| Old |Run|math-cordic|965.9 ms|22562.5000|62.5000|-|90.25 MB|
| **New** |	|	| **912.8 ms (-5%)** | **21312.5000 (-6%)** | **62.5000 (0%)** | **-** | **85.48 MB (-5%)** |
| Old |Run|math-partial-sums|304.1 ms|7250.0000|-|-|29.04 MB|
| **New** |	|	| **292.2 ms (-4%)** | **7250.0000 (0%)** | **-** | **-** | **29.03 MB (0%)** |
| Old |Run|math-spectral-norm|363.0 ms|18062.5000|-|-|72.31 MB|
| **New** |	|	| **344.4 ms (-5%)** | **16875.0000 (-7%)** | **-** | **-** | **67.63 MB (-6%)** |
| Old |Run|regexp-dna|342.1 ms|2312.5000|1875.0000|1562.5000|13.55 MB|
| **New** |	|	| **341.2 ms (0%)** | **2187.5000 (-5%)** | **1875.0000 (0%)** | **1500.0000 (-4%)** | **13.55 MB (0%)** |
| Old |Run|string-base64|271.9 ms|8875.0000|500.0000|-|37.16 MB|
| **New** |	|	| **265.3 ms (-2%)** | **9312.5000 (+5%)** | **375.0000 (-25%)** | **-** | **38.79 MB (+4%)** |
| Old |Run|string-fasta|452.5 ms|27125.0000|62.5000|-|108.53 MB|
| **New** |	|	| **426.7 ms (-6%)** | **26750.0000 (-1%)** | **-** | **-** | **107.01 MB (-1%)** |
| Old |Run|string-tagcloud|212.6 ms|14562.5000|1750.0000|625.0000|67.2 MB|
| **New** |	|	| **206.3 ms (-3%)** | **14375.0000 (-1%)** | **1875.0000 (+7%)** | **750.0000 (+20%)** | **65.99 MB (-2%)** |
| Old |Run|string-unpack-code|163.3 ms|14062.5000|3937.5000|937.5000|68.64 MB|
| **New** |	|	| **162.1 ms (-1%)** | **13687.5000 (-3%)** | **4500.0000 (+14%)** | **937.5000 (0%)** | **64.88 MB (-5%)** |
| Old |Run|string-validate-input|184.7 ms|7375.0000|312.5000|62.5000|34.26 MB|
| **New** |	|	| **179.4 ms (-3%)** | **7437.5000 (+1%)** | **500.0000 (+60%)** | **125.0000 (+100%)** | **34.08 MB (-1%)** |


## UncacheableExpressionsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Benchmark|500|349.9 ms|52312.5000|875.0000|210.48 MB|
| **New** |	|	| **332.4 ms (-5%)** | **49125.0000 (-6%)** | **125.0000 (-86%)** | **196.69 MB (-7%)** |


