### PR TITLE
Optimize object expressions and type conversions

### DIFF
--- a/Jint/Native/Boolean/BooleanConstructor.cs
+++ b/Jint/Native/Boolean/BooleanConstructor.cs
@@ -57,10 +57,17 @@ namespace Jint.Native.Boolean
 
         public BooleanInstance Construct(bool value)
         {
-            var instance = new BooleanInstance(Engine);
-            instance.Prototype = PrototypeObject;
-            instance.PrimitiveValue = value;
-            instance.Extensible = true;
+            return Construct(value ? JsBoolean.True : JsBoolean.False);
+        }
+        
+        public BooleanInstance Construct(JsBoolean value)
+        {
+            var instance = new BooleanInstance(Engine)
+            {
+                Prototype = PrototypeObject,
+                PrimitiveValue = value,
+                Extensible = true
+            };
 
             return instance;
         }

--- a/Jint/Native/JsBoolean.cs
+++ b/Jint/Native/JsBoolean.cs
@@ -5,8 +5,8 @@ namespace Jint.Native
 {
     public sealed class JsBoolean : JsValue, IEquatable<JsBoolean>
     {
-        public static readonly JsValue False = new JsBoolean(false);
-        public static readonly JsValue True = new JsBoolean(true);
+        public static readonly JsBoolean False = new JsBoolean(false);
+        public static readonly JsBoolean True = new JsBoolean(true);
 
         internal static readonly object BoxedTrue = true;
         internal static readonly object BoxedFalse = false;

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -10,7 +10,7 @@ namespace Jint.Native
         private static readonly JsString[] _charToJsValue;
         private static readonly JsString[] _charToStringJsValue;
 
-        private static readonly JsString Empty = new JsString("");
+        public static readonly JsString Empty = new JsString("");
         private static readonly JsString NullString = new JsString("null");
 
         internal string _value;
@@ -56,6 +56,8 @@ namespace Jint.Native
         {
             return string.IsNullOrEmpty(_value);
         }
+
+        public virtual int Length => _value.Length;
 
         internal static JsString Create(string value)
         {
@@ -178,6 +180,8 @@ namespace Jint.Native
                     || _stringBuilder != null && _stringBuilder.Length == 0;
             }
 
+            public override int Length => _stringBuilder?.Length ?? _value?.Length ?? 0;
+
             public override object ToObject()
             {
                 return _stringBuilder.ToString();
@@ -190,15 +194,14 @@ namespace Jint.Native
                     return _stringBuilder.Equals(cs._stringBuilder);
                 }
 
-                if (other.Type == Types.String)
+                if (other is JsString jsString)
                 {
-                    var otherString = other.AsStringWithoutTypeCheck();
-                    if (otherString.Length != _stringBuilder.Length)
+                    if (jsString._value.Length != Length)
                     {
                         return false;
                     }
 
-                    return ToString() == otherString;
+                    return ToString() == jsString._value;
                 }
 
                 return base.Equals(other);

--- a/Jint/Native/Number/NumberConstructor.cs
+++ b/Jint/Native/Number/NumberConstructor.cs
@@ -63,10 +63,17 @@ namespace Jint.Native.Number
 
         public NumberInstance Construct(double value)
         {
-            var instance = new NumberInstance(Engine);
-            instance.Prototype = PrototypeObject;
-            instance.NumberData = value;
-            instance.Extensible = true;
+            return Construct(JsNumber.Create(value));
+        }
+
+        public NumberInstance Construct(JsNumber value)
+        {
+            var instance = new NumberInstance(Engine)
+            {
+                Prototype = PrototypeObject,
+                NumberData = value,
+                Extensible = true
+            };
 
             return instance;
         }

--- a/Jint/Native/Number/NumberInstance.cs
+++ b/Jint/Native/Number/NumberInstance.cs
@@ -18,7 +18,7 @@ namespace Jint.Native.Number
 
         JsValue IPrimitiveInstance.PrimitiveValue => NumberData;
 
-        public JsValue NumberData { get; set; }
+        public JsNumber NumberData { get; set; }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsNegativeZero(double x)

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -21,10 +21,12 @@ namespace Jint.Native.Number
 
         public static NumberPrototype CreatePrototypeObject(Engine engine, NumberConstructor numberConstructor)
         {
-            var obj = new NumberPrototype(engine);
-            obj.Prototype = engine.Object.PrototypeObject;
-            obj.NumberData = 0;
-            obj.Extensible = true;
+            var obj = new NumberPrototype(engine)
+            {
+                Prototype = engine.Object.PrototypeObject,
+                NumberData = JsNumber.Create(0),
+                Extensible = true
+            };
 
             obj.FastAddProperty("constructor", numberConstructor, true, false, true);
 

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -100,6 +100,18 @@ namespace Jint.Native.Object
 
             return obj;
         }
+        
+        internal ObjectInstance Construct(int propertyCount)
+        {
+            var obj = new ObjectInstance(_engine)
+            {
+                Extensible = true,
+                Prototype = Engine.Object.PrototypeObject,
+                _properties =  propertyCount > 0 ? new Dictionary<string, PropertyDescriptor>(propertyCount) : null
+            };
+
+            return obj;
+        }
 
         public JsValue GetPrototypeOf(JsValue thisObject, JsValue[] arguments)
         {
@@ -144,7 +156,7 @@ namespace Jint.Native.Object
             var ownProperties = o.GetOwnProperties().ToList();
             if (o is StringInstance s)
             {
-                var length = s.PrimitiveValue.AsStringWithoutTypeCheck().Length;
+                var length = s.PrimitiveValue.Length;
                 array = Engine.Array.ConstructFast((uint) (ownProperties.Count + length));
                 for (var i = 0; i < length; i++)
                 {

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -19,7 +19,7 @@ namespace Jint.Native.Object
     public class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     {
         protected Dictionary<string, PropertyDescriptor> _intrinsicProperties;
-        protected Dictionary<string, PropertyDescriptor> _properties;
+        protected internal Dictionary<string, PropertyDescriptor> _properties;
         
         private readonly string _class;
         protected readonly Engine _engine;
@@ -780,7 +780,7 @@ namespace Jint.Native.Object
                 case "String":
                     if (this is StringInstance stringInstance)
                     {
-                        return stringInstance.PrimitiveValue.AsStringWithoutTypeCheck();
+                        return stringInstance.PrimitiveValue.ToString();
                     }
 
                     break;
@@ -814,7 +814,7 @@ namespace Jint.Native.Object
                 case "Number":
                     if (this is NumberInstance numberInstance)
                     {
-                        return ((JsNumber) numberInstance.NumberData)._value;
+                        return numberInstance.NumberData._value;
                     }
 
                     break;

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -70,12 +70,18 @@ namespace Jint.Native.String
 
         public StringInstance Construct(string value)
         {
-            var instance = new StringInstance(Engine);
-            instance.Prototype = PrototypeObject;
-            instance.PrimitiveValue = value;
-            instance.Extensible = true;
+            return Construct(JsString.Create(value));
+        }
 
-            instance.SetOwnProperty("length", new PropertyDescriptor(value.Length, PropertyFlag.AllForbidden));
+        public StringInstance Construct(JsString value)
+        {
+            var instance = new StringInstance(Engine)
+            {
+                Prototype = PrototypeObject,
+                PrimitiveValue = value,
+                Extensible = true,
+                _length = new PropertyDescriptor(value.Length, PropertyFlag.AllForbidden)
+            };
 
             return instance;
         }

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.String
         private const string PropertyNameLength = "length";
         private const int PropertyNameLengthLength = 6;
 
-        private PropertyDescriptor _length;
+        internal PropertyDescriptor _length;
 
         public StringInstance(Engine engine)
             : base(engine, objectClass: "String")
@@ -21,7 +21,7 @@ namespace Jint.Native.String
 
         JsValue IPrimitiveInstance.PrimitiveValue => PrimitiveValue;
 
-        public JsValue PrimitiveValue { get; set; }
+        public JsString PrimitiveValue { get; set; }
 
         private static bool IsInt(double d)
         {

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -25,7 +25,7 @@ namespace Jint.Native.String
         {
             var obj = new StringPrototype(engine);
             obj.Prototype = engine.Object.PrototypeObject;
-            obj.PrimitiveValue = "";
+            obj.PrimitiveValue = JsString.Empty;
             obj.Extensible = true;
             obj.SetOwnProperty("length", new PropertyDescriptor(0, PropertyFlag.AllForbidden));
             obj.SetOwnProperty("constructor", new PropertyDescriptor(stringConstructor, PropertyFlag.NonEnumerable));

--- a/Jint/Native/Symbol/SymbolConstructor.cs
+++ b/Jint/Native/Symbol/SymbolConstructor.cs
@@ -115,10 +115,17 @@ namespace Jint.Native.Symbol
 
         public SymbolInstance Construct(string description)
         {
-            var instance = new SymbolInstance(Engine);
-            instance.Prototype = PrototypeObject;
-            instance.SymbolData = new JsSymbol(description);
-            instance.Extensible = true;
+            return Construct(new JsSymbol(description));
+        }
+
+        public SymbolInstance Construct(JsSymbol symbol)
+        {
+            var instance = new SymbolInstance(Engine)
+            {
+                Prototype = PrototypeObject,
+                SymbolData = symbol, 
+                Extensible = true
+            };
 
             return instance;
         }


### PR DESCRIPTION
* fast path for common object expression transformation from properties to new object
* some conversion tweaks for common cases
* constructors for JsValues that are aleady resolved, no need to create them again

## UncacheableExpressionsBenchmark

| **Diff**|Method|N|Mean|Gen 0|Gen 1|Allocated|
|------- |-------|-------|-------:|-------:|-------:|-------:|
| Old |Benchmark|500|296.8 ms|36812.5000|125.0000|147.43 MB|
| **New** |	|	| **278.6 ms (-6%)** | **33750.0000 (-8%)** | **-** | **135.01 MB (-8%)** |
