### PR TITLE
Improved support for defining custom JsString deriving type

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -182,7 +182,7 @@ namespace Jint
 
         public Engine SetValue(string name, string value)
         {
-            return SetValue(name, new JsString(value));
+            return SetValue(name, JsString.Create(value));
         }
 
         public Engine SetValue(string name, double value)

--- a/Jint/Native/JsBigInt.cs
+++ b/Jint/Native/JsBigInt.cs
@@ -46,14 +46,13 @@ public sealed class JsBigInt : JsValue, IEquatable<JsBigInt>
     }
 
 
-    public override object ToObject()
-    {
-        return _value;
-    }
+    public override object ToObject() => _value;
+
+    internal override bool ToBoolean() => _value != 0;
 
     public static bool operator ==(JsBigInt a, double b)
     {
-        return a is not null && TypeConverter.IsIntegralNumber(b) && a._value == (long) b;
+        return TypeConverter.IsIntegralNumber(b) && a._value == (long) b;
     }
 
     public static bool operator !=(JsBigInt a, double b)

--- a/Jint/Native/JsBoolean.cs
+++ b/Jint/Native/JsBoolean.cs
@@ -19,10 +19,9 @@ public sealed class JsBoolean : JsValue, IEquatable<JsBoolean>
 
     internal static JsBoolean Create(bool value) => value ? True : False;
 
-    public override object ToObject()
-    {
-        return _value ? BoxedTrue : BoxedFalse;
-    }
+    public override object ToObject() => _value ? BoxedTrue : BoxedFalse;
+
+    internal override bool ToBoolean() => _value;
 
     public override string ToString()
     {

--- a/Jint/Native/JsNull.cs
+++ b/Jint/Native/JsNull.cs
@@ -8,15 +8,11 @@ public sealed class JsNull : JsValue, IEquatable<JsNull>
     {
     }
 
-    public override object ToObject()
-    {
-        return null!;
-    }
+    public override object ToObject() => null!;
 
-    public override string ToString()
-    {
-        return "null";
-    }
+    internal override bool ToBoolean() => false;
+
+    public override string ToString() => "null";
 
     public override bool IsLooselyEqual(JsValue value)
     {

--- a/Jint/Native/JsNumber.cs
+++ b/Jint/Native/JsNumber.cs
@@ -70,9 +70,16 @@ public sealed class JsNumber : JsValue, IEquatable<JsNumber>
         _value = value;
     }
 
-    public override object ToObject()
+    public override object ToObject() => _value;
+
+    internal override bool ToBoolean()
     {
-        return _value;
+        if (_type == InternalTypes.Integer)
+        {
+            return (int) _value != 0;
+        }
+
+        return _value != 0 && !double.IsNaN(_value);
     }
 
     internal static JsNumber Create(object value)
@@ -256,11 +263,6 @@ public sealed class JsNumber : JsValue, IEquatable<JsNumber>
     }
 
     public override bool Equals(JsValue? obj)
-    {
-        return Equals(obj as JsNumber);
-    }
-
-    public override bool Equals(object? obj)
     {
         return Equals(obj as JsNumber);
     }

--- a/Jint/Native/JsSymbol.cs
+++ b/Jint/Native/JsSymbol.cs
@@ -16,10 +16,7 @@ public sealed class JsSymbol : JsValue, IEquatable<JsSymbol>
         _value = value;
     }
 
-    public override object ToObject()
-    {
-        return _value;
-    }
+    public override object ToObject() => _value;
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-symboldescriptivestring

--- a/Jint/Native/JsUndefined.cs
+++ b/Jint/Native/JsUndefined.cs
@@ -8,15 +8,11 @@ public sealed class JsUndefined : JsValue, IEquatable<JsUndefined>
     {
     }
 
-    public override object ToObject()
-    {
-        return null!;
-    }
+    public override object ToObject() => null!;
 
-    public override string ToString()
-    {
-        return "undefined";
-    }
+    internal override bool ToBoolean() => false;
+
+    public override string ToString() => "undefined";
 
     public override bool IsLooselyEqual(JsValue value)
     {

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -147,6 +147,11 @@ namespace Jint.Native
         public abstract object ToObject();
 
         /// <summary>
+        /// Coerces boolean value from <see cref="JsValue"/> instance.
+        /// </summary>
+        internal virtual bool ToBoolean() => true;
+
+        /// <summary>
         /// Invoke the current value as function.
         /// </summary>
         /// <param name="engine">The engine handling the invoke.</param>

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -278,11 +278,6 @@ namespace Jint.Runtime.Interop
             return Equals(obj as ObjectWrapper);
         }
 
-        public override bool Equals(object? obj)
-        {
-            return Equals(obj as ObjectWrapper);
-        }
-
         public bool Equals(ObjectWrapper? other)
         {
             if (ReferenceEquals(null, other))

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -68,7 +68,7 @@ namespace Jint.Runtime
         // how many decimals to check when determining if double is actually an int
         private const double DoubleIsIntegerTolerance = double.Epsilon * 100;
 
-        internal static readonly string[] intToString = new string[1024];
+        private static readonly string[] intToString = new string[1024];
         private static readonly string[] charToString = new string[256];
 
         static TypeConverter()
@@ -172,29 +172,7 @@ namespace Jint.Runtime
         /// <summary>
         /// https://tc39.es/ecma262/#sec-toboolean
         /// </summary>
-        public static bool ToBoolean(JsValue o)
-        {
-            var type = o._type & ~InternalTypes.InternalFlags;
-            switch (type)
-            {
-                case InternalTypes.Boolean:
-                    return ((JsBoolean) o)._value;
-                case InternalTypes.Undefined:
-                case InternalTypes.Null:
-                    return false;
-                case InternalTypes.Integer:
-                    return (int) ((JsNumber) o)._value != 0;
-                case InternalTypes.Number:
-                    var n = ((JsNumber) o)._value;
-                    return n != 0 && !double.IsNaN(n);
-                case InternalTypes.String:
-                    return !((JsString) o).IsNullOrEmpty();
-                case InternalTypes.BigInt:
-                    return ((JsBigInt) o)._value != 0;
-                default:
-                    return true;
-            }
-        }
+        public static bool ToBoolean(JsValue o) => o.ToBoolean();
 
         /// <summary>
         /// https://tc39.es/ecma262/#sec-tonumeric


### PR DESCRIPTION
* move ToBoolean as virtual method to JsValue

This PR opens possibility for uses cases like in RavenDB where they have a custom string type that can be expensive to materialize from encoded format. Now logic checks length before trying to do operations like equality, indexof or implicit logical boolean operators. Test case covers new features and materialization avoidance.