### PR TITLE
Fixed rest/spread bug with empty object

### DIFF
--- a/Jint.Tests/Runtime/DestructuringTests.cs
+++ b/Jint.Tests/Runtime/DestructuringTests.cs
@@ -62,4 +62,10 @@ public class DestructuringTests
     {
         _engine.Execute("return function([x, ...[y, ...z]]) { equal(1, x); equal(2, y); equal('3,4', z + ''); }([1, 2, 3, 4]);");
     }
+
+    [Fact]
+    public void EmptyRest()
+    {
+        _engine.Execute("function test({ ...props }){}; test({});");
+    }
 }

--- a/Jint/Runtime/Environments/FunctionEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/FunctionEnvironmentRecord.cs
@@ -221,7 +221,7 @@ namespace Jint.Runtime.Environments
                     {
                         if (((RestElement) property).Argument is Identifier restIdentifier)
                         {
-                            var rest = _engine.Realm.Intrinsics.Object.Construct(argumentObject.Properties!.Count - processedProperties!.Count);
+                            var rest = _engine.Realm.Intrinsics.Object.Construct((argumentObject.Properties?.Count ?? 0) - processedProperties!.Count);
                             argumentObject.CopyDataProperties(rest, processedProperties);
                             SetItemSafely(restIdentifier.Name, rest, initiallyEmpty);
                         }


### PR DESCRIPTION
Fixed the NullReferenceException for the following code:
```js
function test({ ...props }) { }
test({})
```