### PR TITLE
Add fast paths for object Get/Set for simple objects

### DIFF
--- a/Jint.Benchmark/ClassBenchmark.cs
+++ b/Jint.Benchmark/ClassBenchmark.cs
@@ -1,0 +1,54 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+[MemoryDiagnoser]
+public class ClassBenchmark
+{
+    private Engine _engine;
+
+    [IterationSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute("""
+                        class A { x = 1; }; 
+                        class B extends A { y = 2; };
+                        class C extends B { z = 3; }; 
+                        class D extends C { x2 = 1; };
+                        class E extends D { x3 = 1; };
+                        class F extends E { x4 = 1; }
+                        """);
+        _engine.Execute("const target = new F();");
+    }
+
+    [Benchmark]
+    public void ConstructSimple()
+    {
+        var script = Engine.PrepareScript("new A();");
+        for (var i = 0; i < 400_000; ++i)
+        {
+            _engine.Evaluate(script);
+        }
+    }
+
+    [Benchmark]
+    public void ConstructDeepInheritance()
+    {
+        var script = Engine.PrepareScript("new F();");
+        for (var i = 0; i < 80_000; ++i)
+        {
+            _engine.Evaluate(script);
+        }
+    }
+
+    [Benchmark]
+    public void GetSet()
+    {
+        var script = Engine.PrepareScript("target.x4 = 42; target.x4;");
+        for (var i = 0; i < 500_000; ++i)
+        {
+            _engine.Evaluate(script);
+        }
+    }
+}


### PR DESCRIPTION
## Jint.Benchmark.ClassBenchmark

| **Diff**|Method|Mean|Error|Allocated|
|------- |-------|-------:|-------|-------:|
| Old |ConstructSimple|139.6 ms|2.40 ms|369.26 MB|
| **New** |	| **134.8 ms (-3%)** | **2.11 ms** | **369.26 MB (0%)** |
| Old |ConstructDeepInheritance|157.5 ms|3.15 ms|330.2 MB|
| **New** |	| **152.1 ms (-3%)** | **3.00 ms** | **330.2 MB (0%)** |
| Old |GetSet|120.1 ms|2.00 ms|343.33 MB|
| **New** |	| **117.8 ms (-2%)** | **1.20 ms** | **343.33 MB (0%)** |


