### PR TITLE
Make ObjectWrapper ClrType public

### DIFF
--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -123,7 +123,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
     }
 
     public object Target { get; }
-    internal Type ClrType { get; }
+    public Type ClrType { get; }
 
     internal override bool IsArrayLike => _typeDescriptor.IsArrayLike;
 


### PR DESCRIPTION
In the scenario described in https://github.com/sebastienros/jint/issues/1945 I need to get the CLR type of `ObjectWrapper`. This PR makes the corresponding property public.