### PR TITLE
Ability to set Array.prototype as prototype for array-like object wrappers

### DIFF
--- a/Jint.Tests/Runtime/Domain/FloatIndexer.cs
+++ b/Jint.Tests/Runtime/Domain/FloatIndexer.cs
@@ -1,21 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Jint.Tests.Runtime.Domain
+﻿namespace Jint.Tests.Runtime.Domain
 {
     public class FloatIndexer
     {
-		public string this[int index]
-		{
-			get
-			{
-				return "";
-				//throw new Exception();
-			}
-		}
-
-	}
+		public string this[int index] => "";
+    }
 }

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -674,13 +674,20 @@ namespace Jint.Tests.Runtime
             ");
         }
 
-        private class ReadOnlyList : IReadOnlyList<int>
+        private class ReadOnlyList : IReadOnlyList<Person>
         {
-            private static readonly int[] _data = Enumerable.Range(1, 6).ToArray();
-            
-            public IEnumerator<int> GetEnumerator()
+            private static readonly Person[] _data = new  Person[]
             {
-                return ((IEnumerable<int>) _data).GetEnumerator();
+                new Person()
+                {
+                    Age = 12,
+                    Name = "johtn"
+                },
+            };
+            
+            public IEnumerator<Person> GetEnumerator()
+            {
+                return ((IEnumerable<Person>) _data).GetEnumerator();
             }
 
             IEnumerator IEnumerable.GetEnumerator()
@@ -690,7 +697,7 @@ namespace Jint.Tests.Runtime
 
             public int Count => _data.Length;
 
-            public int this[int index] => _data[index];
+            public Person this[int index] => _data[index];
         }
         
         [Fact]
@@ -703,16 +710,8 @@ namespace Jint.Tests.Runtime
 
             _engine.SetValue("o", obj);
 
-            var first = _engine.Execute("o.values[0]").GetCompletionValue().AsNumber();
-            Assert.Equal(1, first);
-            
-            var parts = _engine.Execute("o.values.filter(function(x){ return x % 2 == 0; })").GetCompletionValue().ToObject();
+            var name = _engine.Execute("o.values.filter(x => x.age == 12)[0].name").GetCompletionValue().ToString();
 
-            Assert.True(parts.GetType().IsArray);
-            Assert.Equal(3, ((object[])parts).Length);
-            Assert.Equal(2d, ((object[])parts)[0]);
-            Assert.Equal(4d, ((object[])parts)[1]);
-            Assert.Equal(6d, ((object[])parts)[2]);
         }
 
         [Fact]

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -57,7 +57,7 @@ namespace Jint.Native.Array
             _length = new PropertyDescriptor(length, PropertyFlag.OnlyWritable);
         }
 
-        internal override bool IsArrayLike => true;
+        public override bool IsArrayLike => true;
 
         public override bool DefineOwnProperty(JsValue property, PropertyDescriptor desc)
         {

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -348,8 +348,8 @@ namespace Jint.Native
 
             // if no known type could be guessed, wrap it as an ObjectInstance
             var h = engine.Options._WrapObjectHandler;
-            ObjectInstance o = h != null ? h(value) : null;
-            return o ?? new ObjectWrapper(engine, value);
+            var o = h?.Invoke(value) ?? new ObjectWrapper(engine, value);
+            return o;
         }
 
         private static JsValue Convert(Engine e, object v)

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -348,7 +348,7 @@ namespace Jint.Native
 
             // if no known type could be guessed, wrap it as an ObjectInstance
             var h = engine.Options._WrapObjectHandler;
-            var o = h?.Invoke(value) ?? new ObjectWrapper(engine, value);
+            var o = h?.Invoke(engine, value) ?? new ObjectWrapper(engine, value);
             return o;
         }
 

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1090,9 +1090,9 @@ namespace Jint.Native.Object
             }
         }
 
-        internal virtual bool IsArrayLike => TryGetValue(CommonProperties.Length, out var lengthValue)
-                                             && lengthValue.IsNumber()
-                                             && ((JsNumber) lengthValue)._value >= 0;
+        public virtual bool IsArrayLike => TryGetValue(CommonProperties.Length, out var lengthValue)
+                                           && lengthValue.IsNumber()
+                                           && ((JsNumber) lengthValue)._value >= 0;
 
 
         public virtual uint Length => (uint) TypeConverter.ToLength(Get(CommonProperties.Length));

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -18,7 +18,7 @@ namespace Jint
         private bool _allowClr;
         private bool _allowClrWrite = true;
         private readonly List<IObjectConverter> _objectConverters = new List<IObjectConverter>();
-        private Func<object, ObjectInstance> _wrapObjectHandler;
+        private Func<Engine, object, ObjectInstance> _wrapObjectHandler;
         private int _maxRecursionDepth = -1;
         private TimeSpan _regexTimeoutInterval = TimeSpan.FromSeconds(10);
         private CultureInfo _culture = CultureInfo.CurrentCulture;
@@ -82,7 +82,7 @@ namespace Jint
         /// ObjectInstance using class ObjectWrapper. This function can be used to
         /// register a handler for a customized handling.
         /// </summary>
-        public Options SetWrapObjectHandler(Func<object, ObjectInstance> wrapObjectHandler)
+        public Options SetWrapObjectHandler(Func<Engine, object, ObjectInstance> wrapObjectHandler)
         {
             _wrapObjectHandler = wrapObjectHandler;
             return this;
@@ -201,7 +201,7 @@ namespace Jint
 
         internal List<IConstraint> _Constraints => _constraints;
 
-        internal Func<object, ObjectInstance> _WrapObjectHandler => _wrapObjectHandler;
+        internal Func<Engine, object, ObjectInstance> _WrapObjectHandler => _wrapObjectHandler;
 
         internal int MaxRecursionDepth => _maxRecursionDepth;
 

--- a/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
@@ -9,60 +9,73 @@ namespace Jint.Runtime.Descriptors.Specialized
     {
         private readonly Engine _engine;
         private readonly object _key;
-        private readonly object _item;
+        private readonly object _target;
         private readonly PropertyInfo _indexer;
         private readonly MethodInfo _containsKey;
 
-        public IndexDescriptor(Engine engine, Type targetType, string key, object item) : base(PropertyFlag.CustomJsValue)
+        public IndexDescriptor(Engine engine, Type targetType, string key, object target) : base(PropertyFlag.CustomJsValue)
         {
             _engine = engine;
-            _item = item;
+            _target = target;
 
+            if (!TryFindIndexer(engine, targetType, key, out _indexer, out _containsKey, out _key))
+            {
+                ExceptionHelper.ThrowArgumentException("invalid indexing configuration, target indexer not found");
+            }
+
+            Writable = engine.Options._IsClrWriteAllowed;
+        }
+        
+        public IndexDescriptor(Engine engine, string key, object item)
+            : this(engine, item.GetType(), key, item)
+        {
+        }
+
+        internal static bool TryFindIndexer(
+            Engine engine,
+            Type targetType,
+            string propertyName, 
+            out PropertyInfo indexerProperty,
+            out MethodInfo containsKeyMethod, 
+            out object indexerKey)
+        {
             // get all instance indexers with exactly 1 argument
-            var indexers = targetType.GetProperties();
             var paramTypeArray = new Type[1];
 
             // try to find first indexer having either public getter or setter with matching argument type
-            foreach (var indexer in indexers)
+            foreach (var candidate in targetType.GetProperties())
             {
-                var indexParameters = indexer.GetIndexParameters();
+                var indexParameters = candidate.GetIndexParameters();
                 if (indexParameters.Length != 1)
                 {
                     continue;
                 }
 
-                if (indexer.GetGetMethod() != null || indexer.GetSetMethod() != null)
+                if (candidate.GetGetMethod() != null || candidate.GetSetMethod() != null)
                 {
                     var paramType = indexParameters[0].ParameterType;
 
-                    if (_engine.ClrTypeConverter.TryConvert(key, paramType, CultureInfo.InvariantCulture, out _key))
+                    if (engine.ClrTypeConverter.TryConvert(propertyName, paramType, CultureInfo.InvariantCulture, out indexerKey))
                     {
-                        _indexer = indexer;
+                        indexerProperty = candidate;
                         // get contains key method to avoid index exception being thrown in dictionaries
                         paramTypeArray[0] = paramType;
-                        _containsKey = targetType.GetMethod("ContainsKey", paramTypeArray);
-                        break;
+                        containsKeyMethod = targetType.GetMethod("ContainsKey", paramTypeArray);
+                        return true;
                     }
                 }
             }
 
-            Writable = engine.Options._IsClrWriteAllowed;
-        }
-
-        public IndexDescriptor(Engine engine, string key, object item)
-            : this(engine, item.GetType(), key, item)
-        {
+            indexerProperty = default;
+            containsKeyMethod = default;
+            indexerKey = default;
+            return false;
         }
 
         protected internal override JsValue CustomValue
         {
             get
             {
-                if (_indexer == null)
-                {
-                    return JsValue.Undefined;
-                }
-
                 var getter = _indexer.GetGetMethod();
 
                 if (getter == null)
@@ -74,7 +87,7 @@ namespace Jint.Runtime.Descriptors.Specialized
 
                 if (_containsKey != null)
                 {
-                    if ((_containsKey.Invoke(_item, parameters) as bool?) != true)
+                    if ((_containsKey.Invoke(_target, parameters) as bool?) != true)
                     {
                         return JsValue.Undefined;
                     }
@@ -82,7 +95,7 @@ namespace Jint.Runtime.Descriptors.Specialized
 
                 try
                 {
-                    return JsValue.FromObject(_engine, getter.Invoke(_item, parameters));
+                    return JsValue.FromObject(_engine, getter.Invoke(_target, parameters));
                 }
                 catch
                 {
@@ -92,11 +105,6 @@ namespace Jint.Runtime.Descriptors.Specialized
 
             set
             {
-                if (_indexer == null)
-                {
-                    return;
-                }
-
                 var setter = _indexer.GetSetMethod();
                 if (setter == null)
                 {
@@ -104,7 +112,7 @@ namespace Jint.Runtime.Descriptors.Specialized
                 }
 
                 object[] parameters = {_key, value?.ToObject()};
-                setter.Invoke(_item, parameters);
+                setter.Invoke(_target, parameters);
             }
         }
     }

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -282,7 +282,8 @@ namespace Jint.Runtime.Interop
             var key = value == null ? $"Null->{type}" : $"{value.GetType()}->{type}";
 #endif
 
-            var canConvert = _knownConversions.GetOrAdd(key, _ =>
+            // string conversion is not stable, "filter" -> int is invalid, "0" -> int is valid
+            var canConvert = value is string || _knownConversions.GetOrAdd(key, _ =>
             {
                 try
                 {

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -32,9 +32,6 @@ namespace Jint.Runtime.Interop
                 var functionInstance = new ClrFunctionInstance(engine, "length", (thisObj, arguments) => JsNumber.Create((int) lengthProperty.GetValue(obj)));
                 var descriptor = new GetSetPropertyDescriptor(functionInstance, Undefined, PropertyFlag.Configurable);
                 AddProperty(CommonProperties.Length, descriptor);
-                
-                // finally, add support for array's methods by default
-                _prototype = engine.Array.PrototypeObject;
             }
         }
 
@@ -64,7 +61,7 @@ namespace Jint.Runtime.Interop
 
         public object Target { get; }
 
-        internal override bool IsArrayLike { get; }
+        public override bool IsArrayLike { get; }
 
         public override bool Set(JsValue property, JsValue value, JsValue receiver)
         {

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -576,7 +576,7 @@ namespace Jint.Runtime
                         yield break;
                     }
 
-                    matchingByParameterCount = matchingByParameterCount ?? new List<Tuple<T, JsValue[]>>();
+                    matchingByParameterCount ??= new List<Tuple<T, JsValue[]>>();
                     matchingByParameterCount.Add(new Tuple<T, JsValue[]>(m, arguments));
                 }
                 else if (parameterInfos.Length > arguments.Length)


### PR DESCRIPTION
* when we see object implementing ICollection or read-only like interface it should be safe to access as array like
* should not assign indexers which are invalid for usage (property is string and indexer uses int)
* assign Array.prototype to array-like objects allowing filter etc, only used when object doesn't have anything suitable itself
