### PR TITLE
Support passing a dictionary inside an object

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -2044,5 +2044,39 @@ namespace Jint.Tests.Runtime
             Assert.NotNull(c.ToString());
             Assert.Equal((uint)0, c.As<ObjectInstance>().Length);
         }
+
+        class DictionaryWrapper
+        {
+            public IDictionary<string, object> Values { get; set; }
+        }
+
+        class DictionaryTest
+        {
+            public void Test1(IDictionary<string, object> values)
+            {
+                Assert.Equal(1, Convert.ToInt32(values["a"]));
+            }
+
+            public void Test2(DictionaryWrapper dictionaryObject)
+            {
+                Assert.Equal(1, Convert.ToInt32(dictionaryObject.Values["a"]));
+            }
+        }
+
+        [Fact]
+        public void ShouldBeAbleToPassDictionaryToMethod()
+        {
+            var engine = new Engine();
+            engine.SetValue("dictionaryTest", new DictionaryTest());
+            engine.Execute("dictionaryTest.test1({ a: 1 });");
+        }
+
+        [Fact]
+        public void ShouldBeAbleToPassDictionaryInObjectToMethod()
+        {
+            var engine = new Engine();
+            engine.SetValue("dictionaryTest", new DictionaryTest());
+            engine.Execute("dictionaryTest.test2({ values: { a: 1 } });");
+        }
     }
 }

--- a/Jint/Extensions/ReflectionExtensions.cs
+++ b/Jint/Extensions/ReflectionExtensions.cs
@@ -11,7 +11,7 @@ namespace Jint.Extensions
             {
                 case MemberTypes.Field:
                     var fieldInfo = (FieldInfo) memberInfo;
-                    if (fieldInfo.FieldType == value?.GetType())
+                    if (value != null && fieldInfo.FieldType.IsAssignableFrom(value.GetType()))
                     {
                         fieldInfo.SetValue(forObject, value);
                     }
@@ -19,7 +19,7 @@ namespace Jint.Extensions
                     break;
                 case MemberTypes.Property:
                     var propertyInfo = (PropertyInfo) memberInfo;
-                    if (propertyInfo.PropertyType == value?.GetType())
+                    if (value != null && propertyInfo.PropertyType.IsAssignableFrom(value.GetType()))
                     {
                         propertyInfo.SetValue(forObject, value);
                     }


### PR DESCRIPTION
Currently it is only possible to pass a dictionary only directly as a method parameter, but not if it is wrapped in an object.