### PR TITLE
added full support for interop with methods that have default values

### DIFF
--- a/Jint.Tests/Runtime/Domain/A.cs
+++ b/Jint.Tests/Runtime/Domain/A.cs
@@ -104,5 +104,25 @@ namespace Jint.Tests.Runtime.Domain
         {
             callback(18);
         }
+
+        public int Call19(int a = 0)
+        {
+            return a;
+        }
+
+        public static int Call19Static(int a = 0)
+        {
+            return a;
+        }
+
+        public int Call20(int a, int b = 1, int c = 2)
+        {
+            return a + b + c;
+        }
+
+        public static int Call20Static(int a, int b = 1, int c = 2)
+        {
+            return a + b + c;
+        }
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Jint.Native;
 using Jint.Native.Array;
 using Jint.Native.Object;
+using Jint.Runtime.Interop;
 using Jint.Tests.Runtime.Converters;
 using Jint.Tests.Runtime.Domain;
 using Shapes;
@@ -167,6 +168,28 @@ namespace Jint.Tests.Runtime
                 assert(callArgumentAndParams('a','1') === 'a:1');
                 assert(callArgumentAndParams('a') === 'a:');
                 assert(callArgumentAndParams() === ':');
+            ");
+        }
+
+        [Fact]
+        public void DelegateWithDefaultValueParametersCanBeInvoked()
+        {
+            var instance = new A();
+            _engine.SetValue("Instance", instance);
+            _engine.SetValue("Class", TypeReference.CreateTypeReference(_engine, typeof(A)));
+
+            RunTest(@"
+                assert(Instance.Call19() === 0);
+                assert(Instance.Call19(1) === 1);
+                assert(Instance.Call20(1) === 4);
+                assert(Instance.Call20(1, 2) === 5);
+                assert(Instance.Call20(1 , 2, 3) === 6);
+
+                assert(Class.Call19Static() === 0);
+                assert(Class.Call19Static(1) === 1);
+                assert(Class.Call20Static(1) === 4);
+                assert(Class.Call20Static(1, 2) === 5);
+                assert(Class.Call20Static(1 , 2, 3) === 6);
             ");
         }
 

--- a/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
@@ -31,7 +31,7 @@ namespace Jint.Runtime.Interop
 
             var converter = Engine.ClrTypeConverter;
 
-            foreach (var tuple in TypeConverter.FindBestMatch(methodInfos, ArgumentProvider))
+            foreach (var tuple in TypeConverter.FindBestMatch(_engine, methodInfos, ArgumentProvider))
             {
                 var method = tuple.Item1;
                 var arguments = tuple.Item2;

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -53,7 +53,7 @@ namespace Jint.Runtime.Interop
 
             var constructors = ReferenceType.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
 
-            foreach (var tuple in TypeConverter.FindBestMatch(constructors, (info, b) => arguments))
+            foreach (var tuple in TypeConverter.FindBestMatch(_engine, constructors, (info, b) => arguments))
             {
                 var method = tuple.Item1;
 


### PR DESCRIPTION
Hi jint devs,
as mentioned on gitter, I was looking for a way to interop with C# methods that make use of default values.  After some hints from @sebastienros, I implemented this behaviour myself: Default Values should now be fully supported, including a unit test.

Even if it works, I am not totally happy, especially with the `JsValue.FromObject()` part. What is the best way to convert/cast the default value? Or is this maybe not the best place for the code?