### PR TITLE
Add default 10 second timeout for promise unwrapping

### DIFF
--- a/Jint.Tests/Runtime/TestClasses/AsyncTestClass.cs
+++ b/Jint.Tests/Runtime/TestClasses/AsyncTestClass.cs
@@ -8,14 +8,14 @@ internal class AsyncTestClass
 
     public async Task AddToStringDelayedAsync(string appendWith)
     {
-        await Task.Delay(1000).ConfigureAwait(false);
+        await Task.Delay(100).ConfigureAwait(false);
 
         StringToAppend += appendWith;
     }
 
     public async Task<string> ReturnDelayedTaskAsync()
     {
-        await Task.Delay(1000).ConfigureAwait(false);
+        await Task.Delay(100).ConfigureAwait(false);
 
         return TestString;
     }


### PR DESCRIPTION
This protects from errors that could hang the engine.