### PR TITLE
Introduce Engine.Evaluate

### DIFF
--- a/Jint.Benchmark/EngineConstructionBenchmark.cs
+++ b/Jint.Benchmark/EngineConstructionBenchmark.cs
@@ -19,7 +19,7 @@ namespace Jint.Benchmark
         public double BuildEngine()
         {
             var engine = new Engine();
-            return engine.Execute(_program).GetCompletionValue().AsNumber();
+            return engine.Evaluate(_program).AsNumber();
         }
     }
 }

--- a/Jint.Repl/Program.cs
+++ b/Jint.Repl/Program.cs
@@ -19,7 +19,7 @@ namespace Jint.Repl
             engine
                 .SetValue("print", new Action<object>(Console.WriteLine))
                 .SetValue("load", new Func<string, object>(
-                    path => engine.Execute(File.ReadAllText(path)).GetCompletionValue())
+                    path => engine.Evaluate(File.ReadAllText(path)))
                 );
 
             var filename = args.Length > 0 ? args[0] : "";
@@ -31,7 +31,7 @@ namespace Jint.Repl
                 }
 
                 var script = File.ReadAllText(filename);
-                var result = engine.GetValue(engine.Execute(script).GetCompletionValue());
+                engine.Evaluate(script);
                 return;
             }
 
@@ -64,7 +64,7 @@ namespace Jint.Repl
 
                 try
                 {
-                    var result = engine.GetValue(engine.Execute(input, parserOptions).GetCompletionValue());
+                    var result = engine.Evaluate(input, parserOptions);
                     if (!result.IsNull() && !result.IsUndefined())
                     {
                         var str = TypeConverter.ToString(engine.Json.Stringify(engine.Json, Arguments.From(result, Undefined.Instance, "  ")));

--- a/Jint.Tests.Test262/Test262Test.cs
+++ b/Jint.Tests.Test262/Test262Test.cs
@@ -113,9 +113,7 @@ namespace Jint.Tests.Test262
                     var parser = new JavaScriptParser(args.At(0).AsString(), options);
                     var script = parser.ParseScript(strict);
 
-                    var value = engine.Execute(script).GetCompletionValue();
-
-                    return value;
+                    return engine.Evaluate(script);
                 }), true, true, true));
             engine.SetValue("$262", o);
 

--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -25,7 +25,7 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void ArrayPrototypeToStringWithArray()
         {
-            var result = _engine.Execute("Array.prototype.toString.call([1,2,3]);").GetCompletionValue().AsString();
+            var result = _engine.Evaluate("Array.prototype.toString.call([1,2,3]);").AsString();
 
             Assert.Equal("1,2,3", result);
         }
@@ -33,7 +33,7 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void ArrayPrototypeToStringWithNumber()
         {
-            var result = _engine.Execute("Array.prototype.toString.call(1);").GetCompletionValue().AsString();
+            var result = _engine.Evaluate("Array.prototype.toString.call(1);").AsString();
 
             Assert.Equal("[object Number]", result);
         }
@@ -41,7 +41,7 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void ArrayPrototypeToStringWithObject()
         {
-            var result = _engine.Execute("Array.prototype.toString.call({});").GetCompletionValue().AsString();
+            var result = _engine.Evaluate("Array.prototype.toString.call({});").AsString();
 
             Assert.Equal("[object Object]", result);
         }
@@ -49,7 +49,7 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void EmptyStringKey()
         {
-            var result = _engine.Execute("var x=[];x[\"\"]=8;x[\"\"];").GetCompletionValue().AsNumber();
+            var result = _engine.Evaluate("var x=[];x[\"\"]=8;x[\"\"];").AsNumber();
 
             Assert.Equal(8, result);
         }
@@ -126,8 +126,8 @@ namespace Jint.Tests.Runtime
                 }";
 
             _engine.Execute(script);
-            _engine.Execute("const a = new MyArr(1,2);");
-            Assert.True(_engine.Execute("a instanceof MyArr").GetCompletionValue().AsBoolean());
+            _engine.Evaluate("const a = new MyArr(1,2);");
+            Assert.True(_engine.Evaluate("a instanceof MyArr").AsBoolean());
         }
     }
 }

--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -18,49 +18,49 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void NaNToString()
         {
-            var value = _engine.Execute("new Date(NaN).toString();").GetCompletionValue().AsString();
+            var value = _engine.Evaluate("new Date(NaN).toString();").AsString();
             Assert.Equal("Invalid Date", value);
         }
 
         [Fact]
         public void NaNToDateString()
         {
-            var value = _engine.Execute("new Date(NaN).toDateString();").GetCompletionValue().AsString();
+            var value = _engine.Evaluate("new Date(NaN).toDateString();").AsString();
             Assert.Equal("Invalid Date", value);
         }
 
         [Fact]
         public void NaNToTimeString()
         {
-            var value = _engine.Execute("new Date(NaN).toTimeString();").GetCompletionValue().AsString();
+            var value = _engine.Evaluate("new Date(NaN).toTimeString();").AsString();
             Assert.Equal("Invalid Date", value);
         }
 
         [Fact]
         public void NaNToLocaleString()
         {
-            var value = _engine.Execute("new Date(NaN).toLocaleString();").GetCompletionValue().AsString();
+            var value = _engine.Evaluate("new Date(NaN).toLocaleString();").AsString();
             Assert.Equal("Invalid Date", value);
         }
 
         [Fact]
         public void NaNToLocaleDateString()
         {
-            var value = _engine.Execute("new Date(NaN).toLocaleDateString();").GetCompletionValue().AsString();
+            var value = _engine.Evaluate("new Date(NaN).toLocaleDateString();").AsString();
             Assert.Equal("Invalid Date", value);
         }
 
         [Fact]
         public void NaNToLocaleTimeString()
         {
-            var value = _engine.Execute("new Date(NaN).toLocaleTimeString();").GetCompletionValue().AsString();
+            var value = _engine.Evaluate("new Date(NaN).toLocaleTimeString();").AsString();
             Assert.Equal("Invalid Date", value);
         }
 
         [Fact]
         public void ToJsonFromNaNObject()
         {
-            var result = _engine.Execute("JSON.stringify({ date: new Date(NaN) });").GetCompletionValue();
+            var result = _engine.Evaluate("JSON.stringify({ date: new Date(NaN) });");
             Assert.Equal("{\"date\":null}", result.ToString());
         }
     }

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -102,7 +102,7 @@ namespace Jint.Tests.Runtime
         public void ShouldInterpretLiterals(object expected, string source)
         {
             var engine = new Engine();
-            var result = engine.Execute(source).GetCompletionValue().ToObject();
+            var result = engine.Evaluate(source).ToObject();
 
             Assert.Equal(expected, result);
         }
@@ -112,8 +112,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var result = engine
-                .Execute("var foo = 'bar'; foo;")
-                .GetCompletionValue()
+                .Evaluate("var foo = 'bar'; foo;")
                 .ToObject();
 
             Assert.Equal("bar", result);
@@ -133,7 +132,7 @@ namespace Jint.Tests.Runtime
         public void ShouldInterpretBinaryExpression(object expected, string source)
         {
             var engine = new Engine();
-            var result = engine.Execute(source).GetCompletionValue().ToObject();
+            var result = engine.Evaluate(source).ToObject();
 
             Assert.Equal(expected, result);
         }
@@ -144,7 +143,7 @@ namespace Jint.Tests.Runtime
         public void ShouldInterpretUnaryExpression(object expected, string source)
         {
             var engine = new Engine();
-            var result = engine.Execute(source).GetCompletionValue().ToObject();
+            var result = engine.Evaluate(source).ToObject();
 
             Assert.Equal(expected, result);
         }
@@ -718,7 +717,7 @@ namespace Jint.Tests.Runtime
         public void OperatorsPrecedence(object expected, string source)
         {
             var engine = new Engine();
-            var result = engine.Execute(source).GetCompletionValue().ToObject();
+            var result = engine.Evaluate(source).ToObject();
 
             Assert.Equal(expected, result);
         }
@@ -744,7 +743,7 @@ namespace Jint.Tests.Runtime
         public void ShouldEvaluateParseInt(object expected, string source)
         {
             var engine = new Engine();
-            var result = engine.Execute(source).GetCompletionValue().ToObject();
+            var result = engine.Evaluate(source).ToObject();
 
             Assert.Equal(expected, result);
         }
@@ -752,14 +751,14 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void ShouldNotExecuteDebuggerStatement()
         {
-            new Engine().Execute("debugger");
+            new Engine().Evaluate("debugger");
         }
 
         [Fact]
         public void ShouldThrowStatementCountOverflow()
         {
             Assert.Throws<StatementsCountOverflowException>(
-                () => new Engine(cfg => cfg.MaxStatements(100)).Execute("while(true);")
+                () => new Engine(cfg => cfg.MaxStatements(100)).Evaluate("while(true);")
             );
         }
 
@@ -767,7 +766,7 @@ namespace Jint.Tests.Runtime
         public void ShouldThrowMemoryLimitExceeded()
         {
             Assert.Throws<MemoryLimitExceededException>(
-                () => new Engine(cfg => cfg.LimitMemory(2048)).Execute("a=[]; while(true){ a.push(0); }")
+                () => new Engine(cfg => cfg.LimitMemory(2048)).Evaluate("a=[]; while(true){ a.push(0); }")
             );
         }
 
@@ -775,7 +774,7 @@ namespace Jint.Tests.Runtime
         public void ShouldThrowTimeout()
         {
             Assert.Throws<TimeoutException>(
-                () => new Engine(cfg => cfg.TimeoutInterval(new TimeSpan(0, 0, 0, 0, 500))).Execute("while(true);")
+                () => new Engine(cfg => cfg.TimeoutInterval(new TimeSpan(0, 0, 0, 0, 500))).Evaluate("while(true);")
             );
         }
 
@@ -797,7 +796,7 @@ namespace Jint.Tests.Runtime
                         });
 
                         engine.SetValue("waitHandle", waitHandle);
-                        engine.Execute(@"
+                        engine.Evaluate(@"
                             function sleep(millisecondsTimeout) {
                                 var totalMilliseconds = new Date().getTime() + millisecondsTimeout;
 
@@ -987,7 +986,7 @@ namespace Jint.Tests.Runtime
                 cfg.Strict();
             });
 
-            var ex = Assert.Throws<RecursionDepthOverflowException>(() => engine.Execute(@"
+            var ex = Assert.Throws<RecursionDepthOverflowException>(() => engine.Evaluate(@"
 var myarr = new Array(5000);
 for (var i = 0; i < myarr.length; i++) {
     myarr[i] = function(i) {
@@ -1005,7 +1004,7 @@ myarr[0](0);
             const string code = @"var obj = { get test() { return this.test + '2';  } }; obj.test;";
             var engine = new Engine(cfg => cfg.LimitRecursion(10));
             
-            Assert.Throws<RecursionDepthOverflowException>(() => engine.Execute(code).GetCompletionValue());
+            Assert.Throws<RecursionDepthOverflowException>(() => engine.Evaluate(code));
         }
 
         [Fact]
@@ -1129,7 +1128,7 @@ myarr[0](0);
         public void ShouldNotAllowModifyingSharedUndefinedDescriptor()
         {
             var e = new Engine();
-            e.Execute("var x = { literal: true };");
+            e.Evaluate("var x = { literal: true };");
 
             var pd = e.GetValue("x").AsObject().GetProperty("doesNotExist");
             Assert.Throws<InvalidOperationException>(() => pd.Value = "oh no, assigning this breaks things");
@@ -1259,7 +1258,7 @@ myarr[0](0);
         [Fact]
         public void JsonParserShouldHandleEmptyString()
         {
-            var ex = Assert.Throws<ParserException>(() => _engine.Execute("JSON.parse('');"));
+            var ex = Assert.Throws<ParserException>(() => _engine.Evaluate("JSON.parse('');"));
             Assert.Equal("Line 1: Unexpected end of input", ex.Message);
        }
 
@@ -1270,10 +1269,10 @@ myarr[0](0);
             // decimals in french are separated by commas
             var engine = new Engine();
 
-            var result = engine.Execute("1.2 + 2.1").GetCompletionValue().AsNumber();
+            var result = engine.Evaluate("1.2 + 2.1").AsNumber();
             Assert.Equal(3.3d, result);
 
-            result = engine.Execute("JSON.parse('{\"x\" : 3.3}').x").GetCompletionValue().AsNumber();
+            result = engine.Evaluate("JSON.parse('{\"x\" : 3.3}').x").AsNumber();
             Assert.Equal(3.3d, result);
         }
 
@@ -1281,7 +1280,7 @@ myarr[0](0);
         public void ShouldGetTheLastSyntaxNode()
         {
             var engine = new Engine();
-            engine.Execute("1.2");
+            engine.Evaluate("1.2");
 
             var result = engine.GetLastSyntaxNode();
             Assert.Equal(Nodes.Literal, result.Type);
@@ -1293,7 +1292,7 @@ myarr[0](0);
             var engine = new Engine();
             try
             {
-                engine.Execute("1.2+ new", new ParserOptions(source: "jQuery.js"));
+                engine.Evaluate("1.2+ new", new ParserOptions(source: "jQuery.js"));
             }
             catch (ParserException e)
             {
@@ -1308,7 +1307,7 @@ myarr[0](0);
         {
             var engine = new Engine();
 
-            var result = engine.Execute("Date.parse('1970-01-01');").GetCompletionValue().AsNumber();
+            var result = engine.Evaluate("Date.parse('1970-01-01');").AsNumber();
             Assert.Equal(0, result);
         }
 
@@ -1328,8 +1327,7 @@ myarr[0](0);
         {
             var date = new DateTime(2016, 1, 1, 13, 0, 0, DateTimeKind.Local);
             var engine = new Engine().SetValue("localDate", date);
-            engine.Execute(@"localDate");
-            var actual = engine.GetCompletionValue().AsDate().ToDateTime();
+            var actual = engine.Evaluate(@"localDate").AsDate().ToDateTime();
             Assert.Equal(date.ToUniversalTime(), actual.ToUniversalTime());
             Assert.Equal(date.ToLocalTime(), actual.ToLocalTime());
         }
@@ -1341,7 +1339,7 @@ myarr[0](0);
 
             var engine = new Engine(cfg => cfg.LocalTimeZone(customTimeZone));
 
-            var result = engine.Execute("Date.UTC(1970,0,1)").GetCompletionValue().AsNumber();
+            var result = engine.Evaluate("Date.UTC(1970,0,1)").AsNumber();
             Assert.Equal(0, result);
         }
 
@@ -1353,19 +1351,19 @@ myarr[0](0);
 
             var engine = new Engine(cfg => cfg.LocalTimeZone(customTimeZone));
 
-            var epochGetLocalMinutes = engine.Execute("var d = new Date(0); d.getMinutes();").GetCompletionValue().AsNumber();
+            var epochGetLocalMinutes = engine.Evaluate("var d = new Date(0); d.getMinutes();").AsNumber();
             Assert.Equal(11, epochGetLocalMinutes);
 
-            var localEpochGetUtcMinutes = engine.Execute("var d = new Date(1970,0,1); d.getUTCMinutes();").GetCompletionValue().AsNumber();
+            var localEpochGetUtcMinutes = engine.Evaluate("var d = new Date(1970,0,1); d.getUTCMinutes();").AsNumber();
             Assert.Equal(49, localEpochGetUtcMinutes);
 
-            var parseLocalEpoch = engine.Execute("Date.parse('January 1, 1970');").GetCompletionValue().AsNumber();
+            var parseLocalEpoch = engine.Evaluate("Date.parse('January 1, 1970');").AsNumber();
             Assert.Equal(-11 * 60 * 1000, parseLocalEpoch);
 
-            var epochToLocalString = engine.Execute("var d = new Date(0); d.toString();").GetCompletionValue().AsString();
+            var epochToLocalString = engine.Evaluate("var d = new Date(0); d.toString();").AsString();
             Assert.Equal("Thu Jan 01 1970 00:11:00 GMT+0011", epochToLocalString);
 
-            var epochToUTCString = engine.Execute("var d = new Date(0); d.toUTCString();").GetCompletionValue().AsString();
+            var epochToUTCString = engine.Evaluate("var d = new Date(0); d.toUTCString();").AsString();
             Assert.Equal("Thu, 01 Jan 1970 00:00:00 GMT", epochToUTCString);
         }
 
@@ -1395,7 +1393,7 @@ myarr[0](0);
             var engine = new Engine(cfg => cfg.LocalTimeZone(customTimeZone));
 
             engine.SetValue("d", date);
-            var result = engine.Execute("Date.parse(d);").GetCompletionValue().AsNumber();
+            var result = engine.Evaluate("Date.parse(d);").AsNumber();
 
             Assert.Equal(0, result);
         }
@@ -1425,7 +1423,7 @@ myarr[0](0);
             var customTimeZone = TimeZoneInfo.CreateCustomTimeZone(customName, new TimeSpan(0, timespanMinutes, 0), customName, customName, customName, null, false);
             var engine = new Engine(cfg => cfg.LocalTimeZone(customTimeZone)).SetValue("d", date);
 
-            var result = engine.Execute("Date.parse(d);").GetCompletionValue().AsNumber();
+            var result = engine.Evaluate("Date.parse(d);").AsNumber();
 
             Assert.Equal(msPriorMidnight, result);
         }
@@ -1452,7 +1450,7 @@ myarr[0](0);
             var testDateTimeOffset = new DateTimeOffset(testDate, customTimeZone.GetUtcOffset(testDate));
             engine.Execute(
                 string.Format("var d = new Date({0},{1},{2},{3},{4},{5},{6});", testDateTimeOffset.Year, testDateTimeOffset.Month - 1, testDateTimeOffset.Day, testDateTimeOffset.Hour, testDateTimeOffset.Minute, testDateTimeOffset.Second, testDateTimeOffset.Millisecond));
-            Assert.Equal(testDateTimeOffset.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'", CultureInfo.InvariantCulture), engine.Execute("d.toISOString();").GetCompletionValue().ToString());
+            Assert.Equal(testDateTimeOffset.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'", CultureInfo.InvariantCulture), engine.Evaluate("d.toISOString();").ToString());
         }
 
         [Theory, MemberData("TestDates")]
@@ -1467,7 +1465,7 @@ myarr[0](0);
 
             var expected = testDateTimeOffset.ToString("ddd MMM dd yyyy HH:mm:ss", CultureInfo.InvariantCulture);
             expected += testDateTimeOffset.ToString(" 'GMT'zzz", CultureInfo.InvariantCulture).Replace(":", "");
-            var actual = engine.Execute("d.toString();").GetCompletionValue().ToString();
+            var actual = engine.Evaluate("d.toString();").ToString();
 
             Assert.Equal(expected, actual);
         }
@@ -1562,10 +1560,10 @@ var prep = function (fn) { fn(); };
         {
             var engine = new Engine();
 
-            var minValue = engine.Execute("new Date('0001-01-01T00:00:00.000')").GetCompletionValue().ToObject();
+            var minValue = engine.Evaluate("new Date('0001-01-01T00:00:00.000')").ToObject();
             Assert.Equal(new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc), minValue);
 
-            var maxValue = engine.Execute("new Date('9999-12-31T23:59:59.999')").GetCompletionValue().ToObject();
+            var maxValue = engine.Evaluate("new Date('9999-12-31T23:59:59.999')").ToObject();
 
 #if NETCOREAPP
             Assert.Equal(new DateTime(9999, 12, 31, 23, 59, 59, 998, DateTimeKind.Utc), maxValue);
@@ -1663,11 +1661,11 @@ var prep = function (fn) { fn(); };
         public void ShouldRoundToFixedDecimal(double number, int fractionDigits, string result)
         {
             var engine = new Engine();
-            var value = engine.Execute(
+            var value = engine.Evaluate(
                 String.Format("new Number({0}).toFixed({1})",
                     number.ToString(CultureInfo.InvariantCulture),
                     fractionDigits.ToString(CultureInfo.InvariantCulture)))
-                .GetCompletionValue().ToObject();
+                .ToObject();
 
             Assert.Equal(value, result);
         }
@@ -1702,7 +1700,7 @@ var prep = function (fn) { fn(); };
 
             engine.DebugHandler.BreakPoints.Add(new BreakPoint(1, 1));
 
-            engine.Execute(@"var local = true;
+            engine.Evaluate(@"var local = true;
                 if (local === true)
                 {}");
 
@@ -1721,7 +1719,7 @@ var prep = function (fn) { fn(); };
 
             engine.DebugHandler.Step += EngineStep;
 
-            engine.Execute(@"var local = true;
+            engine.Evaluate(@"var local = true;
                 var creatingSomeOtherLine = 0;
                 var lastOneIPromise = true");
 
@@ -1741,7 +1739,7 @@ var prep = function (fn) { fn(); };
             engine.DebugHandler.Step += EngineStep;
             engine.DebugHandler.Break += EngineStep;
 
-            engine.Execute(@"var local = true;");
+            engine.Evaluate(@"var local = true;");
 
             engine.DebugHandler.Step -= EngineStep;
             engine.DebugHandler.Break -= EngineStep;
@@ -1769,7 +1767,7 @@ var prep = function (fn) { fn(); };
             engine.DebugHandler.BreakPoints.Add(new BreakPoint(5, 0));
             engine.DebugHandler.Break += EngineStepVerifyDebugInfo;
 
-            engine.Execute(@"var global = true;
+            engine.Evaluate(@"var global = true;
                             function func1()
                             {
                                 var local = false;
@@ -1820,7 +1818,7 @@ var prep = function (fn) { fn(); };
             engine.DebugHandler.BreakPoints.Add(new BreakPoint(5, 16, "condition === true"));
             engine.DebugHandler.BreakPoints.Add(new BreakPoint(6, 16, "condition === false"));
 
-            engine.Execute(@"var local = true;
+            engine.Evaluate(@"var local = true;
                 var condition = true;
                 if (local === true)
                 {
@@ -1843,7 +1841,7 @@ var prep = function (fn) { fn(); };
 
             engine.DebugHandler.Step += EngineStep;
 
-            engine.Execute(@"function func() // first step - then stepping out
+            engine.Evaluate(@"function func() // first step - then stepping out
                 {
                     ; // shall not step
                     ; // not even here
@@ -1865,7 +1863,7 @@ var prep = function (fn) { fn(); };
 
             engine.DebugHandler.Step += EngineStepOutWhenInsideFunction;
 
-            engine.Execute(@"function func() // first step
+            engine.Evaluate(@"function func() // first step
                 {
                     ; // third step - now stepping out
                     ; // it should not step here
@@ -1901,7 +1899,7 @@ var prep = function (fn) { fn(); };
             engine.DebugHandler.BreakPoints.Add(new BreakPoint(4, 33));
             engine.DebugHandler.Break += EngineStep;
 
-            engine.Execute(@"var global = true;
+            engine.Evaluate(@"var global = true;
                             function func1()
                             {
                                 var local =
@@ -1924,7 +1922,7 @@ var prep = function (fn) { fn(); };
             stepMode = StepMode.Over;
             engine.DebugHandler.Step += EngineStep;
 
-            engine.Execute(@"function func() // first step
+            engine.Evaluate(@"function func() // first step
                 {
                     ; // third step - it shall not step here
                     ; // it shall not step here
@@ -1947,7 +1945,7 @@ var prep = function (fn) { fn(); };
             stepMode = StepMode.Over;
             engine.DebugHandler.Step += EngineStep;
 
-            engine.Execute(@"var step1 = 1; // first step
+            engine.Evaluate(@"var step1 = 1; // first step
                 var step2 = 2; // second step
                 if (step1 !== step2) // third step
                 { // fourth step
@@ -2006,7 +2004,7 @@ var prep = function (fn) { fn(); };
         public void HexZeroAsArrayIndexShouldWork()
         {
             var engine = new Engine();
-            engine.Execute("var t = '1234'; var value = null;");
+            engine.Evaluate("var t = '1234'; var value = null;");
             Assert.Equal("1", engine.Execute("value = t[0x0];").GetValue("value").AsString());
             Assert.Equal("1", engine.Execute("value = t[0];").GetValue("value").AsString());
             Assert.Equal("1", engine.Execute("value = t['0'];").GetValue("value").AsString());
@@ -2039,7 +2037,7 @@ var prep = function (fn) { fn(); };
                 .SetValue("equal", new Action<object, object>(Assert.Equal))
                 ;
 
-            engine.Execute(@"
+            engine.Evaluate(@"
                     var d = new Date(1433160000000);
 
                     equal('Mon Jun 01 2015 05:00:00 GMT-0700', d.toString());
@@ -2061,7 +2059,7 @@ var prep = function (fn) { fn(); };
                 .SetValue("equal", new Action<object, object>(Assert.Equal))
                 ;
 
-            engine.Execute(@"
+            engine.Evaluate(@"
                     var d = new Date(2016, 8, 1);
 
                     equal('Thu Sep 01 2016 00:00:00 GMT-0400', d.toString());
@@ -2081,7 +2079,7 @@ var prep = function (fn) { fn(); };
                 .SetValue("log", new Action<object>(Console.WriteLine))
                 .SetValue("assert", new Action<bool>(Assert.True))
                 .SetValue("equal", new Action<object, object>(Assert.Equal))
-                .Execute(@"
+                .Evaluate(@"
                     var d = new Date(1433160000000);
                     equal(Date.parse(d.toString()), d.valueOf());
                     equal(Date.parse(d.toLocaleString()), d.valueOf());
@@ -2101,12 +2099,12 @@ var prep = function (fn) { fn(); };
                 .SetValue("assert", new Action<bool>(Assert.True))
                 .SetValue("equal", new Action<object, object>(Assert.Equal));
 
-            engine.Execute("var d = new Number(-1.23);");
-            engine.Execute("equal('-1.23', d.toString());");
+            engine.Evaluate("var d = new Number(-1.23);");
+            engine.Evaluate("equal('-1.23', d.toString());");
             
             // NET 5 globalization APIs use ICU libraries on newer Windows 10 giving different result
             // build server is older Windows...
-            engine.Execute("assert('-1,230' === d.toLocaleString() || '-1,23' === d.toLocaleString());");
+            engine.Evaluate("assert('-1,230' === d.toLocaleString() || '-1,23' === d.toLocaleString());");
         }
 
         [Fact]
@@ -2191,7 +2189,7 @@ var prep = function (fn) { fn(); };
             try
             {
                 new Engine()
-                    .Execute(@"
+                    .Evaluate(@"
                     function test(s) {
                         o.boom();
                     }
@@ -2232,7 +2230,7 @@ var prep = function (fn) { fn(); };
             engine.SetValue("guid1", guid1);
             engine.SetValue("guid2", guid2);
 
-            var result = engine.Execute("guid1 == guid2").GetCompletionValue().AsBoolean();
+            var result = engine.Evaluate("guid1 == guid2").AsBoolean();
 
             Assert.True(result);
         }
@@ -2241,7 +2239,7 @@ var prep = function (fn) { fn(); };
         public void CanStringifyToConsole()
         {
             var engine = new Engine(options => options.AllowClr(typeof(Console).Assembly));
-            engine.Execute("System.Console.WriteLine(JSON.stringify({x:12, y:14}));");
+            engine.Evaluate("System.Console.WriteLine(JSON.stringify({x:12, y:14}));");
         }
 
         [Fact]
@@ -2253,7 +2251,7 @@ var prep = function (fn) { fn(); };
 
             engine.SetValue("guid1", guid1);
 
-            var result = engine.Execute("guid1 == {}").GetCompletionValue().AsBoolean();
+            var result = engine.Evaluate("guid1 == {}").AsBoolean();
 
             Assert.False(result);
         }
@@ -2263,7 +2261,7 @@ var prep = function (fn) { fn(); };
         {
             // 53.6841659 cannot be converted by V8's DToA => "old" DToA code will be used.
             var engine = new Engine();
-            var val = engine.Execute("JSON.stringify(53.6841659)").GetCompletionValue();
+            var val = engine.Evaluate("JSON.stringify(53.6841659)");
 
             Assert.Equal("53.6841659", val.AsString());
         }
@@ -2272,7 +2270,7 @@ var prep = function (fn) { fn(); };
         public void ShouldStringifyObjectWithPropertiesToSameRef()
         {
             var engine = new Engine();
-            var res = engine.Execute(@"
+            var res = engine.Evaluate(@"
                 var obj = {
                     a : [],
                     a1 : ['str'],
@@ -2282,7 +2280,7 @@ var prep = function (fn) { fn(); };
                 obj.b = obj.a;
                 obj.b1 = obj.a1;
                 JSON.stringify(obj);
-            ").GetCompletionValue();
+            ");
 
             Assert.True(res == "{\"a\":[],\"a1\":[\"str\"],\"a2\":{},\"a3\":{\"prop\":\"val\"},\"b\":[],\"b1\":[\"str\"]}");
         }
@@ -2291,7 +2289,7 @@ var prep = function (fn) { fn(); };
         public void ShouldThrowOnSerializingCyclicRefObject()
         {
             var engine = new Engine();
-            var res = engine.Execute(@"
+            var res = engine.Evaluate(@"
                 (function(){
                     try{
                         a = [];
@@ -2302,7 +2300,7 @@ var prep = function (fn) { fn(); };
                         return ex.message;
                     }
                 })();
-            ").GetCompletionValue();
+            ");
 
             Assert.True(res == "Cyclic reference detected.");
         }
@@ -2322,7 +2320,7 @@ var prep = function (fn) { fn(); };
         public void ShouldEvaluateEscape(object expected, string source)
         {
             var engine = new Engine();
-            var result = engine.Execute(source).GetCompletionValue().ToObject();
+            var result = engine.Evaluate(source).ToObject();
 
             Assert.Equal(expected, result);
         }
@@ -2533,7 +2531,7 @@ var prep = function (fn) { fn(); };
         public void ShouldEvaluateUnescape(object expected, string source)
         {
             var engine = new Engine();
-            var result = engine.Execute(source).GetCompletionValue().ToObject();
+            var result = engine.Evaluate(source).ToObject();
 
             Assert.Equal(expected, result);
         }
@@ -2554,7 +2552,7 @@ var prep = function (fn) { fn(); };
         public void ShouldExtractDateParts(string source, double expected)
         {
             var engine = new Engine();
-            var result = engine.Execute(source).GetCompletionValue().ToObject();
+            var result = engine.Evaluate(source).ToObject();
 
             Assert.Equal(expected, result);
         }
@@ -2568,7 +2566,7 @@ var prep = function (fn) { fn(); };
         public void ShouldPadStart(string source, object expected)
         {
             var engine = new Engine();
-            var result = engine.Execute(source).GetCompletionValue().ToObject();
+            var result = engine.Evaluate(source).ToObject();
 
             Assert.Equal(expected, result);
         }
@@ -2581,8 +2579,7 @@ var prep = function (fn) { fn(); };
         public void ShouldPadEnd(string source, object expected)
         {
             var engine = new Engine();
-            var result = engine.Execute(source).GetCompletionValue().ToObject();
-
+            var result = engine.Evaluate(source).ToObject();
             Assert.Equal(expected, result);
         }
 
@@ -2624,7 +2621,7 @@ var prep = function (fn) { fn(); };
         public void ShouldStartWith(string source, object expected)
         {
             var engine = new Engine();
-            var result = engine.Execute(source).GetCompletionValue().ToObject();
+            var result = engine.Evaluate(source).ToObject();
 
             Assert.Equal(expected, result);
         }
@@ -2734,8 +2731,8 @@ var prep = function (fn) { fn(); };
         public void ShouldSupportDateConsturctorWithArgumentOutOfRange(string expected, string actual)
         {
             var engine = new Engine(o => o.LocalTimeZone(TimeZoneInfo.Utc));
-            var expectedValue = engine.Execute(expected).GetCompletionValue().ToObject();
-            var actualValue = engine.Execute(actual).GetCompletionValue().ToObject();
+            var expectedValue = engine.Evaluate(expected).ToObject();
+            var actualValue = engine.Evaluate(actual).ToObject();
             Assert.Equal(expectedValue, actualValue);
         }
 
@@ -2807,8 +2804,8 @@ function output(x) {
 };
 ";
             _engine.Execute(program);
-            var result1 = (ObjectInstance)_engine.Execute("output(x1)").GetCompletionValue();
-            var result2 = (ObjectInstance)_engine.Execute("output(x2)").GetCompletionValue();
+            var result1 = (ObjectInstance)_engine.Evaluate("output(x1)");
+            var result2 = (ObjectInstance)_engine.Evaluate("output(x2)");
 
             Assert.Equal(9, TypeConverter.ToNumber(result1.Get("TestDictionarySum1")));
             Assert.Equal(9, TypeConverter.ToNumber(result1.Get("TestDictionarySum2")));
@@ -2895,10 +2892,10 @@ function output(x) {
         public void ShouldReportErrorForInvalidJson()
         {
             var engine = new Engine();
-            var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("JSON.parse('[01]')"));
+            var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("JSON.parse('[01]')"));
             Assert.Equal("Unexpected token '1'", ex.Message);
 
-            var voidCompletion = engine.Execute("try { JSON.parse('01') } catch (e) {}").GetCompletionValue();
+            var voidCompletion = engine.Evaluate("try { JSON.parse('01') } catch (e) {}");
             Assert.Equal(JsValue.Undefined, voidCompletion);
         }
 
@@ -2929,22 +2926,22 @@ x.test = {
             );
             Assert.IsType<TestTypeConverter>(engine.ClrTypeConverter);
             engine.SetValue("x", new Testificate());
-            Assert.Throws<JavaScriptException>(() => engine.Execute("c.Name"));
+            Assert.Throws<JavaScriptException>(() => engine.Evaluate("c.Name"));
         }
 
         [Fact]
         public void ShouldAllowDollarPrefixForProperties()
         {
             _engine.SetValue("str", "Hello");
-            _engine.Execute("equal(undefined, str.$ref);");
-            _engine.Execute("equal(undefined, str.ref);");
-            _engine.Execute("equal(undefined, str.$foo);");
-            _engine.Execute("equal(undefined, str.foo);");
-            _engine.Execute("equal(undefined, str['$foo']);");
-            _engine.Execute("equal(undefined, str['foo']);");
+            _engine.Evaluate("equal(undefined, str.$ref);");
+            _engine.Evaluate("equal(undefined, str.ref);");
+            _engine.Evaluate("equal(undefined, str.$foo);");
+            _engine.Evaluate("equal(undefined, str.foo);");
+            _engine.Evaluate("equal(undefined, str['$foo']);");
+            _engine.Evaluate("equal(undefined, str['foo']);");
 
-            _engine.Execute("equal(false, str.hasOwnProperty('$foo'));");
-            _engine.Execute("equal(false, str.hasOwnProperty('foo'));");
+            _engine.Evaluate("equal(false, str.hasOwnProperty('$foo'));");
+            _engine.Evaluate("equal(false, str.hasOwnProperty('foo'));");
         }
 
         [Fact]
@@ -2976,11 +2973,11 @@ x.test = {
         public void RecursiveCallStack()
         {
             var engine = new Engine();
-            Func<string, object> evaluateCode = code => engine.Execute(code).GetCompletionValue();
+            Func<string, object> evaluateCode = code => engine.Evaluate(code);
             var evaluateCodeValue = JsValue.FromObject(engine, evaluateCode);
 
             engine.SetValue("evaluateCode", evaluateCodeValue);
-            var result = (int) engine.Execute(@"evaluateCode('678 + 711')").GetCompletionValue().AsNumber();
+            var result = (int) engine.Evaluate(@"evaluateCode('678 + 711')").AsNumber();
 
             Assert.Equal(1389, result);
         }

--- a/Jint.Tests/Runtime/ErrorTests.cs
+++ b/Jint.Tests/Runtime/ErrorTests.cs
@@ -203,8 +203,8 @@ var x = b(7);";
         {
             var engine = new Engine();
             engine.Execute($"const o = new {type}();");
-            Assert.True(engine.Execute($"o.constructor === {type}").GetCompletionValue().AsBoolean());
-            Assert.Equal(type, engine.Execute("o.constructor.name").GetCompletionValue().AsString());
+            Assert.True(engine.Evaluate($"o.constructor === {type}").AsBoolean());
+            Assert.Equal(type, engine.Evaluate("o.constructor.name").AsString());
         }
 
         private static void EqualIgnoringNewLineDifferences(string expected, string actual)

--- a/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
@@ -20,7 +20,7 @@ namespace Jint.Tests.Runtime.ExtensionMethods
 
             var engine = new Engine(options);
             engine.SetValue("person", person);
-            var age = engine.Execute("person.MultiplyAge(2)").GetCompletionValue().AsInteger();
+            var age = engine.Evaluate("person.MultiplyAge(2)").AsInteger();
 
             Assert.Equal(70, age);
         }
@@ -32,7 +32,7 @@ namespace Jint.Tests.Runtime.ExtensionMethods
             options.AddExtensionMethods(typeof(CustomStringExtensions));
 
             var engine = new Engine(options);
-            var result = engine.Execute("\"Hello World!\".Backwards()").GetCompletionValue().AsString();
+            var result = engine.Evaluate("\"Hello World!\".Backwards()").AsString();
 
             Assert.Equal("!dlroW olleH", result);
         }
@@ -44,7 +44,7 @@ namespace Jint.Tests.Runtime.ExtensionMethods
             options.AddExtensionMethods(typeof(DoubleExtensions));
 
             var engine = new Engine(options);
-            var result = engine.Execute("let numb = 27; numb.Add(13)").GetCompletionValue().AsInteger();
+            var result = engine.Evaluate("let numb = 27; numb.Add(13)").AsInteger();
 
             Assert.Equal(40, result);
         }
@@ -56,7 +56,7 @@ namespace Jint.Tests.Runtime.ExtensionMethods
             options.AddExtensionMethods(typeof(CustomStringExtensions));
 
             var engine = new Engine(options);
-            var result = engine.Execute("\"{'name':'Mickey'}\".DeserializeObject()").GetCompletionValue().ToObject() as dynamic;
+            var result = engine.Evaluate("\"{'name':'Mickey'}\".DeserializeObject()").ToObject() as dynamic;
 
             Assert.Equal("Mickey", result.name);
         }
@@ -70,12 +70,12 @@ namespace Jint.Tests.Runtime.ExtensionMethods
             });
 
             //uses split function from StringPrototype
-            var arr = engine.Execute("'yes,no'.split(',')").GetCompletionValue().AsArray();
+            var arr = engine.Evaluate("'yes,no'.split(',')").AsArray();
             Assert.Equal("yes", arr[0]);
             Assert.Equal("no", arr[1]);
 
             //uses split function from CustomStringExtensions
-            var arr2 = engine.Execute("'yes,no'.split(2)").GetCompletionValue().AsArray();
+            var arr2 = engine.Evaluate("'yes,no'.split(2)").AsArray();
             Assert.Equal("ye", arr2[0]);
             Assert.Equal("s,no", arr2[1]);
         }
@@ -89,7 +89,7 @@ namespace Jint.Tests.Runtime.ExtensionMethods
             });
 
             //uses the overridden split function from OverrideStringPrototypeExtensions
-            var arr = engine.Execute("'yes,no'.split(',')").GetCompletionValue().AsArray();
+            var arr = engine.Evaluate("'yes,no'.split(',')").AsArray();
             Assert.Equal("YES", arr[0]);
             Assert.Equal("NO", arr[1]);
         }
@@ -105,10 +105,10 @@ namespace Jint.Tests.Runtime.ExtensionMethods
             var engine = new Engine(options);
             engine.SetValue("person", person);
 
-            var isBogusInPerson = engine.Execute("'bogus' in person").GetCompletionValue().AsBoolean();
+            var isBogusInPerson = engine.Evaluate("'bogus' in person").AsBoolean();
             Assert.False(isBogusInPerson);
 
-            var propertyValue = engine.Execute("person.bogus").GetCompletionValue();
+            var propertyValue = engine.Evaluate("person.bogus");
             Assert.Equal(JsValue.Undefined, propertyValue);
         }
 
@@ -127,7 +127,7 @@ namespace Jint.Tests.Runtime.ExtensionMethods
             var intList = new List<int>() { 0, 1, 2, 3 };
 
             engine.SetValue("intList", intList);
-            var intSumRes = engine.Execute("intList.Sum()").GetCompletionValue().AsNumber();
+            var intSumRes = engine.Evaluate("intList.Sum()").AsNumber();
             Assert.Equal(6, intSumRes);
         }
 
@@ -138,7 +138,7 @@ namespace Jint.Tests.Runtime.ExtensionMethods
             var stringList = new List<string>() { "working", "linq" };
             engine.SetValue("stringList", stringList);
 
-            var stringSumRes = engine.Execute("stringList.Sum(x => x.length)").GetCompletionValue().AsNumber();
+            var stringSumRes = engine.Evaluate("stringList.Sum(x => x.length)").AsNumber();
             Assert.Equal(11, stringSumRes);
         }
 
@@ -149,7 +149,7 @@ namespace Jint.Tests.Runtime.ExtensionMethods
             var stringList = new List<string>() { "working", "linq" };
             engine.SetValue("stringList", stringList);
 
-            var stringRes = engine.Execute("stringList.Select((x) => x + 'a').ToArray().join()").GetCompletionValue().AsString();
+            var stringRes = engine.Evaluate("stringList.Select((x) => x + 'a').ToArray().join()").AsString();
             Assert.Equal("workinga,linqa", stringRes);
 
             // The method ambiguity resolver is not so smart to choose the Select method with the correct number of parameters

--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -12,10 +12,10 @@ namespace Jint.Tests.Runtime
         public void BindCombinesBoundArgumentsToCallArgumentsCorrectly()
         {
             var e = new Engine();
-            e.Execute("var testFunc = function (a, b, c) { return a + ', ' + b + ', ' + c + ', ' + JSON.stringify(arguments); }");
+            e.Evaluate("var testFunc = function (a, b, c) { return a + ', ' + b + ', ' + c + ', ' + JSON.stringify(arguments); }");
 
-            Assert.Equal("a, 1, a, {\"0\":\"a\",\"1\":1,\"2\":\"a\"}", e.Execute("testFunc('a', 1, 'a');").GetCompletionValue().AsString());
-            Assert.Equal("a, 1, a, {\"0\":\"a\",\"1\":1,\"2\":\"a\"}", e.Execute("testFunc.bind('anything')('a', 1, 'a');").GetCompletionValue().AsString());
+            Assert.Equal("a, 1, a, {\"0\":\"a\",\"1\":1,\"2\":\"a\"}", e.Evaluate("testFunc('a', 1, 'a');").AsString());
+            Assert.Equal("a, 1, a, {\"0\":\"a\",\"1\":1,\"2\":\"a\"}", e.Evaluate("testFunc.bind('anything')('a', 1, 'a');").AsString());
         }
 
         [Fact]
@@ -66,7 +66,7 @@ function execute(doc, args){
             });
             engine.Execute(script);
 
-            var obj = engine.Execute("var obj = {}; execute(obj); return obj;").GetCompletionValue().AsObject();
+            var obj = engine.Evaluate("var obj = {}; execute(obj); return obj;").AsObject();
 
             Assert.Equal("ayende", obj.Get("Name").AsString());
         }

--- a/Jint.Tests/Runtime/GlobalTests.cs
+++ b/Jint.Tests/Runtime/GlobalTests.cs
@@ -9,11 +9,11 @@ namespace Jint.Tests.Runtime
         {
             var e = new Engine();
 
-            Assert.Equal("@", e.Execute("unescape('%40');").GetCompletionValue().AsString());
-            Assert.Equal("@_", e.Execute("unescape('%40_');").GetCompletionValue().AsString());
-            Assert.Equal("@@", e.Execute("unescape('%40%40');").GetCompletionValue().AsString());
-            Assert.Equal("@", e.Execute("unescape('%u0040');").GetCompletionValue().AsString());
-            Assert.Equal("@@", e.Execute("unescape('%u0040%u0040');").GetCompletionValue().AsString());
+            Assert.Equal("@", e.Evaluate("unescape('%40');").AsString());
+            Assert.Equal("@_", e.Evaluate("unescape('%40_');").AsString());
+            Assert.Equal("@@", e.Evaluate("unescape('%40%40');").AsString());
+            Assert.Equal("@", e.Evaluate("unescape('%u0040');").AsString());
+            Assert.Equal("@@", e.Evaluate("unescape('%u0040%u0040');").AsString());
         }
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -58,7 +58,7 @@ namespace Jint.Tests.Runtime
         public void ShouldStringifyNetObjects()
         {
             _engine.SetValue("foo", new Foo());
-            var json = _engine.Execute("JSON.stringify(foo.GetBar())").GetCompletionValue().AsString();
+            var json = _engine.Evaluate("JSON.stringify(foo.GetBar())").AsString();
             Assert.Equal("{\"Test\":\"123\"}", json);
         }
 
@@ -72,7 +72,7 @@ namespace Jint.Tests.Runtime
             expando.bar = "A string";
             engine.SetValue(nameof(expando), expando);
 
-            var result = engine.Execute($"JSON.stringify({nameof(expando)})").GetCompletionValue().AsString();
+            var result = engine.Evaluate($"JSON.stringify({nameof(expando)})").AsString();
             Assert.Equal("{\"foo\":5,\"bar\":\"A string\"}", result);
         }
 
@@ -87,7 +87,7 @@ namespace Jint.Tests.Runtime
             };
             engine.SetValue(nameof(dictionary), dictionary);
 
-            var result = engine.Execute($"JSON.stringify({nameof(dictionary)})").GetCompletionValue().AsString();
+            var result = engine.Evaluate($"JSON.stringify({nameof(dictionary)})").AsString();
             Assert.Equal("{\"foo\":5,\"bar\":\"A string\"}", result);
         }
 
@@ -97,10 +97,10 @@ namespace Jint.Tests.Runtime
             var engine = new Engine();
 
             const string json = "{\"foo\":5,\"bar\":\"A string\"}";
-            var parsed = engine.Execute($"JSON.parse('{json}')").GetCompletionValue().ToObject();
+            var parsed = engine.Evaluate($"JSON.parse('{json}')").ToObject();
             engine.SetValue(nameof(parsed), parsed);
 
-            var result = engine.Execute($"JSON.stringify({nameof(parsed)})").GetCompletionValue().AsString();
+            var result = engine.Evaluate($"JSON.stringify({nameof(parsed)})").AsString();
             Assert.Equal(json, result);
         }
 
@@ -125,8 +125,7 @@ namespace Jint.Tests.Runtime
 
             var result = new Engine()
                 .SetValue("userclass", userClass)
-                .Execute("userclass.TypeProperty.Name;")
-                .GetCompletionValue()
+                .Evaluate("userclass.TypeProperty.Name;")
                 .AsString();
 
             Assert.Equal("Person", result);
@@ -160,9 +159,9 @@ namespace Jint.Tests.Runtime
 
             var company = new Company("Acme Ltd");
             _engine.SetValue("c", company);
-            Assert.Equal("item thingie", _engine.Execute("c.Item").GetCompletionValue());
-            Assert.Equal("item thingie", _engine.Execute("c.item").GetCompletionValue());
-            Assert.Equal("value", _engine.Execute("c['key']").GetCompletionValue());
+            Assert.Equal("item thingie", _engine.Evaluate("c.Item"));
+            Assert.Equal("item thingie", _engine.Evaluate("c.item"));
+            Assert.Equal("value", _engine.Evaluate("c['key']"));
         }
 
         [Fact]
@@ -837,7 +836,7 @@ namespace Jint.Tests.Runtime
 
             e.SetValue("o", obj);
 
-            var name = e.Execute("o.values.filter(x => x.age == 12)[0].name").GetCompletionValue().ToString();
+            var name = e.Evaluate("o.values.filter(x => x.age == 12)[0].name").ToString();
             Assert.Equal("John", name);
         }
 
@@ -848,7 +847,7 @@ namespace Jint.Tests.Runtime
             dynamic expando = new ExpandoObject();
             expando.Name = "test";
             engine.SetValue("expando", expando);
-            Assert.Equal("test", engine.Execute("expando.Name").GetCompletionValue().ToString());
+            Assert.Equal("test", engine.Evaluate("expando.Name").ToString());
         }
 
         [Fact]
@@ -856,9 +855,9 @@ namespace Jint.Tests.Runtime
         {
             var result = _engine
                 .SetValue("values", new[] { 1, 2, 3, 4, 5, 6 })
-                .Execute("values.filter(function(x){ return x % 2 == 0; })");
+                .Evaluate("values.filter(function(x){ return x % 2 == 0; })");
 
-            var parts = result.GetCompletionValue().ToObject();
+            var parts = result.ToObject();
 
             Assert.True(parts.GetType().IsArray);
             Assert.Equal(3, ((object[])parts).Length);
@@ -872,9 +871,9 @@ namespace Jint.Tests.Runtime
         {
             var result = _engine
                 .SetValue("values", new List<object> { 1, 2, 3, 4, 5, 6 })
-                .Execute("new Array(values).filter(function(x){ return x % 2 == 0; })");
+                .Evaluate("new Array(values).filter(function(x){ return x % 2 == 0; })");
 
-            var parts = result.GetCompletionValue().ToObject();
+            var parts = result.ToObject();
 
             Assert.True(parts.GetType().IsArray);
             Assert.Equal(3, ((object[])parts).Length);
@@ -886,8 +885,7 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void ShouldConvertArrayInstanceToArray()
         {
-            var result = _engine.Execute("'foo@bar.com'.split('@');");
-            var parts = result.GetCompletionValue().ToObject();
+            var parts = _engine.Evaluate("'foo@bar.com'.split('@');").ToObject();
 
             Assert.True(parts.GetType().IsArray);
             Assert.Equal(2, ((object[])parts).Length);
@@ -912,16 +910,15 @@ namespace Jint.Tests.Runtime
                 return sum;
             }
             var result = _engine.SetValue("getSum", new Func<JsValue, JsValue>(adder))
-                .Execute("getSum([1,2,3]);");
+                .Evaluate("getSum([1,2,3]);");
 
-            Assert.True(result.GetCompletionValue() == 6);
+            Assert.True(result == 6);
         }
 
         [Fact]
         public void ShouldConvertBooleanInstanceToBool()
         {
-            var result = _engine.Execute("new Boolean(true)");
-            var value = result.GetCompletionValue().ToObject();
+            var value = _engine.Evaluate("new Boolean(true)").ToObject();
 
             Assert.Equal(typeof(bool), value.GetType());
             Assert.Equal(true, value);
@@ -930,8 +927,8 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void ShouldConvertDateInstanceToDateTime()
         {
-            var result = _engine.Execute("new Date(0)");
-            var value = result.GetCompletionValue().ToObject();
+            var result = _engine.Evaluate("new Date(0)");
+            var value = result.ToObject();
 
             Assert.Equal(typeof(DateTime), value.GetType());
             Assert.Equal(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc), value);
@@ -940,8 +937,8 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void ShouldConvertNumberInstanceToDouble()
         {
-            var result = _engine.Execute("new Number(10)");
-            var value = result.GetCompletionValue().ToObject();
+            var result = _engine.Evaluate("new Number(10)");
+            var value = result.ToObject();
 
             Assert.Equal(typeof(double), value.GetType());
             Assert.Equal(10d, value);
@@ -950,8 +947,7 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void ShouldConvertStringInstanceToString()
         {
-            var result = _engine.Execute("new String('foo')");
-            var value = result.GetCompletionValue().ToObject();
+            var value = _engine.Evaluate("new String('foo')").ToObject();
 
             Assert.Equal(typeof(string), value.GetType());
             Assert.Equal("foo", value);
@@ -960,7 +956,7 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void ShouldConvertObjectInstanceToExpando()
         {
-            _engine.Execute("var o = {a: 1, b: 'foo'}");
+            _engine.Evaluate("var o = {a: 1, b: 'foo'}");
             var result = _engine.GetValue("o");
 
             dynamic value = result.ToObject();
@@ -2136,8 +2132,8 @@ namespace Jint.Tests.Runtime
             var p = new Person();
             var engine = new Engine();
             engine.SetValue("P", p);
-            engine.Execute("P.Name = 'b';");
-            engine.Execute("P.Name += 'c';");
+            engine.Evaluate("P.Name = 'b';");
+            engine.Evaluate("P.Name += 'c';");
             Assert.Equal("bc", p.Name);
         }
 
@@ -2146,10 +2142,10 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine(options =>
                 options.AllowClr(typeof(FloatIndexer).GetTypeInfo().Assembly));
-            var c = engine.Execute(@"
+            var c = engine.Evaluate(@"
                 var domain = importNamespace('Jint.Tests.Runtime.Domain');
                 return new domain.FloatIndexer();
-            ").GetCompletionValue();
+            ");
 
             Assert.NotNull(c.ToString());
             Assert.Equal((uint)0, c.As<ObjectInstance>().Length);
@@ -2178,7 +2174,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             engine.SetValue("dictionaryTest", new DictionaryTest());
-            engine.Execute("dictionaryTest.test1({ a: 1 });");
+            engine.Evaluate("dictionaryTest.test1({ a: 1 });");
         }
 
         [Fact]
@@ -2186,7 +2182,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             engine.SetValue("dictionaryTest", new DictionaryTest());
-            engine.Execute("dictionaryTest.test2({ values: { a: 1 } });");
+            engine.Evaluate("dictionaryTest.test2({ values: { a: 1 } });");
         }
 
         [Fact]
@@ -2200,8 +2196,7 @@ namespace Jint.Tests.Runtime
             engine.SetValue("state", state);
 
             var result = (IDictionary<string, object>) engine
-                .Execute("({ supplier: 'S1', ...state.invoice })")
-                .GetCompletionValue()
+                .Evaluate("({ supplier: 'S1', ...state.invoice })")
                 .ToObject();
 
             Assert.Equal("S1", result["supplier"]);
@@ -2239,8 +2234,7 @@ namespace Jint.Tests.Runtime
             engine.SetValue("p", person);
 
             var result = (IDictionary<string, object>) engine
-                .Execute("({ supplier: 'S1', ...p })")
-                .GetCompletionValue()
+                .Evaluate("({ supplier: 'S1', ...p })")
                 .ToObject();
 
             Assert.Equal("S1", result["supplier"]);
@@ -2253,7 +2247,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            engine.Execute("var jsObj = { 'key1' :'value1', 'key2' : 'value2' }");
+            engine.Evaluate("var jsObj = { 'key1' :'value1', 'key2' : 'value2' }");
 
             engine.SetValue("netObj", new Dictionary<string, object>
             {
@@ -2261,12 +2255,12 @@ namespace Jint.Tests.Runtime
                 {"key2", "value2"},
             });
 
-            var jsValue = engine.Execute("jsObj['key1']").GetCompletionValue().AsString();
-            var clrValue = engine.Execute("netObj['key1']").GetCompletionValue().AsString();
+            var jsValue = engine.Evaluate("jsObj['key1']").AsString();
+            var clrValue = engine.Evaluate("netObj['key1']").AsString();
             Assert.Equal(jsValue, clrValue);
 
-            jsValue = engine.Execute("JSON.stringify(jsObj)").GetCompletionValue().AsString();
-            clrValue = engine.Execute("JSON.stringify(netObj)").GetCompletionValue().AsString();
+            jsValue = engine.Evaluate("JSON.stringify(jsObj)").AsString();
+            clrValue = engine.Evaluate("JSON.stringify(netObj)").AsString();
             Assert.Equal(jsValue, clrValue);
 
             // Write properties on screen using showProps function defined on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects
@@ -2279,8 +2273,8 @@ namespace Jint.Tests.Runtime
     }
   return result;
 }");
-            jsValue = engine.Execute("showProps(jsObj, 'theObject')").GetCompletionValue().AsString();
-            clrValue = engine.Execute("showProps(jsObj, 'theObject')").GetCompletionValue().AsString();
+            jsValue = engine.Evaluate("showProps(jsObj, 'theObject')").AsString();
+            clrValue = engine.Evaluate("showProps(jsObj, 'theObject')").AsString();
             Assert.Equal(jsValue, clrValue);
         }
 
@@ -2302,11 +2296,11 @@ namespace Jint.Tests.Runtime
 
             engine.SetValue("m", new HiddenMembers());
 
-            Assert.Equal("Member1", engine.Execute("m.Member1").GetCompletionValue().ToString());
-            Assert.Equal("undefined", engine.Execute("m.Member2").GetCompletionValue().ToString());
-            Assert.Equal("Method1", engine.Execute("m.Method1()").GetCompletionValue().ToString());
+            Assert.Equal("Member1", engine.Evaluate("m.Member1").ToString());
+            Assert.Equal("undefined", engine.Evaluate("m.Member2").ToString());
+            Assert.Equal("Method1", engine.Evaluate("m.Method1()").ToString());
             // check the method itself, not its invokation as it would mean invoking "undefined"
-            Assert.Equal("undefined", engine.Execute("m.Method2").GetCompletionValue().ToString());
+            Assert.Equal("undefined", engine.Evaluate("m.Method2").ToString());
         }
 
         [Fact]
@@ -2324,7 +2318,7 @@ namespace Jint.Tests.Runtime
 
             engine.SetValue("m", new HiddenMembers());
 
-            Assert.Equal("Orange", engine.Execute("m.Member1").GetCompletionValue().ToString());
+            Assert.Equal("Orange", engine.Evaluate("m.Member1").ToString());
         }
 
         [Fact]
@@ -2338,9 +2332,9 @@ namespace Jint.Tests.Runtime
                 log(fia[0]);
             ");
 
-            Assert.Equal(123, engine.Execute("fia[0]").GetCompletionValue().AsNumber());
-            engine.Execute("fia[0] = 678;");
-            Assert.Equal(678, engine.Execute("fia[0]").GetCompletionValue().AsNumber());
+            Assert.Equal(123, engine.Evaluate("fia[0]").AsNumber());
+            engine.Evaluate("fia[0] = 678;");
+            Assert.Equal(678, engine.Evaluate("fia[0]").AsNumber());
         }
 
         [Fact]
@@ -2351,7 +2345,7 @@ namespace Jint.Tests.Runtime
                 new JProperty("name", "test-name")
             };
             _engine.SetValue("o", o);
-            Assert.True(_engine.Execute("return o.name == 'test-name'").GetCompletionValue().AsBoolean());
+            Assert.True(_engine.Evaluate("return o.name == 'test-name'").AsBoolean());
         }
 
         [Fact]
@@ -2359,8 +2353,8 @@ namespace Jint.Tests.Runtime
         {
             var o = new JArray("item1", "item2");
             _engine.SetValue("o", o);
-            Assert.True(_engine.Execute("return o[0] == 'item1'").GetCompletionValue().AsBoolean());
-            Assert.True(_engine.Execute("return o[1] == 'item2'").GetCompletionValue().AsBoolean());
+            Assert.True(_engine.Evaluate("return o[0] == 'item1'").AsBoolean());
+            Assert.True(_engine.Evaluate("return o[1] == 'item2'").AsBoolean());
         }
 
         [Fact]
@@ -2371,13 +2365,13 @@ namespace Jint.Tests.Runtime
 
             _engine.SetValue("o", jObjectWithTypeProperty);
 
-            var typeResult = _engine.Execute("o.Type").GetCompletionValue();
+            var typeResult = _engine.Evaluate("o.Type");
 
             // JToken requires conversion
             Assert.Equal("Cat", TypeConverter.ToString(typeResult));
 
             // weak equality does conversions from native types
-            Assert.True(_engine.Execute("o.Type == 'Cat'").GetCompletionValue().AsBoolean());
+            Assert.True(_engine.Evaluate("o.Type == 'Cat'").AsBoolean());
         }
 
         [Fact]
@@ -2389,8 +2383,8 @@ namespace Jint.Tests.Runtime
             _engine.SetValue("animals", bsonAnimals["Animals"]);
 
             // weak equality does conversions from native types
-            Assert.True(_engine.Execute("animals[0].Type == 'Cat'").GetCompletionValue().AsBoolean());
-            Assert.True(_engine.Execute("animals[0].Id == 1").GetCompletionValue().AsBoolean());
+            Assert.True(_engine.Evaluate("animals[0].Type == 'Cat'").AsBoolean());
+            Assert.True(_engine.Evaluate("animals[0].Id == 1").AsBoolean());
         }
 
         [Fact]
@@ -2401,18 +2395,18 @@ namespace Jint.Tests.Runtime
 
             engine.SetValue("test", test);
 
-            Assert.Equal("a", engine.Execute("test.a").GetCompletionValue().AsString());
-            Assert.Equal("b", engine.Execute("test.b").GetCompletionValue().AsString());
+            Assert.Equal("a", engine.Evaluate("test.a").AsString());
+            Assert.Equal("b", engine.Evaluate("test.b").AsString());
 
-            engine.Execute("test.a = 5; test.b = 10; test.Name = 'Jint'");
+            engine.Evaluate("test.a = 5; test.b = 10; test.Name = 'Jint'");
 
-            Assert.Equal(5, engine.Execute("test.a").GetCompletionValue().AsNumber());
-            Assert.Equal(10, engine.Execute("test.b").GetCompletionValue().AsNumber());
+            Assert.Equal(5, engine.Evaluate("test.a").AsNumber());
+            Assert.Equal(10, engine.Evaluate("test.b").AsNumber());
 
-            Assert.Equal("Jint", engine.Execute("test.Name").GetCompletionValue().AsString());
-            Assert.True(engine.Execute("test.ContainsKey('a')").GetCompletionValue().AsBoolean());
-            Assert.True(engine.Execute("test.ContainsKey('b')").GetCompletionValue().AsBoolean());
-            Assert.False(engine.Execute("test.ContainsKey('c')").GetCompletionValue().AsBoolean());
+            Assert.Equal("Jint", engine.Evaluate("test.Name").AsString());
+            Assert.True(engine.Evaluate("test.ContainsKey('a')").AsBoolean());
+            Assert.True(engine.Evaluate("test.ContainsKey('b')").AsBoolean());
+            Assert.False(engine.Evaluate("test.ContainsKey('c')").AsBoolean());
         }
 
         [Fact]
@@ -2427,7 +2421,7 @@ namespace Jint.Tests.Runtime
             values["title"] = "abc";
 
             _engine.SetValue("parent", parent);
-            Assert.Equal("abc", _engine.Execute("parent.child.item.title").GetCompletionValue());
+            Assert.Equal("abc", _engine.Evaluate("parent.child.item.title"));
         }
 
         private class DynamicClass : DynamicObject
@@ -2463,7 +2457,7 @@ namespace Jint.Tests.Runtime
             var engine = new Engine(options => options.AllowClr(GetType().Assembly));
             engine.SetValue("a", new OverLoading());
             engine.SetValue("E", TypeReference.CreateTypeReference(engine, typeof(IntegerEnum)));
-            Assert.Equal("integer-enum", engine.Execute("a.testFunc(E.a);").GetCompletionValue().AsString());
+            Assert.Equal("integer-enum", engine.Evaluate("a.testFunc(E.a);").AsString());
         }
 
         [Fact]
@@ -2471,7 +2465,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine(options => options.AllowClr(GetType().Assembly));
             engine.SetValue("E", TypeReference.CreateTypeReference(engine, typeof(UintEnum)));
-            Assert.Equal(1, engine.Execute("E.b;").GetCompletionValue().AsNumber());
+            Assert.Equal(1, engine.Evaluate("E.b;").AsNumber());
         }
 
         public class TestItem
@@ -2528,17 +2522,17 @@ namespace Jint.Tests.Runtime
 
             engine.SetValue("lst", lst);
 
-            Assert.Equal(5, engine.Execute("lst.Sum(x => x.Cost);").GetCompletionValue().AsNumber());
-            Assert.Equal(50, engine.Execute("lst.Sum(x => x.Age);").GetCompletionValue().AsNumber());
-            Assert.Equal(3, engine.Execute("lst.Where(x => x.Name == 'b').Count;").GetCompletionValue().AsNumber());
-            Assert.Equal(30, engine.Execute("lst.Where(x => x.Name == 'b').Sum(x => x.Age);").GetCompletionValue().AsNumber());
+            Assert.Equal(5, engine.Evaluate("lst.Sum(x => x.Cost);").AsNumber());
+            Assert.Equal(50, engine.Evaluate("lst.Sum(x => x.Age);").AsNumber());
+            Assert.Equal(3, engine.Evaluate("lst.Where(x => x.Name == 'b').Count;").AsNumber());
+            Assert.Equal(30, engine.Evaluate("lst.Where(x => x.Name == 'b').Sum(x => x.Age);").AsNumber());
         }
 
         [Fact]
         public void ExceptionFromConstructorShouldPropagate()
         {
             _engine.SetValue("Class", TypeReference.CreateTypeReference(_engine, typeof(MemberExceptionTest)));
-            var ex = Assert.Throws<InvalidOperationException>(() => _engine.Execute("new Class(true);"));
+            var ex = Assert.Throws<InvalidOperationException>(() => _engine.Evaluate("new Class(true);"));
             Assert.Equal("thrown as requested", ex.Message);
         }
 
@@ -2548,19 +2542,19 @@ namespace Jint.Tests.Runtime
             // equality same via name
             _engine.SetValue("a", new Person { Name = "Name" });
             _engine.SetValue("b", new Person { Name = "Name" });
-            _engine.Execute("const arr = [ null, a, undefined ];");
+            _engine.Evaluate("const arr = [ null, a, undefined ];");
 
-            Assert.Equal(1, _engine.Execute("arr.filter(x => x == b).length").GetCompletionValue().AsNumber());
-            Assert.Equal(1, _engine.Execute("arr.filter(x => x === b).length").GetCompletionValue().AsNumber());
+            Assert.Equal(1, _engine.Evaluate("arr.filter(x => x == b).length").AsNumber());
+            Assert.Equal(1, _engine.Evaluate("arr.filter(x => x === b).length").AsNumber());
 
-            Assert.True(_engine.Execute("arr.find(x => x == b) === a").GetCompletionValue().AsBoolean());
-            Assert.True(_engine.Execute("arr.find(x => x === b) == a").GetCompletionValue().AsBoolean());
+            Assert.True(_engine.Evaluate("arr.find(x => x == b) === a").AsBoolean());
+            Assert.True(_engine.Evaluate("arr.find(x => x === b) == a").AsBoolean());
 
-            Assert.Equal(1, _engine.Execute("arr.findIndex(x => x == b)").GetCompletionValue().AsNumber());
-            Assert.Equal(1, _engine.Execute("arr.findIndex(x => x === b)").GetCompletionValue().AsNumber());
+            Assert.Equal(1, _engine.Evaluate("arr.findIndex(x => x == b)").AsNumber());
+            Assert.Equal(1, _engine.Evaluate("arr.findIndex(x => x === b)").AsNumber());
 
-            Assert.Equal(1, _engine.Execute("arr.indexOf(b)").GetCompletionValue().AsNumber());
-            Assert.True(_engine.Execute("arr.includes(b)").GetCompletionValue().AsBoolean());
+            Assert.Equal(1, _engine.Evaluate("arr.indexOf(b)").AsNumber());
+            Assert.True(_engine.Evaluate("arr.includes(b)").AsBoolean());
         }
     }
 }

--- a/Jint.Tests/Runtime/JsonTests.cs
+++ b/Jint.Tests/Runtime/JsonTests.cs
@@ -9,7 +9,7 @@ namespace Jint.Tests.Runtime
         {
              var engine = new Engine();
              const string script = @"JSON.parse(""{\""abc\\tdef\"": \""42\""}"");";
-             var obj = engine.Execute(script).GetCompletionValue().AsObject();
+             var obj = engine.Evaluate(script).AsObject();
              Assert.True(obj.HasOwnProperty("abc\tdef"));
         }
     }

--- a/Jint.Tests/Runtime/NumberTests.cs
+++ b/Jint.Tests/Runtime/NumberTests.cs
@@ -27,7 +27,7 @@ namespace Jint.Tests.Runtime
         [InlineData(100, "3.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e+0")]
         public void ToExponential(int fractionDigits, string result)
         {
-            var value = _engine.Execute($"(3).toExponential({fractionDigits}).toString()").GetCompletionValue().AsString();
+            var value = _engine.Evaluate($"(3).toExponential({fractionDigits}).toString()").AsString();
             Assert.Equal(result, value);
         }
 
@@ -37,14 +37,14 @@ namespace Jint.Tests.Runtime
         [InlineData(99, "3.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")]
         public void ToFixed(int fractionDigits, string result)
         {
-            var value = _engine.Execute($"(3).toFixed({fractionDigits}).toString()").GetCompletionValue().AsString();
+            var value = _engine.Evaluate($"(3).toFixed({fractionDigits}).toString()").AsString();
             Assert.Equal(result, value);
         }
 
         [Fact]
         public void ToFixedWith100FractionDigitsThrows()
         {
-            var ex = Assert.Throws<JavaScriptException>(() => _engine.Execute($"(3).toFixed(100)"));
+            var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate($"(3).toFixed(100)"));
             Assert.Equal("100 fraction digits is not supported due to .NET format specifier limitation", ex.Message);
         }
 
@@ -54,7 +54,7 @@ namespace Jint.Tests.Runtime
         [InlineData(100, "3.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")]
         public void ToPrecision(int fractionDigits, string result)
         {
-            var value = _engine.Execute($"(3).toPrecision({fractionDigits}).toString()").GetCompletionValue().AsString();
+            var value = _engine.Evaluate($"(3).toPrecision({fractionDigits}).toString()").AsString();
             Assert.Equal(result, value);
         }
     }

--- a/Jint.Tests/Runtime/ObjectInstanceTests.cs
+++ b/Jint.Tests/Runtime/ObjectInstanceTests.cs
@@ -39,7 +39,7 @@ namespace Jint.Tests.Runtime
                 o.constructor === My{baseType}";
 
             var engine = new Engine();
-            Assert.True(engine.Execute(code).GetCompletionValue().AsBoolean());
+            Assert.True(engine.Evaluate(code).AsBoolean());
         }
     }
 }

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -6,12 +6,6 @@ using Xunit;
 
 namespace Jint.Tests.Runtime
 {
-    internal static class EngineExtensions
-    {
-        internal static JsValue Evaluate(this Engine engine, string code) =>
-            engine.Execute(code).GetCompletionValue().UnwrapIfPromise();
-    }
-
     public class PromiseTests
     {
         #region Manual Promise
@@ -153,7 +147,7 @@ namespace Jint.Tests.Runtime
         public void PromiseResolveViaResolver_ReturnsCorrectValue()
         {
             var engine = new Engine();
-            var res = engine.Evaluate("new Promise((resolve, reject)=>{resolve(66);});");
+            var res = engine.Evaluate("new Promise((resolve, reject)=>{resolve(66);});").UnwrapIfPromise();
             Assert.Equal(66, res);
         }
 
@@ -161,7 +155,7 @@ namespace Jint.Tests.Runtime
         public void PromiseResolveViaStatic_ReturnsCorrectValue()
         {
             var engine = new Engine();
-            Assert.Equal(66, engine.Evaluate("Promise.resolve(66);"));
+            Assert.Equal(66, engine.Evaluate("Promise.resolve(66);").UnwrapIfPromise());
         }
 
         #endregion
@@ -175,7 +169,7 @@ namespace Jint.Tests.Runtime
 
             var ex = Assert.Throws<PromiseRejectedException>(() =>
             {
-                engine.Evaluate("new Promise((resolve, reject)=>{reject('Could not connect');});");
+                engine.Evaluate("new Promise((resolve, reject)=>{reject('Could not connect');});").UnwrapIfPromise();
             });
 
             Assert.Equal("Could not connect", ex.RejectedValue.AsString());
@@ -188,7 +182,7 @@ namespace Jint.Tests.Runtime
 
             var ex = Assert.Throws<PromiseRejectedException>(() =>
             {
-                engine.Evaluate("Promise.reject('Could not connect');");
+                engine.Evaluate("Promise.reject('Could not connect');").UnwrapIfPromise();
             });
 
             Assert.Equal("Could not connect", ex.RejectedValue.AsString());
@@ -204,7 +198,7 @@ namespace Jint.Tests.Runtime
             var engine = new Engine();
 
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => 44).then(result => resolve(result)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => 44).then(result => resolve(result)); });").UnwrapIfPromise();
 
             Assert.Equal(44, res);
         }
@@ -214,7 +208,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "var promise1 = new Promise((resolve, reject) => { resolve(1); }); var promise2 = promise1.then();  promise1 === promise2");
+                "var promise1 = new Promise((resolve, reject) => { resolve(1); }); var promise2 = promise1.then();  promise1 === promise2").UnwrapIfPromise();
 
             Assert.Equal(false, res);
         }
@@ -224,7 +218,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(result => resolve(result)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(result => resolve(result)); });").UnwrapIfPromise();
 
             Assert.Equal(66, res);
         }
@@ -234,7 +228,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            Assert.Equal(JsValue.Undefined, engine.Evaluate("Promise.resolve(33).then(() => {});"));
+            Assert.Equal(JsValue.Undefined, engine.Evaluate("Promise.resolve(33).then(() => {});").UnwrapIfPromise());
         }
 
         [Fact(Timeout = 5000)]
@@ -242,7 +236,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then().then(result => resolve(result)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then().then(result => resolve(result)); });").UnwrapIfPromise();
 
             Assert.Equal(66, res);
         }
@@ -252,7 +246,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => {}).then(result => resolve(result)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => {}).then(result => resolve(result)); });").UnwrapIfPromise();
 
             Assert.Equal(JsValue.Undefined, res);
         }
@@ -262,7 +256,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => { throw 'Thrown Error'; }).catch(result => resolve(result)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => { throw 'Thrown Error'; }).catch(result => resolve(result)); });").UnwrapIfPromise();
 
             Assert.Equal("Thrown Error", res);
         }
@@ -272,7 +266,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => Promise.resolve(55)).then(result => resolve(result)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => Promise.resolve(55)).then(result => resolve(result)); });").UnwrapIfPromise();
 
             Assert.Equal(55, res);
         }
@@ -282,7 +276,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => Promise.reject('Error Message')).catch(result => resolve(result)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => Promise.reject('Error Message')).catch(result => resolve(result)); });").UnwrapIfPromise();
 
             Assert.Equal("Error Message", res);
         }
@@ -296,7 +290,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch(result => resolve(result)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch(result => resolve(result)); });").UnwrapIfPromise();
 
             Assert.Equal("Could not connect", res);
         }
@@ -306,7 +300,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).then(undefined, result => resolve(result)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).then(undefined, result => resolve(result)); });").UnwrapIfPromise();
 
             Assert.Equal("Could not connect", res);
         }
@@ -315,7 +309,7 @@ namespace Jint.Tests.Runtime
         public void PromiseChainedWithHandler_ResolvedAsUndefined()
         {
             var engine = new Engine();
-            Assert.Equal(JsValue.Undefined, engine.Evaluate("Promise.reject('error').catch(() => {});"));
+            Assert.Equal(JsValue.Undefined, engine.Evaluate("Promise.reject('error').catch(() => {});").UnwrapIfPromise());
         }
 
         [Fact(Timeout = 5000)]
@@ -323,7 +317,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch(ex => {}).then(result => resolve(result)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch(ex => {}).then(result => resolve(result)); });").UnwrapIfPromise();
 
             Assert.Equal(JsValue.Undefined, res);
         }
@@ -333,7 +327,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch().catch(result => resolve(result)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch().catch(result => resolve(result)); });").UnwrapIfPromise();
 
             Assert.Equal("Could not connect", res);
         }
@@ -347,7 +341,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).finally(() => resolve(16)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).finally(() => resolve(16)); });").UnwrapIfPromise();
 
             Assert.Equal(16, res);
         }
@@ -366,14 +360,14 @@ namespace Jint.Tests.Runtime
         public void PromiseFinally_ResolvesWithCorrectValue()
         {
             var engine = new Engine();
-            Assert.Equal(2, engine.Evaluate("Promise.resolve(2).finally(() => {})"));
+            Assert.Equal(2, engine.Evaluate("Promise.resolve(2).finally(() => {})").UnwrapIfPromise());
         }
 
         [Fact(Timeout = 5000)]
         public void PromiseFinallyWithNoCallback_ResolvesWithCorrectValue()
         {
             var engine = new Engine();
-            Assert.Equal(2, engine.Evaluate("Promise.resolve(2).finally()"));
+            Assert.Equal(2, engine.Evaluate("Promise.resolve(2).finally()").UnwrapIfPromise());
         }
 
         [Fact(Timeout = 5000)]
@@ -381,7 +375,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            Assert.Equal(2, engine.Evaluate("Promise.resolve(2).finally(() => 6).finally(() => 9);"));
+            Assert.Equal(2, engine.Evaluate("Promise.resolve(2).finally(() => 6).finally(() => 9);").UnwrapIfPromise());
         }
 
         [Fact(Timeout = 5000)]
@@ -389,7 +383,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var res = engine.Evaluate(
-                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(5)}).finally(() => {throw 'Could not connect';}).catch(result => resolve(result)); });");
+                "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(5)}).finally(() => {throw 'Could not connect';}).catch(result => resolve(result)); });").UnwrapIfPromise();
 
             Assert.Equal("Could not connect", res);
         }
@@ -402,7 +396,7 @@ namespace Jint.Tests.Runtime
         public void PromiseAll_BadIterable_Rejects()
         {
             var engine = new Engine();
-            Assert.Throws<PromiseRejectedException>(() => { engine.Evaluate("Promise.all();"); });
+            Assert.Throws<PromiseRejectedException>(() => { engine.Evaluate("Promise.all();").UnwrapIfPromise(); });
         }
 
 
@@ -411,7 +405,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            Assert.Equal(new object[] {1d, 2d, 3d}, engine.Evaluate("Promise.all([1,2,3]);").ToObject());
+            Assert.Equal(new object[] {1d, 2d, 3d}, engine.Evaluate("Promise.all([1,2,3]);").UnwrapIfPromise().ToObject());
         }
 
         [Fact(Timeout = 5000)]
@@ -419,7 +413,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             Assert.Equal(new object[] {1d, 2d, 3d},
-                engine.Evaluate("Promise.all([1,Promise.resolve(2),3]);").ToObject());
+                engine.Evaluate("Promise.all([1,Promise.resolve(2),3]);").UnwrapIfPromise().ToObject());
         }
 
         [Fact(Timeout = 5000)]
@@ -429,7 +423,7 @@ namespace Jint.Tests.Runtime
 
             Assert.Throws<PromiseRejectedException>(() =>
             {
-                engine.Evaluate("Promise.all([1,Promise.resolve(2),3, Promise.reject('Cannot connect')]);");
+                engine.Evaluate("Promise.all([1,Promise.resolve(2),3, Promise.reject('Cannot connect')]);").UnwrapIfPromise();
             });
         }
 
@@ -442,7 +436,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            Assert.Throws<PromiseRejectedException>(() => { engine.Evaluate("Promise.race();"); });
+            Assert.Throws<PromiseRejectedException>(() => { engine.Evaluate("Promise.race();").UnwrapIfPromise(); });
         }
 
         [Fact(Timeout = 5000)]
@@ -450,7 +444,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            Assert.Throws<PromiseRejectedException>(() => { engine.Evaluate("Promise.race({});"); });
+            Assert.Throws<PromiseRejectedException>(() => { engine.Evaluate("Promise.race({});").UnwrapIfPromise(); });
         }
 
         [Fact(Timeout = 5000)]
@@ -458,7 +452,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            Assert.Equal(12d, engine.Evaluate("Promise.race([12,2,3]);").ToObject());
+            Assert.Equal(12d, engine.Evaluate("Promise.race([12,2,3]);").UnwrapIfPromise().ToObject());
         }
 
         [Fact(Timeout = 5000)]
@@ -466,7 +460,7 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            Assert.Equal(12d, engine.Evaluate("Promise.race([12,Promise.resolve(2),3]);").ToObject());
+            Assert.Equal(12d, engine.Evaluate("Promise.race([12,Promise.resolve(2),3]);").UnwrapIfPromise().ToObject());
         }
 
         [Fact(Timeout = 5000)]
@@ -474,14 +468,14 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
 
-            Assert.Equal(2d, engine.Evaluate("Promise.race([Promise.resolve(2),6,3]);").ToObject());
+            Assert.Equal(2d, engine.Evaluate("Promise.race([Promise.resolve(2),6,3]);").UnwrapIfPromise().ToObject());
         }
 
         [Fact(Timeout = 5000)]
         public void PromiseRaceMixturePromisesNoPromises_ResolvesCorrectly3()
         {
             var engine = new Engine();
-            var res = engine.Evaluate("Promise.race([new Promise((resolve,reject)=>{}),Promise.resolve(55),3]);");
+            var res = engine.Evaluate("Promise.race([new Promise((resolve,reject)=>{}),Promise.resolve(55),3]);").UnwrapIfPromise();
 
             Assert.Equal(55d, res.ToObject());
         }
@@ -494,7 +488,7 @@ namespace Jint.Tests.Runtime
             Assert.Throws<PromiseRejectedException>(() =>
             {
                 engine.Evaluate(
-                    "Promise.race([new Promise((resolve,reject)=>{}),Promise.reject('Could not connect'),3]);");
+                    "Promise.race([new Promise((resolve,reject)=>{}),Promise.reject('Could not connect'),3]);").UnwrapIfPromise();
             });
         }
 

--- a/Jint.Tests/Runtime/RegExpTests.cs
+++ b/Jint.Tests/Runtime/RegExpTests.cs
@@ -36,7 +36,7 @@ namespace Jint.Tests.Runtime
         public void PreventsInfiniteLoop()
         {
             var engine = new Engine();
-            var result = (ArrayInstance)engine.Execute("'x'.match(/|/g);").GetCompletionValue();
+            var result = (ArrayInstance)engine.Evaluate("'x'.match(/|/g);");
             Assert.Equal((uint) 2, result.Length);
             Assert.Equal("", result[0]);
             Assert.Equal("", result[1]);
@@ -46,7 +46,7 @@ namespace Jint.Tests.Runtime
         public void ToStringWithNonRegExpInstanceAndMissingProperties()
         {
             var engine = new Engine();
-            var result = engine.Execute("/./['toString'].call({})").GetCompletionValue().AsString();
+            var result = engine.Evaluate("/./['toString'].call({})").AsString();
 
             Assert.Equal("/undefined/undefined", result);
         }
@@ -55,7 +55,7 @@ namespace Jint.Tests.Runtime
         public void ToStringWithNonRegExpInstanceAndValidProperties()
         {
             var engine = new Engine();
-            var result = engine.Execute("/./['toString'].call({ source: 'a', flags: 'b' })").GetCompletionValue().AsString();
+            var result = engine.Evaluate("/./['toString'].call({ source: 'a', flags: 'b' })").AsString();
 
             Assert.Equal("/a/b", result);
         }
@@ -65,7 +65,7 @@ namespace Jint.Tests.Runtime
         public void ToStringWithRealRegExpInstance()
         {
             var engine = new Engine();
-            var result = engine.Execute("/./['toString'].call(/test/g)").GetCompletionValue().AsString();
+            var result = engine.Evaluate("/./['toString'].call(/test/g)").AsString();
 
             Assert.Equal("/test/g", result);
         }

--- a/Jint.Tests/Runtime/SamplesTests.cs
+++ b/Jint.Tests/Runtime/SamplesTests.cs
@@ -29,8 +29,7 @@ namespace Jint.Tests.Runtime
         {
             var square = new Engine()
                 .SetValue("x", 3)
-                .Execute("x * x")
-                .GetCompletionValue()
+                .Evaluate("x * x")
                 .ToObject();
 
             Assert.Equal(9d, square);

--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -25,8 +25,8 @@ var bar = foo;
 bar += 'bar';
 ";
             var value = _engine.Execute(script);
-            var foo = _engine.Execute("foo").GetCompletionValue().AsString();
-            var bar = _engine.Execute("bar").GetCompletionValue().AsString();
+            var foo = _engine.Evaluate("foo").AsString();
+            var bar = _engine.Evaluate("bar").AsString();
             Assert.Equal("foofoo", foo);
             Assert.Equal("foofoobar", bar);
         }

--- a/Jint.Tests/Runtime/UuidTests.cs
+++ b/Jint.Tests/Runtime/UuidTests.cs
@@ -22,7 +22,7 @@ namespace Jint.Tests.Runtime
 
         private object RunTest(string source)
         {
-            return _engine.Execute(source).GetCompletionValue().ToObject();
+            return _engine.Evaluate(source).ToObject();
         }
 
         [Fact]

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -350,16 +350,20 @@ namespace Jint
             CallStack.Clear();
         }
 
-        public Engine Execute(string source)
-        {
-            return Execute(source, DefaultParserOptions);
-        }
+        public JsValue Evaluate(string source) 
+            => Execute(source, DefaultParserOptions)._completionValue;
 
-        public Engine Execute(string source, ParserOptions parserOptions)
-        {
-            var parser = new JavaScriptParser(source, parserOptions);
-            return Execute(parser.ParseScript());
-        }
+        public JsValue Evaluate(string source, ParserOptions parserOptions)
+            => Execute(source, parserOptions)._completionValue;
+
+        public JsValue Evaluate(Script script)
+            => Execute(script)._completionValue;
+
+        public Engine Execute(string source) 
+            => Execute(source, DefaultParserOptions);
+
+        public Engine Execute(string source, ParserOptions parserOptions) 
+            => Execute(new JavaScriptParser(source, parserOptions).ParseScript());
 
         public Engine Execute(Script script)
         {
@@ -464,6 +468,7 @@ namespace Jint
         /// <summary>
         /// Gets the last evaluated statement completion value
         /// </summary>
+        [Obsolete("Prefer calling Evaluate which returns last completion value. Execute is for initialization and Evaluate returns final result.")]
         public JsValue GetCompletionValue()
         {
             return _completionValue;

--- a/Jint/Runtime/Debugger/BreakPointCollection.cs
+++ b/Jint/Runtime/Debugger/BreakPointCollection.cs
@@ -82,8 +82,7 @@ namespace Jint.Runtime.Debugger
 
                 if (!string.IsNullOrEmpty(breakPoint.Condition))
                 {
-                    var completionValue = engine.Execute(breakPoint.Condition).GetCompletionValue();
-
+                    var completionValue = engine.Evaluate(breakPoint.Condition);
                     if (!completionValue.AsBoolean())
                     {
                         continue;

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ https://channel9.msdn.com/Shows/Code-Conversations/Sebastien-Ros-on-jint-a-Javas
 
 ## Examples
 
-This example defines a new value named `log` pointing to `Console.WriteLine`, then executes 
+This example defines a new value named `log` pointing to `Console.WriteLine`, then runs
 a script calling `log('Hello World!')`. 
 
 ```c#
@@ -106,12 +106,11 @@ engine.Execute(@"
 ");
 ```
 
-Here, the variable `x` is set to `3` and `x * x` is executed in JavaScript. The result is returned to .NET directly, in this case as a `double` value `9`. 
+Here, the variable `x` is set to `3` and `x * x` is evaluated in JavaScript. The result is returned to .NET directly, in this case as a `double` value `9`. 
 ```c#
 var square = new Engine()
     .SetValue("x", 3) // define a new variable
-    .Execute("x * x") // execute a statement
-    .GetCompletionValue() // get the latest statement completion value
+    .Evaluate("x * x") // evaluate a statement
     .ToObject(); // converts the value to .NET
 ```
 
@@ -248,7 +247,7 @@ You can also write a custom constraint by implementing the `IConstraint` interfa
 ```c#
 public interface IConstraint
 {
-    /// Called before a script is executed and useful when you us an engine object for multiple executions.
+    /// Called before a script is run and useful when you us an engine object for multiple executions.
     void Reset();
 
     // Called before each statement to check if your requirements are met.


### PR DESCRIPTION
Code gets more succinct as chaining is no longer needed to get result.  Keeping the GetCompletionValue with Obsolete attribute, maybe someone will yell.