### PR TITLE
Cache wrapped object returned by WrapObjectHandler

### DIFF
--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -254,18 +254,7 @@ namespace Jint
         /// </summary>
         public WrapObjectDelegate WrapObjectHandler { get; set; } = static (engine, target) =>
         {
-            // check global cache, have we already wrapped the value?
-            if (engine._objectWrapperCache.TryGetValue(target, out var wrapped))
-            {
-                return wrapped;
-            }
-
-            wrapped = new ObjectWrapper(engine, target);
-            if (engine.Options.Interop.TrackObjectWrapperIdentity)
-            {
-                engine._objectWrapperCache.Add(target, wrapped);
-            }
-            return wrapped;
+            return new ObjectWrapper(engine, target);
         };
 
         /// <summary>

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -102,7 +102,21 @@ namespace Jint
                     }
                     else
                     {
-                        result = engine.Options.Interop.WrapObjectHandler.Invoke(engine, value);
+                        // check global cache, have we already wrapped the value?
+                        if (engine._objectWrapperCache.TryGetValue(value, out var cached))
+                        {
+                            result = cached;
+                        }
+                        else
+                        {
+                            var wrapped = engine.Options.Interop.WrapObjectHandler.Invoke(engine, value);
+                            result = wrapped;
+
+                            if (engine.Options.Interop.TrackObjectWrapperIdentity && wrapped is not null)
+                            {
+                                engine._objectWrapperCache.Add(value, wrapped);
+                            }
+                        }
                     }
 
                     // if no known type could be guessed, use the default of wrapping using using ObjectWrapper.


### PR DESCRIPTION
As discussed with @libaowei on Gitter related to #1321 and #1326, turns out they has some script that rely on some non-standard behavior of a older version of Jint. Because they want to maintain compatibility for those scripts they decided to use a custom object wrapper.

This pull request make the object wrapper cache available to `WrapObjectHandler` through argument, which was their original intention if I understand correctly.