### PR TITLE
Improve recursion performance v1

### DIFF
--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -1,0 +1,42 @@
+using System.Text;
+
+namespace Jint.Tests.Runtime;
+
+public class EngineLimitTests
+{
+    [Fact]
+    public void ShouldAllowReasonableCallStackDepth()
+    {
+        // 249
+        var functionNestingCount = 300;
+        // generate call tree
+        var sb = new StringBuilder();
+        sb.AppendLine("var x = 10;");
+        sb.AppendLine();
+        for (var i = 1; i <= functionNestingCount; ++i)
+        {
+            sb.Append("function func").Append(i).Append("(func").Append(i).AppendLine("Param) {");
+            sb.Append("    ");
+            if (i != functionNestingCount)
+            {
+                // just to create a bit more nesting add some constructs
+                sb.Append("try { return x++ > 1 ? func").Append(i + 1).Append("(func").Append(i).AppendLine("Param): undefined; } finally { /* nothing*/ }");
+            }
+            else
+            {
+                // use known CLR function to add breakpoint
+                sb.Append("return Math.max(0, func").Append(i).AppendLine("Param);");
+            }
+
+            sb.AppendLine("}");
+            sb.AppendLine();
+        }
+
+        var engine = new Engine();
+        engine.Execute(sb.ToString());
+        Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
+    }
+
+    public static IEnumerable<object[]> Data =>
+        Enumerable.Range(380, 10).Select(x => new object[] { x });
+}

--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -7,20 +7,24 @@ public class EngineLimitTests
     [Fact]
     public void ShouldAllowReasonableCallStackDepth()
     {
-        // 249
-        var functionNestingCount = 300;
+#if RELEASE
+        const int FunctionNestingCount = 350;
+#else
+        const int FunctionNestingCount = 170;
+#endif
+
         // generate call tree
         var sb = new StringBuilder();
         sb.AppendLine("var x = 10;");
         sb.AppendLine();
-        for (var i = 1; i <= functionNestingCount; ++i)
+        for (var i = 1; i <= FunctionNestingCount; ++i)
         {
             sb.Append("function func").Append(i).Append("(func").Append(i).AppendLine("Param) {");
             sb.Append("    ");
-            if (i != functionNestingCount)
+            if (i != FunctionNestingCount)
             {
                 // just to create a bit more nesting add some constructs
-                sb.Append("try { return x++ > 1 ? func").Append(i + 1).Append("(func").Append(i).AppendLine("Param): undefined; } finally { /* nothing*/ }");
+                sb.Append("return x++ > 1 ? func").Append(i + 1).Append("(func").Append(i).AppendLine("Param): undefined;");
             }
             else
             {
@@ -36,7 +40,4 @@ public class EngineLimitTests
         engine.Execute(sb.ToString());
         Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
     }
-
-    public static IEnumerable<object[]> Data =>
-        Enumerable.Range(380, 10).Select(x => new object[] { x });
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1371,6 +1371,8 @@ namespace Jint
             JsValue[] arguments,
             JintExpression? expression)
         {
+            // ensure logic is in sync between Call, Construct and JintCallExpression!
+
             var recursionDepth = CallStack.Push(functionInstance, expression, ExecutionContext);
 
             if (recursionDepth > Options.Constraints.MaxRecursionDepth)
@@ -1402,6 +1404,8 @@ namespace Jint
             JsValue newTarget,
             JintExpression? expression)
         {
+            // ensure logic is in sync between Call, Construct and JintCallExpression!
+
             var recursionDepth = CallStack.Push(functionInstance, expression, ExecutionContext);
 
             if (recursionDepth > Options.Constraints.MaxRecursionDepth)

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Function;
@@ -69,10 +71,135 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override ExpressionResult EvaluateInternal(EvaluationContext context)
         {
-            return NormalCompletion(_calleeExpression is JintSuperExpression
-                ? SuperCall(context)
-                : Call(context)
-            );
+            if (_calleeExpression._expression.Type == Nodes.Super)
+            {
+                return NormalCompletion(SuperCall(context));
+            }
+
+            // https://tc39.es/ecma262/#sec-function-calls
+
+            var reference = _calleeExpression.Evaluate(context).Value;
+
+            if (ReferenceEquals(reference, Undefined.Instance))
+            {
+                return NormalCompletion(Undefined.Instance);
+            }
+
+            var engine = context.Engine;
+            var func = engine.GetValue(reference, false);
+
+            if (func.IsNullOrUndefined() && _expression.IsOptional())
+            {
+                return NormalCompletion(Undefined.Instance);
+            }
+
+            if (reference is Reference referenceRecord
+                && !referenceRecord.IsPropertyReference()
+                && referenceRecord.GetReferencedName() == CommonProperties.Eval
+                && ReferenceEquals(func, engine.Realm.Intrinsics.Eval))
+            {
+                return HandleEval(context, func, engine, referenceRecord);
+            }
+
+            var thisCall = (CallExpression) _expression;
+            var tailCall = IsInTailPosition(thisCall);
+
+            // https://tc39.es/ecma262/#sec-evaluatecall
+
+            JsValue thisValue;
+            var referenceRecord1 = reference as Reference;
+            if (referenceRecord1 is not null)
+            {
+                if (referenceRecord1.IsPropertyReference())
+                {
+                    thisValue = referenceRecord1.GetThisValue();
+                }
+                else
+                {
+                    var baseValue = referenceRecord1.GetBase();
+
+                    // deviation from the spec to support null-propagation helper
+                    if (baseValue.IsNullOrUndefined()
+                        && engine._referenceResolver.TryUnresolvableReference(engine, referenceRecord1, out var value))
+                    {
+                        thisValue = value;
+                    }
+                    else
+                    {
+                        var refEnv = (EnvironmentRecord) baseValue;
+                        thisValue = refEnv.WithBaseObject();
+                    }
+                }
+            }
+            else
+            {
+                thisValue = Undefined.Instance;
+            }
+
+            var argList = ArgumentListEvaluation(context);
+
+            if (!func.IsObject() && !engine._referenceResolver.TryGetCallable(engine, reference, out func))
+            {
+                ThrowMemberisNotFunction(referenceRecord1, reference, engine);
+            }
+
+            var callable = func as ICallable;
+            if (callable is null)
+            {
+                ThrowReferenceNotFunction(referenceRecord1, reference, engine);
+            }
+
+            if (tailCall)
+            {
+                // TODO tail call
+                // PrepareForTailCall();
+            }
+
+            var result = engine.Call(callable, thisValue, argList, _calleeExpression);
+
+            if (!_cached && argList.Length > 0)
+            {
+                engine._jsValueArrayPool.ReturnArray(argList);
+            }
+
+            engine._referencePool.Return(referenceRecord1);
+            return NormalCompletion(result);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowReferenceNotFunction(Reference? referenceRecord1, object reference, Engine engine)
+        {
+            var message = $"{referenceRecord1?.GetReferencedName() ?? reference} is not a function";
+            ExceptionHelper.ThrowTypeError(engine.Realm, message);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowMemberisNotFunction(Reference? referenceRecord1, object reference, Engine engine)
+        {
+            var message = referenceRecord1 == null
+                ? reference + " is not a function"
+                : $"Property '{referenceRecord1.GetReferencedName()}' of object is not a function";
+            ExceptionHelper.ThrowTypeError(engine.Realm, message);
+        }
+
+        private ExpressionResult HandleEval(EvaluationContext context, JsValue func, Engine engine, Reference referenceRecord)
+        {
+            var argList = ArgumentListEvaluation(context);
+            if (argList.Length == 0)
+            {
+                return NormalCompletion(Undefined.Instance);
+            }
+
+            var evalFunctionInstance = (EvalFunctionInstance) func;
+            var evalArg = argList[0];
+            var strictCaller = StrictModeScope.IsStrictModeCode;
+            var evalRealm = evalFunctionInstance._realm;
+            var direct = !_expression.IsOptional();
+            var value = evalFunctionInstance.PerformEval(evalArg, evalRealm, strictCaller, direct);
+            engine._referencePool.Return(referenceRecord);
+            return NormalCompletion(value);
         }
 
         private JsValue SuperCall(EvaluationContext context)
@@ -101,122 +228,6 @@ namespace Jint.Runtime.Interpreter.Expressions
             var activeFunction = envRec._functionObject;
             var superConstructor = activeFunction.GetPrototypeOf();
             return superConstructor;
-        }
-
-        /// <summary>
-        /// https://tc39.es/ecma262/#sec-function-calls
-        /// </summary>
-        private JsValue Call(EvaluationContext context)
-        {
-            var reference = _calleeExpression.Evaluate(context).Value;
-
-            if (ReferenceEquals(reference, Undefined.Instance))
-            {
-                return Undefined.Instance;
-            }
-
-            var engine = context.Engine;
-            var func = engine.GetValue(reference, false);
-
-            if (func.IsNullOrUndefined() && _expression.IsOptional())
-            {
-                return Undefined.Instance;
-            }
-
-            if (reference is Reference referenceRecord
-                && !referenceRecord.IsPropertyReference()
-                && referenceRecord.GetReferencedName() == CommonProperties.Eval
-                && ReferenceEquals(func, engine.Realm.Intrinsics.Eval))
-            {
-                var argList = ArgumentListEvaluation(context);
-                if (argList.Length == 0)
-                {
-                    return Undefined.Instance;
-                }
-
-                var evalFunctionInstance = (EvalFunctionInstance) func;
-                var evalArg = argList[0];
-                var strictCaller = StrictModeScope.IsStrictModeCode;
-                var evalRealm = evalFunctionInstance._realm;
-                var direct = !_expression.IsOptional();
-                var value = evalFunctionInstance.PerformEval(evalArg, evalRealm, strictCaller, direct);
-                engine._referencePool.Return(referenceRecord);
-                return value;
-            }
-
-            var thisCall = (CallExpression) _expression;
-            var tailCall = IsInTailPosition(thisCall);
-            return EvaluateCall(context, func, reference, thisCall.Arguments, tailCall);
-        }
-
-        /// <summary>
-        /// https://tc39.es/ecma262/#sec-evaluatecall
-        /// </summary>
-        private JsValue EvaluateCall(EvaluationContext context, JsValue func, object reference, in NodeList<Expression> arguments, bool tailPosition)
-        {
-            JsValue thisValue;
-            var referenceRecord = reference as Reference;
-            var engine = context.Engine;
-            if (referenceRecord is not null)
-            {
-                if (referenceRecord.IsPropertyReference())
-                {
-                    thisValue = referenceRecord.GetThisValue();
-                }
-                else
-                {
-                    var baseValue = referenceRecord.GetBase();
-
-                    // deviation from the spec to support null-propagation helper
-                    if (baseValue.IsNullOrUndefined()
-                        && engine._referenceResolver.TryUnresolvableReference(engine, referenceRecord, out var value))
-                    {
-                        thisValue = value;
-                    }
-                    else
-                    {
-                        var refEnv = (EnvironmentRecord) baseValue;
-                        thisValue = refEnv.WithBaseObject();
-                    }
-                }
-            }
-            else
-            {
-                thisValue = Undefined.Instance;
-            }
-
-            var argList = ArgumentListEvaluation(context);
-
-            if (!func.IsObject() && !engine._referenceResolver.TryGetCallable(engine, reference, out func))
-            {
-                var message = referenceRecord == null
-                    ? reference + " is not a function"
-                    : $"Property '{referenceRecord.GetReferencedName()}' of object is not a function";
-                ExceptionHelper.ThrowTypeError(engine.Realm, message);
-            }
-
-            var callable = func as ICallable;
-            if (callable is null)
-            {
-                var message = $"{referenceRecord?.GetReferencedName() ?? reference} is not a function";
-                ExceptionHelper.ThrowTypeError(engine.Realm, message);
-            }
-
-            if (tailPosition)
-            {
-                // TODO tail call
-                // PrepareForTailCall();
-            }
-
-            var result = engine.Call(callable, thisValue, argList, _calleeExpression);
-
-            if (!_cached && argList.Length > 0)
-            {
-                engine._jsValueArrayPool.ReturnArray(argList);
-            }
-
-            engine._referencePool.Return(referenceRecord);
-            return result;
         }
 
         /// <summary>

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Function;
@@ -36,6 +37,7 @@ namespace Jint.Runtime.Interpreter
         /// <summary>
         /// https://tc39.es/ecma262/#sec-runtime-semantics-evaluatebody
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal Completion EvaluateBody(EvaluationContext context, FunctionInstance functionObject, JsValue[] argumentsList)
         {
             Completion result;

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -20,8 +20,17 @@ namespace Jint.Runtime.Interpreter.Statements
 
         internal override bool SupportsResume => true;
 
-        protected override Completion ExecuteInternal(EvaluationContext context)
+        /// <summary>
+        /// Optimized for direct access without virtual dispatch.
+        /// </summary>
+        public Completion ExecuteBlock(EvaluationContext context)
         {
+            if (_statementList is null)
+            {
+                _statementList = new JintStatementList(_statement, _statement.Body);
+                _lexicalDeclarations = HoistingScope.GetLexicalDeclarations(_statement);
+            }
+
             EnvironmentRecord? oldEnv = null;
             var engine = context.Engine;
             if (_lexicalDeclarations != null)
@@ -40,6 +49,11 @@ namespace Jint.Runtime.Interpreter.Statements
             }
 
             return blockValue;
+        }
+
+        protected override Completion ExecuteInternal(EvaluationContext context)
+        {
+            return ExecuteBlock(context);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -9,7 +9,7 @@ namespace Jint.Runtime.Interpreter.Statements
     /// </summary>
     internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
     {
-        private JintStatement _body = null!;
+        private ProbablyBlockStatement _body;
         private string? _labelSetName;
         private JintExpression _test = null!;
 
@@ -19,7 +19,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override void Initialize(EvaluationContext context)
         {
-            _body = Build(_statement.Body);
+            _body = new ProbablyBlockStatement(_statement.Body);
             _test = JintExpression.Build(context.Engine, _statement.Test);
             _labelSetName = _statement.LabelSet?.Name;
         }

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -20,7 +20,7 @@ namespace Jint.Runtime.Interpreter.Statements
         private readonly Expression _rightExpression;
         private readonly IterationKind _iterationKind;
 
-        private JintStatement _body = null!;
+        private ProbablyBlockStatement _body;
         private JintExpression? _expr;
         private BindingPattern? _assignmentPattern;
         private JintExpression _right = null!;
@@ -87,7 +87,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 _expr = new JintIdentifierExpression((Identifier) _leftNode);
             }
 
-            _body = Build(_forBody);
+            _body = new ProbablyBlockStatement(_forBody);
             _right = JintExpression.Build(engine, _rightExpression);
         }
 
@@ -147,7 +147,7 @@ namespace Jint.Runtime.Interpreter.Statements
         private Completion BodyEvaluation(
             EvaluationContext context,
             JintExpression? lhs,
-            JintStatement stmt,
+            in ProbablyBlockStatement stmt,
             IteratorInstance iteratorRecord,
             IterationKind iterationKind,
             LhsKind lhsKind,

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -16,7 +16,7 @@ namespace Jint.Runtime.Interpreter.Statements
         private JintExpression? _test;
         private JintExpression? _increment;
 
-        private JintStatement _body = null!;
+        private ProbablyBlockStatement _body;
         private List<string>? _boundNames;
 
         private bool _shouldCreatePerIterationEnvironment;
@@ -28,7 +28,7 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override void Initialize(EvaluationContext context)
         {
             var engine = context.Engine;
-            _body = Build(_statement.Body);
+            _body = new ProbablyBlockStatement(_statement.Body);
 
             if (_statement.Init != null)
             {

--- a/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
@@ -5,9 +5,9 @@ namespace Jint.Runtime.Interpreter.Statements
 {
     internal sealed class JintIfStatement : JintStatement<IfStatement>
     {
-        private JintStatement _statementConsequent = null!;
+        private ProbablyBlockStatement _statementConsequent;
         private JintExpression _test = null!;
-        private JintStatement? _alternate;
+        private ProbablyBlockStatement? _alternate;
 
         public JintIfStatement(IfStatement statement) : base(statement)
         {
@@ -15,9 +15,9 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override void Initialize(EvaluationContext context)
         {
-            _statementConsequent = Build(_statement.Consequent);
+            _statementConsequent = new ProbablyBlockStatement(_statement.Consequent);
             _test = JintExpression.Build(context.Engine, _statement.Test);
-            _alternate = _statement.Alternate != null ? Build(_statement.Alternate) : null;
+            _alternate = _statement.Alternate != null ? new ProbablyBlockStatement(_statement.Alternate) : null;
         }
 
         protected override Completion ExecuteInternal(EvaluationContext context)
@@ -29,7 +29,7 @@ namespace Jint.Runtime.Interpreter.Statements
             }
             else if (_alternate != null)
             {
-                result = _alternate.Execute(context);
+                result = _alternate.Value.Execute(context);
             }
             else
             {

--- a/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
@@ -10,7 +10,7 @@ namespace Jint.Runtime.Interpreter.Statements
     internal sealed class JintWhileStatement : JintStatement<WhileStatement>
     {
         private string? _labelSetName;
-        private JintStatement _body = null!;
+        private ProbablyBlockStatement _body;
         private JintExpression _test = null!;
 
         public JintWhileStatement(WhileStatement statement) : base(statement)
@@ -20,7 +20,7 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override void Initialize(EvaluationContext context)
         {
             _labelSetName = _statement.LabelSet?.Name;
-            _body = Build(_statement.Body);
+            _body = new ProbablyBlockStatement(_statement.Body);
             _test = JintExpression.Build(context.Engine, _statement.Test);
         }
 

--- a/Jint/Runtime/Interpreter/Statements/JintWithStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWithStatement.cs
@@ -9,7 +9,7 @@ namespace Jint.Runtime.Interpreter.Statements
     /// </summary>
     internal sealed class JintWithStatement : JintStatement<WithStatement>
     {
-        private JintStatement _body = null!;
+        private ProbablyBlockStatement _body;
         private JintExpression _object = null!;
 
         public JintWithStatement(WithStatement statement) : base(statement)
@@ -18,7 +18,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override void Initialize(EvaluationContext context)
         {
-            _body = Build(_statement.Body);
+            _body = new ProbablyBlockStatement(_statement.Body);
             _object = JintExpression.Build(context.Engine, _statement.Object);
         }
 

--- a/Jint/Runtime/Interpreter/Statements/ProbablyBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/ProbablyBlockStatement.cs
@@ -1,0 +1,36 @@
+using System.Runtime.CompilerServices;
+using Esprima.Ast;
+
+namespace Jint.Runtime.Interpreter.Statements;
+
+/// <summary>
+/// Helper to remove virtual dispatch from block statements when it's most common target.
+/// This is especially true for things like for statements body
+/// </summary>
+internal readonly struct ProbablyBlockStatement
+{
+    private readonly JintStatement  _target;
+
+    public ProbablyBlockStatement(Statement statement)
+    {
+        if (statement is BlockStatement blockStatement)
+        {
+            _target = new JintBlockStatement(blockStatement);
+        }
+        else
+        {
+            _target = JintStatement.Build(statement);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Completion Execute(EvaluationContext context)
+    {
+        if (_target is JintBlockStatement blockStatement)
+        {
+            return blockStatement.ExecuteBlock(context);
+        }
+
+        return _target.Execute(context);
+    }
+}


### PR DESCRIPTION
Just shuffling code around a bit, making sure less allocations and methods inline better.

releates to #1159

## Esprima.Benchmark.SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |Run|3d-cube|238.03 ms|0.346 ms|3000.0000|333.3333|-|51,129 KB|
| **New** |	|	| **246.55 ms (+4%)** | **0.586 ms** | **3000.0000 (0%)** | **333.3333 (0%)** | **-** | **51,129 KB (0%)** |
| Old |Run|3d-morph|187.54 ms|2.607 ms|3000.0000|1000.0000|333.3333|49,744 KB|
| **New** |	|	| **195.80 ms (+4%)** | **0.391 ms** | **3000.0000 (0%)** | **1000.0000 (0%)** | **333.3333 (0%)** | **49,744 KB (0%)** |
| Old |Run|3d-raytrace|199.38 ms|0.295 ms|5000.0000|1000.0000|-|93,394 KB|
| **New** |	|	| **199.12 ms (0%)** | **0.411 ms** | **5000.0000 (0%)** | **1000.0000 (0%)** | **-** | **93,394 KB (0%)** |
| Old |Run|access-binary-trees|101.04 ms|0.218 ms|4000.0000|1000.0000|-|78,472 KB|
| **New** |	|	| **98.04 ms (-3%)** | **0.234 ms** | **4000.0000 (0%)** | **1000.0000 (0%)** | **-** | **78,472 KB (0%)** |
| Old |Run|access-fannkuch|567.70 ms|2.910 ms|-|-|-|137 KB|
| **New** |	|	| **566.12 ms (0%)** | **2.374 ms** | **-** | **-** | **-** | **137 KB (0%)** |
| Old |Run|access-nbody|229.46 ms|0.665 ms|3666.6667|333.3333|-|63,851 KB|
| **New** |	|	| **230.65 ms (+1%)** | **0.759 ms** | **3000.0000 (-18%)** | **-** | **-** | **63,855 KB (0%)** |
| Old |Run|access-nsieve|187.33 ms|0.483 ms|1000.0000|-|-|21,519 KB|
| **New** |	|	| **190.47 ms (+2%)** | **0.382 ms** | **1000.0000 (0%)** | **-** | **-** | **21,519 KB (0%)** |
| Old |Run|bitop(...)-byte [24]|197.77 ms|1.416 ms|4000.0000|-|-|68,950 KB|
| **New** |	|	| **195.32 ms (-1%)** | **0.485 ms** | **4000.0000 (0%)** | **-** | **-** | **68,950 KB (0%)** |
| Old |Run|bitops-bits-in-byte|307.26 ms|0.754 ms|2500.0000|-|-|45,446 KB|
| **New** |	|	| **311.24 ms (+1%)** | **0.764 ms** | **2500.0000 (0%)** | **-** | **-** | **45,446 KB (0%)** |
| Old |Run|bitops-bitwise-and|212.56 ms|2.164 ms|5000.0000|-|-|93,439 KB|
| **New** |	|	| **191.41 ms (-10%)** | **0.633 ms** | **5000.0000 (0%)** | **-** | **-** | **93,439 KB (0%)** |
| Old |Run|bitops-nsieve-bits|240.73 ms|1.248 ms|3000.0000|1000.0000|-|54,856 KB|
| **New** |	|	| **247.91 ms (+3%)** | **1.652 ms** | **3000.0000 (0%)** | **1000.0000 (0%)** | **-** | **54,856 KB (0%)** |
| Old |Run|contr(...)rsive [21]|145.45 ms|0.291 ms|7000.0000|2000.0000|-|124,118 KB|
| **New** |	|	| **143.34 ms (-1%)** | **0.332 ms** | **7500.0000 (+7%)** | **1750.0000 (-13%)** | **-** | **124,118 KB (0%)** |
| Old |Run|crypto-aes|158.69 ms|0.208 ms|-|-|-|15,560 KB|
| **New** |	|	| **156.52 ms (-1%)** | **0.708 ms** | **-** | **-** | **-** | **15,611 KB (0%)** |
| Old |Run|crypto-md5|126.05 ms|0.388 ms|5000.0000|1000.0000|-|95,416 KB|
| **New** |	|	| **126.28 ms (0%)** | **0.914 ms** | **5000.0000 (0%)** | **1000.0000 (0%)** | **-** | **95,416 KB (0%)** |
| Old |Run|crypto-sha1|129.33 ms|0.433 ms|5000.0000|1000.0000|-|82,075 KB|
| **New** |	|	| **126.92 ms (-2%)** | **0.280 ms** | **5000.0000 (0%)** | **1000.0000 (0%)** | **-** | **82,075 KB (0%)** |
| Old |Run|date-format-tofte|122.40 ms|0.303 ms|2000.0000|-|-|48,636 KB|
| **New** |	|	| **121.71 ms (-1%)** | **0.329 ms** | **2000.0000 (0%)** | **-** | **-** | **48,636 KB (0%)** |
| Old |Run|date-format-xparb|67.91 ms|0.233 ms|1750.0000|750.0000|-|29,417 KB|
| **New** |	|	| **64.83 ms (-5%)** | **0.073 ms** | **1750.0000 (0%)** | **750.0000 (0%)** | **-** | **29,415 KB (0%)** |
| Old |Run|math-cordic|426.56 ms|1.130 ms|7000.0000|-|-|123,974 KB|
| **New** |	|	| **425.90 ms (0%)** | **1.255 ms** | **7000.0000 (0%)** | **-** | **-** | **123,974 KB (0%)** |
| Old |Run|math-partial-sums|155.27 ms|2.959 ms|4000.0000|-|-|68,947 KB|
| **New** |	|	| **152.96 ms (-1%)** | **0.194 ms** | **4000.0000 (0%)** | **-** | **-** | **68,947 KB (0%)** |
| Old |Run|math-spectral-norm|162.92 ms|0.704 ms|4000.0000|-|-|67,176 KB|
| **New** |	|	| **154.90 ms (-5%)** | **0.349 ms** | **4000.0000 (0%)** | **-** | **-** | **67,176 KB (0%)** |
| Old |Run|regexp-dna|107.95 ms|0.482 ms|1000.0000|1000.0000|1000.0000|17,671 KB|
| **New** |	|	| **107.46 ms (0%)** | **0.440 ms** | **800.0000 (-20%)** | **800.0000 (-20%)** | **800.0000 (-20%)** | **17,668 KB (0%)** |
| Old |Run|string-base64|123.15 ms|1.415 ms|-|-|-|12,528 KB|
| **New** |	|	| **123.01 ms (0%)** | **0.390 ms** | **-** | **-** | **-** | **12,527 KB (0%)** |
| Old |Run|string-fasta|230.79 ms|0.888 ms|10000.0000|333.3333|-|167,276 KB|
| **New** |	|	| **225.28 ms (-2%)** | **0.349 ms** | **10000.0000 (0%)** | **333.3333 (0%)** | **-** | **167,276 KB (0%)** |
| Old |Run|string-tagcloud|82.99 ms|0.394 ms|2000.0000|1000.0000|-|48,438 KB|
| **New** |	|	| **81.60 ms (-2%)** | **0.330 ms** | **2000.0000 (0%)** | **1000.0000 (0%)** | **-** | **48,438 KB (0%)** |
| Old |Run|string-unpack-code|82.17 ms|0.129 ms|5000.0000|571.4286|-|84,573 KB|
| **New** |	|	| **82.40 ms (0%)** | **0.208 ms** | **5000.0000 (0%)** | **571.4286 (0%)** | **-** | **84,574 KB (0%)** |
| Old |Run|strin(...)input [21]|1,237.00 ms|24.321 ms|731000.0000|727000.0000|726000.0000|6,352,035 KB|
| **New** |	|	| **1,244.22 ms (+1%)** | **32.819 ms** | **697000.0000 (-5%)** | **693000.0000 (-5%)** | **692000.0000 (-5%)** | **6,352,253 KB (0%)** |


