### PR TITLE
Reset Jint.Benchmark project build properties

### DIFF
--- a/Jint.Benchmark/Directory.Build.props
+++ b/Jint.Benchmark/Directory.Build.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>


### PR DESCRIPTION
Shared settings like `<UseArtifactsOutput>` can confuse benchmarks.