### PR TITLE
Experimental Stackguard

### DIFF
--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -53,8 +53,8 @@ public class EngineLimitTests
     [Fact]
     public void ShouldNotStackoverflowWhenStackGuardEnable()
     {
-        // Can be more than 1000, It does not hit stackoverflow anymore.
-        const int FunctionNestingCount = 1000;
+        // Can be more than 10000, It does not hit stackoverflow anymore.
+        const int FunctionNestingCount = 10000;
 
         // generate call tree
         var sb = new StringBuilder();
@@ -79,7 +79,7 @@ public class EngineLimitTests
             sb.AppendLine();
         }
 
-        var engine = new Engine(option => option.Constraints.MaxExecutionStackCount = 1000);
+        var engine = new Engine(option => option.Constraints.MaxExecutionStackCount = FunctionNestingCount);
         engine.Execute(sb.ToString());
         Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
         Assert.Equal(FunctionNestingCount, engine.Evaluate("x").AsNumber());

--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -9,6 +9,49 @@ public class EngineLimitTests
     [Fact]
     public void ShouldAllowReasonableCallStackDepth()
     {
+        if (OperatingSystem.IsMacOS())
+        {
+            // stack limit differ quite a lot
+            return;
+        }
+
+#if RELEASE
+        const int FunctionNestingCount = 960;
+#else
+        const int FunctionNestingCount = 520;
+#endif
+
+        // generate call tree
+        var sb = new StringBuilder();
+        sb.AppendLine("var x = 10;");
+        sb.AppendLine();
+        for (var i = 1; i <= FunctionNestingCount; ++i)
+        {
+            sb.Append("function func").Append(i).Append("(func").Append(i).AppendLine("Param) {");
+            sb.Append("    ");
+            if (i != FunctionNestingCount)
+            {
+                // just to create a bit more nesting add some constructs
+                sb.Append("return x++ > 1 ? func").Append(i + 1).Append("(func").Append(i).AppendLine("Param): undefined;");
+            }
+            else
+            {
+                // use known CLR function to add breakpoint
+                sb.Append("return Math.max(0, func").Append(i).AppendLine("Param);");
+            }
+
+            sb.AppendLine("}");
+            sb.AppendLine();
+        }
+
+        var engine = new Engine();
+        engine.Execute(sb.ToString());
+        Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
+    }
+
+    [Fact]
+    public void ShouldNotStackoverflowWhenStackGuardEnable()
+    {
         // Can be more than 1000, It does not hit stackoverflow anymore.
         const int FunctionNestingCount = 1000;
 
@@ -35,7 +78,7 @@ public class EngineLimitTests
             sb.AppendLine();
         }
 
-        var engine = new Engine();
+        var engine = new Engine(option => option.Constraints.MaxExecutionStackCount = 1000);
         engine.Execute(sb.ToString());
         Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
         Assert.Equal(FunctionNestingCount, engine.Evaluate("x").AsNumber());

--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -1,11 +1,19 @@
 #if !NETFRAMEWORK
 
 using System.Text;
+using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
 public class EngineLimitTests
 {
+
+#if RELEASE
+    const int FunctionNestingCount = 960;
+#else
+    const int FunctionNestingCount = 520;
+#endif
+
     [Fact]
     public void ShouldAllowReasonableCallStackDepth()
     {
@@ -15,37 +23,10 @@ public class EngineLimitTests
             return;
         }
 
-#if RELEASE
-        const int FunctionNestingCount = 960;
-#else
-        const int FunctionNestingCount = 520;
-#endif
-
-        // generate call tree
-        var sb = new StringBuilder();
-        sb.AppendLine("var x = 1;");
-        sb.AppendLine();
-        for (var i = 1; i <= FunctionNestingCount; ++i)
-        {
-            sb.Append("function func").Append(i).Append("(func").Append(i).AppendLine("Param) {");
-            sb.Append("    ");
-            if (i != FunctionNestingCount)
-            {
-                // just to create a bit more nesting add some constructs
-                sb.Append("return x++ >= 1 ? func").Append(i + 1).Append("(func").Append(i).AppendLine("Param): undefined;");
-            }
-            else
-            {
-                // use known CLR function to add breakpoint
-                sb.Append("return Math.max(0, func").Append(i).AppendLine("Param);");
-            }
-
-            sb.AppendLine("}");
-            sb.AppendLine();
-        }
+        var script = GenerateCallTree(FunctionNestingCount);
 
         var engine = new Engine();
-        engine.Execute(sb.ToString());
+        engine.Execute(script);
         Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
         Assert.Equal(FunctionNestingCount, engine.Evaluate("x").AsNumber());
     }
@@ -53,18 +34,47 @@ public class EngineLimitTests
     [Fact]
     public void ShouldNotStackoverflowWhenStackGuardEnable()
     {
-        // Can be more than 10000, It does not hit stackoverflow anymore.
-        const int FunctionNestingCount = 10000;
+        // Can be more than actual dotnet stacktrace count, It does not hit stackoverflow anymore.
+        int functionNestingCount = FunctionNestingCount * 2;
 
-        // generate call tree
+        var script = GenerateCallTree(functionNestingCount);
+
+        var engine = new Engine(option => option.Constraints.MaxExecutionStackCount = functionNestingCount);
+        engine.Execute(script);
+        Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
+        Assert.Equal(functionNestingCount, engine.Evaluate("x").AsNumber());
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenStackGuardExceed()
+    {
+        // Can be more than actual dotnet stacktrace count, It does not hit stackoverflow anymore.
+        int functionNestingCount = FunctionNestingCount * 2;
+
+        var script = GenerateCallTree(functionNestingCount);
+
+        var engine = new Engine(option => option.Constraints.MaxExecutionStackCount = 500);
+        try
+        {
+            engine.Execute(script);
+            engine.Evaluate("func1(123);");
+        }
+        catch (JavaScriptException jsException)
+        {
+            Assert.Equal("Maximum call stack size exceeded", jsException.Message);
+        }
+    }
+
+    private string GenerateCallTree(int functionNestingCount)
+    {
         var sb = new StringBuilder();
         sb.AppendLine("var x = 1;");
         sb.AppendLine();
-        for (var i = 1; i <= FunctionNestingCount; ++i)
+        for (var i = 1; i <= functionNestingCount; ++i)
         {
             sb.Append("function func").Append(i).Append("(func").Append(i).AppendLine("Param) {");
             sb.Append("    ");
-            if (i != FunctionNestingCount)
+            if (i != functionNestingCount)
             {
                 // just to create a bit more nesting add some constructs
                 sb.Append("return x++ >= 1 ? func").Append(i + 1).Append("(func").Append(i).AppendLine("Param): undefined;");
@@ -78,11 +88,7 @@ public class EngineLimitTests
             sb.AppendLine("}");
             sb.AppendLine();
         }
-
-        var engine = new Engine(option => option.Constraints.MaxExecutionStackCount = FunctionNestingCount);
-        engine.Execute(sb.ToString());
-        Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
-        Assert.Equal(FunctionNestingCount, engine.Evaluate("x").AsNumber());
+        return sb.ToString();
     }
 }
 

--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -23,7 +23,7 @@ public class EngineLimitTests
 
         // generate call tree
         var sb = new StringBuilder();
-        sb.AppendLine("var x = 10;");
+        sb.AppendLine("var x = 1;");
         sb.AppendLine();
         for (var i = 1; i <= FunctionNestingCount; ++i)
         {
@@ -32,7 +32,7 @@ public class EngineLimitTests
             if (i != FunctionNestingCount)
             {
                 // just to create a bit more nesting add some constructs
-                sb.Append("return x++ > 1 ? func").Append(i + 1).Append("(func").Append(i).AppendLine("Param): undefined;");
+                sb.Append("return x++ >= 1 ? func").Append(i + 1).Append("(func").Append(i).AppendLine("Param): undefined;");
             }
             else
             {
@@ -47,6 +47,7 @@ public class EngineLimitTests
         var engine = new Engine();
         engine.Execute(sb.ToString());
         Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
+        Assert.Equal(FunctionNestingCount, engine.Evaluate("x").AsNumber());
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -9,21 +9,12 @@ public class EngineLimitTests
     [Fact]
     public void ShouldAllowReasonableCallStackDepth()
     {
-        if (OperatingSystem.IsMacOS())
-        {
-            // stack limit differ quite a lot
-            return;
-        }
-
-#if RELEASE
-        const int FunctionNestingCount = 960;
-#else
-        const int FunctionNestingCount = 520;
-#endif
+        // Can be more than 1000, It does not hit stackoverflow anymore.
+        const int FunctionNestingCount = 1000;
 
         // generate call tree
         var sb = new StringBuilder();
-        sb.AppendLine("var x = 10;");
+        sb.AppendLine("var x = 1;");
         sb.AppendLine();
         for (var i = 1; i <= FunctionNestingCount; ++i)
         {
@@ -32,7 +23,7 @@ public class EngineLimitTests
             if (i != FunctionNestingCount)
             {
                 // just to create a bit more nesting add some constructs
-                sb.Append("return x++ > 1 ? func").Append(i + 1).Append("(func").Append(i).AppendLine("Param): undefined;");
+                sb.Append("return x++ >= 1 ? func").Append(i + 1).Append("(func").Append(i).AppendLine("Param): undefined;");
             }
             else
             {
@@ -47,6 +38,7 @@ public class EngineLimitTests
         var engine = new Engine();
         engine.Execute(sb.ToString());
         Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
+        Assert.Equal(FunctionNestingCount, engine.Evaluate("x").AsNumber());
     }
 }
 

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1889,7 +1889,6 @@ var prep = function (fn) { fn(); };
         {
             new Engine(options => options.Constraints.MaxExecutionStackCount = 1000)
                             .SetValue("assert", new Action<bool>(Assert.True))
-                            .SetValue("log", new Action<object>(Console.WriteLine))
                             .Evaluate(@"
                     var count = 0;
                     function recurse() {
@@ -1902,8 +1901,6 @@ var prep = function (fn) { fn(); };
                         recurse();
                         assert(false);
                     } catch(err) {
-                        log(err);
-                        log(count);
                         assert(count >= 1000);
                     }
             ");

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1883,6 +1883,36 @@ var prep = function (fn) { fn(); };
             ");
         }
 
+
+        [Fact]
+        public void ShouldThrowErrorWhenMaxExecutionStackCountLimitExceeded()
+        {
+            try{
+                new Engine(options => options.Constraints.MaxExecutionStackCount = 1)
+                                .SetValue("assert", new Action<bool>(Assert.True))
+                                .Evaluate(@"
+                    var count = 0;
+                    function recurse() {
+                        count++;
+                        if(count > 100000) return;
+                        recurse();
+                        return null; // ensure no tail recursion
+                    }
+                    try {
+                        count = 0; 
+                        recurse();
+                        assert(false);
+                    } catch(err) {
+                        assert(true);
+                    }
+                ");
+                Assert.False(true);
+            } catch(InsufficientExecutionStackException){
+                Assert.True(true);
+            }
+        }
+
+
         [Fact]
         public void LocaleNumberShouldUseLocalCulture()
         {

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1887,14 +1887,13 @@ var prep = function (fn) { fn(); };
         [Fact]
         public void ShouldThrowErrorWhenMaxExecutionStackCountLimitExceeded()
         {
-            try{
-                new Engine(options => options.Constraints.MaxExecutionStackCount = 1)
-                                .SetValue("assert", new Action<bool>(Assert.True))
-                                .Evaluate(@"
+            new Engine(options => options.Constraints.MaxExecutionStackCount = 1000)
+                            .SetValue("assert", new Action<bool>(Assert.True))
+                            .SetValue("log", new Action<object>(Console.WriteLine))
+                            .Evaluate(@"
                     var count = 0;
                     function recurse() {
                         count++;
-                        if(count > 100000) return;
                         recurse();
                         return null; // ensure no tail recursion
                     }
@@ -1903,13 +1902,12 @@ var prep = function (fn) { fn(); };
                         recurse();
                         assert(false);
                     } catch(err) {
-                        assert(true);
+                        log(err);
+                        log(count);
+                        assert(count >= 1000);
                     }
-                ");
-                Assert.False(true);
-            } catch(InsufficientExecutionStackException){
-                Assert.True(true);
-            }
+            ");
+
         }
 
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -130,7 +130,7 @@ namespace Jint
             Options.Apply(this);
 
             CallStack = new JintCallStack(Options.Constraints.MaxRecursionDepth >= 0);
-            _stackGuard = new StackGuard();
+            _stackGuard = new StackGuard(Options.Constraints.MaxExecutionStackCount);
         }
 
         private void Reset()

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -63,6 +63,7 @@ namespace Jint
         internal ConditionalWeakTable<object, ObjectInstance>? _objectWrapperCache;
 
         internal readonly JintCallStack CallStack;
+        internal readonly StackGuard _stackGuard;
 
         // needed in initial engine setup, for example CLR function construction
         internal Intrinsics _originalIntrinsics = null!;
@@ -129,6 +130,7 @@ namespace Jint
             Options.Apply(this);
 
             CallStack = new JintCallStack(Options.Constraints.MaxRecursionDepth >= 0);
+            _stackGuard = new StackGuard();
         }
 
         private void Reset()

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -130,7 +130,7 @@ namespace Jint
             Options.Apply(this);
 
             CallStack = new JintCallStack(Options.Constraints.MaxRecursionDepth >= 0);
-            _stackGuard = new StackGuard(Options.Constraints.MaxExecutionStackCount);
+            _stackGuard = new StackGuard(this);
         }
 
         private void Reset()

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -9,6 +9,7 @@ using Jint.Runtime.Interop;
 using Jint.Runtime.Debugger;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Modules;
+using Jint.Runtime.CallStack;
 
 namespace Jint
 {
@@ -386,9 +387,9 @@ namespace Jint
         public int MaxRecursionDepth { get; set; } = -1;
 
         /// <summary>
-        /// Maximum recursion stack count, defaults to 14000 which comes from Chrome and V8 based engines (ClearScript) that can handle 13955.
+        /// Maximum recursion stack count, defaults to -1 (as-is dotnet stacktrace).
         /// </summary>
-        public int MaxExecutionStackCount { get; set; } = 14000;
+        public int MaxExecutionStackCount { get; set; } = StackGuard.Disabled;
 
         /// <summary>
         /// Maximum time a Regex is allowed to run, defaults to 10 seconds.

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -389,6 +389,11 @@ namespace Jint
         /// <summary>
         /// Maximum recursion stack count, defaults to -1 (as-is dotnet stacktrace).
         /// </summary>
+        /// <remarks>
+        /// Chrome and V8 based engines (ClearScript) that can handle 13955.
+        /// When set to a different value except -1, it can reduce slight performance/stack trace readability drawback. (after hitting the engine's own limit),
+        /// When max stack size to be exceeded, Engine throws an exception <see cref="JavaScriptException">.
+        /// </remarks>
         public int MaxExecutionStackCount { get; set; } = StackGuard.Disabled;
 
         /// <summary>

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -386,9 +386,9 @@ namespace Jint
         public int MaxRecursionDepth { get; set; } = -1;
 
         /// <summary>
-        /// Maximum recursion stack count, defaults to 1024.
+        /// Maximum recursion stack count, defaults to 14000 which comes from Chrome and V8 based engines (ClearScript) that can handle 13955.
         /// </summary>
-        public int MaxExecutionStackCount { get; set; } = 1024;
+        public int MaxExecutionStackCount { get; set; } = 14000;
 
         /// <summary>
         /// Maximum time a Regex is allowed to run, defaults to 10 seconds.

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -386,6 +386,11 @@ namespace Jint
         public int MaxRecursionDepth { get; set; } = -1;
 
         /// <summary>
+        /// Maximum recursion stack count, defaults to 1024.
+        /// </summary>
+        public int MaxExecutionStackCount { get; set; } = 1024;
+
+        /// <summary>
         /// Maximum time a Regex is allowed to run, defaults to 10 seconds.
         /// </summary>
         public TimeSpan RegexTimeout { get; set; } = TimeSpan.FromSeconds(10);

--- a/Jint/Runtime/CallStack/StackGuard.cs
+++ b/Jint/Runtime/CallStack/StackGuard.cs
@@ -5,12 +5,13 @@
 
 using System.Runtime.CompilerServices;
 using System.Threading;
-using Jint.Runtime.Interpreter;
 
 namespace Jint.Runtime.CallStack;
 
 internal sealed class StackGuard
 {
+    public const int Disabled = -1;
+
     private readonly Engine _engine;
 
     public StackGuard(Engine engine)
@@ -20,6 +21,11 @@ internal sealed class StackGuard
 
     public bool TryEnterOnCurrentStack()
     {
+        if (_engine.Options.Constraints.MaxExecutionStackCount == Disabled)
+        {
+            return true;
+        }
+
 #if NETFRAMEWORK || NETSTANDARD2_0
         try
         {

--- a/Jint/Runtime/CallStack/StackGuard.cs
+++ b/Jint/Runtime/CallStack/StackGuard.cs
@@ -52,7 +52,7 @@ internal sealed class StackGuard
         // Prefer ValueTuple when available to reduce dependencies on Tuple
         return RunOnEmptyStackCore(static s =>
         {
-            var t = ((Func<T1, TR>, T1))s;
+            var t = ((Func<T1, TR>, T1)) s;
             return t.Item1(t.Item2);
         }, (action, arg1));
 #endif

--- a/Jint/Runtime/CallStack/StackGuard.cs
+++ b/Jint/Runtime/CallStack/StackGuard.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// https://github.com/dotnet/runtime/blob/a0964f9e3793cb36cc01d66c14a61e89ada5e7da/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/StackGuard.cs
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Jint.Runtime.CallStack;
+
+internal sealed class StackGuard
+{
+    private const int MaxExecutionStackCount = 1024;
+
+    private int _executionStackCount;
+
+    public bool TryEnterOnCurrentStack()
+    {
+#if NETFRAMEWORK || NETSTANDARD2_0
+        try
+        {
+            RuntimeHelpers.EnsureSufficientExecutionStack();
+            return true;
+        }
+        catch (InsufficientExecutionStackException)
+        {
+        }
+#else
+        if (RuntimeHelpers.TryEnsureSufficientExecutionStack())
+        {
+            return true;
+        }
+#endif
+
+        if (_executionStackCount < MaxExecutionStackCount)
+        {
+            return false;
+        }
+
+        throw new InsufficientExecutionStackException();
+    }
+
+    public TR RunOnEmptyStack<T1, TR>(Func<T1, TR> action, T1 arg1)
+    {
+#if NETFRAMEWORK || NETSTANDARD2_0
+        return RunOnEmptyStackCore(static s =>
+        {
+            var t = (Tuple<Func<T1, TR>, T1>) s;
+            return t.Item1(t.Item2);
+        }, Tuple.Create(action, arg1));
+#else
+        // Prefer ValueTuple when available to reduce dependencies on Tuple
+        return RunOnEmptyStackCore(static s =>
+        {
+            var t = ((Func<T1, TR>, T1))s;
+            return t.Item1(t.Item2);
+        }, (action, arg1));
+#endif
+    }
+
+    private R RunOnEmptyStackCore<R>(Func<object, R> action, object state)
+    {
+        _executionStackCount++;
+
+        try
+        {
+            // Using default scheduler rather than picking up the current scheduler.
+            Task<R> task = Task.Factory.StartNew((Func<object?, R>) action, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+
+            // Avoid AsyncWaitHandle lazy allocation of ManualResetEvent in the rare case we finish quickly.
+            if (!task.IsCompleted)
+            {
+                // Task.Wait has the potential of inlining the task's execution on the current thread; avoid this.
+                ((IAsyncResult) task).AsyncWaitHandle.WaitOne();
+            }
+
+            // Using awaiter here to propagate original exception
+            return task.GetAwaiter().GetResult();
+        }
+        finally
+        {
+            _executionStackCount--;
+        }
+    }
+}

--- a/Jint/Runtime/CallStack/StackGuard.cs
+++ b/Jint/Runtime/CallStack/StackGuard.cs
@@ -11,14 +11,14 @@ namespace Jint.Runtime.CallStack;
 
 internal sealed class StackGuard
 {
-    private readonly int _maxExecutionStackCount;
+    private readonly Engine _engine;
 
-    public StackGuard(int maxExecutionStackCount)
+    public StackGuard(Engine engine)
     {
-        _maxExecutionStackCount = maxExecutionStackCount;
+        _engine = engine;
     }
 
-    public bool TryEnterOnCurrentStack(EvaluationContext context)
+    public bool TryEnterOnCurrentStack()
     {
 #if NETFRAMEWORK || NETSTANDARD2_0
         try
@@ -36,9 +36,9 @@ internal sealed class StackGuard
         }
 #endif
 
-        if (context.Engine.CallStack.Count > _maxExecutionStackCount)
+        if (_engine.CallStack.Count > _engine.Options.Constraints.MaxExecutionStackCount)
         {
-            ExceptionHelper.ThrowRangeError(context.Engine.Realm, "Maximum call stack size exceeded");
+            ExceptionHelper.ThrowRangeError(_engine.Realm, "Maximum call stack size exceeded");
         }
 
         return false;
@@ -60,6 +60,7 @@ internal sealed class StackGuard
             return t.Item1(t.Item2);
         }, (action, arg1));
 #endif
+
     }
 
     private R RunOnEmptyStackCore<R>(Func<object, R> action, object state)

--- a/Jint/Runtime/CallStack/StackGuard.cs
+++ b/Jint/Runtime/CallStack/StackGuard.cs
@@ -10,9 +10,13 @@ namespace Jint.Runtime.CallStack;
 
 internal sealed class StackGuard
 {
-    private const int MaxExecutionStackCount = 1024;
-
+    private readonly int _maxExecutionStackCount;
     private int _executionStackCount;
+
+    public StackGuard(int maxExecutionStackCount)
+    {
+        _maxExecutionStackCount = maxExecutionStackCount;
+    }
 
     public bool TryEnterOnCurrentStack()
     {
@@ -32,7 +36,7 @@ internal sealed class StackGuard
         }
 #endif
 
-        if (_executionStackCount < MaxExecutionStackCount)
+        if (_executionStackCount < _maxExecutionStackCount)
         {
             return false;
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -78,6 +78,11 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
+            if (!context.Engine._stackGuard.TryEnterOnCurrentStack())
+            {
+                return context.Engine._stackGuard.RunOnEmptyStack(EvaluateInternal, context);
+            }
+
             if (_calleeExpression._expression.Type == Nodes.Super)
             {
                 return SuperCall(context);

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -78,7 +78,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
-            if (!context.Engine._stackGuard.TryEnterOnCurrentStack(context))
+            if (!context.Engine._stackGuard.TryEnterOnCurrentStack())
             {
                 return context.Engine._stackGuard.RunOnEmptyStack(EvaluateInternal, context);
             }

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -78,7 +78,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
-            if (!context.Engine._stackGuard.TryEnterOnCurrentStack())
+            if (!context.Engine._stackGuard.TryEnterOnCurrentStack(context))
             {
                 return context.Engine._stackGuard.RunOnEmptyStack(EvaluateInternal, context);
             }

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -2,7 +2,6 @@ using System.Runtime.CompilerServices;
 using Esprima;
 using Esprima.Ast;
 using Jint.Native;
-using Jint.Runtime.CallStack;
 using Jint.Runtime.Interpreter.Expressions;
 
 namespace Jint.Runtime.Interpreter.Statements
@@ -21,22 +20,15 @@ namespace Jint.Runtime.Interpreter.Statements
     {
         internal readonly Statement _statement;
         private bool _initialized;
-        private readonly StackGuard _stackGuard;
 
         protected JintStatement(Statement statement)
         {
             _statement = statement;
-            _stackGuard = new StackGuard();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Completion Execute(EvaluationContext context)
         {
-            if (!_stackGuard.TryEnterOnCurrentStack())
-            {
-                return _stackGuard.RunOnEmptyStack(Execute, context);
-            }
-
             if (_statement.Type != Nodes.BlockStatement)
             {
                 context.PrepareFor(_statement);


### PR DESCRIPTION
Extend Stack overflow #1159 

## Jint.Benchmark.SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Run|3d-cube|507.0 ms|0.50 ms|45002.7 KB|
| **New** |	|	| **514.5 ms (+1%)** | **1.41 ms** | **45002.7 KB (0%)** |
| Old |Run|3d-morph|369.2 ms|0.89 ms|46270.99 KB|
| **New** |	|	| **369.6 ms (0%)** | **6.06 ms** | **46270.99 KB (0%)** |
| Old |Run|3d-raytrace|393.1 ms|1.18 ms|86663.02 KB|
| **New** |	|	| **416.6 ms (+6%)** | **1.55 ms** | **86663.95 KB (0%)** |
| Old |Run|access-binary-trees|184.1 ms|0.47 ms|62246.95 KB|
| **New** |	|	| **185.2 ms (+1%)** | **0.85 ms** | **62246.95 KB (0%)** |
| Old |Run|access-fannkuch|1,143.4 ms|2.64 ms|140.84 KB|
| **New** |	|	| **1,155.2 ms (+1%)** | **3.39 ms** | **140.84 KB (0%)** |
| Old |Run|access-nbody|451.6 ms|0.85 ms|53295.24 KB|
| **New** |	|	| **447.7 ms (-1%)** | **0.78 ms** | **53295.37 KB (0%)** |
| Old |Run|access-nsieve|351.6 ms|1.11 ms|17154.28 KB|
| **New** |	|	| **356.1 ms (+1%)** | **3.71 ms** | **17154.28 KB (0%)** |
| Old |Run|bitop(...)-byte [24]|326.1 ms|0.55 ms|61949.2 KB|
| **New** |	|	| **327.0 ms (0%)** | **1.40 ms** | **61951.05 KB (0%)** |
| Old |Run|bitops-bits-in-byte|512.6 ms|0.63 ms|40557.47 KB|
| **New** |	|	| **513.6 ms (0%)** | **1.46 ms** | **40556.67 KB (0%)** |
| Old |Run|bitops-bitwise-and|316.0 ms|1.31 ms|55944.75 KB|
| **New** |	|	| **314.5 ms (0%)** | **0.55 ms** | **55938.98 KB (0%)** |
| Old |Run|bitops-nsieve-bits|508.8 ms|1.20 ms|53930.86 KB|
| **New** |	|	| **511.9 ms (+1%)** | **4.17 ms** | **53929.99 KB (0%)** |
| Old |Run|contr(...)rsive [21]|236.6 ms|0.57 ms|92773.68 KB|
| **New** |	|	| **240.7 ms (+2%)** | **1.70 ms** | **92774.11 KB (0%)** |
| Old |Run|crypto-aes|337.7 ms|0.56 ms|11040.45 KB|
| **New** |	|	| **334.7 ms (-1%)** | **1.06 ms** | **11061.7 KB (0%)** |
| Old |Run|crypto-md5|229.0 ms|0.78 ms|82159.74 KB|
| **New** |	|	| **228.8 ms (0%)** | **0.79 ms** | **82159.88 KB (0%)** |
| Old |Run|crypto-sha1|229.2 ms|0.97 ms|68861.36 KB|
| **New** |	|	| **231.7 ms (+1%)** | **0.98 ms** | **68861.36 KB (0%)** |
| Old |Run|date-format-tofte|244.0 ms|0.79 ms|49656.32 KB|
| **New** |	|	| **245.0 ms (0%)** | **1.16 ms** | **49656.11 KB (0%)** |
| Old |Run|date-format-xparb|125.7 ms|0.57 ms|26410.94 KB|
| **New** |	|	| **127.3 ms (+1%)** | **0.59 ms** | **26410.94 KB (0%)** |
| Old |Run|math-cordic|805.1 ms|1.68 ms|86858.78 KB|
| **New** |	|	| **746.2 ms (-7%)** | **1.18 ms** | **86858.78 KB (0%)** |
| Old |Run|math-partial-sums|280.0 ms|0.84 ms|49368.26 KB|
| **New** |	|	| **279.6 ms (0%)** | **0.71 ms** | **49366.21 KB (0%)** |
| Old |Run|math-spectral-norm|291.6 ms|5.46 ms|56616.28 KB|
| **New** |	|	| **281.5 ms (-3%)** | **1.28 ms** | **56618.43 KB (0%)** |
| Old |Run|regexp-dna|284.0 ms|2.02 ms|17660.88 KB|
| **New** |	|	| **288.3 ms (+2%)** | **2.31 ms** | **17778.14 KB (+1%)** |
| Old |Run|string-base64|178.7 ms|0.56 ms|9702.74 KB|
| **New** |	|	| **182.2 ms (+2%)** | **0.43 ms** | **9701.99 KB (0%)** |
| Old |Run|string-fasta|377.0 ms|1.28 ms|104772.56 KB|
| **New** |	|	| **372.4 ms (-1%)** | **1.61 ms** | **104772.56 KB (0%)** |
| Old |Run|string-tagcloud|159.3 ms|0.75 ms|41774.3 KB|
| **New** |	|	| **160.8 ms (+1%)** | **0.74 ms** | **42457.06 KB (+2%)** |
| Old |Run|string-unpack-code|166.1 ms|0.44 ms|77691 KB|
| **New** |	|	| **166.5 ms (0%)** | **1.23 ms** | **80397.21 KB (+3%)** |
| Old |Run|strin(...)input [21]|181.9 ms|0.77 ms|39533.89 KB|
| **New** |	|	| **183.7 ms (+1%)** | **1.54 ms** | **39533.89 KB (0%)** |




