### PR TITLE
Adding cultural check to the "ToUpperCase" string prototype.

### DIFF
--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 public class StringTests
 {
@@ -80,5 +80,23 @@ bar += 'bar';
         var result = engine.Evaluate("({ [`key`]: 'value' })").AsObject();
         Assert.True(result.HasOwnProperty("key"));
         Assert.Equal("value", result["key"]);
+    }
+
+    public static TheoryData GetLithuaniaTestsData()
+    {
+        return new StringTetsLithuaniaData().TestData();
+    }
+
+    /// <summary>
+    /// Lithuanian case is special and Test262 suite tests cover only correct parsing by character. See:
+    /// https://github.com/tc39/test262/blob/main/test/intl402/String/prototype/toLocaleUpperCase/special_casing_Lithuanian.js
+    /// Added logic in the engine needs to parse full strings and not only spare characters. This is what these tests cover.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(GetLithuaniaTestsData))]
+    public void LithuanianToLocaleUpperCase(string parseStr, string result)
+    {
+        var value = _engine.Evaluate($"('{parseStr}').toLocaleUpperCase('lt')").AsString();
+        Assert.Equal(result, value);
     }
 }

--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Jint.Tests.Runtime;
+namespace Jint.Tests.Runtime;
 
 public class StringTests
 {

--- a/Jint.Tests/Runtime/StringTetsLithuaniaData.cs
+++ b/Jint.Tests/Runtime/StringTetsLithuaniaData.cs
@@ -2,109 +2,96 @@
 {
     public class StringTetsLithuaniaData
     {
+        // Contains the non-uppercased string that will be processed by the engine and the expected result.
+        private readonly TheoryData<string, string> fullSetOfData = new TheoryData<string, string>();
+        // From: https://github.com/tc39/test262/blob/main/test/intl402/String/prototype/toLocaleUpperCase/special_casing_Lithuanian.js
+        private readonly string[] softDotted = [
+            "\u0069", "\u006A",   // LATIN SMALL LETTER I..LATIN SMALL LETTER J
+            "\u012F",             // LATIN SMALL LETTER I WITH OGONEK
+            "\u0249",             // LATIN SMALL LETTER J WITH STROKE
+            "\u0268",             // LATIN SMALL LETTER I WITH STROKE
+            "\u029D",             // LATIN SMALL LETTER J WITH CROSSED-TAIL
+            "\u02B2",             // MODIFIER LETTER SMALL J
+            "\u03F3",             // GREEK LETTER YOT
+            "\u0456",             // CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+            "\u0458",             // CYRILLIC SMALL LETTER JE
+            "\u1D62",             // LATIN SUBSCRIPT SMALL LETTER I
+            "\u1D96",             // LATIN SMALL LETTER I WITH RETROFLEX HOOK
+            "\u1DA4",             // MODIFIER LETTER SMALL I WITH STROKE
+            "\u1DA8",             // MODIFIER LETTER SMALL J WITH CROSSED-TAIL
+            "\u1E2D",             // LATIN SMALL LETTER I WITH TILDE BELOW
+            "\u1ECB",             // LATIN SMALL LETTER I WITH DOT BELOW
+            "\u2071",             // SUPERSCRIPT LATIN SMALL LETTER I
+            "\u2148", "\u2149",   // DOUBLE-STRUCK ITALIC SMALL I..DOUBLE-STRUCK ITALIC SMALL J
+            "\u2C7C",             // LATIN SUBSCRIPT SMALL LETTER J
+            "\uD835\uDC22", "\uD835\uDC23",   // MATHEMATICAL BOLD SMALL I..MATHEMATICAL BOLD SMALL J
+            "\uD835\uDC56", "\uD835\uDC57",   // MATHEMATICAL ITALIC SMALL I..MATHEMATICAL ITALIC SMALL J
+            "\uD835\uDC8A", "\uD835\uDC8B",   // MATHEMATICAL BOLD ITALIC SMALL I..MATHEMATICAL BOLD ITALIC SMALL J
+            "\uD835\uDCBE", "\uD835\uDCBF",   // MATHEMATICAL SCRIPT SMALL I..MATHEMATICAL SCRIPT SMALL J
+            "\uD835\uDCF2", "\uD835\uDCF3",   // MATHEMATICAL BOLD SCRIPT SMALL I..MATHEMATICAL BOLD SCRIPT SMALL J
+            "\uD835\uDD26", "\uD835\uDD27",   // MATHEMATICAL FRAKTUR SMALL I..MATHEMATICAL FRAKTUR SMALL J
+            "\uD835\uDD5A", "\uD835\uDD5B",   // MATHEMATICAL DOUBLE-STRUCK SMALL I..MATHEMATICAL DOUBLE-STRUCK SMALL J
+            "\uD835\uDD8E", "\uD835\uDD8F",   // MATHEMATICAL BOLD FRAKTUR SMALL I..MATHEMATICAL BOLD FRAKTUR SMALL J
+            "\uD835\uDDC2", "\uD835\uDDC3",   // MATHEMATICAL SANS-SERIF SMALL I..MATHEMATICAL SANS-SERIF SMALL J
+            "\uD835\uDDF6", "\uD835\uDDF7",   // MATHEMATICAL SANS-SERIF BOLD SMALL I..MATHEMATICAL SANS-SERIF BOLD SMALL J
+            "\uD835\uDE2A", "\uD835\uDE2B",   // MATHEMATICAL SANS-SERIF ITALIC SMALL I..MATHEMATICAL SANS-SERIF ITALIC SMALL J
+            "\uD835\uDE5E", "\uD835\uDE5F",   // MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL I..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL J
+            "\uD835\uDE92", "\uD835\uDE93",   // MATHEMATICAL MONOSPACE SMALL I..MATHEMATICAL MONOSPACE SMALL J
+        ];
+
         // Results obtained from node -v 18.12.0.
+        private readonly string[] softDottedUpperCased = [
+            "I", "J", "Į", "Ɉ", "Ɨ", "Ʝ", "ʲ", "Ϳ", "І", "Ј",
+            "ᵢ", "ᶖ", "ᶤ", "ᶨ", "Ḭ", "Ị", "ⁱ", "ⅈ", "ⅉ", "ⱼ",
+            "𝐢", "𝐣", "𝑖", "𝑗", "𝒊", "𝒋", "𝒾", "𝒿", "𝓲", "𝓳",
+            "𝔦", "𝔧", "𝕚", "𝕛", "𝖎", "𝖏", "𝗂", "𝗃", "𝗶", "𝗷",
+            "𝘪", "𝘫", "𝙞", "𝙟", "𝚒", "𝚓",
+        ];
+
+        /// <summary>
+        /// Creates and adds the data to <fullSetOfData> that will be used for the tests. Six cases:
+        /// 1.- String with character at the beginning of the string.
+        /// 2.- String with double character at the beginning of the string.
+        /// 3.- String with character at the middle of the string.
+        /// 4.- String with double character at the middle of the string.
+        /// 5.- String with character at the end of the string.
+        /// 6.- String with double character at the end of the string.
+        /// </summary>
+        private void AddStringsForChars(string nonCapChar, string toUpperChar)
+        {
+            fullSetOfData.Add($"{nonCapChar}lorem ipsum", $"{toUpperChar}LOREM IPSUM");
+            fullSetOfData.Add($"{nonCapChar}{nonCapChar}lorem ipsum", $"{toUpperChar}{toUpperChar}LOREM IPSUM");
+            fullSetOfData.Add($"lorem{nonCapChar}ipsum", $"LOREM{toUpperChar}IPSUM");
+            fullSetOfData.Add($"lorem{nonCapChar}{nonCapChar}ipsum", $"LOREM{toUpperChar}{toUpperChar}IPSUM");
+            fullSetOfData.Add($"lorem ipsum{nonCapChar}", $"LOREM IPSUM{toUpperChar}");
+            fullSetOfData.Add($"lorem ipsum{nonCapChar}{nonCapChar}", $"LOREM IPSUM{toUpperChar}{toUpperChar}");
+        }
+
+        // All the cases from https://github.com/tc39/test262/blob/main/test/intl402/String/prototype/toLocaleUpperCase/special_casing_Lithuanian.js
         public TheoryData<string, string> TestData()
         {
-            return new TheoryData<string, string> // <stringToParse, result>
+            // COMBINING DOT ABOVE (U+0307) not removed when uppercasing capital I
+            AddStringsForChars("İ", "İ");
+            // COMBINING DOT ABOVE (U+0307) not removed when uppercasing capital J
+            AddStringsForChars("J̇", "J̇");
+            for (int i = 0; i < softDotted.Length; i++)
             {
-                // COMBINING DOT ABOVE (U+0307) not removed when uppercasing capital I and J.
-                // I
-                { "İlorem ipsum", "İLOREM IPSUM" },
-                { "İİlorem ipsum", "İİLOREM IPSUM" },
-                { "loremİipsum", "LOREMİIPSUM" },
-                { "loremİİipsum", "LOREMİİIPSUM" },
-                { "lorem ipsumİ", "LOREM IPSUMİ" },
-                { "lorem ipsumİİ", "LOREM IPSUMİİ" },
-
-                // J
-                { "J̇lorem ipsum", "J̇LOREM IPSUM"  },
-                { "J̇J̇lorem ipsum", "J̇J̇LOREM IPSUM" },
-                { "loremJ̇ipsum", "LOREMJ̇IPSUM" },
-                { "loremJ̇J̇ipsum", "LOREMJ̇J̇IPSUM" },
-                { "lorem ipsumJ̇", "LOREM IPSUMJ̇" },
-                { "lorem ipsumJ̇J̇", "LOREM IPSUMJ̇J̇" },
-
-                // DOT ABOVE (U+0307) removed if its other capital letter other than I or J.
-                { "Ȧlorem ipsum", "ALOREM IPSUM" },
-                { "ȦȦlorem ipsum", "AALOREM IPSUM" },
-                { "loremȦipsum", "LOREMAIPSUM" },
-                { "loremȦȦipsum", "LOREMAAIPSUM" },
-                { "lorem ipsumȦ", "LOREM IPSUMA" },
-                {  "lorem ipsumȦȦ", "LOREM IPSUMAA" },
-
-                // COMBINING DOT ABOVE (U+0307) removed when preceded by Soft_Dotted
+                // COMBINING DOT ABOVE (U+0307) removed when preceded by Soft_Dotted.
                 // Character directly preceded by Soft_Dotted.
-                // "\u0069" + "\u0307", not latin 'i'.
-                { "ilorem ipsum", "ILOREM IPSUM" },
-                { "iilorem ipsum", "IILOREM IPSUM" },
-                { "loremiipsum", "LOREMIIPSUM" },
-                { "loremiiipsum", "LOREMIIIPSUM" },
-                { "loremipsumi", "LOREMIPSUMI" },
-                { "loremipsumii", "LOREMIPSUMII" },
-                // "\u006A" + "\u0307", not latin 'j'.
-                { "j̇lorem ipsum", "JLOREM IPSUM" },
-                { "j̇j̇lorem ipsum", "JJLOREM IPSUM" },
-                { "loremj̇ipsum", "LOREMJIPSUM" },
-                { "loremj̇j̇ipsum", "LOREMJJIPSUM" },
-                { "loremipsumj̇", "LOREMIPSUMJ" },
-                { "loremipsumj̇j̇", "LOREMIPSUMJJ" },
-                // "\u012F" + "\u0307" 
-                { "į̇lorem ipsum", "ĮLOREM IPSUM" },
-                { "į̇į̇lorem ipsum", "ĮĮLOREM IPSUM" },
-                { "loremį̇ipsum", "LOREMĮIPSUM" },
-                { "loremį̇į̇ipsum", "LOREMĮĮIPSUM" },
-                { "loremipsumį̇", "LOREMIPSUMĮ" },
-                { "loremipsumį̇į̇", "LOREMIPSUMĮĮ" },
-            };
+                AddStringsForChars(softDotted[i] + "\u0307", softDottedUpperCased[i]);
+
+                // COMBINING DOT ABOVE (U+0307) removed if preceded by Soft_Dotted.
+                // Character not directly preceded by Soft_Dotted.
+                // - COMBINING DOT BELOW (U+0323), combining class 220 (Below)
+                AddStringsForChars(softDotted[i] + "\u0323\u0307", softDottedUpperCased[i] + "\u0323");
+
+                // COMBINING DOT ABOVE removed if preceded by Soft_Dotted.
+                // Character not directly preceded by Soft_Dotted.
+                // - PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE (U+101FD = D800 DDFD), combining class 220 (Below)
+                AddStringsForChars(softDotted[i] + "\uD800\uDDFD\u0307", softDottedUpperCased[i] + "\uD800\uDDFD");
+            }
+
+            return fullSetOfData;
         }
     }
 }
-
-//var softDotted = [
-//    "\u0069",
-//    "\u006A",   // LATIN SMALL LETTER I..LATIN SMALL LETTER J
-//    "\u012F",             // LATIN SMALL LETTER I WITH OGONEK
-//    "\u0249",             // LATIN SMALL LETTER J WITH STROKE
-//    "\u0268",             // LATIN SMALL LETTER I WITH STROKE
-//    "\u029D",             // LATIN SMALL LETTER J WITH CROSSED-TAIL
-//    "\u02B2",             // MODIFIER LETTER SMALL J
-//    "\u03F3",             // GREEK LETTER YOT
-//    "\u0456",             // CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
-//    "\u0458",             // CYRILLIC SMALL LETTER JE
-//    "\u1D62",             // LATIN SUBSCRIPT SMALL LETTER I
-//    "\u1D96",             // LATIN SMALL LETTER I WITH RETROFLEX HOOK
-//    "\u1DA4",             // MODIFIER LETTER SMALL I WITH STROKE
-//    "\u1DA8",             // MODIFIER LETTER SMALL J WITH CROSSED-TAIL
-//    "\u1E2D",             // LATIN SMALL LETTER I WITH TILDE BELOW
-//    "\u1ECB",             // LATIN SMALL LETTER I WITH DOT BELOW
-//    "\u2071",             // SUPERSCRIPT LATIN SMALL LETTER I
-//    "\u2148",
-//    "\u2149",   // DOUBLE-STRUCK ITALIC SMALL I..DOUBLE-STRUCK ITALIC SMALL J
-//    "\u2C7C",             // LATIN SUBSCRIPT SMALL LETTER J
-//    "\uD835\uDC22",
-//    "\uD835\uDC23",   // MATHEMATICAL BOLD SMALL I..MATHEMATICAL BOLD SMALL J
-//    "\uD835\uDC56",
-//    "\uD835\uDC57",   // MATHEMATICAL ITALIC SMALL I..MATHEMATICAL ITALIC SMALL J
-//    "\uD835\uDC8A",
-//    "\uD835\uDC8B",   // MATHEMATICAL BOLD ITALIC SMALL I..MATHEMATICAL BOLD ITALIC SMALL J
-//    "\uD835\uDCBE",
-//    "\uD835\uDCBF",   // MATHEMATICAL SCRIPT SMALL I..MATHEMATICAL SCRIPT SMALL J
-//    "\uD835\uDCF2",
-//    "\uD835\uDCF3",   // MATHEMATICAL BOLD SCRIPT SMALL I..MATHEMATICAL BOLD SCRIPT SMALL J
-//    "\uD835\uDD26",
-//    "\uD835\uDD27",   // MATHEMATICAL FRAKTUR SMALL I..MATHEMATICAL FRAKTUR SMALL J
-//    "\uD835\uDD5A",
-//    "\uD835\uDD5B",   // MATHEMATICAL DOUBLE-STRUCK SMALL I..MATHEMATICAL DOUBLE-STRUCK SMALL J
-//    "\uD835\uDD8E",
-//    "\uD835\uDD8F",   // MATHEMATICAL BOLD FRAKTUR SMALL I..MATHEMATICAL BOLD FRAKTUR SMALL J
-//    "\uD835\uDDC2",
-//    "\uD835\uDDC3",   // MATHEMATICAL SANS-SERIF SMALL I..MATHEMATICAL SANS-SERIF SMALL J
-//    "\uD835\uDDF6",
-//    "\uD835\uDDF7",   // MATHEMATICAL SANS-SERIF BOLD SMALL I..MATHEMATICAL SANS-SERIF BOLD SMALL J
-//    "\uD835\uDE2A",
-//    "\uD835\uDE2B",   // MATHEMATICAL SANS-SERIF ITALIC SMALL I..MATHEMATICAL SANS-SERIF ITALIC SMALL J
-//    "\uD835\uDE5E",
-//    "\uD835\uDE5F",   // MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL I..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL J
-//    "\uD835\uDE92",
-//    "\uD835\uDE93",   // MATHEMATICAL MONOSPACE SMALL I..MATHEMATICAL MONOSPACE SMALL J
-//];

--- a/Jint.Tests/Runtime/StringTetsLithuaniaData.cs
+++ b/Jint.Tests/Runtime/StringTetsLithuaniaData.cs
@@ -1,0 +1,110 @@
+﻿namespace Jint.Tests.Runtime
+{
+    public class StringTetsLithuaniaData
+    {
+        // Results obtained from node -v 18.12.0.
+        public TheoryData<string, string> TestData()
+        {
+            return new TheoryData<string, string> // <stringToParse, result>
+            {
+                // COMBINING DOT ABOVE (U+0307) not removed when uppercasing capital I and J.
+                // I
+                { "İlorem ipsum", "İLOREM IPSUM" },
+                { "İİlorem ipsum", "İİLOREM IPSUM" },
+                { "loremİipsum", "LOREMİIPSUM" },
+                { "loremİİipsum", "LOREMİİIPSUM" },
+                { "lorem ipsumİ", "LOREM IPSUMİ" },
+                { "lorem ipsumİİ", "LOREM IPSUMİİ" },
+
+                // J
+                { "J̇lorem ipsum", "J̇LOREM IPSUM"  },
+                { "J̇J̇lorem ipsum", "J̇J̇LOREM IPSUM" },
+                { "loremJ̇ipsum", "LOREMJ̇IPSUM" },
+                { "loremJ̇J̇ipsum", "LOREMJ̇J̇IPSUM" },
+                { "lorem ipsumJ̇", "LOREM IPSUMJ̇" },
+                { "lorem ipsumJ̇J̇", "LOREM IPSUMJ̇J̇" },
+
+                // DOT ABOVE (U+0307) removed if its other capital letter other than I or J.
+                { "Ȧlorem ipsum", "ALOREM IPSUM" },
+                { "ȦȦlorem ipsum", "AALOREM IPSUM" },
+                { "loremȦipsum", "LOREMAIPSUM" },
+                { "loremȦȦipsum", "LOREMAAIPSUM" },
+                { "lorem ipsumȦ", "LOREM IPSUMA" },
+                {  "lorem ipsumȦȦ", "LOREM IPSUMAA" },
+
+                // COMBINING DOT ABOVE (U+0307) removed when preceded by Soft_Dotted
+                // Character directly preceded by Soft_Dotted.
+                // "\u0069" + "\u0307", not latin 'i'.
+                { "ilorem ipsum", "ILOREM IPSUM" },
+                { "iilorem ipsum", "IILOREM IPSUM" },
+                { "loremiipsum", "LOREMIIPSUM" },
+                { "loremiiipsum", "LOREMIIIPSUM" },
+                { "loremipsumi", "LOREMIPSUMI" },
+                { "loremipsumii", "LOREMIPSUMII" },
+                // "\u006A" + "\u0307", not latin 'j'.
+                { "j̇lorem ipsum", "JLOREM IPSUM" },
+                { "j̇j̇lorem ipsum", "JJLOREM IPSUM" },
+                { "loremj̇ipsum", "LOREMJIPSUM" },
+                { "loremj̇j̇ipsum", "LOREMJJIPSUM" },
+                { "loremipsumj̇", "LOREMIPSUMJ" },
+                { "loremipsumj̇j̇", "LOREMIPSUMJJ" },
+                // "\u012F" + "\u0307" 
+                { "į̇lorem ipsum", "ĮLOREM IPSUM" },
+                { "į̇į̇lorem ipsum", "ĮĮLOREM IPSUM" },
+                { "loremį̇ipsum", "LOREMĮIPSUM" },
+                { "loremį̇į̇ipsum", "LOREMĮĮIPSUM" },
+                { "loremipsumį̇", "LOREMIPSUMĮ" },
+                { "loremipsumį̇į̇", "LOREMIPSUMĮĮ" },
+            };
+        }
+    }
+}
+
+//var softDotted = [
+//    "\u0069",
+//    "\u006A",   // LATIN SMALL LETTER I..LATIN SMALL LETTER J
+//    "\u012F",             // LATIN SMALL LETTER I WITH OGONEK
+//    "\u0249",             // LATIN SMALL LETTER J WITH STROKE
+//    "\u0268",             // LATIN SMALL LETTER I WITH STROKE
+//    "\u029D",             // LATIN SMALL LETTER J WITH CROSSED-TAIL
+//    "\u02B2",             // MODIFIER LETTER SMALL J
+//    "\u03F3",             // GREEK LETTER YOT
+//    "\u0456",             // CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+//    "\u0458",             // CYRILLIC SMALL LETTER JE
+//    "\u1D62",             // LATIN SUBSCRIPT SMALL LETTER I
+//    "\u1D96",             // LATIN SMALL LETTER I WITH RETROFLEX HOOK
+//    "\u1DA4",             // MODIFIER LETTER SMALL I WITH STROKE
+//    "\u1DA8",             // MODIFIER LETTER SMALL J WITH CROSSED-TAIL
+//    "\u1E2D",             // LATIN SMALL LETTER I WITH TILDE BELOW
+//    "\u1ECB",             // LATIN SMALL LETTER I WITH DOT BELOW
+//    "\u2071",             // SUPERSCRIPT LATIN SMALL LETTER I
+//    "\u2148",
+//    "\u2149",   // DOUBLE-STRUCK ITALIC SMALL I..DOUBLE-STRUCK ITALIC SMALL J
+//    "\u2C7C",             // LATIN SUBSCRIPT SMALL LETTER J
+//    "\uD835\uDC22",
+//    "\uD835\uDC23",   // MATHEMATICAL BOLD SMALL I..MATHEMATICAL BOLD SMALL J
+//    "\uD835\uDC56",
+//    "\uD835\uDC57",   // MATHEMATICAL ITALIC SMALL I..MATHEMATICAL ITALIC SMALL J
+//    "\uD835\uDC8A",
+//    "\uD835\uDC8B",   // MATHEMATICAL BOLD ITALIC SMALL I..MATHEMATICAL BOLD ITALIC SMALL J
+//    "\uD835\uDCBE",
+//    "\uD835\uDCBF",   // MATHEMATICAL SCRIPT SMALL I..MATHEMATICAL SCRIPT SMALL J
+//    "\uD835\uDCF2",
+//    "\uD835\uDCF3",   // MATHEMATICAL BOLD SCRIPT SMALL I..MATHEMATICAL BOLD SCRIPT SMALL J
+//    "\uD835\uDD26",
+//    "\uD835\uDD27",   // MATHEMATICAL FRAKTUR SMALL I..MATHEMATICAL FRAKTUR SMALL J
+//    "\uD835\uDD5A",
+//    "\uD835\uDD5B",   // MATHEMATICAL DOUBLE-STRUCK SMALL I..MATHEMATICAL DOUBLE-STRUCK SMALL J
+//    "\uD835\uDD8E",
+//    "\uD835\uDD8F",   // MATHEMATICAL BOLD FRAKTUR SMALL I..MATHEMATICAL BOLD FRAKTUR SMALL J
+//    "\uD835\uDDC2",
+//    "\uD835\uDDC3",   // MATHEMATICAL SANS-SERIF SMALL I..MATHEMATICAL SANS-SERIF SMALL J
+//    "\uD835\uDDF6",
+//    "\uD835\uDDF7",   // MATHEMATICAL SANS-SERIF BOLD SMALL I..MATHEMATICAL SANS-SERIF BOLD SMALL J
+//    "\uD835\uDE2A",
+//    "\uD835\uDE2B",   // MATHEMATICAL SANS-SERIF ITALIC SMALL I..MATHEMATICAL SANS-SERIF ITALIC SMALL J
+//    "\uD835\uDE5E",
+//    "\uD835\uDE5F",   // MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL I..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL J
+//    "\uD835\uDE92",
+//    "\uD835\uDE93",   // MATHEMATICAL MONOSPACE SMALL I..MATHEMATICAL MONOSPACE SMALL J
+//];

--- a/Jint/Native/String/StringInlHelper.cs
+++ b/Jint/Native/String/StringInlHelper.cs
@@ -1,0 +1,55 @@
+﻿using System.Text;
+
+namespace Jint.Native.String
+{
+    /// <summary>
+    /// Some internacionalization logic that is special or specific to determined culture.
+    /// </summary>
+    internal class StringInlHelper
+    {
+        private static List<int> GetLithuaninanReplaceableCharIdx(string input)
+        {
+            List<int> replaceableCharsIdx = new List<int>();
+            for (int i = 0; i < input.Length; i++)
+            {
+                if (input[i].Equals('\u0307'))
+                {
+                    replaceableCharsIdx.Add(i);
+                }
+            }
+
+            // For capital I and J we do not replace the dot above (\u3017).
+            replaceableCharsIdx
+                .RemoveAll(idx => (idx > 0) && input[idx - 1] == 'I' || input[idx - 1] == 'J');
+
+            return replaceableCharsIdx;
+        }
+
+        /// <summary>
+        /// Lithuanian case is a bit special. For more info see:
+        /// https://github.com/tc39/test262/blob/main/test/intl402/String/prototype/toLocaleUpperCase/special_casing_Lithuanian.js
+        /// </summary>
+        public static string LithuanianStringProcessor(string input)
+        {
+            var replaceableCharsIdx = GetLithuaninanReplaceableCharIdx(input);
+            if (replaceableCharsIdx.Count > 0)
+            {
+                StringBuilder stringBuilder = new StringBuilder(input);
+
+                // Remove characters in reverse order to avoid index shifting
+                for (int i = replaceableCharsIdx.Count - 1; i >= 0; i--)
+                {
+                    int index = replaceableCharsIdx[i];
+                    if (index >= 0 && index < stringBuilder.Length)
+                    {
+                        stringBuilder.Remove(index, 1);
+                    }
+                }
+
+                return stringBuilder.ToString();
+            }
+
+            return input;
+        }
+    }
+}

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -228,51 +228,6 @@ namespace Jint.Native.String
             return TrimEndEx(s.ToString());
         }
 
-        static List<int> GetLithuaninanReplaceableCharIdx(string input)
-        {
-            List<int> replaceableCharsIdx = new List<int>();
-            for (int i = 0; i < input.Length; i++)
-            {
-                if (input[i].Equals('\u0307'))
-                {
-                    replaceableCharsIdx.Add(i);
-                }
-            }
-
-            // For capital I and J we do not replace the dot above (\u3017).
-            replaceableCharsIdx
-                .RemoveAll(idx => (idx > 0) && input[idx - 1] == 'I' || input[idx - 1] == 'J');
-
-            return replaceableCharsIdx;
-        }
-
-        /// <summary>
-        /// Lithuanian case is a bit special. For more info see:
-        /// https://github.com/tc39/test262/blob/main/test/intl402/String/prototype/toLocaleUpperCase/special_casing_Lithuanian.js
-        /// </summary>
-        static string LithuanianStringProcessor(string input)
-        {
-            var replaceableCharsIdx = GetLithuaninanReplaceableCharIdx(input);
-            if (replaceableCharsIdx.Count > 0)
-            {
-                StringBuilder stringBuilder = new StringBuilder(input);
-
-                // Remove characters in reverse order to avoid index shifting
-                for (int i = replaceableCharsIdx.Count - 1; i >= 0; i--)
-                {
-                    int index = replaceableCharsIdx[i];
-                    if (index >= 0 && index < stringBuilder.Length)
-                    {
-                        stringBuilder.Remove(index, 1);
-                    }
-                }
-
-                return stringBuilder.ToString();
-            }
-
-            return input;
-        }
-
         private JsValue ToLocaleUpperCase(JsValue thisObject, JsValue[] arguments)
         {
             TypeConverter.CheckObjectCoercible(_engine, thisObject);
@@ -292,7 +247,7 @@ namespace Jint.Native.String
             }
             if (string.Equals("lt", culture.Name, StringComparison.OrdinalIgnoreCase))
             {
-                s = LithuanianStringProcessor(s);
+                s = StringInlHelper.LithuanianStringProcessor(s);
             }
 
             return new JsString(s.ToUpper(culture));

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -248,6 +248,13 @@ namespace Jint.Native.String
             if (string.Equals("lt", culture.Name, StringComparison.OrdinalIgnoreCase))
             {
                 s = StringInlHelper.LithuanianStringProcessor(s);
+#if NET462
+                // Code specific to .NET Framework 4.6.2.
+                // For no good reason this verison does not upper case these characters correctly.
+                return new JsString(s.ToUpper(culture)
+                    .Replace("ϳ", "Ϳ")
+                    .Replace("ʝ", "Ʝ"));
+#endif
             }
 
             return new JsString(s.ToUpper(culture));


### PR DESCRIPTION
Adding some easy win test fixes. 
Before:
![image](https://github.com/sebastienros/jint/assets/49386405/bf8e661a-e0cc-4364-98d6-4d2fcf44f7f8)
With fix:
![image](https://github.com/sebastienros/jint/assets/49386405/6fda7ab3-980a-4278-8808-18f81c885a5e)

Comments:

- Lithuanian case is quite tricky. Only fixed the tests. Maybe there is some more work to do to check larger texts are upper-case-ed correctly.
- Maybe some very specific functionality in internationalization (such as `LithuanianStringProcessor`) needs its place in the project, kind of some utils folder or similar. Please advice if that needs to be moved somewhere else. 
- I only wanted to fix "ToLocaleUpperCase" tests because it seemed an easy win. Apparently, more tests get fixed. Don't know why and I did not dig into that. 
