### PR TITLE
Only mark array-like if Count or Length present

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -728,7 +729,16 @@ namespace Jint.Tests.Runtime
 
             var name = e.Execute("o.values.filter(x => x.age == 12)[0].name").GetCompletionValue().ToString();
             Assert.Equal("John", name);
-
+        }
+        
+        [Fact]
+        public void CanAccessExpandoObject()
+        {
+            var engine = new Engine();
+            dynamic expando = new ExpandoObject();
+            expando.Name = "test";
+            engine.SetValue("expando", expando);
+            Assert.Equal("test", engine.Execute("expando.Name").GetCompletionValue().ToString());
         }
 
         [Fact]

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -21,21 +21,20 @@ namespace Jint.Runtime.Interop
             var type = obj.GetType();
             if (ObjectIsArrayLikeClrCollection(type))
             {
-                IsArrayLike = true;
-                // create a forwarder to produce length from Count or Length, whichever is present
+                // create a forwarder to produce length from Count or Length if one of them is present
                 var lengthProperty = type.GetProperty("Count") ?? type.GetProperty("Length");
                 if (lengthProperty is null)
                 {
-                    ExceptionHelper.ThrowArgumentException("collection is supposed to either have Count or Length property");
                     return;
                 }
+                IsArrayLike = true;
                 var functionInstance = new ClrFunctionInstance(engine, "length", (thisObj, arguments) => JsNumber.Create((int) lengthProperty.GetValue(obj)));
                 var descriptor = new GetSetPropertyDescriptor(functionInstance, Undefined, PropertyFlag.Configurable);
                 AddProperty(CommonProperties.Length, descriptor);
             }
         }
 
-        internal static bool ObjectIsArrayLikeClrCollection(Type type)
+        private static bool ObjectIsArrayLikeClrCollection(Type type)
         {
             if (typeof(ICollection).IsAssignableFrom(type))
             {


### PR DESCRIPTION
We don't make missing Count of Length an error condition. It's best effort basis to make and ObjectWrapper array-like.

fixes #725