### PR TITLE
Engine.SetValue accepts a nullable object.

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -212,7 +212,7 @@ namespace Jint
             return this;
         }
 
-        public Engine SetValue(string name, object obj)
+        public Engine SetValue(string name, object? obj)
         {
             var value = obj is Type t
                 ? TypeReference.CreateTypeReference(this, t)


### PR DESCRIPTION
When Jint was modified to use nullable reference types, it lost the ability to pass a null value into Engine.SetValue(string, object).  This pull request restores that functionality.