### PR TITLE
Tests of CallStack unwinding after caught exception (and quick patch)

### DIFF
--- a/Jint.Tests/Runtime/CallStackTests.cs
+++ b/Jint.Tests/Runtime/CallStackTests.cs
@@ -14,19 +14,20 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             engine.Execute(@"
-function thrower()
-{
-    throw new Error('test');
-}
+                function thrower()
+                {
+                    throw new Error('test');
+                }
 
-try
-{
-    thrower();
-}
-catch (error)
-{
-}
-");
+                try
+                {
+                    thrower();
+                }
+                catch (error)
+                {
+                }
+                "
+            );
             Assert.Equal(0, engine.CallStack.Count);
         }
 
@@ -35,24 +36,24 @@ catch (error)
         {
             var engine = new Engine();
             engine.Execute(@"
-function thrower2()
-{
-    throw new Error('test');
-}
+                function thrower2()
+                {
+                    throw new Error('test');
+                }
 
-function thrower1()
-{
-    thrower2();
-}
+                function thrower1()
+                {
+                    thrower2();
+                }
 
-try
-{
-    thrower1();
-}
-catch (error)
-{
-}
-");
+                try
+                {
+                    thrower1();
+                }
+                catch (error)
+                {
+                }
+            ");
             Assert.Equal(0, engine.CallStack.Count);
         }
     }

--- a/Jint.Tests/Runtime/CallStackTests.cs
+++ b/Jint.Tests/Runtime/CallStackTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jint.Tests.Runtime
+{
+    public class CallStackTests
+    {
+        [Fact]
+        public void ShouldUnwindAfterCaughtException()
+        {
+            var engine = new Engine();
+            engine.Execute(@"
+function thrower()
+{
+    throw new Error('test');
+}
+
+try
+{
+    thrower();
+}
+catch (error)
+{
+}
+");
+            Assert.Equal(0, engine.CallStack.Count);
+        }
+
+        [Fact]
+        public void ShouldUnwindAfterCaughtExceptionNested()
+        {
+            var engine = new Engine();
+            engine.Execute(@"
+function thrower2()
+{
+    throw new Error('test');
+}
+
+function thrower1()
+{
+    thrower2();
+}
+
+try
+{
+    thrower1();
+}
+catch (error)
+{
+}
+");
+            Assert.Equal(0, engine.CallStack.Count);
+        }
+    }
+}


### PR DESCRIPTION
As mentioned in #852, callstack fails to unwind after catching an exception. Not quite sure where this should be handled. Included two tests, one just showing (by way of nested calls) that it's the entire callstack that fails to unwind - it's not just off by 1.