### PR TITLE
Fix capturing group numbering bug and a few more regex-related issues

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -44,14 +44,8 @@
     "language/literals/regexp/named-groups/forward-reference.js",
 
     // RegExp handling problems
-    "built-ins/RegExp/named-groups/non-unicode-match.js",
-    "built-ins/RegExp/named-groups/non-unicode-property-names-valid.js",
-    "built-ins/RegExp/named-groups/unicode-match.js",
-    "built-ins/RegExp/named-groups/unicode-property-names-valid.js",
     "built-ins/RegExp/prototype/exec/S15.10.6.2_A1_T6.js",
-    "built-ins/String/prototype/split/separator-regexp.js",
     "language/literals/regexp/u-case-mapping.js",
-    "language/literals/regexp/u-surrogate-pairs-atom-escape-decimal.js",
 
     // requires investigation how to process complex function name evaluation for property
     "built-ins/Function/prototype/toString/method-computed-property-name.js",

--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Esprima" Version="3.0.0-rc-03" />
+    <PackageReference Include="Esprima" Version="3.0.0-rc-04" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
     <PackageReference Include="PolySharp" Version="1.13.1">

--- a/Jint/Native/RegExp/JsRegExp.cs
+++ b/Jint/Native/RegExp/JsRegExp.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Esprima;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
@@ -61,6 +62,8 @@ namespace Jint.Native.RegExp
                 }
             }
         }
+
+        public RegExpParseResult ParseResult { get; set; }
 
         public bool DotAll { get; private set; }
         public bool Global { get; private set; }

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -104,14 +104,15 @@ namespace Jint.Native.RegExp
 
             try
             {
-                var regExp = Scanner.AdaptRegExp(p, f, compiled: false, _engine.Options.Constraints.RegexTimeout);
+                var regExpParseResult = Scanner.AdaptRegExp(p, f, compiled: false, _engine.Options.Constraints.RegexTimeout);
 
-                if (regExp is null)
+                if (!regExpParseResult.Success)
                 {
-                    ExceptionHelper.ThrowSyntaxError(_realm, $"Unsupported regular expression: '/{p}/{flags}'");
+                    ExceptionHelper.ThrowSyntaxError(_realm, $"Unsupported regular expression. {regExpParseResult.ConversionError!.Description}");
                 }
 
-                r.Value = regExp;
+                r.Value = regExpParseResult.Regex!;
+                r.ParseResult = regExpParseResult;
             }
             catch (Exception ex)
             {
@@ -135,12 +136,13 @@ namespace Jint.Native.RegExp
             return r;
         }
 
-        public JsRegExp Construct(Regex regExp, string source, string flags)
+        public JsRegExp Construct(Regex regExp, string source, string flags, RegExpParseResult regExpParseResult = default)
         {
             var r = RegExpAlloc(this);
             r.Value = regExp;
             r.Source = source;
             r.Flags = flags;
+            r.ParseResult = regExpParseResult;
 
             RegExpInitialize(r);
 

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -76,12 +76,13 @@ namespace Jint.Runtime.Interpreter.Expressions
             if (expression.TokenType == TokenType.RegularExpression)
             {
                 var regExpLiteral = (RegExpLiteral) _expression;
-                if (regExpLiteral.Value is System.Text.RegularExpressions.Regex regex)
+                var regExpParseResult = regExpLiteral.ParseResult;
+                if (regExpParseResult.Success)
                 {
-                    return context.Engine.Realm.Intrinsics.RegExp.Construct(regex, regExpLiteral.Regex.Pattern, regExpLiteral.Regex.Flags);
+                    return context.Engine.Realm.Intrinsics.RegExp.Construct(regExpParseResult.Regex!, regExpLiteral.Regex.Pattern, regExpLiteral.Regex.Flags, regExpParseResult);
                 }
 
-                ExceptionHelper.ThrowSyntaxError(context.Engine.Realm, $"Unsupported regular expression: '{regExpLiteral.Regex.Pattern}/{regExpLiteral.Regex.Flags}'");
+                ExceptionHelper.ThrowSyntaxError(context.Engine.Realm, $"Unsupported regular expression. {regExpParseResult.ConversionError!.Description}");
             }
 
             return JsValue.FromObject(context.Engine, expression.Value);


### PR DESCRIPTION
Counterpart of https://github.com/sebastienros/esprima-dotnet/pull/392

Besides the issues mentioned in the linked PR, this one also fixes the fast path implementation of `RegExpPrototype.Split`, which is a bit broken.

Unfortunately, the remaining 2 test cases excluded [here](https://github.com/sebastienros/jint/compare/main...adams85:regexp-fixes?expand=1#diff-524efe3f200cee8c6ad344ec2f94e7f14b789909f63be3c1f6b6a9441ee7a5fe) cannot be fixed with our current regex handling approach due to the differences/limitations of the .NET regex engine.

Oh, and one more thing. I'm not sure about this: "https://github.com/adams85/jint/blob/95029c6cbbfc09e81749e39916841296a2e52f4d/Jint/Runtime/Interop/DefaultObjectConverter.cs#L31-L34" I'm afraid that passing a non-adapted, external `Regex` instance to Jint may lead to some pretty confusing behavior. 
