### PR TITLE
Do not throw error immediately when receiving null Regex from Esprima 

### DIFF
--- a/Jint.Tests.Test262/Test262Test.cs
+++ b/Jint.Tests.Test262/Test262Test.cs
@@ -321,12 +321,6 @@ namespace Jint.Tests.Test262
                     reason = "Unicode support and its special cases need more work";
                 }
 
-                if (name.StartsWith("built-ins/RegExp/CharacterClassEscapes/"))
-                {
-                    skip = true;
-                    reason = "for-of not implemented";
-                }
-
                 // Promises
                 if (name.StartsWith("built-ins/Promise/allSettled") ||
                     name.StartsWith("built-ins/Promise/any"))

--- a/Jint.Tests/Runtime/RegExpTests.cs
+++ b/Jint.Tests/Runtime/RegExpTests.cs
@@ -69,5 +69,17 @@ namespace Jint.Tests.Runtime
 
             Assert.Equal("/test/g", result);
         }
+
+        [Fact]
+        public void ShouldNotThrowErrorOnIncompatibleRegex()
+        {
+            var engine = new Engine();
+            Assert.NotNull(engine.Evaluate(@"/[^]*?(:[rp][el]a[\w-]+)[^]*/"));
+            Assert.NotNull(engine.Evaluate("/[^]a/"));
+            Assert.NotNull(engine.Evaluate("new RegExp('[^]a')"));
+
+            Assert.NotNull(engine.Evaluate("/[]/"));
+            Assert.NotNull(engine.Evaluate("new RegExp('[]')"));
+        }
     }
 }

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -111,7 +111,7 @@ namespace Jint.Native.RegExp
                 var timeout = _engine.Options._RegexTimeoutInterval;
                 if (timeout.Ticks > 0)
                 {
-                    r.Value = new Regex(r.Value.ToString(), r.Value.Options, timeout);
+                    r.Value = r.Value != null ? new Regex(r.Value.ToString(), r.Value.Options, timeout) : null;
                 }
             }
             catch (Exception ex)
@@ -142,12 +142,12 @@ namespace Jint.Native.RegExp
             r._prototype = PrototypeObject;
 
             r.Flags = flags;
-            r.Source = regExp.ToString();
+            r.Source = regExp?.ToString();
 
             var timeout = _engine.Options._RegexTimeoutInterval;
             if (timeout.Ticks > 0)
             {
-                r.Value = new Regex(regExp.ToString(), regExp.Options, timeout);
+                r.Value = regExp != null ? new Regex(regExp.ToString(), regExp.Options, timeout) : null;
             }
             else
             {


### PR DESCRIPTION
Sometimes Esprima will return null Regex. That means parsing did not fail, but the Regex is incompatible with C#.

With this PR, Jint will not fail during the parsing when such a Regex is received. It will only fail when that Regex is actually used. This way the user can handle the error, and also error can be avoided if that Regex is not used at all. 

See also: sebastienros/esprima-dotnet#173

Keeping this as draft until Esprima PR is merged and released. (Test will fail without the new Esprima)