### PR TITLE
Inline small block-env slot reset

### DIFF
--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -79,7 +79,7 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
                     {
                         // Reuse environment: update outer reference and reset slots
                         cachedEnv._outerEnv = oldEnv;
-                        blockState.SlotTemplates.AsSpan().CopyTo(cachedEnv._slots);
+                        ResetSlots(cachedEnv._slots!, blockState.SlotTemplates!);
                         blockEnv = cachedEnv;
                     }
                     else
@@ -242,6 +242,28 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
         return ExecuteBlock(context);
+    }
+
+    /// <summary>
+    /// Reset the slots of a reused block environment to the pre-computed templates.
+    /// Hand-rolled small-array fast path: typical block scopes hold 1-3 bindings, where the
+    /// JIT can unroll this loop and avoid the Span construction + generic copy of CopyTo.
+    /// </summary>
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    private static void ResetSlots(Binding[] slots, Binding[] templates)
+    {
+        var len = slots.Length;
+        if (len == templates.Length && len <= 4)
+        {
+            for (var i = 0; i < len; i++)
+            {
+                slots[i] = templates[i];
+            }
+        }
+        else
+        {
+            templates.AsSpan().CopyTo(slots);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Last in the perf series. The cached block-environment reset path in `JintBlockStatement.ExecuteBlock` resets the slot array on every iteration of `let`/`const`-bearing loops via `SlotTemplates.AsSpan().CopyTo(_slots)`. For typical block scopes (1-3 bindings — e.g. `const z, ms, rn` in `stopwatch-modern.js`) the Span construction + generic `CopyTo` overhead is comparable to the work itself.

This PR moves the copy into a tiny static helper with `[MethodImpl(AggressiveInlining)]` and a hand-rolled `<= 4`-element loop. The JIT can unroll this and avoid the intermediate `Span`. Larger block scopes still go through `CopyTo`.

```csharp
[MethodImpl(MethodImplOptions.AggressiveInlining)]
private static void ResetSlots(Binding[] slots, Binding[] templates)
{
    var len = slots.Length;
    if (len == templates.Length && len <= 4)
    {
        for (var i = 0; i < len; i++)
        {
            slots[i] = templates[i];
        }
    }
    else
    {
        templates.AsSpan().CopyTo(slots);
    }
}
```

## Benchmark (stopwatch.js, fresh back-to-back)

Ryzen 9 5950X / .NET 10.0.7. Both runs taken back-to-back on the same session. The `Execute_ParsedScript (let)` baseline run had a bimodal outlier (one iteration at ~340ms pulling the mean to 287ms with StdDev 60ms; median was 246.5ms) — the more honest baseline for that case is the median, against which C6's mean of 243.5ms is also flat.

| Method               | Modern | main      | PR        | Δ time           |
|----------------------|--------|----------:|----------:|-----------------:|
| Execute              | var    | 200.9 ms  | 201.5 ms  | flat             |
| Execute_ParsedScript | var    | 206.0 ms  | 205.4 ms  | flat             |
| Execute              | let    | 243.0 ms  | 239.6 ms  | -1%              |
| Execute_ParsedScript | let    | 246.5 ms* | 243.5 ms  | -1%              |
| Allocated            | all    | ~38.5 MB  | ~38.5 MB  | flat             |

*median, baseline run had a bimodal outlier

So: essentially flat in measurement. The change is justified on **code-path quality** (avoids generic CopyTo overhead on a known-small array) rather than a chase-able number. Worth landing for the same reason as `[AggressiveInlining]` markers elsewhere in this codebase: it expresses a hot-path intent that JIT can act on.

## Validation

- `Jint.Tests` (net10.0): 2861 passed, 0 failed.
- `Jint.Tests.Test262` (net10.0): 98567 passed, 506 skipped, 0 failed.

## Stack context

Sixth and final perf change in the series:
- ✅ #2412 — shape-versioned property cache (merged)
- ✅ #2413 — FunctionEnvironment pool (merged)
- ✅ #2416 — identifier slot cache (merged)
- ✅ #2417 — `(uint)i < (uint)length` doc + cleanups (merged)
- ❌ #2418 — drop Interlocked (abandoned: pool fields are shared via static Test262 harness cache)
- ✅ #2419 — skip empty FunctionEnvironment walk (merged)
- 🟡 **this PR** — small block-env reset

Cumulative measured impact across the series on `stopwatch.js`: ~5% time reduction, ~46% allocation reduction (71 MB → 38.5 MB). The big wins were #2412 (cache fires for configurable properties) and #2413 (env pool, the bulk of the alloc reduction); #2416 / #2419 / this PR are smaller polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)