### PR TITLE
Return old recursion limit capabilities

### DIFF
--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -9,7 +9,7 @@ public class EngineLimitTests
 {
 
 #if RELEASE
-    const int FunctionNestingCount = 840;
+    const int FunctionNestingCount = 1010;
 #else
     const int FunctionNestingCount = 510;
 #endif

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -34,7 +34,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             return context.Engine.GetValue(reference, true);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining | (MethodImplOptions) 512)]
         public object Evaluate(EvaluationContext context)
         {
             var oldSyntaxElement = context.LastSyntaxElement;

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -33,7 +33,7 @@ internal sealed class JintFunctionDefinition
     /// <summary>
     /// https://tc39.es/ecma262/#sec-ordinarycallevaluatebody
     /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining | (MethodImplOptions) 512)]
     internal Completion EvaluateBody(EvaluationContext context, FunctionInstance functionObject, JsValue[] argumentsList)
     {
         Completion result;

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Error;
@@ -63,6 +64,8 @@ namespace Jint.Runtime.Interpreter
             _jintStatements = jintStatements;
         }
 
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining | (MethodImplOptions) 512)]
         public Completion Execute(EvaluationContext context)
         {
             if (!_initialized)

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -26,7 +26,7 @@ namespace Jint.Runtime.Interpreter.Statements
             _statement = statement;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining | (MethodImplOptions) 512)]
         public Completion Execute(EvaluationContext context)
         {
             if (_statement.Type != Nodes.BlockStatement)


### PR DESCRIPTION
We can now actually do better than the old limit `960` which was before NET 8