### PR TITLE
make Random() thread safety

### DIFF
--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.Math
 {
     public sealed class MathInstance : ObjectInstance
     {
-        private static readonly Random _random = new Random();
+        [ThreadStatic] private static Random _random;
 
         private MathInstance(Engine engine) : base(engine, "Math")
         {
@@ -810,6 +810,10 @@ namespace Jint.Native.Math
 
         private static JsValue Random(JsValue thisObject, JsValue[] arguments)
         {
+            if(_random == null)
+            {
+                _random = new Random();
+            }
             return _random.NextDouble();
         }
 

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.Math
 {
     public sealed class MathInstance : ObjectInstance
     {
-        [ThreadStatic] private static Random _random;
+        private Random _random;
 
         private MathInstance(Engine engine) : base(engine, "Math")
         {

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -808,12 +808,13 @@ namespace Jint.Native.Math
             return System.Math.Pow(x, y);
         }
 
-        private static JsValue Random(JsValue thisObject, JsValue[] arguments)
+        private JsValue Random(JsValue thisObject, JsValue[] arguments)
         {
             if(_random == null)
             {
                 _random = new Random();
             }
+            
             return _random.NextDouble();
         }
 


### PR DESCRIPTION
System.Random isn't thread-safe. When multi-threaded sharing instance, Random.Next() will always returns zero.