### PR TITLE
Make JsSet int indexer internal

### DIFF
--- a/Jint/Native/JsSet.cs
+++ b/Jint/Native/JsSet.cs
@@ -22,7 +22,7 @@ public sealed class JsSet : ObjectInstance, IEnumerable<JsValue>
 
     public int Size => _set.Count;
 
-    public JsValue? this[int index]
+    internal JsValue? this[int index]
     {
         get { return index < _set._list.Count ? _set._list[index] : null; }
     }


### PR DESCRIPTION
Might not be easily available if backing storage changes.