### PR TITLE
Avoid creating context for eval if eval is not present

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1134,7 +1134,7 @@ public sealed partial class Engine : IDisposable
         // A https://tc39.es/ecma262/#sec-web-compat-functiondeclarationinstantiation
 
         DeclarativeEnvironment lexEnv;
-        if (!strict)
+        if (configuration.NeedsEvalContext || _isDebugMode)
         {
             lexEnv = JintEnvironment.NewDeclarativeEnvironment(this, varEnv);
             // NOTE: Non-strict functions use a separate lexical Environment Record for top-level lexical declarations


### PR DESCRIPTION
## Jint.Benchmark.DromaeoBenchmark

| **Diff**|Method|Prepared|Modern|Toolchain|Mean|Error|Allocated|
|------- |-------|-------|-------|-------|-------:|-------|-------:|
| Old |CoreEval|False|False|Default|4.326 ms|0.0523 ms|335.29 KB|
| **New** |	| **False** | **False** | **Default** | **4.055 ms (-6%)** | **0.0576 ms** | **335.07 KB (0%)** |
| Old |CoreEval|True|False|Default|4.195 ms|0.0805 ms|320.4 KB|
| **New** |	| **True** | **False** | **Default** | **3.250 ms (-23%)** | **0.1556 ms** | **319.9 KB (0%)** |
| Old |CoreEval|False|True|Default|5.791 ms|0.0592 ms|334.67 KB|
| **New** |	| **False** | **True** | **Default** | **5.713 ms (-1%)** | **0.0736 ms** | **334.11 KB (0%)** |
| Old |CoreEval|True|True|Default|4.207 ms|0.1266 ms|320.24 KB|
| **New** |	| **True** | **True** | **Default** | **3.107 ms (-26%)** | **0.0883 ms** | **319.68 KB (0%)** |
| Old |Cube|False|False|Default|17.182 ms|0.3306 ms|6251.65 KB|
| **New** |	| **False** | **False** | **Default** | **15.315 ms (-11%)** | **0.3507 ms** | **6108.31 KB (-2%)** |
| Old |Cube|True|False|Default|15.908 ms|0.3078 ms|5910.7 KB|
| **New** |	| **True** | **False** | **Default** | **14.575 ms (-8%)** | **0.1862 ms** | **5767.14 KB (-2%)** |
| Old |Cube|False|True|Default|15.419 ms|0.3072 ms|6288.92 KB|
| **New** |	| **False** | **True** | **Default** | **15.130 ms (-2%)** | **0.2797 ms** | **5691.79 KB (-9%)** |
| Old |Cube|True|True|Default|15.910 ms|0.3099 ms|5946.98 KB|
| **New** |	| **True** | **True** | **Default** | **15.702 ms (-1%)** | **0.1648 ms** | **5349.57 KB (-10%)** |
| Old |ObjectArray|False|False|Default|33.551 ms|0.4204 ms|96269.55 KB|
| **New** |	| **False** | **False** | **Default** | **32.569 ms (-3%)** | **0.5995 ms** | **96268.71 KB (0%)** |
| Old |ObjectArray|True|False|Default|33.695 ms|0.2893 ms|96222.59 KB|
| **New** |	| **True** | **False** | **Default** | **35.738 ms (+6%)** | **0.5278 ms** | **96221.35 KB (0%)** |
| Old |ObjectArray|False|True|Default|36.230 ms|0.5786 ms|111437 KB|
| **New** |	| **False** | **True** | **Default** | **37.402 ms (+3%)** | **0.5885 ms** | **111435.55 KB (0%)** |
| Old |ObjectArray|True|True|Default|40.047 ms|0.7343 ms|111391.03 KB|
| **New** |	| **True** | **True** | **Default** | **38.864 ms (-3%)** | **0.4737 ms** | **111389.58 KB (0%)** |
| Old |ObjectRegExp|False|False|Default|126.787 ms|2.3528 ms|147813.98 KB|
| **New** |	| **False** | **False** | **Default** | **125.974 ms (-1%)** | **2.4884 ms** | **152087.7 KB (+3%)** |
| Old |ObjectRegExp|True|False|Default|94.168 ms|1.8010 ms|149495.59 KB|
| **New** |	| **True** | **False** | **Default** | **92.926 ms (-1%)** | **1.7511 ms** | **150098.73 KB (0%)** |
| Old |ObjectRegExp|False|True|Default|132.146 ms|2.6298 ms|169456.27 KB|
| **New** |	| **False** | **True** | **Default** | **133.612 ms (+1%)** | **2.6541 ms** | **163936.79 KB (-3%)** |
| Old |ObjectRegExp|True|True|Default|96.971 ms|2.4121 ms|167558.36 KB|
| **New** |	| **True** | **True** | **Default** | **96.216 ms (-1%)** | **1.6825 ms** | **169688.83 KB (+1%)** |
| Old |ObjectString|False|False|Default|296.005 ms|63.3528 ms|1303449.45 KB|
| **New** |	| **False** | **False** | **Default** | **309.999 ms (+5%)** | **63.1414 ms** | **1303670.05 KB (0%)** |
| Old |ObjectString|True|False|Default|168.306 ms|3.3354 ms|1303394.14 KB|
| **New** |	| **True** | **False** | **Default** | **161.128 ms (-4%)** | **3.1786 ms** | **1303379.77 KB (0%)** |
| Old |ObjectString|False|True|Default|164.027 ms|3.2326 ms|1316843.57 KB|
| **New** |	| **False** | **True** | **Default** | **162.190 ms (-1%)** | **3.2269 ms** | **1317102.48 KB (0%)** |
| Old |ObjectString|True|True|Default|163.129 ms|3.2581 ms|1316720.61 KB|
| **New** |	| **True** | **True** | **Default** | **168.724 ms (+3%)** | **3.3467 ms** | **1316890.9 KB (0%)** |
| Old |StringBase64|False|False|Default|35.649 ms|0.4043 ms|2397.86 KB|
| **New** |	| **False** | **False** | **Default** | **33.227 ms (-7%)** | **0.4095 ms** | **2397.23 KB (0%)** |
| Old |StringBase64|True|False|Default|35.956 ms|0.4941 ms|2297.66 KB|
| **New** |	| **True** | **False** | **Default** | **39.790 ms (+11%)** | **0.7608 ms** | **2296.76 KB (0%)** |
| Old |StringBase64|False|True|Default|40.286 ms|0.4711 ms|12553.82 KB|
| **New** |	| **False** | **True** | **Default** | **45.497 ms (+13%)** | **0.8574 ms** | **12553.05 KB (0%)** |
| Old |StringBase64|True|True|Default|39.629 ms|0.3965 ms|12452.99 KB|
| **New** |	| **True** | **True** | **Default** | **40.311 ms (+2%)** | **0.3903 ms** | **12452.23 KB (0%)** |


