### PR TITLE
Fix module builder loader interaction

### DIFF
--- a/Jint.Tests.PublicInterface/ModuleLoaderTests.cs
+++ b/Jint.Tests.PublicInterface/ModuleLoaderTests.cs
@@ -104,7 +104,7 @@ public class ModuleLoaderTests
         public ResolvedSpecifier Resolve(string? referencingModuleLocation, ModuleRequest moduleRequest)
         {
             Uri uri = Resolve(referencingModuleLocation, moduleRequest.Specifier);
-            return new ResolvedSpecifier(moduleRequest, moduleRequest.Specifier, uri, SpecifierType.Bare);
+            return new ResolvedSpecifier(moduleRequest, uri.ToString(), uri, SpecifierType.Bare);
         }
 
         private Uri Resolve(string? referencingModuleLocation, string specifier)

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -44,9 +44,9 @@ public partial class Engine
                 return module;
             }
 
-            if (_builders.TryGetValue(specifier, out var moduleBuilder))
+            if (_builders.TryGetValue(moduleResolution.Key, out var moduleBuilder))
             {
-                module = LoadFromBuilder(specifier, moduleBuilder, moduleResolution);
+                module = LoadFromBuilder(moduleResolution.Key, moduleBuilder, moduleResolution);
             }
             else
             {
@@ -64,7 +64,7 @@ public partial class Engine
         private BuilderModule LoadFromBuilder(string specifier, ModuleBuilder moduleBuilder, ResolvedSpecifier moduleResolution)
         {
             var parsedModule = moduleBuilder.Parse();
-            var module = new BuilderModule(_engine, _engine.Realm, parsedModule, location: null, async: false);
+            var module = new BuilderModule(_engine, _engine.Realm, parsedModule, location: parsedModule.Location.Source, async: false);
             _modules[moduleResolution.Key] = module;
             moduleBuilder.BindExportedValues(module);
             _builders.Remove(specifier);


### PR DESCRIPTION
Fixes #1747

* The internal dictionary of all available `ModuleBuilder` was used with the unresolved resolution key
* Modules created with the ModuleBuilder did not have any location, which prevented relative module location resolving.
* Public interface test for CustomModuleLoader adjusted to show the expected API usage of the `ResolvedSpecifier.Key` property.