### PR TITLE
Store identifier in local

### DIFF
--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -398,12 +398,13 @@ namespace Jint.Runtime.Interpreter.Expressions
                 var engine = context.Engine;
                 var env = engine.ExecutionContext.LexicalEnvironment;
                 var strict = StrictModeScope.IsStrictModeCode;
+                var identifier = left.Identifier;
                 if (JintEnvironment.TryGetIdentifierEnvironmentWithBinding(
                     env,
-                    left.Identifier,
+                    identifier,
                     out var environmentRecord))
                 {
-                    if (strict && hasEvalOrArguments && left.Identifier.Key != KnownKeys.Eval)
+                    if (strict && hasEvalOrArguments && identifier.Key != KnownKeys.Eval)
                     {
                         ExceptionHelper.ThrowSyntaxError(engine.Realm, "Invalid assignment target");
                     }
@@ -418,10 +419,10 @@ namespace Jint.Runtime.Interpreter.Expressions
 
                     if (right._expression.IsFunctionDefinition())
                     {
-                        ((FunctionInstance) rval).SetFunctionName(left.Identifier.Value);
+                        ((FunctionInstance) rval).SetFunctionName(identifier.Value);
                     }
 
-                    environmentRecord.SetMutableBinding(left.Identifier, rval, strict);
+                    environmentRecord.SetMutableBinding(identifier, rval, strict);
                     return rval;
                 }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -25,11 +25,12 @@ internal sealed class JintIdentifierExpression : JintExpression
         var engine = context.Engine;
         var env = engine.ExecutionContext.LexicalEnvironment;
         var strict = StrictModeScope.IsStrictModeCode;
-        var identifierEnvironment = JintEnvironment.TryGetIdentifierEnvironmentWithBinding(env, Identifier, out var temp)
+        var identifier = Identifier;
+        var identifierEnvironment = JintEnvironment.TryGetIdentifierEnvironmentWithBinding(env, identifier, out var temp)
             ? temp
             : JsValue.Undefined;
 
-        return engine._referencePool.Rent(identifierEnvironment, Identifier.Value, strict, thisValue: null);
+        return engine._referencePool.Rent(identifierEnvironment, identifier.Value, strict, thisValue: null);
     }
 
     public override JsValue GetValue(EvaluationContext context)
@@ -37,9 +38,10 @@ internal sealed class JintIdentifierExpression : JintExpression
         // need to notify correct node when taking shortcut
         context.LastSyntaxElement = _expression;
 
-        if (Identifier.CalculatedValue is not null)
+        var identifier = Identifier;
+        if (identifier.CalculatedValue is not null)
         {
-            return Identifier.CalculatedValue;
+            return identifier.CalculatedValue;
         }
 
         var strict = StrictModeScope.IsStrictModeCode;
@@ -48,7 +50,7 @@ internal sealed class JintIdentifierExpression : JintExpression
 
         if (JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(
                 env,
-                Identifier,
+                identifier,
                 strict,
                 out _,
                 out var value))
@@ -60,7 +62,7 @@ internal sealed class JintIdentifierExpression : JintExpression
         }
         else
         {
-            var reference = engine._referencePool.Rent(JsValue.Undefined, Identifier.Value, strict, thisValue: null);
+            var reference = engine._referencePool.Rent(JsValue.Undefined, identifier.Value, strict, thisValue: null);
             value = engine.GetValue(reference, true);
         }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -53,12 +53,13 @@ namespace Jint.Runtime.Interpreter.Expressions
             var engine = context.Engine;
             if (_objectExpression is JintIdentifierExpression identifierExpression)
             {
-                baseReferenceName = identifierExpression.Identifier.Key.Name;
+                var identifier = identifierExpression.Identifier;
+                baseReferenceName = identifier.Key.Name;
                 var strict = isStrictModeCode;
                 var env = engine.ExecutionContext.LexicalEnvironment;
                 JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(
                     env,
-                    identifierExpression.Identifier,
+                    identifier,
                     strict,
                     out _,
                     out baseValue);


### PR DESCRIPTION

ArrayStressBenchmark:
``` ini

BenchmarkDotNet=v0.13.5, OS=Windows 10 (10.0.19045.3086/22H2/2022Update)
Intel Core i7-4720HQ CPU 2.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.302
  [Host]     : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
```
main:
|               Method |     Mean |    Error |   StdDev |      Gen0 |     Gen1 | Allocated |
|--------------------- |---------:|---------:|---------:|----------:|---------:|----------:|
|              Execute | 24.45 ms | 0.132 ms | 0.123 ms | 2250.0000 | 187.5000 |   7.18 MB |
| Execute_ParsedScript | 22.74 ms | 0.106 ms | 0.094 ms | 2312.5000 |  93.7500 |   7.15 MB |


PR:
|               Method |     Mean |    Error |   StdDev |      Gen0 |     Gen1 | Allocated |
|--------------------- |---------:|---------:|---------:|----------:|---------:|----------:|
|              Execute | 22.85 ms | 0.106 ms | 0.088 ms | 2250.0000 | 187.5000 |   7.18 MB |
| Execute_ParsedScript | 21.95 ms | 0.076 ms | 0.064 ms | 2250.0000 | 250.0000 |   7.15 MB |
