### PR TITLE
Support object wrapper iterator

### DIFF
--- a/Jint/Native/Iterator/IteratorInstance.cs
+++ b/Jint/Native/Iterator/IteratorInstance.cs
@@ -296,12 +296,12 @@ namespace Jint.Native.Iterator
             }
         }
 
-        internal class ObjectWrapper : IIterator
+        internal class ObjectIterator : IIterator
         {
             private readonly ObjectInstance _target;
             private readonly ICallable _nextMethod;
 
-            public ObjectWrapper(ObjectInstance target)
+            public ObjectIterator(ObjectInstance target)
             {
                 _target = target;
                 _nextMethod = target.Get(CommonProperties.Next, target) as ICallable

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -202,7 +202,7 @@ namespace Jint.Native
             }
             else
             {
-                iterator = new IteratorInstance.ObjectWrapper(obj);
+                iterator = new IteratorInstance.ObjectIterator(obj);
             }
             return true;
         }

--- a/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
@@ -13,7 +13,8 @@ namespace Jint.Runtime.Descriptors.Specialized
         private readonly PropertyInfo _indexer;
         private readonly MethodInfo _containsKey;
 
-        public IndexDescriptor(Engine engine, Type targetType, string key, object target) : base(PropertyFlag.CustomJsValue)
+        public IndexDescriptor(Engine engine, Type targetType, string key, object target)
+            : base(PropertyFlag.Enumerable | PropertyFlag.CustomJsValue)
         {
             _engine = engine;
             _target = target;

--- a/Jint/Runtime/Descriptors/Specialized/PropertyInfoDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/PropertyInfoDescriptor.cs
@@ -10,7 +10,8 @@ namespace Jint.Runtime.Descriptors.Specialized
         private readonly PropertyInfo _propertyInfo;
         private readonly object _item;
 
-        public PropertyInfoDescriptor(Engine engine, PropertyInfo propertyInfo, object item) : base(PropertyFlag.CustomJsValue)
+        public PropertyInfoDescriptor(Engine engine, PropertyInfo propertyInfo, object item) 
+            : base(PropertyFlag.Enumerable | PropertyFlag.CustomJsValue)
         {
             _engine = engine;
             _propertyInfo = propertyInfo;

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -86,7 +86,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 {
                     _canBuildFast = false;
                     _properties[i] = null;
-                    _valueExpressions[i] = Build(_engine, spreadElement.Argument);
+                    _valueExpressions[i] = new JintSpreadExpression(_engine, spreadElement);
                 }
                 else
                 {

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -86,7 +86,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 {
                     _canBuildFast = false;
                     _properties[i] = null;
-                    _valueExpressions[i] = new JintSpreadExpression(_engine, spreadElement);
+                    _valueExpressions[i] = Build(_engine, spreadElement.Argument);
                 }
                 else
                 {

--- a/Jint/Runtime/KnownKeys.cs
+++ b/Jint/Runtime/KnownKeys.cs
@@ -4,5 +4,6 @@ namespace Jint.Runtime
     {
         internal static readonly Key Arguments = "arguments";
         internal static readonly Key Eval = "eval";
+        internal static readonly Key Length = "length";
     }
 }


### PR DESCRIPTION
Object wrapper didn't support getting an iterator which is key part to some JS functionality. Added iterator with logic that for me at least makes sense - for dictionaries only get keys and for "standard" objects use public fields and properties.

fixes #748