### PR TITLE
Fix double evaluation when Operator Overloading is enabled

### DIFF
--- a/Jint.Tests/Runtime/OperatorOverloadingTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadingTests.cs
@@ -315,5 +315,29 @@ namespace Jint.Tests.Runtime
             ");
         }
 
+        [Fact]
+        public void OperatorOverloading_ShouldEvaluateOnlyOnce()
+        {
+            RunTest(@"
+                var c;
+                var resolve = v => { c++; return v; };
+
+                c = 0;
+                var n1 = resolve(1) + 2;
+                equal(n1, 3);
+                equal(c, 1);
+
+                c = 0;
+                var n2 = resolve(2) + resolve(3);
+                equal(n2, 5);
+                equal(c, 2);
+
+                c = 0;
+                var n3 = -resolve(1);
+                equal(n3, -1);
+                equal(c, 1);
+            ");
+        }
+
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -27,9 +27,9 @@ namespace Jint.Runtime.Interpreter.Expressions
             _right = Build(_engine, expression.Right);
         }
 
-        protected bool TryOperatorOverloading(string clrName, out object result)
+        protected bool TryOperatorOverloading(JsValue left, JsValue right, string clrName, out object result)
         {
-            return TryOperatorOverloading(_engine, _left.GetValue(), _right.GetValue(), clrName, out result);
+            return TryOperatorOverloading(_engine, left, right, clrName, out result);
         }
 
         internal static bool TryOperatorOverloading(Engine engine, JsValue leftValue, JsValue rightValue, string clrName, out object result)
@@ -267,14 +267,14 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             protected override object EvaluateInternal()
             {
+                var left = _left.GetValue();
+                var right = _right.GetValue();
+
                 if (_engine.Options._IsOperatorOverloadingAllowed
-                    && TryOperatorOverloading("op_LessThan", out var opResult))
+                    && TryOperatorOverloading(left, right, "op_LessThan", out var opResult))
                 {
                     return opResult;
                 }
-
-                var left = _left.GetValue();
-                var right = _right.GetValue();
                 var value = Compare(left, right);
 
                 return value._type == InternalTypes.Undefined
@@ -291,14 +291,15 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             protected override object EvaluateInternal()
             {
+                var left = _left.GetValue();
+                var right = _right.GetValue();
+
                 if (_engine.Options._IsOperatorOverloadingAllowed
-                    && TryOperatorOverloading("op_GreaterThan", out var opResult))
+                    && TryOperatorOverloading(left, right, "op_GreaterThan", out var opResult))
                 {
                     return opResult;
                 }
 
-                var left = _left.GetValue();
-                var right = _right.GetValue();
                 var value = Compare(right, left, false);
 
                 return value._type == InternalTypes.Undefined
@@ -315,14 +316,14 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             protected override object EvaluateInternal()
             {
+                var left = _left.GetValue();
+                var right = _right.GetValue();
+
                 if (_engine.Options._IsOperatorOverloadingAllowed
-                    && TryOperatorOverloading("op_Addition", out var opResult))
+                    && TryOperatorOverloading(left, right, "op_Addition", out var opResult))
                 {
                     return opResult;
                 }
-
-                var left = _left.GetValue();
-                var right = _right.GetValue();
 
                 if (AreIntegerOperands(left, right))
                 {
@@ -344,14 +345,14 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             protected override object EvaluateInternal()
             {
+                var left = _left.GetValue();
+                var right = _right.GetValue();
+
                 if (_engine.Options._IsOperatorOverloadingAllowed
-                    && TryOperatorOverloading("op_Subtraction", out var opResult))
+                    && TryOperatorOverloading(left, right, "op_Subtraction", out var opResult))
                 {
                     return opResult;
                 }
-
-                var left = _left.GetValue();
-                var right = _right.GetValue();
 
                 return AreIntegerOperands(left, right)
                     ? JsNumber.Create(left.AsInteger() - right.AsInteger())
@@ -367,14 +368,14 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             protected override object EvaluateInternal()
             {
+                var left = _left.GetValue();
+                var right = _right.GetValue();
+
                 if (_engine.Options._IsOperatorOverloadingAllowed
-                    && TryOperatorOverloading("op_Multiply", out var opResult))
+                    && TryOperatorOverloading(left, right, "op_Multiply", out var opResult))
                 {
                     return opResult;
                 }
-
-                var left = _left.GetValue();
-                var right = _right.GetValue();
 
                 if (AreIntegerOperands(left, right))
                 {
@@ -398,14 +399,14 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             protected override object EvaluateInternal()
             {
+                var left = _left.GetValue();
+                var right = _right.GetValue();
+
                 if (_engine.Options._IsOperatorOverloadingAllowed
-                    && TryOperatorOverloading("op_Division", out var opResult))
+                    && TryOperatorOverloading(left, right, "op_Division", out var opResult))
                 {
                     return opResult;
                 }
-
-                var left = _left.GetValue();
-                var right = _right.GetValue();
 
                 return Divide(left, right);
             }
@@ -422,14 +423,14 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             protected override object EvaluateInternal()
             {
+                var left = _left.GetValue();
+                var right = _right.GetValue();
+
                 if (_engine.Options._IsOperatorOverloadingAllowed
-                    && TryOperatorOverloading(_invert ? "op_Inequality" : "op_Equality", out var opResult))
+                    && TryOperatorOverloading(left, right, _invert ? "op_Inequality" : "op_Equality", out var opResult))
                 {
                     return opResult;
                 }
-
-                var left = _left.GetValue();
-                var right = _right.GetValue();
 
                 return Equal(left, right) == !_invert
                     ? JsBoolean.True
@@ -448,14 +449,14 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             protected override object EvaluateInternal()
             {
+                var leftValue = _left.GetValue();
+                var rightValue = _right.GetValue();
+
                 if (_engine.Options._IsOperatorOverloadingAllowed
-                    && TryOperatorOverloading(_leftFirst ? "op_GreaterThanOrEqual" : "op_LessThanOrEqual", out var opResult))
+                    && TryOperatorOverloading(leftValue, rightValue, _leftFirst ? "op_GreaterThanOrEqual" : "op_LessThanOrEqual", out var opResult))
                 {
                     return opResult;
                 }
-
-                var leftValue = _left.GetValue();
-                var rightValue = _right.GetValue();
 
                 var left = _leftFirst ? leftValue : rightValue;
                 var right = _leftFirst ? rightValue : leftValue;
@@ -525,14 +526,14 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             protected override object EvaluateInternal()
             {
+                var left = _left.GetValue();
+                var right = _right.GetValue();
+
                 if (_engine.Options._IsOperatorOverloadingAllowed
-                    && TryOperatorOverloading("op_Modulus", out var opResult))
+                    && TryOperatorOverloading(left, right, "op_Modulus", out var opResult))
                 {
                     return opResult;
                 }
-
-                var left = _left.GetValue();
-                var right = _right.GetValue();
 
                 if (AreIntegerOperands(left, right))
                 {
@@ -588,14 +589,14 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             protected override object EvaluateInternal()
             {
+                var left = _left.GetValue();
+                var right = _right.GetValue();
+
                 if (_engine.Options._IsOperatorOverloadingAllowed
-                    && TryOperatorOverloading(OperatorClrName, out var opResult))
+                    && TryOperatorOverloading(left, right, OperatorClrName, out var opResult))
                 {
                     return opResult;
                 }
-
-                var left = _left.GetValue();
-                var right = _right.GetValue();
 
                 if (AreIntegerOperands(left, right))
                 {

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -53,6 +53,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override object EvaluateInternal()
         {
+            var v = _argument.GetValue();
             if (_engine.Options._IsOperatorOverloadingAllowed)
             {
                 string operatorClrName = null;
@@ -75,7 +76,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
 
                 if (operatorClrName != null &&
-                    TryOperatorOverloading(_engine, _argument.GetValue(), operatorClrName, out var result))
+                    TryOperatorOverloading(_engine, v, operatorClrName, out var result))
                 {
                     return result;
                 }
@@ -84,19 +85,18 @@ namespace Jint.Runtime.Interpreter.Expressions
             switch (_operator)
             {
                 case UnaryOperator.Plus:
-                    var plusValue = _argument.GetValue();
-                    return plusValue.IsInteger() && plusValue.AsInteger() != 0
-                        ? plusValue
-                        : JsNumber.Create(TypeConverter.ToNumber(plusValue));
+                    return v.IsInteger() && v.AsInteger() != 0
+                        ? v
+                        : JsNumber.Create(TypeConverter.ToNumber(v));
 
                 case UnaryOperator.Minus:
-                    return EvaluateMinus(_argument.GetValue());
+                    return EvaluateMinus(v);
 
                 case UnaryOperator.BitwiseNot:
-                    return JsNumber.Create(~TypeConverter.ToInt32(_argument.GetValue()));
+                    return JsNumber.Create(~TypeConverter.ToInt32(v));
 
                 case UnaryOperator.LogicalNot:
-                    return !TypeConverter.ToBoolean(_argument.GetValue()) ? JsBoolean.True : JsBoolean.False;
+                    return !TypeConverter.ToBoolean(v) ? JsBoolean.True : JsBoolean.False;
 
                 case UnaryOperator.Delete:
                     var r = _argument.Evaluate() as Reference;
@@ -146,7 +146,6 @@ namespace Jint.Runtime.Interpreter.Expressions
                     return bindings.DeleteBinding(property.ToString()) ? JsBoolean.True : JsBoolean.False;
 
                 case UnaryOperator.Void:
-                    _argument.GetValue();
                     return Undefined.Instance;
 
                 case UnaryOperator.TypeOf:
@@ -160,8 +159,6 @@ namespace Jint.Runtime.Interpreter.Expressions
                             return JsString.UndefinedString;
                         }
                     }
-
-                    var v = _argument.GetValue();
 
                     if (v.IsUndefined())
                     {

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -150,6 +150,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     return bindings.DeleteBinding(property.ToString()) ? JsBoolean.True : JsBoolean.False;
 
                 case UnaryOperator.Void:
+                    _argument.GetValue();
                     return Undefined.Instance;
 
                 case UnaryOperator.TypeOf:
@@ -165,7 +166,8 @@ namespace Jint.Runtime.Interpreter.Expressions
                         }
                     }
 
-                    var v = _engine.GetValue(value, true);
+                    // TODO: double evaluation problem
+                    var v = _argument.GetValue();
                     if (v.IsUndefined())
                     {
                         return JsString.UndefinedString;

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -53,50 +53,54 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override object EvaluateInternal()
         {
-            var v = _argument.GetValue();
-            if (_engine.Options._IsOperatorOverloadingAllowed)
-            {
-                string operatorClrName = null;
-                switch (_operator)
-                {
-                    case UnaryOperator.Plus:
-                        operatorClrName = "op_UnaryPlus";
-                        break;
-                    case UnaryOperator.Minus:
-                        operatorClrName = "op_UnaryNegation";
-                        break;
-                    case UnaryOperator.BitwiseNot:
-                        operatorClrName = "op_OnesComplement";
-                        break;
-                    case UnaryOperator.LogicalNot:
-                        operatorClrName = "op_LogicalNot";
-                        break;
-                    default:
-                        break;
-                }
-
-                if (operatorClrName != null &&
-                    TryOperatorOverloading(_engine, v, operatorClrName, out var result))
-                {
-                    return result;
-                }
-            }
-
             switch (_operator)
             {
                 case UnaryOperator.Plus:
+                {
+                    var v = _argument.GetValue();
+                    if (_engine.Options._IsOperatorOverloadingAllowed &&
+                        TryOperatorOverloading(_engine, v, "op_UnaryPlus", out var result))
+                    {
+                        return result;
+                    }
+
                     return v.IsInteger() && v.AsInteger() != 0
                         ? v
                         : JsNumber.Create(TypeConverter.ToNumber(v));
-
+                }
                 case UnaryOperator.Minus:
+                {
+                    var v = _argument.GetValue();
+                    if (_engine.Options._IsOperatorOverloadingAllowed &&
+                        TryOperatorOverloading(_engine, v, "op_UnaryNegation", out var result))
+                    {
+                        return result;
+                    }
+
                     return EvaluateMinus(v);
-
+                }
                 case UnaryOperator.BitwiseNot:
-                    return JsNumber.Create(~TypeConverter.ToInt32(v));
+                {
+                    var v = _argument.GetValue();
+                    if (_engine.Options._IsOperatorOverloadingAllowed &&
+                        TryOperatorOverloading(_engine, v, "op_OnesComplement", out var result))
+                    {
+                        return result;
+                    }
 
+                    return JsNumber.Create(~TypeConverter.ToInt32(v));
+                }
                 case UnaryOperator.LogicalNot:
+                {
+                    var v = _argument.GetValue();
+                    if (_engine.Options._IsOperatorOverloadingAllowed &&
+                        TryOperatorOverloading(_engine, v, "op_LogicalNot", out var result))
+                    {
+                        return result;
+                    }
+
                     return !TypeConverter.ToBoolean(v) ? JsBoolean.True : JsBoolean.False;
+                }
 
                 case UnaryOperator.Delete:
                     var r = _argument.Evaluate() as Reference;
@@ -149,6 +153,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     return Undefined.Instance;
 
                 case UnaryOperator.TypeOf:
+                {
                     var value = _argument.Evaluate();
                     r = value as Reference;
                     if (r != null)
@@ -160,6 +165,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                         }
                     }
 
+                    var v = _engine.GetValue(value, true);
                     if (v.IsUndefined())
                     {
                         return JsString.UndefinedString;
@@ -184,7 +190,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     }
 
                     return JsString.ObjectString;
-
+                }
                 default:
                     ExceptionHelper.ThrowArgumentException();
                     return null;


### PR DESCRIPTION
When you have operator overloading enabled the operands of almost all binary and unary expression are evaluated multiple times. This PR should fix it but it's marked as draft because it was suggested to add some tests to test against it.

The problem is easily verifiable like this:

```
var engine = new Engine(cfg => { cfg.AllowOperatorOverloading(); });
engine.SetValue("Log", (Action<string>) (s => Console.Out.WriteLine(s)));
engine.Execute("const test = () => { Log('Example'); return 1; }; test() + 1; ");
```

This should only print a single `Example` line, but instead prints two.