### PR TITLE
Fix eval-code direct eval var arguments conflict detection

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -86,9 +86,6 @@
     // special casing data
     "built-ins/**/special_casing*.js",
 
-    // eval-code arguments bindings in direct eval
-    "language/eval-code/direct/*-arguments-*.js",
-
     // === INTL402 EXCLUSIONS ===
     // The following tests require full CLDR locale data support which is not available in the default provider.
     // Many of these tests require non-English locales (Spanish, Polish, German, Chinese, etc.) or

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1464,6 +1464,16 @@ public sealed partial class Engine : IDisposable
                     {
                         Throw.SyntaxError(realm);
                     }
+
+                    // Non-arrow functions always have an implicit "arguments" binding per spec
+                    // (10.2.11 FunctionDeclarationInstantiation steps 17-21), even when the
+                    // arguments object creation was optimized away because the function body
+                    // doesn't reference "arguments". Detect this implicit binding conflict.
+                    if (string.Equals(identifier.Name, "arguments", StringComparison.Ordinal)
+                        && funcEnv._functionObject._thisMode != FunctionThisMode.Lexical)
+                    {
+                        Throw.SyntaxError(realm);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Detect implicit `arguments` binding in `EvalDeclarationInstantiation` for non-arrow functions, even when the arguments object creation was optimized away (the body doesn't reference `arguments`)
- Per spec (10.2.11 steps 17-21), every non-arrow function has an implicit `arguments` binding, so `var arguments` inside direct eval during parameter default evaluation must throw `SyntaxError`
- Fixes 192 test262 tests (`language/eval-code/direct/*-arguments-*.js`) with zero performance impact on normal code paths

## Test plan
- [x] All 924 eval-code test262 cases pass (462 files × strict/sloppy)
- [x] Full test262 suite: 92,410 passed, 0 failures, 0 regressions
- [x] Main test suite (Jint.Tests): 2,756 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)