### PR TITLE
Slim down Completion and ExpressionResult struct sizes

### DIFF
--- a/Jint.Tests/Runtime/Debugger/BreakPointTests.cs
+++ b/Jint.Tests/Runtime/Debugger/BreakPointTests.cs
@@ -1,5 +1,4 @@
-﻿using Esprima;
-using Jint.Runtime.Debugger;
+﻿using Jint.Runtime.Debugger;
 
 namespace Jint.Tests.Runtime.Debugger
 {

--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -1,3 +1,5 @@
+#if !NETFRAMEWORK
+
 using System.Text;
 
 namespace Jint.Tests.Runtime;
@@ -8,9 +10,9 @@ public class EngineLimitTests
     public void ShouldAllowReasonableCallStackDepth()
     {
 #if RELEASE
-        const int FunctionNestingCount = 350;
+        const int FunctionNestingCount = 650;
 #else
-        const int FunctionNestingCount = 170;
+        const int FunctionNestingCount = 340;
 #endif
 
         // generate call tree
@@ -41,3 +43,5 @@ public class EngineLimitTests
         Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
     }
 }
+
+#endif

--- a/Jint.Tests/Runtime/NullPropagation.cs
+++ b/Jint.Tests/Runtime/NullPropagation.cs
@@ -1,5 +1,4 @@
-﻿using Esprima;
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
 using Jint.Runtime.References;

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -1,4 +1,5 @@
 ﻿using Esprima;
+using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Native.Promise;
@@ -149,7 +150,8 @@ namespace Jint
             }
             else if (promise.State == PromiseState.Rejected)
             {
-                ExceptionHelper.ThrowJavaScriptException(this, promise.Value, new Completion(CompletionType.Throw, promise.Value, null, Completion._emptyNode));
+                var node = EsprimaExtensions.CreateLocationNode(Location.From(new Position(), new Position(), specifier));
+                ExceptionHelper.ThrowJavaScriptException(this, promise.Value, new Completion(CompletionType.Throw, promise.Value, null, node));
             }
             else if (promise.State != PromiseState.Fulfilled)
             {

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -149,7 +149,7 @@ namespace Jint
             }
             else if (promise.State == PromiseState.Rejected)
             {
-                ExceptionHelper.ThrowJavaScriptException(this, promise.Value, new Completion(CompletionType.Throw, promise.Value, null, Location.From(new Position(), new Position(), specifier)));
+                ExceptionHelper.ThrowJavaScriptException(this, promise.Value, new Completion(CompletionType.Throw, promise.Value, null, Completion._emptyNode));
             }
             else if (promise.State != PromiseState.Fulfilled)
             {

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -735,9 +735,9 @@ namespace Jint
         /// <summary>
         /// Gets the last evaluated <see cref="Node"/>.
         /// </summary>
-        internal Node? GetLastSyntaxNode()
+        internal SyntaxElement? GetLastSyntaxElement()
         {
-            return _activeEvaluationContext?.LastSyntaxNode;
+            return _activeEvaluationContext?.LastSyntaxElement;
         }
 
         /// <summary>

--- a/Jint/EsprimaExtensions.cs
+++ b/Jint/EsprimaExtensions.cs
@@ -429,5 +429,21 @@ namespace Jint
         }
 
         internal readonly record struct Record(JsValue Key, ScriptFunctionInstance Closure);
+
+        /// <summary>
+        /// Creates a dummy node that can be used when only location available and node is required.
+        /// </summary>
+        internal static SyntaxElement CreateLocationNode(in Location location)
+        {
+            return new MinimalSyntaxElement(location);
+        }
+    }
+
+    internal sealed class MinimalSyntaxElement : SyntaxElement
+    {
+        public MinimalSyntaxElement(in Location location)
+        {
+            Location = location;
+        }
     }
 }

--- a/Jint/EsprimaExtensions.cs
+++ b/Jint/EsprimaExtensions.cs
@@ -52,7 +52,7 @@ namespace Jint
             {
                 key = JsValue.Undefined;
             }
-            return new Completion(CompletionType.Normal, key, expression.Location);
+            return new Completion(CompletionType.Normal, key, expression);
         }
 
         private static Completion TryGetComputedPropertyKey<T>(T expression, Engine engine)
@@ -75,7 +75,7 @@ namespace Jint
                 return JintExpression.Build(engine, expression).GetValue(context!);
             }
 
-            return new Completion(CompletionType.Normal, JsValue.Undefined, expression.Location);
+            return new Completion(CompletionType.Normal, JsValue.Undefined, expression);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -68,7 +68,7 @@ namespace Jint.Native.Error
 
             JsValue BuildStackString()
             {
-                var lastSyntaxNode = _engine.GetLastSyntaxNode();
+                var lastSyntaxNode = _engine.GetLastSyntaxElement();
                 if (lastSyntaxNode == null)
                     return Undefined;
 

--- a/Jint/Native/Function/ClassDefinition.cs
+++ b/Jint/Native/Function/ClassDefinition.cs
@@ -198,7 +198,7 @@ namespace Jint.Native.Function
 
             engine.UpdatePrivateEnvironment(outerPrivateEnvironment);
 
-            return new Completion(CompletionType.Normal, F, _body.Location);
+            return new Completion(CompletionType.Normal, F, _body);
         }
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace Jint.Native.Function
                 obj.DefinePropertyOrThrow(propKey, propDesc);
             }
 
-            return new Completion(CompletionType.Normal, obj, method.Location);
+            return new Completion(CompletionType.Normal, obj, method);
         }
     }
 }

--- a/Jint/Runtime/Completion.cs
+++ b/Jint/Runtime/Completion.cs
@@ -25,9 +25,9 @@ namespace Jint.Runtime
         internal static readonly Node _emptyNode = new Identifier("");
         private static readonly Completion _emptyCompletion = new(CompletionType.Normal, null!, _emptyNode);
 
-        internal readonly Node _source;
+        internal readonly SyntaxElement _source;
 
-        internal Completion(CompletionType type, JsValue value, string? target, Node source)
+        internal Completion(CompletionType type, JsValue value, string? target, SyntaxElement source)
         {
             Type = type;
             Value = value;
@@ -35,12 +35,12 @@ namespace Jint.Runtime
             _source = source;
         }
 
-        public Completion(CompletionType type, JsValue value, Node source)
+        public Completion(CompletionType type, JsValue value, SyntaxElement source)
             : this(type, value, null, source)
         {
         }
 
-        public Completion(CompletionType type, string target, Node source)
+        public Completion(CompletionType type, string target, SyntaxElement source)
             : this(type, null!, target, source)
         {
         }

--- a/Jint/Runtime/Completion.cs
+++ b/Jint/Runtime/Completion.cs
@@ -1,11 +1,13 @@
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Esprima;
+using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.Interpreter.Expressions;
 
 namespace Jint.Runtime
 {
-    public enum CompletionType
+    public enum CompletionType : byte
     {
         Normal = 0,
         Return = 1,
@@ -17,23 +19,29 @@ namespace Jint.Runtime
     /// <summary>
     /// https://tc39.es/ecma262/#sec-completion-record-specification-type
     /// </summary>
+    [StructLayout(LayoutKind.Auto)]
     public readonly struct Completion
     {
-        internal Completion(CompletionType type, JsValue value, string? target, in Location location)
+        internal static readonly Node _emptyNode = new Identifier("");
+        private static readonly Completion _emptyCompletion = new(CompletionType.Normal, null!, _emptyNode);
+
+        internal readonly Node _source;
+
+        internal Completion(CompletionType type, JsValue value, string? target, Node source)
         {
             Type = type;
             Value = value;
             Target = target;
-            Location = location;
+            _source = source;
         }
 
-        public Completion(CompletionType type, JsValue value, in Location location)
-            : this(type, value, null, location)
+        public Completion(CompletionType type, JsValue value, Node source)
+            : this(type, value, null, source)
         {
         }
 
-        public Completion(CompletionType type, string target, in Location location)
-            : this(type, null!, target, location)
+        public Completion(CompletionType type, string target, Node source)
+            : this(type, null!, target, source)
         {
         }
 
@@ -43,19 +51,18 @@ namespace Jint.Runtime
             // this cast protects us from getting from type
             Value = (JsValue) result.Value;
             Target = null;
-            Location = result.Location;
+            _source = result._source;
         }
 
         public readonly CompletionType Type;
         public readonly JsValue Value;
         public readonly string? Target;
-        public readonly Location Location;
+        public ref readonly Location Location => ref _source.Location;
 
-        public static Completion Normal(JsValue value, in Location location)
-            => new Completion(CompletionType.Normal, value, location);
+        public static Completion Normal(JsValue value, Node source)
+            => new Completion(CompletionType.Normal, value, source);
 
-        public static Completion Empty()
-            => new Completion(CompletionType.Normal, null!, default);
+        public static ref readonly Completion Empty() => ref _emptyCompletion;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JsValue GetValueOrDefault()
@@ -79,7 +86,7 @@ namespace Jint.Runtime
                 return this;
             }
 
-            return new Completion(Type, value, Target, Location);
+            return new Completion(Type, value, Target, _source);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -19,7 +19,7 @@ namespace Jint.Runtime.Interpreter
         public Completion ResumedCompletion { get; }
         public bool DebugMode { get; }
 
-        public Node LastSyntaxNode { get; set; } = null!;
+        public SyntaxElement LastSyntaxElement { get; set; } = null!;
         public bool OperatorOverloadingAllowed { get; }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
@@ -285,7 +285,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
             }
 
-            return new Completion(CompletionType.Normal, JsValue.Undefined, pattern.Location);
+            return new Completion(CompletionType.Normal, JsValue.Undefined, pattern);
         }
 
         private static Completion HandleObjectPattern(
@@ -398,7 +398,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
             }
 
-            return new Completion(CompletionType.Normal, JsValue.Undefined, pattern.Location);
+            return new Completion(CompletionType.Normal, JsValue.Undefined, pattern);
         }
 
         private static void AssignToReference(

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -415,7 +415,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     }
 
                     environmentRecord.SetMutableBinding(left._expressionName, rval, strict);
-                    return new Completion(CompletionType.Normal, rval, default);
+                    return ExpressionResult.Normal(rval, completion._source);
                 }
 
                 return null;

--- a/Jint/Runtime/Interpreter/Expressions/JintConstantExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintConstantExpression.cs
@@ -18,7 +18,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         public override Completion GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
-            context.LastSyntaxNode = _expression;
+            context.LastSyntaxElement = _expression;
 
             return Completion.Normal(_value, _expression);
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintConstantExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintConstantExpression.cs
@@ -20,7 +20,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             // need to notify correct node when taking shortcut
             context.LastSyntaxNode = _expression;
 
-            return Completion.Normal(_value, _expression.Location);
+            return Completion.Normal(_value, _expression);
         }
 
         protected override ExpressionResult EvaluateInternal(EvaluationContext context) => NormalCompletion(_value);

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -17,12 +17,12 @@ namespace Jint.Runtime.Interpreter.Expressions
     [StructLayout(LayoutKind.Auto)]
     internal readonly struct ExpressionResult
     {
-        internal readonly Node _source;
+        internal readonly SyntaxElement _source;
 
         public readonly ExpressionCompletionType Type;
         public readonly object Value;
 
-        public ExpressionResult(ExpressionCompletionType type, object value, Node source)
+        public ExpressionResult(ExpressionCompletionType type, object value, SyntaxElement source)
         {
             Type = type;
             Value = value;
@@ -36,7 +36,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             return new ExpressionResult((ExpressionCompletionType) result.Type, result.Value, result._source);
         }
 
-        public static ExpressionResult? Normal(JsValue value, Node source)
+        public static ExpressionResult? Normal(JsValue value, SyntaxElement source)
         {
             return new ExpressionResult(ExpressionCompletionType.Normal, value, source);
         }
@@ -83,7 +83,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ExpressionResult Evaluate(EvaluationContext context)
         {
-            context.LastSyntaxNode = _expression;
+            context.LastSyntaxElement = _expression;
             if (!_initialized)
             {
                 Initialize(context);

--- a/Jint/Runtime/Interpreter/Expressions/JintFunctionExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintFunctionExpression.cs
@@ -24,7 +24,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 ? InstantiateOrdinaryFunctionExpression(context, _function.Name!)
                 : InstantiateGeneratorFunctionExpression(context, _function.Name!);
 
-            return Completion.Normal(closure, _expression.Location);
+            return Completion.Normal(closure, _expression);
         }
 
         /// <summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -41,7 +41,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             if (_calculatedValue is not null)
             {
-                return Completion.Normal(_calculatedValue, _expression.Location);
+                return Completion.Normal(_calculatedValue, _expression);
             }
 
             var strict = StrictModeScope.IsStrictModeCode;
@@ -72,7 +72,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 argumentsInstance.Materialize();
             }
 
-            return Completion.Normal(value, _expression.Location);
+            return Completion.Normal(value, _expression);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -37,7 +37,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         public override Completion GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
-            context.LastSyntaxNode = _expression;
+            context.LastSyntaxElement = _expression;
 
             if (_calculatedValue is not null)
             {

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -63,7 +63,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             // need to notify correct node when taking shortcut
             context.LastSyntaxNode = _expression;
 
-            return Completion.Normal(ResolveValue(context), _expression.Location);
+            return Completion.Normal(ResolveValue(context), _expression);
         }
 
         protected override ExpressionResult EvaluateInternal(EvaluationContext context) => NormalCompletion(ResolveValue(context));

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -61,7 +61,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         public override Completion GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
-            context.LastSyntaxNode = _expression;
+            context.LastSyntaxElement = _expression;
 
             return Completion.Normal(ResolveValue(context), _expression);
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -116,7 +116,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             return new ExpressionResult(
                 ExpressionCompletionType.Reference,
                 rent,
-                _expression.Location);
+                _expression);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
@@ -59,7 +59,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             // Reset the location to the "new" keyword so that if an Error object is
             // constructed below, the stack trace will capture the correct location.
-            context.LastSyntaxNode = _expression;
+            context.LastSyntaxElement = _expression;
 
             if (!jsValue.IsConstructor)
             {

--- a/Jint/Runtime/Interpreter/Expressions/JintSpreadExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintSpreadExpression.cs
@@ -24,7 +24,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         public override Completion GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
-            context.LastSyntaxNode = _expression;
+            context.LastSyntaxElement = _expression;
 
             GetValueAndCheckIterator(context, out var objectInstance, out var iterator);
             return Completion.Normal(objectInstance, _expression);

--- a/Jint/Runtime/Interpreter/Expressions/JintSpreadExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintSpreadExpression.cs
@@ -27,7 +27,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             context.LastSyntaxNode = _expression;
 
             GetValueAndCheckIterator(context, out var objectInstance, out var iterator);
-            return Completion.Normal(objectInstance, _expression.Location);
+            return Completion.Normal(objectInstance, _expression);
         }
 
         internal void GetValueAndCheckIterator(EvaluationContext context, out JsValue instance, out IteratorInstance? iterator)

--- a/Jint/Runtime/Interpreter/Expressions/JintThisExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintThisExpression.cs
@@ -16,7 +16,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         public override Completion GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
-            context.LastSyntaxNode = _expression;
+            context.LastSyntaxElement = _expression;
 
             return Completion.Normal(context.Engine.ResolveThisBinding(), _expression);
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintThisExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintThisExpression.cs
@@ -18,7 +18,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             // need to notify correct node when taking shortcut
             context.LastSyntaxNode = _expression;
 
-            return Completion.Normal(context.Engine.ResolveThisBinding(), _expression.Location);
+            return Completion.Normal(context.Engine.ResolveThisBinding(), _expression);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -46,7 +46,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             // need to notify correct node when taking shortcut
             context.LastSyntaxNode = _expression;
 
-            return Completion.Normal(EvaluateJsValue(context), _expression.Location);
+            return Completion.Normal(EvaluateJsValue(context), _expression);
         }
 
         protected override ExpressionResult EvaluateInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -44,7 +44,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         public override Completion GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
-            context.LastSyntaxNode = _expression;
+            context.LastSyntaxElement = _expression;
 
             return Completion.Normal(EvaluateJsValue(context), _expression);
         }

--- a/Jint/Runtime/Interpreter/Expressions/NullishCoalescingExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/NullishCoalescingExpression.cs
@@ -28,7 +28,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         public override Completion GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
-            context.LastSyntaxNode = _expression;
+            context.LastSyntaxElement = _expression;
             return Completion.Normal(EvaluateConstantOrExpression(context), _expression);
         }
 

--- a/Jint/Runtime/Interpreter/Expressions/NullishCoalescingExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/NullishCoalescingExpression.cs
@@ -29,7 +29,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         {
             // need to notify correct node when taking shortcut
             context.LastSyntaxNode = _expression;
-            return Completion.Normal(EvaluateConstantOrExpression(context), _expression.Location);
+            return Completion.Normal(EvaluateConstantOrExpression(context), _expression);
         }
 
         protected override ExpressionResult EvaluateInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -56,7 +56,7 @@ namespace Jint.Runtime.Interpreter
                 result = EvaluateFunctionBody(context, functionObject, argumentsList);
             }
 
-            return new Completion(result.Type, result.GetValueOrDefault().Clone(), result.Target, result.Location);
+            return new Completion(result.Type, result.GetValueOrDefault().Clone(), result.Target, result._source);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace Jint.Runtime.Interpreter
             _bodyExpression ??= JintExpression.Build(_engine, (Expression) Function.Body);
             var jsValue = _bodyExpression?.GetValue(context).Value ?? Undefined.Instance;
             argumentsInstance?.FunctionWasCalled();
-            return new Completion(CompletionType.Return, jsValue, null, Function.Body.Location);
+            return new Completion(CompletionType.Return, jsValue, null, Function.Body);
         }
 
         /// <summary>

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -78,7 +78,7 @@ namespace Jint.Runtime.Interpreter
             }
 
             JintStatement? s = null;
-            var c = new Completion(CompletionType.Normal, null!, null, context.LastSyntaxNode?.Location ?? default);
+            var c = new Completion(CompletionType.Normal, null!, null, context.LastSyntaxNode);
             Completion sl = c;
 
             // The value of a StatementList is the value of the last value-producing item in the StatementList
@@ -96,7 +96,7 @@ namespace Jint.Runtime.Interpreter
                             c.Type,
                             c.Value ?? sl.Value,
                             c.Target,
-                            c.Location);
+                            c._source);
                     }
                     sl = c;
                     lastValue = c.Value ?? lastValue;
@@ -104,8 +104,7 @@ namespace Jint.Runtime.Interpreter
             }
             catch (JavaScriptException v)
             {
-                var location = v.Location == default ? s!.Location : v.Location;
-                var completion = new Completion(CompletionType.Throw, v.Error, null, location);
+                var completion = new Completion(CompletionType.Throw, v.Error, null, s!._statement);
                 return completion;
             }
             catch (TypeErrorException e)
@@ -114,7 +113,7 @@ namespace Jint.Runtime.Interpreter
                 {
                     e.Message
                 });
-                return new Completion(CompletionType.Throw, error, null, s!.Location);
+                return new Completion(CompletionType.Throw, error, null, s!._statement);
             }
             catch (RangeErrorException e)
             {
@@ -122,9 +121,9 @@ namespace Jint.Runtime.Interpreter
                 {
                     e.Message
                 });
-                c = new Completion(CompletionType.Throw, error, null, s!.Location);
+                c = new Completion(CompletionType.Throw, error, null, s!._statement);
             }
-            return new Completion(c.Type, lastValue ?? JsValue.Undefined, c.Target, c.Location);
+            return new Completion(c.Type, lastValue ?? JsValue.Undefined, c.Target, c._source);
         }
 
         /// <summary>

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -73,12 +73,12 @@ namespace Jint.Runtime.Interpreter
             var engine = context.Engine;
             if (_statement != null)
             {
-                context.LastSyntaxNode = _statement;
+                context.LastSyntaxElement = _statement;
                 engine.RunBeforeExecuteStatementChecks(_statement);
             }
 
             JintStatement? s = null;
-            var c = new Completion(CompletionType.Normal, null!, null, context.LastSyntaxNode);
+            var c = new Completion(CompletionType.Normal, null!, null, context.LastSyntaxElement);
             Completion sl = c;
 
             // The value of a StatementList is the value of the last value-producing item in the StatementList
@@ -104,7 +104,12 @@ namespace Jint.Runtime.Interpreter
             }
             catch (JavaScriptException v)
             {
-                var completion = new Completion(CompletionType.Throw, v.Error, null, s!._statement);
+                SyntaxElement source = s!._statement;
+                if (v.Location != default)
+                {
+                    source = EsprimaExtensions.CreateLocationNode(v.Location);
+                }
+                var completion = new Completion(CompletionType.Throw, v.Error, null, source);
                 return completion;
             }
             catch (TypeErrorException e)

--- a/Jint/Runtime/Interpreter/Statements/JintBreakStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBreakStatement.cs
@@ -16,7 +16,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
-            return new Completion(CompletionType.Break, null!, _label, Location);
+            return new Completion(CompletionType.Break, null!, _label, _statement);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintClassDeclarationStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintClassDeclarationStatement.cs
@@ -29,7 +29,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 env.InitializeBinding(classBinding, completion.Value);
             }
 
-            return new Completion(CompletionType.Normal, null!, null, Location);
+            return new Completion(CompletionType.Normal, null!, null, _statement);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintContinueStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintContinueStatement.cs
@@ -16,7 +16,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
-            return new Completion(CompletionType.Continue, _labelName!, Location);
+            return new Completion(CompletionType.Continue, _labelName!, _statement);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintDebuggerStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDebuggerStatement.cs
@@ -29,7 +29,7 @@ namespace Jint.Runtime.Interpreter.Statements
                     break;
             }
 
-            return new Completion(CompletionType.Normal, null!, null, Location);
+            return new Completion(CompletionType.Normal, null!, null, _statement);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -41,7 +41,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 {
                     if (completion.Type == CompletionType.Break && (completion.Target == null || completion.Target == _labelSetName))
                     {
-                        return new Completion(CompletionType.Normal, v, null, Location);
+                        return new Completion(CompletionType.Normal, v, null, _statement);
                     }
 
                     if (completion.Type != CompletionType.Normal)

--- a/Jint/Runtime/Interpreter/Statements/JintEmptyStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintEmptyStatement.cs
@@ -10,7 +10,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
-            return new Completion(CompletionType.Normal, null!, null, Location);
+            return new Completion(CompletionType.Normal, null!, null, _statement);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
@@ -26,7 +26,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 return new Completion(result);
             }
 
-            return new Completion(CompletionType.Normal, context.Engine.GetValue((Reference) result.Value, true), null, Location);
+            return new Completion(CompletionType.Normal, context.Engine.GetValue((Reference) result.Value, true), null, _statement);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -95,7 +95,7 @@ namespace Jint.Runtime.Interpreter.Statements
         {
             if (!HeadEvaluation(context, out var keyResult))
             {
-                return new Completion(CompletionType.Normal, JsValue.Undefined, null, Location);
+                return new Completion(CompletionType.Normal, JsValue.Undefined, null, _statement);
             }
 
             return BodyEvaluation(context, _expr, _body, keyResult, IterationKind.Enumerate, _lhsKind);
@@ -170,7 +170,7 @@ namespace Jint.Runtime.Interpreter.Statements
                     if (!iteratorRecord.TryIteratorStep(out var nextResult))
                     {
                         close = true;
-                        return new Completion(CompletionType.Normal, v, null, Location);
+                        return new Completion(CompletionType.Normal, v, null, _statement!);
                     }
 
                     if (iteratorKind == IteratorKind.Async)
@@ -203,7 +203,7 @@ namespace Jint.Runtime.Interpreter.Statements
                         {
                             var identifier = (Identifier) ((VariableDeclaration) _leftNode).Declarations[0].Id;
                             lhsName ??= identifier.Name;
-                            lhsRef = new ExpressionResult(ExpressionCompletionType.Normal, engine.ResolveBinding(lhsName), identifier.Location);
+                            lhsRef = new ExpressionResult(ExpressionCompletionType.Normal, engine.ResolveBinding(lhsName), identifier);
                         }
                     }
 
@@ -281,7 +281,7 @@ namespace Jint.Runtime.Interpreter.Statements
                     if (result.Type == CompletionType.Break && (result.Target == null || result.Target == _statement?.LabelSet?.Name))
                     {
                         completionType = CompletionType.Normal;
-                        return new Completion(CompletionType.Normal, v, null, Location);
+                        return new Completion(CompletionType.Normal, v, null, _statement!);
                     }
 
                     if (result.Type != CompletionType.Continue || (result.Target != null && result.Target != _statement?.LabelSet?.Name))

--- a/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
@@ -33,7 +33,7 @@ namespace Jint.Runtime.Interpreter.Statements
             }
             else
             {
-                return new Completion(CompletionType.Normal, null!, Location);
+                return new Completion(CompletionType.Normal, null!, _statement);
             }
 
             return result;

--- a/Jint/Runtime/Interpreter/Statements/JintImportDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintImportDeclaration.cs
@@ -15,7 +15,7 @@ internal sealed class JintImportDeclaration : JintStatement<ImportDeclaration>
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
         // just to ensure module context or valid
-        context.Engine.GetActiveScriptOrModule().AsModule(context.Engine, context.LastSyntaxNode.Location);
+        context.Engine.GetActiveScriptOrModule().AsModule(context.Engine, context.LastSyntaxElement.Location);
         return Completion.Empty();
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintLabeledStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintLabeledStatement.cs
@@ -26,7 +26,7 @@ namespace Jint.Runtime.Interpreter.Statements
             if (result.Type == CompletionType.Break && result.Target == _labelName)
             {
                 var value = result.Value;
-                return new Completion(CompletionType.Normal, value, null, Location);
+                return new Completion(CompletionType.Normal, value, null, _statement);
             }
 
             return result;

--- a/Jint/Runtime/Interpreter/Statements/JintReturnStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintReturnStatement.cs
@@ -25,7 +25,7 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
             var jsValue = _argument?.GetValue(context).Value ?? Undefined.Instance;
-            return new Completion(CompletionType.Return, jsValue, null, Location);
+            return new Completion(CompletionType.Return, jsValue, null, _statement);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -9,7 +9,7 @@ namespace Jint.Runtime.Interpreter.Statements
 {
     internal abstract class JintStatement<T> : JintStatement where T : Statement
     {
-        internal readonly T _statement;
+        internal new readonly T _statement;
 
         protected JintStatement(T statement) : base(statement)
         {
@@ -19,7 +19,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
     internal abstract class JintStatement
     {
-        private readonly Statement _statement;
+        internal readonly Statement _statement;
         private bool _initialized;
 
         protected JintStatement(Statement statement)
@@ -54,7 +54,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected abstract Completion ExecuteInternal(EvaluationContext context);
 
-        public Location Location => _statement.Location;
+        public ref readonly Location Location => ref _statement.Location;
 
         /// <summary>
         /// Opportunity to build one-time structures and caching based on lexical context.
@@ -111,7 +111,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 var jsValue = JintLiteralExpression.ConvertToJsValue(l);
                 if (jsValue is not null)
                 {
-                    return new Completion(CompletionType.Return, jsValue, null, rs.Location);
+                    return new Completion(CompletionType.Return, jsValue, null, rs);
                 }
             }
 
@@ -128,7 +128,7 @@ namespace Jint.Runtime.Interpreter.Statements
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected Completion NormalCompletion(JsValue value)
         {
-            return new Completion(CompletionType.Normal, value, _statement.Location);
+            return new Completion(CompletionType.Normal, value, _statement);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -32,7 +32,7 @@ namespace Jint.Runtime.Interpreter.Statements
         {
             if (_statement.Type != Nodes.BlockStatement)
             {
-                context.LastSyntaxNode = _statement;
+                context.LastSyntaxElement = _statement;
                 context.Engine.RunBeforeExecuteStatementChecks(_statement);
             }
 

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
@@ -37,7 +37,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
             var engine = context.Engine;
             JsValue v = Undefined.Instance;
-            Node l = context.LastSyntaxNode;
+            SyntaxElement l = context.LastSyntaxElement;
             JintSwitchCase? defaultCase = null;
             bool hit = false;
 

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
@@ -37,7 +37,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
             var engine = context.Engine;
             JsValue v = Undefined.Instance;
-            Location l = context.LastSyntaxNode.Location;
+            Node l = context.LastSyntaxNode;
             JintSwitchCase? defaultCase = null;
             bool hit = false;
 
@@ -81,7 +81,7 @@ namespace Jint.Runtime.Interpreter.Statements
                         return r;
                     }
 
-                    l = r.Location;
+                    l = r._source;
                     v = r.Value ?? Undefined.Instance;
                 }
             }
@@ -109,7 +109,7 @@ namespace Jint.Runtime.Interpreter.Statements
                     return r;
                 }
 
-                l = r.Location;
+                l = r._source;
                 v = r.Value ?? Undefined.Instance;
             }
 

--- a/Jint/Runtime/Interpreter/Statements/JintThrowStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintThrowStatement.cs
@@ -22,7 +22,7 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
             var completion = _argument.GetValue(context);
-            return new Completion(CompletionType.Throw, completion.Value, null, completion.Location);
+            return new Completion(CompletionType.Throw, completion.Value, null, completion._source);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
@@ -8,8 +8,6 @@ namespace Jint.Runtime.Interpreter.Statements
 {
     internal sealed class JintVariableDeclaration : JintStatement<VariableDeclaration>
     {
-        private static readonly Completion VoidCompletion = new(CompletionType.Normal, null!, default);
-
         private ResolvedDeclaration[] _declarations = Array.Empty<ResolvedDeclaration>();
 
         private sealed class ResolvedDeclaration
@@ -127,7 +125,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 }
             }
 
-            return VoidCompletion;
+            return Completion.Empty();
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
@@ -37,7 +37,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 var jsValue = _test.GetValue(context).Value;
                 if (!TypeConverter.ToBoolean(jsValue))
                 {
-                    return new Completion(CompletionType.Normal, v, null, Location);
+                    return new Completion(CompletionType.Normal, v, null, _statement);
                 }
 
                 var completion = _body.Execute(context);
@@ -51,7 +51,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 {
                     if (completion.Type == CompletionType.Break && (completion.Target == null || completion.Target == _labelSetName))
                     {
-                        return new Completion(CompletionType.Normal, v, null, Location);
+                        return new Completion(CompletionType.Normal, v, null, _statement);
                     }
 
                     if (completion.Type != CompletionType.Normal)

--- a/Jint/Runtime/Interpreter/Statements/JintWithStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWithStatement.cs
@@ -38,7 +38,7 @@ namespace Jint.Runtime.Interpreter.Statements
             }
             catch (JavaScriptException e)
             {
-                c = new Completion(CompletionType.Throw, e.Error, _statement.Location);
+                c = new Completion(CompletionType.Throw, e.Error, _statement);
             }
             finally
             {

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -26,7 +26,7 @@ public class JavaScriptException : JintException
     private readonly JavaScriptErrorWrapperException _jsErrorException;
 
     public string? JavaScriptStackTrace => _jsErrorException.StackTrace;
-    public Location Location => _jsErrorException.Location;
+    public ref readonly Location Location => ref _jsErrorException.Location;
     public JsValue Error => _jsErrorException.Error;
 
     internal JavaScriptException(ErrorConstructor errorConstructor)
@@ -64,9 +64,11 @@ public class JavaScriptException : JintException
     private class JavaScriptErrorWrapperException : JintException
     {
         private string? _callStack;
+        private Location _location;
 
         public JsValue Error { get; }
-        public Location Location { get; private set; }
+
+        public ref readonly Location Location => ref _location;
 
         internal JavaScriptErrorWrapperException(JsValue error, string? message = null)
             : base(message ?? GetMessage(error))
@@ -76,12 +78,12 @@ public class JavaScriptException : JintException
 
         internal void SetLocation(Location location)
         {
-            Location = location;
+            _location = location;
         }
 
         internal void SetCallstack(Engine engine, Location location, bool overwriteExisting)
         {
-            Location = location;
+            _location = location;
 
             var errObj = Error.IsObject() ? Error.AsObject() : null;
             if (errObj is null)


### PR DESCRIPTION
Both `Completion` and `EvaluationResult` were needlessly using full copy of `Location` for error reporting needs. It's enough to hold on to source Esprima syntax element and then get the location from there when needed. This improves stack capacity greatly.

Relates to #1159

/cc @KurtGokhan @CreepGin 

## Old layouts

```
Type layout for 'Completion'
Size: 48 bytes. Paddings: 4 bytes (%8 of empty space)
|=======================================|
|   0-7: JsValue Value (8 bytes)        |
|---------------------------------------|
|  8-15: String Target (8 bytes)        |
|---------------------------------------|
| 16-19: CompletionType Type (4 bytes)  |
| |================================|    |
| |   0-3: Int32 value__ (4 bytes) |    |
| |================================|    |
|---------------------------------------|
| 20-23: padding (4 bytes)              |
|---------------------------------------|
| 24-47: Location Location (24 bytes)   |
| |===================================| |
| |   0-7: String Source (8 bytes)    | |
| |-----------------------------------| |
| |  8-15: Position Start (8 bytes)   | |
| | |===============================| | |
| | |   0-3: Int32 Line (4 bytes)   | | |
| | |-------------------------------| | |
| | |   4-7: Int32 Column (4 bytes) | | |
| | |===============================| | |
| |-----------------------------------| |
| | 16-23: Position End (8 bytes)     | |
| | |===============================| | |
| | |   0-3: Int32 Line (4 bytes)   | | |
| | |-------------------------------| | |
| | |   4-7: Int32 Column (4 bytes) | | |
| | |===============================| | |
| |===================================| |
|=======================================|


Type layout for 'ExpressionResult'
Size: 40 bytes. Paddings: 7 bytes (%17 of empty space)
|===============================================|
|   0-7: Object Value (8 bytes)                 |
|-----------------------------------------------|
|     8: ExpressionCompletionType Type (1 byte) |
| |==============================|              |
| |     0: Byte value__ (1 byte) |              |
| |==============================|              |
|-----------------------------------------------|
|  9-15: padding (7 bytes)                      |
|-----------------------------------------------|
| 16-39: Location Location (24 bytes)           |
| |===================================|         |
| |   0-7: String Source (8 bytes)    |         |
| |-----------------------------------|         |
| |  8-15: Position Start (8 bytes)   |         |
| | |===============================| |         |
| | |   0-3: Int32 Line (4 bytes)   | |         |
| | |-------------------------------| |         |
| | |   4-7: Int32 Column (4 bytes) | |         |
| | |===============================| |         |
| |-----------------------------------|         |
| | 16-23: Position End (8 bytes)     |         |
| | |===============================| |         |
| | |   0-3: Int32 Line (4 bytes)   | |         |
| | |-------------------------------| |         |
| | |   4-7: Int32 Column (4 bytes) | |         |
| | |===============================| |         |
| |===================================|         |
|===============================================|
```

## New layouts

```
Type layout for 'Completion'
Size: 32 bytes. Paddings: 7 bytes (%21 of empty space)
|========================================|
|   0-7: SyntaxElement _source (8 bytes) |
|----------------------------------------|
|  8-15: JsValue Value (8 bytes)         |
|----------------------------------------|
| 16-23: String Target (8 bytes)         |
|----------------------------------------|
|    24: CompletionType Type (1 byte)    |
| |==============================|       |
| |     0: Byte value__ (1 byte) |       |
| |==============================|       |
|----------------------------------------|
| 25-31: padding (7 bytes)               |
|========================================|
Type layout for 'ExpressionResult'
Size: 24 bytes. Paddings: 7 bytes (%29 of empty space)
|===============================================|
|   0-7: SyntaxElement _source (8 bytes)        |
|-----------------------------------------------|
|  8-15: Object Value (8 bytes)                 |
|-----------------------------------------------|
|    16: ExpressionCompletionType Type (1 byte) |
| |==============================|              |
| |     0: Byte value__ (1 byte) |              |
| |==============================|              |
|-----------------------------------------------|
| 17-23: padding (7 bytes)                      |
|===============================================|
```