### PR TITLE
Implement Operator Overloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ project.lock.json
 
 .idea
 BenchmarkDotNet.Artifacts*
+.vscode

--- a/Jint.Tests/Runtime/MethodAmbiguityTests.cs
+++ b/Jint.Tests/Runtime/MethodAmbiguityTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Xunit;
+
+namespace Jint.Tests.Runtime
+{
+    public class MethodAmbiguityTests : IDisposable
+    {
+        private readonly Engine _engine;
+
+        public MethodAmbiguityTests()
+        {
+            _engine = new Engine(cfg => cfg
+                .AllowOperatorOverloading())
+                .SetValue("log", new Action<object>(Console.WriteLine))
+                .SetValue("throws", new Func<Action, Exception>(Assert.Throws<Exception>))
+                .SetValue("assert", new Action<bool>(Assert.True))
+                .SetValue("assertFalse", new Action<bool>(Assert.False))
+                .SetValue("equal", new Action<object, object>(Assert.Equal))
+                .SetValue("TestClass", typeof(TestClass))
+                .SetValue("ChildTestClass", typeof(ChildTestClass))
+            ;
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+
+        private void RunTest(string source)
+        {
+            _engine.Execute(source);
+        }
+
+        public class TestClass
+        {
+            public int TestMethod(double a, string b, double c) => 0;
+            public int TestMethod(double a, double b, double c) => 1;
+            public int TestMethod(TestClass a, string b, double c) => 2;
+            public int TestMethod(TestClass a, TestClass b, double c) => 3;
+            public int TestMethod(TestClass a, TestClass b, TestClass c) => 4;
+            public int TestMethod(TestClass a, double b, string c) => 5;
+            public int TestMethod(ChildTestClass a, double b, string c) => 6;
+
+            public static implicit operator TestClass(double i) => new TestClass();
+            public static implicit operator double(TestClass tc) => 0;
+            public static explicit operator string(TestClass tc) => "";
+        }
+
+        public class ChildTestClass : TestClass { }
+
+        [Fact]
+        public void BestMatchingMethodShouldBeCalled()
+        {
+            RunTest(@"
+                var tc = new TestClass();
+                var cc = new ChildTestClass();
+
+                equal(0, tc.TestMethod(0, '', 0));
+                equal(1, tc.TestMethod(0, 0, 0));
+                equal(2, tc.TestMethod(tc, '', 0));
+                equal(3, tc.TestMethod(tc, tc, 0));
+                equal(4, tc.TestMethod(tc, tc, tc));
+                equal(5, tc.TestMethod(tc, tc, ''));
+                equal(5, tc.TestMethod(0, 0, ''));
+
+                equal(6, tc.TestMethod(cc, 0, ''));
+                equal(1, tc.TestMethod(cc, 0, 0));
+                equal(6, tc.TestMethod(cc, 0, tc));
+            ");
+        }
+    }
+}

--- a/Jint.Tests/Runtime/MethodAmbiguityTests.cs
+++ b/Jint.Tests/Runtime/MethodAmbiguityTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Jint.Native;
+using System;
 using Xunit;
 
 namespace Jint.Tests.Runtime
@@ -39,6 +40,7 @@ namespace Jint.Tests.Runtime
             public int TestMethod(TestClass a, TestClass b, TestClass c) => 4;
             public int TestMethod(TestClass a, double b, string c) => 5;
             public int TestMethod(ChildTestClass a, double b, string c) => 6;
+            public int TestMethod(ChildTestClass a, string b, JsValue c) => 7;
 
             public static implicit operator TestClass(double i) => new TestClass();
             public static implicit operator double(TestClass tc) => 0;
@@ -64,7 +66,9 @@ namespace Jint.Tests.Runtime
 
                 equal(6, tc.TestMethod(cc, 0, ''));
                 equal(1, tc.TestMethod(cc, 0, 0));
+                equal(6, tc.TestMethod(cc, cc, ''));
                 equal(6, tc.TestMethod(cc, 0, tc));
+                equal(7, tc.TestMethod(cc, '', {}));
             ");
         }
     }

--- a/Jint.Tests/Runtime/OperatorOverloadingTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadingTests.cs
@@ -33,6 +33,8 @@ namespace Jint.Tests.Runtime
         {
             public double X { get; }
             public double Y { get; }
+            public double SqrMagnitude => X * X + Y * Y;
+            public double Magnitude => Math.Sqrt(SqrMagnitude);
 
             public Vector2(double x, double y)
             {
@@ -47,13 +49,22 @@ namespace Jint.Tests.Runtime
             public static Vector2 operator *(Vector2 left, double right) => new Vector2(left.X * right, left.Y * right);
             public static Vector2 operator /(Vector2 left, double right) => new Vector2(left.X / right, left.Y / right);
 
-            public static double operator +(Vector2 operand) => Math.Sqrt(operand.X * operand.X + operand.Y * operand.Y);
+            public static bool operator >(Vector2 left, Vector2 right) => left.Magnitude > right.Magnitude;
+            public static bool operator <(Vector2 left, Vector2 right) => left.Magnitude < right.Magnitude;
+            public static bool operator >=(Vector2 left, Vector2 right) => left.Magnitude >= right.Magnitude;
+            public static bool operator <=(Vector2 left, Vector2 right) => left.Magnitude <= right.Magnitude;
+            public static Vector2 operator %(Vector2 left, Vector2 right) => new Vector2(left.X % right.X, left.Y % right.Y);
+            public static double operator &(Vector2 left, Vector2 right) => left.X * right.X + left.Y * right.Y;
+            public static Vector2 operator |(Vector2 left, Vector2 right) => right * ((left & right) / right.SqrMagnitude);
+
+
+            public static double operator +(Vector2 operand) => operand.Magnitude;
             public static Vector2 operator -(Vector2 operand) => new Vector2(-operand.X, -operand.Y);
-            public static bool operator !(Vector2 operand) => (+operand) == 0;
+            public static bool operator !(Vector2 operand) => operand.Magnitude == 0;
             public static Vector2 operator ~(Vector2 operand) => new Vector2(operand.Y, operand.X);
             public static Vector2 operator ++(Vector2 operand) => new Vector2(operand.X + 1, operand.Y + 1);
             public static Vector2 operator --(Vector2 operand) => new Vector2(operand.X - 1, operand.Y - 1);
-            
+
             public static implicit operator Vector3(Vector2 val) => new Vector3(val.X, val.Y, 0);
             public static bool operator !=(Vector2 left, Vector2 right) => !(left == right);
             public static bool operator ==(Vector2 left, Vector2 right) => left.X == right.X && left.Y == right.Y;
@@ -74,20 +85,9 @@ namespace Jint.Tests.Runtime
                 Z = z;
             }
 
-            public static Vector3 operator +(Vector3 left, double right)
-            {
-                return new Vector3(left.X + right, left.Y + right, left.Z + right);
-            }
-
-            public static Vector3 operator +(double left, Vector3 right)
-            {
-                return new Vector3(right.X + left, right.Y + left, right.Z + left);
-            }
-
-            public static Vector3 operator +(Vector3 left, Vector3 right)
-            {
-                return new Vector3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
-            }
+            public static Vector3 operator +(Vector3 left, double right) => new Vector3(left.X + right, left.Y + right, left.Z + right);
+            public static Vector3 operator +(double left, Vector3 right) => new Vector3(right.X + left, right.Y + left, right.Z + left);
+            public static Vector3 operator +(Vector3 left, Vector3 right) => new Vector3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
         }
 
         [Fact]
@@ -117,6 +117,37 @@ namespace Jint.Tests.Runtime
                 var r5 = v1 / n;
                 equal(1 / 6, r5.X);
                 equal(2 / 6, r5.Y);
+
+                var r6 = v2 % new Vector2(2, 3);
+                equal(1, r6.X);
+                equal(1, r6.Y);
+
+                var r7 = v2 & v1;
+                equal(11, r7);
+
+                var r8 = new Vector2(3, 4) | new Vector2(2, 0);
+                equal(3, r8.X);
+                equal(0, r8.Y);
+
+                
+                var vSmall = new Vector2(3, 4);
+                var vBig = new Vector2(4, 4);
+
+                assert(vSmall < vBig);
+                assert(vSmall <= vBig);
+                assert(vSmall <= vSmall);
+                assert(vBig > vSmall);
+                assert(vBig >= vSmall);
+                assert(vBig >= vBig);
+
+                assertFalse(vSmall > vSmall);
+                assertFalse(vSmall < vSmall);
+                assertFalse(vSmall > vBig);
+                assertFalse(vSmall >= vBig);
+                assertFalse(vBig < vBig);
+                assertFalse(vBig > vBig);
+                assertFalse(vBig < vSmall);
+                assertFalse(vBig <= vSmall);
             ");
         }
 

--- a/Jint.Tests/Runtime/OperatorOverloadingTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadingTests.cs
@@ -40,81 +40,35 @@ namespace Jint.Tests.Runtime
                 Y = y;
             }
 
-            public static Vector2 operator +(Vector2 left, Vector2 right)
-            {
-                return new Vector2(left.X + right.X, left.Y + right.Y);
-            }
+            public static Vector2 operator +(Vector2 left, Vector2 right) => new Vector2(left.X + right.X, left.Y + right.Y);
 
-            public static Vector2 operator +(Vector2 left, double right)
-            {
-                return new Vector2(left.X + right, left.Y + right);
-            }
+            public static Vector2 operator +(Vector2 left, double right) => new Vector2(left.X + right, left.Y + right);
 
-            public static Vector2 operator +(string left, Vector2 right)
-            {
-                // This exists to test if the operator overloading can choose the correct method
-                return new Vector2(right.X, right.Y);
-            }
+            // This exists to test if the operator overloading can choose the correct method
+            public static Vector2 operator +(string left, Vector2 right) => new Vector2(right.X, right.Y);
 
-            public static Vector2 operator *(Vector2 left, double right)
-            {
-                return new Vector2(left.X * right, left.Y * right);
-            }
+            public static Vector2 operator *(Vector2 left, double right) => new Vector2(left.X * right, left.Y * right);
 
-            public static Vector2 operator /(Vector2 left, double right)
-            {
-                return new Vector2(left.X / right, left.Y / right);
-            }
+            public static Vector2 operator /(Vector2 left, double right) => new Vector2(left.X / right, left.Y / right);
 
-            public static Vector2 operator +(double left, Vector2 right)
-            {
-                return new Vector2(right.X + left, right.Y + left);
-            }
+            public static Vector2 operator +(double left, Vector2 right) => new Vector2(right.X + left, right.Y + left);
 
-            public static implicit operator Vector3(Vector2 val)
-            {
-                return new Vector3(val.X, val.Y, 0);
-            }
+            public static implicit operator Vector3(Vector2 val) => new Vector3(val.X, val.Y, 0);
 
-            public static bool operator !=(Vector2 left, Vector2 right)
-            {
-                return !(left == right);
-            }
+            public static bool operator !=(Vector2 left, Vector2 right) => !(left == right);
 
-            public static bool operator ==(Vector2 left, Vector2 right)
-            {
-                return left.X == right.X && left.Y == right.Y;
-            }
+            public static bool operator ==(Vector2 left, Vector2 right) => left.X == right.X && left.Y == right.Y;
 
-            public override bool Equals(object obj)
-            {
-                return ReferenceEquals(this, obj);
-            }
+            public override bool Equals(object obj) => ReferenceEquals(this, obj);
 
-            public override int GetHashCode()
-            {
-                return X.GetHashCode() + Y.GetHashCode();
-            }
+            public override int GetHashCode() => X.GetHashCode() + Y.GetHashCode();
 
-            public static double operator +(Vector2 operand)
-            {
-                return Math.Sqrt(operand.X * operand.X + operand.Y * operand.Y);
-            }
-
-            public static Vector2 operator -(Vector2 operand)
-            {
-                return new Vector2(-operand.X, -operand.Y);
-            }
-
-            public static bool operator !(Vector2 operand)
-            {
-                return (+operand) == 0;
-            }
-
-            public static Vector2 operator ~(Vector2 operand)
-            {
-                return new Vector2(operand.Y, operand.X);
-            }
+            public static double operator +(Vector2 operand) => Math.Sqrt(operand.X * operand.X + operand.Y * operand.Y);
+            public static Vector2 operator -(Vector2 operand) => new Vector2(-operand.X, -operand.Y);
+            public static bool operator !(Vector2 operand) => (+operand) == 0;
+            public static Vector2 operator ~(Vector2 operand) => new Vector2(operand.Y, operand.X);
+            public static Vector2 operator ++(Vector2 operand) => new Vector2(operand.X + 1, operand.Y + 1);
+            public static Vector2 operator --(Vector2 operand) => new Vector2(operand.X - 1, operand.Y - 1);
         }
 
         public class Vector3
@@ -227,6 +181,29 @@ namespace Jint.Tests.Runtime
 
                 equal(bv.X, 4);
                 equal(bv.Y, 3);
+            ");
+        }
+
+        [Fact]
+        public void OperatorOverloading_IncrementOperatorShouldWork()
+        {
+            RunTest(@"
+                var v = new Vector2(3, 22);
+                var original = v;
+                var pre = ++v;
+                var post = v++;
+
+                equal(original.X, 3);
+                equal(pre.X, 4);
+                equal(post.X, 4);
+                equal(v.X, 5);
+
+                var decPre = --v;
+                var decPost = v--;
+
+                equal(decPre.X, 4);
+                equal(decPost.X, 4);
+                equal(v.X, 3);
             ");
         }
 

--- a/Jint.Tests/Runtime/OperatorOverloadingTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadingTests.cs
@@ -41,27 +41,11 @@ namespace Jint.Tests.Runtime
             }
 
             public static Vector2 operator +(Vector2 left, Vector2 right) => new Vector2(left.X + right.X, left.Y + right.Y);
-
             public static Vector2 operator +(Vector2 left, double right) => new Vector2(left.X + right, left.Y + right);
-
-            // This exists to test if the operator overloading can choose the correct method
             public static Vector2 operator +(string left, Vector2 right) => new Vector2(right.X, right.Y);
-
-            public static Vector2 operator *(Vector2 left, double right) => new Vector2(left.X * right, left.Y * right);
-
-            public static Vector2 operator /(Vector2 left, double right) => new Vector2(left.X / right, left.Y / right);
-
             public static Vector2 operator +(double left, Vector2 right) => new Vector2(right.X + left, right.Y + left);
-
-            public static implicit operator Vector3(Vector2 val) => new Vector3(val.X, val.Y, 0);
-
-            public static bool operator !=(Vector2 left, Vector2 right) => !(left == right);
-
-            public static bool operator ==(Vector2 left, Vector2 right) => left.X == right.X && left.Y == right.Y;
-
-            public override bool Equals(object obj) => ReferenceEquals(this, obj);
-
-            public override int GetHashCode() => X.GetHashCode() + Y.GetHashCode();
+            public static Vector2 operator *(Vector2 left, double right) => new Vector2(left.X * right, left.Y * right);
+            public static Vector2 operator /(Vector2 left, double right) => new Vector2(left.X / right, left.Y / right);
 
             public static double operator +(Vector2 operand) => Math.Sqrt(operand.X * operand.X + operand.Y * operand.Y);
             public static Vector2 operator -(Vector2 operand) => new Vector2(-operand.X, -operand.Y);
@@ -69,6 +53,12 @@ namespace Jint.Tests.Runtime
             public static Vector2 operator ~(Vector2 operand) => new Vector2(operand.Y, operand.X);
             public static Vector2 operator ++(Vector2 operand) => new Vector2(operand.X + 1, operand.Y + 1);
             public static Vector2 operator --(Vector2 operand) => new Vector2(operand.X - 1, operand.Y - 1);
+            
+            public static implicit operator Vector3(Vector2 val) => new Vector3(val.X, val.Y, 0);
+            public static bool operator !=(Vector2 left, Vector2 right) => !(left == right);
+            public static bool operator ==(Vector2 left, Vector2 right) => left.X == right.X && left.Y == right.Y;
+            public override bool Equals(object obj) => ReferenceEquals(this, obj);
+            public override int GetHashCode() => X.GetHashCode() + Y.GetHashCode();
         }
 
         public class Vector3
@@ -109,24 +99,24 @@ namespace Jint.Tests.Runtime
                 var n = 6;
 
                 var r1 = v1 + v2;
-                equal(r1.X, 4);
-                equal(r1.Y, 6);
+                equal(4, r1.X);
+                equal(6, r1.Y);
 
                 var r2 = n + v1;
-                equal(r2.X, 7);
-                equal(r2.Y, 8);
+                equal(7, r2.X);
+                equal(8, r2.Y);
 
                 var r3 = v1 + n;
-                equal(r3.X, 7);
-                equal(r3.Y, 8);
+                equal(7, r3.X);
+                equal(8, r3.Y);
 
                 var r4 = v1 * n;
-                equal(r4.X, 6);
-                equal(r4.Y, 12);
+                equal(6, r4.X);
+                equal(12, r4.Y);
 
                 var r5 = v1 / n;
-                equal(r5.X, 1 / 6);
-                equal(r5.Y, 2 / 6);
+                equal(1 / 6, r5.X);
+                equal(2 / 6, r5.Y);
             ");
         }
 
@@ -137,9 +127,9 @@ namespace Jint.Tests.Runtime
                 var v1 = new Vector2(1, 2);
                 var v2 = new Vector3(4, 5, 6);
                 var res = v1 + v2;
-                equal(res.X, 5);
-                equal(res.Y, 7);
-                equal(res.Z, 6);
+                equal(5, res.X);
+                equal(7, res.Y);
+                equal(6, res.Z);
             ");
         }
 
@@ -173,14 +163,14 @@ namespace Jint.Tests.Runtime
                 assert(!v0);
                 assertFalse(!v);
 
-                equal(+v0, 0);
-                equal(+v, 5);
-                equal(+rv, 5);
-                equal(rv.X, -3);
-                equal(rv.Y, -4);
+                equal(0, +v0);
+                equal(5, +v);
+                equal(5, +rv);
+                equal(-3, rv.X);
+                equal(-4, rv.Y);
 
-                equal(bv.X, 4);
-                equal(bv.Y, 3);
+                equal(4, bv.X);
+                equal(3, bv.Y);
             ");
         }
 
@@ -193,17 +183,17 @@ namespace Jint.Tests.Runtime
                 var pre = ++v;
                 var post = v++;
 
-                equal(original.X, 3);
-                equal(pre.X, 4);
-                equal(post.X, 4);
-                equal(v.X, 5);
+                equal(3, original.X);
+                equal(4, pre.X);
+                equal(4, post.X);
+                equal(5, v.X);
 
                 var decPre = --v;
                 var decPost = v--;
 
-                equal(decPre.X, 4);
-                equal(decPost.X, 4);
-                equal(v.X, 3);
+                equal(4, decPre.X);
+                equal(4, decPost.X);
+                equal(3, v.X);
             ");
         }
 

--- a/Jint.Tests/Runtime/OperatorOverloadingTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadingTests.cs
@@ -17,6 +17,7 @@ namespace Jint.Tests.Runtime
                 .SetValue("equal", new Action<object, object>(Assert.Equal))
                 .SetValue("Vector2", typeof(Vector2))
                 .SetValue("Vector3", typeof(Vector3))
+                .SetValue("Vector2Child", typeof(Vector2Child))
             ;
         }
 
@@ -70,6 +71,13 @@ namespace Jint.Tests.Runtime
             public static bool operator ==(Vector2 left, Vector2 right) => left.X == right.X && left.Y == right.Y;
             public override bool Equals(object obj) => ReferenceEquals(this, obj);
             public override int GetHashCode() => X.GetHashCode() + Y.GetHashCode();
+        }
+
+        public class Vector2Child : Vector2
+        {
+            public Vector2Child(double x, double y) : base(x, y) { }
+
+            public static Vector2Child operator +(Vector2Child left, double right) => new Vector2Child(left.X + 2 * right, left.Y + 2 * right);
         }
 
         public class Vector3
@@ -225,6 +233,27 @@ namespace Jint.Tests.Runtime
                 equal(4, decPre.X);
                 equal(4, decPost.X);
                 equal(3, v.X);
+            ");
+        }
+
+        [Fact]
+        public void OperatorOverloading_ShouldWorkOnDerivedClasses()
+        {
+            RunTest(@"
+                var v1 = new Vector2Child(1, 2);
+                var v2 = new Vector2Child(3, 4);
+                var n = 5;
+
+                var v1v2 = v1 + v2;
+                var v1n = v1 + n;
+
+                // Uses the (Vector2 + Vector2) operator on the parent class
+                equal(4, v1v2.X);
+                equal(6, v1v2.Y);
+
+                // Uses the (Vector2Child + double) operator on the child class
+                equal(11, v1n.X);
+                equal(12, v1n.Y);
             ");
         }
 

--- a/Jint.Tests/Runtime/OperatorOverloadingTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadingTests.cs
@@ -84,6 +84,16 @@ namespace Jint.Tests.Runtime
             {
                 return left.X == right.X && left.Y == right.Y;
             }
+
+            public override bool Equals(object obj)
+            {
+                return ReferenceEquals(this, obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return X.GetHashCode() + Y.GetHashCode();
+            }
         }
 
         public class Vector3

--- a/Jint.Tests/Runtime/OperatorOverloadingTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadingTests.cs
@@ -13,6 +13,7 @@ namespace Jint.Tests.Runtime
                 .AllowOperatorOverloading())
                 .SetValue("log", new Action<object>(Console.WriteLine))
                 .SetValue("assert", new Action<bool>(Assert.True))
+                .SetValue("assertFalse", new Action<bool>(Assert.False))
                 .SetValue("equal", new Action<object, object>(Assert.Equal))
                 .SetValue("Vector2", typeof(Vector2))
                 .SetValue("Vector3", typeof(Vector3))
@@ -94,6 +95,26 @@ namespace Jint.Tests.Runtime
             {
                 return X.GetHashCode() + Y.GetHashCode();
             }
+
+            public static double operator +(Vector2 operand)
+            {
+                return Math.Sqrt(operand.X * operand.X + operand.Y * operand.Y);
+            }
+
+            public static Vector2 operator -(Vector2 operand)
+            {
+                return new Vector2(-operand.X, -operand.Y);
+            }
+
+            public static bool operator !(Vector2 operand)
+            {
+                return (+operand) == 0;
+            }
+
+            public static Vector2 operator ~(Vector2 operand)
+            {
+                return new Vector2(operand.Y, operand.X);
+            }
         }
 
         public class Vector3
@@ -126,7 +147,7 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
-        public void OperatorOverloading_ShouldWork()
+        public void OperatorOverloading_BinaryOperators()
         {
             RunTest(@"
                 var v1 = new Vector2(1, 2);
@@ -134,24 +155,24 @@ namespace Jint.Tests.Runtime
                 var n = 6;
 
                 var r1 = v1 + v2;
-                assert(r1.X === 4);
-                assert(r1.Y === 6);
+                equal(r1.X, 4);
+                equal(r1.Y, 6);
 
                 var r2 = n + v1;
-                assert(r2.X === 7);
-                assert(r2.Y === 8);
+                equal(r2.X, 7);
+                equal(r2.Y, 8);
 
                 var r3 = v1 + n;
-                assert(r3.X === 7);
-                assert(r3.Y === 8);
+                equal(r3.X, 7);
+                equal(r3.Y, 8);
 
                 var r4 = v1 * n;
-                assert(r4.X === 6);
-                assert(r4.Y === 12);
+                equal(r4.X, 6);
+                equal(r4.Y, 12);
 
                 var r5 = v1 / n;
-                assert(r5.X === (1 / 6));
-                assert(r5.Y === (2 / 6));
+                equal(r5.X, 1 / 6);
+                equal(r5.Y, 2 / 6);
             ");
         }
 
@@ -162,9 +183,9 @@ namespace Jint.Tests.Runtime
                 var v1 = new Vector2(1, 2);
                 var v2 = new Vector3(4, 5, 6);
                 var res = v1 + v2;
-                assert(res.X === 5);
-                assert(res.Y === 7);
-                assert(res.Z === 6);
+                equal(res.X, 5);
+                equal(res.Y, 7);
+                equal(res.Z, 6);
             ");
         }
 
@@ -175,15 +196,39 @@ namespace Jint.Tests.Runtime
                 var v1 = new Vector2(1, 2);
                 var v2 = new Vector2(1, 2);
                 assert(v1 == v2);
-                assert(!(v1 != v2));
+                assertFalse(v1 != v2);
                 assert(v1 !== v2);
-                assert(!(v1 === v2));
+                assertFalse(v1 === v2);
 
 
                 var z1 = new Vector3(1, 2, 3);
                 var z2 = new Vector3(1, 2, 3);
-                assert(!(z1 == z2));
+                assertFalse(z1 == z2);
             ");
         }
+
+        [Fact]
+        public void OperatorOverloading_UnaryOperators()
+        {
+            RunTest(@"
+                var v0 = new Vector2(0, 0);
+                var v = new Vector2(3, 4);
+                var rv = -v;
+                var bv = ~v;
+                
+                assert(!v0);
+                assertFalse(!v);
+
+                equal(+v0, 0);
+                equal(+v, 5);
+                equal(+rv, 5);
+                equal(rv.X, -3);
+                equal(rv.Y, -4);
+
+                equal(bv.X, 4);
+                equal(bv.Y, 3);
+            ");
+        }
+
     }
 }

--- a/Jint.Tests/Runtime/OperatorOverloadingTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadingTests.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using Xunit;
+
+namespace Jint.Tests.Runtime
+{
+    public class OperatorOverloadingTests : IDisposable
+    {
+        private readonly Engine _engine;
+
+        public OperatorOverloadingTests()
+        {
+            _engine = new Engine(cfg => cfg
+                .AllowOperatorOverloading())
+                .SetValue("log", new Action<object>(Console.WriteLine))
+                .SetValue("assert", new Action<bool>(Assert.True))
+                .SetValue("equal", new Action<object, object>(Assert.Equal))
+                .SetValue("Vector2", typeof(Vector2))
+                .SetValue("Vector3", typeof(Vector3))
+            ;
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+
+        private void RunTest(string source)
+        {
+            _engine.Execute(source);
+        }
+
+        public class Vector2
+        {
+            public double X { get; }
+            public double Y { get; }
+
+            public Vector2(double x, double y)
+            {
+                X = x;
+                Y = y;
+            }
+
+            public static Vector2 operator +(Vector2 left, Vector2 right)
+            {
+                return new Vector2(left.X + right.X, left.Y + right.Y);
+            }
+
+            public static Vector2 operator +(Vector2 left, double right)
+            {
+                return new Vector2(left.X + right, left.Y + right);
+            }
+
+            public static Vector2 operator +(string left, Vector2 right)
+            {
+                // This exists to test if the operator overloading can choose the correct method
+                return new Vector2(right.X, right.Y);
+            }
+
+            public static Vector2 operator *(Vector2 left, double right)
+            {
+                return new Vector2(left.X * right, left.Y * right);
+            }
+
+            public static Vector2 operator /(Vector2 left, double right)
+            {
+                return new Vector2(left.X / right, left.Y / right);
+            }
+
+            public static Vector2 operator +(double left, Vector2 right)
+            {
+                return new Vector2(right.X + left, right.Y + left);
+            }
+
+            public static implicit operator Vector3(Vector2 val)
+            {
+                return new Vector3(val.X, val.Y, 0);
+            }
+
+            public static bool operator !=(Vector2 left, Vector2 right)
+            {
+                return !(left == right);
+            }
+
+            public static bool operator ==(Vector2 left, Vector2 right)
+            {
+                return left.X == right.X && left.Y == right.Y;
+            }
+        }
+
+        public class Vector3
+        {
+            public double X { get; }
+            public double Y { get; }
+            public double Z { get; }
+
+            public Vector3(double x, double y, double z)
+            {
+                X = x;
+                Y = y;
+                Z = z;
+            }
+
+            public static Vector3 operator +(Vector3 left, double right)
+            {
+                return new Vector3(left.X + right, left.Y + right, left.Z + right);
+            }
+
+            public static Vector3 operator +(double left, Vector3 right)
+            {
+                return new Vector3(right.X + left, right.Y + left, right.Z + left);
+            }
+
+            public static Vector3 operator +(Vector3 left, Vector3 right)
+            {
+                return new Vector3(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
+            }
+        }
+
+        [Fact]
+        public void OperatorOverloading_ShouldWork()
+        {
+            RunTest(@"
+                var v1 = new Vector2(1, 2);
+                var v2 = new Vector2(3, 4);
+                var n = 6;
+
+                var r1 = v1 + v2;
+                assert(r1.X === 4);
+                assert(r1.Y === 6);
+
+                var r2 = n + v1;
+                assert(r2.X === 7);
+                assert(r2.Y === 8);
+
+                var r3 = v1 + n;
+                assert(r3.X === 7);
+                assert(r3.Y === 8);
+
+                var r4 = v1 * n;
+                assert(r4.X === 6);
+                assert(r4.Y === 12);
+
+                var r5 = v1 / n;
+                assert(r5.X === (1 / 6));
+                assert(r5.Y === (2 / 6));
+            ");
+        }
+
+        [Fact]
+        public void OperatorOverloading_ShouldCoerceTypes()
+        {
+            RunTest(@"
+                var v1 = new Vector2(1, 2);
+                var v2 = new Vector3(4, 5, 6);
+                var res = v1 + v2;
+                assert(res.X === 5);
+                assert(res.Y === 7);
+                assert(res.Z === 6);
+            ");
+        }
+
+        [Fact]
+        public void OperatorOverloading_ShouldWorkForEqualityButNotForStrictEquality()
+        {
+            RunTest(@"
+                var v1 = new Vector2(1, 2);
+                var v2 = new Vector2(1, 2);
+                assert(v1 == v2);
+                assert(!(v1 != v2));
+                assert(v1 !== v2);
+                assert(!(v1 === v2));
+
+
+                var z1 = new Vector3(1, 2, 3);
+                var z2 = new Vector3(1, 2, 3);
+                assert(!(z1 == z2));
+            ");
+        }
+    }
+}

--- a/Jint/Extensions/ReflectionExtensions.cs
+++ b/Jint/Extensions/ReflectionExtensions.cs
@@ -44,6 +44,12 @@ namespace Jint.Extensions
                 .Where(m => m.IsExtensionMethod());
         }
 
+        internal static IEnumerable<MethodInfo> GetOperatorOverloadMethods(this Type type)
+        {
+            return type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                .Where(m => m.IsSpecialName);
+        }
+
         private static bool IsExtensionMethod(this MethodBase methodInfo)
         {
             return methodInfo.IsDefined(typeof(ExtensionAttribute), true);

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -24,6 +24,7 @@ namespace Jint
         private DebuggerStatementHandling _debuggerStatementHandling;
         private bool _allowClr;
         private bool _allowClrWrite = true;
+        private bool _allowOperatorOverloading;
         private readonly List<IObjectConverter> _objectConverters = new();
         private Func<Engine, object, ObjectInstance> _wrapObjectHandler;
         private MemberAccessorDelegate _memberAccessor;
@@ -127,7 +128,7 @@ namespace Jint
                 JsValue key = overloads.Key;
                 PropertyDescriptor descriptorWithFallback = null;
                 PropertyDescriptor descriptorWithoutFallback = null;
-                
+
                 if (prototype.HasOwnProperty(key) && prototype.GetOwnProperty(key).Value is ClrFunctionInstance clrFunctionInstance)
                 {
                     descriptorWithFallback = CreateMethodInstancePropertyDescriptor(clrFunctionInstance);
@@ -207,6 +208,12 @@ namespace Jint
         public Options AllowClrWrite(bool allow = true)
         {
             _allowClrWrite = allow;
+            return this;
+        }
+
+        public Options AllowOperatorOverloading(bool allow = true)
+        {
+            _allowOperatorOverloading = allow;
             return this;
         }
 
@@ -334,6 +341,8 @@ namespace Jint
         internal bool IsDebugMode { get; private set; }
 
         internal bool _IsClrWriteAllowed => _allowClrWrite;
+
+        internal bool _IsOperatorOverloadingAllowed => _allowOperatorOverloading;
 
         internal Predicate<Exception> _ClrExceptionsHandler => _clrExceptionsHandler;
 

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -222,12 +222,9 @@ namespace Jint.Runtime.Interop
 #endif
 
                 var castOperator = _knownCastOperators.GetOrAdd(key, _ =>
-                    valueType
-                    .GetMethods(BindingFlags.Public | BindingFlags.Static)
-                    .Concat(type.GetMethods(BindingFlags.Public | BindingFlags.Static))
-                    .FirstOrDefault(m =>
-                        m.IsSpecialName
-                        && type.IsAssignableFrom(m.ReturnType)
+                    valueType.GetOperatorOverloadMethods()
+                    .Concat(type.GetOperatorOverloadMethods())
+                    .FirstOrDefault(m => type.IsAssignableFrom(m.ReturnType)
                         && (m.Name == "op_Implicit" || m.Name == "op_Explicit")));
 
                 if (castOperator != null)

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 using Esprima.Ast;
+using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime.Interop;
@@ -48,10 +49,10 @@ namespace Jint.Runtime.Interpreter.Expressions
 #endif
                 var method = _knownOperators.GetOrAdd(key, _ =>
                 {
-                    var leftMethods = leftType.GetMethods(BindingFlags.Static | BindingFlags.Public);
-                    var rightMethods = rightType.GetMethods(BindingFlags.Static | BindingFlags.Public);
+                    var leftMethods = leftType.GetOperatorOverloadMethods();
+                    var rightMethods = rightType.GetOperatorOverloadMethods();
 
-                    var methods = leftMethods.Concat(rightMethods).Where(x => x.IsSpecialName && x.Name == clrName && x.GetParameters().Length == 2);
+                    var methods = leftMethods.Concat(rightMethods).Where(x => x.Name == clrName && x.GetParameters().Length == 2);
                     var _methods = MethodDescriptor.Build(methods.ToArray());
 
                     return TypeConverter.FindBestMatch(_engine, _methods, _ => arguments).FirstOrDefault()?.Item1;

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -1,4 +1,5 @@
 using Esprima.Ast;
+using Jint.Extensions;
 using Jint.Native;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interop;
@@ -225,8 +226,8 @@ namespace Jint.Runtime.Interpreter.Expressions
 #endif
                 var method = _knownOperators.GetOrAdd(key, _ =>
                 {
-                    var foundMethod = operandType.GetMethods(BindingFlags.Static | BindingFlags.Public)
-                        .FirstOrDefault(x => x.IsSpecialName && x.Name == clrName && x.GetParameters().Length == 1);
+                    var foundMethod = operandType.GetOperatorOverloadMethods()
+                        .FirstOrDefault(x => x.Name == clrName && x.GetParameters().Length == 1);
 
                     if (foundMethod != null)
                     {

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -74,7 +74,8 @@ namespace Jint.Runtime.Interpreter.Expressions
                         break;
                 }
 
-                if (operatorClrName != null && TryOperatorOverloading(operatorClrName, out var result))
+                if (operatorClrName != null &&
+                    TryOperatorOverloading(_engine, _argument.GetValue(), operatorClrName, out var result))
                 {
                     return result;
                 }
@@ -208,9 +209,8 @@ namespace Jint.Runtime.Interpreter.Expressions
             return JsNumber.Create(double.IsNaN(n) ? double.NaN : n * -1);
         }
 
-        private bool TryOperatorOverloading(string clrName, out object result)
+        internal static bool TryOperatorOverloading(Engine _engine, JsValue value, string clrName, out JsValue result)
         {
-            var value = _argument.GetValue();
             var operand = value.ToObject();
 
             if (operand != null)

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -1,12 +1,23 @@
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.Environments;
+using Jint.Runtime.Interop;
 using Jint.Runtime.References;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
     internal sealed class JintUnaryExpression : JintExpression
     {
+#if NETSTANDARD
+        private static readonly ConcurrentDictionary<(string OperatorName, System.Type Operand), MethodDescriptor> _knownOperators = 
+            new ConcurrentDictionary<(string OperatorName, System.Type Operand), MethodDescriptor>();
+#else
+        private static readonly ConcurrentDictionary<string, MethodDescriptor> _knownOperators = new ConcurrentDictionary<string, MethodDescriptor>();
+#endif
+
         private readonly JintExpression _argument;
         private readonly UnaryOperator _operator;
 
@@ -42,6 +53,33 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override object EvaluateInternal()
         {
+            if (_engine.Options._IsOperatorOverloadingAllowed)
+            {
+                string operatorClrName = null;
+                switch (_operator)
+                {
+                    case UnaryOperator.Plus:
+                        operatorClrName = "op_UnaryPlus";
+                        break;
+                    case UnaryOperator.Minus:
+                        operatorClrName = "op_UnaryNegation";
+                        break;
+                    case UnaryOperator.BitwiseNot:
+                        operatorClrName = "op_OnesComplement";
+                        break;
+                    case UnaryOperator.LogicalNot:
+                        operatorClrName = "op_LogicalNot";
+                        break;
+                    default:
+                        break;
+                }
+
+                if (operatorClrName != null && TryOperatorOverloading(operatorClrName, out var result))
+                {
+                    return result;
+                }
+            }
+
             switch (_operator)
             {
                 case UnaryOperator.Plus:
@@ -83,9 +121,9 @@ namespace Jint.Runtime.Interpreter.Expressions
                         {
                             ExceptionHelper.ThrowReferenceError(_engine, r);
                         }
-                        
+
                         var o = TypeConverter.ToObject(_engine, r.GetBase());
-                        var deleteStatus  = o.Delete(r.GetReferencedName());
+                        var deleteStatus = o.Delete(r.GetReferencedName());
                         if (!deleteStatus && r.IsStrictReference())
                         {
                             ExceptionHelper.ThrowTypeError(_engine);
@@ -168,6 +206,43 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             var n = TypeConverter.ToNumber(minusValue);
             return JsNumber.Create(double.IsNaN(n) ? double.NaN : n * -1);
+        }
+
+        private bool TryOperatorOverloading(string clrName, out object result)
+        {
+            var value = _argument.GetValue();
+            var operand = value.ToObject();
+
+            if (operand != null)
+            {
+                var operandType = operand.GetType();
+                var arguments = new[] { value };
+
+#if NETSTANDARD
+                var key = (clrName, operandType);
+#else
+                var key = $"{clrName}->{operandType}";
+#endif
+                var method = _knownOperators.GetOrAdd(key, _ =>
+                {
+                    var foundMethod = operandType.GetMethods(BindingFlags.Static | BindingFlags.Public)
+                        .FirstOrDefault(x => x.IsSpecialName && x.Name == clrName && x.GetParameters().Length == 1);
+
+                    if (foundMethod != null)
+                    {
+                        return new MethodDescriptor(foundMethod);
+                    }
+                    return null;
+                });
+
+                if (method != null)
+                {
+                    result = method.Call(_engine, null, arguments);
+                    return true;
+                }
+            }
+            result = null;
+            return false;
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -61,16 +61,32 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             var value = _engine.GetValue(reference, false);
             var isInteger = value._type == InternalTypes.Integer;
-            var newValue = isInteger
-                ? JsNumber.Create(value.AsInteger() + _change)
-                : JsNumber.Create(TypeConverter.ToNumber(value) + _change);
+
+            JsValue newValue = null;
+
+            var operatorOverloaded = false;
+            if (_engine.Options._IsOperatorOverloadingAllowed)
+            {
+                if (JintUnaryExpression.TryOperatorOverloading(_engine, _argument.GetValue(), _change > 0 ? "op_Increment" : "op_Decrement", out var result))
+                {
+                    operatorOverloaded = true;
+                    newValue = result;
+                }
+            }
+
+            if (!operatorOverloaded)
+            {
+                newValue = isInteger
+                    ? JsNumber.Create(value.AsInteger() + _change)
+                    : JsNumber.Create(TypeConverter.ToNumber(value) + _change);
+            }
 
             _engine.PutValue(reference, newValue);
             _engine._referencePool.Return(reference);
 
             return _prefix
                 ? newValue
-                : (isInteger ? value : JsNumber.Create(TypeConverter.ToNumber(value)));
+                : (isInteger || operatorOverloaded ? value : JsNumber.Create(TypeConverter.ToNumber(value)));
         }
 
         private JsValue UpdateIdentifier()
@@ -91,14 +107,30 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
 
                 var isInteger = value._type == InternalTypes.Integer;
-                var newValue = isInteger
+
+                JsValue newValue = null;
+
+                var operatorOverloaded = false;
+                if (_engine.Options._IsOperatorOverloadingAllowed)
+                {
+                    if (JintUnaryExpression.TryOperatorOverloading(_engine, _argument.GetValue(), _change > 0 ? "op_Increment" : "op_Decrement", out var result))
+                    {
+                        operatorOverloaded = true;
+                        newValue = result;
+                    }
+                }
+
+                if (!operatorOverloaded)
+                {
+                    newValue = isInteger
                     ? JsNumber.Create(value.AsInteger() + _change)
                     : JsNumber.Create(TypeConverter.ToNumber(value) + _change);
+                }
 
                 environmentRecord.SetMutableBinding(name.Key.Name, newValue, strict);
                 return _prefix
                     ? newValue
-                    : (isInteger ? value : JsNumber.Create(TypeConverter.ToNumber(value)));
+                    : (isInteger || operatorOverloaded ? value : JsNumber.Create(TypeConverter.ToNumber(value)));
             }
 
             return null;

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -30,7 +30,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
             else if (expression.Operator == UnaryOperator.Decrement)
             {
-                _change = - 1;
+                _change = -1;
             }
             else
             {

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Esprima.Ast;
+using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Number;
 using Jint.Native.Number.Dtoa;
@@ -644,11 +645,10 @@ namespace Jint.Runtime
                             }
                             else
                             {
-                                if (argType.GetMethods(BindingFlags.Public | BindingFlags.Static)
-                                  .Any(m => m.IsSpecialName &&
-                                      paramType.IsAssignableFrom(m.ReturnType) &&
-                                           (m.Name == "op_Implicit" ||
-                                            m.Name == "op_Explicit")))
+                                if (argType.GetOperatorOverloadMethods()
+                                  .Any(m => paramType.IsAssignableFrom(m.ReturnType) &&
+                                    (m.Name == "op_Implicit" ||
+                                    m.Name == "op_Explicit")))
                                 {
                                     score -= 100;
                                 }

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Native;
@@ -108,7 +110,7 @@ namespace Jint.Runtime
                 }
             }
 
-            return OrdinaryToPrimitive(oi, preferredType == Types.None ? Types.Number :  preferredType);
+            return OrdinaryToPrimitive(oi, preferredType == Types.None ? Types.Number : preferredType);
         }
 
         /// <summary>
@@ -118,7 +120,7 @@ namespace Jint.Runtime
         {
             JsString property1;
             JsString property2;
-            
+
             if (hint == Types.String)
             {
                 property1 = (JsString) "toString";
@@ -335,7 +337,7 @@ namespace Jint.Runtime
 
             return integer;
         }
-        
+
         /// <summary>
         /// https://tc39.es/ecma262/#sec-tointeger
         /// </summary>
@@ -398,7 +400,7 @@ namespace Jint.Runtime
         /// </summary>
         public static ushort ToUint16(JsValue o)
         {
-            return  o._type == InternalTypes.Integer
+            return o._type == InternalTypes.Integer
                 ? (ushort) (uint) o.AsInteger()
                 : (ushort) (uint) ToNumber(o);
         }
@@ -446,7 +448,7 @@ namespace Jint.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string ToString(double d)
         {
-            if (d > long.MinValue && d < long.MaxValue  && Math.Abs(d % 1) <= DoubleIsIntegerTolerance)
+            if (d > long.MinValue && d < long.MaxValue && Math.Abs(d % 1) <= DoubleIsIntegerTolerance)
             {
                 // we are dealing with integer that can be cached
                 return ToString((long) d);
@@ -585,7 +587,7 @@ namespace Jint.Runtime
             {
                 var parameterInfos = m.Parameters;
                 var arguments = argumentProvider(m);
-                if (arguments.Length <= parameterInfos.Length 
+                if (arguments.Length <= parameterInfos.Length
                     && arguments.Length >= parameterInfos.Length - m.ParameterDefaultValuesCount)
                 {
                     if (methods.Length == 0 && arguments.Length == 0)
@@ -604,28 +606,30 @@ namespace Jint.Runtime
                 yield break;
             }
 
+            List<Tuple<int, Tuple<MethodDescriptor, JsValue[]>>> scoredList = null;
+
             foreach (var tuple in matchingByParameterCount)
             {
-                var perfectMatch = true;
+                var score = 0;
                 var parameters = tuple.Item1.Parameters;
                 var arguments = tuple.Item2;
                 for (var i = 0; i < arguments.Length; i++)
                 {
                     var jsValue = arguments[i];
                     var arg = jsValue.ToObject();
+                    var argType = arg?.GetType();
                     var paramType = parameters[i].ParameterType;
                     if (arg == null)
                     {
                         if (!TypeIsNullable(paramType))
                         {
-                            perfectMatch = false;
-                            break;
+                            score -= 10000;
                         }
                     }
-                    else if (arg.GetType() != paramType)
+                    else if (argType != paramType)
                     {
                         // check if we can do conversion from int value to enum
-                        if (paramType.IsEnum && 
+                        if (paramType.IsEnum &&
                             jsValue is JsNumber jsNumber
                             && jsNumber.IsInteger()
                             && Enum.IsDefined(paramType, jsNumber.AsInteger()))
@@ -634,24 +638,47 @@ namespace Jint.Runtime
                         }
                         else
                         {
-                            // no can do
-                            perfectMatch = false;
-                            break;
+                            if (paramType.IsAssignableFrom(argType))
+                            {
+                                score -= 1;
+                            }
+                            else
+                            {
+                                if (argType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                                  .Any(m => m.IsSpecialName &&
+                                      paramType.IsAssignableFrom(m.ReturnType) &&
+                                           (m.Name == "op_Implicit" ||
+                                            m.Name == "op_Explicit")))
+                                {
+                                    score -= 100;
+                                }
+                                else
+                                {
+                                    score -= 10000;
+                                }
+                            }
                         }
                     }
                 }
 
-                if (perfectMatch)
+                if (score == 0)
                 {
-                    yield return new Tuple<MethodDescriptor, JsValue[]>(tuple.Item1, arguments);
+                    yield return Tuple.Create(tuple.Item1, arguments);
                     yield break;
+                }
+                else
+                {
+                    scoredList ??= new List<Tuple<int, Tuple<MethodDescriptor, JsValue[]>>>();
+                    scoredList.Add(Tuple.Create(score, tuple));
                 }
             }
 
-            for (var i = 0; i < matchingByParameterCount.Count; i++)
+            if (scoredList != null)
             {
-                var tuple = matchingByParameterCount[i];
-                yield return new Tuple<MethodDescriptor, JsValue[]>(tuple.Item1, tuple.Item2);
+                foreach (var item in scoredList.OrderByDescending(x => x.Item1))
+                {
+                    yield return item.Item2;
+                }
             }
         }
 

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -627,6 +627,11 @@ namespace Jint.Runtime
                             score -= 10000;
                         }
                     }
+                    else if (paramType == typeof(JsValue))
+                    {
+                        // JsValue is convertible to. But it is still not a perfect match
+                        score -= 1;
+                    }
                     else if (argType != paramType)
                     {
                         // check if we can do conversion from int value to enum
@@ -641,7 +646,7 @@ namespace Jint.Runtime
                         {
                             if (paramType.IsAssignableFrom(argType))
                             {
-                                score -= 1;
+                                score -= 10;
                             }
                             else
                             {
@@ -654,7 +659,7 @@ namespace Jint.Runtime
                                 }
                                 else
                                 {
-                                    score -= 10000;
+                                    score -= 1000;
                                 }
                             }
                         }


### PR DESCRIPTION
Normally, Ecmascript does not allow operator overloading and [the specs](https://tc39.es/ecma262/#sec-addition-operator-plus) are pretty clear on how to handle operators. But since we are running on C#, we may as well use operators that are defined on the C# side. So I added an option for that. The option is off by default.

Binary operators will try to find a C# side overloaded operator first and use it. If it cannot find, will fall back to Ecmascript behavior. (I forgot to do it for unary so the PR is draft for now. Will do asap.)
Also, when this option is turned on, the default type converter will try to find implicit/explicit cast operator and use it as a last resort.