### PR TITLE
Flatten declarative record instance creation lookups

### DIFF
--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -318,6 +318,7 @@ public abstract partial class Function : ObjectInstance, ICallable
     /// <summary>
     /// https://tc39.es/ecma262/#sec-prepareforordinarycall
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal ref readonly ExecutionContext PrepareForOrdinaryCall(JsValue newTarget)
     {
         var callerContext = _engine.ExecutionContext;


### PR DESCRIPTION
## Jint.Benchmark.DromaeoBenchmark

| **Diff**|Method|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Run|dromaeo-3d-cube|15.819 ms|0.2254 ms|6215.84 KB|
| **New** |	|	| **15.554 ms (-2%)** | **0.1525 ms** | **6216.3 KB (0%)** |
| Old |Run|dromaeo-core-eval|3.104 ms|0.0271 ms|327.06 KB|
| **New** |	|	| **3.079 ms (-1%)** | **0.0210 ms** | **327.19 KB (0%)** |
| Old |Run|dromaeo-object-array|32.001 ms|0.3956 ms|96258.39 KB|
| **New** |	|	| **31.902 ms (0%)** | **0.3696 ms** | **96258.62 KB (0%)** |
| Old |Run|droma(...)egexp [21]|125.062 ms|2.4842 ms|153003.42 KB|
| **New** |	|	| **120.858 ms (-3%)** | **2.4037 ms** | **149368.27 KB (-2%)** |
| Old |Run|droma(...)tring [21]|236.668 ms|5.6226 ms|1315871.9 KB|
| **New** |	|	| **241.047 ms (+2%)** | **5.4212 ms** | **1315886.06 KB (0%)** |
| Old |Run|droma(...)ase64 [21]|35.197 ms|0.4473 ms|2367.03 KB|
| **New** |	|	| **35.006 ms (-1%)** | **0.5659 ms** | **2367.19 KB (0%)** |
| Old |Run|dromaeo-3d-cube|14.756 ms|0.1177 ms|5877.58 KB|
| **New** |	|	| **15.066 ms (+2%)** | **0.1503 ms** | **5877.58 KB (0%)** |
| Old |Run|dromaeo-core-eval|3.102 ms|0.0214 ms|311.99 KB|
| **New** |	|	| **3.172 ms (+2%)** | **0.0338 ms** | **312.03 KB (0%)** |
| Old |Run|dromaeo-object-array|33.778 ms|0.3316 ms|96210.97 KB|
| **New** |	|	| **31.913 ms (-6%)** | **0.4134 ms** | **96210.99 KB (0%)** |
| Old |Run|droma(...)egexp [21]|92.682 ms|1.8531 ms|151745.54 KB|
| **New** |	|	| **92.870 ms (0%)** | **1.8416 ms** | **147608.14 KB (-3%)** |
| Old |Run|droma(...)tring [21]|236.521 ms|6.5869 ms|1315630.8 KB|
| **New** |	|	| **242.929 ms (+3%)** | **7.2076 ms** | **1315639.04 KB (0%)** |
| Old |Run|droma(...)ase64 [21]|34.549 ms|0.3772 ms|2267.87 KB|
| **New** |	|	| **34.142 ms (-1%)** | **0.4362 ms** | **2267.87 KB (0%)** |


## Jint.Benchmark.SunSpiderBenchmark

| **Diff**|Method|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |Run|3d-cube|122.31 ms|1.074 ms|44654 KB|
| **New** |	|	| **119.59 ms (-2%)** | **1.472 ms** | **44654.44 KB (0%)** |
| Old |Run|3d-morph|109.49 ms|0.546 ms|46257.53 KB|
| **New** |	|	| **106.14 ms (-3%)** | **0.890 ms** | **46257.56 KB (0%)** |
| Old |Run|3d-raytrace|114.83 ms|1.183 ms|84207.66 KB|
| **New** |	|	| **116.12 ms (+1%)** | **1.067 ms** | **84208.51 KB (0%)** |
| Old |Run|access-binary-trees|63.80 ms|1.087 ms|57318.84 KB|
| **New** |	|	| **64.74 ms (+1%)** | **0.819 ms** | **57318.89 KB (0%)** |
| Old |Run|access-fannkuch|271.66 ms|1.627 ms|103.78 KB|
| **New** |	|	| **270.13 ms (-1%)** | **1.920 ms** | **103.81 KB (0%)** |
| Old |Run|access-nbody|126.07 ms|1.371 ms|53117.16 KB|
| **New** |	|	| **127.27 ms (+1%)** | **1.524 ms** | **53117.5 KB (0%)** |
| Old |Run|access-nsieve|89.70 ms|0.948 ms|17142.49 KB|
| **New** |	|	| **95.20 ms (+6%)** | **0.693 ms** | **17142.55 KB (0%)** |
| Old |Run|bitop(...)-byte [24]|97.99 ms|1.698 ms|56948.4 KB|
| **New** |	|	| **98.81 ms (+1%)** | **1.752 ms** | **56948.48 KB (0%)** |
| Old |Run|bitops-bits-in-byte|150.35 ms|1.124 ms|37044.63 KB|
| **New** |	|	| **150.62 ms (0%)** | **2.092 ms** | **37044.69 KB (0%)** |
| Old |Run|bitops-bitwise-and|83.46 ms|1.002 ms|55939.01 KB|
| **New** |	|	| **84.14 ms (+1%)** | **1.291 ms** | **55939.01 KB (0%)** |
| Old |Run|bitops-nsieve-bits|140.51 ms|0.851 ms|53916.29 KB|
| **New** |	|	| **139.02 ms (-1%)** | **0.968 ms** | **53916.36 KB (0%)** |
| Old |Run|contr(...)rsive [21]|75.41 ms|1.199 ms|83183.56 KB|
| **New** |	|	| **76.29 ms (+1%)** | **0.959 ms** | **83183.65 KB (0%)** |
| Old |Run|crypto-aes|85.34 ms|1.228 ms|10336.77 KB|
| **New** |	|	| **83.39 ms (-2%)** | **0.627 ms** | **10340.07 KB (0%)** |
| Old |Run|crypto-md5|71.35 ms|1.374 ms|77797.5 KB|
| **New** |	|	| **70.01 ms (-2%)** | **0.701 ms** | **77797.85 KB (0%)** |
| Old |Run|crypto-sha1|67.24 ms|0.677 ms|64485.15 KB|
| **New** |	|	| **67.07 ms (0%)** | **0.323 ms** | **64485.4 KB (0%)** |
| Old |Run|date-format-tofte|65.19 ms|1.253 ms|53477.73 KB|
| **New** |	|	| **65.16 ms (0%)** | **1.135 ms** | **53478.07 KB (0%)** |
| Old |Run|date-format-xparb|38.58 ms|0.762 ms|24992.59 KB|
| **New** |	|	| **37.72 ms (-2%)** | **0.747 ms** | **24992.81 KB (0%)** |
| Old |Run|math-cordic|219.38 ms|3.397 ms|81976.09 KB|
| **New** |	|	| **218.52 ms (0%)** | **3.578 ms** | **81976.22 KB (0%)** |
| Old |Run|math-partial-sums|75.92 ms|0.503 ms|49367.7 KB|
| **New** |	|	| **77.13 ms (+2%)** | **0.762 ms** | **49367.74 KB (0%)** |
| Old |Run|math-spectral-norm|80.14 ms|1.222 ms|51826.74 KB|
| **New** |	|	| **78.92 ms (-2%)** | **1.524 ms** | **51826.89 KB (0%)** |
| Old |Run|regexp-dna|100.03 ms|0.765 ms|16828.87 KB|
| **New** |	|	| **100.04 ms (0%)** | **1.275 ms** | **16827.46 KB (0%)** |
| Old |Run|string-base64|52.01 ms|0.665 ms|3156.06 KB|
| **New** |	|	| **52.06 ms (0%)** | **0.744 ms** | **3156.13 KB (0%)** |
| Old |Run|string-fasta|112.31 ms|1.676 ms|102598.66 KB|
| **New** |	|	| **112.46 ms (0%)** | **2.187 ms** | **102598.78 KB (0%)** |
| Old |Run|string-tagcloud|52.25 ms|0.699 ms|40456.12 KB|
| **New** |	|	| **51.79 ms (-1%)** | **0.923 ms** | **40456.21 KB (0%)** |
| Old |Run|string-unpack-code|50.66 ms|0.807 ms|69834.49 KB|
| **New** |	|	| **50.95 ms (+1%)** | **0.927 ms** | **69834.99 KB (0%)** |
| Old |Run|strin(...)input [21]|42.80 ms|0.486 ms|19905.84 KB|
| **New** |	|	| **42.60 ms (0%)** | **0.761 ms** | **19905.97 KB (0%)** |


