### PR TITLE
Fix async test harness priority, await in computed properties, and forbidden extensions

### DIFF
--- a/Jint.Tests.Test262/Test262Test.cs
+++ b/Jint.Tests.Test262/Test262Test.cs
@@ -51,7 +51,11 @@ public abstract partial class Test262Test
             // Capture Test262 async test markers from $DONE via doneprintHandle.js
             if (message.StartsWith("Test262:AsyncTest", StringComparison.Ordinal))
             {
-                _asyncResult = message;
+                // AsyncTestFailure takes priority - once recorded, never overwrite with AsyncTestComplete
+                if (_asyncResult is null || !_asyncResult.StartsWith("Test262:AsyncTestFailure:", StringComparison.Ordinal))
+                {
+                    _asyncResult = message;
+                }
             }
             return message;
         }));

--- a/Jint/AstExtensions.cs
+++ b/Jint/AstExtensions.cs
@@ -79,7 +79,8 @@ public static class AstExtensions
             or NodeType.YieldExpression
             or NodeType.TemplateLiteral
             or NodeType.ArrayExpression
-            or NodeType.ObjectExpression)
+            or NodeType.ObjectExpression
+            or NodeType.AwaitExpression)
         {
             var context = engine._activeEvaluationContext ?? new EvaluationContext(engine);
             var result = JintExpression.Build(expression).GetValue(context);

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -47,7 +47,8 @@ public sealed class ScriptFunction : Function, IConstructor
 
         if (!function.Strict
             && function.Function is not ArrowFunctionExpression
-            && !function.Function.Generator)
+            && !function.Function.Generator
+            && !function.Function.Async)
         {
             SetProperty(KnownKeys.Arguments, new GetSetPropertyDescriptor.ThrowerPropertyDescriptor(engine, PropertyFlag.Configurable));
             SetProperty(KnownKeys.Caller, new PropertyDescriptor(Undefined, PropertyFlag.Configurable));


### PR DESCRIPTION
## Summary

- **Test262 harness**: `AsyncTestFailure` marker now takes priority over `AsyncTestComplete`, fixing tests where `$DONE(error)` is followed by `$DONE()` in try/catch patterns
- **AstExtensions**: Add `AwaitExpression` to computed property key evaluation allow-list, fixing `[await expr]` in object/class property names returning `undefined`
- **ScriptFunction**: Exclude async functions from getting own `.caller`/`.arguments` properties per ECMAScript spec forbidden extensions

Fixes #2354

## Test plan

- [x] 9 `cpn-*-from-await-expression` test262 tests now genuinely pass
- [x] 6 `forbidden-ext` async function tests now pass
- [x] Full test262 suite: 0 failures, 95981 passed
- [x] Full Jint.Tests suite: 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)