### PR TITLE
Fix iterating a clr list proxy and length property

### DIFF
--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -464,6 +464,9 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 
     private static JsValue Iterator(JsValue thisObject, JsCallArguments arguments)
     {
+        if (thisObject is JsProxy proxy)
+            return Iterator(proxy._target, arguments);
+
         var wrapper = (ObjectWrapper) thisObject;
 
         return wrapper._typeDescriptor.IsDictionary
@@ -473,6 +476,9 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 
     private static JsNumber GetLength(JsValue thisObject, JsCallArguments arguments)
     {
+        if (thisObject is JsProxy proxy)
+            return GetLength(proxy._target, arguments);
+
         var wrapper = (ObjectWrapper) thisObject;
         return JsNumber.Create((int) (wrapper._typeDescriptor.LengthProperty?.GetValue(wrapper.Target) ?? 0));
     }


### PR DESCRIPTION
When iterating over a JsProxy of a clr list or access its length property, jint fails with `System.InvalidCastException : Unable to cast object of type 'Jint.Native.JsProxy' to type 'Jint.Runtime.Interop.ObjectWrapper'.`

This PR fixes the issue - but I am pretty sure, that there is a "better" more solid solution for it?