### PR TITLE
Publish symbol package

### DIFF
--- a/Jint.Benchmark/Jint.Benchmark.csproj
+++ b/Jint.Benchmark/Jint.Benchmark.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Jint.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>Jint.Benchmark</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -15,6 +14,7 @@
     <AssemblyOriginatorKeyFile>..\Jint\Jint.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <LangVersion>8</LangVersion>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <None Include=".\Scripts\**" CopyToOutputDirectory="PreserveNewest" />

--- a/Jint.Repl/Jint.Repl.csproj
+++ b/Jint.Repl/Jint.Repl.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />

--- a/Jint/Directory.Build.props
+++ b/Jint/Directory.Build.props
@@ -10,12 +10,12 @@
     <PackageId>Jint</PackageId>
     <PackageTags>javascript, interpreter</PackageTags>
     <PackageProjectUrl>https://github.com/sebastienros/jint</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/sebastienros/jint/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
 
-    <!-- SourceLink support -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
   </PropertyGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ test_script:
   - dotnet test .\Jint.Tests.Ecma\Jint.Tests.Ecma.csproj -c Release
   - dotnet test .\Jint.Tests.Test262\Jint.Tests.Test262.csproj -c Release
 artifacts:
-  - path: 'Jint\**\*.nupkg'
+  - path: 'Jint\**\*.*nupkg'
 deploy:  
   - provider: NuGet
     on:
@@ -51,5 +51,4 @@ deploy:
     server: https://www.nuget.org/api/v2/package
     api_key:
       secure: yZBBCLlJTphpHCezRUxyDny1mBbDw7xFG/2Rwt21A8khKp6KJCxFEYx4k9IihOjO
-    skip_symbols: true
-    artifact: /.*\.nupkg/
+    artifact: /.*\.*nupkg/


### PR DESCRIPTION
Less size for published package, debug support for debuggers. Also set the license expression instead of the obsolete URL. Update netcoreapp3.0 to netcoreapp3.1.

Just noticed that Esprima is BSD-3 and Jint is BSD-2, intentional?