### PR TITLE
Remove exposed CLR type equality requirement from ObjectWrapper.Equals

### DIFF
--- a/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
+++ b/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
@@ -87,10 +87,7 @@ public class InteropExplicitTypeTests
     public void EqualTest()
     {
         Assert.Equal(_engine.Evaluate("holder.I1"), _engine.Evaluate("holder.i1"));
-        Assert.NotEqual(_engine.Evaluate("holder.I1"), _engine.Evaluate("holder.ci1"));
-
         Assert.Equal(_engine.Evaluate("holder.Super"), _engine.Evaluate("holder.super"));
-        Assert.NotEqual(_engine.Evaluate("holder.Super"), _engine.Evaluate("holder.ci1"));
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -3263,5 +3263,25 @@ try {
             engine.Execute("capture(maxDate);");
             Assert.Equal(DateTime.MaxValue, dt);
         }
+
+        private class Container
+        {
+            private readonly Child _child = new();
+            public Child Child => _child;
+            public BaseClass Get() => _child;
+        }
+
+        private class BaseClass { }
+
+        private class Child : BaseClass { }
+
+        [Fact]
+        public void AccessingBaseTypeShouldBeEqualToAccessingDerivedType()
+        {
+            var engine = new Engine().SetValue("container", new Container());
+            var res = engine.Evaluate("container.Child === container.Get()"); // These two should be the same object. But this PR makes `container.Get()` return a different object
+
+            Assert.True(res.AsBoolean());
+        }
     }
 }

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -517,12 +517,7 @@ namespace Jint.Native
                 case Types.Symbol:
                     return x == y;
                 case Types.Object:
-                    if (x is ObjectWrapper xo && y is ObjectWrapper yo)
-                    {
-                        return ReferenceEquals(xo.Target, yo.Target)
-                            && xo.ClrType == yo.ClrType;
-                    }
-                    return false;
+                    return x is ObjectWrapper xo && y is ObjectWrapper yo && ReferenceEquals(xo.Target, yo.Target);
                 default:
                     return false;
             }

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -301,10 +301,7 @@ namespace Jint.Runtime.Interop
             return Target is ICollection ? 0 : base.GetSmallestIndex(length);
         }
 
-        public override bool Equals(JsValue? obj)
-        {
-            return Equals(obj as ObjectWrapper);
-        }
+        public override bool Equals(JsValue? obj) => Equals(obj as ObjectWrapper);
 
         public bool Equals(ObjectWrapper? other)
         {
@@ -318,14 +315,13 @@ namespace Jint.Runtime.Interop
                 return true;
             }
 
-            return Equals(Target, other.Target) && Equals(ClrType, other.ClrType);
+            return Equals(Target, other.Target);
         }
 
         public override int GetHashCode()
         {
             var hashCode = -1468639730;
             hashCode = hashCode * -1521134295 + Target.GetHashCode();
-            hashCode = hashCode * -1521134295 + ClrType.GetHashCode();
             return hashCode;
         }
 


### PR DESCRIPTION
I can't wrap my head around why we would need to have `Equals` to check object wrapper's exposed type as current `ReferenceEquals` is already a strong guarantee. There might be cases to only expose member of exposed type but we shouldn't state that pointer to same object isn't the same object based on what was exposed.

This should return the behavior expected with @CreepGin 's Unity integration.

/cc @CreepGin @viruscamp 