### PR TITLE
Don't find hidden property instead of the hiding property

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
+++ b/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
@@ -280,4 +280,25 @@ public partial class InteropTests
 
         engine.Invoking(e => e.Evaluate("obj.AgeMissing")).Should().Throw<MissingMemberException>();
     }
+
+    public class ClassWithPropertyToHide
+    {
+        public int x { get; set; } = 2;
+        public int y { get; set; } = 3;
+    }
+
+    public class ClassThatHidesProperty : ClassWithPropertyToHide
+    {
+        public new bool x { get; set; } = true;
+    }
+
+    [Fact]
+    public void ShouldRespectExplicitHiding()
+    {
+        var engine = new Engine();
+
+        engine.SetValue("obj", new ClassThatHidesProperty());
+        engine.Evaluate("obj.x").AsBoolean().Should().BeTrue();
+        engine.Evaluate("obj.y").AsNumber().Should().Be(3);
+    }
 }

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -317,6 +317,14 @@ public sealed class TypeResolver
                     {
                         if (memberNameComparer.Equals(name, memberName))
                         {
+                            // If one property hides another (e.g., by public new), the derived property is returned.
+                            if (property is not null
+                                && p.DeclaringType is not null
+                                && property.DeclaringType is not null
+                                && property.DeclaringType.IsSubclassOf(p.DeclaringType))
+                            {
+                                continue;
+                            }
                             property = p;
                             break;
                         }


### PR DESCRIPTION
resolves sebastienros/jint#1962

When `TypeResolver:TryFindMemberAccessor` resolves a property, it might find one that was hidden where the non-hidden one would normally be found by C++ member access.

For example, when you access the `A` member from JavaScript, you may get the hidden one (I say "may" because `Type:GetProperties` does not specify an order in a number of versions of .NET supported by jint).

```
class Foo
{
    public int A {get;set;}
    public string B {get;set;}
}

class Bar :  Foo
{
	public new float A { get; set; }
}
```

([This dotnet fiddle](http://dotnetfiddle.net/NQRXIJ) shows that both `A` elements are iterated by `GetProperties` even though if `b` is a `Bar`, `b.A` unambiguously refers to `Bar:A`)

This change ensures that in the case where a property in a derived class hides another, the derived one is resolved to.