### PR TITLE
Updated esprima-dotnet reference

### DIFF
--- a/Jint.Tests/Parser/JavascriptParserTests.cs
+++ b/Jint.Tests/Parser/JavascriptParserTests.cs
@@ -172,5 +172,16 @@ namespace Jint.Tests.Parser
         {
             Assert.Throws<JavaScriptException>(() => new Engine().Execute("~ (WE0=1)--- l('1');"));
         }
+
+
+        [Theory]
+        [InlineData("....")]
+        [InlineData("while")]
+        [InlineData("var")]
+        [InlineData("-.-")]
+        public void ShouldThrowParserExceptionForInvalidCode(string code)
+        {
+            Assert.Throws<ParserException>(() => new JavaScriptParser(code).ParseProgram());
+        }
     }
 }

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -7,6 +7,6 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Esprima" Version="1.0.0-beta-1186" />
+    <PackageReference Include="Esprima" Version="1.0.0-beta-1202" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Jint had reference to esprima 1.0.0-beta-1186 which was causing IndexOutOfRangeException exception while parsing invalid code:
`new JavaScriptParser("....").ParseProgram();`

After updating reference to  1.0.0-beta-1202, it now throws ParserException which is expected.
I've also added tests for this case.

> System.IndexOutOfRangeException: Index was outside the bounds of the array.
>    at Esprima.Scanner.ScanPunctuator() in C:\projects\esprima-dotnet\src\Esprima\Scanner.cs:line 696
>    at Esprima.Scanner.Lex() in C:\projects\esprima-dotnet\src\Esprima\Scanner.cs:line 1699
>    at Esprima.JavaScriptParser.NextToken() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 259
>    at Esprima.JavaScriptParser.ParsePrimaryExpression() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 618
>    at Esprima.JavaScriptParser.InheritCoverGrammar[T](Func`1 parseFunction) in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 497
>    at Esprima.JavaScriptParser.ParseLeftHandSideExpressionAllowCall() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 1351
>    at Esprima.JavaScriptParser.InheritCoverGrammar[T](Func`1 parseFunction) in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 497
>    at Esprima.JavaScriptParser.ParseUpdateExpression() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 1486
>    at Esprima.JavaScriptParser.ParseUnaryExpression() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 1535
>    at Esprima.JavaScriptParser.InheritCoverGrammar[T](Func`1 parseFunction) in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 497
>    at Esprima.JavaScriptParser.ParseExponentiationExpression() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 1545
>    at Esprima.JavaScriptParser.InheritCoverGrammar[T](Func`1 parseFunction) in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 497
>    at Esprima.JavaScriptParser.ParseBinaryExpression() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 1655
>    at Esprima.JavaScriptParser.InheritCoverGrammar[T](Func`1 parseFunction) in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 497
>    at Esprima.JavaScriptParser.ParseConditionalExpression() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 1722
>    at Esprima.JavaScriptParser.ParseAssignmentExpression() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 1862
>    at Esprima.JavaScriptParser.IsolateCoverGrammar[T](Func`1 parseFunction) in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 474
>    at Esprima.JavaScriptParser.ParseExpression() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 1955
>    at Esprima.JavaScriptParser.ParseExpressionStatement() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 2415
>    at Esprima.JavaScriptParser.ParseStatement() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 3011
>    at Esprima.JavaScriptParser.ParseStatementListItem() in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 2025
>    at Esprima.JavaScriptParser.ParseProgram(Boolean strict) in C:\projects\esprima-dotnet\src\Esprima\JavascriptParser.cs:line 162