### PR TITLE
Hide, rename and move some methods

### DIFF
--- a/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
+++ b/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
@@ -61,7 +61,7 @@ public class ConstraintUsageTests
             for (var i = 0; i < 100; ++i)
             {
                 Thread.Sleep(TimeSpan.FromMilliseconds(200));
-                engine.CheckConstraints();
+                engine.Constraints.Check();
             }
 
             return "didn't throw!";

--- a/Jint.Tests.PublicInterface/RavenApiUsageTests.cs
+++ b/Jint.Tests.PublicInterface/RavenApiUsageTests.cs
@@ -46,7 +46,7 @@ public class RavenApiUsageTests
     {
         var engine = new Engine(options => options.MaxStatements(123));
 
-        var constraint = engine.Advanced.FindConstraint<MaxStatementsConstraint>();
+        var constraint = engine.Constraints.Find<MaxStatementsConstraint>();
         Assert.NotNull(constraint);
 
         var oldMaxStatements = constraint.MaxStatements;
@@ -193,6 +193,13 @@ public class RavenApiUsageTests
         var engine = new Engine();
         engine.SetValue("value", new CustomUndefined());
         Assert.Equal("foo", engine.Evaluate("value ? value + 'bar' : 'foo'"));
+    }
+
+    [Fact]
+    public void CanResetCallStack()
+    {
+        var engine = new Engine();
+        engine.Advanced.ResetCallStack();
     }
 }
 

--- a/Jint.Tests.Test262/Test262Test.cs
+++ b/Jint.Tests.Test262/Test262Test.cs
@@ -89,8 +89,8 @@ public abstract partial class Test262Test
         if (file.Type == ProgramType.Module)
         {
             var specifier = "./" + Path.GetFileName(file.FileName);
-            engine.AddModule(specifier, builder => builder.AddSource(file.Program));
-            engine.ImportModule(specifier);
+            engine.Modules.Add(specifier, builder => builder.AddSource(file.Program));
+            engine.Modules.Import(specifier);
         }
         else
         {

--- a/Jint.Tests/Runtime/Debugger/BreakPointTests.cs
+++ b/Jint.Tests/Runtime/Debugger/BreakPointTests.cs
@@ -55,8 +55,8 @@ namespace Jint.Tests.Runtime.Debugger
         {
             var engine = new Engine(options => options.DebugMode());
 
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(4, 5, "i === 1"));
-            Assert.Collection(engine.DebugHandler.BreakPoints,
+            engine.Debugger.BreakPoints.Set(new BreakPoint(4, 5, "i === 1"));
+            Assert.Collection(engine.Debugger.BreakPoints,
                 breakPoint =>
                 {
                     Assert.Equal(4, breakPoint.Location.Line);
@@ -64,8 +64,8 @@ namespace Jint.Tests.Runtime.Debugger
                     Assert.Equal("i === 1", breakPoint.Condition);
                 });
 
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(4, 5));
-            Assert.Collection(engine.DebugHandler.BreakPoints,
+            engine.Debugger.BreakPoints.Set(new BreakPoint(4, 5));
+            Assert.Collection(engine.Debugger.BreakPoints,
                 breakPoint =>
                 {
                     Assert.Equal(4, breakPoint.Location.Line);
@@ -79,15 +79,15 @@ namespace Jint.Tests.Runtime.Debugger
         {
             var engine = new Engine(options => options.DebugMode());
 
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(4, 5, "i === 1"));
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(5, 6, "j === 2"));
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(10, 7, "x > 5"));
-            Assert.Equal(3, engine.DebugHandler.BreakPoints.Count);
+            engine.Debugger.BreakPoints.Set(new BreakPoint(4, 5, "i === 1"));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(5, 6, "j === 2"));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(10, 7, "x > 5"));
+            Assert.Equal(3, engine.Debugger.BreakPoints.Count);
 
-            engine.DebugHandler.BreakPoints.RemoveAt(new BreakLocation(null, 4, 5));
-            engine.DebugHandler.BreakPoints.RemoveAt(new BreakLocation(null, 10, 7));
+            engine.Debugger.BreakPoints.RemoveAt(new BreakLocation(null, 4, 5));
+            engine.Debugger.BreakPoints.RemoveAt(new BreakLocation(null, 10, 7));
 
-            Assert.Collection(engine.DebugHandler.BreakPoints,
+            Assert.Collection(engine.Debugger.BreakPoints,
                 breakPoint =>
                 {
                     Assert.Equal(5, breakPoint.Location.Line);
@@ -101,11 +101,11 @@ namespace Jint.Tests.Runtime.Debugger
         {
             var engine = new Engine(options => options.DebugMode());
 
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(4, 5, "i === 1"));
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(5, 6, "j === 2"));
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(10, 7, "x > 5"));
-            Assert.True(engine.DebugHandler.BreakPoints.Contains(new BreakLocation(null, 5, 6)));
-            Assert.False(engine.DebugHandler.BreakPoints.Contains(new BreakLocation(null, 8, 9)));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(4, 5, "i === 1"));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(5, 6, "j === 2"));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(10, 7, "x > 5"));
+            Assert.True(engine.Debugger.BreakPoints.Contains(new BreakLocation(null, 5, 6)));
+            Assert.False(engine.Debugger.BreakPoints.Contains(new BreakLocation(null, 8, 9)));
         }
 
         [Fact]
@@ -120,7 +120,7 @@ x++; y *= 2;
             var engine = new Engine(options => options.DebugMode());
 
             bool didBreak = false;
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 Assert.Equal(4, info.Location.Start.Line);
                 Assert.Equal(5, info.Location.Start.Column);
@@ -128,7 +128,7 @@ x++; y *= 2;
                 return StepMode.None;
             };
 
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(4, 5));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(4, 5));
             engine.Execute(script);
             Assert.True(didBreak);
         }
@@ -152,10 +152,10 @@ test(z);";
 
             var engine = new Engine(options => { options.DebugMode(); });
 
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint("script2", 3, 0));
+            engine.Debugger.BreakPoints.Set(new BreakPoint("script2", 3, 0));
 
             bool didBreak = false;
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 Assert.Equal("script2", info.Location.Source);
                 Assert.Equal(3, info.Location.Start.Line);
@@ -190,7 +190,7 @@ debugger;
                 .DebuggerStatementHandling(DebuggerStatementHandling.Script));
 
             bool didBreak = false;
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 Assert.Equal(PauseType.DebuggerStatement, info.PauseType);
                 didBreak = true;
@@ -216,13 +216,13 @@ debugger;
 
             bool didBreak = false;
             int stepCount = 0;
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 didBreak = true;
                 return StepMode.None;
             };
 
-            engine.DebugHandler.Step += (sender, info) =>
+            engine.Debugger.Step += (sender, info) =>
             {
                 stepCount++;
                 return StepMode.Into;
@@ -247,9 +247,9 @@ debugger;
 
             int breakCount = 0;
 
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(2, 0));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(2, 0));
 
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 Assert.Equal(PauseType.Break, info.PauseType);
                 breakCount++;
@@ -275,10 +275,10 @@ debugger;
             bool didStep = true;
             bool didBreak = true;
 
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(2, 0));
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(4, 0));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(2, 0));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(4, 0));
 
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 didBreak = true;
                 // first breakpoint shouldn't cause us to get here, because we're stepping,
@@ -287,7 +287,7 @@ debugger;
                 return StepMode.None;
             };
 
-            engine.DebugHandler.Step += (sender, info) =>
+            engine.Debugger.Step += (sender, info) =>
             {
                 didStep = true;
                 if (TestHelpers.ReachedLiteral(info, "first breakpoint"))
@@ -315,10 +315,10 @@ debugger;
                 .DebugMode()
                 .DebuggerStatementHandling(DebuggerStatementHandling.Script));
 
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(2, 0));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(2, 0));
 
             int breakTriggered = 0;
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 breakTriggered++;
                 return StepMode.None;
@@ -343,11 +343,11 @@ test();";
 
             var engine = new Engine(options => options.DebugMode());
 
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(4, 0));
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(6, 0));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(4, 0));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(6, 0));
 
             int step = 0;
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 step++;
                 switch (step)
@@ -387,12 +387,12 @@ foo();
             int breakpointsReached = 0;
 
             // This breakpoint will be hit:
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(6, 0, "x == 0"));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(6, 0, "x == 0"));
             // This condition is an error (y is not defined). DebugHandler will
             // treat it as an unmatched breakpoint:
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(7, 0, "y == 0"));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(7, 0, "y == 0"));
 
-            engine.DebugHandler.Step += (sender, info) =>
+            engine.Debugger.Step += (sender, info) =>
             {
                 if (info.ReachedLiteral("before breakpoint"))
                 {
@@ -409,7 +409,7 @@ foo();
                 return StepMode.Into;
             };
 
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 breakpointsReached++;
                 return StepMode.Into;
@@ -446,11 +446,11 @@ for (let i = 0; i < 10; i++)
 ";
             var engine = new Engine(options => options.DebugMode().InitialStepMode(StepMode.None));
 
-            engine.DebugHandler.BreakPoints.Set(
+            engine.Debugger.BreakPoints.Set(
                 new SimpleHitConditionBreakPoint(4, 4, condition: null, hitCondition: 5));
 
             int numberOfBreaks = 0;
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 Assert.True(info.ReachedLiteral("breakpoint"));
                 var extendedBreakPoint = Assert.IsType<SimpleHitConditionBreakPoint>(info.BreakPoint);

--- a/Jint.Tests/Runtime/Debugger/CallStackTests.cs
+++ b/Jint.Tests/Runtime/Debugger/CallStackTests.cs
@@ -110,7 +110,7 @@ bar()";
             bool atReturn = false;
             bool didCheckReturn = false;
 
-            engine.DebugHandler.Step += (sender, info) =>
+            engine.Debugger.Step += (sender, info) =>
             {
                 if (atReturn)
                 {

--- a/Jint.Tests/Runtime/Debugger/DebugHandlerTests.cs
+++ b/Jint.Tests/Runtime/Debugger/DebugHandlerTests.cs
@@ -23,7 +23,7 @@ namespace Jint.Tests.Runtime.Debugger
 
             bool didPropertyAccess = false;
 
-            engine.DebugHandler.Step += (sender, info) =>
+            engine.Debugger.Step += (sender, info) =>
             {
                 // We should never reach "fail", because the only way it's executed is from
                 // within this Step handler

--- a/Jint.Tests/Runtime/Debugger/EvaluateTests.cs
+++ b/Jint.Tests/Runtime/Debugger/EvaluateTests.cs
@@ -22,7 +22,7 @@ namespace Jint.Tests.Runtime.Debugger
 
             TestHelpers.TestAtBreak(script, (engine, info) =>
             {
-                var evaluated = engine.DebugHandler.Evaluate("x");
+                var evaluated = engine.Debugger.Evaluate("x");
                 Assert.IsType<JsNumber>(evaluated);
                 Assert.Equal(50, evaluated.AsNumber());
             });
@@ -32,7 +32,7 @@ namespace Jint.Tests.Runtime.Debugger
         public void ThrowsIfNoCurrentContext()
         {
             var engine = new Engine(options => options.DebugMode());
-            var exception = Assert.Throws<DebugEvaluationException>(() => engine.DebugHandler.Evaluate("let x = 1;"));
+            var exception = Assert.Throws<DebugEvaluationException>(() => engine.Debugger.Evaluate("let x = 1;"));
             Assert.Null(exception.InnerException); // Not a JavaScript or parser exception
         }
 
@@ -51,7 +51,7 @@ namespace Jint.Tests.Runtime.Debugger
 
             TestHelpers.TestAtBreak(script, (engine, info) =>
             {
-                var exception = Assert.Throws<DebugEvaluationException>(() => engine.DebugHandler.Evaluate("y"));
+                var exception = Assert.Throws<DebugEvaluationException>(() => engine.Debugger.Evaluate("y"));
                 Assert.IsType<JavaScriptException>(exception.InnerException);
             });
         }
@@ -72,7 +72,7 @@ namespace Jint.Tests.Runtime.Debugger
             TestHelpers.TestAtBreak(script, (engine, info) =>
             {
                 var exception = Assert.Throws<DebugEvaluationException>(() =>
-                    engine.DebugHandler.Evaluate("this is a syntax error"));
+                    engine.Debugger.Evaluate("this is a syntax error"));
                 Assert.IsType<ParserException>(exception.InnerException);
             });
         }
@@ -100,7 +100,7 @@ namespace Jint.Tests.Runtime.Debugger
                 Assert.Equal(1, engine.CallStack.Count);
                 var frameBefore = engine.CallStack.Stack[0];
 
-                Assert.Throws<DebugEvaluationException>(() => engine.DebugHandler.Evaluate("throws()"));
+                Assert.Throws<DebugEvaluationException>(() => engine.Debugger.Evaluate("throws()"));
                 Assert.Equal(1, engine.CallStack.Count);
                 var frameAfter = engine.CallStack.Stack[0];
                 // Stack frames and some of their properties are structs - can't check reference equality

--- a/Jint.Tests/Runtime/Debugger/ScopeTests.cs
+++ b/Jint.Tests/Runtime/Debugger/ScopeTests.cs
@@ -352,9 +352,9 @@ namespace Jint.Tests.Runtime.Debugger
             add(x, y);";
             TestHelpers.TestAtBreak(engine =>
             {
-                engine.AddModule("imported-module", imported);
-                engine.AddModule("main", main);
-                engine.ImportModule("main");
+                engine.Modules.Add("imported-module", imported);
+                engine.Modules.Add("main", main);
+                engine.Modules.Import("main");
             },
             info =>
             {
@@ -541,8 +541,8 @@ namespace Jint.Tests.Runtime.Debugger
             string main = @"const x = 1; debugger;";
             TestHelpers.TestAtBreak(engine =>
             {
-                engine.AddModule("main", main);
-                engine.ImportModule("main");
+                engine.Modules.Add("main", main);
+                engine.Modules.Import("main");
             },
             info =>
             {

--- a/Jint.Tests/Runtime/Debugger/StepFlowTests.cs
+++ b/Jint.Tests/Runtime/Debugger/StepFlowTests.cs
@@ -13,7 +13,7 @@ namespace Jint.Tests.Runtime.Debugger
                 .InitialStepMode(StepMode.Into));
 
             var nodes = new List<Node>();
-            engine.DebugHandler.Step += (sender, info) =>
+            engine.Debugger.Step += (sender, info) =>
             {
                 nodes.Add(info.CurrentNode);
                 return StepMode.Into;
@@ -261,7 +261,7 @@ let res = c();
 
             var stepStatements = new List<string>();
             var scriptLines = script.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n');
-            engine.DebugHandler.Step += (sender, information) =>
+            engine.Debugger.Step += (sender, information) =>
             {
                 if (information.CurrentNode is not VariableDeclaration && information.CurrentNode is not FunctionDeclaration)
                     OutputPosition(information.Location);

--- a/Jint.Tests/Runtime/Debugger/StepModeTests.cs
+++ b/Jint.Tests/Runtime/Debugger/StepModeTests.cs
@@ -22,7 +22,7 @@ namespace Jint.Tests.Runtime.Debugger
             int steps = 0;
             bool sourceReached = false;
             bool targetReached = false;
-            engine.DebugHandler.Step += (sender, info) =>
+            engine.Debugger.Step += (sender, info) =>
             {
                 if (sourceReached)
                 {
@@ -346,7 +346,7 @@ namespace Jint.Tests.Runtime.Debugger
 
             var engine = new Engine(options => options.DebugMode());
             int step = 0;
-            engine.DebugHandler.Step += (sender, info) =>
+            engine.Debugger.Step += (sender, info) =>
             {
                 switch (step)
                 {
@@ -387,12 +387,12 @@ namespace Jint.Tests.Runtime.Debugger
 
             bool stepping = false;
 
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 stepping = true;
                 return StepMode.Over;
             };
-            engine.DebugHandler.Step += (sender, info) =>
+            engine.Debugger.Step += (sender, info) =>
             {
                 if (stepping)
                 {
@@ -421,7 +421,7 @@ namespace Jint.Tests.Runtime.Debugger
                 .InitialStepMode(StepMode.Into));
 
             int stepCount = 0;
-            engine.DebugHandler.Step += (sender, info) =>
+            engine.Debugger.Step += (sender, info) =>
             {
                 stepCount++;
                 // Start running after first step
@@ -453,7 +453,7 @@ namespace Jint.Tests.Runtime.Debugger
             int stepCount = 0;
             int skipCount = 0;
 
-            engine.DebugHandler.Step += (sender, info) =>
+            engine.Debugger.Step += (sender, info) =>
             {
                 Assert.True(TestHelpers.IsLiteral(info.CurrentNode, "step"));
                 stepCount++;
@@ -461,14 +461,14 @@ namespace Jint.Tests.Runtime.Debugger
                 return stepCount == 1 ? StepMode.None : StepMode.Into;
             };
 
-            engine.DebugHandler.Skip += (sender, info) =>
+            engine.Debugger.Skip += (sender, info) =>
             {
                 Assert.True(TestHelpers.IsLiteral(info.CurrentNode, "skip"));
                 skipCount++;
                 return StepMode.None;
             };
 
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 // Back to stepping after debugger statement
                 return StepMode.Into;

--- a/Jint.Tests/Runtime/Debugger/TestHelpers.cs
+++ b/Jint.Tests/Runtime/Debugger/TestHelpers.cs
@@ -34,7 +34,7 @@ namespace Jint.Tests.Runtime.Debugger
             );
 
             bool didBreak = false;
-            engine.DebugHandler.Break += (sender, info) =>
+            engine.Debugger.Break += (sender, info) =>
             {
                 didBreak = true;
                 breakHandler(sender as Engine, info);

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -1492,15 +1492,15 @@ var prep = function (fn) { fn(); };
 
             var engine = new Engine(options => options.DebugMode());
 
-            engine.DebugHandler.Break += EngineStep;
+            engine.Debugger.Break += EngineStep;
 
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(1, 0));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(1, 0));
 
             engine.Evaluate(@"var local = true;
                 if (local === true)
                 {}");
 
-            engine.DebugHandler.Break -= EngineStep;
+            engine.Debugger.Break -= EngineStep;
 
             Assert.Equal(1, countBreak);
         }
@@ -1513,13 +1513,13 @@ var prep = function (fn) { fn(); };
 
             var engine = new Engine(options => options.DebugMode().InitialStepMode(stepMode));
 
-            engine.DebugHandler.Step += EngineStep;
+            engine.Debugger.Step += EngineStep;
 
             engine.Evaluate(@"var local = true;
                 var creatingSomeOtherLine = 0;
                 var lastOneIPromise = true");
 
-            engine.DebugHandler.Step -= EngineStep;
+            engine.Debugger.Step -= EngineStep;
 
             Assert.Equal(3, countBreak);
         }
@@ -1531,14 +1531,14 @@ var prep = function (fn) { fn(); };
             stepMode = StepMode.Into;
 
             var engine = new Engine(options => options.DebugMode().InitialStepMode(stepMode));
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(1, 1));
-            engine.DebugHandler.Step += EngineStep;
-            engine.DebugHandler.Break += EngineStep;
+            engine.Debugger.BreakPoints.Set(new BreakPoint(1, 1));
+            engine.Debugger.Step += EngineStep;
+            engine.Debugger.Break += EngineStep;
 
             engine.Evaluate(@"var local = true;");
 
-            engine.DebugHandler.Step -= EngineStep;
-            engine.DebugHandler.Break -= EngineStep;
+            engine.Debugger.Step -= EngineStep;
+            engine.Debugger.Break -= EngineStep;
 
             Assert.Equal(1, countBreak);
         }
@@ -1560,8 +1560,8 @@ var prep = function (fn) { fn(); };
             stepMode = StepMode.None;
 
             var engine = new Engine(options => options.DebugMode());
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(5, 0));
-            engine.DebugHandler.Break += EngineStepVerifyDebugInfo;
+            engine.Debugger.BreakPoints.Set(new BreakPoint(5, 0));
+            engine.Debugger.Break += EngineStepVerifyDebugInfo;
 
             engine.Evaluate(@"var global = true;
                             function func1()
@@ -1571,7 +1571,7 @@ var prep = function (fn) { fn(); };
                             }
                             func1();");
 
-            engine.DebugHandler.Break -= EngineStepVerifyDebugInfo;
+            engine.Debugger.Break -= EngineStepVerifyDebugInfo;
 
             Assert.Equal(1, countBreak);
         }
@@ -1607,10 +1607,10 @@ var prep = function (fn) { fn(); };
 
             var engine = new Engine(options => options.DebugMode());
 
-            engine.DebugHandler.Break += EngineStep;
+            engine.Debugger.Break += EngineStep;
 
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(5, 16, "condition === true"));
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(6, 16, "condition === false"));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(5, 16, "condition === true"));
+            engine.Debugger.BreakPoints.Set(new BreakPoint(6, 16, "condition === false"));
 
             engine.Evaluate(@"var local = true;
                 var condition = true;
@@ -1620,7 +1620,7 @@ var prep = function (fn) { fn(); };
                 ;
                 }");
 
-            engine.DebugHandler.Break -= EngineStep;
+            engine.Debugger.Break -= EngineStep;
 
             Assert.Equal(1, countBreak);
         }
@@ -1633,7 +1633,7 @@ var prep = function (fn) { fn(); };
 
             var engine = new Engine(options => options.DebugMode().InitialStepMode(StepMode.Into));
 
-            engine.DebugHandler.Step += EngineStep;
+            engine.Debugger.Step += EngineStep;
 
             engine.Evaluate(@"function func() // first step - then stepping out
                 {
@@ -1643,7 +1643,7 @@ var prep = function (fn) { fn(); };
                 func(); // shall not step
                 ; // shall not step ");
 
-            engine.DebugHandler.Step -= EngineStep;
+            engine.Debugger.Step -= EngineStep;
 
             Assert.Equal(1, countBreak);
         }
@@ -1655,7 +1655,7 @@ var prep = function (fn) { fn(); };
 
             var engine = new Engine(options => options.DebugMode().InitialStepMode(StepMode.Into));
 
-            engine.DebugHandler.Step += EngineStepOutWhenInsideFunction;
+            engine.Debugger.Step += EngineStepOutWhenInsideFunction;
 
             engine.Evaluate(@"function func() // first step
                 {
@@ -1665,7 +1665,7 @@ var prep = function (fn) { fn(); };
                 func(); // second step
                 ; // fourth step ");
 
-            engine.DebugHandler.Step -= EngineStepOutWhenInsideFunction;
+            engine.Debugger.Step -= EngineStepOutWhenInsideFunction;
 
             Assert.Equal(4, countBreak);
         }
@@ -1690,8 +1690,8 @@ var prep = function (fn) { fn(); };
             stepMode = StepMode.None;
 
             var engine = new Engine(options => options.DebugMode());
-            engine.DebugHandler.BreakPoints.Set(new BreakPoint(4, 32));
-            engine.DebugHandler.Break += EngineStep;
+            engine.Debugger.BreakPoints.Set(new BreakPoint(4, 32));
+            engine.Debugger.Break += EngineStep;
 
             engine.Evaluate(@"var global = true;
                             function func1()
@@ -1701,7 +1701,7 @@ var prep = function (fn) { fn(); };
                             }
                             func1();");
 
-            engine.DebugHandler.Break -= EngineStep;
+            engine.Debugger.Break -= EngineStep;
 
             Assert.Equal(1, countBreak);
         }
@@ -1714,7 +1714,7 @@ var prep = function (fn) { fn(); };
 
             var engine = new Engine(options => options.DebugMode().InitialStepMode(stepMode));
 
-            engine.DebugHandler.Step += EngineStep;
+            engine.Debugger.Step += EngineStep;
 
             engine.Evaluate(@"function func() // first step
                 {
@@ -1724,7 +1724,7 @@ var prep = function (fn) { fn(); };
                 func(); // second step
                 ; // third step ");
 
-            engine.DebugHandler.Step -= EngineStep;
+            engine.Debugger.Step -= EngineStep;
 
             Assert.Equal(3, countBreak);
         }
@@ -1737,7 +1737,7 @@ var prep = function (fn) { fn(); };
 
             var engine = new Engine(options => options.DebugMode().InitialStepMode(stepMode));
 
-            engine.DebugHandler.Step += EngineStep;
+            engine.Debugger.Step += EngineStep;
 
             engine.Evaluate(@"var step1 = 1; // first step
                 var step2 = 2; // second step
@@ -1746,7 +1746,7 @@ var prep = function (fn) { fn(); };
                     ; // fourth step
                 }");
 
-            engine.DebugHandler.Step -= EngineStep;
+            engine.Debugger.Step -= EngineStep;
 
             Assert.Equal(4, countBreak);
         }
@@ -2752,7 +2752,7 @@ x.test = {
             var engine = new Engine(options => options
                 .SetTypeConverter(e => new TestTypeConverter())
             );
-            Assert.IsType<TestTypeConverter>(engine.ClrTypeConverter);
+            Assert.IsType<TestTypeConverter>(engine.TypeConverter);
             engine.SetValue("x", new Testificate());
             Assert.Throws<JavaScriptException>(() => engine.Evaluate("c.Name"));
         }
@@ -3004,7 +3004,7 @@ x.test = {
             const string module2 = "export default 'dummy';";
 
             var beforeEvaluateTriggeredCount = 0;
-            engine.DebugHandler.BeforeEvaluate += (sender, ast) =>
+            engine.Debugger.BeforeEvaluate += (sender, ast) =>
             {
                 beforeEvaluateTriggeredCount++;
                 Assert.Equal(engine, sender);
@@ -3026,9 +3026,9 @@ x.test = {
                 }
             };
 
-            engine.AddModule("module1", module1);
-            engine.AddModule("module2", module2);
-            engine.ImportModule("module1");
+            engine.Modules.Add("module1", module1);
+            engine.Modules.Add("module2", module2);
+            engine.Modules.Import("module1");
 
             Assert.Equal(2, beforeEvaluateTriggeredCount);
         }
@@ -3055,7 +3055,7 @@ x.test = {
             const string script = "'dummy';";
 
             var beforeEvaluateTriggered = false;
-            engine.DebugHandler.BeforeEvaluate += (sender, ast) =>
+            engine.Debugger.BeforeEvaluate += (sender, ast) =>
             {
                 beforeEvaluateTriggered = true;
                 Assert.Equal(engine, sender);

--- a/Jint.Tests/Runtime/ErrorTests.cs
+++ b/Jint.Tests/Runtime/ErrorTests.cs
@@ -463,7 +463,7 @@ $variable1 + -variable2 - variable3;");
         public void JavaScriptExceptionLocationOnModuleShouldBeRight()
         {
             var engine = new Engine();
-            engine.AddModule("my_module", @"
+            engine.Modules.Add("my_module", @"
 function throw_error(){
     throw Error(""custom error"")
 }
@@ -471,7 +471,7 @@ function throw_error(){
 throw_error();
             ");
 
-            var ex= Assert.Throws<JavaScriptException>(() => engine.ImportModule("my_module"));
+            var ex= Assert.Throws<JavaScriptException>(() => engine.Modules.Import("my_module"));
             Assert.Equal(ex.Location.Start.Line, 3);
             Assert.Equal(ex.Location.Start.Column, 10);
         }

--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -15,8 +15,8 @@ public class ModuleTests
     [Fact]
     public void ShouldExportNamed()
     {
-        _engine.AddModule("my-module", "export const value = 'exported value';");
-        var ns = _engine.ImportModule("my-module");
+        _engine.Modules.Add("my-module", "export const value = 'exported value';");
+        var ns = _engine.Modules.Import("my-module");
 
         Assert.Equal("exported value", ns.Get("value").AsString());
     }
@@ -24,8 +24,8 @@ public class ModuleTests
     [Fact]
     public void ShouldExportNamedListRenamed()
     {
-        _engine.AddModule("my-module", "const value1 = 1; const value2 = 2; export { value1 as renamed1, value2 as renamed2 }");
-        var ns = _engine.ImportModule("my-module");
+        _engine.Modules.Add("my-module", "const value1 = 1; const value2 = 2; export { value1 as renamed1, value2 as renamed2 }");
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal(1, ns.Get("renamed1").AsInteger());
         Assert.Equal(2, ns.Get("renamed2").AsInteger());
@@ -34,8 +34,8 @@ public class ModuleTests
     [Fact]
     public void ShouldExportDefault()
     {
-        _engine.AddModule("my-module", "export default 'exported value';");
-        var ns = _engine.ImportModule("my-module");
+        _engine.Modules.Add("my-module", "export default 'exported value';");
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal("exported value", ns.Get("default").AsString());
     }
@@ -43,9 +43,9 @@ public class ModuleTests
     [Fact]
     public void ShouldExportAll()
     {
-        _engine.AddModule("module1", "export const value = 'exported value';");
-        _engine.AddModule("module2", "export * from 'module1';");
-        var ns = _engine.ImportModule("module2");
+        _engine.Modules.Add("module1", "export const value = 'exported value';");
+        _engine.Modules.Add("module2", "export * from 'module1';");
+        var ns =  _engine.Modules.Import("module2");
 
         Assert.Equal("exported value", ns.Get("value").AsString());
     }
@@ -53,9 +53,9 @@ public class ModuleTests
     [Fact]
     public void ShouldImportNamed()
     {
-        _engine.AddModule("imported-module", "export const value = 'exported value';");
-        _engine.AddModule("my-module", "import { value } from 'imported-module'; export const exported = value;");
-        var ns = _engine.ImportModule("my-module");
+        _engine.Modules.Add("imported-module", "export const value = 'exported value';");
+        _engine.Modules.Add("my-module", "import { value } from 'imported-module'; export const exported = value;");
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal("exported value", ns.Get("exported").AsString());
     }
@@ -63,9 +63,9 @@ public class ModuleTests
     [Fact]
     public void ShouldImportRenamed()
     {
-        _engine.AddModule("imported-module", "export const value = 'exported value';");
-        _engine.AddModule("my-module", "import { value as renamed } from 'imported-module'; export const exported = renamed;");
-        var ns = _engine.ImportModule("my-module");
+        _engine.Modules.Add("imported-module", "export const value = 'exported value';");
+        _engine.Modules.Add("my-module", "import { value as renamed } from 'imported-module'; export const exported = renamed;");
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal("exported value", ns.Get("exported").AsString());
     }
@@ -73,9 +73,9 @@ public class ModuleTests
     [Fact]
     public void ShouldImportDefault()
     {
-        _engine.AddModule("imported-module", "export default 'exported value';");
-        _engine.AddModule("my-module", "import imported from 'imported-module'; export const exported = imported;");
-        var ns = _engine.ImportModule("my-module");
+        _engine.Modules.Add("imported-module", "export default 'exported value';");
+        _engine.Modules.Add("my-module", "import imported from 'imported-module'; export const exported = imported;");
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal("exported value", ns.Get("exported").AsString());
     }
@@ -83,9 +83,9 @@ public class ModuleTests
     [Fact]
     public void ShouldImportAll()
     {
-        _engine.AddModule("imported-module", "export const value = 'exported value';");
-        _engine.AddModule("my-module", "import * as imported from 'imported-module'; export const exported = imported.value;");
-        var ns = _engine.ImportModule("my-module");
+        _engine.Modules.Add("imported-module", "export const value = 'exported value';");
+        _engine.Modules.Add("my-module", "import * as imported from 'imported-module'; export const exported = imported.value;");
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal("exported value", ns.Get("exported").AsString());
     }
@@ -94,10 +94,10 @@ public class ModuleTests
     public void ShouldImportDynamically()
     {
         var received = false;
-        _engine.AddModule("imported-module", builder => builder.ExportFunction("signal", () => received = true));
-        _engine.AddModule("my-module", "import('imported-module').then(ns => { ns.signal(); });");
+        _engine.Modules.Add("imported-module", builder => builder.ExportFunction("signal", () => received = true));
+        _engine.Modules.Add("my-module", "import('imported-module').then(ns => { ns.signal(); });");
 
-        _engine.ImportModule("my-module");
+         _engine.Modules.Import("my-module");
 
         Assert.True(received);
     }
@@ -105,10 +105,10 @@ public class ModuleTests
     [Fact]
     public void ShouldPropagateParseError()
     {
-        _engine.AddModule("imported", "export const invalid;");
-        _engine.AddModule("my-module", "import { invalid } from 'imported';");
+        _engine.Modules.Add("imported", "export const invalid;");
+        _engine.Modules.Add("my-module", "import { invalid } from 'imported';");
 
-        var exc = Assert.Throws<JavaScriptException>(() => _engine.ImportModule("my-module"));
+        var exc = Assert.Throws<JavaScriptException>(() =>  _engine.Modules.Import("my-module"));
         Assert.Equal("Error while loading module: error in module 'imported': Line 1: Missing initializer in const declaration", exc.Message);
         Assert.Equal("imported", exc.Location.Source);
     }
@@ -116,10 +116,10 @@ public class ModuleTests
     [Fact]
     public void ShouldPropagateLinkError()
     {
-        _engine.AddModule("imported", "export invalid;");
-        _engine.AddModule("my-module", "import { value } from 'imported';");
+        _engine.Modules.Add("imported", "export invalid;");
+        _engine.Modules.Add("my-module", "import { value } from 'imported';");
 
-        var exc = Assert.Throws<JavaScriptException>(() => _engine.ImportModule("my-module"));
+        var exc = Assert.Throws<JavaScriptException>(() =>  _engine.Modules.Import("my-module"));
         Assert.Equal("Error while loading module: error in module 'imported': Line 1: Unexpected identifier", exc.Message);
         Assert.Equal("imported", exc.Location.Source);
     }
@@ -127,9 +127,9 @@ public class ModuleTests
     [Fact]
     public void ShouldPropagateExecuteError()
     {
-        _engine.AddModule("my-module", "throw new Error('imported successfully');");
+        _engine.Modules.Add("my-module", "throw new Error('imported successfully');");
 
-        var exc = Assert.Throws<JavaScriptException>(() => _engine.ImportModule("my-module"));
+        var exc = Assert.Throws<JavaScriptException>(() =>  _engine.Modules.Import("my-module"));
         Assert.Equal("imported successfully", exc.Message);
         Assert.Equal("my-module", exc.Location.Source);
     }
@@ -137,18 +137,18 @@ public class ModuleTests
     [Fact]
     public void ShouldPropagateThrowStatementThroughJavaScriptImport()
     {
-        _engine.AddModule("imported-module", "throw new Error('imported successfully');");
-        _engine.AddModule("my-module", "import 'imported-module';");
+        _engine.Modules.Add("imported-module", "throw new Error('imported successfully');");
+        _engine.Modules.Add("my-module", "import 'imported-module';");
 
-        var exc = Assert.Throws<JavaScriptException>(() => _engine.ImportModule("my-module"));
+        var exc = Assert.Throws<JavaScriptException>(() =>  _engine.Modules.Import("my-module"));
         Assert.Equal("imported successfully", exc.Message);
     }
 
     [Fact]
     public void ShouldAddModuleFromJsValue()
     {
-        _engine.AddModule("my-module", builder => builder.ExportValue("value", JsString.Create("hello world")));
-        var ns = _engine.ImportModule("my-module");
+        _engine.Modules.Add("my-module", builder => builder.ExportValue("value", JsString.Create("hello world")));
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal("hello world", ns.Get("value").AsString());
     }
@@ -156,12 +156,12 @@ public class ModuleTests
     [Fact]
     public void ShouldAddModuleFromClrInstance()
     {
-        _engine.AddModule("imported-module", builder => builder.ExportObject("value", new ImportedClass
+        _engine.Modules.Add("imported-module", builder => builder.ExportObject("value", new ImportedClass
         {
             Value = "instance value"
         }));
-        _engine.AddModule("my-module", "import { value } from 'imported-module'; export const exported = value.value;");
-        var ns = _engine.ImportModule("my-module");
+        _engine.Modules.Add("my-module", "import { value } from 'imported-module'; export const exported = value.value;");
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal("instance value", ns.Get("exported").AsString());
     }
@@ -169,8 +169,8 @@ public class ModuleTests
     [Fact]
     public void ShouldAllowInvokeUserDefinedClass()
     {
-        _engine.AddModule("user", "export class UserDefined { constructor(v) { this._v = v; } hello(c) { return `hello ${this._v}${c}`; } }");
-        var ctor = _engine.ImportModule("user").Get("UserDefined");
+        _engine.Modules.Add("user", "export class UserDefined { constructor(v) { this._v = v; } hello(c) { return `hello ${this._v}${c}`; } }");
+        var ctor =  _engine.Modules.Import("user").Get("UserDefined");
         var instance = _engine.Construct(ctor, JsString.Create("world"));
         var result = instance.GetMethod("hello").Call(instance, JsString.Create("!"));
 
@@ -180,9 +180,9 @@ public class ModuleTests
     [Fact]
     public void ShouldAddModuleFromClrType()
     {
-        _engine.AddModule("imported-module", builder => builder.ExportType<ImportedClass>());
-        _engine.AddModule("my-module", "import { ImportedClass } from 'imported-module'; export const exported = new ImportedClass().value;");
-        var ns = _engine.ImportModule("my-module");
+        _engine.Modules.Add("imported-module", builder => builder.ExportType<ImportedClass>());
+        _engine.Modules.Add("my-module", "import { ImportedClass } from 'imported-module'; export const exported = new ImportedClass().value;");
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal("hello world", ns.Get("exported").AsString());
     }
@@ -191,7 +191,7 @@ public class ModuleTests
     public void ShouldAddModuleFromClrFunction()
     {
         var received = new List<string>();
-        _engine.AddModule("imported-module", builder => builder
+        _engine.Modules.Add("imported-module", builder => builder
             .ExportFunction("act_noargs", () => received.Add("act_noargs"))
             .ExportFunction("act_args", args => received.Add($"act_args:{args[0].AsString()}"))
             .ExportFunction("fn_noargs", () =>
@@ -205,10 +205,10 @@ public class ModuleTests
                 return "ret";
             })
         );
-        _engine.AddModule("my-module", @"
+        _engine.Modules.Add("my-module", @"
 import * as fns from 'imported-module';
 export const result = [fns.act_noargs(), fns.act_args('ok'), fns.fn_noargs(), fns.fn_args('ok')];");
-        var ns = _engine.ImportModule("my-module");
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal(new[]
         {
@@ -234,11 +234,11 @@ export const result = [fns.act_noargs(), fns.act_args('ok'), fns.fn_noargs(), fn
     [Fact]
     public void ShouldAllowExportMultipleImports()
     {
-        _engine.AddModule("@mine/import1", builder => builder.ExportValue("value1", JsNumber.Create(1)));
-        _engine.AddModule("@mine/import2", builder => builder.ExportValue("value2", JsNumber.Create(2)));
-        _engine.AddModule("@mine", "export * from '@mine/import1'; export * from '@mine/import2'");
-        _engine.AddModule("app", "import { value1, value2 } from '@mine'; export const result = `${value1} ${value2}`");
-        var ns = _engine.ImportModule("app");
+        _engine.Modules.Add("@mine/import1", builder => builder.ExportValue("value1", JsNumber.Create(1)));
+        _engine.Modules.Add("@mine/import2", builder => builder.ExportValue("value2", JsNumber.Create(2)));
+        _engine.Modules.Add("@mine", "export * from '@mine/import1'; export * from '@mine/import2'");
+        _engine.Modules.Add("app", "import { value1, value2 } from '@mine'; export const result = `${value1} ${value2}`");
+        var ns =  _engine.Modules.Import("app");
 
         Assert.Equal("1 2", ns.Get("result").AsString());
     }
@@ -246,9 +246,9 @@ export const result = [fns.act_noargs(), fns.act_args('ok'), fns.fn_noargs(), fn
     [Fact]
     public void ShouldAllowNamedStarExport()
     {
-        _engine.AddModule("imported-module", builder => builder.ExportValue("value1", 5));
-        _engine.AddModule("my-module", "export * as ns from 'imported-module';");
-        var ns = _engine.ImportModule("my-module");
+        _engine.Modules.Add("imported-module", builder => builder.ExportValue("value1", 5));
+        _engine.Modules.Add("my-module", "export * as ns from 'imported-module';");
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal(5, ns.Get("ns").Get("value1").AsNumber());
     }
@@ -256,13 +256,13 @@ export const result = [fns.act_noargs(), fns.act_args('ok'), fns.fn_noargs(), fn
     [Fact]
     public void ShouldAllowChaining()
     {
-        _engine.AddModule("dependent-module", "export const dependency = 1;");
-        _engine.AddModule("my-module", builder => builder
+        _engine.Modules.Add("dependent-module", "export const dependency = 1;");
+        _engine.Modules.Add("my-module", builder => builder
             .AddSource("import { dependency } from 'dependent-module';")
             .AddSource("export const output = dependency + 1;")
             .ExportValue("num", JsNumber.Create(-1))
         );
-        var ns = _engine.ImportModule("my-module");
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal(2, ns.Get("output").AsInteger());
         Assert.Equal(-1, ns.Get("num").AsInteger());
@@ -272,10 +272,10 @@ export const result = [fns.act_noargs(), fns.act_args('ok'), fns.fn_noargs(), fn
     public void ShouldImportOnlyOnce()
     {
         var called = 0;
-        _engine.AddModule("imported-module", builder => builder.ExportFunction("count", args => called++));
-        _engine.AddModule("my-module", "import { count } from 'imported-module'; count();");
-        _engine.ImportModule("my-module");
-        _engine.ImportModule("my-module");
+        _engine.Modules.Add("imported-module", builder => builder.ExportFunction("count", args => called++));
+        _engine.Modules.Add("my-module", "import { count } from 'imported-module'; count();");
+         _engine.Modules.Import("my-module");
+         _engine.Modules.Import("my-module");
 
         Assert.Equal(1, called);
     }
@@ -283,14 +283,14 @@ export const result = [fns.act_noargs(), fns.act_args('ok'), fns.fn_noargs(), fn
     [Fact]
     public void ShouldAllowSelfImport()
     {
-        _engine.AddModule("my-globals", "export const globals = { counter: 0 };");
-        _engine.AddModule("my-module", @"
+        _engine.Modules.Add("my-globals", "export const globals = { counter: 0 };");
+        _engine.Modules.Add("my-module", @"
 import { globals } from 'my-globals';
 import {} from 'my-module';
 globals.counter++;
 export const count = globals.counter;
 ");
-        var ns = _engine.ImportModule("my-module");
+        var ns =  _engine.Modules.Import("my-module");
 
         Assert.Equal(1, ns.Get("count").AsInteger());
     }
@@ -300,11 +300,11 @@ export const count = globals.counter;
     {
         // https://tc39.es/ecma262/#sec-example-cyclic-module-record-graphs
 
-        _engine.AddModule("B", "import { a } from 'A'; export const b = 'b';");
-        _engine.AddModule("A", "import { b } from 'B'; export const a = 'a';");
+        _engine.Modules.Add("B", "import { a } from 'A'; export const b = 'b';");
+        _engine.Modules.Add("A", "import { b } from 'B'; export const a = 'a';");
 
-        var nsA = _engine.ImportModule("A");
-        var nsB = _engine.ImportModule("B");
+        var nsA =  _engine.Modules.Import("A");
+        var nsB =  _engine.Modules.Import("B");
 
         Assert.Equal("a", nsA.Get("a").AsString());
         Assert.Equal("b", nsB.Get("b").AsString());
@@ -315,17 +315,17 @@ export const count = globals.counter;
     {
         var engine = new Engine(opts => opts.TimeoutInterval(TimeSpan.FromTicks(1)));
 
-        engine.AddModule("sleep", builder => builder.ExportFunction("sleep", () => Thread.Sleep(100)));
-        engine.AddModule("my-module", "import { sleep } from 'sleep'; for(var i = 0; i < 100; i++) { sleep(); } export const result = 'ok';");
-        Assert.Throws<TimeoutException>(() => engine.ImportModule("my-module"));
+        engine.Modules.Add("sleep", builder => builder.ExportFunction("sleep", () => Thread.Sleep(100)));
+        engine.Modules.Add("my-module", "import { sleep } from 'sleep'; for(var i = 0; i < 100; i++) { sleep(); } export const result = 'ok';");
+        Assert.Throws<TimeoutException>(() => engine.Modules.Import("my-module"));
     }
 
     [Fact]
     public void CanLoadModuleImportsFromFiles()
     {
         var engine = new Engine(options => options.EnableModules(GetBasePath()));
-        engine.AddModule("my-module", "import { User } from './modules/user.js'; export const user = new User('John', 'Doe');");
-        var ns = engine.ImportModule("my-module");
+        engine.Modules.Add("my-module", "import { User } from './modules/user.js'; export const user = new User('John', 'Doe');");
+        var ns = engine.Modules.Import("my-module");
 
         Assert.Equal("John Doe", ns["user"].Get("name").AsString());
     }
@@ -334,7 +334,7 @@ export const count = globals.counter;
     public void CanImportFromFile()
     {
         var engine = new Engine(options => options.EnableModules(GetBasePath()));
-        var ns = engine.ImportModule("./modules/format-name.js");
+        var ns = engine.Modules.Import("./modules/format-name.js");
         var result = engine.Invoke(ns.Get("formatName"), "John", "Doe").AsString();
 
         Assert.Equal("John Doe", result);
@@ -344,7 +344,7 @@ export const count = globals.counter;
     public void CanImportFromFileWithSpacesInPath()
     {
         var engine = new Engine(options => options.EnableModules(GetBasePath()));
-        var ns = engine.ImportModule("./dir with spaces/format name.js");
+        var ns = engine.Modules.Import("./dir with spaces/format name.js");
         var result = engine.Invoke(ns.Get("formatName"), "John", "Doe").AsString();
 
         Assert.Equal("John Doe", result);
@@ -358,8 +358,8 @@ export const count = globals.counter;
         for (var i = 0; i < 5; i++)
         {
             var engine = new Engine();
-            engine.AddModule("__main__", x => x.AddModule(module));
-            var ns = engine.ImportModule("__main__");
+            engine.Modules.Add("__main__", x => x.AddModule(module));
+            var ns = engine.Modules.Import("__main__");
             var result = engine.Invoke(ns.Get("formatName"), "John" + i, "Doe").AsString();
             Assert.Equal($"John{i} Doe", result);
         }

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -1,3 +1,7 @@
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Promise;
+using Jint.Runtime;
 using Jint.Runtime.Environments;
 using Environment = Jint.Runtime.Environments.Environment;
 
@@ -35,6 +39,14 @@ public class AdvancedOperations
     }
 
     /// <summary>
+    /// Initializes list of references of called functions
+    /// </summary>
+    public void ResetCallStack()
+    {
+        _engine.ResetCallStack();
+    }
+
+    /// <summary>
     /// Forcefully processes the current task queues (micro and regular), this API may break and change behavior!
     /// </summary>
     public void ProcessTasks()
@@ -51,18 +63,17 @@ public class AdvancedOperations
     }
 
     /// <summary>
-    /// Return the first constraint that matches the predicate.
+    /// EXPERIMENTAL! Subject to change.
+    ///
+    /// Registers a promise within the currently running EventLoop (has to be called within "ExecuteWithEventLoop" call).
+    /// Note that ExecuteWithEventLoop will not trigger "onFinished" callback until ALL manual promises are settled.
+    ///
+    /// NOTE: that resolve and reject need to be called withing the same thread as "ExecuteWithEventLoop".
+    /// The API assumes that the Engine is called from a single thread.
     /// </summary>
-    public T? FindConstraint<T>() where T : Constraint
+    /// <returns>a Promise instance and functions to either resolve or reject it</returns>
+    public ManualPromise RegisterPromise()
     {
-        foreach (var constraint in _engine._constraints)
-        {
-            if (constraint.GetType() == typeof(T))
-            {
-                return (T) constraint;
-            }
-        }
-
-        return null;
+        return _engine.RegisterPromise();
     }
 }

--- a/Jint/Engine.Constraints.cs
+++ b/Jint/Engine.Constraints.cs
@@ -1,0 +1,54 @@
+namespace Jint;
+
+public partial class Engine
+{
+    public ConstraintOperations Constraints { get; }
+}
+
+public class ConstraintOperations
+{
+    private readonly Engine _engine;
+
+    public ConstraintOperations(Engine engine)
+    {
+        _engine = engine;
+    }
+
+    /// <summary>
+    /// Checks engine's active constraints. Propagates exceptions from constraints.
+    /// </summary>
+    public void Check()
+    {
+        foreach (var constraint in _engine._constraints)
+        {
+            constraint.Check();
+        }
+    }
+
+    /// <summary>
+    /// Return the first constraint that matches the predicate.
+    /// </summary>
+    public T? Find<T>() where T : Constraint
+    {
+        foreach (var constraint in _engine._constraints)
+        {
+            if (constraint.GetType() == typeof(T))
+            {
+                return (T) constraint;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resets all execution constraints back to their initial state.
+    /// </summary>
+    public void Reset()
+    {
+        foreach (var constraint in _engine._constraints)
+        {
+            constraint.Reset();
+        }
+    }
+}

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -89,7 +89,7 @@ namespace Jint.Native.Function
                     {
                         // We don't have a statement, but we still need a Location for debuggers. DebugHandler will infer one from
                         // the function body:
-                        _engine.DebugHandler.OnReturnPoint(
+                        _engine.Debugger.OnReturnPoint(
                             _functionDefinition.Function.Body,
                             result.Type == CompletionType.Normal ? Undefined : result.Value
                         );
@@ -171,7 +171,7 @@ namespace Jint.Native.Function
                     {
                         // We don't have a statement, but we still need a Location for debuggers. DebugHandler will infer one from
                         // the function body:
-                        _engine.DebugHandler.OnReturnPoint(
+                        _engine.Debugger.OnReturnPoint(
                             _functionDefinition.Function.Body,
                             result.Type == CompletionType.Normal ? thisArgument : result.Value
                         );

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -132,7 +132,7 @@ namespace Jint
         /// </summary>
         public static Options SetTypeConverter(this Options options, Func<Engine, ITypeConverter> typeConverterFactory)
         {
-            options._configurations.Add(engine => engine.ClrTypeConverter = typeConverterFactory(engine));
+            options._configurations.Add(engine => engine.TypeConverter = typeConverterFactory(engine));
             return options;
         }
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -141,12 +141,12 @@ namespace Jint
                         (thisObj, arguments) =>
                         {
                             var specifier = TypeConverter.ToString(arguments.At(0));
-                            return engine.ImportModule(specifier);
+                            return engine.Modules.Import(specifier);
                         }),
                     PropertyFlag.AllForbidden));
             }
 
-            engine.ModuleLoader = Modules.ModuleLoader;
+            engine.Modules = new ModuleOperations(engine, Modules.ModuleLoader);
         }
 
         private static void AttachExtensionMethodsToPrototypes(Engine engine)

--- a/Jint/Runtime/Host.cs
+++ b/Jint/Runtime/Host.cs
@@ -120,7 +120,7 @@ namespace Jint.Runtime
         /// </summary>
         internal virtual Module GetImportedModule(IScriptOrModule? referrer, ModuleRequest request)
         {
-            return Engine.LoadModule(referrer?.Location, request);
+            return Engine.Modules.Load(referrer?.Location, request);
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace Jint.Runtime
             try
             {
                 // This should instead return the PromiseInstance returned by ModuleRecord.Evaluate (currently done in Engine.EvaluateModule), but until we have await this will do.
-                Engine.ImportModule(moduleRequest.Specifier, referrer?.Location);
+                Engine.Modules.Import(moduleRequest.Specifier, referrer?.Location);
                 promise.Resolve(JsValue.Undefined);
             }
             catch (JavaScriptException ex)

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -56,7 +56,7 @@ namespace Jint.Runtime.Interop
             int jsArgumentsCount = arguments.Length;
             int jsArgumentsWithoutParamsCount = Math.Min(jsArgumentsCount, delegateNonParamsArgumentsCount);
 
-            var clrTypeConverter = Engine.ClrTypeConverter;
+            var clrTypeConverter = Engine.TypeConverter;
             var valueCoercionType = Engine.Options.Interop.ValueCoercion;
             var parameters = new object?[delegateArgumentsCount];
 
@@ -116,7 +116,7 @@ namespace Jint.Runtime.Interop
                     }
                     else if (!ReflectionExtensions.TryConvertViaTypeCoercion(paramsParameterType, valueCoercionType, value, out converted))
                     {
-                        converted = Engine.ClrTypeConverter.Convert(
+                        converted = Engine.TypeConverter.Convert(
                             value.ToObject(),
                             paramsParameterType!,
                             CultureInfo.InvariantCulture);

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -127,7 +127,7 @@ namespace Jint.Runtime.Interop
                     }
                     else if (!ReflectionExtensions.TryConvertViaTypeCoercion(parameterType, valueCoercionType, value, out converted))
                     {
-                        converted = engine.ClrTypeConverter.Convert(
+                        converted = engine.TypeConverter.Convert(
                             value.ToObject(),
                             parameterType,
                             System.Globalization.CultureInfo.InvariantCulture);

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -158,7 +158,7 @@ namespace Jint.Runtime.Interop
                     : jsArguments;
             }
 
-            var converter = Engine.ClrTypeConverter;
+            var converter = Engine.TypeConverter;
             var thisObj = thisObject.ToObject() ?? _target;
             object?[]? parameters = null;
             foreach (var (method, arguments, _) in TypeConverter.FindBestMatch(_engine, _methods, ArgumentProvider))

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -158,7 +158,7 @@ namespace Jint.Runtime.Interop
                 {
                     object? stringKey = key as string;
                     if (stringKey is not null
-                        || _engine.ClrTypeConverter.TryConvert(key, typeof(string), CultureInfo.InvariantCulture, out stringKey))
+                        || _engine.TypeConverter.TryConvert(key, typeof(string), CultureInfo.InvariantCulture, out stringKey))
                     {
                         var jsString = JsString.Create((string) stringKey!);
                         yield return jsString;

--- a/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
@@ -59,7 +59,7 @@ namespace Jint.Runtime.Interop.Reflection
                 }
                 else
                 {
-                    engine.ClrTypeConverter.TryConvert(propertyName, paramType, CultureInfo.InvariantCulture, out key);
+                    engine.TypeConverter.TryConvert(propertyName, paramType, CultureInfo.InvariantCulture, out key);
                 }
 
                 if (key is not null)

--- a/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
@@ -112,7 +112,7 @@ namespace Jint.Runtime.Interop.Reflection
 
         protected virtual object? ConvertValueToSet(Engine engine, object value)
         {
-            return engine.ClrTypeConverter.Convert(value, _memberType, CultureInfo.InvariantCulture);
+            return engine.TypeConverter.Convert(value, _memberType, CultureInfo.InvariantCulture);
         }
 
         public virtual PropertyDescriptor CreatePropertyDescriptor(Engine engine, object target, bool enumerable = true)

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -52,7 +52,7 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
 
             if (context.DebugMode)
             {
-                context.Engine.DebugHandler.OnStep(_test._expression);
+                context.Engine.Debugger.OnStep(_test._expression);
             }
 
             iterating = TypeConverter.ToBoolean(_test.GetValue(context));

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -208,7 +208,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
                     if (context.DebugMode)
                     {
-                        context.Engine.DebugHandler.OnStep(_leftNode);
+                        context.Engine.Debugger.OnStep(_leftNode);
                     }
 
                     var status = CompletionType.Normal;

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -122,7 +122,7 @@ namespace Jint.Runtime.Interpreter.Statements
                 CreatePerIterationEnvironment(context);
             }
 
-            var debugHandler = context.DebugMode ? context.Engine.DebugHandler : null;
+            var debugHandler = context.DebugMode ? context.Engine.Debugger : null;
 
             while (true)
             {

--- a/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
@@ -31,7 +31,7 @@ namespace Jint.Runtime.Interpreter.Statements
             {
                 if (context.DebugMode)
                 {
-                    context.Engine.DebugHandler.OnStep(_test._expression);
+                    context.Engine.Debugger.OnStep(_test._expression);
                 }
 
                 var jsValue = _test.GetValue(context);

--- a/Jint/Runtime/Modules/DefaultModuleLoader.cs
+++ b/Jint/Runtime/Modules/DefaultModuleLoader.cs
@@ -106,7 +106,7 @@ public class DefaultModuleLoader : ModuleLoader
         var specifier = resolved.ModuleRequest.Specifier;
         if (resolved.Type != SpecifierType.RelativeOrAbsolute)
         {
-            ExceptionHelper.ThrowNotSupportedException($"The default module loader can only resolve files. You can define modules directly to allow imports using {nameof(Engine)}.{nameof(Engine.AddModule)}(). Attempted to resolve: '{specifier}'.");
+            ExceptionHelper.ThrowNotSupportedException($"The default module loader can only resolve files. You can define modules directly to allow imports using {nameof(Engine)}.{nameof(Engine.Modules.Add)}(). Attempted to resolve: '{specifier}'.");
         }
 
         if (resolved.Uri == null)

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ jint> log(bar.ToString());
 
 adding a specific CLR type reference can be done like this
 ```csharp
-engine.SetValue("TheType", TypeReference.CreateTypeReference(engine, typeof(TheType)))
+engine.SetValue("TheType", TypeReference.CreateTypeReference<TheType>(engine));
 ```
 
 and used this way
@@ -351,7 +351,7 @@ var engine = new Engine(options =>
     options.CancellationToken(new CancellationToken(true));
 });
 
-var constraint = engine.FindConstraint<CancellationConstraint>();
+var constraint = engine.Constraints.Find<CancellationConstraint>();
 
 for (var i = 0; i < 10; i++) 
 {
@@ -375,7 +375,7 @@ var engine = new Engine(options =>
     options.EnableModules(@"C:\Scripts");
 })
 
-var ns = engine.ImportModule("./my-module.js");
+var ns = engine.Modules.Import("./my-module.js");
 
 var value = ns.Get("value").AsString();
 ```
@@ -385,9 +385,9 @@ By default, the module resolution algorithm will be restricted to the base path 
 Defining modules using JavaScript source code:
 
 ```c#
-engine.AddModule("user", "export const name = 'John';");
+engine.Modules.Add("user", "export const name = 'John';");
 
-var ns = engine.ImportModule("user");
+var ns = engine.Modules.Import("user");
 
 var name = ns.Get("name").AsString();
 ```
@@ -396,26 +396,26 @@ Defining modules using the module builder, which allows you to export CLR classe
 
 ```c#
 // Create the module 'lib' with the class MyClass and the variable version
-engine.AddModule("lib", builder => builder
+engine.Modules.Add("lib", builder => builder
     .ExportType<MyClass>()
     .ExportValue("version", 15)
 );
 
 // Create a user-defined module and do something with 'lib'
-engine.AddModule("custom", @"
+engine.Modules.Add("custom", @"
     import { MyClass, version } from 'lib';
     const x = new MyClass();
     export const result as x.doSomething();
 ");
 
 // Import the user-defined module; this will execute the import chain
-var ns = engine.ImportModule("custom");
+var ns = engine.Modules.Import("custom");
 
 // The result contains "live" bindings to the module
 var id = ns.Get("result").AsInteger();
 ```
 
-Note that you don't need to `EnableModules` if you only use modules created using `AddModule`.
+Note that you don't need to `EnableModules` if you only use modules created using `Engine.Modules.Add`.
 
 ## .NET Interoperability
 


### PR DESCRIPTION
* Move `Engine.ResetCallStack` to `Engine.Advanced`
* Rename `Engine.ClrTypeConverter` to `Engine.TypeConverter`
* Rename `Engine.DebugHandler` to `Engine.Debugger`
* Move constraint related methods to `Engine.Constraints`
* Move module related methods to `Engine.Modules` and shorten method names
* Move `Engine.RegisterPromise` to `Engine.Advanced.RegisterPromise`