### PR TITLE
Prevent accidental leakage of arguments between separate calls

### DIFF
--- a/Jint.Tests/Runtime/ArgumentsCacheBehaviorTests.cs
+++ b/Jint.Tests/Runtime/ArgumentsCacheBehaviorTests.cs
@@ -41,6 +41,42 @@ public class ArgumentsCacheBehaviorTests
     }
 
     [Fact]
+    public void NamedArgsForGeneratorsAreNotReusedFromCache()
+    {
+        // Arrange
+        List<JsValue> logValues = new();
+        var engine = new Engine();
+        engine.SetValue("log", logValues.Add);
+
+        // Act
+        engine.Evaluate(
+            """
+            function *method(a, b) {
+              log(a);
+              log(b);
+            }
+              
+            function *other(a, b) {
+              log(a);
+              log(b);
+            }
+
+            var generator1 = method(42, undefined);
+            var generator2 = other(10, undefined);
+            generator1.next();
+            generator2.next();
+            """);
+
+        // Assert
+        Assert.Equal([
+            JsNumber.Create(42),
+            JsValue.Undefined,
+            JsNumber.Create(10),
+            JsValue.Undefined,
+        ], logValues);
+    }
+
+    [Fact]
     public void ArgsForGeneratorsWithBindAreNotReusedFromCache()
     {
         // Arrange

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1059,6 +1059,10 @@ public sealed partial class Engine : IDisposable
         var hasDuplicates = configuration.HasDuplicates;
         var simpleParameterList = configuration.IsSimpleParameterList;
         var hasParameterExpressions = configuration.HasParameterExpressions;
+        if (configuration.RequiresInputArgumentsOwnership)
+        {
+            argumentsList = [.. argumentsList];
+        }
 
         var canInitializeParametersOnDeclaration = simpleParameterList && !configuration.HasDuplicates;
         var arguments = canInitializeParametersOnDeclaration ? argumentsList : null;

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -75,13 +75,6 @@ public sealed class ScriptFunction : Function, IConstructor
                 // actual call
                 var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
 
-                if (ArgumentsNeedToSurviveCall())
-                {
-                    // Take ownership of the array to allow the caller to
-                    // modify/cache it if needed.
-                    arguments = CloneArgumentsArray(arguments);
-                }
-
                 var result = _functionDefinition.EvaluateBody(context, this, arguments);
                 result = calleeContext.LexicalEnvironment.DisposeResources(result);
 
@@ -113,11 +106,6 @@ public sealed class ScriptFunction : Function, IConstructor
 
             return Undefined;
         }
-    }
-
-    private static JsCallArguments CloneArgumentsArray(JsCallArguments arguments)
-    {
-        return [.. arguments];
     }
 
     internal override bool IsConstructor
@@ -224,15 +212,4 @@ public sealed class ScriptFunction : Function, IConstructor
     {
         _isClassConstructor = true;
     }
-
-    /// <summary>
-    /// Checks if an argument array passed to execute this function (see <see cref="Call"/>)
-    /// might still be in use when the call returns.
-    /// </summary>
-    /// <remarks>
-    /// This method will only check if the declaration itself has an indicator for that.
-    /// It will not check if the code running inside the function saves the arguments outside somewhere.
-    /// </remarks>
-    private bool ArgumentsNeedToSurviveCall()
-        => FunctionDeclaration is not null && (FunctionDeclaration.Generator || FunctionDeclaration.Async);
 }

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -192,6 +192,7 @@ internal sealed class JintFunctionDefinition
         public bool IsSimpleParameterList;
         public bool HasParameterExpressions;
         public bool ArgumentsObjectNeeded;
+        public bool RequiresInputArgumentsOwnership;
         public List<Key>? VarNames;
         public LinkedList<FunctionDeclaration>? FunctionsToInitialize;
         public readonly HashSet<Key> FunctionNames = new();
@@ -269,6 +270,17 @@ internal sealed class JintFunctionDefinition
         if (state.ArgumentsObjectNeeded)
         {
             parameterBindings.Add(KnownKeys.Arguments);
+        }
+
+        if (function.Type == NodeType.ArrowFunctionExpression)
+        {
+            state.RequiresInputArgumentsOwnership = state.ArgumentsObjectNeeded ||
+                (function.Async && ArgumentsUsageAstVisitor.HasArgumentsReference(function));
+        }
+        else
+        {
+            state.RequiresInputArgumentsOwnership = state.ArgumentsObjectNeeded &&
+                (function.Async || function.Generator);
         }
 
         state.ParameterBindings = parameterBindings;


### PR DESCRIPTION
While trying to fix a different problem within Jint, I found this problem.

The problem is that the arguments array passed to execute a function internally is added back to the cache after completion. However, some functions invocations live longer than their their first call (generators, async functions [when the implementation for these gets changed]).

Its a niche problem but should be solved anyway I guess.

So imaging the following script (copied from the included new tests)

```js
function *method() {
  log(arguments[0]);
  log(arguments[1]);
}
              
function *other() {
  log(arguments[0]);
  log(arguments[1]);
}
            
var generator1 = method(42, undefined);
var generator2 = other(10, undefined);
generator1.next();
generator2.next();
```

The expected output for this is:
```
42
undefined
10
undefined
```

But without this fix, it is 
```
10
undefined
10
undefined
```

---

Underlying reason:

The basic execution flow is:

Line `var generator1 = method(42, undefined);`
1. For the expression `method(42, undefined)`, an `JsValue[]` is fetched from the internal `JsValueArrayPool`.
2. The array gets filled with `[42, undefined]`
3. The call to `method` returns with a generator object.
4. The `JsValue[]` is returned to the pool

Line `var generator2 = other(10, undefined);`
1. Then the expression `other(10, undefined)` gets evaluated. For that - again - an `JsValue[]` is fetched from the internal `JsValueArrayPool`. **That array however is the same instance which was used to when calling `method` in this particular case**
2. The array is filled with `[10, undefined]`, but this also replaces the arguments used for `method()` because they share the same arguments array instance.
3. This is the actual problem.

Line `.next()` 
1. Now the generators are executed using `.next()` to run the log statements.
2. The generator bodies are executed and the first generator uses the wrong values because the content of its arguments array was changed. 

---

Small detail. First I've had a different implementation within `JintCallExpression` itself but after some investigation, I saw that this was probably the wrong spot for this change. A function where `bind` was used has a different execution path in there (that's where the second generator test comes from) and after some digging I've realized that I would have to change a lot of places.

I've kept the test inside just in case code is moved around later to catch potential regressions.