### PR TITLE
#451 don't allocate date formats each time dates are being parsed

### DIFF
--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -12,6 +12,45 @@ namespace Jint.Native.Date
     {
         internal static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
+        private static readonly string[] DefaultFormats = {
+            "yyyy-MM-ddTHH:mm:ss.FFF",
+            "yyyy-MM-ddTHH:mm:ss",
+            "yyyy-MM-ddTHH:mm",
+            "yyyy-MM-dd",
+            "yyyy-MM",
+            "yyyy"
+        };
+
+        private static readonly string[] SecondaryFormats = {
+            // Formats used in DatePrototype toString methods
+            "ddd MMM dd yyyy HH:mm:ss 'GMT'K",
+            "ddd MMM dd yyyy",
+            "HH:mm:ss 'GMT'K",
+
+            // standard formats
+            "yyyy-M-dTH:m:s.FFFK",
+            "yyyy/M/dTH:m:s.FFFK",
+            "yyyy-M-dTH:m:sK",
+            "yyyy/M/dTH:m:sK",
+            "yyyy-M-dTH:mK",
+            "yyyy/M/dTH:mK",
+            "yyyy-M-d H:m:s.FFFK",
+            "yyyy/M/d H:m:s.FFFK",
+            "yyyy-M-d H:m:sK",
+            "yyyy/M/d H:m:sK",
+            "yyyy-M-d H:mK",
+            "yyyy/M/d H:mK",
+            "yyyy-M-dK",
+            "yyyy/M/dK",
+            "yyyy-MK",
+            "yyyy/MK",
+            "yyyyK",
+            "THH:mm:ss.FFFK",
+            "THH:mm:ssK",
+            "THH:mmK",
+            "THHK"
+        };
+
         public DateConstructor(Engine engine) : base(engine, null, null, false)
         {
         }
@@ -42,49 +81,11 @@ namespace Jint.Native.Date
 
         private JsValue Parse(JsValue thisObj, JsValue[] arguments)
         {
-            DateTime result;
             var date = TypeConverter.ToString(arguments.At(0));
 
-            if (!DateTime.TryParseExact(date, new[]
+            if (!DateTime.TryParseExact(date, DefaultFormats, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var result))
             {
-                "yyyy-MM-ddTHH:mm:ss.FFF",
-                "yyyy-MM-ddTHH:mm:ss",
-                "yyyy-MM-ddTHH:mm",
-                "yyyy-MM-dd",
-                "yyyy-MM",
-                "yyyy"
-            }, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out result))
-            {
-                if (!DateTime.TryParseExact(date, new[]
-                {
-                    // Formats used in DatePrototype toString methods
-                    "ddd MMM dd yyyy HH:mm:ss 'GMT'K",
-                    "ddd MMM dd yyyy",
-                    "HH:mm:ss 'GMT'K",
-
-                    // standard formats
-                    "yyyy-M-dTH:m:s.FFFK",
-                    "yyyy/M/dTH:m:s.FFFK",
-                    "yyyy-M-dTH:m:sK",
-                    "yyyy/M/dTH:m:sK",
-                    "yyyy-M-dTH:mK",
-                    "yyyy/M/dTH:mK",
-                    "yyyy-M-d H:m:s.FFFK",
-                    "yyyy/M/d H:m:s.FFFK",
-                    "yyyy-M-d H:m:sK",
-                    "yyyy/M/d H:m:sK",
-                    "yyyy-M-d H:mK",
-                    "yyyy/M/d H:mK",
-                    "yyyy-M-dK",
-                    "yyyy/M/dK",
-                    "yyyy-MK",
-                    "yyyy/MK",
-                    "yyyyK",
-                    "THH:mm:ss.FFFK",
-                    "THH:mm:ssK",
-                    "THH:mmK",
-                    "THHK"
-                }, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out result))
+                if (!DateTime.TryParseExact(date, SecondaryFormats, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out result))
                 {
                     if (!DateTime.TryParse(date, Engine.Options._Culture, DateTimeStyles.AdjustToUniversal, out result))
                     {
@@ -146,7 +147,7 @@ namespace Jint.Native.Date
         {
             if (arguments.Length < 2)
             {
-                throw new ArgumentOutOfRangeException("arguments", "There must be at least two arguments.");
+                throw new ArgumentOutOfRangeException(nameof(arguments), "There must be at least two arguments.");
             }
 
             var y = TypeConverter.ToNumber(arguments[0]);
@@ -165,7 +166,7 @@ namespace Jint.Native.Date
                 }
             }
 
-            if ((!double.IsNaN(y)) && (0 <= TypeConverter.ToInteger(y)) && (TypeConverter.ToInteger(y) <= 99))
+            if (!double.IsNaN(y) && 0 <= TypeConverter.ToInteger(y) && TypeConverter.ToInteger(y) <= 99)
             {
                 y += 1900;
             }

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -1025,7 +1025,7 @@ namespace Jint.Native.Date
                 case 1:
                     return 28 + leap;
                 default:
-                    throw new ArgumentOutOfRangeException("month");
+                    throw new ArgumentOutOfRangeException(nameof(month));
 
             }
         }

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Native.Argument;
 using Jint.Native.Object;

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using Esprima;
 using Esprima.Ast;
 using Jint.Native;

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.Descriptors;


### PR DESCRIPTION
Moved date parsing format array creation out of parsing, can be private static fields.