### PR TITLE
Remove apparently-redundant `DateFlags` calculation in `JsDate` constructor

### DIFF
--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -1,3 +1,5 @@
+using Jint.Native;
+
 namespace Jint.Tests.Runtime;
 
 public class DateTests
@@ -139,5 +141,29 @@ public class DateTests
     public void CanParseEmptyDate()
     {
         Assert.True(double.IsNaN(_engine.Evaluate("Date.parse('')").AsNumber()));
+    }
+
+    [Fact]
+    public void DateTimeMinValueFlag()
+    {
+        var date = DateTime.MinValue;
+        var jsDate = new JsDate(_engine, date);
+        Assert.Equal(DateFlags.DateTimeMinValue, jsDate._dateValue.Flags);
+
+        date = date.AddMilliseconds(1);
+        jsDate = new JsDate(_engine, date);
+        Assert.Equal(DateFlags.None, jsDate._dateValue.Flags);
+    }
+    
+    [Fact]
+    public void DateTimeMaxValueFlag()
+    {
+        var date = DateTime.MaxValue;
+        var jsDate = new JsDate(_engine, date);
+        Assert.Equal(DateFlags.DateTimeMaxValue, jsDate._dateValue.Flags);
+
+        date = date.AddMilliseconds(-1);
+        jsDate = new JsDate(_engine, date);
+        Assert.Equal(DateFlags.None, jsDate._dateValue.Flags);
     }
 }

--- a/Jint/Native/JsDate.cs
+++ b/Jint/Native/JsDate.cs
@@ -20,14 +20,6 @@ public sealed class JsDate : ObjectInstance
 
     public JsDate(Engine engine, DateTime value) : this(engine, engine.Realm.Intrinsics.Date.FromDateTime(value))
     {
-        if (value == DateTime.MinValue)
-        {
-            _dateValue = _dateValue with { Flags = DateFlags.DateTimeMinValue };
-        }
-        else if (value == DateTime.MinValue)
-        {
-            _dateValue = _dateValue with { Flags = DateFlags.DateTimeMaxValue };
-        }
     }
 
     public JsDate(Engine engine, long dateValue) : this(engine, new DatePresentation(dateValue, DateFlags.None))


### PR DESCRIPTION
Added tests for `DateFlags.DateTime{Min,Max}Value` ref. https://github.com/sebastienros/jint/issues/2057#issuecomment-2666563547

Tests did not fail, indicating this code may be redundant.  

The `JsDate` constructor calls `engine.Realm.Intrinsics.Date.FromDateTime` i.e. this bit which already sets the flags correctly:

https://github.com/sebastienros/jint/blob/f012c8398fbfd0dddd377114169d4d67be210817/Jint/Native/Date/DateConstructor.cs#L197-L207

No other tests failed locally with this change. I hope I haven't overlooked anything else and this resolves https://github.com/sebastienros/jint/issues/2057