### PR TITLE
Fix dynamic importing of JSON modules

### DIFF
--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -36,7 +36,6 @@ public partial class Engine
 
         internal Module Load(string? referencingModuleLocation, ModuleRequest request)
         {
-            var specifier = request.Specifier;
             var moduleResolution = ModuleLoader.Resolve(referencingModuleLocation, request);
 
             if (_modules.TryGetValue(moduleResolution.Key, out var module))

--- a/Jint/Runtime/Host.cs
+++ b/Jint/Runtime/Host.cs
@@ -134,7 +134,7 @@ namespace Jint.Runtime
             try
             {
                 // This should instead return the PromiseInstance returned by ModuleRecord.Evaluate (currently done in Engine.EvaluateModule), but until we have await this will do.
-                Engine.Modules.Import(moduleRequest.Specifier, referrer?.Location);
+                Engine.Modules.Import(moduleRequest, referrer?.Location);
                 promise.Resolve(JsValue.Undefined);
             }
             catch (JavaScriptException ex)

--- a/Jint/Runtime/Modules/SyntheticModule.cs
+++ b/Jint/Runtime/Modules/SyntheticModule.cs
@@ -35,6 +35,7 @@ internal sealed class SyntheticModule : Module
 
     public override void Link()
     {
+        InnerModuleLinking(null!, 0);
     }
 
     public override JsValue Evaluate()


### PR DESCRIPTION
While doing the parser migration, I spotted a bug: dynamically importing JSON modules (e.g. `await import("package.json", { with: { type: "json" } })`) results in an error ("default is not defined").

This PR attempts to fix the issue.