### PR TITLE
Revert too eager script expression based caching

### DIFF
--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -35,7 +35,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
                 var expressionArgument = (Expression) expression.Arguments[i];
                 cachedArgumentsHolder.JintArguments[i] = Build(_engine, expressionArgument);
-                cacheable &= (expressionArgument is Literal || expressionArgument is FunctionExpression);
+                cacheable &= expressionArgument is Literal;
             }
 
             if (cacheable)


### PR DESCRIPTION
RavenDB folks found problem with caching logic, let's revert it and test coverage for the case. Maybe we can refine caching rule later on.

http://issues.hibernatingrhinos.com/issue/RavenDB-12333#focus=streamItem-67-32940-0-0