### PR TITLE
Store and display original stack frames to the user if the same object is re-thrown later

### DIFF
--- a/Jint/Runtime/CommonProperties.cs
+++ b/Jint/Runtime/CommonProperties.cs
@@ -25,5 +25,6 @@ namespace Jint.Runtime
         internal static readonly JsString Configurable = new JsString("configurable");
         internal static readonly JsString Stack = new JsString("stack");
         internal static readonly JsString Message = new JsString("message");
+        internal static readonly JsString OriginalStack = new JsString("original_stack");
     }
 }

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -42,6 +42,23 @@ namespace Jint.Runtime
             _callStack = value;
             if (Error.IsObject())
             {
+                if (!Error.AsObject().HasOwnProperty(CommonProperties.OriginalStack))
+                {
+                    // Store the original stack if this is the first throw only
+                    Error.AsObject()
+                        .FastAddProperty(CommonProperties.OriginalStack, new JsString(value), false, false,false);
+                }
+                if (Error.AsObject().HasOwnProperty(CommonProperties.Stack))
+                {
+                    // If the stack property has been set previously, write the new one together with the original one.
+                    string dividerString = "\nRethrown from:";
+                    bool previousRethrow = Error.AsObject().Get(CommonProperties.Stack).AsString()
+                        .Contains(dividerString);
+                    string dividerSuffix = previousRethrow
+                        ? " (multiple rethrows, showing origin)\n"
+                        : "\n";
+                    value = value + dividerString + dividerSuffix + Error.AsObject().Get(CommonProperties.OriginalStack).AsString();
+                }
                 Error.AsObject()
                     .FastAddProperty(CommonProperties.Stack, new JsString(value), false, false, false);
             }


### PR DESCRIPTION
Frameworks like React catches error objects and re-throws later, debugging these errors can be hard if the stack is lost.

This is a small patch that store the first stack trace and appends the last throw (there can be intermediate traces but showing al of them can create really long and unreadable printouts).