### PR TITLE
Make BindFunctionInstance public

### DIFF
--- a/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+++ b/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Jint\Jint.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+++ b/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
@@ -1,28 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <AssemblyOriginatorKeyFile>..\Jint\Jint.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+    <NoWarn>612</NoWarn>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Jint\Jint.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" Condition=" '$(TargetFramework)' == 'net462' " />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Flurl.Http.Signed" Version="3.2.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MongoDB.Bson.signed" Version="2.14.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/Jint.Tests.PublicInterface/PublicInterfaceTests.cs
+++ b/Jint.Tests.PublicInterface/PublicInterfaceTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using Jint.Native;
 using Jint.Native.Function;
-using Xunit;
 
 namespace Jint.Tests.PublicInterface
 {

--- a/Jint.Tests.PublicInterface/PublicInterfaceTests.cs
+++ b/Jint.Tests.PublicInterface/PublicInterfaceTests.cs
@@ -1,0 +1,100 @@
+using System.Collections.Concurrent;
+using Jint.Native;
+using Jint.Native.Function;
+using Xunit;
+
+namespace Jint.Tests.PublicInterface
+{
+    public class PublicInterfaceTests
+    {
+
+        [Fact]
+        public void BindFunctionInstancesArePublic()
+        {
+            var engine = new Engine(options =>
+            {
+                options.AllowClr();
+            });
+
+            using var emulator = new SetTimeoutEmulator(engine);
+
+            engine.SetValue("emulator", emulator);
+            engine.Execute(@"
+var coolingObject = {
+    coolDownTime: 1000,
+    cooledDown: false
+}
+
+        emulator.SetTimeout(function() {
+    coolingObject.cooledDown = true;
+    }.bind(coolingObject), coolingObject.coolDownTime);
+
+");
+
+        }
+
+        private class SetTimeoutEmulator : IDisposable
+        {
+            private readonly Engine _engine;
+            private readonly ConcurrentQueue<JsValue> _queue = new();
+            private readonly Task _queueProcessor;
+            private readonly CancellationTokenSource _quit = new();
+            private bool _disposedValue;
+
+            public SetTimeoutEmulator(Engine engine)
+            {
+                _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+
+                _queueProcessor = Task.Run(() =>
+                {
+
+                    while (!_quit.IsCancellationRequested)
+                    {
+                        while (_queue.TryDequeue(out var queueEntry))
+                        {
+                            if (queueEntry is FunctionInstance fi)
+                            {
+                                _engine.Invoke(fi);
+                            }
+                            else if (queueEntry is BindFunctionInstance bfi)
+                            {
+                                _engine.Invoke(bfi);
+                            }
+                            else
+                            {
+                                _engine.Execute(queueEntry.ToString());
+                            }
+                        }
+                    }
+                });
+            }
+
+            public void SetTimeout(JsValue script, object timeout)
+            {
+                _queue.Enqueue(script);
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!_disposedValue)
+                {
+                    if (disposing)
+                    {
+                        // TODO: dispose managed state (managed objects)
+                        _quit.Cancel();
+                        _queueProcessor.Wait();
+                    }
+
+                    _disposedValue = true;
+                }
+            }
+
+            public void Dispose()
+            {
+                // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+                Dispose(disposing: true);
+                GC.SuppressFinalize(this);
+            }
+        }
+    }
+}

--- a/Jint.sln
+++ b/Jint.sln
@@ -13,7 +13,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jint.Tests", "Jint.Tests\Ji
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jint.Tests.CommonScripts", "Jint.Tests.CommonScripts\Jint.Tests.CommonScripts.csproj", "{B815F239-6409-4BA7-9461-18317AA2DBED}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jint.Tests.Test262", "Jint.Tests.Test262\Jint.Tests.Test262.csproj", "{62FFFDBD-AB58-490D-9A50-AA7C53BF0409}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jint.Tests.Test262", "Jint.Tests.Test262\Jint.Tests.Test262.csproj", "{62FFFDBD-AB58-490D-9A50-AA7C53BF0409}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jint.Tests.PublicInterface", "Jint.Tests.PublicInterface\Jint.Tests.PublicInterface.csproj", "{70198CE9-7DFE-40CA-BBAC-1454C92C4109}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +47,10 @@ Global
 		{62FFFDBD-AB58-490D-9A50-AA7C53BF0409}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{62FFFDBD-AB58-490D-9A50-AA7C53BF0409}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{62FFFDBD-AB58-490D-9A50-AA7C53BF0409}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70198CE9-7DFE-40CA-BBAC-1454C92C4109}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70198CE9-7DFE-40CA-BBAC-1454C92C4109}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70198CE9-7DFE-40CA-BBAC-1454C92C4109}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70198CE9-7DFE-40CA-BBAC-1454C92C4109}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Jint/Native/Function/BindFunctionInstance.cs
+++ b/Jint/Native/Function/BindFunctionInstance.cs
@@ -6,7 +6,7 @@ namespace Jint.Native.Function
     /// <summary>
     /// https://tc39.es/ecma262/#sec-bound-function-exotic-objects
     /// </summary>
-    internal sealed class BindFunctionInstance : ObjectInstance, IConstructor, ICallable
+    public sealed class BindFunctionInstance : ObjectInstance, IConstructor, ICallable
     {
         private readonly Realm _realm;
 


### PR DESCRIPTION
Make the BindFunctionInstance class public.  Includes a new unit-test project that contains a valid use case for the bind() function.  Note that a new test project was required since the Jint internals are visible to the existing Jint.Tests project.

fixes #1287