### PR TITLE
Fix Stackoverflow error when parseInt is executed

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -754,8 +754,10 @@ namespace Jint.Tests.Runtime
         [InlineData(double.NaN, "parseInt(undefined)")]
         [InlineData(double.NaN, "parseInt(new Boolean(true))")]
         [InlineData(double.NaN, "parseInt(Infinity)")]
+        [InlineData(double.NaN, "parseInt(new Array(100000).join('Z'))")]
         [InlineData(-1d, "parseInt(-1)")]
         [InlineData(-1d, "parseInt('-1')")]
+
         public void ShouldEvaluateParseInt(object expected, string source)
         {
             var engine = new Engine();

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -18,6 +18,7 @@ namespace Jint.Native.Global
     {
         private readonly Realm _realm;
         private readonly StringBuilder _stringBuilder = new();
+        private const int LengthLimitForParserInt = 200;
 
         internal GlobalObject(
             Engine engine,
@@ -203,7 +204,7 @@ namespace Jint.Native.Global
 
         private static double Parse(string number, int radix)
         {
-            if (number == "")
+            if ((number == "") || (number.Length > LengthLimitForParserInt))
             {
                 return double.NaN;
             }


### PR DESCRIPTION
Fix Stackoverflow error when parseInt is executed using a big word as the parameter