### PR TITLE
Issue 1768: make behaviour of SetValue consistent when using interfaces

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
+++ b/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
@@ -108,7 +108,7 @@ namespace Jint.Tests.Runtime
             Assert.Equal("System.Uri", TestAllowGetTypeOption(allowGetType: true));
 
             var ex = Assert.Throws<JavaScriptException>(() => TestAllowGetTypeOption(allowGetType: false));
-            Assert.Equal("Property 'GetType' of object is not a function", ex.Message);
+            Assert.Equal("'System.Uri' does not contain a definition for 'GetType'", ex.Message);
         }
 
         [Fact]

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -302,7 +302,7 @@ namespace Jint
         {
             return obj is Type t
                 ? SetValue(name, t)
-                : SetValue(name, JsValue.FromObject(this, obj));
+                : SetValue(name, JsValue.FromObjectWithType(this, obj, typeof(T)));
         }
 
         internal void LeaveExecutionContext()

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1406,7 +1406,7 @@ namespace Jint.Native.Object
             var callable = jsValue as ICallable;
             if (callable is null)
             {
-                ExceptionHelper.ThrowTypeError(realm, "Value returned for property '" + p + "' of object is not a function");
+                ExceptionHelper.ThrowTypeError(realm, $"Value returned for property '" + p + "' of object is not a function");
             }
             return callable;
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -6,6 +6,7 @@ using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime.CallStack;
 using Jint.Runtime.Environments;
+using Jint.Runtime.Interop;
 using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Expressions
@@ -227,9 +228,20 @@ namespace Jint.Runtime.Interpreter.Expressions
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowMemberIsNotFunction(Reference? referenceRecord1, object reference, Engine engine)
         {
-            var message = referenceRecord1 == null
-                ? reference + " is not a function"
-                : $"Property '{referenceRecord1.ReferencedName}' of object is not a function";
+            string message = reference + " is not a function";
+
+            if (referenceRecord1 != null)
+            {
+                if (referenceRecord1.ThisValue is ObjectWrapper clrObject)
+                {
+                    message = $"'{clrObject.ClrType}' does not contain a definition for '{referenceRecord1.ReferencedName}'";
+                }
+                else
+                {
+                    message = $"Property '{referenceRecord1.ReferencedName}' of object is not a function";
+                }
+            }
+
             ExceptionHelper.ThrowTypeError(engine.Realm, message);
         }
 


### PR DESCRIPTION
When passing an instance of a C# object using one of its interfaces into the engine using SetValue, the interpreter incorrectly allowed method calls to class methods not defined in the interface. This behavior violates the principle of least privilege and can lead to unintended side effects or security vulnerabilities, as users could execute methods that were meant to be inaccessible through the interface abstraction. This PR fixes that and ads a more descriptive exception message to avoid users considering it a bug.