### PR TITLE
Fix throwing on accessing CLR FunctionDeclaration

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Jint.Native;
+using Jint.Native.Function;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
 using Jint.Tests.Runtime.Converters;
@@ -3544,5 +3545,44 @@ try {
         var props = obj.GetOwnProperties().Select(x => x.Key.ToString()).ToList();
          
         props.Should().BeEquivalentTo(["Get_A"]);
+    }
+    
+    [Fact]
+    public void ShouldNotThrowOnInspectingClrFunction()
+    {
+        var engine = new Engine();
+        
+        engine.SetValue("clrDelegate", () => 4);
+        
+        var val = engine.GetValue("clrDelegate");
+
+        var fn = val as Function;
+        var decl = fn!.FunctionDeclaration;
+
+        decl.Should().BeNull();
+    }
+    
+    private class ShouldNotThrowOnInspectingClrFunctionTestClass
+    {
+        public int MyInt()
+        {
+            return 4;
+        }
+    }
+    
+    [Fact]
+    public void ShouldNotThrowOnInspectingClrClassFunction()
+    {
+        var engine = new Engine();
+        
+        engine.SetValue("clrCls", new ShouldNotThrowOnInspectingClrFunctionTestClass());
+        
+        var val = engine.GetValue("clrCls");
+        var clrFn = val.Get("MyInt");
+        
+        var fn = clrFn as Function;
+        var decl = fn!.FunctionDeclaration;
+        
+        decl.Should().BeNull();
     }
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1047,7 +1047,7 @@ public sealed partial class Engine : IDisposable
         var env = (FunctionEnvironment) ExecutionContext.LexicalEnvironment;
         var strict = _isStrict || StrictModeScope.IsStrictModeCode;
 
-        var configuration = func.Initialize();
+        var configuration = func!.Initialize();
         var parameterNames = configuration.ParameterNames;
         var hasDuplicates = configuration.HasDuplicates;
         var simpleParameterList = configuration.IsSimpleParameterList;

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -20,7 +20,7 @@ public abstract partial class Function : ObjectInstance, ICallable
     internal PropertyDescriptor? _nameDescriptor;
 
     internal Environment? _environment;
-    internal readonly JintFunctionDefinition _functionDefinition = null!;
+    internal readonly JintFunctionDefinition? _functionDefinition;
     internal readonly FunctionThisMode _thisMode;
     internal JsValue _homeObject = Undefined;
     internal ConstructorKind _constructorKind = ConstructorKind.Base;
@@ -71,7 +71,7 @@ public abstract partial class Function : ObjectInstance, ICallable
     }
 
     // for example RavenDB wants to inspect this
-    public IFunction FunctionDeclaration => _functionDefinition.Function;
+    public IFunction? FunctionDeclaration => _functionDefinition?.Function;
 
     internal override bool IsCallable => true;
 

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -58,7 +58,7 @@ public sealed class ScriptFunction : Function, IConstructor
     /// </summary>
     protected internal override JsValue Call(JsValue thisObject, JsValue[] arguments)
     {
-        var strict = _functionDefinition.Strict || _thisMode == FunctionThisMode.Strict;
+        var strict = _functionDefinition!.Strict || _thisMode == FunctionThisMode.Strict;
         using (new StrictModeScope(strict, true))
         {
             try
@@ -158,7 +158,7 @@ public sealed class ScriptFunction : Function, IConstructor
 
                 var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
 
-                var result = _functionDefinition.EvaluateBody(context, this, arguments);
+                var result = _functionDefinition!.EvaluateBody(context, this, arguments);
 
                 // The DebugHandler needs the current execution context before the return for stepping through the return point
                 // We exclude the empty constructor generated for classes without an explicit constructor.


### PR DESCRIPTION
I'm open to finding a better solution to the problem described below, as the current fix has weird ergonomics.

Accessing `FunctionDeclaration` of a `MethodInfoFunction` (CLR functions) currently throws - the test* included describes the scenario. I believe accessing the property should never throw (I hate linking to MSDN, alas: https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/property?redirectedfrom=MSDN). 
This forces a sprinkle of `!` in the codebase in places where we know the function is not a CLR function (this is the part I don't like).

_*I've included two tests now, one for the delegate, and one for the method info function._

Unrelated to this, for the debugger I'm working on, I'd need to make at least some information of `MethodInfoFunction` and `DelegateWrapper` public to provide information about the native function (get the parameters, largely the same thing Jint does internally). This is outside of this PR's scope, just announcing ahead of time to discuss, should there be objections to that.

This would be:
- `DelegateWrapper`: `Delegate _d`
- `MethodInfoFunction`: `MethodDescriptor[] _methods`, possibly `ClrFunction _fallbackClrFunctionInstance`