### PR TITLE
Prioritize Non-Generic methods

### DIFF
--- a/Jint.Tests/Runtime/ExtensionMethods/CustomStringExtensions.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/CustomStringExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.Dynamic;
+using System.Linq;
+using Newtonsoft.Json;
 
 namespace Jint.Tests.Runtime.ExtensionMethods
 {
@@ -7,6 +9,16 @@ namespace Jint.Tests.Runtime.ExtensionMethods
         public static string Backwards(this string value)
         {
             return new string(value.Reverse().ToArray());
+        }
+
+        public static T DeserializeObject<T>(this string json)
+        {
+            return JsonConvert.DeserializeObject<T>(json);
+        }
+
+        public static ExpandoObject DeserializeObject(this string json)
+        {
+            return DeserializeObject<ExpandoObject>(json);
         }
     }
 }

--- a/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
@@ -1,4 +1,5 @@
-﻿using Jint.Tests.Runtime.Domain;
+﻿using System.Dynamic;
+using Jint.Tests.Runtime.Domain;
 using Xunit;
 
 namespace Jint.Tests.Runtime.ExtensionMethods
@@ -44,6 +45,18 @@ namespace Jint.Tests.Runtime.ExtensionMethods
             var result = engine.Execute("let numb = 27; numb.Add(13)").GetCompletionValue().AsInteger();
 
             Assert.Equal(40, result);
+        }
+
+        [Fact]
+        public void ShouldPrioritizingNonGenericMethod()
+        {
+            var options = new Options();
+            options.AddExtensionMethods(typeof(CustomStringExtensions));
+
+            var engine = new Engine(options);
+            var result = engine.Execute("\"{'name':'Mickey'}\".DeserializeObject()").GetCompletionValue().ToObject() as dynamic;
+
+            Assert.Equal("Mickey", result.name);
         }
     }
 }

--- a/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
@@ -1,5 +1,4 @@
-﻿using System.Dynamic;
-using Jint.Tests.Runtime.Domain;
+﻿using Jint.Tests.Runtime.Domain;
 using Xunit;
 
 namespace Jint.Tests.Runtime.ExtensionMethods

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -61,12 +61,12 @@ namespace Jint.Runtime.Interop
             static int CreateComparison(MethodDescriptor d1, MethodDescriptor d2)
             {
                 // if its a generic method, put it on the end
-                if (d1.Method.IsGenericMethod)
+                if (d1.Method.IsGenericMethod && !d2.Method.IsGenericMethod)
                 {
                     return 1;
                 }
 
-                if (d2.Method.IsGenericMethod)
+                if (d2.Method.IsGenericMethod && !d1.Method.IsGenericMethod)
                 {
                     return -1;
                 }

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -72,12 +72,12 @@ namespace Jint.Runtime.Interop
                 }
 
                 // put params versions to end, they can be tricky to match and can cause trouble / extra overhead
-                if (d1.HasParams)
+                if (d1.HasParams && !d2.HasParams)
                 {
                     return 1;
                 }
 
-                if (d2.HasParams)
+                if (d2.HasParams && !d1.HasParams)
                 {
                     return -1;
                 }

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -60,6 +60,17 @@ namespace Jint.Runtime.Interop
         {
             static int CreateComparison(MethodDescriptor d1, MethodDescriptor d2)
             {
+                // if its a generic method, put it on the end
+                if (d1.Method.IsGenericMethod)
+                {
+                    return 1;
+                }
+
+                if (d2.Method.IsGenericMethod)
+                {
+                    return -1;
+                }
+
                 // put params versions to end, they can be tricky to match and can cause trouble / extra overhead
                 if (d1.HasParams)
                 {


### PR DESCRIPTION
As mentioned in #814 Generic Methods will now be last in order.
Prevents invoking the Generic Method instead of the Non-Generic Method of same name, if the Generic Method is declared before.

fixes #814