### PR TITLE
Hide Call method from public API

### DIFF
--- a/Jint.Tests/Runtime/Domain/UuidConstructor.cs
+++ b/Jint.Tests/Runtime/Domain/UuidConstructor.cs
@@ -55,7 +55,7 @@ namespace Jint.Tests.Runtime.Domain
             return obj;
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments) => Construct(arguments, null);
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments) => Construct(arguments, null);
 
         public void Configure()
         {

--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -258,5 +258,16 @@ assertEqual(booleanCount, 1);
             Assert.Equal(123, engine.Call(function, 123));
             Assert.Equal(123, engine.Call("bar", 123));
         }
+
+        [Fact]
+        public void CanInvokeFunctionViaEngineInstanceWithCustomThisObj()
+        {
+            var engine = new Engine();
+
+            var function = engine.Evaluate("function baz() { return this; }; baz;");
+
+            Assert.Equal("I'm this!", TypeConverter.ToString(engine.Call(function, "I'm this!", Arguments.Empty)));
+            Assert.Equal("I'm this!", TypeConverter.ToString(function.Call("I'm this!", Arguments.Empty)));
+        }
     }
 }

--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Jint.Native;
 using Jint.Native.Array;
+using Jint.Native.Function;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
 using Xunit;
@@ -125,7 +126,6 @@ assertEqual(booleanCount, 1);
             Assert.Equal(123, arrayInstance[1]);
         }
 
-
         [Fact]
         public void FunctionInstancesCanBePassedToHost()
         {
@@ -158,7 +158,6 @@ assertEqual(booleanCount, 1);
             ev(null, new JsValue[] { 20 });
             Assert.Equal(30, engine.Evaluate("a"));
         }
-
 
         [Fact]
         public void BoundFunctionsCanBePassedToHost()
@@ -214,7 +213,6 @@ assertEqual(booleanCount, 1);
             Assert.Equal(false, ev(JsValue.Undefined, new JsValue[] { JsValue.Undefined }));
         }
 
-
         [Fact]
         public void FunctionsShouldResolveToSameReference()
         {
@@ -224,6 +222,41 @@ assertEqual(booleanCount, 1);
                 function testFn() {}
                 equal(testFn, testFn);
             ");
+        }
+        
+        [Fact]
+        public void CanInvokeCallForFunctionInstance()
+        {
+            var engine = new Engine();
+
+            engine.Evaluate(@"
+                (function () {
+                    function foo(a = 123) { return a; }
+                    foo()
+                })")
+                .As<FunctionInstance>().Call();
+
+            var result = engine.Evaluate(@"
+                (function () {
+                    class Foo { test() { return 123 } }
+                    let f = new Foo()
+                    return f.test()
+                })")
+                .As<FunctionInstance>().Call();
+
+            Assert.True(result.IsInteger());
+            Assert.Equal(123, result.AsInteger());
+        }
+
+        [Fact]
+        public void CanInvokeFunctionViaEngineInstance()
+        {
+            var engine = new Engine();
+
+            var function = engine.Evaluate("function bar(a) { return a; }; bar;");
+
+            Assert.Equal(123, engine.Call(function, 123));
+            Assert.Equal(123, engine.Call("bar", 123));
         }
     }
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1239,7 +1239,7 @@ namespace Jint
         /// <param name="thisObject">Value bound as this.</param>
         /// <param name="arguments">The arguments of the call.</param>
         /// <returns>The value returned by the call.</returns>
-        private JsValue Call(JsValue callable, JsValue thisObject, params JsValue[] arguments)
+        public JsValue Call(JsValue callable, JsValue thisObject, JsValue[] arguments)
         {
             JsValue Callback()
             {

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1211,6 +1211,49 @@ namespace Jint
             _executionContexts.ReplaceTopVariableEnvironment(newEnv);
         }
 
+        /// <summary>
+        /// Invokes the named callable and returns the resulting object.
+        /// </summary>
+        /// <param name="callableName">The name of the callable.</param>
+        /// <param name="arguments">The arguments of the call.</param>
+        /// <returns>The value returned by the call.</returns>
+        public JsValue Call(string callableName, params JsValue[] arguments)
+        {
+            var callable = Evaluate(callableName);
+            return Call(callable, arguments);
+        }
+
+        /// <summary>
+        /// Invokes the callable and returns the resulting object.
+        /// </summary>
+        /// <param name="callable">The callable.</param>
+        /// <param name="arguments">The arguments of the call.</param>
+        /// <returns>The value returned by the call.</returns>
+        public JsValue Call(JsValue callable, params JsValue[] arguments)
+            => Call(callable, thisObject: JsValue.Undefined, arguments);
+
+        /// <summary>
+        /// Invokes the callable and returns the resulting object.
+        /// </summary>
+        /// <param name="callable">The callable.</param>
+        /// <param name="thisObject">Value bound as this.</param>
+        /// <param name="arguments">The arguments of the call.</param>
+        /// <returns>The value returned by the call.</returns>
+        private JsValue Call(JsValue callable, JsValue thisObject, params JsValue[] arguments)
+        {
+            JsValue Callback()
+            {
+                if (!callable.IsCallable)
+                {
+                    ExceptionHelper.ThrowArgumentException(callable + " is not callable");
+                }
+
+                return Call((ICallable) callable, thisObject, arguments, null);
+            }
+
+            return ExecuteWithConstraints(Options.Strict, Callback);
+        }
+
         internal JsValue Call(ICallable callable, JsValue thisObject, JsValue[] arguments, JintExpression expression)
         {
             if (callable is FunctionInstance functionInstance)

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -434,11 +434,13 @@ namespace Jint
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static JsValue Call(this JsValue value, params JsValue[] arguments)
         {
-            if (!value.IsCallable)
+            if (value is not ObjectInstance objectInstance)
             {
-                ExceptionHelper.ThrowArgumentException(value + " is not callable");
+                ExceptionHelper.ThrowArgumentException(value + " is not object");
+                return null;
             }
-            return ((ICallable) value).Call(JsValue.Undefined, arguments);
+
+            return objectInstance.Engine.Call(value, arguments);
         }
 
         /// <summary>

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -443,6 +443,19 @@ namespace Jint
             return objectInstance.Engine.Call(value, arguments);
         }
 
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static JsValue Call(this JsValue value, JsValue thisObj, params JsValue[] arguments)
+        {
+            if (value is not ObjectInstance objectInstance)
+            {
+                ExceptionHelper.ThrowArgumentException(value + " is not object");
+                return null;
+            }
+
+            return objectInstance.Engine.Call(value, thisObj, arguments);
+        }
+
         /// <summary>
         /// If the value is a Promise
         ///     1. If "Fulfilled" returns the value it was fulfilled with

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -263,7 +263,7 @@ namespace Jint.Native.Array
             return oi.IsArray();
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             return Construct(arguments, thisObject);
         }

--- a/Jint/Native/ArrayBuffer/ArrayBufferConstructor.cs
+++ b/Jint/Native/ArrayBuffer/ArrayBufferConstructor.cs
@@ -65,7 +65,7 @@ namespace Jint.Native.ArrayBuffer
             return thisObject;
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             ExceptionHelper.ThrowTypeError(_realm, "Constructor ArrayBuffer requires 'new'");
             return Undefined;

--- a/Jint/Native/BigInt/BigIntConstructor.cs
+++ b/Jint/Native/BigInt/BigIntConstructor.cs
@@ -68,7 +68,7 @@ public sealed class BigIntConstructor : FunctionInstance, IConstructor
         return result;
     }
 
-    public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+    protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
     {
         if (arguments.Length == 0)
         {

--- a/Jint/Native/Boolean/BooleanConstructor.cs
+++ b/Jint/Native/Boolean/BooleanConstructor.cs
@@ -24,7 +24,7 @@ namespace Jint.Native.Boolean
 
         public BooleanPrototype PrototypeObject { get; }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             if (arguments.Length == 0)
             {

--- a/Jint/Native/DataView/DataViewConstructor.cs
+++ b/Jint/Native/DataView/DataViewConstructor.cs
@@ -28,7 +28,7 @@ namespace Jint.Native.DataView
 
         public DataViewPrototype PrototypeObject { get; }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             ExceptionHelper.ThrowTypeError(_realm, "Constructor DataView requires 'new'");
             return Undefined;

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -154,7 +154,7 @@ namespace Jint.Native.Date
             return System.Math.Floor((DateTime.UtcNow - Epoch).TotalMilliseconds);
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             return PrototypeObject.ToString(Construct(Arguments.Empty, thisObject), Arguments.Empty);
         }

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -27,7 +27,7 @@ namespace Jint.Native.Error
 
         public ErrorPrototype PrototypeObject { get; }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             return Construct(arguments, this);
         }

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -26,7 +26,7 @@ namespace Jint.Native.Function
             _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             var callerRealm = _engine.ExecutionContext.Realm;
             var x = arguments.At(0);

--- a/Jint/Native/Function/FunctionConstructor.cs
+++ b/Jint/Native/Function/FunctionConstructor.cs
@@ -31,7 +31,7 @@ namespace Jint.Native.Function
 
         public FunctionPrototype PrototypeObject { get; }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             return Construct(arguments, thisObject);
         }

--- a/Jint/Native/Function/FunctionInstance.cs
+++ b/Jint/Native/Function/FunctionInstance.cs
@@ -70,13 +70,14 @@ namespace Jint.Native.Function
         // for example RavenDB wants to inspect this
         public IFunction FunctionDeclaration => _functionDefinition.Function;
 
+        internal override bool IsCallable => true;
+
+        JsValue ICallable.Call(JsValue thisObject, JsValue[] arguments) => Call(thisObject, arguments);
+
         /// <summary>
         /// Executed when a function object is used as a function
         /// </summary>
-        /// <param name="thisObject"></param>
-        /// <param name="arguments"></param>
-        /// <returns></returns>
-        public abstract JsValue Call(JsValue thisObject, JsValue[] arguments);
+        protected internal abstract JsValue Call(JsValue thisObject, JsValue[] arguments);
 
         public bool Strict => _thisMode == FunctionThisMode.Strict;
 

--- a/Jint/Native/Function/FunctionPrototype.cs
+++ b/Jint/Native/Function/FunctionPrototype.cs
@@ -202,7 +202,7 @@ namespace Jint.Native.Function
             return result;
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             return Undefined;
         }

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -52,7 +52,7 @@ namespace Jint.Native.Function
         /// <summary>
         /// https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist
         /// </summary>
-        public override JsValue Call(JsValue thisArgument, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisArgument, JsValue[] arguments)
         {
             var strict = _thisMode == FunctionThisMode.Strict || _engine._isStrict;
             using (new StrictModeScope(strict, true))

--- a/Jint/Native/Function/ThrowTypeError.cs
+++ b/Jint/Native/Function/ThrowTypeError.cs
@@ -14,7 +14,7 @@ namespace Jint.Native.Function
             PreventExtensions();
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             ExceptionHelper.ThrowTypeError(_realm);
             return null;

--- a/Jint/Native/Map/MapConstructor.cs
+++ b/Jint/Native/Map/MapConstructor.cs
@@ -42,7 +42,7 @@ namespace Jint.Native.Map
             return thisObject;
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             ExceptionHelper.ThrowTypeError(_realm, "Constructor Map requires 'new'");
             return null;

--- a/Jint/Native/Number/NumberConstructor.cs
+++ b/Jint/Native/Number/NumberConstructor.cs
@@ -112,7 +112,7 @@ namespace Jint.Native.Number
             return System.Math.Abs(integer) <= MaxSafeInteger;
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             var n = ProcessFirstParameter(arguments);
             return n;

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -131,7 +131,7 @@ namespace Jint.Native.Object
         /// <summary>
         /// https://tc39.es/ecma262/#sec-object-value
         /// </summary>
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             if (arguments.Length == 0)
             {

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -65,7 +65,7 @@ namespace Jint.Native.Promise
             SetSymbols(symbols);
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             ExceptionHelper.ThrowTypeError(_realm, "Constructor Promise requires 'new'");
             return null;

--- a/Jint/Native/Proxy/ProxyConstructor.cs
+++ b/Jint/Native/Proxy/ProxyConstructor.cs
@@ -33,7 +33,7 @@ namespace Jint.Native.Proxy
             SetProperties(properties);
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             ExceptionHelper.ThrowTypeError(_realm, "Constructor Proxy requires 'new'");
             return null;

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -37,7 +37,7 @@ namespace Jint.Native.RegExp
             SetSymbols(symbols);
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             return Construct(arguments, thisObject);
         }

--- a/Jint/Native/Set/SetConstructor.cs
+++ b/Jint/Native/Set/SetConstructor.cs
@@ -42,7 +42,7 @@ namespace Jint.Native.Set
             return thisObject;
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             ExceptionHelper.ThrowTypeError(_engine.Realm, "Constructor Set requires 'new'");
             return null;

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -139,7 +139,7 @@ namespace Jint.Native.String
             return result.ToString();
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             if (arguments.Length == 0)
             {

--- a/Jint/Native/Symbol/SymbolConstructor.cs
+++ b/Jint/Native/Symbol/SymbolConstructor.cs
@@ -59,7 +59,7 @@ namespace Jint.Native.Symbol
         /// <summary>
         /// http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol-description
         /// </summary>
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             var description = arguments.At(0);
             var descString = description.IsUndefined()

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayConstructor.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayConstructor.cs
@@ -183,7 +183,7 @@ namespace Jint.Native.TypedArray
             return thisObject;
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             ExceptionHelper.ThrowTypeError(_realm, "Abstract class TypedArray not directly constructable");
             return Undefined;

--- a/Jint/Native/TypedArray/TypedArrayConstructor.cs
+++ b/Jint/Native/TypedArray/TypedArrayConstructor.cs
@@ -44,7 +44,7 @@ namespace Jint.Native.TypedArray
             SetProperties(properties);
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             ExceptionHelper.ThrowTypeError(_realm, "Abstract class TypedArray not directly constructable");
             return Undefined;

--- a/Jint/Native/WeakMap/WeakMapConstructor.cs
+++ b/Jint/Native/WeakMap/WeakMapConstructor.cs
@@ -25,7 +25,7 @@ namespace Jint.Native.WeakMap
 
         public WeakMapPrototype PrototypeObject { get; }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             ExceptionHelper.ThrowTypeError(_realm, "Constructor WeakMap requires 'new'");
             return null;

--- a/Jint/Native/WeakSet/WeakSetConstructor.cs
+++ b/Jint/Native/WeakSet/WeakSetConstructor.cs
@@ -24,7 +24,7 @@ namespace Jint.Native.WeakSet
 
         public WeakSetPrototype PrototypeObject { get; }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             ExceptionHelper.ThrowTypeError(_realm, "Constructor WeakSet requires 'new'");
             return null;

--- a/Jint/Runtime/Interop/ClrFunctionInstance.cs
+++ b/Jint/Runtime/Interop/ClrFunctionInstance.cs
@@ -31,7 +31,7 @@ namespace Jint.Runtime.Interop
                 : new PropertyDescriptor(JsNumber.Create(length), lengthFlags);
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments) => _func(thisObject, arguments);
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments) => _func(thisObject, arguments);
 
         public override bool Equals(JsValue obj)
         {

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -37,7 +37,7 @@ namespace Jint.Runtime.Interop
             }
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] jsArguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] jsArguments)
         {
             var parameterInfos = _d.Method.GetParameters();
 

--- a/Jint/Runtime/Interop/GetterFunctionInstance.cs
+++ b/Jint/Runtime/Interop/GetterFunctionInstance.cs
@@ -18,7 +18,7 @@ namespace Jint.Runtime.Interop
             _getter = getter;
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             return _getter(thisObject);
         }

--- a/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
@@ -124,7 +124,7 @@ namespace Jint.Runtime.Interop
             return genericMethodInfo;
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] jsArguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] jsArguments)
         {
             JsValue[] ArgumentProvider(MethodDescriptor method)
             {

--- a/Jint/Runtime/Interop/SetterFunctionInstance.cs
+++ b/Jint/Runtime/Interop/SetterFunctionInstance.cs
@@ -18,7 +18,7 @@ namespace Jint.Runtime.Interop
             _setter = setter;
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             _setter(thisObject, arguments[0]);
 

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -40,7 +40,7 @@ namespace Jint.Runtime.Interop
             return new TypeReference(engine, type);
         }
 
-        public override JsValue Call(JsValue thisObject, JsValue[] arguments)
+        protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
         {
             // direct calls on a TypeReference constructor object is equivalent to the new operator
             return Construct(arguments);


### PR DESCRIPTION
Hiding `Call` like we hid `Construct`, it's now `protected internal` and `ICallable` is explicit implementation, but can still be accessed via extension method helper that gets the Engine instance and then invokes the call via it. 

`Engine.Call` allows to get via name, use existing `JsValue` and pass parameters, overload to also supply thisObj that requires using proper array as arguments parameter to disambiguate and follow JS style.