### PR TITLE
Backport typed array related fixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.45.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="Test262Harness" Version="1.0.0" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" PrivateAssets="all" />

--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -1,5 +1,5 @@
 {
-  "SuiteGitSha": "c3a326ace810e7c80a4e1b8df8c8b704ed223c28",
+  "SuiteGitSha": "694fae5b10fa760951dbc9c2fe22a2fa38383c66",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Jint.Tests.Test262",
@@ -8,18 +8,22 @@
     "Array.fromAsync",
     "async-iteration",
     "Atomics",
+    "Atomics.pause",
     "Float16Array",
     "import-assertions",
     "iterator-helpers",
+    "Math.sumPrecise",
     "promise-try",
     "regexp-duplicate-named-groups",
     "regexp-lookbehind",
     "regexp-modifiers",
     "regexp-unicode-property-escapes",
     "regexp-v-flag",
+    "source-phase-imports",
     "tail-call-optimization",
     "Temporal",
-    "u180e"
+    "u180e",
+    "uint8array-base64"
   ],
   "ExcludedFlags": [
   ],

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -351,7 +351,7 @@ namespace Jint.Native.Array
 
             public override bool TryGetValue(ulong index, out JsValue value)
             {
-                if (index < _target.GetLength())
+                if (_target.IsValidIntegerIndex(index))
                 {
                     value = _target[(int) index];
                     return true;

--- a/Jint/Native/JsTypedArray.cs
+++ b/Jint/Native/JsTypedArray.cs
@@ -52,7 +52,11 @@ namespace Jint.Native
 
         public uint Length => GetLength();
 
-        internal override uint GetLength() => IntrinsicTypedArrayPrototype.MakeTypedArrayWithBufferWitnessRecord(this, ArrayBufferOrder.Unordered).TypedArrayLength;
+        internal override uint GetLength()
+        {
+            var record = IntrinsicTypedArrayPrototype.MakeTypedArrayWithBufferWitnessRecord(this, ArrayBufferOrder.Unordered);
+            return record.IsTypedArrayOutOfBounds ? 0 : record.TypedArrayLength;
+        }
 
         internal override bool IsArrayLike => true;
 

--- a/Jint/Runtime/Interpreter/Expressions/JintArrowFunctionExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintArrowFunctionExpression.cs
@@ -1,5 +1,6 @@
 using Jint.Native;
 using Jint.Native.Function;
+using Jint.Native.Object;
 
 namespace Jint.Runtime.Interpreter.Expressions;
 
@@ -18,8 +19,12 @@ internal sealed class JintArrowFunctionExpression : JintExpression
         var env = engine.ExecutionContext.LexicalEnvironment;
         var privateEnv = engine.ExecutionContext.PrivateEnvironment;
 
+        ObjectInstance prototype = _function.Function.Async
+            ? engine.Realm.Intrinsics.AsyncFunction.PrototypeObject
+            : engine.Realm.Intrinsics.Function.PrototypeObject;
+
         var closure = engine.Realm.Intrinsics.Function.OrdinaryFunctionCreate(
-            engine.Realm.Intrinsics.Function.PrototypeObject,
+            prototype,
             _function,
             FunctionThisMode.Lexical,
             env,


### PR DESCRIPTION
* resizable array buffer length checks should obey bounds checks
* fix async function expression prototype
* upgrade System.Text.Json to version 8.0.4
