### PR TITLE
Fix statement counting code in MaxStatementsConstraint

### DIFF
--- a/Jint.Tests/Runtime/ExecutionConstraintTests.cs
+++ b/Jint.Tests/Runtime/ExecutionConstraintTests.cs
@@ -14,6 +14,20 @@ public class ExecutionConstraintTests
     }
 
     [Fact]
+    public void ShouldCountStatementsPrecisely()
+    {
+        var script = "var x = 0; x++; x + 5";
+
+        // Should not throw if MaxStatements is not exceeded.
+        new Engine(cfg => cfg.MaxStatements(3)).Execute(script);
+
+        // Should throw if MaxStatements is exceeded.
+        Assert.Throws<StatementsCountOverflowException>(
+            () => new Engine(cfg => cfg.MaxStatements(2)).Evaluate(script)
+        );
+    }
+
+    [Fact]
     public void ShouldThrowMemoryLimitExceeded()
     {
         Assert.Throws<MemoryLimitExceededException>(

--- a/Jint/Constraints/MaxStatementsConstraint.cs
+++ b/Jint/Constraints/MaxStatementsConstraint.cs
@@ -18,7 +18,7 @@ public sealed class MaxStatementsConstraint : Constraint
 
     public override void Check()
     {
-        if (MaxStatements > 0 && _statementsCount++ > MaxStatements)
+        if (MaxStatements > 0 && ++_statementsCount > MaxStatements)
         {
             ExceptionHelper.ThrowStatementsCountOverflowException();
         }


### PR DESCRIPTION
Current implementation of MaxStatementsConstraint allows one more statement to be executed. The increment must be in prefix form so value is updated before being used.