### PR TITLE
Fix JsonParser error behavior

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1006,8 +1006,8 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void JsonParserShouldHandleEmptyString()
         {
-            var ex = Assert.Throws<ParserException>(() => _engine.Evaluate("JSON.parse('');"));
-            Assert.Equal("Line 1: Unexpected end of input", ex.Message);
+            var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("JSON.parse('');"));
+            Assert.Equal("Unexpected end of JSON input at position 0", ex.Message);
         }
 
         [Fact]
@@ -2661,7 +2661,7 @@ function output(x) {
         {
             var engine = new Engine();
             var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("JSON.parse('[01]')"));
-            Assert.Equal("Unexpected token '1'", ex.Message);
+            Assert.Equal("Unexpected token '1' in JSON at position 2", ex.Message);
 
             var voidCompletion = engine.Evaluate("try { JSON.parse('01') } catch (e) {}");
             Assert.Equal(JsValue.Undefined, voidCompletion);

--- a/Jint.Tests/Runtime/JsonTests.cs
+++ b/Jint.Tests/Runtime/JsonTests.cs
@@ -1,3 +1,5 @@
+using Jint.Native.Json;
+using Jint.Runtime;
 using Xunit;
 
 namespace Jint.Tests.Runtime
@@ -11,6 +13,40 @@ namespace Jint.Tests.Runtime
              const string script = @"JSON.parse(""{\""abc\\tdef\"": \""42\""}"");";
              var obj = engine.Evaluate(script).AsObject();
              Assert.True(obj.HasOwnProperty("abc\tdef"));
+        }
+
+        [Theory]
+        [InlineData("{\"a\":1", "Unexpected end of JSON input at position 6")]
+        [InlineData("{\"a\":1},", "Unexpected token ',' in JSON at position 7")]
+        [InlineData("{1}", "Unexpected number in JSON at position 1")]
+        [InlineData("{\"a\" \"a\"}", "Unexpected string in JSON at position 5")]
+        [InlineData("{true}", "Unexpected token 'true' in JSON at position 1")]
+        [InlineData("{null}", "Unexpected token 'null' in JSON at position 1")]
+        [InlineData("{:}", "Unexpected token ':' in JSON at position 1")]
+        [InlineData("\"\\xah\"", "Expected hexadecimal digit in JSON at position 4")]
+        [InlineData("0123", "Unexpected token '1' in JSON at position 1")]  // leading 0 (octal number) not allowed
+        [InlineData("1e+A", "Unexpected token 'A' in JSON at position 3")]
+        [InlineData("truE", "Unexpected token 'tru' in JSON at position 0")]
+        [InlineData("nul", "Unexpected token 'nul' in JSON at position 0")]
+        [InlineData("\"ab\t\"", "Invalid character in JSON at position 3")] // invalid char in string literal
+        [InlineData("\"ab", "Unexpected end of JSON input at position 3")] // unterminated string literal
+        [InlineData("alpha", "Unexpected token 'a' in JSON at position 0")]
+        [InlineData("[1,\na]", "Unexpected token 'a' in JSON at position 4")] // multiline
+        [InlineData("\x06", "Unexpected token '\x06' in JSON at position 0")] // control char
+        public void ShouldReportHelpfulSyntaxErrorForInvalidJson(string json, string expectedMessage)
+        {
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+            var ex = Assert.ThrowsAny<JavaScriptException>(() =>
+            {
+                parser.Parse(json);
+            });
+
+            Assert.Equal(expectedMessage, ex.Message);
+
+            var error = ex.Error as Native.Error.ErrorInstance;
+            Assert.NotNull(error);
+            Assert.Equal("SyntaxError", error.Get("name"));
         }
     }
 }


### PR DESCRIPTION
Issues:
* JsonParser sometimes throws JavaScriptException (SyntaxError) and sometimes throws ParserException; should be consistent and always throw one or the other.
* A script that calls JSON.parse(input) should always see a SyntaxError in the case of syntactically invalid input.
* SyntaxError messages should clearly indicate that the error is in JSON data, and indicate the position within the input string.
* SyntaxError messages should not include the entire input string in the message, as it may be arbitrarily long.

Changes:
* Route all exceptions through a common ThrowError(...) method that always throws a SyntaxError
* Clean-up content of error messages and include position of the error. Unfortunately the parser does not track line number accurately, so position is rendered as a single number as opposed to line:column format.
* Add tests to verify the expected error output for each call site of ThrowError(...)