### PR TITLE
Document the (uint)i < (uint)length bounds-check idiom and apply it to four sites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,26 @@ Split into a separate file when:
 - Expression and function definition caching reduces re-evaluation cost
 - AggressiveInlining attributes mark hot paths
 
+### Unsigned-cast bounds check (`(uint)i < (uint)length`)
+
+Prefer `(uint) index < (uint) array.Length` over `index >= 0 && index < array.Length` when guarding an array/Span/list access where the index could be negative. This is an established pattern in this codebase (already used in `DictionarySlim`, `StringDictionarySlim`, `ValueStringBuilder`, `Arguments`, `TypeConverter`, `JsNumber`, `JintIdentifierExpression`, etc.) and across the .NET BCL.
+
+**How it works:** `int.MinValue..-1` cast to `uint` produces values `0x80000000..0xFFFFFFFF` — all greater than any non-negative `int`. So the single unsigned comparison `(uint)i < (uint)length` is true iff `i` is in `[0, length)`. RyuJIT recognizes this idiom and lowers it to a single `cmp` + `jae` instruction; furthermore, the JIT can use the post-comparison range fact to elide the bounds check on the subsequent `array[i]` access (the index is already proven in range).
+
+**When to use:**
+- Manual bounds checks before a direct `array[i]` / `span[i]` / `list[i]` access where `i` could be negative or oversized — typical in pool/cache code, parser fast paths, and `for`-loop chains where the index isn't a fresh loop variable.
+- Defensive validation of an `int` field/argument before indexing.
+- `for (var i = ...; (uint)i < (uint)arr.Length; ...)` loops where the body indexes `arr[i]`.
+
+**When not to use:**
+- Ordinary `for (var i = 0; i < arr.Length; i++)` loops — the JIT already eliminates the bounds check there; the cast is noise.
+- When the index is known non-negative by construction and you just want a single upper-bound check — plain `i < arr.Length` is clearer and equivalent.
+- When the type is already unsigned (`uint`/`nuint`) — the cast is redundant.
+
+**Caveats:**
+- The pattern relies on `length` fitting in `int` (always true for `Array.Length` / `Span<T>.Length`). For `long` lengths (rare), use `(ulong)i < (ulong)length`.
+- Different phrasings can affect the JIT's ability to elide subsequent bounds checks; prefer `(uint)i < (uint)arr.Length` over `(uint)i <= (uint)(arr.Length - 1)` and similar variants.
+
 ## Working with ES Features
 
 When implementing new ECMAScript features:

--- a/Jint/Native/String/StringInlHelper.cs
+++ b/Jint/Native/String/StringInlHelper.cs
@@ -40,7 +40,7 @@ internal class StringInlHelper
             for (int i = replaceableCharsIdx.Count - 1; i >= 0; i--)
             {
                 int index = replaceableCharsIdx[i];
-                if (index >= 0 && index < stringBuilder.Length)
+                if ((uint) index < (uint) stringBuilder.Length)
                 {
                     stringBuilder.Remove(index, 1);
                 }

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
@@ -563,7 +563,7 @@ internal sealed class PlainYearMonthConstructor : Constructor
                         CultureInfo.InvariantCulture, out var month))
                 {
                     // If there's a suffix, check what follows
-                    if (endIndex >= 0 && endIndex < rest.Length)
+                    if ((uint) endIndex < (uint) rest.Length)
                     {
                         var suffix = rest.Substring(endIndex);
                         // If it starts with '-', there's a day component - don't match here, let full date parsing handle it

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -4426,7 +4426,7 @@ internal static class TemporalHelpers
             {
                 // Check for timezone annotation (bracket without "=" or with non-calendar key)
                 var bracketStart = str.IndexOf('[');
-                while (bracketStart >= 0 && bracketStart < str.Length)
+                while ((uint) bracketStart < (uint) str.Length)
                 {
                     var bracketEnd = str.IndexOf(']', bracketStart);
                     if (bracketEnd < 0) break;

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
@@ -668,7 +668,7 @@ internal sealed class ZonedDateTimeConstructor : Constructor
             int lastBracketEnd = -1;
 
             bracketIndex = input.IndexOf('[');
-            while (bracketIndex >= 0 && bracketIndex < input.Length)
+            while ((uint) bracketIndex < (uint) input.Length)
             {
                 var bracketEnd = input.IndexOf(']', bracketIndex);
                 if (bracketEnd < 0) break;


### PR DESCRIPTION
## Summary

Two small unrelated improvements bundled together:

1. **CLAUDE.md** — adds a `Performance Considerations` subsection documenting the unsigned-cast bounds-check idiom (`(uint) i < (uint) length`). The pattern was already used at 15+ sites in this repo (`DictionarySlim`, `StringDictionarySlim`, `ValueStringBuilder`, `Arguments`, `TypeConverter`, `JsNumber`, `JintIdentifierExpression`, ...) but wasn't explicitly documented as a project convention. The new doc explains how it works (single `cmp` + `jae`, JIT can elide the subsequent indexer bounds check), when to apply it, when it adds noise (ordinary `for` loops where the JIT already elides), and the caveats (works only when length fits in `int`).

2. **Four candidate sites** still using the slower `index >= 0 && index < x.Length` form, rewritten to `(uint) index < (uint) x.Length`:
   - `Jint/Native/String/StringInlHelper.cs:43` — `stringBuilder.Remove` guard
   - `Jint/Native/Temporal/TemporalHelpers.cs:4429` — bracket-scan loop while parsing temporal strings
   - `Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs:566` — suffix index check
   - `Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs:671` — bracket-scan loop in ZDT parsing

   These are not hot paths (string parsing called at most a few times per parse), so the change is for **consistency** with the rest of the codebase, not measurable perf. Behavior is identical: both forms accept exactly `[0, length)`.

## Validation

- `Jint.Tests` (net10.0): 2861 passed, 0 failed.
- `Jint.Tests.Test262` (net10.0): 98567 passed, 506 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)