### PR TITLE
The toString() of 'class' and 'function' return SourceText

### DIFF
--- a/Jint/Native/Function/ClassDefinition.cs
+++ b/Jint/Native/Function/ClassDefinition.cs
@@ -19,6 +19,7 @@ internal sealed class ClassDefinition
     internal static readonly MethodDefinition _emptyConstructor;
 
     internal readonly string? _className;
+    private readonly string _classSource;
     private readonly Expression? _superClass;
     private readonly ClassBody _body;
 
@@ -39,10 +40,12 @@ internal sealed class ClassDefinition
 
     public ClassDefinition(
         string? className,
+        string classSource,
         Expression? superClass,
         ClassBody body)
     {
         _className = className;
+        _classSource = classSource;
         _superClass = superClass;
         _body = body;
     }
@@ -145,6 +148,7 @@ internal sealed class ClassDefinition
             F = constructorInfo.Closure;
 
             F.SetFunctionName(_className ?? "");
+            F._sourceText = _classSource;
 
             F.MakeConstructor(writableProperty: false, proto);
             F._constructorKind = _superClass is null ? ConstructorKind.Base : ConstructorKind.Derived;

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -29,6 +29,7 @@ namespace Jint.Native.Function
 
         internal Realm _realm;
         internal PrivateEnvironment? _privateEnvironment;
+        internal string? _sourceText;
         private readonly IScriptOrModule? _scriptOrModule;
 
         protected Function(
@@ -367,7 +368,14 @@ namespace Jint.Native.Function
 
         public override string ToString()
         {
-            // TODO no way to extract SourceText from Esprima at the moment, just returning native code
+            if (_sourceText != null)
+            {
+                return _sourceText;
+            }
+            if ((_sourceText = _functionDefinition?.Function?.ToString()) != null)
+            {
+                return _sourceText;
+            }
             var nameValue = _nameDescriptor != null ? UnwrapJsValue(_nameDescriptor) : JsString.Empty;
             var name = "";
             if (!nameValue.IsUndefined())
@@ -377,7 +385,7 @@ namespace Jint.Native.Function
 
             name = name.TrimStart(_functionNameTrimStartChars);
 
-            return "function " + name + "() { [native code] }";
+            return _sourceText = "function " + name + "() { [native code] }";
         }
 
         private sealed class ObjectInstanceWithConstructor : ObjectInstance

--- a/Jint/Runtime/Interpreter/Expressions/JintClassExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintClassExpression.cs
@@ -1,4 +1,5 @@
 using Esprima.Ast;
+using Esprima.Utils;
 using Jint.Native.Function;
 
 namespace Jint.Runtime.Interpreter.Expressions
@@ -9,7 +10,7 @@ namespace Jint.Runtime.Interpreter.Expressions
 
         public JintClassExpression(ClassExpression expression) : base(expression)
         {
-            _classDefinition = new ClassDefinition(expression.Id?.Name, expression.SuperClass, expression.Body);
+            _classDefinition = new ClassDefinition(className: expression.Id?.Name, classSource: expression.ToString(), superClass: expression.SuperClass, body: expression.Body);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Statements/JintClassDeclarationStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintClassDeclarationStatement.cs
@@ -1,4 +1,5 @@
 using Esprima.Ast;
+using Esprima.Utils;
 using Jint.Native;
 using Jint.Native.Function;
 
@@ -10,7 +11,7 @@ namespace Jint.Runtime.Interpreter.Statements
 
         public JintClassDeclarationStatement(ClassDeclaration classDeclaration) : base(classDeclaration)
         {
-            _classDefinition = new ClassDefinition(className: classDeclaration.Id?.Name, classDeclaration.SuperClass, classDeclaration.Body);
+            _classDefinition = new ClassDefinition(className: classDeclaration.Id?.Name, classSource:classDeclaration.ToString(), superClass: classDeclaration.SuperClass, body: classDeclaration.Body);
         }
 
         protected override Completion ExecuteInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
@@ -1,4 +1,5 @@
 using Esprima.Ast;
+using Esprima.Utils;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Runtime.Interpreter.Expressions;
@@ -21,7 +22,7 @@ internal sealed class JintExportDefaultDeclaration : JintStatement<ExportDefault
     {
         if (_statement.Declaration is ClassDeclaration classDeclaration)
         {
-            _classDefinition = new ClassDefinition(className: classDeclaration.Id?.Name ?? "default", classDeclaration.SuperClass, classDeclaration.Body);
+            _classDefinition = new ClassDefinition(className: classDeclaration.Id?.Name ?? "default", classSource: classDeclaration.ToString(), superClass: classDeclaration.SuperClass, body: classDeclaration.Body);
         }
         else if (_statement.Declaration is FunctionDeclaration functionDeclaration)
         {


### PR DESCRIPTION
I noticed that the previous reason for returning native code was that Esprima didn't support it (in the ToString comment for Function), but I found that Esprima now supports returning SourceText, so wanted to align with the behaviour of the mainstream js engines.
Unfortunately, passing the Test262 test still requires waiting for Esprima to refine the functionality, but that's outside the scope of this pr and beyond my capabilities (