### PR TITLE
Restore public access to JavaScriptException ctor

### DIFF
--- a/Jint/Runtime/ExceptionHelper.cs
+++ b/Jint/Runtime/ExceptionHelper.cs
@@ -128,12 +128,6 @@ namespace Jint.Runtime
         }
 
         [DoesNotReturn]
-        public static void ThrowJavaScriptException(JsValue value)
-        {
-            throw new JavaScriptException(value);
-        }
-
-        [DoesNotReturn]
         public static void ThrowJavaScriptException(Engine engine, JsValue value, in Completion result)
         {
             throw new JavaScriptException(value).SetJavaScriptCallstack(engine, result.Location);

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -35,13 +35,13 @@ public class JavaScriptException : JintException
         _jsErrorException = (JavaScriptErrorWrapperException) InnerException!;
     }
 
-    internal JavaScriptException(ErrorConstructor errorConstructor, string? message)
+    public JavaScriptException(ErrorConstructor errorConstructor, string? message)
         : base(message, new JavaScriptErrorWrapperException(errorConstructor.Construct(new JsValue[] { message }), message))
     {
         _jsErrorException = (JavaScriptErrorWrapperException) InnerException!;
     }
 
-    internal JavaScriptException(JsValue error)
+    public JavaScriptException(JsValue error)
         : base(GetMessage(error), new JavaScriptErrorWrapperException(error, GetMessage(error)))
     {
         _jsErrorException = (JavaScriptErrorWrapperException) InnerException!;


### PR DESCRIPTION
* This may not be the optimal solution for allowing interop code to raise JS errors, but for the time being it is the most straightfoward and simple thing to do.