### PR TITLE
Update Regex terminology in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ The synchronous `UnwrapIfPromise` is still available for scenarios where blockin
   - number -> double
   - string -> string
   - boolean -> bool
-  - Regex -> RegExp
+  - Regexp -> RegEx
   - Function -> Delegate
 - Extensions methods
 


### PR DESCRIPTION
Apparently I have to make a pull request in order to propose a fix for a 2 character switchup
Fixes #2331