### PR TITLE
Adjust Engine.SetValue(string, string?) to accept null value.

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -201,7 +201,7 @@ namespace Jint
         /// <summary>
         /// Registers a string value as variable.
         /// </summary>
-        public Engine SetValue(string name, string value)
+        public Engine SetValue(string name, string? value)
         {
             return SetValue(name, value is null ? JsValue.Null : JsString.Create(value));
         }


### PR DESCRIPTION
It is valid to pass a nullable string to SetValue.  Might as well adjust the annotations to indicate that.

```
string? name = null;
engine.SetValue("name", name);
```