### PR TITLE
Allowing to use nullable propagation on callables again. Fixed #1041

### DIFF
--- a/Jint.Tests/Runtime/NullPropagation.cs
+++ b/Jint.Tests/Runtime/NullPropagation.cs
@@ -1,4 +1,5 @@
-﻿using Esprima;
+﻿using System;
+using Esprima;
 using Jint.Native;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
@@ -22,8 +23,18 @@ namespace Jint.Tests.Runtime
                 return value.IsNull() || value.IsUndefined();
             }
 
-            public bool TryGetCallable(Engine engine, object reference, out JsValue value)
+            public bool TryGetCallable(Engine engine, object callee, out JsValue value)
             {
+                if (callee is Reference reference)
+                {
+                    var name = reference.GetReferencedName().AsString();
+                    if (name == "filter")
+                    {
+                        value = new ClrFunctionInstance(engine, "map", (thisObj, values) => engine.Array.Construct(Array.Empty<JsValue>()));
+                        return true;
+                    }
+                }
+
                 value = new ClrFunctionInstance(engine, "anonymous", (thisObj, values) => thisObj);
                 return true;
             }
@@ -32,6 +43,24 @@ namespace Jint.Tests.Runtime
             {
                 return true;
             }
+        }
+
+        [Fact]
+        public void CanCallFilterOnNull()
+        {
+            var engine = new Engine(cfg => cfg.SetReferencesResolver(new NullPropagationReferenceResolver()));
+
+            const string Script = @"
+var input = {};
+
+var output = { Tags : input.Tags.filter(x=>x!=null) };
+";
+
+            engine.Execute(Script);
+
+            var output = engine.GetValue("output").AsObject();
+
+            Assert.True(output.Get("Tags").IsArray());
         }
 
         [Fact]

--- a/Jint.Tests/Runtime/NullPropagation.cs
+++ b/Jint.Tests/Runtime/NullPropagation.cs
@@ -30,7 +30,7 @@ namespace Jint.Tests.Runtime
                     var name = reference.GetReferencedName().AsString();
                     if (name == "filter")
                     {
-                        value = new ClrFunctionInstance(engine, "map", (thisObj, values) => engine.Array.Construct(Array.Empty<JsValue>()));
+                        value = new ClrFunctionInstance(engine, "map", (thisObj, values) => engine.Realm.Intrinsics.Array.ConstructFast(0));
                         return true;
                     }
                 }

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -167,11 +167,13 @@ namespace Jint.Runtime.Interpreter.Expressions
                     if (baseValue.IsNullOrUndefined()
                         && engine._referenceResolver.TryUnresolvableReference(engine, referenceRecord, out var value))
                     {
-                        return value;
+                        thisValue = value;
                     }
-
-                    var refEnv = (EnvironmentRecord) baseValue;
-                    thisValue = refEnv.WithBaseObject();
+                    else
+                    {
+                        var refEnv = (EnvironmentRecord) baseValue;
+                        thisValue = refEnv.WithBaseObject();   
+                    }
                 }
             }
             else


### PR DESCRIPTION
In `EvaluateCall`, we shouldn't short circuit if we detected that the value is null and the nullable reference returned true, we still need to call to the callable