### PR TITLE
Remove ExpressionResult

### DIFF
--- a/Jint.Tests.Test262/Test262ModuleLoader.cs
+++ b/Jint.Tests.Test262/Test262ModuleLoader.cs
@@ -53,7 +53,7 @@ internal sealed class Test262ModuleLoader : IModuleLoader
         catch (Exception ex)
         {
             var message = $"Could not load module {resolved.Uri?.LocalPath}: {ex.Message}";
-            ExceptionHelper.ThrowJavaScriptException(engine, message, Completion.Empty());
+            ExceptionHelper.ThrowJavaScriptException(engine, message, (Location) default);
             module = null;
         }
 

--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -10,9 +10,9 @@ public class EngineLimitTests
     public void ShouldAllowReasonableCallStackDepth()
     {
 #if RELEASE
-        const int FunctionNestingCount = 810;
+        const int FunctionNestingCount = 990;
 #else
-        const int FunctionNestingCount = 460;
+        const int FunctionNestingCount = 570;
 #endif
 
         // generate call tree

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -150,7 +150,7 @@ namespace Jint
             else if (promise.State == PromiseState.Rejected)
             {
                 var node = EsprimaExtensions.CreateLocationNode(Location.From(new Position(), new Position(), specifier));
-                ExceptionHelper.ThrowJavaScriptException(this, promise.Value, new Completion(CompletionType.Throw, promise.Value, node));
+                ExceptionHelper.ThrowJavaScriptException(this, promise.Value, node.Location);
             }
             else if (promise.State != PromiseState.Fulfilled)
             {

--- a/Jint/EsprimaExtensions.cs
+++ b/Jint/EsprimaExtensions.cs
@@ -18,22 +18,22 @@ namespace Jint
 
         public static JsValue GetKey(this Expression expression, Engine engine, bool resolveComputed = false)
         {
-            var completion = TryGetKey(expression, engine, resolveComputed);
-            if (completion.Value is not null)
+            var key = TryGetKey(expression, engine, resolveComputed);
+            if (key is not null)
             {
-                return TypeConverter.ToPropertyKey(completion.Value);
+                return TypeConverter.ToPropertyKey(key);
             }
 
             ExceptionHelper.ThrowArgumentException("Unable to extract correct key, node type: " + expression.Type);
             return JsValue.Undefined;
         }
 
-        internal static Completion TryGetKey<T>(this T property, Engine engine) where T : IProperty
+        internal static JsValue TryGetKey<T>(this T property, Engine engine) where T : IProperty
         {
             return TryGetKey(property.Key, engine, property.Computed);
         }
 
-        internal static Completion TryGetKey<T>(this T expression, Engine engine, bool resolveComputed) where T : Expression
+        internal static JsValue TryGetKey<T>(this T expression, Engine engine, bool resolveComputed) where T : Expression
         {
             JsValue key;
             if (expression is Literal literal)
@@ -52,10 +52,10 @@ namespace Jint
             {
                 key = JsValue.Undefined;
             }
-            return new Completion(CompletionType.Normal, key, expression);
+            return key;
         }
 
-        private static Completion TryGetComputedPropertyKey<T>(T expression, Engine engine)
+        private static JsValue TryGetComputedPropertyKey<T>(T expression, Engine engine)
             where T : Expression
         {
             if (expression.Type is Nodes.Identifier
@@ -75,7 +75,7 @@ namespace Jint
                 return JintExpression.Build(engine, expression).GetValue(context!);
             }
 
-            return new Completion(CompletionType.Normal, JsValue.Undefined, expression);
+            return JsValue.Undefined;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Runtime/Environments/FunctionEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/FunctionEnvironmentRecord.cs
@@ -229,7 +229,7 @@ namespace Jint.Runtime.Environments
                         else if (p.Key is CallExpression callExpression)
                         {
                             var jintCallExpression = new JintCallExpression(callExpression);
-                            var jsValue = jintCallExpression.GetValue(context).Value;
+                            var jsValue = jintCallExpression.GetValue(context);
                             propertyName = TypeConverter.ToJsString(jsValue);
                         }
                         else
@@ -368,7 +368,7 @@ namespace Jint.Runtime.Environments
                 _engine.EnterExecutionContext(new ExecutionContext(null, paramVarEnv, paramVarEnv, null, _engine.Realm, null));
                 try
                 {
-                    argument = jintExpression.GetValue(context).Value;
+                    argument = jintExpression.GetValue(context);
                 }
                 finally
                 {

--- a/Jint/Runtime/ExceptionHelper.cs
+++ b/Jint/Runtime/ExceptionHelper.cs
@@ -144,15 +144,15 @@ namespace Jint.Runtime
         }
 
         [DoesNotReturn]
-        public static void ThrowJavaScriptException(ErrorConstructor errorConstructor, string message)
+        public static void ThrowJavaScriptException(Engine engine, JsValue value, in Location location)
         {
-            throw new JavaScriptException(errorConstructor, message);
+            throw new JavaScriptException(value).SetJavaScriptCallstack(engine, location);
         }
 
         [DoesNotReturn]
-        public static void ThrowJavaScriptException(ErrorConstructor errorConstructor, string message, Engine engine, Location location)
+        public static void ThrowJavaScriptException(ErrorConstructor errorConstructor, string message)
         {
-            throw new JavaScriptException(errorConstructor, message).SetJavaScriptCallstack(engine, location);
+            throw new JavaScriptException(errorConstructor, message);
         }
 
         [DoesNotReturn]

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -44,4 +44,7 @@ internal sealed class EvaluationContext
         Target = null;
         Completion = CompletionType.Normal;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsAbrupt() => Completion != CompletionType.Normal;
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
@@ -35,7 +35,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             _initialized = true;
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             var engine = context.Engine;
             var a = engine.Realm.Intrinsics.Array.ArrayCreate(_hasSpreads ? 0 : (uint) _expressions.Length);
@@ -71,7 +71,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
                 else
                 {
-                    var value = expr.GetValue(context).Value;
+                    var value = expr.GetValue(context);
                     a.SetIndexValue(arrayIndexCounter++, value, updateLength: false);
                 }
             }
@@ -81,7 +81,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 a.SetLength(arrayIndexCounter);
             }
 
-            return NormalCompletion(a);
+            return a;
         }
 
         private sealed class ArraySpreadProtocol : IteratorProtocol

--- a/Jint/Runtime/Interpreter/Expressions/JintArrowFunctionExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintArrowFunctionExpression.cs
@@ -13,7 +13,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             _function = new JintFunctionDefinition(function);
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             var engine = context.Engine;
             var scope = engine.ExecutionContext.LexicalEnvironment;
@@ -30,7 +30,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 closure.SetFunctionName(JsString.Empty);
             }
 
-            return NormalCompletion(closure);
+            return closure;
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -35,9 +35,9 @@ namespace Jint.Runtime.Interpreter.Expressions
             return new JintAssignmentExpression(engine, expression);
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
-            var lref = _left.Evaluate(context).Value as Reference;
+            var lref = _left.Evaluate(context) as Reference;
             if (lref is null)
             {
                 ExceptionHelper.ThrowReferenceError(context.Engine.Realm, "not a valid reference");
@@ -93,7 +93,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                 if (operatorClrName != null)
                 {
-                    var rval = _right.GetValue(context).Value;
+                    var rval = _right.GetValue(context);
                     if (JintBinaryExpression.TryOperatorOverloading(context, lval, rval, operatorClrName, out var result))
                     {
                         lval = JsValue.FromObject(context.Engine, result);
@@ -108,7 +108,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 {
                     case AssignmentOperator.PlusAssign:
                     {
-                        var rval = _right.GetValue(context).Value;
+                        var rval = _right.GetValue(context);
                         if (AreIntegerOperands(lval, rval))
                         {
                             lval = (long) lval.AsInteger() + rval.AsInteger();
@@ -142,7 +142,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                     case AssignmentOperator.MinusAssign:
                     {
-                        var rval = _right.GetValue(context).Value;
+                        var rval = _right.GetValue(context);
                         if (AreIntegerOperands(lval, rval))
                         {
                             lval = JsNumber.Create(lval.AsInteger() - rval.AsInteger());
@@ -161,7 +161,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                     case AssignmentOperator.TimesAssign:
                     {
-                        var rval = _right.GetValue(context).Value;
+                        var rval = _right.GetValue(context);
                         if (AreIntegerOperands(lval, rval))
                         {
                             lval = (long) lval.AsInteger() * rval.AsInteger();
@@ -184,14 +184,14 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                     case AssignmentOperator.DivideAssign:
                     {
-                        var rval = _right.GetValue(context).Value;
+                        var rval = _right.GetValue(context);
                         lval = Divide(context, lval, rval);
                         break;
                     }
 
                     case AssignmentOperator.ModuloAssign:
                     {
-                        var rval = _right.GetValue(context).Value;
+                        var rval = _right.GetValue(context);
                         if (lval.IsUndefined() || rval.IsUndefined())
                         {
                             lval = Undefined.Instance;
@@ -210,42 +210,42 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                     case AssignmentOperator.BitwiseAndAssign:
                     {
-                        var rval = _right.GetValue(context).Value;
+                        var rval = _right.GetValue(context);
                         lval = TypeConverter.ToInt32(lval) & TypeConverter.ToInt32(rval);
                         break;
                     }
 
                     case AssignmentOperator.BitwiseOrAssign:
                     {
-                        var rval = _right.GetValue(context).Value;
+                        var rval = _right.GetValue(context);
                         lval = TypeConverter.ToInt32(lval) | TypeConverter.ToInt32(rval);
                         break;
                     }
 
                     case AssignmentOperator.BitwiseXorAssign:
                     {
-                        var rval = _right.GetValue(context).Value;
+                        var rval = _right.GetValue(context);
                         lval = TypeConverter.ToInt32(lval) ^ TypeConverter.ToInt32(rval);
                         break;
                     }
 
                     case AssignmentOperator.LeftShiftAssign:
                     {
-                        var rval = _right.GetValue(context).Value;
+                        var rval = _right.GetValue(context);
                         lval = TypeConverter.ToInt32(lval) << (int) (TypeConverter.ToUint32(rval) & 0x1F);
                         break;
                     }
 
                     case AssignmentOperator.RightShiftAssign:
                     {
-                        var rval = _right.GetValue(context).Value;
+                        var rval = _right.GetValue(context);
                         lval = TypeConverter.ToInt32(lval) >> (int) (TypeConverter.ToUint32(rval) & 0x1F);
                         break;
                     }
 
                     case AssignmentOperator.UnsignedRightShiftAssign:
                     {
-                        var rval = _right.GetValue(context).Value;
+                        var rval = _right.GetValue(context);
                         lval = (uint) TypeConverter.ToInt32(lval) >> (int) (TypeConverter.ToUint32(rval) & 0x1F);
                         break;
                     }
@@ -254,7 +254,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     {
                         if (!lval.IsNullOrUndefined())
                         {
-                            return NormalCompletion(lval);
+                            return lval;
                         }
 
                         var rval = NamedEvaluation(context, _right);
@@ -266,7 +266,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     {
                         if (!TypeConverter.ToBoolean(lval))
                         {
-                            return NormalCompletion(lval);
+                            return lval;
                         }
 
                         var rval = NamedEvaluation(context, _right);
@@ -278,7 +278,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     {
                         if (TypeConverter.ToBoolean(lval))
                         {
-                            return NormalCompletion(lval);
+                            return lval;
                         }
 
                         var rval = NamedEvaluation(context, _right);
@@ -288,7 +288,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                     case AssignmentOperator.ExponentiationAssign:
                     {
-                        var rval = _right.GetValue(context).Value;
+                        var rval = _right.GetValue(context);
                         if (!lval.IsBigInt() && !rval.IsBigInt())
                         {
                             lval = JsNumber.Create(System.Math.Pow(TypeConverter.ToNumber(lval), TypeConverter.ToNumber(rval)));
@@ -315,12 +315,12 @@ namespace Jint.Runtime.Interpreter.Expressions
             engine.PutValue(lref, lval);
 
             engine._referencePool.Return(lref);
-            return NormalCompletion(lval);
+            return lval;
         }
 
         private JsValue NamedEvaluation(EvaluationContext context, JintExpression expression)
         {
-            var rval = expression.GetValue(context).Value;
+            var rval = expression.GetValue(context);
             if (expression._expression.IsAnonymousFunctionDefinition() && _left._expression.Type == Nodes.Identifier)
             {
                 ((FunctionInstance) rval).SetFunctionName(((Identifier) _left._expression).Name);
@@ -352,9 +352,9 @@ namespace Jint.Runtime.Interpreter.Expressions
                 _right = Build(context.Engine, assignmentExpression.Right);
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                ExpressionResult? completion = null;
+                object? completion = null;
                 if (_leftIdentifier != null)
                 {
                     completion = AssignToIdentifier(context, _leftIdentifier, _right, _evalOrArguments);
@@ -363,11 +363,11 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
 
             // https://262.ecma-international.org/5.1/#sec-11.13.1
-            private ExpressionResult SetValue(EvaluationContext context)
+            private JsValue SetValue(EvaluationContext context)
             {
                 // slower version
                 var engine = context.Engine;
-                var lref = _left.Evaluate(context).Value as Reference;
+                var lref = _left.Evaluate(context) as Reference;
                 if (lref is null)
                 {
                     ExceptionHelper.ThrowReferenceError(engine.Realm, "not a valid reference");
@@ -375,14 +375,14 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                 lref.AssertValid(engine.Realm);
 
-                var rval = _right.GetValue(context).GetValueOrDefault();
+                var rval = _right.GetValue(context);
 
                 engine.PutValue(lref, rval);
                 engine._referencePool.Return(lref);
-                return NormalCompletion(rval);
+                return rval;
             }
 
-            internal static ExpressionResult? AssignToIdentifier(
+            internal static object? AssignToIdentifier(
                 EvaluationContext context,
                 JintIdentifierExpression left,
                 JintExpression right,
@@ -402,12 +402,12 @@ namespace Jint.Runtime.Interpreter.Expressions
                     }
 
                     var completion = right.GetValue(context);
-                    if (completion.IsAbrupt())
+                    if (context.IsAbrupt())
                     {
                         return completion;
                     }
 
-                    var rval = completion.Value.Clone();
+                    var rval = completion.Clone();
 
                     if (right._expression.IsFunctionDefinition())
                     {
@@ -415,7 +415,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     }
 
                     environmentRecord.SetMutableBinding(left.Identifier, rval, strict);
-                    return ExpressionResult.Normal(rval);
+                    return rval;
                 }
 
                 return null;

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -154,7 +154,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 {
                     // we have fixed result
                     var context = new EvaluationContext(engine);
-                    return new JintConstantExpression(expression, result.GetValue(context).Value);
+                    return new JintConstantExpression(expression, result.GetValue(context));
                 }
             }
 
@@ -181,12 +181,12 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var left = _left.GetValue(context).Value;
-                var right = _right.GetValue(context).Value;
+                var left = _left.GetValue(context);
+                var right = _right.GetValue(context);
                 var equal = left == right;
-                return NormalCompletion(equal ? JsBoolean.True : JsBoolean.False);
+                return equal ? JsBoolean.True : JsBoolean.False;
             }
         }
 
@@ -196,11 +196,11 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var left = _left.GetValue(context).Value;
-                var right = _right.GetValue(context).Value;
-                return NormalCompletion(left == right ? JsBoolean.False : JsBoolean.True);
+                var left = _left.GetValue(context);
+                var right = _right.GetValue(context);
+                return left == right ? JsBoolean.False : JsBoolean.True;
             }
         }
 
@@ -210,20 +210,20 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var left = _left.GetValue(context).Value;
-                var right = _right.GetValue(context).Value;
+                var left = _left.GetValue(context);
+                var right = _right.GetValue(context);
 
                 if (context.OperatorOverloadingAllowed
                     && TryOperatorOverloading(context, left, right, "op_LessThan", out var opResult))
                 {
-                    return NormalCompletion(JsValue.FromObject(context.Engine, opResult));
+                    return JsValue.FromObject(context.Engine, opResult);
                 }
 
                 var value = Compare(left, right);
 
-                return NormalCompletion(value._type == InternalTypes.Undefined ? JsBoolean.False : value);
+                return value._type == InternalTypes.Undefined ? JsBoolean.False : value;
             }
         }
 
@@ -233,20 +233,20 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var left = _left.GetValue(context).Value;
-                var right = _right.GetValue(context).Value;
+                var left = _left.GetValue(context);
+                var right = _right.GetValue(context);
 
                 if (context.OperatorOverloadingAllowed
                     && TryOperatorOverloading(context, left, right, "op_GreaterThan", out var opResult))
                 {
-                    return NormalCompletion(JsValue.FromObject(context.Engine, opResult));
+                    return JsValue.FromObject(context.Engine, opResult);
                 }
 
                 var value = Compare(right, left, false);
 
-                return NormalCompletion(value._type == InternalTypes.Undefined ? JsBoolean.False : value);
+                return value._type == InternalTypes.Undefined ? JsBoolean.False : value;
             }
         }
 
@@ -256,20 +256,20 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var left = _left.GetValue(context).Value;
-                var right = _right.GetValue(context).Value;
+                var left = _left.GetValue(context);
+                var right = _right.GetValue(context);
 
                 if (context.OperatorOverloadingAllowed
                     && TryOperatorOverloading(context, left, right, "op_Addition", out var opResult))
                 {
-                    return NormalCompletion(JsValue.FromObject(context.Engine, opResult));
+                    return JsValue.FromObject(context.Engine, opResult);
                 }
 
                 if (AreIntegerOperands(left, right))
                 {
-                    return NormalCompletion(JsNumber.Create((long)left.AsInteger() + right.AsInteger()));
+                    return JsNumber.Create((long)left.AsInteger() + right.AsInteger());
                 }
 
                 var lprim = TypeConverter.ToPrimitive(left);
@@ -289,7 +289,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     result = JsBigInt.Create(TypeConverter.ToBigInt(lprim) + TypeConverter.ToBigInt(rprim));
                 }
 
-                return NormalCompletion(result);
+                return result;
             }
         }
 
@@ -299,15 +299,15 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var left = _left.GetValue(context).Value;
-                var right = _right.GetValue(context).Value;
+                var left = _left.GetValue(context);
+                var right = _right.GetValue(context);
 
                 if (context.OperatorOverloadingAllowed
                     && TryOperatorOverloading(context, left, right, "op_Subtraction", out var opResult))
                 {
-                    return NormalCompletion(JsValue.FromObject(context.Engine, opResult));
+                    return JsValue.FromObject(context.Engine, opResult);
                 }
 
                 JsValue number;
@@ -327,7 +327,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     number = JsBigInt.Create(TypeConverter.ToBigInt(left) - TypeConverter.ToBigInt(right));
                 }
 
-                return NormalCompletion(number);
+                return number;
             }
         }
 
@@ -337,10 +337,10 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var left = _left.GetValue(context).Value;
-                var right = _right.GetValue(context).Value;
+                var left = _left.GetValue(context);
+                var right = _right.GetValue(context);
 
                 JsValue result;
                 if (context.OperatorOverloadingAllowed
@@ -368,7 +368,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     }
                 }
 
-                return NormalCompletion(result);
+                return result;
             }
         }
 
@@ -378,20 +378,20 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var left = _left.GetValue(context).Value;
-                var right = _right.GetValue(context).Value;
+                var left = _left.GetValue(context);
+                var right = _right.GetValue(context);
 
                 if (context.OperatorOverloadingAllowed
                     && TryOperatorOverloading(context, left, right, "op_Division", out var opResult))
                 {
-                    return NormalCompletion(JsValue.FromObject(context.Engine, opResult));
+                    return JsValue.FromObject(context.Engine, opResult);
                 }
 
                 left = TypeConverter.ToNumeric(left);
                 right = TypeConverter.ToNumeric(right);
-                return NormalCompletion(Divide(context, left, right));
+                return Divide(context, left, right);
             }
         }
 
@@ -404,15 +404,15 @@ namespace Jint.Runtime.Interpreter.Expressions
                 _invert = invert;
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var left = _left.GetValue(context).Value;
-                var right = _right.GetValue(context).Value;
+                var left = _left.GetValue(context);
+                var right = _right.GetValue(context);
 
                 if (context.OperatorOverloadingAllowed
                     && TryOperatorOverloading(context, left, right, _invert ? "op_Inequality" : "op_Equality", out var opResult))
                 {
-                    return NormalCompletion(JsValue.FromObject(context.Engine, opResult));
+                    return JsValue.FromObject(context.Engine, opResult);
                 }
 
                 // if types match, we can take faster strict equality
@@ -420,7 +420,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     ? left.Equals(right)
                     : left.IsLooselyEqual(right);
 
-                return NormalCompletion(equality == !_invert ? JsBoolean.True : JsBoolean.False);
+                return equality == !_invert ? JsBoolean.True : JsBoolean.False;
             }
         }
 
@@ -433,22 +433,22 @@ namespace Jint.Runtime.Interpreter.Expressions
                 _leftFirst = leftFirst;
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var leftValue = _left.GetValue(context).Value;
-                var rightValue = _right.GetValue(context).Value;
+                var leftValue = _left.GetValue(context);
+                var rightValue = _right.GetValue(context);
 
                 if (context.OperatorOverloadingAllowed
                     && TryOperatorOverloading(context, leftValue, rightValue, _leftFirst ? "op_GreaterThanOrEqual" : "op_LessThanOrEqual", out var opResult))
                 {
-                    return NormalCompletion(JsValue.FromObject(context.Engine, opResult));
+                    return JsValue.FromObject(context.Engine, opResult);
                 }
 
                 var left = _leftFirst ? leftValue : rightValue;
                 var right = _leftFirst ? rightValue : leftValue;
 
                 var value = Compare(left, right, _leftFirst);
-                return NormalCompletion(value.IsUndefined() || ((JsBoolean) value)._value ? JsBoolean.False : JsBoolean.True);
+                return value.IsUndefined() || ((JsBoolean) value)._value ? JsBoolean.False : JsBoolean.True;
             }
         }
 
@@ -458,11 +458,11 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var leftValue = _left.GetValue(context).Value;
-                var rightValue = _right.GetValue(context).Value;
-                return NormalCompletion(leftValue.InstanceofOperator(rightValue) ? JsBoolean.True : JsBoolean.False);
+                var leftValue = _left.GetValue(context);
+                var rightValue = _right.GetValue(context);
+                return leftValue.InstanceofOperator(rightValue) ? JsBoolean.True : JsBoolean.False;
             }
         }
 
@@ -472,10 +472,10 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var leftReference = _left.GetValue(context).Value;
-                var rightReference = _right.GetValue(context).Value;
+                var leftReference = _left.GetValue(context);
+                var rightReference = _right.GetValue(context);
 
                 var left = TypeConverter.ToNumeric(leftReference);
                 var right = TypeConverter.ToNumeric(rightReference);
@@ -489,23 +489,23 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                     if (exponentNumber.IsNaN())
                     {
-                        return NormalCompletion(JsNumber.DoubleNaN);
+                        return JsNumber.DoubleNaN;
                     }
 
                     if (exponentNumber.IsZero())
                     {
-                        return NormalCompletion(JsNumber.PositiveOne);
+                        return JsNumber.PositiveOne;
                     }
 
                     if (baseNumber.IsNaN())
                     {
-                        return NormalCompletion(JsNumber.DoubleNaN);
+                        return JsNumber.DoubleNaN;
                     }
 
                     var exponentValue = exponentNumber._value;
                     if (baseNumber.IsPositiveInfinity())
                     {
-                        return NormalCompletion(exponentValue > 0 ? JsNumber.DoublePositiveInfinity : JsNumber.PositiveZero);
+                        return exponentValue > 0 ? JsNumber.DoublePositiveInfinity : JsNumber.PositiveZero;
                     }
 
                     static bool IsOddIntegral(double value) => TypeConverter.IsIntegralNumber(value) && value % 2 != 0;
@@ -514,24 +514,24 @@ namespace Jint.Runtime.Interpreter.Expressions
                     {
                         if (exponentValue > 0)
                         {
-                            return NormalCompletion(IsOddIntegral(exponentValue) ? JsNumber.DoubleNegativeInfinity : JsNumber.DoublePositiveInfinity);
+                            return IsOddIntegral(exponentValue) ? JsNumber.DoubleNegativeInfinity : JsNumber.DoublePositiveInfinity;
                         }
 
-                        return NormalCompletion(IsOddIntegral(exponentValue) ? JsNumber.NegativeZero : JsNumber.PositiveZero);
+                        return IsOddIntegral(exponentValue) ? JsNumber.NegativeZero : JsNumber.PositiveZero;
                     }
 
                     if (baseNumber.IsPositiveZero())
                     {
-                        return NormalCompletion(exponentValue > 0 ? JsNumber.PositiveZero : JsNumber.DoublePositiveInfinity);
+                        return exponentValue > 0 ? JsNumber.PositiveZero : JsNumber.DoublePositiveInfinity;
                     }
 
                     if (baseNumber.IsNegativeZero())
                     {
                         if (exponentValue > 0)
                         {
-                            return NormalCompletion(IsOddIntegral(exponentValue) ? JsNumber.NegativeZero : JsNumber.PositiveZero);
+                            return IsOddIntegral(exponentValue) ? JsNumber.NegativeZero : JsNumber.PositiveZero;
                         }
-                        return NormalCompletion(IsOddIntegral(exponentValue) ? JsNumber.DoubleNegativeInfinity : JsNumber.DoublePositiveInfinity);
+                        return IsOddIntegral(exponentValue) ? JsNumber.DoubleNegativeInfinity : JsNumber.DoublePositiveInfinity;
                     }
 
                     var baseValue = baseNumber._value;
@@ -539,33 +539,33 @@ namespace Jint.Runtime.Interpreter.Expressions
                     {
                         if (Math.Abs(baseValue) > 1)
                         {
-                            return NormalCompletion(JsNumber.DoublePositiveInfinity);
+                            return JsNumber.DoublePositiveInfinity;
                         }
                         if (Math.Abs(baseValue) == 1)
                         {
-                            return NormalCompletion(JsNumber.DoubleNaN);
+                            return JsNumber.DoubleNaN;
                         }
 
-                        return NormalCompletion(JsNumber.PositiveZero);
+                        return JsNumber.PositiveZero;
                     }
 
                     if (exponentNumber.IsNegativeInfinity())
                     {
                         if (Math.Abs(baseValue) > 1)
                         {
-                            return NormalCompletion(JsNumber.PositiveZero);
+                            return JsNumber.PositiveZero;
                         }
                         if (Math.Abs(baseValue) == 1)
                         {
-                            return NormalCompletion(JsNumber.DoubleNaN);
+                            return JsNumber.DoubleNaN;
                         }
 
-                        return NormalCompletion(JsNumber.DoublePositiveInfinity);
+                        return JsNumber.DoublePositiveInfinity;
                     }
 
                     if (baseValue < 0 && !TypeConverter.IsIntegralNumber(exponentValue))
                     {
-                        return NormalCompletion(JsNumber.DoubleNaN);
+                        return JsNumber.DoubleNaN;
                     }
 
                     result = JsNumber.Create(Math.Pow(baseNumber._value, exponentValue));
@@ -587,7 +587,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     result = JsBigInt.Create(BigInteger.Pow(left.AsBigInt(), (int) exponent));
                 }
 
-                return NormalCompletion(result);
+                return result;
             }
         }
 
@@ -597,10 +597,10 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var left = _left.GetValue(context).Value;
-                var right = _right.GetValue(context).Value;
+                var left = _left.GetValue(context);
+                var right = _right.GetValue(context);
 
                 var oi = right as ObjectInstance;
                 if (oi is null)
@@ -608,7 +608,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     ExceptionHelper.ThrowTypeError(context.Engine.Realm, "in can only be used with an object");
                 }
 
-                return NormalCompletion(oi.HasProperty(left) ? JsBoolean.True : JsBoolean.False);
+                return oi.HasProperty(left) ? JsBoolean.True : JsBoolean.False;
             }
         }
 
@@ -618,15 +618,15 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var left = _left.GetValue(context).Value;
-                var right = _right.GetValue(context).Value;
+                var left = _left.GetValue(context);
+                var right = _right.GetValue(context);
 
                 if (context.OperatorOverloadingAllowed
                     && TryOperatorOverloading(context, left, right, "op_Modulus", out var opResult))
                 {
-                    return NormalCompletion(JsValue.FromObject(context.Engine, opResult));
+                    return JsValue.FromObject(context.Engine, opResult);
                 }
 
                 var result = Undefined.Instance;
@@ -702,7 +702,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     }
                 }
 
-                return NormalCompletion(result);
+                return result;
             }
         }
 
@@ -732,15 +732,15 @@ namespace Jint.Runtime.Interpreter.Expressions
                 _operator = expression.Operator;
             }
 
-            protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+            protected override object EvaluateInternal(EvaluationContext context)
             {
-                var lval = _left.GetValue(context).Value;
-                var rval = _right.GetValue(context).Value;
+                var lval = _left.GetValue(context);
+                var rval = _right.GetValue(context);
 
                 if (context.OperatorOverloadingAllowed
                     && TryOperatorOverloading(context, lval, rval, OperatorClrName, out var opResult))
                 {
-                    return NormalCompletion(JsValue.FromObject(context.Engine, opResult));
+                    return JsValue.FromObject(context.Engine, opResult);
                 }
 
                 var lnum = TypeConverter.ToNumeric(lval);
@@ -782,10 +782,10 @@ namespace Jint.Runtime.Interpreter.Expressions
                             break;
                     }
 
-                    return NormalCompletion(result);
+                    return result;
                 }
 
-                return NormalCompletion(EvaluateNonInteger(context.Engine.Realm, lnum, rnum));
+                return EvaluateNonInteger(context.Engine.Realm, lnum, rnum);
             }
 
             private JsValue EvaluateNonInteger(Realm realm, JsValue left, JsValue right)

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -73,20 +73,20 @@ namespace Jint.Runtime.Interpreter.Expressions
             _cachedArguments = cachedArgumentsHolder;
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             if (_calleeExpression._expression.Type == Nodes.Super)
             {
-                return NormalCompletion(SuperCall(context));
+                return SuperCall(context);
             }
 
             // https://tc39.es/ecma262/#sec-function-calls
 
-            var reference = _calleeExpression.Evaluate(context).Value;
+            var reference = _calleeExpression.Evaluate(context);
 
             if (ReferenceEquals(reference, Undefined.Instance))
             {
-                return NormalCompletion(Undefined.Instance);
+                return Undefined.Instance;
             }
 
             var engine = context.Engine;
@@ -94,7 +94,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             if (func.IsNullOrUndefined() && _expression.IsOptional())
             {
-                return NormalCompletion(Undefined.Instance);
+                return Undefined.Instance;
             }
 
             var referenceRecord = reference as Reference;
@@ -197,7 +197,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
 
             engine._referencePool.Return(referenceRecord);
-            return NormalCompletion(result);
+            return result;
         }
 
         [DoesNotReturn]
@@ -218,12 +218,12 @@ namespace Jint.Runtime.Interpreter.Expressions
             ExceptionHelper.ThrowTypeError(engine.Realm, message);
         }
 
-        private ExpressionResult HandleEval(EvaluationContext context, JsValue func, Engine engine, Reference referenceRecord)
+        private JsValue HandleEval(EvaluationContext context, JsValue func, Engine engine, Reference referenceRecord)
         {
             var argList = ArgumentListEvaluation(context);
             if (argList.Length == 0)
             {
-                return NormalCompletion(Undefined.Instance);
+                return Undefined.Instance;
             }
 
             var evalFunctionInstance = (EvalFunctionInstance) func;
@@ -233,7 +233,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             var direct = !_expression.IsOptional();
             var value = evalFunctionInstance.PerformEval(evalArg, evalRealm, strictCaller, direct);
             engine._referencePool.Return(referenceRecord);
-            return NormalCompletion(value);
+            return value;
         }
 
         private JsValue SuperCall(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Expressions/JintClassExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintClassExpression.cs
@@ -12,7 +12,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             _classDefinition = new ClassDefinition(expression.Id?.Name, expression.SuperClass, expression.Body);
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             var env = context.Engine.ExecutionContext.LexicalEnvironment;
             return _classDefinition.BuildConstructor(context, env);

--- a/Jint/Runtime/Interpreter/Expressions/JintConditionalExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintConditionalExpression.cs
@@ -15,9 +15,9 @@ namespace Jint.Runtime.Interpreter.Expressions
             _alternate = Build(engine, expression.Alternate);
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
-            return TypeConverter.ToBoolean(_test.GetValue(context).Value)
+            return TypeConverter.ToBoolean(_test.GetValue(context))
                 ? _consequent.GetValue(context)
                 : _alternate.GetValue(context);
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintConstantExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintConstantExpression.cs
@@ -1,28 +1,26 @@
 using Esprima.Ast;
 using Jint.Native;
 
-namespace Jint.Runtime.Interpreter.Expressions
+namespace Jint.Runtime.Interpreter.Expressions;
+
+/// <summary>
+/// Constant JsValue returning expression.
+/// </summary>
+internal sealed class JintConstantExpression : JintExpression
 {
-    /// <summary>
-    /// Constant JsValue returning expression.
-    /// </summary>
-    internal sealed class JintConstantExpression : JintExpression
+    private readonly JsValue _value;
+
+    public JintConstantExpression(Expression expression, JsValue value) : base(expression)
     {
-        private readonly JsValue _value;
-
-        public JintConstantExpression(Expression expression, JsValue value) : base(expression)
-        {
-            _value = value;
-        }
-
-        public override Completion GetValue(EvaluationContext context)
-        {
-            // need to notify correct node when taking shortcut
-            context.LastSyntaxElement = _expression;
-
-            return new(CompletionType.Normal, _value, _expression);
-        }
-
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context) => NormalCompletion(_value);
+        _value = value;
     }
+
+    public override JsValue GetValue(EvaluationContext context)
+    {
+        // need to notify correct node when taking shortcut
+        context.LastSyntaxElement = _expression;
+        return _value;
+    }
+
+    protected override object EvaluateInternal(EvaluationContext context) => _value;
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintFunctionExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintFunctionExpression.cs
@@ -1,4 +1,5 @@
 using Esprima.Ast;
+using Jint.Native;
 using Jint.Native.Function;
 using Jint.Runtime.Environments;
 
@@ -13,18 +14,18 @@ namespace Jint.Runtime.Interpreter.Expressions
             _function = new JintFunctionDefinition(function);
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             return GetValue(context);
         }
 
-        public override Completion GetValue(EvaluationContext context)
+        public override JsValue GetValue(EvaluationContext context)
         {
             var closure = !_function.Function.Generator
                 ? InstantiateOrdinaryFunctionExpression(context, _function.Name!)
                 : InstantiateGeneratorFunctionExpression(context, _function.Name!);
 
-            return new(CompletionType.Normal, closure, _expression);
+            return closure;
         }
 
         /// <summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -20,7 +20,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         public bool HasEvalOrArguments => Identifier.HasEvalOrArguments;
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             var engine = context.Engine;
             var env = engine.ExecutionContext.LexicalEnvironment;
@@ -29,17 +29,17 @@ namespace Jint.Runtime.Interpreter.Expressions
                 ? temp
                 : JsValue.Undefined;
 
-            return NormalCompletion(engine._referencePool.Rent(identifierEnvironment, Identifier.StringValue, strict, thisValue: null));
+            return engine._referencePool.Rent(identifierEnvironment, Identifier.StringValue, strict, thisValue: null);
         }
 
-        public override Completion GetValue(EvaluationContext context)
+        public override JsValue GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
             context.LastSyntaxElement = _expression;
 
             if (Identifier.CalculatedValue is not null)
             {
-                return new(CompletionType.Normal, Identifier.CalculatedValue, _expression);
+                return Identifier.CalculatedValue;
             }
 
             var strict = StrictModeScope.IsStrictModeCode;
@@ -70,7 +70,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 argumentsInstance.Materialize();
             }
 
-            return new(CompletionType.Normal, value, _expression);
+            return value;
         }
 
         [DoesNotReturn]

--- a/Jint/Runtime/Interpreter/Expressions/JintImportExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintImportExpression.cs
@@ -22,15 +22,15 @@ internal sealed class JintImportExpression : JintExpression
     /// <summary>
     /// https://tc39.es/ecma262/#sec-import-calls
     /// </summary>
-    protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+    protected override object EvaluateInternal(EvaluationContext context)
     {
         var referencingScriptOrModule = context.Engine.GetActiveScriptOrModule();
         var argRef = _importExpression.Evaluate(context);
-        var specifier = context.Engine.GetValue(argRef.Value); //.UnwrapIfPromise();
+        var specifier = context.Engine.GetValue(argRef); //.UnwrapIfPromise();
         var promiseCapability = PromiseConstructor.NewPromiseCapability(context.Engine, context.Engine.Realm.Intrinsics.Promise);
         var specifierString = TypeConverter.ToString(specifier);
         context.Engine._host.ImportModuleDynamically(referencingScriptOrModule, specifierString, promiseCapability);
         context.Engine.RunAvailableContinuations();
-        return NormalCompletion(promiseCapability.PromiseInstance);
+        return promiseCapability.PromiseInstance;
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -61,16 +61,14 @@ namespace Jint.Runtime.Interpreter.Expressions
             return null;
         }
 
-        public override Completion GetValue(EvaluationContext context)
+        public override JsValue GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
             context.LastSyntaxElement = _expression;
-
-            JsValue value = ResolveValue(context);
-            return new(CompletionType.Normal, value, _expression);
+            return ResolveValue(context);
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context) => NormalCompletion(ResolveValue(context));
+        protected override object EvaluateInternal(EvaluationContext context) => ResolveValue(context);
 
         private JsValue ResolveValue(EvaluationContext context)
         {

--- a/Jint/Runtime/Interpreter/Expressions/JintLogicalAndExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLogicalAndExpression.cs
@@ -20,18 +20,18 @@ namespace Jint.Runtime.Interpreter.Expressions
             _right = Build(context.Engine, expression.Right);
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
-            var left = _left.GetValue(context).Value;
+            var left = _left.GetValue(context);
 
             if (left is JsBoolean b && !b._value)
             {
-                return NormalCompletion(b);
+                return b;
             }
 
             if (!TypeConverter.ToBoolean(left))
             {
-                return NormalCompletion(left);
+                return left;
             }
 
             return _right.GetValue(context);

--- a/Jint/Runtime/Interpreter/Expressions/JintLogicalOrExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLogicalOrExpression.cs
@@ -14,18 +14,18 @@ namespace Jint.Runtime.Interpreter.Expressions
             _right = Build(engine, expression.Right);
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
-            var left = _left.GetValue(context).Value;
+            var left = _left.GetValue(context);
 
             if (left is JsBoolean b && b._value)
             {
-                return NormalCompletion(b);
+                return b;
             }
 
             if (TypeConverter.ToBoolean(left))
             {
-                return NormalCompletion(left);
+                return left;
             }
 
             return _right.GetValue(context);

--- a/Jint/Runtime/Interpreter/Expressions/JintMetaPropertyExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMetaPropertyExpression.cs
@@ -12,12 +12,12 @@ namespace Jint.Runtime.Interpreter.Expressions
         /// <summary>
         /// https://tc39.es/ecma262/#sec-meta-properties
         /// </summary>
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             var expression = (MetaProperty) _expression;
             if (expression.Meta.Name == "new" && expression.Property.Name == "target")
             {
-                return NormalCompletion(context.Engine.GetNewTarget());
+                return context.Engine.GetNewTarget();
             }
 
             if (expression.Meta.Name == "import" && expression.Property.Name == "meta")
@@ -37,7 +37,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     module.ImportMeta = importMeta;
                 }
 
-                return NormalCompletion(importMeta);
+                return importMeta;
             }
 
             ExceptionHelper.ThrowNotImplementedException();

--- a/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
@@ -35,12 +35,12 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             var engine = context.Engine;
 
             // todo: optimize by defining a common abstract class or interface
-            var jsValue = _calleeExpression.GetValue(context).Value;
+            var jsValue = _calleeExpression.GetValue(context);
 
             JsValue[] arguments;
             if (_jintArguments.Length == 0)
@@ -71,7 +71,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             engine._jsValueArrayPool.ReturnArray(arguments);
 
-            return NormalCompletion(instance);
+            return instance;
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintSequenceExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintSequenceExpression.cs
@@ -26,15 +26,15 @@ namespace Jint.Runtime.Interpreter.Expressions
             _expressions = temp;
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             var result = Undefined.Instance;
             foreach (var expression in _expressions)
             {
-                result = expression.GetValue(context).Value;
+                result = expression.GetValue(context);
             }
 
-            return NormalCompletion(result);
+            return result;
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintSpreadExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintSpreadExpression.cs
@@ -15,24 +15,24 @@ namespace Jint.Runtime.Interpreter.Expressions
             _argumentName = (expression.Argument as Identifier)?.Name;
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             GetValueAndCheckIterator(context, out var objectInstance, out var iterator);
-            return NormalCompletion(objectInstance);
+            return objectInstance;
         }
 
-        public override Completion GetValue(EvaluationContext context)
+        public override JsValue GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
             context.LastSyntaxElement = _expression;
 
             GetValueAndCheckIterator(context, out var objectInstance, out var iterator);
-            return new(CompletionType.Normal, objectInstance, _expression);
+            return objectInstance;
         }
 
         internal void GetValueAndCheckIterator(EvaluationContext context, out JsValue instance, out IteratorInstance? iterator)
         {
-            instance = _argument.GetValue(context).Value;
+            instance = _argument.GetValue(context);
             if (instance is null || !instance.TryGetIterator(context.Engine.Realm, out iterator))
             {
                 iterator = null;

--- a/Jint/Runtime/Interpreter/Expressions/JintSuperExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintSuperExpression.cs
@@ -9,12 +9,12 @@ namespace Jint.Runtime.Interpreter.Expressions
         {
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             var envRec = (FunctionEnvironmentRecord) context.Engine.ExecutionContext.GetThisEnvironment();
             var activeFunction = envRec._functionObject;
             var superConstructor = activeFunction.GetPrototypeOf();
-            return NormalCompletion(superConstructor!);
+            return superConstructor!;
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
@@ -27,7 +27,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             _quasi.DoInitialize(context);
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             var engine = context.Engine;
             var tagger = engine.GetValue(_tagIdentifier.GetValue(context)) as ICallable;
@@ -45,13 +45,13 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             for (int i = 0; i < expressions.Length; ++i)
             {
-                args[i + 1] = expressions[i].GetValue(context).Value;
+                args[i + 1] = expressions[i].GetValue(context);
             }
 
             var result = tagger.Call(JsValue.Undefined, args);
             engine._jsValueArrayPool.ReturnArray(args);
 
-            return NormalCompletion(result);
+            return result;
         }
 
         /// <summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintTemplateLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTemplateLiteralExpression.cs
@@ -43,16 +43,16 @@ namespace Jint.Runtime.Interpreter.Expressions
                 if (i < _expressions.Length)
                 {
                     var completion = _expressions[i].GetValue(context);
-                    sb.Builder.Append(completion.Value);
+                    sb.Builder.Append(completion);
                 }
             }
 
             return JsString.Create(sb.ToString());
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
-            return NormalCompletion(BuildString(context));
+            return BuildString(context);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintThisExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintThisExpression.cs
@@ -9,18 +9,16 @@ namespace Jint.Runtime.Interpreter.Expressions
         {
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
-            return NormalCompletion(context.Engine.ResolveThisBinding());
+            return context.Engine.ResolveThisBinding();
         }
 
-        public override Completion GetValue(EvaluationContext context)
+        public override JsValue GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
             context.LastSyntaxElement = _expression;
-
-            JsValue value = context.Engine.ResolveThisBinding();
-            return new(CompletionType.Normal, value, _expression);
+            return context.Engine.ResolveThisBinding();
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -41,18 +41,16 @@ namespace Jint.Runtime.Interpreter.Expressions
             return new JintUnaryExpression(engine, expression);
         }
 
-        public override Completion GetValue(EvaluationContext context)
+        public override JsValue GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
             context.LastSyntaxElement = _expression;
-
-            JsValue value = EvaluateJsValue(context);
-            return new(CompletionType.Normal, value, _expression);
+            return EvaluateJsValue(context);
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
-            return NormalCompletion(EvaluateJsValue(context));
+            return EvaluateJsValue(context);
         }
 
         private JsValue EvaluateJsValue(EvaluationContext context)
@@ -62,7 +60,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             {
                 case UnaryOperator.Plus:
                 {
-                    var v = _argument.GetValue(context).Value;
+                    var v = _argument.GetValue(context);
                     if (context.OperatorOverloadingAllowed &&
                         TryOperatorOverloading(context, v, "op_UnaryPlus", out var result))
                     {
@@ -73,7 +71,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
                 case UnaryOperator.Minus:
                 {
-                    var v = _argument.GetValue(context).Value;
+                    var v = _argument.GetValue(context);
                     if (context.OperatorOverloadingAllowed &&
                         TryOperatorOverloading(context, v, "op_UnaryNegation", out var result))
                     {
@@ -84,7 +82,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
                 case UnaryOperator.BitwiseNot:
                 {
-                    var v = _argument.GetValue(context).Value;
+                    var v = _argument.GetValue(context);
                     if (context.OperatorOverloadingAllowed &&
                         TryOperatorOverloading(context, v, "op_OnesComplement", out var result))
                     {
@@ -101,7 +99,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 }
                 case UnaryOperator.LogicalNot:
                 {
-                    var v = _argument.GetValue(context).Value;
+                    var v = _argument.GetValue(context);
                     if (context.OperatorOverloadingAllowed &&
                         TryOperatorOverloading(context, v, "op_LogicalNot", out var result))
                     {
@@ -113,7 +111,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                 case UnaryOperator.Delete:
                     // https://262.ecma-international.org/5.1/#sec-11.4.1
-                    if (_argument.Evaluate(context).Value is not Reference r)
+                    if (_argument.Evaluate(context) is not Reference r)
                     {
                         return JsBoolean.True;
                     }
@@ -176,7 +174,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     var result = _argument.Evaluate(context);
                     JsValue v;
 
-                    if (result.Value is Reference rf)
+                    if (result is Reference rf)
                     {
                         if (rf.IsUnresolvableReference())
                         {
@@ -188,7 +186,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     }
                     else
                     {
-                        v = (JsValue) result.Value;
+                        v = (JsValue) result;
                     }
 
                     if (v.IsUndefined())

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -41,19 +41,19 @@ namespace Jint.Runtime.Interpreter.Expressions
             _evalOrArguments = _leftIdentifier?.HasEvalOrArguments == true;
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
             var fastResult = _leftIdentifier != null
                 ? UpdateIdentifier(context)
                 : null;
 
-            return NormalCompletion(fastResult ?? UpdateNonIdentifier(context));
+            return fastResult ?? UpdateNonIdentifier(context);
         }
 
         private JsValue UpdateNonIdentifier(EvaluationContext context)
         {
             var engine = context.Engine;
-            var reference = _argument.Evaluate(context).Value as Reference;
+            var reference = _argument.Evaluate(context) as Reference;
             if (reference is null)
             {
                 ExceptionHelper.ThrowTypeError(engine.Realm, "Invalid left-hand side expression");
@@ -69,7 +69,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             var operatorOverloaded = false;
             if (context.OperatorOverloadingAllowed)
             {
-                if (JintUnaryExpression.TryOperatorOverloading(context, _argument.GetValue(context).Value, _change > 0 ? "op_Increment" : "op_Decrement", out var result))
+                if (JintUnaryExpression.TryOperatorOverloading(context, _argument.GetValue(context), _change > 0 ? "op_Increment" : "op_Decrement", out var result))
                 {
                     operatorOverloaded = true;
                     newValue = result;
@@ -140,7 +140,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 var operatorOverloaded = false;
                 if (context.OperatorOverloadingAllowed)
                 {
-                    if (JintUnaryExpression.TryOperatorOverloading(context, _argument.GetValue(context).Value, _change > 0 ? "op_Increment" : "op_Decrement", out var result))
+                    if (JintUnaryExpression.TryOperatorOverloading(context, _argument.GetValue(context), _change > 0 ? "op_Increment" : "op_Decrement", out var result))
                     {
                         operatorOverloaded = true;
                         newValue = result;

--- a/Jint/Runtime/Interpreter/Expressions/NullishCoalescingExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/NullishCoalescingExpression.cs
@@ -25,27 +25,26 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
         }
 
-        public override Completion GetValue(EvaluationContext context)
+        public override JsValue GetValue(EvaluationContext context)
         {
             // need to notify correct node when taking shortcut
             context.LastSyntaxElement = _expression;
-            JsValue value = EvaluateConstantOrExpression(context);
-            return new(CompletionType.Normal, value, _expression);
+            return EvaluateConstantOrExpression(context);
         }
 
-        protected override ExpressionResult EvaluateInternal(EvaluationContext context)
+        protected override object EvaluateInternal(EvaluationContext context)
         {
-            return NormalCompletion(EvaluateConstantOrExpression(context));
+            return EvaluateConstantOrExpression(context);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private JsValue EvaluateConstantOrExpression(EvaluationContext context)
         {
-            var left = _left.GetValue(context).Value;
+            var left = _left.GetValue(context);
 
             return !left.IsNullOrUndefined()
                 ? left
-                : _constant ?? _right!.GetValue(context).Value;
+                : _constant ?? _right!.GetValue(context);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -39,7 +39,7 @@ internal sealed class JintFunctionDefinition
         {
             // https://tc39.es/ecma262/#sec-runtime-semantics-evaluateconcisebody
             _bodyExpression ??= JintExpression.Build(context.Engine, (Expression) Function.Body);
-            var jsValue = _bodyExpression.GetValue(context).GetValueOrDefault().Clone();
+            var jsValue = _bodyExpression.GetValue(context).Clone();
             result = new Completion(CompletionType.Return, jsValue, Function.Body);
         }
         else if (Function.Generator)

--- a/Jint/Runtime/Interpreter/Statements/JintClassDeclarationStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintClassDeclarationStatement.cs
@@ -16,17 +16,17 @@ namespace Jint.Runtime.Interpreter.Statements
         {
             var engine = context.Engine;
             var env = engine.ExecutionContext.LexicalEnvironment;
-            var completion = _classDefinition.BuildConstructor(context, env);
+            var value = _classDefinition.BuildConstructor(context, env);
 
-            if (completion.IsAbrupt())
+            if (context.IsAbrupt())
             {
-                return completion;
+                return new Completion(context.Completion, value, _statement);
             }
 
             var classBinding = _classDefinition._className;
             if (classBinding != null)
             {
-                env.InitializeBinding(classBinding, completion.Value);
+                env.InitializeBinding(classBinding, value);
             }
 
             return new Completion(CompletionType.Normal, null!, _statement);

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -55,7 +55,7 @@ namespace Jint.Runtime.Interpreter.Statements
                     context.Engine.DebugHandler.OnStep(_test._expression);
                 }
 
-                iterating = TypeConverter.ToBoolean(_test.GetValue(context).Value);
+                iterating = TypeConverter.ToBoolean(_test.GetValue(context));
             } while (iterating);
 
             return new Completion(CompletionType.Normal, v, ((JintStatement) this)._statement);

--- a/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
@@ -47,32 +47,32 @@ internal sealed class JintExportDefaultDeclaration : JintStatement<ExportDefault
         JsValue value;
         if (_classDefinition is not null)
         {
-            value = _classDefinition.BuildConstructor(context, env).GetValueOrDefault();
+            value = _classDefinition.BuildConstructor(context, env);
             var classBinding = _classDefinition._className;
             if (classBinding != null)
             {
                 env.CreateMutableBinding(classBinding);
                 env.InitializeBinding(classBinding, value);
             }
-        }     
+        }
         else if (_functionDeclaration is not null)
         {
             value = _functionDeclaration.Execute(context).GetValueOrDefault();
         }
         else if (_assignmentExpression is not null)
         {
-            value = _assignmentExpression.GetValue(context).GetValueOrDefault();
+            value = _assignmentExpression.GetValue(context);
         }
         else
         {
-            value = _simpleExpression!.GetValue(context).GetValueOrDefault();
+            value = _simpleExpression!.GetValue(context);
         }
 
         if (value is ObjectInstance oi && !oi.HasOwnProperty("name"))
         {
             oi.SetFunctionName("default");
         }
-        
+
         env.InitializeBinding("*default*", value);
         return Completion.Empty();
     }

--- a/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
@@ -18,6 +18,6 @@ internal sealed class JintExpressionStatement : JintStatement<ExpressionStatemen
 
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
-        return _expression.GetValue(context);
+        return new Completion(context.Completion, _expression.GetValue(context), _statement);
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -129,7 +129,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 {
                     debugHandler?.OnStep(_test._expression);
 
-                    if (!TypeConverter.ToBoolean(_test.GetValue(context).Value))
+                    if (!TypeConverter.ToBoolean(_test.GetValue(context)))
                     {
                         return new Completion(CompletionType.Normal, v, ((JintStatement) this)._statement);
                     }

--- a/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
@@ -23,7 +23,7 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
             Completion result;
-            if (TypeConverter.ToBoolean(_test.GetValue(context).Value))
+            if (TypeConverter.ToBoolean(_test.GetValue(context)))
             {
                 result = _statementConsequent.Execute(context);
             }

--- a/Jint/Runtime/Interpreter/Statements/JintReturnStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintReturnStatement.cs
@@ -24,7 +24,6 @@ internal sealed class JintReturnStatement : JintStatement<ReturnStatement>
 
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
-        var jsValue = _argument?.GetValue(context).Value ?? Undefined.Instance;
-        return new Completion(CompletionType.Return, jsValue, _statement);
+        return new Completion(CompletionType.Return, _argument?.GetValue(context) ?? Undefined.Instance, _statement);
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
@@ -59,7 +59,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 }
                 else
                 {
-                    var clauseSelector = clause.Test.GetValue(context).Value;
+                    var clauseSelector = clause.Test.GetValue(context);
                     if (clauseSelector == input)
                     {
                         hit = true;

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchStatement.cs
@@ -24,7 +24,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
-            var value = _discriminant.GetValue(context).Value;
+            var value = _discriminant.GetValue(context);
             var r = _switchBlock.Execute(context, value);
             if (r.Type == CompletionType.Break && context.Target == _statement.LabelSet?.Name)
             {

--- a/Jint/Runtime/Interpreter/Statements/JintThrowStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintThrowStatement.cs
@@ -21,8 +21,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
-            var completion = _argument.GetValue(context);
-            return new Completion(CompletionType.Throw, completion.Value, completion._source);
+            return new Completion(CompletionType.Throw, _argument.GetValue(context), _argument._expression);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
@@ -68,12 +68,11 @@ namespace Jint.Runtime.Interpreter.Statements
             {
                 if (_statement.Kind != VariableDeclarationKind.Var && declaration.Left != null)
                 {
-                    var lhs = (Reference) declaration.Left.Evaluate(context).Value;
+                    var lhs = (Reference) declaration.Left.Evaluate(context);
                     var value = JsValue.Undefined;
                     if (declaration.Init != null)
                     {
-                        var completion = declaration.Init.GetValue(context);
-                        value = completion.Value.Clone();
+                        value = declaration.Init.GetValue(context).Clone();
                         if (declaration.Init._expression.IsFunctionDefinition())
                         {
                             ((FunctionInstance) value).SetFunctionName(lhs.GetReferencedName());
@@ -91,12 +90,12 @@ namespace Jint.Runtime.Interpreter.Statements
                             ? engine.ExecutionContext.LexicalEnvironment
                             : null;
 
-                        var completion = declaration.Init.GetValue(context);
+                        var value = declaration.Init.GetValue(context);
 
                         BindingPatternAssignmentExpression.ProcessPatterns(
                             context,
                             declaration.LeftPattern,
-                            completion.Value,
+                            value,
                             environment,
                             checkPatternPropertyReference: _statement.Kind != VariableDeclarationKind.Var);
                     }
@@ -108,11 +107,10 @@ namespace Jint.Runtime.Interpreter.Statements
                                  declaration.EvalOrArguments) is null)
                     {
                         // slow path
-                        var lhs = (Reference) declaration.Left!.Evaluate(context).Value;
+                        var lhs = (Reference) declaration.Left!.Evaluate(context);
                         lhs.AssertValid(engine.Realm);
 
-                        var completion = declaration.Init.GetValue(context);
-                        var value = completion.Value.Clone();
+                        var value = declaration.Init.GetValue(context).Clone();
 
                         if (declaration.Init._expression.IsFunctionDefinition())
                         {

--- a/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
@@ -34,7 +34,7 @@ namespace Jint.Runtime.Interpreter.Statements
                     context.Engine.DebugHandler.OnStep(_test._expression);
                 }
 
-                var jsValue = _test.GetValue(context).Value;
+                var jsValue = _test.GetValue(context);
                 if (!TypeConverter.ToBoolean(jsValue))
                 {
                     return new Completion(CompletionType.Normal, v, _statement);

--- a/Jint/Runtime/Interpreter/Statements/JintWithStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWithStatement.cs
@@ -24,7 +24,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
-            var jsValue = _object.GetValue(context).Value;
+            var jsValue = _object.GetValue(context);
             var engine = context.Engine;
             var obj = TypeConverter.ToObject(engine.Realm, jsValue);
             var oldEnv = engine.ExecutionContext.LexicalEnvironment;

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -49,13 +49,13 @@ public class JavaScriptException : JintException
 
     public string GetJavaScriptErrorString() => _jsErrorException.ToString();
 
-    public JavaScriptException SetJavaScriptCallstack(Engine engine, Location location, bool overwriteExisting = false)
+    public JavaScriptException SetJavaScriptCallstack(Engine engine, in Location location, bool overwriteExisting = false)
     {
         _jsErrorException.SetCallstack(engine, location, overwriteExisting);
         return this;
     }
 
-    public JavaScriptException SetJavaScriptLocation(Location location)
+    public JavaScriptException SetJavaScriptLocation(in Location location)
     {
         _jsErrorException.SetLocation(location);
         return this;

--- a/Jint/Runtime/Modules/DefaultModuleLoader.cs
+++ b/Jint/Runtime/Modules/DefaultModuleLoader.cs
@@ -137,7 +137,7 @@ public sealed class DefaultModuleLoader : IModuleLoader
         }
         catch (Exception)
         {
-            ExceptionHelper.ThrowJavaScriptException(engine, $"Could not load module {resolved.Uri?.LocalPath}", Completion.Empty());
+            ExceptionHelper.ThrowJavaScriptException(engine, $"Could not load module {resolved.Uri?.LocalPath}", (Location) default);
             module = null;
         }
 

--- a/Jint/Runtime/Modules/SourceTextModuleRecord.cs
+++ b/Jint/Runtime/Modules/SourceTextModuleRecord.cs
@@ -343,7 +343,8 @@ internal class SourceTextModuleRecord : CyclicModuleRecord
             {
                 _engine.EnterExecutionContext(moduleContext);
                 var statementList = new JintStatementList(null, _source.Body);
-                var result = statementList.Execute(_engine._activeEvaluationContext ?? new EvaluationContext(_engine)); //Create new evaluation context when called from e.g. module tests
+                var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
+                var result = statementList.Execute(context); //Create new evaluation context when called from e.g. module tests
                 _engine.LeaveExecutionContext();
                 return result;
             }


### PR DESCRIPTION
While it felt like a good idea at the time, it has negative effect on stack handling and also creates some perf hit.

## Jint.Benchmark.SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Run|3d-cube|234.49 ms|0.403 ms|49017.03 KB|
| **New** |	|	| **218.62 ms (-7%)** | **0.296 ms** | **49017.03 KB (0%)** |
| Old |Run|3d-morph|176.66 ms|0.218 ms|48367.5 KB|
| **New** |	|	| **162.56 ms (-8%)** | **0.289 ms** | **48368.18 KB (0%)** |
| Old |Run|3d-raytrace|176.66 ms|0.344 ms|88376.62 KB|
| **New** |	|	| **163.68 ms (-7%)** | **0.324 ms** | **88376.56 KB (0%)** |
| Old |Run|access-binary-trees|78.34 ms|0.181 ms|60933.53 KB|
| **New** |	|	| **77.39 ms (-1%)** | **0.151 ms** | **60932.51 KB (0%)** |
| Old |Run|access-fannkuch|488.22 ms|2.301 ms|136.34 KB|
| **New** |	|	| **453.04 ms (-7%)** | **2.400 ms** | **136.34 KB (0%)** |
| Old |Run|access-nbody|205.19 ms|0.371 ms|63665.94 KB|
| **New** |	|	| **194.53 ms (-5%)** | **0.408 ms** | **63665.8 KB (0%)** |
| Old |Run|access-nsieve|168.77 ms|0.187 ms|21517.44 KB|
| **New** |	|	| **165.07 ms (-2%)** | **0.191 ms** | **21520.51 KB (0%)** |
| Old |Run|bitop(...)-byte [24]|157.58 ms|0.545 ms|56949.04 KB|
| **New** |	|	| **157.10 ms (0%)** | **0.738 ms** | **56949.04 KB (0%)** |
| Old |Run|bitops-bits-in-byte|251.87 ms|0.376 ms|37045.07 KB|
| **New** |	|	| **236.18 ms (-6%)** | **0.676 ms** | **37044.95 KB (0%)** |
| Old |Run|bitops-bitwise-and|139.45 ms|0.484 ms|55938.79 KB|
| **New** |	|	| **152.61 ms (+9%)** | **0.313 ms** | **55938.76 KB (0%)** |
| Old |Run|bitops-nsieve-bits|235.63 ms|0.830 ms|54072.5 KB|
| **New** |	|	| **213.20 ms (-10%)** | **0.915 ms** | **54072.5 KB (0%)** |
| Old |Run|contr(...)rsive [21]|102.28 ms|0.188 ms|83186.02 KB|
| **New** |	|	| **103.48 ms (+1%)** | **0.262 ms** | **83184.26 KB (0%)** |
| Old |Run|crypto-aes|149.30 ms|0.168 ms|14004.18 KB|
| **New** |	|	| **139.87 ms (-6%)** | **0.325 ms** | **14004.03 KB (0%)** |
| Old |Run|crypto-md5|103.88 ms|0.340 ms|77906.85 KB|
| **New** |	|	| **98.70 ms (-5%)** | **0.200 ms** | **77908.26 KB (0%)** |
| Old |Run|crypto-sha1|103.84 ms|0.231 ms|64567.48 KB|
| **New** |	|	| **98.68 ms (-5%)** | **0.170 ms** | **64567.52 KB (0%)** |
| Old |Run|date-format-tofte|108.50 ms|1.043 ms|43346.05 KB|
| **New** |	|	| **102.18 ms (-6%)** | **0.105 ms** | **43346.05 KB (0%)** |
| Old |Run|date-format-xparb|59.25 ms|0.624 ms|24848.68 KB|
| **New** |	|	| **55.39 ms (-7%)** | **0.130 ms** | **24847.7 KB (0%)** |
| Old |Run|math-cordic|361.44 ms|1.372 ms|81978.58 KB|
| **New** |	|	| **336.49 ms (-7%)** | **0.639 ms** | **81976.24 KB (0%)** |
| Old |Run|math-partial-sums|130.78 ms|0.684 ms|50095.98 KB|
| **New** |	|	| **132.01 ms (+1%)** | **0.274 ms** | **50096.08 KB (0%)** |
| Old |Run|math-spectral-norm|129.94 ms|0.240 ms|51833.97 KB|
| **New** |	|	| **133.59 ms (+3%)** | **0.604 ms** | **51833.87 KB (0%)** |
| Old |Run|regexp-dna|106.16 ms|0.472 ms|17667.54 KB|
| **New** |	|	| **105.45 ms (-1%)** | **0.231 ms** | **17668.97 KB (0%)** |
| Old |Run|string-base64|107.50 ms|0.187 ms|11241.92 KB|
| **New** |	|	| **105.69 ms (-2%)** | **0.235 ms** | **11243.11 KB (0%)** |
| Old |Run|string-fasta|203.13 ms|0.326 ms|148053.52 KB|
| **New** |	|	| **194.59 ms (-4%)** | **0.321 ms** | **148053.38 KB (0%)** |
| Old |Run|string-tagcloud|73.63 ms|0.210 ms|44033.8 KB|
| **New** |	|	| **69.67 ms (-5%)** | **0.400 ms** | **44035 KB (0%)** |
| Old |Run|string-unpack-code|71.39 ms|0.146 ms|74420.91 KB|
| **New** |	|	| **70.46 ms (-1%)** | **0.089 ms** | **74422 KB (0%)** |
| Old |Run|strin(...)input [21]|81.44 ms|0.190 ms|39744.77 KB|
| **New** |	|	| **79.62 ms (-2%)** | **0.330 ms** | **39746.35 KB (0%)** |


