### PR TITLE
Json \u escape sequence was not case insensitive

### DIFF
--- a/Jint.Tests/Runtime/JsonTests.cs
+++ b/Jint.Tests/Runtime/JsonTests.cs
@@ -28,6 +28,10 @@ namespace Jint.Tests.Runtime
         [InlineData("{\"a\":\"\\u0000\"}", "\0")]
         [InlineData("{\"a\":\"\\u0001\"}", "\x01")]
         [InlineData("{\"a\":\"\\u0061\"}", "a")]
+        [InlineData("{\"a\":\"\\u003C\"}", "<")]
+        [InlineData("{\"a\":\"\\u003E\"}", ">")]
+        [InlineData("{\"a\":\"\\u003c\"}", "<")]
+        [InlineData("{\"a\":\"\\u003e\"}", ">")]
         public void ShouldParseEscapedCharactersCorrectly(string json, string expectedCharacter)
         {
             var engine = new Engine();

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -103,7 +103,7 @@ namespace Jint.Native.Json
             {
                 if (_index < _length + 1 && IsHexDigit(_source[_index]))
                 {
-                    char ch = _source[_index++];
+                    char ch = char.ToLower(_source[_index++], CultureInfo.InvariantCulture);
                     code = code * 16 + "0123456789abcdef".IndexOf(ch);
                 }
                 else


### PR DESCRIPTION
When a JSON strings contains the escape sequence `\uXXX`, the JSON parser only converted it properly if the hexadecimal characters `A-F` where in lower case.

This means, `\u003C` would get converted to a different character compared to `\u003c`.

The method `IsHexDigit` allows both versions - upper and lower case characters. The `.IndexOf()` did return -1 for upper case characters resulting in an invalid conversion.

Tests where added for this case.