### PR TITLE
Add ClearScript V8 to engine comparison benchmarks, trim suite, add script-to-host interop suite

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,9 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
     <PackageVersion Include="ICU4N" Version="60.1.0-alpha.440" />
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.123" />
+    <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.5.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" PrivateAssets="all" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />

--- a/Jint.Benchmark/EngineComparisonBenchmark.cs
+++ b/Jint.Benchmark/EngineComparisonBenchmark.cs
@@ -1,7 +1,8 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Reports;
+using Microsoft.ClearScript.V8;
 using Okojo.Parsing;
 using Okojo.Runtime;
 using OkojoCompiler = Okojo.Compiler.JsCompiler;
@@ -26,9 +27,10 @@ public class EngineComparisonBenchmark
 
     private static readonly Dictionary<string, Prepared<Script>> _parsedScripts = new();
 
-    // Okojo has no engine-level strict switch (unlike the other engines' flags); the whole program is
-    // made strict by a leading "use strict" directive, so it runs in global strict mode like the rest.
-    private static readonly Dictionary<string, string> _okojoFiles = new();
+    // Okojo has no engine-level strict switch and V8 has no strict flag either (unlike the other
+    // engines); their whole program is made strict by a leading "use strict" directive, so both
+    // run in global strict mode like the rest.
+    private static readonly Dictionary<string, string> _strictFiles = new();
 
     // Okojo's realm-independent prepared artifact is the parsed program (JsProgram). Bytecode
     // (JsScript) is compiled against a specific realm, so — mirroring the fresh-engine-per-iteration
@@ -36,28 +38,26 @@ public class EngineComparisonBenchmark
     // realm. The gap to the Okojo lane is parsing cost, matching Jint_ParsedScript.
     private static readonly Dictionary<string, JsProgram> _okojoPrograms = new();
 
+    // ClearScript's realm-independent prepared artifact is a V8Script compiled once by a shared
+    // V8Runtime; each ClearScript_Compiled operation runs it in a fresh script engine (a fresh V8
+    // context) created from that runtime, mirroring the cached-artifact + fresh-engine rule of the
+    // Jint_ParsedScript and Okojo_Prepared lanes.
+    private static readonly Dictionary<string, V8Script> _compiledScripts = new();
+    private static V8Runtime _v8Runtime;
+
     private static readonly Dictionary<string, string> _files = new()
     {
         { "array-stress", null },
-        { "evaluation", null },
         { "evaluation-modern", null },
-        { "json-parse", null },
         { "json-parse-modern", null },
         { "linq-js", null },
         { "minimal", null },
-        { "stopwatch", null },
         { "stopwatch-modern", null },
-        { "dromaeo-3d-cube", null },
         { "dromaeo-3d-cube-modern", null },
-        { "dromaeo-core-eval", null },
         { "dromaeo-core-eval-modern", null },
-        { "dromaeo-object-array", null },
         { "dromaeo-object-array-modern", null },
-        { "dromaeo-object-regexp", null },
         { "dromaeo-object-regexp-modern", null },
-        { "dromaeo-object-string", null },
         { "dromaeo-object-string-modern", null },
-        { "dromaeo-string-base64", null },
         { "dromaeo-string-base64-modern", null },
     };
 
@@ -70,6 +70,8 @@ public class EngineComparisonBenchmark
     [GlobalSetup]
     public void Setup()
     {
+        _v8Runtime = new V8Runtime();
+
         foreach (var fileName in _files.Keys.ToList())
         {
             var script = File.ReadAllText($"Scripts/{fileName}.js");
@@ -80,10 +82,23 @@ public class EngineComparisonBenchmark
             _files[fileName] = script;
             _parsedScripts[fileName] = Engine.PrepareScript(script, strict: true);
 
-            var okojoSource = "\"use strict\";" + Environment.NewLine + script;
-            _okojoFiles[fileName] = okojoSource;
-            _okojoPrograms[fileName] = JavaScriptParser.ParseScript(okojoSource);
+            var strictSource = "\"use strict\";" + Environment.NewLine + script;
+            _strictFiles[fileName] = strictSource;
+            _okojoPrograms[fileName] = JavaScriptParser.ParseScript(strictSource);
+            _compiledScripts[fileName] = _v8Runtime.Compile(strictSource);
         }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        foreach (var compiled in _compiledScripts.Values)
+        {
+            compiled.Dispose();
+        }
+        _compiledScripts.Clear();
+        _v8Runtime?.Dispose();
+        _v8Runtime = null;
     }
 
     [ParamsSource(nameof(FileNames))]
@@ -112,7 +127,7 @@ public class EngineComparisonBenchmark
     public void Okojo()
     {
         using var runtime = JsRuntime.Create();
-        runtime.Execute(_okojoFiles[FileName]);
+        runtime.Execute(_strictFiles[FileName]);
     }
 
     [Benchmark]
@@ -143,7 +158,16 @@ public class EngineComparisonBenchmark
     [Benchmark]
     public void ClearScript()
     {
-       var engine = new Microsoft.ClearScript.V8.V8ScriptEngine();
-       engine.Evaluate(_files[FileName]);
+        // A fresh V8ScriptEngine is a fresh V8 isolate + context; disposal is mandatory as the
+        // isolate lives on the native heap that the CLR garbage collector never observes.
+        using var engine = new V8ScriptEngine();
+        engine.Execute(_strictFiles[FileName]);
+    }
+
+    [Benchmark]
+    public void ClearScript_Compiled()
+    {
+        using var engine = _v8Runtime.CreateScriptEngine();
+        engine.Execute(_compiledScripts[FileName]);
     }
 }

--- a/Jint.Benchmark/EngineComparisonBenchmark.cs
+++ b/Jint.Benchmark/EngineComparisonBenchmark.cs
@@ -139,4 +139,11 @@ public class EngineComparisonBenchmark
         // if script is expecting global context as `this`
         engine.Eval(_files[FileName], null, engine);
     }
+
+    [Benchmark]
+    public void ClearScript()
+    {
+       var engine = new Microsoft.ClearScript.V8.V8ScriptEngine();
+       engine.Evaluate(_files[FileName]);
+    }
 }

--- a/Jint.Benchmark/EngineComparisonInteropBenchmark.cs
+++ b/Jint.Benchmark/EngineComparisonInteropBenchmark.cs
@@ -1,0 +1,147 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Order;
+using Microsoft.ClearScript.V8;
+using Microsoft.ClearScript.V8.FastProxy;
+using YantraClrProxy = YantraJS.Core.Clr.ClrProxy;
+using YantraContext = YantraJS.Core.JSContext;
+using YantraString = YantraJS.Core.JSString;
+using YantraValue = YantraJS.Core.JSValue;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Compares the cost of script → host ("interop") traffic across the engines: the same scripts
+/// drive a loop of host method calls, host property reads/writes, strings crossing the boundary
+/// and host array traversal.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Okojo is absent because its public API cannot enable CLR access (0.1.2-preview.1 exposes no
+/// equivalent of the AllowClrAccess option its own error message refers to).
+/// </para>
+/// <para>
+/// The host members are lowercase on purpose: YantraJS camel-cases CLR member names while the
+/// other engines surface them verbatim, and already-lowercase names are the fixed point of both
+/// conventions — letting every engine run byte-identical scripts.
+/// </para>
+/// <para>
+/// Each script validates its aggregate and throws on a mismatch, so an engine that silently
+/// mis-marshals (e.g. returns undefined) fails the benchmark instead of posting a fantasy time.
+/// </para>
+/// </remarks>
+[Config(typeof(EngineComparisonBenchmark.Config))]
+[RankColumn]
+[MemoryDiagnoser]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByParams)]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+[BenchmarkCategory("EngineComparison", "EngineComparisonInterop")]
+public class EngineComparisonInteropBenchmark
+{
+    public class InteropHost
+    {
+        public int value { get; set; }
+        public int[] numbers { get; } = Enumerable.Range(0, 100).ToArray();
+        public int count => numbers.Length;
+        public int add(int a, int b) => a + b;
+        public string concat(string a, string b) => a + b;
+    }
+
+    // ClearScript's recommended low-overhead interop path (the FastProxy API introduced in 7.5):
+    // members are registered explicitly and marshal without allocation for fundamental types.
+    public sealed class FastInteropHost : V8FastHostObject<FastInteropHost>
+    {
+        private int _value;
+        private readonly int[] _numbers = Enumerable.Range(0, 100).ToArray();
+
+        static FastInteropHost()
+        {
+            Configure(static configuration =>
+            {
+                configuration.AddPropertyAccessors("value",
+                    static (FastInteropHost self, in V8FastResult result) => result.Set(self._value),
+                    static (FastInteropHost self, in V8FastArg value) => self._value = value.GetInt32("value"));
+                configuration.AddPropertyGetter("count",
+                    static (FastInteropHost self, in V8FastResult result) => result.Set(self._numbers.Length));
+                configuration.AddPropertyGetter("numbers",
+                    static (FastInteropHost self, in V8FastResult result) => result.Set(self._numbers));
+                configuration.AddMethodGetter("add", 2,
+                    static (FastInteropHost self, in V8FastArgs args, in V8FastResult result) =>
+                        result.Set(args.GetInt32(0, "a") + args.GetInt32(1, "b")));
+                configuration.AddMethodGetter("concat", 2,
+                    static (FastInteropHost self, in V8FastArgs args, in V8FastResult result) =>
+                        result.Set(args.GetString(0, "a") + args.GetString(1, "b")));
+            });
+        }
+    }
+
+    private static readonly Dictionary<string, string> _files = new()
+    {
+        { "interop-method-calls", null },
+        { "interop-property-access", null },
+        { "interop-string-passing", null },
+        { "interop-collection-traversal", null },
+    };
+
+    private static readonly Dictionary<string, string> _strictFiles = new();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        foreach (var fileName in _files.Keys.ToList())
+        {
+            var script = File.ReadAllText($"Scripts/{fileName}.js");
+            _files[fileName] = script;
+            _strictFiles[fileName] = "\"use strict\";" + Environment.NewLine + script;
+        }
+    }
+
+    [ParamsSource(nameof(FileNames))]
+    public string FileName { get; set; }
+
+    public IEnumerable<string> FileNames()
+    {
+        return _files.Select(entry => entry.Key);
+    }
+
+    [Benchmark]
+    public void Jint()
+    {
+        var engine = new Engine(static options => options.Strict());
+        engine.SetValue("host", new InteropHost());
+        engine.Execute(_files[FileName]);
+    }
+
+    [Benchmark]
+    public void NilJS()
+    {
+        var context = new NiL.JS.Core.Context(strict: true);
+        context.DefineVariable("host").Assign(context.GlobalContext.ProxyValue(new InteropHost()));
+        context.Eval(_files[FileName]);
+    }
+
+    [Benchmark]
+    public void YantraJS()
+    {
+        var context = new YantraContext();
+        context[(YantraValue)new YantraString("host")] = YantraClrProxy.Marshal(new InteropHost());
+        context.Eval(_files[FileName], null, context);
+    }
+
+    [Benchmark]
+    public void ClearScript()
+    {
+        using var engine = new V8ScriptEngine();
+        engine.AddHostObject("host", new InteropHost());
+        engine.Execute(_strictFiles[FileName]);
+    }
+
+    [Benchmark]
+    public void ClearScript_FastProxy()
+    {
+        using var engine = new V8ScriptEngine();
+        engine.AddHostObject("host", new FastInteropHost());
+        engine.Execute(_strictFiles[FileName]);
+    }
+}

--- a/Jint.Benchmark/Jint.Benchmark.csproj
+++ b/Jint.Benchmark/Jint.Benchmark.csproj
@@ -29,6 +29,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.ClearScript.V8" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" />
     <PackageReference Include="NiL.JS" />
     <PackageReference Include="Okojo" />
     <PackageReference Include="YantraJS.Core" />

--- a/Jint.Benchmark/README.md
+++ b/Jint.Benchmark/README.md
@@ -1,8 +1,11 @@
 # Engine comparison benchmarks
 
-This project benchmarks Jint against the other managed JavaScript engines for .NET
-([NiL.JS](https://github.com/nilproject/NiL.JS), [Okojo](https://github.com/akeit0/okojo) and
-[YantraJS](https://github.com/yantrajs/yantra)) across a set of representative scripts.
+This project benchmarks Jint against the other JavaScript engines available to .NET applications:
+the managed engines ([NiL.JS](https://github.com/nilproject/NiL.JS),
+[Okojo](https://github.com/akeit0/okojo) and [YantraJS](https://github.com/yantrajs/yantra)) and
+[ClearScript](https://github.com/ClearFoundry/ClearScript) — Microsoft-originated, now
+ClearFoundry-maintained bindings to Google's native V8 engine (the JIT inside Chrome and Node.js) —
+across a set of representative scripts.
 
 ## How each engine executes
 
@@ -12,29 +15,25 @@ The engines reach the result in different ways, which shapes the numbers below:
 * **NiL.JS** — interpreter (with an optimizing pass over its syntax tree).
 * **Okojo** — interpreter that compiles the script to bytecode and runs it on a virtual machine.
 * **YantraJS** — compiler: it emits .NET IL, which the CLR then JIT-compiles to native code.
+* **ClearScript (V8)** — native V8 behind a managed ↔ native interop bridge: a multi-tier
+  optimizing JIT running outside the CLR, with every host interaction crossing the native boundary.
 
-Only the engine that compiles to IL runs ahead on tight numeric/call loops — the structural
-interpreter-vs-compiler gap. On every script in this table Jint is the fastest **interpreter**.
+The structural consequences shape the whole table. Only the two compilers (YantraJS and V8) run
+ahead on long, tight numeric/call loops, where compiled code approaches native speed. The
+interpreters own the other end of the trade: engine start-up and small scripts, where even a
+context created from a pre-warmed V8 isolate costs ~460 µs for work Jint completes in about a
+microsecond. And pure-JS compute is only half of an embedding story — the other half is the
+script ↔ host boundary, measured separately in the
+[interop section](#script--host-interop) below, where the price of V8's native boundary inverts
+the picture.
 
-## At a glance (4.13.0)
+## The scripts
 
-Using Jint's recommended production path (a cached prepared script) and comparing against the
-**closest competitor** on each script:
-
-* **Fastest engine on 17 of the 21 scripts** — leading the object, string, base64, regex and JSON
-  scripts by **1.1×–4.2×** over the next-fastest engine, starting tiny scripts up **~3×–6×** faster
-  (`minimal` executes in **~1 microsecond**), and leading `dromaeo-core-eval`. The
-  `json-parse` row is a Jint win outright: **the fastest of any engine**, ahead of the closest
-  competitor while allocating the least in the field.
-* **Fastest interpreter on every script.** On the remaining four rows only the engine that compiles
-  JavaScript to IL is ahead: `dromaeo-3d-cube` runs **1.30×** ahead of the next interpreter and
-  `stopwatch` / `stopwatch-modern` — long the closest-fought interpreter rows — lead the nearest
-  interpreter by **~1.4× / ~1.7×**.
-* **Among the lowest memory use in the field.** Jint and Okojo are the two low-allocation engines:
-  Jint allocates the least on almost every script (Okojo edges it on the two `object-array`
-  workloads), while NiL.JS and YantraJS allocate one to two orders of magnitude more — up to
-  **471×** more than Jint on `dromaeo-string-base64` — which means much lighter GC pressure in real
-  applications.
+One variant per workload, 12 scripts in total. Where the suite previously carried both a classic
+ES5 script and an ES2015+ `-modern` rewrite of it, only the modern variant is kept — that is how
+JavaScript is written today, and the duplicated rows ranked the engines nearly identically while
+doubling the wall-clock time of a full run. (The classic scripts remain in `Scripts/` and are still
+used by the Jint-only benchmarks.)
 
 ## Running the benchmarks
 
@@ -48,6 +47,9 @@ Notes:
 
 * The `--` separator is required so the arguments are forwarded to BenchmarkDotNet instead of being
   consumed by `dotnet run`.
+* `--allCategories EngineComparison` runs both the script suite and the interop suite; use
+  `--allCategories EngineComparisonInterop` for the interop suite alone, or
+  `--filter "*EngineComparisonBenchmark*"` for the script suite alone.
 * Results are written to `BenchmarkDotNet.Artifacts/results/` — the
   `*-report-github.md` file is the table reproduced below.
 * To re-measure a single engine (e.g. after a package bump) without disturbing the rest of the
@@ -58,106 +60,138 @@ Notes:
 
 ## How to read the table
 
-* All engines are run in **global strict mode** — one competitor (YantraJS) is strict-only, and one
-  (Okojo) has no engine-level strict switch, so its source carries a leading `"use strict"`
+* All engines are run in **global strict mode** — YantraJS is strict-only, and Okojo and
+  ClearScript have no engine-level strict switch, so their source carries a leading `"use strict"`
   directive. Strict mode improves performance across the board.
-* `Jint` re-parses the script source on every operation; `Jint_ParsedScript` reuses a cached
-  `Prepared<Script>` produced once by `Engine.PrepareScript`. The gap between the two is pure
-  parsing cost — **in production you should cache the prepared script**, which is what
-  `Jint_ParsedScript` represents.
-* `Okojo` likewise re-parses and re-compiles on every operation; `Okojo_Prepared` reuses a parsed
-  program (Okojo's realm-independent artifact) and re-compiles the bytecode against each run's own
-  fresh realm — so its gap to `Okojo` is parsing cost, mirroring the two Jint lanes.
-* The `*-modern` scripts are ES2015+ rewrites (`const`, arrow functions, …) of the classic ES5
-  scripts. Every engine in the field parses ES2015+, so all of them report a result on the `-modern`
-  rows.
-* `Mean` is time per operation (lower is better); `Allocated` is managed memory per operation
-  (lower is better). `Rank` groups results that are statistically tied.
+* Every operation uses a **fresh engine** — the embedding pattern where executions must not leak
+  state into each other.
+* Three engines have a **cached-artifact lane** next to the re-parse lane, and the pairs mean the
+  same thing: `Jint_ParsedScript` reuses a `Prepared<Script>` produced once by
+  `Engine.PrepareScript`; `Okojo_Prepared` reuses a parsed program (Okojo's realm-independent
+  artifact) and re-compiles the bytecode against each run's fresh realm; `ClearScript_Compiled`
+  reuses a `V8Script` compiled once by a shared `V8Runtime` and runs it in a fresh script engine (a
+  fresh V8 context) created from that runtime. The gap to the re-parse lane is parsing/compilation
+  cost — **in production you should cache the prepared artifact**, which is what these lanes
+  represent.
+* The plain `ClearScript` lane creates a full V8 isolate + context per operation — the honest cost
+  when each request gets a fully isolated engine, and the reason its short-script rows start around
+  a millisecond. `ClearScript_Compiled` shares one isolate (and its warmed JIT state) across
+  operations while still using a fresh context per operation — ClearScript's recommended production
+  path.
+* **`Allocated` counts managed memory only.** ClearScript's working memory lives on V8's native
+  heap, which the managed diagnoser cannot see — the few dozen KB in its rows are interop-bridge
+  overhead, not a memory-use figure comparable with the managed engines. Memory claims in this
+  document therefore compare the managed engines with each other.
+* V8 runs background threads (tiered JIT compilation, garbage collection). `Mean` is the wall-clock
+  time the executing thread observes; total CPU consumed is higher than for the single-threaded
+  managed engines, which matters on saturated servers.
+* `Mean` is time per operation (lower is better); `Rank` groups results that are statistically
+  tied. The separately measured ClearScript rows are merged into each script's block by mean.
+* The `dromaeo-object-regexp-modern` row is the highest-variance in the table (for Jint it is
+  dominated by .NET `Regex`); treat small gaps there — including ClearScript's fresh-engine lane
+  appearing ahead of its compiled lane — as run-to-run noise.
 
-## Where Jint leads
+## At a glance (Jint 4.13.0)
 
-Numbers use Jint's recommended production path (`Jint_ParsedScript`, a cached prepared script) and
-compare against the closest competitor on each script.
+Using each engine's recommended production path (for Jint a cached prepared script,
+`Jint_ParsedScript`; for ClearScript a precompiled `V8Script` on a shared runtime,
+`ClearScript_Compiled`):
 
-* **Tiny-script latency.** `minimal` runs in **1.0 µs** and `evaluation` / `evaluation-modern` in
-  ~4.3–4.5 µs — **~3× and ~6× faster than the closest competitor**.
-* **Cached scripts avoid re-parsing.** `linq-js` drops from 1,173 µs (re-parsed every run) to
-  **56 µs** when the prepared script is reused — ~21× — which is also **5.7× faster than the
-  next-fastest engine**. Cache your `Prepared<Script>` in production.
-* **eval-heavy code.** `dromaeo-core-eval` runs in **0.92 ms — 1.32× faster than the closest
-  competitor** (the modern variant is 1.58× faster); eval bodies execute on the same per-iteration
-  fast paths as regular function bodies.
-* **Object, string, base64 and regex workloads.** Jint is the fastest engine on
-  `dromaeo-object-array` (**2.1×**), `dromaeo-object-string` (**1.14×**, over Okojo — the closest
-  competitor here), `dromaeo-object-regexp` (**4.0×**) and `dromaeo-string-base64` (**1.21×**,
-  allocating **12× less** than the next engine).
-* **JSON parsing** (`json-parse` / `json-parse-modern`): **19.0 ms / 17.5 ms — the fastest of any
-  engine**, ahead of the closest competitor while allocating the least in the field (21 MB vs
-  27–66 MB). Parsed objects build a shared hidden class, so an array of like-shaped records is one
-  allocation per record instead of a property dictionary each.
-* **Call- and closure-heavy loops** (`stopwatch` / `stopwatch-modern`): **~94 ms and 90 ms — the
-  fastest interpreter, ~1.4× / ~1.7× ahead of the nearest interpreter** (previously the
-  closest-fought rows in the table).
-* **Heavy floating-point math among interpreters.** `dromaeo-3d-cube` runs in **4.66 ms — 1.30×
-  ahead of every other interpreter** — while allocating the least of any engine on that script
-  (1.4 MB vs 2.2–7.4 MB).
-* **Jint and Okojo are the two frugal engines; NiL.JS and YantraJS allocate far more,** which means
-  far less GC pressure in real applications:
+* **The table splits cleanly down the middle between Jint and native V8: each is the fastest
+  engine on 6 of the 12 scripts.** A tree-walking managed interpreter beating or matching the JIT
+  inside Chrome on half the field is the headline; no other managed engine wins a single row.
+* **Jint wins everything start-up-shaped and everything eval-shaped.** `minimal` runs in
+  **1.0 µs vs V8's 461 µs (~450×)** — and ~1,200× against a cold V8 isolate; `evaluation-modern`
+  is **~107×** ahead; loading the LINQ.js library (`linq-js`) is **~10×** ahead. On
+  `dromaeo-core-eval-modern` — code built around `eval`, which no compile cache can help —
+  Jint is **1.35×** ahead of V8, and it also leads `dromaeo-object-array-modern` (**1.07×**) and
+  `array-stress` (statistically tied).
+* **V8 wins the long compute rows**: `dromaeo-3d-cube-modern` (2.5×), `json-parse-modern` (1.7×),
+  `stopwatch-modern` (5.6×) and the two string-crunching rows, `dromaeo-object-string-modern`
+  (8.8×) and `dromaeo-string-base64-modern` (9.7×). The `dromaeo-object-regexp-modern` gap
+  (1.06×) is within that row's variance.
+* **Jint is the fastest managed engine on 10 of 12 scripts** (the IL-compiling YantraJS leads
+  `dromaeo-3d-cube-modern` and `stopwatch-modern`) and **the fastest interpreter on all 12**.
+* **Among the managed engines, Jint and Okojo allocate the least** — NiL.JS and YantraJS allocate
+  one to two orders of magnitude more (up to 471× more than Jint on
+  `dromaeo-string-base64-modern`), which means far heavier GC pressure in real applications.
+  (ClearScript's rows cannot be compared here — its memory lives on the V8 native heap, which the
+  managed diagnoser does not see.)
+* **Pure-JS compute is where V8 is strongest — and it is still only half the story.** The
+  [interop suite](#script--host-interop) below measures the other half, the script ↔ host
+  boundary, where the picture inverts.
 
-  | Benchmark | Jint | Okojo | NiL.JS | YantraJS |
-  |--- |---: |---: |---: |---: |
-  | `dromaeo-object-string` | **21 MB** | 33 MB | 1,323 MB | 1,614 MB |
-  | `dromaeo-string-base64` | **1.6 MB** | 43 MB | 19 MB | 746 MB |
-  | `dromaeo-object-array` | 8.9 MB | **6.8 MB** | 17 MB | 215 MB |
-  | `stopwatch` | **12 MB** | 21 MB | 93 MB | 211 MB |
-  | `json-parse` | **21 MB** | 27 MB | 64 MB | 43 MB |
+## Script ↔ host interop
 
-## Where Jint trails
+Embedding a JavaScript engine is rarely about pure computation — scripts exist to drive the host
+application, and in interop-heavy systems the script ↔ host boundary dominates. This is also where
+the engines differ structurally: the managed engines dispatch host calls in-process, while every
+ClearScript host interaction crosses the managed ↔ native V8 boundary and marshals its arguments
+across it.
 
-Only the engine that compiles JavaScript to IL remains ahead, and only on tight numeric/call loops
-where compiled code runs close to native speed — the structural interpreter-vs-compiler gap:
+`EngineComparisonInteropBenchmark` (run with `--allCategories EngineComparisonInterop`) drives
+four byte-identical scripts against each engine: a host method-call loop, a host property
+read/write loop, strings crossing the boundary, and traversal of a host `int[]`. Details that
+keep the comparison fair:
 
-* **Heavy floating-point / matrix math** (`dromaeo-3d-cube`): 4.66 ms vs the IL compiler's 2.46 ms
-  (1.9×). Every interpreter is behind Jint on this script.
-* **Call- and closure-heavy loops with frequent `new Date()`** (`stopwatch` / `stopwatch-modern`):
-  ~94 ms / 90 ms vs the IL compiler's 56 ms / 60 ms (1.68× / 1.50×) — while allocating 18×–19× less
-  than it. Either way Jint is the fastest interpreter on both rows.
+* Host members are lowercase (`host.add`, `host.value`, …) because YantraJS camel-cases CLR
+  member names while the other engines surface them verbatim — already-lowercase names are the
+  fixed point of both conventions, so every engine runs the same source.
+* Each script validates its final aggregate and throws on a mismatch, so an engine that silently
+  mis-marshals (undefined, NaN) fails loudly instead of posting a fantasy time.
+* `ClearScript` binds the host object with plain `AddHostObject` (reflection-based, like the
+  managed engines); `ClearScript_FastProxy` uses ClearScript 7.5's FastProxy API — explicit
+  member registration with zero-allocation marshaling for fundamental types — its recommended
+  path for hot host objects.
+* Okojo is absent: 0.1.2-preview.1 provides no public way to enable CLR access.
+* As above, `Allocated` is meaningful for the managed engines but only counts bridge overhead
+  for the two ClearScript lanes.
 
-## What's new in 4.13.0
+What the numbers show:
 
-Measured against the 4.12.0 release; the comparison field is unchanged (same engines and versions).
-The 4.13.0 improvements visible in this fresh-engine table:
+* **The managed engines win every interop row.** Crossing the native boundary costs plain
+  ClearScript **5.7×–7.0×** against Jint on method calls, property access and string passing —
+  the mirror image of the pure-compute table, and the half of the story that matters most in
+  chatty embedding scenarios.
+* **FastProxy narrows the gap but does not close it**: still **2.4×–3.6×** behind Jint on those
+  rows, and it trades away convenience — every member is hand-registered instead of reflected.
+  Its zero-allocation claim is real, though: 13 KB managed allocation on the method-call row
+  where reflective ClearScript burns 12.8 MB.
+* **Among the managed engines the interop crown is shared**: NiL.JS leads method calls and
+  collection traversal, YantraJS property access and string passing, with Jint close behind on
+  all three of the non-traversal rows.
+* **The collection-traversal row is Jint's weak spot, and the fix is one line of script.** The
+  shared script deliberately re-reads `host.numbers` inside the loop, and Jint re-wraps the host
+  array on every read (32.9 MB allocated). Hoisting the collection into a local
+  (`var numbers = host.numbers;`) drops Jint from 19 ms to **~1.1 ms / 0.3 MB** — faster than
+  every other engine on this row. Caching repeated wraps of the same host object is a Jint
+  improvement opportunity this suite now tracks.
 
-* **Faster arithmetic-heavy math.** `dromaeo-3d-cube` drops from 5.11 ms to **4.66 ms** (−9%) and
-  `dromaeo-string-base64` from 24.3 ms to **21.8 ms** (−10%). A hot-path arithmetic campaign added
-  unboxed operand lanes for the binary operators
-  ([#2664](https://github.com/sebastienros/jint/pull/2664)), an int32 fast lane for remainder
-  ([#2671](https://github.com/sebastienros/jint/pull/2671)), flag-proven `Unsafe.As` casts
-  ([#2673](https://github.com/sebastienros/jint/pull/2673)), and removed a native `fmod` from
-  integral detection ([#2662](https://github.com/sebastienros/jint/pull/2662)).
-* **Tighter reads and branches.** Member-expression identifier reads now route through the
-  identifier caches ([#2660](https://github.com/sebastienros/jint/pull/2660)), strict-equality
-  guards against `undefined` / `null` / `typeof` are fused
-  ([#2658](https://github.com/sebastienros/jint/pull/2658)), and the identifier slot cache was
-  restructured hop-0-first ([#2689](https://github.com/sebastienros/jint/pull/2689)) — trimming
-  `dromaeo-core-eval` (−6%), `dromaeo-object-array` (−6%) and `json-parse` (−5%).
-* **Cheaper loops and calls (mostly steady-state).** Several wins target long-lived engines and so
-  show less on this fresh-engine table: `for..of` over an array no longer allocates an
-  iterator-result object per element (**~260× less allocation** on the hot path,
-  [#2700](https://github.com/sebastienros/jint/pull/2700)); the tight-loop fast lane now covers
-  `while` / `do-while` ([#2688](https://github.com/sebastienros/jint/pull/2688)); per-call nested
-  function instantiation is allocation-free ([#2684](https://github.com/sebastienros/jint/pull/2684));
-  and `&&` / `||` ([#2701](https://github.com/sebastienros/jint/pull/2701)), `x == null`
-  ([#2702](https://github.com/sebastienros/jint/pull/2702)) and value-producing `i++`
-  ([#2703](https://github.com/sebastienros/jint/pull/2703)) execute on unboxed / slot fast paths.
-* **A Proxy overhaul and correctness fixes.** Proxy trap dispatch was rebuilt to forward with
-  effectively zero allocation and gained a public CLR trap API
-  (`Engine.Advanced.CreateProxy` + `ProxyHandler`), alongside a batch of Proxy, RegExp and async
-  correctness fixes from the pre-release review.
-
-The `dromaeo-object-regexp` rows are dominated by .NET `Regex` and are the highest-variance in the
-table; the regex execution path is unchanged from 4.12.0, so treat that row as roughly flat rather
-than a movement.
+| Method                | FileName                     | Mean        | StdDev      | Rank | Allocated   |
+|---------------------- |----------------------------- |------------:|------------:|-----:|------------:|
+| NilJS                 | interop-collection-traversal |  1,356.3 us |    23.93 us |    1 |  4088.14 KB |
+| YantraJS              | interop-collection-traversal |  4,001.4 us |    32.28 us |    2 |  5399.83 KB |
+| ClearScript_FastProxy | interop-collection-traversal | 10,156.4 us |   231.71 us |    3 |  1185.69 KB |
+| ClearScript           | interop-collection-traversal | 13,118.8 us |    42.26 us |    4 |  5016.25 KB |
+| Jint                  | interop-collection-traversal | 19,023.3 us | 2,959.99 us |    5 | 32909.04 KB |
+|                       |                              |             |             |      |             |
+| NilJS                 | interop-method-calls         |  1,340.9 us |    13.28 us |    1 |  2437.94 KB |
+| YantraJS              | interop-method-calls         |  2,189.6 us |    18.99 us |    2 |  3355.13 KB |
+| Jint                  | interop-method-calls         |  2,522.6 us |    37.61 us |    3 |  1892.97 KB |
+| ClearScript_FastProxy | interop-method-calls         |  6,138.3 us |    30.53 us |    4 |    12.95 KB |
+| ClearScript           | interop-method-calls         | 17,593.5 us |   135.49 us |    5 | 12752.52 KB |
+|                       |                              |             |             |      |             |
+| YantraJS              | interop-property-access      |  1,540.4 us |    11.38 us |    1 |  1870.68 KB |
+| NilJS                 | interop-property-access      |  1,873.0 us |    10.42 us |    2 |  4391.52 KB |
+| Jint                  | interop-property-access      |  2,239.4 us |    23.47 us |    3 |   797.57 KB |
+| ClearScript_FastProxy | interop-property-access      |  5,841.7 us |    55.72 us |    4 |    12.58 KB |
+| ClearScript           | interop-property-access      | 14,606.0 us |   331.24 us |    5 | 10561.79 KB |
+|                       |                              |             |             |      |             |
+| YantraJS              | interop-string-passing       |    661.0 us |     4.60 us |    1 |  1823.71 KB |
+| NilJS                 | interop-string-passing       |    844.2 us |     4.52 us |    2 |  1179.64 KB |
+| Jint                  | interop-string-passing       |  1,098.1 us |     7.00 us |    3 |   383.95 KB |
+| ClearScript_FastProxy | interop-string-passing       |  3,986.1 us |    36.28 us |    4 |   247.16 KB |
+| ClearScript           | interop-string-passing       |  6,234.2 us |    42.55 us |    5 |  2470.18 KB |
 
 ## Engine versions
 
@@ -165,9 +199,11 @@ than a movement.
 * NiL.JS 2.6.1722
 * Okojo 0.1.2-preview.1
 * YantraJS.Core 1.2.406
+* Microsoft.ClearScript.V8 7.5.1
 
 Jint, NiL.JS and YantraJS numbers are from the 4.13.0 release run; the Okojo rows were measured
-separately on the same machine and .NET runtime and merged in. Last updated 2026-07-15.
+separately on the same machine and .NET runtime and merged in. The ClearScript rows and the interop
+table were measured 2026-07-20 on the same machine and .NET runtime. Last updated 2026-07-20.
 
 ```
 
@@ -179,151 +215,112 @@ AMD Ryzen 9 5950X 3.40GHz, 1 CPU, 32 logical and 16 physical cores
 
 
 ```
-| Method            | FileName                     | Mean             | StdDev         | Rank | Allocated     |
-|------------------ |----------------------------- |-----------------:|---------------:|-----:|--------------:|
-| Jint_ParsedScript | array-stress                 |     2,256.761 us |      7.1240 us |    1 |    1060.39 KB |
-| Jint              | array-stress                 |     2,315.740 us |     14.6480 us |    1 |    1089.12 KB |
-| YantraJS          | array-stress                 |     2,792.018 us |     27.8405 us |    2 |   17123.82 KB |
-| NilJS             | array-stress                 |     5,133.058 us |     18.8123 us |    3 |    4521.19 KB |
-| Okojo_Prepared    | array-stress                 |     5,434.204 us |     40.9309 us |    4 |    2681.62 KB |
-| Okojo             | array-stress                 |     5,494.069 us |     43.4340 us |    4 |    2697.39 KB |
-|                   |                              |                  |                |      |               |
-| YantraJS          | dromaeo-3d-cube              |     2,461.143 us |      8.2646 us |    1 |    7596.01 KB |
-| Jint_ParsedScript | dromaeo-3d-cube              |     4,661.673 us |      7.1767 us |    2 |    1416.99 KB |
-| Jint              | dromaeo-3d-cube              |     5,145.748 us |     11.2630 us |    3 |    1721.05 KB |
-| NilJS             | dromaeo-3d-cube              |     6,067.962 us |     29.0884 us |    4 |    4903.32 KB |
-| Okojo             | dromaeo-3d-cube              |     7,128.906 us |     24.4769 us |    5 |    2463.17 KB |
-| Okojo_Prepared    | dromaeo-3d-cube              |     7,232.647 us |     15.2943 us |    5 |    2295.53 KB |
-|                   |                              |                  |                |      |               |
-| YantraJS          | dromaeo-3d-cube-modern       |     2,455.419 us |     10.9833 us |    1 |    7514.24 KB |
-| Jint_ParsedScript | dromaeo-3d-cube-modern       |     4,766.692 us |     20.9342 us |    2 |    1340.62 KB |
-| Jint              | dromaeo-3d-cube-modern       |     5,081.631 us |     21.2716 us |    3 |    1644.48 KB |
-| NilJS             | dromaeo-3d-cube-modern       |     7,095.752 us |     35.0040 us |    4 |    5977.95 KB |
-| Okojo_Prepared    | dromaeo-3d-cube-modern       |     7,321.080 us |     18.7803 us |    5 |    2311.29 KB |
-| Okojo             | dromaeo-3d-cube-modern       |     7,321.862 us |     28.8572 us |    5 |    2496.04 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | dromaeo-core-eval            |       916.407 us |      3.0409 us |    1 |     340.27 KB |
-| Jint              | dromaeo-core-eval            |       927.436 us |      5.9208 us |    1 |     360.72 KB |
-| NilJS             | dromaeo-core-eval            |     1,209.535 us |      7.7293 us |    2 |     1577.1 KB |
-| YantraJS          | dromaeo-core-eval            |     4,783.342 us |     36.2068 us |    3 |   35784.73 KB |
-| Okojo_Prepared    | dromaeo-core-eval            |     5,194.773 us |     88.9601 us |    4 |    4609.03 KB |
-| Okojo             | dromaeo-core-eval            |     5,257.288 us |     61.6742 us |    4 |    4621.81 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | dromaeo-core-eval-modern     |       909.369 us |      5.7235 us |    1 |     340.21 KB |
-| Jint              | dromaeo-core-eval-modern     |       926.399 us |      2.4254 us |    1 |     359.93 KB |
-| NilJS             | dromaeo-core-eval-modern     |     1,435.926 us |      5.1354 us |    2 |    1575.94 KB |
-| YantraJS          | dromaeo-core-eval-modern     |     4,866.540 us |     51.7995 us |    3 |   35784.84 KB |
-| Okojo             | dromaeo-core-eval-modern     |     5,144.141 us |     62.8990 us |    4 |    4627.67 KB |
-| Okojo_Prepared    | dromaeo-core-eval-modern     |     5,225.851 us |     78.2768 us |    4 |    4613.46 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | dromaeo-object-array         |    11,131.395 us |    207.2574 us |    1 |    9115.86 KB |
-| Jint              | dromaeo-object-array         |    11,318.284 us |    192.7535 us |    1 |    9164.27 KB |
-| YantraJS          | dromaeo-object-array         |    23,278.391 us |    171.9981 us |    2 |  220010.57 KB |
-| Okojo_Prepared    | dromaeo-object-array         |    38,466.730 us |    123.7053 us |    3 |    6973.53 KB |
-| Okojo             | dromaeo-object-array         |    38,739.367 us |    411.2380 us |    3 |    6999.78 KB |
-| NilJS             | dromaeo-object-array         |    50,973.780 us |     92.4295 us |    4 |   17862.17 KB |
-|                   |                              |                  |                |      |               |
-| Jint              | dromaeo-object-array-modern  |    14,258.293 us |    154.7903 us |    1 |    9165.37 KB |
-| Jint_ParsedScript | dromaeo-object-array-modern  |    14,570.784 us |    167.2733 us |    1 |    9117.79 KB |
-| YantraJS          | dromaeo-object-array-modern  |    24,713.087 us |    480.4059 us |    2 |  223803.18 KB |
-| Okojo_Prepared    | dromaeo-object-array-modern  |    39,672.749 us |     82.5583 us |    3 |    6984.54 KB |
-| Okojo             | dromaeo-object-array-modern  |    40,965.505 us |     63.8418 us |    4 |    7013.55 KB |
-| NilJS             | dromaeo-object-array-modern  |    51,511.299 us |    140.7231 us |    5 |   17863.19 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | dromaeo-object-regexp        |   131,607.741 us |  6,710.3205 us |    1 |  157427.53 KB |
-| Jint              | dromaeo-object-regexp        |   137,174.876 us |  5,429.6440 us |    1 |  158919.15 KB |
-| NilJS             | dromaeo-object-regexp        |   529,601.127 us |  8,878.2362 us |    2 |  766996.89 KB |
-| YantraJS          | dromaeo-object-regexp        |   695,104.586 us |  7,907.4654 us |    3 |  825611.63 KB |
-| Okojo             | dromaeo-object-regexp        | 1,790,480.007 us | 11,704.0554 us |    4 | 1798210.36 KB |
-| Okojo_Prepared    | dromaeo-object-regexp        | 1,808,627.392 us |  6,421.8392 us |    4 | 1799342.77 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | dromaeo-object-regexp-modern |   125,900.462 us |  5,143.9732 us |    1 |  157138.22 KB |
-| Jint              | dromaeo-object-regexp-modern |   127,541.094 us |  6,915.9485 us |    1 |  156436.69 KB |
-| NilJS             | dromaeo-object-regexp-modern |   527,152.460 us |  6,296.1280 us |    2 |  767231.57 KB |
-| YantraJS          | dromaeo-object-regexp-modern |   707,109.067 us |  8,559.8541 us |    3 |  831286.49 KB |
-| Okojo             | dromaeo-object-regexp-modern | 1,825,988.240 us | 12,449.7110 us |    4 | 1801468.92 KB |
-| Okojo_Prepared    | dromaeo-object-regexp-modern | 1,853,339.280 us | 15,718.2952 us |    4 | 1799047.36 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | dromaeo-object-string        |    44,236.228 us |    894.4357 us |    1 |   21517.32 KB |
-| Jint              | dromaeo-object-string        |    44,765.976 us |    358.2312 us |    1 |   21690.78 KB |
-| Okojo             | dromaeo-object-string        |    50,282.033 us |    809.8340 us |    2 |   33471.35 KB |
-| Okojo_Prepared    | dromaeo-object-string        |    50,346.630 us |  1,032.0417 us |    2 |    33457.2 KB |
-| NilJS             | dromaeo-object-string        |   140,032.067 us |  3,391.8404 us |    3 |  1355029.2 KB |
-| YantraJS          | dromaeo-object-string        |   168,246.208 us |  4,540.7816 us |    4 | 1653121.45 KB |
-|                   |                              |                  |                |      |               |
-| Jint              | dromaeo-object-string-modern |    52,281.562 us |  1,265.5325 us |    1 |   21495.39 KB |
-| Okojo_Prepared    | dromaeo-object-string-modern |    54,182.270 us |    876.1328 us |    1 |   33451.08 KB |
-| Okojo             | dromaeo-object-string-modern |    54,754.242 us |  1,330.5147 us |    1 |   33538.01 KB |
-| Jint_ParsedScript | dromaeo-object-string-modern |    56,936.391 us |  1,731.9417 us |    1 |   21317.66 KB |
-| NilJS             | dromaeo-object-string-modern |   142,747.049 us |  3,997.6165 us |    2 | 1355011.41 KB |
-| YantraJS          | dromaeo-object-string-modern |   169,179.149 us |  3,759.4630 us |    3 | 1656324.17 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | dromaeo-string-base64        |    21,833.256 us |     61.4609 us |    1 |    1620.51 KB |
-| Jint              | dromaeo-string-base64        |    22,527.694 us |     51.7302 us |    2 |     1720.5 KB |
-| NilJS             | dromaeo-string-base64        |    26,319.325 us |    168.7616 us |    3 |   19588.66 KB |
-| Okojo_Prepared    | dromaeo-string-base64        |    28,397.267 us |     68.0999 us |    4 |    43734.5 KB |
-| Okojo             | dromaeo-string-base64        |    28,438.659 us |     97.5886 us |    4 |   43806.57 KB |
-| YantraJS          | dromaeo-string-base64        |    33,295.734 us |    367.4019 us |    5 |  763555.06 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | dromaeo-string-base64-modern |    25,894.140 us |     54.7045 us |    1 |    1620.97 KB |
-| Jint              | dromaeo-string-base64-modern |    27,010.827 us |     60.4811 us |    2 |    1721.37 KB |
-| Okojo_Prepared    | dromaeo-string-base64-modern |    28,505.601 us |    197.3657 us |    3 |   43745.96 KB |
-| Okojo             | dromaeo-string-base64-modern |    31,410.661 us |    150.0738 us |    4 |   43824.53 KB |
-| YantraJS          | dromaeo-string-base64-modern |    32,057.062 us |    484.4823 us |    4 |  764771.13 KB |
-| NilJS             | dromaeo-string-base64-modern |    32,844.012 us |    344.3122 us |    4 |   31360.29 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | evaluation                   |         4.505 us |      0.0172 us |    1 |      17.55 KB |
-| Jint              | evaluation                   |        14.413 us |      0.0294 us |    2 |      28.19 KB |
-| NilJS             | evaluation                   |        25.128 us |      0.0647 us |    3 |      22.36 KB |
-| YantraJS          | evaluation                   |       132.453 us |      1.1654 us |    4 |     703.42 KB |
-| Okojo_Prepared    | evaluation                   |     1,574.309 us |     24.5322 us |    5 |    1280.28 KB |
-| Okojo             | evaluation                   |     1,609.272 us |     36.2644 us |    5 |    1286.73 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | evaluation-modern            |         4.314 us |      0.0139 us |    1 |      17.16 KB |
-| Jint              | evaluation-modern            |        13.762 us |      0.0431 us |    2 |      28.28 KB |
-| NilJS             | evaluation-modern            |        25.719 us |      0.1213 us |    3 |      22.35 KB |
-| YantraJS          | evaluation-modern            |       127.944 us |      0.8540 us |    4 |      703.4 KB |
-| Okojo_Prepared    | evaluation-modern            |     1,552.680 us |     35.7149 us |    5 |    1283.36 KB |
-| Okojo             | evaluation-modern            |     1,637.282 us |     28.8504 us |    5 |     1290.5 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | json-parse                   |    19,015.252 us |     42.5062 us |    1 |   21368.26 KB |
-| Jint              | json-parse                   |    20,265.080 us |    227.1496 us |    2 |   21404.21 KB |
-| YantraJS          | json-parse                   |    25,410.563 us |    195.4429 us |    3 |   44331.31 KB |
-| Okojo_Prepared    | json-parse                   |    26,848.594 us |     52.9249 us |    4 |    27231.9 KB |
-| Okojo             | json-parse                   |    26,850.924 us |     73.0589 us |    4 |   27262.65 KB |
-| NilJS             | json-parse                   |   128,678.536 us |    826.0189 us |    5 |    66014.1 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | json-parse-modern            |    17,514.534 us |     56.3865 us |    1 |   21377.29 KB |
-| Jint              | json-parse-modern            |    17,530.900 us |     60.9269 us |    1 |   21412.83 KB |
-| YantraJS          | json-parse-modern            |    24,620.339 us |    281.6592 us |    2 |   43167.22 KB |
-| Okojo             | json-parse-modern            |    26,597.647 us |    284.9263 us |    3 |   27271.68 KB |
-| Okojo_Prepared    | json-parse-modern            |    26,846.415 us |     56.2260 us |    3 |   27235.28 KB |
-| NilJS             | json-parse-modern            |   125,067.457 us |    472.8780 us |    4 |   67095.19 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | linq-js                      |        56.124 us |      0.1793 us |    1 |     199.59 KB |
-| YantraJS          | linq-js                      |       322.556 us |      1.9429 us |    2 |    1049.75 KB |
-| Jint              | linq-js                      |     1,172.644 us |      4.8812 us |    3 |    1298.82 KB |
-| NilJS             | linq-js                      |     3,825.634 us |     12.0575 us |    4 |    2739.46 KB |
-| Okojo_Prepared    | linq-js                      |     7,080.933 us |    327.1464 us |    5 |    4131.48 KB |
-| Okojo             | linq-js                      |     8,180.639 us |     92.8429 us |    6 |    4928.45 KB |
-|                   |                              |                  |                |      |               |
-| Jint_ParsedScript | minimal                      |         1.023 us |      0.0079 us |    1 |       9.33 KB |
-| Jint              | minimal                      |         2.156 us |      0.0666 us |    2 |      11.26 KB |
-| NilJS             | minimal                      |         2.910 us |      0.0167 us |    3 |       4.51 KB |
-| YantraJS          | minimal                      |       127.611 us |      1.1214 us |    4 |     697.62 KB |
-| Okojo             | minimal                      |     1,432.968 us |     40.8994 us |    5 |     1249.1 KB |
-| Okojo_Prepared    | minimal                      |     1,448.889 us |     38.0131 us |    5 |    1247.19 KB |
-|                   |                              |                  |                |      |               |
-| YantraJS          | stopwatch                    |    56,173.667 us |    249.9468 us |    1 |  215655.06 KB |
-| Jint_ParsedScript | stopwatch                    |    94,493.023 us |    670.4730 us |    2 |   12086.91 KB |
-| Jint              | stopwatch                    |    95,565.990 us |    777.4872 us |    2 |    12118.7 KB |
-| NilJS             | stopwatch                    |   133,199.477 us |    538.3957 us |    3 |   94876.49 KB |
-| Okojo             | stopwatch                    |   147,027.552 us |    962.2557 us |    4 |   21467.24 KB |
-| Okojo_Prepared    | stopwatch                    |   147,292.810 us |  2,545.5226 us |    4 |   21444.76 KB |
-|                   |                              |                  |                |      |               |
-| YantraJS          | stopwatch-modern             |    59,827.731 us |    223.9642 us |    1 |  234033.07 KB |
-| Jint_ParsedScript | stopwatch-modern             |    89,643.204 us |    378.7984 us |    2 |   12087.93 KB |
-| Jint              | stopwatch-modern             |    90,244.348 us |    679.2107 us |    2 |   12120.31 KB |
-| Okojo             | stopwatch-modern             |   154,027.404 us |    605.5049 us |    3 |   21468.89 KB |
-| Okojo_Prepared    | stopwatch-modern             |   155,334.860 us |  1,594.1182 us |    3 |   21444.11 KB |
-| NilJS             | stopwatch-modern             |   222,745.085 us |  5,723.3724 us |    4 |  324502.66 KB |
+| Method               | FileName                     | Mean             | StdDev         | Rank | Allocated     |
+|--------------------- |----------------------------- |-----------------:|---------------:|-----:|--------------:|
+| Jint_ParsedScript    | array-stress                 |     2,256.761 us |      7.1240 us |    1 |    1060.39 KB |
+| Jint                 | array-stress                 |     2,315.740 us |     14.6480 us |    1 |    1089.12 KB |
+| ClearScript_Compiled | array-stress                 |     2,385.5 us   |    123.68 us   |    1 |       8.14 KB |
+| YantraJS             | array-stress                 |     2,792.018 us |     27.8405 us |    2 |   17123.82 KB |
+| ClearScript          | array-stress                 |     3,975.7 us   |    117.77 us   |    3 |      15.88 KB |
+| NilJS                | array-stress                 |     5,133.058 us |     18.8123 us |    4 |    4521.19 KB |
+| Okojo_Prepared       | array-stress                 |     5,434.204 us |     40.9309 us |    5 |    2681.62 KB |
+| Okojo                | array-stress                 |     5,494.069 us |     43.4340 us |    5 |    2697.39 KB |
+|                      |                              |                  |                |      |               |
+| ClearScript_Compiled | dromaeo-3d-cube-modern       |     1,894.5 us   |     33.83 us   |    1 |       9.32 KB |
+| YantraJS             | dromaeo-3d-cube-modern       |     2,455.419 us |     10.9833 us |    2 |    7514.24 KB |
+| ClearScript          | dromaeo-3d-cube-modern       |     3,986.9 us   |     52.25 us   |    3 |      14.53 KB |
+| Jint_ParsedScript    | dromaeo-3d-cube-modern       |     4,766.692 us |     20.9342 us |    4 |    1340.62 KB |
+| Jint                 | dromaeo-3d-cube-modern       |     5,081.631 us |     21.2716 us |    5 |    1644.48 KB |
+| NilJS                | dromaeo-3d-cube-modern       |     7,095.752 us |     35.0040 us |    6 |    5977.95 KB |
+| Okojo_Prepared       | dromaeo-3d-cube-modern       |     7,321.080 us |     18.7803 us |    7 |    2311.29 KB |
+| Okojo                | dromaeo-3d-cube-modern       |     7,321.862 us |     28.8572 us |    7 |    2496.04 KB |
+|                      |                              |                  |                |      |               |
+| Jint_ParsedScript    | dromaeo-core-eval-modern     |       909.369 us |      5.7235 us |    1 |     340.21 KB |
+| Jint                 | dromaeo-core-eval-modern     |       926.399 us |      2.4254 us |    1 |     359.93 KB |
+| ClearScript_Compiled | dromaeo-core-eval-modern     |     1,228.0 us   |      8.54 us   |    2 |       8.17 KB |
+| NilJS                | dromaeo-core-eval-modern     |     1,435.926 us |      5.1354 us |    3 |    1575.94 KB |
+| ClearScript          | dromaeo-core-eval-modern     |     2,536.1 us   |     21.49 us   |    4 |      12.91 KB |
+| YantraJS             | dromaeo-core-eval-modern     |     4,866.540 us |     51.7995 us |    5 |   35784.84 KB |
+| Okojo                | dromaeo-core-eval-modern     |     5,144.141 us |     62.8990 us |    6 |    4627.67 KB |
+| Okojo_Prepared       | dromaeo-core-eval-modern     |     5,225.851 us |     78.2768 us |    6 |    4613.46 KB |
+|                      |                              |                  |                |      |               |
+| Jint                 | dromaeo-object-array-modern  |    14,258.293 us |    154.7903 us |    1 |    9165.37 KB |
+| Jint_ParsedScript    | dromaeo-object-array-modern  |    14,570.784 us |    167.2733 us |    1 |    9117.79 KB |
+| ClearScript_Compiled | dromaeo-object-array-modern  |    15,663.4 us   |     95.13 us   |    2 |      16.66 KB |
+| ClearScript          | dromaeo-object-array-modern  |    20,471.0 us   |    213.00 us   |    3 |     110.06 KB |
+| YantraJS             | dromaeo-object-array-modern  |    24,713.087 us |    480.4059 us |    4 |  223803.18 KB |
+| Okojo_Prepared       | dromaeo-object-array-modern  |    39,672.749 us |     82.5583 us |    5 |    6984.54 KB |
+| Okojo                | dromaeo-object-array-modern  |    40,965.505 us |     63.8418 us |    6 |    7013.55 KB |
+| NilJS                | dromaeo-object-array-modern  |    51,511.299 us |    140.7231 us |    7 |   17863.19 KB |
+|                      |                              |                  |                |      |               |
+| ClearScript          | dromaeo-object-regexp-modern |   103,294.6 us   |    910.06 us   |    1 |      32.74 KB |
+| ClearScript_Compiled | dromaeo-object-regexp-modern |   119,046.5 us   |  5,092.80 us   |    2 |      15.58 KB |
+| Jint_ParsedScript    | dromaeo-object-regexp-modern |   125,900.462 us |  5,143.9732 us |    2 |  157138.22 KB |
+| Jint                 | dromaeo-object-regexp-modern |   127,541.094 us |  6,915.9485 us |    2 |  156436.69 KB |
+| NilJS                | dromaeo-object-regexp-modern |   527,152.460 us |  6,296.1280 us |    3 |  767231.57 KB |
+| YantraJS             | dromaeo-object-regexp-modern |   707,109.067 us |  8,559.8541 us |    4 |  831286.49 KB |
+| Okojo                | dromaeo-object-regexp-modern | 1,825,988.240 us | 12,449.7110 us |    5 | 1801468.92 KB |
+| Okojo_Prepared       | dromaeo-object-regexp-modern | 1,853,339.280 us | 15,718.2952 us |    5 | 1799047.36 KB |
+|                      |                              |                  |                |      |               |
+| ClearScript_Compiled | dromaeo-object-string-modern |     5,940.5 us   |    115.62 us   |    1 |      15.81 KB |
+| ClearScript          | dromaeo-object-string-modern |     8,775.3 us   |    101.99 us   |    2 |       25.3 KB |
+| Jint                 | dromaeo-object-string-modern |    52,281.562 us |  1,265.5325 us |    3 |   21495.39 KB |
+| Okojo_Prepared       | dromaeo-object-string-modern |    54,182.270 us |    876.1328 us |    3 |   33451.08 KB |
+| Okojo                | dromaeo-object-string-modern |    54,754.242 us |  1,330.5147 us |    3 |   33538.01 KB |
+| Jint_ParsedScript    | dromaeo-object-string-modern |    56,936.391 us |  1,731.9417 us |    3 |   21317.66 KB |
+| NilJS                | dromaeo-object-string-modern |   142,747.049 us |  3,997.6165 us |    4 | 1355011.41 KB |
+| YantraJS             | dromaeo-object-string-modern |   169,179.149 us |  3,759.4630 us |    5 | 1656324.17 KB |
+|                      |                              |                  |                |      |               |
+| ClearScript_Compiled | dromaeo-string-base64-modern |     2,656.1 us   |     42.79 us   |    1 |       8.84 KB |
+| ClearScript          | dromaeo-string-base64-modern |     4,658.0 us   |     88.66 us   |    2 |      15.31 KB |
+| Jint_ParsedScript    | dromaeo-string-base64-modern |    25,894.140 us |     54.7045 us |    3 |    1620.97 KB |
+| Jint                 | dromaeo-string-base64-modern |    27,010.827 us |     60.4811 us |    4 |    1721.37 KB |
+| Okojo_Prepared       | dromaeo-string-base64-modern |    28,505.601 us |    197.3657 us |    5 |   43745.96 KB |
+| Okojo                | dromaeo-string-base64-modern |    31,410.661 us |    150.0738 us |    6 |   43824.53 KB |
+| YantraJS             | dromaeo-string-base64-modern |    32,057.062 us |    484.4823 us |    6 |  764771.13 KB |
+| NilJS                | dromaeo-string-base64-modern |    32,844.012 us |    344.3122 us |    6 |   31360.29 KB |
+|                      |                              |                  |                |      |               |
+| Jint_ParsedScript    | evaluation-modern            |         4.314 us |      0.0139 us |    1 |      17.16 KB |
+| Jint                 | evaluation-modern            |        13.762 us |      0.0431 us |    2 |      28.28 KB |
+| NilJS                | evaluation-modern            |        25.719 us |      0.1213 us |    3 |      22.35 KB |
+| YantraJS             | evaluation-modern            |       127.944 us |      0.8540 us |    4 |      703.4 KB |
+| ClearScript_Compiled | evaluation-modern            |       461.1 us   |      2.25 us   |    5 |        6.1 KB |
+| ClearScript          | evaluation-modern            |     1,252.3 us   |     13.64 us   |    6 |      10.97 KB |
+| Okojo_Prepared       | evaluation-modern            |     1,552.680 us |     35.7149 us |    7 |    1283.36 KB |
+| Okojo                | evaluation-modern            |     1,637.282 us |     28.8504 us |    7 |     1290.5 KB |
+|                      |                              |                  |                |      |               |
+| ClearScript_Compiled | json-parse-modern            |    10,429.5 us   |    124.76 us   |    1 |      10.15 KB |
+| ClearScript          | json-parse-modern            |    12,448.8 us   |    241.20 us   |    2 |      17.69 KB |
+| Jint_ParsedScript    | json-parse-modern            |    17,514.534 us |     56.3865 us |    3 |   21377.29 KB |
+| Jint                 | json-parse-modern            |    17,530.900 us |     60.9269 us |    3 |   21412.83 KB |
+| YantraJS             | json-parse-modern            |    24,620.339 us |    281.6592 us |    4 |   43167.22 KB |
+| Okojo                | json-parse-modern            |    26,597.647 us |    284.9263 us |    5 |   27271.68 KB |
+| Okojo_Prepared       | json-parse-modern            |    26,846.415 us |     56.2260 us |    5 |   27235.28 KB |
+| NilJS                | json-parse-modern            |   125,067.457 us |    472.8780 us |    6 |   67095.19 KB |
+|                      |                              |                  |                |      |               |
+| Jint_ParsedScript    | linq-js                      |        56.124 us |      0.1793 us |    1 |     199.59 KB |
+| YantraJS             | linq-js                      |       322.556 us |      1.9429 us |    2 |    1049.75 KB |
+| ClearScript_Compiled | linq-js                      |       555.1 us   |     10.31 us   |    3 |       6.21 KB |
+| Jint                 | linq-js                      |     1,172.644 us |      4.8812 us |    4 |    1298.82 KB |
+| ClearScript          | linq-js                      |     2,257.4 us   |     21.01 us   |    5 |      10.97 KB |
+| NilJS                | linq-js                      |     3,825.634 us |     12.0575 us |    6 |    2739.46 KB |
+| Okojo_Prepared       | linq-js                      |     7,080.933 us |    327.1464 us |    7 |    4131.48 KB |
+| Okojo                | linq-js                      |     8,180.639 us |     92.8429 us |    8 |    4928.45 KB |
+|                      |                              |                  |                |      |               |
+| Jint_ParsedScript    | minimal                      |         1.023 us |      0.0079 us |    1 |       9.33 KB |
+| Jint                 | minimal                      |         2.156 us |      0.0666 us |    2 |      11.26 KB |
+| NilJS                | minimal                      |         2.910 us |      0.0167 us |    3 |       4.51 KB |
+| YantraJS             | minimal                      |       127.611 us |      1.1214 us |    4 |     697.62 KB |
+| ClearScript_Compiled | minimal                      |       460.6 us   |      4.61 us   |    5 |        6.1 KB |
+| ClearScript          | minimal                      |     1,235.0 us   |     14.77 us   |    6 |      10.97 KB |
+| Okojo                | minimal                      |     1,432.968 us |     40.8994 us |    7 |     1249.1 KB |
+| Okojo_Prepared       | minimal                      |     1,448.889 us |     38.0131 us |    7 |    1247.19 KB |
+|                      |                              |                  |                |      |               |
+| ClearScript_Compiled | stopwatch-modern             |    15,999.1 us   |    238.49 us   |    1 |       8.82 KB |
+| ClearScript          | stopwatch-modern             |    20,285.1 us   |    291.74 us   |    2 |      22.64 KB |
+| YantraJS             | stopwatch-modern             |    59,827.731 us |    223.9642 us |    3 |  234033.07 KB |
+| Jint_ParsedScript    | stopwatch-modern             |    89,643.204 us |    378.7984 us |    4 |   12087.93 KB |
+| Jint                 | stopwatch-modern             |    90,244.348 us |    679.2107 us |    4 |   12120.31 KB |
+| Okojo                | stopwatch-modern             |   154,027.404 us |    605.5049 us |    5 |   21468.89 KB |
+| Okojo_Prepared       | stopwatch-modern             |   155,334.860 us |  1,594.1182 us |    5 |   21444.11 KB |
+| NilJS                | stopwatch-modern             |   222,745.085 us |  5,723.3724 us |    6 |  324502.66 KB |

--- a/Jint.Benchmark/Scripts/interop-collection-traversal.js
+++ b/Jint.Benchmark/Scripts/interop-collection-traversal.js
@@ -1,0 +1,12 @@
+// Host arrays do not expose a JavaScript "length" in every engine (ClearScript surfaces the CLR
+// member instead), so the element count is read from a dedicated host property.
+var sum = 0;
+var count = host.count;
+for (var pass = 0; pass < 100; pass++) {
+    for (var i = 0; i < count; i++) {
+        sum += host.numbers[i];
+    }
+}
+if (sum !== 495000) {
+    throw new Error('unexpected sum: ' + sum);
+}

--- a/Jint.Benchmark/Scripts/interop-method-calls.js
+++ b/Jint.Benchmark/Scripts/interop-method-calls.js
@@ -1,0 +1,7 @@
+var sum = 0;
+for (var i = 0; i < 10000; i++) {
+    sum += host.add(i, 1);
+}
+if (sum !== 50005000) {
+    throw new Error('unexpected sum: ' + sum);
+}

--- a/Jint.Benchmark/Scripts/interop-property-access.js
+++ b/Jint.Benchmark/Scripts/interop-property-access.js
@@ -1,0 +1,8 @@
+var sum = 0;
+for (var i = 0; i < 10000; i++) {
+    host.value = i;
+    sum += host.value;
+}
+if (sum !== 49995000) {
+    throw new Error('unexpected sum: ' + sum);
+}

--- a/Jint.Benchmark/Scripts/interop-string-passing.js
+++ b/Jint.Benchmark/Scripts/interop-string-passing.js
@@ -1,0 +1,7 @@
+var length = 0;
+for (var i = 0; i < 2000; i++) {
+    length += host.concat('abcdefgh', String(i)).length;
+}
+if (length !== 22890) {
+    throw new Error('unexpected length: ' + length);
+}


### PR DESCRIPTION
Resurrects this PR on top of current `main` (original commit by @viceice kept, packages moved to ClearScript 7.5.1) and extends it into the full benchmark-field refresh discussed in #2706.

Closes #2706.

## What's in here

1. **ClearScript V8 joins the comparison** (`Microsoft.ClearScript.V8` 7.5.1, now maintained by ClearFoundry):
   - The `ClearScript` lane now **disposes the engine** — the original lane leaked a native V8 isolate per iteration, which skews every subsequent measurement — and runs strict-prefixed source like the Okojo lanes (V8 has no engine-level strict switch).
   - New `ClearScript_Compiled` lane mirroring `Jint_ParsedScript` / `Okojo_Prepared`: a `V8Script` compiled once by a shared `V8Runtime`, executed in a fresh script engine (fresh V8 context) per operation — ClearScript's recommended production path.
2. **Suite trimmed to one variant per workload** (21 → 12 scripts): where a classic ES5 script had an ES2015+ `-modern` rewrite, only the modern variant remains. The duplicated rows ranked the engines nearly identically while doubling full-run wall clock. Classic scripts stay in `Scripts/` for the Jint-only benchmarks.
3. **New script ↔ host interop suite** (`EngineComparisonInteropBenchmark`): four byte-identical scripts (host method calls, property access, strings crossing the boundary, host array traversal) against Jint, NiL.JS, YantraJS, ClearScript and ClearScript's 7.5 **FastProxy** fast path. Design notes: host members are lowercase because YantraJS camel-cases CLR member names while the other engines don't; every script validates its aggregate and throws on mismatch so silent mis-marshaling can't post a time; Okojo is absent because 0.1.2-preview.1 has no public way to enable CLR access.
4. **README rewritten** for the new field, with freshly measured ClearScript and interop numbers merged in (measured on the same Ryzen 5950X / .NET 10.0.9 box as the 4.13.0 table).

## Headline results

Comparing production paths (`Jint_ParsedScript` vs `ClearScript_Compiled`), **the 12-script table splits 6/6 between Jint and native V8** — no other managed engine wins a row:

- Jint wins everything start-up- and eval-shaped: `minimal` **1.0 µs vs 461 µs (~450×)**, `evaluation-modern` ~107×, `linq-js` ~10×, `dromaeo-core-eval-modern` 1.35×, plus `dromaeo-object-array-modern` (1.07×) and `array-stress` (statistically tied).
- V8 wins the long compute rows: 3d-cube 2.5×, json-parse 1.7×, stopwatch 5.6×, object-string 8.8×, base64 9.7× (regexp within that row's variance).

**The interop suite inverts the picture — the managed engines win every row.** Plain ClearScript pays **5.7–7.0×** vs Jint on method calls / property access / string passing; the FastProxy path narrows that to **2.4–3.6×** at the cost of hand-registering every member (its zero-allocation marshaling is real, though: 13 KB vs 12.8 MB managed allocations on the method-call row).

The suite also surfaced an honest Jint finding on day one: re-reading a host array property inside a loop re-wraps it every iteration (19 ms / 32.9 MB on the traversal row). Hoisting the collection into a local drops Jint to **~1.1 ms / 0.3 MB — faster than every other engine on that row**; caching repeated wraps of the same host object is a follow-up improvement opportunity in Jint itself.

## Fairness notes baked into the README

- `Allocated` counts managed memory only — ClearScript's working memory lives on V8's native heap, so its rows are bridge overhead, not comparable memory figures; memory claims compare managed engines only.
- V8 runs background JIT/GC threads: `Mean` is wall-clock of the executing thread, total CPU is higher than the single-threaded managed engines.
- The full Dry-job smoke of all 116 cases passes; the measured tables come from default-job runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)