### PR TITLE
Fix iteration in interop

### DIFF
--- a/Jint.Tests/Runtime/Domain/Company.cs
+++ b/Jint.Tests/Runtime/Domain/Company.cs
@@ -35,5 +35,13 @@ namespace Jint.Tests.Runtime.Domain
         {
             return string.Compare(_name, other.Name, StringComparison.CurrentCulture);
         }
+
+        public IEnumerable<char> GetNameChars()
+        {
+            foreach (var c in _name)
+            {
+                yield return c;
+            }
+        }
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -574,6 +574,16 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
+        public void ShouldForOfOnEnumerable()
+        {
+            _engine.SetValue("c", new Company("name"));
+
+            var result = _engine.Evaluate("var l = ''; for (var x of c.getNameChars()) l += x + ','; return l;").AsString();
+
+            Assert.Equal("n,a,m,e,", result);
+        }
+
+        [Fact]
         public void ShouldThrowWhenForOfOnObject()
         {
             // normal objects are not iterable in javascript

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -530,6 +530,61 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
+        public void ShouldForOfOnLists()
+        {
+            _engine.SetValue("list", new List<string> { "a", "b" });
+
+            var result = _engine.Evaluate("var l = ''; for (var x of list) l += x; return l;").AsString();
+
+            Assert.Equal("ab", result);
+        }
+
+        [Fact]
+        public void ShouldForOfOnArrays()
+        {
+            _engine.SetValue("arr", new[] { "a", "b" });
+
+            var result = _engine.Evaluate("var l = ''; for (var x of arr) l += x; return l;").AsString();
+
+            Assert.Equal("ab", result);
+        }
+
+        [Fact]
+        public void ShouldForOfOnDictionaries()
+        {
+            _engine.SetValue("dict", new Dictionary<string, string> { {"a", "1"}, {"b", "2"} });
+
+            var result = _engine.Evaluate("var l = ''; for (var x of dict) l += x; return l;").AsString();
+
+            Assert.Equal("a,1b,2", result);
+        }
+
+        [Fact]
+        public void ShouldForOfOnExpandoObject()
+        {
+            dynamic o = new ExpandoObject();
+            o.a = 1;
+            o.b = 2;
+
+            _engine.SetValue("dynamic", o);
+
+            var result = _engine.Evaluate("var l = ''; for (var x of dynamic) l += x; return l;").AsString();
+
+            Assert.Equal("a,1b,2", result);
+        }
+
+        [Fact]
+        public void ShouldThrowWhenForOfOnObject()
+        {
+            // normal objects are not iterable in javascript
+            var o = new { A = 1, B = 2 };
+            _engine.SetValue("anonymous", o);
+
+            var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("for (var x of anonymous) {}"));
+            Assert.Equal("The value is not iterable", ex.Message);
+        }
+
+        [Fact]
         public void CanAccessAnonymousObject()
         {
             var p = new

--- a/Jint/Native/Array/ArrayIteratorPrototype.cs
+++ b/Jint/Native/Array/ArrayIteratorPrototype.cs
@@ -18,16 +18,6 @@ namespace Jint.Native.Array
         {
         }
 
-        internal IteratorInstance Construct(ObjectInstance array, Func<Intrinsics, Prototype> prototypeSelector)
-        {
-            var instance = new ArrayLikeIterator(Engine, array, ArrayIteratorType.KeyAndValue)
-            {
-                _prototype = prototypeSelector(_realm.Intrinsics)
-            };
-
-            return instance;
-        }
-
         internal IteratorInstance Construct(ObjectInstance array, ArrayIteratorType kind)
         {
             var instance = new ArrayLikeIterator(Engine, array, kind)

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -193,7 +193,7 @@ namespace Jint.Native
             var objectInstance = TypeConverter.ToObject(realm, this);
 
             if (!objectInstance.TryGetValue(GlobalSymbolRegistry.Iterator, out var value)
-                || !(value is ICallable callable))
+                || value is not ICallable callable)
             {
                 iterator = null;
                 return false;

--- a/Jint/Native/Map/MapIteratorPrototype.cs
+++ b/Jint/Native/Map/MapIteratorPrototype.cs
@@ -74,6 +74,5 @@ namespace Jint.Native.Map
                 return false;
             }
         }
-
     }
 }

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using Jint.Native;
+using Jint.Native.Iterator;
 using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime.Descriptors;
@@ -23,20 +24,14 @@ namespace Jint.Runtime.Interop
         {
             Target = obj;
             _typeDescriptor = TypeDescriptor.Get(obj.GetType());
-            if (_typeDescriptor.IsArrayLike)
+            if (_typeDescriptor.LengthProperty is not null)
             {
                 // create a forwarder to produce length from Count or Length if one of them is present
-                var lengthProperty = obj.GetType().GetProperty("Count") ?? obj.GetType().GetProperty("Length");
-                if (lengthProperty is null)
-                {
-                    return;
-                }
-                var functionInstance = new ClrFunctionInstance(engine, "length", (_, _) => JsNumber.Create((int) lengthProperty.GetValue(obj)));
+                var functionInstance = new ClrFunctionInstance(engine, "length", GetLength);
                 var descriptor = new GetSetPropertyDescriptor(functionInstance, Undefined, PropertyFlag.Configurable);
                 SetProperty(KnownKeys.Length, descriptor);
             }
         }
-
 
         public object Target { get; }
 
@@ -215,18 +210,24 @@ namespace Jint.Runtime.Interop
 
             if (property.IsSymbol() && property == GlobalSymbolRegistry.Iterator)
             {
-                var iteratorFunction = new ClrFunctionInstance(
-                    Engine, "iterator",
-                    (thisObject, arguments) => _engine.Realm.Intrinsics.ArrayIteratorPrototype.Construct(this, intrinsics => intrinsics.IteratorPrototype),
-                    1,
-                    PropertyFlag.Configurable);
-                var iteratorProperty = new PropertyDescriptor(iteratorFunction, PropertyFlag.Configurable | PropertyFlag.Writable);
-                SetProperty(GlobalSymbolRegistry.Iterator, iteratorProperty);
-                return iteratorProperty;
+                // if we have array-like or dictionary or expando, we can provide iterator
+                if (_typeDescriptor.IsArrayLike || _typeDescriptor.IsDictionary)
+                {
+                    var iteratorFunction = new ClrFunctionInstance(
+                        Engine,
+                        "iterator",
+                        Iterator,
+                        1,
+                        PropertyFlag.Configurable);
+
+                    var iteratorProperty = new PropertyDescriptor(iteratorFunction, PropertyFlag.Configurable | PropertyFlag.Writable);
+                    SetProperty(GlobalSymbolRegistry.Iterator, iteratorProperty);
+                    return iteratorProperty;
+                }
             }
 
             var member = property.ToString();
-            var result = Engine.Options.Interop.MemberAccessor?.Invoke(Engine, Target, member);
+            var result = Engine.Options.Interop.MemberAccessor(Engine, Target, member);
             if (result is not null)
             {
                 return new PropertyDescriptor(result, PropertyFlag.OnlyEnumerable);
@@ -253,6 +254,25 @@ namespace Jint.Runtime.Interop
                 };
             }
             return engine.Options.Interop.TypeResolver.GetAccessor(engine, target.GetType(), member.Name, Factory).CreatePropertyDescriptor(engine, target);
+        }
+
+        private static JsValue Iterator(JsValue thisObj, JsValue[] arguments)
+        {
+            var wrapper = (ObjectWrapper) thisObj;
+            var intrinsics = wrapper._engine.Realm.Intrinsics;
+
+            if (wrapper._typeDescriptor.IsDictionary)
+            {
+                return new DictionaryIterator(wrapper._engine, wrapper);
+            }
+
+            return new ListIterator(wrapper._engine, (IList) wrapper.Target);
+        }
+
+        private static JsValue GetLength(JsValue thisObj, JsValue[] arguments)
+        {
+            var wrapper = (ObjectWrapper) thisObj;
+            return JsNumber.Create((int) wrapper._typeDescriptor.LengthProperty.GetValue(wrapper.Target));
         }
 
         public override bool Equals(JsValue obj)
@@ -284,5 +304,59 @@ namespace Jint.Runtime.Interop
         {
             return Target?.GetHashCode() ?? 0;
         }
+
+        private sealed class DictionaryIterator : IteratorInstance
+        {
+            private readonly ObjectWrapper _target;
+            private readonly IEnumerator<JsValue> _enumerator;
+
+            public DictionaryIterator(Engine engine, ObjectWrapper target) : base(engine)
+            {
+                _target = target;
+                _enumerator = target.EnumerateOwnPropertyKeys(Types.String).GetEnumerator();
+            }
+
+            public override bool TryIteratorStep(out ObjectInstance nextItem)
+            {
+                if (_enumerator.MoveNext())
+                {
+                    var key = _enumerator.Current;
+                    var value = _target.Get(key);
+
+                    nextItem = new KeyValueIteratorPosition(_engine, key, value);
+                    return true;
+                }
+
+                nextItem = KeyValueIteratorPosition.Done;
+                return false;
+            }
+        }
+
+        private sealed class ListIterator : IteratorInstance
+        {
+            private readonly IList _list;
+            private int _position;
+
+            public ListIterator(Engine engine, IList list) : base(engine)
+            {
+                _list = list;
+                _position = 0;
+            }
+
+            public override bool TryIteratorStep(out ObjectInstance nextItem)
+            {
+                if (_position < _list.Count)
+                {
+                    var value = _list[_position];
+                    _position++;
+                    nextItem = new ValueIteratorPosition(_engine, FromObject(_engine, value));
+                    return true;
+                }
+
+                nextItem = KeyValueIteratorPosition.Done;
+                return false;
+            }
+        }
+
     }
 }

--- a/Jint/Runtime/Interop/TypeDescriptor.cs
+++ b/Jint/Runtime/Interop/TypeDescriptor.cs
@@ -14,6 +14,7 @@ namespace Jint.Runtime.Interop
         {
             IsArrayLike = DetermineIfObjectIsArrayLikeClrCollection(type);
             IsDictionary = typeof(IDictionary).IsAssignableFrom(type) || typeof(IDictionary<string, object>).IsAssignableFrom(type);
+            IsEnumerable = typeof(IEnumerable).IsAssignableFrom(type);
 
             if (IsArrayLike)
             {
@@ -25,7 +26,10 @@ namespace Jint.Runtime.Interop
         public bool IsArrayLike { get; }
         public bool IsIntegerIndexedArray { get; }
         public bool IsDictionary { get; }
+        public bool IsEnumerable { get; }
         public PropertyInfo LengthProperty { get; }
+
+        public bool Iterable => IsArrayLike || IsDictionary || IsEnumerable;
 
         public static TypeDescriptor Get(Type type)
         {

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -340,7 +340,7 @@ namespace Jint.Runtime.Interpreter.Statements
             AsyncIterate
         }
 
-        internal class ObjectKeyVisitor : IteratorInstance
+        private sealed class ObjectKeyVisitor : IteratorInstance
         {
             public ObjectKeyVisitor(Engine engine, ObjectInstance obj)
                 : base(engine, CreateEnumerator(engine, obj))


### PR DESCRIPTION
* array-like when list or array should iterate values (like Set)
* dictionary-likes should iterate keys and values (like Map)
* IEnumerable behaves like custom Iterable added to regular JS object (enumerates values as-is)
* any other object type is unsupported like in normal JS (like basic objects { "A": 1 })