### PR TITLE
Allow access to declared Members on DynamicObject

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -2344,12 +2344,17 @@ namespace Jint.Tests.Runtime
             Assert.Equal("a", engine.Execute("test.a").GetCompletionValue().AsString());
             Assert.Equal("b", engine.Execute("test.b").GetCompletionValue().AsString());
 
-            engine.Execute("test.a = 5; test.b = 10;");
+            engine.Execute("test.a = 5; test.b = 10; test.Name = 'Jint'");
 
             Assert.Equal(5, engine.Execute("test.a").GetCompletionValue().AsNumber());
             Assert.Equal(10, engine.Execute("test.b").GetCompletionValue().AsNumber());
+
+            Assert.Equal("Jint", engine.Execute("test.Name").GetCompletionValue().AsString());
+            Assert.True(engine.Execute("test.ContainsKey('a')").GetCompletionValue().AsBoolean());
+            Assert.True(engine.Execute("test.ContainsKey('b')").GetCompletionValue().AsBoolean());
+            Assert.False(engine.Execute("test.ContainsKey('c')").GetCompletionValue().AsBoolean());
         }
-        
+
         private class DynamicClass : DynamicObject
         {
             private readonly Dictionary<string, object> _properties = new Dictionary<string, object>();
@@ -2368,6 +2373,12 @@ namespace Jint.Tests.Runtime
             {
                 _properties[binder.Name] = value;
                 return true;
+            }
+
+            public string Name { get; set; }
+            public bool ContainsKey(string key)
+            {
+                return _properties.ContainsKey(key);
             }
         }
             

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -266,11 +266,6 @@ namespace Jint.Runtime.Interop
 
         private static ReflectionAccessor ResolvePropertyDescriptorFactory(Engine engine, Type type, string memberName)
         {
-            if (typeof(DynamicObject).IsAssignableFrom(type))
-            {
-                return new DynamicObjectAccessor(typeof(void), memberName);
-            }
-            
             var isNumber = uint.TryParse(memberName, out _);
 
             // we can always check indexer if there's one, and then fall back to properties if indexer returns null
@@ -280,6 +275,11 @@ namespace Jint.Runtime.Interop
             if (!isNumber && TryFindStringPropertyAccessor(type, memberName, indexer, out var temp))
             {
                 return temp;
+            }
+
+            if (typeof(DynamicObject).IsAssignableFrom(type))
+            {
+                return new DynamicObjectAccessor(type, memberName);
             }
 
             // if no methods are found check if target implemented indexing


### PR DESCRIPTION
Fixes #856 
Just moved the part which checks for DynamicObject after checking for Declared Members.
Extended the Test "CanAccessDynamicObject" to also access Declared Members.

Hopefully this is helpfull and not just nonsense...