### PR TITLE
Improve function interop

### DIFF
--- a/Jint/Native/Function/FunctionInstance.cs
+++ b/Jint/Native/Function/FunctionInstance.cs
@@ -307,7 +307,7 @@ namespace Jint.Native.Function
             }
             else
             {
-                if (thisArgument == null || thisArgument.IsNullOrUndefined())
+                if (thisArgument is null || thisArgument.IsNullOrUndefined())
                 {
                     var globalEnv = calleeRealm.GlobalEnv;
                     thisValue = globalEnv.GlobalThisValue;

--- a/Jint/Native/Function/FunctionInstance.cs
+++ b/Jint/Native/Function/FunctionInstance.cs
@@ -307,7 +307,7 @@ namespace Jint.Native.Function
             }
             else
             {
-                if (thisArgument.IsNullOrUndefined())
+                if (thisArgument == null || thisArgument.IsNullOrUndefined())
                 {
                     var globalEnv = calleeRealm.GlobalEnv;
                     thisValue = globalEnv.GlobalThisValue;

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -138,7 +138,8 @@ namespace Jint.Native.Function
             {
                 try
                 {
-                    var result = OrdinaryCallEvaluateBody(_engine._activeEvaluationContext, arguments, calleeContext);
+                    var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
+                    var result = OrdinaryCallEvaluateBody(context, arguments, calleeContext);
 
                     // The DebugHandler needs the current execution context before the return for stepping through the return point
                     if (_engine._isDebugMode && result.Type != CompletionType.Throw)

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -959,10 +959,9 @@ namespace Jint.Native.Object
                     break;
 
                 case ObjectClass.Function:
-                    if (this is FunctionInstance function)
+                    if (this is ICallable function)
                     {
-                        converted = new Func<JsValue, JsValue[], JsValue>(
-                            (thisVal, args) => function.Engine.Invoke(function, (object) thisVal, args));
+                        converted = (Func<JsValue, JsValue[], JsValue>) function.Call;
                     }
 
                     break;


### PR DESCRIPTION
The last fixes I did were not ideal. Same function would resolve to different reference, and bound functions would not work. Also `Call` utility is a more proper way to solve this now I think.