### PR TITLE
Improve Function.prototype.toString() to return source text for non-native functions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Acornima" Version="1.4.0" />
-    <PackageVersion Include="Acornima.Extras" Version="1.4.0" />
+    <PackageVersion Include="Acornima" Version="0.1.0-dev-20260412-1816" />
+    <PackageVersion Include="Acornima.Extras" Version="0.1.0-dev-20260412-1816" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.TestAdapter" Version="0.13.12" />
     <PackageVersion Include="FluentAssertions" Version="[7.2.2]" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Acornima" Version="0.1.0-dev-20260412-1816" />
-    <PackageVersion Include="Acornima.Extras" Version="0.1.0-dev-20260412-1816" />
+    <PackageVersion Include="Acornima" Version="1.5.0" />
+    <PackageVersion Include="Acornima.Extras" Version="1.5.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.TestAdapter" Version="0.13.12" />
     <PackageVersion Include="FluentAssertions" Version="[7.2.2]" />

--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Runtime;
@@ -334,5 +335,397 @@ assertEqual(booleanCount, 1);
 
         Assert.Equal(values[0], found1);
         Assert.Equal(values[1], found2);
+    }
+
+    [Theory]
+    [InlineData(
+        """
+        /* before */ function fn() {
+          return 0;
+        } /* after */
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        function fn() {
+          return 0;
+        }
+        """)]
+    [InlineData(
+        """
+        /* before */ async function* g() {
+          yield 0;
+        } /* after */
+        [g.toString(), g.toString()]
+        """,
+        """
+        async function* g() {
+          yield 0;
+        }
+        """)]
+    [InlineData(
+        """
+        /* before */ var fn = async function f() {
+          return 0;
+        } /* after */ ;
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        async function f() {
+          return 0;
+        }
+        """)]
+    [InlineData(
+        """
+        /* before */ let g = function*() {
+          yield 0;
+        }; /* after */
+        [g.toString(), g.toString()]
+        """,
+        """
+        function*() {
+          yield 0;
+        }
+        """)]
+    [InlineData(
+        """
+        /* before */ var fn = () => {
+          return 0;
+        } /* after */
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        () => {
+          return 0;
+        }
+        """)]
+    [InlineData(
+        """
+        /* before */ const o = {
+          m () {
+            return 0;
+          }
+        } /* after */
+        const m = o.m;
+        [m.toString(), m.toString()]
+        """,
+        """
+        m () {
+            return 0;
+          }
+        """)]
+    [InlineData(
+        """
+        /* before */ const o = {
+          *g( ) {
+            yield 0;
+          }
+        } /* after */
+        const g = o.g;
+        [g.toString(), g.toString()]
+        """,
+        """
+        *g( ) {
+            yield 0;
+          }
+        """)]
+    [InlineData(
+        """
+        /* before */ const o = {
+          get p() {
+            return 0;
+          }
+        } /* after */
+        const getter = Object.getOwnPropertyDescriptor(o, "p").get;
+        [getter.toString(), getter.toString()]
+        """,
+        """
+        get p() {
+            return 0;
+          }
+        """)]
+    [InlineData(
+        """
+        /* before */ const o = {
+          set p(_) {
+          }
+        } /* after */
+        const setter = Object.getOwnPropertyDescriptor(o, "p").set;
+        [setter.toString(), setter.toString()]
+        """,
+        """
+        set p(_) {
+          }
+        """)]
+    [InlineData(
+        """
+        /* before */ class A extends Object.prototype.constructor {
+          constructor() { super(); }
+        } /* after */
+        const ctor = A.prototype.constructor;
+        [ctor.toString(), ctor.toString()]
+        """,
+        """
+        class A extends Object.prototype.constructor {
+          constructor() { super(); }
+        }
+        """)]
+    [InlineData(
+        """
+        /* before */ class A {
+          m() {
+            return 0;
+          }
+        } /* after */
+        const m = A.prototype.m;
+        [m.toString(), m.toString()]
+        """,
+        """
+        m() {
+            return 0;
+          }
+        """)]
+    [InlineData(
+        """
+        /* before */ class A {
+          * g( ) {
+            yield 0;
+          }
+        } /* after */
+        const g = A.prototype.g;
+        [g.toString(), g.toString()]
+        """,
+        """
+        * g( ) {
+            yield 0;
+          }
+        """)]
+    [InlineData(
+        """
+        /* before */ class A {
+          get p() {
+            return 0;
+          }
+        } /* after */
+        const getter = Object.getOwnPropertyDescriptor(A.prototype, "p").get;
+        [getter.toString(), getter.toString()]
+        """,
+        """
+        get p() {
+            return 0;
+          }
+        """)]
+    [InlineData(
+        """
+        /* before */ class A {
+          set p(_) {
+          }
+        } /* after */
+        const setter = Object.getOwnPropertyDescriptor(A.prototype, "p").set;
+        [setter.toString(), setter.toString()]
+        """,
+        """
+        set p(_) {
+          }
+        """)]
+    [InlineData(
+        """
+        /* before */ class A {
+          static m() {
+            return 0;
+          }
+        } /* after */
+        const m = A.m;
+        [m.toString(), m.toString()]
+        """,
+        """
+        m() {
+            return 0;
+          }
+        """)]
+    [InlineData(
+        """
+        /* before */ class A {
+          static async * g() {
+            yield 0;
+          }
+        } /* after */
+        const g = A.g;
+        [g.toString(), g.toString()]
+        """,
+        """
+        async * g() {
+            yield 0;
+          }
+        """)]
+    [InlineData(
+        """
+        /* before */ class A {
+          static get p() {
+            return 0;
+          }
+        } /* after */
+        const getter = Object.getOwnPropertyDescriptor(A, "p").get;
+        [getter.toString(), getter.toString()]
+        """,
+        """
+        get p() {
+            return 0;
+          }
+        """)]
+    [InlineData(
+        """
+        /* before */ class A {
+          static set p(_) {
+          }
+        } /* after */
+        const setter = Object.getOwnPropertyDescriptor(A, "p").set;
+        [setter.toString(), setter.toString()]
+        """,
+        """
+        set p(_) {
+          }
+        """)]
+    [InlineData(
+        """
+        var fn = /* before */Function()/* after */;
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        function anonymous(
+        ) {
+
+        }
+        """)]
+    [InlineData(
+        """
+        var Generator = (function*() {}).constructor;
+        var fn = /* before */Generator()/* after */;
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        function* anonymous(
+        ) {
+
+        }
+        """)]
+    [InlineData(
+        """
+        var AsyncFunction = (async function() {}).constructor;
+        var fn = /* before */AsyncFunction()/* after */;
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        async function anonymous(
+        ) {
+
+        }
+        """)]
+    [InlineData(
+        """
+        var AsyncGenerator = (async function*() {}).constructor;
+        var fn = /* before */AsyncGenerator()/* after */;
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        async function* anonymous(
+        ) {
+
+        }
+        """)]
+    [InlineData(
+        """
+        var p1 = "a //", p2 = "/*a */ b, c";
+        var fn = /* before */Function(p1, p2, "return Promise.resolve(a+b+c) /* d */ //")/* after */;
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        function anonymous(a //,/*a */ b, c
+        ) {
+        return Promise.resolve(a+b+c) /* d */ //
+        }
+        """)]
+    [InlineData(
+        """
+        var Generator = (function*() {}).constructor;
+        var p1 = "a //", p2 = "/*a */ b, c";
+        var fn = /* before */Generator(p1, p2, "return Promise.resolve(a+b+c) /* d */ //")/* after */;
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        function* anonymous(a //,/*a */ b, c
+        ) {
+        return Promise.resolve(a+b+c) /* d */ //
+        }
+        """)]
+    [InlineData(
+        """
+        var AsyncFunction = (async function() {}).constructor;
+        var p1 = "a //", p2 = "/*a */ b, c";
+        var fn = /* before */AsyncFunction(p1, p2, "return Promise.resolve(a+b+c) /* d */ //")/* after */; 
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        async function anonymous(a //,/*a */ b, c
+        ) {
+        return Promise.resolve(a+b+c) /* d */ //
+        }
+        """)]
+    [InlineData(
+        """
+        var AsyncGenerator = (async function*() {}).constructor;
+        var p1 = "a //", p2 = "/*a */ b, c";
+        var fn = /* before */AsyncGenerator(p1, p2, "return Promise.resolve(a+b+c) /* d */ //")/* after */; 
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        async function* anonymous(a //,/*a */ b, c
+        ) {
+        return Promise.resolve(a+b+c) /* d */ //
+        }
+        """)]
+    [InlineData(
+        """
+        eval('function fn() {\n}');
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        function fn() {
+        }
+        """)]
+    [InlineData(
+        """
+        const fn = new ShadowRealm().evaluate('(\n)=>0');
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        (
+        )=>0
+        """)]
+    [InlineData(
+        """
+        const fn = (0, eval)(
+          new ShadowRealm().evaluate('(\n)=>0')
+        );
+        [fn.toString(), fn.toString()]
+        """,
+        """
+        (
+        )=>0
+        """)]
+    public void ToStringShouldProduceStandardsCompliantResultByDefault(string code, string expectedResult)
+    {
+        code = Regex.Replace(code, @"\r\n?", "\n", RegexOptions.CultureInvariant); // normalize line endings to '\n'
+        expectedResult = Regex.Replace(expectedResult, @"\r\n?", "\n", RegexOptions.CultureInvariant); // normalize line endings to '\n'
+
+        var returnValue = new Engine().Evaluate(code);
+
+        var actualResults = Assert.IsType<JsArray>(returnValue);
+        Assert.Equal(2u, actualResults.Length);
+
+        var actualResult1 = Assert.IsType<JsString>(actualResults[0]).ToString();
+        Assert.Equal(expectedResult, actualResult1);
+
+        var actualResult2 = Assert.IsType<JsString>(actualResults[1]).ToString();
+        Assert.Same(actualResult1, actualResult2);
     }
 }

--- a/Jint/AstExtensions.cs
+++ b/Jint/AstExtensions.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Native.Object;
@@ -16,6 +17,8 @@ public static class AstExtensions
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
     internal static readonly SourceLocation DefaultLocation;
 #pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
+
+    private static Tokenizer? s_cachedTokenizer;
 
     public static JsValue GetKey<T>(this T property, Engine engine) where T : IProperty => GetKey(property.Key, engine, property.Computed);
 
@@ -325,7 +328,7 @@ public static class AstExtensions
     /// <summary>
     /// https://tc39.es/ecma262/#sec-runtime-semantics-definemethod
     /// </summary>
-    internal static Record DefineMethod<T>(this T m, ObjectInstance obj, ObjectInstance? functionPrototype = null) where T : IProperty
+    internal static Record DefineMethod<T>(this T m, ObjectInstance obj, ObjectInstance? functionPrototype = null, INode? sourceTextNode = null) where T : IProperty
     {
         var engine = obj.Engine;
         var propKey = TypeConverter.ToPropertyKey(m.GetKey(engine));
@@ -342,7 +345,18 @@ public static class AstExtensions
             Throw.SyntaxError(engine.Realm);
         }
 
-        var definition = new JintFunctionDefinition(function);
+        int sourceTextStart, sourceTextEnd;
+        if (sourceTextNode is not null)
+        {
+            (sourceTextStart, sourceTextEnd) = sourceTextNode.Range;
+        }
+        else
+        {
+            sourceTextStart = m is MethodDefinition { Static: true } ? ~m.RangeRef.Start : m.RangeRef.Start;
+            sourceTextEnd = m.RangeRef.End;
+        }
+
+        var definition = new JintFunctionDefinition(function, sourceTextStart, sourceTextEnd);
         var closure = intrinsics.Function.OrdinaryFunctionCreate(prototype, definition, definition.ThisMode, env, privateEnv);
         closure.MakeMethod(obj);
 
@@ -521,6 +535,23 @@ public static class AstExtensions
             VariableDeclarationKind.Using => DisposeHint.Sync,
             _ => DisposeHint.Normal,
         };
+    }
+
+    internal static int GetSecondTokenStartIndex(string sourceText, int start, int end)
+    {
+        var tokenizer = Interlocked.Exchange(ref s_cachedTokenizer, value: null) ?? new Tokenizer(string.Empty);
+        try
+        {
+            tokenizer.Reset(sourceText, start, end - start, SourceType.Script);
+            tokenizer.Next();
+            tokenizer.Next(); // skip first token + potential whitespace and/or comments
+            return tokenizer.Current.Start;
+        }
+        finally
+        {
+            tokenizer.Reset(string.Empty);
+            Volatile.Write(ref s_cachedTokenizer, tokenizer);
+        }
     }
 
     private sealed class MinimalSyntaxElement : Node

--- a/Jint/AstExtensions.cs
+++ b/Jint/AstExtensions.cs
@@ -328,7 +328,7 @@ public static class AstExtensions
     /// <summary>
     /// https://tc39.es/ecma262/#sec-runtime-semantics-definemethod
     /// </summary>
-    internal static Record DefineMethod<T>(this T m, ObjectInstance obj, ObjectInstance? functionPrototype = null, INode? sourceTextNode = null) where T : IProperty
+    internal static Record DefineMethod<T>(this T m, ObjectInstance obj, ObjectInstance? functionPrototype, INode sourceTextNode) where T : IProperty
     {
         var engine = obj.Engine;
         var propKey = TypeConverter.ToPropertyKey(m.GetKey(engine));
@@ -345,18 +345,7 @@ public static class AstExtensions
             Throw.SyntaxError(engine.Realm);
         }
 
-        int sourceTextStart, sourceTextEnd;
-        if (sourceTextNode is not null)
-        {
-            (sourceTextStart, sourceTextEnd) = sourceTextNode.Range;
-        }
-        else
-        {
-            sourceTextStart = m is MethodDefinition { Static: true } ? ~m.RangeRef.Start : m.RangeRef.Start;
-            sourceTextEnd = m.RangeRef.End;
-        }
-
-        var definition = new JintFunctionDefinition(function, sourceTextStart, sourceTextEnd);
+        var definition = new JintFunctionDefinition(function, sourceTextNode);
         var closure = intrinsics.Function.OrdinaryFunctionCreate(prototype, definition, definition.ThisMode, env, privateEnv);
         closure.MakeMethod(obj);
 

--- a/Jint/Engine.Ast.cs
+++ b/Jint/Engine.Ast.cs
@@ -20,25 +20,17 @@ public partial class Engine
         source ??= "<anonymous>";
         options ??= ScriptPreparationOptions.Default;
 
-        var astAnalyzer = new AstAnalyzer(options);
+        var sourceOffset = options.ParsingOptions.SourceOffset;
+        var padding = AcornimaExtensions.CreateSourceOffsetPadding(sourceOffset);
+        var paddedCode = padding.Length > 0 ? padding + code : code;
+
+        var astAnalyzer = new AstAnalyzer(code, options);
         var parserOptions = options.GetParserOptions();
         var parser = new Parser(parserOptions with { OnNode = astAnalyzer.NodeVisitor });
 
         try
         {
-            Script preparedScript;
-            var sourceOffset = options.ParsingOptions.SourceOffset;
-            var padding = AcornimaExtensions.CreateSourceOffsetPadding(sourceOffset);
-
-            if (padding.Length > 0)
-            {
-                var paddedCode = padding + code;
-                preparedScript = parser.ParseScript(paddedCode, padding.Length, code.Length, source, strict);
-            }
-            else
-            {
-                preparedScript = parser.ParseScript(code, source, strict);
-            }
+            var preparedScript = parser.ParseScript(paddedCode, padding.Length, code.Length, source, strict);
 
             return new Prepared<Script>(preparedScript, parserOptions);
         }
@@ -59,7 +51,7 @@ public partial class Engine
         source ??= "<anonymous>";
         options ??= ModulePreparationOptions.Default;
 
-        var astAnalyzer = new AstAnalyzer(options);
+        var astAnalyzer = new AstAnalyzer(code, options);
         var parserOptions = options.GetParserOptions();
         var parser = new Parser(parserOptions with { OnNode = astAnalyzer.NodeVisitor });
 
@@ -77,11 +69,13 @@ public partial class Engine
 
     private sealed class AstAnalyzer
     {
+        private readonly string _sourceText;
         private readonly IPreparationOptions<IParsingOptions> _preparationOptions;
         private readonly Dictionary<string, Environment.BindingName> _bindingNames = new(StringComparer.Ordinal);
 
-        public AstAnalyzer(IPreparationOptions<IParsingOptions> preparationOptions)
+        public AstAnalyzer(string sourceText, IPreparationOptions<IParsingOptions> preparationOptions)
         {
+            _sourceText = sourceText;
             _preparationOptions = preparationOptions;
         }
 
@@ -115,7 +109,7 @@ public partial class Engine
                 case NodeType.ArrowFunctionExpression:
                 case NodeType.FunctionDeclaration:
                 case NodeType.FunctionExpression:
-                    node.UserData = JintFunctionDefinition.BuildState((IFunction) node);
+                    node.UserData = JintFunctionDefinition.BuildState((IFunction) node, _sourceText);
                     break;
 
                 case NodeType.Program:

--- a/Jint/Engine.Ast.cs
+++ b/Jint/Engine.Ast.cs
@@ -79,7 +79,7 @@ public partial class Engine
             _preparationOptions = preparationOptions;
         }
 
-        public void NodeVisitor(Node node, OnNodeContext _)
+        public void NodeVisitor(Node node, in OnNodeContext _)
         {
             switch (node.Type)
             {

--- a/Jint/Engine.Ast.cs
+++ b/Jint/Engine.Ast.cs
@@ -24,7 +24,7 @@ public partial class Engine
         var padding = AcornimaExtensions.CreateSourceOffsetPadding(sourceOffset);
         var paddedCode = padding.Length > 0 ? padding + code : code;
 
-        var astAnalyzer = new AstAnalyzer(code, options);
+        var astAnalyzer = new AstAnalyzer(options);
         var parserOptions = options.GetParserOptions();
         var parser = new Parser(parserOptions with { OnNode = astAnalyzer.NodeVisitor });
 
@@ -51,7 +51,7 @@ public partial class Engine
         source ??= "<anonymous>";
         options ??= ModulePreparationOptions.Default;
 
-        var astAnalyzer = new AstAnalyzer(code, options);
+        var astAnalyzer = new AstAnalyzer(options);
         var parserOptions = options.GetParserOptions();
         var parser = new Parser(parserOptions with { OnNode = astAnalyzer.NodeVisitor });
 
@@ -69,17 +69,15 @@ public partial class Engine
 
     private sealed class AstAnalyzer
     {
-        private readonly string _sourceText;
         private readonly IPreparationOptions<IParsingOptions> _preparationOptions;
         private readonly Dictionary<string, Environment.BindingName> _bindingNames = new(StringComparer.Ordinal);
 
-        public AstAnalyzer(string sourceText, IPreparationOptions<IParsingOptions> preparationOptions)
+        public AstAnalyzer(IPreparationOptions<IParsingOptions> preparationOptions)
         {
-            _sourceText = sourceText;
             _preparationOptions = preparationOptions;
         }
 
-        public void NodeVisitor(Node node, in OnNodeContext _)
+        public void NodeVisitor(Node node, in OnNodeContext ctx)
         {
             switch (node.Type)
             {
@@ -109,7 +107,7 @@ public partial class Engine
                 case NodeType.ArrowFunctionExpression:
                 case NodeType.FunctionDeclaration:
                 case NodeType.FunctionExpression:
-                    node.UserData = JintFunctionDefinition.BuildState((IFunction) node, _sourceText);
+                    node.UserData = JintFunctionDefinition.BuildState((IFunction) node, ctx.Input);
                     break;
 
                 case NodeType.Program:

--- a/Jint/Engine.Defaults.cs
+++ b/Jint/Engine.Defaults.cs
@@ -1,3 +1,5 @@
+using Jint.Native.Function;
+
 namespace Jint;
 
 public partial class Engine
@@ -45,4 +47,16 @@ public partial class Engine
             return RegExpParseResult.ForSuccess(additionalData: this);
         }
     }
+
+    /// <summary>
+    /// Cached OnNode callback that stores the source text being parsed in <see cref="Node.UserData"/> of function nodes
+    /// to support <see cref="Function.ToString"><c>Function.prototype.toString()</c> implementation</see>.
+    /// </summary>
+    internal static readonly OnNodeHandler DefaultNodeHandler = static (node, ctx) =>
+    {
+        if (node.Type is NodeType.ArrowFunctionExpression or NodeType.FunctionDeclaration or NodeType.FunctionExpression)
+        {
+            node.UserData = ctx.Input;
+        }
+    };
 }

--- a/Jint/Engine.Defaults.cs
+++ b/Jint/Engine.Defaults.cs
@@ -52,7 +52,7 @@ public partial class Engine
     /// Cached OnNode callback that stores the source text being parsed in <see cref="Node.UserData"/> of function nodes
     /// to support <see cref="Function.ToString"><c>Function.prototype.toString()</c> implementation</see>.
     /// </summary>
-    internal static readonly OnNodeHandler DefaultNodeHandler = static (node, ctx) =>
+    internal static readonly OnNodeHandler DefaultNodeHandler = static (node, in ctx) =>
     {
         if (node.Type is NodeType.ArrowFunctionExpression or NodeType.FunctionDeclaration or NodeType.FunctionExpression)
         {

--- a/Jint/Extensions/AcornimaExtensions.cs
+++ b/Jint/Extensions/AcornimaExtensions.cs
@@ -7,12 +7,11 @@ internal static class AcornimaExtensions
     public static Script ParseScriptGuarded(this Parser parser, Realm realm, string code, Position sourceOffset = default, string? source = null, bool strict = false)
     {
         var padding = CreateSourceOffsetPadding(sourceOffset);
+        var paddedCode = padding.Length > 0 ? padding + code : code;
 
         try
         {
-            return padding.Length > 0
-                ? parser.ParseScript(padding + code, padding.Length, code.Length, source, strict)
-                : parser.ParseScript(code, source, strict);
+            return parser.ParseScript(paddedCode, padding.Length, code.Length, source, strict);
         }
         catch (ParseErrorException e)
         {
@@ -26,9 +25,14 @@ internal static class AcornimaExtensions
     /// </summary>
     internal static string CreateSourceOffsetPadding(Position sourceOffset)
     {
-        var lineOffset = sourceOffset.Line > 0 ? sourceOffset.Line - 1 : 0;
-        var columnOffset = sourceOffset.Column > 0 ? sourceOffset.Column : 0;
-        return new string('\n', lineOffset) + new string(' ', columnOffset);
+        if (sourceOffset.Line > 0)
+        {
+            var lineOffset = sourceOffset.Line - 1;
+            var columnOffset = sourceOffset.Column > 0 ? sourceOffset.Column : 0;
+            return new string('\n', lineOffset) + new string(' ', columnOffset);
+        }
+
+        return string.Empty;
     }
 
     public static Module ParseModuleGuarded(this Parser parser, Engine engine, string code, string? source = null)

--- a/Jint/Native/Function/ClassDefinition.cs
+++ b/Jint/Native/Function/ClassDefinition.cs
@@ -37,18 +37,16 @@ internal sealed class ClassDefinition
         _emptyConstructor = CreateConstructorMethodDefinition(parser, "class temp { constructor() {} }");
     }
 
-    private readonly NodeList<Decorator> _classDecorators;
+    private readonly IClass _class;
 
     public ClassDefinition(
         string? className,
-        Expression? superClass,
-        ClassBody body,
-        in NodeList<Decorator> classDecorators = default)
+        IClass @class)
     {
         _className = className;
-        _superClass = superClass;
-        _body = body;
-        _classDecorators = classDecorators;
+        _superClass = @class.SuperClass;
+        _body = @class.Body;
+        _class = @class;
     }
 
     /// <summary>
@@ -79,7 +77,7 @@ internal sealed class ClassDefinition
         if (hasDecorators)
         {
             // Evaluate class-level decorators
-            classDecoratorValues = EvaluateDecorators(context, _classDecorators);
+            classDecoratorValues = EvaluateDecorators(context, _class.Decorators);
 
             // Evaluate element-level decorators
             ref readonly var bodyElements = ref _body.Body;
@@ -183,7 +181,7 @@ internal sealed class ClassDefinition
         ScriptFunction F;
         try
         {
-            var constructorInfo = constructor.DefineMethod(proto, constructorParent);
+            var constructorInfo = constructor.DefineMethod(proto, constructorParent, _class);
             F = constructorInfo.Closure;
 
             F.SetFunctionName(_className ?? classBinding ?? "");
@@ -766,9 +764,10 @@ internal sealed class ClassDefinition
             return DefineMethodProperty(obj, methodDef.Key, methodDef.Closure, enumerable);
         }
 
-        var getter = method.Kind == PropertyKind.Get;
+        var sourceTextStart = method is MethodDefinition { Static: true } ? ~method.RangeRef.Start : method.RangeRef.Start;
+        var sourceTextEnd = method.RangeRef.End;
 
-        var definition = new JintFunctionDefinition(function);
+        var definition = new JintFunctionDefinition(function, sourceTextStart, sourceTextEnd);
         var intrinsics = engine.Realm.Intrinsics;
 
         var value = method.TryGetKey(engine);
@@ -803,6 +802,8 @@ internal sealed class ClassDefinition
         }
         else
         {
+            var getter = method.Kind == PropertyKind.Get;
+
             var closure = intrinsics.Function.OrdinaryFunctionCreate(intrinsics.Function.PrototypeObject, definition, definition.ThisMode, env, privateEnv);
             closure.MakeMethod(obj);
             closure.SetFunctionName(propKey, getter ? "get" : "set");
@@ -1092,7 +1093,7 @@ internal sealed class ClassDefinition
     /// </summary>
     private bool HasDecorators()
     {
-        if (_classDecorators.Count > 0) return true;
+        if (_class.Decorators.Count > 0) return true;
 
         ref readonly var elements = ref _body.Body;
         for (var i = 0; i < elements.Count; i++)

--- a/Jint/Native/Function/ClassDefinition.cs
+++ b/Jint/Native/Function/ClassDefinition.cs
@@ -181,7 +181,7 @@ internal sealed class ClassDefinition
         ScriptFunction F;
         try
         {
-            var constructorInfo = constructor.DefineMethod(proto, constructorParent, _class);
+            var constructorInfo = constructor.DefineMethod(proto, constructorParent, sourceTextNode: _class);
             F = constructorInfo.Closure;
 
             F.SetFunctionName(_className ?? classBinding ?? "");
@@ -759,15 +759,12 @@ internal sealed class ClassDefinition
 
         if (method.Kind != PropertyKind.Get && method.Kind != PropertyKind.Set && !function.Generator)
         {
-            var methodDef = method.DefineMethod(obj);
+            var methodDef = method.DefineMethod(obj, functionPrototype: null, sourceTextNode: method);
             methodDef.Closure.SetFunctionName(methodDef.Key);
             return DefineMethodProperty(obj, methodDef.Key, methodDef.Closure, enumerable);
         }
 
-        var sourceTextStart = method is MethodDefinition { Static: true } ? ~method.RangeRef.Start : method.RangeRef.Start;
-        var sourceTextEnd = method.RangeRef.End;
-
-        var definition = new JintFunctionDefinition(function, sourceTextStart, sourceTextEnd);
+        var definition = new JintFunctionDefinition(function, sourceTextNode: method);
         var intrinsics = engine.Realm.Intrinsics;
 
         var value = method.TryGetKey(engine);

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -375,9 +375,19 @@ public abstract partial class Function : ObjectInstance, ICallable
 
     public override string ToString()
     {
-        if (_functionDefinition?.Function is Node node && _engine.Options.Host.FunctionToStringHandler(this, node) is { } s)
+        if (_functionDefinition is not null)
         {
-            return s;
+            var functionNode = (Node) _functionDefinition.Function;
+            if (_engine.Options.Host.FunctionToStringHandler(this, functionNode) is { } s)
+            {
+                return s;
+            }
+
+            var state = _functionDefinition.Initialize();
+            if (state.SourceText.GetValue(_functionDefinition.SourceTextStart, _functionDefinition.SourceTextEnd) is { } sourceText)
+            {
+                return sourceText;
+            }
         }
 
         var nameValue = _nameDescriptor != null ? UnwrapJsValue(_nameDescriptor) : JsString.Empty;

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -377,14 +377,14 @@ public abstract partial class Function : ObjectInstance, ICallable
     {
         if (_functionDefinition is not null)
         {
-            var functionNode = (Node) _functionDefinition.Function;
-            if (_engine.Options.Host.FunctionToStringHandler(this, functionNode) is { } s)
+            var sourceTextNode = (Node) _functionDefinition.SourceTextNode;
+            if (_engine.Options.Host.FunctionToStringHandler(this, sourceTextNode) is { } s)
             {
                 return s;
             }
 
             var state = _functionDefinition.Initialize();
-            if (state.SourceText.GetValue(_functionDefinition.SourceTextStart, _functionDefinition.SourceTextEnd) is { } sourceText)
+            if (state.SourceText.GetValue(sourceTextNode) is { } sourceText)
             {
                 return sourceText;
             }

--- a/Jint/Native/Function/FunctionInstance.Dynamic.cs
+++ b/Jint/Native/Function/FunctionInstance.Dynamic.cs
@@ -84,16 +84,16 @@ public partial class Function
                 switch (kind)
                 {
                     case FunctionKind.Normal:
-                        functionExpression = "function anonymous() {}";
+                        functionExpression = "function anonymous(\n) {\n\n}";
                         break;
                     case FunctionKind.Generator:
-                        functionExpression = "function* anonymous() {}";
+                        functionExpression = "function* anonymous(\n) {\n\n}";
                         break;
                     case FunctionKind.Async:
-                        functionExpression = "async function anonymous() {}";
+                        functionExpression = "async function anonymous(\n) {\n\n}";
                         break;
                     case FunctionKind.AsyncGenerator:
-                        functionExpression = "async function* anonymous() {}";
+                        functionExpression = "async function* anonymous(\n) {\n\n}";
                         break;
                     default:
                         Throw.ArgumentOutOfRangeException(nameof(kind), kind.ToString());

--- a/Jint/Native/Function/FunctionInstance.Dynamic.cs
+++ b/Jint/Native/Function/FunctionInstance.Dynamic.cs
@@ -84,16 +84,16 @@ public partial class Function
                 switch (kind)
                 {
                     case FunctionKind.Normal:
-                        functionExpression = "function f(){}";
+                        functionExpression = "function anonymous() {}";
                         break;
                     case FunctionKind.Generator:
-                        functionExpression = "function* f(){}";
+                        functionExpression = "function* anonymous() {}";
                         break;
                     case FunctionKind.Async:
-                        functionExpression = "async function f(){}";
+                        functionExpression = "async function anonymous() {}";
                         break;
                     case FunctionKind.AsyncGenerator:
-                        functionExpression = "async function* f(){}";
+                        functionExpression = "async function* anonymous() {}";
                         break;
                     default:
                         Throw.ArgumentOutOfRangeException(nameof(kind), kind.ToString());
@@ -105,16 +105,16 @@ public partial class Function
                 switch (kind)
                 {
                     case FunctionKind.Normal:
-                        functionExpression = "function f(";
+                        functionExpression = "function anonymous(";
                         break;
                     case FunctionKind.Async:
-                        functionExpression = "async function f(";
+                        functionExpression = "async function anonymous(";
                         break;
                     case FunctionKind.Generator:
-                        functionExpression = "function* f(";
+                        functionExpression = "function* anonymous(";
                         break;
                     case FunctionKind.AsyncGenerator:
-                        functionExpression = "async function* f(";
+                        functionExpression = "async function* anonymous(";
                         break;
                     default:
                         Throw.ArgumentOutOfRangeException(nameof(kind), kind.ToString());
@@ -124,7 +124,7 @@ public partial class Function
                 // Per spec (CreateDynamicFunction step 29), a line feed follows the parameters,
                 // and the body is wrapped with line feeds (step 16). This ensures HTML-like
                 // comments (<!-- and -->) are correctly handled as line comments.
-                functionExpression += p + "\n){\n" + body + "\n}";
+                functionExpression += p + "\n) {\n" + body + "\n}";
             }
 
             var parserOptions = _engine.GetActiveParserOptions();

--- a/Jint/Native/Function/SourceText.cs
+++ b/Jint/Native/Function/SourceText.cs
@@ -14,7 +14,7 @@ namespace Jint.Native.Function
             _fullSourceTextOrBoxedValue = fullSourceText;
         }
 
-        public string? GetValue(int start, int end)
+        public string? GetValue(Node sourceTextNode)
         {
             if (_fullSourceTextOrBoxedValue is null)
             {
@@ -28,13 +28,19 @@ namespace Jint.Native.Function
 
             var fullSourceText = (string) _fullSourceTextOrBoxedValue;
 
-            if (start < 0)
+            var (start, end) = sourceTextNode.Range;
+
+            // In the case of static class methods, the static keyword is not included.
+            if (sourceTextNode is MethodDefinition { Static: true } m)
             {
-                start = AstExtensions.GetSecondTokenStartIndex(fullSourceText, ~start, end);
+                start = AstExtensions.GetSecondTokenStartIndex(fullSourceText, start, end);
             }
 
             var value = fullSourceText.Substring(start, end - start);
+
+            // Setting this field also releases the reference to the full source text string instance.
             _fullSourceTextOrBoxedValue = new StrongBox<string>(value);
+
             return value;
         }
     }

--- a/Jint/Native/Function/SourceText.cs
+++ b/Jint/Native/Function/SourceText.cs
@@ -1,0 +1,41 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Jint.Native.Function
+{
+    internal struct SourceText
+    {
+        // Either a string that stores the full source text that the function was parsed from,
+        // or a StrongBox<string> containing the materialized source text of the function,
+        // or null when the function doesn't have source text.
+        private object? _fullSourceTextOrBoxedValue;
+
+        public SourceText(string? fullSourceText)
+        {
+            _fullSourceTextOrBoxedValue = fullSourceText;
+        }
+
+        public string? GetValue(int start, int end)
+        {
+            if (_fullSourceTextOrBoxedValue is null)
+            {
+                return null;
+            }
+
+            if (_fullSourceTextOrBoxedValue is StrongBox<string> boxedValue)
+            {
+                return boxedValue.Value;
+            }
+
+            var fullSourceText = (string) _fullSourceTextOrBoxedValue;
+
+            if (start < 0)
+            {
+                start = AstExtensions.GetSecondTokenStartIndex(fullSourceText, ~start, end);
+            }
+
+            var value = fullSourceText.Substring(start, end - start);
+            _fullSourceTextOrBoxedValue = new StrongBox<string>(value);
+            return value;
+        }
+    }
+}

--- a/Jint/Native/ShadowRealm/ShadowRealm.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealm.cs
@@ -387,6 +387,8 @@ public sealed class ShadowRealm : ObjectInstance
 
             return GetWrappedValue(callerRealm, callerRealm, result);
         }
+
+        public override string ToString() => _wrappedTargetFunction.ToString();
     }
 
     /// <summary>

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -495,9 +495,19 @@ public class Options
         public bool StringCompilationAllowed { get; set; } = true;
 
         /// <summary>
-        /// Possibility to override Jint's default function() { [native code] } format for functions using AST Node.
-        /// If callback return null, Jint will use its own default logic.
+        /// Possibility to override Jint's default <c>Function.prototype.toString()</c> implementation.
+        /// If the callback returns <see langword="null"/>, Jint will use its own default logic.
         /// </summary>
+        /// <remarks>
+        /// In most cases, the AST node passed to the callback is of type <see cref="IFunction" />.
+        /// However, there are some special cases:<br/>
+        /// - For class constructors, a node of type <see cref="IClass"/> is passed
+        ///   since <c>toString()</c> should return the code of the entire class as per specification.<br/>
+        /// - For class methods and getters/setters, a node of type <see cref="MethodDefinition"/> is passed
+        ///   since <c>toString()</c> should include the <c>get</c> or <c>set</c> tokens for getters/setters and the member name as per specification.<br/>
+        /// - For object methods and getters/setters, a node of type <see cref="ObjectProperty"/> is passed
+        ///   since <c>toString()</c> should include the <c>get</c> or <c>set</c> tokens for getters/setters and the member name as per specification.
+        /// </remarks>
         public Func<Function, Node, string?> FunctionToStringHandler { get; set; } = (_, _) => null;
     }
 

--- a/Jint/ParsingOptions.cs
+++ b/Jint/ParsingOptions.cs
@@ -43,6 +43,7 @@ public sealed record ScriptParsingOptions : IParsingOptions
         AllowReturnOutsideFunction = true,
         AllowTopLevelUsing = true,
         OnRegExp = Engine.DefaultConvertRegExpHandler,
+        OnNode = Engine.DefaultNodeHandler,
     };
 
     public static readonly ScriptParsingOptions Default = new();
@@ -110,6 +111,7 @@ public sealed record class ModuleParsingOptions : IParsingOptions
     private static readonly ParserOptions _defaultParserOptions = Engine.BaseParserOptions with
     {
         OnRegExp = Engine.DefaultConvertRegExpHandler,
+        OnNode = Engine.DefaultNodeHandler,
     };
 
     public static readonly ModuleParsingOptions Default = new();

--- a/Jint/Runtime/Interpreter/Expressions/JintClassExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintClassExpression.cs
@@ -9,7 +9,7 @@ internal sealed class JintClassExpression : JintExpression
 
     public JintClassExpression(ClassExpression expression) : base(expression)
     {
-        _classDefinition = new ClassDefinition(expression.Id?.Name, expression.SuperClass, expression.Body, expression.Decorators);
+        _classDefinition = new ClassDefinition(expression.Id?.Name, expression);
     }
 
     protected override object EvaluateInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -32,7 +32,7 @@ internal sealed class JintObjectExpression : JintExpression
 
         public JsString? KeyJsString => _keyJsString ??= _key != null ? JsString.Create(_key) : null;
 
-        public JintFunctionDefinition GetFunctionDefinition(Engine engine)
+        public JintFunctionDefinition GetFunctionDefinition(Engine engine, Property property)
         {
             if (_functionDefinition is not null)
             {
@@ -45,7 +45,7 @@ internal sealed class JintObjectExpression : JintExpression
                 Throw.SyntaxError(engine.Realm);
             }
 
-            _functionDefinition = new JintFunctionDefinition(function);
+            _functionDefinition = new JintFunctionDefinition(function, property.Range);
             return _functionDefinition;
         }
     }
@@ -240,7 +240,7 @@ internal sealed class JintObjectExpression : JintExpression
             }
             else if (property.Kind is PropertyKind.Get or PropertyKind.Set)
             {
-                var function = objectProperty.GetFunctionDefinition(engine);
+                var function = objectProperty.GetFunctionDefinition(engine, property);
                 var closure = engine.Realm.Intrinsics.Function.OrdinaryFunctionCreate(
                     engine.Realm.Intrinsics.Function.PrototypeObject,
                     function,

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -21,10 +21,10 @@ internal sealed class JintObjectExpression : JintExpression
     {
         internal readonly string? _key;
         private JsString? _keyJsString;
-        internal readonly Property _value;
+        internal readonly Acornima.Ast.ObjectProperty _value;
         private JintFunctionDefinition? _functionDefinition;
 
-        public ObjectProperty(string? key, Property property)
+        public ObjectProperty(string? key, Acornima.Ast.ObjectProperty property)
         {
             _key = key;
             _value = property;
@@ -32,7 +32,7 @@ internal sealed class JintObjectExpression : JintExpression
 
         public JsString? KeyJsString => _keyJsString ??= _key != null ? JsString.Create(_key) : null;
 
-        public JintFunctionDefinition GetFunctionDefinition(Engine engine, Property property)
+        public JintFunctionDefinition GetFunctionDefinition(Engine engine, Acornima.Ast.ObjectProperty property)
         {
             if (_functionDefinition is not null)
             {
@@ -45,7 +45,7 @@ internal sealed class JintObjectExpression : JintExpression
                 Throw.SyntaxError(engine.Realm);
             }
 
-            _functionDefinition = new JintFunctionDefinition(function, property.Range);
+            _functionDefinition = new JintFunctionDefinition(function, sourceTextNode: property);
             return _functionDefinition;
         }
     }

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -21,11 +21,23 @@ internal sealed class JintFunctionDefinition
     public readonly string? Name;
     public readonly IFunction Function;
 
-    public JintFunctionDefinition(IFunction function)
+    // A negative (bitwise complement) start value indicates that the first token needs to be skipped.
+    // (This is for handling static class members.)
+    public readonly int SourceTextStart, SourceTextEnd;
+
+    public JintFunctionDefinition(IFunction function, int sourceTextStart, int sourceTextEnd)
     {
         Function = function;
         Name = !string.IsNullOrEmpty(function.Id?.Name) ? function.Id!.Name : null;
+        SourceTextStart = sourceTextStart;
+        SourceTextEnd = sourceTextEnd;
     }
+
+    public JintFunctionDefinition(IFunction function, Acornima.Range sourceTextRange)
+        : this(function, sourceTextRange.Start, sourceTextRange.End) { }
+
+    public JintFunctionDefinition(IFunction function)
+        : this(function, function.RangeRef.Start, function.RangeRef.End) { }
 
     public bool Strict => Function.IsStrict();
 
@@ -257,7 +269,11 @@ internal sealed class JintFunctionDefinition
     internal State Initialize()
     {
         var node = (Node) Function;
-        var state = (State) (node.UserData ??= BuildState(Function));
+        var stateOrFullSourceText = node.UserData;
+        if (stateOrFullSourceText is not State state)
+        {
+            node.UserData = state = BuildState(Function, stateOrFullSourceText as string);
+        }
         return state;
     }
 
@@ -298,10 +314,12 @@ internal sealed class JintFunctionDefinition
         public bool EnvironmentMayEscape;
         public Binding[]? _cachedSlots;
 
+        public SourceText SourceText;
+
         internal readonly record struct VariableValuePair(Key Name, JsValue? InitialValue);
     }
 
-    internal static State BuildState(IFunction function)
+    internal static State BuildState(IFunction function, string? fullSourceText = null)
     {
         var state = new State();
 
@@ -555,6 +573,8 @@ internal sealed class JintFunctionDefinition
                 }
             }
         }
+
+        state.SourceText = new SourceText(fullSourceText);
 
         return state;
     }

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -21,23 +21,19 @@ internal sealed class JintFunctionDefinition
     public readonly string? Name;
     public readonly IFunction Function;
 
-    // A negative (bitwise complement) start value indicates that the first token needs to be skipped.
-    // (This is for handling static class members.)
-    public readonly int SourceTextStart, SourceTextEnd;
+    // Stores the AST node needed for creating the source text.
+    // (This might be different from the Function node, e.g., in the case of class methods.)
+    public readonly INode SourceTextNode;
 
-    public JintFunctionDefinition(IFunction function, int sourceTextStart, int sourceTextEnd)
+    public JintFunctionDefinition(IFunction function, INode sourceTextNode)
     {
         Function = function;
         Name = !string.IsNullOrEmpty(function.Id?.Name) ? function.Id!.Name : null;
-        SourceTextStart = sourceTextStart;
-        SourceTextEnd = sourceTextEnd;
+        SourceTextNode = sourceTextNode;
     }
 
-    public JintFunctionDefinition(IFunction function, Acornima.Range sourceTextRange)
-        : this(function, sourceTextRange.Start, sourceTextRange.End) { }
-
     public JintFunctionDefinition(IFunction function)
-        : this(function, function.RangeRef.Start, function.RangeRef.End) { }
+        : this(function, function) { }
 
     public bool Strict => Function.IsStrict();
 

--- a/Jint/Runtime/Interpreter/Statements/JintClassDeclarationStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintClassDeclarationStatement.cs
@@ -9,7 +9,7 @@ internal sealed class JintClassDeclarationStatement : JintStatement<ClassDeclara
 
     public JintClassDeclarationStatement(ClassDeclaration classDeclaration) : base(classDeclaration)
     {
-        _classDefinition = new ClassDefinition(className: classDeclaration.Id?.Name, classDeclaration.SuperClass, classDeclaration.Body, classDeclaration.Decorators);
+        _classDefinition = new ClassDefinition(className: classDeclaration.Id?.Name, classDeclaration);
     }
 
     protected override Completion ExecuteInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
@@ -17,7 +17,7 @@ internal sealed class JintExportDefaultDeclaration : JintStatement<ExportDefault
     {
         if (statement.Declaration is ClassDeclaration classDeclaration)
         {
-            _classDefinition = new ClassDefinition(className: classDeclaration.Id?.Name ?? "default", classDeclaration.SuperClass, classDeclaration.Body);
+            _classDefinition = new ClassDefinition(className: classDeclaration.Id?.Name ?? "default", classDeclaration);
         }
         else if (statement.Declaration is FunctionDeclaration functionDeclaration)
         {


### PR DESCRIPTION
I took a stab at implementing `Function.prototype.toString()` according to [the spec](https://tc39.es/ecma262/#sec-function.prototype.tostring). So this is another attempt at what #1726 tried to achieve, it's just takes the correct path instead of trying to convert the AST back to source code.

However, this requires the full source text to be kept around as it would be a performance killer to materialize the source text for functions eagerly. So this is deferred until execution. Once the source text is created, the reference to the full code is released. This way GC can at least collect that once source text for every function is materialized.

It passes the relevant test262 tests (it's failing here because it requires a minor non-breaking change on the parser side, which hasn't been released to Nuget yet). According to my manual tests, it also produces correct results for crazy dynamic cases like

```js
eval('function fn() {}');
fn.toString()
```

or

```
(async () => {
  async function f() {}
  var AsyncFunction = f.constructor;
  var p1 = "a", p2 = "/*a */ b, c";
  var g = /* before */AsyncFunction(p1, p2, "return Promise.resolve(a+b+c) /* d */ //")/* after */; 
  console.log(g.toString());
  console.log(await g(1, 2, 3));
})()
```

If the PR is welcome, I'll finalize it soon.