### PR TITLE
Make JsonParser escape character parsing more strict

### DIFF
--- a/Jint.Tests/Runtime/JsonTests.cs
+++ b/Jint.Tests/Runtime/JsonTests.cs
@@ -45,7 +45,7 @@ namespace Jint.Tests.Runtime
         [InlineData("{true}", "Unexpected token 'true' in JSON at position 1")]
         [InlineData("{null}", "Unexpected token 'null' in JSON at position 1")]
         [InlineData("{:}", "Unexpected token ':' in JSON at position 1")]
-        [InlineData("\"\\xah\"", "Expected hexadecimal digit in JSON at position 4")]
+        [InlineData("\"\\uah\"", "Expected hexadecimal digit in JSON at position 4")]
         [InlineData("0123", "Unexpected token '1' in JSON at position 1")]  // leading 0 (octal number) not allowed
         [InlineData("1e+A", "Unexpected token 'A' in JSON at position 3")]
         [InlineData("truE", "Unexpected token 'tru' in JSON at position 0")]
@@ -55,6 +55,7 @@ namespace Jint.Tests.Runtime
         [InlineData("alpha", "Unexpected token 'a' in JSON at position 0")]
         [InlineData("[1,\na]", "Unexpected token 'a' in JSON at position 4")] // multiline
         [InlineData("\x06", "Unexpected token '\x06' in JSON at position 0")] // control char
+        [InlineData("{\"\\v\":1}", "Unexpected token 'v' in JSON at position 3")] // invalid escape sequence
         public void ShouldReportHelpfulSyntaxErrorForInvalidJson(string json, string expectedMessage)
         {
             var engine = new Engine();


### PR DESCRIPTION
This is a continuation of #1160 

This PR removes support for non-standard `\v`, `\x00`, `\0123` and `\(any char here)`, and will throw an error instead.

This behavior is matching other common JSON parser like `JSON.parse` found in nodejs.

```js
// node v16.13.0
JSON.parse('{"\\v":1}')
// Uncaught SyntaxError: Unexpected token v in JSON at position 3
```

```cs
// Newtonsoft.Json 13.0.1
const string json = @"{""\v"":1}";
var obj1 = Newtonsoft.Json.JsonConvert.DeserializeObject(json);
// Newtonsoft.Json.JsonReaderException: Bad JSON escape sequence: \v. Path '', line 1, position 4.
```