### PR TITLE
Drop redundant out-var reset after int.TryParse failure

### DIFF
--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -564,7 +564,6 @@ internal static class NonIsoCalendars
 
         if (!int.TryParse(monthCode.AsSpan(1, 2), NumberStyles.None, CultureInfo.InvariantCulture, out displayMonth))
         {
-            displayMonth = 0;
             return false;
         }
 


### PR DESCRIPTION
## Summary

\`int.TryParse\` already guarantees the out variable is set to \`0\` on failure (.NET BCL contract since v1), so the explicit \`displayMonth = 0;\` reset inside the failure branch of \`NonIsoCalendars.TryValidateMonthCode\` is dead code. One-line cleanup caught in the #2409 review.

## Test plan
- [x] \`dotnet build --configuration Release Jint/Jint.csproj\` clean (4 target frameworks).
- [x] No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)