### PR TITLE
Small performance optimization to string handling

### DIFF
--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1245,7 +1245,10 @@ namespace Jint.Native.Array
             sb.Builder.Append(s);
             for (uint k = 1; k < len; k++)
             {
-                sb.Builder.Append(sep);
+                if (sep != "")
+                {
+                    sb.Builder.Append(sep);
+                }
                 sb.Builder.Append(StringFromJsValue(o.Get(k)));
             }
 

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -196,17 +196,6 @@ public class JsString : JsValue, IEquatable<JsString>
         return _value;
     }
 
-    public JsArray ToArray(Engine engine)
-    {
-        var array = engine.Realm.Intrinsics.Array.ArrayCreate((uint) _value.Length);
-        for (int i = 0; i < _value.Length; ++i)
-        {
-            array.SetIndexValue((uint) i, _value[i], updateLength: false);
-        }
-
-        return array;
-    }
-
     internal int IndexOf(string value, StringComparison comparisonType)
     {
         return ToString().IndexOf(value, comparisonType);

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -55,7 +55,16 @@ namespace Jint.Native.String
                 return JsString.Empty;
             }
 
+            if (arguments.Length == 1)
+            {
+                return JsString.Create((char) TypeConverter.ToUint16(arguments[0]));
+            }
+
+#if NETSTANDARD2_1_OR_GREATER
+            var elements = length < 512 ? stackalloc char[length] : new char[length];
+#else
             var elements = new char[length];
+#endif
             for (var i = 0; i < elements.Length; i++ )
             {
                 var nextCu = TypeConverter.ToUint16(arguments[i]);

--- a/Jint/Runtime/Interpreter/Statements/ProbablyBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/ProbablyBlockStatement.cs
@@ -11,28 +11,29 @@ namespace Jint.Runtime.Interpreter.Statements;
 [StructLayout(LayoutKind.Auto)]
 internal readonly struct ProbablyBlockStatement
 {
-    private readonly JintStatement  _target;
+    private readonly JintStatement? _statement = null;
+    private readonly JintBlockStatement? _blockStatement = null;
 
     public ProbablyBlockStatement(Statement statement)
     {
         if (statement is BlockStatement blockStatement)
         {
-            _target = new JintBlockStatement(blockStatement);
+            _blockStatement = new JintBlockStatement(blockStatement);
         }
         else
         {
-            _target = JintStatement.Build(statement);
+            _statement = JintStatement.Build(statement);
         }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Completion Execute(EvaluationContext context)
     {
-        if (_target is JintBlockStatement blockStatement)
+        if (_blockStatement is not null)
         {
-            return blockStatement.ExecuteBlock(context);
+            return _blockStatement.ExecuteBlock(context);
         }
 
-        return _target.Execute(context);
+        return _statement!.Execute(context);
     }
 }


### PR DESCRIPTION
* no need to call `PutValue` when target is not an object and value was mutated in-place
* fast path for `FromCharCode`
* improve `ProbablyBlockStatement`

## Jint.Benchmark.DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Run|dromaeo-3d-cube|25.803 ms|0.0178 ms|6247.69 KB|
| **New** |	|	| **25.639 ms (-1%)** | **0.0151 ms** | **6248.21 KB (0%)** |
| Old |Run|dromaeo-core-eval|6.258 ms|0.0199 ms|321.58 KB|
| **New** |	|	| **5.597 ms (-11%)** | **0.0244 ms** | **321.84 KB (0%)** |
| Old |Run|dromaeo-object-array|72.128 ms|0.1724 ms|101492.07 KB|
| **New** |	|	| **69.330 ms (-4%)** | **0.2562 ms** | **101492.03 KB (0%)** |
| Old |Run|droma(...)egexp [21]|231.533 ms|1.5412 ms|172628.85 KB|
| **New** |	|	| **222.238 ms (-4%)** | **1.9947 ms** | **174399.84 KB (+1%)** |
| Old |Run|droma(...)tring [21]|431.184 ms|37.0669 ms|1325371.05 KB|
| **New** |	|	| **436.327 ms (+1%)** | **36.2579 ms** | **1322129.7 KB (0%)** |
| Old |Run|droma(...)ase64 [21]|71.958 ms|0.1181 ms|7658.61 KB|
| **New** |	|	| **70.192 ms (-2%)** | **0.3129 ms** | **6537.35 KB (-15%)** |



