### PR TITLE
Ensure that relative imports from module import are module-relative

### DIFF
--- a/Jint.Tests/Runtime/Modules/DefaultModuleLoaderTests.cs
+++ b/Jint.Tests/Runtime/Modules/DefaultModuleLoaderTests.cs
@@ -21,6 +21,20 @@ public class DefaultModuleLoaderTests
         Assert.Equal(SpecifierType.RelativeOrAbsolute, resolved.Type);
     }
 
+
+    [Fact]
+    public void ShouldResolveRelativeToReferencingModuleSpecifier()
+    {
+        var resolver = new DefaultModuleLoader("file:///project");
+
+        var resolved = resolver.Resolve("referencing-module", new ModuleRequest("./local-module-file.js", []));
+
+        Assert.Equal("./local-module-file.js", resolved.ModuleRequest.Specifier);
+        Assert.Equal("file:///project/referencing-module/local-module-file.js", resolved.Key);
+        Assert.Equal("file:///project/referencing-module/local-module-file.js", resolved.Uri?.AbsoluteUri);
+        Assert.Equal(SpecifierType.RelativeOrAbsolute, resolved.Type);
+    }
+
     [Theory]
     [InlineData("./../../other.js")]
     [InlineData("../../model/other.js")]

--- a/Jint/Runtime/Modules/DefaultModuleLoader.cs
+++ b/Jint/Runtime/Modules/DefaultModuleLoader.cs
@@ -116,7 +116,16 @@ public class DefaultModuleLoader : ModuleLoader
             */
             if (Uri.TryCreate(referencingModuleLocation, UriKind.Absolute, out var referencingLocation) ||
                 Uri.TryCreate(_basePath, referencingModuleLocation, out referencingLocation))
+            {
+                if (!Path.HasExtension(referencingLocation.LocalPath) && referencingLocation.LocalPath[^1] != '/')
+                {
+                    var uriBuilder = new UriBuilder(referencingLocation);
+                    uriBuilder.Path += '/';
+                    return uriBuilder.Uri;
+                }
+
                 return referencingLocation;
+            }
         }
         return _basePath;
     }


### PR DESCRIPTION
Consider the Engine configuration with enabled modules:

```
options.EnableModules("/modules-directory");
```

where the contents of `/modules-directory` is:
```
/modules-directory/my-module/index.js
/modules-directory/my-module/helper-file.js
```
The content of the index file references the helper file is:
```
export * from "./helper-file.js";
```

Note that the path to `./some-file.js` is relative to the index file.

If we then do
```
engine.Modules.Add("my-module", File.ReadAllText("/modules-directory/my-module/index.js"));
```

Then when calling into `my-module`, the `some-file.js` file should be found from the `/modules-directory/my-module` directory, and not from `/modules-directory`.

