### PR TITLE
Optimize JSON serialization

### DIFF
--- a/Jint/Native/Function/FunctionInstance.cs
+++ b/Jint/Native/Function/FunctionInstance.cs
@@ -104,7 +104,7 @@ namespace Jint.Native.Function
             }
         }
 
-        internal override IEnumerable<JsValue> GetInitialOwnStringPropertyKeys()
+        internal sealed override IEnumerable<JsValue> GetInitialOwnStringPropertyKeys()
         {
             if (_length != null)
             {

--- a/Jint/Native/String/StringInstance.cs
+++ b/Jint/Native/String/StringInstance.cs
@@ -33,7 +33,7 @@ internal class StringInstance : ObjectInstance, IPrimitiveInstance
         return false;
     }
 
-    public override PropertyDescriptor GetOwnProperty(JsValue property)
+    public sealed override PropertyDescriptor GetOwnProperty(JsValue property)
     {
         if (property == CommonProperties.Infinity)
         {
@@ -66,7 +66,7 @@ internal class StringInstance : ObjectInstance, IPrimitiveInstance
         return new PropertyDescriptor(str[index], PropertyFlag.OnlyEnumerable);
     }
 
-    public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
+    public sealed override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
     {
         foreach (var entry in base.GetOwnProperties())
         {
@@ -79,12 +79,12 @@ internal class StringInstance : ObjectInstance, IPrimitiveInstance
         }
     }
 
-    internal override IEnumerable<JsValue> GetInitialOwnStringPropertyKeys()
+    internal sealed override IEnumerable<JsValue> GetInitialOwnStringPropertyKeys()
     {
-        return new[] { JsString.LengthString };
+        yield return JsString.LengthString;
     }
 
-    public override List<JsValue> GetOwnPropertyKeys(Types types)
+    public sealed override List<JsValue> GetOwnPropertyKeys(Types types)
     {
         var keys = new List<JsValue>(StringData.Length + 1);
         if ((types & Types.String) != 0)
@@ -105,7 +105,7 @@ internal class StringInstance : ObjectInstance, IPrimitiveInstance
         return keys;
     }
 
-    protected internal override void SetOwnProperty(JsValue property, PropertyDescriptor desc)
+    protected internal sealed override void SetOwnProperty(JsValue property, PropertyDescriptor desc)
     {
         if (property == CommonProperties.Length)
         {
@@ -117,7 +117,7 @@ internal class StringInstance : ObjectInstance, IPrimitiveInstance
         }
     }
 
-    public override void RemoveOwnProperty(JsValue property)
+    public sealed override void RemoveOwnProperty(JsValue property)
     {
         if (property == CommonProperties.Length)
         {

--- a/Jint/Pooling/StringBuilderPool.cs
+++ b/Jint/Pooling/StringBuilderPool.cs
@@ -47,7 +47,7 @@ namespace Jint.Pooling
                 var builder = Builder;
 
                 // do not store builders that are too large.
-                if (builder.Capacity <= 1024)
+                if (builder.Capacity <= 1024 * 1024)
                 {
                     builder.Clear();
                     _pool.Free(builder);

--- a/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
@@ -170,7 +170,7 @@ namespace Jint.Runtime.Interop.Reflection
                 }
             }
 
-            return new ReflectionDescriptor(engine, this, target, false);
+            return new ReflectionDescriptor(engine, this, target, enumerable: true);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
@@ -1,7 +1,6 @@
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Function;
-using Jint.Native.Object;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
 


### PR DESCRIPTION
* optimize ObjectInstance.GetOwnPropertyKeys for non-sorting case
* increase StringBuilderPool max capacity check
* smarter checks for integer numbers in JsonParser

## Jint.Benchmark.JsonBenchmark

| **Diff**|Method|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Parse|bestbuy_dataset.json|297.742 ms|5.7835 ms|115.01 MB|
| **New** |	|	| **299.811 ms (+1%)** | **4.3964 ms** | **114.15 MB (-1%)** |
| Old |Stringify|bestbuy_dataset.json|142.319 ms|2.2880 ms|104.63 MB|
| **New** |	|	| **127.802 ms (-10%)** | **1.9511 ms** | **90.18 MB (-14%)** |
| Old |Parse|twitter.json|3.023 ms|0.0057 ms|3.64 MB|
| **New** |	|	| **2.995 ms (-1%)** | **0.0111 ms** | **3.61 MB (-1%)** |
| Old |Stringify|twitter.json|2.926 ms|0.0241 ms|2.74 MB|
| **New** |	|	| **2.434 ms (-17%)** | **0.0118 ms** | **1.4 MB (-49%)** |


/cc @tomatosalat0 