### PR TITLE
Remove implicit using for System.Linq

### DIFF
--- a/Jint/Collections/HybridDictionary.cs
+++ b/Jint/Collections/HybridDictionary.cs
@@ -169,7 +169,7 @@ namespace Jint.Collections
                 return _list.GetEnumerator();
             }
 
-            return Enumerable.Empty<KeyValuePair<Key, TValue>>().GetEnumerator();
+            return System.Linq.Enumerable.Empty<KeyValuePair<Key, TValue>>().GetEnumerator();
 
         }
 
@@ -185,7 +185,7 @@ namespace Jint.Collections
                 return _list.GetEnumerator();
             }
 
-            return Enumerable.Empty<KeyValuePair<Key, TValue>>().GetEnumerator();
+            return System.Linq.Enumerable.Empty<KeyValuePair<Key, TValue>>().GetEnumerator();
         }
 
         public bool Remove(Key key)

--- a/Jint/Collections/StringDictionarySlim.cs
+++ b/Jint/Collections/StringDictionarySlim.cs
@@ -6,6 +6,7 @@
 
 using System.Collections;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace Jint.Collections

--- a/Jint/Extensions/ReflectionExtensions.cs
+++ b/Jint/Extensions/ReflectionExtensions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Jint.Native;
@@ -43,13 +44,13 @@ namespace Jint.Extensions
         internal static IEnumerable<MethodInfo> GetExtensionMethods(this Type type)
         {
             return type.GetMethods(BindingFlags.Public | BindingFlags.Static)
-                .Where(m => m.IsExtensionMethod());
+                .Where(static m => m.IsExtensionMethod());
         }
 
         internal static IEnumerable<MethodInfo> GetOperatorOverloadMethods(this Type type)
         {
             return type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
-                .Where(m => m.IsSpecialName);
+                .Where(static m => m.IsSpecialName);
         }
 
         private static bool IsExtensionMethod(this MethodBase methodInfo)

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Remove="System.Linq" />
     <Using Remove="System.Net.Http" />
     <Using Remove="System.Threading" />
   </ItemGroup>

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Jint.Collections;
 using Jint.Native.Iterator;
 using Jint.Native.Map;

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Esprima;

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -272,7 +272,7 @@ namespace Jint.Native.Object
             return keys;
         }
 
-        internal virtual IEnumerable<JsValue> GetInitialOwnStringPropertyKeys() => Enumerable.Empty<JsValue>();
+        internal virtual IEnumerable<JsValue> GetInitialOwnStringPropertyKeys() => System.Linq.Enumerable.Empty<JsValue>();
 
         protected virtual void AddProperty(JsValue property, PropertyDescriptor descriptor)
         {

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -939,10 +939,10 @@ namespace Jint.Native.String
                 return s;
             }
 
-            targetLength = targetLength - s.Length;
+            targetLength -= s.Length;
             if (targetLength > padString.Length)
             {
-                padString = string.Join("", Enumerable.Repeat(padString, (targetLength / padString.Length) + 1));
+                padString = string.Join("", System.Linq.Enumerable.Repeat(padString, (targetLength / padString.Length) + 1));
             }
 
             return padStart

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Jint.Collections;
 using Jint.Native.Array;
 using Jint.Native.ArrayBuffer;

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using Jint.Native;
 using Jint.Runtime;

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -1,5 +1,6 @@
 ﻿using System.Dynamic;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using Jint.Native;
 using Jint.Native.Object;

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
 using Esprima;
 using Esprima.Ast;
@@ -108,7 +109,7 @@ namespace Jint.Runtime.CallStack
 
         public override string ToString()
         {
-            return string.Join("->", _stack.Select(cse => cse.ToString()).Reverse());
+            return string.Join("->", _stack.Select(static cse => cse.ToString()).Reverse());
         }
 
         internal string BuildCallStackString(Location location, int excludeTop = 0)

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Jint.Extensions;

--- a/Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs
+++ b/Jint/Runtime/Interop/Reflection/ExtensionMethodCache.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using Jint.Extensions;

--- a/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
@@ -113,7 +113,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         internal sealed class JintEmptyArrayExpression : JintExpression
         {
-            public static JintEmptyArrayExpression Instance = new(new ArrayExpression(NodeList.Create(Enumerable.Empty<Expression?>())));
+            public static JintEmptyArrayExpression Instance = new(new ArrayExpression(NodeList.Create(System.Linq.Enumerable.Empty<Expression?>())));
 
             private JintEmptyArrayExpression(Expression expression) : base(expression)
             {

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -56,9 +57,9 @@ namespace Jint.Runtime.Interpreter.Expressions
                     var rightMethods = rightType.GetOperatorOverloadMethods();
 
                     var methods = leftMethods.Concat(rightMethods).Where(x => x.Name == clrName && x.GetParameters().Length == 2);
-                    var _methods = MethodDescriptor.Build(methods.ToArray());
+                    var methodDescriptors = MethodDescriptor.Build(methods.ToArray());
 
-                    return TypeConverter.FindBestMatch(context.Engine, _methods, _ => arguments).FirstOrDefault().Method;
+                    return TypeConverter.FindBestMatch(context.Engine, methodDescriptors, _ => arguments).FirstOrDefault().Method;
                 });
 
                 if (method != null)

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -244,7 +244,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         internal sealed class JintEmptyObjectExpression : JintExpression
         {
-            public static JintEmptyObjectExpression Instance = new(new ObjectExpression(NodeList.Create(Enumerable.Empty<Node>())));
+            public static JintEmptyObjectExpression Instance = new(new ObjectExpression(NodeList.Create(System.Linq.Enumerable.Empty<Node>())));
 
             private JintEmptyObjectExpression(Expression expression) : base(expression)
             {


### PR DESCRIPTION
Easier to track possible accidental introduction and other usage.