### PR TITLE
Fix JSON parser line number initialization

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1217,6 +1217,13 @@ myarr[0](0);
         }
 
         [Fact]
+        public void JsonParserShouldHandleEmptyString()
+        {
+            var ex = Assert.Throws<ParserException>(() => _engine.Execute("JSON.parse('');"));
+            Assert.Equal("Line 1: Unexpected end of input", ex.Message);
+       }
+
+        [Fact]
         [ReplaceCulture("fr-FR")]
         public void ShouldBeCultureInvariant()
         {

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -797,7 +797,7 @@ namespace Jint.Native.Json
         {
             _source = code;
             _index = 0;
-            _lineNumber = (_source.Length > 0) ? 1 : 0;
+            _lineNumber = 1;
             _lineStart = 0;
             _length = _source.Length;
             _lookahead = null;


### PR DESCRIPTION
Initializing line number always to 1 as Esprima expects line numbers to start from 1.

fixes #823