### PR TITLE
[WIP] Added support for anonymous objects.

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2641,8 +2641,8 @@ function output(x) {
 	var values = x.Values;
 	var generated = x.Elements.reduce(function(_obj, _cur) {_obj[(function(a){return a.Name;})(_cur)] = (function(a){return a.Decimal;})(_cur);return _obj;}, {});
 	return {
-        TestDictionary1 : values, 
-        TestDictionary2 : x.Values, 
+        TestDictionary1 : values,
+        TestDictionary2 : x.Values,
         TestDictionaryDirectAccess1 : Object.keys(x.Values).length,
         TestDictionaryDirectAccess2 : Object.keys(x.Values),
         TestDictionaryDirectAccess4 : Object.keys(x.Values).map(function(a){return x.Values[a];}),
@@ -2660,11 +2660,11 @@ function output(x) {
         TestGeneratedDictionarySum1 : Object.keys(generated).map(function(a){return{Key: a,Value:generated[a]};}).map(function(a){return a.Value;}).reduce(function(a, b) { return a + b; }, 0),
         TestGeneratedDictionarySum2 : Object.keys(x.Elements.reduce(function(_obj, _cur) {_obj[(function(a){return a.Name;})(_cur)] = (function(a){return a.Decimal;})(_cur);return _obj;}, {})).map(function(a){return{Key: a,Value:x.Elements.reduce(function(_obj, _cur) {_obj[(function(a){return a.Name;})(_cur)] = (function(a){return a.Decimal;})(_cur);return _obj;}, {})[a]};}).map(function(a){return a.Value;}).reduce(function(a, b) { return a + b; }, 0),
         TestGeneratedDictionaryAverage1 : Object.keys(generated).map(function(a){return{Key: a,Value:generated[a]};}).map(function(a){return a.Value;}).reduce(function(a, b) { return a + b; }, 0)/(Object.keys(generated).length||1),
-        TestGeneratedDictionaryAverage2 : Object.keys(x.Elements.reduce(function(_obj, _cur) {_obj[(function(a){return a.Name;})(_cur)] = (function(a){return a.Decimal;})(_cur);return _obj;}, {})).map(function(a){return{Key: a,Value:x.Elements.reduce(function(_obj, _cur) {_obj[(function(a){return a.Name;})(_cur)] = (function(a){return a.Decimal;})(_cur);return _obj;}, {})[a]};}).map(function(a){return a.Value;}).reduce(function(a, b) { return a + b; }, 0)/(Object.keys(x.Elements.reduce(function(_obj, _cur) {_obj[(function(a){return a.Name;})(_cur)] = (function(a){return a.Decimal;})(_cur);return _obj;}, {})).length||1), 
+        TestGeneratedDictionaryAverage2 : Object.keys(x.Elements.reduce(function(_obj, _cur) {_obj[(function(a){return a.Name;})(_cur)] = (function(a){return a.Decimal;})(_cur);return _obj;}, {})).map(function(a){return{Key: a,Value:x.Elements.reduce(function(_obj, _cur) {_obj[(function(a){return a.Name;})(_cur)] = (function(a){return a.Decimal;})(_cur);return _obj;}, {})[a]};}).map(function(a){return a.Value;}).reduce(function(a, b) { return a + b; }, 0)/(Object.keys(x.Elements.reduce(function(_obj, _cur) {_obj[(function(a){return a.Name;})(_cur)] = (function(a){return a.Decimal;})(_cur);return _obj;}, {})).length||1),
         TestGeneratedDictionaryDirectAccess1 : Object.keys(generated),
         TestGeneratedDictionaryDirectAccess2 : Object.keys(generated).map(function(a){return generated[a];}),
-        TestGeneratedDictionaryDirectAccess3 : Object.keys(generated).length, 
-        TestList1 : elements.reduce(function(a, b) { return a + b; }, 0), 
+        TestGeneratedDictionaryDirectAccess3 : Object.keys(generated).length,
+        TestList1 : elements.reduce(function(a, b) { return a + b; }, 0),
         TestList2 : x.Elements.map(function(a){return a.Decimal;}).reduce(function(a, b) { return a + b; }, 0),
         TestList3 : x.Elements.map(function(a){return a.Decimal;}).reduce(function(a, b) { return a + b; }, 0),
         TestList4 : x.Elements.map(function(a){return a.Decimal;}).reduce(function(a, b) { return a + b; }, 0)/(x.Elements.length||1),
@@ -2766,6 +2766,36 @@ function output(x) {
 
             var voidCompletion = engine.Execute("try { JSON.parse('01') } catch (e) {}").GetCompletionValue();
             Assert.Equal(JsValue.Undefined, voidCompletion);
+        }
+
+        [Fact]
+        public void ShouldParseAnonymousToTypeObject()
+        {
+            var obj = new Wrapper();
+            var engine = new Engine()
+                .SetValue("x", obj);
+            var js = @"
+x.test = {
+    name: 'Testificate',
+    init (a, b) {
+        return a + b
+    }
+}";
+            engine.Execute(js);
+
+            Assert.Equal("Testificate", obj.Test.Name);
+            Assert.Equal(5, obj.Test.Init(2, 3));
+        }
+
+        private class Wrapper
+        {
+            public Testificate Test { get; set; }
+        }
+
+        private class Testificate
+        {
+            public string Name { get; set; }
+            public Func<int, int, int> Init { get; set; }
         }
     }
 }

--- a/Jint/Extensions/JavascriptExtensions.cs
+++ b/Jint/Extensions/JavascriptExtensions.cs
@@ -6,10 +6,9 @@ namespace Jint.Extensions
     {
         internal static string UpperToLowerCamelCase(this string str)
         {
-            var sb = new StringBuilder();
-            sb.Append(char.ToLowerInvariant(str[0]));
-            sb.Append(str.Substring(1));
-            return sb.ToString();
+            var arr = str.ToCharArray();
+            arr[0] = char.ToLowerInvariant(arr[0]);
+            return new string(arr);
         }
     }
 }

--- a/Jint/Extensions/JavascriptExtensions.cs
+++ b/Jint/Extensions/JavascriptExtensions.cs
@@ -2,9 +2,9 @@ using System.Text;
 
 namespace Jint.Extensions
 {
-    public static class JavascriptExtensions
+    internal static class JavascriptExtensions
     {
-        public static string UpperToLowerCamelCase(this string str)
+        internal static string UpperToLowerCamelCase(this string str)
         {
             var sb = new StringBuilder();
             sb.Append(char.ToLowerInvariant(str[0]));

--- a/Jint/Extensions/JavascriptExtensions.cs
+++ b/Jint/Extensions/JavascriptExtensions.cs
@@ -1,0 +1,15 @@
+using System.Text;
+
+namespace Jint.Extensions
+{
+    public static class JavascriptExtensions
+    {
+        public static string UpperToLowerCamelCase(this string str)
+        {
+            var sb = new StringBuilder();
+            sb.Append(char.ToLowerInvariant(str[0]));
+            sb.Append(str.Substring(1));
+            return sb.ToString();
+        }
+    }
+}

--- a/Jint/Extensions/ReflectionExtensions.cs
+++ b/Jint/Extensions/ReflectionExtensions.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Reflection;
+
+namespace Jint.Extensions
+{
+    public static class ReflectionExtensions
+    {
+        public static void SetValue(this MemberInfo memberInfo, object forObject, object value)
+        {
+            switch (memberInfo.MemberType)
+            {
+                case MemberTypes.Field:
+                    var fieldInfo = (FieldInfo) memberInfo;
+                    if (fieldInfo.FieldType == value?.GetType())
+                    {
+                        fieldInfo.SetValue(forObject, value);
+                    }
+
+                    break;
+                case MemberTypes.Property:
+                    var propertyInfo = (PropertyInfo) memberInfo;
+                    if (propertyInfo.PropertyType == value?.GetType())
+                    {
+                        propertyInfo.SetValue(forObject, value);
+                    }
+                    break;
+            }
+        }
+
+        public static Type GetDefinedType(this MemberInfo memberInfo)
+        {
+            switch (memberInfo)
+            {
+                case PropertyInfo propertyInfo:
+                    return propertyInfo.PropertyType;
+                case FieldInfo fieldInfo:
+                    return fieldInfo.FieldType;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Jint/Extensions/ReflectionExtensions.cs
+++ b/Jint/Extensions/ReflectionExtensions.cs
@@ -3,9 +3,9 @@ using System.Reflection;
 
 namespace Jint.Extensions
 {
-    public static class ReflectionExtensions
+    internal static class ReflectionExtensions
     {
-        public static void SetValue(this MemberInfo memberInfo, object forObject, object value)
+        internal static void SetValue(this MemberInfo memberInfo, object forObject, object value)
         {
             switch (memberInfo.MemberType)
             {
@@ -27,7 +27,7 @@ namespace Jint.Extensions
             }
         }
 
-        public static Type GetDefinedType(this MemberInfo memberInfo)
+        internal static Type GetDefinedType(this MemberInfo memberInfo)
         {
             switch (memberInfo)
             {

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -207,7 +207,8 @@ namespace Jint.Runtime.Interop
             if (value is ExpandoObject eObj)
             {
                 // public empty constructor required
-                if (!type.GetConstructors().Any(x => x.GetParameters().Length == 0 && x.IsPublic)) return null;
+                if (type.IsValueType && type.GetConstructors().Length > 0 ||
+                    !type.IsValueType && !type.GetConstructors().Any(x => x.GetParameters().Length == 0 && x.IsPublic)) return null;
 
                 var dict = (IDictionary<string, object>) eObj;
                 var obj = Activator.CreateInstance(type, new object[0]);
@@ -215,8 +216,7 @@ namespace Jint.Runtime.Interop
                 var members = type.GetMembers().Where(x => x.MemberType == MemberTypes.Property || x.MemberType == MemberTypes.Field).ToArray();
                 foreach (var member in members)
                 {
-                    // TODO fix naming conventions
-                    var name = member.Name.ToLower();
+                    var name = member.Name.UpperToLowerCamelCase();
                     if (dict.TryGetValue(name, out var val))
                     {
                         var output = Convert(val, member.GetDefinedType(), formatProvider);


### PR DESCRIPTION
As I mentioned in https://github.com/sebastienros/jint/issues/635#issuecomment-512963364 I cannot assign an anonymous object `{}` to a typed object. This can be very annoying if you want to have 'friendly scripting support' and its more idiomatic in JS as well.

You can now assign an anonymous object to a typed property/field of a given object:

```cs
public void ShouldParseAnonymousToTypeObject(){
      var obj = new Wrapper();
      var engine = new Engine().SetValue("x", obj);
}

private class Wrapper
{
     public Testificate Test { get; set; }
}

private class Testificate
{
     public string Name { get; set; }
     public Func<int, int, int> Init { get; set; }
}
```

```js
x.test = {
    name: 'Testificate',
    init (a, b) {
        return a + b
    }
}
```

See `EngineTests.ShouldParseAnonymousToTypeObject` for the full test.

* [x] <del>WIP as I don't know how I shall handle namings in JS <-> C#. Currently I'm doing only `ToLower` because it's easy for this test. Because I use the `ExpandoObject` as a `IDictionary<string, object>` the names are case sensitive. Shall I implement case-insensitivity for this or are there other conventions?</del> -> see `UpperToLowerCamelCase`
* [x] <del>Is LINQ fine? Because of the GC allocations.</del> -> No
* [ ] I noticed that I have to use an explicit wrapper to assign a field/property. I cannot simply overwrite `x` with my `Testificate` object. In a wrapper (property/field assignment) it works fine. Is this by design or a bug?
* [ ] As this PR is approved I will add more tests. Just a proof of concept for now. Maybe it will be denied anyway. It works for my use case so why not share it?