### PR TITLE
Reduce Engine references in expressions

### DIFF
--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -10,7 +10,7 @@ public class EngineLimitTests
     public void ShouldAllowReasonableCallStackDepth()
     {
 #if RELEASE
-        const int FunctionNestingCount = 990;
+        const int FunctionNestingCount = 1000;
 #else
         const int FunctionNestingCount = 570;
 #endif

--- a/Jint/EsprimaExtensions.cs
+++ b/Jint/EsprimaExtensions.cs
@@ -72,7 +72,7 @@ namespace Jint
                 or Nodes.YieldExpression)
             {
                 var context = engine._activeEvaluationContext;
-                return JintExpression.Build(engine, expression).GetValue(context!);
+                return JintExpression.Build(expression).GetValue(context!);
             }
 
             return JsValue.Undefined;

--- a/Jint/Native/Function/ClassDefinition.cs
+++ b/Jint/Native/Function/ClassDefinition.cs
@@ -88,7 +88,7 @@ namespace Jint.Native.Function
             else
             {
                 engine.UpdateLexicalEnvironment(classScope);
-                var superclass = JintExpression.Build(engine, _superClass).GetValue(context);
+                var superclass = JintExpression.Build(_superClass).GetValue(context);
                 engine.UpdateLexicalEnvironment(env);
 
                 if (superclass.IsNull())

--- a/Jint/Runtime/Environments/FunctionEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/FunctionEnvironmentRecord.cs
@@ -360,7 +360,7 @@ namespace Jint.Runtime.Environments
             if (argument.IsUndefined())
             {
                 var expression = right.As<Expression>();
-                var jintExpression = JintExpression.Build(_engine, expression);
+                var jintExpression = JintExpression.Build(expression);
 
                 var oldEnv = _engine.ExecutionContext.LexicalEnvironment;
                 var paramVarEnv = JintEnvironment.NewDeclarativeEnvironment(_engine, oldEnv);

--- a/Jint/Runtime/ExceptionHelper.cs
+++ b/Jint/Runtime/ExceptionHelper.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using Esprima;
+using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Error;
 using Jint.Runtime.CallStack;
@@ -57,9 +58,9 @@ namespace Jint.Runtime
         }
 
         [DoesNotReturn]
-        public static void ThrowTypeErrorNoEngine(string? message = null)
+        public static void ThrowTypeErrorNoEngine(string? message = null, Node? source = null)
         {
-            throw new TypeErrorException(message);
+            throw new TypeErrorException(message, source);
         }
 
         [DoesNotReturn]

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -18,6 +18,15 @@ internal sealed class EvaluationContext
         _shouldRunBeforeExecuteStatementChecks = engine._constraints.Length > 0 || engine._isDebugMode;
     }
 
+    // for fast evaluation checks only
+    public EvaluationContext()
+    {
+        Engine = null!;
+        ResumedCompletion = default; // TODO later
+        OperatorOverloadingAllowed = false;
+        _shouldRunBeforeExecuteStatementChecks = false;
+    }
+
     public readonly Engine Engine;
     public readonly Completion ResumedCompletion;
     public bool DebugMode => Engine._isDebugMode;

--- a/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
@@ -21,7 +21,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override void Initialize(EvaluationContext context)
         {
-            _right = Build(context.Engine, ((AssignmentExpression) _expression).Right);
+            _right = Build(((AssignmentExpression) _expression).Right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
@@ -239,7 +239,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                         if (value.IsUndefined())
                         {
-                            var jintExpression = Build(engine, assignmentPattern.Right);
+                            var jintExpression = Build(assignmentPattern.Right);
                             var completion = jintExpression.GetValue(context);
                             if (context.IsAbrupt())
                             {
@@ -308,7 +308,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     var identifier = p.Key as Identifier;
                     if (identifier == null || p.Computed)
                     {
-                        var keyExpression = Build(context.Engine, p.Key);
+                        var keyExpression = Build(p.Key);
                         var value = keyExpression.GetValue(context);
                         if (context.IsAbrupt())
                         {
@@ -327,7 +327,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                         source.TryGetValue(sourceKey, out var value);
                         if (value.IsUndefined())
                         {
-                            var jintExpression = Build(context.Engine, assignmentPattern.Right);
+                            var jintExpression = Build(assignmentPattern.Right);
                             var completion = jintExpression.GetValue(context);
                             if (context.IsAbrupt())
                             {

--- a/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
@@ -25,7 +25,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 var expr = node.Elements[n];
                 if (expr != null)
                 {
-                    var expression = Build(engine, expr);
+                    var expression = Build(expr);
                     _expressions[n] = expression;
                     _hasSpreads |= expr.Type == Nodes.SpreadElement;
                 }

--- a/Jint/Runtime/Interpreter/Expressions/JintArrowFunctionExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintArrowFunctionExpression.cs
@@ -8,7 +8,7 @@ namespace Jint.Runtime.Interpreter.Expressions
     {
         private readonly JintFunctionDefinition _function;
 
-        public JintArrowFunctionExpression(Engine engine, ArrowFunctionExpression function) : base(function)
+        public JintArrowFunctionExpression(ArrowFunctionExpression function) : base(function)
         {
             _function = new JintFunctionDefinition(function);
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -13,14 +13,14 @@ namespace Jint.Runtime.Interpreter.Expressions
         private readonly JintExpression _right;
         private readonly AssignmentOperator _operator;
 
-        private JintAssignmentExpression(Engine engine, AssignmentExpression expression) : base(expression)
+        private JintAssignmentExpression(AssignmentExpression expression) : base(expression)
         {
-            _left = Build(engine, (Expression) expression.Left);
-            _right = Build(engine, expression.Right);
+            _left = Build((Expression) expression.Left);
+            _right = Build(expression.Right);
             _operator = expression.Operator;
         }
 
-        internal static JintExpression Build(Engine engine, AssignmentExpression expression)
+        internal static JintExpression Build(AssignmentExpression expression)
         {
             if (expression.Operator == AssignmentOperator.Assign)
             {
@@ -32,7 +32,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 return new SimpleAssignmentExpression(expression);
             }
 
-            return new JintAssignmentExpression(engine, expression);
+            return new JintAssignmentExpression(expression);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
@@ -345,11 +345,11 @@ namespace Jint.Runtime.Interpreter.Expressions
             protected override void Initialize(EvaluationContext context)
             {
                 var assignmentExpression = (AssignmentExpression) _expression;
-                _left = Build(context.Engine, (Expression) assignmentExpression.Left);
+                _left = Build((Expression) assignmentExpression.Left);
                 _leftIdentifier = _left as JintIdentifierExpression;
                 _evalOrArguments = _leftIdentifier?.HasEvalOrArguments == true;
 
-                _right = Build(context.Engine, assignmentExpression.Right);
+                _right = Build(assignmentExpression.Right);
             }
 
             protected override object EvaluateInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -29,7 +29,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             var expression = (CallExpression) _expression;
             ref readonly var expressionArguments = ref expression.Arguments;
 
-            _calleeExpression = Build(engine, expression.Callee);
+            _calleeExpression = Build(expression.Callee);
             var cachedArgumentsHolder = new CachedArgumentsHolder
             {
                 JintArguments = new JintExpression[expressionArguments.Count]
@@ -44,7 +44,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             for (var i = 0; i < expressionArguments.Count; i++)
             {
                 var expressionArgument = expressionArguments[i];
-                cachedArgumentsHolder.JintArguments[i] = Build(engine, expressionArgument);
+                cachedArgumentsHolder.JintArguments[i] = Build(expressionArgument);
                 cacheable &= expressionArgument.Type == Nodes.Literal;
                 _hasSpreads |= CanSpread(expressionArgument);
                 if (expressionArgument is ArrayExpression ae)

--- a/Jint/Runtime/Interpreter/Expressions/JintConditionalExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintConditionalExpression.cs
@@ -8,11 +8,11 @@ namespace Jint.Runtime.Interpreter.Expressions
         private readonly JintExpression _consequent;
         private readonly JintExpression _alternate;
 
-        public JintConditionalExpression(Engine engine, ConditionalExpression expression) : base(expression)
+        public JintConditionalExpression(ConditionalExpression expression) : base(expression)
         {
-            _test = Build(engine, expression.Test);
-            _consequent = Build(engine, expression.Consequent);
-            _alternate = Build(engine, expression.Alternate);
+            _test = Build(expression.Test);
+            _consequent = Build(expression.Consequent);
+            _alternate = Build(expression.Alternate);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -101,24 +101,24 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
         }
 
-        protected internal static JintExpression Build(Engine engine, Expression expression)
+        protected internal static JintExpression Build(Expression expression)
         {
             var result = expression.Type switch
             {
-                Nodes.AssignmentExpression => JintAssignmentExpression.Build(engine, (AssignmentExpression) expression),
+                Nodes.AssignmentExpression => JintAssignmentExpression.Build((AssignmentExpression) expression),
                 Nodes.ArrayExpression => new JintArrayExpression((ArrayExpression) expression),
-                Nodes.ArrowFunctionExpression => new JintArrowFunctionExpression(engine, (ArrowFunctionExpression) expression),
-                Nodes.BinaryExpression => JintBinaryExpression.Build(engine, (BinaryExpression) expression),
+                Nodes.ArrowFunctionExpression => new JintArrowFunctionExpression((ArrowFunctionExpression) expression),
+                Nodes.BinaryExpression => JintBinaryExpression.Build((BinaryExpression) expression),
                 Nodes.CallExpression => new JintCallExpression((CallExpression) expression),
-                Nodes.ConditionalExpression => new JintConditionalExpression(engine, (ConditionalExpression) expression),
+                Nodes.ConditionalExpression => new JintConditionalExpression((ConditionalExpression) expression),
                 Nodes.FunctionExpression => new JintFunctionExpression((FunctionExpression) expression),
                 Nodes.Identifier => new JintIdentifierExpression((Identifier) expression),
                 Nodes.Literal => JintLiteralExpression.Build((Literal) expression),
                 Nodes.LogicalExpression => ((BinaryExpression) expression).Operator switch
                 {
                     BinaryOperator.LogicalAnd => new JintLogicalAndExpression((BinaryExpression) expression),
-                    BinaryOperator.LogicalOr => new JintLogicalOrExpression(engine, (BinaryExpression) expression),
-                    BinaryOperator.NullishCoalescing => new NullishCoalescingExpression(engine, (BinaryExpression) expression),
+                    BinaryOperator.LogicalOr => new JintLogicalOrExpression((BinaryExpression) expression),
+                    BinaryOperator.NullishCoalescing => new NullishCoalescingExpression((BinaryExpression) expression),
                     _ => null
                 },
                 Nodes.MemberExpression => new JintMemberExpression((MemberExpression) expression),
@@ -127,8 +127,8 @@ namespace Jint.Runtime.Interpreter.Expressions
                 Nodes.SequenceExpression => new JintSequenceExpression((SequenceExpression) expression),
                 Nodes.ThisExpression => new JintThisExpression((ThisExpression) expression),
                 Nodes.UpdateExpression => new JintUpdateExpression((UpdateExpression) expression),
-                Nodes.UnaryExpression => JintUnaryExpression.Build(engine, (UnaryExpression) expression),
-                Nodes.SpreadElement => new JintSpreadExpression(engine, (SpreadElement) expression),
+                Nodes.UnaryExpression => JintUnaryExpression.Build((UnaryExpression) expression),
+                Nodes.SpreadElement => new JintSpreadExpression((SpreadElement) expression),
                 Nodes.TemplateLiteral => new JintTemplateLiteralExpression((TemplateLiteral) expression),
                 Nodes.TaggedTemplateExpression => new JintTaggedTemplateExpression((TaggedTemplateExpression) expression),
                 Nodes.ClassExpression => new JintClassExpression((ClassExpression) expression),
@@ -163,7 +163,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
             else
             {
-                JintBinaryExpression.AssertValidBigIntArithmeticOperands(context, left, right);
+                JintBinaryExpression.AssertValidBigIntArithmeticOperands(left, right);
                 var x = TypeConverter.ToBigInt(left);
                 var y = TypeConverter.ToBigInt(right);
 

--- a/Jint/Runtime/Interpreter/Expressions/JintImportExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintImportExpression.cs
@@ -16,7 +16,7 @@ internal sealed class JintImportExpression : JintExpression
     protected override void Initialize(EvaluationContext context)
     {
         var expression = ((Import) _expression).Source;
-        _importExpression = Build(context.Engine, expression);
+        _importExpression = Build(expression);
     }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintLogicalAndExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLogicalAndExpression.cs
@@ -16,8 +16,8 @@ namespace Jint.Runtime.Interpreter.Expressions
         protected override void Initialize(EvaluationContext context)
         {
             var expression = (BinaryExpression) _expression;
-            _left = Build(context.Engine, expression.Left);
-            _right = Build(context.Engine, expression.Right);
+            _left = Build(expression.Left);
+            _right = Build(expression.Right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Expressions/JintLogicalOrExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLogicalOrExpression.cs
@@ -8,10 +8,10 @@ namespace Jint.Runtime.Interpreter.Expressions
         private readonly JintExpression _left;
         private readonly JintExpression _right;
 
-        public JintLogicalOrExpression(Engine engine, BinaryExpression expression) : base(expression)
+        public JintLogicalOrExpression(BinaryExpression expression) : base(expression)
         {
-            _left = Build(engine, expression.Left);
-            _right = Build(engine, expression.Right);
+            _left = Build(expression.Left);
+            _right = Build(expression.Right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -23,7 +23,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override void Initialize(EvaluationContext context)
         {
-            _objectExpression = Build(context.Engine, _memberExpression.Object);
+            _objectExpression = Build(_memberExpression.Object);
 
             if (!_memberExpression.Computed)
             {
@@ -36,7 +36,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             if (_determinedProperty is null)
             {
-                _propertyExpression = Build(context.Engine, _memberExpression.Property);
+                _propertyExpression = Build(_memberExpression.Property);
             }
         }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
@@ -16,10 +16,8 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override void Initialize(EvaluationContext context)
         {
-            var engine = context.Engine;
-
             var expression = (NewExpression) _expression;
-            _calleeExpression = Build(engine, expression.Callee);
+            _calleeExpression = Build(expression.Callee);
 
             if (expression.Arguments.Count <= 0)
             {
@@ -30,7 +28,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             for (var i = 0; i < _jintArguments.Length; i++)
             {
                 var argument = expression.Arguments[i];
-                _jintArguments[i] = Build(engine, argument);
+                _jintArguments[i] = Build(argument);
                 _hasSpreads |= argument.Type == Nodes.SpreadElement;
             }
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -93,7 +93,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     if (p.Kind is PropertyKind.Init)
                     {
                         var propertyValue = p.Value;
-                        _valueExpressions[i] = Build(engine, (Expression) propertyValue);
+                        _valueExpressions[i] = Build((Expression) propertyValue);
                         _canBuildFast &= !propertyValue.IsFunctionDefinition();
                     }
                     else
@@ -105,7 +105,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 {
                     _canBuildFast = false;
                     _properties[i] = null;
-                    _valueExpressions[i] = Build(engine, spreadElement.Argument);
+                    _valueExpressions[i] = Build(spreadElement.Argument);
                 }
                 else
                 {

--- a/Jint/Runtime/Interpreter/Expressions/JintSequenceExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintSequenceExpression.cs
@@ -14,13 +14,12 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override void Initialize(EvaluationContext context)
         {
-            var engine = context.Engine;
             var expression = (SequenceExpression) _expression;
             ref readonly var expressions = ref expression.Expressions;
             var temp = new JintExpression[expressions.Count];
             for (var i = 0; i < (uint) temp.Length; i++)
             {
-                temp[i] = Build(engine, expressions[i]);
+                temp[i] = Build(expressions[i]);
             }
 
             _expressions = temp;

--- a/Jint/Runtime/Interpreter/Expressions/JintSpreadExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintSpreadExpression.cs
@@ -9,9 +9,9 @@ namespace Jint.Runtime.Interpreter.Expressions
         private readonly JintExpression _argument;
         private readonly string? _argumentName;
 
-        public JintSpreadExpression(Engine engine, SpreadElement expression) : base(expression)
+        public JintSpreadExpression(SpreadElement expression) : base(expression)
         {
-            _argument = Build(engine, expression.Argument);
+            _argument = Build(expression.Argument);
             _argumentName = (expression.Argument as Identifier)?.Name;
         }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
@@ -21,10 +21,9 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override void Initialize(EvaluationContext context)
         {
-            var engine = context.Engine;
-            _tagIdentifier = Build(engine, _taggedTemplateExpression.Tag);
+            _tagIdentifier = Build(_taggedTemplateExpression.Tag);
             _quasi = new JintTemplateLiteralExpression(_taggedTemplateExpression.Quasi);
-            _quasi.DoInitialize(context);
+            _quasi.DoInitialize();
         }
 
         protected override object EvaluateInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Expressions/JintTemplateLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTemplateLiteralExpression.cs
@@ -17,17 +17,16 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override void Initialize(EvaluationContext context)
         {
-            DoInitialize(context);
+            DoInitialize();
         }
 
-        internal void DoInitialize(EvaluationContext context)
+        internal void DoInitialize()
         {
-            var engine = context.Engine;
             _expressions = new JintExpression[_templateLiteralExpression.Expressions.Count];
             for (var i = 0; i < _templateLiteralExpression.Expressions.Count; i++)
             {
                 var exp = _templateLiteralExpression.Expressions[i];
-                _expressions[i] = Build(engine, exp);
+                _expressions[i] = Build(exp);
             }
 
             _initialized = true;

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -23,7 +23,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         {
             var expression = (UpdateExpression) _expression;
             _prefix = expression.Prefix;
-            _argument = Build(context.Engine, expression.Argument);
+            _argument = Build(expression.Argument);
             if (expression.Operator == UnaryOperator.Increment)
             {
                 _change = 1;

--- a/Jint/Runtime/Interpreter/Expressions/NullishCoalescingExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/NullishCoalescingExpression.cs
@@ -10,9 +10,9 @@ namespace Jint.Runtime.Interpreter.Expressions
         private readonly JintExpression? _right;
         private readonly JsValue? _constant;
 
-        public NullishCoalescingExpression(Engine engine, BinaryExpression expression) : base(expression)
+        public NullishCoalescingExpression(BinaryExpression expression) : base(expression)
         {
-            _left = Build(engine, expression.Left);
+            _left = Build(expression.Left);
 
             // we can create a fast path for common literal case like variable ?? 0
             if (expression.Right is Literal l)
@@ -21,7 +21,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
             else
             {
-                _right = Build(engine, expression.Right);
+                _right = Build(expression.Right);
             }
         }
 

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -38,7 +38,7 @@ internal sealed class JintFunctionDefinition
         if (Function.Expression)
         {
             // https://tc39.es/ecma262/#sec-runtime-semantics-evaluateconcisebody
-            _bodyExpression ??= JintExpression.Build(context.Engine, (Expression) Function.Body);
+            _bodyExpression ??= JintExpression.Build((Expression) Function.Body);
             var jsValue = _bodyExpression.GetValue(context).Clone();
             result = new Completion(CompletionType.Return, jsValue, Function.Body);
         }

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -126,21 +126,22 @@ namespace Jint.Runtime.Interpreter
             }
             if (exception is TypeErrorException typeErrorException)
             {
-                return CreateThrowCompletion(context.Engine.Realm.Intrinsics.TypeError, typeErrorException, s!);
+                var node = typeErrorException.Node ?? s!._statement;
+                return CreateThrowCompletion(context.Engine.Realm.Intrinsics.TypeError, typeErrorException, node);
             }
             if (exception is RangeErrorException rangeErrorException)
             {
-                return CreateThrowCompletion(context.Engine.Realm.Intrinsics.RangeError, rangeErrorException, s!);
+                return CreateThrowCompletion(context.Engine.Realm.Intrinsics.RangeError, rangeErrorException, s!._statement);
             }
 
             // should not happen unless there's problem in the engine
             throw exception;
         }
 
-        private static Completion CreateThrowCompletion(ErrorConstructor errorConstructor, Exception e, JintStatement s)
+        private static Completion CreateThrowCompletion(ErrorConstructor errorConstructor, Exception e, SyntaxElement s)
         {
             var error = errorConstructor.Construct(new JsValue[] { e.Message });
-            return new Completion(CompletionType.Throw, error, s._statement);
+            return new Completion(CompletionType.Throw, error, s);
         }
 
         private static Completion CreateThrowCompletion(JintStatement? s, JavaScriptException v)

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -20,7 +20,7 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override void Initialize(EvaluationContext context)
         {
             _body = new ProbablyBlockStatement(_statement.Body);
-            _test = JintExpression.Build(context.Engine, _statement.Test);
+            _test = JintExpression.Build(_statement.Test);
             _labelSetName = _statement.LabelSet?.Name;
         }
 

--- a/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
@@ -30,11 +30,11 @@ internal sealed class JintExportDefaultDeclaration : JintStatement<ExportDefault
         }
         else if (_statement.Declaration is AssignmentExpression assignmentExpression)
         {
-            _assignmentExpression = JintAssignmentExpression.Build(context.Engine, assignmentExpression);
+            _assignmentExpression = JintAssignmentExpression.Build(assignmentExpression);
         }
         else
         {
-            _simpleExpression = JintExpression.Build(context.Engine, (Expression) _statement.Declaration);
+            _simpleExpression = JintExpression.Build((Expression) _statement.Declaration);
         }
     }
 

--- a/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
@@ -13,7 +13,7 @@ internal sealed class JintExpressionStatement : JintStatement<ExpressionStatemen
 
     protected override void Initialize(EvaluationContext context)
     {
-        _expression = JintExpression.Build(context.Engine, _statement.Expression);
+        _expression = JintExpression.Build(_statement.Expression);
     }
 
     protected override Completion ExecuteInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -88,7 +88,7 @@ namespace Jint.Runtime.Interpreter.Statements
             }
 
             _body = new ProbablyBlockStatement(_forBody);
-            _right = JintExpression.Build(engine, _rightExpression);
+            _right = JintExpression.Build(_rightExpression);
         }
 
         protected override Completion ExecuteInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -45,18 +45,18 @@ namespace Jint.Runtime.Interpreter.Statements
                 }
                 else
                 {
-                    _initExpression = JintExpression.Build(engine, (Expression) _statement.Init);
+                    _initExpression = JintExpression.Build((Expression) _statement.Init);
                 }
             }
 
             if (_statement.Test != null)
             {
-                _test = JintExpression.Build(engine, _statement.Test);
+                _test = JintExpression.Build(_statement.Test);
             }
 
             if (_statement.Update != null)
             {
-                _increment = JintExpression.Build(engine, _statement.Update);
+                _increment = JintExpression.Build(_statement.Update);
             }
         }
 

--- a/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
@@ -16,7 +16,7 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override void Initialize(EvaluationContext context)
         {
             _statementConsequent = new ProbablyBlockStatement(_statement.Consequent);
-            _test = JintExpression.Build(context.Engine, _statement.Test);
+            _test = JintExpression.Build(_statement.Test);
             _alternate = _statement.Alternate != null ? new ProbablyBlockStatement(_statement.Alternate) : null;
         }
 

--- a/Jint/Runtime/Interpreter/Statements/JintReturnStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintReturnStatement.cs
@@ -18,7 +18,7 @@ internal sealed class JintReturnStatement : JintStatement<ReturnStatement>
     protected override void Initialize(EvaluationContext context)
     {
         _argument = _statement.Argument != null
-            ? JintExpression.Build(context.Engine, _statement.Argument)
+            ? JintExpression.Build(_statement.Argument)
             : null;
     }
 

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
@@ -128,7 +128,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
                 if (switchCase.Test != null)
                 {
-                    Test = JintExpression.Build(engine, switchCase.Test);
+                    Test = JintExpression.Build(switchCase.Test);
                 }
             }
         }

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchStatement.cs
@@ -17,9 +17,8 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override void Initialize(EvaluationContext context)
         {
-            var engine = context.Engine;
             _switchBlock = new JintSwitchBlock(_statement.Cases);
-            _discriminant = JintExpression.Build(engine, _statement.Discriminant);
+            _discriminant = JintExpression.Build(_statement.Discriminant);
         }
 
         protected override Completion ExecuteInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Statements/JintThrowStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintThrowStatement.cs
@@ -16,7 +16,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override void Initialize(EvaluationContext context)
         {
-            _argument = JintExpression.Build(context.Engine, _statement.Argument);
+            _argument = JintExpression.Build(_statement.Argument);
         }
 
         protected override Completion ExecuteInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
@@ -41,12 +41,12 @@ namespace Jint.Runtime.Interpreter.Statements
                 }
                 else
                 {
-                    left = JintExpression.Build(engine, (Identifier) declaration.Id);
+                    left = JintExpression.Build((Identifier) declaration.Id);
                 }
 
                 if (declaration.Init != null)
                 {
-                    init = JintExpression.Build(engine, declaration.Init);
+                    init = JintExpression.Build(declaration.Init);
                 }
 
                 var leftIdentifier = left as JintIdentifierExpression;

--- a/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
@@ -21,7 +21,7 @@ namespace Jint.Runtime.Interpreter.Statements
         {
             _labelSetName = _statement.LabelSet?.Name;
             _body = new ProbablyBlockStatement(_statement.Body);
-            _test = JintExpression.Build(context.Engine, _statement.Test);
+            _test = JintExpression.Build(_statement.Test);
         }
 
         protected override Completion ExecuteInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Statements/JintWithStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWithStatement.cs
@@ -19,7 +19,7 @@ namespace Jint.Runtime.Interpreter.Statements
         protected override void Initialize(EvaluationContext context)
         {
             _body = new ProbablyBlockStatement(_statement.Body);
-            _object = JintExpression.Build(context.Engine, _statement.Object);
+            _object = JintExpression.Build(_statement.Object);
         }
 
         protected override Completion ExecuteInternal(EvaluationContext context)

--- a/Jint/Runtime/TypeErrorException.cs
+++ b/Jint/Runtime/TypeErrorException.cs
@@ -1,3 +1,5 @@
+using Esprima.Ast;
+
 namespace Jint.Runtime
 {
     /// <summary>
@@ -5,8 +7,11 @@ namespace Jint.Runtime
     /// </summary>
     internal sealed class TypeErrorException : JintException
     {
-        public TypeErrorException(string? message) : base(message)
+        public TypeErrorException(string? message, Node? node) : base(message)
         {
+            Node = node;
         }
+
+        public Node? Node { get; }
     }
 }


### PR DESCRIPTION
Reduces possibility for hidden engine references and makes expressions more static, allowing later caching too.

## Jint.Benchmark.SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Run|3d-cube|219.76 ms|0.612 ms|49017.03 KB|
| **New** |	|	| **216.89 ms (-1%)** | **0.380 ms** | **49017.87 KB (0%)** |
| Old |Run|3d-morph|168.84 ms|1.767 ms|48367.71 KB|
| **New** |	|	| **162.61 ms (-4%)** | **0.237 ms** | **48368.9 KB (0%)** |
| Old |Run|3d-raytrace|167.10 ms|0.189 ms|88376.8 KB|
| **New** |	|	| **164.49 ms (-2%)** | **0.369 ms** | **88376.7 KB (0%)** |
| Old |Run|access-binary-trees|75.98 ms|0.158 ms|60932.51 KB|
| **New** |	|	| **77.33 ms (+2%)** | **0.207 ms** | **60933.23 KB (0%)** |
| Old |Run|access-fannkuch|472.85 ms|1.516 ms|136.34 KB|
| **New** |	|	| **458.60 ms (-3%)** | **3.567 ms** | **136.34 KB (0%)** |
| Old |Run|access-nbody|190.42 ms|0.484 ms|63665.8 KB|
| **New** |	|	| **194.87 ms (+2%)** | **0.341 ms** | **63665.94 KB (0%)** |
| Old |Run|access-nsieve|169.97 ms|0.233 ms|21517.26 KB|
| **New** |	|	| **160.64 ms (-5%)** | **0.231 ms** | **21518.16 KB (0%)** |
| Old |Run|bitop(...)-byte [24]|149.14 ms|0.263 ms|56949.13 KB|
| **New** |	|	| **145.16 ms (-3%)** | **0.357 ms** | **56951.32 KB (0%)** |
| Old |Run|bitops-bits-in-byte|234.09 ms|1.196 ms|37044.95 KB|
| **New** |	|	| **246.40 ms (+5%)** | **0.438 ms** | **37047.82 KB (0%)** |
| Old |Run|bitops-bitwise-and|147.59 ms|0.742 ms|55938.9 KB|
| **New** |	|	| **146.68 ms (-1%)** | **1.767 ms** | **55938.9 KB (0%)** |
| Old |Run|bitops-nsieve-bits|220.17 ms|0.160 ms|54072.38 KB|
| **New** |	|	| **215.08 ms (-2%)** | **0.468 ms** | **54072.38 KB (0%)** |
| Old |Run|contr(...)rsive [21]|102.95 ms|0.163 ms|83184.26 KB|
| **New** |	|	| **100.32 ms (-3%)** | **0.168 ms** | **83184.26 KB (0%)** |
| Old |Run|crypto-aes|144.64 ms|0.159 ms|14010.22 KB|
| **New** |	|	| **141.89 ms (-2%)** | **0.168 ms** | **14000.9 KB (0%)** |
| Old |Run|crypto-md5|96.32 ms|0.174 ms|77906.74 KB|
| **New** |	|	| **101.50 ms (+5%)** | **0.128 ms** | **77906.77 KB (0%)** |
| Old |Run|crypto-sha1|102.81 ms|0.192 ms|64567.48 KB|
| **New** |	|	| **103.70 ms (+1%)** | **0.818 ms** | **64567.56 KB (0%)** |
| Old |Run|date-format-tofte|101.39 ms|0.342 ms|43344.18 KB|
| **New** |	|	| **103.05 ms (+2%)** | **0.195 ms** | **43344.33 KB (0%)** |
| Old |Run|date-format-xparb|56.35 ms|0.060 ms|24847.7 KB|
| **New** |	|	| **56.18 ms (0%)** | **0.064 ms** | **24847.73 KB (0%)** |
| Old |Run|math-cordic|323.15 ms|1.176 ms|81977.11 KB|
| **New** |	|	| **331.94 ms (+3%)** | **1.141 ms** | **81975.49 KB (0%)** |
| Old |Run|math-partial-sums|129.05 ms|0.393 ms|50095.98 KB|
| **New** |	|	| **124.07 ms (-4%)** | **0.282 ms** | **50095.95 KB (0%)** |
| Old |Run|math-spectral-norm|132.25 ms|0.267 ms|51833.87 KB|
| **New** |	|	| **120.76 ms (-9%)** | **0.511 ms** | **51833.84 KB (0%)** |
| Old |Run|regexp-dna|107.50 ms|0.413 ms|17666.29 KB|
| **New** |	|	| **106.14 ms (-1%)** | **0.470 ms** | **17667.31 KB (0%)** |
| Old |Run|string-base64|103.53 ms|0.185 ms|11243.06 KB|
| **New** |	|	| **101.81 ms (-2%)** | **0.316 ms** | **11242.54 KB (0%)** |
| Old |Run|string-fasta|192.31 ms|0.418 ms|148053.54 KB|
| **New** |	|	| **198.17 ms (+3%)** | **0.646 ms** | **148053.38 KB (0%)** |
| Old |Run|string-tagcloud|70.16 ms|0.836 ms|44033.92 KB|
| **New** |	|	| **70.30 ms (0%)** | **0.936 ms** | **44033.83 KB (0%)** |
| Old |Run|string-unpack-code|69.08 ms|0.157 ms|74420.88 KB|
| **New** |	|	| **71.65 ms (+4%)** | **0.129 ms** | **74420.91 KB (0%)** |
| Old |Run|strin(...)input [21]|80.86 ms|0.142 ms|39746.38 KB|
| **New** |	|	| **81.21 ms (0%)** | **0.126 ms** | **39745.33 KB (0%)** |


