### PR TITLE
Fix building on GH Actions Ubuntu 24.04

### DIFF
--- a/Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj
+++ b/Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+++ b/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>612</NoWarn>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>


### PR DESCRIPTION
Mono is no longer present so build fails for full framework.