### PR TITLE
More improvements for CLR Interop

### DIFF
--- a/Jint.Repl/Program.cs
+++ b/Jint.Repl/Program.cs
@@ -66,22 +66,20 @@ namespace Jint.Repl
                 try
                 {
                     var result = engine.Evaluate(input, parserOptions);
+                    JsValue str = result;
                     if (!result.IsPrimitive() && result is not IPrimitiveInstance)
                     {
-                        var str = serializer.Serialize(result, JsValue.Undefined, "  ");
-                        Console.WriteLine(str);
+                        str = serializer.Serialize(result, JsValue.Undefined, "  ");
+                        if (str == JsValue.Undefined)
+                        {
+                            str = result;
+                        }
                     }
-                    else
+                    else if (result.IsString())
                     {
-                        if (result.IsString())
-                        {
-                            Console.WriteLine(serializer.Serialize(result, JsValue.Undefined, JsValue.Undefined));
-                        }
-                        else
-                        {
-                            Console.WriteLine(result);
-                        }
+                        str = serializer.Serialize(result, JsValue.Undefined, JsValue.Undefined);
                     }
+                    Console.WriteLine(str);
                 }
                 catch (JavaScriptException je)
                 {

--- a/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
+++ b/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
@@ -1,293 +1,291 @@
-﻿
+﻿namespace Jint.Tests.Runtime;
+
 using Jint.Runtime.Interop;
 
-namespace Jint.Tests.Runtime
+public class InteropExplicitTypeTests
 {
-    public class InteropExplicitTypeTests
+    public interface I1
     {
-        public interface I1
+        string Name { get; }
+    }
+
+    public class Super
+    {
+        public string Name { get; } = "Super";
+    }
+
+    public class CI1 : Super, I1
+    {
+        public new string Name { get; } = "CI1";
+
+        string I1.Name { get; } = "CI1 as I1";
+    }
+
+    public class Indexer<T>
+    {
+        private readonly T t;
+        public Indexer(T t)
         {
-            string Name { get; }
+            this.t = t;
+        }
+        public T this[int index]
+        {
+            get { return t; }
+        }
+    }
+
+    public class InterfaceHolder
+    {
+        public InterfaceHolder()
+        {
+            var ci1 = new CI1();
+            this.ci1 = ci1;
+            this.i1 = ci1;
+            this.super = ci1;
+
+            this.IndexerCI1 = new Indexer<CI1>(ci1);
+            this.IndexerI1 = new Indexer<I1>(ci1);
+            this.IndexerSuper = new Indexer<Super>(ci1);
         }
 
-        public class Super
+        public readonly CI1 ci1;
+        public readonly I1 i1;
+        public readonly Super super;
+
+        public CI1 CI1 { get => ci1; }
+        public I1 I1 { get => i1; }
+        public Super Super { get => super; }
+
+        public CI1 GetCI1() => ci1;
+        public I1 GetI1() => i1;
+        public Super GetSuper() => super;
+
+        public Indexer<CI1> IndexerCI1 { get; }
+        public Indexer<I1> IndexerI1 { get; }
+        public Indexer<Super> IndexerSuper { get; }
+
+    }
+
+    private readonly Engine _engine;
+    private readonly InterfaceHolder holder;
+
+    public InteropExplicitTypeTests()
+    {
+        holder = new InterfaceHolder();
+        _engine = new Engine(cfg => cfg.AllowClr(
+                    typeof(CI1).Assembly,
+                    typeof(Console).Assembly,
+                    typeof(File).Assembly))
+                .SetValue("log", new Action<object>(Console.WriteLine))
+                .SetValue("assert", new Action<bool>(Assert.True))
+                .SetValue("equal", new Action<object, object>(Assert.Equal))
+                .SetValue("holder", holder)
+        ;
+    }
+    [Fact]
+    public void EqualTest()
+    {
+        Assert.Equal(_engine.Evaluate("holder.I1"), _engine.Evaluate("holder.i1"));
+        Assert.NotEqual(_engine.Evaluate("holder.I1"), _engine.Evaluate("holder.ci1"));
+
+        Assert.Equal(_engine.Evaluate("holder.Super"), _engine.Evaluate("holder.super"));
+        Assert.NotEqual(_engine.Evaluate("holder.Super"), _engine.Evaluate("holder.ci1"));
+    }
+
+    [Fact]
+    public void ExplicitInterfaceFromField()
+    {
+        Assert.Equal(holder.i1.Name, _engine.Evaluate("holder.i1.Name"));
+        Assert.NotEqual(holder.i1.Name, _engine.Evaluate("holder.ci1.Name"));
+    }
+
+    [Fact]
+    public void ExplicitInterfaceFromProperty()
+    {
+        Assert.Equal(holder.I1.Name, _engine.Evaluate("holder.I1.Name"));
+        Assert.NotEqual(holder.I1.Name, _engine.Evaluate("holder.CI1.Name"));
+    }
+
+    [Fact]
+    public void ExplicitInterfaceFromMethod()
+    {
+        Assert.Equal(holder.GetI1().Name, _engine.Evaluate("holder.GetI1().Name"));
+        Assert.NotEqual(holder.GetI1().Name, _engine.Evaluate("holder.GetCI1().Name"));
+    }
+
+    [Fact]
+    public void ExplicitInterfaceFromIndexer()
+    {
+        Assert.Equal(holder.IndexerI1[0].Name, _engine.Evaluate("holder.IndexerI1[0].Name"));
+    }
+
+
+    [Fact]
+    public void SuperClassFromField()
+    {
+        Assert.Equal(holder.super.Name, _engine.Evaluate("holder.super.Name"));
+        Assert.NotEqual(holder.super.Name, _engine.Evaluate("holder.ci1.Name"));
+    }
+
+    [Fact]
+    public void SuperClassFromProperty()
+    {
+        Assert.Equal(holder.Super.Name, _engine.Evaluate("holder.Super.Name"));
+        Assert.NotEqual(holder.Super.Name, _engine.Evaluate("holder.CI1.Name"));
+    }
+
+    [Fact]
+    public void SuperClassFromMethod()
+    {
+        Assert.Equal(holder.GetSuper().Name, _engine.Evaluate("holder.GetSuper().Name"));
+        Assert.NotEqual(holder.GetSuper().Name, _engine.Evaluate("holder.GetCI1().Name"));
+    }
+
+    [Fact]
+    public void SuperClassFromIndexer()
+    {
+        Assert.Equal(holder.IndexerSuper[0].Name, _engine.Evaluate("holder.IndexerSuper[0].Name"));
+    }
+
+    public struct NullabeStruct : I1
+    {
+        public NullabeStruct()
         {
-            public string Name { get; } = "Super";
         }
+        public string name = "NullabeStruct";
 
-        public class CI1 : Super, I1
+        public string Name { get => name; }
+
+        string I1.Name { get => "NullabeStruct as I1"; }
+    }
+
+    public class NullableHolder
+    {
+        public I1 I1 { get; set; }
+        public NullabeStruct? NullabeStruct { get; set; }
+    }
+
+    [Fact]
+    public void TypedObjectWrapperForNullableType()
+    {
+        var nullableHolder = new NullableHolder();
+        _engine.SetValue("nullableHolder", nullableHolder);
+        _engine.SetValue("nullabeStruct", new NullabeStruct());
+
+        Assert.Equal(_engine.Evaluate("nullableHolder.NullabeStruct"), Native.JsValue.Null);
+        _engine.Evaluate("nullableHolder.NullabeStruct = nullabeStruct");
+        Assert.Equal(_engine.Evaluate("nullableHolder.NullabeStruct.Name"), nullableHolder.NullabeStruct?.Name);
+    }
+
+    [Fact]
+    public void ClrHelperUnwrap()
+    {
+        Assert.NotEqual(holder.CI1.Name, _engine.Evaluate("holder.I1.Name"));
+        Assert.Equal(holder.CI1.Name, _engine.Evaluate("clrHelper.unwrap(holder.I1).Name"));
+    }
+
+    [Fact]
+    public void ClrHelperWrap()
+    {
+        _engine.Execute("Jint = importNamespace('Jint');");
+        Assert.NotEqual(holder.I1.Name, _engine.Evaluate("holder.CI1.Name"));
+        Assert.Equal(holder.I1.Name, _engine.Evaluate("clrHelper.wrap(holder.CI1, Jint.Tests.Runtime.InteropExplicitTypeTests.I1).Name"));
+    }
+
+    [Fact]
+    public void ClrHelperTypeOf()
+    {
+        Action<Engine> runner = engine =>
         {
-            public new string Name { get; } = "CI1";
+            engine.SetValue("clrobj", new object());
+            Assert.Equal(engine.Evaluate("System.Object"), engine.Evaluate("clrHelper.typeOf(clrobj)"));
+        };
 
-            string I1.Name { get; } = "CI1 as I1";
-        }
-
-        public class Indexer<T>
+        runner.Invoke(new Engine(cfg =>
         {
-            private readonly T t;
-            public Indexer(T t)
-            {
-                this.t = t;
-            }
-            public T this[int index]
-            {
-                get { return t; }
-            }
-        }
+            cfg.AllowClr();
+            cfg.Interop.AllowGetType = true;
+        }));
 
-        public class InterfaceHolder
+        var ex = Assert.Throws<InvalidOperationException>(() =>
         {
-            public InterfaceHolder()
-            {
-                var ci1 = new CI1();
-                this.ci1 = ci1;
-                this.i1 = ci1;
-                this.super = ci1;
-
-                this.IndexerCI1 = new Indexer<CI1>(ci1);
-                this.IndexerI1 = new Indexer<I1>(ci1);
-                this.IndexerSuper = new Indexer<Super>(ci1);
-            }
-
-            public readonly CI1 ci1;
-            public readonly I1 i1;
-            public readonly Super super;
-
-            public CI1 CI1 { get => ci1; }
-            public I1 I1 { get => i1; }
-            public Super Super { get => super; }
-
-            public CI1 GetCI1() => ci1;
-            public I1 GetI1() => i1;
-            public Super GetSuper() => super;
-
-            public Indexer<CI1> IndexerCI1 { get; }
-            public Indexer<I1> IndexerI1 { get; }
-            public Indexer<Super> IndexerSuper { get; }
-
-        }
-
-        private readonly Engine _engine;
-        private readonly InterfaceHolder holder;
-
-        public InteropExplicitTypeTests()
-        {
-            holder = new InterfaceHolder();
-            _engine = new Engine(cfg => cfg.AllowClr(
-                        typeof(CI1).Assembly,
-                        typeof(Console).Assembly,
-                        typeof(File).Assembly))
-                    .SetValue("log", new Action<object>(Console.WriteLine))
-                    .SetValue("assert", new Action<bool>(Assert.True))
-                    .SetValue("equal", new Action<object, object>(Assert.Equal))
-                    .SetValue("holder", holder)
-            ;
-        }
-        [Fact]
-        public void EqualTest()
-        {
-            Assert.Equal(_engine.Evaluate("holder.I1"), _engine.Evaluate("holder.i1"));
-            Assert.NotEqual(_engine.Evaluate("holder.I1"), _engine.Evaluate("holder.ci1"));
-
-            Assert.Equal(_engine.Evaluate("holder.Super"), _engine.Evaluate("holder.super"));
-            Assert.NotEqual(_engine.Evaluate("holder.Super"), _engine.Evaluate("holder.ci1"));
-        }
-
-        [Fact]
-        public void ExplicitInterfaceFromField()
-        {
-            Assert.Equal(holder.i1.Name, _engine.Evaluate("holder.i1.Name"));
-            Assert.NotEqual(holder.i1.Name, _engine.Evaluate("holder.ci1.Name"));
-        }
-
-        [Fact]
-        public void ExplicitInterfaceFromProperty()
-        {
-            Assert.Equal(holder.I1.Name, _engine.Evaluate("holder.I1.Name"));
-            Assert.NotEqual(holder.I1.Name, _engine.Evaluate("holder.CI1.Name"));
-        }
-
-        [Fact]
-        public void ExplicitInterfaceFromMethod()
-        {
-            Assert.Equal(holder.GetI1().Name, _engine.Evaluate("holder.GetI1().Name"));
-            Assert.NotEqual(holder.GetI1().Name, _engine.Evaluate("holder.GetCI1().Name"));
-        }
-
-        [Fact]
-        public void ExplicitInterfaceFromIndexer()
-        {
-            Assert.Equal(holder.IndexerI1[0].Name, _engine.Evaluate("holder.IndexerI1[0].Name"));
-        }
-
-
-        [Fact]
-        public void SuperClassFromField()
-        {
-            Assert.Equal(holder.super.Name, _engine.Evaluate("holder.super.Name"));
-            Assert.NotEqual(holder.super.Name, _engine.Evaluate("holder.ci1.Name"));
-        }
-
-        [Fact]
-        public void SuperClassFromProperty()
-        {
-            Assert.Equal(holder.Super.Name, _engine.Evaluate("holder.Super.Name"));
-            Assert.NotEqual(holder.Super.Name, _engine.Evaluate("holder.CI1.Name"));
-        }
-
-        [Fact]
-        public void SuperClassFromMethod()
-        {
-            Assert.Equal(holder.GetSuper().Name, _engine.Evaluate("holder.GetSuper().Name"));
-            Assert.NotEqual(holder.GetSuper().Name, _engine.Evaluate("holder.GetCI1().Name"));
-        }
-
-        [Fact]
-        public void SuperClassFromIndexer()
-        {
-            Assert.Equal(holder.IndexerSuper[0].Name, _engine.Evaluate("holder.IndexerSuper[0].Name"));
-        }
-
-        public struct NullabeStruct: I1
-        {
-            public NullabeStruct()
-            {
-            }
-            public string name = "NullabeStruct";
-
-            public string Name { get => name; }
-
-            string I1.Name { get => "NullabeStruct as I1"; }
-        }
-
-        public class NullableHolder
-        {
-            public I1? I1 { get; set; }
-            public NullabeStruct? NullabeStruct { get; set; }
-        }
-
-        [Fact]
-        public void TypedObjectWrapperForNullableType()
-        {
-            var nullableHolder = new NullableHolder();
-            _engine.SetValue("nullableHolder", nullableHolder);
-            _engine.SetValue("nullabeStruct", new NullabeStruct());
-
-            Assert.Equal(_engine.Evaluate("nullableHolder.NullabeStruct"), Native.JsValue.Null);
-            _engine.Evaluate("nullableHolder.NullabeStruct = nullabeStruct");
-            Assert.Equal(_engine.Evaluate("nullableHolder.NullabeStruct.Name"), nullableHolder.NullabeStruct?.Name);
-        }
-
-        [Fact]
-        public void ClrUnwrap()
-        {
-            Assert.NotEqual(holder.CI1.Name, _engine.Evaluate("holder.I1.Name"));
-            Assert.Equal(holder.CI1.Name, _engine.Evaluate("clrUnwrap(holder.I1).Name"));
-        }
-
-        [Fact]
-        public void ClrWrap()
-        {
-            _engine.Execute("Jint = importNamespace('Jint');");
-            Assert.NotEqual(holder.I1.Name, _engine.Evaluate("holder.CI1.Name"));
-            Assert.Equal(holder.I1.Name, _engine.Evaluate("clrWrap(holder.CI1, Jint.Tests.Runtime.InteropExplicitTypeTests.I1).Name"));
-        }
-
-        [Fact]
-        public void ClrType()
-        {
-            Action<Engine> runner = engine =>
-            {
-                engine.SetValue("clrobj", new object());
-                Assert.Equal(engine.Evaluate("System.Object"), engine.Evaluate("clrType(clrobj)"));
-            };
-
             runner.Invoke(new Engine(cfg =>
             {
                 cfg.AllowClr();
-                cfg.Interop.AllowGetType = true;
             }));
+        });
+        Assert.Equal("Invalid when Engine.Options.Interop.AllowGetType == false", ex.Message);
+    }
 
-            var ex = Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            {
-                runner.Invoke(new Engine(cfg =>
-                {
-                    cfg.AllowClr();
-                }));
-            });
-            Assert.Equal("clrType is not defined", ex.Message);
-        }
-
-        [Fact]
-        public void ClrTypeForNestedType()
+    [Fact]
+    public void ClrHelperTypeOfForNestedType()
+    {
+        var engine = new Engine(cfg =>
         {
-            var engine = new Engine(cfg =>
-            {
-                cfg.AllowClr(GetType().Assembly);
-                cfg.Interop.AllowGetType = true;
-            });
+            cfg.AllowClr(GetType().Assembly);
+            cfg.Interop.AllowGetType = true;
+        });
 
-            engine.SetValue("holder", holder);
-            engine.Execute("Jint = importNamespace('Jint');");
-            Assert.Equal(engine.Evaluate("Jint.Tests.Runtime.InteropExplicitTypeTests.CI1"), engine.Evaluate("clrType(holder.CI1)"));
-            Assert.Equal(engine.Evaluate("Jint.Tests.Runtime.InteropExplicitTypeTests.I1"), engine.Evaluate("clrType(holder.I1)"));
-        }
+        engine.SetValue("holder", holder);
+        engine.Execute("Jint = importNamespace('Jint');");
+        Assert.Equal(engine.Evaluate("Jint.Tests.Runtime.InteropExplicitTypeTests.CI1"), engine.Evaluate("clrHelper.typeOf(holder.CI1)"));
+        Assert.Equal(engine.Evaluate("Jint.Tests.Runtime.InteropExplicitTypeTests.I1"), engine.Evaluate("clrHelper.typeOf(holder.I1)"));
+    }
 
-        public class TypeHolder
+    public class TypeHolder
+    {
+        public static Type Type => typeof(TypeHolder);
+    }
+
+    [Fact]
+    public void ClrHelperTypeToObject()
+    {
+        Action<Engine> runner = engine =>
         {
-            public static Type Type => typeof(TypeHolder);
-        }
+            engine.SetValue("TypeHolder", typeof(TypeHolder));
+            Assert.True(engine.Evaluate("TypeHolder") is TypeReference);
+            Assert.True(engine.Evaluate("clrHelper.typeToObject(TypeHolder)") is ObjectWrapper);
+        };
 
-        [Fact]
-        public void ClrTypeToObject()
+        runner.Invoke(new Engine(cfg =>
         {
-            Action<Engine> runner = engine =>
-            {
-                engine.SetValue("TypeHolder", typeof(TypeHolder));
-                Assert.True(engine.Evaluate("TypeHolder") is TypeReference);
-                Assert.True(engine.Evaluate("clrTypeToObject(TypeHolder)") is ObjectWrapper);
-            };
+            cfg.AllowClr();
+            cfg.Interop.AllowGetType = true;
+        }));
 
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
             runner.Invoke(new Engine(cfg =>
             {
                 cfg.AllowClr();
-                cfg.Interop.AllowGetType = true;
             }));
+        });
+        Assert.Equal("Invalid when Engine.Options.Interop.AllowGetType == false", ex.Message);
+    }
 
-            var ex = Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            {
-                runner.Invoke(new Engine(cfg =>
-                {
-                    cfg.AllowClr();
-                }));
-            });
-            Assert.Equal("clrTypeToObject is not defined", ex.Message);
-        }
-
-        [Fact]
-        public void ClrObjectToType()
+    [Fact]
+    public void ClrHelperObjectToType()
+    {
+        Action<Engine> runner = engine =>
         {
-            Action<Engine> runner = engine =>
-            {
-                engine.SetValue("TypeHolder", typeof(TypeHolder));
-                Assert.True(engine.Evaluate("TypeHolder.Type") is ObjectWrapper);
-                Assert.True(engine.Evaluate("clrObjectToType(TypeHolder.Type)") is TypeReference);
-            };
+            engine.SetValue("TypeHolder", typeof(TypeHolder));
+            Assert.True(engine.Evaluate("TypeHolder.Type") is ObjectWrapper);
+            Assert.True(engine.Evaluate("clrHelper.objectToType(TypeHolder.Type)") is TypeReference);
+        };
 
+        runner.Invoke(new Engine(cfg =>
+        {
+            cfg.AllowClr();
+            cfg.Interop.AllowGetType = true;
+        }));
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
             runner.Invoke(new Engine(cfg =>
             {
                 cfg.AllowClr();
-                cfg.Interop.AllowGetType = true;
             }));
-
-            var ex = Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            {
-                runner.Invoke(new Engine(cfg =>
-                {
-                    cfg.AllowClr();
-                }));
-            });
-            Assert.Equal("clrObjectToType is not defined", ex.Message);
-        }
+        });
+        Assert.Equal("Invalid when Engine.Options.Interop.AllowGetType == false", ex.Message);
     }
 }

--- a/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
+++ b/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
@@ -201,10 +201,9 @@ namespace Jint.Tests.Runtime
         [Fact]
         public void TestNestedClrType()
         {
-            // Important! nested type cannot be got from parent type, only from namespace
-            _engine.Execute("nsInteropExplicitTypeTests = importNamespace('Jint.Tests.Runtime.InteropExplicitTypeTests');");
-            Assert.Equal(_engine.Evaluate("nsInteropExplicitTypeTests.CI1"), _engine.Evaluate("clrType(holder.CI1)"));
-            Assert.Equal(_engine.Evaluate("nsInteropExplicitTypeTests.I1"), _engine.Evaluate("clrType(holder.I1)"));
+            _engine.Execute("Jint = importNamespace('Jint');");
+            Assert.Equal(_engine.Evaluate("Jint.Tests.Runtime.InteropExplicitTypeTests.CI1"), _engine.Evaluate("clrType(holder.CI1)"));
+            Assert.Equal(_engine.Evaluate("Jint.Tests.Runtime.InteropExplicitTypeTests.I1"), _engine.Evaluate("clrType(holder.I1)"));
         }
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.TypeReference.cs
+++ b/Jint.Tests/Runtime/InteropTests.TypeReference.cs
@@ -197,18 +197,4 @@ public partial class InteropTests
     {
         public string Value => "Hello world";
     }
-
-    public class TypeHolder
-    {
-        public static Type ThisType => typeof(TypeHolder);
-    }
-
-    [Fact]
-    public void ValueTypeAsTypeReferenceNotObjectWrapper()
-    {
-        var tt = TypeReference.CreateTypeReference<TypeHolder>(_engine);
-        _engine.SetValue("TypeHolder", tt);
-        Assert.Equal(tt, _engine.Evaluate("TypeHolder"));
-        Assert.Equal(tt, _engine.Evaluate("TypeHolder.ThisType"));
-    }
 }

--- a/Jint.Tests/Runtime/InteropTests.TypeReference.cs
+++ b/Jint.Tests/Runtime/InteropTests.TypeReference.cs
@@ -197,4 +197,18 @@ public partial class InteropTests
     {
         public string Value => "Hello world";
     }
+
+    public class TypeHolder
+    {
+        public static Type ThisType => typeof(TypeHolder);
+    }
+
+    [Fact]
+    public void ValueTypeAsTypeReferenceNotObjectWrapper()
+    {
+        var tt = TypeReference.CreateTypeReference<TypeHolder>(_engine);
+        _engine.SetValue("TypeHolder", tt);
+        Assert.Equal(tt, _engine.Evaluate("TypeHolder"));
+        Assert.Equal(tt, _engine.Evaluate("TypeHolder.ThisType"));
+    }
 }

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -1894,6 +1894,18 @@ namespace Jint.Tests.Runtime
         }
 
         [Fact]
+        public void ShouldGetNestedTypeFromParentType()
+        {
+            RunTest(@"
+                var Shapes = importNamespace('Shapes');
+                var usages = Shapes.Circle.Meta.Usage;
+                assert(usages.Public === 0);
+                assert(usages.Private === 1);
+                assert(usages.Internal === 11);
+            ");
+        }
+
+        [Fact]
         public void ShouldGetNestedNestedProp()
         {
             RunTest(@"

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -120,39 +120,9 @@ namespace Jint
                         (thisObj, arguments) =>
                             new NamespaceReference(engine, TypeConverter.ToString(arguments.At(0)))),
                     PropertyFlag.AllForbidden));
-                engine.Realm.GlobalObject.SetProperty("clrToString", new PropertyDescriptor(new ClrFunctionInstance(
-                        engine,
-                        "clrToString",
-                        ClrHelper.ClrToString),
+                engine.Realm.GlobalObject.SetProperty("clrHelper", new PropertyDescriptor(
+                    new ObjectWrapper(engine, new ClrHelper(Interop)),
                     PropertyFlag.AllForbidden));
-                engine.Realm.GlobalObject.SetProperty("clrUnwrap", new PropertyDescriptor(new ClrFunctionInstance(
-                        engine,
-                        "clrUnwrap",
-                        ClrHelper.ClrUnwrap),
-                    PropertyFlag.AllForbidden));
-                engine.Realm.GlobalObject.SetProperty("clrWrap", new PropertyDescriptor(new ClrFunctionInstance(
-                        engine,
-                        "clrWrap",
-                        ClrHelper.ClrWrap),
-                    PropertyFlag.AllForbidden));
-                if (Interop.AllowGetType)
-                {
-                    engine.Realm.GlobalObject.SetProperty("clrType", new PropertyDescriptor(new ClrFunctionInstance(
-                            engine,
-                            "clrType",
-                            ClrHelper.ClrType),
-                        PropertyFlag.AllForbidden));
-                    engine.Realm.GlobalObject.SetProperty("clrTypeToObject", new PropertyDescriptor(new ClrFunctionInstance(
-                            engine,
-                            "clrTypeToObject",
-                            ClrHelper.ClrTypeToObject),
-                        PropertyFlag.AllForbidden));
-                    engine.Realm.GlobalObject.SetProperty("clrObjectToType", new PropertyDescriptor(new ClrFunctionInstance(
-                            engine,
-                            "clrObjectToType",
-                            ClrHelper.ClrObjectToType),
-                        PropertyFlag.AllForbidden));
-                }
             }
 
             if (Interop.ExtensionMethodTypes.Count > 0)
@@ -203,10 +173,7 @@ namespace Jint
                 string name = overloads.Key;
                 PropertyDescriptor CreateMethodInstancePropertyDescriptor(ClrFunctionInstance? function)
                 {
-                    var instance = function is null
-                        ? new MethodInfoFunctionInstance(engine, MethodDescriptor.Build(overloads.ToList()), name)
-                        : new MethodInfoFunctionInstance(engine, MethodDescriptor.Build(overloads.ToList()), name, function);
-
+                    var instance = new MethodInfoFunctionInstance(engine, objectType, name, MethodDescriptor.Build(overloads.ToList()), function);
                     return new PropertyDescriptor(instance, PropertyFlag.AllForbidden);
                 }
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -120,26 +120,39 @@ namespace Jint
                         (thisObj, arguments) =>
                             new NamespaceReference(engine, TypeConverter.ToString(arguments.At(0)))),
                     PropertyFlag.AllForbidden));
+                engine.Realm.GlobalObject.SetProperty("clrToString", new PropertyDescriptor(new ClrFunctionInstance(
+                        engine,
+                        "clrToString",
+                        ClrHelper.ClrToString),
+                    PropertyFlag.AllForbidden));
                 engine.Realm.GlobalObject.SetProperty("clrUnwrap", new PropertyDescriptor(new ClrFunctionInstance(
-                    engine,
-                    "clrUnwrap",
-                    ClrHelper.ClrUnwrap),
+                        engine,
+                        "clrUnwrap",
+                        ClrHelper.ClrUnwrap),
                     PropertyFlag.AllForbidden));
                 engine.Realm.GlobalObject.SetProperty("clrWrap", new PropertyDescriptor(new ClrFunctionInstance(
-                    engine,
-                    "clrWrap",
-                    ClrHelper.ClrWrap),
+                        engine,
+                        "clrWrap",
+                        ClrHelper.ClrWrap),
                     PropertyFlag.AllForbidden));
-                engine.Realm.GlobalObject.SetProperty("clrType", new PropertyDescriptor(new ClrFunctionInstance(
-                    engine,
-                    "clrType",
-                    ClrHelper.ClrType),
-                    PropertyFlag.AllForbidden));
-                engine.Realm.GlobalObject.SetProperty("clrToString", new PropertyDescriptor(new ClrFunctionInstance(
-                    engine,
-                    "clrToString",
-                    ClrHelper.ClrToString),
-                    PropertyFlag.AllForbidden));
+                if (Interop.AllowGetType)
+                {
+                    engine.Realm.GlobalObject.SetProperty("clrType", new PropertyDescriptor(new ClrFunctionInstance(
+                            engine,
+                            "clrType",
+                            ClrHelper.ClrType),
+                        PropertyFlag.AllForbidden));
+                    engine.Realm.GlobalObject.SetProperty("clrTypeToObject", new PropertyDescriptor(new ClrFunctionInstance(
+                            engine,
+                            "clrTypeToObject",
+                            ClrHelper.ClrTypeToObject),
+                        PropertyFlag.AllForbidden));
+                    engine.Realm.GlobalObject.SetProperty("clrObjectToType", new PropertyDescriptor(new ClrFunctionInstance(
+                            engine,
+                            "clrObjectToType",
+                            ClrHelper.ClrObjectToType),
+                        PropertyFlag.AllForbidden));
+                }
             }
 
             if (Interop.ExtensionMethodTypes.Count > 0)

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -120,21 +120,25 @@ namespace Jint
                         (thisObj, arguments) =>
                             new NamespaceReference(engine, TypeConverter.ToString(arguments.At(0)))),
                     PropertyFlag.AllForbidden));
-                engine.Realm.GlobalObject.SetProperty("unwrapClr", new PropertyDescriptor(new ClrFunctionInstance(
+                engine.Realm.GlobalObject.SetProperty("clrUnwrap", new PropertyDescriptor(new ClrFunctionInstance(
                     engine,
-                    "unwrapClr",
-                    (thisObj, arguments) =>
-                    {
-                        var arg = arguments.At(0);
-                        if (arg is ObjectWrapper obj)
-                        {
-                            return new ObjectWrapper(engine, obj.Target);
-                        }
-                        else
-                        {
-                            return arg;
-                        }
-                    }),
+                    "clrUnwrap",
+                    ClrHelper.ClrUnwrap),
+                    PropertyFlag.AllForbidden));
+                engine.Realm.GlobalObject.SetProperty("clrWrap", new PropertyDescriptor(new ClrFunctionInstance(
+                    engine,
+                    "clrWrap",
+                    ClrHelper.ClrWrap),
+                    PropertyFlag.AllForbidden));
+                engine.Realm.GlobalObject.SetProperty("clrType", new PropertyDescriptor(new ClrFunctionInstance(
+                    engine,
+                    "clrType",
+                    ClrHelper.ClrType),
+                    PropertyFlag.AllForbidden));
+                engine.Realm.GlobalObject.SetProperty("clrToString", new PropertyDescriptor(new ClrFunctionInstance(
+                    engine,
+                    "clrToString",
+                    ClrHelper.ClrToString),
                     PropertyFlag.AllForbidden));
             }
 
@@ -183,11 +187,12 @@ namespace Jint
 
             foreach (var overloads in methods.GroupBy(x => x.Name))
             {
+                string name = overloads.Key;
                 PropertyDescriptor CreateMethodInstancePropertyDescriptor(ClrFunctionInstance? function)
                 {
                     var instance = function is null
-                        ? new MethodInfoFunctionInstance(engine, MethodDescriptor.Build(overloads.ToList()))
-                        : new MethodInfoFunctionInstance(engine, MethodDescriptor.Build(overloads.ToList()), function);
+                        ? new MethodInfoFunctionInstance(engine, MethodDescriptor.Build(overloads.ToList()), name)
+                        : new MethodInfoFunctionInstance(engine, MethodDescriptor.Build(overloads.ToList()), name, function);
 
                     return new PropertyDescriptor(instance, PropertyFlag.AllForbidden);
                 }

--- a/Jint/Runtime/Interop/ClrFunctionInstance.cs
+++ b/Jint/Runtime/Interop/ClrFunctionInstance.cs
@@ -10,7 +10,6 @@ namespace Jint.Runtime.Interop
     /// </summary>
     public sealed class ClrFunctionInstance : FunctionInstance, IEquatable<ClrFunctionInstance>
     {
-        private readonly string? _name;
         internal readonly Func<JsValue, JsValue[], JsValue> _func;
 
         public ClrFunctionInstance(
@@ -19,9 +18,8 @@ namespace Jint.Runtime.Interop
             Func<JsValue, JsValue[], JsValue> func,
             int length = 0,
             PropertyFlag lengthFlags = PropertyFlag.AllForbidden)
-            : base(engine, engine.Realm, name != null ? new JsString(name) : null)
+            : base(engine, engine.Realm, new JsString(name))
         {
-            _name = name;
             _func = func;
 
             _prototype = engine._originalIntrinsics.Function.PrototypeObject;
@@ -76,7 +74,5 @@ namespace Jint.Runtime.Interop
 
             return false;
         }
-
-        public override string ToString() => "function " + _name + "() { [native code] }";
     }
 }

--- a/Jint/Runtime/Interop/ClrHelper.cs
+++ b/Jint/Runtime/Interop/ClrHelper.cs
@@ -31,12 +31,34 @@ namespace Jint.Runtime.Interop
             {
                 return TypeReference.CreateTypeReference(obj.Engine, obj.ClrType);
             }
-            return JsValue.Null;
+            return JsValue.Undefined;
         }
 
         public static JsValue ClrToString(JsValue thisObject, JsValue[] arguments)
         {
             return arguments.At(0).ToString();
+        }
+
+
+        public static JsValue ClrTypeToObject(JsValue thisObject, JsValue[] arguments)
+        {
+            var arg = arguments.At(0);
+            if (arg is TypeReference tr)
+            {
+                var engine = tr.Engine;
+                return engine.Options.Interop.WrapObjectHandler.Invoke(engine, tr.ReferenceType, null) ?? JsValue.Undefined;
+            }
+            return JsValue.Undefined;
+        }
+
+        public static JsValue ClrObjectToType(JsValue thisObject, JsValue[] arguments)
+        {
+            var arg = arguments.At(0);
+            if (arg is ObjectWrapper obj && obj.Target is Type t)
+            {
+                return TypeReference.CreateTypeReference(obj.Engine, t);
+            }
+            return JsValue.Undefined;
         }
     }
 }

--- a/Jint/Runtime/Interop/ClrHelper.cs
+++ b/Jint/Runtime/Interop/ClrHelper.cs
@@ -1,0 +1,42 @@
+﻿using Jint.Native;
+
+namespace Jint.Runtime.Interop
+{
+    public static class ClrHelper
+    {
+        public static JsValue ClrUnwrap(JsValue thisObject, JsValue[] arguments)
+        {
+            var arg = arguments.At(0);
+            if (arg is ObjectWrapper obj)
+            {
+                return new ObjectWrapper(obj.Engine, obj.Target);
+            }
+            return arg;
+        }
+
+        public static JsValue ClrWrap(JsValue thisObject, JsValue[] arguments)
+        {
+            var arg = arguments.At(0);
+            if (arg is ObjectWrapper obj && arguments.At(1) is TypeReference type)
+            {
+                return new ObjectWrapper(obj.Engine, obj.Target, type.ReferenceType);
+            }
+            return arg;
+        }
+
+        public static JsValue ClrType(JsValue thisObject, JsValue[] arguments)
+        {
+            var arg = arguments.At(0);
+            if (arg is ObjectWrapper obj)
+            {
+                return TypeReference.CreateTypeReference(obj.Engine, obj.ClrType);
+            }
+            return JsValue.Null;
+        }
+
+        public static JsValue ClrToString(JsValue thisObject, JsValue[] arguments)
+        {
+            return arguments.At(0).ToString();
+        }
+    }
+}

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -37,7 +37,7 @@ namespace Jint
         public static bool TryConvert(Engine engine, object value, Type? type, [NotNullWhen(true)] out JsValue? result)
         {
             result = null;
-            Type valueType = ObjectWrapper.ClrType(value, type);
+            Type valueType = ObjectWrapper.GetClrType(value, type);
 
             var typeMappers = _typeMappers;
 

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -100,6 +100,10 @@ namespace Jint
                             }
                         }
                     }
+                    else if (value is Type tt)
+                    {
+                        result = TypeReference.CreateTypeReference(engine, tt);
+                    }
                     else
                     {
                         // check global cache, have we already wrapped the value?

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -100,10 +100,6 @@ namespace Jint
                             }
                         }
                     }
-                    else if (value is Type tt)
-                    {
-                        result = TypeReference.CreateTypeReference(engine, tt);
-                    }
                     else
                     {
                         // check global cache, have we already wrapped the value?

--- a/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
@@ -9,19 +9,18 @@ namespace Jint.Runtime.Interop
 {
     internal sealed class MethodInfoFunctionInstance : FunctionInstance
     {
-        private static readonly JsString _name = new JsString("Function");
         private readonly MethodDescriptor[] _methods;
         private readonly ClrFunctionInstance? _fallbackClrFunctionInstance;
 
-        public MethodInfoFunctionInstance(Engine engine, MethodDescriptor[] methods)
-            : base(engine, engine.Realm, _name)
+        public MethodInfoFunctionInstance(Engine engine, MethodDescriptor[] methods, string name)
+            : base(engine, engine.Realm, new JsString(name))
         {
             _methods = methods;
             _prototype = engine.Realm.Intrinsics.Function.PrototypeObject;
         }
 
-        public MethodInfoFunctionInstance(Engine engine, MethodDescriptor[] methods, ClrFunctionInstance fallbackClrFunctionInstance)
-            : this(engine, methods)
+        public MethodInfoFunctionInstance(Engine engine, MethodDescriptor[] methods, string name, ClrFunctionInstance fallbackClrFunctionInstance)
+            : this(engine, methods, name)
         {
             _fallbackClrFunctionInstance = fallbackClrFunctionInstance;
         }

--- a/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunctionInstance.cs
@@ -9,20 +9,24 @@ namespace Jint.Runtime.Interop
 {
     internal sealed class MethodInfoFunctionInstance : FunctionInstance
     {
+        private readonly Type _targetType;
+        private readonly string _name;
         private readonly MethodDescriptor[] _methods;
         private readonly ClrFunctionInstance? _fallbackClrFunctionInstance;
 
-        public MethodInfoFunctionInstance(Engine engine, MethodDescriptor[] methods, string name)
+        public MethodInfoFunctionInstance(
+            Engine engine,
+            Type targetType,
+            string name,
+            MethodDescriptor[] methods,
+            ClrFunctionInstance? fallbackClrFunctionInstance = null)
             : base(engine, engine.Realm, new JsString(name))
         {
+            _targetType = targetType;
+            _name = name;
             _methods = methods;
-            _prototype = engine.Realm.Intrinsics.Function.PrototypeObject;
-        }
-
-        public MethodInfoFunctionInstance(Engine engine, MethodDescriptor[] methods, string name, ClrFunctionInstance fallbackClrFunctionInstance)
-            : this(engine, methods, name)
-        {
             _fallbackClrFunctionInstance = fallbackClrFunctionInstance;
+            _prototype = engine.Realm.Intrinsics.Function.PrototypeObject;
         }
 
         private static bool IsGenericParameter(object argObj, Type parameterType)
@@ -283,6 +287,11 @@ namespace Jint.Runtime.Interop
 
             newArgumentsCollection[nonParamsArgumentsCount] = jsArray;
             return newArgumentsCollection;
+        }
+
+        public override string ToString()
+        {
+            return $"function {_targetType}.{_name}() {{ [native code] }}";
         }
     }
 }

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -94,7 +94,7 @@ namespace Jint.Runtime.Interop
             // and only then in mscorlib. Probelm usage: System.IO.File.CreateText
 
             // search in loaded assemblies
-            var lookupAssemblies = new[] {Assembly.GetCallingAssembly(), Assembly.GetExecutingAssembly()};
+            var lookupAssemblies = new[] { Assembly.GetCallingAssembly(), Assembly.GetExecutingAssembly() };
 
             foreach (var assembly in lookupAssemblies)
             {
@@ -192,7 +192,7 @@ namespace Jint.Runtime.Interop
 
         public override string ToString()
         {
-            return "[clr namespace: " + _path + "]";
+            return "[CLR namespace: " + _path + "]";
         }
     }
 }

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -192,7 +192,7 @@ namespace Jint.Runtime.Interop
 
         public override string ToString()
         {
-            return "[Namespace: " + _path + "]";
+            return "[clr namespace: " + _path + "]";
         }
     }
 }

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -34,7 +34,7 @@ namespace Jint.Runtime.Interop
         }
 
         public object Target { get; }
-        public Type ClrType { get; }
+        internal Type ClrType { get; }
 
         public override bool IsArrayLike => _typeDescriptor.IsArrayLike;
 
@@ -254,7 +254,7 @@ namespace Jint.Runtime.Interop
                 return member switch
                 {
                     PropertyInfo pi => new PropertyAccessor(pi.Name, pi),
-                    MethodBase mb => new MethodAccessor(MethodDescriptor.Build(new[] {mb}), member.Name),
+                    MethodBase mb => new MethodAccessor(target.GetType(), member.Name, MethodDescriptor.Build(new[] { mb })),
                     FieldInfo fi => new FieldAccessor(fi),
                     _ => null
                 };
@@ -262,7 +262,7 @@ namespace Jint.Runtime.Interop
             return engine.Options.Interop.TypeResolver.GetAccessor(engine, target.GetType(), member.Name, Factory).CreatePropertyDescriptor(engine, target);
         }
 
-        public static Type GetClrType(object obj, Type? type)
+        internal static Type GetClrType(object obj, Type? type)
         {
             if (type is null || type == typeof(object))
             {
@@ -368,7 +368,7 @@ namespace Jint.Runtime.Interop
 
             public override void Close(CompletionType completion)
             {
-               (_enumerator as IDisposable)?.Dispose();
+                (_enumerator as IDisposable)?.Dispose();
                 base.Close(completion);
             }
 

--- a/Jint/Runtime/Interop/Reflection/MethodAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/MethodAccessor.cs
@@ -4,11 +4,13 @@ namespace Jint.Runtime.Interop.Reflection
 {
     internal sealed class MethodAccessor : ReflectionAccessor
     {
+        private readonly string _name;
         private readonly MethodDescriptor[] _methods;
 
-        public MethodAccessor(MethodDescriptor[] methods) : base(null!, null!)
+        public MethodAccessor(MethodDescriptor[] methods, string name) : base(null!, null!)
         {
             _methods = methods;
+            _name = name;
         }
 
         public override bool Writable => false;
@@ -24,7 +26,7 @@ namespace Jint.Runtime.Interop.Reflection
 
         public override PropertyDescriptor CreatePropertyDescriptor(Engine engine, object target, bool enumerable = true)
         {
-            return new(new MethodInfoFunctionInstance(engine, _methods), PropertyFlag.AllForbidden);
+            return new(new MethodInfoFunctionInstance(engine, _methods, _name), PropertyFlag.AllForbidden);
         }
     }
 }

--- a/Jint/Runtime/Interop/Reflection/MethodAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/MethodAccessor.cs
@@ -4,13 +4,16 @@ namespace Jint.Runtime.Interop.Reflection
 {
     internal sealed class MethodAccessor : ReflectionAccessor
     {
+        private readonly Type _targetType;
         private readonly string _name;
         private readonly MethodDescriptor[] _methods;
 
-        public MethodAccessor(MethodDescriptor[] methods, string name) : base(null!, null!)
+        public MethodAccessor(Type targetType, string name, MethodDescriptor[] methods)
+            : base(null!, name)
         {
-            _methods = methods;
+            _targetType = targetType;
             _name = name;
+            _methods = methods;
         }
 
         public override bool Writable => false;
@@ -26,7 +29,7 @@ namespace Jint.Runtime.Interop.Reflection
 
         public override PropertyDescriptor CreatePropertyDescriptor(Engine engine, object target, bool enumerable = true)
         {
-            return new(new MethodInfoFunctionInstance(engine, _methods, _name), PropertyFlag.AllForbidden);
+            return new(new MethodInfoFunctionInstance(engine, _targetType, _name, _methods), PropertyFlag.AllForbidden);
         }
     }
 }

--- a/Jint/Runtime/Interop/Reflection/NestedTypeAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/NestedTypeAccessor.cs
@@ -1,0 +1,21 @@
+
+namespace Jint.Runtime.Interop.Reflection
+{
+    internal sealed class NestedTypeAccessor : ReflectionAccessor
+    {
+        public NestedTypeAccessor(Type type, string name) : base(type, name)
+        {
+        }
+
+        public override bool Writable => false;
+
+        protected override object? DoGetValue(object target)
+        {
+            return _memberType;
+        }
+
+        protected override void DoSetValue(object target, object? value)
+        {
+        }
+    }
+}

--- a/Jint/Runtime/Interop/Reflection/NestedTypeAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/NestedTypeAccessor.cs
@@ -3,15 +3,17 @@ namespace Jint.Runtime.Interop.Reflection
 {
     internal sealed class NestedTypeAccessor : ReflectionAccessor
     {
-        public NestedTypeAccessor(Type type, string name) : base(type, name)
+        private readonly TypeReference _typeReference;
+        public NestedTypeAccessor(TypeReference typeReference, string name) : base(typeof(Type), name)
         {
+            _typeReference = typeReference;
         }
 
         public override bool Writable => false;
 
         protected override object? DoGetValue(object target)
         {
-            return _memberType;
+            return _typeReference;
         }
 
         protected override void DoSetValue(object target, object? value)

--- a/Jint/Runtime/Interop/Reflection/NestedTypeAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/NestedTypeAccessor.cs
@@ -1,23 +1,22 @@
+namespace Jint.Runtime.Interop.Reflection;
 
-namespace Jint.Runtime.Interop.Reflection
+internal sealed class NestedTypeAccessor : ReflectionAccessor
 {
-    internal sealed class NestedTypeAccessor : ReflectionAccessor
+    private readonly TypeReference _typeReference;
+
+    public NestedTypeAccessor(TypeReference typeReference, string name) : base(typeof(Type), name)
     {
-        private readonly TypeReference _typeReference;
-        public NestedTypeAccessor(TypeReference typeReference, string name) : base(typeof(Type), name)
-        {
-            _typeReference = typeReference;
-        }
+        _typeReference = typeReference;
+    }
 
-        public override bool Writable => false;
+    public override bool Writable => false;
 
-        protected override object? DoGetValue(object target)
-        {
-            return _typeReference;
-        }
+    protected override object? DoGetValue(object target)
+    {
+        return _typeReference;
+    }
 
-        protected override void DoSetValue(object target, object? value)
-        {
-        }
+    protected override void DoSetValue(object target, object? value)
+    {
     }
 }

--- a/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
@@ -12,7 +12,7 @@ namespace Jint.Runtime.Interop.Reflection
     /// </summary>
     internal abstract class ReflectionAccessor
     {
-        private readonly Type _memberType;
+        protected readonly Type _memberType;
         private readonly object? _memberName;
         private readonly PropertyInfo? _indexer;
 

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -349,7 +349,7 @@ namespace Jint.Runtime.Interop
 
         public override string ToString()
         {
-            return "[clr type: " + ReferenceType + "]";
+            return "[CLR type: " + ReferenceType + "]";
         }
     }
 }

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -346,5 +346,10 @@ namespace Jint.Runtime.Interop
 
             return derivedType != null && baseType != null && (derivedType == baseType || derivedType.IsSubclassOf(baseType));
         }
+
+        public override string ToString()
+        {
+            return "[clr type: " + ReferenceType + "]";
+        }
     }
 }

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -307,7 +307,8 @@ namespace Jint.Runtime.Interop
             var nestedType = type.GetNestedType(memberName, bindingFlags);
             if (nestedType != null)
             {
-                accessor = new NestedTypeAccessor(nestedType, memberName);
+                var typeReference = TypeReference.CreateTypeReference(engine, nestedType);
+                accessor = new NestedTypeAccessor(typeReference, memberName);
                 return true;
             }
 

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -303,6 +303,14 @@ namespace Jint.Runtime.Interop
                 return true;
             }
 
+            // look for nested type
+            var nestedType = type.GetNestedType(memberName, bindingFlags);
+            if (nestedType != null)
+            {
+                accessor = new NestedTypeAccessor(nestedType, memberName);
+                return true;
+            }
+
             accessor = default;
             return false;
         }

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -160,7 +160,7 @@ namespace Jint.Runtime.Interop
 
             if (explicitMethods?.Count > 0)
             {
-                return new MethodAccessor(MethodDescriptor.Build(explicitMethods));
+                return new MethodAccessor(MethodDescriptor.Build(explicitMethods), memberName);
             }
 
             // try to find explicit indexer implementations
@@ -193,7 +193,7 @@ namespace Jint.Runtime.Interop
 
                 if (matches.Count > 0)
                 {
-                    return new MethodAccessor(MethodDescriptor.Build(matches));
+                    return new MethodAccessor(MethodDescriptor.Build(matches), memberName);
                 }
             }
 
@@ -299,7 +299,7 @@ namespace Jint.Runtime.Interop
 
             if (methods?.Count > 0)
             {
-                accessor = new MethodAccessor(MethodDescriptor.Build(methods));
+                accessor = new MethodAccessor(MethodDescriptor.Build(methods), memberName);
                 return true;
             }
 

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -160,7 +160,7 @@ namespace Jint.Runtime.Interop
 
             if (explicitMethods?.Count > 0)
             {
-                return new MethodAccessor(MethodDescriptor.Build(explicitMethods), memberName);
+                return new MethodAccessor(type, memberName, MethodDescriptor.Build(explicitMethods));
             }
 
             // try to find explicit indexer implementations
@@ -193,7 +193,7 @@ namespace Jint.Runtime.Interop
 
                 if (matches.Count > 0)
                 {
-                    return new MethodAccessor(MethodDescriptor.Build(matches), memberName);
+                    return new MethodAccessor(type, memberName, MethodDescriptor.Build(matches));
                 }
             }
 
@@ -299,7 +299,7 @@ namespace Jint.Runtime.Interop
 
             if (methods?.Count > 0)
             {
-                accessor = new MethodAccessor(MethodDescriptor.Build(methods), memberName);
+                accessor = new MethodAccessor(type, memberName, MethodDescriptor.Build(methods));
                 return true;
             }
 


### PR DESCRIPTION
- Simplize nested CLR Type, can be got directly from parent type
- Add more CLR helper functions: clrUnwrap, clrWrap, clrToString, clrType, clrTypeToObject, clrObjectToType. The last 3 need Options.Interop.AllowGetType == true.
- Make CLR objects ToString meaningful: NamespaceReference, TypeReference, ClrFunctionInstance, MethodInfoFunctionInstance
- Make Jint.Repl call ToString when Serialize failed