### PR TITLE
Add support for isolated execution context

### DIFF
--- a/Jint.Benchmark/EnginePoolBenchmark.cs
+++ b/Jint.Benchmark/EnginePoolBenchmark.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using Jint.Pooling;
+
+namespace Jint.Benchmark
+{
+    [MemoryDiagnoser]
+    public class EnginePoolBenchmark
+    {
+        private static readonly Options options = new Options().Strict();
+        
+        private static readonly List<string> files = new List<string>
+        {
+            "dromaeo-3d-cube",
+            "dromaeo-core-eval",
+            "dromaeo-object-array",
+            "dromaeo-object-regexp",
+            "dromaeo-object-string",
+            "dromaeo-string-base64"
+        };
+
+        private IsolatedEngineFactory factory;
+        private Engine _engine;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            factory = new IsolatedEngineFactory(options, InitializeEngine);
+
+            _engine = new Engine(options);
+            InitializeEngine(_engine);
+        }
+
+        /// <summary>
+        /// Test case where we discard the pool and data.
+        /// </summary>
+        [Benchmark]
+        public void RunUsingPooledIsolated()
+        {
+            using var engine = factory.Build();
+            RunScript(engine);
+        }
+
+        /// <summary>
+        /// Using one engine that isn't able to clean up.
+        /// </summary>
+        [Benchmark]
+        public void RunUsingDirtiedEngineInstance()
+        {
+            RunScript(_engine);
+        }
+
+        /// <summary>
+        /// Test case to do always the manual labour.
+        /// </summary>
+        [Benchmark]
+        public void RunUsingNewEngineInstance()
+        {
+            var freshEngine = new Engine(options);
+            InitializeEngine(freshEngine);
+            RunScript(freshEngine);
+        }
+
+        private static void RunScript(IScriptExecutor engine)
+        {
+            for (int i = 5; i < 20; ++i)
+            {
+                engine.Evaluate($"Init({i});");
+            }
+        }
+
+        private static void InitializeEngine(IEngine engine)
+        {
+            engine.SetValue("log", new Action<object>(Console.WriteLine));
+            engine.SetValue("assert", new Action<bool>(b => { }));
+            engine.SetValue("name", 123);
+            engine.Evaluate(@"
+                                    var startTest = function () { };
+                                    var test = function (name, fn) { fn(); };
+                                    var endTest = function () { };
+                                    var prep = function (fn) { fn(); };
+                    ");
+
+            foreach (var fileName in files)
+            {
+                var content = File.ReadAllText($"Scripts/dromaeo/{fileName}.js");
+                engine.Evaluate(content);
+            }
+        }
+    }
+}

--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -5,6 +5,7 @@
     <AssemblyOriginatorKeyFile>..\Jint\Jint.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Runtime\Scripts\*.*;Parser\Scripts\*.*" />
@@ -16,6 +17,7 @@
     <Reference Include="Microsoft.CSharp" Condition=" '$(TargetFramework)' == 'net461' " />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Flurl.Http.Signed" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="MongoDB.Bson.signed" Version="2.11.2" />

--- a/Jint.Tests/Runtime/EnginePoolTests.cs
+++ b/Jint.Tests/Runtime/EnginePoolTests.cs
@@ -1,0 +1,36 @@
+using FluentAssertions;
+using Jint.Pooling;
+using Jint.Runtime;
+using Xunit;
+
+namespace Jint.Tests.Runtime
+{
+    public class EnginePoolTests
+    {
+        [Fact]
+        public void LimitsShouldNotBeActiveDuringInitialization()
+        {
+            var options = new Options()
+                .Strict()
+                .MaxStatements(2);
+            
+            // we cannot run three statements with this configuration
+            const string script = "Math.max(1, 2); Math.max(1, 2); Math.max(1, 2);";
+
+            var pool = new IsolatedEngineFactory(options, e =>
+            {
+                // unless we are initializing the engine
+                e.Evaluate(script);
+            });
+
+            using var engine = pool.Build();
+            
+            // no longer allowed for many statements 
+            var ex = Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate(script));
+            ex.Message.Should().Be("The maximum number of statements executed has reached allowed limit (2).");
+            
+            // allowed for less statements
+            engine.Evaluate("Math.max(1, 2); Math.max(1, 2);");
+        }
+    }
+}

--- a/Jint.Tests/Runtime/IsolatedContextTests.cs
+++ b/Jint.Tests/Runtime/IsolatedContextTests.cs
@@ -1,0 +1,90 @@
+using System;
+using FluentAssertions;
+using Jint.Native;
+using Jint.Runtime;
+using Xunit;
+
+namespace Jint.Tests.Runtime
+{
+    public class IsolatedContextTests
+    {
+        [Fact]
+        public void IsolatedContextCanBeUsedAndDisposed()
+        {
+            var engineFactory = new DefaultEngineFactory(new Options().Strict());
+            var engine = engineFactory.Build();
+            engine.SetValue("assert", new Action<bool>(Assert.True));
+
+            // Set outer variable in global scope
+            engine.SetValue("outer", 123);
+            engine.SetValue("outerClrArray", new[] { "a", "b", "c" });
+            engine.Evaluate("var outerJsArray = [ 'a', 'b', 'c' ];");
+            engine.Evaluate("assert(outer === 123)");
+            engine.Evaluate("outer").ToObject().Should().Be(123);
+
+            // outer scope functions and trusted, they can break things, so be aware
+            engine.Evaluate("function outerBreaker() { var m = Math.max; delete Math.max; assert(typeof Math.max === 'undefined');  Math.max = m; }");
+
+            // Enter new execution context
+            using (engine.ActivateIsolatedContext())
+            {
+                // Can see global scope
+                engine.Evaluate("assert(outer === 123)");
+
+                // Can modify global scope
+                engine.Evaluate("outer = 321");
+                engine.Evaluate("outer").ToObject().Should().Be(321);
+
+                // Create variable in new context
+                engine.Evaluate("var inner = 456");
+                engine.Evaluate("assert(inner === 456)");
+
+                engine.Evaluate("function innerBreaker() { Math.max = null; }");
+
+                engine.Evaluate("var m = Math.max; outerBreaker();");
+                engine.Evaluate("Math.max").Should().BeAssignableTo<ICallable>();
+                engine.Evaluate("m === Math.max").AsBoolean().Should().BeTrue();
+                
+                // cannot break anything
+                Assert.Throws<NotSupportedException>(() => engine.Evaluate("innerBreaker();"));
+                Assert.Throws<NotSupportedException>(() => engine.Evaluate("Math.max = null;"));
+                Assert.Throws<NotSupportedException>(() => engine.Evaluate("outerJsArray[0] = null;"));
+                Assert.Throws<NotSupportedException>(() => engine.Evaluate("outerClrArray[0] = null;"));
+                
+                // but we can redeclare the whole math thing and make it "better" in this context
+                engine.Evaluate("var Math = ({});");
+                engine.Evaluate("Math.max = () => 42;");
+
+                engine.Evaluate("outerJsArray = [ 'c' ];");
+                engine.Evaluate("outerJsArray[0]").AsString().Should().Be("c");
+
+                var maxInner = engine.Evaluate("Math.max(1, 2);").AsNumber();
+                maxInner.Should().Be(42);
+            }
+
+            // The new variable is no longer visible
+            engine.Evaluate("assert(typeof inner === 'undefined')");
+
+            // The new variable is not in the global scope
+            var ex = Assert.Throws<JavaScriptException>(()  => engine.Evaluate("inner"));
+            ex.Message.Should().Be("inner is not defined");
+
+            var max = engine.Evaluate("Math.max");
+            max.ToObject().Should().NotBeNull();
+            
+            // and we should again get reasonable results from max
+            var maxOuter = engine.Evaluate("Math.max(1, 2);").AsNumber();
+            maxOuter.Should().Be(2);
+
+            // array back to itself
+            engine.Evaluate("outerJsArray[0]").AsString().Should().Be("a");
+
+            // but can again break things
+            engine.Evaluate("Math.max = null;");
+            engine.Evaluate("Math.max").ToObject().Should().BeNull();
+
+            engine.Evaluate("outerBreaker();");
+            engine.Evaluate("Math.max").ToObject().Should().BeNull();
+        }
+    }
+}

--- a/Jint/Constraints/ConstraintsOptionsExtensions.cs
+++ b/Jint/Constraints/ConstraintsOptionsExtensions.cs
@@ -21,7 +21,7 @@ namespace Jint
         {
             options.WithoutConstraint(x => x is MemoryLimit);
 
-            if (memoryLimit > 0 && memoryLimit < int.MaxValue)
+            if (memoryLimit > 0 && memoryLimit < long.MaxValue)
             {
                 options.Constraint(new MemoryLimit(memoryLimit));
             }

--- a/Jint/Constraints/MaxStatements.cs
+++ b/Jint/Constraints/MaxStatements.cs
@@ -14,10 +14,12 @@ namespace Jint.Constraints
 
         public void Check()
         {
-            if (_maxStatements > 0 && _statementsCount++ > _maxStatements)
+            if (_maxStatements > 0 && _statementsCount >= _maxStatements)
             {
-                ExceptionHelper.ThrowStatementsCountOverflowException();
+                ExceptionHelper.ThrowStatementsCountOverflowException(_statementsCount, _maxStatements);
             }
+
+            _statementsCount++;
         }
 
         public void Reset()

--- a/Jint/DefaultEngineFactory.cs
+++ b/Jint/DefaultEngineFactory.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+using System;
+
+namespace Jint
+{
+    /// <summary>
+    /// Default engine factory for creating <see cref="IEngine" /> instances.
+    /// </summary>
+    public sealed class DefaultEngineFactory : EngineFactory<IEngine>
+    {
+        /// <summary>
+        /// Creates a new instance default engine factory.
+        /// </summary>
+        /// <param name="options">Options to use for each new Engine instance.</param>
+        /// <param name="initialize">Actions to run against the engine to create initial state, any execution constraints are not honored during this step!</param>
+        public DefaultEngineFactory(Options options, Action<IEngine>? initialize = null) : base(options, initialize)
+        {
+        }
+        
+        public override IEngine Build()
+        {
+            return CreateAndInitializeEngine();
+        }
+    }
+}

--- a/Jint/Engine.Isolation.cs
+++ b/Jint/Engine.Isolation.cs
@@ -1,0 +1,157 @@
+using System;
+using Jint.Collections;
+using Jint.Native.Global;
+using Jint.Runtime;
+using Jint.Runtime.Environments;
+
+namespace Jint
+{
+    public partial class Engine : IEngine
+    {
+        void IScriptExecutor.SetValue(string name, object value)
+        {
+            SetValue(name, value);
+        }
+
+        void IScriptExecutor.SetValue(string name, int value)
+        {
+            SetValue(name, value);
+        }
+
+        void IScriptExecutor.SetValue(string name, double value)
+        {
+            SetValue(name, value);
+        }
+
+        void IScriptExecutor.SetValue(string name, bool value)
+        {
+            SetValue(name, value);
+        }
+
+        void IScriptExecutor.SetValue(string name, string value)
+        {
+            SetValue(name, value);
+        }
+
+        /// <summary>
+        /// Activates isolated context in which introduced variables will be destroyed when returned <see cref="IDisposable"/>
+        /// has been disposed.
+        /// </summary>
+        /// <remarks>This is not fool proof and might leak information, use with care!</remarks>
+        /// <returns>A handle to use for disposal.</returns>
+        public IDisposable ActivateIsolatedContext()
+        {
+            var originalGlobalEnvironment = GlobalEnvironment;
+            if (originalGlobalEnvironment.GetType() != typeof(GlobalEnvironmentRecord))
+            {
+                ExceptionHelper.ThrowInvalidOperationException(
+                    "Cannot enter isolated context when global environment is not default, did you already enter?");
+            }
+
+            if (_executionContexts.Count != 1)
+            {
+                ExceptionHelper.ThrowInvalidOperationException(
+                    "Cannot enter isolated context when execution context stack is not on root level");
+            }
+
+            if (!_isStrict)
+            {
+                ExceptionHelper.ThrowInvalidOperationException(
+                    "Cannot enter isolated context when engine is not in strict mode");
+            }
+
+            var originalGlobal = Global;
+            var propertyLessGlobal = new GlobalObject(this)
+            {
+                _properties = new PropertyDictionary()
+            };
+
+            var newGlobal = new IsolatedEnvironmentRecord(this, propertyLessGlobal, originalGlobalEnvironment);
+            GlobalEnvironment = newGlobal;
+            Global = propertyLessGlobal;
+
+            var context = new ExecutionContext(newGlobal, newGlobal);
+            _executionContexts.Push(context);
+
+            return new ContextRestorer(this, originalGlobalEnvironment, originalGlobal);
+        }
+
+        /// <summary>
+        /// Allows temporarily disable or change constraint checks for the engine.
+        /// Useful for example when initializing engine state with large scripts and/or logic by supplying empty array.
+        /// </summary>
+        /// <param name="newConstraints">New constraints to have in effect during disposable time frame.</param>
+        /// <returns>A <see cref="IDisposable"/> that should be disposed when original constraints should come back into effect.</returns>
+        public IDisposable ActivateTemporaryConstraints(IConstraint[] newConstraints)
+        {
+            if (newConstraints is null)
+            {
+                ExceptionHelper.ThrowArgumentNullException(nameof(newConstraints));
+            }
+
+            var state = new ConstraintRestorer(
+                this,
+                _constraints,
+                newConstraints);
+
+            return state;
+        }
+
+        private readonly struct ContextRestorer : IDisposable
+        {
+            private readonly Engine _engine;
+            private readonly GlobalEnvironmentRecord _originalGlobalEnvironment;
+            private readonly GlobalObject _originalGlobal;
+
+            public ContextRestorer(Engine engine, GlobalEnvironmentRecord originalGlobalEnvironment,
+                GlobalObject originalGlobal)
+            {
+                _engine = engine;
+                _originalGlobalEnvironment = originalGlobalEnvironment;
+                _originalGlobal = originalGlobal;
+            }
+
+            public void Dispose()
+            {
+                if (_engine.GlobalEnvironment.GetType() != typeof(IsolatedEnvironmentRecord))
+                {
+                    ExceptionHelper.ThrowInvalidOperationException(
+                        "Cannot leave isolated context when global environment is not isolated, did you already dispose?");
+                }
+
+                if (_engine._executionContexts.Count != 2)
+                {
+                    ExceptionHelper.ThrowInvalidOperationException(
+                        "Cannot enter isolated context when execution context stack is not on root level");
+                }
+
+                _engine.GlobalEnvironment = _originalGlobalEnvironment;
+                _engine.Global = _originalGlobal;
+                _engine._executionContexts.Pop();
+            }
+        }
+
+        public void Dispose()
+        {
+            // currently no-op
+        }
+
+        private readonly struct ConstraintRestorer : IDisposable
+        {
+            private readonly Engine _engine;
+            private readonly IConstraint[] _oldConstraints;
+
+            public ConstraintRestorer(Engine engine, IConstraint[] activeConstraints, IConstraint[] newConstraints)
+            {
+                _engine = engine;
+                _oldConstraints = activeConstraints;
+                _engine._constraints = newConstraints;
+            }
+
+            public void Dispose()
+            {
+                _engine._constraints = _oldConstraints;
+            }
+        }
+    }
+}

--- a/Jint/EngineFactory.cs
+++ b/Jint/EngineFactory.cs
@@ -1,0 +1,34 @@
+#nullable enable
+
+using System;
+
+namespace Jint
+{
+    /// <summary>
+    /// Convenience base class for engine factories.
+    /// </summary>
+    public abstract class EngineFactory<T> : IEngineFactory<T>
+    {
+        private readonly Options _options;
+        private readonly Action<IEngine>? _initialize;
+
+        protected EngineFactory(Options options, Action<IEngine>? initialize)
+        {
+            _options = options;
+            _initialize = initialize;
+        }
+
+        public abstract T Build();
+
+        protected Engine CreateAndInitializeEngine()
+        {
+            var engine = new Engine(_options);
+            using (engine.ActivateTemporaryConstraints(Array.Empty<IConstraint>()))
+            {
+                _initialize?.Invoke(engine);
+            }
+
+            return engine;
+        }
+    }
+}

--- a/Jint/IEngine.cs
+++ b/Jint/IEngine.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Jint
+{
+    /// <summary>
+    /// Exposes limited set of engine operations to work with.
+    /// </summary>
+    public interface IEngine : IScriptExecutor
+    {
+        /// <summary>
+        /// Activates isolated context in which introduced variables will be destroyed when returned <see cref="IDisposable"/>
+        /// has been disposed.
+        /// </summary>
+        /// <remarks>This is not fool proof and might leak information, use with care!</remarks>
+        /// <returns>A handle to use for disposal.</returns>
+        IDisposable ActivateIsolatedContext();
+
+        /// <summary>
+        /// Allows temporarily disable or change constraint checks for the engine.
+        /// Useful for example when initializing engine state with large scripts and/or logic by supplying empty array.
+        /// </summary>
+        /// <param name="newConstraints">New constraints to have in effect during disposable time frame.</param>
+        /// <returns>A <see cref="IDisposable"/> that should be disposed when original constraints should come back into effect.</returns>
+        IDisposable ActivateTemporaryConstraints(IConstraint[] newConstraints);
+    }
+}

--- a/Jint/IEngineFactory.cs
+++ b/Jint/IEngineFactory.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Jint
+{
+    /// <summary>
+    /// Service interface for creating new engines.
+    /// </summary>
+    public interface IEngineFactory<out T>
+    {
+        /// <summary>
+        /// Builds a new engine instance. When you are done using it, you should call <see cref="IDisposable.Dispose"/>.
+        /// </summary>
+        /// <returns></returns>
+        T Build();
+    }
+}

--- a/Jint/IScriptExecutor.cs
+++ b/Jint/IScriptExecutor.cs
@@ -1,0 +1,63 @@
+using System;
+using Esprima;
+using Esprima.Ast;
+using Jint.Native;
+
+namespace Jint
+{
+    /// <summary>
+    /// Allows setting values and evaluating statements and expressions inside engine context.
+    /// </summary>
+    public interface IScriptExecutor : IDisposable
+    {
+        /// <summary>
+        /// Sets variable to engine's global scope.
+        /// </summary>
+        /// <param name="name">Variable's name.</param>
+        /// <param name="value">Variable's value.</param>
+        void SetValue(string name, object value);
+
+        /// <summary>
+        /// Sets variable to engine's global scope.
+        /// </summary>
+        /// <param name="name">Variable's name.</param>
+        /// <param name="value">Variable's value.</param>
+        void SetValue(string name, int value);
+        
+        /// <summary>
+        /// Sets variable to engine's global scope.
+        /// </summary>
+        /// <param name="name">Variable's name.</param>
+        /// <param name="value">Variable's value.</param>
+        void SetValue(string name, double value);
+        
+        /// <summary>
+        /// Sets variable to engine's global scope.
+        /// </summary>
+        /// <param name="name">Variable's name.</param>
+        /// <param name="value">Variable's value.</param>
+        void SetValue(string name, string value);
+        
+        /// <summary>
+        /// Sets variable to engine's global scope.
+        /// </summary>
+        /// <param name="name">Variable's name.</param>
+        /// <param name="value">Variable's value.</param>
+        void SetValue(string name, bool value);
+
+        /// <summary>
+        /// Evaluates given source script and returns last evaluation result.
+        /// </summary>
+        /// <param name="source">Script to parse and evaluate.</param>
+        /// <param name="parserOptions">Parsing options to use.</param>
+        /// <returns>The last value that script evaluation produced.</returns>
+        JsValue Evaluate(string source, ParserOptions parserOptions = null);
+        
+        /// <summary>
+        /// Evaluates given script, ideal for running already parsed scripts when parsing overhead should be avoided.
+        /// </summary>
+        /// <param name="script">Pre-parsed script to run.</param>
+        /// <returns>The last value that script evaluation produced.</returns>
+        JsValue Evaluate(Script script);
+    }
+}

--- a/Jint/Native/Argument/ArgumentsInstance.cs
+++ b/Jint/Native/Argument/ArgumentsInstance.cs
@@ -48,7 +48,7 @@ namespace Jint.Native.Argument
             ClearProperties();
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             _canReturnToPool = false;
             var args = _args;

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -40,7 +40,7 @@ namespace Jint.Native.Array
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var properties = new PropertyDictionary(3, checkExistingKeys: false)
             {

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -245,7 +245,7 @@ namespace Jint.Native.Array
             base.AddProperty(property, descriptor);
         }
 
-        protected override bool TryGetProperty(JsValue property, out PropertyDescriptor descriptor)
+        protected internal override bool TryGetProperty(JsValue property, out PropertyDescriptor descriptor)
         {
             if (property == CommonProperties.Length)
             {

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -38,7 +38,7 @@ namespace Jint.Native.Array
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var unscopables = new ObjectInstance(_engine)
             {

--- a/Jint/Native/Boolean/BooleanPrototype.cs
+++ b/Jint/Native/Boolean/BooleanPrototype.cs
@@ -28,7 +28,7 @@ namespace Jint.Native.Boolean
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var properties = new PropertyDictionary(3, checkExistingKeys: false)
             {

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -76,7 +76,7 @@ namespace Jint.Native.Date
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;
             const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -39,7 +39,7 @@ namespace Jint.Native.Date
             return obj;
         }
 
-        protected override  void Initialize()
+        protected internal override  void Initialize()
         {
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;
             const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;

--- a/Jint/Native/Error/ErrorPrototype.cs
+++ b/Jint/Native/Error/ErrorPrototype.cs
@@ -37,7 +37,7 @@ namespace Jint.Native.Error
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var properties = new PropertyDictionary(3, checkExistingKeys: false)
             {

--- a/Jint/Native/Function/FunctionPrototype.cs
+++ b/Jint/Native/Function/FunctionPrototype.cs
@@ -30,7 +30,7 @@ namespace Jint.Native.Function
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -18,7 +18,7 @@ namespace Jint.Native.Global
     {
         private readonly StringBuilder _stringBuilder = new StringBuilder();
 
-        private GlobalObject(Engine engine) : base(engine)
+        internal GlobalObject(Engine engine) : base(engine)
         {
         }
 
@@ -27,8 +27,14 @@ namespace Jint.Native.Global
             return new GlobalObject(engine);
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
+            if (_properties != null)
+            {
+                // already forced
+                return;
+            }
+            
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;
             const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
             var properties = new PropertyDictionary(40, checkExistingKeys: false)

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -25,7 +25,7 @@ namespace Jint.Native.Iterator
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var properties = new PropertyDictionary(2, checkExistingKeys: false)
             {

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -293,16 +293,16 @@ namespace Jint.Native
         /// </summary>
         public static JsValue FromObject(Engine engine, object value)
         {
-            if (value == null)
+            return value switch
             {
-                return Null;
-            }
+                null => Null,
+                JsValue jsValue => jsValue,
+                _ => ConvertToJsValue(engine, value)
+            };
+        }
 
-            if (value is JsValue jsValue)
-            {
-                return jsValue;
-            }
-
+        private static JsValue ConvertToJsValue(Engine engine, object value)
+        {
             var converters = engine.Options._ObjectConverters;
             var convertersCount = converters.Count;
             for (var i = 0; i < convertersCount; i++)

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -23,7 +23,7 @@ namespace Jint.Native.Json
             return json;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var properties = new PropertyDictionary(2, checkExistingKeys: false)
             {

--- a/Jint/Native/Map/MapConstructor.cs
+++ b/Jint/Native/Map/MapConstructor.cs
@@ -38,7 +38,7 @@ namespace Jint.Native.Map
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var symbols = new SymbolDictionary(1)
             {

--- a/Jint/Native/Map/MapInstance.cs
+++ b/Jint/Native/Map/MapInstance.cs
@@ -25,7 +25,7 @@ namespace Jint.Native.Map
             return base.GetOwnProperty(property);
         }
 
-        protected override bool TryGetProperty(JsValue property, out PropertyDescriptor descriptor)
+        protected internal override bool TryGetProperty(JsValue property, out PropertyDescriptor descriptor)
         {
             if (property == CommonProperties.Size)
             {

--- a/Jint/Native/Map/MapPrototype.cs
+++ b/Jint/Native/Map/MapPrototype.cs
@@ -29,7 +29,7 @@ namespace Jint.Native.Map
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
             var properties = new PropertyDictionary(12, checkExistingKeys: false)

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -27,7 +27,7 @@ namespace Jint.Native.Math
             return math;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var properties = new PropertyDictionary(45, checkExistingKeys: false)
             {

--- a/Jint/Native/Number/NumberConstructor.cs
+++ b/Jint/Native/Number/NumberConstructor.cs
@@ -39,7 +39,7 @@ namespace Jint.Native.Number
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var properties = new PropertyDictionary(15, checkExistingKeys: false)
             {

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -35,7 +35,7 @@ namespace Jint.Native.Number
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var properties = new PropertyDictionary(8, checkExistingKeys: false)
             {

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -29,7 +29,7 @@ namespace Jint.Native.Object
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             _prototype = Engine.Function.PrototypeObject;
 

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -261,7 +261,7 @@ namespace Jint.Native.Object
             SetProperty(property, descriptor);
         }
 
-        protected virtual bool TryGetProperty(JsValue property, out PropertyDescriptor descriptor)
+        protected internal virtual bool TryGetProperty(JsValue property, out PropertyDescriptor descriptor)
         {
             descriptor = null;
 
@@ -871,7 +871,7 @@ namespace Jint.Native.Object
             Initialize();
         }
 
-        protected virtual void Initialize()
+        protected internal virtual void Initialize()
         {
         }
 

--- a/Jint/Native/Object/ObjectPrototype.cs
+++ b/Jint/Native/Object/ObjectPrototype.cs
@@ -24,7 +24,7 @@ namespace Jint.Native.Object
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -42,7 +42,7 @@ namespace Jint.Native.Promise
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;

--- a/Jint/Native/Promise/PromisePrototype.cs
+++ b/Jint/Native/Promise/PromisePrototype.cs
@@ -26,7 +26,7 @@ namespace Jint.Native.Promise
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;
             const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;

--- a/Jint/Native/Proxy/ProxyConstructor.cs
+++ b/Jint/Native/Proxy/ProxyConstructor.cs
@@ -45,7 +45,7 @@ namespace Jint.Native.Proxy
             return Construct(target.AsObject(), handler.AsObject());
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var properties = new PropertyDictionary(1, checkExistingKeys: false)
             {

--- a/Jint/Native/ReadOnlyJsValue.cs
+++ b/Jint/Native/ReadOnlyJsValue.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Native
+{
+    internal class ReadOnlyJsValue
+    {
+        public static JsValue Create(JsValue inner)
+        {
+            // immutable types are OK to return as-is
+            switch (inner.Type)
+            {
+                case Types.Undefined:
+                case Types.Null:
+                case Types.Boolean:
+                case Types.String:
+                case Types.Number:
+                case Types.Symbol:
+                    return inner;
+                case Types.Object:
+                    return new ReadOnlyObject((ObjectInstance) inner);
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private sealed class ReadOnlyObject : ObjectInstance, ICallable
+        {
+            private readonly ObjectInstance _inner;
+
+            public ReadOnlyObject(ObjectInstance inner) : base(inner.Engine, inner.Class, inner._type)
+            {
+                _inner = inner;
+            }
+
+            public override bool Set(JsValue property, JsValue value, JsValue receiver)
+            {
+                return ExceptionHelper.ThrowNotSupportedException<bool>();
+            }
+
+            public override bool Extensible => false;
+
+            public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
+            {
+                return _inner.GetOwnProperties();
+            }
+
+            public override List<JsValue> GetOwnPropertyKeys(Types types = Types.None | Types.String | Types.Symbol)
+            {
+                return _inner.GetOwnPropertyKeys(types);
+            }
+
+            protected override void AddProperty(JsValue property, PropertyDescriptor descriptor)
+            {
+                ExceptionHelper.ThrowNotSupportedException<bool>();
+            }
+
+            protected internal override bool TryGetProperty(JsValue property, out PropertyDescriptor descriptor)
+            {
+                return _inner.TryGetProperty(property, out descriptor);
+            }
+
+            public override void RemoveOwnProperty(JsValue property)
+            {
+                ExceptionHelper.ThrowNotSupportedException<bool>();
+            }
+
+            public override PropertyDescriptor GetOwnProperty(JsValue property)
+            {
+                return _inner.GetOwnProperty(property);
+            }
+
+            protected internal override void SetOwnProperty(JsValue property, PropertyDescriptor desc)
+            {
+                ExceptionHelper.ThrowNotSupportedException<bool>();
+            }
+
+            public override bool HasProperty(JsValue property) => _inner.HasProperty(property);
+
+            public override bool Delete(JsValue property) => ExceptionHelper.ThrowNotSupportedException<bool>();
+
+            public override bool DefineOwnProperty(JsValue property, PropertyDescriptor desc)
+            {
+                return ExceptionHelper.ThrowNotSupportedException<bool>();
+            }
+
+            protected internal override void Initialize() => _inner.Initialize();
+
+            internal override bool FindWithCallback(JsValue[] arguments, out uint index, out JsValue value, bool visitUnassigned)
+            {
+                return _inner.FindWithCallback(arguments, out index, out value, visitUnassigned);
+            }
+
+            public override bool IsArrayLike => _inner.IsArrayLike;
+            public override uint Length => _inner.Length;
+
+            public override JsValue PreventExtensions()
+            {
+                return ExceptionHelper.ThrowNotSupportedException<bool>();
+            }
+
+            protected internal override ObjectInstance GetPrototypeOf() => (ObjectInstance) Create(_inner.GetPrototypeOf());
+
+            public override bool SetPrototypeOf(JsValue value)
+            {
+                return ExceptionHelper.ThrowNotSupportedException<bool>();
+            }
+
+            public override bool IsArray() => _inner.IsArray();
+
+            internal override bool IsConstructor => _inner.IsConstructor;
+
+            public override bool HasOwnProperty(JsValue property) => _inner.HasOwnProperty(property);
+
+            public override JsValue Get(JsValue property, JsValue receiver) => _inner.Get(property, receiver);
+
+            public override string ToString() => _inner.ToString();
+
+            public override bool Equals(object obj) => _inner.Equals(obj);
+
+            public override int GetHashCode() => _inner.GetHashCode();
+
+            internal override JsValue DoClone() => Create(_inner.DoClone());
+
+            internal override bool IsCallable => _inner.IsCallable;
+
+            public override object ToObject() => _inner.ToObject();
+
+            public override bool Equals(JsValue other) => _inner.Equals(other);
+
+            public JsValue Call(JsValue thisObject, JsValue[] arguments)
+            {
+                if (!(_inner is ICallable callable))
+                {
+                    ExceptionHelper.ThrowTypeError(_inner.Engine);
+                    return null;
+                }
+
+                return callable.Call(thisObject, arguments);
+            }
+        }
+    }
+}

--- a/Jint/Native/Reflect/ReflectInstance.cs
+++ b/Jint/Native/Reflect/ReflectInstance.cs
@@ -25,7 +25,7 @@ namespace Jint.Native.Reflect
             return math;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var properties = new PropertyDictionary(14, checkExistingKeys: false)
             {

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -38,7 +38,7 @@ namespace Jint.Native.RegExp
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var symbols = new SymbolDictionary(1)
             {

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -44,7 +44,7 @@ namespace Jint.Native.RegExp
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;
 

--- a/Jint/Native/Set/SetConstructor.cs
+++ b/Jint/Native/Set/SetConstructor.cs
@@ -37,7 +37,7 @@ namespace Jint.Native.Set
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var symbols = new SymbolDictionary(1)
             {

--- a/Jint/Native/Set/SetInstance.cs
+++ b/Jint/Native/Set/SetInstance.cs
@@ -24,7 +24,7 @@ namespace Jint.Native.Set
             return base.GetOwnProperty(property);
         }
 
-        protected override bool TryGetProperty(JsValue property, out PropertyDescriptor descriptor)
+        protected internal override bool TryGetProperty(JsValue property, out PropertyDescriptor descriptor)
         {
             if (property == CommonProperties.Size)
             {

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -29,7 +29,7 @@ namespace Jint.Native.Set
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var properties = new PropertyDictionary(12, checkExistingKeys: false)
             {

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -41,7 +41,7 @@ namespace Jint.Native.String
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             var properties = new PropertyDictionary(3, checkExistingKeys: false)
             {

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -39,7 +39,7 @@ namespace Jint.Native.String
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;
             const PropertyFlag propertyFlags = lengthFlags | PropertyFlag.Writable;

--- a/Jint/Native/Symbol/SymbolConstructor.cs
+++ b/Jint/Native/Symbol/SymbolConstructor.cs
@@ -38,7 +38,7 @@ namespace Jint.Native.Symbol
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;
             const PropertyFlag propertyFlags = PropertyFlag.AllForbidden;

--- a/Jint/Native/Symbol/SymbolPrototype.cs
+++ b/Jint/Native/Symbol/SymbolPrototype.cs
@@ -29,7 +29,7 @@ namespace Jint.Native.Symbol
             return obj;
         }
 
-        protected override void Initialize()
+        protected internal override void Initialize()
         {
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;
             const PropertyFlag propertyFlags = PropertyFlag.Configurable;

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -350,8 +350,6 @@ namespace Jint
 
         internal List<IObjectConverter> _ObjectConverters => _objectConverters;
 
-        internal List<IConstraint> _Constraints => _constraints;
-
         internal Func<Engine, object, ObjectInstance> _WrapObjectHandler => _wrapObjectHandler;
         internal MemberAccessorDelegate _MemberAccessor => _memberAccessor;
 
@@ -364,6 +362,12 @@ namespace Jint
         internal TimeZoneInfo _LocalTimeZone => _localTimeZone;
 
         internal IReferenceResolver ReferenceResolver => _referenceResolver;
+
+        /// <summary>
+        /// Builds current constraint set, can be used for example when running same engine instance with different
+        /// temporary constrains using <see cref="Engine.ActivateTemporaryConstraints"/>.
+        /// </summary>
+        public IConstraint[] BuildConstraints() => _constraints.ToArray();
 
         private sealed class DefaultReferenceResolver : IReferenceResolver
         {

--- a/Jint/Pooling/IIsolatedEngine.cs
+++ b/Jint/Pooling/IIsolatedEngine.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Jint.Pooling
+{
+    public interface IIsolatedEngine : IScriptExecutor
+    {
+        /// <summary>
+        /// Allows temporarily disable or change constraint checks for the engine.
+        /// Useful for example when initializing engine state with large scripts and/or logic by supplying empty array.
+        /// </summary>
+        /// <param name="newConstraints">New constraints to have in effect during disposable time frame.</param>
+        /// <returns>A <see cref="IDisposable"/> that should be disposed when original constraints should come back into effect.</returns>
+        IDisposable ActivateTemporaryConstraints(IConstraint[] newConstraints);
+    }
+}

--- a/Jint/Pooling/IIsolatedEngineFactory.cs
+++ b/Jint/Pooling/IIsolatedEngineFactory.cs
@@ -1,0 +1,7 @@
+namespace Jint.Pooling
+{
+    public interface IIsolatedEngineFactory : IEngineFactory<IIsolatedEngine>
+    {
+        
+    }
+}

--- a/Jint/Pooling/IsolatedEngineFactory.cs
+++ b/Jint/Pooling/IsolatedEngineFactory.cs
@@ -1,0 +1,144 @@
+using System;
+using Esprima;
+using Esprima.Ast;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Pooling
+{
+    /// <summary>
+    /// Produces engines that have activated isolation context which tries to restrict dirtying the context.
+    /// Offers a pool of engines that can be initialized to certain state and then used with temporary state that
+    /// will be discarded. Every engine in pool should be configured to be in strict mode.
+    /// </summary>
+    public sealed class IsolatedEngineFactory : EngineFactory<IIsolatedEngine>, IIsolatedEngineFactory
+    {
+        private readonly ObjectPool<Engine> _enginePool;
+
+        /// <summary>
+        /// Creates a new instance of an engine pool.
+        /// </summary>
+        /// <param name="options">Options to use for each new Engine instance.</param>
+        /// <param name="initialize">Actions to run against the engine to create initial state, any execution constraints are not honored during this step!</param>
+        /// <param name="size">Size of the pool, defaults to 10.</param>
+        public IsolatedEngineFactory(Options options, Action<IEngine> initialize, int size = 10) 
+            : base(options, initialize)
+        {
+            if (!options.IsStrict)
+            {
+                throw new ArgumentException("options must be set to be in strict mode");
+            }
+            _enginePool = new ObjectPool<Engine>(CreateAndInitializeEngine, size);
+        }
+
+        /// <summary>
+        /// Gets a new engine instance. If there are free items in the pool, one is returned from the pool, otherwise a new instance will be allocated.
+        /// Isolated execution context will be created to shield pooled engine from permanent changes.
+        /// </summary>
+        public override IIsolatedEngine Build()
+        {
+            Engine engine;
+            lock (_enginePool)
+            {
+                engine = _enginePool.Allocate();
+            }
+
+            return new EngineWrapper(engine, this, engine.ActivateIsolatedContext());
+        }
+
+        private void Return(Engine engine)
+        {
+            lock (_enginePool)
+            {
+                _enginePool.Free(engine);
+            }
+        }
+
+        private sealed class EngineWrapper : IIsolatedEngine
+        {
+            private readonly Engine _engine;
+            private readonly IsolatedEngineFactory _pool;
+            private IDisposable _context;
+
+            public EngineWrapper(Engine engine, IsolatedEngineFactory pool, IDisposable context)
+            {
+                _engine = engine;
+                _pool = pool;
+                _context = context;
+            }
+
+            public void SetValue(string name, object obj)
+            {
+                AssertNotDisposed();
+                _engine.SetValue(name, obj);
+            }
+
+            public void SetValue(string name, bool obj)
+            {
+                AssertNotDisposed();
+                _engine.SetValue(name, obj);
+            }
+
+            public void SetValue(string name, int obj)
+            {
+                AssertNotDisposed();
+                _engine.SetValue(name, obj);
+            }
+
+            public void SetValue(string name, string obj)
+            {
+                AssertNotDisposed();
+                _engine.SetValue(name, obj);
+            }
+
+            public void SetValue(string name, double obj)
+            {
+                AssertNotDisposed();
+                _engine.SetValue(name, obj);
+            }
+
+            public JsValue Evaluate(string source, ParserOptions parserOptions)
+            {
+                AssertNotDisposed();
+                return _engine.Evaluate(source, parserOptions ?? Engine.DefaultParserOptions);
+            }
+
+            public JsValue Evaluate(Script program)
+            {
+                AssertNotDisposed();
+                return _engine.Evaluate(program);
+            }
+
+            public IDisposable ActivateTemporaryConstraints(IConstraint[] newConstraints)
+            {
+                AssertNotDisposed();
+                return _engine.ActivateTemporaryConstraints(newConstraints);
+            }
+
+            public void Dispose()
+            {
+                AssertNotDisposed();
+
+                try
+                {
+                    _context.Dispose();
+                    _context = null;
+                }
+                finally
+                {
+                    _pool.Return(_engine);
+                }
+
+                _context = null;
+            }
+
+            private void AssertNotDisposed()
+            {
+                if (_context is null)
+                {
+                    ExceptionHelper.ThrowObjectDisposedException("This engine instance has already been disposed");
+                }
+            }
+        }
+    }
+}

--- a/Jint/Runtime/ExceptionHelper.cs
+++ b/Jint/Runtime/ExceptionHelper.cs
@@ -125,9 +125,9 @@ namespace Jint.Runtime
         }
 
         [DoesNotReturn]
-        public static void ThrowStatementsCountOverflowException()
+        public static void ThrowStatementsCountOverflowException(int executed, int allowed)
         {
-            throw new StatementsCountOverflowException();
+            throw new StatementsCountOverflowException(allowed);
         }
 
         [DoesNotReturn]
@@ -220,6 +220,12 @@ namespace Jint.Runtime
         public static void ThrowExecutionCanceledException()
         {
             throw new ExecutionCanceledException();
+        }
+
+        [DoesNotReturn]
+        public static void ThrowObjectDisposedException(string message)
+        {
+            throw new ObjectDisposedException(message);
         }
     }
 }

--- a/Jint/Runtime/ExecutionContextStack.cs
+++ b/Jint/Runtime/ExecutionContextStack.cs
@@ -37,5 +37,7 @@ namespace Jint.Runtime
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref readonly ExecutionContext Pop() => ref _stack.Pop();
+        
+        public int Count => _stack._size;
     }
 }

--- a/Jint/Runtime/StatementsCountOverflowException.cs
+++ b/Jint/Runtime/StatementsCountOverflowException.cs
@@ -2,7 +2,13 @@
 {
     public sealed class StatementsCountOverflowException : JintException 
     {
-        public StatementsCountOverflowException() : base("The maximum number of statements executed have been reached.")
+        public StatementsCountOverflowException()
+            : base("The maximum number of statements executed have been reached.")
+        {
+        }
+
+        internal StatementsCountOverflowException(int allowed) 
+            : base($"The maximum number of statements executed has reached allowed limit ({allowed}).")
         {
         }
     }


### PR DESCRIPTION
This seems to work now quite nicely, at least as a proof of concept. A disposable context can be created which allows introducing variables and whatnot and when context is disposed they disappear. Also sets everything resolved from outer context (say the real global) as read-only and throws errors if you try to do something like `Math.max = null;`.

Here's the code sample from test case demonstrating the functionality:

```csharp
var engine = new Engine(options => options.Strict());
engine.SetValue("assert", new Action<bool>(Assert.True));

// Set outer variable in global scope
engine.SetValue("outer", 123);
engine.Execute("assert(outer === 123)");
engine.GetValue("outer").ToObject().Should().Be(123);

// Enter new execution context
using (engine.EnterIsolatedContext())
{
	// Can see global scope
	engine.Execute("assert(outer === 123)");

	// Can modify global scope
	engine.Execute("outer = 321");
	engine.GetValue("outer").ToObject().Should().Be(321);

	// Create variable in new context
	engine.Execute("var inner = 456");
	var value = engine.Execute("inner").GetCompletionValue();
	engine.Execute("assert(inner === 456)");

	// cannot break anything
	Assert.Throws<NotSupportedException>(() => engine.Execute("Math.max = null;"));
}

// The new variable is no longer visible
engine.Execute("assert(typeof inner === 'undefined')");

// The new variable is not in the global scope
engine.GetValue("inner").ToObject().Should().BeNull();

var max = engine.Execute("Math.max").GetCompletionValue();
max.ToObject().Should().NotBeNull();

// but can again break things
engine.Execute("Math.max = null;");
engine.GetValue("Math.max").ToObject().Should().BeNull();
```

When coupled with default engine pool implementation (to be done) this should allow the common pattern people request, a pre-warmed engine with scripts that can then be called with temporary catching context that is cleaned after the call.

Relates to
* https://github.com/sebastienros/jint/issues/756
* https://github.com/sebastienros/jint/issues/695
* https://github.com/sebastienros/jint/issues/491

fixes #738
fixes #805