### PR TITLE
Complete Promise implementation

### DIFF
--- a/Jint.Tests.Test262/BuiltIns/PromiseTests.cs
+++ b/Jint.Tests.Test262/BuiltIns/PromiseTests.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Jint.Tests.Test262.BuiltIns
+{
+    public class PromiseTests : Test262Test
+    {
+        [Theory(DisplayName = "built-ins\\Promise")]
+        [MemberData(nameof(SourceFiles), "built-ins\\Promise", false)]
+        [MemberData(nameof(SourceFiles), "built-ins\\Promise", true, Skip = "Skipped")]
+        protected void Promise(SourceFile sourceFile)
+        {
+            RunTestInternal(sourceFile);
+        }
+    }
+}

--- a/Jint.Tests.Test262/test/skipped.json
+++ b/Jint.Tests.Test262/test/skipped.json
@@ -1,5 +1,17 @@
 [
   {
+    "source": "built-ins/Promise/prototype/finally/species-symbol.js",
+    "reason": "classes not implemented"
+  },
+  {
+    "source": "built-ins/Promise/prototype/finally/subclass-species-constructor-reject-count.js",
+    "reason": "classes not implemented"
+  },
+  {
+    "source": "built-ins/Promise/prototype/finally/subclass-species-constructor-resolve-count.js",
+    "reason": "classes not implemented"
+  },
+  {
     "source": "language/expressions/assignment/fn-name-lhs-cover.js",
     "reason": "Currently quite impossible to detect if assignment target is CoverParenthesizedExpression"
   },
@@ -62,12 +74,8 @@
     "reason": "Windows line ending differences"
   },
   {
-    "source": "built-ins/Symbol/species/builtin-getter-name.js",
-    "reason": "Promise not implemented"
-  },
-  {
     "source": "language/expressions/object/method-definition/object-method-returns-promise.js",
-    "reason": "Promise not implemented"
+    "reason": "async not implemented"
   },
   {
     "source": "built-ins/Symbol/species/subclassing.js",

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -34,7 +34,7 @@ namespace Jint.Tests.Runtime
 
         #region Ctor
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public void PromiseCtorWithNoResolver_Throws()
         {
             var engine = new Engine();
@@ -45,7 +45,7 @@ namespace Jint.Tests.Runtime
             });
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public void PromiseCtorWithInvalidResolver_Throws()
         {
             var engine = new Engine();
@@ -56,7 +56,7 @@ namespace Jint.Tests.Runtime
             });
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public void PromiseCtorWithValidResolver_DoesNotThrow()
         {
             var engine = new Engine();
@@ -64,7 +64,7 @@ namespace Jint.Tests.Runtime
             engine.Execute("new Promise((resolve, reject)=>{});");
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public void PromiseCtor_ReturnsPromiseJsValue()
         {
             var engine = new Engine();
@@ -76,7 +76,7 @@ namespace Jint.Tests.Runtime
 
         #region Resolve
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseResolveViaResolver_ReturnsCorrectValue()
         {
             var engine = new Engine();
@@ -84,7 +84,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(66, await engine.Execute("new Promise((resolve, reject)=>{resolve(66);});").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseResolveViaStatic_ReturnsCorrectValue()
         {
             var engine = new Engine();
@@ -96,7 +96,7 @@ namespace Jint.Tests.Runtime
 
         #region Reject
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseRejectViaResolver_ThrowsPromiseRejectedException()
         {
             var engine = new Engine();
@@ -109,7 +109,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal("Could not connect", ex.RejectedValue.AsString());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseRejectViaStatic_ThrowsPromiseRejectedException()
         {
             var engine = new Engine();
@@ -126,7 +126,7 @@ namespace Jint.Tests.Runtime
 
         #region Then
         
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseChainedThen_HandlerCalledWithCorrectValue()
         {
             var engine = new Engine();
@@ -134,7 +134,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(44, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => 44).then(result => resolve(result)); });").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public void PromiseThen_ReturnsNewPromiseInstance()
         {
             var engine = new Engine();
@@ -142,7 +142,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(false, engine.Execute("var promise1 = new Promise((resolve, reject) => { resolve(1); }); var promise2 = promise1.then();  promise1 === promise2").GetCompletionValue());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseThen_CalledCorrectlyOnResolve()
         {
             var engine = new Engine();
@@ -150,7 +150,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(66, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(result => resolve(result)); });").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseResolveChainedWithHandler_ResolvedAsUndefined()
         {
             var engine = new Engine();
@@ -158,7 +158,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(JsValue.Undefined, await engine.Execute("Promise.resolve(33).then(() => {});").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseChainedThenWithUndefinedCallback_PassesThroughValueCorrectly()
         {
             var engine = new Engine();
@@ -166,7 +166,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(66, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then().then(result => resolve(result)); });").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseChainedThenWithCallbackReturningUndefined_PassesThroughUndefinedCorrectly()
         {
             var engine = new Engine();
@@ -174,7 +174,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(JsValue.Undefined, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => {}).then(result => resolve(result)); });").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseChainedThenThrowsError_ChainedCallsCatchWithThrownError()
         {
             var engine = new Engine();
@@ -182,7 +182,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal("Thrown Error", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => { throw 'Thrown Error'; }).catch(result => resolve(result)); });").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseChainedThenReturnsResolvedPromise_ChainedCallsThenWithPromiseValue()
         {
             var engine = new Engine();
@@ -190,7 +190,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(55, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => Promise.resolve(55)).then(result => resolve(result)); });").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseChainedThenReturnsRejectedPromise_ChainedCallsCatchWithPromiseValue()
         {
             var engine = new Engine();
@@ -202,7 +202,7 @@ namespace Jint.Tests.Runtime
 
         #region Catch
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseCatch_CalledCorrectlyOnReject()
         {
             var engine = new Engine();
@@ -210,7 +210,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal("Could not connect", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch(result => resolve(result)); });").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseThenWithCatch_CalledCorrectlyOnReject()
         {
             var engine = new Engine();
@@ -218,7 +218,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal("Could not connect", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).then(undefined, result => resolve(result)); });").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseChainedWithHandler_ResolvedAsUndefined()
         {
             var engine = new Engine();
@@ -226,7 +226,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(JsValue.Undefined, await engine.Execute("Promise.reject('error').catch(() => {});").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseChainedCatchThen_ThenCallWithUndefined()
         {
             var engine = new Engine();
@@ -234,7 +234,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(JsValue.Undefined, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch(ex => {}).then(result => resolve(result)); });").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseChainedCatchWithUndefinedHandler_CatchChainedCorrectly()
         {
             var engine = new Engine();
@@ -246,7 +246,7 @@ namespace Jint.Tests.Runtime
 
         #region Finally
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseChainedFinally_HandlerCalled()
         {
             var engine = new Engine();
@@ -254,7 +254,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(16, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).finally(() => resolve(16)); });").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public void PromiseFinally_ReturnsNewPromiseInstance()
         {
             var engine = new Engine();
@@ -262,7 +262,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(false, engine.Execute("var promise1 = new Promise((resolve, reject) => { resolve(1); }); var promise2 = promise1.finally();  promise1 === promise2").GetCompletionValue());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseFinally_ResolvesWithCorrectValue()
         {
             var engine = new Engine();
@@ -270,7 +270,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(2, await engine.Execute("Promise.resolve(2).finally(() => {})").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseFinallyWithNoCallback_ResolvesWithCorrectValue()
         {
             var engine = new Engine();
@@ -278,7 +278,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(2, await engine.Execute("Promise.resolve(2).finally()").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseFinallyChained_ResolvesWithCorrectValue()
         {
             var engine = new Engine();
@@ -286,7 +286,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(2, await engine.Execute("Promise.resolve(2).finally(() => 6).finally(() => 9);").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseFinallyWhichThrows_ResolvesWithError()
         {
             var engine = new Engine();
@@ -298,7 +298,7 @@ namespace Jint.Tests.Runtime
 
         #region All
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public void PromiseAllNoArg_Throws()
         {
             var engine = new Engine();
@@ -306,7 +306,7 @@ namespace Jint.Tests.Runtime
             Assert.Throws<JavaScriptException>(() => { engine.Execute("Promise.all();"); });
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public void PromiseAllInvalidIterator_Throws()
         {
             var engine = new Engine();
@@ -314,7 +314,7 @@ namespace Jint.Tests.Runtime
             Assert.Throws<JavaScriptException>(() => { engine.Execute("Promise.all({});"); });
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseAllNoPromises_ResolvesCorrectly()
         {
             var engine = new Engine();
@@ -322,7 +322,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(new object[] { 1d, 2d, 3d }, (await engine.Execute("Promise.all([1,2,3]);").GetCompletionValueAsync()).ToObject());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseAllMixturePromisesNoPromises_ResolvesCorrectly()
         {
             var engine = new Engine();
@@ -330,7 +330,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(new object[] { 1d, 2d, 3d }, (await engine.Execute("Promise.all([1,Promise.resolve(2),3]);").GetCompletionValueAsync()).ToObject());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseAllMixturePromisesNoPromisesOneRejects_ResolvesCorrectly()
         {
             var engine = new Engine();
@@ -345,7 +345,7 @@ namespace Jint.Tests.Runtime
 
         #region Race
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public void PromiseRaceNoArg_Throws()
         {
             var engine = new Engine();
@@ -353,7 +353,7 @@ namespace Jint.Tests.Runtime
             Assert.Throws<JavaScriptException>(() => { engine.Execute("Promise.race();"); });
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public void PromiseRaceInvalidIterator_Throws()
         {
             var engine = new Engine();
@@ -361,7 +361,7 @@ namespace Jint.Tests.Runtime
             Assert.Throws<JavaScriptException>(() => { engine.Execute("Promise.race({});"); });
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseRaceNoPromises_ResolvesCorrectly()
         {
             var engine = new Engine();
@@ -369,7 +369,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(12d, (await engine.Execute("Promise.race([12,2,3]);").GetCompletionValueAsync()).ToObject());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseRaceMixturePromisesNoPromises_ResolvesCorrectly()
         {
             var engine = new Engine();
@@ -377,7 +377,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(12d, (await engine.Execute("Promise.race([12,Promise.resolve(2),3]);").GetCompletionValueAsync()).ToObject());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseRaceMixturePromisesNoPromises_ResolvesCorrectly2()
         {
             var engine = new Engine();
@@ -385,7 +385,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(2d, (await engine.Execute("Promise.race([Promise.resolve(2),6,3]);").GetCompletionValueAsync()).ToObject());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseRaceMixturePromisesNoPromises_ResolvesCorrectly3()
         {
             var engine = new Engine();
@@ -393,7 +393,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(55d, (await engine.Execute("Promise.race([new Promise((resolve,reject)=>{}),Promise.resolve(55),3]);").GetCompletionValueAsync()).ToObject());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PromiseRaceMixturePromisesNoPromises_ResolvesCorrectly4()
         {
             var engine = new Engine();
@@ -408,7 +408,7 @@ namespace Jint.Tests.Runtime
 
         #region TaskToPromise
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task MethodTaskToPromise_CompletesCorrectly()
         {
             var engine = new Engine();
@@ -418,7 +418,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(12d, await engine.Execute("TestObject.testAsyncMethod(3,4);").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task MethodTaskToPromiseWrapped_CompletesCorrectly()
         {
             var engine = new Engine();
@@ -428,7 +428,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(12d, await engine.Execute("new Promise((resolve, reject) =>  TestObject.testAsyncMethod(3,4).then(res => resolve(res)));").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PropertyTaskToPromiseWrapped_CompletesCorrectly()
         {
             var engine = new Engine();
@@ -438,7 +438,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(66d, await engine.Execute("new Promise((resolve, reject) =>  TestObject.testAsyncProperty.then(res => resolve(res)));").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task MethodTaskToPromiseWrappedWithoutReturnValue_ReturnsUndefined()
         {
             var engine = new Engine();
@@ -448,7 +448,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal(JsValue.Undefined, await engine.Execute("new Promise((resolve, reject) =>  TestObject.testAsyncMethodNoReturnValue().then(res => resolve(res)));").GetCompletionValueAsync());
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PropertyTaskToPromiseThatThrowsException_ThrowsPromiseRejectedException()
         {
             var engine = new Engine();
@@ -463,7 +463,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal("Could not connect", ((Exception)ex.RejectedValue.ToObject()).Message);
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task PropertyTaskToPromiseThatThrowsExceptionWrapped_ThrowsPromiseRejectedException()
         {
             var engine = new Engine();

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Jint.Tests.Runtime
 {
-    public class PromiseTests
+    public class PromiseTestClass
     {
         public Task<int> TestAsyncProperty
         {
@@ -31,7 +31,10 @@ namespace Jint.Tests.Runtime
             await Task.Delay(100);
             throw new Exception("Could not connect");
         }
+    }
 
+    public class PromiseTests
+    {
         #region Ctor
 
         [Fact(Timeout = 5000)]
@@ -413,7 +416,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            engine.SetValue("TestObject", this);
+            engine.SetValue("TestObject", new PromiseTestClass());
 
             Assert.Equal(12d, await engine.Execute("TestObject.testAsyncMethod(3,4);").GetCompletionValueAsync());
         }
@@ -423,7 +426,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            engine.SetValue("TestObject", this);
+            engine.SetValue("TestObject", new PromiseTestClass());
 
             Assert.Equal(12d, await engine.Execute("new Promise((resolve, reject) =>  TestObject.testAsyncMethod(3,4).then(res => resolve(res)));").GetCompletionValueAsync());
         }
@@ -433,7 +436,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            engine.SetValue("TestObject", this);
+            engine.SetValue("TestObject", new PromiseTestClass());
 
             Assert.Equal(66d, await engine.Execute("new Promise((resolve, reject) =>  TestObject.testAsyncProperty.then(res => resolve(res)));").GetCompletionValueAsync());
         }
@@ -443,7 +446,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            engine.SetValue("TestObject", this);
+            engine.SetValue("TestObject", new PromiseTestClass());
 
             Assert.Equal(JsValue.Undefined, await engine.Execute("new Promise((resolve, reject) =>  TestObject.testAsyncMethodNoReturnValue().then(res => resolve(res)));").GetCompletionValueAsync());
         }
@@ -453,7 +456,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            engine.SetValue("TestObject", this);
+            engine.SetValue("TestObject", new PromiseTestClass());
 
             var ex = await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
             {
@@ -468,7 +471,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            engine.SetValue("TestObject", this);
+            engine.SetValue("TestObject", new PromiseTestClass());
 
             var ex = await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
             {

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -142,6 +142,14 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
+        public async Task PromiseResolveChainedWithHandler_ResolvedAsUndefined()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(JsValue.Undefined, await engine.Execute("Promise.resolve(33).then(() => {});").GetCompletionValueAsync());
+        }
+
+        [Fact]
         public async Task PromiseChainedThenWithUndefinedCallback_PassesThroughValueCorrectly()
         {
             var engine = new Engine();
@@ -199,6 +207,14 @@ namespace Jint.Tests.Runtime
             var engine = new Engine();
 
             Assert.Equal("Could not connect", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).then(undefined, result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseChainedWithHandler_ResolvedAsUndefined()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(JsValue.Undefined, await engine.Execute("Promise.reject('error').catch(() => {});").GetCompletionValueAsync());
         }
 
         [Fact]

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Jint.Native;
-using Jint.Native.Array;
 using Jint.Native.Promise;
 using Jint.Runtime;
 using Xunit;
@@ -283,6 +280,116 @@ namespace Jint.Tests.Runtime
             var engine = new Engine();
 
             Assert.Equal("Could not connect", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(5)}).finally(() => {throw 'Could not connect';}).catch(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        #endregion
+
+        #region All
+
+        [Fact]
+        public void PromiseAllNoArg_Throws()
+        {
+            var engine = new Engine();
+
+            Assert.Throws<JavaScriptException>(() => { engine.Execute("Promise.all();"); });
+        }
+
+        [Fact]
+        public void PromiseAllInvalidIterator_Throws()
+        {
+            var engine = new Engine();
+
+            Assert.Throws<JavaScriptException>(() => { engine.Execute("Promise.all({});"); });
+        }
+
+        [Fact]
+        public async Task PromiseAllNoPromises_ResolvesCorrectly()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(new object[] { 1d, 2d, 3d }, (await engine.Execute("Promise.all([1,2,3]);").GetCompletionValueAsync()).ToObject());
+        }
+
+        [Fact]
+        public async Task PromiseAllMixturePromisesNoPromises_ResolvesCorrectly()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(new object[] { 1d, 2d, 3d }, (await engine.Execute("Promise.all([1,Promise.resolve(2),3]);").GetCompletionValueAsync()).ToObject());
+        }
+
+        [Fact]
+        public async Task PromiseAllMixturePromisesNoPromisesOneRejects_ResolvesCorrectly()
+        {
+            var engine = new Engine();
+
+            await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+            {
+                await engine.Execute("Promise.all([1,Promise.resolve(2),3, Promise.reject('Cannot connect')]);").GetCompletionValueAsync();
+            });
+        }
+
+        #endregion
+
+        #region Race
+
+        [Fact]
+        public void PromiseRaceNoArg_Throws()
+        {
+            var engine = new Engine();
+
+            Assert.Throws<JavaScriptException>(() => { engine.Execute("Promise.race();"); });
+        }
+
+        [Fact]
+        public void PromiseRaceInvalidIterator_Throws()
+        {
+            var engine = new Engine();
+
+            Assert.Throws<JavaScriptException>(() => { engine.Execute("Promise.race({});"); });
+        }
+
+        [Fact]
+        public async Task PromiseRaceNoPromises_ResolvesCorrectly()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(12d, (await engine.Execute("Promise.race([12,2,3]);").GetCompletionValueAsync()).ToObject());
+        }
+
+        [Fact]
+        public async Task PromiseRaceMixturePromisesNoPromises_ResolvesCorrectly()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(12d, (await engine.Execute("Promise.race([12,Promise.resolve(2),3]);").GetCompletionValueAsync()).ToObject());
+        }
+
+        [Fact]
+        public async Task PromiseRaceMixturePromisesNoPromises_ResolvesCorrectly2()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(2d, (await engine.Execute("Promise.race([Promise.resolve(2),6,3]);").GetCompletionValueAsync()).ToObject());
+        }
+
+        [Fact]
+        public async Task PromiseRaceMixturePromisesNoPromises_ResolvesCorrectly3()
+        {
+            var engine = new Engine();
+            
+            Assert.Equal(55d, (await engine.Execute("Promise.race([new Promise((resolve,reject)=>{}),Promise.resolve(55),3]);").GetCompletionValueAsync()).ToObject());
+        }
+
+        [Fact]
+        public async Task PromiseRaceMixturePromisesNoPromises_ResolvesCorrectly4()
+        {
+            var engine = new Engine();
+
+            await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+            {
+                await engine.Execute("Promise.race([new Promise((resolve,reject)=>{}),Promise.reject('Could not connect'),3]);").GetCompletionValueAsync();
+            });
         }
 
         #endregion

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -2,19 +2,162 @@
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Jint.Native.Array;
+using Jint.Native.Promise;
+using Jint.Runtime;
 using Xunit;
 
 namespace Jint.Tests.Runtime
 {
     public class PromiseTests
     {
+        public Task<int> TestAsyncProperty
+        {
+            get { return Task.Run(() => 66); }
+        }
+
+        public async Task<int> TestAsyncMethod(int x, int y)
+        {
+            await Task.Delay(100);
+
+            return x * y;
+        }
+
         [Fact]
-        public async Task Test()
+        public void PromiseCtorWithNoResolver_Throws()
         {
             var engine = new Engine();
 
-            var res = await engine.Execute("var res = 0;new Promise((resolve, reject) =>resolve(12)).then(result => {res = result});").GetCompletionValueAsync();
+            Assert.Throws<JavaScriptException>(() =>
+            {
+                engine.Execute("new Promise();");
+            });
         }
 
+        [Fact]
+        public void PromiseCtorWithInvalidResolver_Throws()
+        {
+            var engine = new Engine();
+
+            Assert.Throws<JavaScriptException>(() =>
+            {
+                engine.Execute("new Promise({});");
+            });
+        }
+
+        [Fact]
+        public void PromiseCtorWithValidResolver_DoesNotThrow()
+        {
+            var engine = new Engine();
+
+            engine.Execute("new Promise((resolve, reject)=>{});");
+        }
+
+        [Fact]
+        public void PromiseCtor_ReturnsPromiseJsValue()
+        {
+            var engine = new Engine();
+
+            Assert.IsType<PromiseInstance>(engine.Execute("new Promise((resolve, reject)=>{});").GetCompletionValue());
+        }
+
+        [Fact]
+        public async Task PromiseResolveViaResolver_ReturnsCorrectValue()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(66, await engine.Execute("new Promise((resolve, reject)=>{resolve(66);});").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseResolveViaStatic_ReturnsCorrectValue()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(66, await engine.Execute("Promise.resolve(66);").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseThen_CalledCorrectlyOnResolve()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(66, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseChainedThen_CalledCorrectlyOnResolve()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(66, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then().then(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseChainedThen_HandlerCalledWithCorrectValue()
+        {
+            var engine = new Engine();
+
+            //Assert.Equal(44, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => 44).then(res => res * 2); });").GetCompletionValueAsync());
+            Assert.Equal(44, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => 44).then(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public void PromiseThen_ReturnsNewPromiseInstance()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(false, engine.Execute("var promise1 = new Promise((resolve, reject) => { resolve(1); }); var promise2 = promise1.then();  promise1 === promise2").GetCompletionValue());
+        }
+
+        [Fact]
+        public async Task PromiseRejectViaResolver_ThrowsPromiseRejectedException()
+        {
+            var engine = new Engine();
+
+            var ex = await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+            {
+                await engine.Execute("new Promise((resolve, reject)=>{reject('Could not connect');});").GetCompletionValueAsync();
+            });
+
+            Assert.Equal("Could not connect", ex.RejectedValue.AsString());
+        }
+
+        [Fact]
+        public async Task PromiseRejectViaStatic_ThrowsPromiseRejectedException()
+        {
+            var engine = new Engine();
+
+            var ex = await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+            {
+                await engine.Execute("Promise.reject('Could not connect');").GetCompletionValueAsync();
+            });
+
+            Assert.Equal("Could not connect", ex.RejectedValue.AsString());
+        }
+
+        [Fact]
+        public async Task PromiseCatch_CalledCorrectlyOnReject()
+        {
+            var engine = new Engine();
+
+            Assert.Equal("Could not connect", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseThenWithCatch_CalledCorrectlyOnReject()
+        {
+            var engine = new Engine();
+
+            Assert.Equal("Could not connect", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).then(undefined, result => resolve(result)); });").GetCompletionValueAsync());
+        }
+        /*
+        [Fact]
+        public async Task PromiseChainedCatch_CalledCorrectlyOnReject()
+        {
+            var engine = new Engine();
+
+            Assert.Equal("Could not connect", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch().catch(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+        */
     }
 }

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -82,7 +82,7 @@ namespace Jint.Tests.Runtime
 
             Assert.Equal(66, await engine.Execute("Promise.resolve(66);").GetCompletionValueAsync());
         }
-
+        
         #endregion
 
         #region Reject
@@ -231,6 +231,58 @@ namespace Jint.Tests.Runtime
             var engine = new Engine();
 
             Assert.Equal("Could not connect", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch().catch(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        #endregion
+
+        #region Finally
+
+        [Fact]
+        public async Task PromiseChainedFinally_HandlerCalled()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(16, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).finally(() => resolve(16)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public void PromiseFinally_ReturnsNewPromiseInstance()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(false, engine.Execute("var promise1 = new Promise((resolve, reject) => { resolve(1); }); var promise2 = promise1.finally();  promise1 === promise2").GetCompletionValue());
+        }
+
+        [Fact]
+        public async Task PromiseFinally_ResolvesWithCorrectValue()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(2, await engine.Execute("Promise.resolve(2).finally(() => {})").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseFinallyWithNoCallback_ResolvesWithCorrectValue()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(2, await engine.Execute("Promise.resolve(2).finally()").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseFinallyChained_ResolvesWithCorrectValue()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(2, await engine.Execute("Promise.resolve(2).finally(() => 6).finally(() => 9);").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseFinallyWhichThrows_ResolvesWithError()
+        {
+            var engine = new Engine();
+
+            Assert.Equal("Could not connect", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(5)}).finally(() => {throw 'Could not connect';}).catch(result => resolve(result)); });").GetCompletionValueAsync());
         }
 
         #endregion

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Jint.Native.Array;
+using Xunit;
+
+namespace Jint.Tests.Runtime
+{
+    public class PromiseTests
+    {
+        [Fact]
+        public async Task Test()
+        {
+            var engine = new Engine();
+
+            var res = await engine.Execute("var res = 0;new Promise((resolve, reject) =>resolve(12)).then(result => {res = result});").GetCompletionValueAsync();
+        }
+
+    }
+}

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Jint.Native;
 using Jint.Native.Array;
 using Jint.Native.Promise;
 using Jint.Runtime;
@@ -21,6 +22,8 @@ namespace Jint.Tests.Runtime
 
             return x * y;
         }
+
+        #region Ctor
 
         [Fact]
         public void PromiseCtorWithNoResolver_Throws()
@@ -60,6 +63,10 @@ namespace Jint.Tests.Runtime
             Assert.IsType<PromiseInstance>(engine.Execute("new Promise((resolve, reject)=>{});").GetCompletionValue());
         }
 
+        #endregion
+
+        #region Resolve
+
         [Fact]
         public async Task PromiseResolveViaResolver_ReturnsCorrectValue()
         {
@@ -76,38 +83,9 @@ namespace Jint.Tests.Runtime
             Assert.Equal(66, await engine.Execute("Promise.resolve(66);").GetCompletionValueAsync());
         }
 
-        [Fact]
-        public async Task PromiseThen_CalledCorrectlyOnResolve()
-        {
-            var engine = new Engine();
+        #endregion
 
-            Assert.Equal(66, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(result => resolve(result)); });").GetCompletionValueAsync());
-        }
-
-        [Fact]
-        public async Task PromiseChainedThen_CalledCorrectlyOnResolve()
-        {
-            var engine = new Engine();
-
-            Assert.Equal(66, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then().then(result => resolve(result)); });").GetCompletionValueAsync());
-        }
-
-        [Fact]
-        public async Task PromiseChainedThen_HandlerCalledWithCorrectValue()
-        {
-            var engine = new Engine();
-
-            //Assert.Equal(44, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => 44).then(res => res * 2); });").GetCompletionValueAsync());
-            Assert.Equal(44, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => 44).then(result => resolve(result)); });").GetCompletionValueAsync());
-        }
-
-        [Fact]
-        public void PromiseThen_ReturnsNewPromiseInstance()
-        {
-            var engine = new Engine();
-
-            Assert.Equal(false, engine.Execute("var promise1 = new Promise((resolve, reject) => { resolve(1); }); var promise2 = promise1.then();  promise1 === promise2").GetCompletionValue());
-        }
+        #region Reject
 
         [Fact]
         public async Task PromiseRejectViaResolver_ThrowsPromiseRejectedException()
@@ -135,6 +113,78 @@ namespace Jint.Tests.Runtime
             Assert.Equal("Could not connect", ex.RejectedValue.AsString());
         }
 
+        #endregion
+
+        #region Then
+        
+        [Fact]
+        public async Task PromiseChainedThen_HandlerCalledWithCorrectValue()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(44, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => 44).then(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public void PromiseThen_ReturnsNewPromiseInstance()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(false, engine.Execute("var promise1 = new Promise((resolve, reject) => { resolve(1); }); var promise2 = promise1.then();  promise1 === promise2").GetCompletionValue());
+        }
+
+        [Fact]
+        public async Task PromiseThen_CalledCorrectlyOnResolve()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(66, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseChainedThenWithUndefinedCallback_PassesThroughValueCorrectly()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(66, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then().then(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseChainedThenWithCallbackReturningUndefined_PassesThroughUndefinedCorrectly()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(JsValue.Undefined, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => {}).then(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseChainedThenThrowsError_ChainedCallsCatchWithThrownError()
+        {
+            var engine = new Engine();
+
+            Assert.Equal("Thrown Error", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => { throw 'Thrown Error'; }).catch(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseChainedThenReturnsResolvedPromise_ChainedCallsThenWithPromiseValue()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(55, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => Promise.resolve(55)).then(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseChainedThenReturnsRejectedPromise_ChainedCallsCatchWithPromiseValue()
+        {
+            var engine = new Engine();
+
+            Assert.Equal("Error Message", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => Promise.reject('Error Message')).catch(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        #endregion
+
+        #region Catch
+
         [Fact]
         public async Task PromiseCatch_CalledCorrectlyOnReject()
         {
@@ -150,14 +200,23 @@ namespace Jint.Tests.Runtime
 
             Assert.Equal("Could not connect", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).then(undefined, result => resolve(result)); });").GetCompletionValueAsync());
         }
-        /*
+
         [Fact]
-        public async Task PromiseChainedCatch_CalledCorrectlyOnReject()
+        public async Task PromiseChainedCatchThen_ThenCallWithUndefined()
+        {
+            var engine = new Engine();
+
+            Assert.Equal(JsValue.Undefined, await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch(ex => {}).then(result => resolve(result)); });").GetCompletionValueAsync());
+        }
+
+        [Fact]
+        public async Task PromiseChainedCatchWithUndefinedHandler_CatchChainedCorrectly()
         {
             var engine = new Engine();
 
             Assert.Equal("Could not connect", await engine.Execute("new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch().catch(result => resolve(result)); });").GetCompletionValueAsync());
         }
-        */
+
+        #endregion
     }
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -386,7 +386,9 @@ namespace Jint
         internal Engine Execute(Script program, bool threadLock)
         {
             if (threadLock)
+            {
                 _threadLock.Wait();
+            }
 
             try
             {
@@ -416,7 +418,9 @@ namespace Jint
             finally
             {
                 if (threadLock)
+                {
                     _threadLock.Release();
+                }
             }
 
             return this;
@@ -439,7 +443,7 @@ namespace Jint
 
             if (startContinuationsTask)
             {
-                Task.Run(async () =>
+                Task.Factory.StartNew(async () =>
                 {
                     while (true)
                     {

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -401,20 +401,25 @@ namespace Jint
             CallStack.Clear();
         }
 
-        public Engine Execute(string source)
+        public Engine Execute(string source) => Execute(source, true);
+        public Engine Execute(string source, ParserOptions parserOptions) => Execute(source, parserOptions, true);
+        public Engine Execute(Script program) => Execute(program, true);
+
+        internal Engine Execute(string source, bool threadLock)
         {
-            return Execute(source, DefaultParserOptions);
+            return Execute(source, DefaultParserOptions, threadLock);
         }
 
-        public Engine Execute(string source, ParserOptions parserOptions)
+        internal Engine Execute(string source, ParserOptions parserOptions, bool threadLock)
         {
             var parser = new JavaScriptParser(source, parserOptions);
-            return Execute(parser.ParseScript());
+            return Execute(parser.ParseScript(), threadLock);
         }
 
-        public Engine Execute(Script program)
+        internal Engine Execute(Script program, bool threadLock)
         {
-            _threadLock.Wait();
+            if (threadLock)
+                _threadLock.Wait();
 
             try
             {
@@ -450,7 +455,8 @@ namespace Jint
             }
             finally
             {
-                _threadLock.Release();
+                if (threadLock)
+                    _threadLock.Release();
             }
 
             return this;
@@ -649,10 +655,10 @@ namespace Jint
                         && TryHandleStringValue(property, s, ref o, out var jsValue))
                     {
                         return jsValue;
-                    }
+                        }
 
                     if (o is null)
-                    {
+                        {
                         o = TypeConverter.ToObject(this, baseValue);
                     }
 

--- a/Jint/IteratorExtensions.cs
+++ b/Jint/IteratorExtensions.cs
@@ -6,7 +6,7 @@ namespace Jint
 {
     internal static class IteratorExtensions
     {
-        internal static JsValue[] CopyToArray(this IteratorInstance iterator)
+        internal static List<JsValue> CopyToList(this IteratorInstance iterator)
         {
             var items = new List<JsValue>();
 
@@ -18,7 +18,7 @@ namespace Jint
                 item = iterator.Next();
             }
 
-            return items.ToArray();
+            return items;
         }
     }
 }

--- a/Jint/IteratorExtensions.cs
+++ b/Jint/IteratorExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using Jint.Native;
+using Jint.Native.Iterator;
+
+namespace Jint
+{
+    internal static class IteratorExtensions
+    {
+        internal static JsValue[] CopyToArray(this IteratorInstance iterator)
+        {
+            var items = new List<JsValue>();
+
+            var item = iterator.Next();
+
+            while (item.GetProperty("done").Value.AsBoolean() == false)
+            {
+                items.Add(item.GetProperty("value").Value);
+                item = iterator.Next();
+            }
+
+            return items.ToArray();
+        }
+    }
+}

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -28,7 +28,7 @@ namespace Jint.Native.Global
         }
 
         protected override void Initialize()
-        {
+            {
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;
             const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
             var properties = new PropertyDictionary(40, checkExistingKeys: false)
@@ -39,6 +39,7 @@ namespace Jint.Native.Global
                 ["Array"] = new PropertyDescriptor(Engine.Array, propertyFlags),
                 ["Map"] = new PropertyDescriptor(Engine.Map, propertyFlags),
                 ["Set"] = new PropertyDescriptor(Engine.Set, propertyFlags),
+                ["Promise"] = new PropertyDescriptor(Engine.Promise, propertyFlags),
                 ["String"] = new PropertyDescriptor(Engine.String, propertyFlags),
                 ["RegExp"] = new PropertyDescriptor(Engine.RegExp, propertyFlags),
                 ["Number"] = new PropertyDescriptor(Engine.Number, propertyFlags),
@@ -710,7 +711,7 @@ namespace Jint.Native.Global
         internal bool HasProperty(in Key property)
         {
             return GetOwnProperty(property) != PropertyDescriptor.Undefined;
-        }
+    }
 
         internal PropertyDescriptor GetProperty(in Key property) => GetOwnProperty(property);
 

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -28,7 +28,7 @@ namespace Jint.Native.Global
         }
 
         protected override void Initialize()
-            {
+        {
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;
             const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
             var properties = new PropertyDictionary(40, checkExistingKeys: false)

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -4,11 +4,13 @@ using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Jint.Native.Array;
 using Jint.Native.Date;
 using Jint.Native.Iterator;
 using Jint.Native.Number;
 using Jint.Native.Object;
+using Jint.Native.Promise;
 using Jint.Native.RegExp;
 using Jint.Native.Symbol;
 using Jint.Runtime;
@@ -345,6 +347,11 @@ namespace Jint.Native
 
                 return JsNumber.Create(System.Convert.ToInt32(value));
             }
+
+            //  If a net task we want to wrap as a js promise
+            //  todo - custom task types eg ValueTask<>.  Not sure these can be supported generically without writing the associated state machine code
+            if (value is Task task)
+                return new PromiseInstance(engine, task);
 
             // if no known type could be guessed, wrap it as an ObjectInstance
             var h = engine.Options._WrapObjectHandler;

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -351,10 +351,12 @@ namespace Jint.Native
             //  If a net task we want to wrap as a js promise
             //  todo - custom task types eg ValueTask<>.  Not sure these can be supported generically without writing the associated state machine code
             if (value is Task task)
+            {
                 return new PromiseInstance(engine, task)
                 {
                     _prototype = engine.Promise.PrototypeObject
                 };
+            }
 
             // if no known type could be guessed, wrap it as an ObjectInstance
             var h = engine.Options._WrapObjectHandler;

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -351,7 +351,10 @@ namespace Jint.Native
             //  If a net task we want to wrap as a js promise
             //  todo - custom task types eg ValueTask<>.  Not sure these can be supported generically without writing the associated state machine code
             if (value is Task task)
-                return new PromiseInstance(engine, task);
+                return new PromiseInstance(engine, task)
+                {
+                    _prototype = engine.Promise.PrototypeObject
+                };
 
             // if no known type could be guessed, wrap it as an ObjectInstance
             var h = engine.Options._WrapObjectHandler;

--- a/Jint/Native/Object/ObjectClass.cs
+++ b/Jint/Native/Object/ObjectClass.cs
@@ -14,6 +14,7 @@ namespace Jint.Native.Object
         Math,
         Number,
         Object,
+        Promise,
         Proxy,
         Reflect,
         RegExp,

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -1,7 +1,9 @@
-﻿using Jint.Native.Function;
+﻿using Jint.Collections;
+using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
 
 namespace Jint.Native.Promise
 {
@@ -31,6 +33,16 @@ namespace Jint.Native.Promise
             return obj;
         }
 
+        protected override void Initialize()
+        {
+            var properties = new PropertyDictionary(2, checkExistingKeys: false)
+            {
+                ["resolve"] = new PropertyDescriptor(new PropertyDescriptor(new ClrFunctionInstance(Engine, "resolve", Resolve, 1), PropertyFlag.NonEnumerable)),
+                ["reject"] = new PropertyDescriptor(new PropertyDescriptor(new ClrFunctionInstance(Engine, "reject", Reject, 1), PropertyFlag.NonEnumerable)),
+            };
+            SetProperties(properties);
+        }
+
         public override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             if (thisObject.IsUndefined())
@@ -57,5 +69,8 @@ namespace Jint.Native.Promise
 
             return instance;
         }
+
+        public PromiseInstance Resolve(JsValue thisRef, JsValue[] args) => PromiseInstance.CreateResolved(Engine, args.Length >= 1 ? args[0] : Undefined);
+        public PromiseInstance Reject(JsValue thisRef, JsValue[] args) => PromiseInstance.CreateRejected(Engine, args.Length >= 1 ? args[0] : Undefined);
     }
 }

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -1,0 +1,61 @@
+﻿using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Native.Promise
+{
+    public sealed class PromiseConstructor : FunctionInstance, IConstructor
+    {
+        private static readonly JsString _functionName = new JsString("Promise");
+
+        private PromiseConstructor(Engine engine)
+            : base(engine, _functionName, false)
+        {
+        }
+
+        public PromisePrototype PrototypeObject { get; private set; }
+
+        public static PromiseConstructor CreatePromiseConstructor(Engine engine)
+        {
+            var obj = new PromiseConstructor(engine)
+            {
+                _prototype = engine.Function.PrototypeObject
+            };
+
+            // The value of the [[Prototype]] internal property of the Set constructor is the Function prototype object
+            obj.PrototypeObject = PromisePrototype.CreatePrototypeObject(engine, obj);
+            obj._length = new PropertyDescriptor(0, PropertyFlag.Configurable);
+            obj._prototype = obj.PrototypeObject;
+
+            return obj;
+        }
+
+        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        {
+            if (thisObject.IsUndefined())
+            {
+                ExceptionHelper.ThrowTypeError(_engine, "Constructor Set requires 'new'");
+            }
+
+            return Construct(arguments, thisObject);
+        }
+
+        public ObjectInstance Construct(JsValue[] arguments, JsValue receiver)
+        {
+            FunctionInstance promiseResolver = null;
+
+            if (arguments.Length == 0 || (promiseResolver = arguments[0] as FunctionInstance) == null)
+                ExceptionHelper.ThrowTypeError(_engine, $"Promise resolver {(arguments.Length >= 1 ? arguments[0].Type.ToString() : Undefined.ToString())} is not a function");
+
+            var instance = new PromiseInstance(Engine, promiseResolver)
+            {
+                _prototype = PrototypeObject
+            };
+
+            instance.InvokePromiseResolver();
+
+            return instance;
+        }
+    }
+}

--- a/Jint/Native/Promise/PromiseInstance.cs
+++ b/Jint/Native/Promise/PromiseInstance.cs
@@ -49,7 +49,11 @@ namespace Jint.Native.Promise
 
         public static PromiseInstance CreateResolved(Engine engine, JsValue result)
         {
-            var resolved = new PromiseInstance(engine);
+            var resolved = new PromiseInstance(engine)
+            {
+                Prototype = engine.Promise.PrototypeObject,
+                Extensible = true
+            };
 
             resolved._tcs.SetResult(result);
             resolved.State = PromiseState.Resolved;
@@ -59,7 +63,11 @@ namespace Jint.Native.Promise
 
         public static PromiseInstance CreateRejected(Engine engine, JsValue result)
         {
-            var rejected = new PromiseInstance(engine);
+            var rejected = new PromiseInstance(engine)
+            {
+                Prototype = engine.Promise.PrototypeObject,
+                Extensible = true
+            };
 
             rejected._tcs.SetException(new PromiseRejectedException(result));
             rejected.State = PromiseState.Rejected;

--- a/Jint/Native/Promise/PromiseInstance.cs
+++ b/Jint/Native/Promise/PromiseInstance.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Jint.Native.Function;
 using Jint.Native.Object;
@@ -39,11 +41,14 @@ namespace Jint.Native.Promise
                     var taskType = t.GetType();
                     var resultProperty = taskType.GetProperty("Result", BindingFlags.Instance | BindingFlags.Public);
 
-                    if (resultProperty != null)
+                    if (resultProperty != null && resultProperty.PropertyType.Name != "VoidTaskResult")
                         returnValue = FromObject(_engine, resultProperty.GetValue(t));
                     
                     _tcs.SetResult(returnValue);
+                    return;
                 }
+
+                _tcs.SetException(new PromiseRejectedException(FromObject(Engine, t.Exception?.InnerExceptions.FirstOrDefault() ?? new Exception("An unhandled exception was thrown"))));
             });
         }
 

--- a/Jint/Native/Promise/PromiseInstance.cs
+++ b/Jint/Native/Promise/PromiseInstance.cs
@@ -51,8 +51,7 @@ namespace Jint.Native.Promise
         {
             var resolved = new PromiseInstance(engine)
             {
-                Prototype = engine.Promise.PrototypeObject,
-                Extensible = true
+                _prototype = engine.Promise.PrototypeObject
             };
 
             resolved._tcs.SetResult(result);
@@ -65,8 +64,7 @@ namespace Jint.Native.Promise
         {
             var rejected = new PromiseInstance(engine)
             {
-                Prototype = engine.Promise.PrototypeObject,
-                Extensible = true
+                _prototype = engine.Promise.PrototypeObject
             };
 
             rejected._tcs.SetException(new PromiseRejectedException(result));

--- a/Jint/Native/Promise/PromiseInstance.cs
+++ b/Jint/Native/Promise/PromiseInstance.cs
@@ -15,38 +15,11 @@ namespace Jint.Native.Promise
         public Task<JsValue> Task => _tcs.Task;
         public PromiseState State { get; private set; }
 
-        private PromiseInstance(Engine engine) : base(engine, ObjectClass.Promise)
+        internal PromiseInstance(Engine engine) : base(engine, ObjectClass.Promise)
         {
 
         }
-
-        public PromiseInstance(Engine engine, PromiseInstance chainTo) : this(engine)
-        {
-            /*
-            chainTo.Task.ContinueWith(t =>
-            {
-                if (t.Status == TaskStatus.RanToCompletion)
-                {
-                    _tcs.SetResult(t.Result);
-                    State = PromiseState.Resolved;
-                }
-
-                else if (t.IsFaulted)
-                {
-                    _tcs.SetException(t.Exception?.InnerExceptions.FirstOrDefault() ?? new PromiseRejectedException(Undefined));
-                    State = PromiseState.Rejected;
-                }
-
-                //  Else cancelled
-                else
-                {
-                    _tcs.SetException(new PromiseRejectedException(Undefined));
-                    State = PromiseState.Rejected;
-                }
-            });
-            */
-        }
-
+        
         public PromiseInstance(Engine engine, FunctionInstance promiseResolver)
             : this(engine)
         {

--- a/Jint/Native/Promise/PromiseInstance.cs
+++ b/Jint/Native/Promise/PromiseInstance.cs
@@ -1,0 +1,54 @@
+﻿using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.Native.Promise
+{
+    public class PromiseInstance : ObjectInstance
+    {
+        private readonly FunctionInstance _promiseResolver;
+        private readonly TaskCompletionSource<JsValue> _tcs = new TaskCompletionSource<JsValue>();
+
+        public Task<JsValue> Task => _tcs.Task;
+        public PromiseState State { get; private set; }
+
+        public PromiseInstance(Engine engine, FunctionInstance promiseResolver)
+            : base(engine, ObjectClass.Promise)
+        {
+            _promiseResolver = promiseResolver;
+        }
+
+        internal void InvokePromiseResolver()
+        {
+            _promiseResolver.Invoke(new ClrFunctionInstance(_engine, "", Resolve, 1), new ClrFunctionInstance(_engine, "", Reject, 1));
+        }
+
+        private JsValue Resolve(JsValue thisValue, JsValue[] args)
+        {
+            //  Only first resolve/reject is actioned.  Further calls are invalid and ignored
+            if (State == PromiseState.Resolving)
+            {
+                _tcs.SetResult(args[0]);
+                State = PromiseState.Resolved;
+            }
+
+            return JsValue.Undefined;
+        }
+
+        private JsValue Reject(JsValue thisValue, JsValue[] args)
+        {
+            //  Only first resolve/reject is actioned.  Further calls are invalid and ignored
+            if (State == PromiseState.Resolving)
+            {
+                _tcs.SetException(new PromiseRejectedException());
+                State = PromiseState.Rejected;
+            }
+
+            return JsValue.Undefined;
+        }
+    }
+}

--- a/Jint/Native/Promise/PromisePrototype.cs
+++ b/Jint/Native/Promise/PromisePrototype.cs
@@ -140,11 +140,9 @@ namespace Jint.Native.Promise
                     {
                         continuation = () =>
                         {
-                            var result = rejectedCallback.Invoke(rejectValue);
+                            rejectedCallback.Invoke(rejectValue);
 
-                            //todo - if the above throws or returns a promise which is rejected then reject the chained promise too
-
-                            //  Else chain is restored
+                            //  Chain is restored after handling catch
                             chainedPromise.Resolve(Undefined, new[] {Undefined});
                         };
                     }

--- a/Jint/Native/Promise/PromisePrototype.cs
+++ b/Jint/Native/Promise/PromisePrototype.cs
@@ -43,8 +43,13 @@ namespace Jint.Native.Promise
 
         public JsValue Then(JsValue thisValue, JsValue[] args)
         {
-            if (!(thisValue is PromiseInstance promise))
-                throw ExceptionHelper.ThrowTypeError(_engine, "Method Promise.prototype.then called on incompatible receiver");
+            var promise = thisValue as PromiseInstance;
+
+            if (promise == null)
+            {
+                ExceptionHelper.ThrowTypeError(_engine, "Method Promise.prototype.then called on incompatible receiver");
+                return null;
+            }
 
             var chainedPromise = new PromiseInstance(Engine)
             {
@@ -159,8 +164,13 @@ namespace Jint.Native.Promise
 
         public JsValue Finally(JsValue thisValue, JsValue[] args)
         {
-            if (!(thisValue is PromiseInstance promise))
-                throw ExceptionHelper.ThrowTypeError(_engine, "Method Promise.prototype.then called on incompatible receiver");
+            var promise = thisValue as PromiseInstance;
+
+            if (promise == null)
+            {
+                ExceptionHelper.ThrowTypeError(_engine, "Method Promise.prototype.then called on incompatible receiver");
+                return null;
+            }
 
             var chainedPromise = new PromiseInstance(Engine)
             {

--- a/Jint/Native/Promise/PromisePrototype.cs
+++ b/Jint/Native/Promise/PromisePrototype.cs
@@ -1,0 +1,76 @@
+﻿using System.Threading.Tasks;
+using Jint.Collections;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.Native.Promise
+{
+    public sealed class PromisePrototype : ObjectInstance
+    {
+        private PromiseConstructor _promiseConstructor;
+
+        private PromisePrototype(Engine engine) : base(engine)
+        {
+        }
+
+        public static PromisePrototype CreatePrototypeObject(Engine engine, PromiseConstructor promiseConstructor)
+        {
+            var obj = new PromisePrototype(engine)
+            {
+                _prototype = engine.Object.PrototypeObject,
+                _promiseConstructor = promiseConstructor
+            };
+
+            return obj;
+        }
+
+        protected override void Initialize()
+        {
+            var properties = new PropertyDictionary(15, checkExistingKeys: false)
+            {
+                ["constructor"] = new PropertyDescriptor(_promiseConstructor, PropertyFlag.NonEnumerable),
+                ["then"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "then", Then, 1, PropertyFlag.Configurable), true, false, true),
+                ["catch"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "catch", Catch, 1, PropertyFlag.Configurable), true, false, true)
+            };
+            SetProperties(properties);
+        }
+        
+        public JsValue Then(JsValue thisValue, JsValue[] args)
+        {
+            if (!(thisValue is PromiseInstance promise))
+                throw ExceptionHelper.ThrowTypeError(_engine, "Method Promise.prototype.then called on incompatible receiver");
+            
+            promise.Task.ContinueWith(t =>
+            {
+                if (args.Length == 0 || !(args[0] is FunctionInstance thenCallback))
+                    return;
+
+                _engine.QueuePromiseContinuation(() => thenCallback.Invoke(t.Result));
+
+            }, TaskContinuationOptions.OnlyOnRanToCompletion);
+
+            return promise;
+        }
+
+        public JsValue Catch(JsValue thisValue, JsValue[] args)
+        {
+            if (!(thisValue is PromiseInstance promise))
+                throw ExceptionHelper.ThrowTypeError(_engine, "Method Promise.prototype.catch called on incompatible receiver");
+
+            promise.Task.ContinueWith(t =>
+            {
+                if (args.Length == 0 || !(args[0] is FunctionInstance catchCallback))
+                    return;
+
+                _engine.QueuePromiseContinuation(() => catchCallback.Invoke(Undefined));
+
+            }, TaskContinuationOptions.OnlyOnFaulted);
+
+            return promise;
+        }
+
+    }
+}

--- a/Jint/Native/Promise/PromiseState.cs
+++ b/Jint/Native/Promise/PromiseState.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Jint.Native.Promise
+{
+    public enum PromiseState
+    {
+        Resolving,
+        Resolved,
+        Rejected
+    }
+}

--- a/Jint/Native/Promise/PromiseState.cs
+++ b/Jint/Native/Promise/PromiseState.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Jint.Native.Promise
+﻿namespace Jint.Native.Promise
 {
     public enum PromiseState
     {

--- a/Jint/Native/Reflect/ReflectInstance.cs
+++ b/Jint/Native/Reflect/ReflectInstance.cs
@@ -58,16 +58,10 @@ namespace Jint.Native.Reflect
         private JsValue Construct(JsValue thisObject, JsValue[] arguments)
         {
             var targetArgument = arguments.At(0);
-            if (!(targetArgument is IConstructor target))
-            {
-                return ExceptionHelper.ThrowTypeError<JsValue>(_engine, targetArgument + " is not a constructor");
-            }
+            var target = AssertConstructor(_engine, targetArgument);
 
             var newTargetArgument = arguments.At(2, arguments[0]);
-            if (!(newTargetArgument is IConstructor newTarget))
-            {
-                return ExceptionHelper.ThrowTypeError<JsValue>(_engine, newTargetArgument + " is not a constructor");
-            }
+            AssertConstructor(_engine, newTargetArgument);
 
             var args = _engine.Function.PrototypeObject.CreateListFromArrayLike(arguments.At(1));
 

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -136,7 +136,7 @@ namespace Jint.Runtime.Debugger
 
             if (!string.IsNullOrEmpty(breakpoint.Condition))
             {
-                var completionValue = _engine.Execute(breakpoint.Condition).GetCompletionValue();
+                var completionValue = _engine.Execute(breakpoint.Condition, false).GetCompletionValue();
                 return ((JsBoolean) completionValue)._value;
             }
 

--- a/Jint/Runtime/ExceptionHelper.cs
+++ b/Jint/Runtime/ExceptionHelper.cs
@@ -62,7 +62,7 @@ namespace Jint.Runtime
             return default;
         }
 
-        public static Exception ThrowTypeError(Engine engine, string message = null, Exception exception = null)
+        public static void ThrowTypeError(Engine engine, string message = null, Exception exception = null)
         {
             throw new JavaScriptException(engine.TypeError, message, exception);
         }

--- a/Jint/Runtime/ExceptionHelper.cs
+++ b/Jint/Runtime/ExceptionHelper.cs
@@ -62,7 +62,7 @@ namespace Jint.Runtime
             return default;
         }
 
-        public static void ThrowTypeError(Engine engine, string message = null, Exception exception = null)
+        public static Exception ThrowTypeError(Engine engine, string message = null, Exception exception = null)
         {
             throw new JavaScriptException(engine.TypeError, message, exception);
         }

--- a/Jint/Runtime/PromiseRejectedException.cs
+++ b/Jint/Runtime/PromiseRejectedException.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Text;
 using Jint.Native;
 
 namespace Jint.Runtime

--- a/Jint/Runtime/PromiseRejectedException.cs
+++ b/Jint/Runtime/PromiseRejectedException.cs
@@ -3,7 +3,6 @@ using Jint.Native;
 
 namespace Jint.Runtime
 {
-    [Serializable]
     public class PromiseRejectedException : Exception
     {
         public JsValue RejectedValue { get; }

--- a/Jint/Runtime/PromiseRejectedException.cs
+++ b/Jint/Runtime/PromiseRejectedException.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Jint.Native;
+﻿using Jint.Native;
 
 namespace Jint.Runtime
 {
-    public class PromiseRejectedException : Exception
+    public class PromiseRejectedException : JintException
     {
         public JsValue RejectedValue { get; }
 

--- a/Jint/Runtime/PromiseRejectedException.cs
+++ b/Jint/Runtime/PromiseRejectedException.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Jint.Runtime
+{
+    [Serializable]
+    public class PromiseRejectedException : Exception
+    {
+        //
+        // For guidelines regarding the creation of new exception types, see
+        //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpgenref/html/cpconerrorraisinghandlingguidelines.asp
+        // and
+        //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/dncscol/html/csharp07192001.asp
+        //
+
+        public PromiseRejectedException()
+        {
+        }
+
+        public PromiseRejectedException(string message) : base(message)
+        {
+        }
+
+        public PromiseRejectedException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        protected PromiseRejectedException(
+            SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Jint/Runtime/PromiseRejectedException.cs
+++ b/Jint/Runtime/PromiseRejectedException.cs
@@ -2,35 +2,19 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
+using Jint.Native;
 
 namespace Jint.Runtime
 {
     [Serializable]
     public class PromiseRejectedException : Exception
     {
-        //
-        // For guidelines regarding the creation of new exception types, see
-        //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpgenref/html/cpconerrorraisinghandlingguidelines.asp
-        // and
-        //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/dncscol/html/csharp07192001.asp
-        //
+        public JsValue RejectedValue { get; }
 
-        public PromiseRejectedException()
+        public PromiseRejectedException(JsValue value) : base($"Promise was rejected with value {value}")
         {
+            RejectedValue = value;
         }
 
-        public PromiseRejectedException(string message) : base(message)
-        {
-        }
-
-        public PromiseRejectedException(string message, Exception inner) : base(message, inner)
-        {
-        }
-
-        protected PromiseRejectedException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
-        {
-        }
     }
 }


### PR DESCRIPTION
Branch that provides a complete implementation of a Promise as per the specs.

Only missing method is Promise.allSettled() which it seems isn't widely supported in browsers at the moment.

The Promises are implemented, built upon and wrap .net Tasks

If the return value of a CLR method returns a Task or Task<T> then this is automatically converted to a Promise in the run time.  This allows you to now use fully asynchronous javascript code in Jint.

GetCompletionValueAsync() has been added to Engine which awaits and unwraps the execution completion value if it's a Promise type.  If the completion value isn't a Promise then it's just returned as per GetCompletionValue().

Due to the nature of the Promise continuations I've had to add thread locking to the engine execution, as otherwise it'd be possible for multiple threads to execute code concurrently within the same engine.

I've added a fairly comprehensive set of tests which covers all the specs as far as I can tell.

This opens the door for async/await keywords to be supported (as they essentially use promises 'under the hood').  Is it possible for the Esprima library to be updated to support parsing of async/await keywords and methods?  If so I'm more than happy to add support for async/await in Jint too.