### PR TITLE
PublicInterface test for CancellationConstraint.Reset

### DIFF
--- a/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
+++ b/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
@@ -1,0 +1,42 @@
+﻿using Jint.Constraints;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface
+{
+    public class ConstraintUsageTests
+    {
+        [Fact]
+        public void CanFindAndResetCancellationConstraint()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+            var engine = new Engine(new Options().CancellationToken(cts.Token));
+
+            // expect constraint to abort execution due to timeout
+            Assert.Throws<ExecutionCanceledException>(WaitAndCompute);
+
+            // ensure constraint can be obtained publicly
+            var cancellationConstraint = engine.FindConstraint<CancellationConstraint>();
+            Assert.NotNull(cancellationConstraint);
+
+            // reset constraint, expect computation to finish this time
+            using var cts2 = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+            cancellationConstraint.Reset(cts2.Token);
+            Assert.Equal("done", WaitAndCompute());
+
+            string WaitAndCompute()
+            {
+                var result = engine.Evaluate(@"
+                    function sleep(millisecondsTimeout) {
+                        var totalMilliseconds = new Date().getTime() + millisecondsTimeout;
+
+                        while (new Date() < totalMilliseconds) { }
+                    }
+
+                    sleep(200);
+                    return 'done';
+                ");
+                return result.AsString();
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -331,15 +331,15 @@ var engine = new Engine(options =>
 });
 ```
 
-When you reuse the engine you want to use cancellation tokens you have to reset the token before each call of `Execute`:
+When you reuse the engine and want to use cancellation tokens you have to reset the token before each call of `Execute`:
 
 ```c#
-var constraint = new CancellationConstraint();
-
 var engine = new Engine(options =>
 {
-    options.Constraint(constraint);
+    options.CancellationToken(new CancellationToken(true));
 });
+
+var constraint = engine.FindConstraint<CancellationConstraint>();
 
 for (var i = 0; i < 10; i++) 
 {


### PR DESCRIPTION
Adds a PublicInterface test that fetches a `CancellationConstraint` with the `FindConstraint<>` method and calls its overloaded `Reset()` method in order to pass in a new `CancellationToken`.

---
### Update README

The example usage of CancellationConstraint demonstrated in the README doesn't work anymore because the constructor was made internal.

A dummy CancellationToken must be provided when creating the constraint if one intends to pass the actual one via Reset(). `default` doesn't work though, as the constraint won't be created then.

see #1345