### PR TITLE
Ensure support for custom null and undefined

### DIFF
--- a/Jint/Native/JsNull.cs
+++ b/Jint/Native/JsNull.cs
@@ -10,8 +10,6 @@ public sealed class JsNull : JsValue, IEquatable<JsNull>
 
     public override object ToObject() => null!;
 
-    internal override bool ToBoolean() => false;
-
     public override string ToString() => "null";
 
     public override bool IsLooselyEqual(JsValue value)

--- a/Jint/Native/JsUndefined.cs
+++ b/Jint/Native/JsUndefined.cs
@@ -10,8 +10,6 @@ public sealed class JsUndefined : JsValue, IEquatable<JsUndefined>
 
     public override object ToObject() => null!;
 
-    internal override bool ToBoolean() => false;
-
     public override string ToString() => "undefined";
 
     public override bool IsLooselyEqual(JsValue value)

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -149,7 +149,7 @@ namespace Jint.Native
         /// <summary>
         /// Coerces boolean value from <see cref="JsValue"/> instance.
         /// </summary>
-        internal virtual bool ToBoolean() => true;
+        internal virtual bool ToBoolean() => _type > InternalTypes.Null;
 
         /// <summary>
         /// Invoke the current value as function.


### PR DESCRIPTION
When there was custom JsUndefined or JsNull implementation, new `ToBoolean` didn't account for that.