### PR TITLE
Removed ProxyInstance ToString override so calls the property 'toString'

### DIFF
--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -19,17 +19,6 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
-        public void ProxyCanBeRevokedWithoutContext()
-        {
-            new Engine()
-                .Execute(@"
-                    var revocable = Proxy.revocable({}, {});
-                    var revoke = revocable.revoke;
-                    revoke.call(null);
-                ");
-        }
-
-        [Fact]
         public void ArrowFunctionShouldBeExtensible()
         {
             new Engine()

--- a/Jint.Tests/Runtime/ProxyTests.cs
+++ b/Jint.Tests/Runtime/ProxyTests.cs
@@ -1,0 +1,40 @@
+﻿namespace Jint.Tests.Runtime
+{
+    public class ProxyTests
+    {
+        [Fact]
+        public void ProxyCanBeRevokedWithoutContext()
+        {
+            new Engine()
+                .Execute(@"
+                    var revocable = Proxy.revocable({}, {});
+                    var revoke = revocable.revoke;
+                    revoke.call(null);
+                ");
+        }
+
+        [Fact]
+        public void ProxyToStringUseTarget()
+        {
+            var engine = new Engine().Execute(@"
+                const targetWithToString = {toString: () => 'target'}
+            ");
+            Assert.Equal("target", engine.Evaluate("new Proxy(targetWithToString, {}).toString()").AsString());
+            Assert.Equal("target", engine.Evaluate("`${new Proxy(targetWithToString, {})}`").AsString());
+        }
+
+        [Fact]
+        public void ProxyToStringUseHandler()
+        {
+            var engine = new Engine().Execute(@"
+                const handler = { get: (target, prop, receiver) => prop === 'toString' ? () => 'handler' : Reflect.get(target, prop, receiver) }
+                const targetWithToString = {toString: () => 'target'}
+            ");
+
+            Assert.Equal("handler", engine.Evaluate("new Proxy({}, handler).toString()").AsString());
+            Assert.Equal("handler", engine.Evaluate("new Proxy(targetWithToString, handler).toString()").AsString());
+            Assert.Equal("handler", engine.Evaluate("`${new Proxy({}, handler)}`").AsString());
+            Assert.Equal("handler", engine.Evaluate("`${new Proxy(targetWithToString, handler)}`").AsString());
+        }
+    }
+}

--- a/Jint/Native/Proxy/ProxyInstance.cs
+++ b/Jint/Native/Proxy/ProxyInstance.cs
@@ -598,6 +598,6 @@ namespace Jint.Native.Proxy
             }
         }
 
-        public override string ToString() => "function () { [native code] }";
+        public override string ToString() => IsCallable ? "function () { [native code] }" : base.ToString();
     }
 }


### PR DESCRIPTION
This reverts a change in ProxyInstance.ToString from #736. All the proxy string conversions match V8 10.4.132.20. I added some tests, not sure if you want to test to that level.

fixes #1249 