### PR TITLE
Decode import URI before using it as a file name

### DIFF
--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -332,6 +332,16 @@ export const count = globals.counter;
         Assert.Equal("John Doe", result);
     }
 
+    [Fact]
+    public void CanImportFromFileWithSpacesInPath()
+    {
+        var engine = new Engine(options => options.EnableModules(GetBasePath()));
+        var ns = engine.ImportModule("./dir with spaces/format name.js");
+        var result = engine.Invoke(ns.Get("formatName"), "John", "Doe").AsString();
+
+        Assert.Equal("John Doe", result);
+    }
+
     internal static string GetBasePath()
     {
         var assemblyDirectory = new DirectoryInfo(AppDomain.CurrentDomain.RelativeSearchPath ?? AppDomain.CurrentDomain.BaseDirectory);

--- a/Jint.Tests/Runtime/Scripts/dir with spaces/format name.js
+++ b/Jint.Tests/Runtime/Scripts/dir with spaces/format name.js
@@ -1,0 +1,3 @@
+export function formatName(firstName, lastName) {
+    return `${firstName} ${lastName}`;
+}

--- a/Jint.Tests/Runtime/Scripts/dir with spaces/format name.js
+++ b/Jint.Tests/Runtime/Scripts/dir with spaces/format name.js
@@ -1,3 +1,4 @@
 export function formatName(firstName, lastName) {
     return `${firstName} ${lastName}`;
 }
+

--- a/Jint/Runtime/Modules/DefaultModuleLoader.cs
+++ b/Jint/Runtime/Modules/DefaultModuleLoader.cs
@@ -120,14 +120,14 @@ public sealed class DefaultModuleLoader : IModuleLoader
         {
             ExceptionHelper.ThrowInvalidOperationException($"Module '{resolved.Specifier}' of type '{resolved.Type}' has no resolved URI.");
         }
-
-        if (!File.Exists(resolved.Uri.AbsolutePath))
+        var file_name = Uri.UnescapeDataString(resolved.Uri.AbsolutePath);
+        if (!File.Exists(file_name))
         {
             ExceptionHelper.ThrowArgumentException("Module Not Found: ", resolved.Specifier);
             return default;
         }
 
-        var code = File.ReadAllText(resolved.Uri.LocalPath);
+        var code = File.ReadAllText(file_name);
 
         Module module;
         try

--- a/Jint/Runtime/Modules/DefaultModuleLoader.cs
+++ b/Jint/Runtime/Modules/DefaultModuleLoader.cs
@@ -120,14 +120,14 @@ public sealed class DefaultModuleLoader : IModuleLoader
         {
             ExceptionHelper.ThrowInvalidOperationException($"Module '{resolved.Specifier}' of type '{resolved.Type}' has no resolved URI.");
         }
-        var file_name = Uri.UnescapeDataString(resolved.Uri.AbsolutePath);
-        if (!File.Exists(file_name))
+        var fileName = Uri.UnescapeDataString(resolved.Uri.AbsolutePath);
+        if (!File.Exists(fileName))
         {
             ExceptionHelper.ThrowArgumentException("Module Not Found: ", resolved.Specifier);
             return default;
         }
 
-        var code = File.ReadAllText(file_name);
+        var code = File.ReadAllText(fileName);
 
         Module module;
         try


### PR DESCRIPTION
This fixes imports from paths that contains spaces (and other characters that are escaped in URIs).