### PR TITLE
Capture original exception stacktrace in ThrowMeaningfulException

### DIFF
--- a/Jint.Tests/Runtime/ErrorTests.cs
+++ b/Jint.Tests/Runtime/ErrorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Esprima;
 using Jint.Runtime;
+using Jint.Tests.Runtime.TestClasses;
 using System;
 using System.Collections.Generic;
 using Xunit;
@@ -282,6 +283,21 @@ var x = b(7);";
             EqualIgnoringNewLineDifferences(expected, ex.ToString());
         }
 
+        [Fact]
+        public void StackTraceIsForOriginalException()
+        {
+            var engine = new Engine();
+            engine.SetValue("HelloWorld", new HelloWorld());
+            const string script = @"HelloWorld.ThrowException();";
+
+            var ex = Assert.Throws<DivideByZeroException>(() => engine.Execute(script));
+
+            const string expected = @"System.DivideByZeroException: Attempted to divide by zero.
+   at Jint.Tests.Runtime.TestClasses.HelloWorld.ThrowException() in C:\Jint\jint\Jint.Tests\Runtime\TestClasses\HelloWorld.cs:line ";
+
+            StartsWithIgnoringNewLineDifferences(expected, ex.ToString());
+        }
+
         [Theory]
         [InlineData("Error")]
         [InlineData("EvalError")]
@@ -302,6 +318,13 @@ var x = b(7);";
             expected = expected.Replace("\r\n", "\n");
             actual = actual.Replace("\r\n", "\n");
             Assert.Equal(expected, actual);
+        }
+
+        private static void StartsWithIgnoringNewLineDifferences(string expectedStartString, string actualString)
+        {
+            expectedStartString = expectedStartString.Replace("\r\n", "\n");
+            actualString = actualString.Replace("\r\n", "\n");
+            Assert.StartsWith(expectedStartString, actualString);
         }
     }
 }

--- a/Jint.Tests/Runtime/ErrorTests.cs
+++ b/Jint.Tests/Runtime/ErrorTests.cs
@@ -292,10 +292,9 @@ var x = b(7);";
 
             var ex = Assert.Throws<DivideByZeroException>(() => engine.Execute(script));
 
-            const string expected = @"System.DivideByZeroException: Attempted to divide by zero.
-   at Jint.Tests.Runtime.TestClasses.HelloWorld.ThrowException() in C:\Jint\jint\Jint.Tests\Runtime\TestClasses\HelloWorld.cs:line ";
+            const string expected = "HelloWorld";
 
-            StartsWithIgnoringNewLineDifferences(expected, ex.ToString());
+            ContainsIgnoringNewLineDifferences(expected, ex.ToString());
         }
 
         [Theory]
@@ -320,11 +319,11 @@ var x = b(7);";
             Assert.Equal(expected, actual);
         }
 
-        private static void StartsWithIgnoringNewLineDifferences(string expectedStartString, string actualString)
+        private static void ContainsIgnoringNewLineDifferences(string expectedSubstring, string actualString)
         {
-            expectedStartString = expectedStartString.Replace("\r\n", "\n");
+            expectedSubstring = expectedSubstring.Replace("\r\n", "\n");
             actualString = actualString.Replace("\r\n", "\n");
-            Assert.StartsWith(expectedStartString, actualString);
+            Assert.Contains(expectedSubstring, actualString);
         }
     }
 }

--- a/Jint.Tests/Runtime/TestClasses/HelloWorld.cs
+++ b/Jint.Tests/Runtime/TestClasses/HelloWorld.cs
@@ -1,0 +1,11 @@
+﻿namespace Jint.Tests.Runtime.TestClasses
+{
+    public class HelloWorld
+    {
+        public void ThrowException()
+        {
+            int zero = 0;
+            int x = 5 / zero;
+        }
+    }
+}

--- a/Jint/Runtime/ExceptionHelper.cs
+++ b/Jint/Runtime/ExceptionHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Jint.Native;
 using Jint.Runtime.CallStack;
 using Jint.Runtime.References;
@@ -141,7 +142,7 @@ namespace Jint.Runtime
                 ThrowError(engine, meaningfulException.Message);
             }
 
-            throw meaningfulException;
+            ExceptionDispatchInfo.Capture(meaningfulException).Throw();
         }
 
         [DoesNotReturn]


### PR DESCRIPTION
Use ExceptionDispatchInfo to capture the original stacktrace in ThrowMeaningfulException

fixes #963