### PR TITLE
Fix compat-table failures: Array.at, AnnexB if-decl, Proxy observable gets

### DIFF
--- a/Jint/HoistingScope.cs
+++ b/Jint/HoistingScope.cs
@@ -319,15 +319,20 @@ internal sealed class HoistingScope
                                 // Track this function name as a lexical binding so inner scopes
                                 // can't AnnexB-hoist a same-named function (replacing with var
                                 // would conflict with this block-level lexical binding).
-                                if (effectiveLexicalNames is null)
+                                // Skip for IfStatement branches - sibling branches (consequent/alternate)
+                                // are not nested scopes and should not block each other.
+                                if (node.Type is not NodeType.IfStatement)
                                 {
-                                    effectiveLexicalNames = new HashSet<string>(StringComparer.Ordinal);
+                                    if (effectiveLexicalNames is null)
+                                    {
+                                        effectiveLexicalNames = new HashSet<string>(StringComparer.Ordinal);
+                                    }
+                                    else if (ReferenceEquals(effectiveLexicalNames, enclosingLexicalNames))
+                                    {
+                                        effectiveLexicalNames = new HashSet<string>(enclosingLexicalNames, StringComparer.Ordinal);
+                                    }
+                                    effectiveLexicalNames.Add(fnName);
                                 }
-                                else if (ReferenceEquals(effectiveLexicalNames, enclosingLexicalNames))
-                                {
-                                    effectiveLexicalNames = new HashSet<string>(enclosingLexicalNames, StringComparer.Ordinal);
-                                }
-                                effectiveLexicalNames.Add(fnName);
                             }
                         }
                     }

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -890,22 +890,22 @@ public sealed class ArrayPrototype : ArrayInstance
         var len = target.GetLength();
         var relativeIndex = TypeConverter.ToInteger(arguments.At(0));
 
-        ulong actualIndex;
+        long actualIndex;
         if (relativeIndex < 0)
         {
-            actualIndex = (ulong) (len + relativeIndex);
+            actualIndex = (long) (len + relativeIndex);
         }
         else
         {
-            actualIndex = (ulong) relativeIndex;
+            actualIndex = (long) relativeIndex;
         }
 
-        if (actualIndex < 0 || actualIndex >= len)
+        if (actualIndex < 0 || (ulong) actualIndex >= len)
         {
             return Undefined;
         }
 
-        return target.Get(actualIndex);
+        return target.Get((ulong) actualIndex);
     }
 
     /// <summary>

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -479,6 +479,17 @@ public sealed class RegExpConstructor : Constructor
         return r;
     }
 
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-regexpcreate
+    /// RegExpCreate(P, F) - creates a new RegExp without calling IsRegExp on the pattern.
+    /// Used by String.prototype.match/search/split per spec.
+    /// </summary>
+    internal JsRegExp RegExpCreate(JsValue pattern, JsValue flags)
+    {
+        var r = RegExpAlloc(this);
+        return RegExpInitialize(r, pattern, flags);
+    }
+
     private JsRegExp RegExpAlloc(JsValue newTarget)
     {
         if (ReferenceEquals(newTarget, this))

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -161,9 +161,10 @@ internal sealed class RegExpPrototype : Prototype
         }
 
         // check if we can access fast path
+        // Derive sticky from already-read flags string to avoid extra observable property access
         if (!fullUnicode
             && !mayHaveNamedCaptures
-            && !TypeConverter.ToBoolean(rx.Get(PropertySticky))
+            && !flags.Contains('y')
             && rx is JsRegExp rei && rei.HasDefaultRegExpExec)
         {
             var count = global ? int.MaxValue : 1;

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -865,13 +865,15 @@ internal sealed class StringPrototype : StringInstance
         // Coerce into a number, true will become 1
         var lim = limit.IsUndefined() ? uint.MaxValue : TypeConverter.ToUint32(limit);
 
+        // Per spec, if we got here the separator didn't have @@split, so just ToString it.
+        // Don't call IsRegExp - it would be an observable extra property access (@@match).
         if (separator.IsNull())
         {
             separator = "null";
         }
         else if (!separator.IsUndefined())
         {
-            if (!separator.IsRegExp())
+            if (separator is not JsRegExp)
             {
                 separator = TypeConverter.ToJsString(separator); // Coerce into a string, for an object call toString()
             }
@@ -1014,7 +1016,7 @@ internal sealed class StringPrototype : StringInstance
             }
         }
 
-        var rx = (JsRegExp) _realm.Intrinsics.RegExp.Construct([regex]);
+        var rx = _realm.Intrinsics.RegExp.RegExpCreate(regex, JsValue.Undefined);
         var s = TypeConverter.ToJsString(thisObject);
         return _engine.Invoke(rx, GlobalSymbolRegistry.Search, [s]);
     }
@@ -1187,7 +1189,7 @@ internal sealed class StringPrototype : StringInstance
             }
         }
 
-        var rx = (JsRegExp) _realm.Intrinsics.RegExp.Construct([regex]);
+        var rx = _realm.Intrinsics.RegExp.RegExpCreate(regex, JsValue.Undefined);
 
         var s = TypeConverter.ToJsString(thisObject);
         return _engine.Invoke(rx, GlobalSymbolRegistry.Match, [s]);


### PR DESCRIPTION
## Summary
**Bug fixes (commit 1):**
- Fix `Array.prototype.at()` returning wrong value for negative out-of-bounds indices (`[1,2,3].at(-4)` returned `1` instead of `undefined`) — `ulong` cast truncated negative doubles to 0
- Fix AnnexB `if-decl-else-decl` with same function name in both branches — sibling branches incorrectly blocked each other via `effectiveLexicalNames`
- Use spec `RegExpCreate` instead of full `RegExp.Construct` in `String.prototype.match/search` to avoid extra `IsRegExp` call (observable extra `Symbol.match` access through Proxy)
- Remove observable `sticky` property read in `RegExp.prototype[Symbol.replace]` fast path — derive from already-read `flags` string
- Fix `String.prototype.split` to use direct `JsRegExp` type check instead of `IsRegExp()` to avoid observable `Symbol.match` access

Found via [compat-table](https://github.com/nicolo-ribaudo/compat-table) runner, cross-referenced with ECMAScript spec and V8 behavior.

## Test plan
- [x] Full test262 suite: 95,985 passed, 0 failures (+4 new passing from AsyncIterator)
- [x] Compat-table ES5: 73/73 (100%)
- [x] Compat-table ES6: 697/700 (was 692, +5)
- [x] Compat-table ES2016+: 228/250 (was 227, +1)
- [x] Compat-table esnext: 34/43 (was 17, +17)
- [x] Compat-table esintl: 29/29 (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)