### PR TITLE
Restructure and internalize

### DIFF
--- a/Jint.Tests/Runtime/NullPropagation.cs
+++ b/Jint.Tests/Runtime/NullPropagation.cs
@@ -1,7 +1,6 @@
 ﻿using Jint.Native;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
-using Jint.Runtime.References;
 
 namespace Jint.Tests.Runtime
 {

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -5,62 +5,62 @@ namespace Jint;
 public partial class Engine
 {
     public AdvancedOperations Advanced { get; }
-}
 
-public class AdvancedOperations
-{
-    private readonly Engine _engine;
-
-    public AdvancedOperations(Engine engine)
+    public class AdvancedOperations
     {
-        _engine = engine;
-    }
+        private readonly Engine _engine;
 
-    /// <summary>
-    /// Gets current stack trace that is active in engine.
-    /// </summary>
-    public string StackTrace
-    {
-        get
+        internal AdvancedOperations(Engine engine)
         {
-            var lastSyntaxElement = _engine._lastSyntaxElement;
-            if (lastSyntaxElement is null)
-            {
-                return string.Empty;
-            }
-
-            return _engine.CallStack.BuildCallStackString(lastSyntaxElement.Location);
+            _engine = engine;
         }
-    }
 
-    /// <summary>
-    /// Initializes list of references of called functions
-    /// </summary>
-    public void ResetCallStack()
-    {
-        _engine.ResetCallStack();
-    }
+        /// <summary>
+        /// Gets current stack trace that is active in engine.
+        /// </summary>
+        public string StackTrace
+        {
+            get
+            {
+                var lastSyntaxElement = _engine._lastSyntaxElement;
+                if (lastSyntaxElement is null)
+                {
+                    return string.Empty;
+                }
 
-    /// <summary>
-    /// Forcefully processes the current task queues (micro and regular), this API may break and change behavior!
-    /// </summary>
-    public void ProcessTasks()
-    {
-        _engine.RunAvailableContinuations();
-    }
+                return _engine.CallStack.BuildCallStackString(lastSyntaxElement.Location);
+            }
+        }
 
-    /// <summary>
-    /// EXPERIMENTAL! Subject to change.
-    ///
-    /// Registers a promise within the currently running EventLoop (has to be called within "ExecuteWithEventLoop" call).
-    /// Note that ExecuteWithEventLoop will not trigger "onFinished" callback until ALL manual promises are settled.
-    ///
-    /// NOTE: that resolve and reject need to be called withing the same thread as "ExecuteWithEventLoop".
-    /// The API assumes that the Engine is called from a single thread.
-    /// </summary>
-    /// <returns>a Promise instance and functions to either resolve or reject it</returns>
-    public ManualPromise RegisterPromise()
-    {
-        return _engine.RegisterPromise();
+        /// <summary>
+        /// Initializes list of references of called functions
+        /// </summary>
+        public void ResetCallStack()
+        {
+            _engine.ResetCallStack();
+        }
+
+        /// <summary>
+        /// Forcefully processes the current task queues (micro and regular), this API may break and change behavior!
+        /// </summary>
+        public void ProcessTasks()
+        {
+            _engine.RunAvailableContinuations();
+        }
+
+        /// <summary>
+        /// EXPERIMENTAL! Subject to change.
+        ///
+        /// Registers a promise within the currently running EventLoop (has to be called within "ExecuteWithEventLoop" call).
+        /// Note that ExecuteWithEventLoop will not trigger "onFinished" callback until ALL manual promises are settled.
+        ///
+        /// NOTE: that resolve and reject need to be called withing the same thread as "ExecuteWithEventLoop".
+        /// The API assumes that the Engine is called from a single thread.
+        /// </summary>
+        /// <returns>a Promise instance and functions to either resolve or reject it</returns>
+        public ManualPromise RegisterPromise()
+        {
+            return _engine.RegisterPromise();
+        }
     }
 }

--- a/Jint/Engine.Constraints.cs
+++ b/Jint/Engine.Constraints.cs
@@ -3,52 +3,52 @@ namespace Jint;
 public partial class Engine
 {
     public ConstraintOperations Constraints { get; }
-}
 
-public class ConstraintOperations
-{
-    private readonly Engine _engine;
-
-    public ConstraintOperations(Engine engine)
+    public class ConstraintOperations
     {
-        _engine = engine;
-    }
+        private readonly Engine _engine;
 
-    /// <summary>
-    /// Checks engine's active constraints. Propagates exceptions from constraints.
-    /// </summary>
-    public void Check()
-    {
-        foreach (var constraint in _engine._constraints)
+        internal ConstraintOperations(Engine engine)
         {
-            constraint.Check();
+            _engine = engine;
         }
-    }
 
-    /// <summary>
-    /// Return the first constraint that matches the predicate.
-    /// </summary>
-    public T? Find<T>() where T : Constraint
-    {
-        foreach (var constraint in _engine._constraints)
+        /// <summary>
+        /// Checks engine's active constraints. Propagates exceptions from constraints.
+        /// </summary>
+        public void Check()
         {
-            if (constraint.GetType() == typeof(T))
+            foreach (var constraint in _engine._constraints)
             {
-                return (T) constraint;
+                constraint.Check();
             }
         }
 
-        return null;
-    }
-
-    /// <summary>
-    /// Resets all execution constraints back to their initial state.
-    /// </summary>
-    public void Reset()
-    {
-        foreach (var constraint in _engine._constraints)
+        /// <summary>
+        /// Return the first constraint that matches the predicate.
+        /// </summary>
+        public T? Find<T>() where T : Constraint
         {
-            constraint.Reset();
+            foreach (var constraint in _engine._constraints)
+            {
+                if (constraint.GetType() == typeof(T))
+                {
+                    return (T) constraint;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Resets all execution constraints back to their initial state.
+        /// </summary>
+        public void Reset()
+        {
+            foreach (var constraint in _engine._constraints)
+            {
+                constraint.Reset();
+            }
         }
     }
 }

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -6,19 +6,18 @@ using Jint.Runtime;
 using Jint.Runtime.Interpreter;
 using Jint.Runtime.Modules;
 
-namespace Jint
-{
-    public partial class Engine
-    {
-        public ModuleOperations Modules { get; internal set; } = null!;
+namespace Jint;
 
-        /// <summary>
-        /// https://tc39.es/ecma262/#sec-getactivescriptormodule
-        /// </summary>
-        internal IScriptOrModule? GetActiveScriptOrModule()
-        {
-            return _executionContexts?.GetActiveScriptOrModule();
-        }
+public partial class Engine
+{
+    public ModuleOperations Modules { get; internal set; } = null!;
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-getactivescriptormodule
+    /// </summary>
+    internal IScriptOrModule? GetActiveScriptOrModule()
+    {
+        return _executionContexts?.GetActiveScriptOrModule();
     }
 
     public class ModuleOperations
@@ -56,7 +55,7 @@ namespace Jint
 
             if (module is SourceTextModule sourceTextModule)
             {
-               _engine.Debugger.OnBeforeEvaluate(sourceTextModule._source);
+                _engine.Debugger.OnBeforeEvaluate(sourceTextModule._source);
             }
 
             return module;

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -19,7 +19,6 @@ using Jint.Runtime.Interop;
 using Jint.Runtime.Interop.Reflection;
 using Jint.Runtime.Interpreter;
 using Jint.Runtime.Interpreter.Expressions;
-using Jint.Runtime.References;
 using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -15,7 +15,7 @@ namespace Jint.Native.Json
         private readonly int _maxDepth;
 
         /// <summary>
-        /// Creates a new parser using the recursion depth specified in <see cref="JsonOptions.MaxParseDepth"/>.
+        /// Creates a new parser using the recursion depth specified in <see cref="Options.JsonOptions.MaxParseDepth"/>.
         /// </summary>
         public JsonParser(Engine engine)
             : this(engine, engine.Options.Json.MaxParseDepth)

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -121,7 +121,7 @@ namespace Jint
         /// ObjectInstance using class ObjectWrapper. This function can be used to
         /// register a handler for a customized handling.
         /// </summary>
-        public static Options SetWrapObjectHandler(this Options options, WrapObjectDelegate wrapObjectHandler)
+        public static Options SetWrapObjectHandler(this Options options, Options.WrapObjectDelegate wrapObjectHandler)
         {
             options.Interop.WrapObjectHandler = wrapObjectHandler;
             return options;
@@ -146,7 +146,7 @@ namespace Jint
         /// The delegate to invoke for each CLR member. If the delegate
         /// returns <c>null</c>, the standard evaluation is performed.
         /// </param>
-        public static Options SetMemberAccessor(this Options options, MemberAccessorDelegate accessor)
+        public static Options SetMemberAccessor(this Options options, Options.MemberAccessorDelegate accessor)
         {
             options.Interop.MemberAccessor = accessor;
             return options;
@@ -191,7 +191,7 @@ namespace Jint
         /// can be used in at try/catch statement. By default these exceptions are bubbled
         /// to the CLR host and interrupt the script execution.
         /// </summary>
-        public static Options CatchClrExceptions(this Options options, ExceptionHandlerDelegate handler)
+        public static Options CatchClrExceptions(this Options options, Options.ExceptionHandlerDelegate handler)
         {
             options.Interop.ExceptionHandler = handler;
             return options;

--- a/Jint/Pooling/ArgumentsInstancePool.cs
+++ b/Jint/Pooling/ArgumentsInstancePool.cs
@@ -2,12 +2,11 @@ using Jint.Native;
 using Jint.Native.Argument;
 using Jint.Native.Function;
 using Jint.Runtime.Environments;
-using Jint.Runtime.References;
 
 namespace Jint.Pooling
 {
     /// <summary>
-    /// Cache reusable <see cref="Reference" /> instances as we allocate them a lot.
+    /// Cache reusable <see cref="JsArguments" /> instances as we allocate them a lot.
     /// </summary>
     internal sealed class ArgumentsInstancePool
     {

--- a/Jint/Pooling/ReferencePool.cs
+++ b/Jint/Pooling/ReferencePool.cs
@@ -1,5 +1,5 @@
 using Jint.Native;
-using Jint.Runtime.References;
+using Jint.Runtime;
 
 namespace Jint.Pooling
 {

--- a/Jint/Runtime/DefaultReferenceResolver.cs
+++ b/Jint/Runtime/DefaultReferenceResolver.cs
@@ -1,6 +1,5 @@
 using Jint.Native;
 using Jint.Runtime.Interop;
-using Jint.Runtime.References;
 
 namespace Jint.Runtime
 {

--- a/Jint/Runtime/Environments/Binding.cs
+++ b/Jint/Runtime/Environments/Binding.cs
@@ -4,7 +4,7 @@ using Jint.Native;
 namespace Jint.Runtime.Environments
 {
     [DebuggerDisplay("Mutable: {Mutable}, Strict: {Strict}, CanBeDeleted: {CanBeDeleted}, Value: {Value}")]
-    public readonly struct Binding
+    internal readonly struct Binding
     {
         public Binding(
             JsValue value,

--- a/Jint/Runtime/ExceptionHelper.cs
+++ b/Jint/Runtime/ExceptionHelper.cs
@@ -7,7 +7,6 @@ using Jint.Native;
 using Jint.Native.Error;
 using Jint.Runtime.CallStack;
 using Jint.Runtime.Modules;
-using Jint.Runtime.References;
 
 namespace Jint.Runtime
 {

--- a/Jint/Runtime/Interop/ClrFunction.cs
+++ b/Jint/Runtime/Interop/ClrFunction.cs
@@ -30,7 +30,7 @@ public sealed class ClrFunction : Function, IEquatable<ClrFunction>
             ? PropertyDescriptor.AllForbiddenDescriptor.ForNumber(length)
             : new PropertyDescriptor(JsNumber.Create(length), lengthFlags);
 
-        _bubbleExceptions = _engine.Options.Interop.ExceptionHandler == InteropOptions._defaultExceptionHandler;
+        _bubbleExceptions = _engine.Options.Interop.ExceptionHandler == Options.InteropOptions._defaultExceptionHandler;
     }
 
     protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments) => _bubbleExceptions ? _func(thisObject, arguments) : CallSlow(thisObject, arguments);

--- a/Jint/Runtime/Interop/ClrHelper.cs
+++ b/Jint/Runtime/Interop/ClrHelper.cs
@@ -4,9 +4,9 @@ using Jint.Native;
 
 public class ClrHelper
 {
-    private readonly InteropOptions _interopOptions;
+    private readonly Options.InteropOptions _interopOptions;
 
-    internal ClrHelper(InteropOptions interopOptions)
+    internal ClrHelper(Options.InteropOptions interopOptions)
     {
         _interopOptions = interopOptions;
     }

--- a/Jint/Runtime/Interop/IReferenceResolver.cs
+++ b/Jint/Runtime/Interop/IReferenceResolver.cs
@@ -1,5 +1,4 @@
 using Jint.Native;
-using Jint.Runtime.References;
 
 namespace Jint.Runtime.Interop
 {

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -16,9 +16,9 @@ namespace Jint.Runtime.Interop
 
         /// <summary>
         /// Registers a filter that determines whether given member is wrapped to interop or returned as undefined.
-        /// By default allows all but will also be limited by <see cref="InteropOptions.AllowGetType"/> configuration.
+        /// By default allows all but will also be limited by <see cref="Options.InteropOptions.AllowGetType"/> configuration.
         /// </summary>
-        /// <seealso cref="InteropOptions.AllowGetType"/>
+        /// <seealso cref="Options.InteropOptions.AllowGetType"/>
         public Predicate<MemberInfo> MemberFilter { get; set; } = _ => true;
 
         internal bool Filter(Engine engine, MemberInfo m)

--- a/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/BindingPatternAssignmentExpression.cs
@@ -3,7 +3,6 @@ using Jint.Native;
 using Jint.Native.Array;
 using Jint.Native.Function;
 using Jint.Native.Iterator;
-using Jint.Runtime.References;
 using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Expressions

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -3,7 +3,6 @@ using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Runtime.Environments;
-using Jint.Runtime.References;
 using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Expressions

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -6,7 +6,6 @@ using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime.CallStack;
 using Jint.Runtime.Environments;
-using Jint.Runtime.References;
 using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Expressions

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -4,7 +4,6 @@ using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Iterator;
 using Jint.Native.Number;
-using Jint.Runtime.References;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -1,7 +1,6 @@
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.Environments;
-using Jint.Runtime.References;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {

--- a/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
@@ -2,7 +2,6 @@ using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.References;
 
 namespace Jint.Runtime.Interpreter.Expressions;
 

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -2,7 +2,6 @@ using Esprima.Ast;
 using Jint.Extensions;
 using Jint.Native;
 using Jint.Runtime.Interop;
-using Jint.Runtime.References;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -1,7 +1,6 @@
 using Esprima.Ast;
 using Jint.Native;
 using Jint.Runtime.Environments;
-using Jint.Runtime.References;
 
 namespace Jint.Runtime.Interpreter.Expressions
 {

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -4,7 +4,6 @@ using Jint.Native;
 using Jint.Native.Iterator;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
-using Jint.Runtime.References;
 using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Statements

--- a/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
@@ -2,7 +2,6 @@ using Esprima.Ast;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Runtime.Interpreter.Expressions;
-using Jint.Runtime.References;
 
 namespace Jint.Runtime.Interpreter.Statements
 {

--- a/Jint/Runtime/Modules/ModuleBuilder.cs
+++ b/Jint/Runtime/Modules/ModuleBuilder.cs
@@ -1,18 +1,15 @@
 using Esprima;
 using Esprima.Ast;
 using Jint.Native;
-using Jint.Runtime;
 using Jint.Runtime.Interop;
-using Jint.Runtime.Modules;
-using Module = Esprima.Ast.Module;
 
-namespace Jint;
+namespace Jint.Runtime.Modules;
 
 public sealed class ModuleBuilder
 {
     private readonly Engine _engine;
     private readonly string _specifier;
-    private Module? _module;
+    private global::Esprima.Ast.Module? _module;
     private readonly List<string> _sourceRaw = new();
     private readonly Dictionary<string, JsValue> _exports = new(StringComparer.Ordinal);
     private readonly ParserOptions _options;
@@ -37,7 +34,7 @@ public sealed class ModuleBuilder
         return this;
     }
 
-    public ModuleBuilder AddModule(Module module)
+    public ModuleBuilder AddModule(global::Esprima.Ast.Module module)
     {
         if (_sourceRaw.Count > 0)
         {
@@ -126,12 +123,12 @@ public sealed class ModuleBuilder
         return this;
     }
 
-    internal Module Parse()
+    internal global::Esprima.Ast.Module Parse()
     {
         if (_module != null) return _module;
         if (_sourceRaw.Count <= 0)
         {
-            return new Module(NodeList.Create(Array.Empty<Statement>()));
+            return new global::Esprima.Ast.Module(NodeList.Create(Array.Empty<Statement>()));
         }
 
         var javaScriptParser = new JavaScriptParser(_options);

--- a/Jint/Runtime/Reference.cs
+++ b/Jint/Runtime/Reference.cs
@@ -4,7 +4,7 @@ using Jint.Native;
 using Jint.Runtime.Environments;
 using Environment = Jint.Runtime.Environments.Environment;
 
-namespace Jint.Runtime.References;
+namespace Jint.Runtime;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-reference-record-specification-type

--- a/Jint/StrictModeScope.cs
+++ b/Jint/StrictModeScope.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 namespace Jint
 {
     [StructLayout(LayoutKind.Auto)]
-    public readonly struct StrictModeScope : IDisposable
+    internal readonly struct StrictModeScope : IDisposable
     {
         private readonly bool _strict;
         private readonly bool _force;


### PR DESCRIPTION
* Move `Reference` to `Jint.Runtime` namespace
* Internalize `Binding`
* Internalize Advanced operations constructors
* Make Advanced operations inner classes
* Make Options sub-options inner classes
* Move delegate definitions under options
* Make `StrictModeScope` internal
* Move `ModuleBuilder` under `Runtime.Modules` namespace