### PR TITLE
Disable object identity tracking by default under interop

### DIFF
--- a/Jint.Tests/Runtime/WeakSetMapTests.cs
+++ b/Jint.Tests/Runtime/WeakSetMapTests.cs
@@ -63,7 +63,7 @@ public class WeakSetMapTests
     [Fact]
     public void WeakSetWithInteropObject()
     {
-        var engine = new Engine();
+        var engine = new Engine(options => options.Interop.TrackObjectWrapperIdentity = true);
 
         engine.SetValue("context", new { Item = new Item { Value = "Test" } });
 
@@ -89,7 +89,7 @@ public class WeakSetMapTests
         parent.Child = child;
         child.Parent = parent;
 
-        var engine = new Engine();
+        var engine = new Engine(options => options.Interop.TrackObjectWrapperIdentity = true);
 
         engine.SetValue("context", new { Parent = parent });
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -251,20 +251,18 @@ namespace Jint
         public List<IObjectConverter> ObjectConverters { get; } = new();
 
         /// <summary>
-        /// Whether identity map is persisted for object wrappers in order to maintain object identity.
-        /// Defaults to true.
+        /// Whether identity map is persisted for object wrappers in order to maintain object identity. This can cause
+        /// memory usage to grow when targeting large set and freeing of memory can be delayed due to ConditionalWeakTable semantics.
+        /// Defaults to false.
         /// </summary>
-        public bool TrackObjectWrapperIdentity { get; set; } = true;
+        public bool TrackObjectWrapperIdentity { get; set; } = false;
 
         /// <summary>
         /// If no known type could be guessed, objects are by default wrapped as an
         /// ObjectInstance using class ObjectWrapper. This function can be used to
         /// change the behavior.
         /// </summary>
-        public WrapObjectDelegate WrapObjectHandler { get; set; } = static (engine, target) =>
-        {
-            return new ObjectWrapper(engine, target);
-        };
+        public WrapObjectDelegate WrapObjectHandler { get; set; } = static (engine, target) => new ObjectWrapper(engine, target);
 
         /// <summary>
         ///


### PR DESCRIPTION
This feature can cause delayed GC and worry amongst users. Let's disable this feature by default so people don't report Jint leaking memory when GC is just delayed due to conditional weak table.