### PR TITLE
Fix module-graphs-does-not-hang and import abrupt return test262 failures

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -88,11 +88,6 @@
 
     // eval-code arguments bindings in direct eval
     "language/eval-code/direct/*-arguments-*.js",
-    // dynamic import attributes abrupt return
-    "language/expressions/dynamic-import/import-attributes/2nd-param-evaluation-abrupt-return.js",
-    // TLA with complex module graph - dynamic import inside TLA module doesn't settle
-    // when module has both static and dynamic imports with cyclic dependencies
-    "language/module-code/top-level-await/module-graphs-does-not-hang.js",
 
     // === INTL402 EXCLUSIONS ===
     // The following tests require full CLDR locale data support which is not available in the default provider.

--- a/Jint/Runtime/Interpreter/Expressions/JintImportExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintImportExpression.cs
@@ -31,7 +31,16 @@ internal sealed class JintImportExpression : JintExpression
 
         var referrer = context.Engine.GetActiveScriptOrModule();
         var specifier = _specifierExpression.GetValue(context); //.UnwrapIfPromise();
+        if (context.IsGeneratorAborted())
+        {
+            return specifier;
+        }
+
         var options = _optionsExpression?.GetValue(context) ?? JsValue.Undefined;
+        if (context.IsGeneratorAborted())
+        {
+            return options;
+        }
 
         var promiseCapability = PromiseConstructor.NewPromiseCapability(context.Engine, context.Engine.Realm.Intrinsics.Promise);
 

--- a/Jint/Runtime/Interpreter/Expressions/JintSequenceExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintSequenceExpression.cs
@@ -32,17 +32,39 @@ internal sealed class JintSequenceExpression : JintExpression
             _initialized = true;
         }
 
-        var result = JsValue.Undefined;
-        foreach (var expression in _expressions)
+        var expressions = _expressions;
+        var startIndex = 0;
+
+        // When resuming a generator, skip sub-expressions that were already evaluated
+        // before the yield point to avoid duplicate side effects
+        var suspendable = context.Engine.ExecutionContext.Suspendable;
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out SequenceSuspendData? suspendData))
         {
-            result = expression.GetValue(context);
+            startIndex = suspendData!.ExpressionIndex;
+        }
+
+        var result = JsValue.Undefined;
+        for (var i = startIndex; i < expressions.Length; i++)
+        {
+            result = expressions[i].GetValue(context);
 
             // Check for generator suspension after each expression
-            if (context.IsSuspended())
+            if (context.IsSuspended() || context.IsGeneratorAborted())
             {
+                // Record which sub-expression we were at for proper resume
+                if (suspendable is not null && context.IsSuspended())
+                {
+                    var data = suspendable.Data.GetOrCreate<SequenceSuspendData>(this);
+                    data.ExpressionIndex = i;
+                }
+
                 return result;
             }
         }
+
+        // Clear suspend data when sequence completes normally
+        suspendable?.Data.Clear(this);
 
         return result;
     }

--- a/Jint/Runtime/Modules/CyclicModule.cs
+++ b/Jint/Runtime/Modules/CyclicModule.cs
@@ -507,6 +507,7 @@ public abstract class CyclicModule : Module
                 }
                 else
                 {
+                    m._asyncEvaluation = false;
                     m.Status = ModuleStatus.Evaluated;
                     if (m._topLevelCapability is not null)
                     {

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -99,6 +99,19 @@ internal sealed class BlockSuspendData : SuspendData
     public Jint.Runtime.Environments.Environment? OuterEnvironment { get; set; }
 }
 
+/// <summary>
+/// Stores the state of a sequence expression when a generator yields inside it.
+/// Tracks which sub-expression was being evaluated when the generator suspended,
+/// so on resume we skip already-evaluated sub-expressions (avoiding duplicate side effects).
+/// </summary>
+internal sealed class SequenceSuspendData : SuspendData
+{
+    /// <summary>
+    /// The index of the sub-expression that was being evaluated when the generator suspended.
+    /// </summary>
+    public int ExpressionIndex { get; set; }
+}
+
 internal sealed class SuspendDataDictionary
 {
     /// <summary>


### PR DESCRIPTION
## Summary
- **AsyncModuleExecutionFulfilled**: Set `_asyncEvaluation = false` in the `execList` loop per spec step 12.c.iii, fixing TLA module graphs where dynamic `import()` never settles because already-evaluated modules retain stale async state
- **JintImportExpression**: Add `IsGeneratorAborted()` checks after evaluating specifier/options so `import()` bails out when `generator.return()` is called via `yield`
- **JintSequenceExpression**: Track suspension index via `SequenceSuspendData` to skip already-evaluated sub-expressions on generator resume (preventing duplicate side effects), and add `IsGeneratorAborted()` to stop evaluation on generator return

Removes test262 exclusions for `module-graphs-does-not-hang.js` and `2nd-param-evaluation-abrupt-return.js` (+3 newly passing test cases, 0 regressions across 92,218 tests).

## Test plan
- [x] `dotnet test --filter "module-graphs-does-not-hang"` — passes (1 case)
- [x] `dotnet test --filter "2nd-param-evaluation-abrupt-return"` — passes (2 cases: strict + sloppy)
- [x] `dotnet test --filter "top-level-await"` — 253 passed, 0 failed
- [x] `dotnet test --filter "dynamic-import"` — 1,129 passed, 0 failed
- [x] Full unit tests (Jint.Tests) — 2,761 passed, 0 failed
- [x] Full test262 suite — 92,218 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)