### PR TITLE
Add public IsCallable() and IsConstructor() extension methods

### DIFF
--- a/Jint.Tests.PublicInterface/PublicInterfaceTests.cs
+++ b/Jint.Tests.PublicInterface/PublicInterfaceTests.cs
@@ -47,6 +47,51 @@ var coolingObject = {
         Assert.Equal((uint) 3, arguments.Length);
     }
 
+    [Fact]
+    public void IsCallableReturnsTrueForFunctions()
+    {
+        var engine = new Engine();
+        var func = engine.Evaluate("(function() {})");
+        Assert.True(func.IsCallable());
+
+        var arrow = engine.Evaluate("(() => {})");
+        Assert.True(arrow.IsCallable());
+    }
+
+    [Fact]
+    public void IsCallableReturnsFalseForNonFunctions()
+    {
+        var engine = new Engine();
+        Assert.False(JsValue.Undefined.IsCallable());
+        Assert.False(JsValue.Null.IsCallable());
+        Assert.False(JsNumber.Create(42).IsCallable());
+        Assert.False(new JsString("hello").IsCallable());
+        Assert.False(engine.Evaluate("({})").IsCallable());
+    }
+
+    [Fact]
+    public void IsConstructorReturnsTrueForConstructors()
+    {
+        var engine = new Engine();
+        var ctor = engine.Evaluate("(class Foo {})");
+        Assert.True(ctor.IsConstructor());
+
+        var func = engine.Evaluate("(function Bar() {})");
+        Assert.True(func.IsConstructor());
+    }
+
+    [Fact]
+    public void IsConstructorReturnsFalseForNonConstructors()
+    {
+        var engine = new Engine();
+        Assert.False(JsValue.Undefined.IsConstructor());
+        Assert.False(JsValue.Null.IsConstructor());
+        Assert.False(JsNumber.Create(42).IsConstructor());
+
+        var arrow = engine.Evaluate("(() => {})");
+        Assert.False(arrow.IsConstructor());
+    }
+
     private sealed class SetTimeoutEmulator : IDisposable
     {
         private readonly Engine _engine;

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -134,6 +134,20 @@ public static class JsValueExtensions
         return value._type == InternalTypes.Symbol;
     }
 
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsCallable(this JsValue value)
+    {
+        return value.IsCallable;
+    }
+
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsConstructor(this JsValue value)
+    {
+        return value.IsConstructor;
+    }
+
     /// <summary>
     /// https://tc39.es/ecma262/#sec-canbeheldweakly
     /// </summary>


### PR DESCRIPTION
## Summary
- Adds `IsCallable()` and `IsConstructor()` public extension methods on `JsValue`, closing the gap in the public type-checking API (#2338)
- Follows the same pattern as existing `IsArray()`, `IsDate()`, `IsPromise()`, etc. extension methods
- Delegates to the existing internal `IsCallable` / `IsConstructor` properties — no internal changes needed

## Test plan
- [x] Added 4 tests in `PublicInterfaceTests` covering positive and negative cases for both methods
- [x] All tests pass on both `net10.0` and `net472` target frameworks
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)