### PR TITLE
fix build conditions

### DIFF
--- a/Jint/Jint.csproj
+++ b/Jint/Jint.csproj
@@ -19,7 +19,7 @@
 
     <NoWarn>$(NoWarn);1591</NoWarn>
 
-    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
 
     <PolySharpExcludeGeneratedTypes>System.Runtime.CompilerServices.RequiresLocationAttribute</PolySharpExcludeGeneratedTypes>
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
@@ -30,7 +30,7 @@
     <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_PARSE;SUPPORTS_WEAK_TABLE_ADD_OR_UPDATE;SUPPORTS_WEAK_TABLE_CLEAR</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <DefineConstants>$(DefineConstants);SUPPORTS_HALF</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
The current conditions are wrong and don't work as intended

- https://learn.microsoft.com/en-us/visualstudio/msbuild/property-functions?view=vs-2022#msbuild-targetframework-and-targetplatform-functions

```
$([MSBuild]::IsTargetFrameworkCompatible('net8.0', 'net7.0')) => false
$([MSBuild]::IsTargetFrameworkCompatible('net8.0', 'net6.0')) => false
```


That's why `new Float16Array(2)` throws on `net8.0`

```
Assert.That(caughtException, expression)
  Expected: <Jint.Runtime.JavaScriptException>
  But was:  <System.NotSupportedException: cannot handle element type
   at Jint.Native.Object.ObjectInstance.ToObject(ObjectTraverseStack stack)
   at Jint.Native.Object.ObjectInstance.ToObject()
   at Jint.Runtime.Interop.InteropHelper.CalculateMethodParameterScore(Engine engine, ParameterInfo parameter, JsValue parameterValue)
   at Jint.Runtime.Interop.InteropHelper.CalculateMethodScore(Engine engine, MethodDescriptor method, JsValue[] arguments)
   at Jint.Runtime.Interop.InteropHelper.FindBestMatch(Engine engine, MethodDescriptor[] methods, Func`2 argumentProvider)+MoveNext()
   at Jint.Runtime.Interop.MethodInfoFunction.Call(JsValue thisObject, JsValue[] jsArguments)
   at Jint.Runtime.Interpreter.Expressions.JintCallExpression.EvaluateInternal(EvaluationContext context)
   at Jint.Runtime.Interpreter.Expressions.JintExpression.GetValue(EvaluationContext context)
   at Jint.Runtime.Interpreter.Statements.JintExpressionStatement.ExecuteInternal(EvaluationContext context)
   at Jint.Engine.ScriptEvaluation(ScriptRecord scriptRecord, ParserOptions parserOptions)
   at Jint.Engine.<>c__DisplayClass99_0.<Execute>b__0()
   at Jint.Engine.ExecuteWithConstraints[T](Boolean strict, Func`1 callback)
   at Jint.Engine.Execute(Prepared`1& preparedScript)
   at Jint.Engine.Evaluate(Prepared`1& preparedScript)
   at Jint.Engine.Evaluate(String code, String source)
```