### PR TITLE
Add tasks to defaultobjectconverter

### DIFF
--- a/Jint.Tests/Runtime/TestClasses/AsyncTestClass.cs
+++ b/Jint.Tests/Runtime/TestClasses/AsyncTestClass.cs
@@ -1,0 +1,40 @@
+﻿namespace Jint.Tests.Runtime.TestClasses
+{
+    internal class AsyncTestClass
+    {
+        public static readonly string TestString = "Hello World";
+
+        public string StringToAppend { get; set; } = string.Empty;
+
+        public async Task AddToStringDelayedAsync(string appendWith)
+        {
+            await Task.Delay(1000).ConfigureAwait(false);
+
+            StringToAppend += appendWith;
+        }
+
+        public async Task<string> ReturnDelayedTaskAsync()
+        {
+            await Task.Delay(1000).ConfigureAwait(false);
+
+            return TestString;
+        }
+
+        public Task<string> ReturnCompletedTask()
+        {
+            return Task.FromResult(TestString);
+        }
+
+        public Task<string> ReturnCancelledTask(CancellationToken token)
+        {
+            return Task.FromCanceled<string>(token);
+        }
+
+        public async Task<string> ThrowAfterDelayAsync()
+        {
+            await Task.Delay(100).ConfigureAwait(false);
+
+            throw new Exception("Task threw exception");
+        }
+    }
+}

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1059,7 +1059,7 @@ namespace Jint.Native.Object
                         converted = result;
                         break;
                     }
-                    
+
                     if (this is JsTypedArray typedArrayInstance)
                     {
                         converted = typedArrayInstance._arrayElementType switch
@@ -1703,14 +1703,14 @@ namespace Jint.Native.Object
                     var i = 0;
                     if (_obj._properties is not null)
                     {
-                        foreach(var key in _obj._properties)
+                        foreach (var key in _obj._properties)
                         {
                             keys[i++] = new KeyValuePair<JsValue, JsValue>(key.Key.Name, UnwrapJsValue(key.Value, _obj));
                         }
                     }
                     if (_obj._symbols is not null)
                     {
-                        foreach(var key in _obj._symbols)
+                        foreach (var key in _obj._symbols)
                         {
                             keys[i++] = new KeyValuePair<JsValue, JsValue>(key.Key, UnwrapJsValue(key.Value, _obj));
                         }

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -69,67 +69,80 @@ namespace Jint
                 if (value is Delegate d)
                 {
                     result = new DelegateWrapper(engine, d);
+                    return result is not null;
                 }
-                else
+
+                if (value is Task task)
                 {
-                    var t = value.GetType();
+                    result = JsValue.ConvertAwaitableToPromise(engine, task);
+                    return result is not null;
+                }
 
-                    if (!engine.Options.Interop.AllowSystemReflection
-                        && t.Namespace?.StartsWith("System.Reflection", StringComparison.Ordinal) == true)
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
+                if (value is ValueTask valueTask)
+                {
+                    result = JsValue.ConvertAwaitableToPromise(engine, valueTask);
+                    return result is not null;
+                }
+#endif
+
+                var t = value.GetType();
+
+                if (!engine.Options.Interop.AllowSystemReflection
+                    && t.Namespace?.StartsWith("System.Reflection", StringComparison.Ordinal) == true)
+                {
+                    const string Message = "Cannot access System.Reflection namespace, check Engine's interop options";
+                    ExceptionHelper.ThrowInvalidOperationException(Message);
+                }
+
+                if (t.IsEnum)
+                {
+                    var ut = Enum.GetUnderlyingType(t);
+
+                    if (ut == typeof(ulong))
                     {
-                        const string Message = "Cannot access System.Reflection namespace, check Engine's interop options";
-                        ExceptionHelper.ThrowInvalidOperationException(Message);
-                    }
-
-                    if (t.IsEnum)
-                    {
-                        var ut = Enum.GetUnderlyingType(t);
-
-                        if (ut == typeof(ulong))
-                        {
-                            result = JsNumber.Create(Convert.ToDouble(value, CultureInfo.InvariantCulture));
-                        }
-                        else
-                        {
-                            if (ut == typeof(uint) || ut == typeof(long))
-                            {
-                                result = JsNumber.Create(Convert.ToInt64(value, CultureInfo.InvariantCulture));
-                            }
-                            else
-                            {
-                                result = JsNumber.Create(Convert.ToInt32(value, CultureInfo.InvariantCulture));
-                            }
-                        }
+                        result = JsNumber.Create(Convert.ToDouble(value, CultureInfo.InvariantCulture));
                     }
                     else
                     {
-                        // check global cache, have we already wrapped the value?
-                        if (engine._objectWrapperCache?.TryGetValue(value, out var cached) == true)
+                        if (ut == typeof(uint) || ut == typeof(long))
                         {
-                            result = cached;
+                            result = JsNumber.Create(Convert.ToInt64(value, CultureInfo.InvariantCulture));
                         }
                         else
                         {
-                            var wrapped = engine.Options.Interop.WrapObjectHandler.Invoke(engine, value, type);
-
-                            if (ReferenceEquals(wrapped?.GetPrototypeOf(), engine.Realm.Intrinsics.Object.PrototypeObject)
-                                && engine._typeReferences?.TryGetValue(t, out var typeReference) == true)
-                            {
-                                wrapped.SetPrototypeOf(typeReference);
-                            }
-
-                            result = wrapped;
-
-                            if (engine.Options.Interop.TrackObjectWrapperIdentity && wrapped is not null)
-                            {
-                                engine._objectWrapperCache ??= new ConditionalWeakTable<object, ObjectInstance>();
-                                engine._objectWrapperCache.Add(value, wrapped);
-                            }
+                            result = JsNumber.Create(Convert.ToInt32(value, CultureInfo.InvariantCulture));
                         }
                     }
-
-                    // if no known type could be guessed, use the default of wrapping using using ObjectWrapper.
                 }
+                else
+                {
+                    // check global cache, have we already wrapped the value?
+                    if (engine._objectWrapperCache?.TryGetValue(value, out var cached) == true)
+                    {
+                        result = cached;
+                    }
+                    else
+                    {
+                        var wrapped = engine.Options.Interop.WrapObjectHandler.Invoke(engine, value, type);
+
+                        if (ReferenceEquals(wrapped?.GetPrototypeOf(), engine.Realm.Intrinsics.Object.PrototypeObject)
+                            && engine._typeReferences?.TryGetValue(t, out var typeReference) == true)
+                        {
+                            wrapped.SetPrototypeOf(typeReference);
+                        }
+
+                        result = wrapped;
+
+                        if (engine.Options.Interop.TrackObjectWrapperIdentity && wrapped is not null)
+                        {
+                            engine._objectWrapperCache ??= new ConditionalWeakTable<object, ObjectInstance>();
+                            engine._objectWrapperCache.Add(value, wrapped);
+                        }
+                    }
+                }
+
+                // if no known type could be guessed, use the default of wrapping using using ObjectWrapper.                
             }
 
             return result is not null;


### PR DESCRIPTION
With this PR it's possible to call object methods that return tasks.

For example:

```c#
var engine = new Engine();
engine.SetValue("log", new Action<object>(Console.WriteLine))
    .SetValue("getTest", new Func<TestClass>(() => new()))
    .SetValue("__result", 0);

engine.Execute("""

(async () => {
    __result = "Before call";
    let testClass = getTest();

    __result = await testClass.GetDelayedStringAsync();
})();

""");

Console.WriteLine(engine.GetValue("__result"));


public class TestClass
{
    public async Task<string> GetDelayedStringAsync()
    {
        await Task.Delay(5000).ConfigureAwait(false);

        return "This is a delayed string";
    }
}
```

Before PR:

![image](https://github.com/sebastienros/jint/assets/102589380/58d90a6e-39e8-4a0a-9a97-0cb5bd1f989a)

After PR:

![image](https://github.com/sebastienros/jint/assets/102589380/e682d09a-69c7-4cb7-8e53-6d53331670a9)
