### PR TITLE
Cache binding location in JintIdentifierExpression slot fast path

### DIFF
--- a/Jint/Runtime/Environments/JintEnvironment.cs
+++ b/Jint/Runtime/Environments/JintEnvironment.cs
@@ -83,6 +83,12 @@ internal static class JintEnvironment
         // Reuse a pooled FunctionEnvironment when the function's bindings cannot escape the call
         // (no closure capture, not a generator/async). Re-bind to the new function/target/outer env
         // and reset transient state. Slot storage is handled below.
+        //
+        // Important invariant for downstream callers: any env that an inner closure could resolve
+        // bindings from (i.e. a closure-target env) must not be pool-eligible — JintIdentifierExpression's
+        // slot-binding cache caches resolve-env references and trusts that they remain stable for
+        // the lifetime of the function instance that captured them. If the EnvironmentMayEscape gate
+        // is widened beyond closure-targets, that cache must be revisited.
         if (state is { EnvironmentMayEscape: false }
             && Interlocked.Exchange(ref state._cachedEnv, null) is { } cachedEnv
             && ReferenceEquals(cachedEnv._engine, engine))

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -12,6 +12,20 @@ internal sealed class JintIdentifierExpression : JintExpression
     private Environment? _cachedEnvironment;
     private bool _cachedStrict;
 
+    // Slot-binding location cache: when an identifier resolves to a slot in some
+    // (possibly outer) DeclarativeEnvironment, remember the env reference and slot
+    // index so subsequent reads can skip the env-chain walk and SlotIndexOf scan.
+    // Validity: walk from the current execution env up looking for _cachedSlotEnv via
+    // ReferenceEquals — closure-captured envs cannot be pooled (escape-detection prevents it),
+    // so their identity is stable for the lifetime of the function instance that captured them.
+    // Strict-mode is intentionally not validated: a single AST node's strictness is fixed by
+    // its enclosing scope at parse time, so it cannot change between calls.
+    private DeclarativeEnvironment? _cachedSlotEnv;
+    private int _cachedSlotIndex = -1;
+
+    // Bounded walk: chain depth is typically 1-3 in real code; deeper chains fall through.
+    private const int MaxSlotCacheChainDepth = 4;
+
     public JintIdentifierExpression(Identifier expression) : base(expression)
     {
         _identifier = expression.UserData as Environment.BindingName
@@ -77,6 +91,35 @@ internal sealed class JintIdentifierExpression : JintExpression
         var strict = StrictModeScope.IsStrictModeCode;
         JsValue? value;
 
+        // Slot-cache fast path: walk from the current env up the chain looking for the cached
+        // resolving env via ReferenceEquals. When found, read the slot value directly,
+        // skipping HasBinding + SlotIndexOf at every intermediate env.
+        var cachedSlotEnv = _cachedSlotEnv;
+        if (cachedSlotEnv is not null)
+        {
+            var search = env;
+            for (var hops = 0; hops < MaxSlotCacheChainDepth && search is not null; hops++)
+            {
+                if (ReferenceEquals(search, cachedSlotEnv))
+                {
+                    var slots = cachedSlotEnv._slots;
+                    var idx = _cachedSlotIndex;
+                    if (slots is not null && (uint) idx < (uint) slots.Length)
+                    {
+                        value = slots[idx].Value;
+                        if (value is null)
+                        {
+                            ThrowNotInitialized(engine);
+                        }
+                        return MaterializeIfArguments(value);
+                    }
+                    break;
+                }
+                search = search._outerEnv;
+            }
+        }
+
+
         if (ReferenceEquals(env, _cachedEnvironment)
             && _cachedStrict == strict
             && env.TryGetBinding(identifier, strict, out value))
@@ -103,6 +146,25 @@ internal sealed class JintIdentifierExpression : JintExpression
                 _cachedEnvironment = null;
             }
 
+            // Populate slot-binding cache when the resolved env stores this binding in a fixed slot.
+            // Closure-captured envs cannot be pooled (escape detection prevents it), so caching the
+            // env reference is safe; slot indices are immutable for the lifetime of the env.
+            if (identifierEnvironment is DeclarativeEnvironment denv
+                && denv._slots is not null
+                && denv._slotNames is { } slotNames)
+            {
+                var key = identifier.Key;
+                for (var i = 0; i < slotNames.Length; i++)
+                {
+                    if (slotNames[i] == key)
+                    {
+                        _cachedSlotEnv = denv;
+                        _cachedSlotIndex = i;
+                        break;
+                    }
+                }
+            }
+
             if (value is null)
             {
                 ThrowNotInitialized(engine);
@@ -114,12 +176,17 @@ internal sealed class JintIdentifierExpression : JintExpression
             value = engine.GetValue(reference, returnReferenceToPool: true);
         }
 
+        return MaterializeIfArguments(value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static JsValue MaterializeIfArguments(JsValue value)
+    {
         // make sure arguments access freezes state
         if (value is JsArguments argumentsInstance)
         {
             argumentsInstance.Materialize();
         }
-
         return value;
     }
 


### PR DESCRIPTION
## Summary

The existing identifier-read cache only fires when the binding is in the current `LexicalEnvironment` — a closure-captured reference (the common case for inner functions reading outer-scope variables) always falls through to `TryGetIdentifierEnvironmentWithBindingValue`, which walks the env chain and does a `SlotIndexOf` scan at each step.

This PR caches the resolving `DeclarativeEnvironment` and slot index on the AST node. On subsequent reads, the env chain is walked looking for the cached env via `ReferenceEquals` (cheap) instead of `HasBinding` / `SlotIndexOf` at every hop. Once found, the slot value is read directly.

## Why it's safe

Validity rests on a structural invariant:
- **Closure-captured envs cannot be pooled** — escape detection (`EnvironmentMayEscape`, recently widened to also cover non-fixed-slot functions in #2413) prevents pooling of any env that an inner function captures, so the cached resolve-env reference is stable for the lifetime of the function instance that captured it.
- **Slot names are immutable** after env construction (set once in `JintEnvironment.NewFunctionEnvironment` / `JintBlockStatement.ExecuteBlock`), so the cached slot index remains correct.
- **Cross-function-instance polymorphism** (a function literal re-evaluated in a loop produces distinct closures over distinct outer envs) thrashes the cache but stays correct — the chain walk simply doesn't find the previously-cached env on the new chain, falls through to the existing resolution path, and updates the cache.

The walk is bounded to 4 hops; chains deeper than that fall through to the original logic. Module envs and dictionary-based bindings are not cached (only DeclarativeEnvironment slots).

## Benchmark (stopwatch.js, clean machine)

Ryzen 9 5950X / .NET 10.0.7. Baseline + PR taken back-to-back on an idle machine; std-dev ≤2ms.

| Method               | Modern | main (post #2413) | PR        | Δ       |
|----------------------|--------|------------------:|----------:|--------:|
| Execute              | var    | 198.8 ms          | 204.0 ms  | +2.6% (within noise) |
| Execute_ParsedScript | var    | 209.5 ms          | 206.8 ms  | -1.3%   |
| Execute              | let    | 245.1 ms          | 240.7 ms  | -1.8%   |
| Execute_ParsedScript | let    | 266.2 ms          | 253.4 ms  | **-4.8%** |
| Allocated            | all    | ~38.5 MB          | ~38.5 MB  | flat    |

The `let` cases benefit most because the inner closures in `stopwatch-modern.js` resolve outer-scope `let` bindings via slots — exactly what the new cache short-circuits. The `Execute (var)` +2.6% is within run-to-run variance (we've seen ±5% on this machine even on idle runs); it's flat in spirit. Allocations are unchanged.

This is a small, predictable win; the bigger picture is that this enables Change 5 (skip-empty-callee-env, queued behind this) to land safely — that change relies on the slot cache absorbing the work skipped by the empty-env walk shortcut.

## Validation

- `Jint.Tests` (net10.0): 2861 passed, 0 failed.
- `Jint.Tests.Test262` (net10.0): 98567 passed, 506 skipped, 0 failed.

## Stacked work

Third of six related performance changes. Remaining branches on `lahma/jint` (`perf/drop-interlocked`, `perf/skip-empty-callee-env`, `perf/block-env-reset`) are rebased on top and queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)