### PR TITLE
Variable statement optimization

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -542,7 +542,7 @@ namespace Jint
                     _referencePool.Return(reference);
                 }
 
-                if (!(reference._baseValue._type != Types.Object && reference._baseValue._type != Types.None))
+                if (reference._baseValue._type == Types.Object)
                 {
                     var o = TypeConverter.ToObject(this, baseValue);
                     var v = o.Get(referencedName);

--- a/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
@@ -35,7 +35,7 @@ namespace Jint.Runtime.Environments
             }
 
             // we unwrap by name
-            binding = new Binding(null, false, false);
+            binding = default;
             return true;
         }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -1,6 +1,8 @@
+using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Number;
+using Jint.Runtime.Environments;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
@@ -9,8 +11,8 @@ namespace Jint.Runtime.Interpreter.Expressions
         // require sub-classes to set to false explicitly to skip virtual call
         protected bool _initialized = true;
 
-        protected internal readonly Engine _engine;
-        protected internal readonly INode _expression;
+        protected readonly Engine _engine;
+        protected readonly INode _expression;
 
         protected JintExpression(Engine engine, INode expression)
         {
@@ -326,6 +328,38 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
                 targetArray[i] = jintExpressions[i].GetValue();
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected bool TryGetIdentifierEnvironmentWithBindingValue(
+            string expressionName,
+            out EnvironmentRecord record,
+            out JsValue value)
+        {
+            var env = _engine.ExecutionContext.LexicalEnvironment;
+            var strict = StrictModeScope.IsStrictModeCode;
+            return LexicalEnvironment.TryGetIdentifierEnvironmentWithBindingValue(
+                env,
+                expressionName,
+                strict,
+                out record,
+                out value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected bool TryGetIdentifierEnvironmentWithBindingValue(
+            bool strict,
+            string expressionName,
+            out EnvironmentRecord record,
+            out JsValue value)
+        {
+            var env = _engine.ExecutionContext.LexicalEnvironment;
+            return LexicalEnvironment.TryGetIdentifierEnvironmentWithBindingValue(
+                env,
+                expressionName,
+                strict,
+                out record,
+                out value);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -36,9 +36,8 @@ namespace Jint.Runtime.Interpreter.Expressions
                 return _calculatedValue;
             }
 
-            var env = _engine.ExecutionContext.LexicalEnvironment;
             var strict = StrictModeScope.IsStrictModeCode;
-            return LexicalEnvironment.TryGetIdentifierEnvironmentWithBindingValue(env, _expressionName, strict, out _, out var value)
+            return TryGetIdentifierEnvironmentWithBindingValue(strict, _expressionName, out _, out var value)
                 ? value
                 : _engine.GetValue(new Reference(JsValue.Undefined, _expressionName, strict), true);
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -47,7 +47,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override object EvaluateInternal()
         {
-            return GetValue();
+            return _cachedValue ?? ResolveValue();
         }
 
         private JsValue ResolveValue()

--- a/Jint/Runtime/Interpreter/Expressions/JintThisExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintThisExpression.cs
@@ -1,4 +1,5 @@
 using Esprima.Ast;
+using Jint.Native;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
@@ -10,6 +11,14 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override object EvaluateInternal()
         {
+            return _engine.ExecutionContext.ThisBinding;
+        }
+
+        public override JsValue GetValue()
+        {
+            // need to notify correct node when taking shortcut
+            _engine._lastSyntaxNode = _expression;
+
             return _engine.ExecutionContext.ThisBinding;
         }
     }

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -1,6 +1,5 @@
 using Esprima.Ast;
 using Jint.Native;
-using Jint.Runtime.Environments;
 using Jint.Runtime.References;
 
 namespace Jint.Runtime.Interpreter.Expressions
@@ -60,13 +59,10 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         private JsValue UpdateIdentifier()
         {
-            var env = _engine.ExecutionContext.LexicalEnvironment;
             var strict = StrictModeScope.IsStrictModeCode;
             var name = _leftIdentifier._expressionName;
-            if (LexicalEnvironment.TryGetIdentifierEnvironmentWithBindingValue(
-                env,
+            if (TryGetIdentifierEnvironmentWithBindingValue(
                 name,
-                strict,
                 out var environmentRecord,
                 out var value))
             {
@@ -84,6 +80,5 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             return null;
         }
-
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -6,9 +6,11 @@ namespace Jint.Runtime.Interpreter.Statements
 {
     internal abstract class JintStatement<T> : JintStatement where T : Statement
     {
+        // require sub-classes to set to false explicitly to skip virtual call
+        protected bool _initialized = true;
+
         protected readonly Engine _engine;
         protected readonly T _statement;
-        private bool _initialized;
 
         protected JintStatement(Engine engine, T statement)
         {


### PR DESCRIPTION
Small cleanup and more smarts to variable statement handling. Gave a nice perf boost.

## Jint.Benchmark.ArrayBenchmark

| **Diff**|Method|N|Mean|Gen 0/1k Op|Gen 1/1k Op|Gen 2/1k Op|Allocated Memory/Op|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------|
| Old |Slice|100|367.6 us|172.3633|-|-|707.81 KB|
| **New** |	|	| **361.2 us (-2%)** | **172.8516 (0%)** | **-** | **-** | **709.38 KB (0%)** |
| Old |Concat|100|477.7 us|188.4766|-|-|773.44 KB|
| **New** |	|	| **486.3 us (+2%)** | **188.9648 (0%)** | **-** | **-** | **775 KB (0%)** |
| Old |Unshift|100|18,520.8 us|3593.7500|-|-|14829.69 KB|
| **New** |	|	| **17,421.3 us (-6%)** | **3593.7500 (0%)** | **-** | **-** | **14837.5 KB (0%)** |
| Old |Push|100|10,193.7 us|390.6250|-|-|1626.56 KB|
| **New** |	|	| **8,688.8 us (-15%)** | **390.6250 (0%)** | **-** | **-** | **1635.94 KB (+1%)** |
| Old |Index|100|12,042.4 us|437.5000|-|-|1844.53 KB|
| **New** |	|	| **9,636.6 us (-20%)** | **437.5000 (0%)** | **-** | **-** | **1855.47 KB (+1%)** |
| Old |Map|100|2,573.8 us|527.3438|-|-|2167.19 KB|
| **New** |	|	| **2,552.5 us (-1%)** | **527.3438 (0%)** | **-** | **-** | **2170.31 KB (0%)** |
| Old |Apply|100|575.5 us|202.1484|-|-|830.47 KB|
| **New** |	|	| **589.4 us (+2%)** | **203.1250 (0%)** | **-** | **-** | **832.03 KB (0%)** |
| Old |JsonStringifyParse|100|4,696.4 us|1289.0625|-|-|5305.47 KB|
| **New** |	|	| **4,689.9 us (0%)** | **1289.0625 (0%)** | **-** | **-** | **5308.59 KB (0%)** |
| Old |FilterWithString|100|27,132.1 us|3406.2500|-|-|14055.47 KB|
| **New** |	|	| **27,186.6 us (0%)** | **3406.2500 (0%)** | **-** | **-** | **14057.03 KB (0%)** |


## Jint.Benchmark.ArrayStressBenchmark

| **Diff**|Method|N|Mean|Gen 0/1k Op|Gen 1/1k Op|Gen 2/1k Op|Allocated Memory/Op|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------|
| Old |Jint|20|501.3 ms|59000.0000|1000.0000|-|241.13 MB|
| **New** |	|	| **474.5 ms (-5%)** | **59000.0000 (0%)** | **1000.0000 (0%)** | **-** | **241.14 MB (0%)** |


## Jint.Benchmark.DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Gen 0/1k Op|Gen 1/1k Op|Gen 2/1k Op|Allocated Memory/Op|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------|
| Old |Run|dromaeo-3d-cube|66.19 ms|1250.0000|250.0000|-|7420.14 KB|
| **New** |	|	| **56.85 ms (-14%)** | **1333.3333 (+7%)** | **222.2222 (-11%)** | **-** | **7425.44 KB (0%)** |
| Old |Run|dromaeo-core-eval|12.32 ms|78.1250|-|-|354.59 KB|
| **New** |	|	| **12.07 ms (-2%)** | **78.1250 (0%)** | **-** | **-** | **355.67 KB (0%)** |
| Old |Run|dromaeo-object-array|144.69 ms|41500.0000|1500.0000|250.0000|174935.63 KB|
| **New** |	|	| **138.05 ms (-5%)** | **41500.0000 (0%)** | **1500.0000 (0%)** | **250.0000 (0%)** | **174935.02 KB (0%)** |
| Old |Run|droma(...)egexp [21]|851.65 ms|49000.0000|28000.0000|19000.0000|409974.95 KB|
| **New** |	|	| **791.45 ms (-7%)** | **52000.0000 (+6%)** | **33000.0000 (+18%)** | **21000.0000 (+11%)** | **407718 KB (-1%)** |
| Old |Run|droma(...)tring [21]|1,123.20 ms|216000.0000|175000.0000|172000.0000|1387665.61 KB|
| **New** |	|	| **1,100.73 ms (-2%)** | **217000.0000 (0%)** | **176000.0000 (+1%)** | **173000.0000 (+1%)** | **1387969.02 KB (0%)** |


## Jint.Benchmark.EvaluationBenchmark

| **Diff**|Method|N|Mean|Gen 0/1k Op|Gen 1/1k Op|Gen 2/1k Op|Allocated Memory/Op|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------|
| Old |Jint|20|742.4 us|139.6484|-|-|575.47 KB|
| **New** |	|	| **742.8 us (0%)** | **140.6250 (+1%)** | **-** | **-** | **577.97 KB (0%)** |


## Jint.Benchmark.StopwatchBenchmark

| **Diff**|Method|N|Mean|Gen 0/1k Op|Gen 1/1k Op|Gen 2/1k Op|Allocated Memory/Op|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------|
| Old |Jint|1|1.035 s|12000.0000|-|-|51.61 MB|
| **New** |	|	| **923.1 ms (-13%)** | **12000.0000 (0%)** | **-** | **-** | **51.61 MB (0%)** |


## Jint.Benchmark.UncacheableExpressionsBenchmark

| **Diff**|Method|N|Mean|Gen 0/1k Op|Gen 1/1k Op|Gen 2/1k Op|Allocated Memory/Op|
|------- |-------|-------|-------:|-------:|-------:|-------:|-------|
| Old |Benchmark|500|232.5 ms|30333.3333|-|-|121.4 MB|
| **New** |	|	| **198.1 ms (-15%)** | **30333.3333 (0%)** | **-** | **-** | **121.4 MB (0%)** |


