### PR TITLE
Fix DST offset applied incorrectly near daylight saving transitions

### DIFF
--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -226,4 +226,32 @@ public class DateTests
         jsDate = new JsDate(_engine, date);
         Assert.Equal(DateFlags.None, jsDate._dateValue.Flags);
     }
+
+    [Fact]
+    public void DstTransitionShouldUseCorrectOffset()
+    {
+        TimeZoneInfo nztz;
+        try
+        {
+            nztz = TimeZoneInfo.FindSystemTimeZoneById("New Zealand Standard Time");
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            nztz = TimeZoneInfo.FindSystemTimeZoneById("Pacific/Auckland");
+        }
+
+        var engine = new Engine(options => options.LocalTimeZone(nztz));
+
+        // NZDT (GMT+13) ends at 3:00 AM on the first Sunday of April 2025.
+        // At midnight April 6, we are still in NZDT (GMT+13).
+        var result1 = engine.Evaluate("new Date(2025, 3, 6, 0, 0, 0).toString()").AsString();
+        Assert.Contains("GMT+1300", result1);
+        Assert.Contains("Apr 06 2025 00:00:00", result1);
+
+        // NZDT (GMT+13) begins at 2:00 AM on the last Sunday of September 2025.
+        // At midnight Sep 28, we are still in NZST (GMT+12).
+        var result2 = engine.Evaluate("new Date(2025, 8, 28, 0, 0, 0).toString()").AsString();
+        Assert.Contains("GMT+1200", result2);
+        Assert.Contains("Sep 28 2025 00:00:00", result2);
+    }
 }

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -1295,8 +1295,14 @@ internal sealed class DatePrototype : Prototype
 
     internal DatePresentation Utc(DatePresentation t)
     {
+        // t represents local time encoded as epoch milliseconds. GetUtcOffset treats
+        // its argument as a UTC instant, so a single-pass conversion uses the wrong
+        // DST offset near transitions. Use a two-pass approach matching the ES spec's
+        // UTC(t): first estimate UTC, then get the correct offset at that UTC instant.
         var offset = _timeSystem.GetUtcOffset(t.Value).TotalMilliseconds;
-        return t - offset;
+        var estimatedUtc = (t - offset).Value;
+        var refinedOffset = _timeSystem.GetUtcOffset(estimatedUtc).TotalMilliseconds;
+        return t - refinedOffset;
     }
 
     private static int HourFromTime(DatePresentation t)

--- a/Jint/Runtime/DefaultTimeSystem.cs
+++ b/Jint/Runtime/DefaultTimeSystem.cs
@@ -116,8 +116,12 @@ public class DefaultTimeSystem : ITimeSystem
 
         if (convertToUtcAfter)
         {
+            // datePresentation is local time encoded as epoch milliseconds.
+            // Two-pass conversion to get correct DST offset near transitions.
             var offset = GetUtcOffset(datePresentation.Value).TotalMilliseconds;
-            datePresentation -= offset;
+            var estimatedUtc = (datePresentation - offset).Value;
+            var refinedOffset = GetUtcOffset(estimatedUtc).TotalMilliseconds;
+            datePresentation -= refinedOffset;
         }
 
         epochMilliseconds = datePresentation.Value;


### PR DESCRIPTION
## Summary
- Fixes #2355
- The `Utc()` method in `DatePrototype` treated local time as a UTC instant when querying `GetUtcOffset`, causing the wrong DST offset to be used near daylight saving transitions (e.g., midnight in NZ timezone on DST transition days)
- Changed to a two-pass approach matching the ES spec's `UTC(t)`: estimate UTC first, then get the correct offset at that UTC instant
- Applied the same fix in `DefaultTimeSystem.TryParse` for date strings parsed without timezone info

## Test plan
- [x] Added `DstTransitionShouldUseCorrectOffset` test covering NZ fall-back (April) and spring-forward (September) transitions
- [x] All 29 Date tests pass
- [x] Full Jint.Tests suite passes (2781 passed, 0 failures)
- [x] Test262 conformance suite passes (95,988 passed, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)