### PR TITLE
Fix ambiguity errors when compiling with Esprima source in tree.

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -441,12 +441,12 @@ namespace Jint
         {
             if (_maxStatements > 0 && _statementsCount++ > _maxStatements)
             {
-                ExceptionHelper.ThrowStatementsCountOverflowException();
+                Jint.Runtime.ExceptionHelper.ThrowStatementsCountOverflowException();
             }
 
             if (_timeoutTicks > 0 && _timeoutTicks < DateTime.UtcNow.Ticks)
             {
-                ExceptionHelper.ThrowTimeoutException();
+                Jint.Runtime.ExceptionHelper.ThrowTimeoutException();
             }
 
             if (_memoryLimit > 0)
@@ -456,12 +456,12 @@ namespace Jint
                     var memoryUsage = GetAllocatedBytesForCurrentThread() - _initialMemoryUsage;
                     if (memoryUsage > _memoryLimit)
                     {
-                        ExceptionHelper.ThrowMemoryLimitExceededException($"Script has allocated {memoryUsage} but is limited to {_memoryLimit}");
+                        Jint.Runtime.ExceptionHelper.ThrowMemoryLimitExceededException($"Script has allocated {memoryUsage} but is limited to {_memoryLimit}");
                     }
                 }
                 else
                 {
-                    ExceptionHelper.ThrowPlatformNotSupportedException("The current platform doesn't support MemoryLimit.");
+                    Jint.Runtime.ExceptionHelper.ThrowPlatformNotSupportedException("The current platform doesn't support MemoryLimit.");
                 }
             }
 
@@ -504,7 +504,7 @@ namespace Jint
                     return val;
                 }
 
-                ExceptionHelper.ThrowReferenceError(this, reference);
+                Jint.Runtime.ExceptionHelper.ThrowReferenceError(this, reference);
             }
 
             var baseValue = reference._baseValue;
@@ -556,7 +556,7 @@ namespace Jint
 
             if (!(baseValue is EnvironmentRecord record))
             {
-                return ExceptionHelper.ThrowArgumentException<JsValue>();
+                return Jint.Runtime.ExceptionHelper.ThrowArgumentException<JsValue>();
             }
 
             var bindingValue = record.GetBindingValue(reference.GetReferencedName(), reference._strict);
@@ -579,7 +579,7 @@ namespace Jint
             {
                 if (reference._strict)
                 {
-                    ExceptionHelper.ThrowReferenceError(this, reference);
+                    Jint.Runtime.ExceptionHelper.ThrowReferenceError(this, reference);
                 }
 
                 Global.Put(referencedName, value, false);
@@ -613,7 +613,7 @@ namespace Jint
             {
                 if (throwOnError)
                 {
-                    ExceptionHelper.ThrowTypeError(this);
+                    Jint.Runtime.ExceptionHelper.ThrowTypeError(this);
                 }
                 return;
             }
@@ -624,7 +624,7 @@ namespace Jint
             {
                 if (throwOnError)
                 {
-                    ExceptionHelper.ThrowTypeError(this);
+                    Jint.Runtime.ExceptionHelper.ThrowTypeError(this);
                 }
                 return;
             }
@@ -640,7 +640,7 @@ namespace Jint
             {
                 if (throwOnError)
                 {
-                    ExceptionHelper.ThrowTypeError(this);
+                    Jint.Runtime.ExceptionHelper.ThrowTypeError(this);
                 }
             }
         }
@@ -690,7 +690,7 @@ namespace Jint
         /// <returns>The value returned by the function call.</returns>
         public JsValue Invoke(JsValue value, object thisObj, object[] arguments)
         {
-            var callable = value as ICallable ?? ExceptionHelper.ThrowArgumentException<ICallable>("Can only invoke functions");
+            var callable = value as ICallable ?? Jint.Runtime.ExceptionHelper.ThrowArgumentException<ICallable>("Can only invoke functions");
 
             var items = _jsValueArrayPool.RentArray(arguments.Length);
             for (int i = 0; i < arguments.Length; ++i)
@@ -867,7 +867,7 @@ namespace Jint
                         {
                             if (existingProp.IsAccessorDescriptor() || !existingProp.Enumerable)
                             {
-                                ExceptionHelper.ThrowTypeError(this);
+                                Jint.Runtime.ExceptionHelper.ThrowTypeError(this);
                             }
                         }
                     }
@@ -887,7 +887,7 @@ namespace Jint
         {
             if (string.IsNullOrEmpty(propertyValue))
             {
-                ExceptionHelper.ThrowArgumentException(propertyName);
+                Jint.Runtime.ExceptionHelper.ThrowArgumentException(propertyName);
             }
         }
     }

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -102,10 +102,10 @@ namespace Jint.Native.Function
             {
                 if (e.Description == Messages.InvalidLHSInAssignment)
                 {
-                    ExceptionHelper.ThrowReferenceError(_engine, (string) null);
+                    Jint.Runtime.ExceptionHelper.ThrowReferenceError(_engine, (string) null);
                 }
 
-                ExceptionHelper.ThrowSyntaxError(_engine);
+                Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine);
                 return null;
             }
         }

--- a/Jint/Native/Function/FunctionConstructor.cs
+++ b/Jint/Native/Function/FunctionConstructor.cs
@@ -78,7 +78,7 @@ namespace Jint.Native.Function
             }
             catch (ParserException)
             {
-                ExceptionHelper.ThrowSyntaxError(_engine);
+                Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine);
                 return null;
             }
 
@@ -132,7 +132,7 @@ namespace Jint.Native.Function
         {
             if (arguments.Length != 2)
             {
-                ExceptionHelper.ThrowArgumentException("Apply has to be called with two arguments.");
+                Jint.Runtime.ExceptionHelper.ThrowArgumentException("Apply has to be called with two arguments.");
             }
 
             var func = thisObject.TryCast<ICallable>();
@@ -141,7 +141,7 @@ namespace Jint.Native.Function
 
             if (func is null)
             {
-                return ExceptionHelper.ThrowTypeError<object>(Engine);
+                return Jint.Runtime.ExceptionHelper.ThrowTypeError<object>(Engine);
             }
 
             if (argArray.IsNullOrUndefined())
@@ -152,7 +152,7 @@ namespace Jint.Native.Function
             var argArrayObj = argArray.TryCast<ObjectInstance>();
             if (ReferenceEquals(argArrayObj, null))
             {
-                ExceptionHelper.ThrowTypeError(Engine);
+                Jint.Runtime.ExceptionHelper.ThrowTypeError(Engine);
             }
 
             var len = argArrayObj.Get("length");

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -98,7 +98,7 @@ namespace Jint.Native.Json
                 }
                 else
                 {
-                    ExceptionHelper.ThrowSyntaxError(_engine, $"Expected hexadecimal digit:{_source}");
+                    Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine, $"Expected hexadecimal digit:{_source}");
                 }
             }
             return (char)code;
@@ -153,7 +153,7 @@ namespace Jint.Native.Json
                         };
             }
 
-            ExceptionHelper.ThrowSyntaxError(_engine, string.Format(Messages.UnexpectedToken, code));
+            Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine, string.Format(Messages.UnexpectedToken, code));
             return null;
         }
 
@@ -183,7 +183,7 @@ namespace Jint.Native.Json
                     // decimal number starts with '0' such as '09' is illegal.
                     if (ch > 0 && IsDecimalDigit(ch))
                     {
-                        ExceptionHelper.ThrowSyntaxError(_engine, string.Format(Messages.UnexpectedToken, ch));
+                        Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine, string.Format(Messages.UnexpectedToken, ch));
                     }
                 }
 
@@ -222,7 +222,7 @@ namespace Jint.Native.Json
                 }
                 else
                 {
-                    ExceptionHelper.ThrowSyntaxError(_engine, string.Format(Messages.UnexpectedToken, _source.CharCodeAt(_index)));
+                    Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine, string.Format(Messages.UnexpectedToken, _source.CharCodeAt(_index)));
                 }
             }
 
@@ -258,7 +258,7 @@ namespace Jint.Native.Json
                 };
             }
 
-            ExceptionHelper.ThrowSyntaxError(_engine, string.Format(Messages.UnexpectedToken, s));
+            Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine, string.Format(Messages.UnexpectedToken, s));
             return null;
         }
 
@@ -284,7 +284,7 @@ namespace Jint.Native.Json
                 };
             }
 
-            ExceptionHelper.ThrowSyntaxError(_engine, string.Format(Messages.UnexpectedToken, s));
+            Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine, string.Format(Messages.UnexpectedToken, s));
             return null;
         }
 
@@ -309,7 +309,7 @@ namespace Jint.Native.Json
 
                 if (ch <= 31)
                 {
-                    ExceptionHelper.ThrowSyntaxError(_engine, $"Invalid character '{ch}', position:{_index}, string:{_source}");
+                    Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine, $"Invalid character '{ch}', position:{_index}, string:{_source}");
                 }
 
                 if (ch == '\\')
@@ -401,7 +401,7 @@ namespace Jint.Native.Json
 
             if (quote != 0)
             {
-                ExceptionHelper.ThrowSyntaxError(_engine, string.Format(Messages.UnexpectedToken, _source));
+                Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine, string.Format(Messages.UnexpectedToken, _source));
             }
 
             return new Token
@@ -716,7 +716,7 @@ namespace Jint.Native.Json
                 var name = Lex().Value.ToString();
                 if (PropertyNameContainsInvalidChar0To31(name))
                 {
-                    ExceptionHelper.ThrowSyntaxError(_engine, $"Invalid character in property name '{name}'");
+                    Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine, $"Invalid character in property name '{name}'");
                 }
 
                 Expect(":");
@@ -841,7 +841,7 @@ namespace Jint.Native.Json
 
                 if(_lookahead.Type != Tokens.EOF)
                 {
-                    ExceptionHelper.ThrowSyntaxError(_engine, $"Unexpected {_lookahead.Type} {_lookahead.Value}");
+                    Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine, $"Unexpected {_lookahead.Type} {_lookahead.Value}");
                 }
                 return jsv;
             }

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -73,7 +73,7 @@ namespace Jint.Native.RegExp
 
             if (!flags.IsUndefined() && !ReferenceEquals(r, null))
             {
-                ExceptionHelper.ThrowTypeError(Engine);
+                Jint.Runtime.ExceptionHelper.ThrowTypeError(Engine);
             }
 
             if (pattern.IsUndefined())
@@ -105,7 +105,7 @@ namespace Jint.Native.RegExp
             }
             catch (Exception e)
             {
-                ExceptionHelper.ThrowSyntaxError(_engine, e.Message);
+                Jint.Runtime.ExceptionHelper.ThrowSyntaxError(_engine, e.Message);
             }
 
             var s = p;


### PR DESCRIPTION
Any source file that has `using` both `Jint.Runtime` and `Esprima` fails to compile due to ambiguous class ExceptionHelper:
https://github.com/sebastienros/jint/blob/dev/Jint/Runtime/ExceptionHelper.cs
https://github.com/sebastienros/esprima-dotnet/blob/dev/src/Esprima/ExceptionHelper.cs

Only happens if you place Esprima source inside jint's source tree to build a single dll instead of several.