### PR TITLE
Remove Enum.HasFlag usage

### DIFF
--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -629,7 +629,6 @@ namespace Jint.Native.Array
 
             public override void Set(ulong index, JsValue value, bool updateLength = false, bool throwOnError = true)
             {
-                EnsureCapacity(index + 1);
                 _target.SetAt((int)index, value);
             }
 

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1019,7 +1019,12 @@ namespace Jint.Native.Array
                 ExceptionHelper.ThrowTypeError(_realm, "Invalid array length");
             }
 
-            o.EnsureCapacity(len + argCount);
+            // only prepare for larger if we cannot rely on default growth algorithm
+            if (len + argCount > 2 * len)
+            {
+                o.EnsureCapacity(len + argCount);
+            }
+
             var minIndex = o.GetSmallestIndex(len);
             for (var k = len; k > minIndex; k--)
             {

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -396,7 +396,7 @@ namespace Jint.Runtime.Descriptors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsDataDescriptor()
         {
-            if (_flags.HasFlag(PropertyFlag.NonData))
+            if ((_flags & PropertyFlag.NonData) != PropertyFlag.None)
             {
                 return false;
             }
@@ -413,41 +413,6 @@ namespace Jint.Runtime.Descriptors
         public bool IsGenericDescriptor()
         {
             return !IsDataDescriptor() && !IsAccessorDescriptor();
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool TryGetValue(ObjectInstance thisArg, out JsValue value)
-        {
-            value = JsValue.Undefined;
-
-            // IsDataDescriptor logic inlined
-            if ((_flags & (PropertyFlag.WritableSet | PropertyFlag.Writable)) != PropertyFlag.None)
-            {
-                var val = (_flags & PropertyFlag.CustomJsValue) != PropertyFlag.None
-                    ? CustomValue
-                    : _value;
-
-                if (!ReferenceEquals(val, null))
-                {
-                    value = val;
-                    return true;
-                }
-            }
-
-            if (this == Undefined)
-            {
-                return false;
-            }
-
-            var getter = Get;
-            if (!ReferenceEquals(getter, null) && !getter.IsUndefined())
-            {
-                // if getter is not undefined it must be ICallable
-                var callable = (ICallable) getter;
-                value = callable.Call(thisArg, Arguments.Empty);
-            }
-
-            return true;
         }
 
         private sealed class UndefinedPropertyDescriptor : PropertyDescriptor

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -81,7 +81,7 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
     {
         if (_engine.Options.Interop.AllowWrite)
         {
-            EnsureCapacity(index);
+            EnsureCapacity(index + 1);
             DoSetAt(index, ConvertToItemType(value));
         }
     }

--- a/Jint/Runtime/Interop/Reflection/FieldAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/FieldAccessor.cs
@@ -12,7 +12,7 @@ internal sealed class FieldAccessor : ReflectionAccessor
         _fieldInfo = fieldInfo;
     }
 
-    public override bool Writable => !_fieldInfo.Attributes.HasFlag(FieldAttributes.InitOnly);
+    public override bool Writable => (_fieldInfo.Attributes & FieldAttributes.InitOnly) == (FieldAttributes) 0;
 
     protected override object? DoGetValue(object target, string memberName)
     {

--- a/Jint/Runtime/Interpreter/Expressions/JintYieldExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintYieldExpression.cs
@@ -13,7 +13,7 @@ internal sealed class JintYieldExpression : JintExpression
 
     protected override object EvaluateInternal(EvaluationContext context)
     {
-        if (!context.Engine.Options.ExperimentalFeatures.HasFlag(ExperimentalFeature.Generators))
+        if ((context.Engine.Options.ExperimentalFeatures & ExperimentalFeature.Generators) == ExperimentalFeature.None)
         {
             ExceptionHelper.ThrowJavaScriptException(
                 context.Engine.Intrinsics.Error,


### PR DESCRIPTION
* cleanup Array capacity usage

## Jint.Benchmark.ArrayBenchmark

| **Diff**|Method|N|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Slice|100|130.0 μs|2.40 μs|261.72 KB|
| **New** |	|	| **130.0 μs (0%)** | **1.26 μs** | **261.72 KB (0%)** |
| Old |Concat|100|158.7 μs|2.51 μs|301.56 KB|
| **New** |	|	| **162.6 μs (+2%)** | **2.05 μs** | **301.56 KB (0%)** |
| Old |Unshift|100|3,974.6 μs|52.74 μs|3521.1 KB|
| **New** |	|	| **3,599.1 μs (-9%)** | **23.64 μs** | **950.78 KB (-73%)** |
| Old |Push|100|2,544.4 μs|47.43 μs|857.81 KB|
| **New** |	|	| **2,456.0 μs (-3%)** | **28.59 μs** | **857.81 KB (0%)** |
| Old |Index|100|2,091.3 μs|30.77 μs|797.66 KB|
| **New** |	|	| **2,036.7 μs (-3%)** | **13.99 μs** | **797.66 KB (0%)** |
| Old |Map|100|1,321.4 μs|9.44 μs|3105.47 KB|
| **New** |	|	| **1,267.4 μs (-4%)** | **24.30 μs** | **3105.47 KB (0%)** |
| Old |Apply|100|203.6 μs|2.66 μs|381.25 KB|
| **New** |	|	| **199.5 μs (-2%)** | **3.36 μs** | **381.25 KB (0%)** |
| Old |JsonStringifyParse|100|767.5 μs|10.07 μs|1139.84 KB|
| **New** |	|	| **723.1 μs (-6%)** | **11.36 μs** | **1139.84 KB (0%)** |
| Old |FilterWithString|100|13,550.1 μs|87.94 μs|31723.44 KB|
| **New** |	|	| **12,957.8 μs (-4%)** | **157.20 μs** | **31723.44 KB (0%)** |


## Jint.Benchmark.DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Run|dromaeo-3d-cube|15.361 ms|0.2319 ms|6304.9 KB|
| **New** |	|	| **14.371 ms (-6%)** | **0.1843 ms** | **6304.9 KB (0%)** |
| Old |Run|dromaeo-core-eval|2.965 ms|0.0272 ms|327.84 KB|
| **New** |	|	| **2.907 ms (-2%)** | **0.0515 ms** | **327.85 KB (0%)** |
| Old |Run|dromaeo-object-array|30.340 ms|0.2168 ms|100367.74 KB|
| **New** |	|	| **30.342 ms (0%)** | **0.5993 ms** | **96259.97 KB (-4%)** |
| Old |Run|droma(...)egexp [21]|125.913 ms|2.4917 ms|149305.36 KB|
| **New** |	|	| **123.978 ms (-2%)** | **2.4238 ms** | **149512.19 KB (0%)** |
| Old |Run|droma(...)tring [21]|244.682 ms|7.4719 ms|1315772.28 KB|
| **New** |	|	| **254.491 ms (+4%)** | **12.2366 ms** | **1315824.61 KB (0%)** |
| Old |Run|droma(...)ase64 [21]|32.340 ms|0.3925 ms|2367.97 KB|
| **New** |	|	| **31.735 ms (-2%)** | **0.3830 ms** | **2367.97 KB (0%)** |
| Old |Run|dromaeo-3d-cube|14.309 ms|0.2242 ms|5966.65 KB|
| **New** |	|	| **14.210 ms (-1%)** | **0.1203 ms** | **5966.65 KB (0%)** |
| Old |Run|dromaeo-core-eval|2.756 ms|0.0360 ms|312.78 KB|
| **New** |	|	| **2.838 ms (+3%)** | **0.0369 ms** | **312.77 KB (0%)** |
| Old |Run|dromaeo-object-array|30.960 ms|0.2786 ms|100320.34 KB|
| **New** |	|	| **30.122 ms (-3%)** | **0.4704 ms** | **96212.55 KB (-4%)** |
| Old |Run|droma(...)egexp [21]|91.318 ms|1.8183 ms|149465.94 KB|
| **New** |	|	| **89.879 ms (-2%)** | **1.7373 ms** | **152114.11 KB (+2%)** |
| Old |Run|droma(...)tring [21]|245.548 ms|7.9732 ms|1315748.16 KB|
| **New** |	|	| **257.183 ms (+5%)** | **10.7585 ms** | **1315791.94 KB (0%)** |
| Old |Run|droma(...)ase64 [21]|30.625 ms|0.2784 ms|2268.79 KB|
| **New** |	|	| **31.143 ms (+2%)** | **0.2223 ms** | **2268.79 KB (0%)** |


## Jint.Benchmark.SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Run|3d-cube|114.75 ms|1.258 ms|45166.13 KB|
| **New** |	|	| **112.53 ms (-2%)** | **1.339 ms** | **45166.13 KB (0%)** |
| Old |Run|3d-morph|101.34 ms|0.999 ms|46258.23 KB|
| **New** |	|	| **102.93 ms (+2%)** | **0.760 ms** | **46258.23 KB (0%)** |
| Old |Run|3d-raytrace|111.46 ms|1.184 ms|86421.18 KB|
| **New** |	|	| **110.41 ms (-1%)** | **1.443 ms** | **86421.11 KB (0%)** |
| Old |Run|access-binary-trees|61.46 ms|0.812 ms|62249.49 KB|
| **New** |	|	| **59.85 ms (-3%)** | **1.071 ms** | **62249.48 KB (0%)** |
| Old |Run|access-fannkuch|258.02 ms|3.203 ms|103.93 KB|
| **New** |	|	| **251.60 ms (-2%)** | **2.830 ms** | **103.93 KB (0%)** |
| Old |Run|access-nbody|119.50 ms|1.098 ms|53296.5 KB|
| **New** |	|	| **116.24 ms (-3%)** | **1.778 ms** | **53296.43 KB (0%)** |
| Old |Run|access-nsieve|84.69 ms|0.744 ms|17142.87 KB|
| **New** |	|	| **80.19 ms (-5%)** | **1.314 ms** | **17143.41 KB (0%)** |
| Old |Run|bitop(...)-byte [24]|94.56 ms|1.852 ms|61948.56 KB|
| **New** |	|	| **89.96 ms (-5%)** | **1.604 ms** | **61948.61 KB (0%)** |
| Old |Run|bitops-bits-in-byte|139.81 ms|2.126 ms|40544.76 KB|
| **New** |	|	| **133.74 ms (-4%)** | **2.169 ms** | **40544.84 KB (0%)** |
| Old |Run|bitops-bitwise-and|75.48 ms|1.149 ms|55939 KB|
| **New** |	|	| **74.95 ms (-1%)** | **0.752 ms** | **55939 KB (0%)** |
| Old |Run|bitops-nsieve-bits|130.40 ms|2.524 ms|53916.62 KB|
| **New** |	|	| **121.70 ms (-7%)** | **1.888 ms** | **53916.6 KB (0%)** |
| Old |Run|contr(...)rsive [21]|73.50 ms|0.835 ms|92773.21 KB|
| **New** |	|	| **72.07 ms (-2%)** | **1.402 ms** | **92773.21 KB (0%)** |
| Old |Run|crypto-aes|77.89 ms|0.978 ms|10776.09 KB|
| **New** |	|	| **78.54 ms (+1%)** | **1.501 ms** | **10775.64 KB (0%)** |
| Old |Run|crypto-md5|67.97 ms|1.202 ms|82178.11 KB|
| **New** |	|	| **66.37 ms (-2%)** | **1.281 ms** | **82178.15 KB (0%)** |
| Old |Run|crypto-sha1|65.43 ms|0.570 ms|68862.68 KB|
| **New** |	|	| **65.72 ms (0%)** | **1.272 ms** | **68862.68 KB (0%)** |
| Old |Run|date-format-tofte|62.58 ms|1.122 ms|56975.49 KB|
| **New** |	|	| **64.63 ms (+3%)** | **1.244 ms** | **56975.49 KB (0%)** |
| Old |Run|date-format-xparb|36.36 ms|0.488 ms|26401.74 KB|
| **New** |	|	| **36.01 ms (-1%)** | **0.564 ms** | **26401.76 KB (0%)** |
| Old |Run|math-cordic|209.53 ms|3.404 ms|86860.2 KB|
| **New** |	|	| **200.15 ms (-4%)** | **2.615 ms** | **86860.2 KB (0%)** |
| Old |Run|math-partial-sums|71.79 ms|0.762 ms|49367.94 KB|
| **New** |	|	| **71.01 ms (-1%)** | **0.516 ms** | **49367.98 KB (0%)** |
| Old |Run|math-spectral-norm|75.72 ms|0.965 ms|56617.95 KB|
| **New** |	|	| **77.19 ms (+2%)** | **1.314 ms** | **56617.9 KB (0%)** |
| Old |Run|regexp-dna|89.96 ms|1.119 ms|16829.77 KB|
| **New** |	|	| **90.79 ms (+1%)** | **0.547 ms** | **16829.07 KB (0%)** |
| Old |Run|string-base64|48.02 ms|0.742 ms|3156.41 KB|
| **New** |	|	| **45.56 ms (-5%)** | **0.522 ms** | **3156.41 KB (0%)** |
| Old |Run|string-fasta|106.64 ms|1.291 ms|104786.13 KB|
| **New** |	|	| **108.01 ms (+1%)** | **1.890 ms** | **104786.13 KB (0%)** |
| Old |Run|string-tagcloud|52.49 ms|0.905 ms|42082.15 KB|
| **New** |	|	| **50.74 ms (-3%)** | **0.974 ms** | **42082.09 KB (0%)** |
| Old |Run|string-unpack-code|48.23 ms|0.943 ms|73813.13 KB|
| **New** |	|	| **47.83 ms (-1%)** | **0.897 ms** | **73813.19 KB (0%)** |
| Old |Run|strin(...)input [21]|38.54 ms|0.531 ms|20688.07 KB|
| **New** |	|	| **39.38 ms (+2%)** | **0.735 ms** | **20688.07 KB (0%)** |


