### PR TITLE
Native async implementation of ExecuteAsync and InvokeAsync

### DIFF
--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jint.Tests.Runtime
+{
+    public class AsyncTests
+    {
+        public class TestMethods
+        {
+            public class TestClass
+            {
+                public string Name { get; set; }
+            }
+
+            public class TestStruct
+            {
+                public string Name { get; set; }
+            }
+
+            public static Dictionary<string, object> ExpectedMethodResults = new Dictionary<string, object>
+            {
+                { nameof(GetAsyncObject), nameof(GetAsyncObject) },
+                { nameof(GetAsyncVoid), null },
+                { nameof(GetSynchronousObject), nameof(GetSynchronousObject) },
+                { nameof(GetSynchronousVoid), null },
+                { nameof(GetAsyncDouble), 42d },
+                { nameof(GetAsyncTestClass), new TestClass { Name = "MyTestClass" } },
+                { nameof(GetAsyncTestStruct), new TestStruct { Name = "MyTestStruct" } },
+                { nameof(GetAsyncDate), DateTime.Parse("1111-11-11 11:11:11").ToUniversalTime() },
+                { nameof(GetAsyncEcho), "Echo..." }
+            };
+
+            private const int _delay = 50;
+
+            public string MethodInvoked { get; private set; }
+
+            public async Task<DateTime> GetAsyncDate()
+            {
+                await Task.Delay(_delay).ConfigureAwait(true);
+                MethodInvoked = nameof(GetAsyncDate);
+                return (DateTime)ExpectedMethodResults[MethodInvoked];
+            }
+
+            public async Task<double> GetAsyncDouble()
+            {
+                await Task.Delay(_delay).ConfigureAwait(true);
+                MethodInvoked = nameof(GetAsyncDouble);
+                return (double)ExpectedMethodResults[MethodInvoked];
+            }
+
+            public async Task<string> GetAsyncEcho(string echo = "Echo...")
+            {
+                await Task.Delay(_delay).ConfigureAwait(true);
+                MethodInvoked = nameof(GetAsyncEcho);
+                return (string)ExpectedMethodResults[MethodInvoked];
+            }
+
+            public async Task<object> GetAsyncObject()
+            {
+                await Task.Delay(_delay).ConfigureAwait(true);
+                MethodInvoked = nameof(GetAsyncObject);
+                return (object)ExpectedMethodResults[MethodInvoked];
+            }
+
+            public async Task<TestClass> GetAsyncTestClass()
+            {
+                await Task.Delay(_delay).ConfigureAwait(true);
+                MethodInvoked = nameof(GetAsyncTestClass);
+                return (TestClass)ExpectedMethodResults[MethodInvoked];
+            }
+
+            public async Task<TestStruct> GetAsyncTestStruct()
+            {
+                await Task.Delay(_delay).ConfigureAwait(true);
+                MethodInvoked = nameof(GetAsyncTestStruct);
+                return (TestStruct)ExpectedMethodResults[MethodInvoked];
+            }
+
+            public async Task GetAsyncVoid()
+            {
+                await Task.Delay(_delay);
+                MethodInvoked = nameof(GetAsyncVoid);
+            }
+
+            public object GetSynchronousObject()
+            {
+                Task.Delay(_delay).Wait();
+                MethodInvoked = nameof(GetSynchronousObject);
+                return ExpectedMethodResults[MethodInvoked];
+            }
+
+            public void GetSynchronousVoid()
+            {
+                Task.Delay(_delay).Wait();
+                MethodInvoked = nameof(GetSynchronousVoid);
+            }
+        }
+
+        [Fact]
+        public async void ClrMethodHandlesImmediateExceptions()
+        {
+            var engine = new Engine();
+
+            var testMethods = new TestMethods();
+            engine.SetValue("badMethod", new Func<Task>(() => throw new Exception("MyException")));
+
+            var script = "badMethod();";
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                var result = (await engine.ExecuteAsync(script))
+                   .GetCompletionValue().ToObject();
+            });
+        }
+
+        [Fact]
+        public async void ClrMethodHandlesLateExceptions()
+        {
+            var engine = new Engine();
+
+            var testMethods = new TestMethods();
+            engine.SetValue("badMethod", new Func<Task>(async () =>
+            {
+                await Task.Delay(200);
+                throw new Exception("MyException");
+            }));
+
+            var script = "badMethod();";
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                var result = (await engine.ExecuteAsync(script))
+                   .GetCompletionValue().ToObject();
+            });
+        }
+
+        [Fact]
+        public async void ClrMethodAreAwaited()
+        {
+            var engine = new Engine();
+
+            var testMethods = new TestMethods();
+            engine.SetValue("testMethods", testMethods);
+
+            var methodNames = TestMethods.ExpectedMethodResults.Keys;
+
+            foreach (var methodName in methodNames)
+            {
+                var script = $"testMethods.{methodName}();";
+                var result = (await engine.ExecuteAsync(script))
+                    .GetCompletionValue().ToObject();
+
+                var expected = TestMethods.ExpectedMethodResults[methodName];
+                Assert.Equal(expected, result);
+                Assert.Equal(methodName, testMethods.MethodInvoked);
+            }
+        }
+
+        [Fact]
+        public async void ClrMethodAssignmentsAreAwaited()
+        {
+            var engine = new Engine();
+
+            var testMethods = new TestMethods();
+            engine.SetValue("testMethods", testMethods);
+
+            var methodNames = TestMethods.ExpectedMethodResults.Keys;
+
+            foreach (var methodName in methodNames)
+            {
+                var script = $"var result = testMethods.{methodName}(); return result;";
+                var result = (await engine.ExecuteAsync(script))
+                    .GetCompletionValue().ToObject();
+
+                var expected = TestMethods.ExpectedMethodResults[methodName];
+                Assert.Equal(expected, result);
+                Assert.Equal(methodName, testMethods.MethodInvoked);
+            }
+        }
+
+        [Fact]
+        public async void DelegatesAreAwaited()
+        {
+            var engine = new Engine();
+
+            var testMethods = new TestMethods();
+            engine.SetValue(nameof(TestMethods.GetAsyncDouble), new Func<Task<double>>(async () => await testMethods.GetAsyncDouble()))
+                .SetValue(nameof(TestMethods.GetAsyncObject), new Func<Task<object>>(async () => await testMethods.GetAsyncObject()))
+                .SetValue(nameof(TestMethods.GetAsyncVoid), new Func<Task>(async () => await testMethods.GetAsyncVoid()))
+                .SetValue(nameof(TestMethods.GetSynchronousObject), new Func<object>(() => testMethods.GetSynchronousObject()))
+                .SetValue(nameof(TestMethods.GetSynchronousVoid), new Action(() => testMethods.GetSynchronousVoid()))
+                .SetValue(nameof(TestMethods.GetAsyncTestClass), new Func<Task<TestMethods.TestClass>>(async () => await testMethods.GetAsyncTestClass()))
+                .SetValue(nameof(TestMethods.GetAsyncTestStruct), new Func<Task<TestMethods.TestStruct>>(async () => await testMethods.GetAsyncTestStruct()))
+                .SetValue(nameof(TestMethods.GetAsyncDate), new Func<Task<DateTime>>(async () => await testMethods.GetAsyncDate()))
+                .SetValue(nameof(TestMethods.GetAsyncEcho), new Func<string, Task<string>>(async s => await testMethods.GetAsyncEcho(s)));
+
+            var methodNames = TestMethods.ExpectedMethodResults.Keys;
+
+            foreach (var methodName in methodNames)
+            {
+                var script = $"{methodName}()";
+                var result = (await engine.ExecuteAsync(script))
+                    .GetCompletionValue().ToObject();
+
+                var expected = TestMethods.ExpectedMethodResults[methodName];
+                Assert.Equal(expected, result);
+                Assert.Equal(methodName, testMethods.MethodInvoked);
+            }
+        }
+    }
+}

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -34,9 +34,10 @@ namespace Jint.Tests.Runtime
         }
 
 
-        private void RunTest(string source)
+        private async void RunTest(string source)
         {
-            _engine.Execute(source);
+            //_engine.Execute(source);
+            await _engine.ExecuteAsync(source);
         }
 
         private string GetEmbeddedFile(string filename)
@@ -480,6 +481,7 @@ namespace Jint.Tests.Runtime
         public void TypeofObjectShouldReturnString()
         {
             RunTest(@"
+                x = undefined;  //When running both the async and sync tests the async fails, as this has already been initialized to an object by the sync (so we set it to undefined)
                 assert(typeof x === 'undefined');
                 assert(typeof 0 === 'number');
                 var x = 0;

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -35,9 +35,10 @@ namespace Jint.Tests.Runtime
         {
         }
 
-        private void RunTest(string source)
+        private async void RunTest(string source)
         {
-            _engine.Execute(source);
+            //_engine.Execute(source);
+            await _engine.ExecuteAsync(source);
         }
 
         [Fact]

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Esprima;
 using Esprima.Ast;
 using Jint.Native;
@@ -397,6 +398,43 @@ namespace Jint
             return this;
         }
 
+        public Task<Engine> ExecuteAsync(string source)
+            => ExecuteAsync(source, DefaultParserOptions);
+
+        public Task<Engine> ExecuteAsync(string source, ParserOptions parserOptions)
+        {
+            var parser = new JavaScriptParser(source, parserOptions);
+            return ExecuteAsync(parser.ParseScript());
+        }
+
+        public async Task<Engine> ExecuteAsync(Script program)
+        {
+            ResetConstraints();
+            ResetLastStatement();
+            ResetCallStack();
+
+            using (new StrictModeScope(_isStrict || program.Strict))
+            {
+                DeclarationBindingInstantiation(
+                    DeclarationBindingType.GlobalCode,
+                    program.HoistingScope,
+                    functionInstance: null,
+                    arguments: null);
+
+                var list = new JintStatementList(this, null, program.Body);
+                var result = await list.ExecuteAsync();
+                if (result.Type == CompletionType.Throw)
+                {
+                    var ex = new JavaScriptException(result.GetValueOrDefault()).SetCallstack(this, result.Location);
+                    throw ex;
+                }
+
+                _completionValue = result.GetValueOrDefault();
+            }
+
+            return this;
+        }
+
         private void ResetLastStatement()
         {
             _lastSyntaxNode = null;
@@ -671,6 +709,66 @@ namespace Jint
             }
 
             var result = callable.Call(JsValue.FromObject(this, thisObj), items);
+            _jsValueArrayPool.ReturnArray(items);
+
+            return result;
+        }
+
+
+        /// <summary>
+        /// Invoke the current value as function.
+        /// </summary>
+        /// <param name="propertyName">The name of the function to call.</param>
+        /// <param name="arguments">The arguments of the function call.</param>
+        /// <returns>The value returned by the function call.</returns>
+        public Task<JsValue> InvokeAsync(string propertyName, params object[] arguments)
+        {
+            return InvokeAsync(propertyName, null, arguments);
+        }
+
+        /// <summary>
+        /// Invoke the current value as function.
+        /// </summary>
+        /// <param name="propertyName">The name of the function to call.</param>
+        /// <param name="thisObj">The this value inside the function call.</param>
+        /// <param name="arguments">The arguments of the function call.</param>
+        /// <returns>The value returned by the function call.</returns>
+        public Task<JsValue> InvokeAsync(string propertyName, object thisObj, object[] arguments)
+        {
+            var value = GetValue(propertyName);
+
+            return InvokeAsync(value, thisObj, arguments);
+        }
+
+        /// <summary>
+        /// Invoke the current value as function.
+        /// </summary>
+        /// <param name="value">The function to call.</param>
+        /// <param name="arguments">The arguments of the function call.</param>
+        /// <returns>The value returned by the function call.</returns>
+        public Task<JsValue> InvokeAsync(JsValue value, params object[] arguments)
+        {
+            return InvokeAsync(value, null, arguments);
+        }
+
+        /// <summary>
+        /// Invoke the current value as function.
+        /// </summary>
+        /// <param name="value">The function to call.</param>
+        /// <param name="thisObj">The this value inside the function call.</param>
+        /// <param name="arguments">The arguments of the function call.</param>
+        /// <returns>The value returned by the function call.</returns>
+        public async Task<JsValue> InvokeAsync(JsValue value, object thisObj, object[] arguments)
+        {
+            var callable = value as ICallable ?? ExceptionHelper.ThrowArgumentException<ICallable>("Can only invoke functions");
+
+            var items = _jsValueArrayPool.RentArray(arguments.Length);
+            for (int i = 0; i < arguments.Length; ++i)
+            {
+                items[i] = JsValue.FromObject(this, arguments[i]);
+            }
+
+            var result = await callable.CallAsync(JsValue.FromObject(this, thisObj), items);
             _jsValueArrayPool.ReturnArray(items);
 
             return result;

--- a/Jint/EsprimaExtensions.cs
+++ b/Jint/EsprimaExtensions.cs
@@ -12,7 +12,7 @@ namespace Jint
     {
         public static JsValue GetKey(this Property property, Engine engine) => GetKey(property.Key, engine, property.Computed);
 
-        internal static JsValue GetKey<T>(this T expression, Engine engine, bool computed) where T : class, Expression
+        private static JsValue GetKey<T>(this T expression, Engine engine, bool computed) where T : class, Expression
         {
             if (expression is Literal literal)
             {

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Esprima" Version="1.0.1270" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/Jint/Native/Function/BindFunctionInstance.cs
+++ b/Jint/Native/Function/BindFunctionInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Jint.Native.Object;
 using Jint.Runtime;
 
@@ -25,6 +26,16 @@ namespace Jint.Native.Function
             }
 
             return f.Call(BoundThis, CreateArguments(arguments));
+        }
+
+        public async override Task<JsValue> CallAsync(JsValue thisObject, JsValue[] arguments)
+        {
+            if (!(TargetFunction is FunctionInstance f))
+            {
+                return ExceptionHelper.ThrowTypeError<ObjectInstance>(Engine);
+            }
+
+            return await f.CallAsync(BoundThis, CreateArguments(arguments));
         }
 
         public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -3,6 +3,7 @@ using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Statements;
+using System.Threading.Tasks;
 
 namespace Jint.Native.Function
 {
@@ -99,6 +100,93 @@ namespace Jint.Native.Function
                 if (e.Description == Messages.InvalidLHSInAssignment)
                 {
                     ExceptionHelper.ThrowReferenceError(_engine, (string) null);
+                }
+
+                return ExceptionHelper.ThrowSyntaxError<JsValue>(_engine);
+            }
+        }
+
+        public override Task<JsValue> CallAsync(JsValue thisObject, JsValue[] arguments)
+        {
+            return CallAsync(thisObject, arguments, false);
+        }
+
+        public async Task<JsValue> CallAsync(JsValue thisObject, JsValue[] arguments, bool directCall)
+        {
+            var arg = arguments.At(0);
+            if (arg.Type != Types.String)
+            {
+                return arg;
+            }
+
+            var code = TypeConverter.ToString(arg);
+
+            try
+            {
+                var parser = new JavaScriptParser(code, ParserOptions);
+                var program = parser.ParseScript(StrictModeScope.IsStrictModeCode);
+                using (new StrictModeScope(program.Strict))
+                {
+                    using (new EvalCodeScope())
+                    {
+                        LexicalEnvironment strictVarEnv = null;
+
+                        try
+                        {
+                            if (!directCall)
+                            {
+                                Engine.EnterExecutionContext(Engine.GlobalEnvironment, Engine.GlobalEnvironment, Engine.Global);
+                            }
+
+                            var lexicalEnvironment = _engine.ExecutionContext.LexicalEnvironment;
+                            if (StrictModeScope.IsStrictModeCode)
+                            {
+                                strictVarEnv = LexicalEnvironment.NewDeclarativeEnvironment(Engine, lexicalEnvironment);
+                                Engine.EnterExecutionContext(strictVarEnv, strictVarEnv, Engine.ExecutionContext.ThisBinding);
+                            }
+
+                            var argumentsInstance = Engine.DeclarationBindingInstantiation(
+                                DeclarationBindingType.EvalCode,
+                                program.HoistingScope,
+                                functionInstance: this,
+                                arguments);
+
+                            var statement = JintStatement.Build(_engine, program);
+                            var result = await statement.ExecuteAsync();
+                            var value = result.GetValueOrDefault();
+
+                            argumentsInstance?.FunctionWasCalled();
+
+                            if (result.Type == CompletionType.Throw)
+                            {
+                                var ex = new JavaScriptException(value).SetCallstack(_engine, result.Location);
+                                throw ex;
+                            }
+                            else
+                            {
+                                return value;
+                            }
+                        }
+                        finally
+                        {
+                            if (strictVarEnv != null)
+                            {
+                                Engine.LeaveExecutionContext();
+                            }
+
+                            if (!directCall)
+                            {
+                                Engine.LeaveExecutionContext();
+                            }
+                        }
+                    }
+                }
+            }
+            catch (ParserException e)
+            {
+                if (e.Description == Messages.InvalidLHSInAssignment)
+                {
+                    ExceptionHelper.ThrowReferenceError(_engine, (string)null);
                 }
 
                 return ExceptionHelper.ThrowSyntaxError<JsValue>(_engine);

--- a/Jint/Native/Function/FunctionInstance.cs
+++ b/Jint/Native/Function/FunctionInstance.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
@@ -60,6 +61,9 @@ namespace Jint.Native.Function
         /// <param name="arguments"></param>
         /// <returns></returns>
         public abstract JsValue Call(JsValue thisObject, JsValue[] arguments);
+
+        public virtual Task<JsValue> CallAsync(JsValue thisObject, JsValue[] arguments)
+            => Task.FromResult(Call(thisObject, arguments));
 
         internal LexicalEnvironment Scope => _scope;
 

--- a/Jint/Native/ICallable.cs
+++ b/Jint/Native/ICallable.cs
@@ -1,7 +1,11 @@
-﻿namespace Jint.Native
+﻿using System.Threading.Tasks;
+
+namespace Jint.Native
 {
     public interface ICallable
     {
         JsValue Call(JsValue thisObject, JsValue[] arguments);
+
+        Task<JsValue> CallAsync(JsValue thisObject, JsValue[] arguments);
     }
 }

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Jint.Collections;
 using Jint.Native.Function;
 using Jint.Native.Iterator;
@@ -482,6 +483,11 @@ namespace Jint.Native.Object
                 o.CreateDataPropertyOrThrow(propertyKey, value);
 
                 return Undefined;
+            }
+
+            public Task<JsValue> CallAsync(JsValue thisObject, JsValue[] arguments)
+            {
+                return Task.FromResult(Call(thisObject, arguments));
             }
         }
     }

--- a/Jint/Native/Proxy/ProxyInstance.cs
+++ b/Jint/Native/Proxy/ProxyInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -47,6 +48,17 @@ namespace Jint.Native.Proxy
             }
 
             return ((ICallable) _target).Call(thisObject, arguments);
+        }
+
+        public override Task<JsValue> CallAsync(JsValue thisObject, JsValue[] arguments)
+        {
+            var jsValues = new[] { _target, thisObject, _engine.Array.Construct(arguments) };
+            if (TryCallHandler(TrapApply, jsValues, out var result))
+            {
+                return Task.FromResult(result);
+            }
+
+            return ((ICallable)_target).CallAsync(thisObject, arguments);
         }
 
         public ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)

--- a/Jint/Runtime/Interop/AsyncHelpers.cs
+++ b/Jint/Runtime/Interop/AsyncHelpers.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+
+namespace Jint.Runtime.Interop
+{
+    public static class AsyncHelpers
+    {
+        public async static Task<object> AwaitWhenAsyncResult(this object callResult)
+        {
+            var task = callResult as Task;
+            if (task == null) return callResult; //Not a Task
+
+            await task;
+
+            // Return the result, unless it's a VoidTaskResult
+            return IsVoidTaskResult(task)
+                ? null
+                : (object)((dynamic)task)?.Result;
+        }
+
+        private static bool IsVoidTaskResult(Task task)
+        {
+            // VoidTaskResult is an internal Microsoft class that is used as the generic type of a generic task, to indicate it has no result
+            // Task<VoidTaskResult> correlates to the standard non generic Task
+            var taskType = task.GetType();
+            return taskType.IsGenericType
+                && taskType.GenericTypeArguments[0].Name == "VoidTaskResult";
+        }
+    }
+}

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Reflection;
+using System.Threading.Tasks;
 using Jint.Native;
 using Jint.Native.Function;
 
@@ -117,6 +118,98 @@ namespace Jint.Runtime.Interop
             try
             {
                 return FromObject(Engine, _d.DynamicInvoke(parameters));
+            }
+            catch (TargetInvocationException exception)
+            {
+                ExceptionHelper.ThrowMeaningfulException(_engine, exception);
+                throw;
+            }
+        }
+
+        public async override Task<JsValue> CallAsync(JsValue thisObject, JsValue[] jsArguments)
+        {
+            var parameterInfos = _d.Method.GetParameters();
+
+#if NETFRAMEWORK
+            if (parameterInfos.Length > 0 && parameterInfos[0].ParameterType == typeof(System.Runtime.CompilerServices.Closure))
+            {
+                var reducedLength = parameterInfos.Length - 1;
+                var reducedParameterInfos = new ParameterInfo[reducedLength];
+                Array.Copy(parameterInfos, 1, reducedParameterInfos, 0, reducedLength);
+                parameterInfos = reducedParameterInfos;
+            }
+#endif
+
+            int delegateArgumentsCount = parameterInfos.Length;
+            int delegateNonParamsArgumentsCount = _delegateContainsParamsArgument ? delegateArgumentsCount - 1 : delegateArgumentsCount;
+
+            int jsArgumentsCount = jsArguments.Length;
+            int jsArgumentsWithoutParamsCount = Math.Min(jsArgumentsCount, delegateNonParamsArgumentsCount);
+
+            var parameters = new object[delegateArgumentsCount];
+
+            // convert non params parameter to expected types
+            for (var i = 0; i < jsArgumentsWithoutParamsCount; i++)
+            {
+                var parameterType = parameterInfos[i].ParameterType;
+
+                if (parameterType == typeof(JsValue))
+                {
+                    parameters[i] = jsArguments[i];
+                }
+                else
+                {
+                    parameters[i] = Engine.ClrTypeConverter.Convert(
+                        jsArguments[i].ToObject(),
+                        parameterType,
+                        CultureInfo.InvariantCulture);
+                }
+            }
+
+            // assign null to parameters not provided
+            for (var i = jsArgumentsWithoutParamsCount; i < delegateNonParamsArgumentsCount; i++)
+            {
+                if (parameterInfos[i].ParameterType.IsValueType)
+                {
+                    parameters[i] = Activator.CreateInstance(parameterInfos[i].ParameterType);
+                }
+                else
+                {
+                    parameters[i] = null;
+                }
+            }
+
+            // assign params to array and converts each objet to expected type
+            if (_delegateContainsParamsArgument)
+            {
+                int paramsArgumentIndex = delegateArgumentsCount - 1;
+                int paramsCount = Math.Max(0, jsArgumentsCount - delegateNonParamsArgumentsCount);
+
+                object[] paramsParameter = new object[paramsCount];
+                var paramsParameterType = parameterInfos[paramsArgumentIndex].ParameterType.GetElementType();
+
+                for (var i = paramsArgumentIndex; i < jsArgumentsCount; i++)
+                {
+                    var paramsIndex = i - paramsArgumentIndex;
+
+                    if (paramsParameterType == typeof(JsValue))
+                    {
+                        paramsParameter[paramsIndex] = jsArguments[i];
+                    }
+                    else
+                    {
+                        paramsParameter[paramsIndex] = Engine.ClrTypeConverter.Convert(
+                            jsArguments[i].ToObject(),
+                            paramsParameterType,
+                            CultureInfo.InvariantCulture);
+                    }
+                }
+                parameters[paramsArgumentIndex] = paramsParameter;
+            }
+            try
+            {
+                var result = await _d.DynamicInvoke(parameters).AwaitWhenAsyncResult();
+                return FromObject(Engine, result);
             }
             catch (TargetInvocationException exception)
             {

--- a/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading.Tasks;
 using Jint.Native;
 using Jint.Native.Function;
 
@@ -85,6 +86,85 @@ namespace Jint.Runtime.Interop
                 try
                 {
                     return FromObject(Engine, method.Invoke(thisObject.ToObject(), parameters));
+                }
+                catch (TargetInvocationException exception)
+                {
+                    ExceptionHelper.ThrowMeaningfulException(_engine, exception);
+                }
+            }
+
+            return ExceptionHelper.ThrowTypeError<JsValue>(_engine, "No public methods with the specified arguments were found.");
+        }
+
+        public override Task<JsValue> CallAsync(JsValue thisObject, JsValue[] arguments)
+        {
+            return InvokeAsync(_methods, thisObject, arguments);
+        }
+
+        public async Task<JsValue> InvokeAsync(MethodInfo[] methodInfos, JsValue thisObject, JsValue[] jsArguments)
+        {
+            JsValue[] ArgumentProvider(MethodInfo method, bool hasParams) =>
+                hasParams
+                    ? ProcessParamsArrays(jsArguments, method)
+                    : jsArguments;
+
+            var converter = Engine.ClrTypeConverter;
+
+            foreach (var tuple in TypeConverter.FindBestMatch(_engine, methodInfos, ArgumentProvider))
+            {
+                var method = tuple.Item1;
+                var arguments = tuple.Item2;
+
+                var parameters = new object[arguments.Length];
+                var methodParameters = method.GetParameters();
+                var argumentsMatch = true;
+
+                for (var i = 0; i < arguments.Length; i++)
+                {
+                    var parameterType = methodParameters[i].ParameterType;
+
+                    if (typeof(JsValue).IsAssignableFrom(parameterType))
+                    {
+                        parameters[i] = arguments[i];
+                    }
+                    else if (parameterType == typeof(JsValue[]) && arguments[i].IsArray())
+                    {
+                        // Handle specific case of F(params JsValue[])
+
+                        var arrayInstance = arguments[i].AsArray();
+                        var len = TypeConverter.ToInt32(arrayInstance.Get(CommonProperties.Length, this));
+                        var result = new JsValue[len];
+                        for (uint k = 0; k < len; k++)
+                        {
+                            result[k] = arrayInstance.TryGetValue(k, out var value) ? value : Undefined;
+                        }
+                        parameters[i] = result;
+                    }
+                    else
+                    {
+                        if (!converter.TryConvert(arguments[i].ToObject(), parameterType, CultureInfo.InvariantCulture, out parameters[i]))
+                        {
+                            argumentsMatch = false;
+                            break;
+                        }
+
+                        if (parameters[i] is LambdaExpression lambdaExpression)
+                        {
+                            parameters[i] = lambdaExpression.Compile();
+                        }
+                    }
+                }
+
+                if (!argumentsMatch)
+                {
+                    continue;
+                }
+
+                // todo: cache method info
+                try
+                {
+                    var result = await method.Invoke(thisObject.ToObject(), parameters).AwaitWhenAsyncResult();
+                    return FromObject(Engine, result);
                 }
                 catch (TargetInvocationException exception)
                 {

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
+using System.Threading.Tasks;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
@@ -68,6 +69,9 @@ namespace Jint.Runtime.Interop
                 return ExceptionHelper.ThrowTypeError<JsValue>(_engine, "Invalid generic type parameter on " + _path + ", if this is not a generic type / method, are you missing a lookup assembly?", e);
             }
         }
+
+        public Task<JsValue> CallAsync(JsValue thisObject, JsValue[] arguments) 
+            => Task.FromResult(Call(thisObject, arguments));
 
         public override JsValue Get(JsValue property, JsValue receiver)
         {

--- a/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Array;
@@ -31,6 +32,13 @@ namespace Jint.Runtime.Interpreter.Expressions
         protected override object EvaluateInternal()
         {
             var rightValue = _right.GetValue();
+            ProcessPatterns(_engine, _pattern, rightValue, true);
+            return rightValue;
+        }
+
+        protected async override Task<object> EvaluateInternalAsync()
+        {
+            var rightValue = await _right.GetValueAsync();
             ProcessPatterns(_engine, _pattern, rightValue, true);
             return rightValue;
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
@@ -2,6 +2,7 @@ using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Array;
 using Jint.Native.Iterator;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
@@ -72,6 +73,56 @@ namespace Jint.Runtime.Interpreter.Expressions
                 else
                 {
                     var value = expr.GetValue();
+                    a.SetIndexValue(arrayIndexCounter++, value, updateLength: false);
+                }
+            }
+
+            if (_hasSpreads)
+            {
+                a.SetLength(arrayIndexCounter);
+            }
+
+            return a;
+        }
+
+        protected async override Task<object> EvaluateInternalAsync()
+        {
+            var a = _engine.Array.ConstructFast(_hasSpreads ? 0 : (uint)_expressions.Length);
+            var expressions = _expressions;
+
+            uint arrayIndexCounter = 0;
+            for (uint i = 0; i < (uint)expressions.Length; i++)
+            {
+                var expr = expressions[i];
+                if (expr == null)
+                {
+                    arrayIndexCounter++;
+                    continue;
+                }
+
+                if (_hasSpreads && expr is JintSpreadExpression jse)
+                {
+                    jse.GetValueAndCheckIterator(out var objectInstance, out var iterator);
+                    // optimize for array
+                    if (objectInstance is ArrayInstance ai)
+                    {
+                        var length = ai.GetLength();
+                        var newLength = arrayIndexCounter + length;
+                        a.EnsureCapacity(newLength);
+                        a.CopyValues(ai, sourceStartIndex: 0, targetStartIndex: arrayIndexCounter, length);
+                        arrayIndexCounter += length;
+                        a.SetLength(newLength);
+                    }
+                    else
+                    {
+                        var protocol = new ArraySpreadProtocol(_engine, a, iterator, arrayIndexCounter);
+                        protocol.Execute();
+                        arrayIndexCounter += protocol._addedCount;
+                    }
+                }
+                else
+                {
+                    var value = await expr.GetValueAsync();
                     a.SetIndexValue(arrayIndexCounter++, value, updateLength: false);
                 }
             }

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -3,6 +3,7 @@ using Jint.Native;
 using Jint.Native.Function;
 using Jint.Runtime.Environments;
 using Jint.Runtime.References;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
@@ -74,6 +75,121 @@ namespace Jint.Runtime.Interpreter.Expressions
         protected override object EvaluateInternal()
         {
             var callee = _calleeExpression.Evaluate();
+            var expression = (CallExpression)_expression;
+
+            if (_isDebugMode)
+            {
+                _engine.DebugHandler.AddToDebugCallStack(expression);
+            }
+
+            // todo: implement as in http://www.ecma-international.org/ecma-262/5.1/#sec-11.2.4
+
+            var cachedArguments = _cachedArguments;
+            var arguments = System.Array.Empty<JsValue>();
+            if (_cached)
+            {
+                arguments = cachedArguments.CachedArguments;
+            }
+            else
+            {
+                if (cachedArguments.JintArguments.Length > 0)
+                {
+                    if (_hasSpreads)
+                    {
+                        arguments = BuildArgumentsWithSpreads(cachedArguments.JintArguments);
+                    }
+                    else
+                    {
+                        arguments = _engine._jsValueArrayPool.RentArray(cachedArguments.JintArguments.Length);
+                        BuildArguments(cachedArguments.JintArguments, arguments);
+                    }
+                }
+            }
+
+
+            var func = _engine.GetValue(callee, false);
+            var r = callee as Reference;
+
+            if (_maxRecursionDepth >= 0)
+            {
+                var stackItem = new CallStackElement(expression, func, r?.GetReferencedName()?.ToString() ?? "anonymous function");
+
+                var recursionDepth = _engine.CallStack.Push(stackItem);
+
+                if (recursionDepth > _maxRecursionDepth)
+                {
+                    _engine.CallStack.Pop();
+                    ExceptionHelper.ThrowRecursionDepthOverflowException(_engine.CallStack, stackItem.ToString());
+                }
+            }
+
+            if (func._type == InternalTypes.Undefined)
+            {
+                ExceptionHelper.ThrowTypeError(_engine, r == null ? "" : $"Object has no method '{r.GetReferencedName()}'");
+            }
+
+            if (!func.IsObject())
+            {
+                if (_engine._referenceResolver == null || !_engine._referenceResolver.TryGetCallable(_engine, callee, out func))
+                {
+                    ExceptionHelper.ThrowTypeError(_engine,
+                        r == null ? "" : $"Property '{r.GetReferencedName()}' of object is not a function");
+                }
+            }
+
+            if (!(func is ICallable callable))
+            {
+                var message = $"{r?.GetReferencedName() ?? ""} is not a function";
+                return ExceptionHelper.ThrowTypeError<object>(_engine, message);
+            }
+
+            var thisObject = Undefined.Instance;
+            if (r != null)
+            {
+                var baseValue = r.GetBase();
+                if ((baseValue._type & InternalTypes.ObjectEnvironmentRecord) == 0)
+                {
+                    thisObject = baseValue;
+                }
+                else
+                {
+                    var env = (EnvironmentRecord)baseValue;
+                    thisObject = env.ImplicitThisValue();
+                }
+
+                // is it a direct call to eval ? http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.1.1
+                if (r.GetReferencedName() == CommonProperties.Eval && callable is EvalFunctionInstance instance)
+                {
+                    var value = instance.Call(thisObject, arguments, true);
+                    _engine._referencePool.Return(r);
+                    return value;
+                }
+            }
+
+            var result = callable.Call(thisObject, arguments);
+
+            if (_isDebugMode)
+            {
+                _engine.DebugHandler.PopDebugCallStack();
+            }
+
+            if (_maxRecursionDepth >= 0)
+            {
+                _engine.CallStack.Pop();
+            }
+
+            if (!_cached && arguments.Length > 0)
+            {
+                _engine._jsValueArrayPool.ReturnArray(arguments);
+            }
+
+            _engine._referencePool.Return(r);
+            return result;
+        }
+
+        protected async override Task<object> EvaluateInternalAsync()
+        {
+            var callee = await _calleeExpression.EvaluateAsync();
             var expression = (CallExpression) _expression;
 
             if (_isDebugMode)
@@ -165,7 +281,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
             }
 
-            var result = callable.Call(thisObject, arguments);
+            var result = await callable.CallAsync(thisObject, arguments);
 
             if (_isDebugMode)
             {

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Array;
@@ -32,6 +33,11 @@ namespace Jint.Runtime.Interpreter.Expressions
             return _engine.GetValue(Evaluate(), true);
         }
 
+        public async virtual Task<JsValue> GetValueAsync()
+        {
+            return _engine.GetValue(await EvaluateAsync(), true);
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object Evaluate()
         {
@@ -44,6 +50,18 @@ namespace Jint.Runtime.Interpreter.Expressions
             return EvaluateInternal();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Task<object> EvaluateAsync()
+        {
+            _engine._lastSyntaxNode = _expression;
+            if (!_initialized)
+            {
+                Initialize();
+                _initialized = true;
+            }
+            return EvaluateInternalAsync();
+        }
+
         /// <summary>
         /// Opportunity to build one-time structures and caching based on lexical context.
         /// </summary>
@@ -52,6 +70,9 @@ namespace Jint.Runtime.Interpreter.Expressions
         }
 
         protected abstract object EvaluateInternal();
+
+        protected virtual Task<object> EvaluateInternalAsync()
+            => Task.FromResult(EvaluateInternal());
 
         protected internal static JintExpression Build(Engine engine, Expression expression)
         {

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Esprima;
 using Esprima.Ast;
 using Jint.Native;
@@ -60,6 +61,8 @@ namespace Jint.Runtime.Interpreter.Expressions
         }
 
         protected override object EvaluateInternal() => ResolveValue();
+        protected override Task<object> EvaluateInternalAsync() => Task.FromResult(EvaluateInternal());
+
 
         private JsValue ResolveValue()
         {

--- a/Jint/Runtime/Interpreter/Expressions/JintLogicalAndExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLogicalAndExpression.cs
@@ -1,5 +1,6 @@
 using Esprima.Ast;
 using Jint.Native;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
@@ -29,6 +30,23 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
 
             return _right.GetValue();
+        }
+
+        protected async override Task<object> EvaluateInternalAsync()
+        {
+            var left = await _left.GetValueAsync();
+
+            if (left is JsBoolean b && !b._value)
+            {
+                return b;
+            }
+
+            if (!TypeConverter.ToBoolean(left))
+            {
+                return left;
+            }
+
+            return await _right.GetValueAsync();
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintLogicalOrExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLogicalOrExpression.cs
@@ -1,5 +1,6 @@
 using Esprima.Ast;
 using Jint.Native;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
@@ -29,6 +30,23 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
 
             return _right.GetValue();
+        }
+
+        protected async override Task<object> EvaluateInternalAsync()
+        {
+            var left = await _left.GetValueAsync();
+
+            if (left is JsBoolean b && b._value)
+            {
+                return b;
+            }
+
+            if (TypeConverter.ToBoolean(left))
+            {
+                return left;
+            }
+
+            return await _right.GetValueAsync();
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -1,6 +1,7 @@
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.References;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
@@ -81,6 +82,48 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
 
             var property = _determinedProperty ?? _propertyExpression.GetValue();
+            TypeConverter.CheckObjectCoercible(_engine, baseValue, (MemberExpression)_expression, baseReferenceName);
+            return _engine._referencePool.Rent(baseValue, TypeConverter.ToPropertyKey(property), isStrictModeCode);
+        }
+
+        protected async override Task<object> EvaluateInternalAsync()
+        {
+            string baseReferenceName = null;
+            JsValue baseValue = null;
+            var isStrictModeCode = StrictModeScope.IsStrictModeCode;
+
+            if (_objectIdentifierExpression != null)
+            {
+                baseReferenceName = _objectIdentifierExpression.ExpressionName;
+                var strict = isStrictModeCode;
+                TryGetIdentifierEnvironmentWithBindingValue(
+                    strict,
+                    _objectIdentifierExpression.ExpressionName,
+                    out _,
+                    out baseValue);
+            }
+            else if (_objectThisExpression != null)
+            {
+                baseValue = await _objectThisExpression.GetValueAsync();
+            }
+
+            if (baseValue is null)
+            {
+                // fast checks failed
+                var baseReference = await _objectExpression.EvaluateAsync();
+                if (baseReference is Reference reference)
+                {
+                    baseReferenceName = reference.GetReferencedName().ToString();
+                    baseValue = _engine.GetValue(reference, false);
+                    _engine._referencePool.Return(reference);
+                }
+                else
+                {
+                    baseValue = _engine.GetValue(baseReference, false);
+                }
+            }
+
+            var property = _determinedProperty ?? await _propertyExpression.GetValueAsync();
             TypeConverter.CheckObjectCoercible(_engine, baseValue, (MemberExpression) _expression, baseReferenceName);
             return _engine._referencePool.Rent(baseValue,  TypeConverter.ToPropertyKey(property), isStrictModeCode);
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Esprima.Ast;
 using Jint.Native;
 
@@ -52,6 +53,38 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             // todo: optimize by defining a common abstract class or interface
             var jsValue = _calleeExpression.GetValue();
+            if (!(jsValue is IConstructor callee))
+            {
+                return ExceptionHelper.ThrowTypeError<object>(_engine, "The object can't be used as constructor.");
+            }
+
+            // construct the new instance using the Function's constructor method
+            var instance = callee.Construct(arguments, jsValue);
+
+            _engine._jsValueArrayPool.ReturnArray(arguments);
+
+            return instance;
+        }
+
+        protected async override Task<object> EvaluateInternalAsync()
+        {
+            JsValue[] arguments;
+            if (_jintArguments.Length == 0)
+            {
+                arguments = Array.Empty<JsValue>();
+            }
+            else if (_hasSpreads)
+            {
+                arguments = BuildArgumentsWithSpreads(_jintArguments);
+            }
+            else
+            {
+                arguments = _engine._jsValueArrayPool.RentArray(_jintArguments.Length);
+                BuildArguments(_jintArguments, arguments);
+            }
+
+            // todo: optimize by defining a common abstract class or interface
+            var jsValue = await _calleeExpression.GetValueAsync();
             if (!(jsValue is IConstructor callee))
             {
                 return ExceptionHelper.ThrowTypeError<object>(_engine, "The object can't be used as constructor.");

--- a/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
@@ -2,6 +2,7 @@ using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Array;
 using Jint.Runtime.Descriptors;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
@@ -44,6 +45,29 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
 
             var result = tagger.Call(JsValue.Undefined, args);
+            _engine._jsValueArrayPool.ReturnArray(args);
+
+            return result;
+        }
+
+        protected async override Task<object> EvaluateInternalAsync()
+        {
+            var tagger = _engine.GetValue(await _tagIdentifier.GetValueAsync()) as ICallable
+                ?? ExceptionHelper.ThrowTypeError<ICallable>(_engine, "Argument must be callable");
+
+            var expressions = _quasi._expressions;
+
+            var args = _engine._jsValueArrayPool.RentArray((expressions.Length + 1));
+
+            var template = GetTemplateObject();
+            args[0] = template;
+
+            for (int i = 0; i < expressions.Length; ++i)
+            {
+                args[i + 1] = await expressions[i].GetValueAsync();
+            }
+
+            var result = await tagger.CallAsync(JsValue.Undefined, args);
             _engine._jsValueArrayPool.ReturnArray(args);
 
             return result;

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -1,6 +1,7 @@
 ﻿using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.Interpreter.Statements;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter
 {
@@ -99,6 +100,66 @@ namespace Jint.Runtime.Interpreter
                 c = new Completion(CompletionType.Throw, error, null, s.Location);
             }
             return new Completion(c.Type, c.GetValueOrDefault(), c.Identifier, c.Location);
-        } 
+        }
+
+        public async Task<Completion> ExecuteAsync()
+        {
+            if (!_initialized)
+            {
+                Initialize();
+                _initialized = true;
+            }
+
+            if (_statement != null)
+            {
+                _engine._lastSyntaxNode = _statement;
+                _engine.RunBeforeExecuteStatementChecks(_statement);
+            }
+
+            JintStatement s = null;
+            var c = new Completion(CompletionType.Normal, null, null, _engine._lastSyntaxNode?.Location ?? default);
+            Completion sl = c;
+            try
+            {
+                foreach (var pair in _jintStatements)
+                {
+                    s = pair.Statement;
+                    c = pair.Value ?? await s.ExecuteAsync();
+                    if (c.Type != CompletionType.Normal)
+                    {
+                        return new Completion(
+                            c.Type,
+                            c.Value ?? sl.Value,
+                            c.Identifier,
+                            c.Location);
+                    }
+
+                    sl = c;
+                }
+            }
+            catch (JavaScriptException v)
+            {
+                var location = v.Location == default ? s.Location : v.Location;
+                var completion = new Completion(CompletionType.Throw, v.Error, null, location);
+                return completion;
+            }
+            catch (TypeErrorException e)
+            {
+                var error = _engine.TypeError.Construct(new JsValue[]
+                {
+                    e.Message
+                });
+                return new Completion(CompletionType.Throw, error, null, s.Location);
+            }
+            catch (RangeErrorException e)
+            {
+                var error = _engine.RangeError.Construct(new JsValue[]
+                {
+                    e.Message
+                });
+                c = new Completion(CompletionType.Throw, error, null, s.Location);
+            }
+            return new Completion(c.Type, c.GetValueOrDefault(), c.Identifier, c.Location);
+        }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -1,4 +1,5 @@
 using Esprima.Ast;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -14,6 +15,11 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override Completion ExecuteInternal()
         {
             return _statementList.Execute();
+        }
+
+        protected override Task<Completion> ExecuteInternalAsync()
+        {
+            return _statementList.ExecuteAsync();
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -1,6 +1,7 @@
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.Interpreter.Expressions;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -47,6 +48,38 @@ namespace Jint.Runtime.Interpreter.Statements
                 }
 
                 iterating = TypeConverter.ToBoolean(_test.GetValue());
+            } while (iterating);
+
+            return new Completion(CompletionType.Normal, v, null, Location);
+        }
+
+        protected async override Task<Completion> ExecuteInternalAsync()
+        {
+            JsValue v = Undefined.Instance;
+            bool iterating;
+
+            do
+            {
+                var completion = await _body.ExecuteAsync();
+                if (!ReferenceEquals(completion.Value, null))
+                {
+                    v = completion.Value;
+                }
+
+                if (completion.Type != CompletionType.Continue || completion.Identifier != _labelSetName)
+                {
+                    if (completion.Type == CompletionType.Break && (completion.Identifier == null || completion.Identifier == _labelSetName))
+                    {
+                        return new Completion(CompletionType.Normal, v, null, Location);
+                    }
+
+                    if (completion.Type != CompletionType.Normal)
+                    {
+                        return completion;
+                    }
+                }
+
+                iterating = TypeConverter.ToBoolean(await _test.GetValueAsync());
             } while (iterating);
 
             return new Completion(CompletionType.Normal, v, null, Location);

--- a/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
@@ -1,5 +1,6 @@
 using Esprima.Ast;
 using Jint.Runtime.Interpreter.Expressions;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -15,6 +16,11 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override Completion ExecuteInternal()
         {
             var value = _expression.GetValue();
+            return new Completion(CompletionType.Normal, value, null, Location);
+        }
+
+        protected async override Task<Completion> ExecuteInternalAsync() {
+            var value = await _expression.GetValueAsync();
             return new Completion(CompletionType.Normal, value, null, Location);
         }
     }

--- a/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
@@ -1,5 +1,6 @@
 using Esprima.Ast;
 using Jint.Runtime.Interpreter.Expressions;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -26,6 +27,25 @@ namespace Jint.Runtime.Interpreter.Statements
             else if (_alternate != null)
             {
                 result = _alternate.Execute();
+            }
+            else
+            {
+                return new Completion(CompletionType.Normal, null, null, Location);
+            }
+
+            return result;
+        }
+
+        protected async override Task<Completion> ExecuteInternalAsync()
+        {
+            Completion result;
+            if (TypeConverter.ToBoolean(await _test.GetValueAsync()))
+            {
+                result = await _statementConsequent.ExecuteAsync();
+            }
+            else if (_alternate != null)
+            {
+                result = await _alternate.ExecuteAsync();
             }
             else
             {

--- a/Jint/Runtime/Interpreter/Statements/JintLabeledStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintLabeledStatement.cs
@@ -1,4 +1,5 @@
 using Esprima.Ast;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -19,6 +20,21 @@ namespace Jint.Runtime.Interpreter.Statements
             // containing label and could keep a table per program with all the labels
             // labeledStatement.Body.LabelSet = labeledStatement.Label;
             var result = _body.Execute();
+            if (result.Type == CompletionType.Break && result.Identifier == _labelName)
+            {
+                var value = result.Value;
+                return new Completion(CompletionType.Normal, value, null, Location);
+            }
+
+            return result;
+        }
+
+        protected async override Task<Completion> ExecuteInternalAsync()
+        {
+            // TODO: Esprima added Statement.Label, maybe not necessary as this line is finding the
+            // containing label and could keep a table per program with all the labels
+            // labeledStatement.Body.LabelSet = labeledStatement.Label;
+            var result = await _body.ExecuteAsync();
             if (result.Type == CompletionType.Break && result.Identifier == _labelName)
             {
                 var value = result.Value;

--- a/Jint/Runtime/Interpreter/Statements/JintReturnStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintReturnStatement.cs
@@ -1,6 +1,7 @@
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.Interpreter.Expressions;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -21,6 +22,12 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override Completion ExecuteInternal()
         {
             var jsValue = _argument?.GetValue() ?? Undefined.Instance;
+            return new Completion(CompletionType.Return, jsValue, null, Location);
+        }
+
+        protected async override Task<Completion> ExecuteInternalAsync()
+        {
+            var jsValue = await _argument?.GetValueAsync() ?? Undefined.Instance;
             return new Completion(CompletionType.Return, jsValue, null, Location);
         }
     }

--- a/Jint/Runtime/Interpreter/Statements/JintScript.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintScript.cs
@@ -1,4 +1,5 @@
 using Esprima.Ast;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -14,6 +15,10 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override Completion ExecuteInternal()
         {
             return _list.Execute();
+        }
+
+        protected override Task<Completion> ExecuteInternalAsync() {
+            return _list.ExecuteAsync();
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Esprima;
 using Esprima.Ast;
 using Jint.Runtime.Interpreter.Expressions;
@@ -44,7 +45,25 @@ namespace Jint.Runtime.Interpreter.Statements
             return ExecuteInternal();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Task<Completion> ExecuteAsync()
+        {
+            _engine._lastSyntaxNode = _statement;
+            _engine.RunBeforeExecuteStatementChecks(_statement);
+
+            if (!_initialized)
+            {
+                Initialize();
+                _initialized = true;
+            }
+
+            return ExecuteInternalAsync();
+        }
+
         protected abstract Completion ExecuteInternal();
+
+        protected virtual Task<Completion> ExecuteInternalAsync()
+            => Task.FromResult(ExecuteInternal());
 
         public Location Location => _statement.Location;
 

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchStatement.cs
@@ -1,5 +1,6 @@
 using Esprima.Ast;
 using Jint.Runtime.Interpreter.Expressions;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -20,6 +21,18 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override Completion ExecuteInternal()
         {
             var jsValue = _discriminant.GetValue();
+            var r = _switchBlock.Execute(jsValue);
+            if (r.Type == CompletionType.Break && r.Identifier == _statement.LabelSet?.Name)
+            {
+                return new Completion(CompletionType.Normal, r.Value, null, Location);
+            }
+
+            return r;
+        }
+
+        protected async override Task<Completion> ExecuteInternalAsync()
+        {
+            var jsValue = await _discriminant.GetValueAsync();
             var r = _switchBlock.Execute(jsValue);
             if (r.Type == CompletionType.Break && r.Identifier == _statement.LabelSet?.Name)
             {

--- a/Jint/Runtime/Interpreter/Statements/JintThrowStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintThrowStatement.cs
@@ -1,5 +1,6 @@
 using Esprima.Ast;
 using Jint.Runtime.Interpreter.Expressions;
+using System.Threading.Tasks;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -23,6 +24,12 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override Completion ExecuteInternal()
         {
             var jsValue = _argument.GetValue();
+            return new Completion(CompletionType.Throw, jsValue, null, _statement.Location);
+        }
+
+        protected async override Task<Completion> ExecuteInternalAsync()
+        {
+            var jsValue = await _argument.GetValueAsync();
             return new Completion(CompletionType.Throw, jsValue, null, _statement.Location);
         }
     }

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -49,14 +49,19 @@ namespace Jint.Runtime
                     for (var index = 0; index < cse.CallExpression.Arguments.Count; index++)
                     {
                         if (index != 0)
+                        {
                             sb.Builder.Append(", ");
+                        }
                         var arg = cse.CallExpression.Arguments[index];
                         if (arg is Expression pke)
-                            sb.Builder.Append(pke.GetKey(engine, computed: false));
+                        {
+                            sb.Builder.Append(GetPropertyKey(pke));
+                        }
                         else
+                        {
                             sb.Builder.Append(arg);
+                        }
                     }
-
 
                     sb.Builder.Append(") @ ")
                         .Append(cse.CallExpression.Location.Source)
@@ -70,6 +75,29 @@ namespace Jint.Runtime
             }
 
             return this;
+        }
+
+        /// <summary>
+        /// A version of <see cref="EsprimaExtensions.GetKey"/> that cannot get into loop as we are already building a stack.
+        /// </summary>
+        private static string GetPropertyKey(Expression expression)
+        {
+            if (expression is Literal literal)
+            {
+                return EsprimaExtensions.LiteralKeyToString(literal);
+            }
+
+            if (expression is Identifier identifier)
+            {
+                return identifier.Name;
+            }
+
+            if (expression is StaticMemberExpression staticMemberExpression)
+            {
+                return GetPropertyKey(staticMemberExpression.Object) + "." + GetPropertyKey(staticMemberExpression.Property);
+            }
+
+            return "?";
         }
 
         private static string GetErrorMessage(JsValue error)

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -405,7 +405,7 @@ namespace Jint.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string ToString(ulong i)
         {
-            return i >= 0 && i < (ulong) intToString.Length
+            return i < (ulong) intToString.Length
                 ? intToString[i]
                 : i.ToString();
         }


### PR DESCRIPTION
Unit tests are good, but needs an implementation that shares them with the sync version.
I thought you could maybe just have two separate engines, and have RunTest execute the code on each of them. You could then tell by the stack trace which of them failed, or have an outer assertion that pointed this out. Let me know what you think.