### PR TITLE
Improve array access performance

### DIFF
--- a/Jint.Tests.PublicInterface/RavenApiUsageTests.cs
+++ b/Jint.Tests.PublicInterface/RavenApiUsageTests.cs
@@ -3,7 +3,6 @@ using Jint.Constraints;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Runtime;
-using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 
 namespace Jint.Tests.PublicInterface;
@@ -58,20 +57,6 @@ public class RavenApiUsageTests
     }
 
     [Fact]
-    public void CanConstructArrayInstanceFromDescriptorArray()
-    {
-        var descriptors = new[]
-        {
-            new PropertyDescriptor(42, writable: false, enumerable: false, configurable: false),
-        };
-
-        var engine = new Engine();
-        var array = new JsArray(engine, descriptors);
-        Assert.Equal(1L, array.Length);
-        Assert.Equal(42, array[0]);
-    }
-
-    [Fact]
     public void CanGetPropertyDescriptor()
     {
         var engine = new Engine();
@@ -97,15 +82,6 @@ public class RavenApiUsageTests
 
         TestArrayAccess(engine, array1, "array1");
 
-        var array3 = new JsArray(engine, new[]
-        {
-            new PropertyDescriptor(JsNumber.Create(1), true, true, true),
-            new PropertyDescriptor(JsNumber.Create(2), true, true, true),
-            new PropertyDescriptor(JsNumber.Create(3), true, true, true),
-        });
-        engine.SetValue("array3", array3);
-        TestArrayAccess(engine, array3, "array3");
-
         engine.SetValue("obj", obj);
         Assert.Equal("test", engine.Evaluate("obj.name"));
 
@@ -114,10 +90,6 @@ public class RavenApiUsageTests
         Assert.Equal(1, engine.Evaluate("emptyArray.push(1); return emptyArray.length"));
 
         engine.SetValue("emptyArray", new JsArray(engine, Array.Empty<JsValue>()));
-        Assert.Equal(0, engine.Evaluate("emptyArray.length"));
-        Assert.Equal(1, engine.Evaluate("emptyArray.push(1); return emptyArray.length"));
-
-        engine.SetValue("emptyArray", new JsArray(engine, Array.Empty<PropertyDescriptor>()));
         Assert.Equal(0, engine.Evaluate("emptyArray.length"));
         Assert.Equal(1, engine.Evaluate("emptyArray.push(1); return emptyArray.length"));
 

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -15,34 +15,30 @@ namespace Jint.Native.Array
         private const int MaxDenseArrayLength = 10_000_000;
 
         // we have dense and sparse, we usually can start with dense and fall back to sparse when necessary
-        // entries are lazy and can be either of type PropertyDescriptor or plain JsValue while there is no need for extra info
-        internal object?[]? _dense;
-        private Dictionary<uint, object?>? _sparse;
+        // when we have plain JsValues, _denseValues is used - if any operation occurs which requires setting more property flags
+        // we convert to _sparse and _denseValues is set to null - it will be a slow array
+        internal JsValue?[]? _dense;
+
+        private Dictionary<uint, PropertyDescriptor?>? _sparse;
 
         private ObjectChangeFlags _objectChangeFlags;
-        private bool _isObjectArray = true;
 
         private protected ArrayInstance(Engine engine, InternalTypes type) : base(engine, type: type)
         {
-            _dense = System.Array.Empty<object?>();
+            _dense = System.Array.Empty<JsValue?>();
         }
 
         private protected ArrayInstance(Engine engine, uint capacity = 0, uint length = 0) : base(engine, type: InternalTypes.Object | InternalTypes.Array)
         {
-            _prototype = engine.Realm.Intrinsics.Array.PrototypeObject;
-
-            if (capacity > engine.Options.Constraints.MaxArraySize)
-            {
-                ThrowMaximumArraySizeReachedException(engine, capacity);
-            }
+            InitializePrototypeAndValidateCapacity(engine, capacity);
 
             if (capacity < MaxDenseArrayLength)
             {
-                _dense = capacity > 0 ? new object?[capacity] : System.Array.Empty<object?>();
+                _dense = capacity > 0 ? new JsValue?[capacity] : System.Array.Empty<JsValue?>();
             }
             else
             {
-                _sparse = new Dictionary<uint, object?>(1024);
+                _sparse = new Dictionary<uint, PropertyDescriptor?>(1024);
             }
 
             _length = new PropertyDescriptor(length, PropertyFlag.OnlyWritable);
@@ -50,33 +46,12 @@ namespace Jint.Native.Array
 
         private protected ArrayInstance(Engine engine, JsValue[] items) : base(engine, type: InternalTypes.Object | InternalTypes.Array)
         {
-            Initialize(engine, items);
-        }
-
-        private protected ArrayInstance(Engine engine, PropertyDescriptor[] items) : base(engine, type: InternalTypes.Object | InternalTypes.Array)
-        {
-            Initialize(engine, items);
-        }
-
-        private protected ArrayInstance(Engine engine, object[] items) : base(engine, type: InternalTypes.Object | InternalTypes.Array)
-        {
-            Initialize(engine, items);
-        }
-
-        private void Initialize<T>(Engine engine, T[] items) where T : class
-        {
-            if (items.Length > engine.Options.Constraints.MaxArraySize)
-            {
-                ThrowMaximumArraySizeReachedException(engine, (uint) items.Length);
-            }
-
-            _prototype = engine.Realm.Intrinsics.Array.PrototypeObject;
-            _isObjectArray = typeof(T) == typeof(object);
+            InitializePrototypeAndValidateCapacity(engine, capacity: 0);
 
             int length;
             if (items == null || items.Length == 0)
             {
-                _dense = System.Array.Empty<object>();
+                _dense = System.Array.Empty<JsValue>();
                 length = 0;
             }
             else
@@ -86,6 +61,16 @@ namespace Jint.Native.Array
             }
 
             _length = new PropertyDescriptor(length, PropertyFlag.OnlyWritable);
+        }
+
+        private void InitializePrototypeAndValidateCapacity(Engine engine, uint capacity)
+        {
+            _prototype = engine.Realm.Intrinsics.Array.PrototypeObject;
+
+            if (capacity > engine.Options.Constraints.MaxArraySize)
+            {
+                ThrowMaximumArraySizeReachedException(engine, capacity);
+            }
         }
 
         public sealed override bool IsArrayLike => true;
@@ -133,149 +118,155 @@ namespace Jint.Native.Array
 
         public sealed override bool DefineOwnProperty(JsValue property, PropertyDescriptor desc)
         {
+            if (property == CommonProperties.Length)
+            {
+                return DefineLength(desc);
+            }
+
             var isArrayIndex = IsArrayIndex(property, out var index);
             TrackChanges(property, desc, isArrayIndex);
 
             if (isArrayIndex)
             {
+                ConvertToSparse();
                 return DefineOwnProperty(index, desc);
             }
 
-            if (property == CommonProperties.Length)
+            return base.DefineOwnProperty(property, desc);
+        }
+
+        private bool DefineLength(PropertyDescriptor desc)
+        {
+            var value = desc.Value;
+            if (ReferenceEquals(value, null))
             {
-                var value = desc.Value;
-                if (ReferenceEquals(value, null))
-                {
-                    return base.DefineOwnProperty(CommonProperties.Length, desc);
-                }
-
-                var newLenDesc = new PropertyDescriptor(desc);
-                uint newLen = TypeConverter.ToUint32(value);
-                if (newLen != TypeConverter.ToNumber(value))
-                {
-                    ExceptionHelper.ThrowRangeError(_engine.Realm);
-                }
-
-                var oldLenDesc = _length;
-                var oldLen = (uint) TypeConverter.ToNumber(oldLenDesc!.Value);
-
-                newLenDesc.Value = newLen;
-                if (newLen >= oldLen)
-                {
-                    return base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
-                }
-
-                if (!oldLenDesc.Writable)
-                {
-                    return false;
-                }
-
-                bool newWritable;
-                if (!newLenDesc.WritableSet || newLenDesc.Writable)
-                {
-                    newWritable = true;
-                }
-                else
-                {
-                    newWritable = false;
-                    newLenDesc.Writable = true;
-                }
-
-                var succeeded = base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
-                if (!succeeded)
-                {
-                    return false;
-                }
-
-                var count = _dense?.Length ?? _sparse!.Count;
-                if (count < oldLen - newLen)
-                {
-                    if (_dense != null)
-                    {
-                        for (uint keyIndex = 0; keyIndex < _dense.Length; ++keyIndex)
-                        {
-                            if (_dense[keyIndex] == null)
-                            {
-                                continue;
-                            }
-
-                            // is it the index of the array
-                            if (keyIndex >= newLen && keyIndex < oldLen)
-                            {
-                                var deleteSucceeded = Delete(keyIndex);
-                                if (!deleteSucceeded)
-                                {
-                                    newLenDesc.Value = keyIndex + 1;
-                                    if (!newWritable)
-                                    {
-                                        newLenDesc.Writable = false;
-                                    }
-
-                                    base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
-                                    return false;
-                                }
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // in the case of sparse arrays, treat each concrete element instead of
-                        // iterating over all indexes
-                        var keys = new List<uint>(_sparse!.Keys);
-                        var keysCount = keys.Count;
-                        for (var i = 0; i < keysCount; i++)
-                        {
-                            var keyIndex = keys[i];
-
-                            // is it the index of the array
-                            if (keyIndex >= newLen && keyIndex < oldLen)
-                            {
-                                var deleteSucceeded = Delete(TypeConverter.ToString(keyIndex));
-                                if (!deleteSucceeded)
-                                {
-                                    newLenDesc.Value = JsNumber.Create(keyIndex + 1);
-                                    if (!newWritable)
-                                    {
-                                        newLenDesc.Writable = false;
-                                    }
-
-                                    base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
-                                    return false;
-                                }
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    while (newLen < oldLen)
-                    {
-                        // algorithm as per the spec
-                        oldLen--;
-                        var deleteSucceeded = Delete(oldLen);
-                        if (!deleteSucceeded)
-                        {
-                            newLenDesc.Value = oldLen + 1;
-                            if (!newWritable)
-                            {
-                                newLenDesc.Writable = false;
-                            }
-
-                            base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
-                            return false;
-                        }
-                    }
-                }
-
-                if (!newWritable)
-                {
-                    base.DefineOwnProperty(CommonProperties.Length, new PropertyDescriptor(value: null, PropertyFlag.WritableSet));
-                }
-
-                return true;
+                return base.DefineOwnProperty(CommonProperties.Length, desc);
             }
 
-            return base.DefineOwnProperty(property, desc);
+            var newLenDesc = new PropertyDescriptor(desc);
+            uint newLen = TypeConverter.ToUint32(value);
+            if (newLen != TypeConverter.ToNumber(value))
+            {
+                ExceptionHelper.ThrowRangeError(_engine.Realm);
+            }
+
+            var oldLenDesc = _length;
+            var oldLen = (uint) TypeConverter.ToNumber(oldLenDesc!.Value);
+
+            newLenDesc.Value = newLen;
+            if (newLen >= oldLen)
+            {
+                return base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
+            }
+
+            if (!oldLenDesc.Writable)
+            {
+                return false;
+            }
+
+            bool newWritable;
+            if (!newLenDesc.WritableSet || newLenDesc.Writable)
+            {
+                newWritable = true;
+            }
+            else
+            {
+                newWritable = false;
+                newLenDesc.Writable = true;
+            }
+
+            var succeeded = base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
+            if (!succeeded)
+            {
+                return false;
+            }
+
+            var count = _dense?.Length ?? _sparse!.Count;
+            if (count < oldLen - newLen)
+            {
+                if (_dense != null)
+                {
+                    for (uint keyIndex = 0; keyIndex < _dense.Length; ++keyIndex)
+                    {
+                        if (_dense[keyIndex] == null)
+                        {
+                            continue;
+                        }
+
+                        // is it the index of the array
+                        if (keyIndex >= newLen && keyIndex < oldLen)
+                        {
+                            var deleteSucceeded = Delete(keyIndex);
+                            if (!deleteSucceeded)
+                            {
+                                newLenDesc.Value = keyIndex + 1;
+                                if (!newWritable)
+                                {
+                                    newLenDesc.Writable = false;
+                                }
+
+                                base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
+                                return false;
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    // in the case of sparse arrays, treat each concrete element instead of
+                    // iterating over all indexes
+                    var keys = new List<uint>(_sparse!.Keys);
+                    var keysCount = keys.Count;
+                    for (var i = 0; i < keysCount; i++)
+                    {
+                        var keyIndex = keys[i];
+
+                        // is it the index of the array
+                        if (keyIndex >= newLen && keyIndex < oldLen)
+                        {
+                            var deleteSucceeded = Delete(TypeConverter.ToString(keyIndex));
+                            if (!deleteSucceeded)
+                            {
+                                newLenDesc.Value = JsNumber.Create(keyIndex + 1);
+                                if (!newWritable)
+                                {
+                                    newLenDesc.Writable = false;
+                                }
+
+                                base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                while (newLen < oldLen)
+                {
+                    // algorithm as per the spec
+                    oldLen--;
+                    var deleteSucceeded = Delete(oldLen);
+                    if (!deleteSucceeded)
+                    {
+                        newLenDesc.Value = oldLen + 1;
+                        if (!newWritable)
+                        {
+                            newLenDesc.Writable = false;
+                        }
+
+                        base.DefineOwnProperty(CommonProperties.Length, newLenDesc);
+                        return false;
+                    }
+                }
+            }
+
+            if (!newWritable)
+            {
+                base.DefineOwnProperty(CommonProperties.Length, new PropertyDescriptor(value: null, PropertyFlag.WritableSet));
+            }
+
+            return true;
         }
 
         private bool DefineOwnProperty(uint index, PropertyDescriptor desc)
@@ -397,39 +388,28 @@ namespace Jint.Native.Array
             if (temp != null)
             {
                 var length = System.Math.Min(temp.Length, GetLength());
-                for (var i = 0; i < length; i++)
+                for (uint i = 0; i < length; i++)
                 {
                     var value = temp[i];
                     if (value != null)
                     {
-                        if (value is not PropertyDescriptor descriptor)
+                        if (_sparse is null || !_sparse.TryGetValue(i, out var descriptor) || descriptor is null)
                         {
-                            if (EnsureCompatibleDense(typeof(PropertyDescriptor)))
-                            {
-                                temp = _dense!;
-                            }
-                            temp[i] = descriptor = new PropertyDescriptor((JsValue) value, PropertyFlag.ConfigurableEnumerableWritable);
+                            _sparse ??= new Dictionary<uint, PropertyDescriptor?>();
+                            _sparse[i] = descriptor = new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable);
                         }
                         yield return new KeyValuePair<JsValue, PropertyDescriptor>(TypeConverter.ToString(i), descriptor);
                     }
                 }
             }
-            else
+            else if (_sparse != null)
             {
-                foreach (var entry in _sparse!)
+                foreach (var entry in _sparse)
                 {
                     var value = entry.Value;
                     if (value is not null)
                     {
-                        if (value is not PropertyDescriptor descriptor)
-                        {
-                            if (EnsureCompatibleDense(typeof(PropertyDescriptor)))
-                            {
-                                temp = _dense!;
-                            }
-                            _sparse[entry.Key] = descriptor = new PropertyDescriptor((JsValue) value, PropertyFlag.ConfigurableEnumerableWritable);
-                        }
-                        yield return new KeyValuePair<JsValue, PropertyDescriptor>(TypeConverter.ToString(entry.Key), descriptor);
+                        yield return new KeyValuePair<JsValue, PropertyDescriptor>(TypeConverter.ToString(entry.Key), value);
                     }
                 }
             }
@@ -497,33 +477,12 @@ namespace Jint.Native.Array
         public sealed override bool Set(JsValue property, JsValue value, JsValue receiver)
         {
             var isSafeSelfTarget = IsSafeSelfTarget(receiver);
-            if (isSafeSelfTarget && IsArrayIndex(property, out var index))
+            var isArrayIndex = IsArrayIndex(property, out var index);
+            if (isSafeSelfTarget && isArrayIndex)
             {
-                var temp = _dense;
-                if (temp is not null && CanUseFastAccess)
+                if (CanUseFastAccess)
                 {
-                    var current = index < temp.Length ? temp[index] : null;
-                    if (current is not PropertyDescriptor p || p.IsDefaultArrayValueDescriptor())
-                    {
-                        SetIndexValue(index, value, true);
-                        return true;
-                    }
-                }
-
-                // slower and more allocating
-                if (TryGetDescriptor(index, out var descriptor))
-                {
-                    if (descriptor.IsDefaultArrayValueDescriptor())
-                    {
-                        // fast path with direct write without allocations
-                        descriptor.Value = value;
-                        return true;
-                    }
-                }
-                else if (CanUseFastAccess)
-                {
-                    // we know it's to be written to own array backing field as new value
-                    SetIndexValue(index, value, true);
+                    SetIndexValue(index, value, updateLength: true);
                     return true;
                 }
             }
@@ -542,6 +501,27 @@ namespace Jint.Native.Array
             }
 
             return base.HasProperty(property);
+        }
+
+        internal bool HasProperty(ulong index)
+        {
+            if (index < uint.MaxValue)
+            {
+                var temp = _dense;
+                if (temp != null)
+                {
+                    if (index < (uint) temp.Length && temp[index] is not null)
+                    {
+                        return true;
+                    }
+                }
+                else if (_sparse!.ContainsKey((uint) index))
+                {
+                    return true;
+                }
+            }
+
+            return base.HasProperty(index);
         }
 
         protected internal sealed override void SetOwnProperty(JsValue property, PropertyDescriptor desc)
@@ -568,11 +548,15 @@ namespace Jint.Native.Array
 
             if (isArrayIndex)
             {
-                if (!desc.IsDefaultArrayValueDescriptor())
+                if (!desc.IsDefaultArrayValueDescriptor() && desc.Flags != PropertyFlag.None)
                 {
                     _objectChangeFlags |= ObjectChangeFlags.NonDefaultDataDescriptorUsage;
                 }
-                _objectChangeFlags |= ObjectChangeFlags.ArrayIndex;
+
+                if (GetType() != typeof(JsArray))
+                {
+                    _objectChangeFlags |= ObjectChangeFlags.ArrayIndex;
+                }
             }
             else
             {
@@ -712,8 +696,7 @@ namespace Jint.Native.Array
             {
                 if (index < (uint) temp.Length)
                 {
-                    var value = temp[index];
-                    if (value is JsValue || value is PropertyDescriptor { Configurable: true })
+                    if (!TryGetDescriptor(index, out var descriptor) || descriptor.Configurable)
                     {
                         temp[index] = null;
                         return true;
@@ -763,37 +746,26 @@ namespace Jint.Native.Array
                 if (index < (uint) temp.Length)
                 {
                     var value = temp[index];
-                    if (value is JsValue jsValue)
+                    if (value != null)
                     {
-                        if (EnsureCompatibleDense(typeof(PropertyDescriptor)))
+                        if (_sparse is null || !_sparse.TryGetValue(index, out descriptor) || descriptor is null)
                         {
-                            temp = _dense!;
+                            _sparse ??= new Dictionary<uint, PropertyDescriptor?>();
+                            _sparse[index] = descriptor = new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable);
                         }
-                        temp[index] = descriptor = new PropertyDescriptor(jsValue, PropertyFlag.ConfigurableEnumerableWritable);
-                    }
-                    else if (value is PropertyDescriptor propertyDescriptor)
-                    {
-                        descriptor = propertyDescriptor;
+
+                        descriptor.Value = value;
+                        return true;
                     }
                 }
-                return descriptor != null;
+                return false;
             }
 
-            if (_sparse!.TryGetValue(index, out var sparseValue))
-            {
-                if (sparseValue is JsValue jsValue)
-                {
-                    _sparse[index] = descriptor = new PropertyDescriptor(jsValue, PropertyFlag.ConfigurableEnumerableWritable);
-                }
-                else if (sparseValue is PropertyDescriptor propertyDescriptor)
-                {
-                    descriptor = propertyDescriptor;
-                }
-            }
-
+            _sparse?.TryGetValue(index, out descriptor);
             return descriptor is not null;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool TryGetValue(uint index, out JsValue value)
         {
             value = GetValue(index, unwrapFromNonDataDescriptor: true)!;
@@ -803,6 +775,12 @@ namespace Jint.Native.Array
                 return true;
             }
 
+            return TryGetValueUnlikely(index, out value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool TryGetValueUnlikely(uint index, out JsValue value)
+        {
             if (!CanUseFastAccess)
             {
                 // slow path must be checked for prototype
@@ -825,54 +803,75 @@ namespace Jint.Native.Array
             return false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private JsValue? GetValue(uint index, bool unwrapFromNonDataDescriptor)
         {
-            object? value = null;
             var temp = _dense;
             if (temp != null)
             {
                 if (index < (uint) temp.Length)
                 {
-                    value = temp[index];
+                    return temp[index];
                 }
-            }
-            else
-            {
-                _sparse!.TryGetValue(index, out value);
+                return null;
             }
 
-            if (value is JsValue jsValue)
+            return GetValueUnlikely(index, unwrapFromNonDataDescriptor);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private JsValue? GetValueUnlikely(uint index, bool unwrapFromNonDataDescriptor)
+        {
+            JsValue? value = null;
+            if (_sparse!.TryGetValue(index, out var descriptor) && descriptor != null)
             {
-                return jsValue;
+                value = descriptor.IsDataDescriptor() || unwrapFromNonDataDescriptor
+                    ? UnwrapJsValue(descriptor)
+                    : null;
             }
 
-            if (value is PropertyDescriptor propertyDescriptor)
-            {
-                return propertyDescriptor.IsDataDescriptor() || unwrapFromNonDataDescriptor ? UnwrapJsValue(propertyDescriptor) : null;
-            }
-
-            return null;
+            return value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteArrayValue(uint index, object? value)
+        private void WriteArrayValue(uint index, PropertyDescriptor descriptor)
         {
-            var dense = _dense;
-            if (dense != null && index < (uint) dense.Length)
+            var temp = _dense;
+            if (temp != null && descriptor.IsDefaultArrayValueDescriptor())
             {
-                if (value is not null && !_isObjectArray && EnsureCompatibleDense(value is JsValue ? typeof(JsValue) : typeof(PropertyDescriptor)))
+                if (index < (uint) temp.Length)
                 {
-                    dense = _dense;
+                    temp[index] = descriptor.Value;
                 }
-                dense![index] = value;
+                else
+                {
+                    WriteArrayValueUnlikely(index, descriptor.Value);
+                }
             }
             else
             {
-                WriteArrayValueUnlikely(index, value);
+                WriteArrayValueUnlikely(index, descriptor);
             }
         }
 
-        private void WriteArrayValueUnlikely(uint index, object? value)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteArrayValue(uint index, JsValue? value)
+        {
+            var temp = _dense;
+            if (temp != null)
+            {
+                if (index < (uint) temp.Length)
+                {
+                    temp[index] = value;
+                    return;
+                }
+            }
+
+            WriteArrayValueUnlikely(index, value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void WriteArrayValueUnlikely(uint index, JsValue? value)
         {
             // calculate eagerly so we know if we outgrow
             var dense = _dense;
@@ -892,50 +891,45 @@ namespace Jint.Native.Array
             }
             else
             {
-                if (dense != null)
-                {
-                    ConvertToSparse();
-                }
-
-                _sparse![index] = value;
+                ConvertToSparse();
+                _sparse![index] = new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable);
             }
         }
 
-        /// <summary>
-        /// Converts to object array when needed. Returns true if conversion was made.
-        /// </summary>
-        private bool EnsureCompatibleDense(Type expectedElementType)
+        private void WriteArrayValueUnlikely(uint index, PropertyDescriptor? value)
         {
-            if (!_isObjectArray)
+            if (_sparse == null)
             {
-                return CheckConversionUnlikely(expectedElementType);
+                ConvertToSparse();
             }
 
-            return false;
-        }
-
-        private bool CheckConversionUnlikely(Type expectedElementType)
-        {
-            var currentElementType = _dense!.GetType().GetElementType();
-            if (currentElementType != typeof(object) && !expectedElementType.IsAssignableFrom(currentElementType))
-            {
-                // triggers conversion for array
-                EnsureCapacity((uint) _dense.Length, force: true);
-                return true;
-            }
-
-            return false;
+            _sparse![index] = value;
         }
 
         private void ConvertToSparse()
         {
-            _sparse = new Dictionary<uint, object?>(_dense!.Length <= 1024 ? _dense.Length : 0);
             // need to move data
-            for (uint i = 0; i < (uint) _dense.Length; ++i)
+            var temp = _dense;
+
+            if (temp is null)
             {
-                if (_dense[i] != null)
+                return;
+            }
+
+            _sparse ??= new Dictionary<uint, PropertyDescriptor?>();
+            for (uint i = 0; i < (uint) temp.Length; ++i)
+            {
+                var value = temp[i];
+                if (value != null)
                 {
-                    _sparse[i] = _dense[i];
+                    _sparse.TryGetValue(i, out var descriptor);
+                    descriptor ??= new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable);
+                    descriptor.Value = value;
+                    _sparse[i] = descriptor;
+                }
+                else
+                {
+                    _sparse.Remove(i);
                 }
             }
 
@@ -962,10 +956,9 @@ namespace Jint.Native.Array
             }
 
             // need to grow
-            var newArray = new object[capacity];
+            var newArray = new JsValue[capacity];
             System.Array.Copy(dense, newArray, dense.Length);
             _dense = newArray;
-            _isObjectArray = true;
         }
 
         public JsValue[] ToArray()
@@ -1020,14 +1013,7 @@ namespace Jint.Native.Array
                     var value = temp[i];
                     if (value != null)
                     {
-                        if (value is not PropertyDescriptor descriptor)
-                        {
-                            yield return new IndexedEntry(i, (JsValue) value);
-                        }
-                        else
-                        {
-                            yield return new IndexedEntry(i, descriptor.Value);
-                        }
+                        yield return new IndexedEntry(i, value);
                     }
                 }
             }
@@ -1035,17 +1021,10 @@ namespace Jint.Native.Array
             {
                 foreach (var entry in _sparse!)
                 {
-                    var value = entry.Value;
-                    if (value is not null)
+                    var descriptor = entry.Value;
+                    if (descriptor is not null)
                     {
-                        if (value is not PropertyDescriptor descriptor)
-                        {
-                            yield return new IndexedEntry((int) entry.Key, (JsValue) value);
-                        }
-                        else
-                        {
-                            yield return new IndexedEntry((int) entry.Key, descriptor.Value);
-                        }
+                        yield return new IndexedEntry((int) entry.Key, descriptor.Value);
                     }
                 }
             }
@@ -1069,7 +1048,7 @@ namespace Jint.Native.Array
             }
             else
             {
-                WriteValueSlow(n, new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable));
+                WriteValueSlow(n, value);
             }
 
             // check if we can set length fast without breaking ECMA specification
@@ -1146,15 +1125,15 @@ namespace Jint.Native.Array
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void WriteValueSlow(double n, PropertyDescriptor desc)
+        private void WriteValueSlow(double n, JsValue value)
         {
-            if (n < uint.MaxValue)
+            if (n < ArrayOperations.MaxArrayLength)
             {
-                WriteArrayValue((uint) n, desc);
+                WriteArrayValue((uint) n, value);
             }
             else
             {
-                DefinePropertyOrThrow((uint) n, desc);
+                DefinePropertyOrThrow((uint) n, new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable));
             }
         }
 
@@ -1325,21 +1304,18 @@ namespace Jint.Native.Array
             }
 
             var dense = _dense;
-            if (dense != null && sourceDense != null
-                               && (uint) dense.Length >= targetStartIndex + length
-                               && dense[targetStartIndex] is null)
+            if (dense != null
+                && sourceDense != null
+                && (uint) dense.Length >= targetStartIndex + length
+                && dense[targetStartIndex] is null)
             {
                 uint j = 0;
                 for (var i = sourceStartIndex; i < sourceStartIndex + length; ++i, j++)
                 {
-                    object? sourceValue;
+                    JsValue? sourceValue;
                     if (i < (uint) sourceDense.Length && sourceDense[i] != null)
                     {
                         sourceValue = sourceDense[i];
-                        if (sourceValue is PropertyDescriptor propertyDescriptor)
-                        {
-                            sourceValue = UnwrapJsValue(propertyDescriptor);
-                        }
                     }
                     else
                     {

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1648,10 +1648,10 @@ namespace Jint.Native.Array
             return element;
         }
 
-        private object[] CreateBackingArray(ulong length)
+        private JsValue[] CreateBackingArray(ulong length)
         {
             ValidateArrayLength(length);
-            return new object[length];
+            return new JsValue[length];
         }
 
         private void ValidateArrayLength(ulong length)

--- a/Jint/Native/JsArray.cs
+++ b/Jint/Native/JsArray.cs
@@ -1,5 +1,4 @@
 using Jint.Native.Array;
-using Jint.Runtime.Descriptors;
 
 namespace Jint.Native;
 
@@ -21,15 +20,5 @@ public sealed class JsArray : ArrayInstance
     /// </summary>
     public JsArray(Engine engine, JsValue[] items) : base(engine, items)
     {
-    }
-
-    internal static JsArray CreateEmpty(Engine engine)
-    {
-        return new JsArray(engine)
-        {
-            _prototype = engine.Realm.Intrinsics.Array.PrototypeObject,
-            _dense = System.Array.Empty<JsValue>(),
-            _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.OnlyWritable)
-        };
     }
 }

--- a/Jint/Native/JsArray.cs
+++ b/Jint/Native/JsArray.cs
@@ -23,15 +23,13 @@ public sealed class JsArray : ArrayInstance
     {
     }
 
-    /// <summary>
-    /// Possibility to construct valid array fast, requires that supplied array does not have holes.
-    /// The array will be owned and modified by Jint afterwards.
-    /// </summary>
-    public JsArray(Engine engine, PropertyDescriptor[] items) : base(engine, items)
+    internal static JsArray CreateEmpty(Engine engine)
     {
-    }
-
-    internal JsArray(Engine engine, object[] items) : base(engine, items)
-    {
+        return new JsArray(engine)
+        {
+            _prototype = engine.Realm.Intrinsics.Array.PrototypeObject,
+            _dense = System.Array.Empty<JsValue>(),
+            _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.OnlyWritable)
+        };
     }
 }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -555,6 +555,7 @@ namespace Jint.Native.Object
             return SetUnlikely(property, value, receiver);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private bool SetUnlikely(JsValue property, JsValue value, JsValue receiver)
         {
             var ownDesc = GetOwnProperty(property);
@@ -1510,7 +1511,7 @@ namespace Jint.Native.Object
             }
 
             var min = length;
-            foreach (var entry in Properties)
+            foreach (var entry in GetOwnProperties())
             {
                 if (ulong.TryParse(entry.Key.ToString(), out var index))
                 {
@@ -1520,7 +1521,7 @@ namespace Jint.Native.Object
 
             if (Prototype?.Properties != null)
             {
-                foreach (var entry in Prototype.Properties)
+                foreach (var entry in Prototype.GetOwnProperties())
                 {
                     if (ulong.TryParse(entry.Key.ToString(), out var index))
                     {

--- a/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
@@ -121,12 +121,12 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             protected override object EvaluateInternal(EvaluationContext context)
             {
-                return new JsArray(context.Engine, Array.Empty<JsValue>());
+                return JsArray.CreateEmpty(context.Engine);
             }
 
             public override JsValue GetValue(EvaluationContext context)
             {
-                return new JsArray(context.Engine, Array.Empty<JsValue>());
+                return JsArray.CreateEmpty(context.Engine);
             }
         }
     }

--- a/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
@@ -121,12 +121,12 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             protected override object EvaluateInternal(EvaluationContext context)
             {
-                return JsArray.CreateEmpty(context.Engine);
+                return new JsArray(context.Engine, Array.Empty<JsValue>());
             }
 
             public override JsValue GetValue(EvaluationContext context)
             {
-                return JsArray.CreateEmpty(context.Engine);
+                return new JsArray(context.Engine, Array.Empty<JsValue>());
             }
         }
     }

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -845,40 +845,45 @@ namespace Jint.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string ToString(long i)
         {
-            return i >= 0 && i < intToString.Length
-                ? intToString[i]
+            var temp = intToString;
+            return (ulong) i < (ulong) temp.Length
+                ? temp[i]
                 : i.ToString();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string ToString(int i)
         {
-            return i >= 0 && i < intToString.Length
-                ? intToString[i]
+            var temp = intToString;
+            return (uint) i < (uint) temp.Length
+                ? temp[i]
                 : i.ToString();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string ToString(uint i)
         {
-            return i < (uint) intToString.Length
-                ? intToString[i]
+            var temp = intToString;
+            return i < (uint) temp.Length
+                ? temp[i]
                 : i.ToString();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string ToString(char c)
         {
-            return c >= 0 && c < charToString.Length
-                ? charToString[c]
+            var temp = charToString;
+            return (uint) c < (uint) temp.Length
+                ? temp[c]
                 : c.ToString();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static string ToString(ulong i)
         {
-            return i >= 0 && i < (ulong) intToString.Length
-                ? intToString[i]
+            var temp = intToString;
+            return i < (ulong) temp.Length
+                ? temp[i]
                 : i.ToString();
         }
 


### PR DESCRIPTION
* always have `JsValue` in array and use sparse as helper to remove type checks
* faster paths for `HasProperty` against `JsArray`
* remove `JsArray` constructor taking `PropertyDescriptor[]`

``` 

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.23531.1001)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=8.0.100-preview.7.23376.3
  [Host]     : .NET 6.0.21 (6.0.2123.36311), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.21 (6.0.2123.36311), X64 RyuJIT AVX2


```

## Jint.Benchmark.ArrayBenchmark

| **Diff**|Method|Toolchain|N|Mean|Error|Allocated|
|------- |-------|-------|-------|-------:|-------|-------:|
| Old |Slice|Default|100|254.7 μs|1.14 μs|253.13 KB|
| **New** |	| **Default** |	| **248.8 μs (-2%)** | **0.89 μs** | **253.13 KB (0%)** |
| Old |Concat|Default|100|370.6 μs|0.83 μs|345.31 KB|
| **New** |	| **Default** |	| **352.1 μs (-5%)** | **0.86 μs** | **345.31 KB (0%)** |
| Old |Unshift|Default|100|9,286.4 μs|33.91 μs|3490.63 KB|
| **New** |	| **Default** |	| **8,072.0 μs (-13%)** | **36.66 μs** | **3490.63 KB (0%)** |
| Old |Push|Default|100|5,120.0 μs|15.08 μs|850.79 KB|
| **New** |	| **Default** |	| **4,920.7 μs (-4%)** | **15.89 μs** | **850.79 KB (0%)** |
| Old |Index|Default|100|3,659.3 μs|22.31 μs|778.91 KB|
| **New** |	| **Default** |	| **3,801.0 μs (+4%)** | **60.79 μs** | **778.91 KB (0%)** |
| Old |Map|Default|100|2,118.3 μs|12.55 μs|3107.03 KB|
| **New** |	| **Default** |	| **2,188.5 μs (+3%)** | **9.72 μs** | **3107.03 KB (0%)** |
| Old |Apply|Default|100|365.4 μs|1.41 μs|360.16 KB|
| **New** |	| **Default** |	| **325.5 μs (-11%)** | **0.95 μs** | **360.16 KB (0%)** |
| Old |JsonStringifyParse|Default|100|1,215.9 μs|3.24 μs|989.06 KB|
| **New** |	| **Default** |	| **1,162.1 μs (-4%)** | **3.82 μs** | **989.06 KB (0%)** |
| Old |FilterWithString|Default|100|20,864.1 μs|95.51 μs|31775.27 KB|
| **New** |	| **Default** |	| **22,257.2 μs (+7%)** | **129.98 μs** | **31775.27 KB (0%)** |


## Jint.Benchmark.ArrayStressBenchmark

| **Diff**|Method|Toolchain|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Execute|Default|12.85 ms|0.023 ms|7.18 MB|
| **New** |	| **Default** | **11.34 ms (-12%)** | **0.025 ms** | **6.94 MB (-3%)** |
| Old |Execute_ParsedScript|Default|12.96 ms|0.023 ms|7.15 MB|
| **New** |	| **Default** | **10.85 ms (-16%)** | **0.035 ms** | **6.92 MB (-3%)** |


## Jint.Benchmark.DromaeoBenchmark

| **Diff**|Method|Toolchain|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------|-------:|-------|-------:|
| Old |Run|Default|dromaeo-3d-cube|29.956 ms|0.0460 ms|6265.54 KB|
| **New** |	| **Default** |	| **29.517 ms (-1%)** | **0.0581 ms** | **6265.54 KB (0%)** |
| Old |Run|Default|dromaeo-core-eval|7.214 ms|0.0609 ms|321.1 KB|
| **New** |	| **Default** |	| **6.697 ms (-7%)** | **0.0137 ms** | **321.1 KB (0%)** |
| Old |Run|Default|dromaeo-object-array|83.338 ms|0.4098 ms|101708.39 KB|
| **New** |	| **Default** |	| **68.481 ms (-18%)** | **0.2054 ms** | **100749.51 KB (-1%)** |
| Old |Run|Default|droma(...)egexp [21]|289.978 ms|1.1322 ms|171264.47 KB|
| **New** |	| **Default** |	| **290.800 ms (0%)** | **0.8853 ms** | **171297.42 KB (0%)** |
| Old |Run|Default|droma(...)tring [21]|448.547 ms|27.2853 ms|1322093.77 KB|
| **New** |	| **Default** |	| **459.237 ms (+2%)** | **29.4718 ms** | **1322138.92 KB (0%)** |
| Old |Run|Default|droma(...)ase64 [21]|68.534 ms|0.2781 ms|6699.75 KB|
| **New** |	| **Default** |	| **68.975 ms (+1%)** | **0.1983 ms** | **6698.6 KB (0%)** |
| Old |Run|Default|dromaeo-3d-cube|30.105 ms|0.0458 ms|5974.54 KB|
| **New** |	| **Default** |	| **29.019 ms (-4%)** | **0.0426 ms** | **5974.53 KB (0%)** |
| Old |Run|Default|dromaeo-core-eval|6.495 ms|0.0169 ms|308.54 KB|
| **New** |	| **Default** |	| **6.841 ms (+5%)** | **0.0122 ms** | **308.54 KB (0%)** |
| Old |Run|Default|dromaeo-object-array|84.508 ms|0.2758 ms|101669.45 KB|
| **New** |	| **Default** |	| **69.313 ms (-18%)** | **0.1942 ms** | **100709.38 KB (-1%)** |
| Old |Run|Default|droma(...)egexp [21]|279.014 ms|1.0018 ms|172046.3 KB|
| **New** |	| **Default** |	| **281.455 ms (+1%)** | **0.6894 ms** | **165644.37 KB (-4%)** |
| Old |Run|Default|droma(...)tring [21]|454.885 ms|28.6828 ms|1321999.77 KB|
| **New** |	| **Default** |	| **455.295 ms (0%)** | **31.4452 ms** | **1322001.15 KB (0%)** |
| Old |Run|Default|droma(...)ase64 [21]|66.898 ms|0.1182 ms|6612.38 KB|
| **New** |	| **Default** |	| **66.510 ms (-1%)** | **0.1254 ms** | **6612.9 KB (0%)** |





