### PR TITLE
Support configuring whether dynamic (eval) JavaScript code is allowed

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2883,6 +2883,21 @@ x.test = {
         }
 
         [Fact]
+        public void CanDisableCompilation()
+        {
+            var engine = new Engine(options =>
+            {
+                options.StringCompilationAllowed = false;
+            });
+
+            var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("eval('1+1');"));
+            Assert.Equal("String compilation is not allowed", ex.Message);
+
+            ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Function('1+1');"));
+            Assert.Equal("String compilation is not allowed", ex.Message);
+        }
+
+        [Fact]
         public void ExecuteShouldTriggerBeforeEvaluateEvent()
         {
             TestBeforeEvaluateEvent(

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -70,6 +70,15 @@ namespace Jint
         public IReferenceResolver ReferenceResolver { get; set; } = DefaultReferenceResolver.Instance;
 
         /// <summary>
+        /// Whether calling 'eval' with custom code and function constructors taking function code as string is allowed.
+        /// Defaults to true.
+        /// </summary>
+        /// <remarks>
+        /// https://tc39.es/ecma262/#sec-hostensurecancompilestrings
+        /// </remarks>
+        public bool StringCompilationAllowed { get; set; } = true;
+
+        /// <summary>
         /// Called by the <see cref="Engine"/> instance that loads this <see cref="Options" />
         /// once it is loaded.
         /// </summary>

--- a/Jint/Runtime/Host.cs
+++ b/Jint/Runtime/Host.cs
@@ -108,6 +108,10 @@ namespace Jint.Runtime
         /// </summary>
         public virtual void EnsureCanCompileStrings(Realm callerRealm, Realm evalRealm)
         {
+            if (!Engine.Options.StringCompilationAllowed)
+            {
+                ExceptionHelper.ThrowJavaScriptException(callerRealm.Intrinsics.TypeError, "String compilation is not allowed");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Noticed that for example [EventStore](https://github.com/EventStore/EventStore) wants to forbid `eval` usage, which makes sense: https://github.com/EventStore/EventStore/blob/2a774bb0213f2588ad9760f5529d5c21dc6c12f0/src/EventStore.Projections.Core/Services/Interpreted/JintProjectionStateHandler.cs#L52