### PR TITLE
Fix array performance regression

### DIFF
--- a/Jint.Benchmark/SingleScriptBenchmark.cs
+++ b/Jint.Benchmark/SingleScriptBenchmark.cs
@@ -23,7 +23,7 @@ public abstract class SingleScriptBenchmark
     public void Execute()
     {
         var engine = new Engine(static options => options.Strict());
-        engine.Execute(FileName);
+        engine.Execute(_script);
     }
 
     [Benchmark]

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The entire execution engine was rebuild with performance in mind, in many cases 
 - If you repeatedly run the same script, you should cache the `Script` or `Module` instance produced by Esprima and feed it to Jint instead of the content string
 - You should prefer running engine in strict mode, it improves performance
 
-You can check out [the engine comparison results](Jint.Benchmarks), bear in mind that every use case is different and benchmarks might not reflect your real-world usage.
+You can check out [the engine comparison results](Jint.Benchmark), bear in mind that every use case is different and benchmarks might not reflect your real-world usage.
 
 ## Discussion
 


### PR DESCRIPTION
* `ObjectChangeFlags.NonDefaultDataDescriptorUsage `should only be raised for array index
* inline some unnecessary extra methods
* reuse property descriptor if possible on `Set`