### PR TITLE
Don't allow changes to shared Undefined property descriptor

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1009,6 +1009,16 @@ namespace Jint.Tests.Runtime
             Assert.Throws<ArgumentException>(() => _engine.Invoke(foo, obj, new object[] { }));
         }
 
+        [Fact]
+        public void ShouldNotAllowModifyingSharedUndefinedDescriptor()
+        {
+            var e = new Engine();
+            e.Execute("var x = { literal: true };");
+
+            var pd = e.GetValue("x").AsObject().GetProperty("doesNotExist");
+            Assert.Throws<InvalidOperationException>(() => pd.Value = "oh no, assigning this breaks things");
+        }
+
         [Theory]
         [InlineData("0", 0, 16)]
         [InlineData("1", 1, 16)]

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -7,7 +7,7 @@ namespace Jint.Runtime.Descriptors
 {
     public class PropertyDescriptor
     {
-        public static readonly PropertyDescriptor Undefined = new PropertyDescriptor(PropertyFlag.None);
+        public static readonly PropertyDescriptor Undefined = new UndefinedPropertyDescriptor();
 
         internal PropertyFlag _flags;
         internal JsValue _value;
@@ -382,6 +382,18 @@ namespace Jint.Runtime.Descriptors
             }
 
             return true;
+        }
+
+        private sealed class UndefinedPropertyDescriptor : PropertyDescriptor
+        {
+            public UndefinedPropertyDescriptor() : base(PropertyFlag.None | PropertyFlag.CustomJsValue)
+            {
+            }
+
+            protected internal override JsValue CustomValue
+            {
+                set => ExceptionHelper.ThrowInvalidOperationException("making changes to undefined property's descriptor is not allowed");
+            }
         }
     }
 }


### PR DESCRIPTION
This is basically same as changing runtime's string.Empty, hilarity ensues.