### PR TITLE
Fixes delegates created from expressions.

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Collections.ObjectModel;
+using System.Linq.Expressions;
 using System.Reflection;
 using Jint.Native;
 using Jint.Native.Array;
@@ -118,6 +120,20 @@ namespace Jint.Tests.Runtime
 
             RunTest(@"
                 assert(isnull() === true);
+            ");
+        }
+
+        [Fact]
+        public void DynamicDelegateCanBeSet()
+        {
+            var parameters = new[] { Expression.Parameter(typeof(int)), Expression.Parameter(typeof(int)) };
+            var exp = Expression.Add(parameters[0], parameters[1]);
+            var del = Expression.Lambda(exp, parameters).Compile();
+
+            _engine.SetValue("add", del);
+
+            RunTest(@"
+                assert(add(1,1) === 2);
             ");
         }
 

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Collections.ObjectModel;
 using System.Linq.Expressions;
 using System.Reflection;
 using Jint.Native;
@@ -126,15 +125,17 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void DynamicDelegateCanBeSet()
         {
+#if NETFRAMEWORK
             var parameters = new[] { Expression.Parameter(typeof(int)), Expression.Parameter(typeof(int)) };
             var exp = Expression.Add(parameters[0], parameters[1]);
             var del = Expression.Lambda(exp, parameters).Compile();
 
             _engine.SetValue("add", del);
-
+            
             RunTest(@"
                 assert(add(1,1) === 2);
             ");
+#endif
         }
 
         [Fact]

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Globalization;
 using System.Reflection;
-using System.Linq;
 using Jint.Native;
 using Jint.Native.Function;
+using System.Linq;
 
 namespace Jint.Runtime.Interop
 {

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -38,11 +38,16 @@ namespace Jint.Runtime.Interop
         public override JsValue Call(JsValue thisObject, JsValue[] jsArguments)
         {
             var parameterInfos = _d.Method.GetParameters();
-
+            
+#if NETFRAMEWORK
             if (parameterInfos.Length > 0 && parameterInfos[0].ParameterType.FullName == "System.Runtime.CompilerServices.Closure")
             {
-                parameterInfos = parameterInfos.Skip(1).ToArray();
+                var reducedLength = parameterInfos.Length - 1;
+                var reducedParameterInfos = new ParameterInfo[reducedLength];
+                Array.Copy(parameterInfos, 1, reducedParameterInfos, 0, reducedLength);
+                parameterInfos = reducedParameterInfos;
             }
+#endif
 
             int delegateArgumentsCount = parameterInfos.Length;
             int delegateNonParamsArgumentsCount = _delegateContainsParamsArgument ? delegateArgumentsCount - 1 : delegateArgumentsCount;

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -40,7 +40,7 @@ namespace Jint.Runtime.Interop
             var parameterInfos = _d.Method.GetParameters();
             
 #if NETFRAMEWORK
-            if (parameterInfos.Length > 0 && parameterInfos[0].ParameterType.FullName == "System.Runtime.CompilerServices.Closure")
+            if (parameterInfos.Length > 0 && parameterInfos[0].ParameterType == typeof(System.Runtime.CompilerServices.Closure))
             {
                 var reducedLength = parameterInfos.Length - 1;
                 var reducedParameterInfos = new ParameterInfo[reducedLength];

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Reflection;
+using System.Linq;
 using Jint.Native;
 using Jint.Native.Function;
 
@@ -37,6 +38,12 @@ namespace Jint.Runtime.Interop
         public override JsValue Call(JsValue thisObject, JsValue[] jsArguments)
         {
             var parameterInfos = _d.Method.GetParameters();
+
+            if (parameterInfos.Length > 0 && parameterInfos[0].ParameterType.FullName == "System.Runtime.CompilerServices.Closure")
+            {
+                parameterInfos = parameterInfos.Skip(1).ToArray();
+            }
+
             int delegateArgumentsCount = parameterInfos.Length;
             int delegateNonParamsArgumentsCount = _delegateContainsParamsArgument ? delegateArgumentsCount - 1 : delegateArgumentsCount;
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ build_script:
   - dotnet pack -c Release
 test_script:
   - dotnet test .\Jint.Tests\Jint.Tests.csproj -c Release -f netcoreapp2.1
+  - dotnet test .\Jint.Tests\Jint.Tests.csproj -c Release -f net452
   - dotnet test .\Jint.Tests.CommonScripts\Jint.Tests.CommonScripts.csproj -c Release -f netcoreapp2.1
   - dotnet test .\Jint.Tests.Ecma\Jint.Tests.Ecma.csproj -c Release -f netcoreapp2.1
   - dotnet test .\Jint.Tests.Test262\Jint.Tests.Test262.csproj -c Release -f netcoreapp2.1


### PR DESCRIPTION
Fixes bug where delegates generated from expressions contain a closure as their first argument, causing mapping of parameters to fail.