### PR TITLE
Let exceptions bubble from ReflectionAccessor

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -2733,5 +2733,18 @@ namespace Jint.Tests.Runtime
             var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("a.age = \"It won't work, but it's normal\""));
             Assert.Equal("Input string was not in a correct format.", ex.Message);
         }
+
+        [Fact]
+        public void ShouldLetNotSupportedExceptionBubble()
+        {
+            _engine.SetValue("profile", new Profile());
+            var ex = Assert.Throws<NotSupportedException>(() => _engine.Evaluate("profile.AnyProperty"));
+            Assert.Equal("NOT SUPPORTED", ex.Message);
+        }
+
+        private class Profile
+        {
+            public int AnyProperty => throw new NotSupportedException("NOT SUPPORTED");
+        }
     }
 }

--- a/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
@@ -52,15 +52,6 @@ namespace Jint.Runtime.Interop.Reflection
                 }
                 catch (TargetInvocationException tie)
                 {
-                    switch (tie.InnerException)
-                    {
-                        case ArgumentOutOfRangeException _:
-                        case IndexOutOfRangeException _:
-                        case InvalidOperationException _:
-                        case NotSupportedException _:
-                            return JsValue.Undefined;
-                    }
-
                     ExceptionHelper.ThrowMeaningfulException(engine, tie);
                 }
             }


### PR DESCRIPTION
We let them bubble as-is in other parts of reflection so let's do the same by default in `ReflectionAccessor`, until there's an counter example where it should't. Doesn't break any known test case at least.

fixes #903