### PR TITLE
Rewrite of flaky test

### DIFF
--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Jint.Native;
+using Jint.Runtime;
 using Jint.Tests.Runtime.TestClasses;
 
 namespace Jint.Tests.Runtime;
@@ -43,13 +44,14 @@ public class AsyncTests
     }
 
     [Fact]
-    public void ShouldUnwrapPromiseWithCustomTimeout()
+    public void ShouldRespectCustomProvidedTimeoutWhenUnwrapping()
     {
         Engine engine = new(options => options.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
         engine.SetValue("asyncTestClass", new AsyncTestClass());
         var result = engine.Evaluate("asyncTestClass.ReturnDelayedTaskAsync().then(x=>x)");
-        result = result.UnwrapIfPromise(TimeSpan.FromMilliseconds(200));
-        Assert.Equal(AsyncTestClass.TestString, result);
+        var timeout = TimeSpan.FromMilliseconds(1);
+        var exception = Assert.Throws<PromiseRejectedException>(() => result.UnwrapIfPromise(timeout));
+        Assert.Equal($"Promise was rejected with value Timeout of {timeout} reached", exception.Message);
     }
 
     [Fact]


### PR DESCRIPTION
The test `ShouldUnwrapPromiseWithCustomTimeout` did randomly fail, so I tried to rewrite it to make it reliable.

The test randomly failed with
```
Jint.Tests.Runtime.AsyncTests.ShouldUnwrapPromiseWithCustomTimeout [FAIL]

Error: Jint.Runtime.PromiseRejectedException : Promise was rejected with value Timeout of 00:00:00.2000000 reached
```

which can happen if the system is under high load and the Task state machine didn't get CPU time to process the completed `Task.Delay` within `AsyncTestClass.ReturnDelayedTaskAsync()`.

---

The rewrite attempts to fix that by basically always rejecting the unwrapping with a timeout of 1ms. This ensures that the provided custom timeout is used. The timeout should always happen, independent of when the async state machine got time to process the result.

The test above (`ShouldReturnedTaskConvertedToPromiseInJS`) still checks the happy path for proper unwrapping. 