### PR TITLE
Reduce stack frame size during Call and Construct

### DIFF
--- a/Jint.Tests/Runtime/Debugger/EvaluateTests.cs
+++ b/Jint.Tests/Runtime/Debugger/EvaluateTests.cs
@@ -105,16 +105,7 @@ namespace Jint.Tests.Runtime.Debugger
                 var frameAfter = engine.CallStack.Stack[0];
                 // Stack frames and some of their properties are structs - can't check reference equality
                 // Besides, even if we could, it would be no guarantee. Neither is the following, but it'll do for now.
-                Assert.Equal(frameBefore.CallingExecutionContext.Function,
-                    frameAfter.CallingExecutionContext.Function);
-                Assert.Equal(frameBefore.CallingExecutionContext.LexicalEnvironment,
-                    frameAfter.CallingExecutionContext.LexicalEnvironment);
-                Assert.Equal(frameBefore.CallingExecutionContext.PrivateEnvironment,
-                    frameAfter.CallingExecutionContext.PrivateEnvironment);
-                Assert.Equal(frameBefore.CallingExecutionContext.VariableEnvironment,
-                    frameAfter.CallingExecutionContext.VariableEnvironment);
-                Assert.Equal(frameBefore.CallingExecutionContext.Realm, frameAfter.CallingExecutionContext.Realm);
-
+                Assert.Equal(frameBefore.CallingExecutionContext.LexicalEnvironment, frameAfter.CallingExecutionContext.LexicalEnvironment);
                 Assert.Equal(frameBefore.Arguments, frameAfter.Arguments);
                 Assert.Equal(frameBefore.Expression, frameAfter.Expression);
                 Assert.Equal(frameBefore.Location, frameAfter.Location);

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -171,7 +171,7 @@ namespace Jint
             return context;
         }
 
-        internal ExecutionContext EnterExecutionContext(ExecutionContext context)
+        internal ExecutionContext EnterExecutionContext(in ExecutionContext context)
         {
             _executionContexts.Push(context);
             return context;
@@ -1291,6 +1291,7 @@ namespace Jint
             return ExecuteWithConstraints(Options.Strict, Callback);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal JsValue Call(ICallable callable, JsValue thisObject, JsValue[] arguments, JintExpression? expression)
         {
             if (callable is FunctionInstance functionInstance)
@@ -1354,14 +1355,12 @@ namespace Jint
             JsValue[] arguments,
             JintExpression? expression)
         {
-            var callStackElement = new CallStackElement(functionInstance, expression, ExecutionContext);
-            var recursionDepth = CallStack.Push(callStackElement);
+            var recursionDepth = CallStack.Push(functionInstance, expression, ExecutionContext);
 
             if (recursionDepth > Options.Constraints.MaxRecursionDepth)
             {
-                // pop the current element as it was never reached
-                CallStack.Pop();
-                ExceptionHelper.ThrowRecursionDepthOverflowException(CallStack, callStackElement.ToString());
+                // automatically pops the current element as it was never reached
+                ExceptionHelper.ThrowRecursionDepthOverflowException(CallStack);
             }
 
             JsValue result;
@@ -1387,14 +1386,12 @@ namespace Jint
             JsValue newTarget,
             JintExpression? expression)
         {
-            var callStackElement = new CallStackElement(functionInstance, expression, ExecutionContext);
-            var recursionDepth = CallStack.Push(callStackElement);
+            var recursionDepth = CallStack.Push(functionInstance, expression, ExecutionContext);
 
             if (recursionDepth > Options.Constraints.MaxRecursionDepth)
             {
-                // pop the current element as it was never reached
-                CallStack.Pop();
-                ExceptionHelper.ThrowRecursionDepthOverflowException(CallStack, callStackElement.ToString());
+                // automatically pops the current element as it was never reached
+                ExceptionHelper.ThrowRecursionDepthOverflowException(CallStack);
             }
 
             ObjectInstance result;

--- a/Jint/Native/JsBigInt.cs
+++ b/Jint/Native/JsBigInt.cs
@@ -113,7 +113,7 @@ public sealed class JsBigInt : JsValue, IEquatable<JsBigInt>
             return false;
         }
 
-        return ReferenceEquals(this, other) || _value.Equals(other._value);
+        return ReferenceEquals(this, other) || _value == other._value;
     }
 
     public override int GetHashCode()

--- a/Jint/Runtime/CallStack/CallStackElement.cs
+++ b/Jint/Runtime/CallStack/CallStackElement.cs
@@ -1,17 +1,16 @@
 using Esprima;
 using Esprima.Ast;
 using Jint.Native.Function;
-using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
 
 namespace Jint.Runtime.CallStack
 {
-    internal readonly struct CallStackElement
+    internal readonly struct CallStackElement : IEquatable<CallStackElement>
     {
         public CallStackElement(
             FunctionInstance function,
             JintExpression? expression,
-            ExecutionContext callingExecutionContext)
+            in CallStackExecutionContext callingExecutionContext)
         {
             Function = function;
             Expression = expression;
@@ -20,7 +19,7 @@ namespace Jint.Runtime.CallStack
 
         public readonly FunctionInstance Function;
         public readonly JintExpression? Expression;
-        public readonly ExecutionContext CallingExecutionContext;
+        public readonly CallStackExecutionContext CallingExecutionContext;
 
         public Location Location
         {
@@ -51,6 +50,24 @@ namespace Jint.Runtime.CallStack
             }
 
             return name ?? "(anonymous)";
+        }
+
+        public bool Equals(CallStackElement other)
+        {
+            return Function.Equals(other.Function) && Equals(Expression, other.Expression);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is CallStackElement other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Function.GetHashCode() * 397) ^ (Expression != null ? Expression.GetHashCode() : 0);
+            }
         }
     }
 }

--- a/Jint/Runtime/Debugger/CallFrame.cs
+++ b/Jint/Runtime/Debugger/CallFrame.cs
@@ -8,11 +8,15 @@ namespace Jint.Runtime.Debugger
 {
     public sealed class CallFrame
     {
-        private readonly ExecutionContext _context;
+        private readonly CallStackExecutionContext _context;
         private readonly CallStackElement? _element;
         private readonly Lazy<DebugScopes> _scopeChain;
 
-        internal CallFrame(CallStackElement? element, ExecutionContext context, Location location, JsValue? returnValue)
+        internal CallFrame(
+            CallStackElement? element,
+            in CallStackExecutionContext context,
+            Location location,
+            JsValue? returnValue)
         {
             _element = element;
             _context = context;

--- a/Jint/Runtime/Debugger/DebugCallStack.cs
+++ b/Jint/Runtime/Debugger/DebugCallStack.cs
@@ -12,7 +12,7 @@ namespace Jint.Runtime.Debugger
         internal DebugCallStack(Engine engine, Location location, JintCallStack callStack, JsValue? returnValue)
         {
             _stack = new List<CallFrame>(callStack.Count + 1);
-            var executionContext = engine.ExecutionContext;
+            var executionContext = new CallStackExecutionContext(engine.ExecutionContext);
             foreach (var element in callStack.Stack)
             {
                 _stack.Add(new CallFrame(element, executionContext, location, returnValue));

--- a/Jint/Runtime/ExceptionHelper.cs
+++ b/Jint/Runtime/ExceptionHelper.cs
@@ -152,9 +152,9 @@ namespace Jint.Runtime
         }
 
         [DoesNotReturn]
-        public static void ThrowRecursionDepthOverflowException(JintCallStack currentStack,
-            string currentExpressionReference)
+        public static void ThrowRecursionDepthOverflowException(JintCallStack currentStack)
         {
+            var currentExpressionReference = currentStack.Pop().ToString();
             throw new RecursionDepthOverflowException(currentStack, currentExpressionReference);
         }
 


### PR DESCRIPTION
Both `Call` and `Construct` instantiated `new CallStackElement(functionInstance, expression, ExecutionContext);` which effectively became part of the call's stack frame and for deeply nested function invocations (recursion) it really adds up. This PR slims down required constructs and moves instantiation to call stack `Push` side. Now the construct now longer takes stack space during the two types of invocations and also the Jint's storage is smaller.

Relates to #1159

/cc @KurtGokhan @Jither 

# Struct layout

## Old CallStackElement

```
Type layout for 'CallStackElement'
Size: 64 bytes. Paddings: 0 bytes (%0 of empty space)
|==================================================================|
|   0-7: FunctionInstance Function (8 bytes)                       |
|------------------------------------------------------------------|
|  8-15: JintExpression Expression (8 bytes)                       |
|------------------------------------------------------------------|
| 16-63: ExecutionContext CallingExecutionContext (48 bytes)       |
| |==============================================================| |
| |   0-7: IScriptOrModule ScriptOrModule (8 bytes)              | |
| |--------------------------------------------------------------| |
| |  8-15: EnvironmentRecord LexicalEnvironment (8 bytes)        | |
| |--------------------------------------------------------------| |
| | 16-23: EnvironmentRecord VariableEnvironment (8 bytes)       | |
| |--------------------------------------------------------------| |
| | 24-31: PrivateEnvironmentRecord PrivateEnvironment (8 bytes) | |
| |--------------------------------------------------------------| |
| | 32-39: Realm Realm (8 bytes)                                 | |
| |--------------------------------------------------------------| |
| | 40-47: FunctionInstance Function (8 bytes)                   | |
| |==============================================================| |
|==================================================================|
```

## New CallStackElement

```
Type layout for 'CallStackElement'
Size: 24 bytes. Paddings: 0 bytes (%0 of empty space)
|====================================================================|
|   0-7: FunctionInstance Function (8 bytes)                         |
|--------------------------------------------------------------------|
|  8-15: JintExpression Expression (8 bytes)                         |
|--------------------------------------------------------------------|
| 16-23: CallStackExecutionContext CallingExecutionContext (8 bytes) |
| |=======================================================|          |
| |   0-7: EnvironmentRecord LexicalEnvironment (8 bytes) |          |
| |=======================================================|          |
|====================================================================|

```

# Benchmarks

## Esprima.Benchmark.SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |Run|3d-cube|243.15 ms|0.954 ms|3000.0000|333.3333|-|51,131 KB|
| **New** |	|	| **243.26 ms (0%)** | **0.386 ms** | **3000.0000 (0%)** | **333.3333 (0%)** | **-** | **51,131 KB (0%)** |
| Old |Run|3d-morph|206.28 ms|0.376 ms|3000.0000|1000.0000|333.3333|49,749 KB|
| **New** |	|	| **185.42 ms (-10%)** | **0.401 ms** | **3000.0000 (0%)** | **1000.0000 (0%)** | **333.3333 (0%)** | **49,748 KB (0%)** |
| Old |Run|3d-raytrace|200.33 ms|0.318 ms|5000.0000|1000.0000|-|93,399 KB|
| **New** |	|	| **202.00 ms (+1%)** | **0.330 ms** | **5666.6667 (+13%)** | **333.3333 (-67%)** | **-** | **93,399 KB (0%)** |
| Old |Run|access-binary-trees|105.43 ms|0.360 ms|4000.0000|1000.0000|-|78,474 KB|
| **New** |	|	| **99.65 ms (-5%)** | **0.252 ms** | **4000.0000 (0%)** | **1000.0000 (0%)** | **-** | **78,474 KB (0%)** |
| Old |Run|access-fannkuch|589.74 ms|2.189 ms|-|-|-|138 KB|
| **New** |	|	| **589.48 ms (0%)** | **1.991 ms** | **-** | **-** | **-** | **138 KB (0%)** |
| Old |Run|access-nbody|226.02 ms|0.370 ms|3666.6667|333.3333|-|63,854 KB|
| **New** |	|	| **226.56 ms (0%)** | **0.451 ms** | **3666.6667 (0%)** | **333.3333 (0%)** | **-** | **63,854 KB (0%)** |
| Old |Run|access-nsieve|188.38 ms|0.243 ms|1000.0000|-|-|21,521 KB|
| **New** |	|	| **190.19 ms (+1%)** | **0.907 ms** | **1000.0000 (0%)** | **-** | **-** | **21,521 KB (0%)** |
| Old |Run|bitop(...)-byte [24]|206.29 ms|0.894 ms|4000.0000|-|-|68,952 KB|
| **New** |	|	| **197.65 ms (-4%)** | **0.342 ms** | **4000.0000 (0%)** | **-** | **-** | **68,952 KB (0%)** |
| Old |Run|bitops-bits-in-byte|316.62 ms|0.527 ms|2500.0000|-|-|45,448 KB|
| **New** |	|	| **310.83 ms (-2%)** | **0.980 ms** | **2500.0000 (0%)** | **-** | **-** | **45,448 KB (0%)** |
| Old |Run|bitops-bitwise-and|221.52 ms|1.108 ms|5000.0000|-|-|93,442 KB|
| **New** |	|	| **229.40 ms (+4%)** | **2.104 ms** | **5000.0000 (0%)** | **-** | **-** | **93,442 KB (0%)** |
| Old |Run|bitops-nsieve-bits|247.82 ms|1.168 ms|3000.0000|1000.0000|-|54,858 KB|
| **New** |	|	| **242.72 ms (-2%)** | **0.973 ms** | **3000.0000 (0%)** | **1000.0000 (0%)** | **-** | **54,868 KB (0%)** |
| Old |Run|contr(...)rsive [21]|151.45 ms|0.319 ms|7000.0000|2000.0000|-|124,120 KB|
| **New** |	|	| **145.68 ms (-4%)** | **0.478 ms** | **7500.0000 (+7%)** | **1750.0000 (-13%)** | **-** | **124,122 KB (0%)** |
| Old |Run|crypto-aes|161.65 ms|0.120 ms|-|-|-|15,551 KB|
| **New** |	|	| **162.73 ms (+1%)** | **0.853 ms** | **-** | **-** | **-** | **15,593 KB (0%)** |
| Old |Run|crypto-md5|132.87 ms|0.469 ms|5000.0000|1000.0000|-|95,424 KB|
| **New** |	|	| **134.50 ms (+1%)** | **0.932 ms** | **5000.0000 (0%)** | **1000.0000 (0%)** | **-** | **95,424 KB (0%)** |
| Old |Run|crypto-sha1|137.99 ms|0.352 ms|5000.0000|1000.0000|-|82,082 KB|
| **New** |	|	| **131.62 ms (-5%)** | **0.231 ms** | **5000.0000 (0%)** | **1000.0000 (0%)** | **-** | **82,082 KB (0%)** |
| Old |Run|date-format-tofte|126.74 ms|0.306 ms|3000.0000|1000.0000|-|59,209 KB|
| **New** |	|	| **125.49 ms (-1%)** | **0.463 ms** | **3000.0000 (0%)** | **1000.0000 (0%)** | **-** | **59,209 KB (0%)** |
| Old |Run|date-format-xparb|72.36 ms|0.329 ms|1714.2857|857.1429|-|29,422 KB|
| **New** |	|	| **66.27 ms (-8%)** | **0.202 ms** | **1750.0000 (+2%)** | **750.0000 (-13%)** | **-** | **29,422 KB (0%)** |
| Old |Run|math-cordic|448.38 ms|2.091 ms|7000.0000|-|-|123,976 KB|
| **New** |	|	| **432.80 ms (-3%)** | **0.774 ms** | **7000.0000 (0%)** | **-** | **-** | **123,974 KB (0%)** |
| Old |Run|math-partial-sums|156.55 ms|0.297 ms|4000.0000|-|-|68,950 KB|
| **New** |	|	| **152.84 ms (-2%)** | **0.327 ms** | **4000.0000 (0%)** | **-** | **-** | **68,950 KB (0%)** |
| Old |Run|math-spectral-norm|163.20 ms|0.435 ms|4000.0000|-|-|67,179 KB|
| **New** |	|	| **161.86 ms (-1%)** | **0.654 ms** | **4000.0000 (0%)** | **-** | **-** | **67,179 KB (0%)** |
| Old |Run|regexp-dna|110.34 ms|0.449 ms|1000.0000|1000.0000|1000.0000|17,671 KB|
| **New** |	|	| **106.14 ms (-4%)** | **0.381 ms** | **1200.0000 (+20%)** | **1200.0000 (+20%)** | **1200.0000 (+20%)** | **17,676 KB (0%)** |
| Old |Run|string-base64|126.71 ms|0.263 ms|-|-|-|12,530 KB|
| **New** |	|	| **119.87 ms (-5%)** | **0.347 ms** | **-** | **-** | **-** | **12,525 KB (0%)** |
| Old |Run|string-fasta|231.51 ms|0.665 ms|10000.0000|333.3333|-|167,278 KB|
| **New** |	|	| **232.51 ms (0%)** | **0.819 ms** | **10000.0000 (0%)** | **333.3333 (0%)** | **-** | **167,278 KB (0%)** |
| Old |Run|string-tagcloud|85.35 ms|0.235 ms|2000.0000|1000.0000|-|48,451 KB|
| **New** |	|	| **84.22 ms (-1%)** | **0.222 ms** | **2000.0000 (0%)** | **1000.0000 (0%)** | **-** | **48,451 KB (0%)** |
| Old |Run|string-unpack-code|85.72 ms|0.241 ms|5000.0000|500.0000|-|84,578 KB|
| **New** |	|	| **82.13 ms (-4%)** | **0.240 ms** | **5000.0000 (0%)** | **571.4286 (+14%)** | **-** | **84,578 KB (0%)** |
| Old |Run|strin(...)input [21]|1,233.11 ms|24.490 ms|745000.0000|741000.0000|740000.0000|6,351,865 KB|
| **New** |	|	| **1,182.02 ms (-4%)** | **23.380 ms** | **853000.0000 (+14%)** | **849000.0000 (+15%)** | **848000.0000 (+15%)** | **6,352,495 KB (0%)** |

# Call signature

## Old

```
  .method assembly hidebysig instance class Jint.Native.JsValue
    Call(
      class Jint.Native.Function.FunctionInstance functionInstance,
      class Jint.Native.JsValue thisObject,
      class Jint.Native.JsValue[] arguments,
      class Jint.Runtime.Interpreter.Expressions.JintExpression expression
    ) cil managed
  {
    .param [4]
      .custom instance void System.Runtime.CompilerServices.NullableAttribute::.ctor([in] unsigned int8)
        = (01 00 02 00 00 ) // .....
        // unsigned int8(2) // 0x02
    .maxstack 4
    .locals init (
      [0] valuetype Jint.Runtime.CallStack.CallStackElement callStackElement,
      [1] class Jint.Native.JsValue result
    )
```

## New

```
  .method assembly hidebysig instance class Jint.Native.JsValue
    Call(
      class Jint.Native.Function.FunctionInstance functionInstance,
      class Jint.Native.JsValue thisObject,
      class Jint.Native.JsValue[] arguments,
      class Jint.Runtime.Interpreter.Expressions.JintExpression expression
    ) cil managed
  {
    .param [4]
      .custom instance void System.Runtime.CompilerServices.NullableAttribute::.ctor([in] unsigned int8)
        = (01 00 02 00 00 ) // .....
        // unsigned int8(2) // 0x02
    .maxstack 4
    .locals init (
      [0] class Jint.Native.JsValue result
    )
```
