### PR TITLE
Fix destructuring spec compliance for IteratorClose, done tracking, and binding order

### DIFF
--- a/Jint.Benchmark/DestructuringBenchmark.cs
+++ b/Jint.Benchmark/DestructuringBenchmark.cs
@@ -1,0 +1,118 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+[MemoryDiagnoser]
+public class DestructuringBenchmark
+{
+    private Prepared<Script> _simpleObjectDestructuring;
+    private Prepared<Script> _objectDestructuringWithDefaults;
+    private Prepared<Script> _nestedObjectDestructuring;
+    private Prepared<Script> _simpleArrayDestructuring;
+    private Prepared<Script> _arrayDestructuringWithRest;
+    private Prepared<Script> _forOfDestructuring;
+    private Prepared<Script> _parameterDestructuring;
+    private Prepared<Script> _computedKeyDestructuring;
+    private Prepared<Script> _mixedNested;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _simpleObjectDestructuring = Engine.PrepareScript("""
+            var obj = {a: 1, b: 2, c: 3};
+            for (var i = 0; i < 500000; i++) {
+                var {a, b, c} = obj;
+            }
+            """);
+
+        _objectDestructuringWithDefaults = Engine.PrepareScript("""
+            var obj = {};
+            for (var i = 0; i < 500000; i++) {
+                var {a = 1, b = 2, c = 3} = obj;
+            }
+            """);
+
+        _nestedObjectDestructuring = Engine.PrepareScript("""
+            var obj = {a: {b: 1, c: 2}};
+            for (var i = 0; i < 500000; i++) {
+                var {a: {b, c}} = obj;
+            }
+            """);
+
+        _simpleArrayDestructuring = Engine.PrepareScript("""
+            var arr = [1, 2, 3];
+            for (var i = 0; i < 500000; i++) {
+                var [a, b, c] = arr;
+            }
+            """);
+
+        _arrayDestructuringWithRest = Engine.PrepareScript("""
+            var arr = [1, 2, 3, 4, 5];
+            for (var i = 0; i < 500000; i++) {
+                var [a, ...rest] = arr;
+            }
+            """);
+
+        _forOfDestructuring = Engine.PrepareScript("""
+            var items = [];
+            for (var i = 0; i < 10000; i++) {
+                items.push({a: i, b: i + 1});
+            }
+            var s = 0;
+            for (var {a, b} of items) {
+                s += a + b;
+            }
+            """);
+
+        _parameterDestructuring = Engine.PrepareScript("""
+            function f({a, b}) { return a + b; }
+            var obj = {a: 1, b: 2};
+            var s = 0;
+            for (var i = 0; i < 500000; i++) {
+                s += f(obj);
+            }
+            """);
+
+        _computedKeyDestructuring = Engine.PrepareScript("""
+            var obj = {x: 42};
+            var key = 'x';
+            for (var i = 0; i < 500000; i++) {
+                var {[key]: val} = obj;
+            }
+            """);
+
+        _mixedNested = Engine.PrepareScript("""
+            var obj = {a: 1, items: [10, 20]};
+            for (var i = 0; i < 500000; i++) {
+                var {a, items: [x, y]} = obj;
+            }
+            """);
+    }
+
+    [Benchmark]
+    public void SimpleObject() => new Engine().Execute(_simpleObjectDestructuring);
+
+    [Benchmark]
+    public void ObjectWithDefaults() => new Engine().Execute(_objectDestructuringWithDefaults);
+
+    [Benchmark]
+    public void NestedObject() => new Engine().Execute(_nestedObjectDestructuring);
+
+    [Benchmark]
+    public void SimpleArray() => new Engine().Execute(_simpleArrayDestructuring);
+
+    [Benchmark]
+    public void ArrayWithRest() => new Engine().Execute(_arrayDestructuringWithRest);
+
+    [Benchmark]
+    public void ForOfDestructuring() => new Engine().Execute(_forOfDestructuring);
+
+    [Benchmark]
+    public void ParameterDestructuring() => new Engine().Execute(_parameterDestructuring);
+
+    [Benchmark]
+    public void ComputedKey() => new Engine().Execute(_computedKeyDestructuring);
+
+    [Benchmark]
+    public void MixedNested() => new Engine().Execute(_mixedNested);
+}

--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -21,14 +21,6 @@
   ],
   "ExcludedFiles": [
 
-    // requires rewrite of destructing towards spec
-    "language/destructuring/binding/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js",
-    "language/expressions/assignment/destructuring/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js",
-    "language/expressions/assignment/destructuring/default-expr-throws-iterator-return-get-throws.js",
-    "language/expressions/assignment/destructuring/default-expr-throws-iterator-return-is-not-callable.js",
-    "language/expressions/assignment/destructuring/target-assign-throws-iterator-return-get-throws.js",
-    "language/expressions/assignment/destructuring/target-assign-throws-iterator-return-is-not-callable.js",
-
     // Acornima doesn't implement unicode 15/16/17 yet
     "language/identifiers/*-unicode-15.*.js",
     "language/identifiers/*-unicode-16.*.js",

--- a/Jint/Native/Iterator/IteratorInstance.cs
+++ b/Jint/Native/Iterator/IteratorInstance.cs
@@ -90,9 +90,24 @@ internal abstract class IteratorInstance : ObjectInstance
             return instance;
         }
 
+        /// <summary>
+        /// https://tc39.es/ecma262/#sec-iteratorclose
+        /// </summary>
         public override void Close(CompletionType completion)
         {
-            var callable = _target.GetMethod(CommonProperties.Return);
+            // 7.4.11 IteratorClose ( iteratorRecord, completion )
+            // Step 3: Let innerResult be Completion(GetMethod(iterator, "return")).
+            ICallable? callable;
+            try
+            {
+                callable = _target.GetMethod(CommonProperties.Return);
+            }
+            catch when (completion == CompletionType.Throw)
+            {
+                // Step 5: If completion is a throw completion, return ? completion.
+                return;
+            }
+
             if (callable is null)
             {
                 return;
@@ -103,8 +118,9 @@ internal abstract class IteratorInstance : ObjectInstance
             {
                 innerResult = callable.Call(_target, Arguments.Empty);
             }
-            catch (JavaScriptException) when (completion == CompletionType.Throw)
+            catch when (completion == CompletionType.Throw)
             {
+                // Step 5: If completion is a throw completion, return ? completion.
                 return;
             }
 

--- a/Jint/Runtime/Interpreter/Expressions/DestructuringPatternAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/DestructuringPatternAssignmentExpression.cs
@@ -66,13 +66,28 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
         value = JsValue.Undefined;
         done = false;
 
-        if (!it.TryIteratorStep(out var d))
+        bool stepped;
+        try
+        {
+            stepped = it.TryIteratorStep(out var d);
+            if (stepped)
+            {
+                value = d.Get(CommonProperties.Value);
+            }
+        }
+        catch
+        {
+            // Per spec 13.15.5.5 step 2b: If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            done = true;
+            throw;
+        }
+
+        if (!stepped)
         {
             done = true;
             return false;
         }
 
-        value = d.Get(CommonProperties.Value);
         return true;
     }
 
@@ -231,8 +246,16 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                     }
                     else
                     {
-                        iterator!.TryIteratorStep(out var temp);
-                        value = temp;
+                        try
+                        {
+                            iterator!.TryIteratorStep(out var temp);
+                            value = temp;
+                        }
+                        catch
+                        {
+                            done = true;
+                            throw;
+                        }
                     }
                     ProcessPatterns(context, dp, value, environment);
                 }
@@ -434,6 +457,7 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
         catch
         {
             completionType = CompletionType.Throw;
+            close = true;
             // Clear suspend data on error
             generator?.Data.Clear(pattern);
             throw;
@@ -485,9 +509,11 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                 processedProperties?.Add(sourceKey);
                 if (p.Value is AssignmentPattern assignmentPattern)
                 {
-                    // Per ECMAScript spec (KeyedDestructuringAssignmentEvaluation):
+                    // Per ECMAScript spec (KeyedDestructuringAssignmentEvaluation / KeyedBindingInitialization):
                     // If target is MemberExpression, evaluate lref first, then get value
+                    // For binding patterns (environment != null), ResolveBinding before GetV (spec 14.3.3.3 step 2-3)
                     Reference? memberReference = null;
+                    Reference? bindingRef = null;
                     if (assignmentPattern.Left is MemberExpression memberExpr)
                     {
                         memberReference = GetReferenceFromMember(context, memberExpr);
@@ -495,6 +521,11 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                         {
                             return JsValue.Undefined;
                         }
+                    }
+                    else if (assignmentPattern.Left is Identifier leftId)
+                    {
+                        var target = leftId ?? identifier;
+                        bindingRef = context.Engine.ResolveBinding(target!.Name, environment);
                     }
 
                     var value = source.Get(sourceKey);
@@ -531,7 +562,25 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                             ((Function) value).SetFunctionName(target!.Name);
                         }
 
-                        AssignToIdentifier(context.Engine, target!.Name, value, environment, checkReference);
+                        if (bindingRef is not null)
+                        {
+                            if (environment is not null)
+                            {
+                                bindingRef.InitializeReferencedBinding(value, DisposeHint.Normal);
+                            }
+                            else
+                            {
+                                if (checkReference && bindingRef.IsUnresolvableReference && StrictModeScope.IsStrictModeCode)
+                                {
+                                    Throw.ReferenceError(context.Engine.Realm, bindingRef);
+                                }
+                                context.Engine.PutValue(bindingRef, value);
+                            }
+                        }
+                        else
+                        {
+                            AssignToIdentifier(context.Engine, target!.Name, value, environment, checkReference);
+                        }
                     }
                 }
                 else if (p.Value is DestructuringPattern dp)
@@ -549,8 +598,23 @@ internal sealed class DestructuringPatternAssignmentExpression : JintExpression
                 {
                     var identifierReference = p.Value as Identifier;
                     var target = identifierReference ?? identifier;
+
+                    // Per spec 14.3.3.3 step 2-3: ResolveBinding before GetV
+                    var lhs = context.Engine.ResolveBinding(target!.Name, environment);
                     var value = source.Get(sourceKey);
-                    AssignToIdentifier(context.Engine, target!.Name, value, environment, checkReference);
+
+                    if (environment is not null)
+                    {
+                        lhs.InitializeReferencedBinding(value, DisposeHint.Normal);
+                    }
+                    else
+                    {
+                        if (checkReference && lhs.IsUnresolvableReference && StrictModeScope.IsStrictModeCode)
+                        {
+                            Throw.ReferenceError(context.Engine.Realm, lhs);
+                        }
+                        context.Engine.PutValue(lhs, value);
+                    }
                 }
             }
             else


### PR DESCRIPTION
## Summary

- **IteratorClose error swallowing**: Wrap `GetMethod(iterator, "return")` in try-catch per spec 7.4.11 step 5 — when the original completion is a throw, errors from accessing/validating the `return` property are swallowed so the original error propagates
- **Iterator done tracking**: Set `iteratorRecord.[[Done]]` to true when `IteratorStep` throws (spec 13.15.5.5 step 2b), preventing incorrect `IteratorClose` calls after abrupt iterator completions. Also set `close=true` in the catch block so IteratorClose IS called for non-iterator throws (e.g., default expression evaluation) when the iterator is still open
- **Binding evaluation order**: Resolve bindings before `GetV` in object destructuring per spec 14.3.3.3 step 2-3, fixing evaluation order for both binding and assignment patterns with `with`+Proxy environments
- **Benchmark**: Add `DestructuringBenchmark` with 9 scenarios covering object, array, nested, rest, computed key, for-of, and parameter destructuring

## Test plan

- [x] All 12 originally targeted test262 tests pass (iterator close: 8, binding order: 4)
- [x] 8 additional test262 tests pass from the done-on-throw fix
- [x] Full test262 suite: 91,998 passed, 0 regressions (was 91,978)
- [x] Full Jint.Tests suite: 0 failures
- [x] Benchmark project builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)