### PR TITLE
Should not wrap Type instances as TypeReference by default

### DIFF
--- a/Jint.Tests/Runtime/Domain/Person.cs
+++ b/Jint.Tests/Runtime/Domain/Person.cs
@@ -1,9 +1,13 @@
-﻿namespace Jint.Tests.Runtime.Domain
+﻿using System;
+
+namespace Jint.Tests.Runtime.Domain
 {
     public class Person : IPerson
     {
         public string Name { get; set; }
         public int Age { get; set; }
+
+        public Type TypeProperty { get; set; } = typeof(Person);
 
         public override string ToString()
         {

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -57,6 +57,20 @@ namespace Jint.Tests.Runtime
                 assert(z === 'foo');
             ");
         }
+        
+        [Fact]
+        public void TypePropertyAccess()
+        {
+            var userClass = new Person();
+
+            var result = new Engine()
+                .SetValue("userclass", userClass)
+                .Execute("userclass.TypeProperty.Name;")
+                .GetCompletionValue()
+                .AsString();
+            
+            Assert.Equal("Person", result);
+        }
 
         [Fact]
         public void CanAccessMemberNamedItem()

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -309,7 +309,11 @@ namespace Jint
 
         public Engine SetValue(JsValue name, object obj)
         {
-            return SetValue(name, JsValue.FromObject(this, obj));
+            var value = obj is Type t
+                ? TypeReference.CreateTypeReference(this, t)
+                : JsValue.FromObject(this, obj);
+
+            return SetValue(name, value);
         }
 
         public void LeaveExecutionContext()

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -276,9 +276,6 @@ namespace Jint.Native
         /// <summary>
         /// Creates a valid <see cref="JsValue"/> instance from any <see cref="Object"/> instance
         /// </summary>
-        /// <param name="engine"></param>
-        /// <param name="value"></param>
-        /// <returns></returns>
         public static JsValue FromObject(Engine engine, object value)
         {
             if (value == null)
@@ -309,13 +306,6 @@ namespace Jint.Native
             if (typeMappers.TryGetValue(valueType, out var typeMapper))
             {
                 return typeMapper(engine, value);
-            }
-
-            var type = value as Type;
-            if (type != null)
-            {
-                var typeReference = TypeReference.CreateTypeReference(engine, type);
-                return typeReference;
             }
 
             if (value is System.Array a)


### PR DESCRIPTION
I couldn't find a reason why we would want to convert `Type` instances to `TypeReference` instances unless it's explicit need for type construction (`importNamespace`, explicit `TypeReference.Create`). With this change can now read values like `a.GetType().FullName`, earlier it was hidden as `TypeRefereence` which doesn't expose much. Old behavior can still be achieved by engine type mappers / object converters.

The README shows correct ways to achieve this:

```
and then to assign local namespaces the same way System does it for you, use importNamespace

jint> var Foo = importNamespace('Foo');
jint> var bar = new Foo.Bar();
jint> log(bar.ToString());

adding a specific CLR type reference can be done like this

engine.SetValue("TheType", TypeReference.CreateTypeReference(engine, typeof(TheType)))
```

But there's unit test cases that relies on auto-wrapping:

```
 _engine.SetValue("TestStruct", typeof(TestStruct));
```

So I kept the auto-wrapping when called via `engine.SetValue(name, type)`, but no longer automatic in `JsValue.FromObject`.


fixes #533