### PR TITLE
Use a more specific exception in the `CancellationConstraint` class

### DIFF
--- a/Jint/Constraints/CancellationConstraint.cs
+++ b/Jint/Constraints/CancellationConstraint.cs
@@ -16,7 +16,7 @@ namespace Jint.Constraints
         {
             if (_cancellationToken.IsCancellationRequested)
             {
-                ExceptionHelper.ThrowStatementsCountOverflowException();
+                ExceptionHelper.ThrowExecutionCanceledException();
             }
         }
 

--- a/Jint/Runtime/ExceptionHelper.cs
+++ b/Jint/Runtime/ExceptionHelper.cs
@@ -182,5 +182,10 @@ namespace Jint.Runtime
         {
             throw new MemoryLimitExceededException(message);
         }
+
+        public static void ThrowExecutionCanceledException()
+        {
+            throw new ExecutionCanceledException();
+        }
     }
 }

--- a/Jint/Runtime/ExecutionCanceledException.cs
+++ b/Jint/Runtime/ExecutionCanceledException.cs
@@ -1,0 +1,9 @@
+﻿namespace Jint.Runtime
+{
+    public class ExecutionCanceledException : JintException
+    {
+        public ExecutionCanceledException() : base("The script execution was canceled.")
+        {
+        }
+    }
+}


### PR DESCRIPTION
Currently the `CancellationConstraint` is throwing an exception of type `StatementsCountOverflowException` (same as in the `MaxStatements` constraint). This implementation makes it more difficult to error handling and find their causes.

In this PR, I replaced a exception of type `StatementsCountOverflowException` by an exception of type `ExecutionCanceledException`.