### PR TITLE
Fix Promise.all behavior under interop

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -2556,5 +2556,12 @@ namespace Jint.Tests.Runtime
             Assert.Equal(1, _engine.Evaluate("arr.indexOf(b)").AsNumber());
             Assert.True(_engine.Evaluate("arr.includes(b)").AsBoolean());
         }
+
+        [Fact]
+        public void ObjectWrapperWrappingDictionaryShouldNotBeArrayLike()
+        {
+            var wrapper = new ObjectWrapper(_engine, new Dictionary<string, object>());
+            Assert.False(wrapper.IsArrayLike);
+        }
     }
 }

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -504,7 +504,11 @@ namespace Jint.Tests.Runtime
         public void PromiseRegression_SingleElementArrayWithClrDictionaryInPromiseAll()
         {
             var engine = new Engine();
-            var dictionary = new Dictionary<string, object>() { { "Value 1", 1 }, { "Value 2", "a string" } };
+            var dictionary = new Dictionary<string, object>
+            {
+                { "Value 1", 1 },
+                { "Value 2", "a string" }
+            };
             engine.SetValue("clrDictionary", dictionary);
 
             var resultAsObject = engine

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -381,6 +381,16 @@ namespace Jint.Native.Array
             return jsArray;
         }
 
+        public ArrayInstance ConstructFast(JsValue[] contents)
+        {
+            var instance = ConstructFast((ulong) contents.Length);
+            for (var i = 0; i < contents.Length; i++)
+            {
+                instance.SetIndexValue((uint) i, contents[i], updateLength: false);
+            }
+            return instance;
+        }
+
         internal ArrayInstance ConstructFast(List<JsValue> contents)
         {
             var instance = ConstructFast((ulong) contents.Count);

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -381,6 +381,16 @@ namespace Jint.Native.Array
             return jsArray;
         }
 
+        internal ArrayInstance ConstructFast(List<JsValue> contents)
+        {
+            var instance = ConstructFast((ulong) contents.Count);
+            for (var i = 0; i < contents.Count; i++)
+            {
+                instance.SetIndexValue((uint) i, contents[i], updateLength: false);
+            }
+            return instance;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal ArrayInstance ConstructFast(ulong length)
         {

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Esprima;
 using Esprima.Ast;
 using Jint.Native.Object;
@@ -600,14 +599,6 @@ namespace Jint.Native.Json
             return node;
         }
 
-        public ObjectInstance CreateArrayInstance(IEnumerable<JsValue> values)
-        {
-            var jsValues = values.ToArray();
-            var jsArray = _engine.Array.Construct(jsValues.Length);
-            _engine.Array.PrototypeObject.Push(jsArray, jsValues);
-            return jsArray;
-        }
-
         // Throw an exception
 
         private void ThrowError(Token token, string messageFormat, params object[] arguments)
@@ -693,7 +684,7 @@ namespace Jint.Native.Json
 
             Expect("]");
 
-            return CreateArrayInstance(elements);
+            return _engine.Array.ConstructFast(elements);
         }
 
         public ObjectInstance ParseJsonObject()

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -254,14 +254,14 @@ namespace Jint.Native.Object
         {
             var o = TypeConverter.ToObject(_engine, arguments.At(0));
             var names = o.GetOwnPropertyKeys(Types.String);
-            return _engine.Array.Construct(names.ToArray());
+            return _engine.Array.ConstructFast(names);
         }
 
         private JsValue GetOwnPropertySymbols(JsValue thisObject, JsValue[] arguments)
         {
             var o = TypeConverter.ToObject(_engine, arguments.At(0));
             var keys = o.GetOwnPropertyKeys(Types.Symbol);
-            return _engine.Array.Construct(keys.ToArray());
+            return _engine.Array.ConstructFast(keys);
         }
 
         private JsValue Create(JsValue thisObject, JsValue[] arguments)

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1260,11 +1260,10 @@ namespace Jint.Native.Object
                         }
                         else
                         {
-                            array.SetIndexValue(index, _engine.Array.Construct(new[]
-                            {
-                                property,
-                                value
-                            }), updateLength: false);
+                            var objectInstance = _engine.Array.ConstructFast(2);
+                            objectInstance.SetIndexValue(0,  property, updateLength: false);
+                            objectInstance.SetIndexValue(1, value, updateLength: false);
+                            array.SetIndexValue(index, objectInstance, updateLength: false);
                         }
                     }
 

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -17,7 +17,6 @@ namespace Jint.Native.Promise
         JsValue RejectObj
     );
 
-
     public sealed class PromiseConstructor : FunctionInstance, IConstructor
     {
         private static readonly JsString _functionName = new JsString("Promise");
@@ -230,8 +229,8 @@ namespace Jint.Native.Promise
                 // if "then" method is sync then it will be resolved BEFORE the next iteration cycle
                 if (results.TrueForAll(static x => x != null) && doneIterating)
                 {
-                    resolve.Call(Undefined,
-                        new JsValue[] {Engine.Array.Construct(results.ToArray())});
+                    var array = _engine.Array.ConstructFast(results);
+                    resolve.Call(Undefined, new JsValue[] { array });
                 }
             }
 

--- a/Jint/Native/Proxy/ProxyInstance.cs
+++ b/Jint/Native/Proxy/ProxyInstance.cs
@@ -40,7 +40,7 @@ namespace Jint.Native.Proxy
 
         public JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
-            var jsValues = new[] { _target, thisObject, _engine.Array.Construct(arguments) };
+            var jsValues = new[] { _target, thisObject, _engine.Array.ConstructFast(arguments) };
             if (TryCallHandler(TrapApply, jsValues, out var result))
             {
                 return result;

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Jint.Collections;
-using Jint.Native.Array;
 using Jint.Native.Object;
 using Jint.Native.RegExp;
 using Jint.Native.Symbol;
@@ -335,7 +334,6 @@ namespace Jint.Native.String
 
             // Coerce into a number, true will become 1
             var lim = limit.IsUndefined() ? uint.MaxValue : TypeConverter.ToUint32(limit);
-            var len = s.Length;
 
             if (lim == 0)
             {
@@ -348,10 +346,8 @@ namespace Jint.Native.String
             }
             else if (separator.IsUndefined())
             {
-                var jsValues = _engine._jsValueArrayPool.RentArray(1);
-                jsValues[0] = s;
-                var arrayInstance = (ArrayInstance)Engine.Array.Construct(jsValues);
-                _engine._jsValueArrayPool.ReturnArray(jsValues);
+                var arrayInstance = Engine.Array.ConstructFast(1);
+                arrayInstance.SetIndexValue(0, s, updateLength: false);
                 return arrayInstance;
             }
             else

--- a/Jint/Runtime/Interop/TypeDescriptor.cs
+++ b/Jint/Runtime/Interop/TypeDescriptor.cs
@@ -26,6 +26,12 @@ namespace Jint.Runtime.Interop
         
         private static bool DetermineIfObjectIsArrayLikeClrCollection(Type type)
         {
+            if (typeof(IDictionary).IsAssignableFrom(type))
+            {
+                // dictionaries are considered normal-object-like
+                return false;
+            }
+
             if (typeof(ICollection).IsAssignableFrom(type))
             {
                 return true;


### PR DESCRIPTION
Using direct array create to bypass possible CLR conversion logic, fixes #908 .