### PR TITLE
Reduce memory allocations in array handling

### DIFF
--- a/Jint.Tests.PublicInterface/RavenApiUsageTests.cs
+++ b/Jint.Tests.PublicInterface/RavenApiUsageTests.cs
@@ -1,6 +1,9 @@
 using Esprima.Ast;
 using Jint.Constraints;
+using Jint.Native;
+using Jint.Native.Array;
 using Jint.Native.Function;
+using Jint.Runtime.Descriptors;
 
 namespace Jint.Tests.PublicInterface;
 
@@ -51,5 +54,19 @@ public class RavenApiUsageTests
 
         Assert.Equal(123, oldMaxStatements);
         Assert.Equal(321, constraint.MaxStatements);
+    }
+
+    [Fact]
+    public void CanConstructArrayInstanceFromDescriptorArray()
+    {
+        var descriptors = new[]
+        {
+            new PropertyDescriptor(42, writable: false, enumerable: false, configurable: false),
+        };
+
+        var engine = new Engine();
+        var array = new ArrayInstance(engine, descriptors);
+        Assert.Equal(1l, array.Length);
+        Assert.Equal(42, array[0]);
     }
 }

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -222,7 +222,7 @@ namespace Jint.Native.Array
                 => (ulong) ((JsNumber) _target._length!._value!)._value;
 
             public override void SetLength(ulong length)
-                => _target.Set(CommonProperties.Length, length, true);
+                => _target.SetLength(length);
 
             public override void EnsureCapacity(ulong capacity)
                 => _target.EnsureCapacity((uint) capacity);
@@ -246,13 +246,17 @@ namespace Jint.Native.Array
                 var jsValues = new JsValue[n];
                 for (uint i = 0; i < (uint) jsValues.Length; i++)
                 {
-                    var prop = _target._dense[i] ?? PropertyDescriptor.Undefined;
-                    if (prop == PropertyDescriptor.Undefined)
+                    var prop = _target._dense[i];
+                    if (prop is null)
                     {
-                        prop = _target.Prototype?.GetProperty(i) ?? PropertyDescriptor.Undefined;
+                        prop = _target.Prototype?.Get(i) ?? JsValue.Undefined;
+                    }
+                    else if (prop is not JsValue)
+                    {
+                        prop = _target.UnwrapJsValue((PropertyDescriptor) prop);
                     }
 
-                    var jsValue = _target.UnwrapJsValue(prop);
+                    var jsValue = (JsValue) prop;
                     if ((jsValue.Type & elementTypes) == 0)
                     {
                         ExceptionHelper.ThrowTypeErrorNoEngine("invalid type");

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -459,6 +459,8 @@ namespace Jint.Native.Object
             return Set(property, value, this);
         }
 
+        private static readonly PropertyDescriptor _marker = new(Undefined, PropertyFlag.ConfigurableEnumerableWritable);
+
         /// <summary>
         /// https://tc39.es/ecma262/#sec-ordinarysetwithowndescriptor
         /// </summary>
@@ -473,7 +475,7 @@ namespace Jint.Native.Object
                 {
                     return parent.Set(property, value, receiver);
                 }
-                ownDesc = new PropertyDescriptor(Undefined, PropertyFlag.ConfigurableEnumerableWritable);
+                ownDesc = _marker;
             }
 
             if (ownDesc.IsDataDescriptor())

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -152,7 +152,7 @@ namespace Jint
             for (uint i = 0; i < arrayLength; ++i)
             {
                 var jsItem = JsValue.FromObject(e, array.GetValue(i));
-                jsArray.WriteArrayValue(i, new PropertyDescriptor(jsItem, PropertyFlag.ConfigurableEnumerableWritable));
+                jsArray.WriteArrayValue(i, jsItem);
             }
 
             jsArray.SetOwnProperty(CommonProperties.Length,


### PR DESCRIPTION
This PR changes internal `ArrayInstance` logic to prefer having just plain `JsValue` instances as array elements. `PropertyDescriptor` instances are only created when needed and they replace the original `JsValue` in given index. `PropertyDescriptor`s are usually needed only in very specific scenarios, like get/set property definition for array index.

## Jint.Benchmark.ArrayBenchmark

| **Diff**|Method|N|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Slice|100|231.0 μs|0.46 μs|516.41 KB|
| **New** |	|	| **216.2 μs (-6%)** | **0.78 μs** | **263.28 KB (-49%)** |
| Old |Concat|100|300.6 μs|1.31 μs|593.75 KB|
| **New** |	|	| **297.5 μs (-1%)** | **0.92 μs** | **357.81 KB (-40%)** |
| Old |Unshift|100|8,936.7 μs|30.50 μs|4256.26 KB|
| **New** |	|	| **7,357.2 μs (-18%)** | **64.31 μs** | **3496.88 KB (-18%)** |
| Old |Push|100|3,920.7 μs|4.96 μs|1110.94 KB|
| **New** |	|	| **3,850.3 μs (-2%)** | **7.41 μs** | **857.82 KB (-23%)** |
| Old |Index|100|3,253.0 μs|6.43 μs|1035.94 KB|
| **New** |	|	| **3,166.8 μs (-3%)** | **4.84 μs** | **782.82 KB (-24%)** |
| Old |Map|100|1,783.2 μs|9.63 μs|3038.28 KB|
| **New** |	|	| **1,708.8 μs (-4%)** | **3.42 μs** | **2785.16 KB (-8%)** |
| Old |Apply|100|316.8 μs|0.62 μs|617.19 KB|
| **New** |	|	| **288.1 μs (-9%)** | **0.58 μs** | **364.06 KB (-41%)** |
| Old |JsonStringifyParse|100|1,798.0 μs|12.60 μs|4783.6 KB|
| **New** |	|	| **1,740.7 μs (-3%)** | **15.48 μs** | **4530.47 KB (-5%)** |
| Old |FilterWithString|100|17,487.9 μs|53.12 μs|27879.71 KB|
| **New** |	|	| **16,834.0 μs (-4%)** | **60.75 μs** | **27870.34 KB (0%)** |


## Jint.Benchmark.ArrayStressBenchmark

| **Diff**|Method|Mean|Error|Allocated|
|------- |-------|-------:|-------|-------:|
| Old |Execute|11.07 ms|0.021 ms|8.14 MB|
| **New** |	| **9.954 ms (-10%)** | **0.0175 ms** | **7.23 MB (-11%)** |
| Old |Execute_ParsedScript|11.46 ms|0.015 ms|8.11 MB|
| **New** |	| **9.699 ms (-15%)** | **0.0161 ms** | **7.2 MB (-11%)** |


## Jint.Benchmark.DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Run|dromaeo-3d-cube|25.179 ms|0.0341 ms|7164.43 KB|
| **New** |	|	| **24.658 ms (-2%)** | **0.0334 ms** | **6646.33 KB (-7%)** |
| Old |Run|dromaeo-core-eval|6.188 ms|0.0180 ms|319.54 KB|
| **New** |	|	| **6.076 ms (-2%)** | **0.0136 ms** | **319.54 KB (0%)** |
| Old |Run|dromaeo-object-array|77.493 ms|0.2277 ms|106133.55 KB|
| **New** |	|	| **64.626 ms (-17%)** | **0.1541 ms** | **101908.08 KB (-4%)** |
| Old |Run|droma(...)egexp [21]|300.414 ms|3.8807 ms|236371.71 KB|
| **New** |	|	| **224.000 ms (-25%)** | **2.6476 ms** | **174094.56 KB (-26%)** |
| Old |Run|droma(...)tring [21]|414.263 ms|21.7747 ms|1331608.35 KB|
| **New** |	|	| **441.372 ms (+7%)** | **37.2842 ms** | **1326534.06 KB (0%)** |
| Old |Run|droma(...)ase64 [21]|68.041 ms|0.0719 ms|7791.09 KB|
| **New** |	|	| **72.168 ms (+6%)** | **0.2392 ms** | **7656.83 KB (-2%)** |
| Old |Run|dromaeo-3d-cube|24.028 ms|0.0476 ms|6869.94 KB|
| **New** |	|	| **24.162 ms (+1%)** | **0.0309 ms** | **6351.84 KB (-8%)** |
| Old |Run|dromaeo-core-eval|6.025 ms|0.0160 ms|306.9 KB|
| **New** |	|	| **6.262 ms (+4%)** | **0.0156 ms** | **306.9 KB (0%)** |
| Old |Run|dromaeo-object-array|78.254 ms|1.0812 ms|106095.02 KB|
| **New** |	|	| **68.095 ms (-13%)** | **0.2289 ms** | **101869.75 KB (-4%)** |
| Old |Run|droma(...)egexp [21]|302.018 ms|5.8967 ms|243342.17 KB|
| **New** |	|	| **222.745 ms (-26%)** | **1.7724 ms** | **169797.1 KB (-30%)** |
| Old |Run|droma(...)tring [21]|447.805 ms|34.5716 ms|1331782.48 KB|
| **New** |	|	| **447.424 ms (0%)** | **37.1430 ms** | **1326488.12 KB (0%)** |
| Old |Run|droma(...)ase64 [21]|67.477 ms|0.1332 ms|7701.72 KB|
| **New** |	|	| **71.621 ms (+6%)** | **0.2212 ms** | **7570.01 KB (-2%)** |


