### PR TITLE
Call Dispose on enumerator (#1285)

### DIFF
--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -326,6 +326,12 @@ namespace Jint.Runtime.Interop
                 _enumerator = target.GetEnumerator();
             }
 
+            public override void Close(CompletionType completion)
+            {
+               (_enumerator as IDisposable)?.Dispose();
+                base.Close(completion);
+            }
+
             public override bool TryIteratorStep(out ObjectInstance nextItem)
             {
                 if (_enumerator.MoveNext())


### PR DESCRIPTION
See discussion #1285 : call dispose on enumerator (or execute finally clause on enumerator methods/properties)
- Added a call to (_enumerator as IDisposable)?.Dispose() in EnumerableIterator.Close
- Added 3 test cases : normal termination, on break, on exception