### PR TITLE
Engine execute module resolving

### DIFF
--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -113,7 +113,7 @@ public partial class Engine
 
             if (!_modules.TryGetValue(moduleResolution.Key, out var module))
             {
-                module = Load(referencingModuleLocation: null, request);
+                module = Load(referencingModuleLocation, request);
             }
 
             if (module is not CyclicModule cyclicModule)

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -376,7 +376,7 @@ namespace Jint
         public Engine Execute(Script script)
         {
             var strict = _isStrict || script.Strict;
-            ExecuteWithConstraints(strict, () => ScriptEvaluation(new ScriptRecord(Realm, script, string.Empty)));
+            ExecuteWithConstraints(strict, () => ScriptEvaluation(new ScriptRecord(Realm, script, script.Location.Source)));
 
             return this;
         }
@@ -1594,7 +1594,7 @@ namespace Jint
             clearMethod?.Invoke(_objectWrapperCache, Array.Empty<object>());
 #endif
         }
-        
+
         [DebuggerDisplay("Engine")]
         private sealed class EngineDebugView
         {

--- a/Jint/Runtime/IScriptOrModule.cs
+++ b/Jint/Runtime/IScriptOrModule.cs
@@ -2,5 +2,5 @@ namespace Jint.Runtime;
 
 internal interface IScriptOrModule
 {
-    public string Location { get; }
+    public string? Location { get; }
 }

--- a/Jint/Runtime/ScriptRecord.cs
+++ b/Jint/Runtime/ScriptRecord.cs
@@ -2,4 +2,4 @@ using Esprima.Ast;
 
 namespace Jint.Runtime;
 
-internal sealed record ScriptRecord(Realm Realm, Script EcmaScriptCode, string Location) : IScriptOrModule;
+internal sealed record ScriptRecord(Realm Realm, Script EcmaScriptCode, string? Location) : IScriptOrModule;


### PR DESCRIPTION
# Problem

Non-module scripts can still import modules using the `import()` function. However, `Engine.Execute` and `Engine.Evaluate` always passed `string.Empty` as the source of the current script even if one was specified. 

# Change
With the change, `ScriptRecord` will get the value of `Script.Location.Source` as the source. Tests for `Engine.Execute` and `Engine.Evalute` with a custom `IModuleLoader` checking for a filled `referencingModuleLocation` were added.

The behavior for `Engine.Execute` without passing a `source` has not been changed (source is set to be `<anonymous>`)
