### PR TITLE
Add easier APIs for interop usage

### DIFF
--- a/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
+++ b/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
@@ -8,7 +8,7 @@ public class ConstraintUsageTests
     [Fact]
     public void CanFindAndResetCancellationConstraint()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
         var engine = new Engine(new Options().CancellationToken(cts.Token));
 
         // expect constraint to abort execution due to timeout
@@ -28,9 +28,8 @@ public class ConstraintUsageTests
             var result = engine.Evaluate(@"
                 function sleep(millisecondsTimeout) {
                     var totalMilliseconds = new Date().getTime() + millisecondsTimeout;
-                    while (new Date() < totalMilliseconds) { }
+                    while (new Date().getTime() < totalMilliseconds) { }
                 }
-
                 sleep(200);
                 return 'done';
             ");

--- a/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
+++ b/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
@@ -27,8 +27,11 @@ public class ConstraintUsageTests
         {
             var result = engine.Evaluate(@"
                 function sleep(millisecondsTimeout) {
+                    var x = 0;
                     var totalMilliseconds = new Date().getTime() + millisecondsTimeout;
-                    while (new Date().getTime() < totalMilliseconds) { }
+                    while (new Date().getTime() < totalMilliseconds) {
+                        x++;
+                    }
                 }
                 sleep(200);
                 return 'done';

--- a/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
+++ b/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
@@ -1,42 +1,40 @@
 ﻿using Jint.Constraints;
 using Jint.Runtime;
 
-namespace Jint.Tests.PublicInterface
+namespace Jint.Tests.PublicInterface;
+
+public class ConstraintUsageTests
 {
-    public class ConstraintUsageTests
+    [Fact]
+    public void CanFindAndResetCancellationConstraint()
     {
-        [Fact]
-        public void CanFindAndResetCancellationConstraint()
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        var engine = new Engine(new Options().CancellationToken(cts.Token));
+
+        // expect constraint to abort execution due to timeout
+        Assert.Throws<ExecutionCanceledException>(WaitAndCompute);
+
+        // ensure constraint can be obtained publicly
+        var cancellationConstraint = engine.FindConstraint<CancellationConstraint>();
+        Assert.NotNull(cancellationConstraint);
+
+        // reset constraint, expect computation to finish this time
+        using var cts2 = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+        cancellationConstraint.Reset(cts2.Token);
+        Assert.Equal("done", WaitAndCompute());
+
+        string WaitAndCompute()
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
-            var engine = new Engine(new Options().CancellationToken(cts.Token));
+            var result = engine.Evaluate(@"
+                function sleep(millisecondsTimeout) {
+                    var totalMilliseconds = new Date().getTime() + millisecondsTimeout;
+                    while (new Date() < totalMilliseconds) { }
+                }
 
-            // expect constraint to abort execution due to timeout
-            Assert.Throws<ExecutionCanceledException>(WaitAndCompute);
-
-            // ensure constraint can be obtained publicly
-            var cancellationConstraint = engine.FindConstraint<CancellationConstraint>();
-            Assert.NotNull(cancellationConstraint);
-
-            // reset constraint, expect computation to finish this time
-            using var cts2 = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
-            cancellationConstraint.Reset(cts2.Token);
-            Assert.Equal("done", WaitAndCompute());
-
-            string WaitAndCompute()
-            {
-                var result = engine.Evaluate(@"
-                    function sleep(millisecondsTimeout) {
-                        var totalMilliseconds = new Date().getTime() + millisecondsTimeout;
-
-                        while (new Date() < totalMilliseconds) { }
-                    }
-
-                    sleep(200);
-                    return 'done';
-                ");
-                return result.AsString();
-            }
+                sleep(200);
+                return 'done';
+            ");
+            return result.AsString();
         }
     }
 }

--- a/Jint.Tests.PublicInterface/RavenApiUsageTests.cs
+++ b/Jint.Tests.PublicInterface/RavenApiUsageTests.cs
@@ -1,7 +1,10 @@
 using Esprima.Ast;
 using Jint.Constraints;
+using Jint.Native;
 using Jint.Native.Array;
+using Jint.Native.Date;
 using Jint.Native.Function;
+using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 
@@ -77,5 +80,49 @@ public class RavenApiUsageTests
         var obj = new DirectoryInfo("the-path");
         var propertyDescriptor = ObjectWrapper.GetPropertyDescriptor(engine, obj, obj.GetType().GetProperty(nameof(DirectoryInfo.Name)));
         Assert.Equal("the-path", propertyDescriptor.Value);
+    }
+
+    [Fact]
+    public void CanInjectConstructedObjects()
+    {
+        var engine = new Engine();
+        var obj = new ObjectInstance(engine);
+        obj.FastSetDataProperty("name", "test");
+
+        var emptyArray = new ArrayInstance(engine);
+
+        var array = new ArrayInstance(engine, new object[]
+        {
+            JsNumber.Create(1),
+            JsNumber.Create(2),
+            JsNumber.Create(3)
+        });
+        var date = new DateInstance(engine, new DateTime(2022, 10, 20));
+
+        engine.SetValue("obj", obj);
+        engine.SetValue("emptyArray", emptyArray);
+        engine.SetValue("array", array);
+        engine.SetValue("date", date);
+
+        Assert.Equal("test", engine.Evaluate("obj.name"));
+        Assert.Equal(0, engine.Evaluate("emptyArray.length"));
+        Assert.Equal(1, engine.Evaluate("array.findIndex(x => x === 2)"));
+        Assert.Equal(0, engine.Evaluate("date.getMilliseconds()"));
+
+        array.Push(4);
+        array.Push(new JsValue[] { 5, 6 });
+
+        Assert.Equal(4, array[3]);
+        Assert.Equal(5, array[4]);
+        Assert.Equal(6, array[5]);
+
+        var i = 0;
+        foreach (var entry in array.GetEntries())
+        {
+            Assert.Equal(i.ToString(), entry.Key);
+            Assert.Equal(i + 1, entry.Value);
+            i++;
+        }
+        Assert.Equal(6, i);
     }
 }

--- a/Jint.Tests.PublicInterface/RavenApiUsageTests.cs
+++ b/Jint.Tests.PublicInterface/RavenApiUsageTests.cs
@@ -107,7 +107,7 @@ public class RavenApiUsageTests
         Assert.Equal("test", engine.Evaluate("obj.name"));
         Assert.Equal(0, engine.Evaluate("emptyArray.length"));
         Assert.Equal(1, engine.Evaluate("array.findIndex(x => x === 2)"));
-        Assert.Equal(0, engine.Evaluate("date.getMilliseconds()"));
+        Assert.Equal(2022, engine.Evaluate("date.getFullYear()"));
 
         array.Push(4);
         array.Push(new JsValue[] { 5, 6 });

--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -62,7 +62,7 @@ public class ArrayTests
     public void ArrayLengthFromInitialState()
     {
         var engine = new Engine();
-        var array = new ArrayInstance(engine, 0);
+        var array = new ArrayInstance(engine);
         var length = (int) array.Length;
         Assert.Equal(0, length);
     }

--- a/Jint.Tests/Runtime/Domain/UuidConstructor.cs
+++ b/Jint.Tests/Runtime/Domain/UuidConstructor.cs
@@ -58,8 +58,8 @@ namespace Jint.Tests.Runtime.Domain
 
         public void Configure()
         {
-            FastAddProperty("parse", new ClrFunctionInstance(Engine, "parse", Parse), true, false, true);
-            FastAddProperty("Empty", JsUuid.Empty, true, false, true);
+            FastSetProperty("parse", new PropertyDescriptor(new ClrFunctionInstance(Engine, "parse", Parse), true, false, true));
+            FastSetProperty("Empty", new PropertyDescriptor(JsUuid.Empty, true, false, true));
         }
 
         public UuidInstance Construct(JsUuid uuid) => new UuidInstance(Engine) { PrimitiveValue = uuid, _prototype = PrototypeObject };

--- a/Jint.Tests/Runtime/Domain/UuidPrototype.cs
+++ b/Jint.Tests/Runtime/Domain/UuidPrototype.cs
@@ -1,5 +1,6 @@
 using Jint.Native;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 
 namespace Jint.Tests.Runtime.Domain
@@ -30,15 +31,15 @@ namespace Jint.Tests.Runtime.Domain
                 _prototype = engine.Realm.Intrinsics.Object.PrototypeObject,
             };
 
-            obj.FastAddProperty("constructor", ctor, false, false, true);
+            obj.FastSetProperty("constructor", new PropertyDescriptor(ctor, false, false, true));
 
             return obj;
         }
 
         public void Configure()
         {
-            FastAddProperty("toString", new ClrFunctionInstance(Engine, "toString", ToGuidString), true, false, true);
-            FastAddProperty("valueOf", new ClrFunctionInstance(Engine, "valueOf", ValueOf), true, false, true);
+            FastSetProperty("toString", new PropertyDescriptor(new ClrFunctionInstance(Engine, "toString", ToGuidString), true, false, true));
+            FastSetProperty("valueOf", new PropertyDescriptor(new ClrFunctionInstance(Engine, "valueOf", ValueOf), true, false, true));
         }
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -2689,8 +2689,8 @@ namespace Jint.Tests.Runtime
                 Console.WriteLine(message);
             }
 
-            engine.Realm.GlobalObject.FastAddProperty("global", engine.Realm.GlobalObject, true, true, true);
-            engine.Realm.GlobalObject.FastAddProperty("test", new DelegateWrapper(engine, (Action<string, object>) Test), true, true, true);
+            engine.Realm.GlobalObject.FastSetDataProperty("global", engine.Realm.GlobalObject);
+            engine.Realm.GlobalObject.FastSetDataProperty("test", new DelegateWrapper(engine, (Action<string, object>) Test));
 
             {
                 var ex = Assert.Throws<JavaScriptException>(() => engine.Realm.GlobalObject.ToObject());
@@ -3237,22 +3237,22 @@ try {
             };
 
             engine.SetValue("data", dictionary);
-            
+
             Assert.True(engine.Evaluate("Object.hasOwn(data, 'a')").AsBoolean());
             Assert.True(engine.Evaluate("data['a'] === 1").AsBoolean());
 
             engine.Evaluate("data['a'] = 42");
             Assert.True(engine.Evaluate("data['a'] === 42").AsBoolean());
-            
+
             Assert.Equal(42, dictionary["a"]);
 
             engine.Execute("delete data['a'];");
-            
+
             Assert.False(engine.Evaluate("Object.hasOwn(data, 'a')").AsBoolean());
             Assert.False(engine.Evaluate("data['a'] === 42").AsBoolean());
-            
+
             Assert.False(dictionary.ContainsKey("a"));
-            
+
             var engineNoWrite = new Engine(options => options.Strict().AllowClrWrite(false));
 
             dictionary = new Dictionary<string, int>
@@ -3260,9 +3260,9 @@ try {
                 { "a", 1 },
                 { "b", 2 }
             };
-            
+
             engineNoWrite.SetValue("data", dictionary);
-            
+
             var ex1 = Assert.Throws<JavaScriptException>(() => engineNoWrite.Evaluate("data['a'] = 42"));
             Assert.Equal("Cannot assign to read only property 'a' of System.Collections.Generic.Dictionary`2[System.String,System.Int32]", ex1.Message);
 

--- a/Jint.Tests/Runtime/ObjectInstanceTests.cs
+++ b/Jint.Tests/Runtime/ObjectInstanceTests.cs
@@ -10,8 +10,8 @@ namespace Jint.Tests.Runtime
         {
             var engine = new Engine();
             var instance = new ObjectInstance(engine);
-            instance.FastAddProperty("bare", JsValue.Null, true, true, true);
-            instance.FastAddProperty("scope", JsValue.Null, true, true, true);
+            instance.FastSetDataProperty("bare", JsValue.Null);
+            instance.FastSetDataProperty("scope", JsValue.Null);
             instance.RemoveOwnProperty("bare");
             var propertyNames = instance.GetOwnProperties().Select(x => x.Key).ToList();
             Assert.Equal(new JsValue[] { "scope" }, propertyNames);

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -17,7 +17,7 @@ namespace Jint.Tests.Runtime
             Action<JsValue> resolveFunc = null;
 
             var engine = new Engine();
-            engine.SetValue('f', new Func<JsValue>(() =>
+            engine.SetValue("f", new Func<JsValue>(() =>
             {
                 var (promise, resolve, _) = engine.RegisterPromise();
                 resolveFunc = resolve;
@@ -36,7 +36,7 @@ namespace Jint.Tests.Runtime
             Action<JsValue> rejectFunc = null;
 
             var engine = new Engine();
-            engine.SetValue('f', new Func<JsValue>(() =>
+            engine.SetValue("f", new Func<JsValue>(() =>
             {
                 var (promise, _, reject) = engine.RegisterPromise();
                 rejectFunc = reject;
@@ -96,7 +96,7 @@ namespace Jint.Tests.Runtime
         public void Execute_ConcurrentNormalExecuteCall_WorksFine()
         {
             var engine = new Engine();
-            engine.SetValue('f', new Func<JsValue>(() => engine.RegisterPromise().Promise));
+            engine.SetValue("f", new Func<JsValue>(() => engine.RegisterPromise().Promise));
 
             engine.Execute("f();");
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -174,39 +174,39 @@ namespace Jint
             return context;
         }
 
-        public Engine SetValue(JsValue name, Delegate value)
+        public Engine SetValue(string name, Delegate value)
         {
-            Realm.GlobalObject.FastAddProperty(name, new DelegateWrapper(this, value), true, false, true);
+            Realm.GlobalObject.FastSetProperty(name, new PropertyDescriptor(new DelegateWrapper(this, value), true, false, true));
             return this;
         }
 
-        public Engine SetValue(JsValue name, string value)
+        public Engine SetValue(string name, string value)
         {
             return SetValue(name, new JsString(value));
         }
 
-        public Engine SetValue(JsValue name, double value)
+        public Engine SetValue(string name, double value)
         {
             return SetValue(name, JsNumber.Create(value));
         }
 
-        public Engine SetValue(JsValue name, int value)
+        public Engine SetValue(string name, int value)
         {
             return SetValue(name, JsNumber.Create(value));
         }
 
-        public Engine SetValue(JsValue name, bool value)
+        public Engine SetValue(string name, bool value)
         {
             return SetValue(name, value ? JsBoolean.True : JsBoolean.False);
         }
 
-        public Engine SetValue(JsValue name, JsValue value)
+        public Engine SetValue(string name, JsValue value)
         {
             Realm.GlobalObject.Set(name, value);
             return this;
         }
 
-        public Engine SetValue(JsValue name, object obj)
+        public Engine SetValue(string name, object obj)
         {
             var value = obj is Type t
                 ? TypeReference.CreateTypeReference(this, t)

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -26,6 +26,12 @@ namespace Jint.Native.Array
             _dense = System.Array.Empty<object?>();
         }
 
+        /// <summary>
+        /// Creates a new array instance with defaults.
+        /// </summary>
+        /// <param name="engine">The engine that this array is bound to.</param>
+        /// <param name="capacity">The initial size of underlying data structure, if you know you're going to add N items, provide N.</param>
+        /// <param name="length">Sets the length of the array.</param>
         public ArrayInstance(Engine engine, uint capacity = 0, uint length = 0) : base(engine)
         {
             _prototype = engine.Realm.Intrinsics.Array.PrototypeObject;
@@ -50,6 +56,7 @@ namespace Jint.Native.Array
         /// <summary>
         /// Possibility to construct valid array fast.
         /// Requires that supplied array is of type object[] and it should only contain values inheriting from JsValue.
+        /// The array will be owned and modified by Jint afterwards.
         /// </summary>
         public ArrayInstance(Engine engine, object[] items) : base(engine)
         {
@@ -968,6 +975,9 @@ namespace Jint.Native.Array
             return GetEnumerator();
         }
 
+        /// <summary>
+        /// Pushes the value to the end of the array instance.
+        /// </summary>
         public void Push(JsValue value)
         {
             var initialLength = GetLength();
@@ -1001,15 +1011,18 @@ namespace Jint.Native.Array
             }
         }
 
-        public uint Push(JsValue[] arguments)
+        /// <summary>
+        /// Pushes the given values to the end of the array.
+        /// </summary>
+        public uint Push(JsValue[] values)
         {
             var initialLength = GetLength();
-            var newLength = initialLength + arguments.Length;
+            var newLength = initialLength + values.Length;
 
             // if we see that we are bringing more than normal growth algorithm handles, ensure capacity eagerly
             if (_dense != null
                 && initialLength != 0
-                && arguments.Length > initialLength * 2
+                && values.Length > initialLength * 2
                 && newLength <= MaxDenseArrayLength)
             {
                 EnsureCapacity((uint) newLength);
@@ -1017,7 +1030,7 @@ namespace Jint.Native.Array
 
             var temp = _dense;
             ulong n = initialLength;
-            foreach (var argument in arguments)
+            foreach (var argument in values)
             {
                 if (n < ArrayOperations.MaxArrayLength)
                 {

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1540,10 +1540,7 @@ namespace Jint.Native.Array
                 }
                 if (!result.TryGetValue(key, out var list))
                 {
-                    result[key] = list = new ArrayInstance(_engine)
-                    {
-                        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.OnlyWritable)
-                    };
+                    result[key] = list = new ArrayInstance(_engine);
                 }
 
                 list.SetIndexValue(list.GetLength(), kValue, updateLength: true);

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -239,7 +239,7 @@ namespace Jint.Native.Date
                 static (engine, _, dateValue) => new DateInstance(engine, dateValue), time);
         }
 
-        private double FromDateTime(DateTime dt, bool negative = false)
+        internal double FromDateTime(DateTime dt, bool negative = false)
         {
             var convertToUtcAfter = dt.Kind == DateTimeKind.Unspecified;
 

--- a/Jint/Native/Date/DateInstance.cs
+++ b/Jint/Native/Date/DateInstance.cs
@@ -14,9 +14,17 @@ public sealed class DateInstance : ObjectInstance
 
     internal double _dateValue;
 
-    public DateInstance(Engine engine, double dateValue)
-        : base(engine, ObjectClass.Date)
+    public DateInstance(Engine engine, DateTimeOffset value) : this(engine, value.UtcDateTime)
     {
+    }
+
+    public DateInstance(Engine engine, DateTime value) : this(engine, engine.Realm.Intrinsics.Date.FromDateTime(value))
+    {
+    }
+
+    public DateInstance(Engine engine, double dateValue) : base(engine, ObjectClass.Date)
+    {
+        _prototype = engine.Realm.Intrinsics.Date.PrototypeObject;
         _dateValue = dateValue.TimeClip();
     }
 

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -681,7 +681,7 @@ namespace Jint.Native.Json
                 Expect(":");
                 var value = ParseJsonValue();
 
-                obj.FastAddProperty(name, value, true, true, true);
+                obj.FastSetDataProperty(name, value);
 
                 if (!Match("}"))
                 {

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -30,6 +30,11 @@ namespace Jint.Native.Json
             _engine = engine;
         }
 
+        public JsValue Serialize(JsValue value)
+        {
+            return Serialize(value, JsValue.Undefined, JsValue.Undefined);
+        }
+
         public JsValue Serialize(JsValue value, JsValue replacer, JsValue space)
         {
             _stack = new ObjectTraverseStack(_engine);

--- a/Jint/Native/Object/ObjectInstance.Fast.cs
+++ b/Jint/Native/Object/ObjectInstance.Fast.cs
@@ -1,0 +1,45 @@
+using System.Runtime.CompilerServices;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Native.Object;
+
+/// <summary>
+/// Fast access helpers which violate JavaScript specification, but helpful when accessed
+/// against ObjectInstance and prototype chain is intact.
+/// </summary>
+public partial class ObjectInstance
+{
+    /// <summary>
+    /// Creates data property without checking prototype, property existence and overwrites any data already present.
+    /// </summary>
+    /// <remarks>
+    /// Does not conform to JavaScript specification prototype etc. handling etc.
+    /// </remarks>
+    public void FastSetProperty(string name, PropertyDescriptor value)
+    {
+        SetProperty(name, value);
+    }
+
+    /// <summary>
+    /// Creates data property without checking prototype, property existence and overwrites any data already present.
+    /// </summary>
+    /// <remarks>
+    /// Does not conform to JavaScript specification prototype etc. handling etc.
+    /// </remarks>
+    public void FastSetProperty(JsValue property, PropertyDescriptor value)
+    {
+        SetProperty(property, value);
+    }
+
+    /// <summary>
+    /// Creates data property (configurable, enumerable, writable) without checking prototype, property existence and overwrites any data already present.
+    /// </summary>
+    /// <remarks>
+    /// Does not conform to JavaScript specification prototype etc. handling etc.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void FastSetDataProperty(string name, JsValue value)
+    {
+        SetProperty(name, new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable));
+    }
+}

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -17,7 +17,7 @@ using Jint.Runtime.Interop;
 
 namespace Jint.Native.Object
 {
-    public class ObjectInstance : JsValue, IEquatable<ObjectInstance>
+    public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     {
         private bool _initialized;
         private readonly ObjectClass _class;
@@ -853,29 +853,11 @@ namespace Jint.Native.Object
                 if (mutable != null)
                 {
                     // replace old with new type that supports get and set
-                    o.FastSetProperty(property, mutable);
+                    o.SetOwnProperty(property, mutable);
                 }
             }
 
             return true;
-        }
-
-        /// <summary>
-        /// Optimized version of [[Put]] when the property is known to be undeclared already
-        /// </summary>
-        public void FastAddProperty(JsValue name, JsValue value, bool writable, bool enumerable, bool configurable)
-        {
-            SetOwnProperty(name, new PropertyDescriptor(value, writable, enumerable, configurable));
-        }
-
-        /// <summary>
-        /// Optimized version of [[Put]] when the property is known to be already declared
-        /// </summary>
-        /// <param name="name"></param>
-        /// <param name="value"></param>
-        public void FastSetProperty(JsValue name, PropertyDescriptor value)
-        {
-            SetOwnProperty(name, value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1204,10 +1186,11 @@ namespace Jint.Native.Object
         /// https://tc39.es/ecma262/#sec-createdatapropertyorthrow
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool CreateDataProperty(JsValue p, JsValue v)
+        public bool CreateDataProperty(JsValue p, JsValue v)
         {
             return DefineOwnProperty(p, new PropertyDescriptor(v, PropertyFlag.ConfigurableEnumerableWritable));
         }
+
 
         /// <summary>
         /// https://tc39.es/ecma262/#sec-createdataproperty

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -380,8 +380,8 @@ namespace Jint.Native.Promise
                                     alreadyCalled = true;
 
                                     var res = Engine.Realm.Intrinsics.Object.Construct(2);
-                                    res.FastAddProperty("status", "fulfilled", true, true, true);
-                                    res.FastAddProperty("value", args.At(0), true, true, true);
+                                    res.FastSetDataProperty("status", "fulfilled");
+                                    res.FastSetDataProperty("value", args.At(0));
                                     results[capturedIndex] = res;
 
                                     ResolveIfFinished();
@@ -397,8 +397,8 @@ namespace Jint.Native.Promise
                                     alreadyCalled = true;
 
                                     var res = Engine.Realm.Intrinsics.Object.Construct(2);
-                                    res.FastAddProperty("status", "rejected", true, true, true);
-                                    res.FastAddProperty("reason", args.At(0), true, true, true);
+                                    res.FastSetDataProperty("status", "rejected");
+                                    res.FastSetDataProperty("reason", args.At(0));
                                     results[capturedIndex] = res;
 
                                     ResolveIfFinished();

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -875,8 +875,8 @@ namespace Jint.Native.RegExp
 
                 // "aaa".match() => [ '', index: 0, input: 'aaa' ]
                 var array = R.Engine.Realm.Intrinsics.Array.ArrayCreate(1);
-                array.FastAddProperty(PropertyIndex, lastIndex, true, true, true);
-                array.FastAddProperty(PropertyInput, s, true, true, true);
+                array.FastSetDataProperty(PropertyIndex._value, lastIndex);
+                array.FastSetDataProperty(PropertyInput._value, s);
                 array.SetIndexValue(0, JsString.Empty, updateLength: false);
                 return array;
             }

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using Jint.Native;
 using Jint.Native.Array;
 using Jint.Runtime;
-using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 
 namespace Jint

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -155,23 +155,16 @@ namespace Jint
 
         private static JsValue ConvertArray(Engine e, object v)
         {
-            var array = (Array)v;
-            var arrayLength = (uint)array.Length;
+            var array = (Array) v;
+            var arrayLength = (uint) array.Length;
 
-            var jsArray = new ArrayInstance(e, arrayLength)
-            {
-                _prototype = e.Realm.Intrinsics.Array.PrototypeObject
-            };
-
+            var values = new object[arrayLength];
             for (uint i = 0; i < arrayLength; ++i)
             {
-                var jsItem = JsValue.FromObject(e, array.GetValue(i));
-                jsArray.WriteArrayValue(i, jsItem);
+                values[i] = JsValue.FromObject(e, array.GetValue(i));
             }
 
-            jsArray.SetOwnProperty(CommonProperties.Length,
-                new PropertyDescriptor(arrayLength, PropertyFlag.OnlyWritable));
-            return jsArray;
+            return new ArrayInstance(e, values);
         }
     }
 }

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -3,6 +3,7 @@ using Jint.Native;
 using Jint.Native.Error;
 using Jint.Native.Object;
 using Jint.Pooling;
+using Jint.Runtime.Descriptors;
 
 namespace Jint.Runtime;
 
@@ -100,7 +101,7 @@ public class JavaScriptException : JintException
             else
             {
                 _callStack = engine.CallStack.BuildCallStackString(location);
-                errObj.FastAddProperty(CommonProperties.Stack, _callStack, false, false, false);
+                errObj.FastSetProperty(CommonProperties.Stack._value, new PropertyDescriptor(_callStack, false, false, false));
             }
         }
 


### PR DESCRIPTION
This tweaks some APIs easier for interop use based on RavenDB usage:

* `Date`, `ArrayInstance`  and `Object` can be constructed correctly by using constructor for the default case
* Optimize and harmonize `FastSet*` scenario when object instance is owned
* Change `Engine.SetValue` to take string as property, one cannot set `Symbol`s via the API anyway
* Expose `ArrayInstance.Push` to public API
* Add `ArrayInstance.GetEntries` which allows to enumerate array key-value-pairs