### PR TITLE
Add ValueTask and ValueTask<T> to Promise conversion

### DIFF
--- a/Jint.Tests/Runtime/AwaitTests.cs
+++ b/Jint.Tests/Runtime/AwaitTests.cs
@@ -78,4 +78,74 @@ public class AsyncTests
         engine.Execute("async function hello() {await myAsyncMethod();myAsyncMethod2();} hello();");
         Assert.Equal("12", log);
     }
+
+#if NETFRAMEWORK == false
+    [Fact]
+    public void ShouldValueTaskConvertedToPromiseInJS()
+    {
+        Engine engine = new();
+        engine.SetValue("callable", Callable);
+        var result = engine.Evaluate("callable().then(x=>x*2)");
+        result = result.UnwrapIfPromise();
+        Assert.Equal(2, result);
+
+        static async ValueTask<int> Callable()
+        {
+            await Task.Delay(10);
+            Assert.True(true);
+            return 1;
+        }
+    }
+
+    [Fact]
+    public void ShouldValueTaskCatchWhenCancelled()
+    {
+        Engine engine = new();
+        CancellationTokenSource cancel = new();
+        cancel.Cancel();
+        engine.SetValue("token", cancel.Token);
+        engine.SetValue("callable", Callable);
+        engine.SetValue("assert", new Action<bool>(Assert.True));
+        var result = engine.Evaluate("callable(token).then(_ => assert(false)).catch(_ => assert(true))");
+        result = result.UnwrapIfPromise();
+        static async ValueTask Callable(CancellationToken token)
+        {
+            await ValueTask.FromCanceled(token);
+        }
+    }
+
+    [Fact]
+    public void ShouldValueTaskCatchWhenThrowError()
+    {
+        Engine engine = new();
+        engine.SetValue("callable", Callable);
+        engine.SetValue("assert", new Action<bool>(Assert.True));
+        var result = engine.Evaluate("callable().then(_ => assert(false)).catch(_ => assert(true))");
+
+        static async ValueTask Callable()
+        {
+            await Task.Delay(10);
+            throw new Exception();
+        }
+    }
+
+    [Fact]
+    public void ShouldValueTaskAwaitCurrentStack()
+    {
+        //https://github.com/sebastienros/jint/issues/514#issuecomment-1507127509
+        Engine engine = new();
+        string log = "";
+        engine.SetValue("myAsyncMethod", new Func<ValueTask>(async () =>
+        {
+            await Task.Delay(1000);
+            log += "1";
+        }));
+        engine.SetValue("myAsyncMethod2", new Action(() =>
+        {
+            log += "2";
+        }));
+        engine.Execute("async function hello() {await myAsyncMethod();myAsyncMethod2();} hello();");
+        Assert.Equal("12", log);
+    }
+#endif
 }


### PR DESCRIPTION
This PR extends the work done in #1567 to add support for converting `ValueTask` and `ValueTask<T>` to promises.

This support is only available for .NET Standard 2.1 and .NET (non-Framework) targets. Support for .NET Framework and .NET Standard 2.0 targets could be enabled by adding a reference to [System.Threading.Tasks.Extensions](https://www.nuget.org/packages/System.Threading.Tasks.Extensions).