### PR TITLE
Don't overwrite default export from `SourceTextModule`

### DIFF
--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -44,6 +44,22 @@ public class ModuleTests
     }
 
     [Fact]
+    public void ShouldExportDefaultFunctionWithoutName()
+    {
+        _engine.Modules.Add("module1", "export default function main() { return 1; }");
+        _engine.Modules.Add("module2", "export default function () { return 1; }");
+        var ns = _engine.Modules.Import("module1");
+
+        var func = ns.Get("default");
+        Assert.Equal(1, func.Call());
+
+        ns = _engine.Modules.Import("module2");
+
+        func = ns.Get("default");
+        Assert.Equal(1, func.Call());
+    }
+
+    [Fact]
     public void ShouldExportAll()
     {
         _engine.Modules.Add("module1", "export const value = 'exported value';");

--- a/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
@@ -42,6 +42,13 @@ internal sealed class JintExportDefaultDeclaration : JintStatement<ExportDefault
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
         var env = context.Engine.ExecutionContext.LexicalEnvironment;
+        if (env.HasBinding("*default*"))
+        {
+            // We already have the default binding.
+            // Initialized in SourceTextModule.InitializeEnvironment.
+            return Completion.Empty();
+        }
+
         JsValue value;
         if (_classDefinition is not null)
         {


### PR DESCRIPTION
Before this `JintExportDefaultDeclaration.ExecuteInternal` always overwrites the probably existing binding from `SourceTextModule.InitializeEnvironment`.

- Fixes #1951