### PR TITLE
Update Acornima to 1.3.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Acornima" Version="1.3.1" />
-    <PackageVersion Include="Acornima.Extras" Version="1.3.1" />
+    <PackageVersion Include="Acornima" Version="1.3.2" />
+    <PackageVersion Include="Acornima.Extras" Version="1.3.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.TestAdapter" Version="0.13.12" />
     <PackageVersion Include="FluentAssertions" Version="[7.2.2]" />

--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -23,10 +23,6 @@
     "language/identifiers/*-unicode-16.*.js",
     "language/identifiers/*-unicode-17.*.js",
 
-    // Acornima parsing limitations
-    "language/statements/await-using/syntax/await-using-valid-for-await-using-of-of.js",
-    "language/statements/using/syntax/using-for-statement.js",
-
     // Currently quite impossible to detect if assignment target is CoverParenthesizedExpression
     "language/expressions/assignment/fn-name-lhs-cover.js",
 
@@ -363,32 +359,9 @@
 
     // === ANNEX B EXCLUSIONS ===
 
-    // Acornima parser limitation: assignment target type validation for call expressions
-    // Per B.3.7, non-strict mode should allow CallExpression as assignment target in certain cases
-    // Requires Acornima AllowCallExpressionAsLhs option (pending upstream PR)
-    "annexB/language/expressions/assignmenttargettype/callexpression-as-for-in-lhs.js",
-    "annexB/language/expressions/assignmenttargettype/callexpression-as-for-of-lhs.js",
-    "annexB/language/expressions/assignmenttargettype/callexpression-in-compound-assignment.js",
-    "annexB/language/expressions/assignmenttargettype/callexpression-in-postfix-update.js",
-    "annexB/language/expressions/assignmenttargettype/callexpression-in-prefix-update.js",
-    "annexB/language/expressions/assignmenttargettype/callexpression.js",
-    "annexB/language/expressions/assignmenttargettype/cover-callexpression-and-asyncarrowhead.js",
-
     // Acornima parser/RegExp limitation: malformed named groups in non-unicode mode
     // Per B.1.2, non-unicode RegExp should accept some malformed named group syntax
-    "annexB/built-ins/RegExp/named-groups/non-unicode-malformed.js",
-
-    // Acornima parser limitation: using/await-using in single-statement positions not rejected
-    // Fix pending: https://github.com/adams85/acornima/pull/32
-    "language/statements/await-using/syntax/await-using-invalid-for-in.js",
-    "language/statements/await-using/syntax/with-initializer-do-statement-while-expression.js",
-    "language/statements/await-using/syntax/with-initializer-for-statement.js",
-    "language/statements/await-using/syntax/with-initializer-if-expression-statement.js",
-    "language/statements/await-using/syntax/with-initializer-if-expression-statement-else-statement.js",
-    "language/statements/await-using/syntax/with-initializer-label-statement.js",
-    "language/statements/await-using/syntax/with-initializer-while-expression-statement.js",
-    "language/statements/using/syntax/using-invalid-for-in.js",
-    "language/statements/using/syntax/with-initializer-for-statement.js"
+    "annexB/built-ins/RegExp/named-groups/non-unicode-malformed.js"
 
   ]
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -48,7 +48,7 @@ internal sealed class JintUpdateExpression : JintExpression
         var reference = _argument.Evaluate(context) as Reference;
         if (reference is null)
         {
-            Throw.TypeError(engine.Realm, "Invalid left-hand side expression");
+            Throw.ReferenceError(engine.Realm, "Invalid left-hand side in assignment");
         }
 
         reference.AssertValid(engine.Realm);

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -118,7 +118,9 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 expr = new JintMemberExpression(memberExpression);
                 break;
             default:
-                expr = new JintIdentifierExpression((Identifier) _leftNode);
+                expr = _leftNode is Expression expression
+                    ? JintExpression.Build(expression)
+                    : new JintIdentifierExpression((Identifier) _leftNode);
                 break;
         }
     }
@@ -463,7 +465,11 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     }
                     else
                     {
-                        var reference = (Reference) lhsRef;
+                        var reference = lhsRef as Reference;
+                        if (reference is null)
+                        {
+                            Throw.ReferenceError(engine.Realm, "Invalid left-hand side in assignment");
+                        }
                         if (lhsKind == LhsKind.LexicalBinding || _leftNode.Type == NodeType.Identifier && !reference.IsUnresolvableReference)
                         {
                             reference.InitializeReferencedBinding(nextValue, _disposeHint);


### PR DESCRIPTION
## Summary
- Bumps Acornima from 1.3.1 to 1.3.2, which includes Annex B.3.9 (CallExpression as assignment target) and using/await-using edge case fixes
- Adds runtime handling for CallExpression in LHS positions (update expressions, for-in/for-of), throwing spec-correct ReferenceError
- Removes 18 test262 exclusions that are now passing with the new parser

## Test plan
- [x] `dotnet build --configuration Release` passes with zero warnings
- [x] `dotnet test Jint.Tests` — 2807 passed, 0 failed
- [x] `dotnet test Jint.Tests.Test262` — 96,334 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)