### PR TITLE
Make JsSet public

### DIFF
--- a/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+++ b/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Acornima.Extras" />
+    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Flurl.Http.Signed" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MongoDB.Bson.signed" />

--- a/Jint.Tests.PublicInterface/SetTests.cs
+++ b/Jint.Tests.PublicInterface/SetTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using Jint.Native;
+
+namespace Jint.Tests.Runtime;
+
+public class SetTests
+{
+    [Fact]
+    public void ConConstructSet()
+    {
+        var engine = new Engine();
+
+        var set = engine.Intrinsics.Set.Construct();
+        set.Add(42);
+        set.Add("foo");
+        set.Size.Should().Be(2);
+
+        set.Should().ContainInOrder(42, "foo");
+
+        set.Has(42).Should().BeTrue();
+        set.Has("foo").Should().BeTrue();
+        set.Has(24).Should().BeFalse();
+
+        engine.SetValue("s", set);
+        engine.Evaluate("s.size").Should().Be((JsNumber) 2);
+        engine.Evaluate("s.has(42)").Should().Be(JsBoolean.True);
+        engine.Evaluate("s.has('foo')").Should().Be(JsBoolean.True);
+        engine.Evaluate("s.has(24)").Should().Be(JsBoolean.False);
+
+        set.Remove(42).Should().BeTrue();
+        set.Has(42).Should().BeFalse();
+        engine.Evaluate("s.has(42)").Should().Be(JsBoolean.False);
+        engine.Evaluate("s.size").Should().Be((JsNumber) 1);
+
+        set.Clear();
+        set.Should().BeEmpty();
+        set.Size.Should().Be(0);
+        engine.Evaluate("s.size").Should().Be((JsNumber) 0);
+    }
+}

--- a/Jint/Native/JsSet.cs
+++ b/Jint/Native/JsSet.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -5,11 +6,11 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native;
 
-public sealed class JsSet : ObjectInstance
+public sealed class JsSet : ObjectInstance, IEnumerable<JsValue>
 {
     internal readonly OrderedSet<JsValue> _set;
 
-    public JsSet(Engine engine) : this(engine, new OrderedSet<JsValue>(SameValueZeroComparer.Instance))
+    internal JsSet(Engine engine) : this(engine, new OrderedSet<JsValue>(SameValueZeroComparer.Instance))
     {
     }
 
@@ -53,7 +54,7 @@ public sealed class JsSet : ObjectInstance
 
     public bool Has(JsValue key) => _set.Contains(key);
 
-    public bool SetDelete(JsValue key) => _set.Remove(key);
+    public bool Remove(JsValue key) => _set.Remove(key);
 
     internal void ForEach(ICallable callable, JsValue thisArg)
     {
@@ -74,4 +75,8 @@ public sealed class JsSet : ObjectInstance
     internal ObjectInstance Entries() => _engine.Realm.Intrinsics.SetIteratorPrototype.ConstructEntryIterator(this);
 
     internal ObjectInstance Values() => _engine.Realm.Intrinsics.SetIteratorPrototype.ConstructValueIterator(this);
+
+    public IEnumerator<JsValue> GetEnumerator() => _set.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Jint/Native/JsSet.cs
+++ b/Jint/Native/JsSet.cs
@@ -5,7 +5,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native;
 
-internal sealed class JsSet : ObjectInstance
+public sealed class JsSet : ObjectInstance
 {
     internal readonly OrderedSet<JsValue> _set;
 
@@ -47,17 +47,17 @@ internal sealed class JsSet : ObjectInstance
         return base.TryGetProperty(property, out descriptor);
     }
 
-    internal void Add(JsValue value) => _set.Add(value);
+    public void Add(JsValue value) => _set.Add(value);
 
-    internal void Remove(JsValue value) => _set.Remove(value);
+    public void Remove(JsValue value) => _set.Remove(value);
 
-    internal void Clear() => _set.Clear();
+    public void Clear() => _set.Clear();
 
-    internal bool Has(JsValue key) => _set.Contains(key);
+    public bool Has(JsValue key) => _set.Contains(key);
 
-    internal bool SetDelete(JsValue key) => _set.Remove(key);
+    public bool SetDelete(JsValue key) => _set.Remove(key);
 
-    internal void ForEach(ICallable callable, JsValue thisArg)
+    public void ForEach(ICallable callable, JsValue thisArg)
     {
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = this;
@@ -73,7 +73,7 @@ internal sealed class JsSet : ObjectInstance
         _engine._jsValueArrayPool.ReturnArray(args);
     }
 
-    internal ObjectInstance Entries() => _engine.Realm.Intrinsics.SetIteratorPrototype.ConstructEntryIterator(this);
+    public ObjectInstance Entries() => _engine.Realm.Intrinsics.SetIteratorPrototype.ConstructEntryIterator(this);
 
-    internal ObjectInstance Values() => _engine.Realm.Intrinsics.SetIteratorPrototype.ConstructValueIterator(this);
+    public ObjectInstance Values() => _engine.Realm.Intrinsics.SetIteratorPrototype.ConstructValueIterator(this);
 }

--- a/Jint/Native/JsSet.cs
+++ b/Jint/Native/JsSet.cs
@@ -13,7 +13,7 @@ public sealed class JsSet : ObjectInstance
     {
     }
 
-    public JsSet(Engine engine, OrderedSet<JsValue> set) : base(engine)
+    internal JsSet(Engine engine, OrderedSet<JsValue> set) : base(engine)
     {
         _set = set;
         _prototype = _engine.Realm.Intrinsics.Set.PrototypeObject;
@@ -49,15 +49,13 @@ public sealed class JsSet : ObjectInstance
 
     public void Add(JsValue value) => _set.Add(value);
 
-    public void Remove(JsValue value) => _set.Remove(value);
-
     public void Clear() => _set.Clear();
 
     public bool Has(JsValue key) => _set.Contains(key);
 
     public bool SetDelete(JsValue key) => _set.Remove(key);
 
-    public void ForEach(ICallable callable, JsValue thisArg)
+    internal void ForEach(ICallable callable, JsValue thisArg)
     {
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = this;
@@ -73,7 +71,7 @@ public sealed class JsSet : ObjectInstance
         _engine._jsValueArrayPool.ReturnArray(args);
     }
 
-    public ObjectInstance Entries() => _engine.Realm.Intrinsics.SetIteratorPrototype.ConstructEntryIterator(this);
+    internal ObjectInstance Entries() => _engine.Realm.Intrinsics.SetIteratorPrototype.ConstructEntryIterator(this);
 
-    public ObjectInstance Values() => _engine.Realm.Intrinsics.SetIteratorPrototype.ConstructValueIterator(this);
+    internal ObjectInstance Values() => _engine.Realm.Intrinsics.SetIteratorPrototype.ConstructValueIterator(this);
 }

--- a/Jint/Native/Set/SetConstructor.cs
+++ b/Jint/Native/Set/SetConstructor.cs
@@ -8,7 +8,7 @@ using Jint.Runtime.Interop;
 
 namespace Jint.Native.Set;
 
-internal sealed class SetConstructor : Constructor
+public sealed class SetConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Set");
 
@@ -37,25 +37,14 @@ internal sealed class SetConstructor : Constructor
         SetSymbols(symbols);
     }
 
-    private static JsValue Species(JsValue thisObject, JsValue[] arguments)
-    {
-        return thisObject;
-    }
+    public JsSet Construct() => ConstructSet(this);
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-set-iterable
     /// </summary>
     public override ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
     {
-        if (newTarget.IsUndefined())
-        {
-            ExceptionHelper.ThrowTypeError(_engine.Realm);
-        }
-
-        var set = OrdinaryCreateFromConstructor(
-            newTarget,
-            static intrinsics => intrinsics.Set.PrototypeObject,
-            static (Engine engine, Realm _, object? _) => new JsSet(engine));
+        var set = ConstructSet(newTarget);
 
         if (arguments.Length > 0 && !arguments[0].IsNullOrUndefined())
         {
@@ -91,5 +80,24 @@ internal sealed class SetConstructor : Constructor
         }
 
         return set;
+    }
+
+    private JsSet ConstructSet(JsValue newTarget)
+    {
+        if (newTarget.IsUndefined())
+        {
+            ExceptionHelper.ThrowTypeError(_engine.Realm);
+        }
+
+        var set = OrdinaryCreateFromConstructor(
+            newTarget,
+            static intrinsics => intrinsics.Set.PrototypeObject,
+            static (Engine engine, Realm _, object? _) => new JsSet(engine));
+        return set;
+    }
+
+    private static JsValue Species(JsValue thisObject, JsValue[] arguments)
+    {
+        return thisObject;
     }
 }

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -85,7 +85,7 @@ internal sealed class SetPrototype : Prototype
     private JsBoolean Delete(JsValue thisObject, JsValue[] arguments)
     {
         var set = AssertSetInstance(thisObject);
-        return set.SetDelete(arguments.At(0))
+        return set.Remove(arguments.At(0))
             ? JsBoolean.True
             : JsBoolean.False;
     }
@@ -119,7 +119,7 @@ internal sealed class SetPrototype : Prototype
                     var inOther = TypeConverter.ToBoolean(otherRec.Has.Call(otherRec.Set, args));
                     if (inOther)
                     {
-                        resultSetData.SetDelete(e);
+                        resultSetData.Remove(e);
                         index--;
                     }
                 }
@@ -144,7 +144,7 @@ internal sealed class SetPrototype : Prototype
                 nextValue = JsNumber.PositiveZero;
             }
 
-            resultSetData.SetDelete(nextValue);
+            resultSetData.Remove(nextValue);
         }
 
         return resultSetData;
@@ -308,7 +308,7 @@ internal sealed class SetPrototype : Prototype
             {
                 if (inResult)
                 {
-                    resultSetData.SetDelete(nextValue);
+                    resultSetData.Remove(nextValue);
                 }
             }
             else

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -119,7 +119,7 @@ internal sealed class SetPrototype : Prototype
                     var inOther = TypeConverter.ToBoolean(otherRec.Has.Call(otherRec.Set, args));
                     if (inOther)
                     {
-                        resultSetData.Remove(e);
+                        resultSetData.SetDelete(e);
                         index--;
                     }
                 }
@@ -144,7 +144,7 @@ internal sealed class SetPrototype : Prototype
                 nextValue = JsNumber.PositiveZero;
             }
 
-            resultSetData.Remove(nextValue);
+            resultSetData.SetDelete(nextValue);
         }
 
         return resultSetData;
@@ -308,7 +308,7 @@ internal sealed class SetPrototype : Prototype
             {
                 if (inResult)
                 {
-                    resultSetData.Remove(nextValue);
+                    resultSetData.SetDelete(nextValue);
                 }
             }
             else

--- a/Jint/Runtime/Intrinsics.cs
+++ b/Jint/Runtime/Intrinsics.cs
@@ -198,7 +198,7 @@ public sealed partial class Intrinsics
     internal MapIteratorPrototype MapIteratorPrototype =>
         _mapIteratorPrototype ??= new MapIteratorPrototype(_engine, _realm, IteratorPrototype);
 
-    internal SetConstructor Set =>
+    public SetConstructor Set =>
         _set ??= new SetConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
 
     internal SetIteratorPrototype SetIteratorPrototype =>

--- a/Jint/Runtime/OrderedSet.cs
+++ b/Jint/Runtime/OrderedSet.cs
@@ -1,6 +1,8 @@
+using System.Collections;
+
 namespace Jint.Runtime;
 
-internal sealed class OrderedSet<T>
+internal sealed class OrderedSet<T> : IEnumerable<T>
 {
     internal List<T> _list;
     internal HashSet<T> _set;
@@ -61,4 +63,8 @@ internal sealed class OrderedSet<T>
         _set.Remove(item);
         return _list.Remove(item);
     }
+
+    public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Jint/Runtime/OrderedSet.cs
+++ b/Jint/Runtime/OrderedSet.cs
@@ -1,6 +1,6 @@
 namespace Jint.Runtime;
 
-public sealed class OrderedSet<T>
+internal sealed class OrderedSet<T>
 {
     internal List<T> _list;
     internal HashSet<T> _set;

--- a/Jint/Runtime/OrderedSet.cs
+++ b/Jint/Runtime/OrderedSet.cs
@@ -1,6 +1,6 @@
 namespace Jint.Runtime;
 
-internal sealed class OrderedSet<T>
+public sealed class OrderedSet<T>
 {
     internal List<T> _list;
     internal HashSet<T> _set;


### PR DESCRIPTION
Allow use of the `Jint.Native.JsSet` class outside of expressions, allowing consumers to cast to this type and call its members.

For example, you might want to convert it to a `HashSet<T>` to use it elsewhere without being tied to using Jint types.

The `OrderedSet` class also had to be made `public` due to its use in the `JsSet` constructor.