### PR TITLE
Generate test262 test cases on build if missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,8 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v2
 
-    - name: Generate test cases
-      working-directory: ./Jint.Tests.Test262
-      run: dotnet tool restore && dotnet test262 generate
-
     - name: Test
-      run: dotnet test --configuration Release --logger:"console;verbosity=quiet"
+      run: dotnet test --configuration Release --logger GitHubActions
 
     - name: Pack with dotnet
       run: dotnet pack --output artifacts --configuration Release -p:PackageVersion=3.0.0-preview-$GITHUB_RUN_NUMBER

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,12 +17,8 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v2
 
-    - name: Generate test cases
-      working-directory: ./Jint.Tests.Test262
-      run: dotnet tool restore && dotnet test262 generate
-
     - name: Test
-      run: dotnet test --configuration Release --logger:"console;verbosity=quiet"
+      run: dotnet test --configuration Release --logger GitHubActions
 
   linux:
     runs-on: ubuntu-latest
@@ -34,9 +30,5 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v2
 
-    - name: Generate test cases
-      working-directory: ./Jint.Tests.Test262
-      run: dotnet tool restore && dotnet test262 generate
-
     - name: Test
-      run: dotnet test --configuration Release --logger:"console;verbosity=quiet"
+      run: dotnet test --configuration Release --logger GitHubActions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,8 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v2
 
-    - name: Generate test cases
-      working-directory: ./Jint.Tests.Test262
-      run: dotnet tool restore && dotnet test262 generate
-
     - name: Test
-      run: dotnet test --configuration Release --logger:"console;verbosity=quiet"
+      run: dotnet test --configuration Release --logger GitHubActions
 
     - name: Pack with dotnet
       run: |

--- a/Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj
+++ b/Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj
@@ -1,18 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <!--<TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>-->
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Scripts\*.*" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />
   </ItemGroup>
+
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
+
 </Project>

--- a/Jint.Tests.Test262/Jint.Tests.Test262.csproj
+++ b/Jint.Tests.Test262/Jint.Tests.Test262.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <!--<TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>-->
@@ -6,20 +7,48 @@
     <SignAssembly>true</SignAssembly>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
+    <GeneratedTestSuiteDir>Generated</GeneratedTestSuiteDir>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />
   </ItemGroup>
+
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Test262Harness" Version="0.0.17" />
   </ItemGroup>
+
   <ItemGroup>
     <Using Include="NUnit.Framework" />
   </ItemGroup>
+
   <ItemGroup>
-    <Content Include=".config\*" />
+    <Content Include=".config\dotnet-tools.json" />
   </ItemGroup>
+
+  <!-- Based on the idea presented at https://mhut.ch/journal/2015/06/30/build-time-code-generation-in-msbuild -->
+  <Target Name="GenerateTestSuite" DependsOnTargets="_GenerateTestSuite" BeforeTargets="BeforeBuild" Condition="!Exists($([System.IO.Path]::Combine($(MSBuildThisFileDirectory), $(GeneratedTestSuiteDir))))">
+    <ItemGroup>
+      <Compile Include="$(GeneratedTestSuiteDir)\**\*.cs" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_GenerateTestSuite">
+    <Exec Command="dotnet tool restore" />
+    <Exec Command="dotnet test262 generate" />
+  </Target>
+
+  <Target Name="DeleteTestSuite" DependsOnTargets="_DeleteTestSuite" AfterTargets="AfterClean" Condition="Exists($([System.IO.Path]::Combine($(MSBuildThisFileDirectory), $(GeneratedTestSuiteDir))))">
+    <RemoveDir Directories="$(GeneratedTestSuiteDir)" />
+  </Target>
+
+  <Target Name="_DeleteTestSuite">
+    <ItemGroup>
+      <Compile Remove="$(GeneratedTestSuiteDir)\**\*.cs" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
@@ -8,21 +9,27 @@
     <LangVersion>latest</LangVersion>
     <NoWarn>612</NoWarn>
   </PropertyGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Runtime\Scripts\*.*;Parser\Scripts\*.*" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" Condition=" '$(TargetFramework)' == 'net462' " />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Flurl.Http.Signed" Version="3.2.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="MongoDB.Bson.signed" Version="2.14.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Porting automatic test case generation if missing from Esprima side, adding GitHubActions logger.

relates to #1196