### PR TITLE
Fix array indexing with hex literal

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1886,6 +1886,16 @@ var prep = function (fn) { fn(); };
         }
 
         [Fact]
+        public void HexZeroAsArrayIndexShouldWork()
+        {
+            var engine = new Engine();
+            engine.Execute("var t = '1234'; var value = null;");
+            Assert.Equal("1", engine.Execute("value = t[0x0];").GetValue("value").AsString());
+            Assert.Equal("1", engine.Execute("value = t[0];").GetValue("value").AsString());
+            Assert.Equal("1", engine.Execute("value = t['0'];").GetValue("value").AsString());
+        }
+
+        [Fact]
         public void DatePrototypeFunctionWorkOnDateOnly()
         {
             RunTest(@"

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -37,18 +37,8 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             if (literal.TokenType == TokenType.NumericLiteral)
             {
-                var isIntValue = int.TryParse(literal.Raw, out var intValue);
-                if (!isIntValue && literal.Raw.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
-                {
-                    // TODO spanify
-                    var hex = literal.Raw.Substring(2);
-                    if (uint.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var hexIntValue))
-                    {
-                        return JsNumber.Create(hexIntValue);
-                    }
-                }
-
-                return isIntValue
+                var intValue = (int) literal.NumericValue;
+                return literal.NumericValue == intValue
                        && (intValue != 0 || BitConverter.DoubleToInt64Bits(literal.NumericValue) != JsNumber.NegativeZeroBits)
                     ? JsNumber.Create(intValue)
                     : JsNumber.Create(literal.NumericValue);


### PR DESCRIPTION
When string was indexed with non-integer value, the logic incorrectly expected that the target would be the prototype member (like 'indexOf'). Now checking that indexing is done correctly. Also tweaked hex literals to be pre-calculated as integers.

fixes #710 