### PR TITLE
Reflect and Proxy APIs

### DIFF
--- a/Jint.Benchmark/Jint.Benchmark.csproj
+++ b/Jint.Benchmark/Jint.Benchmark.csproj
@@ -22,7 +22,7 @@
     <ProjectReference Include="..\Jint\Jint.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Include="Jurassic" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NiL.JS.NetCore" Version="2.5.1327" />

--- a/Jint.Repl/Jint.Repl.csproj
+++ b/Jint.Repl/Jint.Repl.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj
+++ b/Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\Jint\Jint.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Jint.Tests.Ecma/Jint.Tests.Ecma.csproj
+++ b/Jint.Tests.Ecma/Jint.Tests.Ecma.csproj
@@ -6,7 +6,7 @@
     <ProjectReference Include="..\Jint\Jint.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Jint.Tests.Test262/Jint.Tests.Test262.csproj
+++ b/Jint.Tests.Test262/Jint.Tests.Test262.csproj
@@ -6,7 +6,7 @@
     <ProjectReference Include="..\Jint\Jint.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Jint.Tests.Test262/ProxyTests.cs
+++ b/Jint.Tests.Test262/ProxyTests.cs
@@ -1,0 +1,15 @@
+﻿using Xunit;
+
+namespace Jint.Tests.Test262
+{
+    public class ProxyTests : Test262Test
+    {
+        [Theory(DisplayName = "built-ins\\Proxy")]
+        [MemberData(nameof(SourceFiles), "built-ins\\Proxy", false)]
+        [MemberData(nameof(SourceFiles), "built-ins\\Proxy", true, Skip = "Skipped")]
+        protected void RunTest(SourceFile sourceFile)
+        {
+            RunTestInternal(sourceFile);
+        }
+    }
+}

--- a/Jint.Tests.Test262/ReflectTests.cs
+++ b/Jint.Tests.Test262/ReflectTests.cs
@@ -1,0 +1,15 @@
+﻿using Xunit;
+
+namespace Jint.Tests.Test262
+{
+    public class ReflectTests : Test262Test
+    {
+        [Theory(DisplayName = "built-ins\\Reflect")]
+        [MemberData(nameof(SourceFiles), "built-ins\\Reflect", false)]
+        [MemberData(nameof(SourceFiles), "built-ins\\Reflect", true, Skip = "Skipped")]
+        protected void RunTest(SourceFile sourceFile)
+        {
+            RunTestInternal(sourceFile);
+        }
+    }
+}

--- a/Jint.Tests.Test262/Test262Test.cs
+++ b/Jint.Tests.Test262/Test262Test.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Jint.Runtime;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -13,7 +15,7 @@ namespace Jint.Tests.Test262
 {
     public abstract class Test262Test
     {
-        private static readonly string[] Sources;
+        private static readonly Dictionary<string, string> Sources;
 
         private static readonly string BasePath;
 
@@ -24,6 +26,11 @@ namespace Jint.Tests.Test262
 
         private static readonly HashSet<string> _strictSkips =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        
+        private static readonly Dictionary<string, string> extraSourceFiles = new Dictionary<string, string>()
+        {
+            { "built-ins/Array/isArray/descriptor.js", "propertyHelper.js"}
+        };
 
         static Test262Test()
         {
@@ -37,17 +44,18 @@ namespace Jint.Tests.Test262
 
             string[] files =
             {
-                @"harness\sta.js",
-                @"harness\assert.js",
-                @"harness\propertyHelper.js",
-                @"harness\compareArray.js",
-                @"harness\decimalToHexString.js",
+                "sta.js",
+                "assert.js",
+                "propertyHelper.js",
+                "compareArray.js",
+                "decimalToHexString.js",
+                "proxyTrapsHelper.js",
             };
 
-            Sources = new string[files.Length];
+            Sources = new Dictionary<string, string>(files.Length);
             for (var i = 0; i < files.Length; i++)
             {
-                Sources[i] = File.ReadAllText(Path.Combine(BasePath, files[i]));
+                Sources[files[i]] = File.ReadAllText(Path.Combine(BasePath, "harness", files[i]));
             }
 
             var content = File.ReadAllText(Path.Combine(BasePath, "test/skipped.json"));
@@ -67,13 +75,27 @@ namespace Jint.Tests.Test262
         {
             var engine = new Engine(cfg => cfg
                 .LocalTimeZone(_pacificTimeZone)
-                .Strict(strict));
+                .Strict(strict)
+            );
 
-            for (int i = 0; i < Sources.Length; ++i)
+            engine.Execute(Sources["sta.js"]);
+            engine.Execute(Sources["assert.js"]);
+            
+            var includes = Regex.Match(code, @"includes: \[(.+?)\]");
+            if (includes.Success)
             {
-                engine.Execute(Sources[i]);
+                var files = includes.Groups[1].Captures[0].Value.Split(',');
+                foreach (var file in files)
+                {
+                    engine.Execute(Sources[file.Trim()]);
+                }
             }
 
+            if (code.IndexOf("propertyHelper.js", StringComparison.OrdinalIgnoreCase) != -1)
+            {
+                engine.Execute(Sources["propertyHelper.js"]);
+            }
+            
             string lastError = null;
 
             bool negative = code.IndexOf("negative:", StringComparison.Ordinal) > -1;
@@ -121,12 +143,12 @@ namespace Jint.Tests.Test262
 
         public static IEnumerable<object[]> SourceFiles(string pathPrefix, bool skipped)
         {
-            var results = new List<object[]>();
+            var results = new ConcurrentBag<object[]>();
             var fixturesPath = Path.Combine(BasePath, "test");
             var searchPath = Path.Combine(fixturesPath, pathPrefix);
             var files = Directory.GetFiles(searchPath, "*", SearchOption.AllDirectories);
 
-            foreach (var file in files)
+            Parallel.ForEach(files, file =>
             {
                 var name = file.Substring(fixturesPath.Length + 1).Replace("\\", "/");
                 bool skip = _skipReasons.TryGetValue(name, out var reason);
@@ -174,10 +196,6 @@ namespace Jint.Tests.Test262
                             case "Symbol.species":
                                 skip = true;
                                 reason = "Symbol.species not implemented";
-                                break;
-                            case "Proxy":
-                                skip = true;
-                                reason = "Proxies not implemented";
                                 break;
                             case "object-spread":
                                 skip = true;
@@ -246,7 +264,7 @@ namespace Jint.Tests.Test262
                         }
                     }
                 }
-
+                
                 if (code.IndexOf("SpecialCasing.txt") > -1)
                 {
                     skip = true;
@@ -281,7 +299,7 @@ namespace Jint.Tests.Test262
                         sourceFile
                     });
                 }
-            }
+            });
 
             return results;
         }

--- a/Jint.Tests.Test262/test/skipped.json
+++ b/Jint.Tests.Test262/test/skipped.json
@@ -1,5 +1,9 @@
 [
   {
+    "source": "built-ins/Proxy/enumerate/removed-does-not-trigger.js",
+    "reason": "for-of not implemented"
+  },
+  {
     "source": "built-ins/Array/prototype/concat/create-ctor-non-object.js",
     "reason": "Constructor functions not implemented"
   },
@@ -180,14 +184,6 @@
     "reason": "WeakSet not implemented"
   },
   {
-    "source": "built-ins/Array/prototype/reverse/length-exceeding-integer-limit-with-proxy.js",
-    "reason": "proxies not implemented"
-  },
-  {
-    "source": "built-ins/Array/prototype/slice/length-exceeding-integer-limit-proxied-array.js",
-    "reason": "proxies not implemented"
-  },
-  {
     "source": "built-ins/Array/prototype/splice/create-non-array-invalid-len.js",
     "reason": "requires constructor functions"
   },
@@ -334,14 +330,6 @@
     "reason": "destructing not implemented"
   },
   {
-    "source": "language/rest-parameters/arrow-function.js",
-    "reason": "Github issue #600 - rest parameters hang when not set"
-  },
-  {
-    "source": "language/rest-parameters/object-pattern.js",
-    "reason": "destructing not implemented"
-  },
-  {
     "source": "built-ins/Math/pow/int32_min-exponent.js",
     "reason": "const not implemented"
   },
@@ -350,16 +338,8 @@
     "reason": "Line feed problems (git, windows, linux)"
   },
   {
-    "source": "built-ins/Number/prototype/toPrecision/range.js",
-    "reason": "Github issue #599 - dtoa function not precise enough"
-  },
-  {
     "source": "built-ins/Number/prototype/toFixed/range.js",
-    "reason": "Github issue #599 - dtoa function not precise enough"
-  },
-  {
-    "source": "built-ins/Number/prototype/toExponential/range.js",
-    "reason": "Github issue #599 - dtoa function not precise enough"
+    "reason": "100 fraction digits is not supported due to .NET format specifier limitation"
   },
   {
     "source": "language/types/number/8.5.1.js",
@@ -584,41 +564,20 @@
 
   {
     "source": "language/expressions/object/method.js",
-    "reason": "setPrototypeOf not implemented"
+    "reason": "super not implemented"
   },
   {
     "source": "language/expressions/object/setter-super-prop.js",
-    "reason": "setPrototypeOf not implemented"
+    "reason": "super not implemented"
   },
   {
     "source": "language/expressions/object/getter-super-prop.js",
-    "reason": "setPrototypeOf not implemented"
+    "reason": "super not implemented"
   },
 
 
   {
     "source": "language/expressions/object/fn-name-arrow.js",
-    "reason": "symbols not identifiable in property name"
-  },
-  {
-    "source": "language/expressions/object/fn-name-cover.js",
-    "reason": "symbols not identifiable in property name"
-  },
-  {
-    "source": "language/expressions/object/fn-name-fn.js",
-    "reason": "symbols not identifiable in property name"
-  },
-  {
-    "source": "language/expressions/object/method-definition/fn-name-fn.js",
-    "reason": "symbols not identifiable in property name"
-  },
-  {
-    "source": "language/expressions/object/method-definition/name-name-prop-symbol.js",
-    "reason": "symbols not identifiable in property name"
-  },
-
-
-  {
     "source": "language/expressions/arrow-function/scope-paramsbody-var-open.js",
     "reason": "not implemented: Creation of new variable environment for the function body (as distinct from that for the function's parameters)"
   },

--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -12,7 +12,7 @@
     <Reference Include="Microsoft.CSharp" Condition=" '$(TargetFramework)' == 'net452' " />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -558,7 +558,7 @@ namespace Jint.Tests.Runtime
                     str += z;
                 }
 
-                assert(str == 'xystrz');
+                equal('xystrz', str);
             ");
         }
 
@@ -987,7 +987,7 @@ namespace Jint.Tests.Runtime
             ");
 
             var obj = _engine.GetValue("obj").AsObject();
-            var getFoo = obj.Get("getFoo");
+            var getFoo = obj.Get("getFoo", obj);
 
             Assert.Equal("foo is 5, bar is 7", _engine.Invoke(getFoo, obj, new object[] { 7 }).AsString());
         }
@@ -1000,7 +1000,7 @@ namespace Jint.Tests.Runtime
             ");
 
             var obj = _engine.GetValue("obj").AsObject();
-            var foo = obj.Get("foo");
+            var foo = obj.Get("foo", obj);
 
             Assert.Throws<ArgumentException>(() => _engine.Invoke(foo, obj, new object[] { }));
         }

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -468,8 +468,8 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void PocosCanReturnObjectInstanceDirectly()
         {
-            var x = new ObjectInstance(_engine) { Extensible = true};
-            x.Put("foo", new JsString("bar"), false);
+            var x = new ObjectInstance(_engine);
+            x.Set("foo", new JsString("bar"));
 
             var o = new
             {

--- a/Jint.Tests/Runtime/NullPropagation.cs
+++ b/Jint.Tests/Runtime/NullPropagation.cs
@@ -100,7 +100,7 @@ function test2(arg) {
             var engine = new Engine(cfg => cfg.SetReferencesResolver(new NullPropagationReferenceResolver()));
 
             var jsObject = engine.Object.Construct(Arguments.Empty);
-            jsObject.Put("NullField", JsValue.Null, true);
+            jsObject.Set("NullField", JsValue.Null);
 
             var script = @"
 this.is_nullfield_not_null = this.NullField !== null;

--- a/Jint.Tests/Runtime/ObjectInstanceTests.cs
+++ b/Jint.Tests/Runtime/ObjectInstanceTests.cs
@@ -16,7 +16,7 @@ namespace Jint.Tests.Runtime
             instance.FastAddProperty("scope", JsValue.Null, true, true, true);
             instance.RemoveOwnProperty("bare");
             var propertyNames = instance.GetOwnProperties().Select(x => x.Key).ToList();
-            Assert.Equal(new [] { "scope" }, propertyNames);
+            Assert.Equal(new Key[] { "scope" }, propertyNames);
         }
     }
 }

--- a/Jint/Collections/StringDictionarySlim.cs
+++ b/Jint/Collections/StringDictionarySlim.cs
@@ -19,7 +19,7 @@ namespace Jint.Collections
     /// </summary>
     [DebuggerTypeProxy(typeof(DictionarySlimDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
-    internal sealed class StringDictionarySlim<TValue> : IReadOnlyCollection<KeyValuePair<string, TValue>>
+    internal sealed class StringDictionarySlim<TValue> : IReadOnlyCollection<KeyValuePair<Key, TValue>>
     {
         // We want to initialize without allocating arrays. We also want to avoid null checks.
         // Array.Empty would give divide by zero in modulo operation. So we use static one element arrays.
@@ -228,7 +228,7 @@ namespace Jint.Collections
         /// <summary>
         /// Gets an enumerator over the dictionary
         /// </summary>
-        IEnumerator<KeyValuePair<string, TValue>> IEnumerable<KeyValuePair<string, TValue>>.GetEnumerator() =>
+        IEnumerator<KeyValuePair<Key, TValue>> IEnumerable<KeyValuePair<Key, TValue>>.GetEnumerator() =>
             new Enumerator(this);
 
         /// <summary>
@@ -236,12 +236,12 @@ namespace Jint.Collections
         /// </summary>
         IEnumerator IEnumerable.GetEnumerator() => new Enumerator(this);
 
-        public struct Enumerator : IEnumerator<KeyValuePair<string, TValue>>
+        public struct Enumerator : IEnumerator<KeyValuePair<Key, TValue>>
         {
             private readonly StringDictionarySlim<TValue> _dictionary;
             private int _index;
             private int _count;
-            private KeyValuePair<string, TValue> _current;
+            private KeyValuePair<Key, TValue> _current;
 
             internal Enumerator(StringDictionarySlim<TValue> dictionary)
             {
@@ -264,13 +264,13 @@ namespace Jint.Collections
                 while (_dictionary._entries[_index].next < -1)
                     _index++;
 
-                _current = new KeyValuePair<string, TValue>(
+                _current = new KeyValuePair<Key, TValue>(
                     _dictionary._entries[_index].key,
                     _dictionary._entries[_index++].value);
                 return true;
             }
 
-            public KeyValuePair<string, TValue> Current => _current;
+            public KeyValuePair<Key, TValue> Current => _current;
 
             object IEnumerator.Current => _current;
 
@@ -307,7 +307,7 @@ namespace Jint.Collections
             }
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public KeyValuePair<string, V>[] Items
+            public KeyValuePair<Key, V>[] Items
             {
                 get
                 {

--- a/Jint/Directory.Build.props
+++ b/Jint/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(SourceLinkEnabled)' != 'false'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
   <!-- Called after so that the <VersionSuffix> is built after the local ones -->

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -59,7 +59,7 @@ namespace Jint
                 ThrowWrongTypeException(value, "symbol");
             }
 
-            return ((JsSymbol) value)._value;
+            return ((JsSymbol) value).ToPropertyKey();
         }
 
         private static void ThrowWrongTypeException(JsValue value, string expectedType)

--- a/Jint/Key.cs
+++ b/Jint/Key.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Jint.Native;
 using Jint.Runtime;
 
 namespace Jint
@@ -23,22 +24,42 @@ namespace Jint
             }
         }
 
-        public Key(string name)
+        public Key(string name) : this(name, symbolIdentity: 0)
+        {
+        }
+
+        internal Key(string name, int symbolIdentity)
         {
             if (name == null)
             {
                 ExceptionHelper.ThrowArgumentException("name cannot be null");
             }
             Name = name;
-            HashCode = name.GetHashCode();
+            HashCode = name.GetHashCode() * 397 ^ symbolIdentity.GetHashCode();
+            _symbolIdentity = symbolIdentity;
         }
 
         public readonly string Name;
         internal readonly int HashCode;
+        internal readonly int _symbolIdentity;
+
+        public Types Type => _symbolIdentity == 0 ? Types.String : Types.Symbol;
+
+        public bool IsSymbol => _symbolIdentity != 0;
 
         public static implicit operator Key(string name)
         {
             return new Key(name);
+        }
+
+        public static implicit operator Key(JsSymbol name)
+        {
+            return name.ToPropertyKey();
+        }
+
+        public static implicit operator JsValue(in Key key)
+        {
+            return !key.IsSymbol ? (JsValue) JsString.Create(key.Name) : new JsSymbol(key.Name, key._symbolIdentity);
         }
 
         public static implicit operator Key(int value)
@@ -53,6 +74,12 @@ namespace Jint
             return value < keys.Length ? keys[value] : BuildKey(value);
         }
 
+        public static implicit operator Key(ulong value)
+        {
+            var keys = indexKeys;
+            return value < (ulong) keys.Length ? keys[value] : new Key(value.ToString());
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Key BuildKey(long value)
         {
@@ -63,27 +90,27 @@ namespace Jint
 
         public static bool operator ==(in Key a, Key b)
         {
-            return a.HashCode == b.HashCode && a.Name == b.Name;
+            return a.HashCode == b.HashCode && a.Name == b.Name && a._symbolIdentity == b._symbolIdentity;
         }
 
         public static bool operator !=(in Key a, Key b)
         {
-            return a.HashCode != b.HashCode || a.Name != b.Name;
+            return a.HashCode != b.HashCode || a.Name != b.Name || a._symbolIdentity != b._symbolIdentity;
         }
 
         public static bool operator ==(in Key a, string b)
         {
-            return a.Name == b;
+            return a.Name == b && a._symbolIdentity == 0;
         }
 
         public static bool operator !=(in Key a, string b)
         {
-            return a.Name != b;
+            return a.Name != b || a._symbolIdentity > 0;
         }
 
         public bool Equals(Key other)
         {
-            return HashCode == other.HashCode && Name == other.Name;
+            return Name == other.Name && _symbolIdentity == other._symbolIdentity;
         }
 
         public override bool Equals(object obj)

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -1,0 +1,268 @@
+using Jint.Native.Number;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Native.Array
+{
+    internal abstract class ArrayOperations
+    {
+        protected internal const ulong MaxArrayLength = 4294967295;
+        protected internal const ulong MaxArrayLikeLength = NumberConstructor.MaxSafeInteger;
+
+        public static ArrayOperations For(ObjectInstance instance)
+        {
+            if (instance is ArrayInstance arrayInstance)
+            {
+                return new ArrayInstanceOperations(arrayInstance);
+            }
+
+            return new ObjectInstanceOperations(instance);
+        }
+
+        public static ArrayOperations For(Engine engine, JsValue thisObj)
+        {
+            var instance = TypeConverter.ToObject(engine, thisObj);
+            return For(instance);
+        }
+
+        public abstract ObjectInstance Target { get; }
+
+        public abstract ulong GetSmallestIndex(ulong length);
+
+        public abstract uint GetLength();
+
+        public abstract ulong GetLongLength();
+
+        public abstract void SetLength(ulong length);
+
+        public abstract void EnsureCapacity(ulong capacity);
+
+        public abstract JsValue Get(ulong index);
+
+        public virtual JsValue[] GetAll(Types elementTypes)
+        {
+            var n = (int) GetLength();
+            var jsValues = new JsValue[n];
+            for (uint i = 0; i < (uint) jsValues.Length; i++)
+            {
+                var jsValue = Get(i);
+                if ((jsValue.Type & elementTypes) == 0)
+                {
+                    ExceptionHelper.ThrowTypeErrorNoEngine<object>("invalid type");
+                }
+
+                jsValues[i] = jsValue;
+            }
+
+            return jsValues;
+        }
+
+        public abstract bool TryGetValue(ulong index, out JsValue value);
+
+        public bool HasProperty(ulong index) => Target.HasProperty(index);
+
+        public abstract void Set(ulong index, JsValue value, bool throwOnError);
+
+        public abstract void DeletePropertyOrThrow(ulong index);
+
+        private sealed class ObjectInstanceOperations : ArrayOperations<ObjectInstance>
+        {
+            public ObjectInstanceOperations(ObjectInstance target) : base(target)
+            {
+            }
+
+            private double GetIntegerLength()
+            {
+                var descValue = _target.Get("length", _target);
+                if (!ReferenceEquals(descValue, null))
+                {
+                    return TypeConverter.ToInteger(descValue);
+                }
+
+                return 0;
+            }
+
+            public override ulong GetSmallestIndex(ulong length)
+            {
+                // there are some evil tests that iterate a lot with unshift..
+                if (_target._properties == null)
+                {
+                    return 0;
+                }
+
+                var min = length;
+                foreach (var entry in _target._properties)
+                {
+                    if (ulong.TryParse(entry.Key, out var index))
+                    {
+                        min = System.Math.Min(index, min);
+                    }
+                }
+
+                if (_target.Prototype?._properties != null)
+                {
+                    foreach (var entry in _target.Prototype._properties)
+                    {
+                        if (ulong.TryParse(entry.Key, out var index))
+                        {
+                            min = System.Math.Min(index, min);
+                        }
+                    }
+                }
+
+                return min;
+            }
+
+            public override uint GetLength()
+            {
+                var integerLength = GetIntegerLength();
+                return (uint) (integerLength >= 0 ? integerLength : 0);
+            }
+
+            public override ulong GetLongLength()
+            {
+                var integerLength = GetIntegerLength();
+                if (integerLength <= 0)
+                {
+                    return 0;
+                }
+
+                return (ulong) System.Math.Min(integerLength, MaxArrayLikeLength);
+            }
+
+            public override void SetLength(ulong length)
+            {
+                _target.Set("length", length, true);
+            }
+
+            public override void EnsureCapacity(ulong capacity)
+            {
+            }
+
+            public override JsValue Get(ulong index)
+            {
+                return _target.Get(TypeConverter.ToString(index), _target);
+            }
+
+            public override bool TryGetValue(ulong index, out JsValue value)
+            {
+                var propertyName = TypeConverter.ToString(index);
+                var property = _target.GetProperty(propertyName);
+                var kPresent = property != PropertyDescriptor.Undefined;
+                value = kPresent ? _target.UnwrapJsValue(property) : JsValue.Undefined;
+                return kPresent;
+            }
+
+            public override void Set(ulong index, JsValue value, bool throwOnError)
+            {
+                _target.Set(TypeConverter.ToString(index), value, throwOnError);
+            }
+
+            public override void DeletePropertyOrThrow(ulong index)
+            {
+                _target.DeletePropertyOrThrow(TypeConverter.ToString(index));
+            }
+        }
+
+        private sealed class ArrayInstanceOperations : ArrayOperations<ArrayInstance>
+        {
+            public ArrayInstanceOperations(ArrayInstance target) : base(target)
+            {
+            }
+
+            public override ulong GetSmallestIndex(ulong length)
+            {
+                return _target.GetSmallestIndex();
+            }
+
+            public override uint GetLength()
+            {
+                return (uint) ((JsNumber) _target._length._value)._value;
+            }
+
+            public override ulong GetLongLength()
+            {
+                return (ulong) ((JsNumber) _target._length._value)._value;
+            }
+
+            public override void SetLength(ulong length)
+            {
+                _target.Set("length", length, true);
+            }
+
+            public override void EnsureCapacity(ulong capacity)
+            {
+                _target.EnsureCapacity((uint) capacity);
+            }
+
+            public override bool TryGetValue(ulong index, out JsValue value)
+            {
+                // array max size is uint
+                return _target.TryGetValue((uint) index, out value);
+            }
+
+            public override JsValue Get(ulong index)
+            {
+                return _target.Get((uint) index);
+            }
+
+            public override JsValue[] GetAll(Types elementTypes)
+            {
+                var n = _target.Length;
+
+                if (_target._dense == null || _target._dense.Length < n)
+                {
+                    return base.GetAll(elementTypes);
+                }
+
+                // optimized
+                var jsValues = new JsValue[n];
+                for (uint i = 0; i < (uint) jsValues.Length; i++)
+                {
+                    var prop = _target._dense[i] ?? PropertyDescriptor.Undefined;
+                    if (prop == PropertyDescriptor.Undefined)
+                    {
+                        prop = _target.Prototype?.GetProperty(i) ?? PropertyDescriptor.Undefined;
+                    }
+
+                    var jsValue = _target.UnwrapJsValue(prop);
+                    if ((jsValue.Type & elementTypes) == 0)
+                    {
+                        ExceptionHelper.ThrowTypeErrorNoEngine<object>("invalid type");
+                    }
+
+                    jsValues[i] = jsValue;
+                }
+
+                return jsValues;
+            }
+
+            public override void DeletePropertyOrThrow(ulong index)
+            {
+                _target.DeleteAt((uint) index);
+            }
+
+            public override void Set(ulong index, JsValue value, bool throwOnError)
+            {
+                _target.SetIndexValue((uint) index, value, throwOnError);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Adapter to use optimized array operations when possible.
+    ///     Gaps the difference between ArgumentsInstance and ArrayInstance.
+    /// </summary>
+    internal abstract class ArrayOperations<T> : ArrayOperations where T : ObjectInstance
+    {
+        protected readonly T _target;
+
+        protected ArrayOperations(T target)
+        {
+            _target = target;
+        }
+
+        public override ObjectInstance Target => _target;
+    }
+}

--- a/Jint/Native/Boolean/BooleanConstructor.cs
+++ b/Jint/Native/Boolean/BooleanConstructor.cs
@@ -17,16 +17,15 @@ namespace Jint.Native.Boolean
         public static BooleanConstructor CreateBooleanConstructor(Engine engine)
         {
             var obj = new BooleanConstructor(engine);
-            obj.Extensible = true;
 
             // The value of the [[Prototype]] internal property of the Boolean constructor is the Function prototype object
-            obj.Prototype = engine.Function.PrototypeObject;
+            obj._prototype = engine.Function.PrototypeObject;
             obj.PrototypeObject = BooleanPrototype.CreatePrototypeObject(engine, obj);
 
             obj._length = PropertyDescriptor.AllForbiddenDescriptor.NumberOne;
 
             // The initial value of Boolean.prototype is the Boolean prototype object
-            obj._prototype = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
+            obj._prototypeDescriptor = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
 
             return obj;
         }
@@ -44,9 +43,7 @@ namespace Jint.Native.Boolean
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.7.2.1
         /// </summary>
-        /// <param name="arguments"></param>
-        /// <returns></returns>
-        public ObjectInstance Construct(JsValue[] arguments)
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
         {
             return Construct(TypeConverter.ToBoolean(arguments.At(0)));
         }
@@ -62,9 +59,8 @@ namespace Jint.Native.Boolean
         {
             var instance = new BooleanInstance(Engine)
             {
-                Prototype = PrototypeObject,
+                _prototype = PrototypeObject,
                 PrimitiveValue = value,
-                Extensible = true
             };
 
             return instance;

--- a/Jint/Native/Boolean/BooleanPrototype.cs
+++ b/Jint/Native/Boolean/BooleanPrototype.cs
@@ -20,9 +20,8 @@ namespace Jint.Native.Boolean
         {
             var obj = new BooleanPrototype(engine)
             {
-                Prototype = engine.Object.PrototypeObject,
+                _prototype = engine.Object.PrototypeObject,
                 PrimitiveValue = false,
-                Extensible = true,
                 _booleanConstructor = booleanConstructor
             };
 

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -62,8 +62,7 @@ namespace Jint.Native.Date
         {
             var obj = new DateConstructor(engine)
             {
-                Extensible = true,
-                Prototype = engine.Function.PrototypeObject
+                _prototype = engine.Function.PrototypeObject
             };
 
             // The value of the [[Prototype]] internal property of the Date constructor is the Function prototype object
@@ -72,7 +71,7 @@ namespace Jint.Native.Date
             obj._length = new PropertyDescriptor(7, PropertyFlag.AllForbidden);
 
             // The initial value of Date.prototype is the Date prototype object
-            obj._prototype = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
+            obj._prototypeDescriptor = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
 
             return obj;
         }
@@ -121,15 +120,13 @@ namespace Jint.Native.Date
 
         public override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
-            return PrototypeObject.ToString(Construct(Arguments.Empty), Arguments.Empty);
+            return PrototypeObject.ToString(Construct(Arguments.Empty, thisObject), Arguments.Empty);
         }
 
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.3
         /// </summary>
-        /// <param name="arguments"></param>
-        /// <returns></returns>
-        public ObjectInstance Construct(JsValue[] arguments)
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
         {
             if (arguments.Length == 0)
             {
@@ -207,11 +204,10 @@ namespace Jint.Native.Date
         public DateInstance Construct(DateTime value)
         {
             var instance = new DateInstance(Engine)
-                {
-                    Prototype = PrototypeObject,
-                    PrimitiveValue = FromDateTime(value),
-                    Extensible = true
-                };
+            {
+                _prototype = PrototypeObject,
+                PrimitiveValue = FromDateTime(value)
+            };
 
             return instance;
         }
@@ -219,11 +215,10 @@ namespace Jint.Native.Date
         public DateInstance Construct(double time)
         {
             var instance = new DateInstance(Engine)
-                {
-                    Prototype = PrototypeObject,
-                    PrimitiveValue = TimeClip(time),
-                    Extensible = true
-                };
+            {
+                _prototype = PrototypeObject,
+                PrimitiveValue = TimeClip(time)
+            };
 
             return instance;
         }
@@ -258,7 +253,7 @@ namespace Jint.Native.Date
                 result = PrototypeObject.Utc(result);
             }
 
-            return System.Math.Floor(result);
+            return System.Math.Round(result);
         }
     }
 }

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -24,8 +24,7 @@ namespace Jint.Native.Date
         {
             var obj = new DatePrototype(engine)
             {
-                Prototype = engine.Object.PrototypeObject,
-                Extensible = true,
+                _prototype = engine.Object.PrototypeObject,
                 PrimitiveValue = double.NaN,
                 _dateConstructor = dateConstructor
             };
@@ -588,7 +587,7 @@ namespace Jint.Native.Date
                 return Null;
             }
 
-            var toIso = o.Get("toISOString");
+            var toIso = o.Get("toISOString", o);
             if (!toIso.Is<ICallable>())
             {
                 ExceptionHelper.ThrowTypeError(Engine);
@@ -913,7 +912,7 @@ namespace Jint.Native.Date
                 year = isLeapYear ? 2000 : 1999;
             }
 
-            var dateTime = new DateTime((int)year, 1, 1).AddMilliseconds(timeInYear);
+            var dateTime = new DateTime(year, 1, 1).AddMilliseconds(timeInYear);
 
             return Engine.Options._LocalTimeZone.IsDaylightSavingTime(dateTime) ? MsPerHour : 0;
         }

--- a/Jint/Native/Error/ErrorPrototype.cs
+++ b/Jint/Native/Error/ErrorPrototype.cs
@@ -21,17 +21,16 @@ namespace Jint.Native.Error
         {
             var obj = new ErrorPrototype(engine, name)
             {
-                Extensible = true,
                 _errorConstructor = errorConstructor,
             };
 
             if (name != "Error")
             {
-                obj.Prototype = engine.Error.PrototypeObject;
+                obj._prototype = engine.Error.PrototypeObject;
             }
             else
             {
-                obj.Prototype = engine.Object.PrototypeObject;
+                obj._prototype = engine.Object.PrototypeObject;
             }
 
             return obj;
@@ -52,9 +51,9 @@ namespace Jint.Native.Error
                 ExceptionHelper.ThrowTypeError(Engine);
             }
 
-            var name = TypeConverter.ToString(o.Get("name"));
+            var name = TypeConverter.ToString(o.Get("name", this));
 
-            var msgProp = o.Get("message");
+            var msgProp = o.Get("message", this);
             string msg;
             if (msgProp.IsUndefined())
             {

--- a/Jint/Native/Function/ArrowFunctionInstance.cs
+++ b/Jint/Native/Function/ArrowFunctionInstance.cs
@@ -33,8 +33,8 @@ namespace Jint.Native.Function
         {
             _function = function;
 
-            Extensible = false;
-            Prototype = Engine.Function.PrototypeObject;
+            PreventExtensions();
+            _prototype = Engine.Function.PrototypeObject;
 
             _length = new PropertyDescriptor(JsNumber.Create(function._length), PropertyFlag.Configurable);
             _thisBinding = _engine.ExecutionContext.ThisBinding;
@@ -98,16 +98,16 @@ namespace Jint.Native.Function
             }
         }
 
-        public override void Put(in Key propertyName, JsValue value, bool throwOnError)
+        public override bool Set(in Key propertyName, JsValue value, JsValue receiver)
         {
             AssertValidPropertyName(propertyName);
-            base.Put(propertyName, value, throwOnError);
+            return base.Set(propertyName, value, receiver);
         }
 
-        public override JsValue Get(in Key propertyName)
+        public override JsValue Get(in Key propertyName, JsValue receiver)
         {
             AssertValidPropertyName(propertyName);
-            return base.Get(propertyName);
+            return base.Get(propertyName, receiver);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Native/Function/BindFunctionInstance.cs
+++ b/Jint/Native/Function/BindFunctionInstance.cs
@@ -19,22 +19,22 @@ namespace Jint.Native.Function
 
         public override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
-            var f = TargetFunction.TryCast<FunctionInstance>(x =>
+            if (!(TargetFunction is FunctionInstance f))
             {
-                ExceptionHelper.ThrowTypeError(Engine);
-            });
+                return ExceptionHelper.ThrowTypeError<ObjectInstance>(Engine);
+            }
 
             return f.Call(BoundThis, CreateArguments(arguments));
         }
 
-        public ObjectInstance Construct(JsValue[] arguments)
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
         {
-            var target = TargetFunction.TryCast<IConstructor>(x =>
+            if (!(TargetFunction is IConstructor target))
             {
-                ExceptionHelper.ThrowTypeError(Engine);
-            });
+                return ExceptionHelper.ThrowTypeError<ObjectInstance>(Engine);
+            }
 
-            return target.Construct(CreateArguments(arguments));
+            return target.Construct(CreateArguments(arguments), newTarget);
         }
 
         public override bool HasInstance(JsValue v)
@@ -51,5 +51,7 @@ namespace Jint.Native.Function
         {
             return Enumerable.Union(BoundArgs, arguments).ToArray();
         }
+
+        internal override bool IsConstructor => TargetFunction is IConstructor;
     }
 }

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -14,7 +14,7 @@ namespace Jint.Native.Function
         public EvalFunctionInstance(Engine engine, string[] parameters, LexicalEnvironment scope, bool strict) 
             : base(engine, _functionName, parameters, scope, strict)
         {
-            Prototype = Engine.Function.PrototypeObject;
+            _prototype = Engine.Function.PrototypeObject;
             _length = PropertyDescriptor.AllForbiddenDescriptor.NumberOne;
         }
 

--- a/Jint/Native/Function/FunctionConstructor.cs
+++ b/Jint/Native/Function/FunctionConstructor.cs
@@ -24,16 +24,15 @@ namespace Jint.Native.Function
         {
             var obj = new FunctionConstructor(engine)
             {
-                Extensible = true,
                 PrototypeObject = FunctionPrototype.CreatePrototypeObject(engine)
             };
 
             // The initial value of Function.prototype is the standard built-in Function prototype object
 
             // The value of the [[Prototype]] internal property of the Function constructor is the standard built-in Function prototype object
-            obj.Prototype = obj.PrototypeObject;
+            obj._prototype = obj.PrototypeObject;
 
-            obj._prototype = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
+            obj._prototypeDescriptor = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
             obj._length =  PropertyDescriptor.AllForbiddenDescriptor.NumberOne;
 
             return obj;
@@ -43,10 +42,10 @@ namespace Jint.Native.Function
 
         public override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
-            return Construct(arguments);
+            return Construct(arguments, thisObject);
         }
 
-        public ObjectInstance Construct(JsValue[] arguments)
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
         {
             var argCount = arguments.Length;
             string p = "";
@@ -86,10 +85,7 @@ namespace Jint.Native.Function
                 Engine,
                 function,
                 LexicalEnvironment.NewDeclarativeEnvironment(Engine, Engine.ExecutionContext.LexicalEnvironment),
-                function.Strict)
-            {
-                Extensible = true
-            };
+                function.Strict);
 
             return functionObject;
 
@@ -106,10 +102,7 @@ namespace Jint.Native.Function
                 Engine,
                 functionDeclaration,
                 LexicalEnvironment.NewDeclarativeEnvironment(Engine, Engine.ExecutionContext.LexicalEnvironment),
-                functionDeclaration.Strict)
-            {
-                Extensible = true
-            };
+                functionDeclaration.Strict);
 
             return functionObject;
         }
@@ -155,13 +148,13 @@ namespace Jint.Native.Function
                 ExceptionHelper.ThrowTypeError(Engine);
             }
 
-            var len = argArrayObj.Get("length");
+            var len = argArrayObj.Get("length", argArrayObj);
             var n = TypeConverter.ToUint32(len);
             var argList = new JsValue[n];
             for (var index = 0; index < n; index++)
             {
                 var indexName = TypeConverter.ToString(index);
-                var nextArg = argArrayObj.Get(indexName);
+                var nextArg = argArrayObj.Get(indexName, argArrayObj);
                 argList[index] = nextArg;
             }
             return func.Call(thisArg, argList);

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -35,23 +36,21 @@ namespace Jint.Native.Function
         {
             _function = function;
 
-            Extensible = true;
-            Prototype = _engine.Function.PrototypeObject;
+            _prototype = _engine.Function.PrototypeObject;
 
             _length = new PropertyDescriptor(JsNumber.Create(function._length), PropertyFlag.Configurable);
 
             var proto = new ObjectInstanceWithConstructor(engine, this)
             {
-                Extensible = true,
-                Prototype = _engine.Object.PrototypeObject
+                _prototype = _engine.Object.PrototypeObject
             };
 
-            _prototype = new PropertyDescriptor(proto, PropertyFlag.OnlyWritable);
+            _prototypeDescriptor = new PropertyDescriptor(proto, PropertyFlag.OnlyWritable);
 
             if (strict)
             {
-                DefineOwnProperty(KnownKeys.Caller, engine._getSetThrower, false);
-                DefineOwnProperty(KnownKeys.Arguments, engine._getSetThrower, false);
+                DefineOwnProperty(KnownKeys.Caller, engine._getSetThrower);
+                DefineOwnProperty(KnownKeys.Arguments, engine._getSetThrower);
             }
         }
 
@@ -135,25 +134,39 @@ namespace Jint.Native.Function
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-13.2.2
         /// </summary>
-        /// <param name="arguments"></param>
-        /// <returns></returns>
-        public ObjectInstance Construct(JsValue[] arguments)
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
         {
-            var proto = Get(KnownKeys.Prototype).TryCast<ObjectInstance>();
+            var thisArgument = OrdinaryCreateFromConstructor(TypeConverter.ToObject(_engine, newTarget), _engine.Object.PrototypeObject);
 
-            var obj = new ObjectInstance(_engine)
-            {
-                Extensible = true,
-                Prototype = proto ?? _engine.Object.PrototypeObject
-            };
-
-            var result = Call(obj, arguments).TryCast<ObjectInstance>();
+            var result = Call(thisArgument, arguments).TryCast<ObjectInstance>();
             if (!ReferenceEquals(result, null))
             {
                 return result;
             }
 
+            return thisArgument;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ObjectInstance OrdinaryCreateFromConstructor(ObjectInstance constructor, ObjectInstance intrinsicDefaultProto)
+        {
+            var proto = GetPrototypeFromConstructor(constructor, intrinsicDefaultProto);
+
+            var obj = new ObjectInstance(_engine)
+            {
+                _prototype = proto
+            };
             return obj;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ObjectInstance GetPrototypeFromConstructor(ObjectInstance constructor, ObjectInstance intrinsicDefaultProto)
+        {
+            var proto = constructor.Get(KnownKeys.Prototype, constructor) as ObjectInstance;
+            // If Type(proto) is not Object, then
+            //    Let realm be ? GetFunctionRealm(constructor).
+            //    Set proto to realm's intrinsic object named intrinsicDefaultProto.
+            return proto ?? intrinsicDefaultProto;
         }
 
         private class ObjectInstanceWithConstructor : ObjectInstance
@@ -165,11 +178,11 @@ namespace Jint.Native.Function
                 _constructor = new PropertyDescriptor(thisObj, PropertyFlag.NonEnumerable);
             }
 
-            public override IEnumerable<KeyValuePair<string, PropertyDescriptor>> GetOwnProperties()
+            public override IEnumerable<KeyValuePair<Key, PropertyDescriptor>> GetOwnProperties()
             {
                 if (_constructor != null)
                 {
-                    yield return new KeyValuePair<string, PropertyDescriptor>(KnownKeys.Constructor, _constructor);
+                    yield return new KeyValuePair<Key, PropertyDescriptor>(KnownKeys.Constructor, _constructor);
                 }
 
                 foreach (var entry in base.GetOwnProperties())

--- a/Jint/Native/Function/ThrowTypeError.cs
+++ b/Jint/Native/Function/ThrowTypeError.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.Function
             : base(engine, _functionName, System.ArrayExt.Empty<string>(), engine.GlobalEnvironment, false)
         {
             _length = PropertyDescriptor.AllForbiddenDescriptor.NumberZero;
-            Extensible = false;
+            PreventExtensions();
         }
 
         public override JsValue Call(JsValue thisObject, JsValue[] arguments)

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -25,8 +25,7 @@ namespace Jint.Native.Global
         {
             var global = new GlobalObject(engine)
             {
-                Prototype = null,
-                Extensible = true,
+                _prototype = null,
                 _properties = new StringDictionarySlim<PropertyDescriptor>(35)
             };
 
@@ -51,8 +50,10 @@ namespace Jint.Native.Global
             _properties["JSON"] = new PropertyDescriptor(Engine.Json, true, false, true);
             _properties["Error"] = new LazyPropertyDescriptor(() => Engine.Error, true, false, true);
             _properties["EvalError"] = new LazyPropertyDescriptor(() => Engine.EvalError, true, false, true);
+            _properties["Proxy"] = new LazyPropertyDescriptor(() => Engine.Proxy, true, false, true);
             _properties["RangeError"] = new LazyPropertyDescriptor(() => Engine.RangeError, true, false, true);
             _properties["ReferenceError"] = new LazyPropertyDescriptor(() => Engine.ReferenceError, true, false, true);
+            _properties["Reflect"] = new LazyPropertyDescriptor(() => Engine.Reflect, true, false, true);
             _properties["SyntaxError"] = new LazyPropertyDescriptor(() => Engine.SyntaxError, true, false, true);
             _properties["TypeError"] = new LazyPropertyDescriptor(() => Engine.TypeError, true, false, true);
             _properties["URIError"] = new LazyPropertyDescriptor(() => Engine.UriError, true, false, true);
@@ -446,7 +447,7 @@ namespace Jint.Native.Global
                         v = (c - 0xD800) * 0x400 + (kChar - 0xDC00) + 0x10000;
                     }
 
-                    byte[] octets = System.ArrayExt.Empty<byte>();
+                    byte[] octets = ArrayExt.Empty<byte>();
 
                     if (v >= 0 && v <= 0x007F)
                     {

--- a/Jint/Native/IConstructor.cs
+++ b/Jint/Native/IConstructor.cs
@@ -4,7 +4,6 @@ namespace Jint.Native
 {
     public interface IConstructor
     {
-        JsValue Call(JsValue thisObject, JsValue[] arguments);
-        ObjectInstance Construct(JsValue[] arguments);
+        ObjectInstance Construct(JsValue[] arguments, JsValue newTarget);
     }
 }

--- a/Jint/Native/Iterator/IteratorConstructor.cs
+++ b/Jint/Native/Iterator/IteratorConstructor.cs
@@ -22,16 +22,15 @@ namespace Jint.Native.Iterator
         public static IteratorConstructor CreateIteratorConstructor(Engine engine)
         {
             var obj = new IteratorConstructor(engine);
-            obj.Extensible = true;
 
             // The value of the [[Prototype]] internal property of the Map constructor is the Function prototype object
-            obj.Prototype = engine.Function.PrototypeObject;
+            obj._prototype = engine.Function.PrototypeObject;
             obj.PrototypeObject = IteratorPrototype.CreatePrototypeObject(engine, obj);
 
             obj._length = new PropertyDescriptor(0, PropertyFlag.Configurable);
 
             // The initial value of Map.prototype is the Map prototype object
-            obj._prototype = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
+            obj._prototypeDescriptor = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
 
             return obj;
         }
@@ -42,7 +41,7 @@ namespace Jint.Native.Iterator
             return Construct(arguments);
         }
 
-        public ObjectInstance Construct(JsValue[] arguments)
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
         {
             return Construct(Enumerable.Empty<JsValue>());
         }
@@ -51,7 +50,7 @@ namespace Jint.Native.Iterator
         {
             var instance = new IteratorInstance(Engine, enumerable)
             {
-                Prototype = PrototypeObject, Extensible = true
+                _prototype = PrototypeObject
             };
 
             return instance;
@@ -61,7 +60,7 @@ namespace Jint.Native.Iterator
         {
             var instance = new IteratorInstance.ListIterator(Engine, enumerable)
             {
-                Prototype = PrototypeObject, Extensible = true
+                _prototype = PrototypeObject
             };
 
             return instance;
@@ -71,7 +70,7 @@ namespace Jint.Native.Iterator
         {
             var instance = new IteratorInstance.ArrayLikeIterator(Engine, array)
             {
-                Prototype = PrototypeObject, Extensible = true
+                _prototype = PrototypeObject
             };
 
             return instance;
@@ -81,7 +80,7 @@ namespace Jint.Native.Iterator
         {
             var instance = new IteratorInstance.MapIterator(Engine, map)
             {
-                Prototype = PrototypeObject, Extensible = true
+                _prototype = PrototypeObject
             };
 
             return instance;
@@ -91,7 +90,7 @@ namespace Jint.Native.Iterator
         {
             var instance = new IteratorInstance.SetIterator(Engine, set)
             {
-                Prototype = PrototypeObject, Extensible = true
+                _prototype = PrototypeObject
             };
 
             return instance;
@@ -101,7 +100,7 @@ namespace Jint.Native.Iterator
         {
             var instance = new IteratorInstance.SetEntryIterator(Engine, set)
             {
-                Prototype = PrototypeObject, Extensible = true
+                _prototype = PrototypeObject
             };
 
             return instance;
@@ -111,7 +110,7 @@ namespace Jint.Native.Iterator
         {
             var instance = new IteratorInstance.ArrayLikeKeyIterator(Engine, array)
             {
-                Prototype = PrototypeObject, Extensible = true
+                _prototype = PrototypeObject
             };
 
             return instance;
@@ -121,7 +120,7 @@ namespace Jint.Native.Iterator
         {
             var instance = new IteratorInstance.ArrayLikeValueIterator(Engine, array)
             {
-                Prototype = PrototypeObject, Extensible = true
+                _prototype = PrototypeObject
             };
 
             return instance;
@@ -131,7 +130,7 @@ namespace Jint.Native.Iterator
         {
             var instance = new IteratorInstance.StringIterator(Engine, str)
             {
-                Prototype = PrototypeObject, Extensible = true
+                _prototype = PrototypeObject
             };
 
             return instance;

--- a/Jint/Native/Iterator/IteratorInstance.cs
+++ b/Jint/Native/Iterator/IteratorInstance.cs
@@ -113,7 +113,7 @@ namespace Jint.Native.Iterator
 
         public class ArrayLikeIterator : IteratorInstance
         {
-            private readonly ArrayPrototype.ArrayOperations _array;
+            private readonly ArrayOperations _array;
             private uint? _end;
             private uint _position;
 
@@ -125,7 +125,7 @@ namespace Jint.Native.Iterator
                     return;
                 }
 
-                _array = ArrayPrototype.ArrayOperations.For(objectInstance);
+                _array = ArrayOperations.For(objectInstance);
                 _position = 0;
             }
 
@@ -222,13 +222,13 @@ namespace Jint.Native.Iterator
 
         public class ArrayLikeKeyIterator : IteratorInstance
         {
-            private readonly ArrayPrototype.ArrayOperations _operations;
+            private readonly ArrayOperations _operations;
             private uint _position;
             private bool _closed;
 
             public ArrayLikeKeyIterator(Engine engine, ObjectInstance objectInstance) : base(engine)
             {
-                _operations = ArrayPrototype.ArrayOperations.For(objectInstance);
+                _operations = ArrayOperations.For(objectInstance);
                 _position = 0;
             }
 
@@ -247,13 +247,13 @@ namespace Jint.Native.Iterator
 
         public class ArrayLikeValueIterator : IteratorInstance
         {
-            private readonly ArrayPrototype.ArrayOperations _operations;
+            private readonly ArrayOperations _operations;
             private uint _position;
             private bool _closed;
 
             public ArrayLikeValueIterator(Engine engine, ObjectInstance objectInstance) : base(engine)
             {
-                _operations = ArrayPrototype.ArrayOperations.For(objectInstance);
+                _operations = ArrayOperations.For(objectInstance);
                 _position = 0;
             }
 
@@ -279,7 +279,7 @@ namespace Jint.Native.Iterator
             public ObjectWrapper(ObjectInstance target)
             {
                 _target = target;
-                _callable = (ICallable) target.Get("next");
+                _callable = (ICallable) target.Get("next", target);
             }
 
             public ObjectInstance Next()

--- a/Jint/Native/Iterator/IteratorProtocol.cs
+++ b/Jint/Native/Iterator/IteratorProtocol.cs
@@ -68,7 +68,7 @@ namespace Jint.Native.Iterator
 
         protected abstract void ProcessItem(JsValue[] args, JsValue currentValue);
 
-        protected JsValue ExtractValueFromIteratorInstance(JsValue jsValue)
+        protected static JsValue ExtractValueFromIteratorInstance(JsValue jsValue)
         {
             if (jsValue is ArrayInstance ai)
             {

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -14,8 +14,7 @@ namespace Jint.Native.Iterator
         {
             var obj = new IteratorPrototype(engine)
             {
-                Extensible = true,
-                Prototype = engine.Object.PrototypeObject
+                _prototype = engine.Object.PrototypeObject
             };
 
             return obj;

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -19,6 +19,7 @@ namespace Jint.Native
         internal static readonly JsString BooleanString = new JsString("boolean");
         internal static readonly JsString StringString = new JsString("string");
         internal static readonly JsString NumberString = new JsString("number");
+        internal static readonly JsString LengthString = new JsString("length");
 
         internal string _value;
 
@@ -96,6 +97,11 @@ namespace Jint.Native
             }
 
             return new JsString(value);
+        }
+
+        internal override Key ToPropertyKey()
+        {
+            return new Key(_value);
         }
 
         public override string ToString()

--- a/Jint/Native/JsSymbol.cs
+++ b/Jint/Native/JsSymbol.cs
@@ -10,20 +10,26 @@ namespace Jint.Native
     public sealed class JsSymbol : JsValue, IEquatable<JsSymbol>
     {
         internal readonly string _value;
+        private readonly Key _key;
 
-        public JsSymbol(string value) : base(Types.Symbol)
+        internal JsSymbol(string value, int identity) : base(Types.Symbol)
         {
             _value = value;
+            _key = new Key(_value, identity);
         }
 
-        internal JsSymbol(JsValue value) : base(Types.Symbol)
+        internal JsSymbol(JsValue value, int identity) : this(value.IsUndefined() ? "" : value.ToString(), identity)
         {
-            _value = value.IsUndefined() ? "" : value.ToString();
         }
 
         public override object ToObject()
         {
             return _value;
+        }
+
+        internal override Key ToPropertyKey()
+        {
+            return _key;
         }
 
         public override string ToString()
@@ -33,12 +39,12 @@ namespace Jint.Native
 
         public override bool Equals(JsValue obj)
         {
-            return ReferenceEquals(this, obj);
+            return Equals(obj as JsSymbol);
         }
 
         public bool Equals(JsSymbol other)
         {
-            return ReferenceEquals(this, other);
+            return other != null && other._key == _key;
         }
 
         public override int GetHashCode()

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -55,8 +55,7 @@ namespace Jint.Native
         }
 
         [Pure]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IsArray()
+        public virtual bool IsArray()
         {
             return this is ArrayInstance;
         }
@@ -182,7 +181,7 @@ namespace Jint.Native
         {
             var objectInstance = TypeConverter.ToObject(engine, this);
 
-            if (!objectInstance.TryGetValue(GlobalSymbolRegistry.Iterator._value, out var value)
+            if (!objectInstance.TryGetValue(GlobalSymbolRegistry.Iterator, out var value)
                 || !(value is ICallable callable))
             {
                 iterator = null;
@@ -282,6 +281,8 @@ namespace Jint.Native
             get => _type == InternalTypes.Integer ? Types.Number : (Types) _type;
         }
 
+        internal virtual bool IsConstructor => this is IConstructor;
+
         /// <summary>
         /// Creates a valid <see cref="JsValue"/> instance from any <see cref="Object"/> instance
         /// </summary>
@@ -369,8 +370,7 @@ namespace Jint.Native
             var arrayLength = (uint) array.Length;
 
             var jsArray = new ArrayInstance(e, arrayLength);
-            jsArray.Prototype = e.Array.PrototypeObject;
-            jsArray.Extensible = true;
+            jsArray._prototype = e.Array.PrototypeObject;
 
             for (uint i = 0; i < arrayLength; ++i)
             {
@@ -427,6 +427,11 @@ namespace Jint.Native
             argument = completion.Value;
 
             return false;
+        }
+
+        internal virtual Key ToPropertyKey()
+        {
+            return new Key(ToString());
         }
 
         public override string ToString()

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -13,14 +13,13 @@ namespace Jint.Native.Json
         private JsonInstance(Engine engine)
             : base(engine, objectClass: "JSON")
         {
-            Extensible = true;
         }
 
         public static JsonInstance CreateJsonObject(Engine engine)
         {
             var json = new JsonInstance(engine)
             {
-                Prototype = engine.Object.PrototypeObject
+                _prototype = engine.Object.PrototypeObject
             };
             return json;
         }
@@ -36,7 +35,7 @@ namespace Jint.Native.Json
 
         private JsValue AbstractWalkOperation(ObjectInstance thisObject, string prop)
         {
-            JsValue value = thisObject.Get(prop);
+            JsValue value = thisObject.Get(prop, thisObject);
             if (value.IsObject())
             {
                 var valueAsObject = value.AsObject();
@@ -50,7 +49,7 @@ namespace Jint.Native.Json
                         var newValue = AbstractWalkOperation(valAsArray, TypeConverter.ToString(i));
                         if (newValue.IsUndefined())
                         {
-                            valAsArray.Delete(TypeConverter.ToString(i), false);
+                            valAsArray.Delete(TypeConverter.ToString(i));
                         }
                         else
                         {
@@ -61,9 +60,7 @@ namespace Jint.Native.Json
                                 (
                                     value: newValue,
                                     PropertyFlag.ConfigurableEnumerableWritable
-                                ),
-                                false
-                            );
+                                ));
                         }
                         i = i + 1;
                     }
@@ -76,7 +73,7 @@ namespace Jint.Native.Json
                         var newElement = AbstractWalkOperation(valueAsObject, p.Key);
                         if (newElement.IsUndefined())
                         {
-                            valueAsObject.Delete(p.Key, false);
+                            valueAsObject.Delete(p.Key);
                         }
                         else
                         {
@@ -86,9 +83,7 @@ namespace Jint.Native.Json
                                 (
                                     value: newElement,
                                     PropertyFlag.ConfigurableEnumerableWritable
-                                ),
-                                false
-                            );
+                                ));
                         }
                     }
                 }
@@ -109,9 +104,7 @@ namespace Jint.Native.Json
                     new PropertyDescriptor(
                         value: res,
                         PropertyFlag.ConfigurableEnumerableWritable
-                    ),
-                    false
-                );
+                    ));
                 return AbstractWalkOperation(revRes, "");
             }
             return res;

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -672,7 +672,7 @@ namespace Jint.Native.Json
 
         private ObjectInstance ParseJsonArray()
         {
-            var elements = new System.Collections.Generic.List<JsValue>();
+            var elements = new List<JsValue>();
 
             Expect("[");
 
@@ -826,7 +826,7 @@ namespace Jint.Native.Json
             {
                 if (options.Tokens)
                 {
-                    _extra.Tokens = new System.Collections.Generic.List<Token>();
+                    _extra.Tokens = new List<Token>();
                 }
 
             }
@@ -856,7 +856,7 @@ namespace Jint.Native.Json
             public int? Loc;
             public int[] Range;
 
-            public System.Collections.Generic.List<Token> Tokens;
+            public List<Token> Tokens;
         }
 
         private enum Tokens

--- a/Jint/Native/Map/MapConstructor.cs
+++ b/Jint/Native/Map/MapConstructor.cs
@@ -25,8 +25,7 @@ namespace Jint.Native.Map
         {
             var obj = new MapConstructor(engine)
             {
-                Extensible = true,
-                Prototype = engine.Function.PrototypeObject
+                _prototype = engine.Function.PrototypeObject
             };
 
             // The value of the [[Prototype]] internal property of the Map constructor is the Function prototype object
@@ -35,7 +34,7 @@ namespace Jint.Native.Map
             obj._length = new PropertyDescriptor(0, PropertyFlag.Configurable);
 
             // The initial value of Map.prototype is the Map prototype object
-            obj._prototype = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
+            obj._prototypeDescriptor = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
 
             return obj;
         }
@@ -44,7 +43,7 @@ namespace Jint.Native.Map
         {
             _properties = new StringDictionarySlim<PropertyDescriptor>(2)
             {
-                [GlobalSymbolRegistry.Species._value] = new GetSetPropertyDescriptor(get: new ClrFunctionInstance(_engine, "get [Symbol.species]", Species, 0, PropertyFlag.Configurable), set: Undefined, PropertyFlag.Configurable)
+                [GlobalSymbolRegistry.Species] = new GetSetPropertyDescriptor(get: new ClrFunctionInstance(_engine, "get [Symbol.species]", Species, 0, PropertyFlag.Configurable), set: Undefined, PropertyFlag.Configurable)
             };
 
         }
@@ -61,15 +60,14 @@ namespace Jint.Native.Map
                 ExceptionHelper.ThrowTypeError(_engine, "Constructor Map requires 'new'");
             }
 
-            return Construct(arguments);
+            return Construct(arguments, thisObject);
         }
 
-        public ObjectInstance Construct(JsValue[] arguments)
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
         {
             var instance = new MapInstance(Engine)
             {
-                Prototype = PrototypeObject,
-                Extensible = true
+                _prototype = PrototypeObject
             };
 
             if (arguments.Length > 0 && !arguments[0].IsNullOrUndefined())

--- a/Jint/Native/Map/MapInstance.cs
+++ b/Jint/Native/Map/MapInstance.cs
@@ -15,45 +15,6 @@ namespace Jint.Native.Map
             _map = new OrderedDictionary<JsValue, JsValue>();
         }
 
-        /// Implementation from ObjectInstance official specs as the one
-        /// in ObjectInstance is optimized for the general case and wouldn't work
-        /// for arrays
-        public override void Put(in Key propertyName, JsValue value, bool throwOnError)
-        {
-            if (!CanPut(propertyName))
-            {
-                if (throwOnError)
-                {
-                    ExceptionHelper.ThrowTypeError(Engine);
-                }
-
-                return;
-            }
-
-            var ownDesc = GetOwnProperty(propertyName);
-
-            if (ownDesc.IsDataDescriptor())
-            {
-                var valueDesc = new PropertyDescriptor(value, PropertyFlag.None);
-                DefineOwnProperty(propertyName, valueDesc, throwOnError);
-                return;
-            }
-
-            // property is an accessor or inherited
-            var desc = GetProperty(propertyName);
-
-            if (desc.IsAccessorDescriptor())
-            {
-                var setter = desc.Set.TryCast<ICallable>();
-                setter.Call(this, new[] {value});
-            }
-            else
-            {
-                var newDesc = new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable);
-                DefineOwnProperty(propertyName, newDesc, throwOnError);
-            }
-        }
-
         public override PropertyDescriptor GetOwnProperty(in Key propertyName)
         {
             if (propertyName == KnownKeys.Size)

--- a/Jint/Native/Map/MapPrototype.cs
+++ b/Jint/Native/Map/MapPrototype.cs
@@ -23,8 +23,7 @@ namespace Jint.Native.Map
         {
             var obj = new MapPrototype(engine)
             {
-                Extensible = true,
-                Prototype = engine.Object.PrototypeObject,
+                _prototype = engine.Object.PrototypeObject,
                 _mapConstructor = mapConstructor
             };
 
@@ -37,8 +36,8 @@ namespace Jint.Native.Map
             {
                 ["length"] = new PropertyDescriptor(0, PropertyFlag.Configurable),
                 ["constructor"] = new PropertyDescriptor(_mapConstructor, PropertyFlag.NonEnumerable),
-                [GlobalSymbolRegistry.Iterator._value] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "iterator", Iterator, 1, PropertyFlag.Configurable), true, false, true),
-                [GlobalSymbolRegistry.ToStringTag._value] = new PropertyDescriptor("Map", false, false, true),
+                [GlobalSymbolRegistry.Iterator] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "iterator", Iterator, 1, PropertyFlag.Configurable), true, false, true),
+                [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor("Map", false, false, true),
                 ["clear"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "clear", Clear, 0, PropertyFlag.Configurable), true, false, true),
                 ["delete"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "delete", Delete, 1, PropertyFlag.Configurable), true, false, true),
                 ["entries"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "entries", Iterator, 0, PropertyFlag.Configurable), true, false, true),

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -20,8 +20,7 @@ namespace Jint.Native.Math
         {
             var math = new MathInstance(engine)
             {
-                Extensible = true,
-                Prototype = engine.Object.PrototypeObject
+                _prototype = engine.Object.PrototypeObject
             };
 
             return math;

--- a/Jint/Native/Number/NumberConstructor.cs
+++ b/Jint/Native/Number/NumberConstructor.cs
@@ -24,8 +24,7 @@ namespace Jint.Native.Number
         {
             var obj = new NumberConstructor(engine)
             {
-                Extensible = true,
-                Prototype = engine.Function.PrototypeObject
+                _prototype = engine.Function.PrototypeObject
             };
 
             // The value of the [[Prototype]] internal property of the Number constructor is the Function prototype object
@@ -34,7 +33,7 @@ namespace Jint.Native.Number
             obj._length = new PropertyDescriptor(1, PropertyFlag.AllForbidden);
 
             // The initial value of Number.prototype is the Number prototype object
-            obj._prototype = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
+            obj._prototypeDescriptor = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
 
             return obj;
         }
@@ -134,7 +133,7 @@ namespace Jint.Native.Number
         /// </summary>
         /// <param name="arguments"></param>
         /// <returns></returns>
-        public ObjectInstance Construct(JsValue[] arguments)
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
         {
             return Construct(arguments.Length > 0 ? TypeConverter.ToNumber(arguments[0]) : 0);
         }
@@ -150,9 +149,8 @@ namespace Jint.Native.Number
         {
             var instance = new NumberInstance(Engine)
             {
-                Prototype = PrototypeObject,
-                NumberData = value,
-                Extensible = true
+                _prototype = PrototypeObject,
+                NumberData = value
             };
 
             return instance;

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -26,9 +26,8 @@ namespace Jint.Native.Number
         {
             var obj = new NumberPrototype(engine)
             {
-                Prototype = engine.Object.PrototypeObject,
+                _prototype = engine.Object.PrototypeObject,
                 NumberData = JsNumber.Create(0),
-                Extensible = true,
                 _numberConstructor = numberConstructor
             };
 

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Jint.Collections;
 using Jint.Native.Array;
 using Jint.Native.Function;
@@ -19,28 +18,26 @@ namespace Jint.Native.Object
 
         public static ObjectConstructor CreateObjectConstructor(Engine engine)
         {
-            var obj = new ObjectConstructor(engine)
-            {
-                Extensible = true
-            };
+            var obj = new ObjectConstructor(engine);
 
             obj.PrototypeObject = ObjectPrototype.CreatePrototypeObject(engine, obj);
 
             obj._length = PropertyDescriptor.AllForbiddenDescriptor.NumberOne;
-            obj._prototype = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
+            obj._prototypeDescriptor = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
 
             return obj;
         }
 
         protected override void Initialize()
         {
-            Prototype = Engine.Function.PrototypeObject;
+            _prototype = Engine.Function.PrototypeObject;
 
             _properties = new StringDictionarySlim<PropertyDescriptor>(15)
             {
                 ["getPrototypeOf"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "getPrototypeOf", GetPrototypeOf, 1), true, false, true),
                 ["getOwnPropertyDescriptor"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "getOwnPropertyDescriptor", GetOwnPropertyDescriptor, 2), true, false, true),
                 ["getOwnPropertyNames"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "getOwnPropertyNames", GetOwnPropertyNames, 1), true, false, true),
+                ["getOwnPropertySymbols"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "getOwnPropertySymbols", GetOwnPropertySymbols, 1), true, false, true),
                 ["create"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "create", Create, 2), true, false, true),
                 ["defineProperty"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "defineProperty", DefineProperty, 3), true, false, true),
                 ["defineProperties"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "defineProperties", DefineProperties, 2), true, false, true),
@@ -50,7 +47,8 @@ namespace Jint.Native.Object
                 ["isSealed"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "isSealed", IsSealed, 1), true, false, true),
                 ["isFrozen"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "isFrozen", IsFrozen, 1), true, false, true),
                 ["isExtensible"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "isExtensible", IsExtensible, 1), true, false, true),
-                ["keys"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "keys", Keys, 1), true, false, true)
+                ["keys"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "keys", Keys, 1), true, false, true),
+                ["setPrototypeOf"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "setPrototypeOf", SetPrototypeOf, 2), true, false, true)
             };
         }
 
@@ -80,9 +78,12 @@ namespace Jint.Native.Object
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.2.1
         /// </summary>
-        /// <param name="arguments"></param>
-        /// <returns></returns>
         public ObjectInstance Construct(JsValue[] arguments)
+        {
+            return Construct(arguments, this);
+        }
+
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
         {
             if (arguments.Length > 0)
             {
@@ -100,10 +101,9 @@ namespace Jint.Native.Object
             }
 
             var obj = new ObjectInstance(_engine)
-                {
-                    Extensible = true,
-                    Prototype = Engine.Object.PrototypeObject
-                };
+            {
+                _prototype = Engine.Object.PrototypeObject
+            };
 
             return obj;
         }
@@ -112,8 +112,7 @@ namespace Jint.Native.Object
         {
             var obj = new ObjectInstance(_engine)
             {
-                Extensible = true,
-                Prototype = Engine.Object.PrototypeObject,
+                _prototype = Engine.Object.PrototypeObject,
                 _properties =  propertyCount > 1
                     ? new StringDictionarySlim<PropertyDescriptor>(propertyCount)
                     : null
@@ -124,24 +123,36 @@ namespace Jint.Native.Object
 
         public JsValue GetPrototypeOf(JsValue thisObject, JsValue[] arguments)
         {
+            var o = arguments.As<ObjectInstance>(0, _engine);
+            return o.Prototype ?? Null;
+        }
+
+        public JsValue SetPrototypeOf(JsValue thisObject, JsValue[] arguments)
+        {
             var oArg = arguments.At(0);
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null))
+            TypeConverter.CheckObjectCoercible(_engine, oArg);
+
+            var prototype = arguments.At(1);
+            if (!prototype.IsObject() && !prototype.IsNull())
             {
-                ExceptionHelper.ThrowTypeError(Engine);
+                ExceptionHelper.ThrowTypeError(_engine, $"Object prototype may only be an Object or null: {prototype}");
             }
 
-            return o.Prototype ?? Null;
+            if (!(oArg is ObjectInstance o))
+            {
+                return oArg;
+            }
+
+            if (!o.SetPrototypeOf(prototype))
+            {
+                ExceptionHelper.ThrowTypeError(_engine);
+            }
+            return o;
         }
 
         public JsValue GetOwnPropertyDescriptor(JsValue thisObject, JsValue[] arguments)
         {
-            var oArg = arguments.At(0);
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null))
-            {
-                ExceptionHelper.ThrowTypeError(Engine);
-            }
+            var o = arguments.As<ObjectInstance>(0, _engine);
 
             var p = arguments.At(1);
             var name = TypeConverter.ToPropertyKey(p);
@@ -152,52 +163,52 @@ namespace Jint.Native.Object
 
         public JsValue GetOwnPropertyNames(JsValue thisObject, JsValue[] arguments)
         {
-            var oArg = arguments.At(0);
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null))
-            {
-                ExceptionHelper.ThrowTypeError(Engine);
-            }
+            var o = arguments.As<ObjectInstance>(0, _engine);
 
             uint n = 0;
 
             ArrayInstance array = null;
-            var ownProperties = o.GetOwnProperties().ToList();
+            var ownProperties = o.GetOwnPropertyKeys(Types.String);
             if (o is StringInstance s)
             {
                 var length = s.PrimitiveValue.Length;
-                array = Engine.Array.ConstructFast((uint) (ownProperties.Count + length));
+                array = Engine.Array.ConstructFast((uint) (ownProperties.Count + length + 1));
                 for (var i = 0; i < length; i++)
                 {
-                    array.SetIndexValue(n, TypeConverter.ToString(i), updateLength: false);
-                    n++;
+                    array.SetIndexValue(n++, TypeConverter.ToString(i), updateLength: false);
                 }
+
+                array.SetIndexValue(n++, JsString.LengthString, updateLength: false);
             }
 
             array = array ?? Engine.Array.ConstructFast((uint) ownProperties.Count);
             for (var i = 0; i < ownProperties.Count; i++)
             {
                 var p = ownProperties[i];
-                array.SetIndexValue(n, p.Key, false);
-                n++;
+                array.SetIndexValue(n++, p, false);
             }
 
             array.SetLength(n);
             return array;
         }
 
+        public JsValue GetOwnPropertySymbols(JsValue thisObject, JsValue[] arguments)
+        {
+            var o = arguments.As<ObjectInstance>(0, _engine);
+            var keys = o.GetOwnPropertyKeys(Types.Symbol);
+            return _engine.Array.Construct(keys.ToArray());
+        }
+
         public JsValue Create(JsValue thisObject, JsValue[] arguments)
         {
-            var oArg = arguments.At(0);
-
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null) && !oArg.IsNull())
+            var prototype = arguments.At(0);
+            if (!prototype.IsObject() && !prototype.IsNull())
             {
-                ExceptionHelper.ThrowTypeError(Engine);
+                ExceptionHelper.ThrowTypeError(_engine, "Object prototype may only be an Object or null: " + prototype);
             }
 
             var obj = Engine.Object.Construct(Arguments.Empty);
-            obj.Prototype = o;
+            obj._prototype = prototype.IsNull() ? null : prototype.AsObject();
 
             var properties = arguments.At(1);
             if (!properties.IsUndefined())
@@ -214,32 +225,20 @@ namespace Jint.Native.Object
 
         public JsValue DefineProperty(JsValue thisObject, JsValue[] arguments)
         {
-            var oArg = arguments.At(0);
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null))
-            {
-                ExceptionHelper.ThrowTypeError(Engine);
-            }
-
+            var o = arguments.As<ObjectInstance>(0, _engine);
             var p = arguments.At(1);
             var name = TypeConverter.ToPropertyKey(p);
 
             var attributes = arguments.At(2);
             var desc = PropertyDescriptor.ToPropertyDescriptor(Engine, attributes);
+            o.DefinePropertyOrThrow(name, desc);
 
-            o.DefineOwnProperty(name, desc, true);
             return o;
         }
 
         public JsValue DefineProperties(JsValue thisObject, JsValue[] arguments)
         {
-            var oArg = arguments.At(0);
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null))
-            {
-                ExceptionHelper.ThrowTypeError(Engine);
-            }
-
+            var o = arguments.As<ObjectInstance>(0, _engine);
             var properties = arguments.At(1);
             var props = TypeConverter.ToObject(Engine, properties);
             var descriptors = new List<KeyValuePair<string, PropertyDescriptor>>();
@@ -250,13 +249,13 @@ namespace Jint.Native.Object
                     continue;
                 }
 
-                var descObj = props.Get(p.Key);
+                var descObj = props.Get(p.Key, props);
                 var desc = PropertyDescriptor.ToPropertyDescriptor(Engine, descObj);
                 descriptors.Add(new KeyValuePair<string, PropertyDescriptor>(p.Key, desc));
             }
             foreach (var pair in descriptors)
             {
-                o.DefineOwnProperty(pair.Key, pair.Value, true);
+                o.DefinePropertyOrThrow(pair.Key, pair.Value);
             }
 
             return o;
@@ -264,14 +263,8 @@ namespace Jint.Native.Object
 
         public JsValue Seal(JsValue thisObject, JsValue[] arguments)
         {
-            var oArg = arguments.At(0);
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null))
-            {
-                ExceptionHelper.ThrowTypeError(Engine);
-            }
-
-            var properties = new List<KeyValuePair<string, PropertyDescriptor>>(o.GetOwnProperties());
+            var o = arguments.As<ObjectInstance>(0, _engine);
+            var properties = new List<KeyValuePair<Key, PropertyDescriptor>>(o.GetOwnProperties());
             foreach (var prop in properties)
             {
                 var propertyDescriptor = prop.Value;
@@ -281,24 +274,18 @@ namespace Jint.Native.Object
                     FastSetProperty(prop.Key, propertyDescriptor);
                 }
 
-                o.DefineOwnProperty(prop.Key, propertyDescriptor, true);
+                o.DefinePropertyOrThrow(prop.Key, propertyDescriptor);
             }
 
-            o.Extensible = false;
+            o.PreventExtensions();
 
             return o;
         }
 
         public JsValue Freeze(JsValue thisObject, JsValue[] arguments)
         {
-            var oArg = arguments.At(0);
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null))
-            {
-                ExceptionHelper.ThrowTypeError(Engine);
-            }
-
-            var properties = new List<KeyValuePair<string, PropertyDescriptor>>(o.GetOwnProperties());
+            var o = arguments.As<ObjectInstance>(0, _engine);
+            var properties = new List<KeyValuePair<Key, PropertyDescriptor>>(o.GetOwnProperties());
             foreach (var p in properties)
             {
                 var desc = o.GetOwnProperty(p.Key);
@@ -317,37 +304,24 @@ namespace Jint.Native.Object
                     mutable.Configurable = false;
                     desc = mutable;
                 }
-                o.DefineOwnProperty(p.Key, desc, true);
+                o.DefinePropertyOrThrow(p.Key, desc);
             }
 
-            o.Extensible = false;
+            o.PreventExtensions();
 
             return o;
         }
 
         public JsValue PreventExtensions(JsValue thisObject, JsValue[] arguments)
         {
-            var oArg = arguments.At(0);
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null))
-            {
-                ExceptionHelper.ThrowTypeError(Engine);
-            }
-
-            o.Extensible = false;
-
+            var o = arguments.As<ObjectInstance>(0, _engine);
+            o.PreventExtensions();
             return o;
         }
 
         public JsValue IsSealed(JsValue thisObject, JsValue[] arguments)
         {
-            var oArg = arguments.At(0);
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null))
-            {
-                ExceptionHelper.ThrowTypeError(Engine);
-            }
-
+            var o = arguments.As<ObjectInstance>(0, _engine);
             foreach (var prop in o.GetOwnProperties())
             {
                 if (prop.Value.Configurable)
@@ -366,13 +340,7 @@ namespace Jint.Native.Object
 
         public JsValue IsFrozen(JsValue thisObject, JsValue[] arguments)
         {
-            var oArg = arguments.At(0);
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null))
-            {
-                ExceptionHelper.ThrowTypeError(Engine);
-            }
-
+            var o = arguments.As<ObjectInstance>(0, _engine);
             foreach (var pair in o.GetOwnProperties())
             {
                 var desc = pair.Value;
@@ -399,39 +367,57 @@ namespace Jint.Native.Object
 
         public JsValue IsExtensible(JsValue thisObject, JsValue[] arguments)
         {
-            var oArg = arguments.At(0);
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null))
-            {
-                ExceptionHelper.ThrowTypeError(Engine);
-            }
-
+            var o = arguments.As<ObjectInstance>(0, _engine);
             return o.Extensible;
         }
 
         public JsValue Keys(JsValue thisObject, JsValue[] arguments)
         {
-            var oArg = arguments.At(0);
-            var o = oArg.TryCast<ObjectInstance>();
-            if (ReferenceEquals(o, null))
-            {
-                ExceptionHelper.ThrowTypeError(Engine);
-            }
+            return EnumerableOwnPropertyNames(arguments, EnumerableOwnPropertyNamesKind.Key);
+        }
 
-            var enumerableProperties = o.GetOwnProperties()
-                .Where(x => x.Value.Enumerable)
-                .ToArray();
-            var n = enumerableProperties.Length;
+        private JsValue EnumerableOwnPropertyNames(JsValue[] arguments, EnumerableOwnPropertyNamesKind kind)
+        {
+            var o = arguments.As<ObjectInstance>(0, _engine);
+            var ownKeys = o.GetOwnPropertyKeys(Types.String);
 
-            var array = Engine.Array.ConstructFast((uint) n);
+            var array = Engine.Array.ConstructFast((uint) ownKeys.Count);
             uint index = 0;
-            foreach (var prop in enumerableProperties)
+            foreach (var key in ownKeys)
             {
-                var p = prop.Key;
-                array.SetIndexValue(index, p, updateLength: false);
-                index++;
+                var propertyName = key.ToPropertyKey();
+                var desc = o.GetOwnProperty(propertyName);
+                if (desc != PropertyDescriptor.Undefined && desc.Enumerable)
+                {
+                    if (kind == EnumerableOwnPropertyNamesKind.Key)
+                    {
+                        array.SetIndexValue(index, key, updateLength: false);
+                    }
+                    else
+                    {
+                        var value = o.Get(propertyName, o);
+                        if (kind == EnumerableOwnPropertyNamesKind.Value)
+                        {
+                            array.SetIndexValue(index, value, updateLength: false);
+                        }
+                        else
+                        {
+                            array.SetIndexValue(index, _engine.Array.Construct(new [] { key, value }), updateLength: false);
+                        }
+                    }
+                    index++;
+                }
             }
+
+            array.SetLength(index);
             return array;
+        }
+
+        private enum EnumerableOwnPropertyNamesKind
+        {
+            Key,
+            Value,
+            KeyValue
         }
     }
 }

--- a/Jint/Native/Object/ObjectPrototype.cs
+++ b/Jint/Native/Object/ObjectPrototype.cs
@@ -17,7 +17,6 @@ namespace Jint.Native.Object
         {
             var obj = new ObjectPrototype(engine)
             {
-                Extensible = true,
                 _objectConstructor = objectConstructor
             };
 
@@ -87,7 +86,7 @@ namespace Jint.Native.Object
         private JsValue ToLocaleString(JsValue thisObject, JsValue[] arguments)
         {
             var o = TypeConverter.ToObject(Engine, thisObject);
-            var toString = o.Get("toString").TryCast<ICallable>(x =>
+            var toString = o.Get("toString", o).TryCast<ICallable>(x =>
             {
                 ExceptionHelper.ThrowTypeError(Engine);
             });

--- a/Jint/Native/Proxy/ProxyConstructor.cs
+++ b/Jint/Native/Proxy/ProxyConstructor.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Jint.Collections;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.Native.Proxy
+{
+    public sealed class ProxyConstructor : FunctionInstance, IConstructor
+    {
+        private static readonly JsString _name = new JsString("Proxy");
+
+        private ProxyConstructor(Engine engine)
+            : base(engine, _name, strict: false)
+        {
+        }
+
+        public static ProxyConstructor CreateProxyConstructor(Engine engine)
+        {
+            var obj = new ProxyConstructor(engine);
+            obj._length = new PropertyDescriptor(2, PropertyFlag.Configurable);
+            return obj;
+        }
+
+        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        {
+            return ExceptionHelper.ThrowTypeError<JsValue>(_engine, "Constructor Proxy requires 'new'");
+        }
+
+        /// <summary>
+        /// https://www.ecma-international.org/ecma-262/6.0/index.html#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget
+        /// </summary>
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
+        {
+            var target = arguments.At(0);
+            var handler = arguments.At(1);
+
+            if (!target.IsObject() || !handler.IsObject())
+            {
+                return ExceptionHelper.ThrowTypeError<ObjectInstance>(_engine, "Cannot create proxy with a non-object as target or handler");
+            }
+            return Construct(target.AsObject(), handler.AsObject());
+        }
+
+        protected override void Initialize()
+        {
+            _properties = new StringDictionarySlim<PropertyDescriptor>(3)
+            {
+                ["revocable"] = new PropertyDescriptor(new ClrFunctionInstance(_engine, "revocable", Revocable, 2, PropertyFlag.Configurable), true, true, true)
+            };
+        }
+
+        protected override ObjectInstance GetPrototypeOf()
+        {
+            return _engine.Function.Prototype;
+        }
+
+        public ProxyInstance Construct(ObjectInstance target, ObjectInstance handler)
+        {
+            if (target is ProxyInstance targetProxy && targetProxy._handler is null)
+            {
+                ExceptionHelper.ThrowTypeError(_engine);
+            }
+            if (handler is ProxyInstance handlerProxy && handlerProxy._handler is null)
+            {
+                ExceptionHelper.ThrowTypeError(_engine);
+            }
+            var instance = new ProxyInstance(Engine, target, handler);
+            return instance;
+        }
+
+        private JsValue Revocable(JsValue thisObject, JsValue[] arguments)
+        {
+            var p = _engine.Proxy.Construct(arguments, Undefined);
+            var result = _engine.Object.Construct(ArrayExt.Empty<JsValue>());
+            result.DefineOwnProperty("revoke", new PropertyDescriptor(new ClrFunctionInstance(_engine, name: null, Revoke, 0, PropertyFlag.Configurable), PropertyFlag.ConfigurableEnumerableWritable));
+            result.DefineOwnProperty("proxy", new PropertyDescriptor(Construct(arguments, thisObject), PropertyFlag.ConfigurableEnumerableWritable));
+            return result;
+        }
+
+        private JsValue Revoke(JsValue thisObject, JsValue[] arguments)
+        {
+            var o = thisObject.AsObject();
+            var proxy = (ProxyInstance) o.Get("proxy");
+            proxy._handler = null;
+            proxy._target = null;
+            return Undefined;
+        }
+    }
+}

--- a/Jint/Native/Proxy/ProxyInstance.cs
+++ b/Jint/Native/Proxy/ProxyInstance.cs
@@ -1,0 +1,486 @@
+﻿using System.Collections.Generic;
+using Jint.Native.Function;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Native.Proxy
+{
+    public class ProxyInstance : FunctionInstance, IConstructor
+    {
+        internal ObjectInstance _target;
+        internal ObjectInstance _handler;
+
+        private static readonly Key TrapApply = "apply";
+        private static readonly Key TrapGet = "get";
+        private static readonly Key TrapSet = "set";
+        private static readonly Key TrapPreventExtensions = "preventExtensions";
+        private static readonly Key TrapIsExtensible = "isExtensible";
+        private static readonly Key TrapDefineProperty = "defineProperty";
+        private static readonly Key TrapDeleteProperty = "deleteProperty";
+        private static readonly Key TrapGetOwnPropertyDescriptor = "getOwnPropertyDescriptor";
+        private static readonly Key TrapHas = "has";
+        private static readonly Key TrapGetProtoTypeOf = "getPrototypeOf";
+        private static readonly Key TrapSetProtoTypeOf = "setPrototypeOf";
+        private static readonly Key TrapOwnKeys = "ownKeys";
+        private static readonly Key TrapConstruct = "construct";
+
+        private static readonly Key KeyFunctionRevoke = "revoke";
+
+        public ProxyInstance(
+            Engine engine,
+            ObjectInstance target,
+            ObjectInstance handler)
+            : base(engine, JsString.Empty, false, "Proxy")
+        {
+            _target = target;
+            _handler = handler;
+        }
+
+        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        {
+            var jsValues = new[] { _target, thisObject, _engine.Array.Construct(arguments) };
+            if (TryCallHandler(TrapApply, jsValues, out var result))
+            {
+                return result;
+            }
+
+            return ((ICallable) _target).Call(thisObject, arguments);
+        }
+
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
+        {
+            var argArray = _engine.Array.Construct(arguments, _engine.Array);
+
+            if (!TryCallHandler(TrapConstruct, new[] { _target, argArray, newTarget }, out var result))
+            {
+                if (!(_target is IConstructor constructor))
+                {
+                    return ExceptionHelper.ThrowTypeError<ObjectInstance>(_engine);
+                }
+                return constructor.Construct(arguments, newTarget);
+            }
+
+            if (!(result is ObjectInstance oi))
+            {
+                return ExceptionHelper.ThrowTypeError<ObjectInstance>(_engine);
+            }
+           
+            return oi;
+        }
+
+        public override bool IsArray()
+        {
+            if (_handler is null)
+            {
+                return ExceptionHelper.ThrowTypeError<bool>(_engine);
+            }
+            return _target.IsArray();
+        }
+
+        internal override bool IsConstructor => 
+            _handler.TryGetValue(TrapConstruct, out var handlerFunction) && handlerFunction is IConstructor;
+
+        public override JsValue Get(in Key propertyName, JsValue receiver)
+        {
+            if (propertyName == KeyFunctionRevoke || !TryCallHandler(TrapGet, new JsValue[] {_target, propertyName, this}, out var result))
+            {
+                AssertTargetNotRevoked(propertyName);
+                return _target.Get(in propertyName, receiver);
+            }
+
+            AssertTargetNotRevoked(propertyName);
+            var targetDesc = _target.GetOwnProperty(propertyName);
+            if (targetDesc != PropertyDescriptor.Undefined)
+            {
+                if (targetDesc.IsDataDescriptor() && !targetDesc.Configurable && !targetDesc.Writable && !ReferenceEquals(result, targetDesc._value))
+                {
+                   ExceptionHelper.ThrowTypeError(_engine);
+                }
+                if (targetDesc.IsAccessorDescriptor() && !targetDesc.Configurable && targetDesc.Get.IsUndefined() && !result.IsUndefined())
+                {
+                   ExceptionHelper.ThrowTypeError(_engine, $"'get' on proxy: property '{propertyName}' is a non-configurable accessor property on the proxy target and does not have a getter function, but the trap did not return 'undefined' (got '{result}')");
+                }
+            }
+
+            return result;
+        }
+
+        internal override List<JsValue> GetOwnPropertyKeys(Types types)
+        {
+            if (!TryCallHandler(TrapOwnKeys, new JsValue[] {_target }, out var result))
+            {
+                return _target.GetOwnPropertyKeys(types);
+            }
+
+            var trapResult = new List<JsValue>(_engine.Function.PrototypeObject.CreateListFromArrayLike(result, Types.String | Types.Symbol));
+
+            if (trapResult.Count != new HashSet<JsValue>(trapResult).Count)
+            {
+                ExceptionHelper.ThrowTypeError(_engine);
+            }
+
+            var extensibleTarget = _target.Extensible;
+            var targetKeys = _target.GetOwnPropertyKeys(types);
+            var targetConfigurableKeys = new List<Key>();
+            var targetNonconfigurableKeys = new List<Key>();
+
+            foreach (var jsValue in targetKeys)
+            {
+                var key = jsValue.ToPropertyKey();
+                var desc = _target.GetOwnProperty(key);
+                if (desc != PropertyDescriptor.Undefined && !desc.Configurable)
+                {
+                    targetNonconfigurableKeys.Add(key);
+                }
+                else
+                {
+                    targetConfigurableKeys.Add(key);
+                }
+                
+            }
+
+            if (extensibleTarget && targetNonconfigurableKeys.Count == 0)
+            {
+                return trapResult;
+            }
+            
+            var uncheckedResultKeys = new HashSet<Key>();
+            foreach (var jsValue in trapResult)
+            {
+                uncheckedResultKeys.Add(jsValue.ToPropertyKey());
+            }
+
+            for (var i = 0; i < targetNonconfigurableKeys.Count; i++)
+            {
+                var key = targetNonconfigurableKeys[i];
+                if (!uncheckedResultKeys.Remove(key))
+                {
+                    ExceptionHelper.ThrowTypeError(_engine);
+                }
+            }
+
+            if (extensibleTarget)
+            {
+                return trapResult;
+            }
+
+            for (var i = 0; i < targetConfigurableKeys.Count; i++)
+            {
+                var key = targetConfigurableKeys[i];
+                if (!uncheckedResultKeys.Remove(key))
+                {
+                    ExceptionHelper.ThrowTypeError(_engine);
+                }
+            }
+
+            if (uncheckedResultKeys.Count > 0)
+            {
+                ExceptionHelper.ThrowTypeError(_engine);
+            }
+
+            return trapResult;
+        }
+
+        public override PropertyDescriptor GetOwnProperty(in Key propertyName)
+        {
+            if (!TryCallHandler(TrapGetOwnPropertyDescriptor, new JsValue[] {_target, propertyName, this}, out var result))
+            {
+                return _target.GetOwnProperty(propertyName);
+            }
+
+            if (!result.IsObject() && !result.IsUndefined())
+            {
+                ExceptionHelper.ThrowTypeError(_engine);
+            }
+
+            var targetDesc = _target.GetOwnProperty(propertyName);
+
+            if (result.IsUndefined())
+            {
+                if (targetDesc == PropertyDescriptor.Undefined)
+                {
+                    return targetDesc;
+                }
+
+                if (!targetDesc.Configurable || !_target.Extensible)
+                {
+                    ExceptionHelper.ThrowTypeError(_engine);
+                }
+
+                return PropertyDescriptor.Undefined;
+            }
+
+            var extensibleTarget = _target.Extensible;
+            var resultDesc = PropertyDescriptor.ToPropertyDescriptor(_engine, result);
+
+            var valid = IsCompatiblePropertyDescriptor(extensibleTarget, resultDesc, targetDesc);
+            if (!valid)
+            {
+                ExceptionHelper.ThrowTypeError(_engine);
+            }
+
+            if (!resultDesc.Configurable && (targetDesc == PropertyDescriptor.Undefined || targetDesc.Configurable))
+            {
+                ExceptionHelper.ThrowTypeError(_engine);
+            }
+
+            return resultDesc;
+        }
+
+        public override bool Set(in Key propertyName, JsValue value, JsValue receiver)
+        {
+            if (!TryCallHandler(TrapSet, new[] { _target, propertyName, value, this }, out var trapResult))
+            {
+                return _target.Set(propertyName, value, receiver);
+            }
+
+            var result = TypeConverter.ToBoolean(trapResult);
+            if (!result)
+            {
+                return false;
+            }
+
+            var targetDesc  = _target.GetOwnProperty(propertyName);
+            if (targetDesc != PropertyDescriptor.Undefined)
+            {
+                if (targetDesc.IsDataDescriptor() && !targetDesc.Configurable && !targetDesc.Writable)
+                {
+                    if (targetDesc.Value != value)
+                    {
+                        ExceptionHelper.ThrowTypeError(_engine);
+                    }
+                }
+
+                if (targetDesc.IsAccessorDescriptor() && !targetDesc.Configurable)
+                {
+                    if (targetDesc.Set.IsUndefined())
+                    {
+                        ExceptionHelper.ThrowTypeError(_engine);
+                    }
+                }
+            }
+            
+            return true;
+        }
+
+        public override bool DefineOwnProperty(in Key propertyName, PropertyDescriptor desc)
+        {
+            var arguments = new[] { _target, propertyName, PropertyDescriptor.FromPropertyDescriptor(_engine, desc) };
+            if (!TryCallHandler(TrapDefineProperty, arguments, out var result))
+            {
+                return _target.DefineOwnProperty(propertyName, desc);
+            }
+
+            var success = TypeConverter.ToBoolean(result);
+            if (!success)
+            {
+                return false;
+            }
+
+            var targetDesc = _target.GetOwnProperty(propertyName);
+            var extensibleTarget = _target.Extensible;
+            var settingConfigFalse = !desc.Configurable;
+
+            if (targetDesc == PropertyDescriptor.Undefined)
+            {
+                if (!extensibleTarget || settingConfigFalse)
+                {
+                    ExceptionHelper.ThrowTypeError(_engine);
+                }
+            }
+            else
+            {
+                if (!IsCompatiblePropertyDescriptor(extensibleTarget, desc, targetDesc))
+                {
+                    ExceptionHelper.ThrowTypeError(_engine);
+                }
+                if (targetDesc.Configurable && settingConfigFalse)
+                {
+                    ExceptionHelper.ThrowTypeError(_engine);
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsCompatiblePropertyDescriptor(bool extensible, PropertyDescriptor desc, PropertyDescriptor current)
+        {
+            return ValidateAndApplyPropertyDescriptor(null, "", extensible, desc, current);
+        }
+
+        public override bool HasProperty(in Key propertyName)
+        {
+            if (!TryCallHandler(TrapHas, new JsValue[] { _target, propertyName }, out var jsValue))
+            {
+                return _target.HasProperty(propertyName);
+            }
+
+            var trapResult = TypeConverter.ToBoolean(jsValue);
+
+            if (!trapResult)
+            {
+                var targetDesc = _target.GetOwnProperty(propertyName);
+                if (targetDesc != PropertyDescriptor.Undefined)
+                {
+                    if (!targetDesc.Configurable)
+                    {
+                        ExceptionHelper.ThrowTypeError(_engine);
+                    }
+
+                    if (!_target.Extensible)
+                    {
+                        ExceptionHelper.ThrowTypeError(_engine);
+                    }
+                }
+            }
+
+            return trapResult;
+        }
+
+        public override bool Delete(in Key propertyName)
+        {
+            if (!TryCallHandler(TrapDeleteProperty, new JsValue[] { _target, propertyName }, out var result))
+            {
+                return _target.Delete(propertyName);
+            }
+
+            var success = TypeConverter.ToBoolean(result);
+
+            if (success)
+            {
+                var targetDesc = _target.GetOwnProperty(propertyName);
+                if (targetDesc != PropertyDescriptor.Undefined && !targetDesc.Configurable)
+                {
+                    ExceptionHelper.ThrowTypeError(_engine, $"'deleteProperty' on proxy: trap returned truish for property '{propertyName}' which is non-configurable in the proxy target");
+                }
+            }
+
+            return success;
+        }
+
+        public override JsValue PreventExtensions()
+        {
+            if (!TryCallHandler(TrapPreventExtensions, new[] { _target }, out var result))
+            {
+                return _target.PreventExtensions();
+            }
+
+            var success = TypeConverter.ToBoolean(result);
+
+            if (success && _target.Extensible)
+            {
+                ExceptionHelper.ThrowTypeError(_engine);
+            }
+
+            return success ? JsBoolean.True : JsBoolean.False;
+        }
+
+        public override bool Extensible
+        {
+            get
+            {
+                if (!TryCallHandler(TrapIsExtensible, new[] { _target }, out var result))
+                {
+                    return _target.Extensible;
+                }
+
+                var booleanTrapResult = TypeConverter.ToBoolean(result);
+                var targetResult = _target.Extensible;
+                if (booleanTrapResult != targetResult)
+                {
+                    ExceptionHelper.ThrowTypeError(_engine);
+                }
+                return booleanTrapResult;
+            }
+        }
+
+        protected override ObjectInstance GetPrototypeOf()
+        {
+            if (!TryCallHandler(TrapGetProtoTypeOf, new [] { _target }, out var handlerProto ))
+            {
+                return _target.Prototype;
+            }
+
+            if (!handlerProto.IsObject() && !handlerProto.IsNull())
+            {
+                ExceptionHelper.ThrowTypeError(_engine, "'getPrototypeOf' on proxy: trap returned neither object nor null");
+            }
+
+            if (_target.Extensible)
+            {
+                return (ObjectInstance) handlerProto;
+            }
+
+            if (!ReferenceEquals(handlerProto, _target.Prototype))
+            {
+                ExceptionHelper.ThrowTypeError(_engine);
+            }
+
+            return (ObjectInstance) handlerProto;
+        }
+
+        public override bool SetPrototypeOf(JsValue value)
+        {
+            if (!TryCallHandler(TrapSetProtoTypeOf, new[] { _target, value }, out var result))
+            {
+                return _target.SetPrototypeOf(value);
+            }
+
+            var success = TypeConverter.ToBoolean(result);
+
+            if (!success)
+            {
+                return false;
+            }
+
+            if (_target.Extensible)
+            {
+                return true;
+            }
+
+            if (!ReferenceEquals(value, _target.Prototype))
+            {
+                ExceptionHelper.ThrowTypeError(_engine);
+            }
+
+            return true;
+        }
+
+        private bool TryCallHandler(in Key propertyName, JsValue[] arguments, out JsValue result)
+        {
+            AssertNotRevoked(propertyName);
+            
+            result = Undefined;
+            if (_handler.TryGetValue(propertyName, out var handlerFunction)
+                && !handlerFunction.IsNullOrUndefined())
+            {
+                if (!(handlerFunction is ICallable callable))
+                {
+                    return ExceptionHelper.ThrowTypeError<bool>(_engine, $"{_handler} returned for property '{propertyName}' of object '{_target}' is not a function");
+                }
+
+                result = callable.Call(_handler, arguments);
+                return true;
+            }
+
+            return false;
+        }
+
+        internal void AssertNotRevoked(in Key key)
+        {
+            if (_handler is null)
+            {
+                ExceptionHelper.ThrowTypeError(_engine, $"Cannot perform '{key}' on a proxy that has been revoked");
+            }
+        }
+
+        internal void AssertTargetNotRevoked(in Key key)
+        {
+            if (_target is null)
+            {
+                ExceptionHelper.ThrowTypeError(_engine, $"Cannot perform '{key}' on a proxy that has been revoked");
+            }
+        }
+    }
+}

--- a/Jint/Native/Proxy/ProxyPrototype.cs
+++ b/Jint/Native/Proxy/ProxyPrototype.cs
@@ -1,0 +1,37 @@
+﻿using Jint.Collections;
+using Jint.Native.Object;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Native.Proxy
+{
+    /// <summary>
+    /// https://www.ecma-international.org/ecma-262/6.0/index.html#sec-proxy-object-internal-methods-and-internal-slots
+    /// </summary>
+    public sealed class ProxyPrototype : ObjectInstance
+    {
+        private ProxyConstructor _proxyConstructor;
+
+        private ProxyPrototype(Engine engine) : base(engine)
+        {
+        }
+
+        public static ProxyPrototype CreatePrototypeObject(Engine engine, ProxyConstructor proxyConstructor)
+        {
+            var obj = new ProxyPrototype(engine)
+            {
+                _prototype = engine.Object.PrototypeObject,
+                _proxyConstructor = proxyConstructor
+            };
+
+            return obj;
+        }
+
+        protected override void Initialize()
+        {
+            _properties = new StringDictionarySlim<PropertyDescriptor>(3)
+            {
+                ["constructor"] = new PropertyDescriptor(_proxyConstructor, PropertyFlag.NonEnumerable)
+            };
+        }
+    }
+}

--- a/Jint/Native/Reflect/ReflectInstance.cs
+++ b/Jint/Native/Reflect/ReflectInstance.cs
@@ -1,0 +1,203 @@
+﻿using Jint.Collections;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.Native.Reflect
+{
+    /// <summary>
+    /// https://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect-object
+    /// </summary>
+    public sealed class ReflectInstance : ObjectInstance
+    {
+        private ReflectInstance(Engine engine) : base(engine, "Reflect")
+        {
+        }
+
+        public static ReflectInstance CreateReflectObject(Engine engine)
+        {
+            var math = new ReflectInstance(engine)
+            {
+                _prototype = engine.Object.PrototypeObject
+            };
+
+            return math;
+        }
+
+        protected override void Initialize()
+        {
+            _properties = new StringDictionarySlim<PropertyDescriptor>(14)
+            {
+                ["apply"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "apply", Apply, 3, PropertyFlag.Configurable), true, false, true),
+                ["construct"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "construct", Construct, 2, PropertyFlag.Configurable), true, false, true),
+                ["defineProperty"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "defineProperty", DefineProperty, 3, PropertyFlag.Configurable), true, false, true),
+                ["deleteProperty"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "deleteProperty", DeleteProperty, 2, PropertyFlag.Configurable), true, false, true),
+                ["get"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "get", Get, 2, PropertyFlag.Configurable), true, false, true),
+                ["getOwnPropertyDescriptor"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "getOwnPropertyDescriptor", GetOwnPropertyDescriptor, 2, PropertyFlag.Configurable), true, false, true),
+                ["getPrototypeOf"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "getPrototypeOf", GetPrototypeOf, 1, PropertyFlag.Configurable), true, false, true),
+                ["has"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "has", Has, 2, PropertyFlag.Configurable), true, false, true),
+                ["isExtensible"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "isExtensible", IsExtensible, 1, PropertyFlag.Configurable), true, false, true),
+                ["ownKeys"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "ownKeys", OwnKeys, 1, PropertyFlag.Configurable), true, false, true),
+                ["preventExtensions"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "preventExtensions", PreventExtensions, 1, PropertyFlag.Configurable), true, false, true),
+                ["set"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "set", Set, 3, PropertyFlag.Configurable), true, false, true),
+                ["setPrototypeOf"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "setPrototypeOf", SetPrototypeOf, 2, PropertyFlag.Configurable), true, false, true),
+            };
+        }
+
+        private JsValue Apply(JsValue thisObject, JsValue[] arguments)
+        {
+            return _engine.Function.PrototypeObject.Apply(arguments.At(0), new[]
+            {
+                arguments.At(1),
+                arguments.At(2)
+            });
+        }
+
+        private JsValue Construct(JsValue thisObject, JsValue[] arguments)
+        {
+            var targetArgument = arguments.At(0);
+            if (!(targetArgument is IConstructor target))
+            {
+                return ExceptionHelper.ThrowTypeError<JsValue>(_engine, targetArgument + " is not a constructor");
+            }
+
+            var newTargetArgument = arguments.At(2, arguments[0]);
+            if (!(newTargetArgument is IConstructor newTarget))
+            {
+                return ExceptionHelper.ThrowTypeError<JsValue>(_engine, newTargetArgument + " is not a constructor");
+            }
+
+            var args = _engine.Function.PrototypeObject.CreateListFromArrayLike(arguments.At(1));
+
+            return target.Construct(args, newTargetArgument);
+        }
+
+        private JsValue DefineProperty(JsValue thisObject, JsValue[] arguments)
+        {
+            var o = arguments.As<ObjectInstance>(0, _engine);
+            var p = arguments.At(1);
+            var name = TypeConverter.ToPropertyKey(p);
+
+            var attributes = arguments.At(2);
+            var desc = PropertyDescriptor.ToPropertyDescriptor(Engine, attributes);
+
+            return o.DefineOwnProperty(name, desc);
+        }
+
+        private JsValue DeleteProperty(JsValue thisObject, JsValue[] arguments)
+        {
+            var target = arguments.At(0);
+            if (!(target is ObjectInstance o))
+            {
+                return ExceptionHelper.ThrowTypeError<JsValue>(_engine, "Reflect.deleteProperty called on non-object");
+            }
+
+            var property = TypeConverter.ToPropertyKey(arguments.At(1));
+            return o.Delete(property) ? JsBoolean.True : JsBoolean.False;
+        }
+
+        private JsValue Has(JsValue thisObject, JsValue[] arguments)
+        {
+            var target = arguments.At(0);
+            if (!(target is ObjectInstance o))
+            {
+                return ExceptionHelper.ThrowTypeError<JsValue>(_engine, "Reflect.has called on non-object");
+            }
+
+            var property = TypeConverter.ToPropertyKey(arguments.At(1));
+            return o.HasProperty(property) ? JsBoolean.True : JsBoolean.False;
+        }
+
+        private JsValue Set(JsValue thisObject, JsValue[] arguments)
+        {
+            var target = arguments.At(0);
+            var property = TypeConverter.ToPropertyKey(arguments.At(1));
+            var value = arguments.At(2);
+            var receiver = arguments.At(3, target);
+
+            if (!(target is ObjectInstance o))
+            {
+                return ExceptionHelper.ThrowTypeError<JsValue>(_engine, "Reflect.set called on non-object");
+            }
+
+            return o.Set(property, value, receiver);
+        }
+
+        private JsValue Get(JsValue thisObject, JsValue[] arguments)
+        {
+            var target = arguments.At(0);
+            if (!(target is ObjectInstance o))
+            {
+                return ExceptionHelper.ThrowTypeError<JsValue>(_engine, "Reflect.get called on non-object");
+            }
+
+            var receiver = arguments.At(2, target);
+            var property = TypeConverter.ToPropertyKey(arguments.At(1));
+            return o.Get(property, receiver);
+        }
+
+        private JsValue GetOwnPropertyDescriptor(JsValue thisObject, JsValue[] arguments)
+        {
+            return _engine.Object.GetOwnPropertyDescriptor(Undefined, arguments);
+        }
+
+        private JsValue OwnKeys(JsValue thisObject, JsValue[] arguments)
+        {
+            var target = arguments.At(0);
+            if (!(target is ObjectInstance o))
+            {
+                return ExceptionHelper.ThrowTypeError<JsValue>(_engine, "Reflect.get called on non-object");
+            }
+
+            var keys = o.GetOwnPropertyKeys(Types.String | Types.Symbol);
+            return _engine.Array.CreateArrayFromList(keys);
+        }
+
+        private JsValue IsExtensible(JsValue thisObject, JsValue[] arguments)
+        {
+            return _engine.Object.IsExtensible(Undefined, arguments);
+        }
+
+        private JsValue PreventExtensions(JsValue thisObject, JsValue[] arguments)
+        {
+            var target = arguments.At(0);
+            if (!(target is ObjectInstance o))
+            {
+                return ExceptionHelper.ThrowTypeError<JsValue>(_engine, "Reflect.preventExtensions called on non-object");
+            }
+
+            return o.PreventExtensions();
+        }
+
+        private JsValue GetPrototypeOf(JsValue thisObject, JsValue[] arguments)
+        {
+            var target = arguments.At(0);
+
+            if (!target.IsObject())
+            {
+                return ExceptionHelper.ThrowTypeError<JsValue>(_engine, "Reflect.getPrototypeOf called on non-object");
+            }
+
+            return _engine.Object.GetPrototypeOf(Undefined, arguments);
+        }
+
+        private JsValue SetPrototypeOf(JsValue thisObject, JsValue[] arguments)
+        {
+            var target = arguments.At(0);
+
+            if (!(target is ObjectInstance o))
+            {
+                return ExceptionHelper.ThrowTypeError<JsValue>(_engine, "Reflect.setPrototypeOf called on non-object");
+            }
+
+            var prototype = arguments.At(1);
+            if (!prototype.IsObject() && !prototype.IsNull())
+            {
+                ExceptionHelper.ThrowTypeError(_engine, $"Object prototype may only be an Object or null: {prototype}");
+            }
+
+            return o.SetPrototypeOf(prototype);
+        }
+    }
+}

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -21,8 +21,7 @@ namespace Jint.Native.RegExp
         {
             var obj = new RegExpConstructor(engine)
             {
-                Extensible = true,
-                Prototype = engine.Function.PrototypeObject
+                _prototype = engine.Function.PrototypeObject
             };
 
             // The value of the [[Prototype]] internal property of the RegExp constructor is the Function prototype object
@@ -31,7 +30,7 @@ namespace Jint.Native.RegExp
             obj._length = new PropertyDescriptor(2, PropertyFlag.AllForbidden);
 
             // The initial value of RegExp.prototype is the RegExp prototype object
-            obj._prototype= new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
+            obj._prototypeDescriptor= new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
 
             return obj;
         }
@@ -48,16 +47,19 @@ namespace Jint.Native.RegExp
                 return pattern;
             }
 
-            return Construct(arguments);
+            return Construct(arguments, thisObject);
+        }
+
+        public ObjectInstance Construct(JsValue[] arguments)
+        {
+            return Construct(arguments, this);
         }
 
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-7.8.5
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.10.4
         /// </summary>
-        /// <param name="arguments"></param>
-        /// <returns></returns>
-        public ObjectInstance Construct(JsValue[] arguments)
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
         {
             string p;
             string f;
@@ -88,8 +90,7 @@ namespace Jint.Native.RegExp
             f = !flags.IsUndefined() ? TypeConverter.ToString(flags) : "";
 
             r = new RegExpInstance(Engine);
-            r.Prototype = PrototypeObject;
-            r.Extensible = true;
+            r._prototype = PrototypeObject;
 
             try
             {
@@ -127,8 +128,7 @@ namespace Jint.Native.RegExp
         public RegExpInstance Construct(string regExp, Engine engine)
         {
             var r = new RegExpInstance(Engine);
-            r.Prototype = PrototypeObject;
-            r.Extensible = true;
+            r._prototype = PrototypeObject;
 
             var scanner = new Scanner(regExp, new ParserOptions { AdaptRegexp = true });
             var body = (string)scanner.ScanRegExpBody().Value;
@@ -153,8 +153,7 @@ namespace Jint.Native.RegExp
         public RegExpInstance Construct(Regex regExp, string flags, Engine engine)
         {
             var r = new RegExpInstance(Engine);
-            r.Prototype = PrototypeObject;
-            r.Extensible = true;
+            r._prototype = PrototypeObject;
 
             r.Flags = flags;
             AssignFlags(r, flags);

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -21,8 +21,7 @@ namespace Jint.Native.RegExp
         {
             var obj = new RegExpPrototype(engine)
             {
-                Prototype = engine.Object.PrototypeObject,
-                Extensible = true,
+                _prototype = engine.Object.PrototypeObject,
                 _regExpConstructor = regExpConstructor
             };
 
@@ -81,7 +80,7 @@ namespace Jint.Native.RegExp
 
             var s = TypeConverter.ToString(arguments.At(0));
             var length = s.Length;
-            var lastIndex = TypeConverter.ToNumber(R.Get("lastIndex"));
+            var lastIndex = TypeConverter.ToNumber(R.Get("lastIndex", R));
             var i = TypeConverter.ToInteger(lastIndex);
             var global = R.Global;
 
@@ -94,14 +93,14 @@ namespace Jint.Native.RegExp
             {
                 // "aaa".match() => [ '', index: 0, input: 'aaa' ]
                 var aa = InitReturnValueArray((ArrayInstance) Engine.Array.Construct(Arguments.Empty), s, 1, 0);
-                aa.DefineOwnProperty("0", new PropertyDescriptor("", PropertyFlag.ConfigurableEnumerableWritable), true);
+                aa.DefinePropertyOrThrow("0", new PropertyDescriptor("", PropertyFlag.ConfigurableEnumerableWritable));
                 return aa;
             }
 
             Match r = null;
             if (i < 0 || i > length)
             {
-                R.Put("lastIndex", (double) 0, true);
+                R.Set("lastIndex", (double) 0, true);
                 return Null;
             }
 
@@ -109,7 +108,7 @@ namespace Jint.Native.RegExp
 
             if (!r.Success)
             {
-                R.Put("lastIndex", (double) 0, true);
+                R.Set("lastIndex", (double) 0, true);
                 return Null;
             }
 
@@ -117,7 +116,7 @@ namespace Jint.Native.RegExp
 
             if (global)
             {
-                R.Put("lastIndex", (double) e, true);
+                R.Set("lastIndex", (double) e, true);
             }
             var n = r.Groups.Count;
             var matchIndex = r.Index;

--- a/Jint/Native/Set/SetConstructor.cs
+++ b/Jint/Native/Set/SetConstructor.cs
@@ -25,8 +25,7 @@ namespace Jint.Native.Set
         {
             var obj = new SetConstructor(engine)
             {
-                Extensible = true,
-                Prototype = engine.Function.PrototypeObject
+                _prototype = engine.Function.PrototypeObject
             };
 
             // The value of the [[Prototype]] internal property of the Set constructor is the Function prototype object
@@ -35,7 +34,7 @@ namespace Jint.Native.Set
             obj._length = new PropertyDescriptor(0, PropertyFlag.Configurable);
 
             // The initial value of Set.prototype is the Set prototype object
-            obj._prototype = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
+            obj._prototypeDescriptor = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
 
             return obj;
         }
@@ -44,7 +43,7 @@ namespace Jint.Native.Set
         {
             _properties = new StringDictionarySlim<PropertyDescriptor>(2)
             {
-                [GlobalSymbolRegistry.Species._value] = new GetSetPropertyDescriptor(get: new ClrFunctionInstance(_engine, "get [Symbol.species]", Species, 0, PropertyFlag.Configurable), set: Undefined, PropertyFlag.Configurable)
+                [GlobalSymbolRegistry.Species] = new GetSetPropertyDescriptor(get: new ClrFunctionInstance(_engine, "get [Symbol.species]", Species, 0, PropertyFlag.Configurable), set: Undefined, PropertyFlag.Configurable)
             };
         }
 
@@ -60,15 +59,14 @@ namespace Jint.Native.Set
                 ExceptionHelper.ThrowTypeError(_engine, "Constructor Set requires 'new'");
             }
 
-            return Construct(arguments);
+            return Construct(arguments, thisObject);
         }
 
-        public ObjectInstance Construct(JsValue[] arguments)
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
         {
             var instance = new SetInstance(Engine)
             {
-                Prototype = PrototypeObject,
-                Extensible = true
+                _prototype = PrototypeObject
             };
             if (arguments.Length > 0 && !arguments[0].IsNullOrUndefined())
             {

--- a/Jint/Native/Set/SetInstance.cs
+++ b/Jint/Native/Set/SetInstance.cs
@@ -14,45 +14,6 @@ namespace Jint.Native.Set
             _set = new OrderedSet<JsValue>();
         }
 
-        /// Implementation from ObjectInstance official specs as the one
-        /// in ObjectInstance is optimized for the general case and wouldn't work
-        /// for arrays
-        public override void Put(in Key propertyName, JsValue value, bool throwOnError)
-        {
-            if (!CanPut(propertyName))
-            {
-                if (throwOnError)
-                {
-                    ExceptionHelper.ThrowTypeError(Engine);
-                }
-
-                return;
-            }
-
-            var ownDesc = GetOwnProperty(propertyName);
-
-            if (ownDesc.IsDataDescriptor())
-            {
-                var valueDesc = new PropertyDescriptor(value, PropertyFlag.None);
-                DefineOwnProperty(propertyName, valueDesc, throwOnError);
-                return;
-            }
-
-            // property is an accessor or inherited
-            var desc = GetProperty(propertyName);
-
-            if (desc.IsAccessorDescriptor())
-            {
-                var setter = desc.Set.TryCast<ICallable>();
-                setter.Call(this, new[] {value});
-            }
-            else
-            {
-                var newDesc = new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable);
-                DefineOwnProperty(propertyName, newDesc, throwOnError);
-            }
-        }
-
         public override PropertyDescriptor GetOwnProperty(in Key propertyName)
         {
             if (propertyName == KnownKeys.Size)

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -23,8 +23,7 @@ namespace Jint.Native.Set
         {
             var obj = new SetPrototype(engine)
             {
-                Extensible = true, 
-                Prototype = engine.Object.PrototypeObject,
+                _prototype = engine.Object.PrototypeObject,
                 _mapConstructor = mapConstructor
             };
 
@@ -37,8 +36,8 @@ namespace Jint.Native.Set
             {
                 ["length"] = new PropertyDescriptor(0, PropertyFlag.Configurable),
                 ["constructor"] = new PropertyDescriptor(_mapConstructor, PropertyFlag.NonEnumerable),
-                [GlobalSymbolRegistry.Iterator._value] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "iterator", Values, 1, PropertyFlag.Configurable), true, false, true),
-                [GlobalSymbolRegistry.ToStringTag._value] = new PropertyDescriptor("Set", false, false, true),
+                [GlobalSymbolRegistry.Iterator] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "iterator", Values, 1, PropertyFlag.Configurable), true, false, true),
+                [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor("Set", false, false, true),
                 ["add"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "add", Add, 1, PropertyFlag.Configurable), true, false, true),
                 ["clear"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "clear", Clear, 0, PropertyFlag.Configurable), true, false, true),
                 ["delete"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "delete", Delete, 1, PropertyFlag.Configurable), true, false, true),

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -23,8 +23,7 @@ namespace Jint.Native.String
         {
             var obj = new StringConstructor(engine)
             {
-                Extensible = true,
-                Prototype = engine.Function.PrototypeObject
+                _prototype = engine.Function.PrototypeObject
             };
 
             // The value of the [[Prototype]] internal property of the String constructor is the Function prototype object
@@ -33,7 +32,7 @@ namespace Jint.Native.String
             obj._length = PropertyDescriptor.AllForbiddenDescriptor.NumberOne;
 
             // The initial value of String.prototype is the String prototype object
-            obj._prototype = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
+            obj._prototypeDescriptor = new PropertyDescriptor(obj.PrototypeObject, PropertyFlag.AllForbidden);
 
             return obj;
         }
@@ -105,9 +104,9 @@ namespace Jint.Native.String
         private JsValue Raw(JsValue thisObj, JsValue[] arguments)
         {
             var cooked = TypeConverter.ToObject(_engine, arguments.At(0));
-            var raw = TypeConverter.ToObject(_engine, cooked.Get("raw"));
+            var raw = TypeConverter.ToObject(_engine, cooked.Get("raw", cooked));
 
-            var operations = ArrayPrototype.ArrayOperations.For(raw);
+            var operations = ArrayOperations.For(raw);
             var length = operations.GetLength();
 
             if (length <= 0)
@@ -152,9 +151,7 @@ namespace Jint.Native.String
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.7.2.1
         /// </summary>
-        /// <param name="arguments"></param>
-        /// <returns></returns>
-        public ObjectInstance Construct(JsValue[] arguments)
+        public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
         {
             string value = "";
             if (arguments.Length > 0)
@@ -175,9 +172,8 @@ namespace Jint.Native.String
         {
             var instance = new StringInstance(Engine)
             {
-                Prototype = PrototypeObject,
+                _prototype = PrototypeObject,
                 PrimitiveValue = value,
-                Extensible = true,
                 _length = PropertyDescriptor.AllForbiddenDescriptor.ForNumber(value.Length)
             };
 

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -71,11 +71,11 @@ namespace Jint.Native.String
             return new PropertyDescriptor(resultStr, PropertyFlag.OnlyEnumerable);
         }
 
-        public override IEnumerable<KeyValuePair<string, PropertyDescriptor>> GetOwnProperties()
+        public override IEnumerable<KeyValuePair<Key, PropertyDescriptor>> GetOwnProperties()
         {
             if (_length != null)
             {
-                yield return new KeyValuePair<string, PropertyDescriptor>(KnownKeys.Length, _length);
+                yield return new KeyValuePair<Key, PropertyDescriptor>(KnownKeys.Length, _length);
             }
 
             foreach (var entry in base.GetOwnProperties())

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -31,9 +31,8 @@ namespace Jint.Native.String
         {
             var obj = new StringPrototype(engine)
             {
-                Prototype = engine.Object.PrototypeObject,
+                _prototype = engine.Object.PrototypeObject,
                 PrimitiveValue = JsString.Empty,
-                Extensible = true,
                 _length = PropertyDescriptor.AllForbiddenDescriptor.NumberZero,
                 _stringConstructor = stringConstructor,
             };
@@ -76,7 +75,7 @@ namespace Jint.Native.String
                 ["includes"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "includes", Includes, 1, PropertyFlag.Configurable), true, false, true),
                 ["normalize"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "normalize", Normalize, 0, PropertyFlag.Configurable), true, false, true),
                 ["repeat"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "repeat", Repeat, 1, PropertyFlag.Configurable), true, false, true),
-                [GlobalSymbolRegistry.Iterator._value] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "[Symbol.iterator]", Iterator, 0, PropertyFlag.Configurable), true, false, true)
+                [GlobalSymbolRegistry.Iterator] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "[Symbol.iterator]", Iterator, 0, PropertyFlag.Configurable), true, false, true)
             };
         }
 
@@ -679,14 +678,14 @@ namespace Jint.Native.String
 
             rx = rx ?? (RegExpInstance) Engine.RegExp.Construct(new[] {regex});
 
-            var global = ((JsBoolean) rx.Get("global"))._value;
+            var global = ((JsBoolean) rx.Get("global", this))._value;
             if (!global)
             {
                 return Engine.RegExp.PrototypeObject.Exec(rx, Arguments.From(s));
             }
             else
             {
-                rx.Put("lastIndex", 0, false);
+                rx.Set("lastIndex", 0, rx);
                 var a = (ArrayInstance) Engine.Array.Construct(Arguments.Empty);
                 int previousLastIndex = 0;
                 uint n = 0;
@@ -700,14 +699,14 @@ namespace Jint.Native.String
                     }
                     else
                     {
-                        var thisIndex = (int) ((JsNumber) rx.Get("lastIndex"))._value;
+                        var thisIndex = (int) ((JsNumber) rx.Get("lastIndex", this))._value;
                         if (thisIndex == previousLastIndex)
                         {
-                            rx.Put("lastIndex", thisIndex + 1, false);
+                            rx.Set("lastIndex", thisIndex + 1, rx);
                             previousLastIndex = thisIndex + 1;
                         }
 
-                        var matchStr = result.Get("0");
+                        var matchStr = result.Get("0", this);
                         a.SetIndexValue(n, matchStr, updateLength: false);
                         n++;
                     }

--- a/Jint/Native/Symbol/GlobalSymbolRegistry.cs
+++ b/Jint/Native/Symbol/GlobalSymbolRegistry.cs
@@ -1,19 +1,75 @@
-﻿using System.Collections.Generic;
+﻿using System.Threading;
+using Jint.Collections;
 
 namespace Jint.Native.Symbol
 {
-    public class GlobalSymbolRegistry : Dictionary<string, JsSymbol>
+    public class GlobalSymbolRegistry
     {
-        public static readonly JsSymbol HasInstance = new JsSymbol("Symbol.hasInstance");
-        public static readonly JsSymbol IsConcatSpreadable = new JsSymbol("Symbol.isConcatSpreadable");
-        public static readonly JsSymbol Iterator = new JsSymbol("Symbol.iterator");
-        public static readonly JsSymbol Match = new JsSymbol("Symbol.match");
-        public static readonly JsSymbol Replace = new JsSymbol("Symbol.replace");
-        public static readonly JsSymbol Search = new JsSymbol("Symbol.search");
-        public static readonly JsSymbol Species = new JsSymbol("Symbol.species");
-        public static readonly JsSymbol Split = new JsSymbol("Symbol.split");
-        public static readonly JsSymbol ToPrimitive = new JsSymbol("Symbol.toPrimitive");
-        public static readonly JsSymbol ToStringTag = new JsSymbol("Symbol.toStringTag");
-        public static readonly JsSymbol Unscopables = new JsSymbol("Symbol.unscopables");
+        public static readonly JsSymbol HasInstance = new JsSymbol("Symbol.hasInstance", 1);
+        public static readonly JsSymbol IsConcatSpreadable = new JsSymbol("Symbol.isConcatSpreadable", 2);
+        public static readonly JsSymbol Iterator = new JsSymbol("Symbol.iterator", 3);
+        public static readonly JsSymbol Match = new JsSymbol("Symbol.match", 4);
+        public static readonly JsSymbol Replace = new JsSymbol("Symbol.replace", 5);
+        public static readonly JsSymbol Search = new JsSymbol("Symbol.search", 6);
+        public static readonly JsSymbol Species = new JsSymbol("Symbol.species", 7);
+        public static readonly JsSymbol Split = new JsSymbol("Symbol.split", 8);
+        public static readonly JsSymbol ToPrimitive = new JsSymbol("Symbol.toPrimitive", 9);
+        public static readonly JsSymbol ToStringTag = new JsSymbol("Symbol.toStringTag", 10);
+        public static readonly JsSymbol Unscopables = new JsSymbol("Symbol.unscopables", 11);
+
+        // well-known globals
+        private static readonly StringDictionarySlim<JsSymbol> _globalLookup;
+
+        // engine-specific created by scripts
+        private StringDictionarySlim<JsSymbol> _customSymbolLookup;
+
+        // custom symbol identity is based on running counter 
+        private int _symbolCounter = 100;
+
+        static GlobalSymbolRegistry()
+        {
+            _globalLookup = new StringDictionarySlim<JsSymbol>
+            {
+                [HasInstance._value] = HasInstance,
+                [IsConcatSpreadable._value] = IsConcatSpreadable,
+                [Iterator._value] = Iterator,
+                [Match._value] = Match,
+                [Replace._value] = Replace,
+                [Search._value] = Search,
+                [Species._value] = Species,
+                [Split._value] = Split,
+                [ToPrimitive._value] = ToPrimitive,
+                [ToStringTag._value] = ToStringTag,
+                [Unscopables._value] = Unscopables
+            };
+        }
+
+        internal bool TryGetSymbol(string key, out JsSymbol symbol)
+        {
+            if (_globalLookup.TryGetValue(key, out symbol))
+            {
+                return true;
+            }
+
+            return _customSymbolLookup != null && _customSymbolLookup.TryGetValue(key, out symbol);
+        }
+
+        internal void Add(JsSymbol symbol)
+        {
+            _customSymbolLookup ??= new StringDictionarySlim<JsSymbol>();
+            _customSymbolLookup[symbol._value] = symbol;
+        }
+
+        internal JsSymbol CreateSymbol(JsValue description)
+        {
+            var identity = Interlocked.Increment(ref _symbolCounter);
+            return new JsSymbol(description, identity);
+        }
+
+        internal JsSymbol CreateSymbol(string description)
+        {
+            var identity = Interlocked.Increment(ref _symbolCounter);
+            return new JsSymbol(description, identity);
+        }
     }
 }

--- a/Jint/Native/Symbol/SymbolPrototype.cs
+++ b/Jint/Native/Symbol/SymbolPrototype.cs
@@ -22,8 +22,7 @@ namespace Jint.Native.Symbol
         {
             var obj = new SymbolPrototype(engine)
             {
-                Prototype = engine.Object.PrototypeObject,
-                Extensible = true,
+                _prototype = engine.Object.PrototypeObject,
                 _symbolConstructor = symbolConstructor
             };
 
@@ -39,12 +38,12 @@ namespace Jint.Native.Symbol
                 ["toString"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "toString", ToSymbolString), true, false, true),
                 ["valueOf"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "valueOf", ValueOf), true, false, true),
                 ["toStringTag"] = new PropertyDescriptor(new JsString("Symbol"), false, false, true),
-                [GlobalSymbolRegistry.ToPrimitive._value] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "toPrimitive", ToPrimitive), false, false, true),
-                [GlobalSymbolRegistry.ToStringTag._value] = new PropertyDescriptor(new JsString("Symbol"), false, false, true)
+                [GlobalSymbolRegistry.ToPrimitive] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "toPrimitive", ToPrimitive), false, false, true),
+                [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor(new JsString("Symbol"), false, false, true)
             };
         }
 
-        public string SymbolDescriptiveString(JsSymbol sym)
+        private string SymbolDescriptiveString(JsSymbol sym)
         {
             return $"Symbol({sym.AsSymbol()})";
         }

--- a/Jint/Pooling/ArgumentsInstancePool.cs
+++ b/Jint/Pooling/ArgumentsInstancePool.cs
@@ -25,8 +25,7 @@ namespace Jint.Pooling
         {
             return new ArgumentsInstance(_engine)
             {
-                Prototype = _engine.Object.PrototypeObject,
-                Extensible = true
+                _prototype = _engine.Object.PrototypeObject
             };
         }
 

--- a/Jint/Runtime/Arguments.cs
+++ b/Jint/Runtime/Arguments.cs
@@ -33,6 +33,18 @@ namespace Jint.Runtime
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T As<T>(this JsValue[] args, int index, Engine engine) where T : JsValue
+        {
+            var value = (uint) index < (uint) args.Length ? args[index] as T : null;
+            if (value is null)
+            {
+                ExceptionHelper.ThrowTypeError<JsValue>(engine);
+            }
+
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static JsValue[] Skip(this JsValue[] args, int count)
         {
             var newLength = args.Length - count;

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -40,18 +40,16 @@ namespace Jint.Runtime.Debugger
 
         internal void AddToDebugCallStack(CallExpression callExpression)
         {
-            var identifier = callExpression.Callee as Esprima.Ast.Identifier;
-            if (identifier != null)
+            if (callExpression.Callee is Identifier identifier)
             {
                 var stack = identifier.Name + "(";
-                var paramStrings = new System.Collections.Generic.List<string>();
+                var paramStrings = new List<string>();
 
                 foreach (var argument in callExpression.Arguments)
                 {
                     if (argument != null)
                     {
-                        var argIdentifier = argument as Esprima.Ast.Identifier;
-                        paramStrings.Add(argIdentifier != null ? argIdentifier.Name : "null");
+                        paramStrings.Add(argument is Identifier argIdentifier ? argIdentifier.Name : "null");
                     }
                     else
                     {

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -238,7 +238,7 @@ namespace Jint.Runtime.Environments
         }
 
         /// <inheritdoc />
-        public override string[] GetAllBindingNames()
+        public override Key[] GetAllBindingNames()
         {
             int size = _set ? 1 : 0;
             if (!ReferenceEquals(_argumentsBinding.Value, null))
@@ -251,7 +251,7 @@ namespace Jint.Runtime.Environments
                 size += _dictionary.Count;
             }
 
-            var keys = size > 0 ? new string[size] : ArrayExt.Empty<string>();
+            var keys = size > 0 ? new Key[size] : ArrayExt.Empty<Key>();
             int n = 0;
             if (_set)
             {
@@ -307,7 +307,7 @@ namespace Jint.Runtime.Environments
         {
             var argument = arguments.Length > index ? arguments[index] : Undefined;
 
-            if (parameter is Esprima.Ast.Identifier identifier)
+            if (parameter is Identifier identifier)
             {
                 SetItemSafely(identifier.Name, argument, initiallyEmpty);
             }
@@ -327,7 +327,7 @@ namespace Jint.Runtime.Environments
 
                 argument = rest;
 
-                if (restElement.Argument is Esprima.Ast.Identifier restIdentifier)
+                if (restElement.Argument is Identifier restIdentifier)
                 {
                     SetItemSafely(restIdentifier.Name, argument, initiallyEmpty);
                 }
@@ -392,18 +392,18 @@ namespace Jint.Runtime.Environments
                 var jsValues = _engine._jsValueArrayPool.RentArray(1);
                 foreach (var property in objectPattern.Properties)
                 {
-                    if (property.Key is Esprima.Ast.Identifier propertyIdentifier)
+                    if (property.Key is Identifier propertyIdentifier)
                     {
-                        argument = argumentObject.Get(propertyIdentifier.Name);
+                        argument = argumentObject.Get(propertyIdentifier.Name, this);
                     }
                     else if (property.Key is Literal propertyLiteral)
                     {
-                        argument = argumentObject.Get(propertyLiteral.Raw);
+                        argument = argumentObject.Get(propertyLiteral.Raw, this);
                     }
                     else if (property.Key is CallExpression callExpression)
                     {
                         var jintCallExpression = JintExpression.Build(_engine, callExpression);
-                        argument = argumentObject.Get(jintCallExpression.GetValue().AsString());
+                        argument = argumentObject.Get(jintCallExpression.GetValue().AsString(), this);
                     }
 
                     jsValues[0] = argument;
@@ -413,9 +413,9 @@ namespace Jint.Runtime.Environments
             }
             else if (parameter is AssignmentPattern assignmentPattern)
             {
-                var idLeft = assignmentPattern.Left as Esprima.Ast.Identifier;
+                var idLeft = assignmentPattern.Left as Identifier;
                 if (idLeft != null
-                    && assignmentPattern.Right is Esprima.Ast.Identifier idRight
+                    && assignmentPattern.Right is Identifier idRight
                     && idLeft.Name == idRight.Name)
                 {
                     ExceptionHelper.ThrowReferenceError(_engine, idRight.Name);
@@ -490,7 +490,7 @@ namespace Jint.Runtime.Environments
                 for (var j = 0; j < declarationsCount; j++)
                 {
                     var d = variableDeclaration.Declarations[j];
-                    if (d.Id is Esprima.Ast.Identifier id)
+                    if (d.Id is Identifier id)
                     {
                         Key dn = id.Name;
                         if (!ContainsKey(dn))

--- a/Jint/Runtime/Environments/EnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/EnvironmentRecord.cs
@@ -69,7 +69,7 @@ namespace Jint.Runtime.Environments
         /// Returns an array of all the defined binding names
         /// </summary>
         /// <returns>The array of all defined bindings</returns>
-        public abstract string[] GetAllBindingNames();
+        public abstract Key[] GetAllBindingNames();
         
         public override object ToObject()
         {

--- a/Jint/Runtime/Interop/ClrFunctionInstance.cs
+++ b/Jint/Runtime/Interop/ClrFunctionInstance.cs
@@ -18,12 +18,11 @@ namespace Jint.Runtime.Interop
             Func<JsValue, JsValue[], JsValue> func,
             int length = 0,
             PropertyFlag lengthFlags = PropertyFlag.AllForbidden)
-            : base(engine, new JsString(name), strict: false)
+            : base(engine, !string.IsNullOrWhiteSpace(name) ? new JsString(name) : null, strict: false)
         {
             _func = func;
 
-            Prototype = engine.Function.PrototypeObject;
-            Extensible = true;
+            _prototype = engine.Function.PrototypeObject;
 
             _length = lengthFlags == PropertyFlag.AllForbidden
                 ? PropertyDescriptor.AllForbiddenDescriptor.ForNumber(length)

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -19,7 +19,7 @@ namespace Jint.Runtime.Interop
             : base(engine, "delegate", null, null, false)
         {
             _d = d;
-            Prototype = engine.Function.PrototypeObject;
+            _prototype = engine.Function.PrototypeObject;
 
             var parameterInfos = _d.Method.GetParameters();
 
@@ -116,7 +116,7 @@ namespace Jint.Runtime.Interop
             }
             try
             {
-                return JsValue.FromObject(Engine, _d.DynamicInvoke(parameters));
+                return FromObject(Engine, _d.DynamicInvoke(parameters));
             }
             catch (TargetInvocationException exception)
             {

--- a/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
@@ -14,7 +14,7 @@ namespace Jint.Runtime.Interop
             : base(engine, "Function", null, null, false)
         {
             _methods = methods;
-            Prototype = engine.Function.PrototypeObject;
+            _prototype = engine.Function.PrototypeObject;
         }
 
         public override JsValue Call(JsValue thisObject, JsValue[] arguments)
@@ -53,11 +53,11 @@ namespace Jint.Runtime.Interop
                         // Handle specific case of F(params JsValue[])
 
                         var arrayInstance = arguments[i].AsArray();
-                        var len = TypeConverter.ToInt32(arrayInstance.Get("length"));
+                        var len = TypeConverter.ToInt32(arrayInstance.Get("length", this));
                         var result = new JsValue[len];
                         for (uint k = 0; k < len; k++)
                         {
-                            result[k] = arrayInstance.TryGetValue(k, out var value) ? value : JsValue.Undefined;
+                            result[k] = arrayInstance.TryGetValue(k, out var value) ? value : Undefined;
                         }
                         parameters[i] = result;
                     }

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -23,23 +23,13 @@ namespace Jint.Runtime.Interop
             _path = path;
         }
 
-        public override bool DefineOwnProperty(in Key propertyName, PropertyDescriptor desc, bool throwOnError)
+        public override bool DefineOwnProperty(in Key propertyName, PropertyDescriptor desc)
         {
-            if (throwOnError)
-            {
-                ExceptionHelper.ThrowTypeError(_engine, "Can't define a property of a NamespaceReference");
-            }
-
             return false;
         }
 
-        public override bool Delete(in Key propertyName, bool throwOnError)
+        public override bool Delete(in Key propertyName)
         {
-            if (throwOnError)
-            {
-                ExceptionHelper.ThrowTypeError(_engine, "Can't delete a property of a NamespaceReference");
-            }
-
             return false;
         }
 
@@ -80,7 +70,7 @@ namespace Jint.Runtime.Interop
             }
         }
 
-        public override JsValue Get(in Key propertyName)
+        public override JsValue Get(in Key propertyName, JsValue receiver)
         {
             var newPath = _path + "." + propertyName;
 

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -23,7 +23,7 @@ namespace Jint.Runtime.Interop
                 IsArrayLike = true;
                 // create a forwarder to produce length from Count
                 var functionInstance = new ClrFunctionInstance(engine, "length", (thisObj, arguments) => collection.Count);
-                var descriptor = new GetSetPropertyDescriptor(functionInstance, Undefined, PropertyFlag.AllForbidden);
+                var descriptor = new GetSetPropertyDescriptor(functionInstance, Undefined, PropertyFlag.Configurable);
                 AddProperty("length", descriptor);
             }
         }
@@ -32,31 +32,22 @@ namespace Jint.Runtime.Interop
 
         internal override bool IsArrayLike { get; }
 
-        public override void Put(in Key propertyName, JsValue value, bool throwOnError)
+        public override bool Set(in Key propertyName, JsValue value, JsValue receiver)
         {
             if (!CanPut(propertyName))
             {
-                if (throwOnError)
-                {
-                    ExceptionHelper.ThrowTypeError(Engine);
-                }
-
-                return;
+                return false;
             }
 
             var ownDesc = GetOwnProperty(propertyName);
 
             if (ownDesc == null)
             {
-                if (throwOnError)
-                {
-                    ExceptionHelper.ThrowTypeError(_engine, "Unknown member: " + propertyName);
-                }
+                return false;
             }
-            else
-            {
-                ownDesc.Value = value;
-            }
+
+            ownDesc.Value = value;
+            return true;
         }
 
         public override PropertyDescriptor GetOwnProperty(in Key propertyName)

--- a/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
@@ -63,11 +63,11 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             var obj = TypeConverter.ToObject(engine, argument);
 
-            ArrayPrototype.ArrayOperations arrayOperations = null;
+            ArrayOperations arrayOperations = null;
             IIterator iterator = null;
             if (obj.IsArrayLike)
             {
-                arrayOperations = ArrayPrototype.ArrayOperations.For(obj);
+                arrayOperations = ArrayOperations.For(obj);
             }
             else
             {
@@ -82,7 +82,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             for (uint i = 0; i < pattern.Elements.Count; i++)
             {
                 var left = pattern.Elements[(int) i];
-                if (left is Esprima.Ast.Identifier identifier)
+                if (left is Identifier identifier)
                 {
                     JsValue value;
                     if (arrayOperations != null)
@@ -162,7 +162,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                             value = jintExpression.GetValue();
                         }
 
-                        if (assignmentPattern.Left is Esprima.Ast.Identifier leftIdentifier)
+                        if (assignmentPattern.Left is Identifier leftIdentifier)
                         {
                             if (assignmentPattern.Right.IsFunctionWithName())
                             {
@@ -196,7 +196,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
                 var left = pattern.Properties[(int) i];
                 string sourceKey;
-                Esprima.Ast.Identifier identifier = left.Key as Esprima.Ast.Identifier;
+                var identifier = left.Key as Identifier;
                 if (identifier == null)
                 {
                     var keyExpression = Build(engine, left.Key);
@@ -223,7 +223,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                         continue;
                     }
                     
-                    var target = assignmentPattern.Left as Esprima.Ast.Identifier ?? identifier;
+                    var target = assignmentPattern.Left as Identifier ?? identifier;
 
                     if (assignmentPattern.Right.IsFunctionWithName())
                     {
@@ -238,7 +238,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
                 else
                 {
-                    var target = left.Value as Esprima.Ast.Identifier ?? identifier;
+                    var target = left.Value as Identifier ?? identifier;
                     AssignToIdentifier(engine, target.Name, value);
                 }
             }

--- a/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
@@ -40,13 +40,14 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
 
             // todo: optimize by defining a common abstract class or interface
-            if (!(_calleeExpression.GetValue() is IConstructor callee))
+            var jsValue = _calleeExpression.GetValue();
+            if (!(jsValue is IConstructor callee))
             {
                 return ExceptionHelper.ThrowTypeError<object>(_engine, "The object can't be used as constructor.");
             }
 
             // construct the new instance using the Function's constructor method
-            var instance = callee.Construct(arguments);
+            var instance = callee.Construct(arguments, jsValue);
 
             _engine._jsValueArrayPool.ReturnArray(arguments);
 

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -26,16 +26,16 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         private class ObjectProperty
         {
-            private readonly Key _name;
+            private readonly Key _key;
             internal readonly Property _value;
 
-            public ObjectProperty(in Key propName, Property property)
+            public ObjectProperty(in Key key, Property property)
             {
-                _name = propName;
+                _key = key;
                 _value = property;
             }
 
-            public ref readonly Key Name => ref _name;
+            public ref readonly Key Key => ref _key;
         }
 
         public JintObjectExpression(Engine engine, ObjectExpression expression) : base(engine, expression)
@@ -63,7 +63,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     propName = literal.Value as string ?? Convert.ToString(literal.Value, provider: null);
                 }
 
-                if (property.Key is Esprima.Ast.Identifier identifier)
+                if (!property.Computed && property.Key is Identifier identifier)
                 {
                     propName = identifier.Name;
                 }
@@ -106,7 +106,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 var objectProperty = _properties[i];
                 var valueExpression = _valueExpressions[i];
                 var propValue = valueExpression.GetValue();
-                properties[objectProperty.Name] = new PropertyDescriptor(propValue, PropertyFlag.ConfigurableEnumerableWritable);
+                properties[objectProperty.Key] = new PropertyDescriptor(propValue, PropertyFlag.ConfigurableEnumerableWritable);
             }
 
             obj._properties = properties;
@@ -115,16 +115,16 @@ namespace Jint.Runtime.Interpreter.Expressions
                                                 
         private object BuildObjectNormal()
         {
-            var obj = _engine.Object.Construct(System.Math.Max(2, _properties.Length));
+            var obj = _engine.Object.Construct(Math.Max(2, _properties.Length));
             bool isStrictModeCode = StrictModeScope.IsStrictModeCode;
 
             for (var i = 0; i < _properties.Length; i++)
             {
                 var objectProperty = _properties[i];
                 var property = objectProperty._value;
-                var propName = !string.IsNullOrEmpty(objectProperty.Name)
-                    ? objectProperty.Name
-                    : (Key) objectProperty._value.Key.GetKey(_engine);
+                var propName = objectProperty.Key.Name.Length > 0
+                    ? objectProperty.Key
+                    : property.GetKey(_engine);
 
                 PropertyDescriptor propDesc;
 
@@ -135,7 +135,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     if (expr._expression.IsFunctionWithName())
                     {
                         var functionInstance = (FunctionInstance) propValue;
-                        functionInstance.SetFunctionName(objectProperty.Name);
+                        functionInstance.SetFunctionName(propName);
                     }
                     propDesc = new PropertyDescriptor(propValue, PropertyFlag.ConfigurableEnumerableWritable);
                 }
@@ -149,8 +149,8 @@ namespace Jint.Runtime.Interpreter.Expressions
                         _engine.ExecutionContext.LexicalEnvironment,
                         isStrictModeCode
                     );
-                    functionInstance.SetFunctionName(objectProperty.Name);
-                    functionInstance._prototype = null;
+                    functionInstance.SetFunctionName(propName);
+                    functionInstance._prototypeDescriptor = null;
 
                     propDesc = new GetSetPropertyDescriptor(
                         get: property.Kind == PropertyKind.Get ? functionInstance : null,
@@ -162,7 +162,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     return ExceptionHelper.ThrowArgumentOutOfRangeException<object>();
                 }
 
-                obj.DefineOwnProperty(propName, propDesc, false);
+                obj.DefineOwnProperty(propName, propDesc);
             }
 
             return obj;

--- a/Jint/Runtime/Interpreter/Expressions/JintSpreadExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintSpreadExpression.cs
@@ -12,7 +12,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         public JintSpreadExpression(Engine engine, SpreadElement expression) : base(engine, expression)
         {
             _argument = Build(engine, expression.Argument);
-            _argumentName = (expression.Argument as Esprima.Ast.Identifier)?.Name;
+            _argumentName = (expression.Argument as Identifier)?.Name;
         }
 
         protected override object EvaluateInternal()

--- a/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
@@ -62,7 +62,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 rawObj.SetIndexValue((uint) i, templateElementValue.Raw, updateLength: false);
             }
 
-            template.DefineOwnProperty("raw", new PropertyDescriptor(rawObj, PropertyFlag.AllForbidden), false);
+            template.DefineOwnProperty("raw", new PropertyDescriptor(rawObj, PropertyFlag.AllForbidden));
             return template;
         }
     }

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -49,9 +49,9 @@ namespace Jint.Runtime.Interpreter
             _body = JintStatement.Build(engine, bodyStatement);
         }
 
-        private IEnumerable<Esprima.Ast.Identifier> GetParameterIdentifiers(INode parameter)
+        private IEnumerable<Identifier> GetParameterIdentifiers(INode parameter)
         {
-            if (parameter is Esprima.Ast.Identifier identifier)
+            if (parameter is Identifier identifier)
             {
                 return new [] { identifier };
             }
@@ -73,7 +73,7 @@ namespace Jint.Runtime.Interpreter
                 return GetParameterIdentifiers(assignmentPattern.Left);
             }
 
-            return Enumerable.Empty<Esprima.Ast.Identifier>();
+            return Enumerable.Empty<Identifier>();
         }
 
         private string[] GetParameterNames(IFunction functionDeclaration)
@@ -85,7 +85,7 @@ namespace Jint.Runtime.Interpreter
             for (var i = 0; i < count; i++)
             {
                 var parameter = functionDeclarationParams[i];
-                if (parameter is Esprima.Ast.Identifier id)
+                if (parameter is Identifier id)
                 {
                     parameterNames.Add(id.Name);
                     if (onlyIdentifiers)

--- a/Jint/Runtime/Interpreter/Statements/JintForInStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInStatement.cs
@@ -20,7 +20,7 @@ namespace Jint.Runtime.Interpreter.Statements
         {
             if (_statement.Left.Type == Nodes.VariableDeclaration)
             {
-                _identifier = JintExpression.Build(engine, (Esprima.Ast.Identifier) ((VariableDeclaration) _statement.Left).Declarations[0].Id);
+                _identifier = JintExpression.Build(engine, (Identifier) ((VariableDeclaration) _statement.Left).Declarations[0].Id);
             }
             else if (_statement.Left.Type == Nodes.MemberExpression)
             {
@@ -28,7 +28,7 @@ namespace Jint.Runtime.Interpreter.Statements
             }
             else
             {
-                _identifier = JintExpression.Build(engine, (Esprima.Ast.Identifier) _statement.Left);
+                _identifier = JintExpression.Build(engine, (Identifier) _statement.Left);
             }
 
             _body = Build(engine, _statement.Body);

--- a/Jint/Runtime/Interpreter/Statements/JintTryStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintTryStatement.cs
@@ -19,7 +19,7 @@ namespace Jint.Runtime.Interpreter.Statements
             if (_statement.Handler != null)
             {
                 _catch = Build(engine, _statement.Handler.Body);
-                _catchParamName = ((Esprima.Ast.Identifier) _statement.Handler.Param).Name;
+                _catchParamName = ((Identifier) _statement.Handler.Param).Name;
             }
 
             if (statement.Finalizer != null)

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -52,7 +52,7 @@ namespace Jint.Runtime
                             sb.Builder.Append(", ");
                         var arg = cse.CallExpression.Arguments[index];
                         if (arg is Expression pke)
-                            sb.Builder.Append(pke.GetKey(engine));
+                            sb.Builder.Append(pke.GetKey(engine, computed: false));
                         else
                             sb.Builder.Append(arg);
                     }
@@ -77,7 +77,7 @@ namespace Jint.Runtime
             if (error.IsObject())
             {
                 var oi = error.AsObject();
-                var message = oi.Get("message").ToString();
+                var message = oi.Get("message", oi).ToString();
                 return message;
             }
             if (error.IsString())
@@ -103,7 +103,7 @@ namespace Jint.Runtime
                     return null;
                 if (Error.IsObject() == false)
                     return null;
-                var callstack = Error.AsObject().Get("callstack");
+                var callstack = Error.AsObject().Get("callstack", Error);
                 if (callstack.IsUndefined())
                     return null;
                 return callstack.AsString();

--- a/Jint/Runtime/References/Reference.cs
+++ b/Jint/Runtime/References/Reference.cs
@@ -51,6 +51,13 @@ namespace Jint.Runtime.References
             return _baseValue._type == InternalTypes.Undefined;
         }
 
+        public bool IsSuperReference()
+        {
+            // TODO super not implemented
+            return false;
+        }
+        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsPropertyReference()
         {

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -13,31 +13,33 @@ using Jint.Pooling;
 
 namespace Jint.Runtime
 {
+    [Flags]
     public enum Types
     {
         None = 0,
         Undefined = 1,
         Null = 2,
-        Boolean = 3,
-        String = 4,
-        Number = 5,
-        Symbol = 9,
-        Object = 10,
-        Completion = 20
+        Boolean = 4,
+        String = 8,
+        Number = 16,
+        Symbol = 64,
+        Object = 128,
+        Completion = 256
     }
 
+    [Flags]
     internal enum InternalTypes
     {
         None = 0,
         Undefined = 1,
         Null = 2,
-        Boolean = 3,
-        String = 4,
-        Number = 5,
-        Integer = 6,
-        Symbol = 9,
-        Object = 10,
-        Completion = 20
+        Boolean = 4,
+        String = 8,
+        Number = 16,
+        Integer = 32,
+        Symbol = 64,
+        Object = 128,
+        Completion = 256
     }
 
     public static class TypeConverter
@@ -369,12 +371,12 @@ namespace Jint.Runtime
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/6.0/#sec-topropertykey
         /// </summary>
-        public static string ToPropertyKey(JsValue o)
+        public static Key ToPropertyKey(JsValue o)
         {
             var key = ToPrimitive(o, Types.String);
             if (key is JsSymbol s)
             {
-                return s._value;
+                return s.ToPropertyKey();
             }
 
             return ToString(key);
@@ -496,7 +498,7 @@ namespace Jint.Runtime
 
         public static IEnumerable<Tuple<MethodBase, JsValue[]>> FindBestMatch<T>(Engine engine, T[] methods, Func<T, bool, JsValue[]> argumentProvider) where T : MethodBase
         {
-            System.Collections.Generic.List<Tuple<T, JsValue[]>> matchingByParameterCount = null;
+            List<Tuple<T, JsValue[]>> matchingByParameterCount = null;
             foreach (var m in methods)
             {
                 bool hasParams = false;
@@ -519,7 +521,7 @@ namespace Jint.Runtime
                         yield break;
                     }
 
-                    matchingByParameterCount = matchingByParameterCount ?? new System.Collections.Generic.List<Tuple<T, JsValue[]>>();
+                    matchingByParameterCount = matchingByParameterCount ?? new List<Tuple<T, JsValue[]>>();
                     matchingByParameterCount.Add(new Tuple<T, JsValue[]>(m, arguments));
                 }
                 else if (parameterInfos.Length > arguments.Length)
@@ -535,7 +537,7 @@ namespace Jint.Runtime
                     {
                         // create missing arguments from default values
 
-                        var argsWithDefaults = new System.Collections.Generic.List<JsValue>(arguments);
+                        var argsWithDefaults = new List<JsValue>(arguments);
                         for (var i = arguments.Length; i < parameterInfos.Length; i++)
                         {
                             var param = parameterInfos[i];
@@ -543,7 +545,7 @@ namespace Jint.Runtime
                             argsWithDefaults.Add(value);
                         }
 
-                        matchingByParameterCount = matchingByParameterCount ?? new System.Collections.Generic.List<Tuple<T, JsValue[]>>();
+                        matchingByParameterCount = matchingByParameterCount ?? new List<Tuple<T, JsValue[]>>();
                         matchingByParameterCount.Add(new Tuple<T, JsValue[]>(m, argsWithDefaults.ToArray()));
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ ES6 features which are being implemented:
 - [ ] [module loaders](https://github.com/lukehoban/es6features/blob/master/README.md#module-loaders)
 - [x] [map + set](https://github.com/lukehoban/es6features/blob/master/README.md#map--set--weakmap--weakset)
 - [ ] [weakmap + weakset](https://github.com/lukehoban/es6features/blob/master/README.md#map--set--weakmap--weakset)
-- [ ] [proxies](https://github.com/lukehoban/es6features/blob/master/README.md#proxies)
+- [x] [proxies](https://github.com/lukehoban/es6features/blob/master/README.md#proxies)
 - [x] [symbols](https://github.com/lukehoban/es6features/blob/master/README.md#symbols)
 - [ ] [subclassable built-ins](https://github.com/lukehoban/es6features/blob/master/README.md#subclassable-built-ins)
 - [ ] [promises](https://github.com/lukehoban/es6features/blob/master/README.md#promises)
@@ -176,7 +176,7 @@ ES6 features which are being implemented:
 - [x] [array APIs](https://github.com/lukehoban/es6features/blob/master/README.md#math--number--string--array--object-apis)
 - [ ] [object APIs](https://github.com/lukehoban/es6features/blob/master/README.md#math--number--string--array--object-apis)
 - [x] [binary and octal literals](https://github.com/lukehoban/es6features/blob/master/README.md#binary-and-octal-literals)
-- [ ] [reflect api](https://github.com/lukehoban/es6features/blob/master/README.md#reflect-api)
+- [x] [reflect api](https://github.com/lukehoban/es6features/blob/master/README.md#reflect-api)
 - [ ] [tail calls](https://github.com/lukehoban/es6features/blob/master/README.md#tail-calls)
 
 ### .NET Interoperability


### PR DESCRIPTION
OK this was quite the chore. I tried to align as much as I could with the spec and changed method names like Put to Set, which is what the spec now uses. Also named helper methods with spec names.

Key can now handle both symbols and "regular" properties, fixed some issues with identities too. Later we should probably rename Key to PropertyKey.

Generally I think some things got cleaned up, sorry for the large PR but the proxy and reflect walk quite hand in hand. Also fixed existing issues that were revealed when proxy support was enabled for tests that were in ignore before. Almost 400 new tests covering the new functionality.