### PR TITLE
Exclude Error constructor from stack trace

### DIFF
--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using Esprima;
@@ -63,6 +64,11 @@ namespace Jint.Runtime.CallStack
             return item;
         }
 
+        public bool TryPeek([NotNullWhen(true)] out CallStackElement item)
+        {
+            return _stack.TryPeek(out item);
+        }
+
         public int Count => _stack._size;
 
         public void Clear()
@@ -76,7 +82,7 @@ namespace Jint.Runtime.CallStack
             return string.Join("->", _stack.Select(cse => cse.ToString()).Reverse());
         }
 
-        internal string BuildCallStackString(Location location)
+        internal string BuildCallStackString(Location location, int excludeTop = 0)
         {
             static void AppendLocation(
                 StringBuilder sb,
@@ -124,7 +130,7 @@ namespace Jint.Runtime.CallStack
             using var sb = StringBuilderPool.Rent();
 
             // stack is one frame behind function-wise when we start to process it from expression level
-            var index = _stack._size - 1;
+            var index = _stack._size - 1 - excludeTop;
             var element = index >= 0 ? _stack[index] : (CallStackElement?) null;
             var shortDescription = element?.ToString() ?? "";
 

--- a/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
@@ -58,9 +58,13 @@ namespace Jint.Runtime.Interpreter.Expressions
                 BuildArguments(context, _jintArguments, arguments);
             }
 
+            // Reset the location to the "new" keyword so that if an Error object is
+            // constructed below, the stack trace will capture the correct location.
+            context.LastSyntaxNode = _expression;
+
             if (!jsValue.IsConstructor)
             {
-                ExceptionHelper.ThrowTypeError(engine.Realm,  _calleeExpression.SourceText + " is not a constructor");
+                ExceptionHelper.ThrowTypeError(engine.Realm, _calleeExpression.SourceText + " is not a constructor");
             }
 
             // construct the new instance using the Function's constructor method

--- a/Jint/Runtime/Interpreter/Statements/JintThrowStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintThrowStatement.cs
@@ -21,8 +21,8 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
-            var jsValue = _argument.GetValue(context).Value;
-            return new Completion(CompletionType.Throw, jsValue, null, _statement.Location);
+            var completion = _argument.GetValue(context);
+            return new Completion(CompletionType.Throw, completion.Value, null, completion.Location);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintTryStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintTryStatement.cs
@@ -33,7 +33,6 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
             var engine = context.Engine;
-            int callStackSizeBeforeExecution = engine.CallStack.Count;
 
             var b = _block.Execute(context);
 


### PR DESCRIPTION
When an error is explicitly thrown from a script, it does make sense to include the Error constructor itself in the captured stack trace. The trace should begin at the point where the Error object is constructed.

Changes:
* If the current function on the call stack is the Error constructor function, exclude it from the captured stack trace.
* Fix issues with reported location so that JavaScriptException.Location is consistent with the location recorded in the stack trace.
* Add new test, adjust existing tests