### PR TITLE
Move data from Completion and ExpressionResult to context

### DIFF
--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -10,9 +10,9 @@ public class EngineLimitTests
     public void ShouldAllowReasonableCallStackDepth()
     {
 #if RELEASE
-        const int FunctionNestingCount = 750;
+        const int FunctionNestingCount = 810;
 #else
-        const int FunctionNestingCount = 420;
+        const int FunctionNestingCount = 460;
 #endif
 
         // generate call tree

--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -10,9 +10,9 @@ public class EngineLimitTests
     public void ShouldAllowReasonableCallStackDepth()
     {
 #if RELEASE
-        const int FunctionNestingCount = 740;
+        const int FunctionNestingCount = 750;
 #else
-        const int FunctionNestingCount = 400;
+        const int FunctionNestingCount = 420;
 #endif
 
         // generate call tree

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -150,7 +150,7 @@ namespace Jint
             else if (promise.State == PromiseState.Rejected)
             {
                 var node = EsprimaExtensions.CreateLocationNode(Location.From(new Position(), new Position(), specifier));
-                ExceptionHelper.ThrowJavaScriptException(this, promise.Value, new Completion(CompletionType.Throw, promise.Value, null, node));
+                ExceptionHelper.ThrowJavaScriptException(this, promise.Value, new Completion(CompletionType.Throw, promise.Value, node));
             }
             else if (promise.State != PromiseState.Fulfilled)
             {

--- a/Jint/Runtime/Completion.cs
+++ b/Jint/Runtime/Completion.cs
@@ -4,82 +4,63 @@ using Esprima;
 using Esprima.Ast;
 using Jint.Native;
 
-namespace Jint.Runtime
+namespace Jint.Runtime;
+
+public enum CompletionType : byte
 {
-    public enum CompletionType : byte
+    Normal = 0,
+    Return = 1,
+    Throw = 2,
+    Break,
+    Continue
+}
+
+/// <summary>
+/// https://tc39.es/ecma262/#sec-completion-record-specification-type
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+public readonly struct Completion
+{
+    private static readonly Node _emptyNode = new Identifier("");
+    private static readonly Completion _emptyCompletion = new(CompletionType.Normal, null!, _emptyNode);
+
+    internal readonly SyntaxElement _source;
+
+    public Completion(CompletionType type, JsValue value, SyntaxElement source)
     {
-        Normal = 0,
-        Return = 1,
-        Throw = 2,
-        Break,
-        Continue
+        Type = type;
+        Value = value;
+        _source = source;
+    }
+
+    public readonly CompletionType Type;
+    public readonly JsValue Value;
+    public ref readonly Location Location => ref _source.Location;
+
+    public static ref readonly Completion Empty() => ref _emptyCompletion;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public JsValue GetValueOrDefault()
+    {
+        return Value ?? Undefined.Instance;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsAbrupt()
+    {
+        return Type != CompletionType.Normal;
     }
 
     /// <summary>
-    /// https://tc39.es/ecma262/#sec-completion-record-specification-type
+    /// https://tc39.es/ecma262/#sec-updateempty
     /// </summary>
-    [StructLayout(LayoutKind.Auto)]
-    public readonly struct Completion
+    internal Completion UpdateEmpty(JsValue value)
     {
-        private static readonly Node _emptyNode = new Identifier("");
-        private static readonly Completion _emptyCompletion = new(CompletionType.Normal, null!, _emptyNode);
-
-        internal readonly SyntaxElement _source;
-
-        internal Completion(CompletionType type, JsValue value, string? target, SyntaxElement source)
+        if (Value is not null)
         {
-            Type = type;
-            Value = value;
-            Target = target;
-            _source = source;
+            return this;
         }
 
-        public Completion(CompletionType type, JsValue value, SyntaxElement source)
-        {
-            Type = type;
-            Value = value;
-            Target = null;
-            _source = source;
-        }
-
-        public Completion(CompletionType type, string target, SyntaxElement source)
-        {
-            Type = type;
-            Value = null!;
-            Target = target;
-            _source = source;
-        }
-
-        public readonly CompletionType Type;
-        public readonly JsValue Value;
-        public readonly string? Target;
-        public ref readonly Location Location => ref _source.Location;
-
-        public static ref readonly Completion Empty() => ref _emptyCompletion;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public JsValue GetValueOrDefault()
-        {
-            return Value ?? Undefined.Instance;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IsAbrupt()
-        {
-            return Type != CompletionType.Normal;
-        }
-
-        /// <summary>
-        /// https://tc39.es/ecma262/#sec-updateempty
-        /// </summary>
-        internal Completion UpdateEmpty(JsValue value)
-        {
-            if (Value is not null)
-            {
-                return this;
-            }
-
-            return new Completion(Type, value, Target, _source);
-        }
+        return new Completion(Type, value, _source);
     }
 }

--- a/Jint/Runtime/Completion.cs
+++ b/Jint/Runtime/Completion.cs
@@ -3,7 +3,6 @@ using System.Runtime.InteropServices;
 using Esprima;
 using Esprima.Ast;
 using Jint.Native;
-using Jint.Runtime.Interpreter.Expressions;
 
 namespace Jint.Runtime
 {
@@ -49,15 +48,6 @@ namespace Jint.Runtime
             Value = null!;
             Target = target;
             _source = source;
-        }
-
-        internal Completion(in ExpressionResult result)
-        {
-            Type = (CompletionType) result.Type;
-            // this cast protects us from getting from type
-            Value = (JsValue) result.Value;
-            Target = null;
-            _source = result._source;
         }
 
         public readonly CompletionType Type;

--- a/Jint/Runtime/Environments/ExecutionContext.cs
+++ b/Jint/Runtime/Environments/ExecutionContext.cs
@@ -1,67 +1,68 @@
+using System.Runtime.InteropServices;
 using Jint.Native.Function;
 
-namespace Jint.Runtime.Environments
+namespace Jint.Runtime.Environments;
+
+[StructLayout(LayoutKind.Auto)]
+internal readonly struct ExecutionContext
 {
-    internal readonly struct ExecutionContext
+    internal ExecutionContext(
+        IScriptOrModule? scriptOrModule,
+        EnvironmentRecord lexicalEnvironment,
+        EnvironmentRecord variableEnvironment,
+        PrivateEnvironmentRecord? privateEnvironment,
+        Realm realm,
+        FunctionInstance? function = null)
     {
-        internal ExecutionContext(
-            IScriptOrModule? scriptOrModule,
-            EnvironmentRecord lexicalEnvironment,
-            EnvironmentRecord variableEnvironment,
-            PrivateEnvironmentRecord? privateEnvironment,
-            Realm realm,
-            FunctionInstance? function = null)
-        {
-            ScriptOrModule = scriptOrModule;
-            LexicalEnvironment = lexicalEnvironment;
-            VariableEnvironment = variableEnvironment;
-            PrivateEnvironment = privateEnvironment;
-            Realm = realm;
-            Function = function;
-        }
+        ScriptOrModule = scriptOrModule;
+        LexicalEnvironment = lexicalEnvironment;
+        VariableEnvironment = variableEnvironment;
+        PrivateEnvironment = privateEnvironment;
+        Realm = realm;
+        Function = function;
+    }
 
-        public readonly IScriptOrModule? ScriptOrModule;
-        public readonly EnvironmentRecord LexicalEnvironment;
-        public readonly EnvironmentRecord VariableEnvironment;
-        public readonly PrivateEnvironmentRecord? PrivateEnvironment;
-        public readonly Realm Realm;
-        public readonly FunctionInstance? Function;
+    public readonly IScriptOrModule? ScriptOrModule;
+    public readonly EnvironmentRecord LexicalEnvironment;
+    public readonly EnvironmentRecord VariableEnvironment;
+    public readonly PrivateEnvironmentRecord? PrivateEnvironment;
+    public readonly Realm Realm;
+    public readonly FunctionInstance? Function;
 
-        public ExecutionContext UpdateLexicalEnvironment(EnvironmentRecord lexicalEnvironment)
-        {
-            return new ExecutionContext(ScriptOrModule, lexicalEnvironment, VariableEnvironment, PrivateEnvironment, Realm, Function);
-        }
+    public ExecutionContext UpdateLexicalEnvironment(EnvironmentRecord lexicalEnvironment)
+    {
+        return new ExecutionContext(ScriptOrModule, lexicalEnvironment, VariableEnvironment, PrivateEnvironment, Realm, Function);
+    }
 
-        public ExecutionContext UpdateVariableEnvironment(EnvironmentRecord variableEnvironment)
-        {
-            return new ExecutionContext(ScriptOrModule, LexicalEnvironment, variableEnvironment, PrivateEnvironment, Realm, Function);
-        }
+    public ExecutionContext UpdateVariableEnvironment(EnvironmentRecord variableEnvironment)
+    {
+        return new ExecutionContext(ScriptOrModule, LexicalEnvironment, variableEnvironment, PrivateEnvironment, Realm, Function);
+    }
 
-        public ExecutionContext UpdatePrivateEnvironment(PrivateEnvironmentRecord? privateEnvironment)
-        {
-            return new ExecutionContext(ScriptOrModule, LexicalEnvironment, VariableEnvironment, privateEnvironment, Realm, Function);
-        }
+    public ExecutionContext UpdatePrivateEnvironment(PrivateEnvironmentRecord? privateEnvironment)
+    {
+        return new ExecutionContext(ScriptOrModule, LexicalEnvironment, VariableEnvironment, privateEnvironment, Realm, Function);
+    }
 
-        /// <summary>
-        /// https://tc39.es/ecma262/#sec-getthisenvironment
-        /// </summary>
-        internal EnvironmentRecord GetThisEnvironment()
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-getthisenvironment
+    /// </summary>
+    internal EnvironmentRecord GetThisEnvironment()
+    {
+        // The loop will always terminate because the list of environments always
+        // ends with the global environment which has a this binding.
+        var lex = LexicalEnvironment;
+        while (true)
         {
-            // The loop will always terminate because the list of environments always
-            // ends with the global environment which has a this binding.
-            var lex = LexicalEnvironment;
-            while (true)
+            if (lex != null)
             {
-                if (lex != null)
+                if (lex.HasThisBinding())
                 {
-                    if (lex.HasThisBinding())
-                    {
-                        return lex;
+                    return lex;
 
-                    }
-
-                    lex = lex._outerEnv;
                 }
+
+                lex = lex._outerEnv;
             }
         }
     }

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Esprima.Ast;
 
 namespace Jint.Runtime.Interpreter;
@@ -24,11 +25,23 @@ internal sealed class EvaluationContext
     public SyntaxElement LastSyntaxElement = null!;
     public readonly bool OperatorOverloadingAllowed;
 
+    // completion record information
+    public string? Target;
+    public CompletionType Completion;
+
     public void RunBeforeExecuteStatementChecks(Statement statement)
     {
         if (_shouldRunBeforeExecuteStatementChecks)
         {
             Engine.RunBeforeExecuteStatementChecks(statement);
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void PrepareFor(Node node)
+    {
+        LastSyntaxElement = node;
+        Target = null;
+        Completion = CompletionType.Normal;
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -415,7 +415,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     }
 
                     environmentRecord.SetMutableBinding(left.Identifier, rval, strict);
-                    return ExpressionResult.Normal(rval, completion._source);
+                    return ExpressionResult.Normal(rval);
                 }
 
                 return null;

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -17,28 +17,25 @@ namespace Jint.Runtime.Interpreter.Expressions
     [StructLayout(LayoutKind.Auto)]
     internal readonly struct ExpressionResult
     {
-        internal readonly SyntaxElement _source;
-
         public readonly ExpressionCompletionType Type;
         public readonly object Value;
 
-        public ExpressionResult(ExpressionCompletionType type, object value, SyntaxElement source)
+        public ExpressionResult(ExpressionCompletionType type, object value)
         {
             Type = type;
             Value = value;
-            _source = source;
         }
 
         public bool IsAbrupt() => Type != ExpressionCompletionType.Normal && Type != ExpressionCompletionType.Reference;
 
         public static implicit operator ExpressionResult(in Completion result)
         {
-            return new ExpressionResult((ExpressionCompletionType) result.Type, result.Value, result._source);
+            return new ExpressionResult((ExpressionCompletionType) result.Type, result.Value);
         }
 
-        public static ExpressionResult? Normal(JsValue value, SyntaxElement source)
+        public static ExpressionResult? Normal(JsValue value)
         {
-            return new ExpressionResult(ExpressionCompletionType.Normal, value, source);
+            return new ExpressionResult(ExpressionCompletionType.Normal, value);
         }
     }
 
@@ -73,11 +70,11 @@ namespace Jint.Runtime.Interpreter.Expressions
             var result = Evaluate(context);
             if (result.Type != ExpressionCompletionType.Reference)
             {
-                return new Completion((CompletionType) result.Type, (JsValue) result.Value, result._source);
+                return new Completion((CompletionType) result.Type, (JsValue) result.Value, context.LastSyntaxElement);
             }
 
             var jsValue = context.Engine.GetValue((Reference) result.Value, true);
-            return new Completion(CompletionType.Normal, jsValue, null, _expression);
+            return new Completion(CompletionType.Normal, jsValue, null, context.LastSyntaxElement);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -112,12 +109,12 @@ namespace Jint.Runtime.Interpreter.Expressions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected ExpressionResult NormalCompletion(JsValue value)
         {
-            return new ExpressionResult(ExpressionCompletionType.Normal, value, _expression);
+            return new ExpressionResult(ExpressionCompletionType.Normal, value);
         }
 
         protected ExpressionResult NormalCompletion(Reference value)
         {
-            return new ExpressionResult(ExpressionCompletionType.Reference, value, _expression);
+            return new ExpressionResult(ExpressionCompletionType.Reference, value);
         }
 
         /// <summary>
@@ -130,7 +127,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected ExpressionResult ThrowCompletion(JsValue value)
         {
-            return new ExpressionResult(ExpressionCompletionType.Throw, value, _expression);
+            return new ExpressionResult(ExpressionCompletionType.Throw, value);
         }
 
         /// <summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -74,13 +74,14 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
 
             var jsValue = context.Engine.GetValue((Reference) result.Value, true);
-            return new Completion(CompletionType.Normal, jsValue, null, context.LastSyntaxElement);
+            return new Completion(CompletionType.Normal, jsValue, context.LastSyntaxElement);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ExpressionResult Evaluate(EvaluationContext context)
         {
-            context.LastSyntaxElement = _expression;
+            context.PrepareFor(_expression);
+
             if (!_initialized)
             {
                 Initialize(context);

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -113,10 +113,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 : TypeConverter.ToPropertyKey(property);
 
             var rent = context.Engine._referencePool.Rent(baseValue, propertyKey, isStrictModeCode, thisValue: actualThis);
-            return new ExpressionResult(
-                ExpressionCompletionType.Reference,
-                rent,
-                _expression);
+            return new ExpressionResult(ExpressionCompletionType.Reference, rent);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -40,7 +40,7 @@ internal sealed class JintFunctionDefinition
             // https://tc39.es/ecma262/#sec-runtime-semantics-evaluateconcisebody
             _bodyExpression ??= JintExpression.Build(context.Engine, (Expression) Function.Body);
             var jsValue = _bodyExpression.GetValue(context).GetValueOrDefault().Clone();
-            result = new Completion(CompletionType.Return, jsValue, null, Function.Body);
+            result = new Completion(CompletionType.Return, jsValue, Function.Body);
         }
         else if (Function.Generator)
         {

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -96,11 +96,7 @@ namespace Jint.Runtime.Interpreter
 
                     if (c.Type != CompletionType.Normal)
                     {
-                        return new Completion(
-                            c.Type,
-                            c.Value ?? sl.Value!,
-                            c.Target,
-                            c._source);
+                        return new Completion(c.Type, c.Value ?? sl.Value!, c._source);
                     }
                     sl = c;
                     if (c.Value is not null)
@@ -119,7 +115,7 @@ namespace Jint.Runtime.Interpreter
                 throw;
             }
 
-            return new Completion(c.Type, lastValue ?? JsValue.Undefined, c.Target, c._source!);
+            return new Completion(c.Type, lastValue ?? JsValue.Undefined, c._source!);
         }
 
         private static Completion HandleException(EvaluationContext context, Exception exception, JintStatement? s)
@@ -144,7 +140,7 @@ namespace Jint.Runtime.Interpreter
         private static Completion CreateThrowCompletion(ErrorConstructor errorConstructor, Exception e, JintStatement s)
         {
             var error = errorConstructor.Construct(new JsValue[] { e.Message });
-            return new Completion(CompletionType.Throw, error, null, s._statement);
+            return new Completion(CompletionType.Throw, error, s._statement);
         }
 
         private static Completion CreateThrowCompletion(JintStatement? s, JavaScriptException v)
@@ -155,7 +151,7 @@ namespace Jint.Runtime.Interpreter
                 source = EsprimaExtensions.CreateLocationNode(v.Location);
             }
 
-            return new Completion(CompletionType.Throw, v.Error, null, source);
+            return new Completion(CompletionType.Throw, v.Error, source);
         }
 
         /// <summary>

--- a/Jint/Runtime/Interpreter/Statements/JintBreakStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBreakStatement.cs
@@ -1,22 +1,19 @@
 using Esprima.Ast;
 
-namespace Jint.Runtime.Interpreter.Statements
+namespace Jint.Runtime.Interpreter.Statements;
+
+/// <summary>
+/// http://www.ecma-international.org/ecma-262/5.1/#sec-12.8
+/// </summary>
+internal sealed class JintBreakStatement : JintStatement<BreakStatement>
 {
-    /// <summary>
-    /// http://www.ecma-international.org/ecma-262/5.1/#sec-12.8
-    /// </summary>
-    internal sealed class JintBreakStatement : JintStatement<BreakStatement>
+    public JintBreakStatement(BreakStatement statement) : base(statement)
     {
-        private readonly string? _label;
+    }
 
-        public JintBreakStatement(BreakStatement statement) : base(statement)
-        {
-            _label = statement.Label?.Name;
-        }
-
-        protected override Completion ExecuteInternal(EvaluationContext context)
-        {
-            return new Completion(CompletionType.Break, null!, _label, _statement);
-        }
+    protected override Completion ExecuteInternal(EvaluationContext context)
+    {
+        context.Target = _statement.Label?.Name;
+        return new Completion(CompletionType.Break, null!, _statement);
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintClassDeclarationStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintClassDeclarationStatement.cs
@@ -29,7 +29,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 env.InitializeBinding(classBinding, completion.Value);
             }
 
-            return new Completion(CompletionType.Normal, null!, null, _statement);
+            return new Completion(CompletionType.Normal, null!, _statement);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintContinueStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintContinueStatement.cs
@@ -1,22 +1,19 @@
 using Esprima.Ast;
 
-namespace Jint.Runtime.Interpreter.Statements
+namespace Jint.Runtime.Interpreter.Statements;
+
+/// <summary>
+/// http://www.ecma-international.org/ecma-262/5.1/#sec-12.7
+/// </summary>
+internal sealed class JintContinueStatement : JintStatement<ContinueStatement>
 {
-    /// <summary>
-    /// http://www.ecma-international.org/ecma-262/5.1/#sec-12.7
-    /// </summary>
-    internal sealed class JintContinueStatement : JintStatement<ContinueStatement>
+    public JintContinueStatement(ContinueStatement statement) : base(statement)
     {
-        private readonly string? _labelName;
+    }
 
-        public JintContinueStatement(ContinueStatement statement) : base(statement)
-        {
-            _labelName = _statement.Label?.Name;
-        }
-
-        protected override Completion ExecuteInternal(EvaluationContext context)
-        {
-            return new Completion(CompletionType.Continue, _labelName!, _statement);
-        }
+    protected override Completion ExecuteInternal(EvaluationContext context)
+    {
+        context.Target = _statement.Label?.Name;
+        return new Completion(CompletionType.Continue, null!, _statement);
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintDebuggerStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDebuggerStatement.cs
@@ -29,7 +29,7 @@ namespace Jint.Runtime.Interpreter.Statements
                     break;
             }
 
-            return new Completion(CompletionType.Normal, null!, null, _statement);
+            return new Completion(CompletionType.Normal, null!, _statement);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -37,11 +37,11 @@ namespace Jint.Runtime.Interpreter.Statements
                     v = completion.Value;
                 }
 
-                if (completion.Type != CompletionType.Continue || completion.Target != _labelSetName)
+                if (completion.Type != CompletionType.Continue || context.Target != _labelSetName)
                 {
-                    if (completion.Type == CompletionType.Break && (completion.Target == null || completion.Target == _labelSetName))
+                    if (completion.Type == CompletionType.Break && (context.Target == null || context.Target == _labelSetName))
                     {
-                        return new Completion(CompletionType.Normal, v, null, _statement);
+                        return new Completion(CompletionType.Normal, v, _statement);
                     }
 
                     if (completion.Type != CompletionType.Normal)

--- a/Jint/Runtime/Interpreter/Statements/JintEmptyStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintEmptyStatement.cs
@@ -1,16 +1,15 @@
 using Esprima.Ast;
 
-namespace Jint.Runtime.Interpreter.Statements
-{
-    internal sealed class JintEmptyStatement : JintStatement<EmptyStatement>
-    {
-        public JintEmptyStatement(EmptyStatement statement) : base(statement)
-        {
-        }
+namespace Jint.Runtime.Interpreter.Statements;
 
-        protected override Completion ExecuteInternal(EvaluationContext context)
-        {
-            return new Completion(CompletionType.Normal, null!, null, _statement);
-        }
+internal sealed class JintEmptyStatement : JintStatement<EmptyStatement>
+{
+    public JintEmptyStatement(EmptyStatement statement) : base(statement)
+    {
+    }
+
+    protected override Completion ExecuteInternal(EvaluationContext context)
+    {
+        return new Completion(CompletionType.Normal, null!, _statement);
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -203,7 +203,7 @@ namespace Jint.Runtime.Interpreter.Statements
                         {
                             var identifier = (Identifier) ((VariableDeclaration) _leftNode).Declarations[0].Id;
                             lhsName ??= identifier.Name;
-                            lhsRef = new ExpressionResult(ExpressionCompletionType.Normal, engine.ResolveBinding(lhsName), identifier);
+                            lhsRef = new ExpressionResult(ExpressionCompletionType.Normal, engine.ResolveBinding(lhsName));
                         }
                     }
 
@@ -218,7 +218,7 @@ namespace Jint.Runtime.Interpreter.Statements
                         if (lhsRef.IsAbrupt())
                         {
                             close = true;
-                            status = new Completion(lhsRef);
+                            status = new Completion((CompletionType) lhsRef.Type, (JsValue) lhsRef.Value!, context.LastSyntaxElement);
                         }
                         else if (lhsKind == LhsKind.LexicalBinding)
                         {

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -95,7 +95,7 @@ namespace Jint.Runtime.Interpreter.Statements
         {
             if (!HeadEvaluation(context, out var keyResult))
             {
-                return new Completion(CompletionType.Normal, JsValue.Undefined, null, _statement);
+                return new Completion(CompletionType.Normal, JsValue.Undefined, _statement);
             }
 
             return BodyEvaluation(context, _expr, _body, keyResult, IterationKind.Enumerate, _lhsKind);
@@ -170,7 +170,7 @@ namespace Jint.Runtime.Interpreter.Statements
                     if (!iteratorRecord.TryIteratorStep(out var nextResult))
                     {
                         close = true;
-                        return new Completion(CompletionType.Normal, v, null, _statement!);
+                        return new Completion(CompletionType.Normal, v, _statement!);
                     }
 
                     if (iteratorKind == IteratorKind.Async)
@@ -278,13 +278,13 @@ namespace Jint.Runtime.Interpreter.Statements
                         v = result.Value;
                     }
 
-                    if (result.Type == CompletionType.Break && (result.Target == null || result.Target == _statement?.LabelSet?.Name))
+                    if (result.Type == CompletionType.Break && (context.Target == null || context.Target == _statement?.LabelSet?.Name))
                     {
                         completionType = CompletionType.Normal;
-                        return new Completion(CompletionType.Normal, v, null, _statement!);
+                        return new Completion(CompletionType.Normal, v, _statement!);
                     }
 
-                    if (result.Type != CompletionType.Continue || (result.Target != null && result.Target != _statement?.LabelSet?.Name))
+                    if (result.Type != CompletionType.Continue || (context.Target != null && context.Target != _statement?.LabelSet?.Name))
                     {
                         completionType = result.Type;
                         if (result.IsAbrupt())

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -141,12 +141,12 @@ namespace Jint.Runtime.Interpreter.Statements
                     v = result.Value;
                 }
 
-                if (result.Type == CompletionType.Break && (result.Target == null || result.Target == _statement?.LabelSet?.Name))
+                if (result.Type == CompletionType.Break && (context.Target == null || context.Target == _statement?.LabelSet?.Name))
                 {
                     return new Completion(CompletionType.Normal, result.Value!, ((JintStatement) this)._statement);
                 }
 
-                if (result.Type != CompletionType.Continue || (result.Target != null && result.Target != _statement?.LabelSet?.Name))
+                if (result.Type != CompletionType.Continue || (context.Target != null && context.Target != _statement?.LabelSet?.Name))
                 {
                     if (result.Type != CompletionType.Normal)
                     {

--- a/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
@@ -33,7 +33,7 @@ namespace Jint.Runtime.Interpreter.Statements
             }
             else
             {
-                return new Completion(CompletionType.Normal, null!, _statement);
+                result = new Completion(CompletionType.Normal, null!, _statement);
             }
 
             return result;

--- a/Jint/Runtime/Interpreter/Statements/JintLabeledStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintLabeledStatement.cs
@@ -23,10 +23,10 @@ namespace Jint.Runtime.Interpreter.Statements
             // containing label and could keep a table per program with all the labels
             // labeledStatement.Body.LabelSet = labeledStatement.Label;
             var result = _body.Execute(context);
-            if (result.Type == CompletionType.Break && result.Target == _labelName)
+            if (result.Type == CompletionType.Break && context.Target == _labelName)
             {
                 var value = result.Value;
-                return new Completion(CompletionType.Normal, value, null, _statement);
+                return new Completion(CompletionType.Normal, value, _statement);
             }
 
             return result;

--- a/Jint/Runtime/Interpreter/Statements/JintReturnStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintReturnStatement.cs
@@ -2,30 +2,29 @@ using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.Interpreter.Expressions;
 
-namespace Jint.Runtime.Interpreter.Statements
+namespace Jint.Runtime.Interpreter.Statements;
+
+/// <summary>
+/// http://www.ecma-international.org/ecma-262/5.1/#sec-12.9
+/// </summary>
+internal sealed class JintReturnStatement : JintStatement<ReturnStatement>
 {
-    /// <summary>
-    /// http://www.ecma-international.org/ecma-262/5.1/#sec-12.9
-    /// </summary>
-    internal sealed class JintReturnStatement : JintStatement<ReturnStatement>
+    private JintExpression? _argument;
+
+    public JintReturnStatement(ReturnStatement statement) : base(statement)
     {
-        private JintExpression? _argument;
+    }
 
-        public JintReturnStatement(ReturnStatement statement) : base(statement)
-        {
-        }
+    protected override void Initialize(EvaluationContext context)
+    {
+        _argument = _statement.Argument != null
+            ? JintExpression.Build(context.Engine, _statement.Argument)
+            : null;
+    }
 
-        protected override void Initialize(EvaluationContext context)
-        {
-            _argument = _statement.Argument != null
-                ? JintExpression.Build(context.Engine, _statement.Argument)
-                : null;
-        }
-
-        protected override Completion ExecuteInternal(EvaluationContext context)
-        {
-            var jsValue = _argument?.GetValue(context).Value ?? Undefined.Instance;
-            return new Completion(CompletionType.Return, jsValue, null, _statement);
-        }
+    protected override Completion ExecuteInternal(EvaluationContext context)
+    {
+        var jsValue = _argument?.GetValue(context).Value ?? Undefined.Instance;
+        return new Completion(CompletionType.Return, jsValue, _statement);
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -31,7 +31,7 @@ namespace Jint.Runtime.Interpreter.Statements
         {
             if (_statement.Type != Nodes.BlockStatement)
             {
-                context.LastSyntaxElement = _statement;
+                context.PrepareFor(_statement);
                 context.RunBeforeExecuteStatementChecks(_statement);
             }
 
@@ -110,7 +110,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 var jsValue = JintLiteralExpression.ConvertToJsValue(l);
                 if (jsValue is not null)
                 {
-                    return new Completion(CompletionType.Return, jsValue, null, rs);
+                    return new Completion(CompletionType.Return, jsValue, rs);
                 }
             }
 

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
@@ -112,7 +112,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 v = r.Value ?? Undefined.Instance;
             }
 
-            return new Completion(CompletionType.Normal, v, null, l);
+            return new Completion(CompletionType.Normal, v, l);
         }
 
         private sealed class JintSwitchCase

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchStatement.cs
@@ -26,7 +26,7 @@ namespace Jint.Runtime.Interpreter.Statements
         {
             var value = _discriminant.GetValue(context).Value;
             var r = _switchBlock.Execute(context, value);
-            if (r.Type == CompletionType.Break && r.Target == _statement.LabelSet?.Name)
+            if (r.Type == CompletionType.Break && context.Target == _statement.LabelSet?.Name)
             {
                 return new Completion(CompletionType.Normal, r.Value, ((JintStatement) this)._statement);
             }

--- a/Jint/Runtime/Interpreter/Statements/JintThrowStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintThrowStatement.cs
@@ -22,7 +22,7 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
             var completion = _argument.GetValue(context);
-            return new Completion(CompletionType.Throw, completion.Value, null, completion._source);
+            return new Completion(CompletionType.Throw, completion.Value, completion._source);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
@@ -37,7 +37,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 var jsValue = _test.GetValue(context).Value;
                 if (!TypeConverter.ToBoolean(jsValue))
                 {
-                    return new Completion(CompletionType.Normal, v, null, _statement);
+                    return new Completion(CompletionType.Normal, v, _statement);
                 }
 
                 var completion = _body.Execute(context);
@@ -47,11 +47,11 @@ namespace Jint.Runtime.Interpreter.Statements
                     v = completion.Value;
                 }
 
-                if (completion.Type != CompletionType.Continue || completion.Target != _labelSetName)
+                if (completion.Type != CompletionType.Continue || context.Target != _labelSetName)
                 {
-                    if (completion.Type == CompletionType.Break && (completion.Target == null || completion.Target == _labelSetName))
+                    if (completion.Type == CompletionType.Break && (context.Target == null || context.Target == _labelSetName))
                     {
-                        return new Completion(CompletionType.Normal, v, null, _statement);
+                        return new Completion(CompletionType.Normal, v, _statement);
                     }
 
                     if (completion.Type != CompletionType.Normal)

--- a/Jint/Runtime/Interpreter/Statements/ProbablyBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/ProbablyBlockStatement.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Esprima.Ast;
 
 namespace Jint.Runtime.Interpreter.Statements;
@@ -7,6 +8,7 @@ namespace Jint.Runtime.Interpreter.Statements;
 /// Helper to remove virtual dispatch from block statements when it's most common target.
 /// This is especially true for things like for statements body
 /// </summary>
+[StructLayout(LayoutKind.Auto)]
 internal readonly struct ProbablyBlockStatement
 {
     private readonly JintStatement  _target;

--- a/Jint/Runtime/Modules/CyclicModuleRecord.cs
+++ b/Jint/Runtime/Modules/CyclicModuleRecord.cs
@@ -256,7 +256,7 @@ public abstract class CyclicModuleRecord : ModuleRecord
         {
             if (_evalError is null)
             {
-                return new Completion(CompletionType.Normal, index, null, default);
+                return new Completion(CompletionType.Normal, index, default);
             }
 
             return _evalError.Value;
@@ -264,7 +264,7 @@ public abstract class CyclicModuleRecord : ModuleRecord
 
         if (Status == ModuleStatus.Evaluating)
         {
-            return new Completion(CompletionType.Normal, index, null, default);
+            return new Completion(CompletionType.Normal, index, default);
         }
 
         if (Status != ModuleStatus.Linked)
@@ -527,7 +527,7 @@ public abstract class CyclicModuleRecord : ModuleRecord
             ExceptionHelper.ThrowInvalidOperationException("Error while evaluating module: Module is in an invalid state");
         }
 
-        module._evalError = new Completion(CompletionType.Throw, error, null, default);
+        module._evalError = new Completion(CompletionType.Throw, error, default);
         module.Status = ModuleStatus.Evaluated;
 
         var asyncParentModules = module._asyncParentModules;

--- a/Jint/StrictModeScope.cs
+++ b/Jint/StrictModeScope.cs
@@ -1,12 +1,15 @@
+using System.Runtime.InteropServices;
+
 namespace Jint
 {
+    [StructLayout(LayoutKind.Auto)]
     public readonly struct StrictModeScope : IDisposable
     {
         private readonly bool _strict;
         private readonly bool _force;
         private readonly ushort _forcedRefCount;
 
-        [ThreadStatic] 
+        [ThreadStatic]
         private static ushort _refCount;
 
         public StrictModeScope(bool strict = true, bool force = false)
@@ -40,7 +43,7 @@ namespace Jint
             if (_force)
             {
                 _refCount = _forcedRefCount;
-            } 
+            }
         }
 
         public static bool IsStrictModeCode => _refCount > 0;


### PR DESCRIPTION
Small steps towards returning data using context instead of structs. `Target` is a prime example of returning possible jump instruction via completion which is not needed in 99% of the cases.

Tests seem to have quite the jitter, but show that we are moving to the right direction.

## Jint.Benchmark.DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Run|dromaeo-3d-cube|27.893 ms|0.0420 ms|7166.38 KB|
| **New** |	|	| **26.489 ms (-5%)** | **0.0326 ms** | **7164.43 KB (0%)** |
| Old |Run|dromaeo-core-eval|7.049 ms|0.0172 ms|320.64 KB|
| **New** |	|	| **7.304 ms (+4%)** | **0.0526 ms** | **319.54 KB (0%)** |
| Old |Run|dromaeo-object-array|81.914 ms|0.3203 ms|106133.43 KB|
| **New** |	|	| **84.156 ms (+3%)** | **0.1687 ms** | **106134.6 KB (0%)** |
| Old |Run|droma(...)egexp [21]|315.073 ms|6.1587 ms|235918.41 KB|
| **New** |	|	| **307.709 ms (-2%)** | **2.6667 ms** | **234367.11 KB (-1%)** |
| Old |Run|droma(...)tring [21]|468.829 ms|34.3012 ms|1331640.95 KB|
| **New** |	|	| **438.789 ms (-6%)** | **31.2505 ms** | **1331443.9 KB (0%)** |
| Old |Run|droma(...)ase64 [21]|75.731 ms|0.6149 ms|7789.08 KB|
| **New** |	|	| **72.038 ms (-5%)** | **0.1586 ms** | **7790.63 KB (0%)** |
| Old |Run|dromaeo-3d-cube|26.340 ms|0.0479 ms|6871.89 KB|
| **New** |	|	| **25.802 ms (-2%)** | **0.0327 ms** | **6869.94 KB (0%)** |
| Old |Run|dromaeo-core-eval|7.048 ms|0.0177 ms|308 KB|
| **New** |	|	| **7.690 ms (+9%)** | **0.0231 ms** | **306.9 KB (0%)** |
| Old |Run|dromaeo-object-array|84.917 ms|0.2181 ms|106094.9 KB|
| **New** |	|	| **81.887 ms (-4%)** | **0.2789 ms** | **106095.02 KB (0%)** |
| Old |Run|droma(...)egexp [21]|313.301 ms|6.1554 ms|234390.18 KB|
| **New** |	|	| **308.210 ms (-2%)** | **2.1133 ms** | **242594.01 KB (+4%)** |
| Old |Run|droma(...)tring [21]|433.911 ms|32.3667 ms|1331568.45 KB|
| **New** |	|	| **400.063 ms (-8%)** | **18.8510 ms** | **1331583.32 KB (0%)** |
| Old |Run|droma(...)ase64 [21]|75.744 ms|0.3382 ms|7701.19 KB|
| **New** |	|	| **69.859 ms (-8%)** | **0.1002 ms** | **7701.22 KB (0%)** |