### PR TITLE
Added the ability to catch the CLR exception from an overridden arithmetic operator.

### DIFF
--- a/Jint.Tests/Runtime/Domain/Dimensional.cs
+++ b/Jint.Tests/Runtime/Domain/Dimensional.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+
+namespace Jint.Tests.Runtime.Domain
+{
+    public class Dimensional : IComparable<Dimensional>
+    {
+        private readonly MeasureUnit[] PossibleMeasureUnits = new MeasureUnit[] { new MeasureUnit("Mass", "kg", 1.0), new MeasureUnit("Mass", "gr", 0.001), new MeasureUnit("Count", "piece", 1.0) };
+
+        public MeasureUnit MeasureUnit { get; private set; }
+
+        public double Value { get; private set; }
+
+        public double NormalizatedValue
+        {
+            get
+            {
+                return Value * MeasureUnit.RelativeValue;
+            }
+        }
+
+        public Dimensional(string measureUnit, double value)
+        {
+            MeasureUnit = GetMeasureUnitByName(measureUnit);
+            Value = value;
+        }
+
+        public static Dimensional operator +(Dimensional left, Dimensional right)
+        {
+            if (left.MeasureUnit.MeasureType != right.MeasureUnit.MeasureType)
+                throw new InvalidOperationException("Dimensionals with different measure types are non-summable");
+
+            return new Dimensional(left.MeasureUnit.RelativeValue <= right.MeasureUnit.RelativeValue ? left.MeasureUnit.Name : right.MeasureUnit.Name,
+                                                            left.Value * left.MeasureUnit.RelativeValue + right.Value * right.MeasureUnit.RelativeValue);
+        }
+
+        private MeasureUnit GetMeasureUnitByName(string name)
+        {
+            return PossibleMeasureUnits.FirstOrDefault(mu => mu.Name == name);
+        }
+
+        public int CompareTo(Dimensional? obj)
+        {
+            if (MeasureUnit.MeasureType != obj.MeasureUnit.MeasureType)
+                throw new InvalidOperationException("Dimensionals with different measure types are non-comparable");
+            return NormalizatedValue.CompareTo(obj.NormalizatedValue);
+        }
+
+        public override string ToString()
+        {
+            return Value.ToString() + " " + MeasureUnit.Name;
+        }
+    }
+
+    public class MeasureUnit
+    {
+        public string MeasureType { get; set; }
+        public string Name { get; set; }
+        public double RelativeValue { get; set; }
+
+        public MeasureUnit(string measureType, string Name, double relativeValue)
+        {
+            this.MeasureType = measureType;
+            this.Name = Name;
+            this.RelativeValue = relativeValue;
+        }
+    }
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Numerics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Extensions;
@@ -63,8 +64,9 @@ namespace Jint.Runtime.Interpreter.Expressions
                         result = method.Call(context.Engine, null, arguments);
                         return true;
                     }
-                    catch
+                    catch (Exception e)
                     {
+                        ExceptionHelper.ThrowMeaningfulException(context.Engine, new TargetInvocationException(e.InnerException));
                         result = null;
                         return false;
                     }


### PR DESCRIPTION
In my work project, I need catch exception from wrong arithmetic operation with my types. See [Issue#1866](https://github.com/sebastienros/jint/issues/1186)