### PR TITLE
Remove Record suffix from types

### DIFF
--- a/Jint.Tests.PublicInterface/FunctionTests.cs
+++ b/Jint.Tests.PublicInterface/FunctionTests.cs
@@ -1,0 +1,29 @@
+using Esprima.Ast;
+using Jint.Native.Function;
+
+namespace Jint.Tests.PublicInterface;
+
+public class FunctionTests
+{
+    [Fact]
+    public void CanConstructorCustomScriptFunction()
+    {
+        var engine = new Engine();
+        var functionExp = new FunctionExpression(
+            new Identifier("f"),
+            NodeList.Create(Array.Empty<Node>()),
+            new BlockStatement(NodeList.Create<Statement>(Array.Empty<Statement>())),
+            generator: false,
+            strict: true,
+            async: false);
+
+        var functionObject = new ScriptFunctionInstance(
+            engine,
+            functionExp,
+            engine.CreateNewDeclarativeEnvironment(),
+            strict: true
+        );
+
+        Assert.NotNull(functionObject);
+    }
+}

--- a/Jint/Engine.Ast.cs
+++ b/Jint/Engine.Ast.cs
@@ -1,9 +1,9 @@
 using Esprima;
 using Esprima.Ast;
 using Jint.Native;
-using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
 using Jint.Runtime.Interpreter.Expressions;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint;
 
@@ -43,7 +43,7 @@ public partial class Engine
 
     private sealed class AstAnalyzer
     {
-        private readonly Dictionary<string, EnvironmentRecord.BindingName> _bindingNames = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Environment.BindingName> _bindingNames = new(StringComparer.Ordinal);
 
         public void NodeVisitor(Node node)
         {
@@ -55,7 +55,7 @@ public partial class Engine
 
                         if (!_bindingNames.TryGetValue(name, out var bindingName))
                         {
-                            _bindingNames[name] = bindingName = new EnvironmentRecord.BindingName(JsString.CachedCreate(name));
+                            _bindingNames[name] = bindingName = new Environment.BindingName(JsString.CachedCreate(name));
                         }
 
                         node.AssociatedData = bindingName;

--- a/Jint/Engine.Helpers.cs
+++ b/Jint/Engine.Helpers.cs
@@ -1,4 +1,5 @@
 using Jint.Runtime.Environments;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint;
 
@@ -10,7 +11,7 @@ public partial class Engine
     /// <summary>
     /// Creates a new declarative environment that has current lexical environment as outer scope.
     /// </summary>
-    public EnvironmentRecord CreateNewDeclarativeEnvironment()
+    public Environment CreateNewDeclarativeEnvironment()
     {
         return JintEnvironment.NewDeclarativeEnvironment(this, ExecutionContext.LexicalEnvironment);
     }

--- a/Jint/EsprimaExtensions.cs
+++ b/Jint/EsprimaExtensions.cs
@@ -10,6 +10,7 @@ using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
 using Jint.Runtime.Interpreter.Expressions;
 using Jint.Runtime.Modules;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint
 {
@@ -282,11 +283,11 @@ namespace Jint
             this Node? expression,
             EvaluationContext context,
             JsValue value,
-            EnvironmentRecord env)
+            Environment env)
         {
             if (expression is Identifier identifier)
             {
-                var catchEnvRecord = (DeclarativeEnvironmentRecord) env;
+                var catchEnvRecord = (DeclarativeEnvironment) env;
                 catchEnvRecord.CreateMutableBindingAndInitialize(identifier.Name, canBeDeleted: false, value);
             }
             else if (expression is BindingPattern bindingPattern)

--- a/Jint/HoistingScope.cs
+++ b/Jint/HoistingScope.cs
@@ -1,5 +1,6 @@
 using Esprima.Ast;
 using Jint.Runtime.Modules;
+using Module = Esprima.Ast.Module;
 
 namespace Jint
 {

--- a/Jint/ModuleBuilder.cs
+++ b/Jint/ModuleBuilder.cs
@@ -4,6 +4,7 @@ using Jint.Native;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
 using Jint.Runtime.Modules;
+using Module = Esprima.Ast.Module;
 
 namespace Jint;
 
@@ -146,7 +147,7 @@ public sealed class ModuleBuilder
         }
     }
 
-    internal void BindExportedValues(BuilderModuleRecord module)
+    internal void BindExportedValues(BuilderModule module)
     {
         foreach (var export in _exports)
         {

--- a/Jint/Native/Argument/ArgumentsInstance.cs
+++ b/Jint/Native/Argument/ArgumentsInstance.cs
@@ -21,7 +21,7 @@ namespace Jint.Native.Argument
         private FunctionInstance _func = null!;
         private Key[] _names = null!;
         private JsValue[] _args = null!;
-        private DeclarativeEnvironmentRecord _env = null!;
+        private DeclarativeEnvironment _env = null!;
         private bool _canReturnToPool;
         private bool _hasRestParameter;
         private bool _materialized;
@@ -35,7 +35,7 @@ namespace Jint.Native.Argument
             FunctionInstance func,
             Key[] names,
             JsValue[] args,
-            DeclarativeEnvironmentRecord env,
+            DeclarativeEnvironment env,
             bool hasRestParameter)
         {
             _func = func;

--- a/Jint/Native/Function/ClassDefinition.cs
+++ b/Jint/Native/Function/ClassDefinition.cs
@@ -7,6 +7,7 @@ using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
 using Jint.Runtime.Interpreter.Expressions;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Native.Function;
 
@@ -49,7 +50,7 @@ internal sealed class ClassDefinition
     /// <summary>
     /// https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation
     /// </summary>
-    public JsValue BuildConstructor(EvaluationContext context, EnvironmentRecord env)
+    public JsValue BuildConstructor(EvaluationContext context, Environment env)
     {
         // A class definition is always strict mode code.
         using var _ = new StrictModeScope(true, true);

--- a/Jint/Native/Function/EvalFunctionInstance.cs
+++ b/Jint/Native/Function/EvalFunctionInstance.cs
@@ -5,6 +5,7 @@ using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Statements;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Native.Function;
 
@@ -57,7 +58,7 @@ internal sealed class EvalFunctionInstance : FunctionInstance
         if (direct)
         {
             var thisEnvRec = _engine.ExecutionContext.GetThisEnvironment();
-            if (thisEnvRec is FunctionEnvironmentRecord functionEnvironmentRecord)
+            if (thisEnvRec is FunctionEnvironment functionEnvironmentRecord)
             {
                 var F = functionEnvironmentRecord._functionObject;
                 inFunction = true;
@@ -142,9 +143,9 @@ internal sealed class EvalFunctionInstance : FunctionInstance
 
         using (new StrictModeScope(strictEval))
         {
-            EnvironmentRecord lexEnv;
-            EnvironmentRecord varEnv;
-            PrivateEnvironmentRecord? privateEnv;
+            Environment lexEnv;
+            Environment varEnv;
+            PrivateEnvironment? privateEnv;
             if (direct)
             {
                 lexEnv = JintEnvironment.NewDeclarativeEnvironment(_engine, ctx.LexicalEnvironment);

--- a/Jint/Native/Function/FunctionConstructor.cs
+++ b/Jint/Native/Function/FunctionConstructor.cs
@@ -3,6 +3,7 @@ using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Native.Function
 {
@@ -48,8 +49,8 @@ namespace Jint.Native.Function
         /// </summary>
         internal FunctionInstance InstantiateFunctionObject(
             JintFunctionDefinition functionDeclaration,
-            EnvironmentRecord scope,
-            PrivateEnvironmentRecord? privateEnv)
+            Environment scope,
+            PrivateEnvironment? privateEnv)
         {
             var function = functionDeclaration.Function;
             if (!function.Generator)
@@ -69,8 +70,8 @@ namespace Jint.Native.Function
         /// </summary>
         private ScriptFunctionInstance InstantiateAsyncFunctionObject(
             JintFunctionDefinition functionDeclaration,
-            EnvironmentRecord env,
-            PrivateEnvironmentRecord? privateEnv)
+            Environment env,
+            PrivateEnvironment? privateEnv)
         {
             var F = OrdinaryFunctionCreate(
                 _realm.Intrinsics.AsyncFunction.PrototypeObject,
@@ -89,8 +90,8 @@ namespace Jint.Native.Function
         /// </summary>
         private ScriptFunctionInstance InstantiateOrdinaryFunctionObject(
             JintFunctionDefinition functionDeclaration,
-            EnvironmentRecord env,
-            PrivateEnvironmentRecord? privateEnv)
+            Environment env,
+            PrivateEnvironment? privateEnv)
         {
             var F = OrdinaryFunctionCreate(
                 _realm.Intrinsics.Function.PrototypeObject,
@@ -110,8 +111,8 @@ namespace Jint.Native.Function
         /// </summary>
         private ScriptFunctionInstance InstantiateGeneratorFunctionObject(
             JintFunctionDefinition functionDeclaration,
-            EnvironmentRecord scope,
-            PrivateEnvironmentRecord? privateScope)
+            Environment scope,
+            PrivateEnvironment? privateScope)
         {
             // TODO generators
             return InstantiateOrdinaryFunctionObject(functionDeclaration, scope, privateScope);

--- a/Jint/Native/Function/FunctionInstance.Dynamic.cs
+++ b/Jint/Native/Function/FunctionInstance.Dynamic.cs
@@ -4,6 +4,7 @@ using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Native.Function;
 
@@ -153,7 +154,7 @@ public partial class FunctionInstance
         var proto = GetPrototypeFromConstructor(newTarget, fallbackProto);
         var realmF = _realm;
         var scope = realmF.GlobalEnv;
-        PrivateEnvironmentRecord? privateEnv = null;
+        PrivateEnvironment? privateEnv = null;
 
         var definition = new JintFunctionDefinition(function);
         FunctionInstance F = OrdinaryFunctionCreate(proto, definition, function.Strict ? FunctionThisMode.Strict : FunctionThisMode.Global, scope, privateEnv);
@@ -185,8 +186,8 @@ public partial class FunctionInstance
         ObjectInstance functionPrototype,
         JintFunctionDefinition function,
         FunctionThisMode thisMode,
-        EnvironmentRecord scope,
-        PrivateEnvironmentRecord? privateScope)
+        Environment scope,
+        PrivateEnvironment? privateScope)
     {
         return new ScriptFunctionInstance(
             _engine,

--- a/Jint/Native/Function/FunctionInstance.cs
+++ b/Jint/Native/Function/FunctionInstance.cs
@@ -7,6 +7,7 @@ using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Native.Function
 {
@@ -18,14 +19,14 @@ namespace Jint.Native.Function
         protected internal PropertyDescriptor? _length;
         internal PropertyDescriptor? _nameDescriptor;
 
-        protected internal EnvironmentRecord? _environment;
+        protected internal Environment? _environment;
         internal readonly JintFunctionDefinition _functionDefinition = null!;
         internal readonly FunctionThisMode _thisMode;
         internal JsValue _homeObject = Undefined;
         internal ConstructorKind _constructorKind = ConstructorKind.Base;
 
         internal Realm _realm;
-        internal PrivateEnvironmentRecord? _privateEnvironment;
+        internal PrivateEnvironment? _privateEnvironment;
         private readonly IScriptOrModule? _scriptOrModule;
 
         protected FunctionInstance(
@@ -40,7 +41,7 @@ namespace Jint.Native.Function
             Engine engine,
             Realm realm,
             JintFunctionDefinition function,
-            EnvironmentRecord env,
+            Environment env,
             FunctionThisMode thisMode)
             : this(
                 engine,
@@ -292,7 +293,7 @@ namespace Jint.Native.Function
 
             var calleeRealm = _realm;
 
-            var localEnv = (FunctionEnvironmentRecord) calleeContext.LexicalEnvironment;
+            var localEnv = (FunctionEnvironment) calleeContext.LexicalEnvironment;
             JsValue thisValue;
             if (_thisMode == FunctionThisMode.Strict)
             {

--- a/Jint/Native/Function/ScriptFunctionInstance.cs
+++ b/Jint/Native/Function/ScriptFunctionInstance.cs
@@ -5,6 +5,7 @@ using Jint.Runtime.Descriptors;
 using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Native.Function
 {
@@ -22,7 +23,7 @@ namespace Jint.Native.Function
         public ScriptFunctionInstance(
             Engine engine,
             IFunction functionDeclaration,
-            EnvironmentRecord env,
+            Environment env,
             bool strict,
             ObjectInstance? proto = null)
             : this(
@@ -37,7 +38,7 @@ namespace Jint.Native.Function
         internal ScriptFunctionInstance(
             Engine engine,
             JintFunctionDefinition function,
-            EnvironmentRecord env,
+            Environment env,
             FunctionThisMode thisMode,
             ObjectInstance? proto = null)
             : base(engine, engine.Realm, function, env, thisMode)
@@ -144,7 +145,7 @@ namespace Jint.Native.Function
             }
 
             var calleeContext = PrepareForOrdinaryCall(newTarget);
-            var constructorEnv = (FunctionEnvironmentRecord) calleeContext.LexicalEnvironment;
+            var constructorEnv = (FunctionEnvironment) calleeContext.LexicalEnvironment;
 
             var strict = _thisMode == FunctionThisMode.Strict;
             using (new StrictModeScope(strict, force: true))

--- a/Jint/Native/ShadowRealm/ShadowRealm.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealm.cs
@@ -11,6 +11,7 @@ using Jint.Runtime.Interop;
 using Jint.Runtime.Interpreter;
 using Jint.Runtime.Interpreter.Statements;
 using Jint.Runtime.Modules;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Native.ShadowRealm;
 
@@ -153,7 +154,7 @@ public sealed class ShadowRealm : ObjectInstance
         var strictEval = script.Strict;
         var runningContext = _engine.ExecutionContext;
         var lexEnv = JintEnvironment.NewDeclarativeEnvironment(_engine, evalRealm.GlobalEnv);
-        EnvironmentRecord varEnv = evalRealm.GlobalEnv;
+        Environment varEnv = evalRealm.GlobalEnv;
 
         if (strictEval)
         {

--- a/Jint/Pooling/ArgumentsInstancePool.cs
+++ b/Jint/Pooling/ArgumentsInstancePool.cs
@@ -35,7 +35,7 @@ namespace Jint.Pooling
             FunctionInstance? func,
             Key[]? formals,
             JsValue[] argumentsList,
-            DeclarativeEnvironmentRecord? env,
+            DeclarativeEnvironment? env,
             bool hasRestParameter)
         {
             var obj = _pool.Allocate();

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -8,6 +8,7 @@ using Jint.Collections;
 using Jint.Native.Function;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.CallStack
 {
@@ -19,9 +20,9 @@ namespace Jint.Runtime.CallStack
             LexicalEnvironment = context.LexicalEnvironment;
         }
 
-        internal readonly EnvironmentRecord LexicalEnvironment;
+        internal readonly Environment LexicalEnvironment;
 
-        internal EnvironmentRecord GetThisEnvironment()
+        internal Environment GetThisEnvironment()
         {
             var lex = LexicalEnvironment;
             while (true)
@@ -155,7 +156,7 @@ namespace Jint.Runtime.CallStack
                 sb.Append(loc.End.Line.ToString(CultureInfo.InvariantCulture));
                 sb.Append(':');
                 sb.Append((loc.Start.Column + 1).ToString(CultureInfo.InvariantCulture)); // report column number instead of index
-                sb.Append(Environment.NewLine);
+                sb.Append(System.Environment.NewLine);
             }
 
             var builder = new ValueStringBuilder();

--- a/Jint/Runtime/Debugger/CallFrame.cs
+++ b/Jint/Runtime/Debugger/CallFrame.cs
@@ -2,7 +2,7 @@ using Esprima;
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.CallStack;
-using Jint.Runtime.Environments;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Debugger
 {
@@ -26,7 +26,7 @@ namespace Jint.Runtime.Debugger
             _scopeChain = new Lazy<DebugScopes>(() => new DebugScopes(Environment));
         }
 
-        private EnvironmentRecord Environment => _context.LexicalEnvironment;
+        private Environment Environment => _context.LexicalEnvironment;
 
         // TODO: CallFrameId
         /// <summary>

--- a/Jint/Runtime/Debugger/DebugScope.cs
+++ b/Jint/Runtime/Debugger/DebugScope.cs
@@ -1,6 +1,7 @@
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime.Environments;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Debugger
 {
@@ -9,14 +10,14 @@ namespace Jint.Runtime.Debugger
     /// </summary>
     public sealed class DebugScope
     {
-        private readonly EnvironmentRecord _record;
+        private readonly Environment _record;
         private string[]? _bindingNames;
 
-        internal DebugScope(DebugScopeType type, EnvironmentRecord record, bool isTopLevel)
+        internal DebugScope(DebugScopeType type, Environment record, bool isTopLevel)
         {
             ScopeType = type;
             _record = record;
-            BindingObject = record is ObjectEnvironmentRecord objEnv ? objEnv._bindingObject : null;
+            BindingObject = record is ObjectEnvironment objEnv ? objEnv._bindingObject : null;
             IsTopLevel = isTopLevel;
         }
 
@@ -56,7 +57,7 @@ namespace Jint.Runtime.Debugger
         /// <returns>Value of the binding</returns>
         public JsValue? GetBindingValue(string name)
         {
-            _record.TryGetBinding(new EnvironmentRecord.BindingName(name), strict: true, out _, out var result);
+            _record.TryGetBinding(new Environment.BindingName(name), strict: true, out _, out var result);
             return result;
         }
 

--- a/Jint/Runtime/Descriptors/Specialized/ClrAccessDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/ClrAccessDescriptor.cs
@@ -1,20 +1,21 @@
 using Jint.Native;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interop;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Descriptors.Specialized
 {
     internal sealed class ClrAccessDescriptor : PropertyDescriptor
     {
-        private readonly DeclarativeEnvironmentRecord _env;
+        private readonly DeclarativeEnvironment _env;
         private readonly Engine _engine;
-        private readonly EnvironmentRecord.BindingName _name;
+        private readonly Environment.BindingName _name;
 
         private GetterFunctionInstance? _get;
         private SetterFunctionInstance? _set;
 
         public ClrAccessDescriptor(
-            DeclarativeEnvironmentRecord env,
+            DeclarativeEnvironment env,
             Engine engine,
             string name)
             : base(value: null, PropertyFlag.Configurable)
@@ -22,7 +23,7 @@ namespace Jint.Runtime.Descriptors.Specialized
             _flags |= PropertyFlag.NonData;
             _env = env;
             _engine = engine;
-            _name = new EnvironmentRecord.BindingName(name);
+            _name = new Environment.BindingName(name);
         }
 
         public override JsValue Get => _get ??= new GetterFunctionInstance(_engine, DoGet);

--- a/Jint/Runtime/Environments/DeclarativeEnvironment.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironment.cs
@@ -9,12 +9,12 @@ namespace Jint.Runtime.Environments
     /// Represents a declarative environment record
     /// https://tc39.es/ecma262/#sec-declarative-environment-records
     /// </summary>
-    internal class DeclarativeEnvironmentRecord : EnvironmentRecord
+    internal class DeclarativeEnvironment : Environment
     {
         internal HybridDictionary<Binding>? _dictionary;
         internal readonly bool _catchEnvironment;
 
-        public DeclarativeEnvironmentRecord(Engine engine, bool catchEnvironment = false) : base(engine)
+        public DeclarativeEnvironment(Engine engine, bool catchEnvironment = false) : base(engine)
         {
             _catchEnvironment = catchEnvironment;
         }

--- a/Jint/Runtime/Environments/Environment.cs
+++ b/Jint/Runtime/Environments/Environment.cs
@@ -8,13 +8,13 @@ namespace Jint.Runtime.Environments
     /// Base implementation of an Environment Record
     /// https://tc39.es/ecma262/#sec-environment-records
     /// </summary>
-    [DebuggerTypeProxy(typeof(EnvironmentRecordDebugView))]
-    public abstract class EnvironmentRecord : JsValue
+    [DebuggerTypeProxy(typeof(EnvironmentDebugView))]
+    public abstract class Environment : JsValue
     {
         protected internal readonly Engine _engine;
-        protected internal EnvironmentRecord? _outerEnv;
+        protected internal Environment? _outerEnv;
 
-        protected EnvironmentRecord(Engine engine) : base(InternalTypes.ObjectEnvironmentRecord)
+        protected Environment(Engine engine) : base(InternalTypes.ObjectEnvironmentRecord)
         {
             _engine = engine;
         }
@@ -143,11 +143,11 @@ namespace Jint.Runtime.Environments
             }
         }
 
-        private sealed class EnvironmentRecordDebugView
+        private sealed class EnvironmentDebugView
         {
-            private readonly EnvironmentRecord _record;
+            private readonly Environment _record;
 
-            public EnvironmentRecordDebugView(EnvironmentRecord record)
+            public EnvironmentDebugView(Environment record)
             {
                 _record = record;
             }

--- a/Jint/Runtime/Environments/ExecutionContext.cs
+++ b/Jint/Runtime/Environments/ExecutionContext.cs
@@ -8,9 +8,9 @@ namespace Jint.Runtime.Environments
     {
         internal ExecutionContext(
             IScriptOrModule? scriptOrModule,
-            EnvironmentRecord lexicalEnvironment,
-            EnvironmentRecord variableEnvironment,
-            PrivateEnvironmentRecord? privateEnvironment,
+            Environment lexicalEnvironment,
+            Environment variableEnvironment,
+            PrivateEnvironment? privateEnvironment,
             Realm realm,
             GeneratorInstance? generator = null,
             FunctionInstance? function = null)
@@ -25,26 +25,26 @@ namespace Jint.Runtime.Environments
         }
 
         public readonly IScriptOrModule? ScriptOrModule;
-        public readonly EnvironmentRecord LexicalEnvironment;
-        public readonly EnvironmentRecord VariableEnvironment;
-        public readonly PrivateEnvironmentRecord? PrivateEnvironment;
+        public readonly Environment LexicalEnvironment;
+        public readonly Environment VariableEnvironment;
+        public readonly PrivateEnvironment? PrivateEnvironment;
         public readonly Realm Realm;
         public readonly FunctionInstance? Function;
         public readonly GeneratorInstance? Generator;
 
         public bool Suspended => Generator?._generatorState == GeneratorState.SuspendedYield;
 
-        public ExecutionContext UpdateLexicalEnvironment(EnvironmentRecord lexicalEnvironment)
+        public ExecutionContext UpdateLexicalEnvironment(Environment lexicalEnvironment)
         {
             return new ExecutionContext(ScriptOrModule, lexicalEnvironment, VariableEnvironment, PrivateEnvironment, Realm, Generator, Function);
         }
 
-        public ExecutionContext UpdateVariableEnvironment(EnvironmentRecord variableEnvironment)
+        public ExecutionContext UpdateVariableEnvironment(Environment variableEnvironment)
         {
             return new ExecutionContext(ScriptOrModule, LexicalEnvironment, variableEnvironment, PrivateEnvironment, Realm, Generator, Function);
         }
 
-        public ExecutionContext UpdatePrivateEnvironment(PrivateEnvironmentRecord? privateEnvironment)
+        public ExecutionContext UpdatePrivateEnvironment(PrivateEnvironment? privateEnvironment)
         {
             return new ExecutionContext(ScriptOrModule, LexicalEnvironment, VariableEnvironment, privateEnvironment, Realm, Generator, Function);
         }
@@ -57,7 +57,7 @@ namespace Jint.Runtime.Environments
         /// <summary>
         /// https://tc39.es/ecma262/#sec-getthisenvironment
         /// </summary>
-        internal EnvironmentRecord GetThisEnvironment()
+        internal Environment GetThisEnvironment()
         {
             // The loop will always terminate because the list of environments always
             // ends with the global environment which has a this binding.

--- a/Jint/Runtime/Environments/FunctionEnvironment.cs
+++ b/Jint/Runtime/Environments/FunctionEnvironment.cs
@@ -13,7 +13,7 @@ namespace Jint.Runtime.Environments
     /// <summary>
     /// https://tc39.es/ecma262/#sec-function-environment-records
     /// </summary>
-    internal sealed class FunctionEnvironmentRecord : DeclarativeEnvironmentRecord
+    internal sealed class FunctionEnvironment : DeclarativeEnvironment
     {
         private enum ThisBindingStatus
         {
@@ -26,7 +26,7 @@ namespace Jint.Runtime.Environments
         private ThisBindingStatus _thisBindingStatus;
         internal readonly FunctionInstance _functionObject;
 
-        public FunctionEnvironmentRecord(
+        public FunctionEnvironment(
             Engine engine,
             FunctionInstance functionObject,
             JsValue newTarget) : base(engine)
@@ -205,7 +205,7 @@ namespace Jint.Runtime.Environments
             {
                 var oldEnv = _engine.ExecutionContext.LexicalEnvironment;
                 var paramVarEnv = JintEnvironment.NewDeclarativeEnvironment(_engine, oldEnv);
-                PrivateEnvironmentRecord? privateEnvironment = null; // TODO PRIVATE check when implemented
+                PrivateEnvironment? privateEnvironment = null; // TODO PRIVATE check when implemented
                 _engine.EnterExecutionContext(paramVarEnv, paramVarEnv, _engine.ExecutionContext.Realm, privateEnvironment);
 
                 try

--- a/Jint/Runtime/Environments/GlobalEnvironment.cs
+++ b/Jint/Runtime/Environments/GlobalEnvironment.cs
@@ -10,14 +10,14 @@ namespace Jint.Runtime.Environments
     /// <summary>
     /// https://tc39.es/ecma262/#sec-global-environment-records
     /// </summary>
-    public sealed class GlobalEnvironmentRecord : EnvironmentRecord
+    public sealed class GlobalEnvironment : Environment
     {
         /// <summary>
         /// A sealed class for global usage.
         /// </summary>
-        internal sealed class GlobalDeclarativeEnvironmentRecord : DeclarativeEnvironmentRecord
+        internal sealed class GlobalDeclarativeEnvironment : DeclarativeEnvironment
         {
-            public GlobalDeclarativeEnvironmentRecord(Engine engine) : base(engine)
+            public GlobalDeclarativeEnvironment(Engine engine) : base(engine)
             {
             }
         }
@@ -28,14 +28,14 @@ namespace Jint.Runtime.Environments
         private readonly GlobalObject? _globalObject;
 
         // Environment records are needed by debugger
-        internal readonly GlobalDeclarativeEnvironmentRecord _declarativeRecord;
+        internal readonly GlobalDeclarativeEnvironment _declarativeRecord;
         private readonly HashSet<string> _varNames = new(StringComparer.Ordinal);
 
-        public GlobalEnvironmentRecord(Engine engine, ObjectInstance global) : base(engine)
+        public GlobalEnvironment(Engine engine, ObjectInstance global) : base(engine)
         {
             _global = global;
             _globalObject = global as GlobalObject;
-            _declarativeRecord = new GlobalDeclarativeEnvironmentRecord(engine);
+            _declarativeRecord = new GlobalDeclarativeEnvironment(engine);
         }
 
         public ObjectInstance GlobalThisValue => _global;

--- a/Jint/Runtime/Environments/JintEnvironment.cs
+++ b/Jint/Runtime/Environments/JintEnvironment.cs
@@ -8,9 +8,9 @@ namespace Jint.Runtime.Environments
     internal static class JintEnvironment
     {
         internal static bool TryGetIdentifierEnvironmentWithBinding(
-            EnvironmentRecord env,
-            in EnvironmentRecord.BindingName name,
-            [NotNullWhen(true)] out EnvironmentRecord? record)
+            Environment env,
+            in Environment.BindingName name,
+            [NotNullWhen(true)] out Environment? record)
         {
             record = env;
 
@@ -33,10 +33,10 @@ namespace Jint.Runtime.Environments
         }
 
         internal static bool TryGetIdentifierEnvironmentWithBindingValue(
-            EnvironmentRecord env,
-            in EnvironmentRecord.BindingName name,
+            Environment env,
+            in Environment.BindingName name,
             bool strict,
-            [NotNullWhen(true)] out EnvironmentRecord? record,
+            [NotNullWhen(true)] out Environment? record,
             [NotNullWhen(true)] out JsValue? value)
         {
             record = env;
@@ -44,7 +44,7 @@ namespace Jint.Runtime.Environments
 
             if (env._outerEnv is null)
             {
-                return ((GlobalEnvironmentRecord) env).TryGetBinding(name, strict, out _, out value);
+                return ((GlobalEnvironment) env).TryGetBinding(name, strict, out _, out value);
             }
 
             while (!ReferenceEquals(record, null))
@@ -67,9 +67,9 @@ namespace Jint.Runtime.Environments
         /// <summary>
         /// https://tc39.es/ecma262/#sec-newdeclarativeenvironment
         /// </summary>
-        internal static DeclarativeEnvironmentRecord NewDeclarativeEnvironment(Engine engine, EnvironmentRecord? outer, bool catchEnvironment = false)
+        internal static DeclarativeEnvironment NewDeclarativeEnvironment(Engine engine, Environment? outer, bool catchEnvironment = false)
         {
-            return new DeclarativeEnvironmentRecord(engine, catchEnvironment)
+            return new DeclarativeEnvironment(engine, catchEnvironment)
             {
                 _outerEnv = outer
             };
@@ -78,9 +78,9 @@ namespace Jint.Runtime.Environments
         /// <summary>
         /// https://tc39.es/ecma262/#sec-newfunctionenvironment
         /// </summary>
-        internal static FunctionEnvironmentRecord NewFunctionEnvironment(Engine engine, FunctionInstance f, JsValue newTarget)
+        internal static FunctionEnvironment NewFunctionEnvironment(Engine engine, FunctionInstance f, JsValue newTarget)
         {
-            return new FunctionEnvironmentRecord(engine, f, newTarget)
+            return new FunctionEnvironment(engine, f, newTarget)
             {
                 _outerEnv = f._environment
             };
@@ -89,9 +89,9 @@ namespace Jint.Runtime.Environments
         /// <summary>
         /// https://tc39.es/ecma262/#sec-newglobalenvironment
         /// </summary>
-        internal static GlobalEnvironmentRecord NewGlobalEnvironment(Engine engine, ObjectInstance objectInstance, JsValue thisValue)
+        internal static GlobalEnvironment NewGlobalEnvironment(Engine engine, ObjectInstance objectInstance, JsValue thisValue)
         {
-            return new GlobalEnvironmentRecord(engine, objectInstance)
+            return new GlobalEnvironment(engine, objectInstance)
             {
                 _outerEnv = null
             };
@@ -100,9 +100,9 @@ namespace Jint.Runtime.Environments
         /// <summary>
         /// https://tc39.es/ecma262/#sec-newobjectenvironment
         /// </summary>
-        internal static ObjectEnvironmentRecord NewObjectEnvironment(Engine engine, ObjectInstance objectInstance, EnvironmentRecord outer, bool provideThis, bool withEnvironment = false)
+        internal static ObjectEnvironment NewObjectEnvironment(Engine engine, ObjectInstance objectInstance, Environment outer, bool provideThis, bool withEnvironment = false)
         {
-            return new ObjectEnvironmentRecord(engine, objectInstance, provideThis, withEnvironment)
+            return new ObjectEnvironment(engine, objectInstance, provideThis, withEnvironment)
             {
                 _outerEnv = outer
             };
@@ -111,17 +111,17 @@ namespace Jint.Runtime.Environments
         /// <summary>
         /// https://tc39.es/ecma262/#sec-newprivateenvironment
         /// </summary>
-        internal static PrivateEnvironmentRecord NewPrivateEnvironment(Engine engine, PrivateEnvironmentRecord? outerPriv)
+        internal static PrivateEnvironment NewPrivateEnvironment(Engine engine, PrivateEnvironment? outerPriv)
         {
-            return new PrivateEnvironmentRecord(outerPriv);
+            return new PrivateEnvironment(outerPriv);
         }
 
         /// <summary>
         /// https://tc39.es/ecma262/#sec-newmoduleenvironment
         /// </summary>
-        internal static ModuleEnvironmentRecord NewModuleEnvironment(Engine engine, EnvironmentRecord outer)
+        internal static ModuleEnvironment NewModuleEnvironment(Engine engine, Environment outer)
         {
-            return new ModuleEnvironmentRecord(engine)
+            return new ModuleEnvironment(engine)
             {
                 _outerEnv = outer
             };

--- a/Jint/Runtime/Environments/ModuleEnvironment.cs
+++ b/Jint/Runtime/Environments/ModuleEnvironment.cs
@@ -9,11 +9,11 @@ namespace Jint.Runtime.Environments;
 /// Represents a module environment record
 /// https://tc39.es/ecma262/#sec-module-environment-records
 /// </summary>
-internal sealed class ModuleEnvironmentRecord : DeclarativeEnvironmentRecord
+internal sealed class ModuleEnvironment : DeclarativeEnvironment
 {
     private readonly HybridDictionary<IndirectBinding> _importBindings = new();
 
-    internal ModuleEnvironmentRecord(Engine engine) : base(engine, false)
+    internal ModuleEnvironment(Engine engine) : base(engine, false)
     {
     }
 
@@ -28,7 +28,7 @@ internal sealed class ModuleEnvironmentRecord : DeclarativeEnvironmentRecord
     /// <summary>
     /// https://tc39.es/ecma262/#sec-createimportbinding
     /// </summary>
-    public void CreateImportBinding(string importName, ModuleRecord module, string name)
+    public void CreateImportBinding(string importName, Module module, string name)
     {
         _importBindings[importName] = new IndirectBinding(module, name);
         CreateImmutableBindingAndInitialize(importName, true, JsValue.Undefined);
@@ -64,5 +64,5 @@ internal sealed class ModuleEnvironmentRecord : DeclarativeEnvironmentRecord
     /// </summary>
     public override bool HasThisBinding() => true;
 
-    private readonly record struct IndirectBinding(ModuleRecord Module, string BindingName);
+    private readonly record struct IndirectBinding(Module Module, string BindingName);
 }

--- a/Jint/Runtime/Environments/ObjectEnvironment.cs
+++ b/Jint/Runtime/Environments/ObjectEnvironment.cs
@@ -10,13 +10,13 @@ namespace Jint.Runtime.Environments
     /// Represents an object environment record
     /// https://tc39.es/ecma262/#sec-object-environment-records
     /// </summary>
-    internal sealed class ObjectEnvironmentRecord : EnvironmentRecord
+    internal sealed class ObjectEnvironment : Environment
     {
         internal readonly ObjectInstance _bindingObject;
         private readonly bool _provideThis;
         private readonly bool _withEnvironment;
 
-        public ObjectEnvironmentRecord(
+        public ObjectEnvironment(
             Engine engine,
             ObjectInstance bindingObject,
             bool provideThis,

--- a/Jint/Runtime/Environments/PrivateEnvironment.cs
+++ b/Jint/Runtime/Environments/PrivateEnvironment.cs
@@ -6,14 +6,14 @@ namespace Jint.Runtime.Environments;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-privateenvironment-records
 /// </summary>
-internal sealed class PrivateEnvironmentRecord
+internal sealed class PrivateEnvironment
 {
-    public PrivateEnvironmentRecord(PrivateEnvironmentRecord? outerPrivEnv)
+    public PrivateEnvironment(PrivateEnvironment? outerPrivEnv)
     {
         OuterPrivateEnvironment = outerPrivEnv;
     }
 
-    public PrivateEnvironmentRecord? OuterPrivateEnvironment { get; }
+    public PrivateEnvironment? OuterPrivateEnvironment { get; }
     public Dictionary<PrivateIdentifier, PrivateName> Names { get; } = new();
 
     /// <summary>

--- a/Jint/Runtime/ExecutionContextStack.cs
+++ b/Jint/Runtime/ExecutionContextStack.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Jint.Collections;
 using Jint.Native.Generator;
 using Jint.Runtime.Environments;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime
 {
@@ -14,21 +15,21 @@ namespace Jint.Runtime
             _stack = new RefStack<ExecutionContext>(capacity);
         }
 
-        public void ReplaceTopLexicalEnvironment(EnvironmentRecord newEnv)
+        public void ReplaceTopLexicalEnvironment(Environment newEnv)
         {
             var array = _stack._array;
             var size = _stack._size;
             array[size - 1] = array[size - 1].UpdateLexicalEnvironment(newEnv);
         }
 
-        public void ReplaceTopVariableEnvironment(EnvironmentRecord newEnv)
+        public void ReplaceTopVariableEnvironment(Environment newEnv)
         {
             var array = _stack._array;
             var size = _stack._size;
             array[size - 1] = array[size - 1].UpdateVariableEnvironment(newEnv);
         }
 
-        public void ReplaceTopPrivateEnvironment(PrivateEnvironmentRecord? newEnv)
+        public void ReplaceTopPrivateEnvironment(PrivateEnvironment? newEnv)
         {
             var array = _stack._array;
             var size = _stack._size;

--- a/Jint/Runtime/Host.cs
+++ b/Jint/Runtime/Host.cs
@@ -59,7 +59,7 @@ namespace Jint.Runtime
             Engine.EnterExecutionContext(newContext);
         }
 
-        protected virtual GlobalEnvironmentRecord CreateGlobalEnvironment(ObjectInstance globalObject)
+        protected virtual GlobalEnvironment CreateGlobalEnvironment(ObjectInstance globalObject)
         {
             return JintEnvironment.NewGlobalEnvironment(Engine, globalObject, globalObject);
         }
@@ -118,7 +118,7 @@ namespace Jint.Runtime
         /// <summary>
         /// https://tc39.es/ecma262/#sec-GetImportedModule
         /// </summary>
-        internal virtual ModuleRecord GetImportedModule(IScriptOrModule? referrer, ModuleRequest request)
+        internal virtual Module GetImportedModule(IScriptOrModule? referrer, ModuleRequest request)
         {
             return Engine.LoadModule(referrer?.Location, request);
         }
@@ -154,7 +154,7 @@ namespace Jint.Runtime
                 var moduleRecord = GetImportedModule(referrer, moduleRequest);
                 try
                 {
-                    var ns = ModuleRecord.GetModuleNamespace(moduleRecord);
+                    var ns = Module.GetModuleNamespace(moduleRecord);
                     payload.Resolve.Call(JsValue.Undefined, new JsValue[] { ns });
                 }
                 catch (JavaScriptException ex)
@@ -177,7 +177,7 @@ namespace Jint.Runtime
         /// <summary>
         /// https://tc39.es/ecma262/#sec-hostgetimportmetaproperties
         /// </summary>
-        public virtual List<KeyValuePair<JsValue, JsValue>> GetImportMetaProperties(ModuleRecord moduleRecord)
+        public virtual List<KeyValuePair<JsValue, JsValue>> GetImportMetaProperties(Module moduleRecord)
         {
             return new List<KeyValuePair<JsValue, JsValue>>();
         }
@@ -185,7 +185,7 @@ namespace Jint.Runtime
         /// <summary>
         /// https://tc39.es/ecma262/#sec-hostfinalizeimportmeta
         /// </summary>
-        public virtual void FinalizeImportMeta(ObjectInstance importMeta, ModuleRecord moduleRecord)
+        public virtual void FinalizeImportMeta(ObjectInstance importMeta, Module moduleRecord)
         {
         }
 

--- a/Jint/Runtime/IScriptOrModule.Extensions.cs
+++ b/Jint/Runtime/IScriptOrModule.Extensions.cs
@@ -5,9 +5,9 @@ namespace Jint.Runtime;
 
 internal static class ScriptOrModuleExtensions
 {
-    public static ModuleRecord AsModule(this IScriptOrModule? scriptOrModule, Engine engine, Location location)
+    public static Module AsModule(this IScriptOrModule? scriptOrModule, Engine engine, Location location)
     {
-        if (scriptOrModule is not ModuleRecord module)
+        if (scriptOrModule is not Module module)
         {
             ExceptionHelper.ThrowSyntaxError(engine.Realm, "Cannot use import/export statements outside a module", location);
             return default!;

--- a/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
@@ -3,8 +3,8 @@ using Jint.Native;
 using Jint.Native.Array;
 using Jint.Native.Function;
 using Jint.Native.Iterator;
-using Jint.Runtime.Environments;
 using Jint.Runtime.References;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
@@ -46,7 +46,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             EvaluationContext context,
             BindingPattern pattern,
             JsValue argument,
-            EnvironmentRecord? environment,
+            Environment? environment,
             bool checkPatternPropertyReference = true)
         {
             if (pattern is ArrayPattern ap)
@@ -82,7 +82,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             EvaluationContext context,
             ArrayPattern pattern,
             JsValue argument,
-            EnvironmentRecord? environment,
+            Environment? environment,
             bool checkReference)
         {
             var engine = context.Engine;
@@ -292,7 +292,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             EvaluationContext context,
             ObjectPattern pattern,
             JsValue argument,
-            EnvironmentRecord? environment,
+            Environment? environment,
             bool checkReference)
         {
             var processedProperties = pattern.Properties.Count > 0 && pattern.Properties[pattern.Properties.Count - 1] is RestElement
@@ -405,7 +405,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             Engine engine,
             Reference lhs,
             JsValue v,
-            EnvironmentRecord? environment)
+            Environment? environment)
         {
             if (environment is null)
             {
@@ -434,7 +434,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             Engine engine,
             string name,
             JsValue rval,
-            EnvironmentRecord? environment,
+            Environment? environment,
             bool checkReference = true)
         {
             var lhs = engine.ResolveBinding(name, environment);

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -4,6 +4,7 @@ using Jint.Native;
 using Jint.Native.Function;
 using Jint.Runtime.Environments;
 using Jint.Runtime.References;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
@@ -312,7 +313,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
 
             // if we did string concatenation in-place, we don't need to update records, objects might have evil setters
-            if (!wasMutatedInPlace || lref.Base is not EnvironmentRecord)
+            if (!wasMutatedInPlace || lref.Base is not Environment)
             {
                 engine.PutValue(lref, newLeftValue!);
             }

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -7,6 +7,7 @@ using Jint.Native.Object;
 using Jint.Runtime.CallStack;
 using Jint.Runtime.Environments;
 using Jint.Runtime.References;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
@@ -145,7 +146,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     }
                     else
                     {
-                        var refEnv = (EnvironmentRecord) baseValue;
+                        var refEnv = (Environment) baseValue;
                         thisObject = refEnv.WithBaseObject();
                     }
                 }
@@ -254,7 +255,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         private ObjectInstance SuperCall(EvaluationContext context)
         {
             var engine = context.Engine;
-            var thisEnvironment = (FunctionEnvironmentRecord) engine.ExecutionContext.GetThisEnvironment();
+            var thisEnvironment = (FunctionEnvironment) engine.ExecutionContext.GetThisEnvironment();
             var newTarget = engine.GetNewTarget(thisEnvironment);
             var func = GetSuperConstructor(thisEnvironment);
             if (func is null || !func.IsConstructor)
@@ -266,7 +267,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             var argList = defaultSuperCall ? DefaultSuperCallArgumentListEvaluation(context) : ArgumentListEvaluation(context);
             var result = ((IConstructor) func).Construct(argList, newTarget);
 
-            var thisER = (FunctionEnvironmentRecord) engine.ExecutionContext.GetThisEnvironment();
+            var thisER = (FunctionEnvironment) engine.ExecutionContext.GetThisEnvironment();
             thisER.BindThisValue(result);
             var F = thisER._functionObject;
 
@@ -278,7 +279,7 @@ namespace Jint.Runtime.Interpreter.Expressions
         /// <summary>
         /// https://tc39.es/ecma262/#sec-getsuperconstructor
         /// </summary>
-        private static ObjectInstance? GetSuperConstructor(FunctionEnvironmentRecord thisEnvironment)
+        private static ObjectInstance? GetSuperConstructor(FunctionEnvironment thisEnvironment)
         {
             var envRec = thisEnvironment;
             var activeFunction = envRec._functionObject;

--- a/Jint/Runtime/Interpreter/Expressions/JintFunctionExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintFunctionExpression.cs
@@ -46,7 +46,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             var runningExecutionContext = engine.ExecutionContext;
             var scope = runningExecutionContext.LexicalEnvironment;
 
-            DeclarativeEnvironmentRecord? funcEnv = null;
+            DeclarativeEnvironment? funcEnv = null;
             if (!string.IsNullOrWhiteSpace(name))
             {
                 funcEnv = JintEnvironment.NewDeclarativeEnvironment(engine, engine.ExecutionContext.LexicalEnvironment);
@@ -88,7 +88,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             var runningExecutionContext = engine.ExecutionContext;
             var scope = runningExecutionContext.LexicalEnvironment;
 
-            DeclarativeEnvironmentRecord? funcEnv = null;
+            DeclarativeEnvironment? funcEnv = null;
             if (!string.IsNullOrWhiteSpace(name))
             {
                 funcEnv = JintEnvironment.NewDeclarativeEnvironment(engine, engine.ExecutionContext.LexicalEnvironment);

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -4,19 +4,20 @@ using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Argument;
 using Jint.Runtime.Environments;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Expressions;
 
 internal sealed class JintIdentifierExpression : JintExpression
 {
-    private EnvironmentRecord.BindingName _identifier = null!;
+    private Environment.BindingName _identifier = null!;
     private bool _initialized;
 
     public JintIdentifierExpression(Identifier expression) : base(expression)
     {
     }
 
-    public EnvironmentRecord.BindingName Identifier
+    public Environment.BindingName Identifier
     {
         get
         {
@@ -33,7 +34,7 @@ internal sealed class JintIdentifierExpression : JintExpression
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnsureIdentifier()
     {
-        _identifier ??= _expression.AssociatedData as EnvironmentRecord.BindingName ?? new EnvironmentRecord.BindingName(((Identifier) _expression).Name);
+        _identifier ??= _expression.AssociatedData as Environment.BindingName ?? new Environment.BindingName(((Identifier) _expression).Name);
     }
 
     public bool HasEvalOrArguments

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -83,7 +83,7 @@ namespace Jint.Runtime.Interpreter.Expressions
             }
             else if (_objectExpression is JintSuperExpression)
             {
-                var env = (FunctionEnvironmentRecord) engine.ExecutionContext.GetThisEnvironment();
+                var env = (FunctionEnvironment) engine.ExecutionContext.GetThisEnvironment();
                 actualThis = env.GetThisBinding();
                 baseValue = env.GetSuperBase();
             }

--- a/Jint/Runtime/Interpreter/Expressions/JintMetaPropertyExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMetaPropertyExpression.cs
@@ -22,7 +22,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
             if (string.Equals(expression.Meta.Name, "import", StringComparison.Ordinal) && string.Equals(expression.Property.Name, "meta", StringComparison.Ordinal))
             {
-                var module = (SourceTextModuleRecord) context.Engine.ExecutionContext.ScriptOrModule!;
+                var module = (SourceTextModule) context.Engine.ExecutionContext.ScriptOrModule!;
                 var importMeta = module.ImportMeta;
                 if (importMeta is null)
                 {

--- a/Jint/Runtime/Interpreter/Expressions/JintSuperExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintSuperExpression.cs
@@ -11,7 +11,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
-            var envRec = (FunctionEnvironmentRecord) context.Engine.ExecutionContext.GetThisEnvironment();
+            var envRec = (FunctionEnvironment) context.Engine.ExecutionContext.GetThisEnvironment();
             var activeFunction = envRec._functionObject;
             var superConstructor = activeFunction.GetPrototypeOf();
             return superConstructor!;

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -1,13 +1,13 @@
 using Esprima.Ast;
 using Jint.Extensions;
 using Jint.Native;
-using Jint.Runtime.Environments;
 using Jint.Runtime.Interop;
 using Jint.Runtime.References;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Reflection;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {
@@ -253,7 +253,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                         ExceptionHelper.ThrowSyntaxError(engine.Realm);
                     }
 
-                    var bindings = (EnvironmentRecord) r.Base;
+                    var bindings = (Environment) r.Base;
                     var property = referencedName;
                     engine._referencePool.Return(r);
 

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -2,8 +2,8 @@ using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Error;
-using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Statements;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter
 {
@@ -183,7 +183,7 @@ namespace Jint.Runtime.Interpreter
         /// </summary>
         internal static void BlockDeclarationInstantiation(
             Engine engine,
-            EnvironmentRecord env,
+            Environment env,
             List<Declaration> declarations)
         {
             var privateEnv = env._engine.ExecutionContext.PrivateEnvironment;

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -1,5 +1,6 @@
 using Esprima.Ast;
 using Jint.Runtime.Environments;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -29,7 +30,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 _lexicalDeclarations = HoistingScope.GetLexicalDeclarations(_statement);
             }
 
-            EnvironmentRecord? oldEnv = null;
+            Environment? oldEnv = null;
             var engine = context.Engine;
             if (_lexicalDeclarations != null)
             {

--- a/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
@@ -1,8 +1,8 @@
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Function;
-using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Statements;
 
@@ -80,7 +80,7 @@ internal sealed class JintExportDefaultDeclaration : JintStatement<ExportDefault
     /// <summary>
     /// https://tc39.es/ecma262/#sec-initializeboundname
     /// </summary>
-    private static void InitializeBoundName(string name, JsValue value, EnvironmentRecord? environment)
+    private static void InitializeBoundName(string name, JsValue value, Environment? environment)
     {
         if (environment is not null)
         {

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -5,6 +5,7 @@ using Jint.Native.Iterator;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
 using Jint.Runtime.References;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -164,7 +165,7 @@ namespace Jint.Runtime.Interpreter.Statements
             {
                 while (true)
                 {
-                    EnvironmentRecord? iterationEnv = null;
+                    Environment? iterationEnv = null;
                     if (!iteratorRecord.TryIteratorStep(out var nextResult))
                     {
                         close = true;
@@ -331,9 +332,9 @@ namespace Jint.Runtime.Interpreter.Statements
             }
         }
 
-        private void BindingInstantiation(EnvironmentRecord environment)
+        private void BindingInstantiation(Environment environment)
         {
-            var envRec = (DeclarativeEnvironmentRecord) environment;
+            var envRec = (DeclarativeEnvironment) environment;
             var variableDeclaration = (VariableDeclaration) _leftNode;
             var boundNames = new List<string>();
             variableDeclaration.GetBoundNames(boundNames);

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -2,6 +2,7 @@ using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -62,8 +63,8 @@ namespace Jint.Runtime.Interpreter.Statements
 
         protected override Completion ExecuteInternal(EvaluationContext context)
         {
-            EnvironmentRecord? oldEnv = null;
-            EnvironmentRecord? loopEnv = null;
+            Environment? oldEnv = null;
+            Environment? loopEnv = null;
             var engine = context.Engine;
             if (_boundNames != null)
             {

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
@@ -2,6 +2,7 @@ using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Statements
 {
@@ -39,10 +40,10 @@ namespace Jint.Runtime.Interpreter.Statements
             var defaultCaseIndex = -1;
 
             var i = 0;
-            EnvironmentRecord? oldEnv = null;
+            Environment? oldEnv = null;
             var temp = _jintSwitchBlock;
 
-            DeclarativeEnvironmentRecord? blockEnv = null;
+            DeclarativeEnvironment? blockEnv = null;
 
             start:
             for (; i < temp.Length; i++)

--- a/Jint/Runtime/Modules/BuilderModule.cs
+++ b/Jint/Runtime/Modules/BuilderModule.cs
@@ -1,4 +1,3 @@
-using Esprima.Ast;
 using Jint.Native;
 
 namespace Jint.Runtime.Modules;
@@ -6,11 +5,11 @@ namespace Jint.Runtime.Modules;
 /// <summary>
 /// This is a custom ModuleRecord implementation for dynamically built modules using <see cref="ModuleBuilder"/>
 /// </summary>
-internal sealed class BuilderModuleRecord : SourceTextModuleRecord
+internal sealed class BuilderModule : SourceTextModule
 {
     private List<KeyValuePair<string, JsValue>> _exportBuilderDeclarations = new();
 
-    internal BuilderModuleRecord(Engine engine, Realm realm, Module source, string? location, bool async)
+    internal BuilderModule(Engine engine, Realm realm, Esprima.Ast.Module source, string? location, bool async)
         : base(engine, realm, source, location, async)
     {
     }

--- a/Jint/Runtime/Modules/FailFastModuleLoader.cs
+++ b/Jint/Runtime/Modules/FailFastModuleLoader.cs
@@ -20,7 +20,7 @@ internal sealed class FailFastModuleLoader : IModuleLoader
         return new ResolvedSpecifier(moduleRequest, moduleRequest.Specifier, Uri: null, SpecifierType.Bare);
     }
 
-    public ModuleRecord LoadModule(Engine engine, ResolvedSpecifier resolved)
+    public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
     {
         ThrowDisabledException();
         return default!;

--- a/Jint/Runtime/Modules/IModuleLoader.cs
+++ b/Jint/Runtime/Modules/IModuleLoader.cs
@@ -13,5 +13,5 @@ public interface IModuleLoader
     /// <summary>
     /// Loads a module from given location.
     /// </summary>
-    public ModuleRecord LoadModule(Engine engine, ResolvedSpecifier resolved);
+    public Module LoadModule(Engine engine, ResolvedSpecifier resolved);
 }

--- a/Jint/Runtime/Modules/Module.cs
+++ b/Jint/Runtime/Modules/Module.cs
@@ -7,41 +7,41 @@ using Jint.Runtime.Environments;
 namespace Jint.Runtime.Modules;
 
 internal sealed record ExportResolveSetItem(
-    CyclicModuleRecord Module,
+    CyclicModule Module,
     string ExportName
 );
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-abstract-module-records
 /// </summary>
-public abstract class ModuleRecord : JsValue, IScriptOrModule
+public abstract class Module : JsValue, IScriptOrModule
 {
     private ObjectInstance _namespace;
     protected readonly Engine _engine;
     protected readonly Realm _realm;
-    internal ModuleEnvironmentRecord _environment;
+    internal ModuleEnvironment _environment;
 
     public string Location { get; }
 
-    internal ModuleRecord(Engine engine, Realm realm, string location) : base(InternalTypes.Module)
+    internal Module(Engine engine, Realm realm, string location) : base(InternalTypes.Module)
     {
         _engine = engine;
         _realm = realm;
         Location = location;
     }
 
-    public abstract List<string> GetExportedNames(List<CyclicModuleRecord> exportStarSet = null);
+    public abstract List<string> GetExportedNames(List<CyclicModule> exportStarSet = null);
     internal abstract ResolvedBinding ResolveExport(string exportName, List<ExportResolveSetItem> resolveSet = null);
     public abstract void Link();
     public abstract JsValue Evaluate();
 
-    protected internal abstract int InnerModuleLinking(Stack<CyclicModuleRecord> stack, int index);
-    protected internal abstract Completion InnerModuleEvaluation(Stack<CyclicModuleRecord> stack, int index, ref int asyncEvalOrder);
+    protected internal abstract int InnerModuleLinking(Stack<CyclicModule> stack, int index);
+    protected internal abstract Completion InnerModuleEvaluation(Stack<CyclicModule> stack, int index, ref int asyncEvalOrder);
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-getmodulenamespace
     /// </summary>
-    public static ObjectInstance GetModuleNamespace(ModuleRecord module)
+    public static ObjectInstance GetModuleNamespace(Module module)
     {
         var ns = module._namespace;
         if (ns is null)
@@ -67,7 +67,7 @@ public abstract class ModuleRecord : JsValue, IScriptOrModule
     /// <summary>
     /// https://tc39.es/ecma262/#sec-modulenamespacecreate
     /// </summary>
-    private static ModuleNamespace CreateModuleNamespace(ModuleRecord module, List<string> unambiguousNames)
+    private static ModuleNamespace CreateModuleNamespace(Module module, List<string> unambiguousNames)
     {
         var m = new ModuleNamespace(module._engine, module, unambiguousNames);
         module._namespace = m;

--- a/Jint/Runtime/Modules/ModuleLoader.cs
+++ b/Jint/Runtime/Modules/ModuleLoader.cs
@@ -1,5 +1,4 @@
 using Esprima;
-using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Json;
 
@@ -12,7 +11,7 @@ public abstract class ModuleLoader : IModuleLoader
 {
     public abstract ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest);
 
-    public ModuleRecord LoadModule(Engine engine, ResolvedSpecifier resolved)
+    public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
     {
         string code;
         try
@@ -28,7 +27,7 @@ public abstract class ModuleLoader : IModuleLoader
         var isJson = resolved.ModuleRequest.Attributes != null
                      && Array.Exists(resolved.ModuleRequest.Attributes, x => string.Equals(x.Key, "type", StringComparison.Ordinal) && string.Equals(x.Value, "json", StringComparison.Ordinal));
 
-        ModuleRecord moduleRecord = isJson
+        Module moduleRecord = isJson
             ? BuildJsonModule(engine, resolved, code)
             : BuildSourceTextModule(engine, resolved, code);
 
@@ -37,7 +36,7 @@ public abstract class ModuleLoader : IModuleLoader
 
     protected abstract string LoadModuleContents(Engine engine, ResolvedSpecifier resolved);
 
-    private static SyntheticModuleRecord BuildJsonModule(Engine engine, ResolvedSpecifier resolved, string code)
+    private static SyntheticModule BuildJsonModule(Engine engine, ResolvedSpecifier resolved, string code)
     {
         var source = resolved.Uri?.LocalPath;
         JsValue module;
@@ -51,12 +50,12 @@ public abstract class ModuleLoader : IModuleLoader
             module = null;
         }
 
-        return new SyntheticModuleRecord(engine, engine.Realm, module, resolved.Uri?.LocalPath);
+        return new SyntheticModule(engine, engine.Realm, module, resolved.Uri?.LocalPath);
     }
-    private static SourceTextModuleRecord BuildSourceTextModule(Engine engine, ResolvedSpecifier resolved, string code)
+    private static SourceTextModule BuildSourceTextModule(Engine engine, ResolvedSpecifier resolved, string code)
     {
         var source = resolved.Uri?.LocalPath;
-        Module module;
+        Esprima.Ast.Module module;
         try
         {
             module = new JavaScriptParser().ParseModule(code, source);
@@ -72,6 +71,6 @@ public abstract class ModuleLoader : IModuleLoader
             module = null;
         }
 
-        return new SourceTextModuleRecord(engine, engine.Realm, module, resolved.Uri?.LocalPath, async: false);
+        return new SourceTextModule(engine, engine.Realm, module, resolved.Uri?.LocalPath, async: false);
     }
 }

--- a/Jint/Runtime/Modules/ModuleNamespace.cs
+++ b/Jint/Runtime/Modules/ModuleNamespace.cs
@@ -14,10 +14,10 @@ namespace Jint.Runtime.Modules;
 /// </summary>
 internal sealed class ModuleNamespace : ObjectInstance
 {
-    private readonly ModuleRecord _module;
+    private readonly Module _module;
     private readonly HashSet<string> _exports;
 
-    public ModuleNamespace(Engine engine, ModuleRecord module, List<string> exports) : base(engine)
+    public ModuleNamespace(Engine engine, Module module, List<string> exports) : base(engine)
     {
         _module = module;
         _exports = new HashSet<string>(exports, StringComparer.Ordinal);
@@ -164,7 +164,7 @@ internal sealed class ModuleNamespace : ObjectInstance
 
         if (string.Equals(binding.BindingName, "*namespace*", StringComparison.Ordinal))
         {
-            return ModuleRecord.GetModuleNamespace(targetModule);
+            return Module.GetModuleNamespace(targetModule);
         }
 
         var targetEnv = targetModule._environment;

--- a/Jint/Runtime/Modules/SourceTextModule.cs
+++ b/Jint/Runtime/Modules/SourceTextModule.cs
@@ -1,5 +1,4 @@
-﻿using Esprima.Ast;
-using Jint.Native.Object;
+﻿using Jint.Native.Object;
 using Jint.Native.Promise;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
@@ -19,9 +18,9 @@ internal sealed record ExportEntry(string? ExportName, ModuleRequest? ModuleRequ
 /// <summary>
 /// https://tc39.es/ecma262/#sec-source-text-module-records
 /// </summary>
-internal class SourceTextModuleRecord : CyclicModuleRecord
+internal class SourceTextModule : CyclicModule
 {
-    internal readonly Module _source;
+    internal readonly Esprima.Ast.Module _source;
     private ExecutionContext _context;
     private ObjectInstance? _importMeta;
     private readonly List<ImportEntry>? _importEntries;
@@ -29,7 +28,7 @@ internal class SourceTextModuleRecord : CyclicModuleRecord
     private readonly List<ExportEntry> _indirectExportEntries;
     private readonly List<ExportEntry> _starExportEntries;
 
-    internal SourceTextModuleRecord(Engine engine, Realm realm, Module source, string? location, bool async)
+    internal SourceTextModule(Engine engine, Realm realm, Esprima.Ast.Module source, string? location, bool async)
         : base(engine, realm, location, async)
     {
         _source = source;
@@ -64,9 +63,9 @@ internal class SourceTextModuleRecord : CyclicModuleRecord
     /// <summary>
     /// https://tc39.es/ecma262/#sec-getexportednames
     /// </summary>
-    public override List<string?> GetExportedNames(List<CyclicModuleRecord>? exportStarSet = null)
+    public override List<string?> GetExportedNames(List<CyclicModule>? exportStarSet = null)
     {
-        exportStarSet ??= new List<CyclicModuleRecord>();
+        exportStarSet ??= new List<CyclicModule>();
         if (exportStarSet.Contains(this))
         {
             //Reached the starting point of an export * circularity

--- a/Jint/Runtime/Modules/SyntheticModule.cs
+++ b/Jint/Runtime/Modules/SyntheticModule.cs
@@ -5,12 +5,12 @@ using Jint.Runtime.Environments;
 
 namespace Jint.Runtime.Modules;
 
-internal sealed class SyntheticModuleRecord : ModuleRecord
+internal sealed class SyntheticModule : Module
 {
     private readonly JsValue _obj;
     private readonly List<string> _exportNames = ["default"];
 
-    internal SyntheticModuleRecord(Engine engine, Realm realm, JsValue obj, string? location)
+    internal SyntheticModule(Engine engine, Realm realm, JsValue obj, string? location)
         : base(engine, realm, location)
     {
         _obj = obj;
@@ -19,7 +19,7 @@ internal sealed class SyntheticModuleRecord : ModuleRecord
         _environment = env;
     }
 
-    public override List<string> GetExportedNames(List<CyclicModuleRecord>? exportStarSet = null) => _exportNames;
+    public override List<string> GetExportedNames(List<CyclicModule>? exportStarSet = null) => _exportNames;
 
     internal override ResolvedBinding? ResolveExport(string exportName, List<ExportResolveSetItem>? resolveSet = null)
     {
@@ -58,7 +58,7 @@ internal sealed class SyntheticModuleRecord : ModuleRecord
         return pc.PromiseInstance;
     }
 
-    protected internal override int InnerModuleLinking(Stack<CyclicModuleRecord> stack, int index)
+    protected internal override int InnerModuleLinking(Stack<CyclicModule> stack, int index)
     {
         foreach (var exportName in _exportNames)
         {
@@ -68,7 +68,7 @@ internal sealed class SyntheticModuleRecord : ModuleRecord
         return index;
     }
 
-    protected internal override Completion InnerModuleEvaluation(Stack<CyclicModuleRecord> stack, int index, ref int asyncEvalOrder)
+    protected internal override Completion InnerModuleEvaluation(Stack<CyclicModule> stack, int index, ref int asyncEvalOrder)
     {
         _environment.SetMutableBinding("default", _obj, strict: true);
         return new Completion(CompletionType.Normal, index, new Identifier(""));

--- a/Jint/Runtime/Realm.cs
+++ b/Jint/Runtime/Realm.cs
@@ -35,7 +35,7 @@ namespace Jint.Runtime
         /// <summary>
         /// The global environment for this realm.
         /// </summary>
-        public GlobalEnvironmentRecord GlobalEnv { get; internal set; } = null!;
+        public GlobalEnvironment GlobalEnv { get; internal set; } = null!;
 
         /// <summary>
         /// Field reserved for use by hosts that need to associate additional information with a Realm Record.

--- a/Jint/Runtime/References/Reference.cs
+++ b/Jint/Runtime/References/Reference.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Runtime.Environments;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.References;
 
@@ -105,6 +106,6 @@ public sealed class Reference
 
     internal void InitializeReferencedBinding(JsValue value)
     {
-        ((EnvironmentRecord) _base).InitializeBinding(TypeConverter.ToString(_referencedName), value);
+        ((Environment) _base).InitializeBinding(TypeConverter.ToString(_referencedName), value);
     }
 }


### PR DESCRIPTION
Just like c# record the spec's name prefix indicates layout/container item, we don't need to make the name longer and harder to comprehend with `Record` suffix.