### PR TITLE
Introduce TypeResolver with member filter and name comparer

### DIFF
--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -6,6 +6,7 @@
     <SignAssembly>true</SignAssembly>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+    <NoWarn>612</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Runtime\Scripts\*.*;Parser\Scripts\*.*" />

--- a/Jint.Tests/Runtime/Domain/HiddenMembers.cs
+++ b/Jint.Tests/Runtime/Domain/HiddenMembers.cs
@@ -1,16 +1,22 @@
-﻿namespace Jint.Tests.Runtime.Domain
+﻿using System;
+
+namespace Jint.Tests.Runtime.Domain
 {
     public class HiddenMembers
     {
+        [Obsolete]
+        public string Field1 = "Field1";
+
+        public string Field2 = "Field2";
+
+        [Obsolete]
         public string Member1 { get; set; } = "Member1";
+
         public string Member2 { get; set; } = "Member2";
-        public string Method1()
-        {
-            return "Method1";
-        }
-        public string Method2()
-        {
-            return "Method2";
-        }
+
+        [Obsolete]
+        public string Method1() => "Method1";
+
+        public string Method2() => "Method2";
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
+++ b/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
@@ -1,0 +1,92 @@
+using System;
+using Jint.Native;
+using Jint.Tests.Runtime.Domain;
+using Xunit;
+
+namespace Jint.Tests.Runtime
+{
+    public partial class InteropTests
+    {
+        [Fact]
+        public void ShouldHideSpecificMembers()
+        {
+            var engine = new Engine(options => options.SetMemberAccessor((e, target, member) =>
+            {
+                if (target is HiddenMembers)
+                {
+                    if (member == nameof(HiddenMembers.Member2) || member == nameof(HiddenMembers.Method2))
+                    {
+                        return JsValue.Undefined;
+                    }
+                }
+
+                return null;
+            }));
+
+            engine.SetValue("m", new HiddenMembers());
+
+            Assert.Equal("Member1", engine.Evaluate("m.Member1").ToString());
+            Assert.Equal("undefined", engine.Evaluate("m.Member2").ToString());
+            Assert.Equal("Method1", engine.Evaluate("m.Method1()").ToString());
+            // check the method itself, not its invokation as it would mean invoking "undefined"
+            Assert.Equal("undefined", engine.Evaluate("m.Method2").ToString());
+        }
+
+        [Fact]
+        public void ShouldOverrideMembers()
+        {
+            var engine = new Engine(options => options.SetMemberAccessor((e, target, member) =>
+            {
+                if (target is HiddenMembers && member == nameof(HiddenMembers.Member1))
+                {
+                    return "Orange";
+                }
+
+                return null;
+            }));
+
+            engine.SetValue("m", new HiddenMembers());
+
+            Assert.Equal("Orange", engine.Evaluate("m.Member1").ToString());
+        }
+
+        [Fact]
+        public void ShouldBeAbleToFilterMembers()
+        {
+            var engine = new Engine(options => options
+                .SetMemberFilter((member, state) => !Attribute.IsDefined(member, typeof(ObsoleteAttribute)))
+            );
+
+            engine.SetValue("m", new HiddenMembers());
+
+            Assert.True(engine.Evaluate("m.Field1").IsUndefined());
+            Assert.True(engine.Evaluate("m.Member1").IsUndefined());
+            Assert.True(engine.Evaluate("m.Method1").IsUndefined());
+
+            Assert.True(engine.Evaluate("m.Field2").IsString());
+            Assert.True(engine.Evaluate("m.Member2").IsString());
+            Assert.True(engine.Evaluate("m.Method2()").IsString());
+        }
+
+        [Fact]
+        public void ShouldBeAbleToHideGetType()
+        {
+            var engine = new Engine(options => options
+                .SetMemberFilter((member, state) => !Attribute.IsDefined(member, typeof(ObsoleteAttribute)))
+            );
+            engine.SetValue("m", new HiddenMembers());
+
+            Assert.True(engine.Evaluate("m.Method1").IsUndefined());
+
+            // reflection could bypass some safeguards
+            Assert.Equal("Method1", engine.Evaluate("m.GetType().GetMethod('Method1').Invoke(m, [])").AsString());
+
+            // but not when we forbid GetType
+            var hiddenGetTypeEngine = new Engine(options => options
+                .SetMemberFilter((member, state) => member.Name != nameof(GetType))
+            );
+            hiddenGetTypeEngine.SetValue("m", new HiddenMembers());
+            Assert.True(hiddenGetTypeEngine.Evaluate("m.GetType").IsUndefined());
+        }
+    }
+}

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -19,7 +19,7 @@ using Xunit;
 
 namespace Jint.Tests.Runtime
 {
-    public class InteropTests : IDisposable
+    public partial class InteropTests : IDisposable
     {
         private readonly Engine _engine;
 
@@ -2276,49 +2276,6 @@ namespace Jint.Tests.Runtime
             jsValue = engine.Evaluate("showProps(jsObj, 'theObject')").AsString();
             clrValue = engine.Evaluate("showProps(jsObj, 'theObject')").AsString();
             Assert.Equal(jsValue, clrValue);
-        }
-
-        [Fact]
-        public void ShouldHideSpecificMembers()
-        {
-            var engine = new Engine(options => options.SetMemberAccessor((e, target, member) =>
-            {
-                if (target is HiddenMembers)
-                {
-                    if (member == nameof(HiddenMembers.Member2) || member == nameof(HiddenMembers.Method2))
-                    {
-                        return JsValue.Undefined;
-                    }
-                }
-
-                return null;
-            }));
-
-            engine.SetValue("m", new HiddenMembers());
-
-            Assert.Equal("Member1", engine.Evaluate("m.Member1").ToString());
-            Assert.Equal("undefined", engine.Evaluate("m.Member2").ToString());
-            Assert.Equal("Method1", engine.Evaluate("m.Method1()").ToString());
-            // check the method itself, not its invokation as it would mean invoking "undefined"
-            Assert.Equal("undefined", engine.Evaluate("m.Method2").ToString());
-        }
-
-        [Fact]
-        public void ShouldOverrideMembers()
-        {
-            var engine = new Engine(options => options.SetMemberAccessor((e, target, member) =>
-            {
-                if (target is HiddenMembers && member == nameof(HiddenMembers.Member1))
-                {
-                    return "Orange";
-                }
-
-                return null;
-            }));
-
-            engine.SetValue("m", new HiddenMembers());
-
-            Assert.Equal("Orange", engine.Evaluate("m.Member1").ToString());
         }
 
         [Fact]

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -82,7 +82,7 @@ namespace Jint
         internal readonly PropertyDescriptor _callerCalleeArgumentsThrowerConfigurable;
         internal readonly PropertyDescriptor _callerCalleeArgumentsThrowerNonConfigurable;
 
-        internal static Dictionary<ClrPropertyDescriptorFactoriesKey, ReflectionAccessor> ReflectionAccessors = new();
+        internal Dictionary<ClrPropertyDescriptorFactoriesKey, ReflectionAccessor> ReflectionAccessors = new();
 
         internal readonly JintCallStack CallStack;
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -28,6 +28,7 @@ namespace Jint
         private readonly List<IObjectConverter> _objectConverters = new();
         private Func<Engine, object, ObjectInstance> _wrapObjectHandler;
         private MemberAccessorDelegate _memberAccessor;
+        private MemberFilter _memberFilter = (_, _) => true;
         private int _maxRecursionDepth = -1;
         private TimeSpan _regexTimeoutInterval = TimeSpan.FromSeconds(10);
         private CultureInfo _culture = CultureInfo.CurrentCulture;
@@ -192,6 +193,16 @@ namespace Jint
         public Options SetMemberAccessor(MemberAccessorDelegate accessor)
         {
             _memberAccessor = accessor;
+            return this;
+        }
+
+        /// <summary>
+        /// Registers a filter that determines whether given member is wrapped to interop or returned as undefined.
+        /// </summary>
+        /// <param name="filter">The filter to use, if filter returns false, member is skipped.</param>
+        public Options SetMemberFilter(MemberFilter filter)
+        {
+            _memberFilter = filter;
             return this;
         }
 
@@ -366,6 +377,7 @@ namespace Jint
 
         internal Func<Engine, object, ObjectInstance> _WrapObjectHandler => _wrapObjectHandler;
         internal MemberAccessorDelegate _MemberAccessor => _memberAccessor;
+        internal MemberFilter _MemberFilter => _memberFilter;
 
         internal int MaxRecursionDepth => _maxRecursionDepth;
 

--- a/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
@@ -60,8 +60,10 @@ namespace Jint.Runtime.Interop.Reflection
                 return null;
             }
 
+            var filter = engine.Options._MemberFilter;
+
             // default indexer wins
-            if (typeof(IList).IsAssignableFrom(targetType))
+            if (typeof(IList).IsAssignableFrom(targetType) && filter(_iListIndexer, null))
             {
                 indexerAccessor = ComposeIndexerFactory(_iListIndexer, typeof(int));
                 if (indexerAccessor != null)
@@ -74,6 +76,11 @@ namespace Jint.Runtime.Interop.Reflection
             // try to find first indexer having either public getter or setter with matching argument type
             foreach (var candidate in targetType.GetProperties())
             {
+                if (!filter(candidate, null))
+                {
+                    continue;
+                }
+
                 var indexParameters = candidate.GetIndexParameters();
                 if (indexParameters.Length != 1)
                 {


### PR DESCRIPTION
Setting a filter allows to reuse all resolution logic and wrapping and on top of that just filter with `MemberInfo`.  Now also caching resolution per engine as options are per engine.

Also adding custom property name comparer.

fixes #275
fixes #342