### PR TITLE
Gracefully handle recursive engine invocations

### DIFF
--- a/Jint.Tests.Test262/Test262Test.cs
+++ b/Jint.Tests.Test262/Test262Test.cs
@@ -100,7 +100,7 @@ namespace Jint.Tests.Test262
                 var parser = new JavaScriptParser(args.At(0).AsString(), options);
                 var script = parser.ParseScript(strict);
 
-                var value = engine.Execute(script, false).GetCompletionValue();
+                var value = engine.Execute(script).GetCompletionValue();
                 
                 return value;
             }), true, true, true));

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2934,6 +2934,19 @@ x.test = {
             Assert.Equal(1, Convert.ToInt32(engine2.GetValue("x").ToObject()));
         }
 
+        [Fact]
+        public void RecursiveCallStack()
+        {
+            var engine = new Engine();
+            Func<string, object> evaluateCode = code => engine.Execute(code).GetCompletionValue();
+            var evaluateCodeValue = JsValue.FromObject(engine, evaluateCode);
+
+            engine.SetValue("evaluateCode", evaluateCodeValue);
+            var result = (int) engine.Execute(@"evaluateCode('678 + 711')").GetCompletionValue().AsNumber();
+
+            Assert.Equal(1389, result);
+        }
+
         private class Wrapper
         {
             public Testificate Test { get; set; }

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -60,6 +60,8 @@ namespace Jint.Runtime.CallStack
             return item;
         }
 
+        public int Count => _stack._size;
+
         public void Clear()
         {
             _stack.Clear();


### PR DESCRIPTION
Recursive calls were not working when stack recording is active. Before this was not an issue when the test case was running without recursion limits and thus the stack collection was off. Now it's always on and surfaced the problem. Now only resetting state if we know that engine has exited cleanly from earlier call.

fixes #835