### PR TITLE
Fix interop stack trace unwind (#1202)

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1353,9 +1353,15 @@ namespace Jint
                 ExceptionHelper.ThrowRecursionDepthOverflowException(CallStack, callStackElement.ToString());
             }
 
-            var result = functionInstance.Call(thisObject, arguments);
-
-            CallStack.Pop();
+            JsValue result;
+            try
+            {
+                result = functionInstance.Call(thisObject, arguments);
+            }
+            finally
+            {
+                CallStack.Pop();
+            }
 
             return result;
         }
@@ -1376,9 +1382,15 @@ namespace Jint
                 ExceptionHelper.ThrowRecursionDepthOverflowException(CallStack, callStackElement.ToString());
             }
 
-            var result = ((IConstructor) functionInstance).Construct(arguments, newTarget);
-
-            CallStack.Pop();
+            ObjectInstance result;
+            try
+            {
+                result = ((IConstructor) functionInstance).Construct(arguments, newTarget);
+            }
+            finally
+            {
+                CallStack.Pop();
+            }
 
             return result;
         }

--- a/Jint/Runtime/Interpreter/Statements/JintTryStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintTryStatement.cs
@@ -48,16 +48,6 @@ namespace Jint.Runtime.Interpreter.Statements
                 // execute catch
                 if (_statement.Handler is not null)
                 {
-                    // Quick-patch for call stack not being unwinded when an exception is caught.
-                    // Ideally, this should instead be solved by always popping the stack when returning
-                    // from a call, regardless of whether it throws (i.e. CallStack.Pop() in finally clause
-                    // in Engine.Call/Engine.Construct - however, that method currently breaks stack traces
-                    // in error messages.
-                    while (callStackSizeBeforeExecution < engine.CallStack.Count)
-                    {
-                        engine.CallStack.Pop();
-                    }
-
                     // https://tc39.es/ecma262/#sec-runtime-semantics-catchclauseevaluation
 
                     var thrownValue = b.Value;

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -1030,7 +1030,8 @@ namespace Jint.Runtime
         {
             referencedName ??= "unknown";
             var message = $"Cannot read property '{referencedName}' of {o}";
-            throw new JavaScriptException(engine.Realm.Intrinsics.TypeError, message).SetJavaScriptCallstack(engine, sourceNode.Location);
+            throw new JavaScriptException(engine.Realm.Intrinsics.TypeError, message)
+                .SetJavaScriptCallstack(engine, sourceNode.Location, overwriteExisting: true);
         }
 
         public static void CheckObjectCoercible(Engine engine, JsValue o)


### PR DESCRIPTION
* remove quick patch from JintTryStatement introduced in #853
* implement "ideal" solution described in #853 (try/finally in Engine.Call and Engine.Construct)
* change behaviour of JavaScriptException.SetJavaScriptCallstack() so that it will not overwrite the existing stack trace unless explicitly told to
* add test

fixes #1202