### PR TITLE
Implement Promise.allSettled

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -92,12 +92,11 @@
     "built-ins/RegExp/prototype/exec/S15.10.6.2_A1_T6.js",
     "built-ins/RegExp/S15.10.2.5_A1_T4.js",
 
-    "built-ins/String/raw/special-characters.js", // Windows line ending differences
-    "language/expressions/object/method-definition/object-method-returns-promise.js", // Promise not implemented
-    "language/statements/class/definition/class-method-returns-promise.js", // Promise not implemented
+    // Windows line ending differences
+    "built-ins/String/raw/special-characters.js",
 
-    // there is bug in suite and bug in Jint, refer to https://github.com/sebastienros/jint/issues/888 and https://github.com/tc39/test262/issues/2985
-    "built-ins/Promise/race/resolve-element-function-name.js",
+    // Async flag is missing from test
+    "language/expressions/object/method-definition/object-method-returns-promise.js",
 
     // parsing of large/small years not implemented in .NET (-271821, +271821)
     "built-ins/Date/parse/time-value-maximum-range.js",

--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -19,7 +19,6 @@
     "FinalizationRegistry",
     "generators",
     "import-assertions",
-    "Promise.allSettled",
     "regexp-duplicate-named-groups",
     "regexp-lookbehind",
     "regexp-unicode-property-escapes",

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -40,30 +40,21 @@ namespace Jint.Native.Promise
         {
             const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
             const PropertyFlag lengthFlags = PropertyFlag.Configurable;
-            var properties = new PropertyDictionary(5, checkExistingKeys: false)
+            var properties = new PropertyDictionary(6, checkExistingKeys: false)
             {
-                ["resolve"] =
-                    new(new PropertyDescriptor(new ClrFunctionInstance(Engine, "resolve", Resolve, 1, lengthFlags),
-                        propertyFlags)),
-                ["reject"] =
-                    new(new PropertyDescriptor(new ClrFunctionInstance(Engine, "reject", Reject, 1, lengthFlags),
-                        propertyFlags)),
-                ["all"] = new(new PropertyDescriptor(new ClrFunctionInstance(Engine, "all", All, 1, lengthFlags),
-                    propertyFlags)),
-                ["allSettled"] = new(new PropertyDescriptor(new ClrFunctionInstance(Engine, "allSettled", AllSettled, 1, lengthFlags),
-                    propertyFlags)),
-                ["any"] = new(new PropertyDescriptor(new ClrFunctionInstance(Engine, "any", Any, 1, lengthFlags),
-                    propertyFlags)),
-                ["race"] = new(new PropertyDescriptor(new ClrFunctionInstance(Engine, "race", Race, 1, lengthFlags),
-                    propertyFlags)),
+                ["resolve"] = new(new PropertyDescriptor(new ClrFunctionInstance(Engine, "resolve", Resolve, 1, lengthFlags), propertyFlags)),
+                ["reject"] = new(new PropertyDescriptor(new ClrFunctionInstance(Engine, "reject", Reject, 1, lengthFlags), propertyFlags)),
+                ["all"] = new(new PropertyDescriptor(new ClrFunctionInstance(Engine, "all", All, 1, lengthFlags), propertyFlags)),
+                ["allSettled"] = new(new PropertyDescriptor(new ClrFunctionInstance(Engine, "allSettled", AllSettled, 1, lengthFlags), propertyFlags)),
+                ["any"] = new(new PropertyDescriptor(new ClrFunctionInstance(Engine, "any", Any, 1, lengthFlags), propertyFlags)),
+                ["race"] = new(new PropertyDescriptor(new ClrFunctionInstance(Engine, "race", Race, 1, lengthFlags), propertyFlags)),
             };
             SetProperties(properties);
 
             var symbols = new SymbolDictionary(1)
             {
                 [GlobalSymbolRegistry.Species] = new GetSetPropertyDescriptor(
-                    get: new ClrFunctionInstance(_engine, "get [Symbol.species]", (thisObj, _) => thisObj, 0,
-                        PropertyFlag.Configurable),
+                    get: new ClrFunctionInstance(_engine, "get [Symbol.species]", (thisObj, _) => thisObj, 0, PropertyFlag.Configurable),
                     set: Undefined, PropertyFlag.Configurable)
             };
             SetSymbols(symbols);

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The entire execution engine was rebuild with performance in mind, in many cases 
 - ✔ `import.meta`
 - ✔ Nullish coalescing operator (`??`)
 - ✔ Optional chaining
-- ❌ `Promise.allSettled`
+- ✔ `Promise.allSettled`
 - ✔ `String.prototype.matchAll`
 
 #### ECMAScript 2021


### PR DESCRIPTION
Implements Promise.allSettled
Spec: https://tc39.es/ecma262/#sec-promise.allsettled

Also reduces code duplication in Promise static methods like `all`, `any`, `allSettled` and `race` since the first 6 steps of those are same in the spec.