### PR TITLE
Improve error handling for JToken property access

### DIFF
--- a/Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj
+++ b/Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj
@@ -9,10 +9,10 @@
     <ProjectReference Include="..\Jint\Jint.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/Jint.Tests.Ecma/Jint.Tests.Ecma.csproj
+++ b/Jint.Tests.Ecma/Jint.Tests.Ecma.csproj
@@ -6,10 +6,10 @@
     <ProjectReference Include="..\Jint\Jint.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/Jint.Tests.Test262/Jint.Tests.Test262.csproj
+++ b/Jint.Tests.Test262/Jint.Tests.Test262.csproj
@@ -6,11 +6,11 @@
     <ProjectReference Include="..\Jint\Jint.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -12,10 +12,11 @@
     <Reference Include="Microsoft.CSharp" Condition=" '$(TargetFramework)' == 'net461' " />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -11,6 +11,7 @@ using Jint.Native.Object;
 using Jint.Runtime.Interop;
 using Jint.Tests.Runtime.Converters;
 using Jint.Tests.Runtime.Domain;
+using Newtonsoft.Json.Linq;
 using Shapes;
 using Xunit;
 
@@ -2252,7 +2253,7 @@ namespace Jint.Tests.Runtime
 
         [Fact]
         public void SettingValueViaIntegerIndexer()
-        {			
+        {
             var engine = new Engine(cfg => cfg.AllowClr(typeof(FloatIndexer).GetTypeInfo().Assembly));
             engine.SetValue("log", new Action<object>(Console.WriteLine));
             engine.Execute(@"
@@ -2260,10 +2261,21 @@ namespace Jint.Tests.Runtime
                 var fia = new domain.IntegerIndexer();
                 log(fia[0]);
             ");
-            
+
             Assert.Equal(123, engine.Execute("fia[0]").GetCompletionValue().AsNumber());
             engine.Execute("fia[0] = 678;");
             Assert.Equal(678, engine.Execute("fia[0]").GetCompletionValue().AsNumber());
+        }
+
+        [Fact]
+        public void AccessingJObjectShouldWork()
+        {
+            var o = new JObject
+            {
+                new JProperty("name", "test-name")
+            };
+            _engine.SetValue("o", o);
+            Assert.True(_engine.Execute("return o.name == 'test-name'").GetCompletionValue().AsBoolean());
         }
     }
 }

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -7,6 +7,6 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Esprima" Version="2.0.0-beta-1298" />
+    <PackageReference Include="Esprima" Version="2.0.0-beta-1310" />
   </ItemGroup>
 </Project>

--- a/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
@@ -105,8 +105,8 @@ namespace Jint.Runtime.Descriptors.Specialized
                         case null:
                             throw;
                         case ArgumentOutOfRangeException _:
-                            return JsValue.Undefined;
                         case IndexOutOfRangeException _:
+                        case InvalidOperationException _:
                             return JsValue.Undefined;
                         default:
                             throw tie.InnerException;

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -83,6 +83,17 @@ namespace Jint.Runtime.Interop
             return true;
         }
 
+        public override JsValue Get(JsValue property, JsValue receiver)
+        {
+            if (property.IsSymbol())
+            {
+                // wrapped objects cannot have symbol properties
+                return Undefined;
+            }
+
+            return base.Get(property, receiver);
+        }
+
         public override List<JsValue> GetOwnPropertyKeys(Types types = Types.None | Types.String | Types.Symbol)
         {
             return new List<JsValue>(EnumerateOwnPropertyKeys(types));


### PR DESCRIPTION
* we can always ignore Symbol properties for CLR objects, they don't exist
* `InvalidOperationException` is something like the `ArgumentOutOfRangeException` and `IndexOutOfRangeException` which we already ignore

fixes #795