### PR TITLE
JSON.parse optimizations, refactoring, DoS-attack prevention

### DIFF
--- a/Jint.Tests/Runtime/JsonTests.cs
+++ b/Jint.Tests/Runtime/JsonTests.cs
@@ -271,7 +271,7 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
-        public void MaxLevelDoesNotInflucePrimitiveValues()
+        public void MaxDepthDoesNotInfluencePrimitiveValues()
         {
             var engine = new Engine();
             var parser = new JsonParser(engine, maxDepth: 1);
@@ -281,6 +281,15 @@ namespace Jint.Tests.Runtime
             Assert.True(parsed["b"].IsBoolean());
             Assert.True(parsed["c"].IsNull());
             Assert.True(parsed["d"].IsString());
+        }
+
+        [Fact]
+        public void MaxDepthGetsUsedFromEngineOptionsConstraints()
+        {
+            var engine = new Engine(options => options.MaxJsonParseDepth(0));
+            var parser = new JsonParser(engine);
+
+            Assert.Throws<JavaScriptException>(() => parser.Parse("[]"));
         }
 
         private static string GenerateDeepNestedArray(int depth)

--- a/Jint.Tests/Runtime/JsonTests.cs
+++ b/Jint.Tests/Runtime/JsonTests.cs
@@ -1,4 +1,6 @@
+using Jint.Native;
 using Jint.Native.Json;
+using Jint.Native.Object;
 using Jint.Runtime;
 
 namespace Jint.Tests.Runtime
@@ -55,6 +57,9 @@ namespace Jint.Tests.Runtime
         [InlineData("[1,\na]", "Unexpected token 'a' in JSON at position 4")] // multiline
         [InlineData("\x06", "Unexpected token '\x06' in JSON at position 0")] // control char
         [InlineData("{\"\\v\":1}", "Unexpected token 'v' in JSON at position 3")] // invalid escape sequence
+        [InlineData("[,]", "Unexpected token ',' in JSON at position 1")]
+        [InlineData("{\"key\": ()}", "Unexpected token '(' in JSON at position 8")]
+        [InlineData(".1", "Unexpected token '.' in JSON at position 0")]
         public void ShouldReportHelpfulSyntaxErrorForInvalidJson(string json, string expectedMessage)
         {
             var engine = new Engine();
@@ -83,6 +88,218 @@ namespace Jint.Tests.Runtime
             var result = engine.Evaluate("JSON.stringify(x, null, 2);").AsString();
 
             Assert.Equal(expectedJson, result);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(100)]
+        public void ShouldParseArrayIndependentOfLengthInSameOrder(int numberOfElements)
+        {
+            string json = $"[{string.Join(",", Enumerable.Range(0, numberOfElements))}]";
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            JsValue result = parser.Parse(json);
+            JsArray array = Assert.IsType<JsArray>(result);
+            Assert.Equal((uint)numberOfElements, array.Length);
+            for (int i = 0; i < numberOfElements; i++)
+            {
+                Assert.Equal(i, (int)array[i].AsNumber());
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(20)]
+        public void ShouldParseStringIndependentOfLength(int stringLength)
+        {
+            string generatedString = string.Join("", Enumerable.Range(0, stringLength).Select(index => 'A' + index));
+            string json = $"\"{generatedString}\"";
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            string value = parser.Parse(json).AsString();
+            Assert.Equal(generatedString, value, StringComparer.Ordinal);
+        }
+
+        [Fact]
+        public void CanParsePrimitivesCorrectly()
+        {
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            Assert.Same(JsBoolean.True, parser.Parse("true"));
+            Assert.Same(JsBoolean.False, parser.Parse("false"));
+            Assert.Same(JsValue.Null, parser.Parse("null"));
+        }
+
+        [Fact]
+        public void CanParseNumbersWithAndWithoutSign()
+        {
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            Assert.Equal(-1, (int)parser.Parse("-1").AsNumber());
+            Assert.Equal(0, (int)parser.Parse("-0").AsNumber());
+            Assert.Equal(0, (int)parser.Parse("0").AsNumber());
+            Assert.Equal(1, (int)parser.Parse("1").AsNumber());
+        }
+
+        [Fact]
+        public void DoesPreservesNumberToMaxSafeInteger()
+        {
+            // see https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.max_safe_integer
+            long maxSafeInteger = 9007199254740991;
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            Assert.Equal(maxSafeInteger, (long)parser.Parse("9007199254740991").AsNumber());
+        }
+
+        [Fact]
+        public void DoesSupportFractionalNumbers()
+        {
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            Assert.Equal(0.1d, parser.Parse("0.1").AsNumber());
+            Assert.Equal(1.1d, parser.Parse("1.1").AsNumber());
+            Assert.Equal(-1.1d, parser.Parse("-1.1").AsNumber());
+        }
+
+        [Fact]
+        public void DoesSupportScientificNotation()
+        {
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            Assert.Equal(100d, parser.Parse("1E2").AsNumber());
+            Assert.Equal(0.01d, parser.Parse("1E-2").AsNumber());
+        }
+
+        [Fact]
+        public void ThrowsExceptionWhenDepthLimitReachedArrays()
+        {
+            string json = GenerateDeepNestedArray(65);
+
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            JavaScriptException ex = Assert.Throws<JavaScriptException>(() => parser.Parse(json));
+            Assert.Equal("Max. depth level of JSON reached at position 64", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowsExceptionWhenDepthLimitReachedObjects()
+        {
+            string json = GenerateDeepNestedObject(65);
+
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            JavaScriptException ex = Assert.Throws<JavaScriptException>(() => parser.Parse(json));
+            Assert.Equal("Max. depth level of JSON reached at position 320", ex.Message);
+        }
+
+        [Fact]
+        public void CanParseMultipleNestedObjects()
+        {
+            string objectA = GenerateDeepNestedObject(63);
+            string objectB = GenerateDeepNestedObject(63);
+            string json = $"{{\"a\":{objectA},\"b\":{objectB} }}";
+
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            ObjectInstance parsed = parser.Parse(json).AsObject();
+            Assert.True(parsed["a"].IsObject());
+            Assert.True(parsed["b"].IsObject());
+        }
+
+        [Fact]
+        public void CanParseMultipleNestedArrays()
+        {
+            string arrayA = GenerateDeepNestedArray(63);
+            string arrayB = GenerateDeepNestedArray(63);
+            string json = $"{{\"a\":{arrayA},\"b\":{arrayB} }}";
+
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            ObjectInstance parsed = parser.Parse(json).AsObject();
+            Assert.True(parsed["a"].IsArray());
+            Assert.True(parsed["b"].IsArray());
+        }
+
+        [Fact]
+        public void ArrayAndObjectDepthNotCountedSeparately()
+        {
+            // individual depth is below the default limit, but combined
+            // a max. depth level is reached.
+            string innerArray = GenerateDeepNestedArray(40);
+            string json = GenerateDeepNestedObject(40, innerArray);
+
+            var engine = new Engine();
+            var parser = new JsonParser(engine);
+
+            JavaScriptException ex = Assert.Throws<JavaScriptException>(() => parser.Parse(json));
+            Assert.Equal("Max. depth level of JSON reached at position 224", ex.Message);
+        }
+
+        [Fact]
+        public void CustomMaxDepthOfZeroDisallowsObjects()
+        {
+            var engine = new Engine();
+            var parser = new JsonParser(engine, maxDepth: 0);
+
+            JavaScriptException ex = Assert.Throws<JavaScriptException>(() => parser.Parse("{}"));
+            Assert.Equal("Max. depth level of JSON reached at position 0", ex.Message);
+        }
+
+        [Fact]
+        public void CustomMaxDepthOfZeroDisallowsArrays()
+        {
+            var engine = new Engine();
+            var parser = new JsonParser(engine, maxDepth: 0);
+
+            JavaScriptException ex = Assert.Throws<JavaScriptException>(() => parser.Parse("[]"));
+            Assert.Equal("Max. depth level of JSON reached at position 0", ex.Message);
+        }
+
+        [Fact]
+        public void MaxLevelDoesNotInflucePrimitiveValues()
+        {
+            var engine = new Engine();
+            var parser = new JsonParser(engine, maxDepth: 1);
+
+            ObjectInstance parsed = parser.Parse("{\"a\": 2, \"b\": true, \"c\": null, \"d\": \"test\"}").AsObject();
+            Assert.True(parsed["a"].IsNumber());
+            Assert.True(parsed["b"].IsBoolean());
+            Assert.True(parsed["c"].IsNull());
+            Assert.True(parsed["d"].IsString());
+        }
+
+        private static string GenerateDeepNestedArray(int depth)
+        {
+            string arrayOpen = new string('[', depth);
+            string arrayClose = new string(']', depth);
+            return $"{arrayOpen}{arrayClose}";
+        }
+
+        private static string GenerateDeepNestedObject(int depth)
+        {
+            return GenerateDeepNestedObject(depth, mostInnerValue: "1");
+        }
+
+        private static string GenerateDeepNestedObject(int depth, string mostInnerValue)
+        {
+            string objectOpen = string.Concat(Enumerable.Repeat("{\"A\":", depth));
+            string objectClose = new string('}', depth);
+            return $"{objectOpen}{mostInnerValue}{objectClose}";
         }
     }
 }

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -366,10 +366,15 @@ namespace Jint.Native.Array
 
         public JsArray ConstructFast(JsValue[] contents)
         {
-            var instance = ArrayCreate((ulong) contents.Length);
-            for (var i = 0; i < contents.Length; i++)
+            return ConstructFast(contents, 0, contents.Length);
+        }
+
+        internal JsArray ConstructFast(JsValue[] contents, int offset, int length)
+        {
+            var instance = ArrayCreate((ulong) length);
+            for (var i = 0; i < length; i++)
             {
-                instance.SetIndexValue((uint) i, contents[i], updateLength: false);
+                instance.SetIndexValue((uint) i, contents[i + offset], updateLength: false);
             }
             return instance;
         }

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -366,15 +366,10 @@ namespace Jint.Native.Array
 
         public JsArray ConstructFast(JsValue[] contents)
         {
-            return ConstructFast(contents, 0, contents.Length);
-        }
-
-        internal JsArray ConstructFast(JsValue[] contents, int offset, int length)
-        {
-            var instance = ArrayCreate((ulong) length);
-            for (var i = 0; i < length; i++)
+            var instance = ArrayCreate((ulong) contents.Length);
+            for (var i = 0; i < contents.Length; i++)
             {
-                instance.SetIndexValue((uint) i, contents[i + offset], updateLength: false);
+                instance.SetIndexValue((uint) i, contents[i], updateLength: false);
             }
             return instance;
         }

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -12,7 +12,6 @@ namespace Jint.Native.Json
 {
     public sealed class JsonParser
     {
-        private static int s_defaultMaxDepth = 64;
         private readonly Engine _engine;
         private readonly int _maxDepth;
 
@@ -20,30 +19,18 @@ namespace Jint.Native.Json
         /// The max. depth level used for new JsonParser instances.
         /// The initial value is 64.
         /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">Is thrown if the provided value is negative.</exception>
-        public static int DefaultMaxDepth
-        {
-            get => s_defaultMaxDepth;
-            set
-            {
-                if (value < 0) throw new ArgumentOutOfRangeException(nameof(DefaultMaxDepth), "The max. depth must be greater or equal to zero");
-                s_defaultMaxDepth = value;
-            }
-        }
 
         /// <summary>
-        /// Creates a new parser with the <see cref="DefaultMaxDepth"/> as the upper
-        /// recursion limit.
+        /// Creates a new parser using the recursion depth specified in <see cref="ConstraintOptions.MaxJsonParseDepth"/>.
         /// </summary>
         public JsonParser(Engine engine)
-            : this(engine, DefaultMaxDepth)
+            : this(engine, engine.Options.Constraints.MaxJsonParseDepth)
         {
         }
 
-        public JsonParser(Engine engine, int maxDepth)
+        public JsonParser(Engine engine, uint maxDepth)
         {
-            if (maxDepth < 0) throw new ArgumentOutOfRangeException(nameof(maxDepth), "The max. depth must be greater or equal to zero");
-            _maxDepth = maxDepth;
+            _maxDepth = (int)maxDepth;
             _engine = engine;
             // Two tokens are "live" during parsing,
             // lookahead and the current one on the stack

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -1,88 +1,122 @@
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Esprima;
-using Esprima.Ast;
 using Jint.Native.Object;
 using Jint.Pooling;
 using Jint.Runtime;
-
-using Range = Esprima.Range;
 
 namespace Jint.Native.Json
 {
     public sealed class JsonParser
     {
+        private static int s_defaultMaxDepth = 64;
         private readonly Engine _engine;
+        private readonly int _maxDepth;
 
-        public JsonParser(Engine engine)
+        /// <summary>
+        /// The max. depth level used for new JsonParser instances.
+        /// The initial value is 64.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Is thrown if the provided value is negative.</exception>
+        public static int DefaultMaxDepth
         {
-            _engine = engine;
+            get => s_defaultMaxDepth;
+            set
+            {
+                if (value < 0) throw new ArgumentOutOfRangeException(nameof(DefaultMaxDepth), "The max. depth must be greater or equal to zero");
+                s_defaultMaxDepth = value;
+            }
         }
 
-        private Extra _extra = null!;
+        /// <summary>
+        /// Creates a new parser with the <see cref="DefaultMaxDepth"/> as the upper
+        /// recursion limit.
+        /// </summary>
+        public JsonParser(Engine engine)
+            : this(engine, DefaultMaxDepth)
+        {
+        }
+
+        public JsonParser(Engine engine, int maxDepth)
+        {
+            if (maxDepth < 0) throw new ArgumentOutOfRangeException(nameof(maxDepth), "The max. depth must be greater or equal to zero");
+            _maxDepth = maxDepth;
+            _engine = engine;
+            // Two tokens are "live" during parsing,
+            // lookahead and the current one on the stack
+            // To add a safety boundary to not overwrite
+            // "still in use" stuff, the buffer contains 5
+            // instead of 2 tokens.
+            _tokenBuffer = new Token[5];
+            for (int i = 0; i < _tokenBuffer.Length; i++)
+            {
+                _tokenBuffer[i] = new Token();
+            }
+            _tokenBufferIndex = 0;
+        }
 
         private int _index; // position in the stream
         private int _length; // length of the stream
-        private int _lineNumber;
-        private int _lineStart;
-        private Location _location;
         private Token _lookahead = null!;
         private string _source = null!;
+        private readonly Token[] _tokenBuffer;
+        private int _tokenBufferIndex;
 
-        private State _state;
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsDecimalDigit(char ch)
         {
-            return (ch >= '0' && ch <= '9');
+            unchecked
+            {
+                // * For characters, which are before the '0', the equation will be negative and then wrap
+                //   around because of the unsigned short cast
+                // * For characters, which are after the '9', the equation will be positive, but >  9
+                // * For digits, the equation will be between int(0) and int(9)
+                return ((ushort) (ch - '0')) <= 9;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsLowerCaseHexAlpha(char ch)
+        {
+            unchecked
+            {
+                return ((ushort) (ch - 'a')) <= 5;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsUpperCaseHexAlpha(char ch)
+        {
+            unchecked
+            {
+                return ((ushort) (ch - 'A')) <= 5;
+            }
         }
 
         private static bool IsHexDigit(char ch)
         {
             return
-                ch >= '0' && ch <= '9' ||
-                ch >= 'a' && ch <= 'f' ||
-                ch >= 'A' && ch <= 'F'
+                IsDecimalDigit(ch) ||
+                IsLowerCaseHexAlpha(ch) ||
+                IsUpperCaseHexAlpha(ch)
                 ;
-        }
-
-        private static bool IsOctalDigit(char ch)
-        {
-            return ch >= '0' && ch <= '7';
         }
 
         private static bool IsWhiteSpace(char ch)
         {
-            return (ch == ' ')  ||
+            return (ch == ' ') ||
                    (ch == '\t') ||
                    (ch == '\n') ||
                    (ch == '\r');
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsLineTerminator(char ch)
         {
             return (ch == 10) || (ch == 13) || (ch == 0x2028) || (ch == 0x2029);
-        }
-
-        private static bool IsNullChar(char ch)
-        {
-            return ch == 'n'
-                || ch == 'u'
-                || ch == 'l'
-                || ch == 'l'
-                ;
-        }
-
-        private static bool IsTrueOrFalseChar(char ch)
-        {
-            return ch == 't'
-                || ch == 'f'
-                || ch == 'r'
-                || ch == 'a'
-                || ch == 'u'
-                || ch == 'l'
-                || ch == 'e'
-                || ch == 's'
-                ;
         }
 
         private char ScanHexEscape()
@@ -104,12 +138,29 @@ namespace Jint.Native.Json
             return (char) code;
         }
 
-        private void SkipWhiteSpace()
+        private char ReadToNextSignificantCharacter()
         {
-            while (_index < _length && IsWhiteSpace(_source[_index]))
+            char result = _index < _length ? _source[_index] : char.MinValue;
+            while (IsWhiteSpace(result))
             {
-                ++_index;
+                if ((++_index) >= _length)
+                    return char.MinValue;
+                result = _source[_index];
             }
+            return result;
+        }
+
+        private Token CreateToken(Tokens type, string text, char firstCharacter, JsValue value, in TextRange range)
+        {
+            Token result = _tokenBuffer[_tokenBufferIndex++];
+            if (_tokenBufferIndex >= _tokenBuffer.Length)
+                _tokenBufferIndex = 0;
+            result.Type = type;
+            result.Text = text;
+            result.FirstCharacter = firstCharacter;
+            result.Value = value;
+            result.Range = range;
+            return result;
         }
 
         private Token ScanPunctuator()
@@ -117,61 +168,51 @@ namespace Jint.Native.Json
             int start = _index;
             char code = start < _source.Length ? _source[_index] : char.MinValue;
 
-            switch ((int) code)
-            {
-                    // Check for most common single-character punctuators.
-                case 46: // . dot
-                case 40: // ( open bracket
-                case 41: // ) close bracket
-                case 59: // ; semicolon
-                case 44: // , comma
-                case 123: // { open curly brace
-                case 125: // } close curly brace
-                case 91: // [
-                case 93: // ]
-                case 58: // :
-                case 63: // ?
-                case 126: // ~
-                    ++_index;
-
-                    string value = TypeConverter.ToString(code);
-                    return new Token
-                    {
-                        Type = Tokens.Punctuator,
-                        Text = value,
-                        Value = value,
-                        LineNumber = _lineNumber,
-                        LineStart = _lineStart,
-                        Range = new[] { start, _index }
-                    };
-            }
-
-            ThrowError(start, Messages.UnexpectedToken, code);
-            return null!;
+            string value = ScanPuncatatorValue(start, code);
+            ++_index;
+            return CreateToken(Tokens.Punctuator, value, code, JsValue.Undefined, new TextRange(start, _index));
         }
 
-        private Token ScanNumericLiteral()
+        private string ScanPuncatatorValue(int start, char code)
         {
-            char ch = _source.CharCodeAt(_index);
+            switch (code)
+            {
+                case '.': return ".";
+                case ',': return ",";
+                case '{': return "{";
+                case '}': return "}";
+                case '[': return "[";
+                case ']': return "]";
+                case ':': return ":";
+                default:
+                    ThrowError(start, Messages.UnexpectedToken, code);
+                    throw new Exception();
+            }
+        }
 
+        private Token ScanNumericLiteral(ref State state)
+        {
+            var sb = state.TokenBuffer;
             int start = _index;
-            string number = "";
+            char ch = _source.CharCodeAt(_index);
+            bool hasFraction = false;
 
             // Number start with a -
             if (ch == '-')
             {
-                number += _source.CharCodeAt(_index++).ToString();
-                ch = _source.CharCodeAt(_index);
+                sb.Append(ch);
+                ch = _source.CharCodeAt(++_index);
             }
 
             if (ch != '.')
             {
-                number += _source.CharCodeAt(_index++).ToString();
-                ch = _source.CharCodeAt(_index);
+                char firstCharacter = ch;
+                sb.Append(ch);
+                ch = _source.CharCodeAt(++_index);
 
                 // Hex number starts with '0x'.
                 // Octal number starts with '0'.
-                if (number == "0")
+                if (sb.Length == 1 && firstCharacter == '0')
                 {
                     // decimal number starts with '0' such as '09' is illegal.
                     if (ch > 0 && IsDecimalDigit(ch))
@@ -180,37 +221,42 @@ namespace Jint.Native.Json
                     }
                 }
 
-                while (IsDecimalDigit(_source.CharCodeAt(_index)))
+                while (IsDecimalDigit((ch = _source.CharCodeAt(_index))))
                 {
-                    number += _source.CharCodeAt(_index++).ToString();
+                    sb.Append(ch);
+                    _index++;
                 }
-                ch = _source.CharCodeAt(_index);
             }
 
             if (ch == '.')
             {
-                number += _source.CharCodeAt(_index++).ToString();
-                while (IsDecimalDigit(_source.CharCodeAt(_index)))
+                hasFraction = true;
+                sb.Append(ch);
+                _index++;
+
+                while (IsDecimalDigit((ch = _source.CharCodeAt(_index))))
                 {
-                    number += _source.CharCodeAt(_index++).ToString();
+                    sb.Append(ch);
+                    _index++;
                 }
-                ch = _source.CharCodeAt(_index);
             }
 
             if (ch == 'e' || ch == 'E')
             {
-                number += _source.CharCodeAt(_index++).ToString();
-
-                ch = _source.CharCodeAt(_index);
+                hasFraction = true;
+                sb.Append(ch);
+                ch = _source.CharCodeAt(++_index);
                 if (ch == '+' || ch == '-')
                 {
-                    number += _source.CharCodeAt(_index++).ToString();
+                    sb.Append(ch);
+                    ch = _source.CharCodeAt(++_index);
                 }
-                if (IsDecimalDigit(_source.CharCodeAt(_index)))
+                if (IsDecimalDigit(ch))
                 {
-                    while (IsDecimalDigit(_source.CharCodeAt(_index)))
+                    while (IsDecimalDigit(ch = _source.CharCodeAt(_index)))
                     {
-                        number += _source.CharCodeAt(_index++).ToString();
+                        sb.Append(ch);
+                        _index++;
                     }
                 }
                 else
@@ -219,53 +265,31 @@ namespace Jint.Native.Json
                 }
             }
 
-            return new Token
-                {
-                    Type = Tokens.Number,
-                    Text = number,
-                    Value = Double.Parse(number, NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture),
-                    LineNumber = _lineNumber,
-                    LineStart = _lineStart,
-                    Range = new[] {start, _index}
-                };
+            string number = sb.ToString();
+            sb.Clear();
+            JsNumber value = hasFraction
+                ? new JsNumber(double.Parse(number, NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture))
+                : new JsNumber(long.Parse(number, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture));
+            return CreateToken(Tokens.Number, number, '\0', value, new TextRange(start, _index));
         }
 
         private Token ScanBooleanLiteral()
         {
             var start = _index;
-            var s = "";
-
-            var boolTrue = false;
-            var boolFalse = false;
             if (ConsumeMatch("true"))
             {
-                boolTrue = true;
-                s = "true";
-            }
-            else if (ConsumeMatch("false"))
-            {
-                boolFalse = true;
-                s = "false";
+                return CreateToken(Tokens.BooleanLiteral, "true", '\t', JsBoolean.True, new TextRange(start, _index));
             }
 
-            if (boolTrue || boolFalse)
+            if (ConsumeMatch("false"))
             {
-                return new Token
-                {
-                    Type = Tokens.BooleanLiteral,
-                    Text = s,
-                    Value = boolTrue,
-                    LineNumber = _lineNumber,
-                    LineStart = _lineStart,
-                    Range = new[] { start, _index }
-                };
+                return CreateToken(Tokens.BooleanLiteral, "false", '\f', JsBoolean.False, new TextRange(start, _index));
             }
 
             ThrowError(start, Messages.UnexpectedTokenIllegal);
             return null!;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool ConsumeMatch(string text)
         {
             var start = _index;
@@ -284,34 +308,23 @@ namespace Jint.Native.Json
             int start = _index;
             if (ConsumeMatch("null"))
             {
-                return new Token
-                {
-                    Type = Tokens.NullLiteral,
-                    Text = "null",
-                    Value = JsValue.Null,
-                    LineNumber = _lineNumber,
-                    LineStart = _lineStart,
-                    Range = new[] { start, _index }
-                };
+                return CreateToken(Tokens.NullLiteral, "null", 'n', JsValue.Null, new TextRange(start, _index));
             }
 
             ThrowError(start, Messages.UnexpectedTokenIllegal);
             return null!;
         }
 
-        private Token ScanStringLiteral()
+        private Token ScanStringLiteral(ref State state)
         {
-            using var wrapper = StringBuilderPool.Rent();
-            var sb = wrapper.Builder;
-
             char quote = _source[_index];
-
             int start = _index;
             ++_index;
 
+            var sb = state.TokenBuffer;
             while (_index < _length)
             {
-                char ch = _source.CharCodeAt(_index++);
+                char ch = _source[_index++];
 
                 if (ch == quote)
                 {
@@ -368,7 +381,7 @@ namespace Jint.Native.Json
                 }
                 else
                 {
-                    sb.Append(ch.ToString());
+                    sb.Append(ch);
                 }
             }
 
@@ -379,70 +392,38 @@ namespace Jint.Native.Json
             }
 
             string value = sb.ToString();
-            return new Token
-            {
-                    Type = Tokens.String,
-                    Text = value,
-                    Value = value,
-                    LineNumber = _lineNumber,
-                    LineStart = _lineStart,
-                    Range = new[] { start, _index }
-                };
+            sb.Clear();
+            return CreateToken(Tokens.String, value, '\"', new JsString(value), new TextRange(start, _index));
         }
 
-        private Token Advance()
+        private Token Advance(ref State state)
         {
-            SkipWhiteSpace();
+            char ch = ReadToNextSignificantCharacter();
 
-            if (_index >= _length)
+            if (ch == char.MinValue)
             {
-                return new Token
-                    {
-                        Type = Tokens.EOF,
-                        LineNumber = _lineNumber,
-                        LineStart = _lineStart,
-                        Range = new[] {_index, _index}
-                    };
-            }
-
-            char ch = _source.CharCodeAt(_index);
-
-            // Very common: ( and ) and ;
-            if (ch == 40 || ch == 41 || ch == 58)
-            {
-                return ScanPunctuator();
+                return CreateToken(Tokens.EOF, string.Empty, '\0', JsValue.Undefined, new TextRange(_index, _index));
             }
 
             // String literal starts with double quote (#34).
             // Single quote (#39) are not allowed in JSON.
-            if (ch == 34)
+            if (ch == '"')
             {
-                return ScanStringLiteral();
-            }
-
-            // Dot (.) char #46 can also start a floating-point number, hence the need
-            // to check the next character.
-            if (ch == 46)
-            {
-                if (IsDecimalDigit(_source.CharCodeAt(_index + 1)))
-                {
-                    return ScanNumericLiteral();
-                }
-                return ScanPunctuator();
+                return ScanStringLiteral(ref state);
             }
 
             if (ch == '-') // Negative Number
             {
                 if (IsDecimalDigit(_source.CharCodeAt(_index + 1)))
                 {
-                    return ScanNumericLiteral();
+                    return ScanNumericLiteral(ref state);
                 }
                 return ScanPunctuator();
             }
 
             if (IsDecimalDigit(ch))
             {
-                return ScanNumericLiteral();
+                return ScanNumericLiteral(ref state);
             }
 
             if (ch == 't' || ch == 'f')
@@ -458,128 +439,35 @@ namespace Jint.Native.Json
             return ScanPunctuator();
         }
 
-        private Token CollectToken()
-        {
-            var start = Position.From(
-                line: _lineNumber,
-                column: _index - _lineStart);
-
-            Token token = Advance();
-
-            var end = Position.From(
-                line: _lineNumber,
-                column: _index - _lineStart);
-
-            _location = Location.From(start, end, _source);
-
-            if (token.Type != Tokens.EOF)
-            {
-                var range = new[] {token.Range[0], token.Range[1]};
-                var value = _source.Substring(token.Range[0], token.Range[1]);
-                _extra.Tokens.Add(new Token
-                    {
-                        Type = token.Type,
-                        Text = value,
-                        Value = value,
-                        Range = range,
-                    });
-            }
-
-            return token;
-        }
-
-        private Token Lex()
+        private Token Lex(ref State state)
         {
             Token token = _lookahead;
-            _index = token.Range[1];
-            _lineNumber = token.LineNumber.HasValue ? token.LineNumber.Value : 0;
-            _lineStart = token.LineStart;
-
-            _lookahead = (_extra.Tokens != null) ? CollectToken() : Advance();
-
-            _index = token.Range[1];
-            _lineNumber = token.LineNumber.HasValue ? token.LineNumber.Value : 0;
-            _lineStart = token.LineStart;
-
+            _index = token.Range.End;
+            _lookahead = Advance(ref state);
+            _index = token.Range.End;
             return token;
         }
 
-        private void Peek()
+        private void Peek(ref State state)
         {
             int pos = _index;
-            int line = _lineNumber;
-            int start = _lineStart;
-            _lookahead = (_extra.Tokens != null) ? CollectToken() : Advance();
+            _lookahead = Advance(ref state);
             _index = pos;
-            _lineNumber = line;
-            _lineStart = start;
         }
 
-        private void MarkStart()
+        [DoesNotReturn]
+        private void ThrowDepthLimitReached(Token token)
         {
-            if (_extra.Loc.HasValue)
-            {
-                _state.MarkerStack.Push(_index - _lineStart);
-                _state.MarkerStack.Push(_lineNumber);
-            }
-            if (_extra.Range != null)
-            {
-                _state.MarkerStack.Push(_index);
-            }
+            ThrowError(token.Range.Start, Messages.MaxDepthLevelReached);
         }
 
-        private T MarkEnd<T>(T node) where T : Node
-        {
-            if (_extra.Range != null)
-            {
-                node.Range = Range.From(_state.MarkerStack.Pop(), _index);
-            }
-            if (_extra.Loc.HasValue)
-            {
-                var start = Position.From(line: _state.MarkerStack.Pop(), column: _state.MarkerStack.Pop());
-                var end = Position.From(line: _lineNumber, column: _index - _lineStart);
-                node.Location = Location.From(start: start, end: end, source: _source);
-                PostProcess(node);
-            }
-            return node;
-        }
-
-        public T MarkEndIf<T>(T node) where T : Node
-        {
-            if (node.Range != default || node.Location != default)
-            {
-                if (_extra.Loc.HasValue)
-                {
-                    _state.MarkerStack.Pop();
-                    _state.MarkerStack.Pop();
-                }
-                if (_extra.Range != null)
-                {
-                    _state.MarkerStack.Pop();
-                }
-            }
-            else
-            {
-                MarkEnd(node);
-            }
-            return node;
-        }
-
-        public Node PostProcess(Node node)
-        {
-            //if (_extra.Source != null)
-            //{
-            //    node.Location.Source = _extra.Source;
-            //}
-
-            return node;
-        }
-
+        [DoesNotReturn]
         private void ThrowError(Token token, string messageFormat, params object[] arguments)
         {
-            ThrowError(token.Range[0], messageFormat, arguments);
+            ThrowError(token.Range.Start, messageFormat, arguments);
         }
 
+        [DoesNotReturn]
         private void ThrowError(int position, string messageFormat, params object[] arguments)
         {
             string msg = System.String.Format(messageFormat, arguments);
@@ -611,85 +499,149 @@ namespace Jint.Native.Json
 
         // Expect the next token to match the specified punctuator.
         // If not, an exception will be thrown.
-
-        private void Expect(string value)
+        private void Expect(ref State state, char value)
         {
-            Token token = Lex();
-            if (token.Type != Tokens.Punctuator || !value.Equals(token.Value))
+            Token token = Lex(ref state);
+            if (token.Type != Tokens.Punctuator || value != token.FirstCharacter)
             {
                 ThrowUnexpected(token);
             }
         }
 
         // Return true if the next token matches the specified punctuator.
-
-        private bool Match(string value)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Match(char value)
         {
-            return _lookahead.Type == Tokens.Punctuator && value.Equals(_lookahead.Value);
+            return _lookahead.Type == Tokens.Punctuator && value == _lookahead.FirstCharacter;
         }
 
-        private ObjectInstance ParseJsonArray()
+        private ObjectInstance ParseJsonArray(ref State state)
         {
-            var elements = new List<JsValue>();
+            if ((++state.CurrentDepth) > _maxDepth)
+                ThrowDepthLimitReached(_lookahead);
+            /*
+             To speed up performance, the list allocation is deferred.
 
-            Expect("[");
+             First the elements are stored within an array received
+             from the .NET array pool.
 
-            while (!Match("]"))
+             If a list contains less elements that the size that array,
+             a Jint array is constructed with the values stored in that
+             array.
+
+             When the number of elements exceed the buffer size,
+             The elements-array gets created and filled with the content
+             of the array. The array will then turn into an
+             intermediate buffer which gets flushed to the list
+             when its full.
+            */
+            List<JsValue>? elements = null;
+
+            Expect(ref state, '[');
+
+            int bufferIndex = 0;
+            JsArray? result = null;
+
+            JsValue[] buffer = ArrayPool<JsValue>.Shared.Rent(16);
+            try
             {
-                if (Match(","))
+                while (!Match(']'))
                 {
-                    Lex();
-                    elements.Add(JsValue.Null);
-                }
-                else
-                {
-                    elements.Add(ParseJsonValue());
+                    buffer[bufferIndex++] = ParseJsonValue(ref state);
 
-                    if (!Match("]"))
+                    if (!Match(']'))
                     {
-                        Expect(",");
+                        Expect(ref state, ',');
+                    }
+
+                    if (bufferIndex >= buffer.Length)
+                    {
+                        if (elements is null)
+                            elements = new List<JsValue>(buffer);
+                        else
+                            elements.AddRange(buffer);
+                        bufferIndex = 0;
                     }
                 }
+
+                // BufferIndex = 0 has two meanings
+                // * Empty JSON array (elements will be null)
+                // * The buffer array has just been flushed (elements will NOT be null)
+                if (bufferIndex > 0)
+                {
+                    if (elements is null)
+                    {
+                        // No element list has been created, all values did fit into the array.
+                        // The Jint-Array can get constructed from that array.
+                        result = _engine.Realm.Intrinsics.Array.ConstructFast(buffer, 0, bufferIndex);
+                    }
+                    else
+                    {
+                        // An element list has been created. Flush the
+                        // remaining added items within the array to that list.
+                        // The bufferIndex == buffer.length allows to pass
+                        // full array directly which avoids any LINQ-call
+                        // Otherwise only the actual used elements are added.
+                        // The "ToArray()" turned out to be slightly faster
+                        // compared to passing the IEnumerable-result of "Take"
+                        // directly.
+                        elements.AddRange(bufferIndex == buffer.Length ? buffer : buffer.Take(bufferIndex).ToArray());
+                    }
+                }
+                else
+                if (elements is null)
+                {
+                    // the JSON array did not have any elements
+                    // aka: []
+                    result = _engine.Realm.Intrinsics.Array.ConstructFast(System.Array.Empty<JsValue>());
+                }
+            }
+            finally
+            {
+                ArrayPool<JsValue>.Shared.Return(buffer);
             }
 
-            Expect("]");
+            Expect(ref state, ']');
+            state.CurrentDepth--;
 
-            return _engine.Realm.Intrinsics.Array.ConstructFast(elements);
+            return result ?? _engine.Realm.Intrinsics.Array.ConstructFast(elements!);
         }
 
-        public ObjectInstance ParseJsonObject()
+        private ObjectInstance ParseJsonObject(ref State state)
         {
-            Expect("{");
+            if ((++state.CurrentDepth) > _maxDepth)
+                ThrowDepthLimitReached(_lookahead);
+            Expect(ref state, '{');
 
             var obj = _engine.Realm.Intrinsics.Object.Construct(Arguments.Empty);
 
-            while (!Match("}"))
+            while (!Match('}'))
             {
                 Tokens type = _lookahead.Type;
                 if (type != Tokens.String)
                 {
-                    ThrowUnexpected(Lex());
+                    ThrowUnexpected(Lex(ref state));
                 }
 
-                var nameToken = Lex();
-                var name = nameToken.Value.ToString();
+                var nameToken = Lex(ref state);
+                var name = nameToken.Text;
                 if (PropertyNameContainsInvalidCharacters(name))
                 {
                     ThrowError(nameToken, Messages.InvalidCharacter);
                 }
 
-                Expect(":");
-                var value = ParseJsonValue();
-
+                Expect(ref state, ':');
+                var value = ParseJsonValue(ref state);
                 obj.FastSetDataProperty(name, value);
 
-                if (!Match("}"))
+                if (!Match('}'))
                 {
-                    Expect(",");
+                    Expect(ref state, ',');
                 }
             }
 
-            Expect("}");
+            Expect(ref state, '}');
+            state.CurrentDepth--;
 
             return obj;
         }
@@ -711,39 +663,26 @@ namespace Jint.Native.Json
         /// It was already parsed by the peek() method.
         /// _lookahead.Value already contain the value.
         /// </summary>
-        /// <returns></returns>
-        private JsValue ParseJsonValue()
+        private JsValue ParseJsonValue(ref State state)
         {
             Tokens type = _lookahead.Type;
-            MarkStart();
-
             switch (type)
             {
                 case Tokens.NullLiteral:
-                    var v = Lex().Value;
-                    return JsValue.Null;
                 case Tokens.BooleanLiteral:
-                    // implicit conversion operator goes through caching
-                    return (bool) Lex().Value ? JsBoolean.True : JsBoolean.False;
                 case Tokens.String:
-                    // implicit conversion operator goes through caching
-                    return new JsString((string) Lex().Value);
                 case Tokens.Number:
-                    return (double) Lex().Value;
+                    return Lex(ref state).Value;
+                case Tokens.Punctuator:
+                    if (_lookahead.FirstCharacter == '[')
+                        return ParseJsonArray(ref state);
+                    if (_lookahead.FirstCharacter == '{')
+                        return ParseJsonObject(ref state);
+                    ThrowUnexpected(Lex(ref state));
+                    break;
             }
 
-            if (Match("["))
-            {
-                return ParseJsonArray();
-            }
-
-            if (Match("{"))
-            {
-                return ParseJsonObject();
-            }
-
-            ThrowUnexpected(Lex());
-
+            ThrowUnexpected(Lex(ref state));
             // can't be reached
             return JsValue.Null;
         }
@@ -757,63 +696,44 @@ namespace Jint.Native.Json
         {
             _source = code;
             _index = 0;
-            _lineNumber = 1;
-            _lineStart = 0;
             _length = _source.Length;
             _lookahead = null!;
-            _state = new State
+
+            using var wrapper = StringBuilderPool.Rent();
+            State state = new State(wrapper.Builder);
+
+            Peek(ref state);
+            JsValue jsv = ParseJsonValue(ref state);
+
+            Peek(ref state);
+
+            if (_lookahead.Type != Tokens.EOF)
             {
-                AllowIn = true,
-                LabelSet = new HashSet<string>(),
-                InFunctionBody = false,
-                InIteration = false,
-                InSwitch = false,
-                LastCommentStart = -1,
-                MarkerStack = new Stack<int>()
-            };
-
-            _extra = new Extra
-                {
-                    Range = new int[0],
-                    Loc = 0,
-
-                };
-
-            if (options != null)
-            {
-                if (options.Tokens)
-                {
-                    _extra.Tokens = new List<Token>();
-                }
-
+                ThrowError(_lookahead, Messages.UnexpectedToken, _lookahead.Text);
             }
-
-            try
-            {
-                MarkStart();
-                Peek();
-                JsValue jsv = ParseJsonValue();
-
-                Peek();
-
-                if(_lookahead.Type != Tokens.EOF)
-                {
-                    ThrowError(_lookahead, Messages.UnexpectedToken, _lookahead.Text);
-                }
-                return jsv;
-            }
-            finally
-            {
-                _extra = new Extra();
-            }
+            return jsv;
         }
 
-        private sealed class Extra
+        private ref struct State
         {
-            public int? Loc;
-            public int[]? Range;
+            public State(StringBuilder tokenBuffer)
+            {
+                TokenBuffer = tokenBuffer;
+                CurrentDepth = 0;
+            }
 
-            public List<Token> Tokens = null!;
+            /// <summary>
+            /// StringBuilder instance which can be used to collect
+            /// characters into a single string. Must only be used
+            /// when no child-parser gets called. Must be cleared
+            /// after usage.
+            /// </summary>
+            public StringBuilder TokenBuffer { get; }
+
+            /// <summary>
+            /// The current recursion depth
+            /// </summary>
+            public int CurrentDepth { get; set; }
         }
 
         private enum Tokens
@@ -826,14 +746,25 @@ namespace Jint.Native.Json
             EOF,
         };
 
-        class Token
+        private class Token
         {
             public Tokens Type;
-            public object Value = null!;
+            public char FirstCharacter;
+            public JsValue Value = JsValue.Undefined;
             public string Text = null!;
-            public int[] Range = null!;
-            public int? LineNumber;
-            public int LineStart;
+            public TextRange Range = default;
+        }
+
+        private readonly struct TextRange
+        {
+            public TextRange(int start, int end)
+            {
+                Start = start;
+                End = end;
+            }
+
+            public int Start { get; }
+            public int End { get; }
         }
 
         static class Messages
@@ -845,18 +776,8 @@ namespace Jint.Native.Json
             public const string UnexpectedNumber = "Unexpected number in JSON";
             public const string UnexpectedString = "Unexpected string in JSON";
             public const string UnexpectedEOS = "Unexpected end of JSON input";
+            public const string MaxDepthLevelReached = "Max. depth level of JSON reached";
         };
-
-        struct State
-        {
-            public int LastCommentStart;
-            public bool AllowIn;
-            public HashSet<string> LabelSet;
-            public bool InFunctionBody;
-            public bool InIteration;
-            public bool InSwitch;
-            public Stack<int> MarkerStack;
-        }
     }
 
     internal static class StringExtensions

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -195,7 +195,6 @@ namespace Jint.Native.Json
             var sb = state.TokenBuffer;
             int start = _index;
             char ch = _source.CharCodeAt(_index);
-            bool hasFraction = false;
 
             // Number start with a -
             if (ch == '-')
@@ -230,7 +229,6 @@ namespace Jint.Native.Json
 
             if (ch == '.')
             {
-                hasFraction = true;
                 sb.Append(ch);
                 _index++;
 
@@ -243,7 +241,6 @@ namespace Jint.Native.Json
 
             if (ch == 'e' || ch == 'E')
             {
-                hasFraction = true;
                 sb.Append(ch);
                 ch = _source.CharCodeAt(++_index);
                 if (ch == '+' || ch == '-')
@@ -267,9 +264,7 @@ namespace Jint.Native.Json
 
             string number = sb.ToString();
             sb.Clear();
-            JsNumber value = hasFraction
-                ? new JsNumber(double.Parse(number, NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture))
-                : new JsNumber(long.Parse(number, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture));
+            JsNumber value = new JsNumber(double.Parse(number, NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture));
             return CreateToken(Tokens.Number, number, '\0', value, new TextRange(start, _index));
         }
 

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -213,12 +213,11 @@ namespace Jint
             return options;
         }
 
-        public static Options MaxJsonParseDepth(this Options options, uint maxDepth)
+        public static Options MaxJsonParseDepth(this Options options, int maxDepth)
         {
-            options.Constraints.MaxJsonParseDepth = maxDepth;
+            options.Json.MaxParseDepth = maxDepth;
             return options;
         }
-
 
         public static Options SetReferencesResolver(this Options options, IReferenceResolver resolver)
         {

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -213,6 +213,12 @@ namespace Jint
             return options;
         }
 
+        public static Options MaxJsonParseDepth(this Options options, uint maxDepth)
+        {
+            options.Constraints.MaxJsonParseDepth = maxDepth;
+            return options;
+        }
+
 
         public static Options SetReferencesResolver(this Options options, IReferenceResolver resolver)
         {

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -101,6 +101,12 @@ namespace Jint
         public bool StringCompilationAllowed { get; set; } = true;
 
         /// <summary>
+        /// Options for the built-in JSON (de)serializer which
+        /// gets used using <c>JSON.parse</c> or <c>JSON.stringify</c>
+        /// </summary>
+        public JsonOptions Json { get; set; } = new();
+
+        /// <summary>
         /// Called by the <see cref="Engine"/> instance that loads this <see cref="Options" />
         /// once it is loaded.
         /// </summary>
@@ -397,12 +403,6 @@ namespace Jint
         /// The maximum size for JavaScript array, defaults to <see cref="uint.MaxValue"/>.
         /// </summary>
         public uint MaxArraySize { get; set; } = uint.MaxValue;
-
-        /// <summary>
-        /// The maximum depth allowed when parsing JSON files using "JSON.parse",
-        /// defaults to 64.
-        /// </summary>
-        public uint MaxJsonParseDepth { get; set; } = 64u;
     }
 
     /// <summary>
@@ -427,5 +427,17 @@ namespace Jint
         /// Module loader implementation, by default exception will be thrown if module loading is not enabled.
         /// </summary>
         public IModuleLoader ModuleLoader { get; set; } = FailFastModuleLoader.Instance;
+    }
+
+    /// <summary>
+    /// JSON.parse / JSON.stringify related customization
+    /// </summary>
+    public class JsonOptions
+    {
+        /// <summary>
+        /// The maximum depth allowed when parsing JSON files using "JSON.parse",
+        /// defaults to 64.
+        /// </summary>
+        public int MaxParseDepth { get; set; } = 64;
     }
 }

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -397,6 +397,12 @@ namespace Jint
         /// The maximum size for JavaScript array, defaults to <see cref="uint.MaxValue"/>.
         /// </summary>
         public uint MaxArraySize { get; set; } = uint.MaxValue;
+
+        /// <summary>
+        /// The maximum depth allowed when parsing JSON files using "JSON.parse",
+        /// defaults to 64.
+        /// </summary>
+        public uint MaxJsonParseDepth { get; set; } = 64u;
     }
 
     /// <summary>


### PR DESCRIPTION
Hi there,

first PR for this project, hopefully got everything right 😃.

I tried to not modify too much to not destroy previous knowledge of the parser code. 

# Summary
* JSON.parse now takes about half the time to complete
* JSON.parse now only allocates about 20% of the previously required memory
* JSON.parse more aligned to the JSON specification
* Added recursion limit to JsonParser to prevent StackOverflow-Exception

## Adjustments to the parser
The old parser did parse the following strings, but they are not valid according to the JSON specification:
* `"[1,]"`: return value was `JsArray([1, null])`
* `".1"`: return value was `JsNumber(0.1)`

These will now throw a JavaScriptException. These cases are baked by tests.

## Recursion limit
Previously the parser did not have a recursion limit. A specially crafted JSON string could lead to a non-handlable `StackOverflowException`. I've added a max. recursion limit which is valid for arrays and objects. The default value is 64 (same as the [default value of System.Text.Json](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializeroptions.maxdepth?view=net-7.0#system-text-json-jsonserializeroptions-maxdepth)). The limit can get adjusted per Parser-Instance or globally using `JsonParser.DefaultMaxDepth`.

## Performance Improvements
I've refactored several areas of the JsonParser to improve the performance. I validated the changes running BenchmarkDotNet using different JSON files. I've used the following sources to get sample JSON files for the benchmark:
* https://github.com/sirthias/borer/tree/master/benchmarks/src/main/resources
* https://github.com/miloyip/nativejson-benchmark/tree/master/data
* https://github.com/algolia/examples/tree/master/demo-personalization (data.json)
* https://github.com/algolia/examples/tree/master/instant-search/instantsearch.js/dataset_import (bestbuy_dataset.json)
The JSON files for the test had a size between 2.7KB and 43.3MB (UTF-8 encoded).

For that I had to remove some old code which either wasn't used at all (like the `_extra`-field) or did not return any useful result with the current implementation (like `ParseJsonObject()` which is now private or `MarkEnd...`).

While the old code was generally about 20% slower compared to the Json.NET parser (Newtonsoft.Json), it now requires about half Json.NET needs when used by calling `JsonConvert.DeserializeObject()`. It is still slower compared to more optimized parsers like System.Text.Json or SpanJson.

### Test execution
The test was basically just
```csharp
[Benchmark]
public void Parse() 
{
    var parser = new JsonParser(_engine);
    parser.Parse( [json string already in memory] );
}
```

To make both parsers runnable within the same test run, I simply copied the changes temporarily into a new class `JsonParser2` and kept the other class unchanged. 

### Results
(quite a lot, but the relevant columns are "Ratio" and "Alloc Ratio")

``` ini

BenchmarkDotNet=v0.13.4, OS=Windows 10 (10.0.19042.2251/20H2/October2020Update)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=7.0.102
  [Host]     : .NET 6.0.13 (6.0.1322.58009), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.13 (6.0.1322.58009), X64 RyuJIT AVX2


```
|    Method |             FileName |            Mean |         Error |        StdDev | Ratio | RatioSD |        Gen0 |       Gen1 |      Gen2 |     Allocated | Alloc Ratio |
|---------- |--------------------- |----------------:|--------------:|--------------:|------:|--------:|------------:|-----------:|----------:|--------------:|------------:|
| **OldParser** | **algol(...)ation [31]** | **1,534,348.91 μs** | **21,656.919 μs** | **20,257.895 μs** |  **1.00** |    **0.00** |  **94000.0000** | **33000.0000** | **4000.0000** | **1553748.27 KB** |        **1.00** |
| NewParser | algol(...)ation [31] |   775,250.79 μs |  8,302.750 μs |  7,766.397 μs |  0.51 |    0.01 |  21000.0000 | 11000.0000 | 2000.0000 |  326915.87 KB |        0.21 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |        **australia-abc** |       **312.18 μs** |      **2.246 μs** |      **2.101 μs** |  **1.00** |    **0.00** |     **62.5000** |    **19.0430** |         **-** |    **1022.43 KB** |        **1.00** |
| NewParser |        australia-abc |       143.85 μs |      0.700 μs |      0.655 μs |  0.46 |    0.00 |     12.2070 |     3.6621 |         - |     201.73 KB |        0.20 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |      **bestbuy_dataset** |   **528,457.14 μs** | **10,458.706 μs** | **10,271.847 μs** |  **1.00** |    **0.00** |  **41000.0000** | **13000.0000** | **3000.0000** |  **650111.23 KB** |        **1.00** |
| NewParser |      bestbuy_dataset |   304,451.35 μs |  5,150.079 μs |  4,565.411 μs |  0.58 |    0.02 |   8000.0000 |  4500.0000 | 1500.0000 |  117774.67 KB |        0.18 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |              **bitcoin** |       **212.40 μs** |      **1.383 μs** |      **1.294 μs** |  **1.00** |    **0.00** |     **38.3301** |     **8.7891** |         **-** |     **630.01 KB** |        **1.00** |
| NewParser |              bitcoin |       101.33 μs |      0.612 μs |      0.543 μs |  0.48 |    0.00 |      8.0566 |     2.1973 |         - |     133.33 KB |        0.21 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |               **canada** |   **116,232.41 μs** |  **2,244.857 μs** |  **3,146.976 μs** |  **1.00** |    **0.00** |  **12400.0000** |  **3800.0000** | **1400.0000** |  **186975.62 KB** |        **1.00** |
| NewParser |               canada |    58,226.87 μs |    844.937 μs |    790.354 μs |  0.50 |    0.02 |   1444.4444 |   777.7778 |  222.2222 |      20835 KB |        0.11 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |         **citm_catalog** |    **22,420.39 μs** |    **446.148 μs** |    **458.161 μs** |  **1.00** |    **0.00** |   **2000.0000** |   **937.5000** |  **125.0000** |   **32245.68 KB** |        **1.00** |
| NewParser |         citm_catalog |     8,347.13 μs |     59.575 μs |     55.726 μs |  0.37 |    0.01 |    468.7500 |   218.7500 |         - |    7862.44 KB |        0.24 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |             **doj-blog** |     **1,074.00 μs** |      **7.967 μs** |      **7.452 μs** |  **1.00** |    **0.00** |    **263.6719** |    **99.6094** |         **-** |     **4334.5 KB** |        **1.00** |
| NewParser |             doj-blog |       390.77 μs |      1.634 μs |      1.365 μs |  0.36 |    0.00 |     33.6914 |    16.6016 |         - |     555.34 KB |        0.13 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |     **eu-lobby-country** |       **134.93 μs** |      **1.002 μs** |      **0.937 μs** |  **1.00** |    **0.00** |     **28.0762** |     **5.6152** |         **-** |      **459.2 KB** |        **1.00** |
| NewParser |     eu-lobby-country |        60.97 μs |      0.512 μs |      0.454 μs |  0.45 |    0.01 |      5.2490 |     0.9766 |         - |      85.88 KB |        0.19 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |   **eu-lobby-financial** |       **745.04 μs** |      **5.226 μs** |      **4.888 μs** |  **1.00** |    **0.00** |    **137.6953** |    **50.7813** |         **-** |    **2258.68 KB** |        **1.00** |
| NewParser |   eu-lobby-financial |       343.75 μs |      2.047 μs |      1.815 μs |  0.46 |    0.00 |     27.3438 |     9.2773 |         - |     451.91 KB |        0.20 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |        **eu-lobby-repr** |     **1,801.72 μs** |     **13.256 μs** |     **11.070 μs** |  **1.00** |    **0.00** |    **337.8906** |   **146.4844** |         **-** |    **5529.42 KB** |        **1.00** |
| NewParser |        eu-lobby-repr |       818.08 μs |      3.248 μs |      2.879 μs |  0.45 |    0.00 |     59.5703 |    21.4844 |         - |     982.02 KB |        0.18 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |        **github-events** |     **1,126.93 μs** |      **7.823 μs** |      **6.935 μs** |  **1.00** |    **0.00** |    **207.0313** |    **85.9375** |         **-** |    **3383.16 KB** |        **1.00** |
| NewParser |        github-events |       500.68 μs |      2.872 μs |      2.686 μs |  0.44 |    0.00 |     41.0156 |    18.5547 |         - |     677.24 KB |        0.20 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |         **github-gists** |       **665.14 μs** |      **7.119 μs** |      **6.659 μs** |  **1.00** |    **0.00** |    **130.8594** |    **50.7813** |         **-** |    **2147.94 KB** |        **1.00** |
| NewParser |         github-gists |       289.54 μs |      1.009 μs |      0.944 μs |  0.44 |    0.00 |     26.3672 |     9.2773 |         - |     432.67 KB |        0.20 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** | **inspe(...)yload [22]** |   **326,536.84 μs** |  **6,355.739 μs** |  **5,634.197 μs** |  **1.00** |    **0.00** |  **22000.0000** |  **8000.0000** | **2000.0000** |  **338250.76 KB** |        **1.00** |
| NewParser | inspe(...)yload [22] |   170,099.88 μs |  2,120.607 μs |  1,879.863 μs |  0.52 |    0.01 |   5000.0000 |  2750.0000 |  750.0000 |   76775.04 KB |        0.23 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |       **json-generator** |       **130.27 μs** |      **0.933 μs** |      **0.873 μs** |  **1.00** |    **0.00** |     **25.3906** |     **4.8828** |         **-** |     **416.81 KB** |        **1.00** |
| NewParser |       json-generator |        63.97 μs |      0.309 μs |      0.289 μs |  0.49 |    0.00 |      5.6152 |     1.0986 |         - |      93.25 KB |        0.22 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |           **meteorites** |     **6,377.50 μs** |     **93.836 μs** |     **87.774 μs** |  **1.00** |    **0.00** |    **757.8125** |   **289.0625** |         **-** |   **12844.52 KB** |        **1.00** |
| NewParser |           meteorites |     2,539.29 μs |     13.003 μs |     12.163 μs |  0.40 |    0.01 |    218.7500 |   109.3750 |         - |    3593.54 KB |        0.28 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |               **movies** |   **210,554.93 μs** |  **4,070.923 μs** |  **5,572.325 μs** |  **1.00** |    **0.00** |  **11333.3333** |  **5333.3333** | **1666.6667** |  **175284.86 KB** |        **1.00** |
| NewParser |               movies |    78,367.06 μs |    552.833 μs |    517.120 μs |  0.38 |    0.01 |   3000.0000 |  1714.2857 |  571.4286 |   43000.17 KB |        0.25 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |         **reddit-scala** |     **1,147.43 μs** |     **11.760 μs** |     **10.425 μs** |  **1.00** |    **0.00** |    **224.6094** |    **99.6094** |         **-** |    **3674.52 KB** |        **1.00** |
| NewParser |         reddit-scala |       554.86 μs |      3.855 μs |      3.606 μs |  0.48 |    0.00 |     47.8516 |    23.4375 |         - |     786.67 KB |        0.21 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |           **rick-morty** |       **231.36 μs** |      **1.671 μs** |      **1.482 μs** |  **1.00** |    **0.00** |     **47.8516** |    **12.9395** |         **-** |     **783.19 KB** |        **1.00** |
| NewParser |           rick-morty |       108.73 μs |      0.682 μs |      0.569 μs |  0.47 |    0.00 |     10.0098 |     2.4414 |         - |     165.44 KB |        0.21 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |         **temp-anomaly** |        **47.08 μs** |      **0.348 μs** |      **0.326 μs** |  **1.00** |    **0.00** |      **8.2397** |     **0.7324** |         **-** |     **135.41 KB** |        **1.00** |
| NewParser |         temp-anomaly |        26.79 μs |      0.156 μs |      0.146 μs |  0.57 |    0.00 |      2.5330 |     0.1831 |         - |       41.5 KB |        0.31 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |         **thai-cinemas** |       **148.31 μs** |      **1.063 μs** |      **0.888 μs** |  **1.00** |    **0.00** |     **30.2734** |     **6.5918** |         **-** |     **496.79 KB** |        **1.00** |
| NewParser |         thai-cinemas |        73.76 μs |      0.339 μs |      0.301 μs |  0.50 |    0.00 |      7.8125 |     1.9531 |         - |     129.46 KB |        0.26 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |              **turkish** |    **15,746.64 μs** |    **271.154 μs** |    **240.371 μs** |  **1.00** |    **0.00** |   **1468.7500** |   **687.5000** |  **109.3750** |   **22860.31 KB** |        **1.00** |
| NewParser |              turkish |     6,270.93 μs |     71.383 μs |     66.771 μs |  0.40 |    0.01 |    406.2500 |   203.1250 |         - |       6742 KB |        0.29 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** |              **twitter** |     **8,107.72 μs** |    **110.434 μs** |    **103.300 μs** |  **1.00** |    **0.00** |    **968.7500** |   **375.0000** |         **-** |    **16247.7 KB** |        **1.00** |
| NewParser |              twitter |     3,179.93 μs |     20.212 μs |     18.907 μs |  0.39 |    0.00 |    226.5625 |   113.2813 |         - |    3727.24 KB |        0.23 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** | **twitt(...)ponse [28]** |       **120.06 μs** |      **0.595 μs** |      **0.528 μs** |  **1.00** |    **0.00** |     **23.8037** |     **4.0283** |         **-** |     **390.14 KB** |        **1.00** |
| NewParser | twitt(...)ponse [28] |        57.25 μs |      0.344 μs |      0.322 μs |  0.48 |    0.00 |      5.1270 |     1.2207 |         - |      84.57 KB |        0.22 |
|           |                      |                 |               |               |       |         |             |            |           |               |             |
| **OldParser** | **twitter_api_response** |       **140.73 μs** |      **1.026 μs** |      **0.960 μs** |  **1.00** |    **0.00** |     **27.0996** |     **5.1270** |         **-** |      **443.7 KB** |        **1.00** |
| NewParser | twitter_api_response |        71.70 μs |      0.648 μs |      0.606 μs |  0.51 |    0.00 |      5.8594 |     1.4648 |         - |      97.39 KB |        0.22 |

Again, I hope I got everything right.