### PR TITLE
Avoiding Mono's ParameterInfo[].AsSpan() bug

### DIFF
--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -134,9 +134,10 @@ namespace Jint.Runtime.Interop
                         if (parameters.Length > arguments.Length)
                         {
                             // all missing ones must be optional
-                            foreach (var parameter in parameters.AsSpan(parameters.Length - arguments.Length))
+                            int start = parameters.Length - arguments.Length + 1;
+                            for (var i = start; i < parameters.Length; i++)
                             {
-                                if (!parameter.IsOptional)
+                                if (!parameters[i].IsOptional)
                                 {
                                     // use original arguments
                                     return arguments;

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -134,7 +134,7 @@ namespace Jint.Runtime.Interop
                         if (parameters.Length > arguments.Length)
                         {
                             // all missing ones must be optional
-                            int start = parameters.Length - arguments.Length + 1;
+                            int start = parameters.Length - arguments.Length;
                             for (var i = start; i < parameters.Length; i++)
                             {
                                 if (!parameters[i].IsOptional)


### PR DESCRIPTION
Changed `AsSpan` usage in `TypeReference.Construct` to plain iteration.

#1543 (beta-2050) has a `ParameterInfo[].AsSpan` usage which will throw `ArrayTypeMismatchException` in Mono (I think only when the target method is static). 

It was reported to mono years ago (https://github.com/mono/mono/issues/17993), but like many other mono bugs, I don't think they will get fixed anytime soon or ever. 

This is breaking things like `new Color(1, 1, 1, 1)` with Unity, or anything similar to this:

```cs
// C#
public struct Foo {
    public Foo(float a, float b) {
    }

    public Foo(float a) {
    }
}
```

```js
// JS
new Foo(1, 1) // throws ArrayTypeMismatchException: Attempted to access an element as a type incompatible with the array.
```