### PR TITLE
Improve stringify for JObject

### DIFF
--- a/Jint.Tests/Runtime/Domain/ArrayConverterTestClass.cs
+++ b/Jint.Tests/Runtime/Domain/ArrayConverterTestClass.cs
@@ -54,7 +54,7 @@ namespace Jint.Tests.Runtime.Domain
         #region NotImplemented
         public TypeCode GetTypeCode()
         {
-            throw new NotImplementedException();
+            return TypeCode.Object;
         }
 
         public bool ToBoolean(IFormatProvider provider)

--- a/Jint.Tests/Runtime/InteropTests.NewtonsoftJson.cs
+++ b/Jint.Tests/Runtime/InteropTests.NewtonsoftJson.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Jint.Native;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
 using Newtonsoft.Json.Linq;
@@ -95,10 +94,7 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void EngineShouldStringifyJObjectFromObjectListWithValuesCorrectly()
         {
-            var engine = new Engine(options =>
-            {
-                options.AddObjectConverter(JTokenConverter.Instance);
-            });
+            var engine = new Engine();
 
             var source = new dynamic[]
             {
@@ -111,48 +107,6 @@ namespace Jint.Tests.Runtime
             var result = fromEngine.ToString();
 
             Assert.Equal("[{\"Text\":\"Text1\",\"Value\":1},{\"Text\":\"Text2\",\"Value\":2}]", result);
-        }
-
-        private sealed class JTokenConverter : IObjectConverter
-        {
-            public static readonly IObjectConverter Instance = new JTokenConverter();
-
-            public bool TryConvert(Engine engine, object value, out JsValue result)
-            {
-                result = null;
-
-                if (!(value is JToken token))
-                {
-                    return false;
-                }
-
-                switch (token.Type)
-                {
-                    case JTokenType.Integer:
-                        result = JsNumber.Create(token.Value<int>());
-                        break;
-                    case JTokenType.Float:
-                        result = JsNumber.Create(token.Value<double>());
-                        break;
-                    case JTokenType.String:
-                        result = JsString.Create(token.Value<string>());
-                        break;
-                    case JTokenType.Boolean:
-                        result = token.Value<bool>() ? JsBoolean.True : JsBoolean.False;
-                        break;
-                    case JTokenType.Null:
-                        result = JsValue.Null;
-                        break;
-                    case JTokenType.Undefined:
-                        result = JsValue.Undefined;
-                        break;
-                    case JTokenType.Date:
-                        result = engine.Realm.Intrinsics.Date.Construct(token.Value<DateTime>());
-                        break;
-                }
-
-                return !(result is null);
-            }
         }
     }
 }

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -98,37 +98,6 @@ namespace Jint.Runtime.Interop
                 return Undefined;
             }
 
-            if (property is JsString stringKey)
-            {
-                var member = stringKey.ToString();
-
-                // expando object for instance
-                if (_typeDescriptor.IsStringKeyedGenericDictionary)
-                {
-                    if (_typeDescriptor.TryGetValue(Target, member, out var value))
-                    {
-                        return FromObject(_engine, value);
-                    }
-                }
-
-                var result = Engine.Options.Interop.MemberAccessor?.Invoke(Engine, Target, member);
-                if (result is not null)
-                {
-                    return result;
-                }
-
-                if (_properties is null || !_properties.ContainsKey(member))
-                {
-                    // can try utilize fast path
-                    var accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, Target.GetType(), member);
-                    var value = accessor.GetValue(_engine, Target);
-                    if (value is not null)
-                    {
-                        return FromObject(_engine, value);
-                    }
-                }
-            }
-
             return base.Get(property, receiver);
         }
 
@@ -152,9 +121,10 @@ namespace Jint.Runtime.Interop
             var processed = basePropertyKeys.Count > 0 ? new HashSet<JsValue>() : null;
 
             var includeStrings = (types & Types.String) != 0;
-            if (includeStrings && Target is IDictionary<string, object> stringKeyedDictionary) // expando object for instance
+            if (includeStrings && _typeDescriptor.IsStringKeyedGenericDictionary) // expando object for instance
             {
-                foreach (var key in stringKeyedDictionary.Keys)
+                var keys = _typeDescriptor.GetKeys(Target);
+                foreach (var key in keys)
                 {
                     var jsString = JsString.Create(key);
                     processed?.Add(jsString);
@@ -166,7 +136,9 @@ namespace Jint.Runtime.Interop
                 // we take values exposed as dictionary keys only
                 foreach (var key in dictionary.Keys)
                 {
-                    if (_engine.ClrTypeConverter.TryConvert(key, typeof(string), CultureInfo.InvariantCulture, out var stringKey))
+                    object stringKey = key as string;
+                    if (stringKey is not null
+                        || _engine.ClrTypeConverter.TryConvert(key, typeof(string), CultureInfo.InvariantCulture, out stringKey))
                     {
                         var jsString = JsString.Create((string) stringKey);
                         processed?.Add(jsString);
@@ -234,6 +206,15 @@ namespace Jint.Runtime.Interop
             }
 
             var member = property.ToString();
+
+            if (_typeDescriptor.IsStringKeyedGenericDictionary)
+            {
+                if (_typeDescriptor.TryGetValue(Target, member, out var value))
+                {
+                    return new PropertyDescriptor(FromObject(_engine, value), PropertyFlag.OnlyEnumerable);
+                }
+            }
+
             var result = Engine.Options.Interop.MemberAccessor(Engine, Target, member);
             if (result is not null)
             {

--- a/Jint/Runtime/Interop/TypeDescriptor.cs
+++ b/Jint/Runtime/Interop/TypeDescriptor.cs
@@ -13,6 +13,7 @@ namespace Jint.Runtime.Interop
         private static readonly Type _stringType = typeof(string);
 
         private readonly PropertyInfo _stringIndexer;
+        private readonly PropertyInfo _keysAccessor;
 
         private TypeDescriptor(Type type)
         {
@@ -24,6 +25,7 @@ namespace Jint.Runtime.Interop
                     && i.GenericTypeArguments[0] == _stringType)
                 {
                     _stringIndexer = i.GetProperty("Item");
+                    _keysAccessor = i.GetProperty("Keys");
                     break;
                 }
             }
@@ -98,6 +100,16 @@ namespace Jint.Runtime.Interop
                 o = null;
                 return false;
             }
+        }
+
+        public ICollection<string> GetKeys(object target)
+        {
+            if (!IsStringKeyedGenericDictionary)
+            {
+                ExceptionHelper.ThrowInvalidOperationException("Not a string-keyed dictionary");
+            }
+
+            return (ICollection<string>)_keysAccessor.GetValue(target);
         }
     }
 }


### PR DESCRIPTION
* https://github.com/sebastienros/jint/issues/1005#issuecomment-968517060
* improves property traversal of JObject fixing serialization
* still requires custom JTokenConverter in order to map Newtonsoft primitives to correct JS primitives, we just don't know how to handle them otherwise