### PR TITLE
Added attributes for including/ignoring fields/properties/constructors/methods

### DIFF
--- a/Jint.Tests/Runtime/Domain/OptInTestClass.cs
+++ b/Jint.Tests/Runtime/Domain/OptInTestClass.cs
@@ -1,0 +1,27 @@
+﻿using Jint.Runtime.Interop;
+
+namespace Jint.Tests.Runtime.Domain
+{
+    [JintClass(DiscoveryModes.OptIn)]
+    public class OptInTestClass
+    {
+        public int TestRemovedField;
+
+        [JintField]
+        public int TestField;
+
+        public int TestRemovedProperty { get; set; }
+
+        [JintProperty]
+        public int TestProperty { get; set; }
+
+        public void TestRemovedMethod()
+        {
+        }
+
+        [JintMethod]
+        public void TestMethod()
+        {
+        }
+    }
+}

--- a/Jint.Tests/Runtime/Domain/OptOutTestClass.cs
+++ b/Jint.Tests/Runtime/Domain/OptOutTestClass.cs
@@ -1,0 +1,27 @@
+﻿using Jint.Runtime.Interop;
+
+namespace Jint.Tests.Runtime.Domain
+{
+    [JintClass(DiscoveryModes.OptOut)]
+    public class OptOutTestClass
+    {
+        [JintIgnore]
+        public int TestRemovedField;
+
+        public int TestField;
+
+        [JintIgnore]
+        public int TestRemovedProperty { get; set; }
+
+        public int TestProperty { get; set; }
+
+        [JintIgnore]
+        public void TestRemovedMethod()
+        {
+        }
+
+        public void TestMethod()
+        {
+        }
+    }
+}

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Jint.Native;
 using Jint.Native.Array;
 using Jint.Native.Object;
+using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 using Jint.Tests.Runtime.Converters;
 using Jint.Tests.Runtime.Domain;
@@ -1629,13 +1630,13 @@ namespace Jint.Tests.Runtime
 
             var objectWrapper = new ObjectWrapper(engine, new OptOutTestClass());
 
-            Assert.Null(objectWrapper.GetProperty(nameof(OptOutTestClass.TestRemovedField)));
-            Assert.Null(objectWrapper.GetProperty(nameof(OptOutTestClass.TestRemovedProperty)));
-            Assert.Null(objectWrapper.GetProperty(nameof(OptOutTestClass.TestRemovedMethod)));
+            Assert.Equal(PropertyDescriptor.Undefined, objectWrapper.GetProperty(nameof(OptOutTestClass.TestRemovedField)));
+            Assert.Equal(PropertyDescriptor.Undefined, objectWrapper.GetProperty(nameof(OptOutTestClass.TestRemovedProperty)));
+            Assert.Equal(PropertyDescriptor.Undefined, objectWrapper.GetProperty(nameof(OptOutTestClass.TestRemovedMethod)));
 
-            Assert.NotNull(objectWrapper.GetProperty(nameof(OptOutTestClass.TestField)));
-            Assert.NotNull(objectWrapper.GetProperty(nameof(OptOutTestClass.TestProperty)));
-            Assert.NotNull(objectWrapper.GetProperty(nameof(OptOutTestClass.TestMethod)));
+            Assert.NotEqual(PropertyDescriptor.Undefined, objectWrapper.GetProperty(nameof(OptOutTestClass.TestField)));
+            Assert.NotEqual(PropertyDescriptor.Undefined, objectWrapper.GetProperty(nameof(OptOutTestClass.TestProperty)));
+            Assert.NotEqual(PropertyDescriptor.Undefined, objectWrapper.GetProperty(nameof(OptOutTestClass.TestMethod)));
         }
 
         [Fact]
@@ -1645,13 +1646,13 @@ namespace Jint.Tests.Runtime
 
             var objectWrapper = new ObjectWrapper(engine, new OptInTestClass());
 
-            Assert.Null(objectWrapper.GetProperty(nameof(OptInTestClass.TestRemovedField)));
-            Assert.Null(objectWrapper.GetProperty(nameof(OptInTestClass.TestRemovedProperty)));
-            Assert.Null(objectWrapper.GetProperty(nameof(OptInTestClass.TestRemovedMethod)));
+            Assert.Equal(PropertyDescriptor.Undefined, objectWrapper.GetProperty(nameof(OptInTestClass.TestRemovedField)));
+            Assert.Equal(PropertyDescriptor.Undefined, objectWrapper.GetProperty(nameof(OptInTestClass.TestRemovedProperty)));
+            Assert.Equal(PropertyDescriptor.Undefined, objectWrapper.GetProperty(nameof(OptInTestClass.TestRemovedMethod)));
 
-            Assert.NotNull(objectWrapper.GetProperty(nameof(OptInTestClass.TestField)));
-            Assert.NotNull(objectWrapper.GetProperty(nameof(OptInTestClass.TestProperty)));
-            Assert.NotNull(objectWrapper.GetProperty(nameof(OptInTestClass.TestMethod)));
+            Assert.NotEqual(PropertyDescriptor.Undefined, objectWrapper.GetProperty(nameof(OptInTestClass.TestField)));
+            Assert.NotEqual(PropertyDescriptor.Undefined, objectWrapper.GetProperty(nameof(OptInTestClass.TestProperty)));
+            Assert.NotEqual(PropertyDescriptor.Undefined, objectWrapper.GetProperty(nameof(OptInTestClass.TestMethod)));
         }
     }
 }

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -73,7 +73,7 @@ namespace Jint.Runtime.Interop
         {
             // look for a property
             PropertyInfo property = null;
-            foreach (var p in type.GetProperties(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public))
+            foreach (var p in TypeUtilities.GetProperties(type, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public))
             {
                 if (EqualsIgnoreCasing(p.Name, propertyName))
                 {
@@ -89,7 +89,7 @@ namespace Jint.Runtime.Interop
 
             // look for a field
             FieldInfo field = null;
-            foreach (var f in type.GetFields(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public))
+            foreach (var f in TypeUtilities.GetFields(type, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public))
             {
                 if (EqualsIgnoreCasing(f.Name, propertyName))
                 {
@@ -105,7 +105,7 @@ namespace Jint.Runtime.Interop
 
             // if no properties were found then look for a method
             List<MethodInfo> methods = null;
-            foreach (var m in type.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public))
+            foreach (var m in TypeUtilities.GetMethods(type, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public))
             {
                 if (EqualsIgnoreCasing(m.Name, propertyName))
                 {
@@ -121,7 +121,7 @@ namespace Jint.Runtime.Interop
 
             // if no methods are found check if target implemented indexing
             PropertyInfo first = null;
-            foreach (var p in type.GetProperties())
+            foreach (var p in TypeUtilities.GetProperties(type))
             {
                 if (p.GetIndexParameters().Length != 0)
                 {
@@ -139,7 +139,7 @@ namespace Jint.Runtime.Interop
             List<PropertyInfo> list = null;
             foreach (Type iface in type.GetInterfaces())
             {
-                foreach (var iprop in iface.GetProperties())
+                foreach (var iprop in TypeUtilities.GetProperties(iface))
                 {
                     if (EqualsIgnoreCasing(iprop.Name, propertyName))
                     {
@@ -158,7 +158,7 @@ namespace Jint.Runtime.Interop
             List<MethodInfo> explicitMethods = null;
             foreach (Type iface in type.GetInterfaces())
             {
-                foreach (var imethod in iface.GetMethods())
+                foreach (var imethod in TypeUtilities.GetMethods(iface))
                 {
                     if (EqualsIgnoreCasing(imethod.Name, propertyName))
                     {
@@ -177,7 +177,7 @@ namespace Jint.Runtime.Interop
             List<PropertyInfo> explicitIndexers = null;
             foreach (Type iface in type.GetInterfaces())
             {
-                foreach (var iprop in iface.GetProperties())
+                foreach (var iprop in TypeUtilities.GetProperties(iface))
                 {
                     if (iprop.GetIndexParameters().Length != 0)
                     {

--- a/Jint/Runtime/Interop/TypeAttributes.cs
+++ b/Jint/Runtime/Interop/TypeAttributes.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+namespace Jint.Runtime.Interop
+{
+    public enum DiscoveryModes
+    {
+        OptOut,
+        OptIn
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public sealed class JintClassAttribute : Attribute
+    {
+        public JintClassAttribute(DiscoveryModes discoveryMode = DiscoveryModes.OptOut)
+        {
+            DiscoveryMode = discoveryMode;
+        }
+
+        public DiscoveryModes DiscoveryMode { get; set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class JintMethodAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class JintPropertyAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public sealed class JintFieldAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Constructor)]
+    public sealed class JintConstructorAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Constructor)]
+    public sealed class JintIgnoreAttribute : Attribute
+    {
+    }
+}

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
@@ -51,7 +52,7 @@ namespace Jint.Runtime.Interop
                 return result;
             }
 
-            var constructors = ReferenceType.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+            var constructors = TypeUtilities.GetConstructors(ReferenceType, BindingFlags.Public | BindingFlags.Instance).ToArray();
 
             foreach (var method in TypeConverter.FindBestMatch(constructors, arguments))
             {
@@ -174,20 +175,20 @@ namespace Jint.Runtime.Interop
                 return PropertyDescriptor.Undefined;
             }
 
-            var propertyInfo = ReferenceType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Static);
+            var propertyInfo = TypeUtilities.GetProperty(ReferenceType, propertyName, BindingFlags.Public | BindingFlags.Static);
             if (propertyInfo != null)
             {
                 return new PropertyInfoDescriptor(Engine, propertyInfo, Type);
             }
 
-            var fieldInfo = ReferenceType.GetField(propertyName, BindingFlags.Public | BindingFlags.Static);
+            var fieldInfo = TypeUtilities.GetField(ReferenceType, propertyName, BindingFlags.Public | BindingFlags.Static);
             if (fieldInfo != null)
             {
                 return new FieldInfoDescriptor(Engine, fieldInfo, Type);
             }
 
             List<MethodInfo> methodInfo = null;
-            foreach (var mi in ReferenceType.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            foreach (var mi in TypeUtilities.GetMethods(ReferenceType, BindingFlags.Public | BindingFlags.Static))
             {
                 if (mi.Name == propertyName)
                 {

--- a/Jint/Runtime/Interop/TypeUtilities.cs
+++ b/Jint/Runtime/Interop/TypeUtilities.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Jint.Runtime.Interop
+{
+    internal static class TypeUtilities
+    {
+        public static IEnumerable<PropertyInfo> GetProperties(Type type)
+        {
+            DiscoveryModes discoveryMode = type.GetCustomAttribute<JintClassAttribute>()?.DiscoveryMode ?? DiscoveryModes.OptOut;
+
+            foreach (var p in type.GetProperties())
+            {
+                if (p.GetCustomAttribute<JintIgnoreAttribute>() != null)
+                {
+                    continue;
+                }
+
+                if (discoveryMode == DiscoveryModes.OptIn && p.GetCustomAttribute<JintPropertyAttribute>() == null)
+                {
+                    continue;
+                }
+
+                yield return p;
+            }
+        }
+
+        public static IEnumerable<PropertyInfo> GetProperties(Type type, BindingFlags bindingFlags)
+        {
+            DiscoveryModes discoveryMode = type.GetCustomAttribute<JintClassAttribute>()?.DiscoveryMode ?? DiscoveryModes.OptOut;
+
+            foreach (var p in type.GetProperties(bindingFlags))
+            {
+                if (p.GetCustomAttribute<JintIgnoreAttribute>() != null)
+                {
+                    continue;
+                }
+
+                if (discoveryMode == DiscoveryModes.OptIn && p.GetCustomAttribute<JintPropertyAttribute>() == null)
+                {
+                    continue;
+                }
+
+                yield return p;
+            }
+        }
+
+        public static PropertyInfo GetProperty(Type type, string name, BindingFlags bindingFlags)
+        {
+            DiscoveryModes discoveryMode = type.GetCustomAttribute<JintClassAttribute>()?.DiscoveryMode ?? DiscoveryModes.OptOut;
+
+            var p = type.GetProperty(name, bindingFlags);
+            if (p != null)
+            {
+                if (p.GetCustomAttribute<JintIgnoreAttribute>() != null)
+                {
+                    return null;
+                }
+
+                if (discoveryMode == DiscoveryModes.OptIn && p.GetCustomAttribute<JintPropertyAttribute>() == null)
+                {
+                    return null;
+                }
+            }
+
+            return p;
+        }
+
+        public static IEnumerable<FieldInfo> GetFields(Type type, BindingFlags bindingFlags)
+        {
+            DiscoveryModes discoveryMode = type.GetCustomAttribute<JintClassAttribute>()?.DiscoveryMode ?? DiscoveryModes.OptOut;
+
+            foreach (var f in type.GetFields(bindingFlags))
+            {
+                if (f.GetCustomAttribute<JintIgnoreAttribute>() != null)
+                {
+                    continue;
+                }
+
+                if (discoveryMode == DiscoveryModes.OptIn && f.GetCustomAttribute<JintFieldAttribute>() == null)
+                {
+                    continue;
+                }
+
+                yield return f;
+            }
+        }
+
+        public static FieldInfo GetField(Type type, string name, BindingFlags bindingFlags)
+        {
+            DiscoveryModes discoveryMode = type.GetCustomAttribute<JintClassAttribute>()?.DiscoveryMode ?? DiscoveryModes.OptOut;
+
+            var f = type.GetField(name, bindingFlags);
+            if (f != null)
+            {
+                if (f.GetCustomAttribute<JintIgnoreAttribute>() != null)
+                {
+                    return null;
+                }
+
+                if (discoveryMode == DiscoveryModes.OptIn && f.GetCustomAttribute<JintFieldAttribute>() == null)
+                {
+                    return null;
+                }
+            }
+
+            return f;
+        }
+
+        public static IEnumerable<MethodInfo> GetMethods(Type type)
+        {
+            DiscoveryModes discoveryMode = type.GetCustomAttribute<JintClassAttribute>()?.DiscoveryMode ?? DiscoveryModes.OptOut;
+
+            foreach (var m in type.GetMethods())
+            {
+                if (m.GetCustomAttribute<JintIgnoreAttribute>() != null)
+                {
+                    continue;
+                }
+
+                if (discoveryMode == DiscoveryModes.OptIn && m.GetCustomAttribute<JintMethodAttribute>() == null)
+                {
+                    continue;
+                }
+
+                yield return m;
+            }
+        }
+
+        public static IEnumerable<MethodInfo> GetMethods(Type type, BindingFlags bindingFlags)
+        {
+            DiscoveryModes discoveryMode = type.GetCustomAttribute<JintClassAttribute>()?.DiscoveryMode ?? DiscoveryModes.OptOut;
+
+            foreach (var m in type.GetMethods(bindingFlags))
+            {
+                if (m.GetCustomAttribute<JintIgnoreAttribute>() != null)
+                {
+                    continue;
+                }
+
+                if (discoveryMode == DiscoveryModes.OptIn && m.GetCustomAttribute<JintMethodAttribute>() == null)
+                {
+                    continue;
+                }
+
+                yield return m;
+            }
+        }
+
+        public static IEnumerable<ConstructorInfo> GetConstructors(Type type, BindingFlags bindingFlags)
+        {
+            DiscoveryModes discoveryMode = type.GetCustomAttribute<JintClassAttribute>()?.DiscoveryMode ?? DiscoveryModes.OptOut;
+
+            foreach (var c in type.GetConstructors(bindingFlags))
+            {
+                if (c.GetCustomAttribute<JintIgnoreAttribute>() != null)
+                {
+                    continue;
+                }
+
+                if (discoveryMode == DiscoveryModes.OptIn && c.GetCustomAttribute<JintConstructorAttribute>() == null)
+                {
+                    continue;
+                }
+
+                yield return c;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change includes the ability to specify which parts of a class should be made visible when using either the TypeReference class or ObjectWrapper.

Classes can be decorated with the new JintClass attribute which will specify whether methods should be discovered via an OptIn or OptOut mode. OptIn discovery requires all fields to be annotated with an attribute to be visible from JS, where OptOut includes all fields by default, but allows removal via the JintIgnore attribute. By default undecorated classes will use the OptOut discovery mode, so will retain existing behavior.

    [JintClass(DiscoveryModes.OptIn)]
    public class Example
    {
        [JintConstructor]
        public Example(int test)
        {
        }

        [JintField]
        public int TestField;

        [JintProperty]
        public int TestProperty { get; set; }

        [JintMethod]
        public void TestMethod()
        {
        }

        public void NotVisibleMethod()
        {
            // This method will not be visible within javascript
        }
    }

Alternatively OptOut can be used to include all fields by default

    [JintClass] // Or [JintClass(DiscoveryModes.OptOut)] - OptOut is default to retain existing behavior
    public class Example
    {
        public Example(int test)
        {
        }

        public int TestField;

        public int TestProperty { get; set; }

        public void TestMethod()
        {
        }

        [JintIgnore]
        public void NotVisibleMethod()
        {
            // This method will not be visible within javascript
        }
    }