### PR TITLE
Implement import-bytes module support

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -5,7 +5,6 @@
   "Namespace": "Jint.Tests.Test262",
   "Parallel": true,
   "ExcludedFeatures": [
-    "import-bytes",
     "import-defer",
     "regexp-lookbehind",
     "regexp-modifiers",

--- a/Jint.Tests.Test262/Test262ModuleLoader.cs
+++ b/Jint.Tests.Test262/Test262ModuleLoader.cs
@@ -35,4 +35,20 @@ internal sealed class Test262ModuleLoader : ModuleLoader
             return stream.ReadToEnd();
         }
     }
+
+    protected override byte[] LoadModuleContentsAsBytes(Engine engine, ResolvedSpecifier resolved)
+    {
+        lock (_fileSystem)
+        {
+            var fileName = Path.Combine(_basePath, resolved.Key).Replace('\\', '/');
+            if (!_fileSystem.FileExists(fileName))
+            {
+                Throw.ModuleResolutionException("Module Not Found", resolved.ModuleRequest.Specifier, parent: null, fileName);
+            }
+            using var stream = _fileSystem.OpenFile(fileName, FileMode.Open, FileAccess.Read);
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
+            return ms.ToArray();
+        }
+    }
 }

--- a/Jint/Runtime/Modules/DefaultModuleLoader.cs
+++ b/Jint/Runtime/Modules/DefaultModuleLoader.cs
@@ -143,6 +143,28 @@ public class DefaultModuleLoader : ModuleLoader
         return File.ReadAllText(fileName);
     }
 
+    protected override byte[] LoadModuleContentsAsBytes(Engine engine, ResolvedSpecifier resolved)
+    {
+        var specifier = resolved.ModuleRequest.Specifier;
+        if (resolved.Type != SpecifierType.RelativeOrAbsolute)
+        {
+            Throw.NotSupportedException($"The default module loader can only resolve files. You can define modules directly to allow imports using {nameof(Engine)}.{nameof(Engine.Modules.Add)}(). Attempted to resolve: '{specifier}'.");
+        }
+
+        if (resolved.Uri == null)
+        {
+            Throw.InvalidOperationException($"Module '{specifier}' of type '{resolved.Type}' has no resolved URI.");
+        }
+
+        var fileName = Uri.UnescapeDataString(resolved.Uri.AbsolutePath);
+        if (!File.Exists(fileName))
+        {
+            Throw.ModuleResolutionException("Module Not Found", specifier, parent: null, fileName);
+        }
+
+        return File.ReadAllBytes(fileName);
+    }
+
     private static bool IsRelative(string specifier)
     {
         return specifier.StartsWith('.') || specifier.StartsWith('/');

--- a/Jint/Runtime/Modules/ModuleFactory.cs
+++ b/Jint/Runtime/Modules/ModuleFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Jint.Native;
+using Jint.Native.ArrayBuffer;
 using Jint.Native.Json;
 
 namespace Jint.Runtime.Modules;
@@ -86,5 +87,22 @@ public static class ModuleFactory
     public static Module BuildJsonModule(Engine engine, JsValue parsedJson, string? location)
     {
         return new SyntheticModule(engine, engine.Realm, parsedJson, location);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Module"/> for the usage within the given <paramref name="engine"/> for the
+    /// provided bytes module data.
+    /// </summary>
+    /// <remarks>
+    /// https://tc39.es/proposal-import-bytes/#sec-create-bytes-module
+    /// </remarks>
+    public static Module BuildBytesModule(Engine engine, ResolvedSpecifier resolved, byte[] bytes)
+    {
+        var arrayBuffer = engine.Realm.Intrinsics.ArrayBuffer.Construct(bytes);
+        arrayBuffer._isImmutable = true;
+
+        var uint8Array = engine.Realm.Intrinsics.Uint8Array.Construct([arrayBuffer], engine.Realm.Intrinsics.Uint8Array);
+
+        return new SyntheticModule(engine, engine.Realm, uint8Array, resolved.Uri?.LocalPath);
     }
 }

--- a/Jint/Runtime/Modules/ModuleLoader.cs
+++ b/Jint/Runtime/Modules/ModuleLoader.cs
@@ -9,6 +9,22 @@ public abstract class ModuleLoader : IModuleLoader
 
     public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
     {
+        if (resolved.ModuleRequest.IsBytesModule())
+        {
+            byte[] bytes;
+            try
+            {
+                bytes = LoadModuleContentsAsBytes(engine, resolved);
+            }
+            catch (Exception)
+            {
+                Throw.JavaScriptException(engine, $"Could not load module {resolved.ModuleRequest.Specifier}", AstExtensions.DefaultLocation);
+                return default!;
+            }
+
+            return ModuleFactory.BuildBytesModule(engine, resolved, bytes);
+        }
+
         string code;
         try
         {
@@ -29,4 +45,13 @@ public abstract class ModuleLoader : IModuleLoader
     }
 
     protected abstract string LoadModuleContents(Engine engine, ResolvedSpecifier resolved);
+
+    /// <summary>
+    /// Loads module contents as raw bytes. Override in derived classes for efficient binary loading.
+    /// </summary>
+    protected virtual byte[] LoadModuleContentsAsBytes(Engine engine, ResolvedSpecifier resolved)
+    {
+        var text = LoadModuleContents(engine, resolved);
+        return System.Text.Encoding.UTF8.GetBytes(text);
+    }
 }

--- a/Jint/Runtime/Modules/ModuleRequestExtensions.cs
+++ b/Jint/Runtime/Modules/ModuleRequestExtensions.cs
@@ -18,4 +18,21 @@ public static class ModuleRequestExtensions
         return request.Attributes != null
             && Array.Exists(request.Attributes, x => string.Equals(x.Key, "type", StringComparison.Ordinal) && string.Equals(x.Value, "json", StringComparison.Ordinal));
     }
+
+    /// <summary>
+    /// Returns true if the provided <paramref name="request"/>
+    /// is a bytes module, otherwise false.
+    /// </summary>
+    /// <example>
+    /// The following JavaScript import statement imports a bytes module
+    /// for which this method would return true.
+    /// <code>
+    /// import value from 'data.bin' with { type: 'bytes' }
+    /// </code>
+    /// </example>
+    public static bool IsBytesModule(this ModuleRequest request)
+    {
+        return request.Attributes != null
+            && Array.Exists(request.Attributes, x => string.Equals(x.Key, "type", StringComparison.Ordinal) && string.Equals(x.Value, "bytes", StringComparison.Ordinal));
+    }
 }

--- a/README.md
+++ b/README.md
@@ -144,9 +144,11 @@ and many more.
 
 #### ECMAScript proposals (no version yet)
 
+- ✔ Await Dictionary (`Promise.allKeyed`, `Promise.allSettledKeyed`)
 - ✔ `Error.isError`
 - ✔ Explicit Resource Management (`using` and `await using`)
 - ✔ Immutable Arraybuffers
+- ✔ Import Bytes (`import x from './file' with { type: 'bytes' }`)
 - ✔ Iterator Sequencing
 - ✔ Joint Iteration
 - ✔ JSON.parse source text access


### PR DESCRIPTION
## Summary
- Implement the TC39 [import-bytes proposal](https://github.com/tc39/proposal-import-bytes) enabling `import data from './file.bin' with { type: 'bytes' }` which returns an immutable `Uint8Array`
- Add `IsBytesModule()` extension, `BuildBytesModule()` factory, and `LoadModuleContentsAsBytes()` virtual method in the module loading pipeline
- Override binary loading in `DefaultModuleLoader` (`File.ReadAllBytes`) and `Test262ModuleLoader` (Zio stream)
- Remove `import-bytes` from excluded test262 features — all 5 test cases pass
- Update README with new feature entry

## Test plan
- [x] All 5 import-bytes test262 tests pass (txt, js, json, png, empty)
- [x] Full test262 suite: 92,215 passed, 0 failures
- [x] Main test suite: 2,756 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)