### PR TITLE
Add support for wrapped generic lists to push and pop items

### DIFF
--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -162,7 +162,7 @@ namespace Jint.Runtime.Interop
 
         public override bool Delete(JsValue property)
         {
-            if (Target is IList && property.IsNumber())
+            if (IsArrayLike && property.IsNumber())
             {
                 return true;
             }


### PR DESCRIPTION
#1822 added support for `push` and `pop` on interop objects that implement `IList`. `JsonArray` from `System.Text.Json` implements `IList<T>` and doesn't work.

My thoughts are that we implement a `GenericIndexWrappedOperations` that will have to use reflection to support adding and removing items.

I guess normal reflection in .NET has gotten fast enough where we don't need any special libraries, right?