### PR TITLE
Fix Date's NaN JSON.stringify

### DIFF
--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -57,5 +57,11 @@ namespace Jint.Tests.Runtime
             Assert.Equal("Invalid Date", value);
         }
 
+        [Fact]
+        public void ToJsonFromNaNObject()
+        {
+            var result = _engine.Execute("JSON.stringify({ date: new Date(NaN) });").GetCompletionValue();
+            Assert.Equal("{\"date\":null}", result.ToString());
+        }
     }
 }

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -688,7 +688,7 @@ namespace Jint.Native.Date
         {
             var o = TypeConverter.ToObject(Engine, thisObj);
             var tv = TypeConverter.ToPrimitive(o, Types.Number);
-            if (tv.IsNumber() && double.IsInfinity(((JsNumber) tv)._value))
+            if (tv.IsNumber() && !IsFinite(((JsNumber) tv)._value))
             {
                 return Null;
             }


### PR DESCRIPTION
fixes #763

`IsFinite` in spec also considers `NaN`, which is not handled currently, event thought the spec for [Date.prototype.toJSON](https://tc39.es/ecma262/#sec-date.prototype.tojson) says so.