### PR TITLE
fix Jint.Tests.csproj to properly reference files in Runtime

### DIFF
--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -9,7 +9,7 @@
     <NoWarn>612</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Runtime\Scripts\*.*;Parser\Scripts\*.*" />
+    <EmbeddedResource Include="Runtime\**\*.cs;Parser\Scripts\*.*;" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />


### PR DESCRIPTION
fix Jint.Tests.csproj to properly reference files in Runtime directory and subdirectories so that build is properly triggered when you update test files (under that directory)