### PR TITLE
System.NullReferenceException caused by RegExp.prototype.toString() fixed

### DIFF
--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -40,11 +40,16 @@ namespace Jint.Native.RegExp
         {
             var regExp = thisObj.TryCast<RegExpInstance>();
 
-            return "/" + regExp.Source + "/"
-                + (regExp.Flags.Contains("g") ? "g" : "")
-                + (regExp.Flags.Contains("i") ? "i" : "")
-                + (regExp.Flags.Contains("m") ? "m" : "")
+            string res = "/" + regExp.Source + "/";
+            if (regExp.Flags != null)
+            {
+                res += (regExp.Flags.Contains("g") ? "g" : "")
+                    + (regExp.Flags.Contains("i") ? "i" : "")
+                    + (regExp.Flags.Contains("m") ? "m" : "")
                 ;
+            }
+
+            return res;
         }
 
         private JsValue Test(JsValue thisObj, JsValue[] arguments)


### PR DESCRIPTION
...see issue #592