### PR TITLE
Debugger API improvements

### DIFF
--- a/Jint.Tests/Runtime/Debugger/BreakPointTests.cs
+++ b/Jint.Tests/Runtime/Debugger/BreakPointTests.cs
@@ -192,6 +192,7 @@ debugger;
             bool didBreak = false;
             engine.DebugHandler.Break += (sender, info) =>
             {
+                Assert.Equal(PauseType.DebuggerStatement, info.PauseType);
                 didBreak = true;
                 return StepMode.None;
             };
@@ -230,6 +231,33 @@ debugger;
             engine.Execute(script);
             Assert.Equal(3, stepCount);
             Assert.False(didBreak);
+        }
+
+        [Fact]
+        public void DebuggerStatementDoesNotTriggerBreakWhenAtBreakPoint()
+        {
+            string script = @"'dummy';
+debugger;
+'dummy';";
+
+            var engine = new Engine(options => options
+                .DebugMode()
+                .DebuggerStatementHandling(DebuggerStatementHandling.Script)
+                .InitialStepMode(StepMode.None));
+
+            int breakCount = 0;
+
+            engine.DebugHandler.BreakPoints.Set(new BreakPoint(2, 0));
+
+            engine.DebugHandler.Break += (sender, info) =>
+            {
+                Assert.Equal(PauseType.Break, info.PauseType);
+                breakCount++;
+                return StepMode.None;
+            };
+
+            engine.Execute(script);
+            Assert.Equal(1, breakCount);
         }
 
         [Fact]

--- a/Jint.Tests/Runtime/Debugger/DebugHandlerTests.cs
+++ b/Jint.Tests/Runtime/Debugger/DebugHandlerTests.cs
@@ -31,7 +31,7 @@ namespace Jint.Tests.Runtime.Debugger
 
                 if (info.ReachedLiteral("target"))
                 {
-                    var obj = info.CurrentScopeChain.Global.GetBindingValue("obj") as ObjectInstance;
+                    var obj = info.CurrentScopeChain[0].GetBindingValue("obj") as ObjectInstance;
                     var prop = obj.GetOwnProperty("name");
                     // This is where reentrance would occur:
                     var value = prop.Get.Invoke(engine);

--- a/Jint.Tests/Runtime/Debugger/ScopeTests.cs
+++ b/Jint.Tests/Runtime/Debugger/ScopeTests.cs
@@ -299,7 +299,8 @@ namespace Jint.Tests.Runtime.Debugger
             {
                 Assert.Collection(info.CurrentScopeChain,
                     scope => AssertScope(scope, DebugScopeType.Local, "arguments", "a"),
-                    scope => AssertScope(scope, DebugScopeType.Closure, "b", "power"), // a, this, arguments shadowed by local
+                    // a, arguments shadowed by local - but still exist in this scope
+                    scope => AssertScope(scope, DebugScopeType.Closure, "a", "arguments", "b", "power"),
                     scope => AssertScope(scope, DebugScopeType.Script, "x", "y", "z"),
                     scope => AssertScope(scope, DebugScopeType.Global, "add"));
             });
@@ -327,7 +328,7 @@ namespace Jint.Tests.Runtime.Debugger
                 Assert.Collection(info.CurrentScopeChain,
                     scope => AssertScope(scope, DebugScopeType.Block, "y"),
                     scope => AssertScope(scope, DebugScopeType.Local, "arguments", "a", "b"),
-                    scope => AssertScope(scope, DebugScopeType.Script, "x", "z"), // y shadowed
+                    scope => AssertScope(scope, DebugScopeType.Script, "x", "y", "z"), // y is shadowed, but still in the scope
                     scope => AssertScope(scope, DebugScopeType.Global, "add"));
             });
         }
@@ -391,7 +392,7 @@ namespace Jint.Tests.Runtime.Debugger
                     scope => AssertScope(scope, DebugScopeType.Block, "x"),
                     scope => AssertScope(scope, DebugScopeType.Block, "y"),
                     scope => AssertScope(scope, DebugScopeType.Local, "arguments", "a", "b"),
-                    scope => AssertScope(scope, DebugScopeType.Script, "z"), // x, y shadowed
+                    scope => AssertScope(scope, DebugScopeType.Script, "x", "y", "z"), // x, y are shadowed, but still in the scope
                     scope => AssertScope(scope, DebugScopeType.Global, "add"));
             });
         }

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2953,18 +2953,31 @@ x.test = {
             );
         }
 
-        private void TestParsedEvent(Action<Engine, string> call, string expectedSource)
+        [Fact]
+        public void ImportModuleShouldTriggerParsedEvent()
+        {
+            TestParsedEvent(
+                (engine, code) =>
+                {
+                    engine.AddModule("my-module", code);
+                    engine.ImportModule("my-module");
+                },
+                expectedSource: "my-module"
+            );
+        }
+
+        private static void TestParsedEvent(Action<Engine, string> call, string expectedSource)
         {
             var engine = new Engine();
 
             const string script = "'dummy';";
 
-            bool parsedTriggered = false;
-            engine.Parsed += (sender, source, ast) =>
+            var parsedTriggered = false;
+            engine.DebugHandler.Parsed += (sender, ast) =>
             {
                 parsedTriggered = true;
                 Assert.Equal(engine, sender);
-                Assert.Equal(expectedSource, source);
+                Assert.Equal(expectedSource, ast.Location.Source);
                 Assert.Collection(ast.Body, node => Assert.True(TestHelpers.IsLiteral(node, "dummy")));
             };
 

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -6,6 +6,7 @@ using Jint.Native.Array;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Debugger;
+using Jint.Tests.Runtime.Debugger;
 using Xunit.Abstractions;
 
 #pragma warning disable 618
@@ -2878,6 +2879,98 @@ x.test = {
             Assert.Equal(2L, array.Length);
             Assert.True(array[0].IsUndefined());
             Assert.True(array[1].IsUndefined());
+        }
+
+        [Fact]
+        public void ExecuteShouldTriggerParsedEvent()
+        {
+            TestParsedEvent(
+                (engine, code) => engine.Execute(code),
+                expectedSource: "<anonymous>"
+            );
+        }
+
+        [Fact]
+        public void ExecuteWithSourceShouldTriggerParsedEvent()
+        {
+            TestParsedEvent(
+                (engine, code) => engine.Execute(code, "mysource"),
+                expectedSource: "mysource"
+            );
+        }
+
+        [Fact]
+        public void ExecuteWithParserOptionsShouldTriggerParsedEvent()
+        {
+            TestParsedEvent(
+                (engine, code) => engine.Execute(code, ParserOptions.Default),
+                expectedSource: "<anonymous>"
+            );
+        }
+
+        [Fact]
+        public void ExecuteWithSourceAndParserOptionsShouldTriggerParsedEvent()
+        {
+            TestParsedEvent(
+                (engine, code) => engine.Execute(code, "mysource", ParserOptions.Default),
+                expectedSource: "mysource"
+            );
+        }
+
+        [Fact]
+        public void EvaluateShouldTriggerParsedEvent()
+        {
+            TestParsedEvent(
+                (engine, code) => engine.Evaluate(code),
+                expectedSource: "<anonymous>"
+            );
+        }
+
+        [Fact]
+        public void EvaluateWithSourceShouldTriggerParsedEvent()
+        {
+            TestParsedEvent(
+                (engine, code) => engine.Evaluate(code, "mysource"),
+                expectedSource: "mysource"
+            );
+        }
+
+        [Fact]
+        public void EvaluateWithParserOptionsShouldTriggerParsedEvent()
+        {
+            TestParsedEvent(
+                (engine, code) => engine.Evaluate(code, ParserOptions.Default),
+                expectedSource: "<anonymous>"
+            );
+        }
+
+        [Fact]
+        public void EvaluateWithSourceAndParserOptionsShouldTriggerParsedEvent()
+        {
+            TestParsedEvent(
+                (engine, code) => engine.Evaluate(code, "mysource", ParserOptions.Default),
+                expectedSource: "mysource"
+            );
+        }
+
+        private void TestParsedEvent(Action<Engine, string> call, string expectedSource)
+        {
+            var engine = new Engine();
+
+            const string script = "'dummy';";
+
+            bool parsedTriggered = false;
+            engine.Parsed += (sender, source, ast) =>
+            {
+                parsedTriggered = true;
+                Assert.Equal(engine, sender);
+                Assert.Equal(expectedSource, source);
+                Assert.Collection(ast.Body, node => Assert.True(TestHelpers.IsLiteral(node, "dummy")));
+            };
+
+            call(engine, script);
+
+            Assert.True(parsedTriggered);
         }
 
         private class Wrapper

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2882,81 +2882,81 @@ x.test = {
         }
 
         [Fact]
-        public void ExecuteShouldTriggerParsedEvent()
+        public void ExecuteShouldTriggerBeforeEvaluateEvent()
         {
-            TestParsedEvent(
+            TestBeforeEvaluateEvent(
                 (engine, code) => engine.Execute(code),
                 expectedSource: "<anonymous>"
             );
         }
 
         [Fact]
-        public void ExecuteWithSourceShouldTriggerParsedEvent()
+        public void ExecuteWithSourceShouldTriggerBeforeEvaluateEvent()
         {
-            TestParsedEvent(
+            TestBeforeEvaluateEvent(
                 (engine, code) => engine.Execute(code, "mysource"),
                 expectedSource: "mysource"
             );
         }
 
         [Fact]
-        public void ExecuteWithParserOptionsShouldTriggerParsedEvent()
+        public void ExecuteWithParserOptionsShouldTriggerBeforeEvaluateEvent()
         {
-            TestParsedEvent(
+            TestBeforeEvaluateEvent(
                 (engine, code) => engine.Execute(code, ParserOptions.Default),
                 expectedSource: "<anonymous>"
             );
         }
 
         [Fact]
-        public void ExecuteWithSourceAndParserOptionsShouldTriggerParsedEvent()
+        public void ExecuteWithSourceAndParserOptionsShouldTriggerBeforeEvaluateEvent()
         {
-            TestParsedEvent(
+            TestBeforeEvaluateEvent(
                 (engine, code) => engine.Execute(code, "mysource", ParserOptions.Default),
                 expectedSource: "mysource"
             );
         }
 
         [Fact]
-        public void EvaluateShouldTriggerParsedEvent()
+        public void EvaluateShouldTriggerBeforeEvaluateEvent()
         {
-            TestParsedEvent(
+            TestBeforeEvaluateEvent(
                 (engine, code) => engine.Evaluate(code),
                 expectedSource: "<anonymous>"
             );
         }
 
         [Fact]
-        public void EvaluateWithSourceShouldTriggerParsedEvent()
+        public void EvaluateWithSourceShouldTriggerBeforeEvaluateEvent()
         {
-            TestParsedEvent(
+            TestBeforeEvaluateEvent(
                 (engine, code) => engine.Evaluate(code, "mysource"),
                 expectedSource: "mysource"
             );
         }
 
         [Fact]
-        public void EvaluateWithParserOptionsShouldTriggerParsedEvent()
+        public void EvaluateWithParserOptionsShouldTriggerBeforeEvaluateEvent()
         {
-            TestParsedEvent(
+            TestBeforeEvaluateEvent(
                 (engine, code) => engine.Evaluate(code, ParserOptions.Default),
                 expectedSource: "<anonymous>"
             );
         }
 
         [Fact]
-        public void EvaluateWithSourceAndParserOptionsShouldTriggerParsedEvent()
+        public void EvaluateWithSourceAndParserOptionsShouldTriggerBeforeEvaluateEvent()
         {
-            TestParsedEvent(
+            TestBeforeEvaluateEvent(
                 (engine, code) => engine.Evaluate(code, "mysource", ParserOptions.Default),
                 expectedSource: "mysource"
             );
         }
 
         [Fact]
-        public void ImportModuleShouldTriggerParsedEvent()
+        public void ImportModuleShouldTriggerBeforeEvaluateEvent()
         {
-            TestParsedEvent(
+            TestBeforeEvaluateEvent(
                 (engine, code) =>
                 {
                     engine.AddModule("my-module", code);
@@ -2966,16 +2966,16 @@ x.test = {
             );
         }
 
-        private static void TestParsedEvent(Action<Engine, string> call, string expectedSource)
+        private static void TestBeforeEvaluateEvent(Action<Engine, string> call, string expectedSource)
         {
             var engine = new Engine();
 
             const string script = "'dummy';";
 
-            var parsedTriggered = false;
-            engine.DebugHandler.Parsed += (sender, ast) =>
+            var beforeEvaluateTriggered = false;
+            engine.DebugHandler.BeforeEvaluate += (sender, ast) =>
             {
-                parsedTriggered = true;
+                beforeEvaluateTriggered = true;
                 Assert.Equal(engine, sender);
                 Assert.Equal(expectedSource, ast.Location.Source);
                 Assert.Collection(ast.Body, node => Assert.True(TestHelpers.IsLiteral(node, "dummy")));
@@ -2983,7 +2983,7 @@ x.test = {
 
             call(engine, script);
 
-            Assert.True(parsedTriggered);
+            Assert.True(beforeEvaluateTriggered);
         }
 
         private class Wrapper

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1584,13 +1584,11 @@ var prep = function (fn) { fn(); };
             Assert.NotNull(debugInfo.CallStack);
             Assert.NotNull(debugInfo.CurrentNode);
             Assert.NotNull(debugInfo.CurrentScopeChain);
-            Assert.NotNull(debugInfo.CurrentScopeChain.Global);
-            Assert.NotNull(debugInfo.CurrentScopeChain.Local);
 
             Assert.Equal(2, debugInfo.CallStack.Count);
             Assert.Equal("func1", debugInfo.CurrentCallFrame.FunctionName);
-            var globalScope = debugInfo.CurrentScopeChain.Global;
-            var localScope = debugInfo.CurrentScopeChain.Local;
+            var globalScope = debugInfo.CurrentScopeChain.Single(s => s.ScopeType == DebugScopeType.Global);
+            var localScope = debugInfo.CurrentScopeChain.Single(s => s.ScopeType == DebugScopeType.Local);
             Assert.Contains("global", globalScope.BindingNames);
             Assert.Equal(true, globalScope.GetBindingValue("global").AsBoolean());
             Assert.Contains("local", localScope.BindingNames);

--- a/Jint.Tests/Runtime/Modules/DefaultModuleLoaderTests.cs
+++ b/Jint.Tests/Runtime/Modules/DefaultModuleLoaderTests.cs
@@ -36,23 +36,6 @@ public class DefaultModuleLoaderTests
     }
 
     [Fact]
-    public void ShouldTriggerLoadedEvent()
-    {
-        var loader = new DefaultModuleLoader(ModuleTests.GetBasePath());
-        bool triggered = false;
-        loader.Loaded += (sender, source, module) =>
-        {
-            Assert.Equal(loader, sender);
-            Assert.NotNull(source);
-            Assert.NotNull(module);
-            triggered = true;
-        };
-        var engine = new Engine(options => options.EnableModules(loader));
-        engine.ImportModule("./modules/format-name.js");
-        Assert.True(triggered);
-    }
-
-    [Fact]
     public void ShouldResolveBareSpecifiers()
     {
         var resolver = new DefaultModuleLoader("/");

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -41,6 +41,11 @@ namespace Jint
                 module = LoaderFromModuleLoader(moduleResolution);
             }
 
+            if (module is SourceTextModuleRecord sourceTextModule)
+            {
+                DebugHandler.OnBeforeEvaluate(sourceTextModule._source);
+            }
+
             return module;
         }
 
@@ -127,11 +132,6 @@ namespace Jint
 
         private JsValue EvaluateModule(string specifier, ModuleRecord cyclicModule)
         {
-            if (cyclicModule is SourceTextModuleRecord sourceTextModule)
-            {
-                DebugHandler.OnBeforeEvaluate(sourceTextModule._source);
-            }
-
             var ownsContext = _activeEvaluationContext is null;
             _activeEvaluationContext ??= new EvaluationContext(this);
             JsValue evaluationResult;

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -41,6 +41,11 @@ namespace Jint
                 module = LoaderFromModuleLoader(moduleResolution);
             }
 
+            if (module is SourceTextModuleRecord sourceTextModule)
+            {
+                DebugHandler.OnParsed(sourceTextModule._source);
+            }
+
             return module;
         }
 

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -41,11 +41,6 @@ namespace Jint
                 module = LoaderFromModuleLoader(moduleResolution);
             }
 
-            if (module is SourceTextModuleRecord sourceTextModule)
-            {
-                DebugHandler.OnParsed(sourceTextModule._source);
-            }
-
             return module;
         }
 
@@ -132,6 +127,11 @@ namespace Jint
 
         private JsValue EvaluateModule(string specifier, ModuleRecord cyclicModule)
         {
+            if (cyclicModule is SourceTextModuleRecord sourceTextModule)
+            {
+                DebugHandler.OnBeforeEvaluate(sourceTextModule._source);
+            }
+
             var ownsContext = _activeEvaluationContext is null;
             _activeEvaluationContext ??= new EvaluationContext(this);
             JsValue evaluationResult;

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -292,7 +292,7 @@ namespace Jint
         /// </summary>
         private Engine ScriptEvaluation(ScriptRecord scriptRecord)
         {
-            DebugHandler.OnParsed(scriptRecord.EcmaScriptCode);
+            DebugHandler.OnBeforeEvaluate(scriptRecord.EcmaScriptCode);
 
             var globalEnv = Realm.GlobalEnv;
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -61,6 +61,13 @@ namespace Jint
         internal Intrinsics _originalIntrinsics = null!;
         internal Host _host = null!;
 
+        public delegate void ParsedHandler(object sender, string source, Script script);
+
+        /// <summary>
+        /// The Parsed event is triggered whenever a script has been passed as a result of execution or evaluation.
+        /// </summary>
+        public event ParsedHandler? Parsed;
+
         /// <summary>
         /// Constructs a new engine instance.
         /// </summary>
@@ -255,6 +262,7 @@ namespace Jint
                 : new JavaScriptParser(parserOptions);
 
             var script = parser.ParseScript(code, source, _isStrict);
+            Parsed?.Invoke(this, source, script);
 
             return Evaluate(script);
         }
@@ -275,6 +283,7 @@ namespace Jint
                 : new JavaScriptParser(parserOptions);
 
             var script = parser.ParseScript(code, source, _isStrict);
+            Parsed?.Invoke(this, source, script);
 
             return Execute(script);
         }
@@ -363,7 +372,7 @@ namespace Jint
 
             Action<JsValue> SettleWith(FunctionInstance settle) => value =>
             {
-                settle.Call(JsValue.Undefined, new[] {value});
+                settle.Call(JsValue.Undefined, new[] { value });
                 RunAvailableContinuations();
             };
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -64,7 +64,7 @@ namespace Jint
         public delegate void ParsedHandler(object sender, string source, Script script);
 
         /// <summary>
-        /// The Parsed event is triggered whenever a script has been passed as a result of execution or evaluation.
+        /// The Parsed event is triggered whenever a script has been parsed as a result of execution or evaluation.
         /// </summary>
         public event ParsedHandler? Parsed;
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -61,13 +61,6 @@ namespace Jint
         internal Intrinsics _originalIntrinsics = null!;
         internal Host _host = null!;
 
-        public delegate void ParsedHandler(object sender, string source, Script script);
-
-        /// <summary>
-        /// The Parsed event is triggered whenever a script has been parsed as a result of execution or evaluation.
-        /// </summary>
-        public event ParsedHandler? Parsed;
-
         /// <summary>
         /// Constructs a new engine instance.
         /// </summary>
@@ -262,7 +255,6 @@ namespace Jint
                 : new JavaScriptParser(parserOptions);
 
             var script = parser.ParseScript(code, source, _isStrict);
-            Parsed?.Invoke(this, source, script);
 
             return Evaluate(script);
         }
@@ -283,7 +275,6 @@ namespace Jint
                 : new JavaScriptParser(parserOptions);
 
             var script = parser.ParseScript(code, source, _isStrict);
-            Parsed?.Invoke(this, source, script);
 
             return Execute(script);
         }
@@ -301,6 +292,8 @@ namespace Jint
         /// </summary>
         private Engine ScriptEvaluation(ScriptRecord scriptRecord)
         {
+            DebugHandler.OnParsed(scriptRecord.EcmaScriptCode);
+
             var globalEnv = Realm.GlobalEnv;
 
             var scriptContext = new ExecutionContext(

--- a/Jint/Runtime/Debugger/BreakLocation.cs
+++ b/Jint/Runtime/Debugger/BreakLocation.cs
@@ -18,7 +18,7 @@ public sealed record BreakLocation
 
     }
 
-    public BreakLocation(string source, Esprima.Position position) : this(source, position.Line, position.Column)
+    public BreakLocation(string? source, Esprima.Position position) : this(source, position.Line, position.Column)
     {
     }
 

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -84,7 +84,7 @@ namespace Jint.Runtime.Debugger
             {
                 throw new DebugEvaluationException("Jint has no active evaluation context");
             }
-            int callStackSize = _engine.CallStack.Count;
+            var callStackSize = _engine.CallStack.Count;
 
             var list = new JintStatementList(null, script.Body);
             Completion result;

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -16,7 +16,7 @@ namespace Jint.Runtime.Debugger
 
     public class DebugHandler
     {
-        public delegate void ParsedEventHandler(object sender, Program ast);
+        public delegate void BeforeEvaluateEventHandler(object sender, Program ast);
         public delegate StepMode DebugEventHandler(object sender, DebugInformation e);
 
         private readonly Engine _engine;
@@ -24,9 +24,9 @@ namespace Jint.Runtime.Debugger
         private int _steppingDepth;
 
         /// <summary>
-        /// The Parsed event is triggered after the engine retrieves a parsed AST of a script or module.
+        /// Triggered before the engine executes/evaluates the parsed AST of a script or module.
         /// </summary>
-        public event ParsedEventHandler? Parsed;
+        public event BeforeEvaluateEventHandler? BeforeEvaluate;
 
         /// <summary>
         /// The Step event is triggered before the engine executes a step-eligible execution point.
@@ -140,11 +140,11 @@ namespace Jint.Runtime.Debugger
             }
         }
 
-        internal void OnParsed(Program ast)
+        internal void OnBeforeEvaluate(Program ast)
         {
             if (ast != null)
             {
-                Parsed?.Invoke(_engine, ast);
+                BeforeEvaluate?.Invoke(_engine, ast);
             }
         }
 

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -16,11 +16,17 @@ namespace Jint.Runtime.Debugger
 
     public class DebugHandler
     {
+        public delegate void ParsedEventHandler(object sender, Program ast);
         public delegate StepMode DebugEventHandler(object sender, DebugInformation e);
 
         private readonly Engine _engine;
         private bool _paused;
         private int _steppingDepth;
+
+        /// <summary>
+        /// The Parsed event is triggered after the engine retrieves a parsed AST of a script or module.
+        /// </summary>
+        public event ParsedEventHandler? Parsed;
 
         /// <summary>
         /// The Step event is triggered before the engine executes a step-eligible execution point.
@@ -131,6 +137,14 @@ namespace Jint.Runtime.Debugger
             catch (ParserException ex)
             {
                 throw new DebugEvaluationException("An error occurred during debugger expression parsing", ex);
+            }
+        }
+
+        internal void OnParsed(Program ast)
+        {
+            if (ast != null)
+            {
+                Parsed?.Invoke(_engine, ast);
             }
         }
 

--- a/Jint/Runtime/Debugger/DebugInformation.cs
+++ b/Jint/Runtime/Debugger/DebugInformation.cs
@@ -14,7 +14,7 @@ namespace Jint.Runtime.Debugger
 
         internal DebugInformation(
             Engine engine,
-            Node currentNode,
+            Node? currentNode,
             Location currentLocation,
             JsValue? returnValue,
             long currentMemoryUsage,
@@ -51,7 +51,7 @@ namespace Jint.Runtime.Debugger
         /// The AST Node that will be executed on next step.
         /// Note that this will be null when execution is at a return point.
         /// </summary>
-        public Node CurrentNode { get; }
+        public Node? CurrentNode { get; }
 
         /// <summary>
         /// The current source Location.

--- a/Jint/Runtime/Debugger/DebugScope.cs
+++ b/Jint/Runtime/Debugger/DebugScope.cs
@@ -10,13 +10,12 @@ namespace Jint.Runtime.Debugger
     public sealed class DebugScope
     {
         private readonly EnvironmentRecord _record;
-        private readonly List<string> _bindingNames;
+        private string[]? _bindingNames;
 
-        internal DebugScope(DebugScopeType type, EnvironmentRecord record, List<string> bindingNames, bool isTopLevel)
+        internal DebugScope(DebugScopeType type, EnvironmentRecord record, bool isTopLevel)
         {
             ScopeType = type;
             _record = record;
-            _bindingNames = bindingNames;
             BindingObject = record is ObjectEnvironmentRecord objEnv ? objEnv._bindingObject : null;
             IsTopLevel = isTopLevel;
         }
@@ -37,9 +36,9 @@ namespace Jint.Runtime.Debugger
         public bool IsTopLevel { get; }
 
         /// <summary>
-        /// Names of all non-shadowed bindings in the scope.
+        /// Names of all bindings in the scope.
         /// </summary>
-        public IReadOnlyList<string> BindingNames => _bindingNames;
+        public IReadOnlyList<string> BindingNames => _bindingNames ??= _record.GetAllBindingNames();
 
         /// <summary>
         /// Binding object for ObjectEnvironmentRecords - that is, Global scope and With scope. Null for other scopes.

--- a/Jint/Runtime/Debugger/DebugScopes.cs
+++ b/Jint/Runtime/Debugger/DebugScopes.cs
@@ -5,30 +5,12 @@ namespace Jint.Runtime.Debugger
 {
     public sealed class DebugScopes : IReadOnlyList<DebugScope>
     {
-        private readonly HashSet<string> _foundBindings = new();
         private readonly List<DebugScope> _scopes = new();
 
         internal DebugScopes(EnvironmentRecord environment)
         {
             Populate(environment);
         }
-
-        /// <summary>
-        /// Shortcut to Global scope.
-        /// </summary>
-        /// <remarks>
-        /// Note that this only includes the object environment record of the Global scope - i.e. it doesn't
-        /// include block scope bindings (let/const).
-        /// </remarks>
-        public DebugScope? Global { get; private set; }
-
-        /// <summary>
-        /// Shortcut to Local scope.
-        /// </summary>
-        /// <remarks>
-        /// Note that this is only present inside functions, and doesn't include block scope bindings (let/const)
-        /// </remarks>
-        public DebugScope? Local { get; private set; }
 
         public DebugScope this[int index] => _scopes[index];
         public int Count => _scopes.Count;
@@ -77,37 +59,10 @@ namespace Jint.Runtime.Debugger
 
         private void AddScope(DebugScopeType type, EnvironmentRecord record, bool isTopLevel = false)
         {
-            var bindings = new List<string>();
-            PopulateBindings(bindings, record);
-
-            if (bindings.Count > 0)
+            if (record.HasBindings())
             {
-                var scope = new DebugScope(type, record, bindings, isTopLevel);
+                var scope = new DebugScope(type, record, isTopLevel);
                 _scopes.Add(scope);
-                switch (type)
-                {
-                    case DebugScopeType.Global:
-                        Global = scope;
-                        break;
-                    case DebugScopeType.Local:
-                        Local = scope;
-                        break;
-                }
-            }
-        }
-
-        private void PopulateBindings(List<string> bindings, EnvironmentRecord record)
-        {
-            var bindingNames = record.GetAllBindingNames();
-
-            foreach (var name in bindingNames)
-            {
-                // Only add non-shadowed bindings
-                if (!_foundBindings.Contains(name))
-                {
-                    bindings.Add(name);
-                    _foundBindings.Add(name);
-                }
             }
         }
 

--- a/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironmentRecord.cs
@@ -153,6 +153,11 @@ namespace Jint.Runtime.Environments
 
         public sealed override JsValue WithBaseObject() => Undefined;
 
+        public sealed override bool HasBindings()
+        {
+            return _dictionary?.Count > 0;
+        }
+
         /// <inheritdoc />
         internal sealed override string[] GetAllBindingNames()
         {

--- a/Jint/Runtime/Environments/EnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/EnvironmentRecord.cs
@@ -85,6 +85,8 @@ namespace Jint.Runtime.Environments
 
         public abstract JsValue WithBaseObject();
 
+        public abstract bool HasBindings();
+
         /// <summary>
         /// Returns an array of all the defined binding names
         /// </summary>

--- a/Jint/Runtime/Environments/GlobalEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/GlobalEnvironmentRecord.cs
@@ -376,6 +376,11 @@ namespace Jint.Runtime.Environments
             _varNames.Add(name);
         }
 
+        public sealed override bool HasBindings()
+        {
+            return _declarativeRecord.HasBindings() || _globalObject?._properties?.Count > 0 || _global._properties?.Count > 0;
+        }
+
         internal override string[] GetAllBindingNames()
         {
             // JT: Rather than introduce a new method for the debugger, I'm reusing this one,

--- a/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/ObjectEnvironmentRecord.cs
@@ -177,6 +177,10 @@ namespace Jint.Runtime.Environments
 
         public override JsValue WithBaseObject() => _withEnvironment ? _bindingObject : Undefined;
 
+        public sealed override bool HasBindings()
+        {
+            return _bindingObject._properties?.Count > 0;
+        }
 
         internal override string[] GetAllBindingNames()
         {

--- a/Jint/Runtime/Interpreter/Statements/JintDebuggerStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDebuggerStatement.cs
@@ -22,9 +22,8 @@ namespace Jint.Runtime.Interpreter.Statements
 
                     System.Diagnostics.Debugger.Break();
                     break;
+                // DebugHandler handles DebuggerStatementHandling.Script during OnStep
                 case DebuggerStatementHandling.Script:
-                    engine.DebugHandler?.OnDebuggerStatement(_statement);
-                    break;
                 case DebuggerStatementHandling.Ignore:
                     break;
             }

--- a/Jint/Runtime/Modules/DefaultModuleLoader.cs
+++ b/Jint/Runtime/Modules/DefaultModuleLoader.cs
@@ -5,18 +5,8 @@ namespace Jint.Runtime.Modules;
 
 public sealed class DefaultModuleLoader : IModuleLoader
 {
-    public delegate void ModuleLoadedEventHandler(object sender, string source, Module module);
-
     private readonly Uri _basePath;
     private readonly bool _restrictToBasePath;
-
-    /// <summary>
-    /// The Loaded event is triggered after a module is loaded and parsed.
-    /// </summary>
-    /// <remarks>
-    /// The event is not triggered if a module was loaded but failed to parse.
-    /// </remarks>
-    public event ModuleLoadedEventHandler? Loaded;
 
     public DefaultModuleLoader(string basePath) : this(basePath, true)
     {
@@ -151,8 +141,6 @@ public sealed class DefaultModuleLoader : IModuleLoader
             ExceptionHelper.ThrowJavaScriptException(engine, $"Could not load module {source}", (Location) default);
             module = null;
         }
-
-        Loaded?.Invoke(this, source, module);
 
         return module;
     }

--- a/Jint/Runtime/Modules/SourceTextModuleRecord.cs
+++ b/Jint/Runtime/Modules/SourceTextModuleRecord.cs
@@ -32,7 +32,7 @@ internal sealed record ExportEntry(
 /// </summary>
 internal class SourceTextModuleRecord : CyclicModuleRecord
 {
-    private readonly Module _source;
+    internal readonly Module _source;
     private ExecutionContext _context;
     private ObjectInstance _importMeta;
     private readonly List<ImportEntry> _importEntries;


### PR DESCRIPTION
* Added `Skip` event to `DebugHandler` (see https://github.com/Jither/Jint.DebuggerExample/blob/main/NOTES.md#Events for rationale)
* Added `Parsed` event to `Engine` for giving e.g. debuggers access to the AST as parsed by the engine, when passing code rather than AST to `Execute`/`Evaluate`.
* `BindingNames` on scopes are now lazily evaluated. Because we still want to leave out scopes without any bindings from scope chains (for now), a `HasBindings()` method has been added to environment records.

### Breaking changes:
* `Global` and `Local` properties on `CallFrame` have been removed. Because Jint's scope system is now more complex (and mostly aligned with other Javascript debuggers), `Global` and `Local` are very arbitrary scopes to make special cases for. Either can, of course, still be retrieved through the `ScopeChain` property on `CallFrame`.
* Shadowed bindings are no longer removed from outer scopes - they're inspectable like any other binding.
* When a breakpoint placed at a `debugger` statement is hit, only one `Break` event will be triggered (with `PauseType = Break`), rather than two (one with `PauseType = Break`, the other with `PauseType = DebuggerStatement`). This aligns the behavior with other debuggers - e.g. Chromium dev tools and Visual Studio's debugger - generally, only one event is triggered per execution point, with the priority being: `Step` > `Break` > `DebuggerStatement` > `Skip`.

These changes would bring https://github.com/Jither/Jint.DebugAdapter back to a place where it can be built against official Jint (although it still has some major issues, and module support in particular hasn't been tested at all yet).