### PR TITLE
Adding constructor with existing options

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2855,8 +2855,8 @@ x.test = {
             var engine1 = new Engine(options);
             var engine2 = new Engine(options);
 
-            Assert.Equal(1, engine1.GetValue("x").ToObject());
-            Assert.Equal(1, engine2.GetValue("x").ToObject());
+            Assert.Equal(1, Convert.ToInt32(engine1.GetValue("x").ToObject()));
+            Assert.Equal(1, Convert.ToInt32(engine2.GetValue("x").ToObject()));
         }
 
         private class Wrapper

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2847,6 +2847,18 @@ x.test = {
                 .SetValue("a", 1);
         }
 
+        [Fact]
+        public void ShouldReuseOptions()
+        {
+            var options = new Options().Configure(e => e.SetValue("x", 1));
+
+            var engine1 = new Engine(options);
+            var engine2 = new Engine(options);
+
+            Assert.Equal(1, engine1.GetValue("x").ToObject());
+            Assert.Equal(1, engine2.GetValue("x").ToObject());
+        }
+
         private class Wrapper
         {
             public Testificate Test { get; set; }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -131,7 +131,7 @@ namespace Jint
         /// <summary>
         /// Constructs a new engine with a custom <see cref="Options"/> instance.
         /// </summary>
-        public Engine(Options options) : this((e, o) => e.Options = o)
+        public Engine(Options options) : this((e, o) => e.Options = options)
         {
         }
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -129,6 +129,13 @@ namespace Jint
         }
 
         /// <summary>
+        /// Constructs a new engine with a custom <see cref="Options"/> instance.
+        /// </summary>
+        public Engine(Options options) : this((e, o) => e.Options = o)
+        {
+        }
+
+        /// <summary>
         /// Constructs a new engine instance and allows customizing options.
         /// </summary>
         /// <remarks>The provided engine instance in callback is not guaranteed to be fully configured</remarks>
@@ -246,7 +253,7 @@ namespace Jint
 
         internal long CurrentMemoryUsage { get; private set; }
 
-        internal Options Options { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        internal Options Options { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; private set; }
 
         #region Debugger
         public delegate StepMode DebugStepDelegate(object sender, DebugInformation e);

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -203,6 +203,8 @@ namespace Jint
             }
 
             ClrTypeConverter = new DefaultTypeConverter(this);
+
+            Options.Apply(this);
         }
     
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -29,6 +29,7 @@ namespace Jint
         private List<Assembly> _lookupAssemblies = new List<Assembly>();
         private Predicate<Exception> _clrExceptionsHandler;
         private IReferenceResolver _referenceResolver = DefaultReferenceResolver.Instance;
+        private readonly List<Action<Engine>> _configurations = new List<Action<Engine>>();
 
         /// <summary>
         /// Run the script in strict mode.
@@ -196,6 +197,29 @@ namespace Jint
         {
             _referenceResolver = resolver;
             return this;
+        }
+
+        /// <summary>
+        /// Registers some custom logic to apply on an <see cref="Engine"/> instance when the options
+        /// are loaded.
+        /// </summary>
+        /// <param name="configuration">The action to register.</param>
+        public Options Configure(Action<Engine> configuration)
+        {
+            _configurations.Add(configuration);
+            return this;
+        }
+
+        /// <summary>
+        /// Called by the <see cref="Engine"/> instance that loads this <see cref="Options" />
+        /// once it is loaded.
+        /// </summary>
+        internal void Apply(Engine engine)
+        {
+            foreach (var configuration in _configurations)
+            {
+                configuration?.Invoke(engine);
+            }
         }
 
         internal bool IsStrict => _strict;


### PR DESCRIPTION
Being able to reuse options instances, and also create custom extension methods on `Options` that can alter the engine state.