### PR TITLE
Debug StepInto stops at beginning of arrow function

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -506,7 +506,7 @@ namespace Jint
             }
         }
 
-        internal void RunBeforeExecuteStatementChecks(Statement? statement)
+        internal void RunBeforeExecuteStatementChecks(StatementListItem? statement)
         {
             // Avoid allocating the enumerator because we run this loop very often.
             foreach (var constraint in _constraints)

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -45,7 +45,7 @@ internal sealed class EvaluationContext
     public string? Target;
     public CompletionType Completion;
 
-    public void RunBeforeExecuteStatementChecks(Statement statement)
+    public void RunBeforeExecuteStatementChecks(StatementListItem statement)
     {
         if (_shouldRunBeforeExecuteStatementChecks)
         {

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -48,6 +48,7 @@ internal sealed class JintFunctionDefinition
                 AsyncFunctionStart(context, promiseCapability, context =>
                 {
                     context.Engine.FunctionDeclarationInstantiation(functionObject, argumentsList);
+                    context.RunBeforeExecuteStatementChecks(Function.Body);
                     var jsValue = _bodyExpression.GetValue(context).Clone();
                     return new Completion(CompletionType.Return, jsValue, _bodyExpression._expression);
                 });
@@ -56,6 +57,7 @@ internal sealed class JintFunctionDefinition
             else
             {
                 argumentsInstance = context.Engine.FunctionDeclarationInstantiation(functionObject, argumentsList);
+                context.RunBeforeExecuteStatementChecks(Function.Body);
                 var jsValue = _bodyExpression.GetValue(context).Clone();
                 result = new Completion(CompletionType.Return, jsValue, Function.Body);
             }


### PR DESCRIPTION
When using `StepMode.Into`, the debugger callback `DebugHandler.Step` did not get fired before the execution of a single expression arrow function.

For example, having this statement
```js
[1, 2, 3].map(v => v * 2)
```
The debugger would not stop before the `v * 2` expression - only after.

In contrast, having this statement
```js
[1, 2, 3].map(function(v) { return v * 2; })
```
The debugger would stop before and after the `return v * 2` expression.

Two tests were added, one for the `function` type and one for the `arrow` type.