### PR TITLE
Optimize declarative environment record handling for functions

### DIFF
--- a/Jint.Benchmark/Properties/AssemblyInfo.cs
+++ b/Jint.Benchmark/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -594,27 +594,9 @@ namespace Jint
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JsValue GetValue(object value)
         {
-            if (value is JsValue jsValue)
-            {
-                return jsValue;
-            }
-
-            return GetValueFromReference(value, false);
+            return GetValue(value, false);
         }
         
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal JsValue GetValue(in Completion completion)
-        {
-            var value = completion.Value;
-            if (value is JsValue jsValue)
-            {
-                return jsValue;
-            }
-            return GetValueFromReference(completion.Value, false);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal JsValue GetValue(object value, bool returnReferenceToPool)
         {
             if (value is JsValue jsValue)
@@ -622,18 +604,9 @@ namespace Jint
                 return jsValue;
             }
 
-            return GetValueFromReference(value, returnReferenceToPool);
-        }
-       
-        internal JsValue GetValueFromReference(object value, bool returnReferenceToPool)
-        {
-            var reference = value as Reference;
-            if (reference == null)
+            if (!(value is Reference reference))
             {
-                if (value is Completion completion)
-                {
-                    return GetValue(completion.Value, returnReferenceToPool);
-                }
+                return ((Completion) value).Value;
             }
 
             if (reference._baseValue._type == Types.Undefined)

--- a/Jint/Native/Argument/ArgumentsInstance.cs
+++ b/Jint/Native/Argument/ArgumentsInstance.cs
@@ -12,7 +12,7 @@ namespace Jint.Native.Argument
     /// <summary>
     /// http://www.ecma-international.org/ecma-262/5.1/#sec-10.6
     /// </summary>
-    public class ArgumentsInstance : ObjectInstance
+    public sealed class ArgumentsInstance : ObjectInstance
     {
         // cache key container for array iteration for less allocations
         private static readonly ThreadLocal<HashSet<string>> _mappedNamed = new ThreadLocal<HashSet<string>>(() => new HashSet<string>());

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -92,7 +92,7 @@ namespace Jint.Native.Array
             if (arguments.Length == 1 && arguments.At(0).IsNumber())
             {
                 var length = TypeConverter.ToUint32(arguments.At(0));
-                if (!TypeConverter.ToNumber(arguments[0]).Equals(length))
+                if (((JsNumber) arguments[0])._value != length)
                 {
                     ExceptionHelper.ThrowRangeError(_engine, "Invalid array length");
                 }

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Runtime.CompilerServices;
 using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -127,12 +128,15 @@ namespace Jint.Native.Array
             return instance;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal ArrayInstance ConstructFast(uint length)
         {
-            var instance = new ArrayInstance(Engine, length);
-            instance.Prototype = PrototypeObject;
-            instance.Extensible = true;
-            instance._length = new PropertyDescriptor(length, PropertyFlag.OnlyWritable);
+            var instance = new ArrayInstance(Engine, length)
+            {
+                Prototype = PrototypeObject,
+                Extensible = true,
+                _length = new PropertyDescriptor(length, PropertyFlag.OnlyWritable)
+            };
             return instance;
         }
     }

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -97,7 +97,7 @@ namespace Jint.Native.Array
                     ExceptionHelper.ThrowRangeError(_engine, "Invalid array length");
                 }
 
-                instance.SetOwnProperty("length", new PropertyDescriptor(length, PropertyFlag.OnlyWritable));
+                instance._length = new PropertyDescriptor(length, PropertyFlag.OnlyWritable);
             }
             else if (arguments.Length == 1 && arguments[0] is ObjectWrapper objectWrapper)
             {
@@ -117,7 +117,7 @@ namespace Jint.Native.Array
             }
             else
             {
-                instance.SetOwnProperty("length", new PropertyDescriptor(0, PropertyFlag.OnlyWritable));
+                instance._length = new PropertyDescriptor(0, PropertyFlag.OnlyWritable);
                 if (arguments.Length > 0)
                 {
                     PrototypeObject.Push(instance, arguments);
@@ -132,7 +132,7 @@ namespace Jint.Native.Array
             var instance = new ArrayInstance(Engine, length);
             instance.Prototype = PrototypeObject;
             instance.Extensible = true;
-            instance.SetOwnProperty("length", new PropertyDescriptor(length, PropertyFlag.OnlyWritable));
+            instance._length = new PropertyDescriptor(length, PropertyFlag.OnlyWritable);
             return instance;
         }
     }

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -526,21 +526,9 @@ namespace Jint.Native.Array
         {
             value = Undefined;
 
-            if (!TryGetDescriptor(index, out var desc)
-                || desc == null
-                || desc == PropertyDescriptor.Undefined
-                || (ReferenceEquals(desc.Value, null) && ReferenceEquals(desc.Get, null)))
-            {
-                desc = GetProperty(TypeConverter.ToString(index));
-            }
-
-            if (desc != null && desc != PropertyDescriptor.Undefined)
-            {
-                bool success = desc.TryGetValue(this, out value);
-                return success;
-            }
-
-            return false;
+            TryGetDescriptor(index, out var desc);
+            desc = desc ?? GetProperty(TypeConverter.ToString(index)) ?? PropertyDescriptor.Undefined; 
+            return desc.TryGetValue(this, out value);
         }
 
         internal bool DeleteAt(uint index)

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -554,13 +554,12 @@ namespace Jint.Native.Array
         {
             if (_dense != null)
             {
-                if (index >= _dense.Length)
+                descriptor = null;
+                if (index < _dense.Length)
                 {
-                    descriptor = null;
-                    return false;
+                    descriptor = _dense[index];
                 }
 
-                descriptor = _dense[index];
                 return descriptor != null;
             }
 

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -16,7 +16,7 @@ namespace Jint.Native.Array
         private const string PropertyNameLength = "length";
         private const int PropertyNameLengthLength = 6;
 
-        private PropertyDescriptor _length;
+        internal PropertyDescriptor _length;
 
         private const int MaxDenseArrayLength = 1024 * 10;
 
@@ -295,7 +295,7 @@ namespace Jint.Native.Array
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public uint GetLength()
         {
-            return (uint) ((JsNumber) _length.Value)._value;
+            return (uint) ((JsNumber) _length._value)._value;
         }
 
         protected override void AddProperty(string propertyName, PropertyDescriptor descriptor)

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -213,11 +213,7 @@ namespace Jint.Native.Array
             var thisArg = arguments.At(1);
             var callable = GetCallable(callbackfn);
 
-            var jsValues = Engine.JsValueArrayPool.RentArray(1);
-            jsValues[0] = len;
-            var a = Engine.Array.Construct(jsValues, len);
-            Engine.JsValueArrayPool.ReturnArray(jsValues);
-            
+            var a = Engine.Array.ConstructFast(len);
             var args = Engine.JsValueArrayPool.RentArray(3);
             for (uint k = 0; k < len; k++)
             {
@@ -230,10 +226,7 @@ namespace Jint.Native.Array
                     a.SetIndexValue(k, mappedValue, updateLength: false);
                 }
             }
-
-            a.SetLength(len);
             Engine.JsValueArrayPool.ReturnArray(args);
-
             return a;
         }
 

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1049,7 +1049,7 @@ namespace Jint.Native.Array
 
                 public override uint GetSmallestIndex() => _array.GetSmallestIndex();
 
-                public override uint GetLength() => _array.GetLength();
+                public override uint GetLength() => (uint) ((JsNumber) _array._length._value)._value;
 
                 public override void SetLength(uint length) => _array.Put("length", length, true);
 

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -5,7 +5,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Error
 {
-    public class ErrorConstructor : FunctionInstance, IConstructor
+    public sealed class ErrorConstructor : FunctionInstance, IConstructor
     {
         private string _name;
 

--- a/Jint/Native/Function/BindFunctionInstance.cs
+++ b/Jint/Native/Function/BindFunctionInstance.cs
@@ -4,7 +4,7 @@ using Jint.Runtime;
 
 namespace Jint.Native.Function
 {
-    public class BindFunctionInstance : FunctionInstance, IConstructor
+    public sealed class BindFunctionInstance : FunctionInstance, IConstructor
     {
         public BindFunctionInstance(Engine engine) : base(engine, System.Array.Empty<string>(), null, false)
         {

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -23,12 +23,13 @@ namespace Jint.Native.Function
 
         public JsValue Call(JsValue thisObject, JsValue[] arguments, bool directCall)
         {
-            if (arguments.At(0).Type != Types.String)
+            var arg = arguments.At(0);
+            if (arg.Type != Types.String)
             {
-                return arguments.At(0);
+                return arg;
             }
 
-            var code = TypeConverter.ToString(arguments.At(0));
+            var code = TypeConverter.ToString(arg);
 
             try
             {

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -6,7 +6,7 @@ using Jint.Runtime.Environments;
 
 namespace Jint.Native.Function
 {
-    public class EvalFunctionInstance: FunctionInstance
+    public sealed class EvalFunctionInstance : FunctionInstance
     {
         private static readonly ParserOptions ParserOptions = new ParserOptions { AdaptRegexp = true, Tolerant = false };
 

--- a/Jint/Native/Function/FunctionInstance.cs
+++ b/Jint/Native/Function/FunctionInstance.cs
@@ -10,11 +10,11 @@ namespace Jint.Native.Function
     {
         private const string PropertyNamePrototype = "prototype";
         private const int PropertyNamePrototypeLength = 9;
-        private PropertyDescriptor _prototype;
+        protected PropertyDescriptor _prototype;
 
         private const string PropertyNameLength = "length";
         private const int PropertyNameLengthLength = 6;
-        private PropertyDescriptor _length;
+        protected PropertyDescriptor _length;
         
         protected FunctionInstance(Engine engine, string[] parameters, LexicalEnvironment scope, bool strict)
             : this(engine, parameters, scope, strict, objectClass: "Function")

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -36,7 +36,7 @@ namespace Jint.Native.Function
             Extensible = true;
             Prototype = _engine.Function.PrototypeObject;
 
-            DefineOwnProperty("length", new PropertyDescriptor(JsNumber.Create(FormalParameters.Length), PropertyFlag.AllForbidden), false);
+            _length = new PropertyDescriptor(JsNumber.Create(FormalParameters.Length), PropertyFlag.AllForbidden);
 
             var proto = new ObjectInstanceWithConstructor(engine, this)
             {
@@ -44,7 +44,7 @@ namespace Jint.Native.Function
                 Prototype = _engine.Object.PrototypeObject
             };
 
-            SetOwnProperty("prototype", new PropertyDescriptor(proto, PropertyFlag.OnlyWritable));
+            _prototype = new PropertyDescriptor(proto, PropertyFlag.OnlyWritable);
 
             if (_functionDeclaration.Id != null)
             {
@@ -150,11 +150,11 @@ namespace Jint.Native.Function
                 {
                     thisBinding = thisArg;
                 }
-                else if (thisArg.IsUndefined() || thisArg.IsNull())
+                else if (thisArg._type == Types.Undefined || thisArg._type == Types.Null)
                 {
                     thisBinding = _engine.Global;
                 }
-                else if (!thisArg.IsObject())
+                else if (thisArg._type != Types.Object)
                 {
                     thisBinding = TypeConverter.ToObject(_engine, thisArg);
                 }

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -191,7 +191,7 @@ namespace Jint.Native
                         return false;
                     }
 
-                    return ToString().Equals(otherString);
+                    return ToString() == otherString;
                 }
 
                 return base.Equals(other);

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -181,7 +181,7 @@ namespace Jint.Native
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T TryCast<T>(Action<JsValue> fail = null) where T : class
         {
-            if (IsObject())
+            if (_type == Types.Object)
             {
                 if (this is T o)
                 {

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -55,7 +55,7 @@ namespace Jint.Native.Number
                 return "NaN";
             }
 
-            if (m.Equals(0))
+            if (m == 0)
             {
                 return "0";
             }
@@ -188,7 +188,7 @@ namespace Jint.Native.Number
                 return "NaN";
             }
 
-            if (x.Equals(0))
+            if (x == 0)
             {
                 return "0";
             }
@@ -212,7 +212,7 @@ namespace Jint.Native.Number
             var fraction = x -  integer;
 
             string result = ToBase(integer, radix);
-            if (!fraction.Equals(0))
+            if (fraction != 0)
             {
                 result += "." + ToFractionBase(fraction, radix);
             }
@@ -245,7 +245,7 @@ namespace Jint.Native.Number
             // http://www.mathpath.org/concepts/Num/frac.htm
 
             const string digits = "0123456789abcdefghijklmnopqrstuvwxyz";
-            if (n.Equals(0))
+            if (n == 0)
             {
                 return "0";
             }
@@ -270,7 +270,7 @@ namespace Jint.Native.Number
                 return "NaN";
             }
 
-            if (m.Equals(0))
+            if (m == 0)
             {
                 return "0";
             }

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -145,7 +145,7 @@ namespace Jint.Native.Object
             if (o is StringInstance s)
             {
                 var length = s.PrimitiveValue.AsStringWithoutTypeCheck().Length;
-                array = Engine.Array.Construct(ownProperties.Count + length);
+                array = Engine.Array.ConstructFast((uint) (ownProperties.Count + length));
                 for (var i = 0; i < length; i++)
                 {
                     array.SetIndexValue(n, TypeConverter.ToString(i), updateLength: false);
@@ -402,11 +402,7 @@ namespace Jint.Native.Object
                 .ToArray();
             var n = enumerableProperties.Length;
 
-            var args = _engine.JsValueArrayPool.RentArray(1);
-            args[0] = n;
-            var array = Engine.Array.Construct(args, (uint) n);
-            _engine.JsValueArrayPool.ReturnArray(args);
-
+            var array = Engine.Array.ConstructFast((uint) n);
             uint index = 0;
             foreach (var prop in enumerableProperties)
             {
@@ -414,7 +410,6 @@ namespace Jint.Native.Object
                 array.SetIndexValue(index, p, updateLength: false);
                 index++;
             }
-            array.SetLength(index);
             return array;
         }
     }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -185,12 +185,9 @@ namespace Jint.Native.Object
         {
             EnsureInitialized();
 
-            if (_properties != null && _properties.TryGetValue(propertyName, out var x))
-            {
-                return x;
-            }
-
-            return PropertyDescriptor.Undefined;
+            PropertyDescriptor descriptor = null;
+            _properties?.TryGetValue(propertyName, out descriptor);
+            return descriptor ?? PropertyDescriptor.Undefined;
         }
 
         protected internal virtual void SetOwnProperty(string propertyName, PropertyDescriptor desc)
@@ -220,12 +217,7 @@ namespace Jint.Native.Object
                 return prop;
             }
 
-            if (ReferenceEquals(Prototype, null))
-            {
-                return PropertyDescriptor.Undefined;
-            }
-
-            return Prototype.GetProperty(propertyName);
+            return Prototype?.GetProperty(propertyName) ?? PropertyDescriptor.Undefined;
         }
 
         public bool TryGetValue(string propertyName, out JsValue value)

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -26,10 +26,9 @@ namespace Jint.Native.Object
         
         public ObjectInstance(Engine engine) : this(engine, "Object")
         {
-            _engine = engine;
         }
         
-        protected ObjectInstance(Engine engine, in string objectClass) : base(Types.Object)
+        protected ObjectInstance(Engine engine, string objectClass) : base(Types.Object)
         {
             _engine = engine;
             _class = objectClass;
@@ -84,7 +83,7 @@ namespace Jint.Native.Object
         /// A String value indicating a specification defined
         /// classification of objects.
         /// </summary>
-        public ref readonly string Class => ref _class;
+        public string Class => _class;
 
         public virtual IEnumerable<KeyValuePair<string, PropertyDescriptor>> GetOwnProperties()
         {
@@ -124,7 +123,7 @@ namespace Jint.Native.Object
         {
             EnsureInitialized();
 
-            return _properties?.ContainsKey(propertyName) ?? false;
+            return _properties?.ContainsKey(propertyName) == true;
         }
 
         public virtual void RemoveOwnProperty(string propertyName)

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -154,7 +154,9 @@ namespace Jint.Native.Object
                 return Undefined;
             }
 
-            if (desc.IsDataDescriptor())
+            // IsDataDescriptor inlined
+            if ((desc._flags & (PropertyFlag.WritableSet | PropertyFlag.Writable)) != 0 
+                || !ReferenceEquals(desc.Value, null))
             {
                 var val = desc.Value;
                 return val ?? Undefined;

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -18,8 +18,8 @@ namespace Jint.Native.Object
 {
     public class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     {
-        private MruPropertyCache2<PropertyDescriptor> _intrinsicProperties;
-        private MruPropertyCache2<PropertyDescriptor> _properties;
+        private Dictionary<string, PropertyDescriptor> _intrinsicProperties;
+        private Dictionary<string, PropertyDescriptor> _properties;
         
         private readonly string _class;
         protected readonly Engine _engine;
@@ -63,7 +63,7 @@ namespace Jint.Native.Object
         {
             if (_intrinsicProperties == null)
             {
-                _intrinsicProperties = new MruPropertyCache2<PropertyDescriptor>();
+                _intrinsicProperties = new Dictionary<string, PropertyDescriptor>(StringComparer.Ordinal);
             }
 
             _intrinsicProperties[symbol.AsSymbol()] = new PropertyDescriptor(value, writable, enumerable, configurable);
@@ -92,7 +92,7 @@ namespace Jint.Native.Object
 
             if (_properties != null)
             {
-                foreach (var pair in _properties.GetEnumerator())
+                foreach (var pair in _properties)
                 {
                     yield return pair;
                 }
@@ -103,7 +103,7 @@ namespace Jint.Native.Object
         {
             if (_properties == null)
             {
-                _properties = new MruPropertyCache2<PropertyDescriptor>();
+                _properties = new Dictionary<string, PropertyDescriptor>(StringComparer.Ordinal);
             }
 
             _properties.Add(propertyName, descriptor);
@@ -196,7 +196,7 @@ namespace Jint.Native.Object
 
             if (_properties == null)
             {
-                _properties = new MruPropertyCache2<PropertyDescriptor>();
+                _properties = new Dictionary<string, PropertyDescriptor>();
             }
 
             _properties[propertyName] = desc;

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -395,18 +395,18 @@ namespace Jint.Native.String
             TypeConverter.CheckObjectCoercible(Engine, thisObj);
 
             var start = TypeConverter.ToNumber(arguments.At(0));
-            if (double.NegativeInfinity.Equals(start))
+            if (double.IsNegativeInfinity(start))
             {
                 start = 0;
             }
-            if (double.PositiveInfinity.Equals(start))
+            if (double.IsPositiveInfinity(start))
             {
                 return string.Empty;
             }
 
             var s = TypeConverter.ToString(thisObj);
             var end = TypeConverter.ToNumber(arguments.At(1));
-            if (double.PositiveInfinity.Equals(end))
+            if (double.IsPositiveInfinity(end))
             {
                 end = s.Length;
             }

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -3,13 +3,12 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Runtime.Interop;
 
 namespace Jint
 {
-    public class Options
+    public sealed class Options
     {
         private bool _discardGlobal;
         private bool _strict;
@@ -177,11 +176,7 @@ namespace Jint
 
         internal long _MemoryLimit => _memoryLimit;
 
-        internal int _MaxStatements
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get { return _maxStatements; }
-        }
+        internal int _MaxStatements => _maxStatements;
 
         internal int MaxRecursionDepth => _maxRecursionDepth;
 

--- a/Jint/Pooling/ObjectPool.cs
+++ b/Jint/Pooling/ObjectPool.cs
@@ -134,7 +134,7 @@ namespace Jint.Pooling
             // We will interlock only when we have a candidate. in a worst case we may miss some
             // recently returned objects. Not a big deal.
             T inst = _firstItem;
-            if (inst != null)
+            if (!ReferenceEquals(inst, null))
             {
                 _firstItem = null;
                 return inst;
@@ -161,7 +161,7 @@ namespace Jint.Pooling
             for (int i = 0; i < items.Length; i++)
             {
                 T inst = items[i].Value;
-                if (inst != null)
+                if (!ReferenceEquals(inst, null))
                 {
                     items[i].Value = null;
                     return inst;
@@ -184,7 +184,7 @@ namespace Jint.Pooling
             Validate(obj);
             ForgetTrackedObject(obj);
  
-            if (_firstItem == null)
+            if (ReferenceEquals(_firstItem, null))
             {
                 // Intentionally not using interlocked here. 
                 // In a worst case scenario two objects may be stored into same slot.
@@ -202,7 +202,7 @@ namespace Jint.Pooling
             var items = _items;
             for (int i = 0; i < items.Length; i++)
             {
-                if (items[i].Value == null)
+                if (ReferenceEquals(items[i].Value, null))
                 {
                     // Intentionally not using interlocked here. 
                     // In a worst case scenario two objects may be stored into same slot.
@@ -265,7 +265,7 @@ namespace Jint.Pooling
             for (int i = 0; i < items.Length; i++)
             {
                 var value = items[i].Value;
-                if (value == null)
+                if (ReferenceEquals(value, null))
                 {
                     return;
                 }

--- a/Jint/Runtime/Debugger/BreakPoint.cs
+++ b/Jint/Runtime/Debugger/BreakPoint.cs
@@ -1,11 +1,7 @@
 ﻿namespace Jint.Runtime.Debugger
 {
-    public class BreakPoint
+    public sealed class BreakPoint
     {
-        public int Line { get; set; }
-        public int Char { get; set; }
-        public string Condition { get; set; }
-
         public BreakPoint(int line, int character)
         {
             Line = line;
@@ -17,5 +13,9 @@
         {
             Condition = condition;
         }
+
+        public int Line { get; }
+        public int Char { get; }
+        public string Condition { get; }
     }
 }

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -326,7 +326,8 @@ namespace Jint.Runtime.Descriptors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsDataDescriptor()
         {
-            return WritableSet || !ReferenceEquals(Value, null);
+            return (_flags & (PropertyFlag.WritableSet | PropertyFlag.Writable)) != 0 
+                   || !ReferenceEquals(Value, null);
         }
 
         /// <summary>

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -354,12 +354,6 @@ namespace Jint.Runtime.Descriptors
         {
             value = JsValue.Undefined;
 
-            if (this == Undefined)
-            {
-                value = JsValue.Undefined;
-                return false;
-            }
-
             // IsDataDescriptor logic inlined
             if ((_flags & (PropertyFlag.WritableSet | PropertyFlag.Writable)) != 0)
             {
@@ -373,7 +367,12 @@ namespace Jint.Runtime.Descriptors
                     return true;
                 }
             }
-
+            
+            if (this == Undefined)
+            {
+                return false;
+            }
+            
             var getter = Get;
             if (!ReferenceEquals(getter, null) && !getter.IsUndefined())
             {

--- a/Jint/Runtime/Environments/Binding.cs
+++ b/Jint/Runtime/Environments/Binding.cs
@@ -2,7 +2,7 @@
 
 namespace Jint.Runtime.Environments
 {
-    public class Binding
+    public sealed class Binding
     {
         public JsValue Value;
         public bool CanBeDeleted;

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -984,10 +984,7 @@ namespace Jint.Runtime
             var elements = arrayExpression.Elements;
             var count = elements.Count;
             
-            var jsValues = _engine.JsValueArrayPool.RentArray(1);
-            jsValues[0] = count;
-            
-            var a = _engine.Array.Construct(jsValues, (uint) count);
+            var a = _engine.Array.ConstructFast((uint) count);
             for (var n = 0; n < count; n++)
             {
                 var expr = elements[n];
@@ -997,9 +994,6 @@ namespace Jint.Runtime
                     a.SetIndexValue((uint) n, value, updateLength: false);
                 }
             }
-            a.SetLength((uint) count);
-            _engine.JsValueArrayPool.ReturnArray(jsValues);
-
             return a;
         }
 

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -179,7 +179,7 @@ namespace Jint.Runtime
                     return double.NaN;
                 }
 
-                if (double.IsInfinity(lN) && rN.Equals(0))
+                if (double.IsInfinity(lN) && rN == 0)
                 {
                     if (NumberInstance.IsNegativeZero(rN))
                     {
@@ -189,12 +189,12 @@ namespace Jint.Runtime
                     return lN;
                 }
 
-                if (lN.Equals(0) && rN.Equals(0))
+                if (lN == 0 && rN == 0)
                 {
                     return double.NaN;
                 }
 
-                if (rN.Equals(0))
+                if (rN == 0)
                 {
                     if (NumberInstance.IsNegativeZero(rN))
                     {
@@ -474,7 +474,7 @@ namespace Jint.Runtime
                 case Types.Number:
                     var nx = ((JsNumber) x)._value;
                     var ny = ((JsNumber) y)._value;
-                    return !double.IsNaN(nx) && !double.IsNaN(ny) && nx.Equals(ny);
+                    return !double.IsNaN(nx) && !double.IsNaN(ny) && nx == ny;
                 case Types.String:
                     return x.AsStringWithoutTypeCheck() == y.AsStringWithoutTypeCheck();
                 case Types.Boolean:
@@ -514,9 +514,9 @@ namespace Jint.Runtime
                     return true;
                 }
 
-                if (nx.Equals(ny))
+                if (nx == ny)
                 {
-                    if (nx.Equals(0))
+                    if (nx == 0)
                     {
                         // +0 !== -0
                         return NumberInstance.IsNegativeZero(nx) == NumberInstance.IsNegativeZero(ny);
@@ -563,7 +563,7 @@ namespace Jint.Runtime
                     return Undefined.Instance;
                 }
 
-                if (nx.Equals(ny))
+                if (nx == ny)
                 {
                     return false;
                 }

--- a/Jint/Runtime/ExpressionIntepreter.cs
+++ b/Jint/Runtime/ExpressionIntepreter.cs
@@ -506,18 +506,26 @@ namespace Jint.Runtime
                 case Types.None:
                     return true;
                 case Types.Number:
-                    var nx = TypeConverter.ToNumber(x);
-                    var ny = TypeConverter.ToNumber(y);
-                    if (!double.IsNaN(nx) && !double.IsNaN(ny) && nx.Equals(ny))
+                var nx = TypeConverter.ToNumber(x);
+                var ny = TypeConverter.ToNumber(y);
+
+                if (double.IsNaN(nx) && double.IsNaN(ny))
+                {
+                    return true;
+                }
+
+                if (nx.Equals(ny))
+                {
+                    if (nx.Equals(0))
                     {
-                        if (nx.Equals(0))
-                        {
-                            // +0 !== -0
-                            return NumberInstance.IsNegativeZero(nx) == NumberInstance.IsNegativeZero(ny);
-                        }
-                        return true;
+                        // +0 !== -0
+                        return NumberInstance.IsNegativeZero(nx) == NumberInstance.IsNegativeZero(ny);
                     }
-                    return false;
+
+                    return true;
+                }
+
+                return false;
                 case Types.String:
                     return TypeConverter.ToString(x) == TypeConverter.ToString(y);
                 case Types.Boolean:
@@ -1027,7 +1035,7 @@ namespace Jint.Runtime
                     }
                     if (r.IsUnresolvableReference())
                     {
-                        if (r.IsStrict())
+                        if (r._strict)
                         {
                             ExceptionHelper.ThrowSyntaxError(_engine);
                         }
@@ -1038,11 +1046,11 @@ namespace Jint.Runtime
                     if (r.IsPropertyReference())
                     {
                         var o = TypeConverter.ToObject(_engine, r.GetBase());
-                        var jsValue = o.Delete(r.GetReferencedName(), r.IsStrict());
+                        var jsValue = o.Delete(r._name, r._strict);
                         _referencePool.Return(r);
                         return jsValue;
                     }
-                    if (r.IsStrict())
+                    if (r._strict)
                     {
                         ExceptionHelper.ThrowSyntaxError(_engine);
                     }

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -10,7 +10,7 @@ using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Runtime.Interop
 {
-    public class TypeReference : FunctionInstance, IConstructor, IObjectWrapper
+    public sealed class TypeReference : FunctionInstance, IConstructor, IObjectWrapper
     {
         private TypeReference(Engine engine)
             : base(engine, null, null, false, "TypeReference")

--- a/Jint/Runtime/MruPropertyCache2.cs
+++ b/Jint/Runtime/MruPropertyCache2.cs
@@ -71,12 +71,12 @@ namespace Jint.Runtime
 
         public bool ContainsKey(string key)
         {
-            if (_set && key.Equals(_key))
+            if (_set && key == _key)
             {
                 return true;
             }
 
-            return _dictionary != null && _dictionary.ContainsKey(key);
+            return _dictionary?.ContainsKey(key) == true;
         }
 
         public IEnumerable<KeyValuePair<string, TValue>> GetEnumerator()
@@ -97,36 +97,28 @@ namespace Jint.Runtime
             }
         }
 
-        public bool Remove(string key)
+        public void Remove(string key)
         {
-            bool removed = false;
-            if (_set && key.Equals(_key))
+            if (_set && key == _key)
             {
                 _set = false;
                 _key = null;
                 _value = null;
-                removed = true;
             }
 
             _dictionary?.Remove(key);
-            return removed;
         }
 
         public bool TryGetValue(string key, out TValue value)
         {
-            if (_set && _key.Equals(key))
+            value = null;
+            if (_set && _key == key)
             {
                 value = _value;
                 return true;
             }
 
-            if (_dictionary == null)
-            {
-                value = null;
-                return false;
-            }
-
-            return _dictionary.TryGetValue(key, out value);
+            return _dictionary?.TryGetValue(key, out value) == true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Runtime/References/Reference.cs
+++ b/Jint/Runtime/References/Reference.cs
@@ -11,9 +11,9 @@ namespace Jint.Runtime.References
     /// </summary>
     public sealed class Reference
     {
-        private JsValue _baseValue;
-        private string _name;
-        private bool _strict;
+        internal JsValue _baseValue;
+        internal string _name;
+        internal bool _strict;
 
         public Reference(JsValue baseValue, string name, bool strict)
         {
@@ -42,13 +42,13 @@ namespace Jint.Runtime.References
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool HasPrimitiveBase()
         {
-            return _baseValue.IsPrimitive();
+            return _baseValue._type != Types.Object && _baseValue._type != Types.None;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsUnresolvableReference()
         {
-            return _baseValue.IsUndefined();
+            return _baseValue._type == Types.Undefined;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Runtime/StatementInterpreter.cs
+++ b/Jint/Runtime/StatementInterpreter.cs
@@ -7,7 +7,7 @@ using Jint.Runtime.References;
 
 namespace Jint.Runtime
 {
-    public class StatementInterpreter
+    public sealed class StatementInterpreter
     {
         private readonly Engine _engine;
 
@@ -515,12 +515,7 @@ namespace Jint.Runtime
                 var declaration = statement.Declarations[i];
                 if (declaration.Init != null)
                 {
-                    if (!(_engine.EvaluateExpression(declaration.Id) is Reference lhs))
-                    {
-                        ExceptionHelper.ThrowArgumentException();
-                        return new Completion();
-                    }
-
+                    var lhs = (Reference) _engine.EvaluateExpression(declaration.Id);
                     lhs.AssertValid(_engine);
 
                     var value = _engine.GetValue(_engine.EvaluateExpression(declaration.Init), true);

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -122,19 +122,22 @@ namespace Jint.Runtime
                 ? StringPrototype.TrimEx(input)
                 : input;
 
-            if (string.IsNullOrEmpty(s))
+            if (s.Length == 0)
             {
                 return 0;
             }
 
-            if ("+Infinity".Equals(s) || "Infinity".Equals(s))
+            if (s.Length == 8 || s.Length == 9)
             {
-                return double.PositiveInfinity;
-            }
+                if ("+Infinity" == s || "Infinity" == s)
+                {
+                    return double.PositiveInfinity;
+                }
 
-            if ("-Infinity".Equals(s))
-            {
-                return double.NegativeInfinity;
+                if ("-Infinity" == s)
+                {
+                    return double.NegativeInfinity;
+                }
             }
 
             // todo: use a common implementation with JavascriptParser
@@ -148,11 +151,11 @@ namespace Jint.Runtime
                         return double.NaN;
                     }
 
-                    double n = Double.Parse(s,
+                    double n = double.Parse(s,
                         NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign |
                         NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite |
                         NumberStyles.AllowExponent, CultureInfo.InvariantCulture);
-                    if (s.StartsWith("-") && n.Equals(0))
+                    if (s.StartsWith("-") && n == 0)
                     {
                         return -0.0;
                     }
@@ -188,7 +191,7 @@ namespace Jint.Runtime
                 return 0;
             }
 
-            if (number.Equals(0) || double.IsInfinity(number))
+            if (number == 0 || double.IsInfinity(number))
             {
                 return number;
             }
@@ -205,7 +208,7 @@ namespace Jint.Runtime
                 return 0;
             }
 
-            if (number.Equals(0) || double.IsInfinity(number))
+            if (number == 0 || double.IsInfinity(number))
             {
                 return number;
             }

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -10,7 +10,6 @@ using Jint.Native.Number;
 using Jint.Native.Object;
 using Jint.Native.String;
 using Jint.Runtime.References;
-using Jint.Native.Symbol;
 
 namespace Jint.Runtime
 {
@@ -27,7 +26,7 @@ namespace Jint.Runtime
         Completion = 20,
     }
 
-    public class TypeConverter
+    public static class TypeConverter
     {
         // how many decimals to check when determining if double is actually an int
         private const double DoubleIsIntegerTolerance = double.Epsilon * 100;
@@ -69,77 +68,46 @@ namespace Jint.Runtime
         /// </summary>
         public static bool ToBoolean(JsValue o)
         {
-            if (o.IsBoolean())
+            switch (o._type)
             {
-                return ((JsBoolean) o)._value;
-            }
-
-            if (o.IsUndefined() || o.IsNull())
-            {
-                return false;
-            }
-
-            if (o.IsNumber())
-            {
-                var n = ((JsNumber) o)._value;
-                if (n.Equals(0) || double.IsNaN(n))
-                {
+                case Types.Boolean:
+                    return ((JsBoolean) o)._value;
+                case Types.Undefined:
+                case Types.Null:
                     return false;
-                }
-
-                return true;
+                case Types.Number:
+                    var n = ((JsNumber) o)._value;
+                    return n != 0 && !double.IsNaN(n);
+                case Types.String:
+                    return !((JsString) o).IsNullOrEmpty();
+                default:
+                    return true;
             }
-
-            if (o.IsString())
-            {
-                return !((JsString) o).IsNullOrEmpty();
-            }
-
-            return true;
         }
 
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-9.3
         /// </summary>
-        /// <param name="o"></param>
-        /// <returns></returns>
         public static double ToNumber(JsValue o)
         {
-            // check number first as this is what is usually expected
-            if (o.IsNumber())
+            switch (o._type)
             {
-                return ((JsNumber) o)._value;
+                // check number first as this is what is usually expected
+                case Types.Number:
+                    return ((JsNumber) o)._value;
+                case Types.Undefined:
+                    return double.NaN;
+                case Types.Null:
+                    return 0;
+                case Types.Object when o is IPrimitiveInstance p:
+                    return ToNumber(ToPrimitive(p.PrimitiveValue, Types.Number));
+                case Types.Boolean:
+                    return ((JsBoolean) o)._value ? 1 : 0;
+                case Types.String:
+                    return ToNumber(o.AsStringWithoutTypeCheck());
+                default:
+                    return ToNumber(ToPrimitive(o, Types.Number));
             }
-
-            if (o.IsUndefined())
-            {
-                return double.NaN;
-            }
-
-            if (o.IsNull())
-            {
-                return 0;
-            }
-
-            if (o._type == Types.Object)
-            {
-                if (o is IPrimitiveInstance p)
-                {
-                    o = p.PrimitiveValue;
-                }
-            }
-
-            if (o.IsBoolean())
-            {
-                return ((JsBoolean) o)._value ? 1 : 0;
-            }
-
-            if (o.IsString())
-            {
-                return ToNumber(o.AsStringWithoutTypeCheck());
-            }
-
-            return ToNumber(ToPrimitive(o, Types.Number));
         }
 
         private static double ToNumber(string input)
@@ -327,97 +295,51 @@ namespace Jint.Runtime
         /// <returns></returns>
         public static string ToString(JsValue o)
         {
-            if (o.IsString())
+            switch (o._type)
             {
-                return o.AsStringWithoutTypeCheck();
+                case Types.String:
+                    return o.AsStringWithoutTypeCheck();
+                case Types.Boolean:
+                    return ((JsBoolean) o)._value ? "true" : "false";
+                case Types.Number:
+                    return ToString(((JsNumber) o)._value);
+                case Types.Symbol:
+                    return o.AsSymbol();
+                case Types.Undefined:
+                    return Undefined.Text;
+                case Types.Null:
+                    return Null.Text;
+                case Types.Object when o is IPrimitiveInstance p:
+                    return ToString(ToPrimitive(p.PrimitiveValue, Types.String));
+                default:
+                    return ToString(ToPrimitive(o, Types.String));
             }
-
-            if (o.IsUndefined())
-            {
-                return Undefined.Text;
-            }
-
-            if (o.IsNull())
-            {
-                return Null.Text;
-            }
-
-            if (o.IsObject())
-            {
-                if (o is IPrimitiveInstance p)
-                {
-                    o = p.PrimitiveValue;
-                }
-                else
-                {
-                    var s = o.AsInstance<SymbolInstance>();
-                    if (!ReferenceEquals(s, null))
-                    {
-                        // TODO: throw a TypeError
-                        // NB: But it requires an Engine reference
-                        ExceptionHelper.ThrowJavaScriptException("TypeError");
-                    }
-                }
-            }
-
-            if (o.IsBoolean())
-            {
-                return ((JsBoolean) o)._value ? "true" : "false";
-            }
-
-            if (o.IsNumber())
-            {
-                return ToString(((JsNumber) o)._value);
-            }
-
-            if (o.IsSymbol())
-            {
-                return o.AsSymbol();
-            }
-
-            return ToString(ToPrimitive(o, Types.String));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ObjectInstance ToObject(Engine engine, JsValue value)
         {
-            if (value.IsObject())
+            switch (value._type)
             {
-                return (ObjectInstance) value;
+                case Types.Object:
+                    return (ObjectInstance) value;
+                case Types.Boolean:
+                    return engine.Boolean.Construct(((JsBoolean) value)._value);
+                case Types.Number:
+                    return engine.Number.Construct(((JsNumber) value)._value);
+                case Types.String:
+                    return engine.String.Construct(value.AsStringWithoutTypeCheck());
+                case Types.Symbol:
+                    return engine.Symbol.Construct(((JsSymbol) value)._value);
+                default:
+                    ExceptionHelper.ThrowTypeError(engine);
+                    return null;
             }
-
-            if (value.IsBoolean())
-            {
-                return engine.Boolean.Construct(((JsBoolean) value)._value);
-            }
-
-            if (value.IsNumber())
-            {
-                return engine.Number.Construct(((JsNumber) value)._value);
-            }
-
-            if (value.IsString())
-            {
-                return engine.String.Construct(value.AsStringWithoutTypeCheck());
-            }
-
-            if (value.IsSymbol())
-            {
-                return engine.Symbol.Construct(((JsSymbol) value)._value);
-            }
-
-            if (value.IsUndefined() || value.IsNull())
-            {
-                ExceptionHelper.ThrowTypeError(engine);
-            }
-            
-            ExceptionHelper.ThrowTypeError(engine);
-            return null;
         }
 
         public static Types GetPrimitiveType(JsValue value)
         {
-            if (value.IsObject())
+            if (value._type == Types.Object)
             {
                 if (value is IPrimitiveInstance primitive)
                 {
@@ -436,7 +358,7 @@ namespace Jint.Runtime
             MemberExpression expression,
             object baseReference)
         {
-            if (!o.IsUndefined() && !o.IsNull())
+            if (o._type != Types.Undefined && o._type != Types.Null)
             {
                 return;
             }
@@ -464,7 +386,7 @@ namespace Jint.Runtime
 
         public static void CheckObjectCoercible(Engine engine, JsValue o)
         {
-            if (o.IsUndefined() || o.IsNull())
+            if (o._type == Types.Undefined || o._type == Types.Null)
             {
                 ExceptionHelper.ThrowTypeError(engine);
             }
@@ -522,7 +444,7 @@ namespace Jint.Runtime
 
         public static bool TypeIsNullable(Type type)
         {
-            return !type.IsValueType() || Nullable.GetUnderlyingType(type) != null;
+            return !type.IsValueType || Nullable.GetUnderlyingType(type) != null;
         }
     }
 }

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -266,7 +266,7 @@ namespace Jint.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string ToString(uint i)
         {
-            return i >= 0 && i < intToString.Length
+            return i < intToString.Length
                 ? intToString[i]
                 : i.ToString();
         }


### PR DESCRIPTION
All kinds of optimizations.

* inline when JIT doesn't do it
* ObjectInstance direct backing field of Dictionary works better,  DeclarativeExecutionContext still benefits from MPC2
* Mostly used net471 target to detect bad inlining, but probably benefits .NET Core and Full Framework better

## ArrayBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Slice|100|444.1 us|161.1328|660.16 KB|
| **New** |	|	| **419.5 us (-6%)** | **161.1328 (0%)** | **660.16 KB (0%)** |
| Old |Concat|100|478.3 us|175.7813|720.31 KB|
| **New** |	|	| **474.5 us (-1%)** | **175.7813 (0%)** | **720.31 KB (0%)** |
| Old |Unshift|100|17,875.9 us|3562.5000|14672.66 KB|
| **New** |	|	| **18,321.2 us (+2%)** | **3562.5000 (0%)** | **14672.66 KB (0%)** |
| Old |Push|100|10,700.9 us|343.7500|1438.28 KB|
| **New** |	|	| **10,259.9 us (-4%)** | **343.7500 (0%)** | **1438.28 KB (0%)** |
| Old |Index|100|11,988.4 us|390.6250|1637.5 KB|
| **New** |	|	| **11,690.5 us (-2%)** | **390.6250 (0%)** | **1637.5 KB (0%)** |
| Old |Map|100|3,191.3 us|691.4063|2833.59 KB|
| **New** |	|	| **2,868.3 us (-10%)** | **687.5000 (-1%)** | **2830.47 KB (0%)** |
| Old |Apply|100|577.0 us|188.4766|774.22 KB|
| **New** |	|	| **582.4 us (+1%)** | **188.4766 (0%)** | **774.22 KB (0%)** |
| Old |JsonStringifyParse|100|4,517.9 us|1273.4375|5225.78 KB|
| **New** |	|	| **4,612.0 us (+2%)** | **1273.4375 (0%)** | **5242.19 KB (0%)** |
| Old |FilterWithString|100|36,423.1 us|5687.5000|23338.28 KB|
| **New** |	|	| **32,967.5 us (-9%)** | **5687.5000 (0%)** | **23335.16 KB (0%)** |


## ArrayStressBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|20|592.4 ms|60000.0000|2937.5000|245.9 MB|
| **New** |	|	| **560.9 ms (-5%)** | **59937.5000 (0%)** | **2937.5000 (0%)** | **245.9 MB (0%)** |


## DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|dromaeo-3d-cube|74.51 ms|1375.0000|250.0000|-|7662.21 KB|
| **New** |	|	| **73.62 ms (-1%)** | **1375.0000 (0%)** | **312.5000 (+25%)** | **-** | **7722.41 KB (+1%)** |
| Old |Run|dromaeo-core-eval|15.75 ms|62.5000|-|-|298.7 KB|
| **New** |	|	| **15.54 ms (-1%)** | **62.5000 (0%)** | **-** | **-** | **298.71 KB (0%)** |
| Old |Run|dromaeo-object-array|157.05 ms|42437.5000|1937.5000|937.5000|178313.12 KB|
| **New** |	|	| **159.04 ms (+1%)** | **42437.5000 (0%)** | **1937.5000 (0%)** | **937.5000 (0%)** | **178313.61 KB (0%)** |
| Old |Run|dromaeo-object-regexp|891.11 ms|53625.0000|32312.5000|21687.5000|414359.71 KB|
| **New** |	|	| **882.77 ms (-1%)** | **53750.0000 (0%)** | **31625.0000 (-2%)** | **22000.0000 (+1%)** | **417256.65 KB (+1%)** |
| Old |Run|dromaeo-object-string|1,198.01 ms|218062.5000|174812.5000|172375.0000|1392917.21 KB|
| **New** |	|	| **1,182.09 ms (-1%)** | **218687.5000 (0%)** | **175250.0000 (0%)** | **172875.0000 (0%)** | **1393573.49 KB (0%)** |
| Old |Run|dromaeo-string-base64|169.39 ms|6375.0000|312.5000|-|27381.53 KB|
| **New** |	|	| **167.69 ms (-1%)** | **6375.0000 (0%)** | **312.5000 (0%)** | **-** | **27381.61 KB (0%)** |


## EvaluationBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Jint|20|670.4 us|119.1406|488.91 KB|
| **New** |	|	| **658.5 us (-2%)** | **118.1641 (-1%)** | **487.34 KB (0%)** |


## LinqJsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Jint|10|71.95 ms|5125.0000|2500.0000|125.0000|30.57 MB|
| **New** |	|	| **69.62 ms (-3%)** | **5062.5000 (-1%)** | **2500.0000 (0%)** | **-** | **30.52 MB (0%)** |


## MinimalScriptBenchmark

| **Diff**|Method|N|Mean|Gen 0|Allocated|
|------- |-------|-------|-------:|-------:|-------:|
| Old |Jint|10|18.42 us|8.1482|33.44 KB|
| **New** |	|	| **20.47 us (+11%)** | **8.1482 (0%)** | **33.44 KB (0%)** |


## StopwatchBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Jint|1|1.141 s|14375.0000|62.5000|57.73 MB|
| **New** |	|	| **1.112 s (-3%)** | **18000.0000 (+25%)** | **62.5000 (0%)** | **72.22 MB (+25%)** |


## SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------:|
| Old |Run|3d-cube|602.3 ms|11875.0000|312.5000|-|49.56 MB|
| **New** |	|	| **588.8 ms (-2%)** | **11875.0000 (0%)** | **312.5000 (0%)** | **-** | **49.56 MB (0%)** |
| Old |Run|3d-morph|565.8 ms|11812.5000|2500.0000|1062.5000|68.03 MB|
| **New** |	|	| **565.3 ms (0%)** | **11812.5000 (0%)** | **2500.0000 (0%)** | **1062.5000 (0%)** | **68.03 MB (0%)** |
| Old |Run|3d-raytrace|486.8 ms|21875.0000|750.0000|125.0000|89.75 MB|
| **New** |	|	| **465.5 ms (-4%)** | **21875.0000 (0%)** | **750.0000 (0%)** | **62.5000 (-50%)** | **89.75 MB (0%)** |
| Old |Run|access-binary-trees|203.4 ms|16500.0000|437.5000|62.5000|68.51 MB|
| **New** |	|	| **192.0 ms (-6%)** | **16625.0000 (+1%)** | **250.0000 (-43%)** | **-** | **68.51 MB (0%)** |
| Old |Run|access-fannkuch|1,872.9 ms|9437.5000|125.0000|-|37.87 MB|
| **New** |	|	| **1,840.8 ms (-2%)** | **9437.5000 (0%)** | **125.0000 (0%)** | **-** | **37.87 MB (0%)** |
| Old |Run|access-nbody|563.8 ms|13062.5000|-|-|52.42 MB|
| **New** |	|	| **551.6 ms (-2%)** | **13062.5000 (0%)** | **-** | **-** | **52.42 MB (0%)** |
| Old |Run|access-nsieve|716.9 ms|15375.0000|3937.5000|1875.0000|73.09 MB|
| **New** |	|	| **694.4 ms (-3%)** | **15375.0000 (0%)** | **3937.5000 (0%)** | **1875.0000 (0%)** | **73.09 MB (0%)** |
| Old |Run|bitops-3bit-bits-in-byte|404.7 ms|17562.5000|-|-|70.27 MB|
| **New** |	|	| **386.4 ms (-5%)** | **17562.5000 (0%)** | **-** | **-** | **70.27 MB (0%)** |
| Old |Run|bitops-bits-in-byte|663.6 ms|11562.5000|62.5000|-|46.44 MB|
| **New** |	|	| **647.6 ms (-2%)** | **11562.5000 (0%)** | **62.5000 (0%)** | **-** | **46.44 MB (0%)** |
| Old |Run|bitops-bitwise-and|427.2 ms|9000.0000|-|-|36.01 MB|
| **New** |	|	| **474.0 ms (+11%)** | **9000.0000 (0%)** | **-** | **-** | **36.01 MB (0%)** |
| Old |Run|bitops-nsieve-bits|697.3 ms|21625.0000|125.0000|-|88.5 MB|
| **New** |	|	| **688.6 ms (-1%)** | **21625.0000 (0%)** | **125.0000 (0%)** | **-** | **88.5 MB (0%)** |
| Old |Run|controlflow-recursive|292.0 ms|23625.0000|-|-|94.61 MB|
| **New** |	|	| **266.0 ms (-9%)** | **23625.0000 (0%)** | **-** | **-** | **94.61 MB (0%)** |
| Old |Run|crypto-aes|435.4 ms|5500.0000|250.0000|-|24.14 MB|
| **New** |	|	| **431.0 ms (-1%)** | **5500.0000 (0%)** | **312.5000 (+25%)** | **-** | **24.12 MB (0%)** |
| Old |Run|crypto-md5|322.3 ms|28000.0000|250.0000|62.5000|114.57 MB|
| **New** |	|	| **302.8 ms (-6%)** | **28000.0000 (0%)** | **250.0000 (0%)** | **62.5000 (0%)** | **114.57 MB (0%)** |
| Old |Run|crypto-sha1|306.3 ms|22687.5000|312.5000|62.5000|92.28 MB|
| **New** |	|	| **296.1 ms (-3%)** | **22687.5000 (0%)** | **312.5000 (0%)** | **62.5000 (0%)** | **92.28 MB (0%)** |
| Old |Run|date-format-tofte|325.1 ms|11875.0000|-|-|47.71 MB|
| **New** |	|	| **319.6 ms (-2%)** | **11687.5000 (-2%)** | **62.5000** | **-** | **47.06 MB (-1%)** |
| Old |Run|date-format-xparb|328.9 ms|10000.0000|250.0000|-|40.85 MB|
| **New** |	|	| **321.7 ms (-2%)** | **10125.0000 (+1%)** | **250.0000 (0%)** | **-** | **41.22 MB (+1%)** |
| Old |Run|math-cordic|914.1 ms|20562.5000|62.5000|-|82.43 MB|
| **New** |	|	| **908.0 ms (-1%)** | **20562.5000 (0%)** | **62.5000 (0%)** | **-** | **82.43 MB (0%)** |
| Old |Run|math-partial-sums|293.1 ms|7000.0000|-|-|28.07 MB|
| **New** |	|	| **280.1 ms (-4%)** | **7000.0000 (0%)** | **-** | **-** | **28.07 MB (0%)** |
| Old |Run|math-spectral-norm|348.2 ms|16875.0000|-|-|67.63 MB|
| **New** |	|	| **328.3 ms (-6%)** | **16875.0000 (0%)** | **-** | **-** | **67.63 MB (0%)** |
| Old |Run|regexp-dna|342.7 ms|2187.5000|1875.0000|1500.0000|13.55 MB|
| **New** |	|	| **344.0 ms (0%)** | **2312.5000 (+6%)** | **1875.0000 (0%)** | **1562.5000 (+4%)** | **13.54 MB (0%)** |
| Old |Run|string-base64|256.9 ms|9312.5000|375.0000|-|38.79 MB|
| **New** |	|	| **249.9 ms (-3%)** | **9312.5000 (0%)** | **375.0000 (0%)** | **-** | **38.79 MB (0%)** |
| Old |Run|string-fasta|432.6 ms|26750.0000|-|-|107.01 MB|
| **New** |	|	| **401.4 ms (-7%)** | **26000.0000 (-3%)** | **62.5000** | **-** | **104.02 MB (-3%)** |
| Old |Run|string-tagcloud|205.8 ms|14000.0000|1687.5000|625.0000|64.92 MB|
| **New** |	|	| **201.1 ms (-2%)** | **14125.0000 (+1%)** | **2062.5000 (+22%)** | **750.0000 (+20%)** | **64.54 MB (-1%)** |
| Old |Run|string-unpack-code|157.0 ms|13750.0000|4750.0000|875.0000|64.88 MB|
| **New** |	|	| **151.1 ms (-4%)** | **13750.0000 (0%)** | **4500.0000 (-5%)** | **1000.0000 (+14%)** | **64.88 MB (0%)** |
| Old |Run|string-validate-input|176.1 ms|7312.5000|375.0000|62.5000|33.53 MB|
| **New** |	|	| **171.0 ms (-3%)** | **7250.0000 (-1%)** | **437.5000 (+17%)** | **62.5000 (0%)** | **33.26 MB (-1%)** |


## UncacheableExpressionsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Benchmark|500|336.2 ms|48625.0000|11250.0000|196.66 MB|
| **New** |	|	| **312.8 ms (-7%)** | **46750.0000 (-4%)** | **250.0000 (-98%)** | **187.34 MB (-5%)** |


