### PR TITLE
Fix var/lexical name hoisting for destructuring patterns

### DIFF
--- a/Jint.Tests/Runtime/DestructuringTests.cs
+++ b/Jint.Tests/Runtime/DestructuringTests.cs
@@ -68,4 +68,54 @@ public class DestructuringTests
     {
         _engine.Execute("function test({ ...props }){}; test({});");
     }
+
+    [Fact]
+    public void VarDestructuringInForOfShouldHoistInStrictMode()
+    {
+        // Nested destructuring var names must be hoisted to function scope.
+        // Previously only Identifier bindings were collected; patterns like [[x]] were skipped,
+        // causing ReferenceError in strict mode.
+        var result = _engine.Evaluate("""
+            'use strict';
+            (function() {
+                var results = [];
+                for (var [[x, y, z] = [4, 5, 6]] of [[]]) {
+                    results.push(x, y, z);
+                }
+                return results.join(',');
+            })()
+            """);
+
+        Assert.Equal("4,5,6", result.AsString());
+    }
+
+    [Fact]
+    public void VarObjectDestructuringInForOfShouldHoistInStrictMode()
+    {
+        var result = _engine.Evaluate("""
+            'use strict';
+            (function() {
+                for (var { a, b } of [{ a: 1, b: 2 }]) {}
+                return a + ',' + b;
+            })()
+            """);
+
+        Assert.Equal("1,2", result.AsString());
+    }
+
+    [Fact]
+    public void VarDestructuringInForAwaitOfShouldHoistInStrictMode()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            'use strict';
+            (async function() {
+                for await (var [[x] = [1]] of [[]]) {}
+                return x;
+            })()
+            """);
+
+        result = result.UnwrapIfPromise();
+        Assert.Equal(1, result.AsInteger());
+    }
 }

--- a/Jint/HoistingScope.cs
+++ b/Jint/HoistingScope.cs
@@ -10,7 +10,7 @@ internal sealed class HoistingScope
     internal readonly List<Key>? _varNames;
 
     internal readonly List<Declaration>? _lexicalDeclarations;
-    internal readonly List<string>? _lexicalNames;
+    internal readonly List<Key>? _lexicalNames;
 
     /// <summary>
     /// B.3.2/B.3.3: Block-level function declarations that need AnnexB var hoisting in sloppy mode.
@@ -22,7 +22,7 @@ internal sealed class HoistingScope
         List<Key>? varNames,
         List<VariableDeclaration>? variableDeclarations,
         List<Declaration>? lexicalDeclarations,
-        List<string>? lexicalNames,
+        List<Key>? lexicalNames,
         List<FunctionDeclaration>? annexBFunctionDeclarations = null)
     {
         _functionDeclarations = functionDeclarations;
@@ -171,7 +171,7 @@ internal sealed class HoistingScope
 
         private readonly bool _collectLexicalNames;
         internal List<Declaration>? _lexicalDeclarations;
-        internal List<string>? _lexicalNames;
+        internal List<Key>? _lexicalNames;
 
         /// <summary>
         /// B.3.2/B.3.3: Function declarations inside blocks/switch cases in sloppy mode.
@@ -271,10 +271,7 @@ internal sealed class HoistingScope
                             ref readonly var nodeList = ref variableDeclaration.Declarations;
                             foreach (var declaration in nodeList)
                             {
-                                if (declaration.Id is Identifier identifier)
-                                {
-                                    _varNames.Add(identifier.Name);
-                                }
+                                declaration.Id.GetBoundNames(_varNames);
                             }
                         }
                     }
@@ -289,10 +286,7 @@ internal sealed class HoistingScope
                             ref readonly var nodeList = ref variableDeclaration.Declarations;
                             foreach (var declaration in nodeList)
                             {
-                                if (declaration.Id is Identifier identifier)
-                                {
-                                    _lexicalNames.Add(identifier.Name);
-                                }
+                                declaration.Id.GetBoundNames(_lexicalNames);
                             }
                         }
                     }

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -344,7 +344,7 @@ internal sealed class JintFunctionDefinition
         }
         else if (!state.HasParameterExpressions)
         {
-            if (state.FunctionNames.Contains(KnownKeys.Arguments) || lexicalNames?.Contains(KnownKeys.Arguments.Name) == true)
+            if (state.FunctionNames.Contains(KnownKeys.Arguments) || lexicalNames?.Contains(KnownKeys.Arguments) == true)
             {
                 state.ArgumentsObjectNeeded = false;
             }
@@ -468,7 +468,7 @@ internal sealed class JintFunctionDefinition
                     continue;
                 }
 
-                if (lexicalNames?.Contains(fn.Name) == true)
+                if (lexicalNames?.Contains(fn) == true)
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- `HoistingScope.ScriptWalker` only collected `Identifier` names when building `_varNames` and `_lexicalNames`, silently skipping destructuring patterns (`ArrayPattern`, `ObjectPattern`, etc.)
- This caused variables like `x` in `for await (var [[x] = [1]] of [[]])` to not be hoisted into the function scope, resulting in `ReferenceError` in strict mode (sloppy mode worked because undeclared assignments create implicit globals)
- Use the existing `GetBoundNames()` method (from `AstExtensions`) which correctly recurses into all pattern types — the same method already used by `Engine.Ast.cs` and `Engine.cs` for declaration instantiation

## Test plan
- [x] `"use strict"; async function fn() { for await (var [[x] = [1]] of [[]]) print(x); }` now prints `1` (was `ReferenceError`)
- [x] All `async-func-dstr-var` and `async-gen-dstr-var` test262 tests pass (632 tests)
- [x] Full test262 suite: 95,999 passed, 0 failures, 0 regressions

Fixes #2354

🤖 Generated with [Claude Code](https://claude.com/claude-code)