### PR TITLE
Promise.withResolvers() returned object had resolve and reject functions swapped

### DIFF
--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -497,4 +497,56 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
 
         Assert.Equal("at <anonymous>:1:56", logMessage?.Trim());
     }
+
+    [Fact]
+    public void WithResolvers_calling_resolve_resolves_promise()
+    {
+        // Arrange
+        using var engine = new Engine();
+        List<string> logMessages = new();
+        engine.SetValue("log", logMessages.Add);
+
+        // Act
+        engine.Execute("""
+                       const p = Promise.withResolvers();
+                       const next = p.promise
+                           .then(() => log('resolved'))
+                           .catch(() => log('rejected'));
+                           
+                       log('start');
+                       p.resolve();
+                       log('end');
+                       """);
+        engine.RunAvailableContinuations();
+
+        // Assert
+        List<string> expected = new() { "start", "end", "resolved" };
+        Assert.Equal(expected, logMessages);
+    }
+
+    [Fact]
+    public void WithResolvers_calling_reject_rejects_promise()
+    {
+        // Arrange
+        using var engine = new Engine();
+        List<string> logMessages = new();
+        engine.SetValue("log", logMessages.Add);
+
+        // Act
+        engine.Execute("""
+                       const p = Promise.withResolvers();
+                       const next = p.promise
+                           .then(() => log('resolved'))
+                           .catch(() => log('rejected'));
+                           
+                       log('start');
+                       p.reject();
+                       log('end');
+                       """);
+        engine.RunAvailableContinuations();
+
+        // Assert
+        List<string> expected = new() { "start", "end", "rejected" };
+        Assert.Equal(expected, logMessages);
+    }
 }

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -255,7 +255,7 @@ internal sealed class PromiseConstructor : Constructor
         if (!TryGetPromiseCapabilityAndIterator(thisObject, arguments, "Promise.all", out var capability, out var promiseResolve, out var iterator))
             return capability.PromiseInstance;
 
-        var (resultingPromise, resolve, reject, _, rejectObj) = capability;
+        var (resultingPromise, resolve, reject, rejectObj, _) = capability;
 
         var results = new List<JsValue>();
         bool doneIterating = false;
@@ -573,7 +573,7 @@ internal sealed class PromiseConstructor : Constructor
         if (!TryGetPromiseCapabilityAndIterator(thisObject, arguments, "Promise.race", out var capability, out var promiseResolve, out var iterator))
             return capability.PromiseInstance;
 
-        var (resultingPromise, resolve, reject, _, rejectObj) = capability;
+        var (resultingPromise, resolve, reject, rejectObj, _) = capability;
 
 
         // 7. Let result be PerformPromiseRace(iteratorRecord, C, promiseCapability, promiseResolve).
@@ -715,6 +715,11 @@ internal sealed class PromiseConstructor : Constructor
             ExceptionHelper.ThrowTypeError(engine.Realm, "reject is not a function");
         }
 
-        return new PromiseCapability(instance, resolve, reject, resolveArg, rejectArg);
+        return new PromiseCapability(
+            PromiseInstance: instance,
+            Resolve: resolve,
+            Reject: reject,
+            RejectObj: rejectArg,
+            ResolveObj: resolveArg);
     }
 }


### PR DESCRIPTION
When using `Promise.withResolvers()`, the returned object had `resolve` and `reject` swapped. Meaning that

```js
const p = Promise.withResolvers();
p.resolve();
return p.promise;
```
did return a _rejected_ promise.

and
```js
const p = Promise.withResolvers();
p.reject();
return p.promise;
```
dir return a _resolved_ promise.

---

The fix: The record `PromiseCapability` had the following property order

```cs
internal sealed record PromiseCapability(
    JsValue PromiseInstance,
    ICallable Resolve,   // <-- Resolve first, Reject last
    ICallable Reject,
    JsValue RejectObj,   // <-- Reject first, Resolve first
    JsValue ResolveObj
);
```

The method `PromiseConstructor.NewPromiseCapability()` however flipped the two last properties when calling the PromiseCapability constructor.

---

Refactoring: In addition to fix the parameter order in `PromiseConstructor.NewPromiseCapability()`, I had to change two methods, which already relied on the flipped assignment: "Promise.race" and "Promise.all". While deconstruction can be nice, I think that the deconstruction usage of `PromiseCapability` might be a reason that this flip was not caught earlier. So:

* Instead of deconstructing into many unused `_` variables, I directly use `PromiseInstance.[Property]`, which makes it easier to spot mistakes
* I changed the order of the last two properties of `PromiseCapability` to keep the order consistent.