### PR TITLE
Optimize URI decode/unescape performance and memory usage

### DIFF
--- a/Jint.Benchmark/DecodeUriBenchmark.cs
+++ b/Jint.Benchmark/DecodeUriBenchmark.cs
@@ -13,11 +13,13 @@ function decimalToPercentHexString(n) {
 
     private Prepared<Script> _decodeUriBulk;
     private Prepared<Script> _decodeUriComponentBulk;
+    private Prepared<Script> _decodeUriNoPercent;
+    private Prepared<Script> _decodeUriErrorPath;
 
     [GlobalSetup]
     public void Setup()
     {
-        // Matches the real test262 S15.1.3.1_A2.5_T1.js pattern with function calls
+        // Matches the real test262 S15.1.3.1_A2.5_T1.js pattern (~1M iterations, 4-byte UTF-8)
         _decodeUriBulk = Engine.PrepareScript(HarnessScript + @"
 for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
   var hexB1 = decimalToPercentHexString(indexB1);
@@ -59,6 +61,25 @@ for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
     }
   }
 }");
+
+        // Matches test262 S15.1.3.1_A2.1_T1.js pattern (65K iterations, no % in input)
+        _decodeUriNoPercent = Engine.PrepareScript(@"
+for (var i = 0; i <= 65535; i++) {
+  if (i !== 0x25) {
+    decodeURI(String.fromCharCode(i));
+  }
+}");
+
+        // Matches test262 S15.1.3.1_A1.10_T1.js pattern (~65K error iterations)
+        _decodeUriErrorPath = Engine.PrepareScript(@"
+var interval = [[0x00, 0x2F], [0x3A, 0x40], [0x47, 0x60], [0x67, 0xFFFF]];
+for (var indexI = 0; indexI < interval.length; indexI++) {
+  for (var indexJ = interval[indexI][0]; indexJ <= interval[indexI][1]; indexJ++) {
+    try {
+      decodeURI('%C0%' + String.fromCharCode(indexJ, indexJ));
+    } catch (e) {}
+  }
+}");
     }
 
     [Benchmark]
@@ -73,5 +94,19 @@ for (var indexB1 = 0xF0; indexB1 <= 0xF4; indexB1++) {
     {
         var engine = new Engine();
         engine.Execute(_decodeUriComponentBulk);
+    }
+
+    [Benchmark]
+    public void DecodeUri_NoPercent()
+    {
+        var engine = new Engine();
+        engine.Execute(_decodeUriNoPercent);
+    }
+
+    [Benchmark]
+    public void DecodeUri_ErrorPath()
+    {
+        var engine = new Engine();
+        engine.Execute(_decodeUriErrorPath);
     }
 }

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -13,7 +13,8 @@ namespace Jint.Native.Global;
 public sealed partial class GlobalObject : ObjectInstance
 {
     private readonly Realm _realm;
-    private readonly StringBuilder _stringBuilder = new();
+    private ErrorDispatchInfo? _uriError;
+    private ErrorDispatchInfo UriError => _uriError ??= Throw.CreateUriError(_realm, "URI malformed");
 
     internal GlobalObject(
         Engine engine,
@@ -391,7 +392,8 @@ public sealed partial class GlobalObject : ObjectInstance
         return builder.ToString();
 
 uriError:
-        _engine.SignalError(Throw.CreateUriError(_realm, "URI malformed"));
+        builder.Dispose();
+        _engine.SignalError(UriError);
         return JsEmpty.Instance;
     }
 
@@ -414,8 +416,13 @@ uriError:
     {
         var strLen = uriString.Length;
 
-        _stringBuilder.EnsureCapacity(strLen);
-        _stringBuilder.Clear();
+        if (!uriString.Contains('%'))
+        {
+            return uriString;
+        }
+
+        var builder = new ValueStringBuilder(stackalloc char[256]);
+        builder.EnsureCapacity(strLen);
 
         Span<byte> octets = stackalloc byte[4];
         for (var k = 0; k < strLen; k++)
@@ -423,7 +430,7 @@ uriError:
             var C = uriString[k];
             if (C != '%')
             {
-                _stringBuilder.Append(C);
+                builder.Append(C);
             }
             else
             {
@@ -450,11 +457,11 @@ uriError:
                     if (reservedSet == null || !reservedSet.Contains(C))
 #pragma warning restore CA2249
                     {
-                        _stringBuilder.Append(C);
+                        builder.Append(C);
                     }
                     else
                     {
-                        _stringBuilder.Append(uriString, start, k - start + 1);
+                        builder.Append(uriString.AsSpan(start, k - start + 1));
                     }
                 }
                 else
@@ -518,7 +525,7 @@ uriError:
                                     goto uriError;
                                 }
 
-                                _stringBuilder.Append((char) codepoint);
+                                builder.Append((char) codepoint);
                                 break;
                             }
                         case 3:
@@ -534,7 +541,7 @@ uriError:
                                     goto uriError;
                                 }
 
-                                _stringBuilder.Append((char) codepoint);
+                                builder.Append((char) codepoint);
                                 break;
                             }
                         case 4:
@@ -554,8 +561,8 @@ uriError:
                                 var offset = codepoint - 0x10000;
                                 var highSurrogate = (char) (0xD800 + (offset >> 10));
                                 var lowSurrogate = (char) (0xDC00 + (offset & 0x3FF));
-                                _stringBuilder.Append(highSurrogate);
-                                _stringBuilder.Append(lowSurrogate);
+                                builder.Append(highSurrogate);
+                                builder.Append(lowSurrogate);
                                 break;
                             }
                     }
@@ -563,10 +570,11 @@ uriError:
             }
         }
 
-        return _stringBuilder.ToString();
+        return builder.ToString();
 
 uriError:
-        _engine.SignalError(Throw.CreateUriError(_realm, "URI malformed"));
+        builder.Dispose();
+        _engine.SignalError(UriError);
         return JsEmpty.Instance;
     }
 
@@ -654,10 +662,14 @@ uriError:
     {
         var uriString = TypeConverter.ToString(arguments.At(0));
 
-        var strLen = uriString.Length;
+        if (!uriString.Contains('%'))
+        {
+            return uriString;
+        }
 
-        _stringBuilder.EnsureCapacity(strLen);
-        _stringBuilder.Clear();
+        var strLen = uriString.Length;
+        var builder = new ValueStringBuilder(stackalloc char[256]);
+        builder.EnsureCapacity(strLen);
 
         for (var k = 0; k < strLen; k++)
         {
@@ -677,10 +689,10 @@ uriError:
                     k += 2;
                 }
             }
-            _stringBuilder.Append(c);
+            builder.Append(c);
         }
 
-        return _stringBuilder.ToString();
+        return builder.ToString();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool AreValidHexChars(ReadOnlySpan<char> input)


### PR DESCRIPTION
## Summary
- Add fast path for strings without `%` in `Decode` and `Unescape` — avoids all builder work when input has no percent-encoded sequences (SIMD-vectorized `Contains` check)
- Replace shared `StringBuilder` instance field with local `ValueStringBuilder` using stack-allocated buffer, matching the pattern already used by `Encode`
- Cache `ErrorDispatchInfo` for URI errors to eliminate per-error heap allocation
- Fix `ValueStringBuilder` leak on error paths in both `Encode` and `Decode` (rented arrays now returned to `ArrayPool`)

### Benchmark comparison

```
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8117/25H2/2025Update/HudsonValley2)
AMD Ryzen 9 5950X 3.40GHz, 1 CPU, 32 logical and 16 physical cores
.NET SDK 10.0.201
  [Host]     : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.5 (10.0.5, 10.0.526.15411), X64 RyuJIT x86-64-v3
```

**Before:**
| Method                  | Mean        | Gen0       | Allocated |
|------------------------ |------------:|-----------:|----------:|
| DecodeUri_Bulk          | 1,220.44 ms | 43000.0000 | 696.79 MB |
| DecodeUriComponent_Bulk | 1,195.48 ms | 43000.0000 | 696.79 MB |
| DecodeUri_NoPercent     |    18.60 ms |   781.2500 |  12.69 MB |
| DecodeUri_ErrorPath     |    45.54 ms |  4500.0000 |  72.19 MB |

**After:**
| Method                  | Mean        | Gen0       | Allocated |
|------------------------ |------------:|-----------:|----------:|
| DecodeUri_Bulk          | 1,171.40 ms | 43000.0000 | 696.79 MB |
| DecodeUriComponent_Bulk | 1,193.51 ms | 43000.0000 | 696.79 MB |
| DecodeUri_NoPercent     |    16.91 ms |   687.5000 |  11.19 MB |
| DecodeUri_ErrorPath     |    44.85 ms |  4333.3333 |  70.19 MB |

| Scenario | Speed | Memory | GC collections |
|---|---|---|---|
| **NoPercent** (65K calls, no `%`) | **9% faster** (18.60 → 16.91 ms) | **12% less** (12.69 → 11.19 MB) | 12% fewer Gen0 |
| **ErrorPath** (65K URIErrors) | 1.5% faster (45.54 → 44.85 ms) | **2.8% less** (72.19 → 70.19 MB) | 4% fewer Gen0 |
| **Bulk** (~1M 4-byte UTF-8 decodes) | ~4% faster (1220 → 1171 ms) | same | same |

## Test plan
- [x] All 222 decodeURI test262 tests pass
- [x] All 112 decodeURIComponent test262 tests pass
- [x] All 124 encodeURI test262 tests pass
- [x] All 3224 escape/unescape test262 tests pass
- [x] Full Jint.Tests suite passes (2818 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)