### PR TITLE
Readonly accessor.

### DIFF
--- a/Jint/Runtime/Interop/Reflection/ReadonlyAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/ReadonlyAccessor.cs
@@ -1,0 +1,31 @@
+﻿using System.Reflection;
+
+namespace Jint.Runtime.Interop.Reflection;
+
+internal class ReadonlyAccessor : ReflectionAccessor
+{
+    private readonly ReflectionAccessor _inner;
+
+    public ReadonlyAccessor(ReflectionAccessor inner)
+        : base(inner.MemberType, null)
+    {
+        _inner = inner;
+    }
+
+    public override bool Writable => false;
+
+    public override object? GetValue(Engine engine, object target, string memberName)
+    {
+        return _inner.GetValue(engine, target, memberName);
+    }
+
+    protected override object? DoGetValue(object target, string memberName)
+    {
+        return null;
+    }
+
+    protected override void DoSetValue(object target, string memberName, object? value)
+    {
+        throw new NotSupportedException("Member is readonly.");
+    }
+}

--- a/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
@@ -38,7 +38,7 @@ internal abstract class ReflectionAccessor
 
     protected abstract void DoSetValue(object target, string memberName, object? value);
 
-    public object? GetValue(Engine engine, object target, string memberName)
+    public virtual object? GetValue(Engine engine, object target, string memberName)
     {
         var constantValue = ConstantValue;
         if (constantValue is not null)


### PR DESCRIPTION
Introduces a new filter to mark objects and accessors as readonly. This is handy when you want to have pure evaluation functions.