### PR TITLE
Allow calling Proxy revoke method without this context

### DIFF
--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -13,5 +13,16 @@ namespace Jint.Tests.Runtime
             Assert.Equal("a, 1, a, {\"0\":\"a\",\"1\":1,\"2\":\"a\"}", e.Execute("testFunc('a', 1, 'a');").GetCompletionValue().AsString());
             Assert.Equal("a, 1, a, {\"0\":\"a\",\"1\":1,\"2\":\"a\"}", e.Execute("testFunc.bind('anything')('a', 1, 'a');").GetCompletionValue().AsString());
         }
+
+        [Fact]
+        public void ProxyCanBeRevokedWithoutContext()
+        {
+            new Engine()
+                .Execute(@"
+                    var revocable = Proxy.revocable({}, {});
+                    var revoke = revocable.revoke;
+                    revoke.call(null);
+                ");
+        }
     }
 }

--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 
 namespace Jint.Tests.Runtime
@@ -22,6 +23,21 @@ namespace Jint.Tests.Runtime
                     var revocable = Proxy.revocable({}, {});
                     var revoke = revocable.revoke;
                     revoke.call(null);
+                ");
+        }
+
+        [Fact]
+        public void ArrowFunctionShouldBeExtensible()
+        {
+            new Engine()
+                .SetValue("assert", new Action<bool>(Assert.True))
+                .Execute(@"
+                    var a = () => null
+                    Object.defineProperty(a, 'hello', { enumerable: true, get: () => 'world' })
+                    assert(a.hello === 'world')
+
+                    a.foo = 'bar';
+                    assert(a.foo === 'bar');
                 ");
         }
     }

--- a/Jint/Native/Function/ArrowFunctionInstance.cs
+++ b/Jint/Native/Function/ArrowFunctionInstance.cs
@@ -32,7 +32,6 @@ namespace Jint.Native.Function
         {
             _function = function;
 
-            PreventExtensions();
             _prototype = Engine.Function.PrototypeObject;
 
             _length = new LazyPropertyDescriptor(() => JsNumber.Create(function.Initialize(engine, this).Length), PropertyFlag.Configurable);

--- a/Jint/Native/Proxy/ProxyConstructor.cs
+++ b/Jint/Native/Proxy/ProxyConstructor.cs
@@ -75,20 +75,20 @@ namespace Jint.Native.Proxy
 
         private JsValue Revocable(JsValue thisObject, JsValue[] arguments)
         {
-            var p = _engine.Proxy.Construct(arguments, Undefined);
-            var result = _engine.Object.Construct(System.Array.Empty<JsValue>());
-            result.DefineOwnProperty(PropertyRevoke, new PropertyDescriptor(new ClrFunctionInstance(_engine, name: null, Revoke, 0, PropertyFlag.Configurable), PropertyFlag.ConfigurableEnumerableWritable));
-            result.DefineOwnProperty(PropertyProxy, new PropertyDescriptor(Construct(arguments, thisObject), PropertyFlag.ConfigurableEnumerableWritable));
-            return result;
-        }
+            var p = Construct(arguments, thisObject);
 
-        private JsValue Revoke(JsValue thisObject, JsValue[] arguments)
-        {
-            var o = thisObject.AsObject();
-            var proxy = (ProxyInstance) o.Get(PropertyProxy);
-            proxy._handler = null;
-            proxy._target = null;
-            return Undefined;
+            System.Func<JsValue, JsValue[], JsValue> revoke = (JsValue thisObject, JsValue[] arguments) =>
+            {
+                var proxy = (ProxyInstance) p;
+                proxy._handler = null;
+                proxy._target = null;
+                return Undefined;
+            };
+
+            var result = _engine.Object.Construct(System.Array.Empty<JsValue>());
+            result.DefineOwnProperty(PropertyRevoke, new PropertyDescriptor(new ClrFunctionInstance(_engine, name: null, revoke, 0, PropertyFlag.Configurable), PropertyFlag.ConfigurableEnumerableWritable));
+            result.DefineOwnProperty(PropertyProxy, new PropertyDescriptor(p, PropertyFlag.ConfigurableEnumerableWritable));
+            return result;
         }
     }
 }


### PR DESCRIPTION
[immer](https://github.com/immerjs/immer) does not work without this fix.

As far as I understand from [the spec](https://tc39.es/ecma262/#sec-proxy.revocable), the revoke method should not depend on `this` value. 

Added a test which throws an exception without this fix.

Edit: I found another little bug which prevented defining properties on arrow functions. It was a small fix so adding it to this PR. I encountered this error while trying some packages with Webpack 5. 

For example, this works in browsers while it throws `Type Error: null` in Jint:

```
var a = () => null
Object.defineProperty(a, 'hello', { enumerable: true, get: () => 'world' })
console.assert(a.hello === 'world')
```