### PR TITLE
Allow delegates to return values from .NET

### DIFF
--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -181,14 +181,12 @@ namespace Jint.Runtime.Interop
 
                         var @vars = Expression.NewArrayInit(jsValueType, initializers);
 
-                        var callExpression = Expression.Block(
-                                                Expression.Call(
+                        var callExpression = Expression.Call(
                                                     Expression.Call(Expression.Constant(function.Target),
                                                         function.Method,
                                                         Expression.Constant(JsValue.Undefined, jsValueType),
                                                         @vars),
-                                                    jsValueType.GetMethod("ToObject")),
-                                                Expression.Empty());
+                                                    jsValueType.GetMethod("ToObject"));
 
                         var dynamicExpression = Expression.Invoke(Expression.Lambda(callExpression, new ReadOnlyCollection<ParameterExpression>(@params)), new ReadOnlyCollection<ParameterExpression>(@params));
 


### PR DESCRIPTION
Removed the void returning block in the delegate handling in function arguments.
This allows expressions like:

 **list.Sum(x => x.cost)**

To be correctly passed through to .NET. Before the change it would say that no matching function found.