### PR TITLE
Prevent GetType and System.Reflection namespace under interop by default

### DIFF
--- a/Jint.Tests/Runtime/Domain/HiddenMembers.cs
+++ b/Jint.Tests/Runtime/Domain/HiddenMembers.cs
@@ -18,5 +18,7 @@ namespace Jint.Tests.Runtime.Domain
         public string Method1() => "Method1";
 
         public string Method2() => "Method2";
+
+        public Type Type => GetType();
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
+++ b/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
@@ -78,18 +78,30 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void ShouldBeAbleToExposeGetType()
         {
-            var engine = new Engine(options => options
-                .SetTypeResolver(new TypeResolver
-                {
-                    // allow unsafe access to GetType
-                    ExposeGetType = true
-                })
-            );
+            var engine = new Engine(options =>
+            {
+                options.Interop.AllowGetType = true;
+                options.Interop.AllowSystemReflection = true;
+            });
             engine.SetValue("m", new HiddenMembers());
             Assert.True(engine.Evaluate("m.GetType").IsCallable());
 
             // reflection could bypass some safeguards
             Assert.Equal("Method1", engine.Evaluate("m.GetType().GetMethod('Method1').Invoke(m, [])").AsString());
+        }
+
+        [Fact]
+        public void ShouldProtectFromReflectionServiceUsage()
+        {
+            var engine = new Engine();
+            engine.SetValue("m", new HiddenMembers());
+
+            // we can get a type reference if it's exposed via property, bypassing GetType
+            var type = engine.Evaluate("m.Type");
+            Assert.IsType<ObjectWrapper>(type);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => engine.Evaluate("m.Type.Module.GetType().Module.GetType('System.DateTime')"));
+            Assert.Equal("Cannot access System.Reflection namespace, check Engine's interop options", ex.Message);
         }
 
         [Fact]

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -152,7 +152,7 @@ namespace Jint
 
         public static Options AllowOperatorOverloading(this Options options, bool allow = true)
         {
-            options.Interop.OperatorOverloadingAllowed = allow;
+            options.Interop.AllowOperatorOverloading = allow;
             return options;
         }
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -188,6 +188,18 @@ namespace Jint
         public bool Enabled { get; set; }
 
         /// <summary>
+        /// Whether to expose <see cref="object.GetType"></see> which can allow bypassing allow lists and open a way to reflection.
+        /// Defaults to false.
+        /// </summary>
+        public bool AllowGetType { get; set; }
+
+        /// <summary>
+        /// Whether Jint should allow wrapping objects from System.Reflection namespace.
+        /// Defaults to false.
+        /// </summary>
+        public bool AllowSystemReflection { get; set; }
+
+        /// <summary>
         /// Whether writing to CLR objects is allowed (set properties), defaults to true.
         /// </summary>
         public bool AllowWrite { get; set; } = true;
@@ -195,7 +207,7 @@ namespace Jint
         /// <summary>
         /// Whether operator overloading resolution is allowed, defaults to false.
         /// </summary>
-        public bool OperatorOverloadingAllowed { get; set; }
+        public bool AllowOperatorOverloading { get; set; }
 
         /// <summary>
         /// Types holding extension methods that should be considered when resolving methods.

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -67,6 +67,14 @@ namespace Jint
                     else
                     {
                         var t = value.GetType();
+
+                        if (!engine.Options.Interop.AllowSystemReflection
+                            && t.Namespace?.StartsWith("System.Reflection") == true)
+                        {
+                            const string message = "Cannot access System.Reflection namespace, check Engine's interop options";
+                            ExceptionHelper.ThrowInvalidOperationException(message);
+                        }
+
                         if (t.IsEnum)
                         {
                             var ut = Enum.GetUnderlyingType(t);

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -212,7 +212,7 @@ namespace Jint.Runtime.Interop
                 return obj;
             }
 
-            if (_engine.Options.Interop.OperatorOverloadingAllowed)
+            if (_engine.Options.Interop.AllowOperatorOverloading)
             {
 #if NETSTANDARD
                 var key = (valueType, type);

--- a/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
@@ -74,7 +74,7 @@ namespace Jint.Runtime.Interop.Reflection
                 return null;
             }
 
-            var filter = engine.Options.Interop.TypeResolver.MemberFilter;
+            var filter = new Func<MemberInfo, bool>(engine.Options.Interop.TypeResolver.Filter);
 
             // default indexer wins
             if (typeof(IList).IsAssignableFrom(targetType) && filter(_iListIndexer))

--- a/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
@@ -74,7 +74,7 @@ namespace Jint.Runtime.Interop.Reflection
                 return null;
             }
 
-            var filter = new Func<MemberInfo, bool>(engine.Options.Interop.TypeResolver.Filter);
+            var filter = new Func<MemberInfo, bool>(m => engine.Options.Interop.TypeResolver.Filter(engine, m));
 
             // default indexer wins
             if (typeof(IList).IsAssignableFrom(targetType) && filter(_iListIndexer))

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -165,7 +165,7 @@ namespace Jint.Runtime.Interop
             }
 
             const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.Static;
-            return typeResolver.TryFindMemberAccessor(type, name, bindingFlags, indexerToTry: null, out var accessor)
+            return typeResolver.TryFindMemberAccessor(_engine, type, name, bindingFlags, indexerToTry: null, out var accessor)
                 ? accessor
                 : ConstantValueAccessor.NullAccessor;
         }

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -18,7 +18,7 @@ namespace Jint.Runtime.Interop
 
         /// <summary>
         /// Registers a filter that determines whether given member is wrapped to interop or returned as undefined.
-        /// By default allows all but will also by limited by <see cref="AllowGetType"/> configuration.
+        /// By default allows all but will also be limited by <see cref="AllowGetType"/> configuration.
         /// </summary>
         /// <seealso cref="AllowGetType"/>
         public Predicate<MemberInfo> MemberFilter { get; set; } = _ => true;

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -18,9 +18,9 @@ namespace Jint.Runtime.Interop
 
         /// <summary>
         /// Registers a filter that determines whether given member is wrapped to interop or returned as undefined.
-        /// By default allows all but will also be limited by <see cref="AllowGetType"/> configuration.
+        /// By default allows all but will also be limited by <see cref="InteropOptions.AllowGetType"/> configuration.
         /// </summary>
-        /// <seealso cref="AllowGetType"/>
+        /// <seealso cref="InteropOptions.AllowGetType"/>
         public Predicate<MemberInfo> MemberFilter { get; set; } = _ => true;
 
         internal bool Filter(Engine engine, MemberInfo m)

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -12,7 +12,7 @@ namespace Jint.Runtime.Interpreter
             Engine = engine;
             DebugMode = engine._isDebugMode;
             ResumedCompletion = resumedCompletion ?? default; // TODO later
-            OperatorOverloadingAllowed = engine.Options.Interop.OperatorOverloadingAllowed;
+            OperatorOverloadingAllowed = engine.Options.Interop.AllowOperatorOverloading;
         }
 
         public Engine Engine { get; }


### PR DESCRIPTION
Seems that this trips people often enough that we shouldn't allow `GetType` by default. Created separate property to control so that overwritten member filter won't cause us trouble, GetType will always by filtered based on configuration.

fixes #993