### PR TITLE
Optimize Intl and Temporal hot paths with caching and algorithmic fixes

### DIFF
--- a/Jint/Native/Intl/DefaultCldrProvider.cs
+++ b/Jint/Native/Intl/DefaultCldrProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Linq;
 using Jint.Native.Intl.Data;
@@ -14,6 +15,13 @@ public sealed class DefaultCldrProvider : ICldrProvider
     /// Singleton instance of the default provider.
     /// </summary>
     public static readonly DefaultCldrProvider Instance = new();
+
+    // Caches for immutable locale-dependent data
+    private static readonly ConcurrentDictionary<string, string[]?> _monthNameCache = new(StringComparer.Ordinal);
+    private static readonly ConcurrentDictionary<string, string[]?> _weekdayNameCache = new(StringComparer.Ordinal);
+    private static readonly ConcurrentDictionary<string, string[]?> _dayPeriodCache = new(StringComparer.Ordinal);
+    private static readonly Lazy<string[]> _supportedCurrencies = new(BuildSupportedCurrencies);
+    private static readonly Lazy<Dictionary<string, string>> _currencyDisplayNames = new(BuildCurrencyDisplayNames);
 
     private DefaultCldrProvider()
     {
@@ -215,7 +223,11 @@ public sealed class DefaultCldrProvider : ICldrProvider
         // Default provider returns basic currency data from .NET
         try
         {
-            var culture = new CultureInfo(RemoveExtensions(locale));
+            var culture = IntlUtilities.GetCultureInfo(locale);
+            if (culture is null)
+            {
+                return null;
+            }
             var region = new RegionInfo(culture.Name);
 
             // Common currency symbols
@@ -319,9 +331,15 @@ public sealed class DefaultCldrProvider : ICldrProvider
 
     public string[]? GetMonthNames(string locale, string style, string? calendar)
     {
-        try
+        var cacheKey = string.Concat(locale, "_", style);
+        return _monthNameCache.GetOrAdd(cacheKey, _ =>
         {
-            var culture = new CultureInfo(RemoveExtensions(locale));
+            var culture = IntlUtilities.GetCultureInfo(locale);
+            if (culture is null)
+            {
+                return null;
+            }
+
             return style switch
             {
                 "long" => culture.DateTimeFormat.MonthNames.Take(12).ToArray(),
@@ -329,18 +347,20 @@ public sealed class DefaultCldrProvider : ICldrProvider
                 "narrow" => culture.DateTimeFormat.AbbreviatedMonthNames.Take(12).Select(m => m.Length > 0 ? m[0].ToString() : m).ToArray(),
                 _ => null
             };
-        }
-        catch
-        {
-            return null;
-        }
+        });
     }
 
     public string[]? GetWeekdayNames(string locale, string style)
     {
-        try
+        var cacheKey = string.Concat(locale, "_", style);
+        return _weekdayNameCache.GetOrAdd(cacheKey, _ =>
         {
-            var culture = new CultureInfo(RemoveExtensions(locale));
+            var culture = IntlUtilities.GetCultureInfo(locale);
+            if (culture is null)
+            {
+                return null;
+            }
+
             return style switch
             {
                 "long" => culture.DateTimeFormat.DayNames,
@@ -348,24 +368,22 @@ public sealed class DefaultCldrProvider : ICldrProvider
                 "narrow" => culture.DateTimeFormat.ShortestDayNames,
                 _ => null
             };
-        }
-        catch
-        {
-            return null;
-        }
+        });
     }
 
     public string[]? GetDayPeriods(string locale, string style, string? calendar)
     {
-        try
+        var cacheKey = string.Concat(locale, "_", style);
+        return _dayPeriodCache.GetOrAdd(cacheKey, _ =>
         {
-            var culture = new CultureInfo(RemoveExtensions(locale));
-            return [culture.DateTimeFormat.AMDesignator, culture.DateTimeFormat.PMDesignator];
-        }
-        catch
-        {
-            return null;
-        }
+            var culture = IntlUtilities.GetCultureInfo(locale);
+            if (culture is null)
+            {
+                return null;
+            }
+
+            return new[] { culture.DateTimeFormat.AMDesignator, culture.DateTimeFormat.PMDesignator };
+        });
     }
 
     public string[]? GetEraNames(string locale, string style, string? calendar)
@@ -393,26 +411,8 @@ public sealed class DefaultCldrProvider : ICldrProvider
             return null;
         }
 
-        // Look up currency name from .NET culture data by finding a culture that uses this currency
         var upperCode = code.ToUpperInvariant();
-        foreach (var culture in IntlUtilities.SpecificCultures.Value)
-        {
-            try
-            {
-                var region = new RegionInfo(culture.Name);
-                if (string.Equals(region.ISOCurrencySymbol, upperCode, StringComparison.OrdinalIgnoreCase))
-                {
-                    return region.CurrencyEnglishName;
-                }
-            }
-            catch
-            {
-                // Skip cultures without region info
-            }
-        }
-
-        // Don't provide fallback - only return names for currencies we actually know about
-        return null;
+        return _currencyDisplayNames.Value.TryGetValue(upperCode, out var name) ? name : null;
     }
 
     // === Locale Data ===
@@ -535,31 +535,7 @@ public sealed class DefaultCldrProvider : ICldrProvider
 
     public IReadOnlyCollection<string> GetSupportedCurrencies()
     {
-        var currencies = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var culture in IntlUtilities.SpecificCultures.Value)
-        {
-            try
-            {
-                var region = new RegionInfo(culture.Name);
-                var currencyCode = region.ISOCurrencySymbol;
-
-                // Filter out invalid currency codes (must be 3 uppercase ASCII letters)
-                // Some cultures have placeholder codes like "¤¤" or "XXX"
-                if (currencyCode.Length == 3 &&
-                    IsUpperAsciiLetter(currencyCode[0]) &&
-                    IsUpperAsciiLetter(currencyCode[1]) &&
-                    IsUpperAsciiLetter(currencyCode[2]) &&
-                    !string.Equals(currencyCode, "XXX", StringComparison.Ordinal)) // XXX is "no currency"
-                {
-                    currencies.Add(currencyCode);
-                }
-            }
-            catch
-            {
-                // Skip cultures without region info
-            }
-        }
-        return currencies.ToArray();
+        return _supportedCurrencies.Value;
     }
 
     public IReadOnlyCollection<string> GetSupportedNumberingSystems()
@@ -773,5 +749,56 @@ public sealed class DefaultCldrProvider : ICldrProvider
     private static string GetUnitPlural(string unit, string style)
     {
         return GetUnitName(unit, style, plural: true);
+    }
+
+    private static string[] BuildSupportedCurrencies()
+    {
+        var currencies = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var culture in IntlUtilities.SpecificCultures.Value)
+        {
+            try
+            {
+                var region = new RegionInfo(culture.Name);
+                var currencyCode = region.ISOCurrencySymbol;
+
+                if (currencyCode.Length == 3 &&
+                    IsUpperAsciiLetter(currencyCode[0]) &&
+                    IsUpperAsciiLetter(currencyCode[1]) &&
+                    IsUpperAsciiLetter(currencyCode[2]) &&
+                    !string.Equals(currencyCode, "XXX", StringComparison.Ordinal))
+                {
+                    currencies.Add(currencyCode);
+                }
+            }
+            catch
+            {
+                // Skip cultures without region info
+            }
+        }
+
+        return currencies.ToArray();
+    }
+
+    private static Dictionary<string, string> BuildCurrencyDisplayNames()
+    {
+        var names = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var culture in IntlUtilities.SpecificCultures.Value)
+        {
+            try
+            {
+                var region = new RegionInfo(culture.Name);
+                var code = region.ISOCurrencySymbol;
+                if (!names.ContainsKey(code))
+                {
+                    names[code] = region.CurrencyEnglishName;
+                }
+            }
+            catch
+            {
+                // Skip cultures without region info
+            }
+        }
+
+        return names;
     }
 }

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Jint.Native.Intl.Data;
@@ -12,6 +13,9 @@ namespace Jint.Native.Intl;
 /// </summary>
 internal static class IntlUtilities
 {
+    // Cache for CultureInfo instances to avoid repeated allocations.
+    // CultureInfo with useUserOverride:false is immutable, safe to cache and share.
+    private static readonly ConcurrentDictionary<string, CultureInfo?> _cultureCache = new(StringComparer.OrdinalIgnoreCase);
     // BCP 47 language tag pattern (permissive to accept Unicode extensions)
     // Accepts: language[-script][-region][-variant]*[-extension]*[-privateuse]
     // Extensions use single-character singletons like -u- for Unicode extensions
@@ -1631,6 +1635,11 @@ internal static class IntlUtilities
             return null;
         }
 
+        return _cultureCache.GetOrAdd(locale, static key => CreateCultureInfo(key));
+    }
+
+    private static CultureInfo? CreateCultureInfo(string locale)
+    {
         try
         {
             // Remove Unicode extensions before creating CultureInfo

--- a/Jint/Native/Intl/NumberFormatPrototype.cs
+++ b/Jint/Native/Intl/NumberFormatPrototype.cs
@@ -253,9 +253,9 @@ internal sealed class NumberFormatPrototype : Prototype
         var startParts = numberFormat.FormatToParts(startNum);
         var endParts = numberFormat.FormatToParts(endNum);
 
-        // Check if formatted values are approximately equal
-        var startFormatted = numberFormat.Format(startNum);
-        var endFormatted = numberFormat.Format(endNum);
+        // Reconstruct formatted strings from parts to avoid redundant Format() calls
+        var startFormatted = JoinParts(startParts);
+        var endFormatted = JoinParts(endParts);
         var approximatelyEqual = string.Equals(startFormatted, endFormatted, StringComparison.Ordinal);
 
         var result = new JsArray(Engine);
@@ -333,5 +333,26 @@ internal sealed class NumberFormatPrototype : Prototype
         }
 
         return number;
+    }
+
+    private static string JoinParts(List<NumberFormatPart> parts)
+    {
+        if (parts.Count == 0)
+        {
+            return "";
+        }
+
+        if (parts.Count == 1)
+        {
+            return parts[0].Value;
+        }
+
+        var sb = new System.Text.StringBuilder();
+        for (var i = 0; i < parts.Count; i++)
+        {
+            sb.Append(parts[i].Value);
+        }
+
+        return sb.ToString();
     }
 }

--- a/Jint/Native/Temporal/DefaultTimeZoneProvider.cs
+++ b/Jint/Native/Temporal/DefaultTimeZoneProvider.cs
@@ -124,6 +124,12 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
     // Built from IanaToWindows keys at static init time.
     private static readonly Dictionary<string, string> IanaCanonicalCasing = BuildCanonicalCasingDict();
 
+    // Reverse lookup: Windows timezone ID → first IANA name. Avoids O(n) scans of IanaToWindows.
+    private static readonly Dictionary<string, string> WindowsToIana = BuildWindowsToIanaDict();
+
+    // Cached result of GetAvailableTimeZones() since timezone list doesn't change during process lifetime.
+    private static readonly Lazy<IReadOnlyCollection<string>> CachedAvailableTimeZones = new(BuildAvailableTimeZones);
+
     /// <summary>
     /// Singleton instance of the default provider.
     /// </summary>
@@ -558,13 +564,10 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
             return canonicalIana;
         }
 
-        // Try reverse lookup
-        foreach (var kvp in IanaToWindows)
+        // Try reverse lookup via cached dictionary
+        if (WindowsToIana.TryGetValue(tz.Id, out var ianaId))
         {
-            if (kvp.Value.Equals(tz.Id, StringComparison.OrdinalIgnoreCase))
-            {
-                return kvp.Key;
-            }
+            return ianaId;
         }
 
         // Fall back to Windows ID if no IANA mapping found
@@ -574,27 +577,7 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
     /// <inheritdoc />
     public IReadOnlyCollection<string> GetAvailableTimeZones()
     {
-        var zones = TimeZoneInfo.GetSystemTimeZones();
-        var result = new HashSet<string>(StringComparer.Ordinal);
-
-        foreach (var zone in zones)
-        {
-            if (!IsWindowsPlatform())
-            {
-                // On Unix, IDs are already IANA
-                result.Add(zone.Id);
-            }
-            else
-            {
-                // On Windows, prefer IANA names from our mapping
-                var iana = IanaToWindows.FirstOrDefault(x =>
-                    x.Value.Equals(zone.Id, StringComparison.OrdinalIgnoreCase)).Key;
-                result.Add(iana ?? zone.Id);
-            }
-        }
-
-        result.Add("UTC");
-        return result.OrderBy(x => x, StringComparer.Ordinal).ToList();
+        return CachedAvailableTimeZones.Value;
     }
 
     /// <inheritdoc />
@@ -607,13 +590,10 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
             return local.Id;
         }
 
-        // Try to find IANA equivalent
-        foreach (var kvp in IanaToWindows)
+        // Try to find IANA equivalent via cached reverse lookup
+        if (WindowsToIana.TryGetValue(local.Id, out var ianaId))
         {
-            if (kvp.Value.Equals(local.Id, StringComparison.OrdinalIgnoreCase))
-            {
-                return kvp.Key;
-            }
+            return ianaId;
         }
 
         return local.Id;
@@ -844,6 +824,43 @@ public sealed class DefaultTimeZoneProvider : ITimeZoneProvider
         totalNs -= (BigInteger) (offset.TotalMilliseconds * 1_000_000);
 
         return totalNs;
+    }
+
+    private static Dictionary<string, string> BuildWindowsToIanaDict()
+    {
+        var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kvp in IanaToWindows)
+        {
+            // First IANA name wins for each Windows ID
+            if (!dict.ContainsKey(kvp.Value))
+            {
+                dict[kvp.Value] = kvp.Key;
+            }
+        }
+
+        return dict;
+    }
+
+    private static List<string> BuildAvailableTimeZones()
+    {
+        var zones = TimeZoneInfo.GetSystemTimeZones();
+        var result = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var zone in zones)
+        {
+            if (!IsWindowsPlatform())
+            {
+                result.Add(zone.Id);
+            }
+            else
+            {
+                // Use cached reverse lookup instead of linear scan
+                result.Add(WindowsToIana.TryGetValue(zone.Id, out var iana) ? iana : zone.Id);
+            }
+        }
+
+        result.Add("UTC");
+        return result.OrderBy(x => x, StringComparer.Ordinal).ToList();
     }
 
     private static Dictionary<string, string> BuildCanonicalCasingDict()

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -182,8 +182,9 @@ internal static class NonIsoCalendars
                     throw new InvalidOperationException("reject");
                 }
 
-                // Constrain to the base month (non-leap version)
-                newOrdinalMonth = MonthCodeToOrdinal(calendar, cal, newYear, calDate.MonthCode.Substring(0, 3), overflow);
+                // Constrain to the base month (non-leap version) — strip trailing 'L' from "M##L"
+                var baseMonthCode = calDate.MonthCode.Length == 4 ? calDate.MonthCode.Substring(0, 3) : calDate.MonthCode;
+                newOrdinalMonth = MonthCodeToOrdinal(calendar, cal, newYear, baseMonthCode, overflow);
             }
         }
         else if (years != 0)
@@ -200,10 +201,12 @@ internal static class NonIsoCalendars
         if (months != 0)
         {
             newOrdinalMonth += months;
-            while (newOrdinalMonth > GetMonthsInYear(calendar, cal, newYear))
+            var monthsInYear = GetMonthsInYear(calendar, cal, newYear);
+            while (newOrdinalMonth > monthsInYear)
             {
-                newOrdinalMonth -= GetMonthsInYear(calendar, cal, newYear);
+                newOrdinalMonth -= monthsInYear;
                 newYear++;
+                monthsInYear = GetMonthsInYear(calendar, cal, newYear);
             }
 
             while (newOrdinalMonth < 1)
@@ -318,9 +321,15 @@ internal static class NonIsoCalendars
                 {
                     totalMonths = calTwo.Month - calOne.Month;
                 }
+                else if (cal is null)
+                {
+                    // Fixed-month calendars: compute directly instead of looping per year
+                    var monthsPerYear = GetMonthsInYear(calendar, null, 0);
+                    totalMonths = (calTwo.Year - calOne.Year) * monthsPerYear + (calTwo.Month - calOne.Month);
+                }
                 else if (calTwo.Year > calOne.Year)
                 {
-                    // Forward: count months from calOne to calTwo
+                    // Variable-month calendars (Chinese, Dangi, Hebrew): must loop
                     for (var y = calOne.Year; y < calTwo.Year; y++)
                     {
                         totalMonths += GetMonthsInYear(calendar, cal, y);
@@ -330,7 +339,7 @@ internal static class NonIsoCalendars
                 }
                 else
                 {
-                    // Backward: count months from calTwo to calOne (negative)
+                    // Variable-month calendars, backward
                     for (var y = calTwo.Year; y < calOne.Year; y++)
                     {
                         totalMonths -= GetMonthsInYear(calendar, cal, y);
@@ -594,6 +603,17 @@ internal static class NonIsoCalendars
 
         for (var y = approxYear - 2; y <= approxYear + 2; y++)
         {
+            // Pre-validate: check if the monthCode exists in this year before calling expensive ToDateTime
+            var isLeapMonthCode = monthCode.Length == 4 && monthCode[3] == 'L';
+            if (isLeapMonthCode)
+            {
+                var leapOrdinal = GetLeapMonthOrdinal(calendar, cal, y);
+                if (leapOrdinal <= 0)
+                {
+                    continue; // No leap month this year — skip
+                }
+            }
+
             try
             {
                 var ordinal = MonthCodeToOrdinal(calendar, cal, y, monthCode, "reject");

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -54,6 +55,9 @@ internal static class TemporalHelpers
     // maxTimeDuration = 2^53 × 10^9 - 1 = 9,007,199,254,740,991,999,999,999
     // This is the maximum time duration in nanoseconds
     public static readonly BigInteger MaxTimeDuration = BigInteger.Parse("9007199254740991999999999", CultureInfo.InvariantCulture);
+
+    // 2^53 seconds in nanoseconds = 9007199254740992 * 10^9 (used by IsValidDuration)
+    private static readonly BigInteger MaxDurationNs = new BigInteger(9007199254740992L) * 1_000_000_000L;
 
     // Time conversion helpers
     public static long TimeToNanoseconds(IsoTime time)
@@ -429,10 +433,10 @@ internal static class TemporalHelpers
                 seconds = double.Parse(match.Groups[10].Value, CultureInfo.InvariantCulture);
                 if (match.Groups[11].Success)
                 {
-                    var fraction = match.Groups[11].Value.PadRight(9, '0');
-                    milliseconds = double.Parse(fraction.AsSpan(0, 3), CultureInfo.InvariantCulture);
-                    microseconds = double.Parse(fraction.AsSpan(3, 3), CultureInfo.InvariantCulture);
-                    nanoseconds = double.Parse(fraction.AsSpan(6, 3), CultureInfo.InvariantCulture);
+                    ParseFractionDigits(match.Groups[11].Value, out var ms, out var us, out var ns);
+                    milliseconds = ms;
+                    microseconds = us;
+                    nanoseconds = ns;
                 }
             }
         }
@@ -762,10 +766,7 @@ internal static class TemporalHelpers
         int millisecond = 0, microsecond = 0, nanosecond = 0;
         if (match.Groups[4].Success)
         {
-            var fraction = match.Groups[4].Value.PadRight(9, '0');
-            millisecond = int.Parse(fraction.AsSpan(0, 3), CultureInfo.InvariantCulture);
-            microsecond = int.Parse(fraction.AsSpan(3, 3), CultureInfo.InvariantCulture);
-            nanosecond = int.Parse(fraction.AsSpan(6, 3), CultureInfo.InvariantCulture);
+            ParseFractionDigits(match.Groups[4].Value, out millisecond, out microsecond, out nanosecond);
         }
 
         var time = new IsoTime(hour, minute, second, millisecond, microsecond, nanosecond);
@@ -904,10 +905,7 @@ internal static class TemporalHelpers
         int millisecond = 0, microsecond = 0, nanosecond = 0;
         if (match.Groups[7].Success)
         {
-            var fraction = match.Groups[7].Value.PadRight(9, '0');
-            millisecond = int.Parse(fraction.AsSpan(0, 3), CultureInfo.InvariantCulture);
-            microsecond = int.Parse(fraction.AsSpan(3, 3), CultureInfo.InvariantCulture);
-            nanosecond = int.Parse(fraction.AsSpan(6, 3), CultureInfo.InvariantCulture);
+            ParseFractionDigits(match.Groups[7].Value, out millisecond, out microsecond, out nanosecond);
         }
 
         // Parse time zone offset
@@ -935,8 +933,7 @@ internal static class TemporalHelpers
             long offsetFractionNs = 0;
             if (match.Groups[13].Success)
             {
-                var offsetFraction = match.Groups[13].Value.PadRight(9, '0');
-                offsetFractionNs = long.Parse(offsetFraction.AsSpan(0, 9), CultureInfo.InvariantCulture);
+                offsetFractionNs = ParseFractionToNanoseconds(match.Groups[13].Value);
             }
 
             offsetNanoseconds = offsetSign * (
@@ -1097,27 +1094,20 @@ internal static class TemporalHelpers
     /// </summary>
     public static bool IsValidDuration(DurationRecord duration)
     {
-        // Check that all components have the same sign
+        // Check that all components are finite and have the same sign (inline to avoid array allocation)
         var sign = 0;
-        double[] components = { duration.Years, duration.Months, duration.Weeks, duration.Days, duration.Hours, duration.Minutes, duration.Seconds, duration.Milliseconds, duration.Microseconds, duration.Nanoseconds };
-
-        foreach (var component in components)
+        if (!CheckDurationComponent(duration.Years, ref sign)
+            || !CheckDurationComponent(duration.Months, ref sign)
+            || !CheckDurationComponent(duration.Weeks, ref sign)
+            || !CheckDurationComponent(duration.Days, ref sign)
+            || !CheckDurationComponent(duration.Hours, ref sign)
+            || !CheckDurationComponent(duration.Minutes, ref sign)
+            || !CheckDurationComponent(duration.Seconds, ref sign)
+            || !CheckDurationComponent(duration.Milliseconds, ref sign)
+            || !CheckDurationComponent(duration.Microseconds, ref sign)
+            || !CheckDurationComponent(duration.Nanoseconds, ref sign))
         {
-            if (double.IsNaN(component) || double.IsInfinity(component))
-                return false;
-
-            if (component > 0)
-            {
-                if (sign < 0)
-                    return false;
-                sign = 1;
-            }
-            else if (component < 0)
-            {
-                if (sign > 0)
-                    return false;
-                sign = -1;
-            }
+            return false;
         }
 
         // Check calendar unit maximums: |years|, |months|, |weeks| < 2^32
@@ -1130,9 +1120,6 @@ internal static class TemporalHelpers
         }
 
         // Check normalized seconds < 2^53
-        // normalizedSeconds = |days| × 86400 + |hours| × 3600 + |minutes| × 60 + |seconds|
-        //                     + |ms| × 10^-3 + |µs| × 10^-6 + |ns| × 10^-9
-        // Using nanoseconds for exact comparison:
         var totalNs = (BigInteger) System.Math.Abs(duration.Days) * 86_400_000_000_000L
                       + (BigInteger) System.Math.Abs(duration.Hours) * 3_600_000_000_000L
                       + (BigInteger) System.Math.Abs(duration.Minutes) * 60_000_000_000L
@@ -1141,11 +1128,26 @@ internal static class TemporalHelpers
                       + (BigInteger) System.Math.Abs(duration.Microseconds) * 1_000L
                       + (BigInteger) System.Math.Abs(duration.Nanoseconds);
 
-        // 2^53 seconds in nanoseconds = 9007199254740992 * 10^9
-        var maxNs = new BigInteger(9007199254740992L) * 1_000_000_000L;
-        if (totalNs >= maxNs)
-        {
+        return totalNs < MaxDurationNs;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool CheckDurationComponent(double component, ref int sign)
+    {
+        if (double.IsNaN(component) || double.IsInfinity(component))
             return false;
+
+        if (component > 0)
+        {
+            if (sign < 0)
+                return false;
+            sign = 1;
+        }
+        else if (component < 0)
+        {
+            if (sign > 0)
+                return false;
+            sign = -1;
         }
 
         return true;
@@ -3276,10 +3278,58 @@ internal static class TemporalHelpers
 
     /// <summary>
     /// Returns the number of bits in the absolute value of a positive BigInteger.
-    /// Compatible with all .NET target frameworks (GetBitLength() is .NET 5+ only).
+    /// Uses native GetBitLength() on .NET 5+, falls back to byte array on older frameworks.
     /// </summary>
+    /// <summary>
+    /// Parses a fractional digit group (1-9 digits) into ms/us/ns without string allocation.
+    /// Each output is a 3-digit group: digits 0-2 → ms, 3-5 → µs, 6-8 → ns.
+    /// </summary>
+    private static void ParseFractionDigits(string digits, out int millisecond, out int microsecond, out int nanosecond)
+    {
+        // Powers of 10 for padding missing digits within each 3-digit group
+        Span<int> multipliers = stackalloc int[] { 100, 10, 1 };
+        millisecond = 0;
+        microsecond = 0;
+        nanosecond = 0;
+        var len = digits.Length;
+
+        for (var i = 0; i < 9; i++)
+        {
+            var digitVal = i < len ? (digits[i] - '0') : 0;
+            var group = i / 3; // 0=ms, 1=us, 2=ns
+            var pos = i % 3;
+            var contribution = digitVal * multipliers[pos];
+
+            switch (group)
+            {
+                case 0: millisecond += contribution; break;
+                case 1: microsecond += contribution; break;
+                case 2: nanosecond += contribution; break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses a fractional digit group (1-9 digits) into a single nanosecond value without string allocation.
+    /// </summary>
+    private static long ParseFractionToNanoseconds(string digits)
+    {
+        long result = 0;
+        var len = digits.Length;
+        for (var i = 0; i < 9; i++)
+        {
+            var digitVal = i < len ? (digits[i] - '0') : 0;
+            result = result * 10 + digitVal;
+        }
+
+        return result;
+    }
+
     private static int GetBigIntegerBitLength(BigInteger abs)
     {
+#if NET5_0_OR_GREATER
+        return (int) abs.GetBitLength();
+#else
         // Convert to byte array (little-endian, unsigned)
         var bytes = abs.ToByteArray();
         var length = bytes.Length;
@@ -3298,6 +3348,7 @@ internal static class TemporalHelpers
         }
 
         return bits;
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- **Cache CultureInfo instances** in `IntlUtilities` via `ConcurrentDictionary` — eliminates repeated `new CultureInfo()` allocations across all 12+ Intl constructors
- **Cache CLDR provider data** — month/weekday/day-period names, supported currencies, and currency display names computed once and cached
- **Static BigInteger constant** for `IsValidDuration` + eliminate `double[]` array allocation with inline component checks
- **Reverse Windows→IANA timezone dictionary** — replaces three O(n) linear scans with O(1) lookups; cache `GetAvailableTimeZones()` result
- **NonIsoCalendars loop fixes** — cache `GetMonthsInYear` per iteration, direct month computation for fixed-month calendars, pre-validate leap months before try-catch
- **Minor Temporal optimizations** — `GetBitLength()` on .NET 5+, `ParseFractionDigits` helper to avoid `PadRight` allocations, reconstruct formatted string from parts

## Benchmark

Test262 suite (95,988 tests, 0 regressions):
- **Before**: 43s test duration
- **After**: 38s test duration
- **~12% improvement**

## Test plan

- [x] `dotnet test --configuration Release Jint.Tests.Test262/Jint.Tests.Test262.csproj` — 95,988 passed, 0 failures
- [x] `dotnet test --configuration Release Jint.Tests/Jint.Tests.csproj` — 2,764 passed, 0 failures
- [x] Before/after timing comparison via `git stash` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)