### PR TITLE
Add CLR write allowed option to engine

### DIFF
--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -14,6 +14,7 @@ namespace Jint
         private bool _strict;
         private bool _allowDebuggerStatement;
         private bool _allowClr;
+        private bool _allowClrWrite = true;
         private readonly List<IObjectConverter> _objectConverters = new List<IObjectConverter>();
         private int _maxStatements;
         private long _memoryLimit;
@@ -83,6 +84,12 @@ namespace Jint
             _allowClr = true;
             _lookupAssemblies.AddRange(assemblies);
             _lookupAssemblies = _lookupAssemblies.Distinct().ToList();
+            return this;
+        }
+
+        public Options AllowClrWrite(bool allow = true)
+        {
+            _allowClrWrite = allow;
             return this;
         }
 
@@ -167,6 +174,8 @@ namespace Jint
         internal bool IsDebugMode { get; private set; }
 
         internal bool _IsClrAllowed => _allowClr;
+
+        internal bool _IsClrWriteAllowed => _allowClrWrite;
 
         internal Predicate<Exception> _ClrExceptionsHandler => _clrExceptionsHandler;
 

--- a/Jint/Runtime/Descriptors/Specialized/FieldInfoDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/FieldInfoDescriptor.cs
@@ -16,7 +16,7 @@ namespace Jint.Runtime.Descriptors.Specialized
             _fieldInfo = fieldInfo;
             _item = item;
 
-            Writable = !fieldInfo.Attributes.HasFlag(FieldAttributes.InitOnly); // don't write to fields marked as readonly
+            Writable = !fieldInfo.Attributes.HasFlag(FieldAttributes.InitOnly) && engine.Options._IsClrWriteAllowed; // don't write to fields marked as readonly
         }
 
         protected internal override JsValue CustomValue

--- a/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
@@ -52,7 +52,7 @@ namespace Jint.Runtime.Descriptors.Specialized
                 ExceptionHelper.ThrowInvalidOperationException("No matching indexer found.");
             }
 
-            Writable = true;
+            Writable = engine.Options._IsClrWriteAllowed;
         }
 
         public IndexDescriptor(Engine engine, string key, object item)

--- a/Jint/Runtime/Descriptors/Specialized/PropertyInfoDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/PropertyInfoDescriptor.cs
@@ -16,7 +16,7 @@ namespace Jint.Runtime.Descriptors.Specialized
             _propertyInfo = propertyInfo;
             _item = item;
 
-            Writable = propertyInfo.CanWrite;
+            Writable = propertyInfo.CanWrite && engine.Options._IsClrWriteAllowed;
         }
 
         protected internal override JsValue CustomValue


### PR DESCRIPTION
I have a number of very complex objects which I'd like to make available to some design people so they can write various expressions (in JS, but they don't need to know that, it'll look like third-grade maths to them) to be used in our system's business logic. I don't want them accidentally using a = instead of == and messing up the entire system's state. I could create a read-only wrapper around the objects, but that'd take a whole lot of unnecessary effort to implement. Instead, I've added an option to disallow writing to CLR objects from JS code. I think this is likely to be something other people will also run into.