### PR TITLE
Don't require Realm in Constructor public constructor

### DIFF
--- a/Jint.Tests.PublicInterface/ConstructorTests.cs
+++ b/Jint.Tests.PublicInterface/ConstructorTests.cs
@@ -54,7 +54,7 @@ public class ConstructorTests
 
 file sealed class DateOnlyConstructor : Constructor
 {
-    public DateOnlyConstructor(Engine engine) : base(engine, engine.Realm, (JsString) "DateOnly")
+    public DateOnlyConstructor(Engine engine) : base(engine, "DateOnly")
     {
     }
 

--- a/Jint/Native/Constructor.cs
+++ b/Jint/Native/Constructor.cs
@@ -6,7 +6,11 @@ namespace Jint.Native;
 
 public abstract class Constructor : FunctionInstance, IConstructor
 {
-    protected Constructor(Engine engine, Realm realm, JsString name) : base(engine, realm, name)
+    protected Constructor(Engine engine, string name) : this(engine, engine.Realm, new JsString(name))
+    {
+    }
+
+    internal Constructor(Engine engine, Realm realm, JsString name) : base(engine, realm, name)
     {
     }
 


### PR DESCRIPTION
Nobody wants to bother about thinking about realms so let's make the basic constructor a bit simpler. We can open Realm-taking one if needed.