### PR TITLE
Drop Interlocked.Exchange in single-threaded pool hot paths

### DIFF
--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
@@ -122,17 +121,16 @@ public sealed class ScriptFunction : Function, IConstructor
             {
                 if (funcEnv is not null)
                 {
-                    // Cache the slot array for reuse by next call to the same function (thread-safe)
+                    // Pool returns: plain writes are sufficient — the engine is single-threaded for a
+                    // given execution; a concurrent misuse would at worst lose a pooled object (one
+                    // extra allocation), never produce stale state.
                     if (funcEnv._slots is { } slots)
                     {
                         System.Array.Clear(slots, 0, slots.Length);
-                        Interlocked.Exchange(ref state!._cachedSlots, slots);
+                        state!._cachedSlots = slots;
                         funcEnv._slots = null;
                     }
-
-                    // Return the env itself to the per-State pool so the next call to a function
-                    // sharing this State (typically the same Function instance) avoids the allocation.
-                    Interlocked.Exchange(ref state!._cachedEnv, funcEnv);
+                    state!._cachedEnv = funcEnv;
                 }
                 _engine.LeaveExecutionContext();
             }

--- a/Jint/Runtime/Environments/JintEnvironment.cs
+++ b/Jint/Runtime/Environments/JintEnvironment.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Threading;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Native.Object;
@@ -89,9 +88,14 @@ internal static class JintEnvironment
         // slot-binding cache caches resolve-env references and trusts that they remain stable for
         // the lifetime of the function instance that captured them. If the EnvironmentMayEscape gate
         // is widened beyond closure-targets, that cache must be revisited.
-        if (state is { EnvironmentMayEscape: false }
-            && Interlocked.Exchange(ref state._cachedEnv, null) is { } cachedEnv
-            && ReferenceEquals(cachedEnv._engine, engine))
+        FunctionEnvironment? cachedEnv = null;
+        if (state is { EnvironmentMayEscape: false })
+        {
+            cachedEnv = state._cachedEnv;
+            state._cachedEnv = null;
+        }
+
+        if (cachedEnv is not null && ReferenceEquals(cachedEnv._engine, engine))
         {
             cachedEnv.Reset(f, newTarget, f._environment);
             env = cachedEnv;
@@ -107,8 +111,9 @@ internal static class JintEnvironment
         if (state is { UseFixedSlots: true })
         {
             env._slotNames = state.SlotNames;
-            // Try to reuse cached slots from previous call to same function (thread-safe)
-            var cached = Interlocked.Exchange(ref state._cachedSlots, null);
+            // Try to reuse cached slots from previous call to same function
+            var cached = state._cachedSlots;
+            state._cachedSlots = null;
             env._slots = cached ?? new Binding[state.SlotNames!.Length];
         }
 

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using Jint.Native;
 using Jint.Native.Promise;
 using Jint.Runtime.Descriptors;
@@ -73,7 +72,8 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
                 if (blockState.SlotNames is not null)
                 {
                     // Try to reuse cached environment (only valid for same Engine)
-                    var cachedEnv = Interlocked.Exchange(ref blockState._cachedEnv, null);
+                    var cachedEnv = blockState._cachedEnv;
+                    blockState._cachedEnv = null;
 
                     if (cachedEnv is not null && ReferenceEquals(cachedEnv._engine, engine))
                     {
@@ -143,7 +143,7 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
                 // Return environment to cache for reuse (slots only exist when CanReuseEnvironment=true)
                 if (blockEnv._slots is not null)
                 {
-                    Interlocked.Exchange(ref blockState._cachedEnv, blockEnv);
+                    blockState._cachedEnv = blockEnv;
                 }
 
                 blockValue = blockEnv.DisposeResources(blockValue);
@@ -262,7 +262,7 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
         /// </summary>
         public readonly bool CanReuseEnvironment;
 
-        // Cached environment for reuse (thread-safe via Interlocked.Exchange)
+        // Cached environment for reuse — single-threaded engine, plain field access is sufficient.
         public DeclarativeEnvironment? _cachedEnv;
 
         public BlockState(DeclarationCache declarationCache, BlockStatement blockStatement)


### PR DESCRIPTION
## Summary

The slot/env/block-env pools added in #2413 (`FunctionEnvironment` pool, `JintBlockStatement._cachedEnv`, `JintFunctionDefinition.State._cachedSlots/_cachedEnv`) all rent and release using `Interlocked.Exchange`. But `Engine` instances are documented as not thread-safe for concurrent script execution — those atomic ops are pure defensive overhead in the only supported usage.

This PR replaces the atomic with plain field access in the three pool sites:
- `JintEnvironment.NewFunctionEnvironment` — env + slot rent
- `ScriptFunction.Call` finally — env + slot release
- `JintBlockStatement.ExecuteBlock` — block-env rent + release

## Why it's safe

Worst-case race in a multi-thread misuse: a tiny extra allocation when two threads both rent and one allocates fresh; never corruption. The existing `ReferenceEquals(_engine, engine)` guard at rent sites already protects against cross-engine reuse if a pooled object happens to land in the wrong engine.

If thread-safety is ever needed, a single boolean on `Engine` plus a branch at the pool sites would be a cleaner reintroduction than the current always-on atomics.

## Performance

Per-op savings of ~2–3 atomic operations are nanoseconds — well below the noise floor of the `stopwatch.js` benchmark on this hardware (~1–2 ms StdDev within a run, ±5% run-to-run variance). The change is **free** at this level of measurement; no regression visible. Ship for code-quality / removing-misleading-thread-safety reasons rather than a chase-able number.

## Validation

- `Jint.Tests` (net10.0): 2861 passed, 0 failed.
- `Jint.Tests.Test262` (net10.0): 98567 passed, 506 skipped, 0 failed (flaky decodeURI timeouts under concurrent test load — known pre-existing pattern, irrelevant to this change).

Rebased on top of latest `main` (post-#2412 / #2413 / #2415 / #2416 / #2417).

## Stacked work

Fourth of six related performance changes. Remaining: `perf/skip-empty-callee-env`, `perf/block-env-reset` queued on `lahma/jint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)