### PR TITLE
Always allow operator overloaded conversion

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -2770,13 +2770,12 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void ShouldBeAbleToUseConvertibleStructAsMethodParameter()
         {
-            var engine = new Engine(options => options.AllowOperatorOverloading());
-            engine.SetValue("test", new DiscordTestClass());
-            engine.SetValue("id", new DiscordId("12345"));
+            _engine.SetValue("test", new DiscordTestClass());
+            _engine.SetValue("id", new DiscordId("12345"));
 
-            Assert.Equal("12345", engine.Evaluate("String(id)").AsString());
-            Assert.Equal("12345", engine.Evaluate("test.echo('12345')").AsString());
-            Assert.Equal("12345", engine.Evaluate("test.create(12345)").AsString());
+            Assert.Equal("12345", _engine.Evaluate("String(id)").AsString());
+            Assert.Equal("12345", _engine.Evaluate("test.echo('12345')").AsString());
+            Assert.Equal("12345", _engine.Evaluate("test.create(12345)").AsString());
         }
 
         private class Profile

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -1197,15 +1197,12 @@ namespace Jint.Runtime
                 return 1;
             }
 
-            if (engine.Options.Interop.AllowOperatorOverloading)
+            foreach (var m in objectValueType.GetOperatorOverloadMethods())
             {
-                foreach (var m in objectValueType.GetOperatorOverloadMethods())
+                if (paramType.IsAssignableFrom(m.ReturnType) && m.Name is "op_Implicit" or "op_Explicit")
                 {
-                    if (paramType.IsAssignableFrom(m.ReturnType) && m.Name is "op_Implicit" or "op_Explicit")
-                    {
-                        // implicit/explicit operator conversion is OK, but not ideal
-                        return 1;
-                    }
+                    // implicit/explicit operator conversion is OK, but not ideal
+                    return 1;
                 }
             }
 


### PR DESCRIPTION
After fixing #1094 I felt that we should actually always allow implicit/explicit operators for conversion. I've adapted code to prefer `ChangeType` and if it doesn't succeed we can still always try operator overloading, which has semantically the same goal as supporting `IConvertible`. So removing checks whether operator overloading is allowed when doing interop, it's already behind allow interop flag anyway.

Thoughts @sebastienros @KurtGokhan ?