### PR TITLE
More tweaks to reduce call stack size

### DIFF
--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -10,9 +10,9 @@ public class EngineLimitTests
     public void ShouldAllowReasonableCallStackDepth()
     {
 #if RELEASE
-        const int FunctionNestingCount = 690;
+        const int FunctionNestingCount = 740;
 #else
-        const int FunctionNestingCount = 350;
+        const int FunctionNestingCount = 400;
 #endif
 
         // generate call tree

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -25,7 +25,7 @@ namespace Jint
     {
         private readonly JavaScriptParser _defaultParser = new(ParserOptions.Default);
 
-        private readonly ExecutionContextStack _executionContexts;
+        internal readonly ExecutionContextStack _executionContexts;
         private JsValue _completionValue = JsValue.Undefined;
         internal EvaluationContext? _activeEvaluationContext;
 
@@ -38,7 +38,7 @@ namespace Jint
 
         // cached access
         internal readonly IObjectConverter[]? _objectConverters;
-        private readonly IConstraint[] _constraints;
+        internal readonly IConstraint[] _constraints;
         internal readonly bool _isDebugMode;
         internal bool _isStrict;
         internal readonly IReferenceResolver _referenceResolver;
@@ -108,13 +108,14 @@ namespace Jint
 
             _constraints = Options.Constraints.Constraints.ToArray();
             _referenceResolver = Options.ReferenceResolver;
-            CallStack = new JintCallStack(Options.Constraints.MaxRecursionDepth >= 0);
 
             _referencePool = new ReferencePool();
             _argumentsInstancePool = new ArgumentsInstancePool(this);
             _jsValueArrayPool = new JsValueArrayPool();
 
             Options.Apply(this);
+
+            CallStack = new JintCallStack(Options.Constraints.MaxRecursionDepth >= 0);
         }
 
         private void Reset()

--- a/Jint/Native/Function/FunctionInstance.cs
+++ b/Jint/Native/Function/FunctionInstance.cs
@@ -320,14 +320,6 @@ namespace Jint.Native.Function
         }
 
         /// <summary>
-        /// https://tc39.es/ecma262/#sec-ordinarycallevaluatebody
-        /// </summary>
-        internal Completion OrdinaryCallEvaluateBody(EvaluationContext context, JsValue[] arguments)
-        {
-            return _functionDefinition.EvaluateBody(context, this, arguments);
-        }
-
-        /// <summary>
         /// https://tc39.es/ecma262/#sec-prepareforordinarycall
         /// </summary>
         internal ExecutionContext PrepareForOrdinaryCall(JsValue newTarget)

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -72,7 +72,8 @@ namespace Jint.Native.Function
 
                     // actual call
                     var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
-                    var result = OrdinaryCallEvaluateBody(context, arguments);
+
+                    var result = _functionDefinition.EvaluateBody(context, this, arguments);
 
                     if (result.Type == CompletionType.Throw)
                     {
@@ -143,7 +144,8 @@ namespace Jint.Native.Function
                 try
                 {
                     var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
-                    var result = OrdinaryCallEvaluateBody(context, arguments);
+
+                    var result = _functionDefinition.EvaluateBody(context, this, arguments);
 
                     // The DebugHandler needs the current execution context before the return for stepping through the return point
                     if (context.DebugMode && result.Type != CompletionType.Throw)

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -7,19 +7,29 @@ namespace Jint.Runtime.Interpreter
     /// </summary>
     internal sealed class EvaluationContext
     {
+        private readonly bool _shouldRunBeforeExecuteStatementChecks;
+
         public EvaluationContext(Engine engine, in Completion? resumedCompletion = null)
         {
             Engine = engine;
-            DebugMode = engine._isDebugMode;
             ResumedCompletion = resumedCompletion ?? default; // TODO later
             OperatorOverloadingAllowed = engine.Options.Interop.AllowOperatorOverloading;
+            _shouldRunBeforeExecuteStatementChecks = engine._constraints.Length > 0 || engine._isDebugMode;
         }
 
         public Engine Engine { get; }
         public Completion ResumedCompletion { get; }
-        public bool DebugMode { get; }
+        public bool DebugMode => Engine._isDebugMode;
 
         public SyntaxElement LastSyntaxElement { get; set; } = null!;
         public bool OperatorOverloadingAllowed { get; }
+
+        public void RunBeforeExecuteStatementChecks(Statement statement)
+        {
+            if (_shouldRunBeforeExecuteStatementChecks)
+            {
+                Engine.RunBeforeExecuteStatementChecks(statement);
+            }
+        }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -469,19 +469,17 @@ namespace Jint.Runtime.Interpreter.Expressions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected static void BuildArguments(EvaluationContext context, JintExpression[] jintExpressions, JsValue[] targetArray)
         {
-            for (var i = 0; i < jintExpressions.Length; i++)
+            for (uint i = 0; i < (uint) jintExpressions.Length; i++)
             {
-                var completion = jintExpressions[i].GetValue(context);
-                targetArray[i] = completion.Value.Clone();
+                targetArray[i] = jintExpressions[i].GetValue(context).Value.Clone();
             }
         }
 
         protected static JsValue[] BuildArgumentsWithSpreads(EvaluationContext context, JintExpression[] jintExpressions)
         {
             var args = new List<JsValue>(jintExpressions.Length);
-            for (var i = 0; i < jintExpressions.Length; i++)
+            foreach (var jintExpression in jintExpressions)
             {
-                var jintExpression = jintExpressions[i];
                 if (jintExpression is JintSpreadExpression jse)
                 {
                     jse.GetValueAndCheckIterator(context, out var objectInstance, out var iterator);

--- a/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
@@ -1,32 +1,23 @@
 using Esprima.Ast;
 using Jint.Runtime.Interpreter.Expressions;
-using Jint.Runtime.References;
 
-namespace Jint.Runtime.Interpreter.Statements
+namespace Jint.Runtime.Interpreter.Statements;
+
+internal sealed class JintExpressionStatement : JintStatement<ExpressionStatement>
 {
-    internal sealed class JintExpressionStatement : JintStatement<ExpressionStatement>
+    private JintExpression _expression = null!;
+
+    public JintExpressionStatement(ExpressionStatement statement) : base(statement)
     {
-        private JintExpression _expression = null!;
+    }
 
-        public JintExpressionStatement(ExpressionStatement statement) : base(statement)
-        {
-        }
+    protected override void Initialize(EvaluationContext context)
+    {
+        _expression = JintExpression.Build(context.Engine, _statement.Expression);
+    }
 
-        protected override void Initialize(EvaluationContext context)
-        {
-            _expression = JintExpression.Build(context.Engine, _statement.Expression);
-        }
-
-        protected override Completion ExecuteInternal(EvaluationContext context)
-        {
-            var result = _expression.Evaluate(context);
-
-            if (result.Type != ExpressionCompletionType.Reference)
-            {
-                return new Completion(result);
-            }
-
-            return new Completion(CompletionType.Normal, context.Engine.GetValue((Reference) result.Value, true), null, _statement);
-        }
+    protected override Completion ExecuteInternal(EvaluationContext context)
+    {
+        return _expression.GetValue(context);
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -33,7 +33,7 @@ namespace Jint.Runtime.Interpreter.Statements
             if (_statement.Type != Nodes.BlockStatement)
             {
                 context.LastSyntaxElement = _statement;
-                context.Engine.RunBeforeExecuteStatementChecks(_statement);
+                context.RunBeforeExecuteStatementChecks(_statement);
             }
 
             if (!_initialized)


### PR DESCRIPTION
Checking some hot paths and ensuring that the stack doesn't contain unnecessary items. The `string-validate-input` is pretty insane, though the tests still pass 🤷🏻‍♂️ 

/cc @KurtGokhan @CreepGin 

## Esprima.Benchmark.SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |Run|3d-cube|217.72 ms|0.453 ms|3000.0000|333.3333|-|51,125 KB|
| **New** |	|	| **206.21 ms (-5%)** | **0.372 ms** | **3000.0000 (0%)** | **333.3333 (0%)** | **-** | **51,125 KB (0%)** |
| Old |Run|3d-morph|160.62 ms|0.226 ms|2000.0000|1000.0000|-|49,744 KB|
| **New** |	|	| **158.71 ms (-1%)** | **0.510 ms** | **3000.0000 (+50%)** | **1250.0000 (+25%)** | **500.0000** | **49,745 KB (0%)** |
| Old |Run|3d-raytrace|173.30 ms|1.197 ms|5000.0000|1000.0000|-|93,390 KB|
| **New** |	|	| **172.14 ms (-1%)** | **2.352 ms** | **5000.0000 (0%)** | **1000.0000 (0%)** | **-** | **93,390 KB (0%)** |
| Old |Run|access-binary-trees|86.68 ms|0.349 ms|4000.0000|1000.0000|-|78,472 KB|
| **New** |	|	| **81.73 ms (-6%)** | **0.177 ms** | **4000.0000 (0%)** | **1000.0000 (0%)** | **-** | **78,472 KB (0%)** |
| Old |Run|access-fannkuch|469.09 ms|1.075 ms|-|-|-|136 KB|
| **New** |	|	| **455.82 ms (-3%)** | **2.175 ms** | **-** | **-** | **-** | **136 KB (0%)** |
| Old |Run|access-nbody|197.97 ms|0.457 ms|3666.6667|-|-|63,853 KB|
| **New** |	|	| **191.97 ms (-3%)** | **0.484 ms** | **3666.6667 (0%)** | **333.3333** | **-** | **63,850 KB (0%)** |
| Old |Run|access-nsieve|157.01 ms|0.295 ms|1000.0000|-|-|21,518 KB|
| **New** |	|	| **164.04 ms (+4%)** | **0.170 ms** | **1000.0000 (0%)** | **-** | **-** | **21,518 KB (0%)** |
| Old |Run|bitop(...)-byte [24]|166.13 ms|0.398 ms|4000.0000|-|-|68,950 KB|
| **New** |	|	| **163.70 ms (-1%)** | **0.509 ms** | **4000.0000 (0%)** | **-** | **-** | **68,950 KB (0%)** |
| Old |Run|bitops-bits-in-byte|262.53 ms|0.422 ms|2000.0000|-|-|45,446 KB|
| **New** |	|	| **244.74 ms (-7%)** | **0.389 ms** | **2000.0000 (0%)** | **-** | **-** | **45,446 KB (0%)** |
| Old |Run|bitops-bitwise-and|178.28 ms|0.559 ms|5000.0000|-|-|93,439 KB|
| **New** |	|	| **168.51 ms (-5%)** | **1.003 ms** | **5000.0000 (0%)** | **-** | **-** | **93,439 KB (0%)** |
| Old |Run|bitops-nsieve-bits|212.82 ms|0.730 ms|3000.0000|1000.0000|-|54,856 KB|
| **New** |	|	| **207.57 ms (-2%)** | **1.581 ms** | **3000.0000 (0%)** | **1000.0000 (0%)** | **-** | **54,856 KB (0%)** |
| Old |Run|contr(...)rsive [21]|122.64 ms|0.226 ms|7400.0000|1600.0000|-|124,119 KB|
| **New** |	|	| **116.13 ms (-5%)** | **0.287 ms** | **7400.0000 (0%)** | **1600.0000 (0%)** | **-** | **124,119 KB (0%)** |
| Old |Run|crypto-aes|138.35 ms|0.317 ms|-|-|-|15,601 KB|
| **New** |	|	| **135.67 ms (-2%)** | **0.378 ms** | **-** | **-** | **-** | **15,590 KB (0%)** |
| Old |Run|crypto-md5|108.69 ms|0.273 ms|5000.0000|1000.0000|-|95,414 KB|
| **New** |	|	| **108.42 ms (0%)** | **0.179 ms** | **5000.0000 (0%)** | **1000.0000 (0%)** | **-** | **95,414 KB (0%)** |
| Old |Run|crypto-sha1|111.83 ms|0.311 ms|5000.0000|1000.0000|-|82,074 KB|
| **New** |	|	| **107.91 ms (-4%)** | **0.302 ms** | **5000.0000 (0%)** | **1000.0000 (0%)** | **-** | **82,074 KB (0%)** |
| Old |Run|date-format-tofte|109.06 ms|0.242 ms|2000.0000|-|-|48,549 KB|
| **New** |	|	| **107.01 ms (-2%)** | **0.285 ms** | **2000.0000 (0%)** | **-** | **-** | **48,549 KB (0%)** |
| Old |Run|date-format-xparb|58.78 ms|0.170 ms|1777.7778|666.6667|-|29,414 KB|
| **New** |	|	| **59.77 ms (+2%)** | **0.073 ms** | **1777.7778 (0%)** | **666.6667 (0%)** | **-** | **29,414 KB (0%)** |
| Old |Run|math-cordic|349.63 ms|1.410 ms|7000.0000|-|-|123,973 KB|
| **New** |	|	| **337.03 ms (-4%)** | **1.368 ms** | **7000.0000 (0%)** | **-** | **-** | **123,973 KB (0%)** |
| Old |Run|math-partial-sums|138.54 ms|0.279 ms|4000.0000|-|-|68,947 KB|
| **New** |	|	| **134.10 ms (-3%)** | **0.537 ms** | **4000.0000 (0%)** | **-** | **-** | **68,947 KB (0%)** |
| Old |Run|math-spectral-norm|136.91 ms|0.462 ms|4000.0000|-|-|67,176 KB|
| **New** |	|	| **135.20 ms (-1%)** | **0.534 ms** | **4000.0000 (0%)** | **-** | **-** | **67,176 KB (0%)** |
| Old |Run|regexp-dna|108.58 ms|0.399 ms|800.0000|800.0000|800.0000|17,672 KB|
| **New** |	|	| **108.34 ms (0%)** | **0.383 ms** | **1000.0000 (+25%)** | **1000.0000 (+25%)** | **1000.0000 (+25%)** | **17,674 KB (0%)** |
| Old |Run|string-base64|104.31 ms|0.330 ms|-|-|-|12,525 KB|
| **New** |	|	| **103.66 ms (-1%)** | **0.365 ms** | **-** | **-** | **-** | **12,523 KB (0%)** |
| Old |Run|string-fasta|204.44 ms|0.353 ms|10000.0000|333.3333|-|167,275 KB|
| **New** |	|	| **197.59 ms (-3%)** | **0.456 ms** | **10000.0000 (0%)** | **333.3333 (0%)** | **-** | **167,275 KB (0%)** |
| Old |Run|string-tagcloud|75.07 ms|0.790 ms|3142.8571|1285.7143|571.4286|48,439 KB|
| **New** |	|	| **73.81 ms (-2%)** | **1.079 ms** | **3142.8571 (0%)** | **1285.7143 (0%)** | **571.4286 (0%)** | **48,438 KB (0%)** |
| Old |Run|string-unpack-code|75.11 ms|0.249 ms|5000.0000|571.4286|-|84,573 KB|
| **New** |	|	| **72.20 ms (-4%)** | **0.397 ms** | **5000.0000 (0%)** | **571.4286 (0%)** | **-** | **84,573 KB (0%)** |
| Old |Run|strin(...)input [21]|1,271.89 ms|25.280 ms|696000.0000|692000.0000|691000.0000|6,352,002 KB|
| **New** |	|	| **84.62 ms (-93%)** | **0.186 ms** | **2000.0000 (-100%)** | **1000.0000 (-100%)** | **-** | **44,618 KB (-99%)** |


