### PR TITLE
Support inheritance chain of CLR objects with instanceof operator

### DIFF
--- a/Jint.Tests/Runtime/InstanceOfTests.cs
+++ b/Jint.Tests/Runtime/InstanceOfTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.Runtime
+{
+    public class InstanceOfTests
+    {
+        [Fact]
+        public void IneritanceChain()
+        {
+            var a = new A();
+            var b = new B();
+            var c = new C();
+
+            var engine = new Engine();
+
+            engine.SetValue("A", TypeReference.CreateTypeReference(engine, typeof(A)));
+            engine.SetValue("B", TypeReference.CreateTypeReference(engine, typeof(B)));
+            engine.SetValue("C", TypeReference.CreateTypeReference(engine, typeof(C)));
+
+            engine.SetValue("a", a);
+            engine.SetValue("b", b);
+            engine.SetValue("c", c);
+
+            Assert.True(engine.Evaluate("a instanceof A").AsBoolean());
+            Assert.False(engine.Evaluate("a instanceof B").AsBoolean());
+            Assert.False(engine.Evaluate("a instanceof C").AsBoolean());
+
+            Assert.True(engine.Evaluate("b instanceof A").AsBoolean());
+            Assert.True(engine.Evaluate("b instanceof B").AsBoolean());
+            Assert.False(engine.Evaluate("b instanceof C").AsBoolean());
+
+            Assert.True(engine.Evaluate("c instanceof A").AsBoolean());
+            Assert.True(engine.Evaluate("c instanceof B").AsBoolean());
+            Assert.True(engine.Evaluate("c instanceof C").AsBoolean());
+        }
+
+        public class A { }
+
+        public class B : A { }
+
+        public class C : B { }
+    }
+}

--- a/Jint.Tests/Runtime/InstanceOfTests.cs
+++ b/Jint.Tests/Runtime/InstanceOfTests.cs
@@ -1,48 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Jint.Runtime.Interop;
+﻿using Jint.Runtime.Interop;
 
-namespace Jint.Tests.Runtime
+namespace Jint.Tests.Runtime;
+
+public class InstanceOfTests
 {
-    public class InstanceOfTests
+    [Fact]
+    public void ShouldSupportInheritanceChainUnderInterop()
     {
-        [Fact]
-        public void IneritanceChain()
-        {
-            var a = new A();
-            var b = new B();
-            var c = new C();
+        var a = new A();
+        var b = new B();
+        var c = new C();
 
-            var engine = new Engine();
+        var engine = new Engine();
 
-            engine.SetValue("A", TypeReference.CreateTypeReference(engine, typeof(A)));
-            engine.SetValue("B", TypeReference.CreateTypeReference(engine, typeof(B)));
-            engine.SetValue("C", TypeReference.CreateTypeReference(engine, typeof(C)));
+        engine.SetValue("A", TypeReference.CreateTypeReference(engine, typeof(A)));
+        engine.SetValue("B", TypeReference.CreateTypeReference(engine, typeof(B)));
+        engine.SetValue("C", TypeReference.CreateTypeReference(engine, typeof(C)));
 
-            engine.SetValue("a", a);
-            engine.SetValue("b", b);
-            engine.SetValue("c", c);
+        engine.SetValue("a", a);
+        engine.SetValue("b", b);
+        engine.SetValue("c", c);
 
-            Assert.True(engine.Evaluate("a instanceof A").AsBoolean());
-            Assert.False(engine.Evaluate("a instanceof B").AsBoolean());
-            Assert.False(engine.Evaluate("a instanceof C").AsBoolean());
+        Assert.True(engine.Evaluate("a instanceof A").AsBoolean());
+        Assert.False(engine.Evaluate("a instanceof B").AsBoolean());
+        Assert.False(engine.Evaluate("a instanceof C").AsBoolean());
 
-            Assert.True(engine.Evaluate("b instanceof A").AsBoolean());
-            Assert.True(engine.Evaluate("b instanceof B").AsBoolean());
-            Assert.False(engine.Evaluate("b instanceof C").AsBoolean());
+        Assert.True(engine.Evaluate("b instanceof A").AsBoolean());
+        Assert.True(engine.Evaluate("b instanceof B").AsBoolean());
+        Assert.False(engine.Evaluate("b instanceof C").AsBoolean());
 
-            Assert.True(engine.Evaluate("c instanceof A").AsBoolean());
-            Assert.True(engine.Evaluate("c instanceof B").AsBoolean());
-            Assert.True(engine.Evaluate("c instanceof C").AsBoolean());
-        }
-
-        public class A { }
-
-        public class B : A { }
-
-        public class C : B { }
+        Assert.True(engine.Evaluate("c instanceof A").AsBoolean());
+        Assert.True(engine.Evaluate("c instanceof B").AsBoolean());
+        Assert.True(engine.Evaluate("c instanceof C").AsBoolean());
     }
+
+    public class A { }
+
+    public class B : A { }
+
+    public class C : B { }
 }


### PR DESCRIPTION
Hi! I implemented the functionality to make instanceof operator behave following the ineritance chain of CLR objects. But, because this not should be the default behavior, I suggest an explicit activation via Options.Runtime or a class Attribute. I made a test for net 6.0 too.

Regards.