### PR TITLE
Fix StringDictionarySlim enumeration after first item delete

### DIFF
--- a/Jint.Tests/Runtime/ObjectInstanceTests.cs
+++ b/Jint.Tests/Runtime/ObjectInstanceTests.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using Jint.Native;
+using Jint.Native.Object;
+using Xunit;
+
+namespace Jint.Tests.Runtime
+{
+    public class ObjectInstanceTests
+    {
+        [Fact]
+        public void RemovingFirstPropertyFromObjectInstancePropertiesBucketAndEnumerating()
+        {
+            var engine = new Engine();
+            var instance = new ObjectInstance(engine);
+            instance.FastAddProperty("bare", JsValue.Null, true, true, true);
+            instance.FastAddProperty("scope", JsValue.Null, true, true, true);
+            instance.RemoveOwnProperty("bare");
+            var propertyNames = instance.GetOwnProperties().Select(x => x.Key).ToList();
+            Assert.Equal(new [] { "scope" }, propertyNames);
+        }
+    }
+}

--- a/Jint/Collections/StringDictionarySlim.cs
+++ b/Jint/Collections/StringDictionarySlim.cs
@@ -240,22 +240,29 @@ namespace Jint.Collections
         {
             private readonly StringDictionarySlim<TValue> _dictionary;
             private int _index;
+            private int _count;
             private KeyValuePair<string, TValue> _current;
 
             internal Enumerator(StringDictionarySlim<TValue> dictionary)
             {
                 _dictionary = dictionary;
                 _index = 0;
+                _count = _dictionary._count;
                 _current = default;
             }
 
             public bool MoveNext()
             {
-                if (_index == _dictionary._count)
+                if (_count == 0)
                 {
                     _current = default;
                     return false;
                 }
+
+                _count--;
+
+                while (_dictionary._entries[_index].next < -1)
+                    _index++;
 
                 _current = new KeyValuePair<string, TValue>(
                     _dictionary._entries[_index].key,
@@ -270,6 +277,8 @@ namespace Jint.Collections
             void IEnumerator.Reset()
             {
                 _index = 0;
+                _count = _dictionary._count;
+                _current = default;
             }
 
             public void Dispose() { }


### PR DESCRIPTION
This was fun to track down. StringDictionarySlim's enumerator was returning deleted items when item that was deleted had first bucket index. This was actually [fixed in CoreFX Labs version](https://github.com/dotnet/corefxlab/commit/f89ccaed1b1a3010517b1f6acb2eb6c273a950bd#diff-893b48d84bbc70491b37c328779f675e) some time ago, we just didn't have the fix incorporated.

Fixes #670 