### PR TITLE
Improve environment initialization performance

### DIFF
--- a/Jint/HoistingScope.cs
+++ b/Jint/HoistingScope.cs
@@ -71,55 +71,6 @@ internal sealed class HoistingScope
             treeWalker._lexicalNames);
     }
 
-    public static List<Declaration>? GetLexicalDeclarations(BlockStatement statement)
-    {
-        List<Declaration>? lexicalDeclarations = null;
-        ref readonly var statementListItems = ref statement.Body;
-        for (var i = 0; i < statementListItems.Count; i++)
-        {
-            var node = statementListItems[i];
-            if (node.Type != NodeType.VariableDeclaration && node.Type != NodeType.FunctionDeclaration && node.Type != NodeType.ClassDeclaration)
-            {
-                continue;
-            }
-
-            if (node is VariableDeclaration { Kind: VariableDeclarationKind.Var })
-            {
-                continue;
-            }
-
-            lexicalDeclarations ??= new List<Declaration>();
-            lexicalDeclarations.Add((Declaration)node);
-        }
-
-        return lexicalDeclarations;
-    }
-
-    public static List<Declaration>? GetLexicalDeclarations(SwitchCase statement)
-    {
-        List<Declaration>? lexicalDeclarations = null;
-        ref readonly var statementListItems = ref statement.Consequent;
-        for (var i = 0; i < statementListItems.Count; i++)
-        {
-            var node = statementListItems[i];
-            if (node.Type != NodeType.VariableDeclaration)
-            {
-                continue;
-            }
-
-            var rootVariable = (VariableDeclaration)node;
-            if (rootVariable.Kind == VariableDeclarationKind.Var)
-            {
-                continue;
-            }
-
-            lexicalDeclarations ??= new List<Declaration>();
-            lexicalDeclarations.Add(rootVariable);
-        }
-
-        return lexicalDeclarations;
-    }
-
     public static void GetImportsAndExports(
         AstModule module,
         out HashSet<ModuleRequest> requestedModules,

--- a/Jint/Runtime/Interpreter/DeclarationCache.cs
+++ b/Jint/Runtime/Interpreter/DeclarationCache.cs
@@ -1,0 +1,105 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Jint.Runtime.Interpreter;
+
+internal readonly record struct DeclarationCache(List<ScopedDeclaration> Declarations, bool AllLexicalScoped);
+
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct ScopedDeclaration(Key[] BoundNames, bool IsConstantDeclaration, Node Declaration);
+
+internal static class DeclarationCacheBuilder
+{
+    public static DeclarationCache Build(List<Declaration>? lexicalDeclarations)
+    {
+        if (lexicalDeclarations is null)
+        {
+            return new DeclarationCache([], AllLexicalScoped: true);
+        }
+
+        var allLexical = true;
+        List<Key> boundNames = [];
+        List<ScopedDeclaration> declarations = [];
+        for (var i = 0; i < lexicalDeclarations.Count; i++)
+        {
+            var d = lexicalDeclarations[i];
+            Collect(boundNames, d, ref allLexical, declarations);
+        }
+
+        return new DeclarationCache(declarations, allLexical);
+    }
+
+    public static DeclarationCache Build(BlockStatement statement)
+    {
+        var allLexical = true;
+        List<Key> boundNames = [];
+        List<ScopedDeclaration> declarations = [];
+
+        ref readonly var statementListItems = ref statement.Body;
+        foreach (var node in statementListItems.AsSpan())
+        {
+            if (node.Type != NodeType.VariableDeclaration && node.Type != NodeType.FunctionDeclaration && node.Type != NodeType.ClassDeclaration)
+            {
+                continue;
+            }
+
+            if (node is VariableDeclaration { Kind: VariableDeclarationKind.Var })
+            {
+                continue;
+            }
+
+            Collect(boundNames, node, ref allLexical, declarations);
+        }
+
+        return new DeclarationCache(declarations, allLexical);
+    }
+
+    public static DeclarationCache Build(SwitchCase statement)
+    {
+        var allLexical = true;
+        List<Key> boundNames = [];
+        List<ScopedDeclaration> declarations = [];
+
+        ref readonly var statementListItems = ref statement.Consequent;
+        foreach (var node in statementListItems.AsSpan())
+        {
+            if (node.Type != NodeType.VariableDeclaration)
+            {
+                continue;
+            }
+
+            var rootVariable = (VariableDeclaration)node;
+            if (rootVariable.Kind == VariableDeclarationKind.Var)
+            {
+                continue;
+            }
+
+            Collect(boundNames, node, ref allLexical, declarations);
+        }
+
+        return new DeclarationCache(declarations, allLexical);
+    }
+
+    private static void Collect(
+        List<Key> boundNames,
+        Node node,
+        ref bool allLexical,
+        List<ScopedDeclaration> declarations)
+    {
+        boundNames.Clear();
+        node.GetBoundNames(boundNames);
+
+        var isConstantDeclaration = false;
+        if (node is VariableDeclaration variableDeclaration)
+        {
+            isConstantDeclaration = variableDeclaration.Kind == VariableDeclarationKind.Const;
+            allLexical &= variableDeclaration.Kind != VariableDeclarationKind.Var;
+        }
+        else
+        {
+            allLexical = false;
+        }
+
+        declarations.Add(new ScopedDeclaration(boundNames.ToArray(), isConstantDeclaration, node));
+    }
+}
+

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -196,14 +196,11 @@ internal sealed class JintFunctionDefinition
         public List<Key>? VarNames;
         public LinkedList<FunctionDeclaration>? FunctionsToInitialize;
         public readonly HashSet<Key> FunctionNames = new();
-        public List<LexicalVariableDeclaration> LexicalDeclarations = [];
+        public DeclarationCache? LexicalDeclarations;
         public HashSet<Key>? ParameterBindings;
         public List<VariableValuePair>? VarsToInitialize;
 
         internal readonly record struct VariableValuePair(Key Name, JsValue? InitialValue);
-
-        [StructLayout(LayoutKind.Auto)]
-        internal readonly record struct LexicalVariableDeclaration(Key BoundName, bool IsConstantDeclaration);
     }
 
     internal static State BuildState(IFunction function)
@@ -325,21 +322,7 @@ internal sealed class JintFunctionDefinition
 
         if (hoistingScope._lexicalDeclarations != null)
         {
-            var boundNames = new List<Key>();
-            var lexicalDeclarations = hoistingScope._lexicalDeclarations;
-            var lexicalDeclarationsCount = lexicalDeclarations.Count;
-            var declarations = new List<State.LexicalVariableDeclaration>(lexicalDeclarationsCount);
-            for (var i = 0; i < lexicalDeclarationsCount; i++)
-            {
-                var d = lexicalDeclarations[i];
-                boundNames.Clear();
-                d.GetBoundNames(boundNames);
-                for (var j = 0; j < boundNames.Count; j++)
-                {
-                    declarations.Add(new State.LexicalVariableDeclaration(boundNames[j], d.IsConstantDeclaration()));
-                }
-            }
-            state.LexicalDeclarations = declarations;
+            state.LexicalDeclarations = DeclarationCacheBuilder.Build(hoistingScope._lexicalDeclarations);
         }
 
         return state;

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -7,7 +7,7 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
 {
     private JintStatementList? _statementList;
     private JintStatement? _singleStatement;
-    private List<Declaration>? _lexicalDeclarations;
+    private DeclarationCache _lexicalDeclarations;
 
     public JintBlockStatement(NestedBlockStatement blockStatement) : base(blockStatement)
     {
@@ -15,7 +15,8 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
 
     protected override void Initialize(EvaluationContext context)
     {
-        _lexicalDeclarations = HoistingScope.GetLexicalDeclarations(_statement);
+        _lexicalDeclarations = DeclarationCacheBuilder.Build(_statement);
+
         if (_statement.Body.Count == 1)
         {
             _singleStatement = Build(_statement.Body[0]);
@@ -38,7 +39,7 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
 
         Environment? oldEnv = null;
         var engine = context.Engine;
-        if (_lexicalDeclarations != null)
+        if (_lexicalDeclarations.Declarations.Count > 0)
         {
             oldEnv = engine.ExecutionContext.LexicalEnvironment;
             var blockEnv = JintEnvironment.NewDeclarativeEnvironment(engine, engine.ExecutionContext.LexicalEnvironment);

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
@@ -8,7 +8,7 @@ namespace Jint.Runtime.Interpreter.Statements;
 internal sealed class JintSwitchBlock
 {
     private readonly NodeList<SwitchCase> _switchBlock;
-    private JintSwitchCase[] _jintSwitchBlock = Array.Empty<JintSwitchCase>();
+    private JintSwitchCase[] _jintSwitchBlock = [];
     private bool _initialized;
 
     public JintSwitchBlock(NodeList<SwitchCase> switchBlock)
@@ -48,7 +48,7 @@ internal sealed class JintSwitchBlock
         for (; i < temp.Length; i++)
         {
             var clause = temp[i];
-            if (clause.LexicalDeclarations is not null && oldEnv is null)
+            if (clause.LexicalDeclarations.Declarations.Count > 0 && oldEnv is null)
             {
                 oldEnv = context.Engine.ExecutionContext.LexicalEnvironment;
                 blockEnv ??= JintEnvironment.NewDeclarativeEnvironment(context.Engine, oldEnv);
@@ -120,12 +120,12 @@ internal sealed class JintSwitchBlock
     {
         internal readonly JintStatementList Consequent;
         internal readonly JintExpression? Test;
-        internal readonly List<Declaration>? LexicalDeclarations;
+        internal readonly DeclarationCache LexicalDeclarations;
 
         public JintSwitchCase(SwitchCase switchCase)
         {
             Consequent = new JintStatementList(statement: null, switchCase.Consequent);
-            LexicalDeclarations = HoistingScope.GetLexicalDeclarations(switchCase);
+            LexicalDeclarations = DeclarationCacheBuilder.Build(switchCase);
 
             if (switchCase.Test != null)
             {

--- a/Jint/Runtime/Modules/SourceTextModule.cs
+++ b/Jint/Runtime/Modules/SourceTextModule.cs
@@ -221,7 +221,7 @@ internal class SourceTextModule : CyclicModule
                 if (string.Equals(ie.ImportName, "*", StringComparison.Ordinal))
                 {
                     var ns = GetModuleNamespace(importedModule);
-                    env.CreateImmutableBinding(ie.LocalName, true);
+                    env.CreateImmutableBinding(ie.LocalName, strict: true);
                     env.InitializeBinding(ie.LocalName, ns);
                 }
                 else
@@ -235,7 +235,7 @@ internal class SourceTextModule : CyclicModule
                     if (string.Equals(resolution.BindingName, "*namespace*", StringComparison.Ordinal))
                     {
                         var ns = GetModuleNamespace(resolution.Module);
-                        env.CreateImmutableBinding(ie.LocalName, true);
+                        env.CreateImmutableBinding(ie.LocalName, strict: true);
                         env.InitializeBinding(ie.LocalName, ns);
                     }
                     else
@@ -275,26 +275,21 @@ internal class SourceTextModule : CyclicModule
             }
         }
 
-        var lexDeclarations = hoistingScope._lexicalDeclarations;
-
-        if (lexDeclarations != null)
+        if (hoistingScope._lexicalDeclarations != null)
         {
-            var boundNames = new List<Key>();
-            for (var i = 0; i < lexDeclarations.Count; i++)
+            var cache = DeclarationCacheBuilder.Build(hoistingScope._lexicalDeclarations);
+            for (var i = 0; i < cache.Declarations.Count; i++)
             {
-                var d = lexDeclarations[i];
-                boundNames.Clear();
-                d.GetBoundNames(boundNames);
-                for (var j = 0; j < boundNames.Count; j++)
+                var declaration = cache.Declarations[i];
+                foreach (var bn in declaration.BoundNames)
                 {
-                    var dn = boundNames[j];
-                    if (d.IsConstantDeclaration())
+                    if (declaration.IsConstantDeclaration)
                     {
-                        env.CreateImmutableBinding(dn);
+                        env.CreateImmutableBinding(bn);
                     }
                     else
                     {
-                        env.CreateMutableBinding(dn);
+                        env.CreateMutableBinding(bn);
                     }
                 }
             }


### PR DESCRIPTION
Instead of just caching the declarations, cache the actual bound name determination. This helps especially with modern syntax utilizing let and const which have specific lexical scope.