### PR TITLE
Fix HTML comments in dynamic Function() and for-in initializer evaluation

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -364,16 +364,9 @@
 
     // === ANNEX B EXCLUSIONS ===
 
-    // Acornima parser limitation: HTML-like comments (<!-- and -->) in dynamic Function() bodies/params
-    // Requires parser option for HTML comments which Acornima doesn't support in function constructor context
-    "annexB/built-ins/Function/createdynfn-html-close-comment-body.js",
-    "annexB/built-ins/Function/createdynfn-html-close-comment-params.js",
-    "annexB/built-ins/Function/createdynfn-html-open-comment-body.js",
-    "annexB/built-ins/Function/createdynfn-html-open-comment-params.js",
-    "annexB/built-ins/Function/createdynfn-no-line-terminator-html-close-comment-body.js",
-
     // Acornima parser limitation: assignment target type validation for call expressions
     // Per B.3.7, non-strict mode should allow CallExpression as assignment target in certain cases
+    // Requires Acornima AllowCallExpressionAsLhs option (pending upstream PR)
     "annexB/language/expressions/assignmenttargettype/callexpression-as-for-in-lhs.js",
     "annexB/language/expressions/assignmenttargettype/callexpression-as-for-of-lhs.js",
     "annexB/language/expressions/assignmenttargettype/callexpression-in-compound-assignment.js",
@@ -381,10 +374,6 @@
     "annexB/language/expressions/assignmenttargettype/callexpression-in-prefix-update.js",
     "annexB/language/expressions/assignmenttargettype/callexpression.js",
     "annexB/language/expressions/assignmenttargettype/cover-callexpression-and-asyncarrowhead.js",
-
-    // Acornima parser limitation: for-in initializer in non-strict mode
-    // Per B.3.6, `for (var x = expr in obj)` should be allowed in sloppy mode
-    "annexB/language/statements/for-in/nonstrict-initializer.js",
 
     // Acornima parser/RegExp limitation: malformed named groups in non-unicode mode
     // Per B.1.2, non-unicode RegExp should accept some malformed named group syntax

--- a/Jint/Native/Function/FunctionInstance.Dynamic.cs
+++ b/Jint/Native/Function/FunctionInstance.Dynamic.cs
@@ -121,27 +121,10 @@ public partial class Function
                         break;
                 }
 
-                if (p.Contains('/'))
-                {
-                    // ensure comments don't screw up things
-                    functionExpression += "\n" + p + "\n";
-                }
-                else
-                {
-                    functionExpression += p;
-                }
-
-                functionExpression += ")";
-
-                if (body.Contains('/'))
-                {
-                    // ensure comments don't screw up things
-                    functionExpression += "{\n" + body + "\n}";
-                }
-                else
-                {
-                    functionExpression += "{" + body + "}";
-                }
+                // Per spec (CreateDynamicFunction step 29), a line feed follows the parameters,
+                // and the body is wrapped with line feeds (step 16). This ensures HTML-like
+                // comments (<!-- and -->) are correctly handled as line comments.
+                functionExpression += p + "\n){\n" + body + "\n}";
             }
 
             var parserOptions = _engine.GetActiveParserOptions();

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -31,6 +31,10 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
     private readonly LhsKind _lhsKind;
     private readonly DisposeHint _disposeHint;
 
+    // AnnexB B.3.6: for-in initializer expression (e.g., `for (var a = expr in obj)`)
+    private readonly JintExpression? _forInVarInitializer;
+    private readonly string? _forInVarName;
+
     public JintForInForOfStatement(ForInStatement statement) : base(statement)
     {
         _leftNode = statement.Left;
@@ -40,6 +44,14 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
         InitializeLhs(out _lhsKind, out _disposeHint, out _tdzNames, out _destructuring, out _assignmentPattern, out _expr);
         _body = new ProbablyBlockStatement(_forBody);
         _right = JintExpression.Build(_rightExpression);
+
+        // AnnexB B.3.6: for-in with initializer
+        if (_leftNode is VariableDeclaration { Kind: VariableDeclarationKind.Var } varDecl
+            && varDecl.Declarations[0] is { Init: not null, Id: Identifier id })
+        {
+            _forInVarInitializer = JintExpression.Build(varDecl.Declarations[0].Init!);
+            _forInVarName = id.Name;
+        }
     }
 
     public JintForInForOfStatement(ForOfStatement statement) : base(statement)
@@ -197,6 +209,15 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
         }
 
         engine.UpdateLexicalEnvironment(tdz);
+
+        // AnnexB B.3.6: evaluate for-in initializer before the right-hand expression
+        if (_forInVarInitializer is not null)
+        {
+            var lhs = engine.ResolveBinding(_forInVarName!);
+            var value = _forInVarInitializer.GetValue(context);
+            engine.PutValue(lhs, value);
+        }
+
         var exprValue = _right.GetValue(context);
         engine.UpdateLexicalEnvironment(oldEnv);
 


### PR DESCRIPTION
## Summary

- **Fix CreateDynamicFunction wrapping** to match spec (steps 16/29): line feeds after params and around body text ensure HTML-like comments (`<!--` and `-->`) are correctly handled as line comments
- **Implement AnnexB B.3.6**: evaluate for-in loop variable initializer before enumeration (e.g., `for (var a = ++effects in {})`)
- Remove 6 test262 exclusions (5 HTML comment + 1 for-in initializer), all now passing

## Details

### CreateDynamicFunction (5 tests)

The spec requires specific line feed placement when constructing the source text:
```
sourceText = prefix + " anonymous(" + P + "\n) {\n" + bodyText + "\n}"
```

Previously, Jint only added newlines when the content contained `/`, which missed HTML-like comments (`<!--`, `-->`). Now always follows the spec layout, which correctly handles:
- `Function("\n-->")` — `-->` preceded by line feed is a valid HTML close comment
- `Function("-->")` — `-->` preceded by line feed (from wrapping) is valid
- `Function("-->", "")` — `-->` in params without preceding line feed correctly throws SyntaxError
- `Function("<!--")` — `<!--` is always a valid HTML open comment

### For-in initializer (1 test)

Per AnnexB B.3.6, `for (var a = expr in obj)` should evaluate the initializer before enumeration. The `JintForInForOfStatement` now detects when the LHS `VariableDeclaration` has a non-null `Init` and evaluates it in `HeadEvaluation` before the right-hand expression.

## Test plan

- [x] All 6 previously-excluded test262 tests now pass
- [x] Full test262 suite: 0 failures, 95999 passed
- [x] Jint.Tests: 0 failures, 2781 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)