### PR TITLE
Make GetLastSyntaxNode method public

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -683,7 +683,7 @@ namespace Jint
         /// <summary>
         /// Gets the last evaluated <see cref="Node"/>.
         /// </summary>
-        internal Node GetLastSyntaxNode()
+        public Node GetLastSyntaxNode()
         {
             return _lastSyntaxNode;
         }


### PR DESCRIPTION
Issue answers and other documentation refer to the engine.GetLastSyntaxNode() method being available. but the method is internal, not public and I was not able to access it in a Unity project using jint.

Simple change of 'internal' to 'public' on line 686 of Engine.cs