### PR TITLE
Implement String.prototype.replaceAll

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -33,7 +33,6 @@
     "resizable-arraybuffer",
     "ShadowRealm",
     "SharedArrayBuffer",
-    "String.prototype.replaceAll",
     "tail-call-optimization",
     "top-level-await",
     "Temporal",
@@ -74,6 +73,9 @@
     // Issue with \r in source string
     "built-ins/RegExp/dotall/without-dotall.js",
     "built-ins/RegExp/dotall/without-dotall-unicode.js",
+    
+    // regex named groups
+    "built-ins/String/prototype/replaceAll/searchValue-replacer-RegExp-call.js",
 
     // requires investigation how to process complex function name evaluation for property
     "built-ins/Function/prototype/toString/method-computed-property-name.js",

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -57,7 +57,7 @@ namespace Jint
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsRegExp(this JsValue value)
         {
-            if (!(value is ObjectInstance oi))
+            if (value is not ObjectInstance oi)
             {
                 return false;
             }

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -1037,7 +1037,7 @@ namespace Jint.Runtime
         {
             if (o._type < InternalTypes.Boolean)
             {
-                ExceptionHelper.ThrowTypeError(engine.Realm);
+                ExceptionHelper.ThrowTypeError(engine.Realm, "Cannot call method on " + o);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The entire execution engine was rebuild with performance in mind, in many cases 
 - ✔ Logical Assignment Operators (`&&=` `||=` `??=`)
 - ✔ Numeric Separators (`1_000`)
 - ❌ `Promise.any` and `AggregateError`
-- ❌ `String.prototype.replaceAll`
+- ✔ `String.prototype.replaceAll`
 - ❌ `WeakRef` and `FinalizationRegistry`
 
 #### ECMAScript 2022


### PR DESCRIPTION
Quite straightforward, had to ignore one test case because has partly named groups usage on regex.