### PR TITLE
Fix array performance regression

### DIFF
--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -72,7 +72,7 @@ namespace Jint.Native.Array
 
         public abstract void CreateDataPropertyOrThrow(ulong index, JsValue value);
 
-        public abstract void Set(ulong index, JsValue value, bool throwOnError);
+        public abstract void Set(ulong index, JsValue value, bool updateLength = false, bool throwOnError = true);
 
         public abstract void DeletePropertyOrThrow(ulong index);
 
@@ -226,7 +226,7 @@ namespace Jint.Native.Array
             public override void CreateDataPropertyOrThrow(ulong index, JsValue value)
                 => _target.CreateDataPropertyOrThrow(JsString.Create(index), value);
 
-            public override void Set(ulong index, JsValue value, bool throwOnError)
+            public override void Set(ulong index, JsValue value, bool updateLength = false, bool throwOnError = true)
                 => _target.Set(JsString.Create(index), value, throwOnError);
 
             public override void DeletePropertyOrThrow(ulong index)
@@ -297,8 +297,8 @@ namespace Jint.Native.Array
             public override void CreateDataPropertyOrThrow(ulong index, JsValue value)
                 => _target.SetIndexValue((uint) index, value, updateLength: false);
 
-            public override void Set(ulong index, JsValue value, bool throwOnError)
-                => _target.Set((uint) index, value, throwOnError);
+            public override void Set(ulong index, JsValue value, bool updateLength = false, bool throwOnError = true)
+                => _target.SetIndexValue((uint) index, value, updateLength);
         }
 
         private sealed class TypedArrayInstanceOperations : ArrayOperations
@@ -357,7 +357,7 @@ namespace Jint.Native.Array
             public override void CreateDataPropertyOrThrow(ulong index, JsValue value)
                 => _target.CreateDataPropertyOrThrow(index, value);
 
-            public override void Set(ulong index, JsValue value, bool throwOnError)
+            public override void Set(ulong index, JsValue value, bool updateLength = false, bool throwOnError = true)
                 => _target[(int) index] = value;
 
             public override void DeletePropertyOrThrow(ulong index)

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -260,7 +260,7 @@ namespace Jint.Native.Array
                 if (fromPresent)
                 {
                     var fromValue = operations.Get((ulong) from);
-                    operations.Set((ulong) to, fromValue, throwOnError: true);
+                    operations.Set((ulong) to, fromValue, updateLength: true, throwOnError: true);
                 }
                 else
                 {
@@ -994,7 +994,8 @@ namespace Jint.Native.Array
         /// </summary>
         private JsValue Sort(JsValue thisObj, JsValue[] arguments)
         {
-            var obj = ArrayOperations.For(TypeConverter.ToObject(_realm, thisObj));
+            var objectInstance = TypeConverter.ToObject(_realm, thisObj);
+            var obj = ArrayOperations.For(objectInstance);
 
             var compareArg = arguments.At(0);
             ICallable compareFn = null;
@@ -1034,12 +1035,11 @@ namespace Jint.Native.Array
                 uint j;
                 for (j = 0; j < itemCount; ++j)
                 {
-                    if (!ReferenceEquals(array[j], null))
-                    {
-                        obj.Set(j, array[j], throwOnError: true);
-                    }
+                    objectInstance.Set(j, array[j], throwOnError: true);
+                    // TODO if we could keep track of data descriptors and whether prototype chain is unchanged
+                    // we could do faster direct write
+                    // obj.Set(j, array[j], updateLength: true, throwOnError: true);
                 }
-
                 for (; j < len; ++j)
                 {
                     obj.DeletePropertyOrThrow(j);

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Dynamic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Jint.Collections;


### PR DESCRIPTION
This was introduced by #1053 where `ArrayOperations` started to call slower `Set` which was not directly accessing indexes. Returned old behavior and tweaked two call sites where it's not safe to do fast access. Added TODO comment for future for trying to improve things by tracking whether given array instance is truly simple (only data descriptors and array prototype chain unmodified).