### PR TITLE
Bugfix/2106 make eval syntax checks not descend into function declarations

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -598,6 +598,19 @@ public partial class EngineTests : IDisposable
     }
 
     [Fact]
+    public void EvalFunctionWithTargetNewParse()
+    {
+        RunTest(@"
+                const code = `function MyClass() {
+                   if (!new.target) throw new Error('Use MyClass as constructor!');
+                }`;
+
+                eval(code);
+                const x = new MyClass();
+            ");
+    }
+
+    [Fact]
     public void ForInStatement()
     {
         var engine = new Engine();

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -604,9 +604,11 @@ public partial class EngineTests : IDisposable
                 const code = `function MyClass() {
                    if (!new.target) throw new Error('Use MyClass as constructor!');
                 }`;
-
                 eval(code);
-                const x = new MyClass();
+                const code2 = `var x = function () {
+                   if (!new.target) throw new Error('Use as constructor!');
+                }`;
+                eval(code2);
             ");
     }
 

--- a/Jint/Native/Function/EvalFunction.cs
+++ b/Jint/Native/Function/EvalFunction.cs
@@ -220,20 +220,12 @@ public sealed class EvalFunction : Function
 
         protected override object? VisitFunctionDeclaration(FunctionDeclaration node)
         {
-            // copy of base implementation without visiting the body
-            if (node.Id is not null)
-            {
-                Visit(node.Id);
-            }
-
-            ref readonly var @params = ref node.Params;
-            for (var i = 0; i < @params.Count; i++)
-            {
-                Visit(@params[i]);
-            }
-
             return node;
         }
 
+        protected override object? VisitFunctionExpression(FunctionExpression node)
+        {
+            return node;
+        }
     }
 }

--- a/Jint/Native/Function/EvalFunction.cs
+++ b/Jint/Native/Function/EvalFunction.cs
@@ -217,5 +217,23 @@ public sealed class EvalFunction : Function
             _containsSuperCall |= callExpression.Callee.Type == NodeType.Super;
             return base.VisitCallExpression(callExpression);
         }
+
+        protected override object? VisitFunctionDeclaration(FunctionDeclaration node)
+        {
+            // copy of base implementation without visiting the body
+            if (node.Id is not null)
+            {
+                Visit(node.Id);
+            }
+
+            ref readonly var @params = ref node.Params;
+            for (var i = 0; i < @params.Count; i++)
+            {
+                Visit(@params[i]);
+            }
+
+            return node;
+        }
+
     }
 }


### PR DESCRIPTION
According to https://tc39.es/ecma262/#sec-static-semantics-contains, function declarations should not be considered for contains checks. 
I'm adding visitor methods in the eval check, that simply skip those and a test showing the now working eval.

fixes #2106