### PR TITLE
Implement AgentCanSuspend check for Atomics.wait

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -13,7 +13,6 @@
     "tail-call-optimization"
   ],
   "ExcludedFlags": [
-    "CanBlockIsFalse"
   ],
   "ExcludedDirectories": [
   ],

--- a/Jint.Tests.Test262/Test262Test.cs
+++ b/Jint.Tests.Test262/Test262Test.cs
@@ -30,6 +30,11 @@ public abstract partial class Test262Test
             cfg.EnableModules(new Test262ModuleLoader(State.Test262Stream.Options.FileSystem, relativePath));
             cfg.ExperimentalFeatures = ExperimentalFeature.All;
             cfg.TimeoutInterval(TimeSpan.FromSeconds(30));
+            // Configure agent blocking based on test flags
+            if (file.Flags.Contains("CanBlockIsFalse"))
+            {
+                cfg.AgentCanSuspend = false;
+            }
             // Use ICU-based CLDR provider for better Intl support
             cfg.Intl.CldrProvider = IcuCldrProvider.Instance;
             // Use NodaTime for accurate IANA timezone support (sub-minute offsets, historical DST)

--- a/Jint/Native/Atomics/AtomicsInstance.cs
+++ b/Jint/Native/Atomics/AtomicsInstance.cs
@@ -542,6 +542,12 @@ internal sealed class AtomicsInstance : ObjectInstance
             }
         }
 
+        // https://tc39.es/ecma262/#sec-dowait step 8
+        if (!Engine.Options.AgentCanSuspend)
+        {
+            Throw.TypeError(_realm, "Atomics.wait cannot be used in this agent");
+        }
+
         var buffer = ta._viewedArrayBuffer;
         var bufferData = buffer._arrayBufferData;
         if (bufferData is null)

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -129,6 +129,15 @@ public class Options
     public ExperimentalFeature ExperimentalFeatures { get; set; }
 
     /// <summary>
+    /// Whether the agent can suspend (block) via Atomics.wait().
+    /// Defaults to true. Set to false for main-thread-like environments where blocking is not allowed.
+    /// </summary>
+    /// <remarks>
+    /// https://tc39.es/ecma262/#sec-agentcansuspend
+    /// </remarks>
+    public bool AgentCanSuspend { get; set; } = true;
+
+    /// <summary>
     /// Called by the <see cref="Engine"/> instance that loads this <see cref="Options" />
     /// once it is loaded.
     /// </summary>


### PR DESCRIPTION
## Summary
- Add `Options.AgentCanSuspend` property (default `true`) to control whether `Atomics.wait()` can block
- Implement [DoWait step 8](https://tc39.es/ecma262/#sec-dowait): throw `TypeError` when `AgentCanSuspend()` is false
- Configure test262 harness to set `AgentCanSuspend = false` for tests with `CanBlockIsFalse` flag
- Remove `CanBlockIsFalse` from excluded flags — no new exclusions needed

## Test plan
- [x] All 356 `Atomics_wait` tests pass (including 4 previously excluded CanBlockIsFalse tests)
- [x] Full test262 suite: 95,985 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)