### PR TITLE
Improve localeCompare implementation

### DIFF
--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -82,6 +82,14 @@ bar += 'bar';
         Assert.Equal("value", result["key"]);
     }
 
+    [Fact]
+    public void ShouldCompareWithLocale()
+    {
+        var engine = new Engine();
+        Assert.Equal(1, engine.Evaluate("'王五'.localeCompare('张三')").AsInteger());
+        Assert.Equal(-1, engine.Evaluate("'王五'.localeCompare('张三', 'zh-CN')").AsInteger());
+    }
+
     public static TheoryData GetLithuaniaTestsData()
     {
         return new StringTetsLithuaniaData().TestData();

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -765,7 +765,14 @@ namespace Jint.Native.String
             var s = TypeConverter.ToString(thisObject);
             var that = TypeConverter.ToString(arguments.At(0));
 
-            return string.CompareOrdinal(s.Normalize(NormalizationForm.FormKD), that.Normalize(NormalizationForm.FormKD));
+            var culture = Engine.Options.Culture;
+
+            if (arguments.Length > 1 && arguments[1].IsString())
+            {
+                culture = CultureInfo.GetCultureInfo(arguments.At(1).AsString());
+            }
+
+            return culture.CompareInfo.Compare(s.Normalize(NormalizationForm.FormKD), that.Normalize(NormalizationForm.FormKD));
         }
 
         /// <summary>


### PR DESCRIPTION
Attempt at fixing #1852. It's not complete as all arguments from the spec are not handled but it handles the common `locale` argument.

fixes #1852