### PR TITLE
Fix typo in README for RegExp to Regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ The synchronous `UnwrapIfPromise` is still available for scenarios where blockin
   - number -> double
   - string -> string
   - boolean -> bool
-  - Regexp -> RegEx
+  - RegExp -> Regex
   - Function -> Delegate
 - Extensions methods
 


### PR DESCRIPTION
Oh my god...I did a typo in the readme now...