### PR TITLE
Update README.md to reflect ES2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,18 @@ The entire execution engine was rebuild with performance in mind, in many cases 
 - ✔ Class Static Block
 - ✔ Error Cause
 
+#### ECMAScript 2023
+
+- ✔ Array find from last
+- ✔ Change Array by copy
+- ✔ Hashbang Grammar
+- ✔ Symbols as WeakMap keys
+
 #### ECMAScript Stage 3 (no version yet)
 
 - ✔ Array find from last
 - ✔ Array.group and Array.groupToMap
-- ✔ Change Array by copy
 - ✔ ShadowRealm
-- ✔ Symbols as WeakMap keys
 
 #### Other
 


### PR DESCRIPTION
Seems that we have everything from 2023 covered: https://github.com/tc39/proposals/blob/main/finished-proposals.md , https://github.com/tc39/ecma262/releases/tag/es2023-candidate-2023-04