### PR TITLE
Improve generic extension methods and Linq interop

### DIFF
--- a/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
@@ -7,14 +7,6 @@ using Xunit;
 
 namespace Jint.Tests.Runtime.ExtensionMethods
 {
-    public static class TestExtensionMethods
-    {
-        public static double TestExtension<T>(this IEnumerable<T> source) where T : IEquatable<Int32>
-        {
-            return 5;
-        }
-    }
-
     public class ExtensionMethodsTest
     {
         [Fact]
@@ -125,7 +117,7 @@ namespace Jint.Tests.Runtime.ExtensionMethods
         {
             return new Engine(opts =>
             {
-                opts.AddExtensionMethods(typeof(Enumerable), typeof(TestExtensionMethods));
+                opts.AddExtensionMethods(typeof(Enumerable));
             });
         }
 
@@ -164,22 +156,6 @@ namespace Jint.Tests.Runtime.ExtensionMethods
             // The method ambiguity resolver is not so smart to choose the Select method with the correct number of parameters
             // Thus, the following script will not work as expected.
             // stringList.Select((x, i) => x + i).ToArray().join()
-        }
-
-        [Fact]
-        public void ExtensionMethodWithGenericTypeConstraintShouldNotBeCalled()
-        {
-            var engine = GetLinqEngine();
-            var stringList = new List<string>() { "working", "linq" };
-            var intList = new List<int>() { 1, 2 };
-            engine.SetValue("intList", intList);
-            engine.SetValue("stringList", stringList);
-
-
-            var intRes = engine.Execute("intList.TestExtension()").GetCompletionValue().AsNumber();
-            Assert.Equal(5, intRes);
-
-            Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Execute("stringList.TestExtension()"));
         }
     }
 }

--- a/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
@@ -1,9 +1,20 @@
 ﻿using Jint.Native;
 using Jint.Tests.Runtime.Domain;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Jint.Tests.Runtime.ExtensionMethods
 {
+    public static class TestExtensionMethods
+    {
+        public static double TestExtension<T>(this IEnumerable<T> source) where T : IEquatable<Int32>
+        {
+            return 5;
+        }
+    }
+
     public class ExtensionMethodsTest
     {
         [Fact]
@@ -108,6 +119,67 @@ namespace Jint.Tests.Runtime.ExtensionMethods
 
             var propertyValue = engine.Execute("person.bogus").GetCompletionValue();
             Assert.Equal(JsValue.Undefined, propertyValue);
+        }
+
+        private Engine GetLinqEngine()
+        {
+            return new Engine(opts =>
+            {
+                opts.AddExtensionMethods(typeof(Enumerable), typeof(TestExtensionMethods));
+            });
+        }
+
+        [Fact]
+        public void LinqExtensionMethodWithoutGenericParameter()
+        {
+            var engine = GetLinqEngine();
+            var intList = new List<int>() { 0, 1, 2, 3 };
+
+            engine.SetValue("intList", intList);
+            var intSumRes = engine.Execute("intList.Sum()").GetCompletionValue().AsNumber();
+            Assert.Equal(6, intSumRes);
+        }
+
+        [Fact]
+        public void LinqExtensionMethodWithSingleGenericParameter()
+        {
+            var engine = GetLinqEngine();
+            var stringList = new List<string>() { "working", "linq" };
+            engine.SetValue("stringList", stringList);
+
+            var stringSumRes = engine.Execute("stringList.Sum(x => x.length)").GetCompletionValue().AsNumber();
+            Assert.Equal(11, stringSumRes);
+        }
+
+        [Fact]
+        public void LinqExtensionMethodWithMultipleGenericParameters()
+        {
+            var engine = GetLinqEngine();
+            var stringList = new List<string>() { "working", "linq" };
+            engine.SetValue("stringList", stringList);
+
+            var stringRes = engine.Execute("stringList.Select((x) => x + 'a').ToArray().join()").GetCompletionValue().AsString();
+            Assert.Equal("workinga,linqa", stringRes);
+
+            // The method ambiguity resolver is not so smart to choose the Select method with the correct number of parameters
+            // Thus, the following script will not work as expected.
+            // stringList.Select((x, i) => x + i).ToArray().join()
+        }
+
+        [Fact]
+        public void ExtensionMethodWithGenericTypeConstraintShouldNotBeCalled()
+        {
+            var engine = GetLinqEngine();
+            var stringList = new List<string>() { "working", "linq" };
+            var intList = new List<int>() { 1, 2 };
+            engine.SetValue("intList", intList);
+            engine.SetValue("stringList", stringList);
+
+
+            var intRes = engine.Execute("intList.TestExtension()").GetCompletionValue().AsNumber();
+            Assert.Equal(5, intRes);
+
+            Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Execute("stringList.TestExtension()"));
         }
     }
 }

--- a/Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs
+++ b/Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs
@@ -48,26 +48,16 @@ namespace Jint.Runtime.Interop.Reflection
             if (method.IsGenericMethodDefinition && method.ContainsGenericParameters)
             {
                 var methodGenerics = method.GetGenericArguments();
-                var objectGenerics = objectType.IsGenericType ? objectType.GetGenericArguments() : new Type[0];
                 var parameterList = Enumerable.Repeat(typeof(object), methodGenerics.Length).ToArray();
 
-                if (parameterList.Length > 0 && objectGenerics.Length > 0)
+                try
                 {
-                    // Not a definitive solution but a workaround for Linq
-                    // Works because most of Linq methods take the List item type as first parameter
-                    parameterList[0] = objectGenerics[0];
+                    return method.MakeGenericMethod(parameterList);
                 }
-
-                if (methodGenerics.Select((x, i) => x.GetGenericParameterConstraints().All(y => y.IsAssignableFrom(parameterList[i]))).All(x => x))
+                catch
                 {
-                    try
-                    {
-                        return method.MakeGenericMethod(parameterList);
-                    }
-                    catch
-                    {
-                        // If it does not work, let it be. We don't need to do anything
-                    }
+                    // Generic parameter constraints failed probably.
+                    // If it does not work, let it be. We don't need to do anything.
                 }
             }
             return method;

--- a/Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs
+++ b/Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs
@@ -43,7 +43,7 @@ namespace Jint.Runtime.Interop.Reflection
 
         public bool HasMethods => _allExtensionMethods.Count > 0;
 
-        private MethodInfo BindMethodGenericParameters(Type objectType, MethodInfo method)
+        private MethodInfo BindMethodGenericParameters(MethodInfo method)
         {
             if (method.IsGenericMethodDefinition && method.ContainsGenericParameters)
             {
@@ -87,7 +87,7 @@ namespace Jint.Runtime.Interop.Reflection
                 }
             }
 
-            methods = results.Select(method => BindMethodGenericParameters(objectType, method)).ToArray();
+            methods = results.Select(BindMethodGenericParameters).ToArray();
 
             // racy, we don't care, worst case we'll catch up later
             Interlocked.CompareExchange(ref _extensionMethods, new Dictionary<Type, MethodInfo[]>(methodLookup)


### PR DESCRIPTION
I tried to implement this in an effort to improve interop capabilities. I thought it would be easy since Jint supports extension methods now. But the problem is, Linq extension methods are generic, and they work with type inference. It is hard (often impossible) to infer types in Javascript, and there are many issues it creates with covariance, contravariance, generic type constraints, and some other stuff. So, a true Linq compatibility is hard. But I did some improvements that make Linq and other generic extension methods partially work.

Related issue #304
