### PR TITLE
Allows the conversion of primses to tasks when pasing an async function as argument

### DIFF
--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1022,6 +1022,18 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             case ObjectClass.Arguments:
             case ObjectClass.Object:
 
+                if ((Engine.Options.ExperimentalFeatures & ExperimentalFeature.TaskInterop) != ExperimentalFeature.None)
+                {
+                    if (this is JsPromise asPromise)
+                    {
+                        var promsiseResult = asPromise.UnwrapIfPromise(Engine.Options.Constraints.PromiseTimeout);
+
+                        converted = promsiseResult is ObjectInstance oi
+                                    ? oi.ToObject(stack)
+                                    : promsiseResult.ToObject();
+                        break;
+                    }
+                }
                 if (this is JsArray arrayInstance)
                 {
                     var result = new object?[arrayInstance.GetLength()];


### PR DESCRIPTION
Allows the conversion of primses to tasks when pasing an async function as argument

Fixes: https://github.com/sebastienros/jint/issues/2194