### PR TITLE
Rethrow CLR function exceptions as JS errors

### DIFF
--- a/Jint/Runtime/Interop/ClrFunctionInstance.cs
+++ b/Jint/Runtime/Interop/ClrFunctionInstance.cs
@@ -41,7 +41,7 @@ namespace Jint.Runtime.Interop
             {
                 if (_engine.Options.Interop.ExceptionHandler(exc))
                 {
-                    ExceptionHelper.ThrowJavaScriptException(_realm.Intrinsics.NativeError, exc.Message);
+                    ExceptionHelper.ThrowJavaScriptException(_realm.Intrinsics.Error, exc.Message);
                 }
                 else
                 {

--- a/Jint/Runtime/Intrinsics.cs
+++ b/Jint/Runtime/Intrinsics.cs
@@ -38,6 +38,7 @@ namespace Jint.Runtime
         private static readonly JsString _syntaxErrorFunctionName = new("SyntaxError");
         private static readonly JsString _typeErrorFunctionName = new("TypeError");
         private static readonly JsString _uriErrorFunctionName = new("URIError");
+        private static readonly JsString _nativeErrorFunctionName = new("NativeError");
 
         private readonly Engine _engine;
         private readonly Realm _realm;
@@ -52,6 +53,7 @@ namespace Jint.Runtime
         private ErrorConstructor? _syntaxError;
         private ErrorConstructor? _typeError;
         private ErrorConstructor? _uriError;
+        private ErrorConstructor? _nativeError;
         private WeakMapConstructor? _weakMap;
         private WeakSetConstructor? _weakSet;
         private WeakRefConstructor? _weakRef;
@@ -260,5 +262,8 @@ namespace Jint.Runtime
 
         public ThrowTypeError ThrowTypeError =>
             _throwTypeError ??= new ThrowTypeError(_engine, _engine.Realm) { _prototype = _engine.Realm.Intrinsics.Function.PrototypeObject };
+        
+        public ErrorConstructor NativeError =>
+            _nativeError ??= new ErrorConstructor(_engine, _realm, Error, Error.PrototypeObject, _nativeErrorFunctionName, static intrinsics => intrinsics.NativeError.PrototypeObject);
     }
 }

--- a/Jint/Runtime/Intrinsics.cs
+++ b/Jint/Runtime/Intrinsics.cs
@@ -38,7 +38,6 @@ namespace Jint.Runtime
         private static readonly JsString _syntaxErrorFunctionName = new("SyntaxError");
         private static readonly JsString _typeErrorFunctionName = new("TypeError");
         private static readonly JsString _uriErrorFunctionName = new("URIError");
-        private static readonly JsString _nativeErrorFunctionName = new("NativeError");
 
         private readonly Engine _engine;
         private readonly Realm _realm;
@@ -53,7 +52,6 @@ namespace Jint.Runtime
         private ErrorConstructor? _syntaxError;
         private ErrorConstructor? _typeError;
         private ErrorConstructor? _uriError;
-        private ErrorConstructor? _nativeError;
         private WeakMapConstructor? _weakMap;
         private WeakSetConstructor? _weakSet;
         private WeakRefConstructor? _weakRef;
@@ -262,8 +260,5 @@ namespace Jint.Runtime
 
         public ThrowTypeError ThrowTypeError =>
             _throwTypeError ??= new ThrowTypeError(_engine, _engine.Realm) { _prototype = _engine.Realm.Intrinsics.Function.PrototypeObject };
-        
-        public ErrorConstructor NativeError =>
-            _nativeError ??= new ErrorConstructor(_engine, _realm, Error, Error.PrototypeObject, _nativeErrorFunctionName, static intrinsics => intrinsics.NativeError.PrototypeObject);
     }
 }


### PR DESCRIPTION
As discussed with @lahma on [gitter](https://gitter.im/sebastienros/jint?at=62de95cbb408e830dc50fdc5). This allows using the `CatchClrExceptions` handler on ClrFunctionInstance. Works for modules and scripts.