### PR TITLE
Add Options.InteropOptions.BuildCallStackHandler

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="NUnit" Version="4.2.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
+    <PackageVersion Include="SourceMaps" Version="0.3.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.45.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="Test262Harness" Version="1.0.1" />

--- a/Jint.Tests.PublicInterface/CallStackTests.cs
+++ b/Jint.Tests.PublicInterface/CallStackTests.cs
@@ -55,7 +55,7 @@ Trace
     {
         var sourceMap = SourceMapParser.Parse("""{"version":3,"file":"custom.js","sourceRoot":"","sources":["custom.ts"],"names":[],"mappings":"AAEA,SAAS,CAAC,CAAC,CAAM;IAChB,MAAM,IAAI,KAAK,CAAC,CAAC,CAAC,CAAC;AACpB,CAAC;AAED,IAAI,CAAC,GAAG,UAAU,CAAM;IACvB,OAAO,CAAC,CAAC,CAAC,CAAC,CAAC;AACb,CAAC,CAAA;AAED,CAAC,CAAC,CAAC,CAAC,CAAC"}""");
 
-        string BuildCallStackHandler(string description, SourceLocation location, List<string> arguments)
+        string BuildCallStackHandler(string description, SourceLocation location, string[] arguments)
         {
             if (location.SourceFile != sourceMap.File)
             {

--- a/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+++ b/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NodaTime" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <PackageReference Include="SourceMaps" />
     <PackageReference Include="System.Text.Json" Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net8.0'))" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -28,7 +28,7 @@ public partial class Engine
                     return string.Empty;
                 }
 
-                return _engine.CallStack.BuildCallStackString(lastSyntaxElement.Location);
+                return _engine.CallStack.BuildCallStackString(_engine, lastSyntaxElement.Location);
             }
         }
 

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -80,7 +80,7 @@ public sealed class ErrorConstructor : Constructor
 
             // If the current function is the ErrorConstructor itself (i.e. "throw new Error(...)" was called
             // from script), exclude it from the stack trace, because the trace should begin at the throw point.
-            return callStack.BuildCallStackString(lastSyntaxNode.Location, currentFunction == this ? 1 : 0);
+            return callStack.BuildCallStackString(_engine, lastSyntaxNode.Location, currentFunction == this ? 1 : 0);
         }
     }
 }

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -128,6 +128,16 @@ public static class OptionsExtensions
     }
 
     /// <summary>
+    /// Sets the handler used to build stack traces. This is useful if the code currently
+    /// running was transpiled (eg. TypeScript) and the source map of original code is available.
+    /// </summary>
+    public static Options SetBuildCallStackHandler(this Options options, Options.BuildCallStackDelegate buildCallStackHandler)
+    {
+        options.Interop.BuildCallStackHandler = buildCallStackHandler;
+        return options;
+    }
+
+    /// <summary>
     /// Sets the type converter to use.
     /// </summary>
     public static Options SetTypeConverter(this Options options, Func<Engine, ITypeConverter> typeConverterFactory)

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -27,6 +27,8 @@ public class Options
 
     public delegate bool ExceptionHandlerDelegate(Exception exception);
 
+    public delegate string? BuildCallStackDelegate(string shortDescription, SourceLocation location, List<string>? arguments);
+
     /// <summary>
     /// Execution constraints for the engine.
     /// </summary>
@@ -296,6 +298,13 @@ public class Options
         /// change the behavior.
         /// </summary>
         public WrapObjectDelegate WrapObjectHandler { get; set; } = static (engine, target, type) => ObjectWrapper.Create(engine, target, type);
+
+        /// <summary>
+        /// The handler used to build stack traces. Changing this enables mapping
+        /// stack traces to code different from the code being executed, eg. when
+        /// executing code transpiled from TypeScript.
+        /// </summary>
+        public BuildCallStackDelegate BuildCallStackHandler { get; set; } = static (string description, SourceLocation location, List<string>? arguments) => null;
 
         /// <summary>
         ///

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -27,7 +27,7 @@ public class Options
 
     public delegate bool ExceptionHandlerDelegate(Exception exception);
 
-    public delegate string? BuildCallStackDelegate(string shortDescription, SourceLocation location, List<string>? arguments);
+    public delegate string? BuildCallStackDelegate(string shortDescription, SourceLocation location, string[]? arguments);
 
     /// <summary>
     /// Execution constraints for the engine.
@@ -304,7 +304,7 @@ public class Options
         /// stack traces to code different from the code being executed, eg. when
         /// executing code transpiled from TypeScript.
         /// </summary>
-        public BuildCallStackDelegate BuildCallStackHandler { get; set; } = static (string description, SourceLocation location, List<string>? arguments) => null;
+        public BuildCallStackDelegate? BuildCallStackHandler { get; set; }
 
         /// <summary>
         ///

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -114,14 +114,29 @@ internal sealed class JintCallStack
         return string.Join("->", _stack.Select(static cse => cse.ToString()).Reverse());
     }
 
-    internal string BuildCallStackString(SourceLocation location, int excludeTop = 0)
+    internal string BuildCallStackString(Engine engine, SourceLocation location, int excludeTop = 0)
     {
         static void AppendLocation(
             ref ValueStringBuilder sb,
             string shortDescription,
             in SourceLocation loc,
-            in CallStackElement? element)
+            in CallStackElement? element,
+            Engine engine)
         {
+            List<string>? arguments = null;
+
+            if (element?.Arguments is not null)
+            {
+                arguments = element.Value.Arguments.Value.Select(GetPropertyKey).ToList();
+            }
+
+            var str = engine.Options.Interop.BuildCallStackHandler.Invoke(shortDescription, loc, arguments);
+            if (!string.IsNullOrEmpty(str))
+            {
+                sb.Append(str);
+                return;
+            }
+
             sb.Append("   at");
 
             if (!string.IsNullOrWhiteSpace(shortDescription))
@@ -130,19 +145,16 @@ internal sealed class JintCallStack
                 sb.Append(shortDescription);
             }
 
-            if (element?.Arguments is not null)
+            if (arguments is not null)
             {
-                // it's a function
                 sb.Append(" (");
-                for (var index = 0; index < element.Value.Arguments.Value.Count; index++)
+                for (var index = 0; index < arguments.Count; index++)
                 {
                     if (index != 0)
                     {
                         sb.Append(", ");
                     }
-
-                    var arg = element.Value.Arguments.Value[index];
-                    sb.Append(GetPropertyKey(arg));
+                    sb.Append(arguments[index]);
                 }
                 sb.Append(')');
             }
@@ -163,7 +175,7 @@ internal sealed class JintCallStack
         var element = index >= 0 ? _stack[index] : (CallStackElement?) null;
         var shortDescription = element?.ToString() ?? "";
 
-        AppendLocation(ref builder, shortDescription, location, element);
+        AppendLocation(ref builder, shortDescription, location, element, engine);
 
         location = element?.Location ?? default;
         index--;
@@ -171,9 +183,9 @@ internal sealed class JintCallStack
         while (index >= -1)
         {
             element = index >= 0 ? _stack[index] : null;
-            shortDescription = element?.ToString() ?? "";
+            shortDescription = element?.ToString() ?? string.Empty;
 
-            AppendLocation(ref builder, shortDescription, location, element);
+            AppendLocation(ref builder, shortDescription, location, element, engine);
 
             location = element?.Location ?? default;
             index--;

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -88,7 +88,7 @@ public class JavaScriptException : JintException
             var errObj = Error.IsObject() ? Error.AsObject() : null;
             if (errObj is null)
             {
-                _callStack = engine.CallStack.BuildCallStackString(location);
+                _callStack = engine.CallStack.BuildCallStackString(engine, location);
                 return;
             }
 
@@ -99,7 +99,7 @@ public class JavaScriptException : JintException
             }
             else
             {
-                _callStack = engine.CallStack.BuildCallStackString(location);
+                _callStack = engine.CallStack.BuildCallStackString(engine, location);
                 errObj.FastSetProperty(CommonProperties.Stack._value, new PropertyDescriptor(_callStack, false, false, false));
             }
         }


### PR DESCRIPTION
A preliminary idea, this would allow one to modify the stack string generation, such as using a map of the source map.