### PR TITLE
Change GH Actions for PR to run on macos-14 instead of macos-latest

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
       run: dotnet test --configuration Release --logger GitHubActions
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-14
     env:
         DOTNET_NOLOGO: true
         DOTNET_CLI_TELEMETRY_OPTOUT: 1


### PR DESCRIPTION
Trying out the the new M1 offering.