### PR TITLE
Fixed RegExp.toString() throws a NullReferenceException if not called…

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2026,7 +2026,7 @@ var prep = function (fn) { fn(); };
         [Fact]
         public void RegExpPrototypeToString()
         {
-            RunTest("assert(RegExp.prototype.toString() === '//');");
+            RunTest("assert(RegExp.prototype.toString() === '/(?:)/');");
         }
 
         [Fact]

--- a/Jint.Tests/Runtime/RegExpTests.cs
+++ b/Jint.Tests/Runtime/RegExpTests.cs
@@ -36,10 +36,38 @@ namespace Jint.Tests.Runtime
         public void PreventsInfiniteLoop()
         {
             var engine = new Engine();
-            var result = (ArrayInstance) engine.Execute("'x'.match(/|/g);").GetCompletionValue();
-            Assert.Equal((uint) 2, result.Length);
+            var result = (ArrayInstance)engine.Execute("'x'.match(/|/g);").GetCompletionValue();
+            Assert.Equal((uint)2, result.Length);
             Assert.Equal("", result[0]);
             Assert.Equal("", result[1]);
+        }
+
+        [Fact]
+        public void ToStringWithNonRegExpInstanceAndMissingProperties()
+        {
+            var engine = new Engine();
+            var result = engine.Execute("/./['toString'].call({})").GetCompletionValue().AsString();
+
+            Assert.Equal("/undefined/undefined", result);
+        }
+
+        [Fact]
+        public void ToStringWithNonRegExpInstanceAndValidProperties()
+        {
+            var engine = new Engine();
+            var result = engine.Execute("/./['toString'].call({ source: 'a', flags: 'b' })").GetCompletionValue().AsString();
+
+            Assert.Equal("/a/b", result);
+        }
+
+
+        [Fact]
+        public void ToStringWithRealRegExpInstance()
+        {
+            var engine = new Engine();
+            var result = engine.Execute("/./['toString'].call(/test/g)").GetCompletionValue().AsString();
+
+            Assert.Equal("/test/g", result);
         }
     }
 }

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -182,6 +182,7 @@ namespace Jint.Native.RegExp
             r.SetOwnProperty("ignoreCase", new PropertyDescriptor(r.IgnoreCase, PropertyFlag.AllForbidden));
             r.SetOwnProperty("multiline", new PropertyDescriptor(r.Multiline, PropertyFlag.AllForbidden));
             r.SetOwnProperty("source", new PropertyDescriptor(r.Source, PropertyFlag.AllForbidden));
+            r.SetOwnProperty("flags", new PropertyDescriptor(r.Flags, PropertyFlag.AllForbidden));
             r.SetOwnProperty("lastIndex", new PropertyDescriptor(0, PropertyFlag.OnlyWritable));
         }
 

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -41,6 +41,7 @@ namespace Jint.Native.RegExp
                 ["ignoreCase"] = new PropertyDescriptor(false, false, false, false),
                 ["multiline"] = new PropertyDescriptor(false, false, false, false),
                 ["source"] = new PropertyDescriptor("(?:)", false, false, false),
+                ["flags"] = new PropertyDescriptor("", false, false, false),
                 ["lastIndex"] = new PropertyDescriptor(0, true, false, false)
             };
         }
@@ -48,7 +49,7 @@ namespace Jint.Native.RegExp
         private static JsValue ToRegExpString(JsValue thisObj, JsValue[] arguments)
         {
             var regexObj = thisObj.TryCast<ObjectInstance>();
-
+            
             if (regexObj.TryGetValue("source", out var source) == false)
                 source = Undefined.ToString();
 

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 using Jint.Collections;
 using Jint.Native.Array;
+using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
@@ -46,18 +47,15 @@ namespace Jint.Native.RegExp
 
         private static JsValue ToRegExpString(JsValue thisObj, JsValue[] arguments)
         {
-            var regExp = thisObj.TryCast<RegExpInstance>();
+            var regexObj = thisObj.TryCast<ObjectInstance>();
 
-            string res = "/" + regExp.Source + "/";
-            if (regExp.Flags != null)
-            {
-                res += (regExp.Flags.Contains("g") ? "g" : "")
-                    + (regExp.Flags.Contains("i") ? "i" : "")
-                    + (regExp.Flags.Contains("m") ? "m" : "")
-                ;
-            }
+            if (regexObj.TryGetValue("source", out var source) == false)
+                source = Undefined.ToString();
 
-            return res;
+            if (regexObj.TryGetValue("flags", out var flags) == false)
+                flags = Undefined.ToString();
+
+            return $"/{source.AsString()}/{flags.AsString()}";
         }
 
         private JsValue Test(JsValue thisObj, JsValue[] arguments)


### PR DESCRIPTION
… with a real RegExp instance

Bit of an obscure one this!  RegExp.prototype.toString() throws a null reference exception if not called with a real RegExp instance.

This pull request brings the method behaviour in line with the v8 engine.

A polyfill library I'm trying to use tests the RegExp prototype this way and hence errors.