### PR TITLE
Enable grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+       # Grouped version updates configuration
+       all-dependencies:
+          patterns:
+            - "*"


### PR DESCRIPTION
Prevents several PRs to be created. This can be improved to group dependencies (test libs, dev libs ...) in case a lib might block others.