### PR TITLE
Add Loaded event to DefaultModuleLoader

### DIFF
--- a/Jint.Tests/Runtime/Modules/DefaultModuleLoaderTests.cs
+++ b/Jint.Tests/Runtime/Modules/DefaultModuleLoaderTests.cs
@@ -36,6 +36,23 @@ public class DefaultModuleLoaderTests
     }
 
     [Fact]
+    public void ShouldTriggerLoadedEvent()
+    {
+        var loader = new DefaultModuleLoader(ModuleTests.GetBasePath());
+        bool triggered = false;
+        loader.Loaded += (sender, source, module) =>
+        {
+            Assert.Equal(loader, sender);
+            Assert.NotNull(source);
+            Assert.NotNull(module);
+            triggered = true;
+        };
+        var engine = new Engine(options => options.EnableModules(loader));
+        engine.ImportModule("./modules/format-name.js");
+        Assert.True(triggered);
+    }
+
+    [Fact]
     public void ShouldResolveBareSpecifiers()
     {
         var resolver = new DefaultModuleLoader("/");


### PR DESCRIPTION
As discussed on Gitter.

Simple addition of event to the default module loader, which is triggered when the loader loads a module. This is helpful for e.g. debuggers and other dev tools, which may need to load the same sources as the engine.

Since the module's AST is readily available, and is also currently needed by debuggers (e.g. for determining possible breakpoint positions), the event passes the AST, along with the source ID generated by the loader.