### PR TITLE
Skip identifier walk through empty FunctionEnvironments

### DIFF
--- a/Jint/Runtime/Environments/JintEnvironment.cs
+++ b/Jint/Runtime/Environments/JintEnvironment.cs
@@ -22,6 +22,18 @@ internal static class JintEnvironment
 
         while (record is not null)
         {
+            // Skip the virtual HasBinding call on FunctionEnvironments that have no own bindings
+            // (zero-arg, zero-var closures like `function () { ... }`). The body's identifier reads
+            // resolve outward; the empty callee env contributes nothing.
+            if (record is FunctionEnvironment fenv
+                && fenv._slots is null
+                && fenv._dictionary is null
+                && record._outerEnv is not null)
+            {
+                record = record._outerEnv;
+                continue;
+            }
+
             if (record.HasBinding(name))
             {
                 return true;
@@ -50,6 +62,16 @@ internal static class JintEnvironment
 
         while (record is not null)
         {
+            // See sibling method above; skip empty FunctionEnvironments outright.
+            if (record is FunctionEnvironment fenv
+                && fenv._slots is null
+                && fenv._dictionary is null
+                && record._outerEnv is not null)
+            {
+                record = record._outerEnv;
+                continue;
+            }
+
             if (record.TryGetBinding(name, strict, out value))
             {
                 return true;


### PR DESCRIPTION
## Summary

Closures with zero parameters and zero local declarations — a tight inner method like `sw.Start()` in the stopwatch benchmark — end up with a `FunctionEnvironment` whose `_slots` and `_dictionary` are both null. Their own bindings are nothing. Identifier reads inside the body always resolve outward through the closure chain, but the env-walk in `JintEnvironment.TryGetIdentifierEnvironmentWithBinding{,Value}` still pays a virtual `TryGetBinding` / `HasBinding` per layer.

This PR skips those empty `FunctionEnvironment` layers outright in the chain walk:

```csharp
if (record is FunctionEnvironment fenv
    && fenv._slots is null
    && fenv._dictionary is null
    && record._outerEnv is not null)
{
    record = record._outerEnv;
    continue;
}
```

Only `FunctionEnvironment` is targeted — `ModuleEnvironment` may carry indirect-import bindings even when slots/dict are null, and `DeclarativeEnvironment` block scopes effectively always have slots when they exist.

The hot-path benefit is small in isolation — the slot-binding cache from #2416 already short-circuits this on cache hits — but it speeds up first-call resolve and cache-miss fallback paths.

## Benchmark (stopwatch.js)

Ryzen 9 5950X / .NET 10.0.7. Baseline + PR taken back-to-back. Run-to-run StdDev was high on this session (4-17ms), so individual numbers should be read with caution; the directional pattern is consistent though.

| Method               | Modern | main      | PR        | Δ time    |
|----------------------|--------|----------:|----------:|----------:|
| Execute              | var    | 249.5 ms  | 203.5 ms  | **-18%**  |
| Execute_ParsedScript | var    | 250.2 ms  | 257.1 ms  | +3% (noise) |
| Execute              | let    | 300.0 ms  | 290.9 ms  | -3%       |
| Execute_ParsedScript | let    | 253.1 ms  | 242.8 ms  | -4%       |
| Allocated            | all    | ~38.5 MB  | ~38.5 MB  | flat      |

Most of the gain is on the parse-each-iteration `Execute (var)` path where the slot cache from #2416 starts cold each iteration; here the empty-env skip removes a virtual call per identifier read in the warmup phase. Allocations are unchanged — this is purely a control-flow tweak.

## Validation

- `Jint.Tests` (net10.0): 2861 passed, 0 failed.
- `Jint.Tests.Test262` (net10.0): 98567 passed, 506 skipped, 0 failed (clean run; transient flakes under concurrent test load are unrelated).

The skip is gated on `is FunctionEnvironment` plus `_slots is null && _dictionary is null`, so any env that could ever resolve a binding is preserved. `record._outerEnv is not null` ensures we still hit the global lookup at the chain end.

## Stacked work

Fifth of six related performance changes. The `perf/drop-interlocked` branch (originally #2418) was abandoned after CI revealed that pool fields on `JintFunctionDefinition.State` are genuinely shared across parallel test fixtures via the static Test262 harness script cache, so the atomic exchanges are required.

Last in the queue is `perf/block-env-reset` on `lahma/jint` — small block-env reset inlining. Will be PR'd after this one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)