### PR TITLE
Fix infinite recursion possibility in call stack string building

### DIFF
--- a/Jint/EsprimaExtensions.cs
+++ b/Jint/EsprimaExtensions.cs
@@ -12,7 +12,7 @@ namespace Jint
     {
         public static JsValue GetKey(this Property property, Engine engine) => GetKey(property.Key, engine, property.Computed);
 
-        internal static JsValue GetKey<T>(this T expression, Engine engine, bool computed) where T : class, Expression
+        private static JsValue GetKey<T>(this T expression, Engine engine, bool computed) where T : class, Expression
         {
             if (expression is Literal literal)
             {

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -49,14 +49,19 @@ namespace Jint.Runtime
                     for (var index = 0; index < cse.CallExpression.Arguments.Count; index++)
                     {
                         if (index != 0)
+                        {
                             sb.Builder.Append(", ");
+                        }
                         var arg = cse.CallExpression.Arguments[index];
                         if (arg is Expression pke)
-                            sb.Builder.Append(pke.GetKey(engine, computed: false));
+                        {
+                            sb.Builder.Append(GetPropertyKey(pke));
+                        }
                         else
+                        {
                             sb.Builder.Append(arg);
+                        }
                     }
-
 
                     sb.Builder.Append(") @ ")
                         .Append(cse.CallExpression.Location.Source)
@@ -70,6 +75,29 @@ namespace Jint.Runtime
             }
 
             return this;
+        }
+
+        /// <summary>
+        /// A version of <see cref="EsprimaExtensions.GetKey"/> that cannot get into loop as we are already building a stack.
+        /// </summary>
+        private static string GetPropertyKey(Expression expression)
+        {
+            if (expression is Literal literal)
+            {
+                return EsprimaExtensions.LiteralKeyToString(literal);
+            }
+
+            if (expression is Identifier identifier)
+            {
+                return identifier.Name;
+            }
+
+            if (expression is StaticMemberExpression staticMemberExpression)
+            {
+                return GetPropertyKey(staticMemberExpression.Object) + "." + GetPropertyKey(staticMemberExpression.Property);
+            }
+
+            return "?";
         }
 
         private static string GetErrorMessage(JsValue error)


### PR DESCRIPTION
The combination of CLR interop and call stack building could lead to infinite recursion. Now using a version that doesn't rely on engine when building the stack.

fixes #719