### PR TITLE
Make JsArguments public

### DIFF
--- a/Jint.Tests.PublicInterface/PublicInterfaceTests.cs
+++ b/Jint.Tests.PublicInterface/PublicInterfaceTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Jint.Native;
+using Jint.Native.Argument;
 using Jint.Native.Function;
 
 namespace Jint.Tests.PublicInterface;
@@ -36,6 +37,15 @@ var coolingObject = {
     }.bind(coolingObject), coolingObject.coolDownTime);
 
 ");
+    }
+
+    [Fact]
+    public void JsArgumentsIsPublic()
+    {
+        // debuggers might want to access the information
+        var obj = new Engine().Execute("function f() { return arguments; }").Evaluate("f('a', 'b', 'c');");
+        var arguments = Assert.IsType<JsArguments>(obj);
+        Assert.Equal((uint) 3, arguments.Length);
     }
 
     private sealed class SetTimeoutEmulator : IDisposable

--- a/Jint/Native/Argument/JsArguments.cs
+++ b/Jint/Native/Argument/JsArguments.cs
@@ -1,5 +1,4 @@
 using System.Threading;
-using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime;
@@ -13,7 +12,7 @@ namespace Jint.Native.Argument
     /// <summary>
     /// https://tc39.es/ecma262/#sec-arguments-exotic-objects
     /// </summary>
-    internal sealed class JsArguments : ObjectInstance
+    public sealed class JsArguments : ObjectInstance
     {
         // cache property container for array iteration for less allocations
         private static readonly ThreadLocal<HashSet<string>> _mappedNamed = new(() => new HashSet<string>(StringComparer.Ordinal));
@@ -102,9 +101,13 @@ namespace Jint.Native.Argument
             DefinePropertyOrThrow(GlobalSymbolRegistry.Iterator, new PropertyDescriptor(iteratorFunction, PropertyFlag.Writable | PropertyFlag.Configurable));
         }
 
-        public ObjectInstance? ParameterMap { get; set; }
+        internal ObjectInstance? ParameterMap { get; set; }
+
+        internal override bool IsArrayLike => true;
 
         internal override bool IsIntegerIndexedArray => true;
+
+        public uint Length => (uint) _args.Length;
 
         public override PropertyDescriptor GetOwnProperty(JsValue property)
         {
@@ -154,7 +157,7 @@ namespace Jint.Native.Argument
 
             if (desc.IsAccessorDescriptor())
             {
-                if (!(desc.Set is ICallable setter))
+                if (desc.Set is not ICallable setter)
                 {
                     return false;
                 }
@@ -179,7 +182,7 @@ namespace Jint.Native.Argument
 
             EnsureInitialized();
 
-            if (!(_func is null) && !ReferenceEquals(ParameterMap, null))
+            if (!ReferenceEquals(ParameterMap, null))
             {
                 var map = ParameterMap;
                 var isMapped = map.GetOwnProperty(property);
@@ -220,7 +223,7 @@ namespace Jint.Native.Argument
         {
             EnsureInitialized();
 
-            if (!(_func is null) && !ReferenceEquals(ParameterMap, null))
+            if (!ReferenceEquals(ParameterMap, null))
             {
                 var map = ParameterMap;
                 var isMapped = map.GetOwnProperty(property);


### PR DESCRIPTION
Debugger implementations would like to see what arguments have been supplied and detect that object is special `arguments` object.