### PR TITLE
Cache more script-global information when preparing AST

### DIFF
--- a/Jint/Collections/ListDictionary.cs
+++ b/Jint/Collections/ListDictionary.cs
@@ -99,7 +99,7 @@ namespace Jint.Collections
             get => _count;
         }
 
-        public void Add(Key key, TValue value)
+        public bool Add(Key key, TValue value, bool tryAdd = false)
         {
             DictionaryNode last = null;
             DictionaryNode node;
@@ -109,6 +109,10 @@ namespace Jint.Collections
                 var oldKey = node.Key;
                 if (checkExistingKeys && oldKey == key)
                 {
+                    if (tryAdd)
+                    {
+                        return false;
+                    }
                     ExceptionHelper.ThrowArgumentException();
                 }
 
@@ -116,6 +120,7 @@ namespace Jint.Collections
             }
 
             AddNode(key, value, last);
+            return true;
         }
 
         private void AddNode(Key key, TValue value, DictionaryNode last)

--- a/Jint/Collections/StringDictionarySlim.cs
+++ b/Jint/Collections/StringDictionarySlim.cs
@@ -171,6 +171,23 @@ namespace Jint.Collections
             return ref AddKey(key, bucketIndex);
         }
 
+        public bool TryAdd(Key key, TValue value)
+        {
+            Entry[] entries = _entries;
+            int bucketIndex = key.HashCode & (_buckets.Length - 1);
+            for (int i = _buckets[bucketIndex] - 1;
+                 (uint)i < (uint)entries.Length; i = entries[i].next)
+            {
+                if (key.Name == entries[i].key.Name)
+                {
+                    return false;
+                }
+            }
+
+            AddKey(key, bucketIndex) = value;
+            return true;
+        }
+
         /// <summary>
         /// Adds a new item and expects key to not to exist.
         /// </summary>

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1237,7 +1237,7 @@ namespace Jint
 
             var functionDeclarations = hoistingScope._functionDeclarations;
             var functionsToInitialize = new LinkedList<JintFunctionDefinition>();
-            var declaredFunctionNames = new HashSet<string>();
+            var declaredFunctionNames = new HashSet<string>(StringComparer.Ordinal);
 
             if (functionDeclarations != null)
             {

--- a/Jint/HoistingScope.cs
+++ b/Jint/HoistingScope.cs
@@ -28,12 +28,11 @@ namespace Jint
         }
 
         public static HoistingScope GetProgramLevelDeclarations(
-            bool strict,
             Program script,
             bool collectVarNames = false,
             bool collectLexicalNames = false)
         {
-            var treeWalker = new ScriptWalker(strict, collectVarNames, collectLexicalNames);
+            var treeWalker = new ScriptWalker(collectVarNames, collectLexicalNames);
             treeWalker.Visit(script, null);
 
             return new HoistingScope(
@@ -46,7 +45,7 @@ namespace Jint
 
         public static HoistingScope GetFunctionLevelDeclarations(bool strict, IFunction node)
         {
-            var treeWalker = new ScriptWalker(strict, collectVarNames: true, collectLexicalNames: true);
+            var treeWalker = new ScriptWalker(collectVarNames: true, collectLexicalNames: true);
             treeWalker.Visit(node.Body, null);
 
             return new HoistingScope(
@@ -63,7 +62,7 @@ namespace Jint
             bool collectLexicalNames = false)
         {
             // modules area always strict
-            var treeWalker = new ScriptWalker(strict: true, collectVarNames, collectLexicalNames);
+            var treeWalker = new ScriptWalker(collectVarNames, collectLexicalNames);
             treeWalker.Visit(module, null);
             return new HoistingScope(
                 treeWalker._functions,
@@ -204,7 +203,6 @@ namespace Jint
         {
             internal List<FunctionDeclaration>? _functions;
 
-            private readonly bool _strict;
             private readonly bool _collectVarNames;
             internal List<VariableDeclaration>? _variableDeclarations;
             internal List<Key>? _varNames;
@@ -213,9 +211,8 @@ namespace Jint
             internal List<Declaration>? _lexicalDeclarations;
             internal List<string>? _lexicalNames;
 
-            public ScriptWalker(bool strict, bool collectVarNames, bool collectLexicalNames)
+            public ScriptWalker(bool collectVarNames, bool collectLexicalNames)
             {
-                _strict = strict;
                 _collectVarNames = collectVarNames;
                 _collectLexicalNames = collectLexicalNames;
             }

--- a/Jint/Runtime/Environments/EnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/EnvironmentRecord.cs
@@ -118,7 +118,6 @@ namespace Jint.Runtime.Environments
         {
             public readonly Key Key;
             public readonly JsString Value;
-            public readonly bool HasEvalOrArguments;
             public readonly JsValue? CalculatedValue;
 
             public BindingName(string value)
@@ -126,7 +125,6 @@ namespace Jint.Runtime.Environments
                 var key = (Key) value;
                 Key = key;
                 Value = JsString.Create(value);
-                HasEvalOrArguments = key == KnownKeys.Eval || key == KnownKeys.Arguments;
                 if (key == KnownKeys.Undefined)
                 {
                     CalculatedValue = Undefined;

--- a/Jint/Runtime/Environments/GlobalEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/GlobalEnvironmentRecord.cs
@@ -343,14 +343,31 @@ namespace Jint.Runtime.Environments
         public void CreateGlobalVarBinding(string name, bool canBeDeleted)
         {
             Key key = name;
-            if (!_global._properties!.ContainsKey(key) && _global.Extensible)
-            {
-                _global._properties[key] = new PropertyDescriptor(Undefined, canBeDeleted
+            if (_global.Extensible && _global._properties!.TryAdd(key, new PropertyDescriptor(Undefined, canBeDeleted
                     ? PropertyFlag.ConfigurableEnumerableWritable | PropertyFlag.MutableBinding
-                    : PropertyFlag.NonConfigurable | PropertyFlag.MutableBinding);
+                    : PropertyFlag.NonConfigurable | PropertyFlag.MutableBinding)))
+            {
+                _varNames.Add(name);
+            }
+        }
+
+        internal void CreateGlobalVarBindings(List<string> names, bool canBeDeleted)
+        {
+            if (!_global.Extensible)
+            {
+                return;
             }
 
-            _varNames.Add(name);
+            for (var i = 0; i < names.Count; i++)
+            {
+                var name = names[i];
+
+                _global._properties!.TryAdd(name,new PropertyDescriptor(Undefined, canBeDeleted
+                    ? PropertyFlag.ConfigurableEnumerableWritable | PropertyFlag.MutableBinding
+                    : PropertyFlag.NonConfigurable | PropertyFlag.MutableBinding));
+
+                _varNames.Add(name);
+            }
         }
 
         /// <summary>

--- a/Jint/Runtime/Environments/GlobalEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/GlobalEnvironmentRecord.cs
@@ -76,7 +76,7 @@ namespace Jint.Runtime.Environments
             out Binding binding,
             [NotNullWhen(true)] out JsValue? value)
         {
-            if (_declarativeRecord.TryGetBinding(name, strict, out binding, out value))
+            if (_declarativeRecord._dictionary is not null && _declarativeRecord.TryGetBinding(name, strict, out binding, out value))
             {
                 return true;
             }

--- a/Jint/Runtime/Environments/GlobalEnvironmentRecord.cs
+++ b/Jint/Runtime/Environments/GlobalEnvironmentRecord.cs
@@ -12,20 +12,30 @@ namespace Jint.Runtime.Environments
     /// </summary>
     public sealed class GlobalEnvironmentRecord : EnvironmentRecord
     {
+        /// <summary>
+        /// A sealed class for global usage.
+        /// </summary>
+        internal sealed class GlobalDeclarativeEnvironmentRecord : DeclarativeEnvironmentRecord
+        {
+            public GlobalDeclarativeEnvironmentRecord(Engine engine) : base(engine)
+            {
+            }
+        }
+
         internal readonly ObjectInstance _global;
 
         // we expect it to be GlobalObject, but need to allow to something host-defined, like Window
         private readonly GlobalObject? _globalObject;
 
         // Environment records are needed by debugger
-        internal readonly DeclarativeEnvironmentRecord _declarativeRecord;
-        private readonly HashSet<string> _varNames = new();
+        internal readonly GlobalDeclarativeEnvironmentRecord _declarativeRecord;
+        private readonly HashSet<string> _varNames = new(StringComparer.Ordinal);
 
         public GlobalEnvironmentRecord(Engine engine, ObjectInstance global) : base(engine)
         {
             _global = global;
             _globalObject = global as GlobalObject;
-            _declarativeRecord = new DeclarativeEnvironmentRecord(engine);
+            _declarativeRecord = new GlobalDeclarativeEnvironmentRecord(engine);
         }
 
         public ObjectInstance GlobalThisValue => _global;

--- a/Jint/Runtime/Environments/JintEnvironment.cs
+++ b/Jint/Runtime/Environments/JintEnvironment.cs
@@ -44,7 +44,7 @@ namespace Jint.Runtime.Environments
 
             if (env._outerEnv is null)
             {
-                return env.TryGetBinding(name, strict, out _, out value);
+                return ((GlobalEnvironmentRecord) env).TryGetBinding(name, strict, out _, out value);
             }
 
             while (!ReferenceEquals(record, null))

--- a/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
@@ -7,6 +7,9 @@ internal sealed class JintExpressionStatement : JintStatement<ExpressionStatemen
 {
     private JintExpression _expression = null!;
 
+    // identifiers are queried the most
+    private JintIdentifierExpression? _identifierExpression;
+
     public JintExpressionStatement(ExpressionStatement statement) : base(statement)
     {
     }
@@ -14,10 +17,15 @@ internal sealed class JintExpressionStatement : JintStatement<ExpressionStatemen
     protected override void Initialize(EvaluationContext context)
     {
         _expression = JintExpression.Build(_statement.Expression);
+        _identifierExpression = _expression as JintIdentifierExpression;
     }
 
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
-        return new Completion(context.Completion, _expression.GetValue(context), _statement);
+        var value = _identifierExpression is not null
+            ? _identifierExpression.GetValue(context)
+            : _expression.GetValue(context);
+
+        return new Completion(context.Completion, value, _statement);
     }
 }


### PR DESCRIPTION
```

BenchmarkDotNet v0.13.10, Windows 11 (10.0.23580.1000)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 8.0.100-rc.2.23502.2
  [Host]     : .NET 6.0.24 (6.0.2423.51814), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.24 (6.0.2423.51814), X64 RyuJIT AVX2


```
| Method            | FileName             | Mean              | StdDev          | Rank | Allocated      |
|------------------ |--------------------- |------------------:|----------------:|-----:|---------------:|
| NilJS             | array-stress         |      7,563.941 μs |      26.9265 μs |    1 |     4533.76 KB |
| Jint_ParsedScript | array-stress         |     11,295.237 μs |      12.1198 μs |    2 |     7085.95 KB |
| Jint              | array-stress         |     11,531.269 μs |      79.8651 μs |    3 |     7112.01 KB |
| Jurassic          | array-stress         |     13,899.086 μs |      23.6976 μs |    4 |    11646.93 KB |
| YantraJS          | array-stress         |     96,276.504 μs |  13,200.8111 μs |    5 |   255624.06 KB |
|                   |                      |                   |                 |      |                |
| YantraJS          | dromaeo-3d-cube      |                NA |              NA |    ? |             NA |
| NilJS             | dromaeo-3d-cube      |     11,733.611 μs |      21.2467 μs |    1 |     4694.63 KB |
| Jint              | dromaeo-3d-cube      |     27,808.227 μs |      43.2092 μs |    2 |     6191.56 KB |
| Jint_ParsedScript | dromaeo-3d-cube      |     28,960.652 μs |      33.2589 μs |    3 |     5895.31 KB |
| Jurassic          | dromaeo-3d-cube      |     49,245.391 μs |     231.0408 μs |    4 |    10670.03 KB |
|                   |                      |                   |                 |      |                |
| NilJS             | dromaeo-core-eval    |      2,645.500 μs |       6.8940 μs |    1 |     1598.78 KB |
| Jint              | dromaeo-core-eval    |      6,559.826 μs |      46.4484 μs |    2 |      350.43 KB |
| Jint_ParsedScript | dromaeo-core-eval    |      6,991.423 μs |      16.7556 μs |    3 |      331.16 KB |
| Jurassic          | dromaeo-core-eval    |     12,078.630 μs |      33.0525 μs |    4 |      2884.9 KB |
| YantraJS          | dromaeo-core-eval    |     14,864.056 μs |      30.9481 μs |    5 |     37062.1 KB |
|                   |                      |                   |                 |      |                |
| Jurassic          | dromaeo-object-array |     51,372.600 μs |     149.7458 μs |    1 |    25814.14 KB |
| Jint_ParsedScript | dromaeo-object-array |     66,942.961 μs |     557.2929 μs |    2 |   100750.55 KB |
| Jint              | dromaeo-object-array |     66,964.835 μs |     145.5401 μs |    2 |   100794.94 KB |
| NilJS             | dromaeo-object-array |     76,040.716 μs |     225.5910 μs |    3 |    17699.41 KB |
| YantraJS          | dromaeo-object-array |  1,378,630.424 μs |  36,726.6758 μs |    4 |  4011669.92 KB |
|                   |                      |                   |                 |      |                |
| YantraJS          | droma(...)egexp [21] |                NA |              NA |    ? |             NA |
| Jint_ParsedScript | droma(...)egexp [21] |    296,615.531 μs |   1,496.6193 μs |    1 |    166663.7 KB |
| Jint              | droma(...)egexp [21] |    301,420.613 μs |   5,604.2127 μs |    1 |   166967.39 KB |
| NilJS             | droma(...)egexp [21] |    602,953.929 μs |   5,058.1777 μs |    2 |   768465.57 KB |
| Jurassic          | droma(...)egexp [21] |    804,190.691 μs |  18,968.0146 μs |    3 |   821324.34 KB |
|                   |                      |                   |                 |      |                |
| NilJS             | droma(...)tring [21] |    423,171.274 μs |   9,276.5352 μs |    1 |  1377952.59 KB |
| Jurassic          | droma(...)tring [21] |    620,107.713 μs |  11,346.6737 μs |    2 |  1458012.63 KB |
| Jint_ParsedScript | droma(...)tring [21] |    635,027.100 μs |  66,711.1507 μs |    2 |  1321946.63 KB |
| Jint              | droma(...)tring [21] |    640,539.196 μs |  66,063.9448 μs |    2 |  1322320.36 KB |
| YantraJS          | droma(...)tring [21] | 16,818,825.887 μs | 269,775.1975 μs |    3 | 49976650.01 KB |
|                   |                      |                   |                 |      |                |
| NilJS             | droma(...)ase64 [21] |     49,228.584 μs |     122.3282 μs |    1 |    19605.08 KB |
| Jint_ParsedScript | droma(...)ase64 [21] |     64,449.974 μs |     243.0846 μs |    2 |     6712.93 KB |
| Jint              | droma(...)ase64 [21] |     65,518.141 μs |     364.5683 μs |    3 |      6807.7 KB |
| Jurassic          | droma(...)ase64 [21] |     87,846.364 μs |     494.6985 μs |    4 |    74320.38 KB |
| YantraJS          | droma(...)ase64 [21] |    160,567.373 μs |   2,737.2815 μs |    5 |   804980.17 KB |
|                   |                      |                   |                 |      |                |
| Jint_ParsedScript | evaluation           |         13.127 μs |       0.0554 μs |    1 |        26.6 KB |
| Jint              | evaluation           |         33.600 μs |       0.1090 μs |    2 |       36.03 KB |
| NilJS             | evaluation           |         61.703 μs |       0.2878 μs |    3 |       23.47 KB |
| YantraJS          | evaluation           |        160.909 μs |       0.6603 μs |    4 |      962.76 KB |
| Jurassic          | evaluation           |      1,591.955 μs |       4.0312 μs |    5 |      420.41 KB |
|                   |                      |                   |                 |      |                |
| YantraJS          | linq-js              |                NA |              NA |    ? |             NA |
| Jint_ParsedScript | linq-js              |        109.327 μs |       0.1165 μs |    1 |      215.49 KB |
| Jint              | linq-js              |      2,158.489 μs |       2.5042 μs |    2 |     1274.99 KB |
| NilJS             | linq-js              |      9,746.259 μs |      45.4357 μs |    3 |     4127.79 KB |
| Jurassic          | linq-js              |     44,514.640 μs |     508.9445 μs |    4 |     9302.34 KB |
|                   |                      |                   |                 |      |                |
| Jint_ParsedScript | minimal              |          3.344 μs |       0.0112 μs |    1 |       12.94 KB |
| Jint              | minimal              |          5.386 μs |       0.0129 μs |    2 |       14.38 KB |
| NilJS             | minimal              |          6.233 μs |       0.0066 μs |    3 |        4.81 KB |
| YantraJS          | minimal              |        154.560 μs |       0.5392 μs |    4 |      957.33 KB |
| Jurassic          | minimal              |        289.447 μs |       0.3610 μs |    5 |      386.24 KB |
|                   |                      |                   |                 |      |                |
| YantraJS          | stopwatch            |    119,730.157 μs |     274.8325 μs |    1 |   224314.32 KB |
| Jurassic          | stopwatch            |    246,744.598 μs |     733.2603 μs |    2 |   156937.28 KB |
| NilJS             | stopwatch            |    287,354.938 μs |     393.6484 μs |    3 |    97362.57 KB |
| Jint              | stopwatch            |    425,628.407 μs |   4,943.8190 μs |    4 |    53040.88 KB |
| Jint_ParsedScript | stopwatch            |    483,575.877 μs |     926.2306 μs |    5 |    53023.46 KB |

Benchmarks with issues:
  EngineComparisonBenchmark.YantraJS: DefaultJob [FileName=dromaeo-3d-cube]
  EngineComparisonBenchmark.YantraJS: DefaultJob [FileName=droma(...)egexp [21]]
  EngineComparisonBenchmark.YantraJS: DefaultJob [FileName=linq-js]
