### PR TITLE
Module-related debugger improvements

### DIFF
--- a/Jint.Tests/Runtime/Debugger/TestHelpers.cs
+++ b/Jint.Tests/Runtime/Debugger/TestHelpers.cs
@@ -24,9 +24,9 @@ namespace Jint.Tests.Runtime.Debugger
         /// Initializes engine in debugmode and executes script until debugger statement,
         /// before calling stepHandler for assertions. Also asserts that a break was triggered.
         /// </summary>
-        /// <param name="script">Script that is basis for testing</param>
+        /// <param name="initialization">Action to initialize and execute scripts</param>
         /// <param name="breakHandler">Handler for assertions</param>
-        public static void TestAtBreak(string script, Action<Engine, DebugInformation> breakHandler)
+        public static void TestAtBreak(Action<Engine> initialization, Action<Engine, DebugInformation> breakHandler)
         {
             var engine = new Engine(options => options
                 .DebugMode()
@@ -41,9 +41,26 @@ namespace Jint.Tests.Runtime.Debugger
                 return StepMode.None;
             };
 
-            engine.Execute(script);
+            initialization(engine);
 
             Assert.True(didBreak, "Test script did not break (e.g. didn't reach debugger statement)");
+        }
+
+        /// <inheritdoc cref="TestAtBreak()"/>
+        public static void TestAtBreak(Action<Engine> initialization, Action<DebugInformation> breakHandler)
+        {
+            TestAtBreak(engine => initialization(engine), (engine, info) => breakHandler(info));
+        }
+
+        /// <summary>
+        /// Initializes engine in debugmode and executes script until debugger statement,
+        /// before calling stepHandler for assertions. Also asserts that a break was triggered.
+        /// </summary>
+        /// <param name="script">Script that is basis for testing</param>
+        /// <param name="breakHandler">Handler for assertions</param>
+        public static void TestAtBreak(string script, Action<Engine, DebugInformation> breakHandler)
+        {
+            TestAtBreak(engine => engine.Execute(script), breakHandler);
         }
 
         /// <inheritdoc cref="TestAtBreak()"/>

--- a/Jint/Native/Function/ClassDefinition.cs
+++ b/Jint/Native/Function/ClassDefinition.cs
@@ -14,7 +14,7 @@ namespace Jint.Native.Function
         private static readonly MethodDefinition _superConstructor;
         internal static CallExpression _defaultSuperCall;
 
-        private static readonly MethodDefinition _emptyConstructor;
+        internal static readonly MethodDefinition _emptyConstructor;
 
         internal readonly string? _className;
         private readonly Expression? _superClass;

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -159,7 +159,11 @@ namespace Jint.Native.Function
                     var result = _functionDefinition.EvaluateBody(context, this, arguments);
 
                     // The DebugHandler needs the current execution context before the return for stepping through the return point
-                    if (context.DebugMode && result.Type != CompletionType.Throw)
+                    // We exclude the empty constructor generated for classes without an explicit constructor.
+                    bool isStep = context.DebugMode &&
+                        result.Type != CompletionType.Throw &&
+                        _functionDefinition.Function != ClassDefinition._emptyConstructor.Value;
+                    if (isStep)
                     {
                         // We don't have a statement, but we still need a Location for debuggers. DebugHandler will infer one from
                         // the function body:

--- a/Jint/Runtime/Debugger/DebugScope.cs
+++ b/Jint/Runtime/Debugger/DebugScope.cs
@@ -57,7 +57,7 @@ namespace Jint.Runtime.Debugger
         /// <returns>Value of the binding</returns>
         public JsValue? GetBindingValue(string name)
         {
-            _record.TryGetBindingValue(name, strict: true, out var result);
+            _record.TryGetBinding(new EnvironmentRecord.BindingName(name), strict: true, out _, out var result);
             return result;
         }
 

--- a/Jint/Runtime/Debugger/DebugScopeType.cs
+++ b/Jint/Runtime/Debugger/DebugScopeType.cs
@@ -79,7 +79,6 @@ namespace Jint.Runtime.Debugger
         /// <summary>
         /// Module scope bindings.
         /// </summary>
-        /// <remarks>Not currently implemented by Jint.</remarks>
         Module,
 
         /// <summary>

--- a/Jint/Runtime/Debugger/DebugScopes.cs
+++ b/Jint/Runtime/Debugger/DebugScopes.cs
@@ -55,6 +55,9 @@ namespace Jint.Runtime.Debugger
                         // If an ObjectEnvironmentRecord is not a GlobalEnvironmentRecord, it's With
                         AddScope(DebugScopeType.With, record);
                         break;
+                    case ModuleEnvironmentRecord:
+                        AddScope(DebugScopeType.Module, record);
+                        break;
                     case DeclarativeEnvironmentRecord der:
                         if (der._catchEnvironment)
                         {

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -124,17 +124,6 @@ namespace Jint.Runtime.Environments
             return null!;
         }
 
-        internal sealed override bool TryGetBindingValue(string name, bool strict, [NotNullWhen(true)] out JsValue? value)
-        {
-            if (_dictionary is not null && _dictionary.TryGetValue(name, out var binding) && binding.IsInitialized())
-            {
-                value = binding.Value;
-                return true;
-            }
-            value = null;
-            return false;
-        }
-
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void ThrowUninitializedBindingError(string name)
         {

--- a/Jint/Runtime/Environments/EnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/EnvironmentRecord.cs
@@ -73,17 +73,6 @@ namespace Jint.Runtime.Environments
         public abstract JsValue GetBindingValue(string name, bool strict);
 
         /// <summary>
-        /// Returns the value of an already existing binding from an environment record. Unlike <see cref="GetBindingValue(string, bool)"/>
-        /// this does not throw an exception for uninitialized bindings, but instead returns false and sets <paramref name="value"/> to null.
-        /// </summary>
-        /// <param name="name">The identifier of the binding</param>
-        /// <param name="strict">Strict mode</param>
-        /// <param name="value">The value of an already existing binding from an environment record.</param>
-        /// <returns>True if the value is initialized, otherwise false.</returns>
-        /// <remarks>This is used for debugger inspection. Note that this will currently still throw if the binding cannot be retrieved (e.g. because it doesn't exist).</remarks>
-        internal abstract bool TryGetBindingValue(string name, bool strict, [NotNullWhen(true)] out JsValue? value);
-
-        /// <summary>
         /// Delete a binding from an environment record. The String value N is the text of the bound name If a binding for N exists, remove the binding and return true. If the binding exists but cannot be removed return false. If the binding does not exist return true.
         /// </summary>
         /// <param name="name">The identifier of the binding</param>

--- a/Jint/Runtime/Environments/GlobalEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/GlobalEnvironmentRecord.cs
@@ -241,37 +241,6 @@ namespace Jint.Runtime.Environments
             return ObjectInstance.UnwrapJsValue(desc, _global);
         }
 
-        internal override bool TryGetBindingValue(string name, bool strict, [NotNullWhen(true)] out JsValue? value)
-        {
-            if (_declarativeRecord.HasBinding(name))
-            {
-                return _declarativeRecord.TryGetBindingValue(name, strict, out value);
-            }
-
-            // see ObjectEnvironmentRecord.TryGetBindingValue
-            var desc = PropertyDescriptor.Undefined;
-            if (_globalObject is not null)
-            {
-                if (_globalObject._properties?.TryGetValue(name, out desc) == false)
-                {
-                    desc = PropertyDescriptor.Undefined;
-                }
-            }
-            else
-            {
-                desc = _global.GetProperty(name);
-            }
-
-            if (strict && desc == PropertyDescriptor.Undefined)
-            {
-                value = null;
-                return false;
-            }
-
-            value = ObjectInstance.UnwrapJsValue(desc, _global);
-            return true;
-        }
-
         public override bool DeleteBinding(string name)
         {
             if (_declarativeRecord.HasBinding(name))

--- a/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
@@ -166,19 +166,6 @@ namespace Jint.Runtime.Environments
             return ObjectInstance.UnwrapJsValue(desc, _bindingObject);
         }
 
-        internal override bool TryGetBindingValue(string name, bool strict, [NotNullWhen(true)] out JsValue? value)
-        {
-            var desc = _bindingObject.GetProperty(name);
-            if (strict && desc == PropertyDescriptor.Undefined)
-            {
-                value = null;
-                return false;
-            }
-
-            value = ObjectInstance.UnwrapJsValue(desc, _bindingObject);
-            return true;
-        }
-
         public override bool DeleteBinding(string name)
         {
             return _bindingObject.Delete(name);


### PR DESCRIPTION
Fixed undefined binding values in module scope
Implemented DebugScopeType.Module - that's one more alignment with Chromium dev-tools.

Not too happy about creating BindingName instances to call `TryGetBinding` - but of course, in terms of performance, this only happens when inspecting - and the change gets rid of the (I think) now redundant `TryGetBindingValue`: `DeclarativeEnvironmentRecord.TryGetBinding` has identical semantics; `ObjectEnvironmentRecord.TryGetBinding` is more up-to-date development-wise (handles `with` and other edge cases); I *think* the same goes for `GlobalEnvironmentRecord`, but that one is harder for me to wrap my head around. Of course, this also circumvents the need for writing a `TryGetBindingValue` for `ModuleEnvironmentRecord`. 😁

The pull request is draft for now, just to have time for spotting edge cases where `TryGetBinding` fails.

ETA: I've done a lot of manual test cases and, as expected, don't really see anywhere it breaks. I don't think it's appropriate to add lots of test cases for `DebugHandler.GetBindingValue` - it's merely a wrapper around `TryGetBinding` which is already thoroughly tested (much more than the old `TryGetBindingValue`). And we don't actually have a spec of how the results should behave - in general, they should simply give the same access to binding values as the script has.

As a "bonus", I threw in the small change to avoid the implicit class constructor triggering a return point step.