### PR TITLE
Improve interop performance against dictionary

### DIFF
--- a/Jint.Benchmark/InteropLambdaBenchmark.cs
+++ b/Jint.Benchmark/InteropLambdaBenchmark.cs
@@ -1,0 +1,432 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Order;
+using Jint.Native;
+using Jint.Native.Function;
+
+namespace Jint.Benchmark;
+
+[RankColumn]
+[MemoryDiagnoser]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByParams)]
+public class InteropLambdaBenchmark
+{
+    private TestData[] _testArray;
+    private TestDataRoot _root;
+    private object _data;
+    private const string FindValue = "SomeKind22222";
+
+    private const int Iterations = 10;
+
+    private Engine _engine;
+
+    private const string ScriptInline = """
+                                        function findIt(data, value) {
+                                            return data.array.find(x => x.value == value);
+                                        }
+                                        """;
+
+    private const string ScriptForLoop = """
+                                         function findIt(data, value) {
+                                             const array = data.array;
+                                             const length = array.length;
+                                             for (let i = 0; i < length; i++) {
+                                                 const item = array[i];
+                                                 if (item.value == value) {
+                                                     return item;
+                                                 }
+                                             }
+                                             
+                                             return null;
+                                         }
+                                         """;
+
+    private Function _forLoopFunction;
+    private Function _inlineFunction;
+    private Func<JsValue, JsValue[], JsValue> _inlineCSharpFunction;
+
+    [Params(TestDataType.ClrObject, TestDataType.Dictionary, TestDataType.JsonNode, TestDataType.JsValue)]
+    public TestDataType Type { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _engine = new Engine();
+
+        _testArray = [new TestData("SomeKind00000"), new TestData("SomeKind1111"), new TestData(FindValue)];
+        _root = new TestDataRoot(_testArray);
+
+        if (Type == TestDataType.ClrObject)
+        {
+            _data = _root;
+        }
+        else if (Type == TestDataType.JsonNode)
+        {
+            _data = JsonSerializer.SerializeToNode(_root, JsonDefaults.JsonSerializerOptions);
+        }
+        else if (Type == TestDataType.Dictionary)
+        {
+            _data = JsonSerializer.Deserialize<Dictionary<string, object>>(JsonSerializer.Serialize(_root, JsonDefaults.JsonSerializerOptions), JsonDefaults.JsonSerializerOptions);
+        }
+        else if (Type == TestDataType.JsValue)
+        {
+            _data = JsonSerializer.Deserialize<JsObject>(JsonSerializer.Serialize(_root, JsonDefaults.JsonSerializerOptions), JsonDefaults.JsonSerializerOptions);
+        }
+
+        _inlineFunction = (Function) _engine.Evaluate(ScriptInline + "findIt;");
+        _inlineCSharpFunction = (Func<JsValue, JsValue[], JsValue>) _inlineFunction.ToObject();
+        _forLoopFunction = (Function) _engine.Evaluate(ScriptForLoop + "findIt;");
+    }
+
+    [Benchmark]
+    public void InlineEngineInvoke()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            var value = _engine.Invoke(_inlineFunction!, [_data, FindValue]).ToObject();
+        }
+    }
+
+    [Benchmark]
+    public void Inline()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            var value = _inlineFunction!.Call(JsValue.FromObject(_engine, _data), JsValue.FromObject(_engine, FindValue)).ToObject();
+        }
+    }
+
+    [Benchmark]
+    public void InlineCSharp()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            var value = _inlineCSharpFunction(JsValue.Undefined, [JsValue.FromObject(_engine, _data), JsValue.FromObject(_engine, FindValue)]).ToObject();
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public void ForLoop()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            var value = _forLoopFunction!.Call(JsValue.FromObject(_engine, _data), JsValue.FromObject(_engine, FindValue)).ToObject();
+        }
+    }
+
+    [Benchmark]
+    public void ForLoopEngineInvoke()
+    {
+        for (var i = 0; i < Iterations; i++)
+        {
+            var value = _engine.Invoke(_forLoopFunction!, [_data, FindValue]).ToObject();
+        }
+    }
+}
+
+public class TestDataRoot
+{
+    public TestData[] array { get; set; }
+
+    public TestDataRoot(TestData[] array)
+    {
+        this.array = array;
+    }
+}
+
+
+public record TestData(string value);
+
+public sealed class DictionaryStringObjectJsonConverter : JsonConverter<Dictionary<string, object>>
+{
+    public override Dictionary<string, object> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException();
+        }
+
+        var dictionary = new Dictionary<string, object>(JsonDefaults.DictionaryCapacity);
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return dictionary;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException();
+            }
+
+            string propertyName = reader.GetString();
+
+            reader.Read();
+
+            dictionary[propertyName] = ReadValue(ref reader, options);
+        }
+
+        throw new JsonException();
+    }
+
+    private object ReadValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.String:
+                return reader.GetString();
+            case JsonTokenType.Number:
+                if (reader.TryGetInt64(out long l))
+                {
+                    return l;
+                }
+
+                return reader.GetDouble();
+            case JsonTokenType.True:
+                return true;
+            case JsonTokenType.False:
+                return false;
+            case JsonTokenType.Null:
+                return null;
+            case JsonTokenType.StartObject:
+                return Read(ref reader, typeof(Dictionary<string, object>), options);
+            case JsonTokenType.StartArray:
+                var list = new List<object>();
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.EndArray)
+                    {
+                        return list;
+                    }
+
+                    list.Add(ReadValue(ref reader, options));
+                }
+
+                throw new JsonException();
+            default:
+                throw new JsonException();
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, Dictionary<string, object> value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        foreach (var kvp in value)
+        {
+            writer.WritePropertyName(kvp.Key);
+            WriteValue(writer, kvp.Value, options);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private void WriteValue(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case string s:
+                writer.WriteStringValue(s);
+                break;
+            case long l:
+                writer.WriteNumberValue(l);
+                break;
+            case double d:
+                writer.WriteNumberValue(d);
+                break;
+            case bool b:
+                writer.WriteBooleanValue(b);
+                break;
+            case null:
+                writer.WriteNullValue();
+                break;
+            case Dictionary<string, object> dict:
+                writer.WriteStartObject();
+                foreach (var kvp in dict)
+                {
+                    writer.WritePropertyName(kvp.Key);
+                    WriteValue(writer, kvp.Value, options);
+                }
+
+                writer.WriteEndObject();
+                break;
+            case List<object> list:
+                writer.WriteStartArray();
+                foreach (var item in list)
+                {
+                    WriteValue(writer, item, options);
+                }
+
+                writer.WriteEndArray();
+                break;
+            case JsonNode node:
+                JsonSerializer.Serialize(writer, node, options);
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported type: {value?.GetType()}");
+        }
+    }
+}
+
+public sealed class NativeJsValueJsonConverter : JsonConverter<JsObject>
+{
+    private readonly Engine _engine = new();
+
+    public override JsObject Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException();
+        }
+
+        var dictionary = new JsObject(_engine);
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return dictionary;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException();
+            }
+
+            string propertyName = reader.GetString();
+
+            reader.Read();
+
+            dictionary[propertyName] = ReadValue(ref reader, options);
+        }
+
+        throw new JsonException();
+    }
+
+    private JsValue ReadValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.String:
+                return reader.GetString();
+            case JsonTokenType.Number:
+                if (reader.TryGetInt64(out long l))
+                {
+                    return l;
+                }
+
+                return reader.GetDouble();
+            case JsonTokenType.True:
+                return true;
+            case JsonTokenType.False:
+                return false;
+            case JsonTokenType.Null:
+                return null;
+            case JsonTokenType.StartObject:
+                return Read(ref reader, typeof(JsObject), options);
+            case JsonTokenType.StartArray:
+                var list = new JsArray(_engine);
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.EndArray)
+                    {
+                        return list;
+                    }
+
+                    list.Push(ReadValue(ref reader, options));
+                }
+
+                throw new JsonException();
+            default:
+                throw new JsonException();
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, JsObject value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        foreach (var kvp in value.GetOwnProperties())
+        {
+            writer.WritePropertyName(kvp.Key.ToString());
+            WriteValue(writer, kvp.Value, options);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private void WriteValue(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case string s:
+                writer.WriteStringValue(s);
+                break;
+            case long l:
+                writer.WriteNumberValue(l);
+                break;
+            case double d:
+                writer.WriteNumberValue(d);
+                break;
+            case bool b:
+                writer.WriteBooleanValue(b);
+                break;
+            case null:
+                writer.WriteNullValue();
+                break;
+            case Dictionary<string, object> dict:
+                writer.WriteStartObject();
+                foreach (var kvp in dict)
+                {
+                    writer.WritePropertyName(kvp.Key);
+                    WriteValue(writer, kvp.Value, options);
+                }
+
+                writer.WriteEndObject();
+                break;
+            case List<object> list:
+                writer.WriteStartArray();
+                foreach (var item in list)
+                {
+                    WriteValue(writer, item, options);
+                }
+
+                writer.WriteEndArray();
+                break;
+            case JsonNode node:
+                JsonSerializer.Serialize(writer, node, options);
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported type: {value?.GetType()}");
+        }
+    }
+}
+
+public static class JsonDefaults
+{
+    public const int DictionaryCapacity = 4;
+
+    public static JsonSerializerOptions JsonSerializerOptions { get; }
+
+    static JsonDefaults()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new DictionaryStringObjectJsonConverter());
+        options.Converters.Add(new NativeJsValueJsonConverter());
+
+        JsonSerializerOptions = options;
+    }
+}
+
+public enum TestDataType
+{
+    ClrObject,
+    JsonNode,
+    Dictionary,
+    JsValue
+}

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -57,9 +57,8 @@ public abstract partial class Function : ObjectInstance, ICallable
         Engine engine,
         Realm realm,
         JsString? name,
-        FunctionThisMode thisMode = FunctionThisMode.Global,
-        ObjectClass objectClass = ObjectClass.Function)
-        : base(engine, objectClass)
+        FunctionThisMode thisMode = FunctionThisMode.Global)
+        : base(engine, ObjectClass.Function)
     {
         if (name is not null)
         {
@@ -365,6 +364,11 @@ public abstract partial class Function : ObjectInstance, ICallable
 
     // native syntax doesn't expect to have private identifier indicator
     private static readonly char[] _functionNameTrimStartChars = ['#'];
+
+    public sealed override object ToObject()
+    {
+        return (JsCallDelegate) Call;
+    }
 
     public override string ToString()
     {

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -160,7 +160,7 @@ internal static class DefaultObjectConverter
     }
 
 #if NET8_0_OR_GREATER
-    private static JsValue? ConvertSystemTextJsonValue(Engine engine, System.Text.Json.Nodes.JsonValue value)
+    private static JsValue? ConvertSystemTextJsonValue(Engine engine, System.Text.Json.Nodes.JsonNode value)
     {
         return value.GetValueKind() switch
         {
@@ -168,13 +168,15 @@ internal static class DefaultObjectConverter
             System.Text.Json.JsonValueKind.Array => JsValue.FromObject(engine, value),
             System.Text.Json.JsonValueKind.String => JsString.Create(value.ToString()),
 #pragma warning disable IL2026, IL3050
-            System.Text.Json.JsonValueKind.Number => value.TryGetValue<int>(out var intValue) ? JsNumber.Create(intValue) : System.Text.Json.JsonSerializer.Deserialize<double>(value),
+            System.Text.Json.JsonValueKind.Number => ((System.Text.Json.Nodes.JsonValue) value).TryGetValue<int>(out var intValue)
+                ? JsNumber.Create(intValue)
+                : System.Text.Json.JsonSerializer.Deserialize<double>(value),
 #pragma warning restore IL2026, IL3050
             System.Text.Json.JsonValueKind.True => JsBoolean.True,
             System.Text.Json.JsonValueKind.False => JsBoolean.False,
             System.Text.Json.JsonValueKind.Undefined => JsValue.Undefined,
             System.Text.Json.JsonValueKind.Null => JsValue.Null,
-            _ => null
+            _ => null,
         };
     }
 #endif

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Function;
@@ -28,11 +29,10 @@ public class DefaultTypeConverter : ITypeConverter
     private static readonly ConcurrentDictionary<TypeConversionKey, MethodInfo?> _knownCastOperators = new();
 
     private static readonly Type intType = typeof(int);
-    private static readonly Type iCallableType = typeof(Func<JsValue, JsValue[], JsValue>);
+    private static readonly Type iCallableType = typeof(JsCallDelegate);
     private static readonly Type jsValueType = typeof(JsValue);
     private static readonly Type objectType = typeof(object);
     private static readonly Type engineType = typeof(Engine);
-    private static readonly Type typeType = typeof(Type);
 
     private static readonly MethodInfo changeTypeIfConvertible = typeof(DefaultTypeConverter).GetMethod(
         "ChangeTypeOnlyIfConvertible", BindingFlags.NonPublic | BindingFlags.Static)!;
@@ -65,6 +65,8 @@ public class DefaultTypeConverter : ITypeConverter
     {
         return TryConvert(value, type, formatProvider, propagateException: false, out converted, out _);
     }
+
+    private static readonly ConditionalWeakTable<IFunction, Delegate> _delegateCache = new();
 
     private bool TryConvert(
         object? value,
@@ -129,18 +131,20 @@ public class DefaultTypeConverter : ITypeConverter
         {
             if (typeof(Delegate).IsAssignableFrom(type) && !type.IsAbstract)
             {
-                // use target function instance as cache holder, this way delegate and target hold same lifetime
-                var delegatePropertyKey = "__jint_delegate_" + type.GUID;
-
-                var func = (Func<JsValue, JsValue[], JsValue>) value;
-                var functionInstance = func.Target as Function;
-
-                var d = functionInstance?.GetHiddenClrObjectProperty(delegatePropertyKey) as Delegate;
-
-                if (d is null)
+                var func = (JsCallDelegate) value;
+                var astFunction = (func.Target as Function)?._functionDefinition?.Function;
+                Delegate d;
+                if (astFunction is not null)
+                {
+                    if (!_delegateCache.TryGetValue(astFunction, out d!))
+                    {
+                        d = BuildDelegate(type, func);
+                        _delegateCache.Add(astFunction, d);
+                    }
+                }
+                else
                 {
                     d = BuildDelegate(type, func);
-                    functionInstance?.SetHiddenClrObjectProperty(delegatePropertyKey, d);
                 }
 
                 converted = d;
@@ -150,8 +154,7 @@ public class DefaultTypeConverter : ITypeConverter
 
         if (type.IsArray)
         {
-            var source = value as object[];
-            if (source == null)
+            if (value is not object[] source)
             {
                 problemMessage = $"Value of object[] type is expected, but actual type is {value.GetType()}";
                 return false;
@@ -268,7 +271,7 @@ public class DefaultTypeConverter : ITypeConverter
 
     private Delegate BuildDelegate(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type,
-        Func<JsValue, JsValue[], JsValue> function)
+        JsCallDelegate function)
     {
         var method = type.GetMethod("Invoke");
         var arguments = method!.GetParameters();
@@ -396,17 +399,4 @@ public class DefaultTypeConverter : ITypeConverter
         return false;
     }
 
-}
-
-internal static class ObjectExtensions
-{
-    public static object? GetHiddenClrObjectProperty(this ObjectInstance obj, string name)
-    {
-        return (obj.Get(name) as IObjectWrapper)?.Target;
-    }
-
-    public static void SetHiddenClrObjectProperty(this ObjectInstance obj, string name, object value)
-    {
-        obj.SetOwnProperty(name, new PropertyDescriptor(ObjectWrapper.Create(obj.Engine, value), PropertyFlag.AllForbidden));
-    }
 }

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -133,19 +133,9 @@ public class DefaultTypeConverter : ITypeConverter
             {
                 var func = (JsCallDelegate) value;
                 var astFunction = (func.Target as Function)?._functionDefinition?.Function;
-                Delegate d;
-                if (astFunction is not null)
-                {
-                    if (!_delegateCache.TryGetValue(astFunction, out d!))
-                    {
-                        d = BuildDelegate(type, func);
-                        _delegateCache.Add(astFunction, d);
-                    }
-                }
-                else
-                {
-                    d = BuildDelegate(type, func);
-                }
+                var d = astFunction is not null
+                    ? _delegateCache.GetValue(astFunction, _ => BuildDelegate(type, func))
+                    : BuildDelegate(type, func);
 
                 converted = d;
                 return true;


### PR DESCRIPTION
I'm adding the test case and also the option which shows converting to native `JsValue` objects from JSON deserialization. If use case is reading then native types should produce best performance. I might have made mistakes so take it with a grain of salt.

The delegate building is now cached against AST node reference so it should align quite well with the idea of preparing and caching AST when needed.

## Jint.Benchmark.InteropLambdaBenchmark

| **Diff**|Type|Method|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |ClrObject|InlineCSharp|13.958 μs|0.1449 μs|30.08 KB|
| **New** |	|	| **12.110 μs (-13%)** | **0.2307 μs** | **28.2 KB (-6%)** |
| Old |ClrObject|InlineEngineInvoke|14.468 μs|0.1819 μs|30 KB|
| **New** |	|	| **12.620 μs (-13%)** | **0.1171 μs** | **28.13 KB (-6%)** |
| Old |ClrObject|Inline|14.810 μs|0.1906 μs|29.61 KB|
| **New** |	|	| **12.871 μs (-13%)** | **0.1735 μs** | **27.73 KB (-6%)** |
| Old |ClrObject|ForLoopEngineInvoke|20.211 μs|0.1940 μs|34.92 KB|
| **New** |	|	| **18.729 μs (-7%)** | **0.3184 μs** | **32.66 KB (-6%)** |
| Old |ClrObject|ForLoop|20.554 μs|0.3373 μs|34.53 KB|
| **New** |	|	| **18.925 μs (-8%)** | **0.3124 μs** | **33.05 KB (-4%)** |
| Old |JsonNode|ForLoop|49.571 μs|0.7526 μs|60.63 KB|
| **New** |	|	| **34.749 μs (-30%)** | **0.6410 μs** | **47.97 KB (-21%)** |
| Old |JsonNode|ForLoopEngineInvoke|50.650 μs|0.6915 μs|61.02 KB|
| **New** |	|	| **34.759 μs (-31%)** | **0.6888 μs** | **47.58 KB (-22%)** |
| Old |JsonNode|Inline|56.960 μs|1.1315 μs|75.87 KB|
| **New** |	|	| **41.791 μs (-27%)** | **0.8285 μs** | **62.82 KB (-17%)** |
| Old |JsonNode|InlineCSharp|61.993 μs|1.2329 μs|76.34 KB|
| **New** |	|	| **41.995 μs (-32%)** | **0.8274 μs** | **63.29 KB (-17%)** |
| Old |JsonNode|InlineEngineInvoke|62.023 μs|1.2133 μs|76.26 KB|
| **New** |	|	| **42.142 μs (-32%)** | **0.8274 μs** | **63.21 KB (-17%)** |
| Old |Dictionary|ForLoop|37.053 μs|0.3455 μs|47.11 KB|
| **New** |	|	| **22.510 μs (-39%)** | **0.2309 μs** | **42.58 KB (-10%)** |
| Old |Dictionary|ForLoopEngineInvoke|37.151 μs|0.4640 μs|47.5 KB|
| **New** |	|	| **23.255 μs (-37%)** | **0.2261 μs** | **33.13 KB (-30%)** |
| Old |Dictionary|Inline|2,421.450 μs|31.9202 μs|150.02 KB|
| **New** |	|	| **23.602 μs (-99%)** | **0.4647 μs** | **42.5 KB (-72%)** |
| Old |Dictionary|InlineEngineInvoke|2,426.210 μs|42.1312 μs|150.42 KB|
| **New** |	|	| **23.608 μs (-99%)** | **0.3058 μs** | **42.11 KB (-72%)** |
| Old |Dictionary|InlineCSharp|2,439.785 μs|47.8304 μs|150.5 KB|
| **New** |	|	| **23.728 μs (-99%)** | **0.3679 μs** | **33.52 KB (-78%)** |
| Old |JsValue|InlineCSharp|8.711 μs|0.1299 μs|18.91 KB|
| **New** |	|	| **8.943 μs (+3%)** | **0.1251 μs** | **18.91 KB (0%)** |
| Old |JsValue|InlineEngineInvoke|9.205 μs|0.1786 μs|18.83 KB|
| **New** |	|	| **9.063 μs (-2%)** | **0.0782 μs** | **18.83 KB (0%)** |
| Old |JsValue|Inline|9.278 μs|0.1288 μs|18.44 KB|
| **New** |	|	| **9.175 μs (-1%)** | **0.1086 μs** | **18.44 KB (0%)** |
| Old |JsValue|ForLoopEngineInvoke|14.978 μs|0.1502 μs|23.75 KB|
| **New** |	|	| **14.975 μs (0%)** | **0.1385 μs** | **23.75 KB (0%)** |
| Old |JsValue|ForLoop|15.345 μs|0.2494 μs|23.36 KB|
| **New** |	|	| **15.260 μs (-1%)** | **0.1876 μs** | **23.36 KB (0%)** |


fixes #2087