### PR TITLE
Always enable modules in Jint.Repl for dynamic import

### DIFF
--- a/Jint.Repl/Program.cs
+++ b/Jint.Repl/Program.cs
@@ -74,13 +74,13 @@ var engine = new Engine(cfg =>
     {
         cfg.TimeoutInterval(TimeSpan.FromSeconds(timeoutSeconds.Value));
     }
-    if (runAsModule)
-    {
-        var basePath = inputFile != null
-            ? Path.GetDirectoryName(Path.GetFullPath(inputFile))!
-            : Directory.GetCurrentDirectory();
-        cfg.EnableModules(basePath, restrictToBasePath: false);
-    }
+
+    // Even if the script is not a module, modules still need to be enabled
+    // for dynamic import to work.
+    var basePath = inputFile != null
+        ? Path.GetDirectoryName(Path.GetFullPath(inputFile))!
+        : Directory.GetCurrentDirectory();
+    cfg.EnableModules(basePath, restrictToBasePath: false);
 });
 
 engine


### PR DESCRIPTION
Dynamic import can be used even if the script itself is not a module. There are about 50 such tests in test262 that would previously fail with "Module loading has been disabled, you need to enable it in engine options" e.g. test/language/expressions/dynamic-import/always-create-new-promise.js