### PR TITLE
Update test262 to latest and fix issues

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -1,5 +1,5 @@
 {
-  "SuiteGitSha": "78c6ec7f1c9fde10f06db68b6d5ee7019aeb0f5f",
+  "SuiteGitSha": "28b31c0bf1960878abb36ab8597a0cae224a684d",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Jint.Tests.Test262",

--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -1,5 +1,5 @@
 {
-  "SuiteGitSha": "91356f52f92691abe62c06d00677332212e99dc8",
+  "SuiteGitSha": "78c6ec7f1c9fde10f06db68b6d5ee7019aeb0f5f",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Jint.Tests.Test262",
@@ -7,7 +7,6 @@
   "ExcludedFeatures": [
     "__getter__",
     "__setter__",
-    "__proto__",
     "AggregateError",
     "async-functions",
     "async-iteration",

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -227,8 +227,6 @@ namespace Jint.Native.Array
                     var kValue = arguments[k];
                     ai.SetIndexValue(k, kValue, updateLength: k == arguments.Length - 1);
                 }
-
-                ai.SetLength((uint) arguments.Length);
             }
             else
             {

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -213,7 +213,26 @@ namespace Jint.Native.Array
             if (thisObj.IsConstructor)
             {
                 a = ((IConstructor) thisObj).Construct(new JsValue[] { len }, thisObj);
+            }
+            else
+            {
+                a = _realm.Intrinsics.Array.Construct(len);
+            }
 
+            if (a is ArrayInstance ai)
+            {
+                // faster for real arrays
+                for (uint k = 0; k < arguments.Length; k++)
+                {
+                    var kValue = arguments[k];
+                    ai.SetIndexValue(k, kValue, updateLength: k == arguments.Length - 1);
+                }
+
+                ai.SetLength((uint) arguments.Length);
+            }
+            else
+            {
+                // slower version
                 for (uint k = 0; k < arguments.Length; k++)
                 {
                     var kValue = arguments[k];
@@ -222,20 +241,6 @@ namespace Jint.Native.Array
                 }
 
                 a.Set(CommonProperties.Length, len, true);
-            }
-            else
-            {
-                // faster for real arrays
-                ArrayInstance ai;
-                a = ai = _realm.Intrinsics.Array.Construct(len);
-
-                for (uint k = 0; k < arguments.Length; k++)
-                {
-                    var kValue = arguments[k];
-                    ai.SetIndexValue(k, kValue, updateLength: false);
-                }
-
-                ai.SetLength((uint) arguments.Length);
             }
 
             return a;

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Jint.Native.Object;
@@ -436,17 +435,18 @@ namespace Jint.Native.Array
         {
             if (ReferenceEquals(receiver, this) && Extensible && IsArrayIndex(property, out var index))
             {
-                if (TryGetDescriptor(index, out var descriptor) && descriptor.IsDefaultArrayValueDescriptor())
+                if (TryGetDescriptor(index, out var descriptor))
                 {
-                    // fast path with direct write without allocations
-                    descriptor.Value = value;
-                    EnsureCorrectLength(index);
-                    return true;
+                    if (descriptor.IsDefaultArrayValueDescriptor())
+                    {
+                        // fast path with direct write without allocations
+                        descriptor.Value = value;
+                        return true;
+                    }
                 }
-
-                if (CanUseFastAccess)
+                else if (CanUseFastAccess)
                 {
-                    // we know it's to be written to own array backing field
+                    // we know it's to be written to own array backing field as new value
                     WriteArrayValue(index, new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable));
                     EnsureCorrectLength(index);
                     return true;

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -15,7 +15,7 @@ namespace Jint.Native.Array
 
         public static ArrayOperations For(ObjectInstance instance)
         {
-            if (instance is ArrayInstance arrayInstance)
+            if (instance is ArrayInstance { CanUseFastAccess: true } arrayInstance)
             {
                 return new ArrayInstanceOperations(arrayInstance);
             }
@@ -294,10 +294,10 @@ namespace Jint.Native.Array
             public override void DeletePropertyOrThrow(ulong index)
                 => _target.DeletePropertyOrThrow((uint) index);
 
-            public override void CreateDataPropertyOrThrow(ulong index, JsValue value)
+            public override void CreateDataPropertyOrThrow(ulong index, JsValue value) 
                 => _target.SetIndexValue((uint) index, value, updateLength: false);
 
-            public override void Set(ulong index, JsValue value, bool updateLength = false, bool throwOnError = true)
+            public override void Set(ulong index, JsValue value, bool updateLength = false, bool throwOnError = true) 
                 => _target.SetIndexValue((uint) index, value, updateLength);
         }
 

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1041,10 +1041,8 @@ namespace Jint.Native.Array
                 uint j;
                 for (j = 0; j < itemCount; ++j)
                 {
-                    objectInstance.Set(j, array[j], throwOnError: true);
-                    // TODO if we could keep track of data descriptors and whether prototype chain is unchanged
-                    // we could do faster direct write
-                    // obj.Set(j, array[j], updateLength: true, throwOnError: true);
+                    var updateLength = j == itemCount - 1;
+                    obj.Set(j, array[j], updateLength: updateLength, throwOnError: true);
                 }
                 for (; j < len; ++j)
                 {
@@ -1424,7 +1422,7 @@ namespace Jint.Native.Array
         /// </summary>
         public JsValue Push(JsValue thisObject, JsValue[] arguments)
         {
-            if (thisObject is ArrayInstance arrayInstance)
+            if (thisObject is ArrayInstance arrayInstance && arrayInstance.CanUseFastAccess)
             {
                 return arrayInstance.Push(arguments);
             }

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -959,6 +959,9 @@ namespace Jint.Native.Array
             return a.Target;
         }
 
+        /// <summary>
+        /// /https://tc39.es/ecma262/#sec-array.prototype.unshift
+        /// </summary>
         private JsValue Unshift(JsValue thisObj, JsValue[] arguments)
         {
             var o = ArrayOperations.For(_realm, thisObj);
@@ -978,7 +981,7 @@ namespace Jint.Native.Array
                 var to = k + argCount - 1;
                 if (o.TryGetValue(from, out var fromValue))
                 {
-                    o.Set(to, fromValue, true);
+                    o.Set(to, fromValue, updateLength: false);
                 }
                 else
                 {
@@ -988,7 +991,7 @@ namespace Jint.Native.Array
 
             for (uint j = 0; j < argCount; j++)
             {
-                o.Set(j, arguments[j], true);
+                o.Set(j, arguments[j], updateLength: false);
             }
 
             o.SetLength(len + argCount);

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -9,6 +9,7 @@ using Jint.Native.Symbol;
 using Jint.Pooling;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.Array
@@ -36,25 +37,6 @@ namespace Jint.Native.Array
 
         protected override void Initialize()
         {
-            var unscopables = new ObjectInstance(_engine)
-            {
-                _prototype = null
-            };
-
-            unscopables.SetDataProperty("at", JsBoolean.True);
-            unscopables.SetDataProperty("copyWithin", JsBoolean.True);
-            unscopables.SetDataProperty("entries", JsBoolean.True);
-            unscopables.SetDataProperty("fill", JsBoolean.True);
-            unscopables.SetDataProperty("find", JsBoolean.True);
-            unscopables.SetDataProperty("findIndex", JsBoolean.True);
-            unscopables.SetDataProperty("findLast", JsBoolean.True);
-            unscopables.SetDataProperty("findLastIndex", JsBoolean.True);
-            unscopables.SetDataProperty("flat", JsBoolean.True);
-            unscopables.SetDataProperty("flatMap", JsBoolean.True);
-            unscopables.SetDataProperty("includes", JsBoolean.True);
-            unscopables.SetDataProperty("keys", JsBoolean.True);
-            unscopables.SetDataProperty("values", JsBoolean.True);
-
             const PropertyFlag propertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
             var properties = new PropertyDictionary(34, checkExistingKeys: false)
             {
@@ -100,7 +82,31 @@ namespace Jint.Native.Array
             var symbols = new SymbolDictionary(2)
             {
                 [GlobalSymbolRegistry.Iterator] = new PropertyDescriptor(_originalIteratorFunction, propertyFlags),
-                [GlobalSymbolRegistry.Unscopables] = new PropertyDescriptor(unscopables, PropertyFlag.Configurable)
+                [GlobalSymbolRegistry.Unscopables] = new LazyPropertyDescriptor(_engine, static state =>
+                {            
+                    var unscopables = new ObjectInstance((Engine) state)
+                    {
+                        _prototype = null
+                    };
+
+                    unscopables.SetDataProperty("at", JsBoolean.True);
+                    unscopables.SetDataProperty("copyWithin", JsBoolean.True);
+                    unscopables.SetDataProperty("entries", JsBoolean.True);
+                    unscopables.SetDataProperty("fill", JsBoolean.True);
+                    unscopables.SetDataProperty("find", JsBoolean.True);
+                    unscopables.SetDataProperty("findIndex", JsBoolean.True);
+                    unscopables.SetDataProperty("findLast", JsBoolean.True);
+                    unscopables.SetDataProperty("findLastIndex", JsBoolean.True);
+                    unscopables.SetDataProperty("flat", JsBoolean.True);
+                    unscopables.SetDataProperty("flatMap", JsBoolean.True);
+                    unscopables.SetDataProperty("groupBy", JsBoolean.True);
+                    unscopables.SetDataProperty("groupByToMap", JsBoolean.True);
+                    unscopables.SetDataProperty("includes", JsBoolean.True);
+                    unscopables.SetDataProperty("keys", JsBoolean.True);
+                    unscopables.SetDataProperty("values", JsBoolean.True);
+
+                    return unscopables;
+                }, PropertyFlag.Configurable)
             };
             SetSymbols(symbols);
         }

--- a/Jint/Native/ArrayBuffer/ArrayBufferInstance.cs
+++ b/Jint/Native/ArrayBuffer/ArrayBufferInstance.cs
@@ -61,10 +61,9 @@ namespace Jint.Native.ArrayBuffer
         internal ArrayBufferInstance CloneArrayBuffer(
             ArrayBufferConstructor constructor,
             int srcByteOffset,
-            uint srcLength,
-            JsValue cloneConstructor)
+            uint srcLength)
         {
-            var targetBuffer = constructor.AllocateArrayBuffer(cloneConstructor, srcLength);
+            var targetBuffer = constructor.AllocateArrayBuffer(_engine.Realm.Intrinsics.ArrayBuffer, srcLength);
             AssertNotDetached();
             var srcBlock = _arrayBufferData;
             var targetBlock = targetBuffer.ArrayBufferData;

--- a/Jint/Native/Object/ObjectChangeFlags.cs
+++ b/Jint/Native/Object/ObjectChangeFlags.cs
@@ -12,5 +12,5 @@ internal enum ObjectChangeFlags
     Property = 1,
     Symbol = 2,
     ArrayIndex = 4,
-    NonDataDescriptorUsage = 8
+    NonDefaultDataDescriptorUsage = 8
 }

--- a/Jint/Native/Object/ObjectChangeFlags.cs
+++ b/Jint/Native/Object/ObjectChangeFlags.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Jint.Native.Object;
+
+/// <summary>
+/// Keeps track of changes to object, mainly meant for prototype change detection.
+/// </summary>
+[Flags]
+internal enum ObjectChangeFlags
+{
+    None = 0,
+    Property = 1,
+    Symbol = 2,
+    ArrayIndex = 4,
+    NonDataDescriptorUsage = 8
+}

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Object
 {
     public sealed class ObjectConstructor : FunctionInstance, IConstructor
     {
-        private static readonly JsString _name = new JsString("delegate");
+        private static readonly JsString _name = new JsString("Object");
 
         internal ObjectConstructor(
             Engine engine,

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1218,15 +1218,16 @@ namespace Jint.Native.Object
         /// <summary>
         /// https://tc39.es/ecma262/#sec-createdatapropertyorthrow
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool CreateDataProperty(JsValue p, JsValue v)
         {
-            var newDesc = new PropertyDescriptor(v, PropertyFlag.ConfigurableEnumerableWritable);
-            return DefineOwnProperty(p, newDesc);
+            return DefineOwnProperty(p, new PropertyDescriptor(v, PropertyFlag.ConfigurableEnumerableWritable));
         }
 
         /// <summary>
         /// https://tc39.es/ecma262/#sec-createdataproperty
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool CreateDataPropertyOrThrow(JsValue p, JsValue v)
         {
             if (!CreateDataProperty(p, v))

--- a/Jint/Native/Object/ObjectPrototype.cs
+++ b/Jint/Native/Object/ObjectPrototype.cs
@@ -46,7 +46,7 @@ namespace Jint.Native.Object
                         }
                         
                         return Undefined;
-                    }, 1, lengthFlags),
+                    }, 0, lengthFlags),
                     enumerable: false, configurable: true),
                 ["toString"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "toString", ToObjectString, 0, lengthFlags), propertyFlags),
                 ["toLocaleString"] = new PropertyDescriptor(new ClrFunctionInstance(Engine, "toLocaleString", ToLocaleString, 0, lengthFlags), propertyFlags),

--- a/Jint/Native/Object/ObjectPrototype.cs
+++ b/Jint/Native/Object/ObjectPrototype.cs
@@ -73,10 +73,13 @@ namespace Jint.Native.Object
         private void TrackChanges(JsValue property)
         {
             EnsureInitialized();
-            _objectChangeFlags |= property.IsSymbol() ? ObjectChangeFlags.Symbol : ObjectChangeFlags.Property;
             if (ArrayInstance.IsArrayIndex(property, out _))
             {
                 _objectChangeFlags |= ObjectChangeFlags.ArrayIndex;
+            }
+            else
+            {
+                _objectChangeFlags |= property.IsSymbol() ? ObjectChangeFlags.Symbol : ObjectChangeFlags.Property;
             }
         }
 

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -607,7 +607,7 @@ namespace Jint.Native.String
             var s = TypeConverter.ToString(thisObj);
             var that = TypeConverter.ToString(arguments.At(0));
 
-            return string.CompareOrdinal(s, that);
+            return string.CompareOrdinal(s.Normalize(NormalizationForm.FormKD), that.Normalize(NormalizationForm.FormKD));
         }
 
         private JsValue LastIndexOf(JsValue thisObj, JsValue[] arguments)

--- a/Jint/Native/TypedArray/TypedArrayConstructor.cs
+++ b/Jint/Native/TypedArray/TypedArrayConstructor.cs
@@ -147,18 +147,15 @@ namespace Jint.Native.TypedArray
             var elementSize = elementType.GetElementSize();
             var byteLength = elementSize * elementLength;
 
-            var bufferConstructor = (JsValue) (!srcData.IsSharedArrayBuffer
-                ? SpeciesConstructor(srcData, _realm.Intrinsics.ArrayBuffer)
-                : _realm.Intrinsics.ArrayBuffer);
-
+            var arrayBuffer = _realm.Intrinsics.ArrayBuffer;
             ArrayBufferInstance data;
             if (elementType == srcType)
             {
-                data = srcData.CloneArrayBuffer(_realm.Intrinsics.ArrayBuffer, srcByteOffset, byteLength, bufferConstructor);
+                data = srcData.CloneArrayBuffer(arrayBuffer, srcByteOffset, byteLength);
             }
             else
             {
-                data = _realm.Intrinsics.ArrayBuffer.AllocateArrayBuffer(bufferConstructor, byteLength);
+                data = arrayBuffer.AllocateArrayBuffer(arrayBuffer, byteLength);
                 srcData.AssertNotDetached();
                 if (srcArray._contentType != o._contentType)
                 {

--- a/Jint/Native/TypedArray/TypedArrayInstance.cs
+++ b/Jint/Native/TypedArray/TypedArrayInstance.cs
@@ -275,23 +275,15 @@ namespace Jint.Native.TypedArray
 
         // helper tot prevent floating point
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void IntegerIndexedElementSet(int index, JsValue value)
+        internal void IntegerIndexedElementSet(int index, JsValue value)
         {
-            if (_contentType != TypedArrayContentType.BigInt)
+            TypedArrayValue numValue = _contentType != TypedArrayContentType.BigInt 
+                ? TypeConverter.ToNumber(value) 
+                : value.ToBigInteger(_engine);
+
+            if (IsValidIntegerIndex(index))
             {
-                var numValue = TypeConverter.ToNumber(value);
-                if (IsValidIntegerIndex(index))
-                {
-                    DoIntegerIndexedElementSet(index, numValue);
-                }
-            }
-            else
-            {
-                var numValue = value.ToBigInteger(_engine);
-                if (IsValidIntegerIndex(index))
-                {
-                    DoIntegerIndexedElementSet(index, numValue);
-                }
+                DoIntegerIndexedElementSet(index, numValue);
             }
         }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -87,6 +87,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     if (!p.Computed && p.Key is Identifier identifier)
                     {
                         propName = identifier.Name;
+                        _canBuildFast &= propName != "__proto__";
                     }
 
                     _properties[i] = new ObjectProperty(propName, p);
@@ -204,6 +205,15 @@ namespace Jint.Runtime.Interpreter.Expressions
                         closure.SetFunctionName(propName);
                     }
 
+                    if (objectProperty._key == "__proto__")
+                    {
+                        if (propValue.IsObject() || propValue.IsNull())
+                        {
+                            obj.SetPrototypeOf(propValue);
+                            continue;
+                        }
+                    }
+                    
                     var propDesc = new PropertyDescriptor(propValue, PropertyFlag.ConfigurableEnumerableWritable);
                     obj.DefinePropertyOrThrow(propName, propDesc);
                 }


### PR DESCRIPTION
Adding support for `__proto__` as they introduced test cases which depend on it. Not endorsed feature but basically every runtime supports its.

Implemented checks when producing array operations handler that checks if array instance chain is uncontaminated and can successfully use the fast path, otherwise choose slower object property based. There are examples where JS gets injected with something like `Object.defineProperty(Object.prototype, "0", some_descriptor_which_has_setter_that_mutates_length)`, so basically catching those rare occasions and switching to slow mode (full property setters instead of fast array index set inside array).

Some other minor tweaks.