### PR TITLE
Tweak object wrapper reported members logic

### DIFF
--- a/Jint/Native/Atomics/AtomicsInstance.cs
+++ b/Jint/Native/Atomics/AtomicsInstance.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using System.Threading;
 using Jint.Collections;
 using Jint.Native.Object;

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -371,13 +371,6 @@ public class Options
         /// All other values are ignored.
         /// </summary>
         public MemberTypes ObjectWrapperReportedMemberTypes { get; set; } = MemberTypes.Field | MemberTypes.Property | MemberTypes.Method;
-
-        /// <summary>
-        /// Whether object wrapper should only report members that are declared on the object type itself, not inherited members. Defaults to false.
-        /// This is different from JS logic where only object's own members are reported and not prototypes.
-        /// </summary>
-        /// <remarks>This configuration does not affect methods, only methods declared in type itself will be reported.</remarks>
-        public bool ObjectWrapperReportOnlyDeclaredMembers { get; set; }
     }
 
     public class ConstraintOptions

--- a/Jint/Runtime/Interop/Reflection/DynamicObjectAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/DynamicObjectAccessor.cs
@@ -1,5 +1,4 @@
 using System.Dynamic;
-using System.Reflection;
 using Jint.Native;
 
 #pragma warning disable IL2092


### PR DESCRIPTION
* to have parity, we shouldn't limit to declared members only as generic search will try to find from all levels
* obey member filter while reporting
* cleanup 