### PR TITLE
Optionally ignore casing when resolving properties

### DIFF
--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -17,6 +17,7 @@ namespace Jint
         private bool _allowDebuggerStatement;
         private bool _allowClr;
         private bool _allowClrWrite = true;
+        private bool _ignoreCasingResolveProperty = true;
         private readonly List<IObjectConverter> _objectConverters = new List<IObjectConverter>();
         private Func<Engine, object, ObjectInstance> _wrapObjectHandler;
         private int _maxRecursionDepth = -1;
@@ -181,6 +182,16 @@ namespace Jint
             return this;
         }
 
+        /// <summary>
+        /// Allow ObjectWrapper's ResolveProperty to _strictly_ match the case whrn resolving properties. 
+        /// The default behaviour is to ignore casing.
+        /// </summary>
+        public Options IgnoreCasingInResolveProperty(bool ignoreCasingResolveProperty = true)
+        {
+            _ignoreCasingResolveProperty = ignoreCasingResolveProperty;
+            return this;
+        }
+
         internal bool _IsGlobalDiscarded => _discardGlobal;
 
         internal bool IsStrict => _strict;
@@ -192,6 +203,8 @@ namespace Jint
         internal bool _IsClrAllowed => _allowClr;
 
         internal bool _IsClrWriteAllowed => _allowClrWrite;
+
+        internal bool _IsIgnoredCasingResolveProperty => _ignoreCasingResolveProperty;
 
         internal Predicate<Exception> _ClrExceptionsHandler => _clrExceptionsHandler;
 

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -117,7 +117,7 @@ namespace Jint.Runtime.Interop
                 PropertyInfo property = null;
                 foreach (var p in type.GetProperties(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public))
                 {
-                    if (EqualsIgnoreCasing(p.Name, propertyName))
+                    if (EqualsIgnoreCasing(p.Name, propertyName, _engine.Options._IsIgnoredCasingResolveProperty))
                     {
                         property = p;
                         break;
@@ -133,7 +133,7 @@ namespace Jint.Runtime.Interop
                 FieldInfo field = null;
                 foreach (var f in type.GetFields(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public))
                 {
-                    if (EqualsIgnoreCasing(f.Name, propertyName))
+                    if (EqualsIgnoreCasing(f.Name, propertyName, _engine.Options._IsIgnoredCasingResolveProperty))
                     {
                         field = f;
                         break;
@@ -149,7 +149,7 @@ namespace Jint.Runtime.Interop
                 List<MethodInfo> methods = null;
                 foreach (var m in type.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public))
                 {
-                    if (EqualsIgnoreCasing(m.Name, propertyName))
+                    if (EqualsIgnoreCasing(m.Name, propertyName, _engine.Options._IsIgnoredCasingResolveProperty))
                     {
                         methods ??= new List<MethodInfo>();
                         methods.Add(m);
@@ -175,7 +175,7 @@ namespace Jint.Runtime.Interop
             {
                 foreach (var iprop in iface.GetProperties())
                 {
-                    if (EqualsIgnoreCasing(iprop.Name, propertyName))
+                    if (EqualsIgnoreCasing(iprop.Name, propertyName, _engine.Options._IsIgnoredCasingResolveProperty))
                     {
                         list ??= new List<PropertyInfo>();
                         list.Add(iprop);
@@ -194,7 +194,7 @@ namespace Jint.Runtime.Interop
             {
                 foreach (var imethod in iface.GetMethods())
                 {
-                    if (EqualsIgnoreCasing(imethod.Name, propertyName))
+                    if (EqualsIgnoreCasing(imethod.Name, propertyName, _engine.Options._IsIgnoredCasingResolveProperty))
                     {
                         explicitMethods ??= new List<MethodInfo>();
                         explicitMethods.Add(imethod);
@@ -219,11 +219,14 @@ namespace Jint.Runtime.Interop
             return (engine, target) => PropertyDescriptor.Undefined;
         }
 
-        private static bool EqualsIgnoreCasing(string s1, string s2)
+        private static bool EqualsIgnoreCasing(string s1, string s2, bool ignoreCasing = true)
         {
             bool equals = false;
             if (s1.Length == s2.Length)
             {
+                if (!ignoreCasing)
+                    return (s1 == s2);
+
                 if (s1.Length > 0)
                 {
                     equals = char.ToLowerInvariant(s1[0]) == char.ToLowerInvariant(s2[0]);


### PR DESCRIPTION
There is an issue with using legacy C# classes due to JINT ignoring the case of the first letter of C# object's member name when it looks them up (e.g. `public void Start();` gets confused with `public bool start;`).

This is also a very lightweight fix for #342.
