### PR TITLE
Upgrade to Acornima v1.6.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Acornima" Version="1.6.0" />
-    <PackageVersion Include="Acornima.Extras" Version="1.6.0" />
+    <PackageVersion Include="Acornima" Version="1.6.1" />
+    <PackageVersion Include="Acornima.Extras" Version="1.6.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.TestAdapter" Version="0.13.12" />
     <PackageVersion Include="FluentAssertions" Version="[7.2.2]" />


### PR DESCRIPTION
In flag v regexp validation, I found a bug that incorrectly rejects quantified modifier groups (e.g., `/(?i:x)?/v`).

I released the [fix](https://github.com/adams85/acornima/commit/6ebd1d2792cb7460d7d80ed3c33b3338af0eb667) in [Acornima v1.6.1](https://github.com/adams85/acornima/releases/tag/v1.6.1).

This PR upgrades Acornima to the patched version.