### PR TITLE
Remove unnecessary ObjectClass types

### DIFF
--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -20,7 +20,7 @@ namespace Jint.Native.Array
 
         private ObjectChangeFlags _objectChangeFlags;
 
-        public ArrayInstance(Engine engine, uint capacity = 0) : base(engine, ObjectClass.Array)
+        public ArrayInstance(Engine engine, uint capacity = 0) : base(engine)
         {
             if (capacity > engine.Options.Constraints.MaxArraySize)
             {
@@ -40,7 +40,7 @@ namespace Jint.Native.Array
         /// <summary>
         /// Possibility to construct valid array fast, requires that supplied array does not have holes.
         /// </summary>
-        public ArrayInstance(Engine engine, PropertyDescriptor[] items) : base(engine, ObjectClass.Array)
+        public ArrayInstance(Engine engine, PropertyDescriptor[] items) : base(engine)
         {
             int length = 0;
             if (items == null || items.Length == 0)
@@ -57,7 +57,7 @@ namespace Jint.Native.Array
             _length = new PropertyDescriptor(length, PropertyFlag.OnlyWritable);
         }
 
-        public ArrayInstance(Engine engine, Dictionary<uint, PropertyDescriptor> items) : base(engine, ObjectClass.Array)
+        public ArrayInstance(Engine engine, Dictionary<uint, PropertyDescriptor> items) : base(engine)
         {
             _sparse = items;
             var length = items?.Count ?? 0;

--- a/Jint/Native/Iterator/IteratorInstance.cs
+++ b/Jint/Native/Iterator/IteratorInstance.cs
@@ -19,7 +19,7 @@ namespace Jint.Native.Iterator
 
         public IteratorInstance(
             Engine engine,
-            IEnumerable<JsValue> enumerable) : base(engine, ObjectClass.Iterator)
+            IEnumerable<JsValue> enumerable) : base(engine)
         {
             _enumerable = enumerable.GetEnumerator();
             _prototype = engine.Realm.Intrinsics.IteratorPrototype;

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -16,7 +16,7 @@ namespace Jint.Native.Json
             Engine engine,
             Realm realm,
             ObjectPrototype objectPrototype)
-            : base(engine, objectClass: ObjectClass.JSON)
+            : base(engine, objectClass: ObjectClass.Object)
         {
             _realm = realm;
             _prototype = objectPrototype;

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -13,7 +13,7 @@ namespace Jint.Native.Math
     {
         private Random _random;
 
-        internal MathInstance(Engine engine, ObjectPrototype objectPrototype) : base(engine, ObjectClass.Math)
+        internal MathInstance(Engine engine, ObjectPrototype objectPrototype) : base(engine)
         {
             _prototype = objectPrototype;
         }

--- a/Jint/Native/Object/ObjectClass.cs
+++ b/Jint/Native/Object/ObjectClass.cs
@@ -3,22 +3,13 @@ namespace Jint.Native.Object
     internal enum ObjectClass : byte
     {
         Arguments,
-        Array,
         Boolean,
         Date,
         Error,
         Function,
-        Iterator,
-        JSON,
-        Math,
         Number,
         Object,
-        Promise,
-        Proxy,
-        Reflect,
         RegExp,
-        String,
-        Symbol,
-        TypeReference
+        String
     }
 }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -33,7 +33,10 @@ namespace Jint.Native.Object
         {
         }
 
-        internal ObjectInstance(Engine engine, ObjectClass objectClass, InternalTypes type = InternalTypes.Object)
+        internal ObjectInstance(
+            Engine engine,
+            ObjectClass objectClass = ObjectClass.Object,
+            InternalTypes type = InternalTypes.Object)
             : base(type)
         {
             _engine = engine;
@@ -914,26 +917,6 @@ namespace Jint.Native.Object
             object converted = null;
             switch (Class)
             {
-                case ObjectClass.Array:
-                    if (this is ArrayInstance arrayInstance)
-                    {
-                        var result = new object[arrayInstance.Length];
-                        for (uint i = 0; i < result.Length; i++)
-                        {
-                            var value = arrayInstance[i];
-                            object valueToSet = null;
-                            if (!value.IsUndefined())
-                            {
-                                valueToSet = value is ObjectInstance oi
-                                    ? oi.ToObject(stack)
-                                    : value.ToObject();
-                            }
-                            result[i] = valueToSet;
-                        }
-                        converted = result;
-                    }
-                    break;
-
                 case ObjectClass.String:
                     if (this is StringInstance stringInstance)
                     {
@@ -981,6 +964,26 @@ namespace Jint.Native.Object
 
                 case ObjectClass.Arguments:
                 case ObjectClass.Object:
+                    
+                    if (this is ArrayInstance arrayInstance)
+                    {
+                        var result = new object[arrayInstance.Length];
+                        for (uint i = 0; i < result.Length; i++)
+                        {
+                            var value = arrayInstance[i];
+                            object valueToSet = null;
+                            if (!value.IsUndefined())
+                            {
+                                valueToSet = value is ObjectInstance oi
+                                    ? oi.ToObject(stack)
+                                    : value.ToObject();
+                            }
+                            result[i] = valueToSet;
+                        }
+                        converted = result;
+                        break;
+                    }
+                    
                     var o = _engine.Options.Interop.CreateClrObject(this);
                     foreach (var p in GetOwnProperties())
                     {

--- a/Jint/Native/Promise/PromiseInstance.cs
+++ b/Jint/Native/Promise/PromiseInstance.cs
@@ -51,7 +51,7 @@ namespace Jint.Native.Promise
         internal List<PromiseReaction> PromiseRejectReactions = new();
         internal List<PromiseReaction> PromiseFulfillReactions = new();
 
-        internal PromiseInstance(Engine engine) : base(engine, ObjectClass.Promise)
+        internal PromiseInstance(Engine engine) : base(engine)
         {
         }
 

--- a/Jint/Native/Reflect/ReflectInstance.cs
+++ b/Jint/Native/Reflect/ReflectInstance.cs
@@ -18,7 +18,7 @@ namespace Jint.Native.Reflect
         internal ReflectInstance(
             Engine engine,
             Realm realm,
-            ObjectPrototype objectPrototype) : base(engine, ObjectClass.Reflect)
+            ObjectPrototype objectPrototype) : base(engine)
         {
             _realm = realm;
             _prototype = objectPrototype;

--- a/Jint/Native/Symbol/SymbolInstance.cs
+++ b/Jint/Native/Symbol/SymbolInstance.cs
@@ -5,8 +5,10 @@ namespace Jint.Native.Symbol
 {
     public sealed class SymbolInstance : ObjectInstance, IPrimitiveInstance
     {
-        internal SymbolInstance(Engine engine, SymbolPrototype prototype, JsSymbol symbol)
-            : base(engine, ObjectClass.Symbol)
+        internal SymbolInstance(
+            Engine engine,
+            SymbolPrototype prototype,
+            JsSymbol symbol) : base(engine)
         {
             _prototype = prototype;
             SymbolData = symbol;

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -42,12 +42,13 @@ namespace Jint.Runtime.Interop
                 var genericTypeReference = arguments[i];
                 if (genericTypeReference.IsUndefined()
                     || !genericTypeReference.IsObject()
-                    || genericTypeReference.AsObject().Class != ObjectClass.TypeReference)
+                    || genericTypeReference.AsObject() is not TypeReference tr)
                 {
                     ExceptionHelper.ThrowTypeError(_engine.Realm, "Invalid generic type parameter on " + _path + ", if this is not a generic type / method, are you missing a lookup assembly?");
+                    return default;
                 }
 
-                genericTypes[i] = ((TypeReference) genericTypeReference).ReferenceType;
+                genericTypes[i] = tr.ReferenceType;
             }
 
             var typeReference = GetPath(_path + "`" + arguments.Length.ToString(CultureInfo.InvariantCulture)).As<TypeReference>();

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -21,7 +21,7 @@ namespace Jint.Runtime.Interop
         private readonly record struct MemberAccessorKey(Type Type, string PropertyName); 
         
         private TypeReference(Engine engine, Type type)
-            : base(engine, engine.Realm, _name, FunctionThisMode.Global, ObjectClass.TypeReference)
+            : base(engine, engine.Realm, _name, FunctionThisMode.Global)
         {
             ReferenceType = type;
 


### PR DESCRIPTION
There are types that are not needed per spec and also cause invalid `toString` behavior as value is used as string presentation.