### PR TITLE
Fix script-level strict mode handling

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2790,6 +2790,19 @@ x.test = {
             Assert.Equal(1, result);
         }
 
+        [Fact]
+        public void ShouldObeyScriptLevelStrictModeInFunctions()
+        {
+            var engine = new Engine();
+            const string source = "'use strict'; var x = () => { delete Boolean.prototype; }; x();";
+            var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate(source));
+            Assert.Equal("Cannot delete property 'prototype' of function Boolean() { [native code] }", ex.Message);
+
+            const string source2 = "'use strict'; delete foobar;";
+            ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate(source2));
+            Assert.Equal("Delete of an unqualified identifier in strict mode.", ex.Message);
+        }
+
         private class Wrapper
         {
             public Testificate Test { get; set; }

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -111,8 +111,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
 
                 case UnaryOperator.Delete:
-                    var r = _argument.Evaluate(context).Value as Reference;
-                    if (r == null)
+                    if (_argument.Evaluate(context).Value is not Reference r)
                     {
                         return JsBoolean.True;
                     }
@@ -121,7 +120,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     {
                         if (r.IsStrictReference())
                         {
-                            ExceptionHelper.ThrowSyntaxError(engine.Realm);
+                            ExceptionHelper.ThrowSyntaxError(engine.Realm, "Delete of an unqualified identifier in strict mode.");
                         }
 
                         engine._referencePool.Return(r);
@@ -139,7 +138,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                         var deleteStatus = o.Delete(r.GetReferencedName());
                         if (!deleteStatus && r.IsStrictReference())
                         {
-                            ExceptionHelper.ThrowTypeError(engine.Realm);
+                            ExceptionHelper.ThrowTypeError(engine.Realm, $"Cannot delete property '{r.GetReferencedName()}' of {o}");
                         }
 
                         engine._referencePool.Return(r);


### PR DESCRIPTION
Normal tests didn't show this problem because engine was set manually to strict or non-strict mode, not based on script value.