### PR TITLE
Separate InternalTypes to allow integer operation optimizations

### DIFF
--- a/Jint.Tests.CommonScripts/SunSpiderTests.cs
+++ b/Jint.Tests.CommonScripts/SunSpiderTests.cs
@@ -30,7 +30,7 @@ namespace Jint.Tests.CommonScripts
         [Theory(DisplayName = "Sunspider")]
         [InlineData("3d-cube", "3d-cube.js")]
         [InlineData("3d-morph", "3d-morph.js")]
-        // TODO Esprima problem [InlineData("3d-raytrace", "3d-raytrace.js")]
+        [InlineData("3d-raytrace", "3d-raytrace.js")]
         [InlineData("access-binary-trees", "access-binary-trees.js")]
         [InlineData("access-fannkuch", "access-fannkuch.js")]
         [InlineData("access-nbody", "access-nbody.js")]

--- a/Jint.Tests.CommonScripts/SunSpiderTests.cs
+++ b/Jint.Tests.CommonScripts/SunSpiderTests.cs
@@ -30,7 +30,7 @@ namespace Jint.Tests.CommonScripts
         [Theory(DisplayName = "Sunspider")]
         [InlineData("3d-cube", "3d-cube.js")]
         [InlineData("3d-morph", "3d-morph.js")]
-        [InlineData("3d-raytrace", "3d-raytrace.js")]
+        // TODO Esprima problem [InlineData("3d-raytrace", "3d-raytrace.js")]
         [InlineData("access-binary-trees", "access-binary-trees.js")]
         [InlineData("access-fannkuch", "access-fannkuch.js")]
         [InlineData("access-nbody", "access-nbody.js")]
@@ -56,15 +56,8 @@ namespace Jint.Tests.CommonScripts
         [InlineData("string-validate-input", "string-validate-input.js")]
         public void RunScript(string name, string url)
         {
-            try
-            {
-                var content = GetEmbeddedFile(url);
-                RunTest(content);
-            }
-            catch
-            {
-                System.Diagnostics.Debug.WriteLine("Can't run {0}", name);
-            }
+            var content = GetEmbeddedFile(url);
+            RunTest(content);
         }
 
         private string GetEmbeddedFile(string filename)

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -496,7 +496,7 @@ namespace Jint
 
         internal JsValue GetValue(Reference reference, bool returnReferenceToPool)
         {
-            if (reference._baseValue._type == Types.Undefined)
+            if (reference._baseValue._type == InternalTypes.Undefined)
             {
                 if (_referenceResolver != null &&
                     _referenceResolver.TryUnresolvableReference(this, reference, out JsValue val))
@@ -523,7 +523,7 @@ namespace Jint
                     _referencePool.Return(reference);
                 }
 
-                if (reference._baseValue._type == Types.Object)
+                if (reference._baseValue._type == InternalTypes.Object)
                 {
                     var o = TypeConverter.ToObject(this, baseValue);
                     var v = o.Get(referencedName);
@@ -575,7 +575,7 @@ namespace Jint
         public void PutValue(Reference reference, JsValue value)
         {
             ref readonly var referencedName = ref reference.GetReferencedName();
-            if (reference._baseValue._type == Types.Undefined)
+            if (reference._baseValue._type == InternalTypes.Undefined)
             {
                 if (reference._strict)
                 {
@@ -587,7 +587,7 @@ namespace Jint
             else if (reference.IsPropertyReference())
             {
                 var baseValue = reference._baseValue;
-                if (reference._baseValue._type == Types.Object || reference._baseValue._type == Types.None)
+                if (reference._baseValue._type == InternalTypes.Object || reference._baseValue._type == InternalTypes.None)
                 {
                     ((ObjectInstance) baseValue).Put(referencedName, value, reference._strict);
                 }

--- a/Jint/Extensions/JavascriptExtensions.cs
+++ b/Jint/Extensions/JavascriptExtensions.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace Jint.Extensions
 {
     internal static class JavascriptExtensions

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -7,6 +7,6 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Esprima" Version="1.0.1246" />
+    <PackageReference Include="Esprima" Version="1.0.1251" />
   </ItemGroup>
 </Project>

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -9,9 +9,9 @@ namespace Jint
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool AsBoolean(this JsValue value)
         {
-            if (value._type != Types.Boolean)
+            if (value._type != InternalTypes.Boolean)
             {
-                ExceptionHelper.ThrowArgumentException($"Expected boolean but got {value._type}");
+                ThrowWrongTypeException(value, "boolean");
             }
 
             return ((JsBoolean) value)._value;
@@ -20,20 +20,26 @@ namespace Jint
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double AsNumber(this JsValue value)
         {
-            if (value._type != Types.Number)
+            if (!value.IsNumber())
             {
-                ExceptionHelper.ThrowArgumentException($"Expected number but got {value._type}");
+                ThrowWrongTypeException(value, "number");
             }
 
             return ((JsNumber) value)._value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int AsInteger(this JsValue value)
+        {
+            return (int) ((JsNumber) value)._value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string AsString(this JsValue value)
         {
-            if (value._type != Types.String)
+            if (value._type != InternalTypes.String)
             {
-                ExceptionHelper.ThrowArgumentException($"Expected string but got {value._type}");
+                ThrowWrongTypeException(value, "string");
             }
 
             return AsStringWithoutTypeCheck(value);
@@ -48,12 +54,17 @@ namespace Jint
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string AsSymbol(this JsValue value)
         {
-            if (value._type != Types.Symbol)
+            if (value._type != InternalTypes.Symbol)
             {
-                ExceptionHelper.ThrowArgumentException($"Expected symbol but got {value._type}");
+                ThrowWrongTypeException(value, "symbol");
             }
 
             return ((JsSymbol) value)._value;
+        }
+
+        private static void ThrowWrongTypeException(JsValue value, string expectedType)
+        {
+            ExceptionHelper.ThrowArgumentException($"Expected {expectedType} but got {value._type}");
         }
     }
 }

--- a/Jint/Key.cs
+++ b/Jint/Key.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Jint.Runtime;
 
 namespace Jint
@@ -11,6 +12,17 @@ namespace Jint
     [DebuggerDisplay("{" + nameof(Name) + "}")]
     public readonly struct Key : IEquatable<Key>
     {
+        // lookup for indexer keys
+        internal static readonly Key[] indexKeys = new Key[TypeConverter.intToString.Length];
+
+        static Key()
+        {
+            for (uint i = 0; i < indexKeys.Length; ++i)
+            {
+                indexKeys[i] = new Key(TypeConverter.ToString(i));
+            }
+        }
+
         public Key(string name)
         {
             if (name == null)
@@ -27,6 +39,24 @@ namespace Jint
         public static implicit operator Key(string name)
         {
             return new Key(name);
+        }
+
+        public static implicit operator Key(int value)
+        {
+            var keys = indexKeys;
+            return (uint) value < keys.Length ? keys[value] : BuildKey(value);
+        }
+
+        public static implicit operator Key(uint value)
+        {
+            var keys = indexKeys;
+            return value < keys.Length ? keys[value] : BuildKey(value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Key BuildKey(long value)
+        {
+            return new Key(value.ToString());
         }
 
         public static implicit operator string(Key key) => key.Name;

--- a/Jint/Native/Argument/ArgumentsInstance.cs
+++ b/Jint/Native/Argument/ArgumentsInstance.cs
@@ -55,13 +55,20 @@ namespace Jint.Native.Argument
             ObjectInstance map = null;
             if (args.Length > 0)
             {
-                var mappedNamed = _mappedNamed.Value;
-                mappedNamed.Clear();
+                HashSet<string> mappedNamed = null;
+                if (!_strict)
+                {
+                    mappedNamed = _mappedNamed.Value;
+                    mappedNamed.Clear();
+                }
                 for (var i = 0; i < (uint) args.Length; i++)
                 {
-                    var indxStr = (Key) TypeConverter.ToString(i);
+                    var indexKey = i < Key.indexKeys.Length
+                        ? Key.indexKeys[i]
+                        : (Key) TypeConverter.ToString(i);
+
                     var val = args[i];
-                    SetOwnProperty(indxStr, new PropertyDescriptor(val, PropertyFlag.ConfigurableEnumerableWritable));
+                    SetOwnProperty(indexKey, new PropertyDescriptor(val, PropertyFlag.ConfigurableEnumerableWritable));
                     if (i < _names.Length)
                     {
                         var name = _names[i];
@@ -69,7 +76,7 @@ namespace Jint.Native.Argument
                         {
                             map = map ?? Engine.Object.Construct(Arguments.Empty);
                             mappedNamed.Add(name);
-                            map.SetOwnProperty(indxStr, new ClrAccessDescriptor(_env, Engine, name));
+                            map.SetOwnProperty(indexKey, new ClrAccessDescriptor(_env, Engine, name));
                         }
                     }
                 }

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -220,7 +220,7 @@ namespace Jint.Native.Array
         {
             // check if we can figure out good size
             var capacity = arguments.Length > 0 ? (uint) arguments.Length : 0;
-            if (arguments.Length == 1 && arguments[0].Type == Types.Number)
+            if (arguments.Length == 1 && arguments[0].IsNumber())
             {
                 var number = ((JsNumber) arguments[0])._value;
                 if (number > 0)

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -384,7 +384,7 @@ namespace Jint.Native.Array
             var prop = GetOwnProperty(index);
             if (prop == PropertyDescriptor.Undefined)
             {
-                prop = Prototype?.GetProperty(TypeConverter.ToString(index)) ?? PropertyDescriptor.Undefined;
+                prop = Prototype?.GetProperty(index) ?? PropertyDescriptor.Undefined;
             }
 
             return UnwrapJsValue(prop);
@@ -398,7 +398,7 @@ namespace Jint.Native.Array
             {
                 return prop;
             }
-            return Prototype?.GetProperty(TypeConverter.ToString(index)) ?? PropertyDescriptor.Undefined;
+            return Prototype?.GetProperty(index) ?? PropertyDescriptor.Undefined;
         }
 
         protected internal override void SetOwnProperty(in Key propertyName, PropertyDescriptor desc)
@@ -561,7 +561,7 @@ namespace Jint.Native.Array
             value = Undefined;
 
             TryGetDescriptor(index, out var desc);
-            desc = desc ?? GetProperty(TypeConverter.ToString(index)) ?? PropertyDescriptor.Undefined;
+            desc = desc ?? GetProperty(index) ?? PropertyDescriptor.Undefined;
             return desc.TryGetValue(this, out value);
         }
 
@@ -734,7 +734,7 @@ namespace Jint.Native.Array
             }
             else
             {
-                DefineOwnProperty(TypeConverter.ToString((uint) n), desc, true);
+                DefineOwnProperty((uint) n, desc, true);
             }
         }
 

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1464,7 +1464,7 @@ namespace Jint.Native.Array
                         var prop = _array._dense[i] ?? PropertyDescriptor.Undefined;
                         if (prop == PropertyDescriptor.Undefined)
                         {
-                            prop = _array.Prototype?.GetProperty(TypeConverter.ToString(i)) ?? PropertyDescriptor.Undefined;
+                            prop = _array.Prototype?.GetProperty(i) ?? PropertyDescriptor.Undefined;
                         }
 
                         jsValues[i] = _array.UnwrapJsValue(prop);

--- a/Jint/Native/Boolean/BooleanPrototype.cs
+++ b/Jint/Native/Boolean/BooleanPrototype.cs
@@ -41,7 +41,7 @@ namespace Jint.Native.Boolean
 
         private JsValue ValueOf(JsValue thisObj, JsValue[] arguments)
         {
-            if (thisObj._type == Types.Boolean)
+            if (thisObj._type == InternalTypes.Boolean)
             {
                 return thisObj;
             }

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -678,13 +678,8 @@ namespace Jint.Native.Date
         /// <summary>
         /// The year of a time value.
         /// </summary>
-        public static double YearFromTime(double t)
+        public static int YearFromTime(double t)
         {
-            if (!AreFinite(t))
-            {
-                return double.NaN;
-            }
-
             var sign = (t < 0) ? -1 : 1;
             var year = (sign < 0) ? 1969 : 1970;
             for (var timeToTimeZero = (long) t; ;)
@@ -818,7 +813,7 @@ namespace Jint.Native.Date
             return Day(t) - DayFromYear(YearFromTime(t));
         }
 
-        public static double DateFromTime(double t)
+        public static int DateFromTime(double t)
         {
             var monthFromTime = MonthFromTime(t);
             var dayWithinYear = DayWithinYear(t);

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -73,11 +73,11 @@ namespace Jint.Native.Function
                 {
                     thisBinding = thisArg;
                 }
-                else if (thisArg._type == Types.Undefined || thisArg._type == Types.Null)
+                else if (thisArg._type == InternalTypes.Undefined || thisArg._type == InternalTypes.Null)
                 {
                     thisBinding = _engine.Global;
                 }
-                else if (thisArg._type != Types.Object)
+                else if (thisArg._type != InternalTypes.Object)
                 {
                     thisBinding = TypeConverter.ToObject(_engine, thisArg);
                 }

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -11,6 +11,8 @@ namespace Jint.Native.Function
     public sealed class ScriptFunctionInstance : FunctionInstance, IConstructor
     {
         internal readonly JintFunctionDefinition _function;
+        private LexicalEnvironment _localEnv;
+
 
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-13.2
@@ -86,7 +88,9 @@ namespace Jint.Native.Function
                     thisBinding = thisArg;
                 }
 
-                var localEnv = LexicalEnvironment.NewDeclarativeEnvironment(_engine, _scope);
+                var localEnv = _localEnv ?? LexicalEnvironment.NewDeclarativeEnvironment(_engine, _scope);
+                localEnv.Reset(_scope);
+                _localEnv = null;
 
                 _engine.EnterExecutionContext(localEnv, localEnv, thisBinding);
 
@@ -121,6 +125,7 @@ namespace Jint.Native.Function
                 finally
                 {
                     _engine.LeaveExecutionContext();
+                    _localEnv = localEnv;
                 }
 
                 return Undefined;

--- a/Jint/Native/JsNumber.cs
+++ b/Jint/Native/JsNumber.cs
@@ -20,7 +20,6 @@ namespace Jint.Native
         // we can cache most common values, doubles are used in indexing too at times so we also cache
         // integer values converted to doubles
         private const int NumbersMax = 1024 * 10;
-        private static readonly JsNumber[] _doubleToJsValue = new JsNumber[NumbersMax];
         private static readonly JsNumber[] _intToJsValue = new JsNumber[NumbersMax];
 
         internal static readonly JsNumber DoubleNaN = new JsNumber(double.NaN);
@@ -38,7 +37,6 @@ namespace Jint.Native
             for (int i = 0; i < NumbersMax; i++)
             {
                 _intToJsValue[i] = new JsNumber(i);
-                _doubleToJsValue[i] = new JsNumber((double) i);
             }
         }
 
@@ -76,7 +74,7 @@ namespace Jint.Native
         internal static JsNumber Create(double value)
         {
             // we can cache positive double zero, but not negative, -0 == 0 in C# but in JS it's a different story
-            var temp = _doubleToJsValue;
+            var temp = _intToJsValue;
             if ((value == 0 && BitConverter.DoubleToInt64Bits(value) != NegativeZeroBits || value >= 1)
                 && value < temp.Length
                 && System.Math.Abs(value % 1) <= DoubleIsIntegerTolerance)

--- a/Jint/Native/JsNumber.cs
+++ b/Jint/Native/JsNumber.cs
@@ -62,6 +62,11 @@ namespace Jint.Native
             _value = value;
         }
 
+        public JsNumber(long value) : base(value < int.MaxValue && value > int.MinValue ? InternalTypes.Integer : InternalTypes.Number)
+        {
+            _value = value;
+        }
+
         public override object ToObject()
         {
             return _value;
@@ -143,6 +148,16 @@ namespace Jint.Native
         internal static JsNumber Create(ulong value)
         {
             if (value < (ulong) _intToJsValue.Length)
+            {
+                return _intToJsValue[value];
+            }
+
+            return new JsNumber(value);
+        }
+
+        internal static JsNumber Create(long value)
+        {
+            if ((ulong) value < (ulong) _intToJsValue.Length)
             {
                 return _intToJsValue[value];
             }

--- a/Jint/Native/JsNumber.cs
+++ b/Jint/Native/JsNumber.cs
@@ -15,7 +15,7 @@ namespace Jint.Native
         // how many decimals to check when determining if double is actually an int
         internal const double DoubleIsIntegerTolerance = double.Epsilon * 100;
 
-        private static readonly long NegativeZeroBits = BitConverter.DoubleToInt64Bits(-0.0);
+        internal static readonly long NegativeZeroBits = BitConverter.DoubleToInt64Bits(-0.0);
 
         // we can cache most common values, doubles are used in indexing too at times so we also cache
         // integer values converted to doubles
@@ -47,12 +47,17 @@ namespace Jint.Native
             _value = value;
         }
 
-        public JsNumber(int value) : base(Types.Number)
+        public JsNumber(int value) : base(InternalTypes.Integer)
         {
             _value = value;
         }
 
-        public JsNumber(uint value) : base(Types.Number)
+        public JsNumber(uint value) : base(value < int.MaxValue ? InternalTypes.Integer : InternalTypes.Number)
+        {
+            _value = value;
+        }
+
+        public JsNumber(ulong value) : base(value < int.MaxValue ? InternalTypes.Integer : InternalTypes.Number)
         {
             _value = value;
         }

--- a/Jint/Native/JsNumber.cs
+++ b/Jint/Native/JsNumber.cs
@@ -73,10 +73,9 @@ namespace Jint.Native
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static JsNumber Create(double value)
         {
-            // we can cache positive double zero, but not negative, -0 == 0 in C# but in JS it's a different story
+            // we expect zero to be on the fast path of integer mostly
             var temp = _intToJsValue;
-            if ((value == 0 && BitConverter.DoubleToInt64Bits(value) != NegativeZeroBits || value >= 1)
-                && value < temp.Length
+            if (value >= 1 && value < temp.Length
                 && System.Math.Abs(value % 1) <= DoubleIsIntegerTolerance)
             {
                 return temp[(uint) value];

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -494,6 +494,11 @@ namespace Jint.Native
             return JsNumber.Create(value);
         }
 
+        public static implicit operator JsValue(long value)
+        {
+            return JsNumber.Create(value);
+        }
+
         public static implicit operator JsValue(ulong value)
         {
             return JsNumber.Create(value);

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -21,9 +21,14 @@ namespace Jint.Native
     {
         public static readonly JsValue Undefined = new JsUndefined();
         public static readonly JsValue Null = new JsNull();
-        internal readonly Types _type;
+        internal readonly InternalTypes _type;
 
         protected JsValue(Types type)
+        {
+            _type = (InternalTypes) type;
+        }
+
+        internal JsValue(InternalTypes type)
         {
             _type = type;
         }
@@ -32,21 +37,21 @@ namespace Jint.Native
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsPrimitive()
         {
-            return _type != Types.Object && _type != Types.None;
+            return _type != InternalTypes.Object && _type != InternalTypes.None;
         }
 
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsUndefined()
         {
-            return _type == Types.Undefined;
+            return _type == InternalTypes.Undefined;
         }
 
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool IsNullOrUndefined()
         {
-            return _type < Types.Boolean;
+            return _type < InternalTypes.Boolean;
         }
 
         [Pure]
@@ -74,49 +79,56 @@ namespace Jint.Native
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsObject()
         {
-            return _type == Types.Object;
+            return _type == InternalTypes.Object;
         }
 
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsString()
         {
-            return _type == Types.String;
+            return _type == InternalTypes.String;
         }
 
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsNumber()
         {
-            return _type == Types.Number;
+            return _type == InternalTypes.Number || _type == InternalTypes.Integer;
+        }
+
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool IsInteger()
+        {
+            return _type == InternalTypes.Integer;
         }
 
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsBoolean()
         {
-            return _type == Types.Boolean;
+            return _type == InternalTypes.Boolean;
         }
 
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsNull()
         {
-            return _type == Types.Null;
+            return _type == InternalTypes.Null;
         }
 
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsCompletion()
         {
-            return _type == Types.Completion;
+            return _type == InternalTypes.Completion;
         }
 
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsSymbol()
         {
-            return _type == Types.Symbol;
+            return _type == InternalTypes.Symbol;
         }
 
         [Pure]
@@ -163,7 +175,7 @@ namespace Jint.Native
 
             return iterator;
         }
-        
+
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool TryGetIterator(Engine engine, out IIterator iterator)
@@ -216,7 +228,7 @@ namespace Jint.Native
         [Pure]
         public Completion AsCompletion()
         {
-            if (_type != Types.Completion)
+            if (_type != InternalTypes.Completion)
             {
                 ExceptionHelper.ThrowArgumentException("The value is not a completion record");
             }
@@ -264,11 +276,10 @@ namespace Jint.Native
             return null;
         }
 
-        // ReSharper disable once ConvertToAutoPropertyWhenPossible // PERF
         public Types Type
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get { return _type; }
+            get => _type == InternalTypes.Integer ? Types.Number : (Types) _type;
         }
 
         /// <summary>
@@ -463,22 +474,27 @@ namespace Jint.Native
             return !a.Equals(b);
         }
 
-        static public implicit operator JsValue(char value)
+        public static implicit operator JsValue(char value)
         {
             return JsString.Create(value);
         }
 
-        static public implicit operator JsValue(int value)
+        public static implicit operator JsValue(int value)
         {
             return JsNumber.Create(value);
         }
 
-        static public implicit operator JsValue(uint value)
+        public static implicit operator JsValue(uint value)
         {
             return JsNumber.Create(value);
         }
 
-        static public implicit operator JsValue(double value)
+        public static implicit operator JsValue(double value)
+        {
+            return JsNumber.Create(value);
+        }
+
+        public static implicit operator JsValue(ulong value)
         {
             return JsNumber.Create(value);
         }
@@ -494,7 +510,7 @@ namespace Jint.Native
             {
                 return Null;
             }
-                
+
             return JsString.Create(value);
         }
 

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -848,7 +848,7 @@ namespace Jint.Native.String
             {
                 return JsNumber.DoubleNaN;
             }
-            return (double) s[position];
+            return (long) s[position];
         }
 
         private JsValue CodePointAt(JsValue thisObj, JsValue[] arguments)
@@ -863,10 +863,10 @@ namespace Jint.Native.String
                 return Undefined;
             }
 
-            var first = (double) s[position];
+            var first = (long) s[position];
             if (first >= 0xD800 && first <= 0xDBFF && s.Length > position + 1)
             {
-                double second = s[position + 1];
+                long second = s[position + 1];
                 if (second >= 0xDC00 && second <= 0xDFFF)
                 {
                     return (first - 0xD800) * 0x400 + second - 0xDC00 + 0x10000;
@@ -886,7 +886,6 @@ namespace Jint.Native.String
                 return "";
             }
             return TypeConverter.ToString(s[(int) position]);
-
         }
 
         private JsValue ValueOf(JsValue thisObj, JsValue[] arguments)

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -218,6 +218,14 @@ namespace Jint.Native.String
 
         private static int ToIntegerSupportInfinity(JsValue numberVal)
         {
+            return numberVal._type == InternalTypes.Integer
+                ? numberVal.AsInteger()
+                : ToIntegerSupportInfinityUnlikely(numberVal);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int ToIntegerSupportInfinityUnlikely(JsValue numberVal)
+        {
             var doubleVal = TypeConverter.ToInteger(numberVal);
             int intVal;
             if (double.IsPositiveInfinity(doubleVal))

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -31,6 +31,16 @@ namespace Jint.Runtime.Environments
         {
         }
 
+        internal void Reset()
+        {
+            _dictionary?.Clear();
+            _set = false;
+            _key = default;
+            _value = default;
+            _argumentsBinding = default;
+            _argumentsBindingWasAccessed = false;
+        }
+
         private void SetItem(in Key key, in Binding value)
         {
             if (_set && _key != key)

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -185,7 +185,7 @@ namespace Jint.Runtime.Environments
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private JsValue UnwrapBindingValue(bool strict, in Binding binding)
         {
-            if (!binding.Mutable && binding.Value._type == Types.Undefined)
+            if (!binding.Mutable && binding.Value._type == InternalTypes.Undefined)
             {
                 if (strict)
                 {

--- a/Jint/Runtime/Environments/LexicalEnvironment.cs
+++ b/Jint/Runtime/Environments/LexicalEnvironment.cs
@@ -13,8 +13,8 @@ namespace Jint.Runtime.Environments
     public sealed class LexicalEnvironment
     {
         private readonly Engine _engine;
-        internal readonly EnvironmentRecord _record;
-        internal readonly LexicalEnvironment _outer;
+        internal EnvironmentRecord _record;
+        internal LexicalEnvironment _outer;
 
         public LexicalEnvironment(Engine engine, EnvironmentRecord record, LexicalEnvironment outer)
         {
@@ -69,7 +69,16 @@ namespace Jint.Runtime.Environments
 
         public static LexicalEnvironment NewDeclarativeEnvironment(Engine engine, LexicalEnvironment outer = null)
         {
-            return new LexicalEnvironment(engine, new DeclarativeEnvironmentRecord(engine), outer);
+            var environment = new LexicalEnvironment(engine, null, null);
+            environment.Reset(outer);
+            return environment;
+        }
+
+        internal void Reset(LexicalEnvironment outer)
+        {
+            _record = _record ?? new DeclarativeEnvironmentRecord(_engine);
+            ((DeclarativeEnvironmentRecord) _record).Reset();
+            _outer = outer;
         }
 
         public static LexicalEnvironment NewObjectEnvironment(Engine engine, ObjectInstance objectInstance, LexicalEnvironment outer, bool provideThis)

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -44,12 +44,10 @@ namespace Jint.Runtime.Interpreter.Expressions
             var rval = _right.GetValue();
             var lval = _engine.GetValue(lref, false);
 
-            var isIntegerOperation = AreIntegerOperands(lval, rval);
-
             switch (_operator)
             {
                 case AssignmentOperator.PlusAssign:
-                    if (isIntegerOperation)
+                    if (AreIntegerOperands(lval, rval))
                     {
                         lval = lval.AsInteger() + rval.AsInteger();
                     }
@@ -76,13 +74,13 @@ namespace Jint.Runtime.Interpreter.Expressions
                     break;
 
                 case AssignmentOperator.MinusAssign:
-                    lval = isIntegerOperation
+                    lval = AreIntegerOperands(lval, rval)
                         ? JsNumber.Create(lval.AsInteger() - rval.AsInteger())
                         : JsNumber.Create(TypeConverter.ToNumber(lval) - TypeConverter.ToNumber(rval));
                     break;
 
                 case AssignmentOperator.TimesAssign:
-                    if (isIntegerOperation)
+                    if (AreIntegerOperands(lval, rval))
                     {
                         lval = (long) lval.AsInteger() * rval.AsInteger();
                     }

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -98,7 +98,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     break;
 
                 case AssignmentOperator.DivideAssign:
-                    lval = Divide(lval, rval, false);
+                    lval = Divide(lval, rval);
                     break;
 
                 case AssignmentOperator.ModuloAssign:

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -10,11 +10,13 @@ namespace Jint.Runtime.Interpreter.Expressions
     {
         private readonly JintExpression _left;
         private readonly JintExpression _right;
+        private readonly AssignmentOperator _operator;
 
         private JintAssignmentExpression(Engine engine, AssignmentExpression expression) : base(engine, expression)
         {
             _left = Build(engine, (Expression) expression.Left);
             _right = Build(engine, expression.Right);
+            _operator = expression.Operator;
         }
 
         internal static JintExpression Build(Engine engine, AssignmentExpression expression)
@@ -42,10 +44,9 @@ namespace Jint.Runtime.Interpreter.Expressions
             var rval = _right.GetValue();
             var lval = _engine.GetValue(lref, false);
 
-            var isIntegerOperation = rval.IsInteger() && lval.IsInteger();
+            var isIntegerOperation = AreIntegerOperands(lval, rval);
 
-            var expression = (AssignmentExpression) _expression;
-            switch (expression.Operator)
+            switch (_operator)
             {
                 case AssignmentOperator.PlusAssign:
                     if (isIntegerOperation)

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -49,7 +49,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 case AssignmentOperator.PlusAssign:
                     if (AreIntegerOperands(lval, rval))
                     {
-                        lval = lval.AsInteger() + rval.AsInteger();
+                        lval = (long) lval.AsInteger() + rval.AsInteger();
                     }
                     else
                     {

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -56,33 +56,47 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         public static bool StrictlyEqual(JsValue x, JsValue y)
         {
-            var typeX = x.Type;
-            var typeY = y.Type;
+            var typeX = x._type;
+            var typeY = y._type;
 
             if (typeX != typeY)
             {
-                return false;
+                if (typeX == InternalTypes.Integer)
+                {
+                    typeX = InternalTypes.Number;
+                }
+                if (typeY == InternalTypes.Integer)
+                {
+                    typeY = InternalTypes.Number;
+                }
+
+                if (typeX != typeY)
+                {
+                    return false;
+                }
             }
 
             switch (typeX)
             {
-                case Types.Undefined:
-                case Types.Null:
+                case InternalTypes.Undefined:
+                case InternalTypes.Null:
                     return true;
-                case Types.Number:
+                case InternalTypes.Integer:
+                    return x.AsInteger() == y.AsInteger();
+                case InternalTypes.Number:
                     var nx = ((JsNumber) x)._value;
                     var ny = ((JsNumber) y)._value;
                     return !double.IsNaN(nx) && !double.IsNaN(ny) && nx == ny;
-                case Types.String:
+                case InternalTypes.String:
                     return x.AsStringWithoutTypeCheck() == y.AsStringWithoutTypeCheck();
-                case Types.Boolean:
+                case InternalTypes.Boolean:
                     return ((JsBoolean) x)._value == ((JsBoolean) y)._value;
-                case Types.Object when x.AsObject() is IObjectWrapper xw:
+                case InternalTypes.Object when x.AsObject() is IObjectWrapper xw:
                     var yw = y.AsObject() as IObjectWrapper;
                     if (yw == null)
                         return false;
                     return Equals(xw.Target, yw.Target);
-                case Types.None:
+                case InternalTypes.None:
                     return true;
                 default:
                     return x == y;
@@ -91,15 +105,20 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         private sealed class JintGenericBinaryExpression : JintBinaryExpression
         {
-            private readonly Func<JsValue, JsValue, JsValue> _operator;
+            private readonly Func<JsValue, JsValue, bool, JsValue> _operator;
 
             public JintGenericBinaryExpression(Engine engine, BinaryExpression expression) : base(engine, expression)
             {
                 switch (_operatorType)
                 {
                     case BinaryOperator.Plus:
-                        _operator = (left, right) =>
+                        _operator = (left, right, integerOperation) =>
                         {
+                            if (integerOperation)
+                            {
+                                return JsNumber.Create(left.AsInteger() + right.AsInteger());
+                            }
+
                             var lprim = TypeConverter.ToPrimitive(left);
                             var rprim = TypeConverter.ToPrimitive(right);
                             return lprim.IsString() || rprim.IsString()
@@ -109,13 +128,27 @@ namespace Jint.Runtime.Interpreter.Expressions
                         break;
 
                     case BinaryOperator.Minus:
-                        _operator = (left, right) => JsNumber.Create(TypeConverter.ToNumber(left) - TypeConverter.ToNumber(right));
+                        _operator = (left, right, integerOperation) =>
+                            integerOperation
+                                ? JsNumber.Create(left.AsInteger() - right.AsInteger())
+                                : JsNumber.Create(TypeConverter.ToNumber(left) - TypeConverter.ToNumber(right));
                         break;
 
                     case BinaryOperator.Times:
-                        _operator = (left, right) => left.IsUndefined() || right.IsUndefined()
-                            ? Undefined.Instance
-                            : JsNumber.Create(TypeConverter.ToNumber(left) * TypeConverter.ToNumber(right));
+                        _operator = (left, right, integerOperation) =>
+                        {
+                            if (integerOperation)
+                            {
+                                return JsNumber.Create((long) left.AsInteger() * right.AsInteger());
+                            }
+
+                            if (left.IsUndefined() || right.IsUndefined())
+                            {
+                                return Undefined.Instance;
+                            }
+
+                            return JsNumber.Create(TypeConverter.ToNumber(left) * TypeConverter.ToNumber(right));
+                        };
                         break;
 
                     case BinaryOperator.Divide:
@@ -123,88 +156,91 @@ namespace Jint.Runtime.Interpreter.Expressions
                         break;
 
                     case BinaryOperator.Modulo:
-                        _operator = (left, right) => left.IsUndefined() || right.IsUndefined()
-                            ? Undefined.Instance
-                            : TypeConverter.ToNumber(left) % TypeConverter.ToNumber(right);
+                        _operator = (left, right, integerOperation) =>
+                        {
+                            if (integerOperation)
+                            {
+                                var asInteger = left.AsInteger();
+                                if (asInteger > 0)
+                                {
+                                    return asInteger % right.AsInteger();
+                                }
+                            }
+
+                            if (left.IsUndefined() || right.IsUndefined())
+                            {
+                                return Undefined.Instance;
+                            }
+
+                            return TypeConverter.ToNumber(left) % TypeConverter.ToNumber(right);
+                        };
 
                         break;
 
                     case BinaryOperator.Equal:
-                        _operator = (left, right) => Equal(left, right)
+                        _operator = (left, right, integerOperation) => Equal(left, right)
                             ? JsBoolean.True
                             : JsBoolean.False;
                         break;
 
                     case BinaryOperator.NotEqual:
-                        _operator = (left, right) => Equal(left, right) ? JsBoolean.False : JsBoolean.True;
+                        _operator = (left, right, integerOperation) => Equal(left, right)
+                            ? JsBoolean.False
+                            : JsBoolean.True;
                         break;
 
                     case BinaryOperator.GreaterOrEqual:
-                        _operator = (left, right) =>
+                        _operator = (left, right, integerOperation) =>
                         {
                             var value = Compare(left, right);
-                            if (value.IsUndefined() || ((JsBoolean) value)._value)
-                            {
-                                value = JsBoolean.False;
-                            }
-                            else
-                            {
-                                value = JsBoolean.True;
-                            }
-
-                            return value;
+                            return value.IsUndefined() || ((JsBoolean) value)._value
+                                ? JsBoolean.False
+                                : JsBoolean.True;
                         };
 
                         break;
 
                     case BinaryOperator.LessOrEqual:
-                        _operator = (left, right) =>
+                        _operator = (left, right, integerOperation) =>
                         {
                             var value = Compare(right, left, false);
-                            if (value.IsUndefined() || ((JsBoolean) value)._value)
-                            {
-                                value = JsBoolean.False;
-                            }
-                            else
-                            {
-                                value = JsBoolean.True;
-                            }
-
-                            return value;
+                            return value.IsUndefined() || ((JsBoolean) value)._value
+                                ? JsBoolean.False
+                                : JsBoolean.True;
                         };
 
                         break;
 
                     case BinaryOperator.BitwiseAnd:
-                        _operator = (left, right) => JsNumber.Create(TypeConverter.ToInt32(left) & TypeConverter.ToInt32(right));
+                        _operator = (left, right, _) => JsNumber.Create(TypeConverter.ToInt32(left) & TypeConverter.ToInt32(right));
                         break;
 
                     case BinaryOperator.BitwiseOr:
-                        _operator = (left, right) => JsNumber.Create(TypeConverter.ToInt32(left) | TypeConverter.ToInt32(right));
+                        _operator = (left, right, _) => JsNumber.Create(TypeConverter.ToInt32(left) | TypeConverter.ToInt32(right));
                         break;
 
                     case BinaryOperator.BitwiseXOr:
-                        _operator = (left, right) => JsNumber.Create(TypeConverter.ToInt32(left) ^ TypeConverter.ToInt32(right));
+                        _operator = (left, right, _) => JsNumber.Create(TypeConverter.ToInt32(left) ^ TypeConverter.ToInt32(right));
                         break;
 
                     case BinaryOperator.LeftShift:
-                        _operator = (left, right) => JsNumber.Create(TypeConverter.ToInt32(left) << (int) (TypeConverter.ToUint32(right) & 0x1F));
+                        _operator = (left, right, _) => JsNumber.Create(TypeConverter.ToInt32(left) << (int) (TypeConverter.ToUint32(right) & 0x1F));
                         break;
 
                     case BinaryOperator.RightShift:
-                        _operator = (left, right) => JsNumber.Create(TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(right) & 0x1F));
+                        _operator = (left, right, _) => JsNumber.Create(TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(right) & 0x1F));
                         break;
 
                     case BinaryOperator.UnsignedRightShift:
-                        _operator = (left, right) => JsNumber.Create((uint) TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(right) & 0x1F));
+                        _operator = (left, right, _) => JsNumber.Create((uint) TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(right) & 0x1F));
                         break;
 
                     case BinaryOperator.Exponentiation:
-                        _operator = (left, right) => JsNumber.Create(Math.Pow(TypeConverter.ToNumber(left), TypeConverter.ToNumber(right)));
+                        _operator = (left, right, _) => JsNumber.Create(Math.Pow(TypeConverter.ToNumber(left), TypeConverter.ToNumber(right)));
                         break;
 
                     case BinaryOperator.InstanceOf:
-                        _operator = (left, right) =>
+                        _operator = (left, right, _) =>
                         {
                             if (!(right is FunctionInstance f))
                             {
@@ -216,7 +252,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                         break;
 
                     case BinaryOperator.In:
-                        _operator = (left, right) =>
+                        _operator = (left, right, integerOperation) =>
                         {
                             if (!(right is ObjectInstance oi))
                             {
@@ -229,7 +265,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                         break;
 
                     default:
-                        _operator = ExceptionHelper.ThrowNotImplementedException<Func<JsValue, JsValue, JsValue>>();
+                        _operator = ExceptionHelper.ThrowNotImplementedException<Func<JsValue, JsValue, bool, JsValue>>();
                         break;
                 }
             }
@@ -238,7 +274,8 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
                 var left = _left.GetValue();
                 var right = _right.GetValue();
-                return _operator(left, right);
+                var isIntegerComparison = left._type == right._type && left._type == InternalTypes.Integer;
+                return _operator(left, right, isIntegerComparison);
             }
         }
 
@@ -252,7 +289,9 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
                 var left = _left.GetValue();
                 var right = _right.GetValue();
-                return StrictlyEqual(left, right) ? JsBoolean.True : JsBoolean.False;
+                return StrictlyEqual(left, right)
+                    ? JsBoolean.True
+                    : JsBoolean.False;
             }
         }
 
@@ -266,7 +305,9 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
                 var left = _left.GetValue();
                 var right = _right.GetValue();
-                return StrictlyEqual(left, right) ? JsBoolean.False : JsBoolean.True;
+                return StrictlyEqual(left, right)
+                    ? JsBoolean.False
+                    : JsBoolean.True;
             }
         }
 
@@ -281,12 +322,10 @@ namespace Jint.Runtime.Interpreter.Expressions
                 var left = _left.GetValue();
                 var right = _right.GetValue();
                 var value = Compare(left, right);
-                if (value._type == Types.Undefined)
-                {
-                    value = JsBoolean.False;
-                }
 
-                return value;
+                return value._type == InternalTypes.Undefined
+                    ? JsBoolean.False
+                    : value;
             }
         }
 
@@ -301,12 +340,10 @@ namespace Jint.Runtime.Interpreter.Expressions
                 var left = _left.GetValue();
                 var right = _right.GetValue();
                 var value = Compare(right, left, false);
-                if (value._type == Types.Undefined)
-                {
-                    value = JsBoolean.False;
-                }
 
-                return value;
+                return value._type == InternalTypes.Undefined
+                    ? JsBoolean.False
+                    : value;
             }
         }
     }

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -12,7 +12,6 @@ namespace Jint.Runtime.Interpreter.Expressions
         private readonly JintExpression _left;
         private readonly JintExpression _right;
         private readonly BinaryOperator _operatorType;
-        private JsValue _calculated;
 
         private JintBinaryExpression(Engine engine, BinaryExpression expression) : base(engine, expression)
         {
@@ -97,8 +96,8 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                 if (!(lval is null) && !(rval is null))
                 {
-                    // we can pre-calculate result
-                    result._calculated = result.GetValue();
+                    // we have fixed result
+                    return new JintConstantExpression(engine, expression, result.GetValue());
                 }
             }
 
@@ -111,7 +110,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             _engine._lastSyntaxNode = _expression;
 
             // we always create a JsValue
-            return _calculated ?? (JsValue) EvaluateInternal();
+            return (JsValue) EvaluateInternal();
         }
 
         public static bool StrictlyEqual(JsValue x, JsValue y)

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Function;
@@ -149,12 +148,6 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool HasIntegerOperands(JsValue left, JsValue right)
-        {
-            return left._type == right._type && left._type == InternalTypes.Integer;
-        }
-
         private sealed class StrictlyEqualBinaryExpression : JintBinaryExpression
         {
             public StrictlyEqualBinaryExpression(Engine engine, BinaryExpression expression) : base(engine, expression)
@@ -234,7 +227,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 var left = _left.GetValue();
                 var right = _right.GetValue();
                 
-                if (HasIntegerOperands(left, right))
+                if (AreIntegerOperands(left, right))
                 {
                     return JsNumber.Create(left.AsInteger() + right.AsInteger());
                 }
@@ -257,7 +250,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 var left = _left.GetValue();
                 var right = _right.GetValue();
                 
-                return HasIntegerOperands(left, right)
+                return AreIntegerOperands(left, right)
                     ? JsNumber.Create(left.AsInteger() - right.AsInteger())
                     : JsNumber.Create(TypeConverter.ToNumber(left) - TypeConverter.ToNumber(right));
             }
@@ -274,7 +267,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 var left = _left.GetValue();
                 var right = _right.GetValue();
                 
-                if (HasIntegerOperands(left, left))
+                if (AreIntegerOperands(left, left))
                 {
                     return JsNumber.Create((long) left.AsInteger() * right.AsInteger());
                 }
@@ -299,7 +292,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 var left = _left.GetValue();
                 var right = _right.GetValue();
 
-                return Divide(left, left, HasIntegerOperands(left, left));
+                return Divide(left, left, AreIntegerOperands(left, left));
             }
         }
 
@@ -408,7 +401,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 var left = _left.GetValue();
                 var right = _right.GetValue();
 
-                if (HasIntegerOperands(left, right))
+                if (AreIntegerOperands(left, right))
                 {
                     var leftInteger = left.AsInteger();
                     var rightInteger = right.AsInteger();

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -98,6 +98,14 @@ namespace Jint.Runtime.Interpreter.Expressions
             return result;
         }
 
+        public override JsValue GetValue()
+        {
+            // need to notify correct node when taking shortcut
+            _engine._lastSyntaxNode = _expression;
+
+            // we always create a JsValue
+            return (JsValue) EvaluateInternal();        }
+
         public static bool StrictlyEqual(JsValue x, JsValue y)
         {
             var typeX = x._type;

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -160,10 +160,11 @@ namespace Jint.Runtime.Interpreter.Expressions
                         {
                             if (integerOperation)
                             {
-                                var asInteger = left.AsInteger();
-                                if (asInteger > 0)
+                                var leftInteger = left.AsInteger();
+                                var rightInteger = right.AsInteger();
+                                if (leftInteger > 0 && rightInteger != 0)
                                 {
-                                    return asInteger % right.AsInteger();
+                                    return leftInteger % rightInteger;
                                 }
                             }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -123,12 +123,12 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
             }
 
-            if (func._type == Types.Undefined)
+            if (func._type == InternalTypes.Undefined)
             {
                 ExceptionHelper.ThrowTypeError(_engine, r == null ? "" : $"Object has no method '{r.GetReferencedName()}'");
             }
 
-            if (func._type != Types.Object)
+            if (func._type != InternalTypes.Object)
             {
                 if (_engine._referenceResolver == null || !_engine._referenceResolver.TryGetCallable(_engine, callee, out func))
                 {

--- a/Jint/Runtime/Interpreter/Expressions/JintConstantExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintConstantExpression.cs
@@ -1,0 +1,33 @@
+using Esprima.Ast;
+using Jint.Native;
+
+namespace Jint.Runtime.Interpreter.Expressions
+{
+    /// <summary>
+    /// Constant JsValue returning expression.
+    /// </summary>
+    internal sealed class JintConstantExpression : JintExpression
+    {
+        private readonly JsValue _value;
+
+        public JintConstantExpression(Engine engine, INode expression, JsValue value) : base(engine, expression)
+        {
+            _value = value;
+        }
+
+        /// <summary>
+        /// Resolves the underlying value for this expression.
+        /// By default uses the Engine for resolving.
+        /// </summary>
+        /// <seealso cref="JintLiteralExpression"/>
+        public override JsValue GetValue()
+        {
+            // need to notify correct node when taking shortcut
+            _engine._lastSyntaxNode = _expression;
+
+            return _value;
+        }
+
+        protected override object EvaluateInternal() => _value;
+    }
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -155,6 +155,11 @@ namespace Jint.Runtime.Interpreter.Expressions
                 return lN > 0 ? double.PositiveInfinity : double.NegativeInfinity;
             }
 
+            if (lN % rN == 0)
+            {
+                return lN / rN;
+            }
+
             return (double) lN / rN;
         }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -132,7 +132,32 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
         }
 
-        protected JsValue Divide(JsValue lval, JsValue rval, bool integerOperation)
+        protected static JsValue Divide(JsValue lval, JsValue rval, bool integerOperation)
+        {
+            return integerOperation
+                ? DivideInteger(lval, rval)
+                : DivideComplex(lval, rval);
+        }
+
+        private static JsValue DivideInteger(JsValue lval, JsValue rval)
+        {
+            var lN = lval.AsInteger();
+            var rN = rval.AsInteger();
+
+            if (lN == 0 && rN == 0)
+            {
+                return JsNumber.DoubleNaN;
+            }
+
+            if (rN == 0)
+            {
+                return lN > 0 ? double.PositiveInfinity : double.NegativeInfinity;
+            }
+
+            return (double) lN / rN;
+        }
+
+        private static JsValue DivideComplex(JsValue lval, JsValue rval)
         {
             if (lval.IsUndefined() || rval.IsUndefined())
             {
@@ -180,6 +205,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                 return lN / rN;
             }
+
         }
 
         protected static bool Equal(JsValue x, JsValue y)

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -133,9 +133,9 @@ namespace Jint.Runtime.Interpreter.Expressions
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected static JsValue Divide(JsValue lval, JsValue rval, bool integerOperation)
+        protected static JsValue Divide(JsValue lval, JsValue rval)
         {
-            return integerOperation
+            return AreIntegerOperands(lval, rval)
                 ? DivideInteger(lval, rval)
                 : DivideComplex(lval, rval);
         }
@@ -330,7 +330,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 ? CompareInteger(x, y, leftFirst)
                 : CompareComplex(x, y, leftFirst);
 
-        private static JsValue CompareInteger(JsValue x, JsValue y, bool leftFirst = true)
+        private static JsValue CompareInteger(JsValue x, JsValue y, bool leftFirst)
         {
             int nx, ny;
             if (leftFirst)
@@ -347,7 +347,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             return nx < ny;
         }
 
-        private static  JsValue CompareComplex(JsValue x, JsValue y, bool leftFirst = true)
+        private static  JsValue CompareComplex(JsValue x, JsValue y, bool leftFirst)
         {
             JsValue px, py;
             if (leftFirst)

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -82,7 +82,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     return new JintIdentifierExpression(engine, (Identifier) expression);
 
                 case Nodes.Literal:
-                    return new JintLiteralExpression(engine, (Literal) expression);
+                    return JintLiteralExpression.Build(engine, (Literal) expression);
 
                 case Nodes.LogicalExpression:
                     var binaryExpression = (BinaryExpression) expression;

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -132,6 +132,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected static JsValue Divide(JsValue lval, JsValue rval, bool integerOperation)
         {
             return integerOperation

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -500,5 +500,11 @@ namespace Jint.Runtime.Interpreter.Expressions
                 out record,
                 out value);
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected static bool AreIntegerOperands(JsValue left, JsValue right)
+        {
+            return left._type == right._type && left._type == InternalTypes.Integer;
+        }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -115,7 +115,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     return new JintUpdateExpression(engine, (UpdateExpression) expression);
 
                 case Nodes.UnaryExpression:
-                    return new JintUnaryExpression(engine, (UnaryExpression) expression);
+                    return JintUnaryExpression.Build(engine, (UnaryExpression) expression);
 
                 case Nodes.SpreadElement:
                     return new JintSpreadExpression(engine, (SpreadElement) expression);

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -28,10 +28,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             if (literal.TokenType == TokenType.NumericLiteral)
             {
-                var validInteger = int.TryParse(literal.Raw, out var intValue)
-                                   && (intValue != 0 || BitConverter.DoubleToInt64Bits(literal.NumericValue) != JsNumber.NegativeZeroBits);
-
-                return validInteger
+                return int.TryParse(literal.Raw, out var intValue) && (intValue != 0 || BitConverter.DoubleToInt64Bits(literal.NumericValue) == JsNumber.NegativeZeroBits)
                     ? JsNumber.Create(intValue)
                     : JsNumber.Create(literal.NumericValue);
             }

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -28,7 +28,8 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             if (literal.TokenType == TokenType.NumericLiteral)
             {
-                return int.TryParse(literal.Raw, out var intValue) && (intValue != 0 || BitConverter.DoubleToInt64Bits(literal.NumericValue) == JsNumber.NegativeZeroBits)
+                return int.TryParse(literal.Raw, out var intValue)
+                       && (intValue != 0 || BitConverter.DoubleToInt64Bits(literal.NumericValue) != JsNumber.NegativeZeroBits)
                     ? JsNumber.Create(intValue)
                     : JsNumber.Create(literal.NumericValue);
             }

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -7,7 +7,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 {
     internal class JintLiteralExpression : JintExpression
     {
-        internal readonly JsValue _cachedValue;
+        private readonly JsValue _cachedValue;
 
         public JintLiteralExpression(Engine engine, Literal expression) : base(engine, expression)
         {
@@ -28,7 +28,10 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             if (literal.TokenType == TokenType.NumericLiteral)
             {
-                return int.TryParse(literal.Raw, out var intValue) && (intValue != 0 || BitConverter.DoubleToInt64Bits(literal.NumericValue) == JsNumber.NegativeZeroBits)
+                var validInteger = int.TryParse(literal.Raw, out var intValue)
+                                   && (intValue != 0 || BitConverter.DoubleToInt64Bits(literal.NumericValue) != JsNumber.NegativeZeroBits);
+
+                return validInteger
                     ? JsNumber.Create(intValue)
                     : JsNumber.Create(literal.NumericValue);
             }

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -1,3 +1,4 @@
+using System;
 using Esprima;
 using Esprima.Ast;
 using Jint.Native;
@@ -27,7 +28,9 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             if (literal.TokenType == TokenType.NumericLiteral)
             {
-                return JsNumber.Create(literal.NumericValue);
+                return int.TryParse(literal.Raw, out var intValue) && (intValue != 0 || BitConverter.DoubleToInt64Bits(literal.NumericValue) == JsNumber.NegativeZeroBits)
+                    ? JsNumber.Create(intValue)
+                    : JsNumber.Create(literal.NumericValue);
             }
 
             if (literal.TokenType == TokenType.StringLiteral)

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -7,11 +7,19 @@ namespace Jint.Runtime.Interpreter.Expressions
 {
     internal class JintLiteralExpression : JintExpression
     {
-        private readonly JsValue _cachedValue;
-
-        public JintLiteralExpression(Engine engine, Literal expression) : base(engine, expression)
+        private JintLiteralExpression(Engine engine, Literal expression) : base(engine, expression)
         {
-            _cachedValue = ConvertToJsValue(expression);
+        }
+
+        internal static JintExpression Build(Engine engine, Literal expression)
+        {
+            var constantValue = ConvertToJsValue(expression);
+            if (!(constantValue is null))
+            {
+                return new JintConstantExpression(engine, expression, constantValue);
+            }
+            
+            return new JintLiteralExpression(engine, expression);
         }
 
         internal static JsValue ConvertToJsValue(Literal literal)
@@ -46,13 +54,11 @@ namespace Jint.Runtime.Interpreter.Expressions
         {
             // need to notify correct node when taking shortcut
             _engine._lastSyntaxNode = _expression;
-            return _cachedValue ?? ResolveValue();
+            
+            return ResolveValue();
         }
 
-        protected override object EvaluateInternal()
-        {
-            return _cachedValue ?? ResolveValue();
-        }
+        protected override object EvaluateInternal() => ResolveValue();
 
         private JsValue ResolveValue()
         {

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -24,7 +24,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             if (!expression.Computed)
             {
-                _determinedPropertyName = ((Esprima.Ast.Identifier) expression.Property).Name;
+                _determinedPropertyName = ((Identifier) expression.Property).Name;
             }
             else
             {
@@ -70,7 +70,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
             }
 
-            var propertyName = !string.IsNullOrEmpty(_determinedPropertyName.Name)
+            var propertyName = _determinedPropertyName.Name.Length > 0
                 ? _determinedPropertyName
                 : (Key) TypeConverter.ToPropertyKey(_propertyExpression.GetValue());
 

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -21,10 +21,18 @@ namespace Jint.Runtime.Interpreter.Expressions
             switch (_operator)
             {
                 case UnaryOperator.Plus:
-                    return JsNumber.Create(TypeConverter.ToNumber(_argument.GetValue()));
+                    var plusValue = _argument.GetValue();
+                    return plusValue.IsInteger()
+                        ? plusValue
+                        : JsNumber.Create(TypeConverter.ToNumber(plusValue));
 
                 case UnaryOperator.Minus:
-                    var n = TypeConverter.ToNumber(_argument.GetValue());
+                    var minusValue = _argument.GetValue();
+                    if (minusValue.IsInteger())
+                    {
+                        return JsNumber.Create(minusValue.AsInteger() * -1);
+                    }
+                    var n = TypeConverter.ToNumber(minusValue);
                     return JsNumber.Create(double.IsNaN(n) ? double.NaN : n * -1);
 
                 case UnaryOperator.BitwiseNot:

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -22,7 +22,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
                 case UnaryOperator.Plus:
                     var plusValue = _argument.GetValue();
-                    return plusValue.IsInteger()
+                    return plusValue.IsInteger() && plusValue.AsInteger() != 0
                         ? plusValue
                         : JsNumber.Create(TypeConverter.ToNumber(plusValue));
 
@@ -30,7 +30,11 @@ namespace Jint.Runtime.Interpreter.Expressions
                     var minusValue = _argument.GetValue();
                     if (minusValue.IsInteger())
                     {
-                        return JsNumber.Create(minusValue.AsInteger() * -1);
+                        var asInteger = minusValue.AsInteger();
+                        if (asInteger != 0)
+                        {
+                            return JsNumber.Create(asInteger * -1);
+                        }
                     }
                     var n = TypeConverter.ToNumber(minusValue);
                     return JsNumber.Create(double.IsNaN(n) ? double.NaN : n * -1);

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -54,13 +54,18 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             reference.AssertValid(_engine);
 
-            var oldValue = TypeConverter.ToNumber(_engine.GetValue(reference, false));
-            var newValue = oldValue + _change;
+            var value = _engine.GetValue(reference, false);
+            var isInteger = value._type == InternalTypes.Integer;
+            var newValue = isInteger
+                ? JsNumber.Create(value.AsInteger() + _change)
+                : JsNumber.Create(TypeConverter.ToNumber(value) + _change);
 
             _engine.PutValue(reference, newValue);
             _engine._referencePool.Return(reference);
 
-            return JsNumber.Create(_prefix ? newValue : oldValue);
+            return _prefix
+                ? newValue
+                : (isInteger ? value : JsNumber.Create(TypeConverter.ToNumber(value)));
         }
 
         private JsValue UpdateIdentifier()
@@ -77,11 +82,15 @@ namespace Jint.Runtime.Interpreter.Expressions
                     ExceptionHelper.ThrowSyntaxError(_engine);
                 }
 
-                var oldValue = TypeConverter.ToNumber(value);
-                var newValue = oldValue + _change;
+                var isInteger = value._type == InternalTypes.Integer;
+                var newValue = isInteger
+                    ? JsNumber.Create(value.AsInteger() + _change)
+                    : JsNumber.Create(TypeConverter.ToNumber(value) + _change);
 
                 environmentRecord.SetMutableBinding(name, newValue, strict);
-                return JsNumber.Create(_prefix ? newValue : oldValue);
+                return _prefix
+                    ? newValue
+                    : (isInteger ? value : JsNumber.Create(TypeConverter.ToNumber(value)));
             }
 
             return null;

--- a/Jint/Runtime/Interpreter/Statements/JintForInStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInStatement.cs
@@ -56,9 +56,9 @@ namespace Jint.Runtime.Interpreter.Statements
                 var keys = _engine.Object.GetOwnPropertyNames(Undefined.Instance, Arguments.From(cursor)).AsArray();
 
                 var length = keys.GetLength();
-                for (var i = 0; i < length; i++)
+                for (uint i = 0; i < length; i++)
                 {
-                    var p = keys.GetOwnProperty(TypeConverter.ToString(i)).Value.AsStringWithoutTypeCheck();
+                    var p = keys.GetOwnProperty(i).Value.AsStringWithoutTypeCheck();
 
                     if (processedKeys.Contains(p))
                     {

--- a/Jint/Runtime/References/Reference.cs
+++ b/Jint/Runtime/References/Reference.cs
@@ -42,21 +42,21 @@ namespace Jint.Runtime.References
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool HasPrimitiveBase()
         {
-            return _baseValue._type != Types.Object && _baseValue._type != Types.None;
+            return _baseValue._type != InternalTypes.Object && _baseValue._type != InternalTypes.None;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsUnresolvableReference()
         {
-            return _baseValue._type == Types.Undefined;
+            return _baseValue._type == InternalTypes.Undefined;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsPropertyReference()
         {
             // http://www.ecma-international.org/ecma-262/5.1/#sec-8.7
-            return _baseValue._type != Types.Object && _baseValue._type != Types.None
-                   || _baseValue._type == Types.Object && !(_baseValue is EnvironmentRecord);
+            return _baseValue._type != InternalTypes.Object && _baseValue._type != InternalTypes.None
+                   || _baseValue._type == InternalTypes.Object && !(_baseValue is EnvironmentRecord);
         }
 
         internal Reference Reassign(JsValue baseValue, in Key name, bool strict)

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -10,7 +10,6 @@ using Jint.Native.Number.Dtoa;
 using Jint.Native.Object;
 using Jint.Native.String;
 using Jint.Pooling;
-using Jint.Runtime.References;
 
 namespace Jint.Runtime
 {
@@ -467,53 +466,16 @@ namespace Jint.Runtime
             return InternalTypes.Object;
         }
 
-        public static void CheckObjectCoercible(
-            Engine engine,
-            JsValue o,
-            MemberExpression expression,
-            object baseReference)
-        {
-            if (o._type > InternalTypes.Null)
-            {
-                return;
-            }
-
-            var referenceResolver = engine.Options.ReferenceResolver;
-            if (referenceResolver != null && referenceResolver.CheckCoercible(o))
-            {
-                return;
-            }
-
-            ThrowTypeError(engine, o, expression, baseReference);
-        }
-
         internal static void CheckObjectCoercible(
             Engine engine,
             JsValue o,
             MemberExpression expression,
             string referenceName)
         {
-            if (o._type > InternalTypes.Null)
+            if (o._type <= InternalTypes.Null || !engine.Options.ReferenceResolver?.CheckCoercible(o) == false)
             {
-                return;
+                ThrowTypeError(engine, o, expression, referenceName);
             }
-
-            var referenceResolver = engine.Options.ReferenceResolver;
-            if (referenceResolver != null && referenceResolver.CheckCoercible(o))
-            {
-                return;
-            }
-
-            ThrowTypeError(engine, o, expression, referenceName);
-        }
-
-        private static void ThrowTypeError(
-            Engine engine,
-            JsValue o,
-            MemberExpression expression,
-            object baseReference)
-        {
-            ThrowTypeError(engine, o, expression, (baseReference as Reference)?.GetReferencedName());
         }
 
         private static void ThrowTypeError(

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -244,26 +244,6 @@ namespace Jint.Runtime
         }
 
         /// <summary>
-        /// Returns unsigned integer from JsValue, 0 if negative, maximum of NumberConstructor.MaxSafeInteger.
-        /// </summary>
-        internal static ulong ToUnsignedInteger(JsValue o)
-        {
-            if (o.IsInteger())
-            {
-                return (ulong) Math.Max(o.AsInteger(), 0);
-            }
-
-            var d = ToInteger(o);
-            if (d < 0)
-            {
-                return 0;
-            }
-            return (ulong) (d < NumberConstructor.MaxSafeInteger
-                ? d
-                : NumberConstructor.MaxSafeInteger);
-        }
-
-        /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-9.4
         /// </summary>
         public static double ToInteger(JsValue o)

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -244,10 +244,28 @@ namespace Jint.Runtime
         }
 
         /// <summary>
+        /// Returns unsigned integer from JsValue, 0 if negative, maximum of NumberConstructor.MaxSafeInteger.
+        /// </summary>
+        internal static ulong ToUnsignedInteger(JsValue o)
+        {
+            if (o.IsInteger())
+            {
+                return (ulong) Math.Max(o.AsInteger(), 0);
+            }
+
+            var d = ToInteger(o);
+            if (d < 0)
+            {
+                return 0;
+            }
+            return (ulong) (d < NumberConstructor.MaxSafeInteger
+                ? d
+                : NumberConstructor.MaxSafeInteger);
+        }
+
+        /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-9.4
         /// </summary>
-        /// <param name="o"></param>
-        /// <returns></returns>
         public static double ToInteger(JsValue o)
         {
             var number = ToNumber(o);
@@ -285,33 +303,32 @@ namespace Jint.Runtime
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-9.5
         /// </summary>
-        /// <param name="o"></param>
-        /// <returns></returns>
         public static int ToInt32(JsValue o)
         {
-            return (int) (uint) ToNumber(o);
+            return o._type == InternalTypes.Integer
+                ? o.AsInteger()
+                : (int) (uint) ToNumber(o);
         }
 
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-9.6
         /// </summary>
-        /// <param name="o"></param>
-        /// <returns></returns>
         public static uint ToUint32(JsValue o)
         {
-            return (uint) ToNumber(o);
+            return o._type == InternalTypes.Integer
+                ? (uint) o.AsInteger()
+                : (uint) ToNumber(o);
         }
 
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-9.7
         /// </summary>
-        /// <param name="o"></param>
-        /// <returns></returns>
         public static ushort ToUint16(JsValue o)
         {
-            return (ushort) (uint) ToNumber(o);
+            return  o._type == InternalTypes.Integer
+                ? (ushort) o.AsInteger()
+                : (ushort) ToNumber(o);
         }
-
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string ToString(long i)

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -326,8 +326,8 @@ namespace Jint.Runtime
         public static ushort ToUint16(JsValue o)
         {
             return  o._type == InternalTypes.Integer
-                ? (ushort) o.AsInteger()
-                : (ushort) ToNumber(o);
+                ? (ushort) (uint) o.AsInteger()
+                : (ushort) (uint) ToNumber(o);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -472,7 +472,7 @@ namespace Jint.Runtime
             MemberExpression expression,
             string referenceName)
         {
-            if (o._type <= InternalTypes.Null || !engine.Options.ReferenceResolver?.CheckCoercible(o) == false)
+            if (o._type < InternalTypes.Boolean && (engine.Options.ReferenceResolver?.CheckCoercible(o)).GetValueOrDefault() != true)
             {
                 ThrowTypeError(engine, o, expression, referenceName);
             }
@@ -491,7 +491,7 @@ namespace Jint.Runtime
 
         public static void CheckObjectCoercible(Engine engine, JsValue o)
         {
-            if (o._type == InternalTypes.Undefined || o._type == InternalTypes.Null)
+            if (o._type < InternalTypes.Boolean)
             {
                 ExceptionHelper.ThrowTypeError(engine);
             }


### PR DESCRIPTION
Here I'm trying out using separate known flag to safe integers. When we know it's a safe integer, we can skip both floating point arithmetic and use faster lookups for results. Consumers still see the exposed `Types` but internally we handle with `InternalTypes` which also has `Integer`.