### PR TITLE
added int vs float diff for function overloads

### DIFF
--- a/Jint.Tests/Runtime/Domain/OverLoading.cs
+++ b/Jint.Tests/Runtime/Domain/OverLoading.cs
@@ -16,5 +16,15 @@ namespace Jint.Tests.Runtime.Domain
         {
             return "uint-enum";
         }
+
+        public string TestFunc(float f)
+        {
+            return "float-val";
+        }
+
+        public string TestFunc(int i)
+        {
+            return "int-val";
+        }
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -2464,6 +2464,15 @@ namespace Jint.Tests.Runtime
             Assert.Equal(1, engine.Evaluate("E.b;").AsNumber());
         }
 
+        [Fact]
+        public void IntegerAndFloatInFunctionOverloads()
+        {
+            var engine = new Engine(options => options.AllowClr(GetType().Assembly));
+            engine.SetValue("a", new OverLoading());
+            Assert.Equal("int-val", engine.Evaluate("a.testFunc(123);").AsString());
+            Assert.Equal("float-val", engine.Evaluate("a.testFunc(12.3);").AsString());
+        }
+
         public class TestItem
         {
             public double Cost { get; set; }

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -1129,9 +1129,20 @@ namespace Jint.Runtime
                 return 5;
             }
 
+            if (paramType == typeof(int) && jsValue.IsInteger())
+            {
+                return 0;
+            }
+
+            if (paramType == typeof(float) && objectValueType == typeof(Double))
+            {
+                return jsValue.IsInteger() ? 1 : 0;
+            }
+
             if (paramType.IsEnum &&
                 jsValue is JsNumber jsNumber
                 && jsNumber.IsInteger()
+                && paramType.GetEnumUnderlyingType() == typeof(int)
                 && Enum.IsDefined(paramType, jsNumber.AsInteger()))
             {
                 // we can do conversion from int value to enum


### PR DESCRIPTION
#1035 

First time contributing here. It felt appropriate to follow and reuse the existing Enum resolution/overloading code and tests.

Also, I added an extra check in the existing Enum resolution code `paramType.GetEnumUnderlyingType() == typeof(int)` because `Enum.IsDefined` would throw if `paramType.GetEnumUnderlyingType()` is not an int (as in the case of an overloaded function with an uint enum param).