### PR TITLE
Ensure DateTime.MinValue can be passed via interop

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -3140,5 +3140,20 @@ try {
             Assert.Equal(null, _engine.Evaluate("Context.method({});").ToObject());
             Assert.Equal(5, _engine.Evaluate("Context.method({ value: 5 });").AsInteger());
         }
+
+        [Fact]
+        public void CanPassDateTimeMinViaInterop()
+        {
+            var engine = new Engine(cfg => cfg.AllowClrWrite());
+
+            var dt = DateTime.UtcNow;
+            engine.SetValue("capture", new Action<object>(o => dt = (DateTime) o));
+            engine.SetValue("minDate", DateTime.MinValue);
+
+            engine.Execute("capture(minDate);");
+            Assert.Equal(DateTime.MinValue, dt);
+
+            // DateTime.MaxValue cannot be handled due to internal presentation that would require tick precision
+        }
     }
 }

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -262,7 +262,7 @@ internal sealed class DateConstructor : Constructor
 
     internal long FromDateTime(DateTime dt, bool negative = false)
     {
-        var convertToUtcAfter = dt.Kind == DateTimeKind.Unspecified;
+        var convertToUtcAfter = dt.Kind == DateTimeKind.Unspecified && dt != DateTime.MinValue;
 
         var dateAsUtc = dt.Kind == DateTimeKind.Local
             ? dt.ToUniversalTime()


### PR DESCRIPTION
Unfortunately `DateTime.MaxValue` is not that easy as it requires tick precision, would require refactoring the internal date presentation (which might not be a bad idea in the long rung).

fixes #778