### PR TITLE
Backport var declaration and reference resolving performance improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
 
   push:
-    branches: [ main ]
+    branches: [ main, 3.x ]
     paths-ignore:
     - 'doc/**'
     - '**.md'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: PR Check
 on:
 
   pull_request:
-    branches: [ main, release/2.x ]
+    branches: [ main, release/2.x, 3.x ]
 
 jobs:
 

--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -1,5 +1,5 @@
 {
-  "SuiteGitSha": "45e740928f9ac3c2144307fee20bb58570fb9588",
+  "SuiteGitSha": "c2ae5ed5e90d86e17730730b003e9b6fb050693e",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Jint.Tests.Test262",
@@ -8,10 +8,12 @@
     "Array.fromAsync",
     "async-iteration",
     "Atomics",
+    "Float16Array",
     "import-assertions",
     "iterator-helpers",
     "regexp-duplicate-named-groups",
     "regexp-lookbehind",
+    "regexp-modifiers",
     "regexp-unicode-property-escapes",
     "regexp-v-flag",
     "tail-call-optimization",
@@ -44,6 +46,9 @@
     "built-ins/RegExp/lookahead-quantifier-match-groups.js",
     "built-ins/RegExp/unicode_full_case_folding.js",
 
+    // needs "small" async rewrite
+    "language/module-code/top-level-await/async-module-does-not-block-sibling-modules.js",
+
     // requires investigation how to process complex function name evaluation for property
     "built-ins/Function/prototype/toString/method-computed-property-name.js",
     "language/expressions/class/elements/class-name-static-initializer-anonymous.js",
@@ -68,7 +73,7 @@
     // C# can't distinguish 1.797693134862315808e+308 and 1.797693134862315708145274237317e+308
     "language/types/number/8.5.1.js",
 
-    // inner binding is immutable (from parameters) Expected SameValue(Â«nullÂ», Â«function() {{ ... }}Â») to be true
+    // inner binding is immutable (from parameters) Expected SameValue(«null», «function() {{ ... }}») to be true
     "language/expressions/function/scope-name-var-open-non-strict.js",
     "language/expressions/function/scope-name-var-open-strict.js",
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -570,6 +570,9 @@ namespace Jint
             return GetValue(reference, returnReferenceToPool);
         }
 
+        /// <summary>
+        /// https://tc39.es/ecma262/#sec-getvalue
+        /// </summary>
         internal JsValue GetValue(Reference reference, bool returnReferenceToPool)
         {
             var baseValue = reference.Base;
@@ -607,7 +610,8 @@ namespace Jint
                         return baseObj.PrivateGet((PrivateName) reference.ReferencedName);
                     }
 
-                    var v = baseObj.Get(property, reference.ThisValue);
+                    reference.EvaluateAndCachePropertyKey();
+                    var v = baseObj.Get(reference.ReferencedName, reference.ThisValue);
                     return v;
                 }
 
@@ -684,33 +688,35 @@ namespace Jint
         /// </summary>
         internal void PutValue(Reference reference, JsValue value)
         {
+            var property = reference.ReferencedName;
             if (reference.IsUnresolvableReference)
             {
-                if (reference.Strict && reference.ReferencedName != CommonProperties.Arguments)
+                if (reference.Strict && property != CommonProperties.Arguments)
                 {
                     ExceptionHelper.ThrowReferenceError(Realm, reference);
                 }
 
-                Realm.GlobalObject.Set(reference.ReferencedName, value, throwOnError: false);
+                Realm.GlobalObject.Set(property, value, throwOnError: false);
             }
             else if (reference.IsPropertyReference)
             {
                 var baseObject = Runtime.TypeConverter.ToObject(Realm, reference.Base);
                 if (reference.IsPrivateReference)
                 {
-                    baseObject.PrivateSet((PrivateName) reference.ReferencedName, value);
+                    baseObject.PrivateSet((PrivateName) property, value);
                     return;
                 }
 
+                reference.EvaluateAndCachePropertyKey();
                 var succeeded = baseObject.Set(reference.ReferencedName, value, reference.ThisValue);
                 if (!succeeded && reference.Strict)
                 {
-                    ExceptionHelper.ThrowTypeError(Realm, "Cannot assign to read only property '" + reference.ReferencedName + "' of " + baseObject);
+                    ExceptionHelper.ThrowTypeError(Realm, "Cannot assign to read only property '" + property + "' of " + baseObject);
                 }
             }
             else
             {
-                ((Environment) reference.Base).SetMutableBinding(Runtime.TypeConverter.ToString(reference.ReferencedName), value, reference.Strict);
+                ((Environment) reference.Base).SetMutableBinding(Runtime.TypeConverter.ToString(property), value, reference.Strict);
             }
         }
 
@@ -891,7 +897,7 @@ namespace Jint
         public JsValue GetValue(JsValue scope, JsValue property)
         {
             var reference = _referencePool.Rent(scope, property, _isStrict, thisValue: null);
-            var jsValue = GetValue(reference, false);
+            var jsValue = GetValue(reference, returnReferenceToPool: false);
             _referencePool.Return(reference);
             return jsValue;
         }
@@ -1002,7 +1008,7 @@ namespace Jint
             for (var i = 0; i < lexNames.Count; i++)
             {
                 var (dn, constant) = lexNames[i];
-                if (env.HasVarDeclaration(dn) || env.HasLexicalDeclaration(dn) || env.HasRestrictedGlobalProperty(dn))
+                if (env.HasLexicalDeclaration(dn) || env.HasRestrictedGlobalProperty(dn))
                 {
                     ExceptionHelper.ThrowSyntaxError(realm, $"Identifier '{dn}' has already been declared");
                 }
@@ -1017,7 +1023,7 @@ namespace Jint
                 }
             }
 
-            // we need to go trough in reverse order to handle the hoisting correctly
+            // we need to go through in reverse order to handle the hoisting correctly
             for (var i = functionToInitialize.Count - 1; i > -1; i--)
             {
                 var f = functionToInitialize[i];
@@ -1367,7 +1373,7 @@ namespace Jint
             {
                 if (varEnvRec is GlobalEnvironment ger)
                 {
-                    ger.CreateGlobalVarBinding(vn, true);
+                    ger.CreateGlobalVarBinding(vn, canBeDeleted: true);
                 }
                 else
                 {

--- a/Jint/Runtime/Interpreter/Expressions/DestructuringPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/DestructuringPatternAssignmentExpression.cs
@@ -145,6 +145,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                     {
                         close = true;
                         var reference = GetReferenceFromMember(context, me);
+
                         JsValue value;
                         if (arrayOperations != null)
                         {

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -127,12 +127,7 @@ namespace Jint.Runtime.Interpreter.Expressions
                 return MakePrivateReference(engine, baseValue, property);
             }
 
-            // only convert if necessary
-            var propertyKey = property.IsInteger() && baseValue.IsIntegerIndexedArray
-                ? property
-                : TypeConverter.ToPropertyKey(property);
-
-            return context.Engine._referencePool.Rent(baseValue, propertyKey, isStrictModeCode, thisValue: actualThis);
+            return context.Engine._referencePool.Rent(baseValue, property, isStrictModeCode, thisValue: actualThis);
         }
 
         /// <summary>

--- a/Jint/Runtime/Reference.cs
+++ b/Jint/Runtime/Reference.cs
@@ -108,4 +108,12 @@ public sealed class Reference
     {
         ((Environment) _base).InitializeBinding(TypeConverter.ToString(_referencedName), value);
     }
+
+    internal void EvaluateAndCachePropertyKey()
+    {
+        if (!(_referencedName.IsInteger() && _base.IsIntegerIndexedArray))
+        {
+            _referencedName = Runtime.TypeConverter.ToPropertyKey(_referencedName);
+        }
+    }
 }


### PR DESCRIPTION
As spec requirements were loosened, makes sense to backport to 3.x. There's performance improvements from now needing to keep track of var global scope names. As Jint takes conformance over performance I believe this is one of the thing that has caused some perf difference compared to more relaxed interpreters.

## Jint.Benchmark.DromaeoBenchmark

| **Diff**|Method|Prepared|Toolchain|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------|-------|-------:|-------|-------:|
| Old |Run|False|Default|dromaeo-3d-cube|23.065 ms|0.4453 ms|6315.24 KB|
| **New** |	| **False** | **Default** |	| **23.154 ms (0%)** | **0.1150 ms** | **6315.24 KB (0%)** |
| Old |Run|False|Default|dromaeo-core-eval|3.974 ms|0.0414 ms|327.5 KB|
| **New** |	| **False** | **Default** |	| **4.470 ms (+12%)** | **0.0272 ms** | **327.5 KB (0%)** |
| Old |Run|False|Default|dromaeo-object-array|43.011 ms|0.2208 ms|100366.86 KB|
| **New** |	| **False** | **Default** |	| **42.965 ms (0%)** | **0.2314 ms** | **100366.84 KB (0%)** |
| Old |Run|False|Default|droma(...)egexp [21]|163.435 ms|3.1650 ms|169264.07 KB|
| **New** |	| **False** | **Default** |	| **149.457 ms (-9%)** | **2.2511 ms** | **151085.44 KB (-11%)** |
| Old |Run|False|Default|droma(...)tring [21]|258.186 ms|5.1544 ms|1321535.77 KB|
| **New** |	| **False** | **Default** |	| **254.019 ms (-2%)** | **5.3817 ms** | **1315881.84 KB (0%)** |
| Old |Run|False|Default|droma(...)ase64 [21]|52.494 ms|0.2681 ms|6052.13 KB|
| **New** |	| **False** | **Default** |	| **47.682 ms (-9%)** | **0.3240 ms** | **2372.22 KB (-61%)** |
| Old |Run|True|Default|dromaeo-3d-cube|21.725 ms|0.0881 ms|5966.66 KB|
| **New** |	| **True** | **Default** |	| **22.114 ms (+2%)** | **0.0699 ms** | **5966.65 KB (0%)** |
| Old |Run|True|Default|dromaeo-core-eval|4.275 ms|0.0236 ms|312.33 KB|
| **New** |	| **True** | **Default** |	| **4.201 ms (-2%)** | **0.0206 ms** | **312.33 KB (0%)** |
| Old |Run|True|Default|dromaeo-object-array|43.135 ms|0.2668 ms|100320.31 KB|
| **New** |	| **True** | **Default** |	| **43.457 ms (+1%)** | **0.2021 ms** | **100320.31 KB (0%)** |
| Old |Run|True|Default|droma(...)egexp [21]|124.964 ms|2.3707 ms|166942.69 KB|
| **New** |	| **True** | **Default** |	| **113.679 ms (-9%)** | **1.6015 ms** | **150766.22 KB (-10%)** |
| Old |Run|True|Default|droma(...)tring [21]|264.836 ms|6.7550 ms|1321333.91 KB|
| **New** |	| **True** | **Default** |	| **261.772 ms (-1%)** | **7.7983 ms** | **1315878.52 KB (0%)** |
| Old |Run|True|Default|droma(...)ase64 [21]|51.299 ms|0.2805 ms|5948.17 KB|
| **New** |	| **True** | **Default** |	| **44.397 ms (-13%)** | **0.1250 ms** | **2268.81 KB (-62%)** |


## Jint.Benchmark.EvaluationBenchmark

| **Diff**|Method|Toolchain|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Execute|Default|24.302 μs|0.1566 μs|39.39 KB|
| **New** |	| **Default** | **24.641 μs (+1%)** | **0.3020 μs** | **39.19 KB (-1%)** |
| Old |Execute_ParsedScript|Default|8.156 μs|0.1338 μs|28.01 KB|
| **New** |	| **Default** | **7.934 μs (-3%)** | **0.0517 μs** | **27.8 KB (-1%)** |


## Jint.Benchmark.MinimalScriptBenchmark

| **Diff**|Method|Toolchain|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Execute|Default|4.273 μs|0.0489 μs|14.66 KB|
| **New** |	| **Default** | **4.132 μs (-3%)** | **0.0265 μs** | **14.46 KB (-1%)** |
| Old |Execute_ParsedScript|Default|2.057 μs|0.0192 μs|12.59 KB|
| **New** |	| **Default** | **1.918 μs (-7%)** | **0.0084 μs** | **12.39 KB (-2%)** |


