### PR TITLE
Implement Error stack property

### DIFF
--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -59,6 +59,11 @@ namespace Jint.Native.Error
                 o.DefinePropertyOrThrow("message", msgDesc);
             }
 
+            var stackString = _engine.CallStack.BuildCallStackString(_engine.GetLastSyntaxNode().Location);
+            var stack = TypeConverter.ToString(stackString);
+            var stackDesc = new PropertyDescriptor(stack, true, false, true);
+            o.DefinePropertyOrThrow(CommonProperties.Stack, stackDesc);
+
             return o;
         }
 

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -59,9 +59,9 @@ namespace Jint.Native.Error
                 o.DefinePropertyOrThrow("message", msgDesc);
             }
 
-            var stackString = _engine.CallStack.BuildCallStackString(_engine.GetLastSyntaxNode().Location);
-            var stack = TypeConverter.ToString(stackString);
-            var stackDesc = new PropertyDescriptor(stack, true, false, true);
+            var lastSyntaxNode = _engine.GetLastSyntaxNode();
+            var stackString = lastSyntaxNode == null ? Undefined : _engine.CallStack.BuildCallStackString(lastSyntaxNode.Location);
+            var stackDesc = new PropertyDescriptor(stackString, true, false, true);
             o.DefinePropertyOrThrow(CommonProperties.Stack, stackDesc);
 
             return o;


### PR DESCRIPTION
Some libraries can do things like `Error().stack` to get the current callstack. I did an implementation that is working but somewhat hacky maybe (using `engine.GetLastSyntaxNode()`). 

It does not give the exactly same string as in V8 or other engines but afaik there is no spec that says what string to return. Only WIP spec is this: https://github.com/tc39/proposal-error-stacks