### PR TITLE
Fix accessing properties defined by a bound function

### DIFF
--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -419,6 +419,8 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             return Undefined;
         }
 
+        if (getter is Function.BindFunction bindFunction) return bindFunction._engine.Call(bindFunction, thisObject);
+
         var functionInstance = (Function.Function) getter;
         return functionInstance._engine.Call(functionInstance, thisObject);
     }


### PR DESCRIPTION
When an object property is defined as a getter, which in turn is a bound function, accessing the property results in `InvalidCastException` in `ObjectInstance.UnwrapFromGetter`, because `getter` variable is `Jint.Native.Function.BindFunction` instead of `Jint.Native.Function.Function`.

Explicit test for `BindFunction` is not ideal and perhaps `ICallable` should be used, but I'm not sure how to properly pass it to `Engine`.

Test code to reproduce the behavior:

```
Console.WriteLine(new Engine().Evaluate("""
	const holder = {
		x: 42,
		getter() { return this.x; }
	};

	const target = {};

	Object.defineProperty(target, "prop", { get: holder.getter.bind(holder) });

	target.prop;
"""));
```

Before fix: throws `InvalidCastException`
After fix: prints out `42`