### PR TITLE
 Add `Options.Constraints.PromiseTimeout` To Control timeout for `DisposeHint.Async` and `JintAwaitExpression`

### DIFF
--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -41,6 +41,7 @@ public class AsyncTests
         result = result.UnwrapIfPromise();
         Assert.Equal(AsyncTestClass.TestString, result);
     }
+
     [Fact]
     public void ShouldUnwrapPromiseWithCustomTimeout()
     {
@@ -54,7 +55,7 @@ public class AsyncTests
     [Fact]
     public void ShouldAwaitUnwrapPromiseWithCustomTimeout()
     {
-        Engine engine = new(options => { options.ExperimentalFeatures = ExperimentalFeature.TaskInterop; options.Constraints.UnwrapIfPromiseTimeout = TimeSpan.FromMilliseconds(500); });
+        Engine engine = new(options => { options.ExperimentalFeatures = ExperimentalFeature.TaskInterop; options.Constraints.PromiseTimeout = TimeSpan.FromMilliseconds(500); });
         engine.SetValue("asyncTestClass", new AsyncTestClass());
         engine.Execute(""" 
         async function test() {

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -54,7 +54,7 @@ public class AsyncTests
     [Fact]
     public void ShouldAwaitUnwrapPromiseWithCustomTimeout()
     {
-        Engine engine = new(options => { options.ExperimentalFeatures = ExperimentalFeature.TaskInterop; options.Constraints.UnwrapIfPromiseTimeout = TimeSpan.FromMilliseconds(200); });
+        Engine engine = new(options => { options.ExperimentalFeatures = ExperimentalFeature.TaskInterop; options.Constraints.UnwrapIfPromiseTimeout = TimeSpan.FromMilliseconds(500); });
         engine.SetValue("asyncTestClass", new AsyncTestClass());
         engine.Execute(""" 
         async function test() {

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -41,6 +41,29 @@ public class AsyncTests
         result = result.UnwrapIfPromise();
         Assert.Equal(AsyncTestClass.TestString, result);
     }
+    [Fact]
+    public void ShouldUnwrapPromiseWithCustomTimeout()
+    {
+        Engine engine = new(options => options.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        engine.SetValue("asyncTestClass", new AsyncTestClass());
+        var result = engine.Evaluate("asyncTestClass.ReturnDelayedTaskAsync().then(x=>x)");
+        result = result.UnwrapIfPromise(TimeSpan.FromMilliseconds(200));
+        Assert.Equal(AsyncTestClass.TestString, result);
+    }
+
+    [Fact]
+    public void ShouldAwaitUnwrapPromiseWithCustomTimeout()
+    {
+        Engine engine = new(options => { options.ExperimentalFeatures = ExperimentalFeature.TaskInterop; options.Constraints.UnwrapIfPromiseTimeout = TimeSpan.FromMilliseconds(200); });
+        engine.SetValue("asyncTestClass", new AsyncTestClass());
+        engine.Execute(""" 
+        async function test() {
+            return await asyncTestClass.ReturnDelayedTaskAsync();
+        }
+        """);
+        var result = engine.Invoke("test").UnwrapIfPromise();
+        Assert.Equal(AsyncTestClass.TestString, result);
+    }
 
     [Fact]
     public void ShouldReturnedCompletedTaskConvertedToPromiseInJS()
@@ -230,7 +253,7 @@ public class AsyncTests
 
         Assert.Equal(expected, log.Select(x => x.AsString()).ToArray());
     }
-    
+
     [Fact]
     public void ShouldPromiseBeResolved()
     {
@@ -240,7 +263,7 @@ public class AsyncTests
         {
             log.Add(str);
         });
-        
+
         const string Script = """
           async function main() {
             return new Promise(function (resolve) {
@@ -268,7 +291,7 @@ public class AsyncTests
             {
                 Task.Delay(ms).ContinueWith(_ => action());
             });
-        
+
         const string Script = """
           var delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
           async function main() {

--- a/Jint/Native/Disposable/DisposeCapability.cs
+++ b/Jint/Native/Disposable/DisposeCapability.cs
@@ -87,7 +87,7 @@ internal sealed class DisposeCapability
                         hasAwaited = true;
                         try
                         {
-                            result = result.UnwrapIfPromise(_engine.Options.Constraints.UnwrapIfPromiseTimeout);
+                            result = result.UnwrapIfPromise(_engine.Options.Constraints.PromiseTimeout);
                         }
                         catch (JavaScriptException e)
                         {

--- a/Jint/Native/Disposable/DisposeCapability.cs
+++ b/Jint/Native/Disposable/DisposeCapability.cs
@@ -87,7 +87,7 @@ internal sealed class DisposeCapability
                         hasAwaited = true;
                         try
                         {
-                            result = result.UnwrapIfPromise();
+                            result = result.UnwrapIfPromise(_engine.Options.Constraints.UnwrapIfPromiseTimeout);
                         }
                         catch (JavaScriptException e)
                         {

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -431,6 +431,12 @@ public class Options
         /// </summary>
         public TimeSpan RegexTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
+
+        /// <summary>
+        /// Maximum time allowed for unwrapping a Promise and getting its resolved/rejected value.
+        /// Defaults to 10 seconds.
+        /// </summary>
+        public TimeSpan UnwrapIfPromiseTimeout { get; set; } = TimeSpan.FromSeconds(10);
         /// <summary>
         /// The maximum size for JavaScript array, defaults to <see cref="uint.MaxValue"/>.
         /// </summary>

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -431,12 +431,12 @@ public class Options
         /// </summary>
         public TimeSpan RegexTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
-
         /// <summary>
         /// Maximum time allowed for unwrapping a Promise and getting its resolved/rejected value.
         /// Defaults to 10 seconds.
         /// </summary>
-        public TimeSpan UnwrapIfPromiseTimeout { get; set; } = TimeSpan.FromSeconds(10);
+        public TimeSpan PromiseTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
         /// <summary>
         /// The maximum size for JavaScript array, defaults to <see cref="uint.MaxValue"/>.
         /// </summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
@@ -34,7 +34,7 @@ internal sealed class JintAwaitExpression : JintExpression
                 value = promiseInstance;
             }
 
-            return value.UnwrapIfPromise(engine.Options.Constraints.UnwrapIfPromiseTimeout);
+            return value.UnwrapIfPromise(engine.Options.Constraints.PromiseTimeout);
         }
         catch (PromiseRejectedException e)
         {

--- a/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
@@ -34,7 +34,7 @@ internal sealed class JintAwaitExpression : JintExpression
                 value = promiseInstance;
             }
 
-            return value.UnwrapIfPromise();
+            return value.UnwrapIfPromise(engine.Options.Constraints.UnwrapIfPromiseTimeout);
         }
         catch (PromiseRejectedException e)
         {


### PR DESCRIPTION
-  feat(option): Add options.Constraints.PromiseTimeout for UnwrapIfPromise (DisposeResources & AwaitExpression)
- test(unit): cover custom timeout path for await
