### PR TITLE
Move interop tests to the public interface test project

### DIFF
--- a/Jint.Tests.PublicInterface/InteropTests.Dynamic.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.Dynamic.cs
@@ -1,9 +1,8 @@
 using System.Dynamic;
 using Jint.Native;
 using Jint.Native.Symbol;
-using Jint.Tests.Runtime.Domain;
 
-namespace Jint.Tests.Runtime
+namespace Jint.Tests.PublicInterface
 {
     public partial class InteropTests
     {
@@ -142,6 +141,12 @@ namespace Jint.Tests.Runtime
             {
                 return _properties.ContainsKey(key);
             }
+        }
+
+        private class Person
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
         }
     }
 }

--- a/Jint.Tests.PublicInterface/InteropTests.Json.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.Json.cs
@@ -1,7 +1,7 @@
 using System.Dynamic;
 using Jint.Runtime.Interop;
 
-namespace Jint.Tests.Runtime;
+namespace Jint.Tests.PublicInterface;
 
 public partial class InteropTests
 {

--- a/Jint.Tests.PublicInterface/InteropTests.NewtonsoftJson.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.NewtonsoftJson.cs
@@ -2,7 +2,7 @@ using Jint.Native;
 using Jint.Runtime;
 using Newtonsoft.Json.Linq;
 
-namespace Jint.Tests.Runtime
+namespace Jint.Tests.PublicInterface
 {
     public partial class InteropTests
     {

--- a/Jint.Tests.PublicInterface/InteropTests.SystemTextJson.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.SystemTextJson.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using System.Text.Json.Nodes;
 using Jint.Runtime.Interop;
 
-namespace Jint.Tests.Runtime;
+namespace Jint.Tests.PublicInterface;
 
 public partial class InteropTests
 {
@@ -37,7 +37,7 @@ public partial class InteropTests
                 var wrapped = new ObjectWrapper(e, target);
                 if (target is JsonArray)
                 {
-                    wrapped.SetPrototypeOf(e.Realm.Intrinsics.Array.PrototypeObject);
+                    wrapped.Prototype = e.Intrinsics.Array.PrototypeObject;
                 }
                 return wrapped;
             };

--- a/Jint.Tests.PublicInterface/InteropTests.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.cs
@@ -1,0 +1,24 @@
+﻿using System.Reflection;
+
+namespace Jint.Tests.PublicInterface
+{
+    public partial class InteropTests : IDisposable
+    {
+        private readonly Engine _engine;
+
+        public InteropTests()
+        {
+            _engine = new Engine(cfg => cfg.AllowClr(
+                        typeof(Console).GetTypeInfo().Assembly,
+                        typeof(File).GetTypeInfo().Assembly))
+                    .SetValue("log", new Action<object>(Console.WriteLine))
+                    .SetValue("assert", new Action<bool>(Assert.True))
+                    .SetValue("equal", new Action<object, object>(Assert.Equal))
+                ;
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+    }
+}

--- a/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+++ b/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NodaTime" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>


### PR DESCRIPTION
Most of those interop tests illustrate how Jint can interact with objects from popular libraries such as `Newtonsoft.Json`, `System.Text.Json` and dynamic objects such as `ExpandoObject`.

Because this can be a valuable reference for Jint users, they should not depend on any internals (which would be off limits for callers.) See #1766 for my endeavor on (successfully) integrating STJ.

This pretty much only moves the files over to the other project and updates the one location where internal code was used. Other tests like Newtonsoft and Dynamic didn't really use any internals, so it was just the namespace update there.

Initially, I moved over all tests that began with `InteropTests` and quickly realized how most of them don't _really_ mean interop in the sense of someone external trying to interface with it. At least I got stopped by various `internal` methods on `ObjectWrapper`, `ObjectInstance` etc. that I simply cannot justify changing just to move the tests.

Let me know if theres more (or possibly also less) you want included with this PR.