### PR TITLE
Implement import text proposal

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -5,9 +5,6 @@
   "Namespace": "Jint.Tests.Test262",
   "Parallel": true,
   "ExcludedFeatures": [
-    // import-text is a separate TC39 proposal (https://github.com/tc39/proposal-import-text),
-    // not implemented yet. Tracked for a follow-up PR.
-    "import-text",
     "tail-call-optimization"
   ],
   "ExcludedFlags": [

--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -753,6 +753,75 @@ export const count = globals.counter;
         Assert.Equal("hello", (await completionTcs.Task).AsString());
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CanStaticallyImportTextModule(bool importViaLoader)
+    {
+        const string TextModuleSpecifier = "./hello.txt";
+        const string TextModuleContent = "hello world";
+
+        const string MainModuleSpecifier = "./main.js";
+        const string MainModuleCode =
+            $$"""
+            import txt from "{{TextModuleSpecifier}}" with { type: "text" };
+            export const msg = txt;
+            """;
+
+        var loaderModules = new Dictionary<string, Func<Engine, ResolvedSpecifier, Module>>();
+        var engine = new Engine(o => o.EnableModules(new TestModuleLoader(loaderModules)));
+
+        loaderModules.Add(TextModuleSpecifier, (engine, resolved) => ModuleFactory.BuildTextModule(engine, resolved, TextModuleContent));
+        if (importViaLoader)
+        {
+            loaderModules.Add(MainModuleSpecifier, (engine, resolved) => ModuleFactory.BuildSourceTextModule(engine, resolved, MainModuleCode));
+        }
+        else
+        {
+            engine.Modules.Add(MainModuleSpecifier, MainModuleCode);
+        }
+
+        var mainModule = engine.Modules.Import(MainModuleSpecifier);
+
+        Assert.Equal(TextModuleContent, mainModule.Get("msg").AsString());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CanDynamicallyImportTextModule(bool importViaLoader)
+    {
+        const string TextModuleSpecifier = "./hello.txt";
+        const string TextModuleContent = "hello world";
+
+        const string MainModuleSpecifier = "./main.js";
+        const string MainModuleCode =
+            $$"""
+            const txt = await import("{{TextModuleSpecifier}}", { with: { type: "text" } });
+            callback(txt.default);
+            """;
+
+        var completionTcs = new TaskCompletionSource<JsValue>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var loaderModules = new Dictionary<string, Func<Engine, ResolvedSpecifier, Module>>();
+        var engine = new Engine(o => o.EnableModules(new TestModuleLoader(loaderModules)))
+            .SetValue("callback", new Action<JsValue>(value => completionTcs.SetResult(value)));
+
+        loaderModules.Add(TextModuleSpecifier, (engine, resolved) => ModuleFactory.BuildTextModule(engine, resolved, TextModuleContent));
+        if (importViaLoader)
+        {
+            loaderModules.Add(MainModuleSpecifier, (engine, resolved) => ModuleFactory.BuildSourceTextModule(engine, resolved, MainModuleCode));
+        }
+        else
+        {
+            engine.Modules.Add(MainModuleSpecifier, MainModuleCode);
+        }
+
+        var mainModule = engine.Modules.Import(MainModuleSpecifier);
+
+        Assert.Equal(TextModuleContent, (await completionTcs.Task).AsString());
+    }
+
     private sealed class TestModuleLoader : IModuleLoader
     {
         private readonly Dictionary<string, Func<Engine, ResolvedSpecifier, Module>> _moduleFactories;

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -20,10 +20,50 @@ public partial class Engine
         return _executionContexts?.GetActiveScriptOrModule();
     }
 
+    // Cache key for the per-engine module map. Per the import-attributes spec,
+    // two requests for the same resolved specifier with different attributes
+    // are distinct module records. Import phase (defer/source) does NOT create
+    // distinct records — defer and evaluation share the same underlying module.
+    internal readonly record struct ModuleCacheKey(string Key, ModuleImportAttribute[] Attributes)
+    {
+        public static ModuleCacheKey From(ResolvedSpecifier resolved)
+            => new(resolved.Key, resolved.ModuleRequest.Attributes ?? []);
+
+        public bool Equals(ModuleCacheKey other)
+        {
+            if (!string.Equals(Key, other.Key, StringComparison.Ordinal))
+            {
+                return false;
+            }
+            var a = Attributes;
+            var b = other.Attributes;
+            if (a.Length != b.Length)
+            {
+                return false;
+            }
+            for (var i = 0; i < a.Length; i++)
+            {
+                if (Array.IndexOf(b, a[i]) < 0)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (StringComparer.Ordinal.GetHashCode(Key) * 397) ^ Attributes.Length;
+            }
+        }
+    }
+
     public class ModuleOperations
     {
         private readonly Engine _engine;
-        private readonly Dictionary<string, Module> _modules = new(StringComparer.Ordinal);
+        private readonly Dictionary<ModuleCacheKey, Module> _modules = new();
         private readonly Dictionary<string, ModuleBuilder> _builders = new(StringComparer.Ordinal);
 
         public ModuleOperations(Engine engine, IModuleLoader moduleLoader)
@@ -37,19 +77,20 @@ public partial class Engine
         internal Module Load(string? referencingModuleLocation, ModuleRequest request)
         {
             var moduleResolution = ModuleLoader.Resolve(referencingModuleLocation, request);
+            var cacheKey = ModuleCacheKey.From(moduleResolution);
 
-            if (_modules.TryGetValue(moduleResolution.Key, out var module))
+            if (_modules.TryGetValue(cacheKey, out var module))
             {
                 return module;
             }
 
             if (_builders.TryGetValue(moduleResolution.Key, out var moduleBuilder))
             {
-                module = LoadFromBuilder(moduleResolution.Key, moduleBuilder, moduleResolution);
+                module = LoadFromBuilder(moduleResolution.Key, moduleBuilder, moduleResolution, cacheKey);
             }
             else
             {
-                module = LoadFromModuleLoader(moduleResolution);
+                module = LoadFromModuleLoader(moduleResolution, cacheKey);
             }
 
             if (module is SourceTextModule sourceTextModule)
@@ -60,21 +101,21 @@ public partial class Engine
             return module;
         }
 
-        private BuilderModule LoadFromBuilder(string specifier, ModuleBuilder moduleBuilder, ResolvedSpecifier moduleResolution)
+        private BuilderModule LoadFromBuilder(string specifier, ModuleBuilder moduleBuilder, ResolvedSpecifier moduleResolution, ModuleCacheKey cacheKey)
         {
             var parsedModule = moduleBuilder.Parse();
             var hasTopLevelAwait = HoistingScope.HasTopLevelAwait(parsedModule.Program!);
             var module = new BuilderModule(_engine, _engine.Realm, parsedModule, location: parsedModule.Program!.Location.SourceFile, async: hasTopLevelAwait);
-            _modules[moduleResolution.Key] = module;
+            _modules[cacheKey] = module;
             moduleBuilder.BindExportedValues(module);
             _builders.Remove(specifier);
             return module;
         }
 
-        private Module LoadFromModuleLoader(ResolvedSpecifier moduleResolution)
+        private Module LoadFromModuleLoader(ResolvedSpecifier moduleResolution, ModuleCacheKey cacheKey)
         {
             var module = ModuleLoader.LoadModule(_engine, moduleResolution);
-            _modules[moduleResolution.Key] = module;
+            _modules[cacheKey] = module;
             return module;
         }
 
@@ -111,7 +152,7 @@ public partial class Engine
         {
             var moduleResolution = ModuleLoader.Resolve(referencingModuleLocation, request);
 
-            if (!_modules.TryGetValue(moduleResolution.Key, out var module))
+            if (!_modules.TryGetValue(ModuleCacheKey.From(moduleResolution), out var module))
             {
                 module = Load(referencingModuleLocation, request);
             }

--- a/Jint/Runtime/Modules/ModuleFactory.cs
+++ b/Jint/Runtime/Modules/ModuleFactory.cs
@@ -104,4 +104,16 @@ public static class ModuleFactory
 
         return new SyntheticModule(engine, engine.Realm, uint8Array, resolved.Uri?.LocalPath);
     }
+
+    /// <summary>
+    /// Creates a <see cref="Module"/> for the usage within the given <paramref name="engine"/> for the
+    /// provided text module contents.
+    /// </summary>
+    /// <remarks>
+    /// https://tc39.es/proposal-import-text/#sec-create-text-module
+    /// </remarks>
+    public static Module BuildTextModule(Engine engine, ResolvedSpecifier resolved, string text)
+    {
+        return new SyntheticModule(engine, engine.Realm, JsString.Create(text), resolved.Uri?.LocalPath);
+    }
 }

--- a/Jint/Runtime/Modules/ModuleLoader.cs
+++ b/Jint/Runtime/Modules/ModuleLoader.cs
@@ -36,6 +36,11 @@ public abstract class ModuleLoader : IModuleLoader
             return default!;
         }
 
+        if (resolved.ModuleRequest.IsTextModule())
+        {
+            return ModuleFactory.BuildTextModule(engine, resolved, code);
+        }
+
         var isJson = resolved.ModuleRequest.IsJsonModule();
         Module moduleRecord = isJson
             ? ModuleFactory.BuildJsonModule(engine, resolved, code)

--- a/Jint/Runtime/Modules/ModuleRequestExtensions.cs
+++ b/Jint/Runtime/Modules/ModuleRequestExtensions.cs
@@ -35,4 +35,21 @@ public static class ModuleRequestExtensions
         return request.Attributes != null
             && Array.Exists(request.Attributes, x => string.Equals(x.Key, "type", StringComparison.Ordinal) && string.Equals(x.Value, "bytes", StringComparison.Ordinal));
     }
+
+    /// <summary>
+    /// Returns true if the provided <paramref name="request"/>
+    /// is a text module, otherwise false.
+    /// </summary>
+    /// <example>
+    /// The following JavaScript import statement imports a text module
+    /// for which this method would return true.
+    /// <code>
+    /// import value from 'file.txt' with { type: 'text' }
+    /// </code>
+    /// </example>
+    public static bool IsTextModule(this ModuleRequest request)
+    {
+        return request.Attributes != null
+            && Array.Exists(request.Attributes, x => string.Equals(x.Key, "type", StringComparison.Ordinal) && string.Equals(x.Value, "text", StringComparison.Ordinal));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds support for the TC39 [Import Text](https://github.com/tc39/proposal-import-text) proposal (Stage 3): `import txt from "./file.txt" with { type: "text" }` binds the UTF-8 decoded file contents as a string, mirroring the existing `type: "json"` / `type: "bytes"` paths. New `ModuleFactory.BuildTextModule` wraps the string in a `SyntheticModule` with a `default` export.
- Fixes a latent cache-key bug surfaced by `language/import/import-attributes/text-self.js`: the per-engine module map was keyed on the resolved specifier string only, so importing the same file with and without `type` attributes collided on one record. The cache is now keyed on `(resolvedSpecifier, attributes)` per the import-attributes spec. Phase is intentionally **excluded** from the key so defer/source imports continue to share a single module record with regular `Evaluation` imports (verified against the import-defer error tests).
- Un-excludes `"import-text"` from the test262 harness. No Acornima changes were required — attribute values already parse generically.

## Test plan

- [x] `dotnet build --configuration Release Jint/Jint.csproj` — 0 warnings, 0 errors
- [x] `dotnet test --configuration Release Jint.Tests/Jint.Tests.csproj --filter "FullyQualifiedName~Jint.Tests.Runtime.ModuleTests"` — 53/53 pass (includes new `CanStaticallyImportTextModule` / `CanDynamicallyImportTextModule` theories)
- [x] `dotnet test --configuration Release Jint.Tests.Test262/Jint.Tests.Test262.csproj` — `Passed: 98551, Failed: 0, Skipped: 522`; all 7 import-text tests (`text-empty.js`, `text-javascript.js`, `text-self.js`, `text-string.js`, `text-via-namespace.js`, `2nd-param-with-type-text.js`) pass with no regressions