### PR TITLE
Fix JsonParser not able to parse "\u0000"

### DIFF
--- a/Jint.Tests/Runtime/JsonTests.cs
+++ b/Jint.Tests/Runtime/JsonTests.cs
@@ -16,6 +16,28 @@ namespace Jint.Tests.Runtime
         }
 
         [Theory]
+        [InlineData("{\"a\":\"\\\"\"}", "\"")] // " quotation mark
+        [InlineData("{\"a\":\"\\\\\"}", "\\")] // \ reverse solidus
+        [InlineData("{\"a\":\"\\/\"}", "/")] // / solidus
+        [InlineData("{\"a\":\"\\b\"}", "\b")] // backspace
+        [InlineData("{\"a\":\"\\f\"}", "\f")] // formfeed
+        [InlineData("{\"a\":\"\\n\"}", "\n")] // linefeed
+        [InlineData("{\"a\":\"\\r\"}", "\r")] // carriage return
+        [InlineData("{\"a\":\"\\t\"}", "\t")] // horizontal tab
+        [InlineData("{\"a\":\"\\u0000\"}", "\0")]
+        [InlineData("{\"a\":\"\\u0001\"}", "\x01")]
+        [InlineData("{\"a\":\"\\u0061\"}", "a")]
+        public void ShouldParseEscapedCharactersCorrectly(string json, string expectedCharacter)
+        {
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            var parsedCharacter = parser.Parse(json).AsObject().Get("a").AsString();
+
+            Assert.Equal(expectedCharacter, parsedCharacter);
+        }
+
+        [Theory]
         [InlineData("{\"a\":1", "Unexpected end of JSON input at position 6")]
         [InlineData("{\"a\":1},", "Unexpected token ',' in JSON at position 7")]
         [InlineData("{1}", "Unexpected number in JSON at position 1")]

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -335,26 +335,17 @@ namespace Jint.Native.Json
                                 break;
                             case 'u':
                             case 'x':
-                                int restore = _index;
                                 char unescaped = ScanHexEscape(ch);
-                                if (unescaped > 0)
-                                {
-                                    sb.Append(unescaped.ToString());
-                                }
-                                else
-                                {
-                                    _index = restore;
-                                    sb.Append(ch.ToString());
-                                }
+                                sb.Append(unescaped);
                                 break;
                             case 'b':
-                                sb.Append("\b");
+                                sb.Append('\b');
                                 break;
                             case 'f':
-                                sb.Append("\f");
+                                sb.Append('\f');
                                 break;
                             case 'v':
-                                sb.Append("\x0B");
+                                sb.Append('\x0B');
                                 break;
 
                             default:


### PR DESCRIPTION
Currently `JSON.parse` does not handle `\u0000` correctly:

```cs
var engine = new Engine();
engine.SetValue("log", new Action<object>(Console.WriteLine));
engine.Execute(@"js code below");
```

```js
const null_text = '{"a":"\\u0000"}';
const null_obj = JSON.parse(null_text);
log(null_text);
log(null_obj.a.length);
log(null_obj.a);

const a_text = '{"a":"\\u0061"}';
const a_obj = JSON.parse(a_text);
log(a_text);
log(a_obj.a.length);
log(a_obj.a);
```

Expected output:

```
{"a":"\u0000"}
1

{"a":"\u0061"}
1
a
```

Current output:

```
{"a":"\u0000"}
5
u0000
{"a":"\u0061"}
1
a
```

This PR removed unneeded check for escaped characters, and added tests to verify escaped characters are correctly parsed.

