### PR TITLE
Various Interop fixes

### DIFF
--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -176,5 +176,25 @@ namespace Jint.Tests.Runtime
             _engine.Execute("assert(!!['hello'].values()[Symbol.iterator])");
             _engine.Execute("assert(!!new Map([['hello', 'world']]).keys()[Symbol.iterator])");
         }
+
+
+
+        [Fact]
+        public void ArraySortDoesNotCrashInDebugMode()
+        {
+            var engine = new Engine(o =>
+            {
+                o.DebugMode(true);
+            });
+            engine.SetValue("equal", new Action<object, object>(Assert.Equal));
+
+            const string code = @"
+                var items = [5,2,4,1];
+                items.sort((a,b) => a - b);
+                equal('1,2,4,5', items.join());
+            ";
+
+            engine.Execute(code);
+        }
     }
 }

--- a/Jint.Tests/Runtime/ConstTests.cs
+++ b/Jint.Tests/Runtime/ConstTests.cs
@@ -39,5 +39,30 @@ namespace Jint.Tests.Runtime
                 }
             ");
         }
+
+        [Fact]
+        public void DestructuringWithFunctionArgReferenceInStrictMode()
+        {
+            _engine.Execute(@"
+                'use strict';
+                function tst(a) {
+                    let [let1, let2, let3] = a;
+                    const [const1, const2, const3] = a;
+                    var [var1, var2, var3] = a;
+                    
+                    equal(1, var1);
+                    equal(2, var2);
+                    equal(undefined, var3);
+                    equal(1, const1);
+                    equal(2, const2);
+                    equal(undefined, const3);
+                    equal(1, let1);
+                    equal(2, let2);
+                    equal(undefined, let3);
+                }
+
+                tst([1,2])
+            ");
+        }
     }
 }

--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -124,5 +124,39 @@ assertEqual(booleanCount, 1);
             Assert.Equal("abc", arrayInstance[0]);
             Assert.Equal(123, arrayInstance[1]);
         }
+
+
+        [Fact]
+        public void FunctionInstancesCanBePassedToHost()
+        {
+            var engine = new Engine();
+            Func<JsValue, JsValue[], JsValue> ev = null;
+
+            void addListener(Func<JsValue, JsValue[], JsValue> callback)
+            {
+                ev = callback;
+            }
+
+            engine.SetValue("addListener", new Action<Func<JsValue, JsValue[], JsValue>>(addListener));
+
+            engine.Execute(@"
+                var a = 5;
+
+                (function() {
+                    var acc = 10;
+                    addListener(function (val) {
+                        a = (val || 0) + acc;
+                    });
+                })();
+");
+
+            Assert.Equal(5, engine.Evaluate("a"));
+
+            ev(null, new JsValue[0]);
+            Assert.Equal(10, engine.Evaluate("a"));
+
+            ev(null, new JsValue[] { 20 });
+            Assert.Equal(30, engine.Evaluate("a"));
+        }
     }
 }

--- a/Jint.Tests/Runtime/MethodAmbiguityTests.cs
+++ b/Jint.Tests/Runtime/MethodAmbiguityTests.cs
@@ -99,6 +99,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal("Class2.Double[]", engine.Evaluate("Class2.Print([ 1, 2 ]); "));
             Assert.Equal("Class2.ExpandoObject", engine.Evaluate("Class2.Print({ x: 1, y: 2 });"));
             Assert.Equal("Class2.Int32", engine.Evaluate("Class2.Print(5);"));
+            Assert.Equal("Class2.Object", engine.Evaluate("Class2.Print(() => '');"));
         }
 
         private struct Class1

--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -35,8 +35,8 @@ bar += 'bar';
         public void TrimLeftRightShouldBeSameAsTrimStartEnd()
         {
             _engine.Execute(@"
-                equal(''.trimLeft, ''.trimStart);
-                equal(''.trimRight, ''.trimEnd);
+                assert(''.trimLeft === ''.trimStart);
+                assert(''.trimRight === ''.trimEnd);
 ");
         }
     }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -368,7 +368,7 @@ namespace Jint
                 constraint.Check();
             }
 
-            if (_isDebugMode)
+            if (_isDebugMode && statement != null)
             {
                 DebugHandler.OnStep(statement);
             }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -426,7 +426,7 @@ namespace Jint.Native.Object
                     return true;
                 }
 
-                var getter = desc.Get ??  Undefined;
+                var getter = desc.Get ?? Undefined;
                 if (getter.IsUndefined())
                 {
                     value = Undefined;
@@ -961,7 +961,8 @@ namespace Jint.Native.Object
                 case ObjectClass.Function:
                     if (this is FunctionInstance function)
                     {
-                        converted = (Func<JsValue, JsValue[], JsValue>) function.Call;
+                        converted = new Func<JsValue, JsValue[], JsValue>(
+                            (thisVal, args) => function.Engine.Invoke(function, (object) thisVal, args));
                     }
 
                     break;
@@ -1311,7 +1312,7 @@ namespace Jint.Native.Object
                         else
                         {
                             var objectInstance = _engine.Realm.Intrinsics.Array.ArrayCreate(2);
-                            objectInstance.SetIndexValue(0,  property, updateLength: false);
+                            objectInstance.SetIndexValue(0, property, updateLength: false);
                             objectInstance.SetIndexValue(1, value, updateLength: false);
                             array.SetIndexValue(index, objectInstance, updateLength: false);
                         }

--- a/Jint/Runtime/Descriptors/Specialized/ReflectionDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/ReflectionDescriptor.cs
@@ -13,8 +13,9 @@ namespace Jint.Runtime.Descriptors.Specialized
         public ReflectionDescriptor(
             Engine engine,
             ReflectionAccessor reflectionAccessor,
-            object target)
-            : base(PropertyFlag.Enumerable | PropertyFlag.CustomJsValue)
+            object target,
+            bool enumerable)
+            : base((enumerable ? PropertyFlag.Enumerable : PropertyFlag.None) | PropertyFlag.CustomJsValue)
         {
             _engine = engine;
             _reflectionAccessor = reflectionAccessor;

--- a/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using Jint.Native;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 
 namespace Jint.Runtime.Interop.Reflection
 {
@@ -150,6 +152,11 @@ namespace Jint.Runtime.Interop.Reflection
 
             object[] parameters = {_key, value};
             _setter!.Invoke(target, parameters);
+        }
+
+        public override PropertyDescriptor CreatePropertyDescriptor(Engine engine, object target)
+        {
+            return new ReflectionDescriptor(engine, this, target, false);
         }
     }
 }

--- a/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
@@ -114,7 +114,7 @@ namespace Jint.Runtime.Interop.Reflection
 
         public virtual PropertyDescriptor CreatePropertyDescriptor(Engine engine, object target)
         {
-            return new ReflectionDescriptor(engine, this, target);
+            return new ReflectionDescriptor(engine, this, target, true);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
@@ -52,7 +52,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         {
             if (pattern is ArrayPattern ap)
             {
-                return HandleArrayPattern(context, ap, argument, environment);
+                return HandleArrayPattern(context, ap, argument, environment, checkObjectPatternPropertyReference);
             }
 
             if (pattern is ObjectPattern op)
@@ -83,7 +83,8 @@ namespace Jint.Runtime.Interpreter.Expressions
             EvaluationContext context,
             ArrayPattern pattern,
             JsValue argument,
-            EnvironmentRecord environment)
+            EnvironmentRecord environment,
+            bool checkReference)
         {
             var engine = context.Engine;
             var realm = engine.Realm;
@@ -141,7 +142,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                             ConsumeFromIterator(iterator, out value, out done);
                         }
 
-                        AssignToIdentifier(engine, identifier.Name, value, environment);
+                        AssignToIdentifier(engine, identifier.Name, value, environment, checkReference);
                     }
                     else if (left is MemberExpression me)
                     {

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ The entire execution engine was rebuild with performance in mind, in many cases 
 - ✔ Promises (Experimental, API is unstable)
 - ✔ Reflect
 - ✔ Proxies
-- ✔ Reflect
 - ✔ Symbols
 - ❌ Tail calls
 - ✔ Typed arrays


### PR DESCRIPTION
I am not sure about the Dictionary accessor. It now uses `TryGetValue` instead of using `Item` and expecting it to throw error when a key is missing. That makes more sense to me logically. But there is this case:

https://github.com/sebastienros/jint/compare/main...KurtGokhan:interop-fixes?expand=1#diff-6f0fbc1958b9b5e571672e8b8c8795a77ac611e89ee8bf7fbe31d2d1eb476942R145

I am not sure if the result should be `undefined` or `0` here.