### PR TITLE
Pool FunctionEnvironment per JintFunctionDefinition.State

### DIFF
--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -75,9 +75,9 @@ public sealed class ScriptFunction : Function, IConstructor
                     Throw.TypeError(calleeContext.Realm, $"Class constructor {_functionDefinition.Name} cannot be invoked without 'new'");
                 }
 
-                // Check if slot array can be cached after this call
+                // Capture funcEnv for end-of-call pool return when bindings can't escape
                 state = _functionDefinition.Initialize();
-                if (state is { UseFixedSlots: true, EnvironmentMayEscape: false })
+                if (state is { EnvironmentMayEscape: false })
                 {
                     funcEnv = (FunctionEnvironment) calleeContext.LexicalEnvironment;
                 }
@@ -120,12 +120,19 @@ public sealed class ScriptFunction : Function, IConstructor
             }
             finally
             {
-                // Cache the slot array for reuse by next call to the same function (thread-safe)
-                if (funcEnv?._slots is { } slots)
+                if (funcEnv is not null)
                 {
-                    System.Array.Clear(slots, 0, slots.Length);
-                    Interlocked.Exchange(ref state!._cachedSlots, slots);
-                    funcEnv._slots = null;
+                    // Cache the slot array for reuse by next call to the same function (thread-safe)
+                    if (funcEnv._slots is { } slots)
+                    {
+                        System.Array.Clear(slots, 0, slots.Length);
+                        Interlocked.Exchange(ref state!._cachedSlots, slots);
+                        funcEnv._slots = null;
+                    }
+
+                    // Return the env itself to the per-State pool so the next call to a function
+                    // sharing this State (typically the same Function instance) avoids the allocation.
+                    Interlocked.Exchange(ref state!._cachedEnv, funcEnv);
                 }
                 _engine.LeaveExecutionContext();
             }

--- a/Jint/Runtime/Environments/DeclarativeEnvironment.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironment.cs
@@ -353,6 +353,14 @@ internal class DeclarativeEnvironment : Environment
         _dictionary = null;
     }
 
+    /// <summary>
+    /// Reset for env-pool reuse: drop any using/await-using disposable resources tracked from the previous call.
+    /// </summary>
+    internal void ClearDisposeCapability()
+    {
+        _disposeCapability = null;
+    }
+
     internal void TransferTo(List<Key> names, DeclarativeEnvironment env)
     {
         var source = _dictionary!;

--- a/Jint/Runtime/Environments/FunctionEnvironment.cs
+++ b/Jint/Runtime/Environments/FunctionEnvironment.cs
@@ -23,7 +23,8 @@ internal sealed class FunctionEnvironment : DeclarativeEnvironment
 
     private JsValue? _thisValue;
     private ThisBindingStatus _thisBindingStatus;
-    internal readonly Function _functionObject;
+    // Mutable so a pooled env can be re-bound to a different Function instance that shares the same State (e.g. function literals re-evaluated in loops).
+    internal Function _functionObject;
 
     public FunctionEnvironment(
         Engine engine,
@@ -40,6 +41,23 @@ internal sealed class FunctionEnvironment : DeclarativeEnvironment
         {
             _thisBindingStatus = ThisBindingStatus.Uninitialized;
         }
+    }
+
+    /// <summary>
+    /// Re-initialize a pooled FunctionEnvironment for a new call. Leaves slot/dictionary handling
+    /// to the caller — they may either clear in place or replace with fresh storage.
+    /// </summary>
+    internal void Reset(Function functionObject, JsValue newTarget, Environment? outerEnv)
+    {
+        _functionObject = functionObject;
+        NewTarget = newTarget;
+        _outerEnv = outerEnv;
+        _thisValue = null;
+        _thisBindingStatus = functionObject._functionDefinition?.Function.Type is NodeType.ArrowFunctionExpression
+            ? ThisBindingStatus.Lexical
+            : ThisBindingStatus.Uninitialized;
+        _dictionary?.Clear();
+        ClearDisposeCapability();
     }
 
 

--- a/Jint/Runtime/Environments/JintEnvironment.cs
+++ b/Jint/Runtime/Environments/JintEnvironment.cs
@@ -77,12 +77,27 @@ internal static class JintEnvironment
     /// </summary>
     internal static FunctionEnvironment NewFunctionEnvironment(Engine engine, Function f, JsValue newTarget)
     {
-        var env = new FunctionEnvironment(engine, f, newTarget)
-        {
-            _outerEnv = f._environment
-        };
-
         var state = f._functionDefinition?.Initialize();
+        FunctionEnvironment env;
+
+        // Reuse a pooled FunctionEnvironment when the function's bindings cannot escape the call
+        // (no closure capture, not a generator/async). Re-bind to the new function/target/outer env
+        // and reset transient state. Slot storage is handled below.
+        if (state is { EnvironmentMayEscape: false }
+            && Interlocked.Exchange(ref state._cachedEnv, null) is { } cachedEnv
+            && ReferenceEquals(cachedEnv._engine, engine))
+        {
+            cachedEnv.Reset(f, newTarget, f._environment);
+            env = cachedEnv;
+        }
+        else
+        {
+            env = new FunctionEnvironment(engine, f, newTarget)
+            {
+                _outerEnv = f._environment,
+            };
+        }
+
         if (state is { UseFixedSlots: true })
         {
             env._slotNames = state.SlotNames;

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -309,6 +309,7 @@ internal sealed class JintFunctionDefinition
         public bool CanUseFastFDI;
         public bool EnvironmentMayEscape;
         public Binding[]? _cachedSlots;
+        public Environments.FunctionEnvironment? _cachedEnv;
 
         public SourceText SourceText;
 
@@ -558,16 +559,25 @@ internal sealed class JintFunctionDefinition
                 state.VarSlotCount = varsToInitialize.Count;
                 state.UseFixedSlots = true;
                 state.CanUseFastFDI = lexicalBindingCount == 0;
-
-                if (function.Generator || function.Async)
-                {
-                    state.EnvironmentMayEscape = true;
-                }
-                else
-                {
-                    state.EnvironmentMayEscape = EnvironmentEscapeAstVisitor.MayEscapeWithReferences(function, slotNames);
-                }
             }
+        }
+
+        // Compute EnvironmentMayEscape unconditionally so consumers (e.g. FunctionEnvironment pooling)
+        // can rely on it without first checking UseFixedSlots. Generators / async functions / direct eval
+        // always escape; otherwise inspect the body. When the function qualified for fixed slots, prefer
+        // the slot-aware analysis (only escapes if a closure actually references a slot variable);
+        // otherwise fall back to the conservative "any inner closure means escape" check.
+        if (function.Generator || function.Async || state.NeedsEvalContext)
+        {
+            state.EnvironmentMayEscape = true;
+        }
+        else if (state.UseFixedSlots)
+        {
+            state.EnvironmentMayEscape = EnvironmentEscapeAstVisitor.MayEscapeWithReferences(function, state.SlotNames!);
+        }
+        else
+        {
+            state.EnvironmentMayEscape = EnvironmentEscapeAstVisitor.MayEscape(function);
         }
 
         state.SourceText = new SourceText(fullSourceText);


### PR DESCRIPTION
## Summary

Slot arrays were already pooled per `State`, but the `FunctionEnvironment` object itself was allocated fresh on every call. For functions whose bindings cannot escape — no closure capture, not a generator/async, which the existing `EnvironmentMayEscape` flag already tracks — the env is trivially safe to reuse: at end-of-call we reset `_thisValue`, `_thisBindingStatus`, `_outerEnv`, `_functionObject`, `NewTarget`, and clear `_dictionary` / `_disposeCapability` before returning it to the pool.

The slot-pooling gate widens from `{UseFixedSlots: true, EnvironmentMayEscape: false}` to `{EnvironmentMayEscape: false}` alone — slot-less envs (zero params/vars, common for tight inner closures like `sw.Start()` in the benchmark) now also pool, which is where the bulk of the allocation reduction comes from.

## Implementation notes

- New `FunctionEnvironment.Reset(...)` method centralizes the per-call cleanup (this-binding, outer env, function ref, dispose capability, dictionary clear). Slot reset is left to the caller, mirroring the existing slot-pool pattern.
- `_functionObject` becomes mutable so a pooled env can be re-bound to a different `Function` instance that shares the same `State` (function literals re-evaluated in loops produce distinct `Function` instances over the same AST).
- Pool storage is a single-slot cache on `JintFunctionDefinition.State._cachedEnv`, mirroring `_cachedSlots`. `Interlocked.Exchange` and `ReferenceEquals(_engine, engine)` are used the same way.
- `Construct` path is unchanged — its env is consumed (`GetThisBinding`) after `LeaveExecutionContext`, so it can't be returned to the pool until that's restructured.

## Benchmark (stopwatch.js, clean machine)

Ryzen 9 5950X / .NET 10.0.7. Both runs back-to-back on an idle machine; std-dev is ≤1.6ms.

| Method               | Modern | main      | PR        | Δ time   | Δ alloc |
|----------------------|--------|----------:|----------:|---------:|--------:|
| Execute              | var    | 197.4 ms  | 197.5 ms  | flat     | -47%    |
| Execute_ParsedScript | var    | 222.5 ms  | 215.3 ms  | -3.2%    | -47%    |
| Execute              | let    | 255.3 ms  | 255.5 ms  | flat     | -47%    |
| Execute_ParsedScript | let    | 264.2 ms  | 241.8 ms  | **-8.5%** | -47%   |
| Allocated            | all    | ~72.3 MB  | ~38.5 MB  | —        | **-46.7%** |

The headline number is the allocation reduction: 72 MB → 38.5 MB on the same workload (391k function calls). Time is mostly flat on the var (re-parsed each iteration) cases and improves 3-8% on the parsed-script (cached AST, warm pool) cases — which is the realistic deployment pattern when reusing `Prepared<Script>` across executions.

## Validation

- `Jint.Tests` (net10.0): 2861 passed, 0 failed.
- `Jint.Tests.Test262` (net10.0): 98567 passed, 506 skipped, **0 failed** (matches `upstream/main`).

The pool-return is gated on `state.EnvironmentMayEscape == false`, so closures that capture the env stay un-pooled (otherwise we'd corrupt their captured reference). Generators and async functions also force `EnvironmentMayEscape = true` and never enter the pool. The existing `Interlocked` + engine-identity checks make cross-engine reuse safe.

## Stacked work

This is the second of six related performance changes; the rest sit on `lahma/jint` as `perf/identifier-slot-cache`, `perf/drop-interlocked`, `perf/skip-empty-callee-env`, `perf/block-env-reset`, all rebased on top of this branch and ready to PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)