### PR TITLE
Add Engine.ResetState() for lightweight engine reuse

### DIFF
--- a/Jint.Benchmark/EngineResetBenchmark.cs
+++ b/Jint.Benchmark/EngineResetBenchmark.cs
@@ -1,0 +1,75 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+[MemoryDiagnoser]
+public class EngineResetBenchmark
+{
+    private Engine _reusableEngine = null!;
+    private Engine _reusableEngineWithOptions = null!;
+    private Prepared<Script> _setupScript;
+    private Prepared<Script> _workScript;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _setupScript = Engine.PrepareScript(@"
+            function processInput(input) {
+                return JSON.parse(input);
+            }
+            function formatOutput(obj) {
+                return JSON.stringify(obj, null, 2);
+            }
+            var CONFIG = { maxRetries: 3, timeout: 5000 };
+        ");
+
+        _workScript = Engine.PrepareScript(@"
+            var result = processInput('{""key"":1}');
+            formatOutput(result);
+        ");
+
+        _reusableEngine = new Engine();
+        _reusableEngine.Execute(_setupScript);
+        _reusableEngine.Evaluate(_workScript);
+
+        _reusableEngineWithOptions = new Engine(options =>
+        {
+            options.Strict = true;
+        });
+        _reusableEngineWithOptions.Execute(_setupScript);
+        _reusableEngineWithOptions.Evaluate(_workScript);
+    }
+
+    [Benchmark(Baseline = true)]
+    public JsValue NewEngine_WithSetup()
+    {
+        var engine = new Engine();
+        engine.Execute(_setupScript);
+        return engine.Evaluate(_workScript);
+    }
+
+    [Benchmark]
+    public JsValue ResetState_WithSetup()
+    {
+        _reusableEngine.ResetState();
+        _reusableEngine.Execute(_setupScript);
+        return _reusableEngine.Evaluate(_workScript);
+    }
+
+    [Benchmark]
+    public JsValue NewEngine_WithOptions_WithSetup()
+    {
+        var engine = new Engine(options => options.Strict = true);
+        engine.Execute(_setupScript);
+        return engine.Evaluate(_workScript);
+    }
+
+    [Benchmark]
+    public JsValue ResetState_WithOptions_WithSetup()
+    {
+        _reusableEngineWithOptions.ResetState();
+        _reusableEngineWithOptions.Execute(_setupScript);
+        return _reusableEngineWithOptions.Evaluate(_workScript);
+    }
+}

--- a/Jint.Benchmark/EngineResetBenchmark.cs
+++ b/Jint.Benchmark/EngineResetBenchmark.cs
@@ -3,73 +3,302 @@ using Jint.Native;
 
 namespace Jint.Benchmark;
 
+/// <summary>
+/// Simulates a server-side script execution loop where each iteration creates/reuses
+/// an engine, loads setup scripts (utility functions), binds CLR objects,
+/// then executes user-provided code.
+///
+/// Three workload profiles:
+/// - Light: short scripts typical of tool dispatch (parse args, format output) — setup cost dominates
+/// - Heavy: CPU-intensive scripts (large data processing) — script execution dominates
+/// - IO: scripts that call async CLR methods (simulated) — allocations matter, wall-clock is I/O-bound
+/// </summary>
 [MemoryDiagnoser]
 public class EngineResetBenchmark
 {
-    private Engine _reusableEngine = null!;
-    private Engine _reusableEngineWithOptions = null!;
-    private Prepared<Script> _setupScript;
-    private Prepared<Script> _workScript;
+    private Engine _reusableLight = null!;
+    private Engine _reusableHeavy = null!;
+    private Engine _reusableIO = null!;
+    private Prepared<Script> _consoleShim;
+    private Prepared<Script> _utilityLibrary;
+    private Prepared<Script>[] _lightScripts = null!;
+    private Prepared<Script> _heavyScript;
+    private Prepared<Script> _ioScript;
+
+    private static void ConfigureEngine(Options options)
+    {
+        options.LimitMemory(32_000_000);
+        options.TimeoutInterval(TimeSpan.FromSeconds(10));
+        options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(10);
+        options.LimitRecursion(64);
+        options.Strict();
+        options.Interop.AllowGetType = false;
+        options.Interop.AllowSystemReflection = false;
+        options.Interop.AllowWrite = false;
+        options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
+    }
+
+    private static void BindClrObjects(Engine engine)
+    {
+        engine.SetValue("__log", new Action<string>(_ => { }));
+        engine.SetValue("config", new { MaxRetries = 3, Timeout = 5000, Region = "us-east-1" });
+    }
+
+    private static void BindIOClrObjects(Engine engine)
+    {
+        BindClrObjects(engine);
+        engine.SetValue("fetchData", new Func<string, Task<string>>(key =>
+            Task.FromResult("{\"id\":1,\"name\":\"test\",\"values\":[1,2,3,4,5]}")));
+        engine.SetValue("sendResult", new Func<string, Task<bool>>(data =>
+            Task.FromResult(true)));
+    }
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _setupScript = Engine.PrepareScript(@"
-            function processInput(input) {
-                return JSON.parse(input);
+        _consoleShim = Engine.PrepareScript("""
+            var console = {
+                log(...a) { __log(a.map(String).join(' ')); },
+                error(...a) { __log('ERROR: ' + a.map(String).join(' ')); },
+                warn(...a) { __log('WARN: ' + a.map(String).join(' ')); },
+                info(...a) { __log('INFO: ' + a.map(String).join(' ')); }
+            };
+            """, "console-shim.js");
+
+        _utilityLibrary = Engine.PrepareScript("""
+            function parseCSV(text) {
+                var lines = text.split('\n');
+                var headers = lines[0].split(',');
+                var result = [];
+                for (var i = 1; i < lines.length; i++) {
+                    if (!lines[i].trim()) continue;
+                    var values = lines[i].split(',');
+                    var obj = {};
+                    for (var j = 0; j < headers.length; j++) {
+                        obj[headers[j].trim()] = values[j] ? values[j].trim() : '';
+                    }
+                    result.push(obj);
+                }
+                return result;
             }
-            function formatOutput(obj) {
-                return JSON.stringify(obj, null, 2);
+            function transformRecords(records, filterFn, mapFn) {
+                return records.filter(filterFn).map(mapFn);
             }
-            var CONFIG = { maxRetries: 3, timeout: 5000 };
-        ");
+            function summarize(data) {
+                var total = data.reduce(function(s, r) { return s + (r.value || 0); }, 0);
+                return JSON.stringify({ count: data.length, total: Math.round(total * 100) / 100, items: data });
+            }
+            """, "utility-library.js");
 
-        _workScript = Engine.PrepareScript(@"
-            var result = processInput('{""key"":1}');
-            formatOutput(result);
-        ");
-
-        _reusableEngine = new Engine();
-        _reusableEngine.Execute(_setupScript);
-        _reusableEngine.Evaluate(_workScript);
-
-        _reusableEngineWithOptions = new Engine(options =>
+        _lightScripts = new[]
         {
-            options.Strict = true;
-        });
-        _reusableEngineWithOptions.Execute(_setupScript);
-        _reusableEngineWithOptions.Evaluate(_workScript);
+            Engine.PrepareScript("""
+                var csv = 'id,name,score\n1,Alice,95\n2,Bob,82\n3,Charlie,91';
+                var data = parseCSV(csv);
+                var result = transformRecords(data,
+                    function(r) { return parseInt(r.score) > 85; },
+                    function(r) { return { name: r.name, value: parseInt(r.score) }; });
+                summarize(result);
+                """),
+            Engine.PrepareScript("""
+                var items = [];
+                for (var i = 0; i < 100; i++) {
+                    items.push({ id: i, value: Math.sin(i) * 100, label: 'item_' + i });
+                }
+                var filtered = items.filter(function(x) { return x.value > 0; });
+                JSON.stringify({ count: filtered.length, avg: filtered.reduce(function(s,x) { return s + x.value; }, 0) / filtered.length });
+                """),
+            Engine.PrepareScript("""
+                var text = 'The quick brown fox jumps over the lazy dog';
+                var words = text.split(' ');
+                var freq = {};
+                words.forEach(function(w) { freq[w] = (freq[w] || 0) + 1; });
+                var sorted = Object.keys(freq).sort();
+                JSON.stringify({ wordCount: words.length, uniqueWords: sorted.length, frequencies: freq });
+                """),
+            Engine.PrepareScript("""
+                var matrix = [];
+                for (var i = 0; i < 10; i++) {
+                    matrix[i] = [];
+                    for (var j = 0; j < 10; j++) {
+                        matrix[i][j] = i * 10 + j;
+                    }
+                }
+                var sum = 0;
+                for (var i = 0; i < 10; i++) sum += matrix[i][i];
+                JSON.stringify({ trace: sum, size: matrix.length });
+                """),
+            Engine.PrepareScript("""
+                var data = { users: [], total: 0 };
+                for (var i = 0; i < 50; i++) {
+                    data.users.push({ id: i, name: 'user' + i, active: i % 3 !== 0 });
+                }
+                data.total = data.users.filter(function(u) { return u.active; }).length;
+                JSON.stringify(data.total);
+                """),
+        };
+
+        // CPU-heavy: process 5000 records with sorting, aggregation, nested loops
+        _heavyScript = Engine.PrepareScript("""
+            var records = [];
+            for (var i = 0; i < 5000; i++) {
+                records.push({
+                    id: i,
+                    category: 'cat' + (i % 20),
+                    value: Math.sin(i) * 1000 + Math.cos(i * 0.5) * 500,
+                    name: 'item_' + i + '_' + String.fromCharCode(65 + (i % 26)),
+                    tags: [i % 10, i % 7, i % 3]
+                });
+            }
+            var grouped = {};
+            records.forEach(function(r) {
+                if (!grouped[r.category]) grouped[r.category] = [];
+                grouped[r.category].push(r);
+            });
+            var summaries = Object.keys(grouped).map(function(cat) {
+                var items = grouped[cat];
+                items.sort(function(a, b) { return b.value - a.value; });
+                var total = items.reduce(function(s, r) { return s + r.value; }, 0);
+                return {
+                    category: cat,
+                    count: items.length,
+                    avg: Math.round(total / items.length * 100) / 100,
+                    top3: items.slice(0, 3).map(function(r) { return r.name; })
+                };
+            });
+            summaries.sort(function(a, b) { return b.avg - a.avg; });
+            JSON.stringify({ categories: summaries.length, topCategory: summaries[0].category });
+            """);
+
+        // I/O-bound: script calls async CLR methods then processes the result
+        _ioScript = Engine.PrepareScript("""
+            (async function() {
+                var raw = await fetchData('key1');
+                var data = JSON.parse(raw);
+                var processed = {
+                    id: data.id,
+                    upperName: data.name.toUpperCase(),
+                    sum: data.values.reduce(function(s, v) { return s + v; }, 0),
+                    doubled: data.values.map(function(v) { return v * 2; })
+                };
+                var sent = await sendResult(JSON.stringify(processed));
+                return JSON.stringify({ success: sent, processed: processed });
+            })()
+            """);
+
+        // Warm up reusable engines
+        _reusableLight = new Engine(ConfigureEngine);
+        BindClrObjects(_reusableLight);
+        _reusableLight.Execute(_consoleShim);
+        _reusableLight.Execute(_utilityLibrary);
+        _reusableLight.Evaluate(_lightScripts[0]);
+
+        _reusableHeavy = new Engine(ConfigureEngine);
+        BindClrObjects(_reusableHeavy);
+        _reusableHeavy.Execute(_consoleShim);
+        _reusableHeavy.Execute(_utilityLibrary);
+        _reusableHeavy.Evaluate(_heavyScript);
+
+        _reusableIO = new Engine(ConfigureEngine);
+        BindIOClrObjects(_reusableIO);
+        _reusableIO.Execute(_consoleShim);
+        _reusableIO.Execute(_utilityLibrary);
+        _reusableIO.EvaluateAsync(_ioScript).GetAwaiter().GetResult();
     }
+
+    // ── Light scripts: setup cost dominates ─────────────────────────────
 
     [Benchmark(Baseline = true)]
-    public JsValue NewEngine_WithSetup()
+    public JsValue Light_NewEngine_10x()
     {
-        var engine = new Engine();
-        engine.Execute(_setupScript);
-        return engine.Evaluate(_workScript);
+        JsValue last = JsValue.Undefined;
+        for (var i = 0; i < 10; i++)
+        {
+            var engine = new Engine(ConfigureEngine);
+            BindClrObjects(engine);
+            engine.Execute(_consoleShim);
+            engine.Execute(_utilityLibrary);
+            last = engine.Evaluate(_lightScripts[i % _lightScripts.Length]);
+        }
+        return last;
     }
 
     [Benchmark]
-    public JsValue ResetState_WithSetup()
+    public JsValue Light_ResetState_10x()
     {
-        _reusableEngine.ResetState();
-        _reusableEngine.Execute(_setupScript);
-        return _reusableEngine.Evaluate(_workScript);
+        JsValue last = JsValue.Undefined;
+        for (var i = 0; i < 10; i++)
+        {
+            _reusableLight.ResetState();
+            BindClrObjects(_reusableLight);
+            _reusableLight.Execute(_consoleShim);
+            _reusableLight.Execute(_utilityLibrary);
+            last = _reusableLight.Evaluate(_lightScripts[i % _lightScripts.Length]);
+        }
+        return last;
+    }
+
+    // ── Heavy scripts: script execution dominates ───────────────────────
+
+    [Benchmark]
+    public JsValue Heavy_NewEngine_10x()
+    {
+        JsValue last = JsValue.Undefined;
+        for (var i = 0; i < 10; i++)
+        {
+            var engine = new Engine(ConfigureEngine);
+            BindClrObjects(engine);
+            engine.Execute(_consoleShim);
+            engine.Execute(_utilityLibrary);
+            last = engine.Evaluate(_heavyScript);
+        }
+        return last;
     }
 
     [Benchmark]
-    public JsValue NewEngine_WithOptions_WithSetup()
+    public JsValue Heavy_ResetState_10x()
     {
-        var engine = new Engine(options => options.Strict = true);
-        engine.Execute(_setupScript);
-        return engine.Evaluate(_workScript);
+        JsValue last = JsValue.Undefined;
+        for (var i = 0; i < 10; i++)
+        {
+            _reusableHeavy.ResetState();
+            BindClrObjects(_reusableHeavy);
+            _reusableHeavy.Execute(_consoleShim);
+            _reusableHeavy.Execute(_utilityLibrary);
+            last = _reusableHeavy.Evaluate(_heavyScript);
+        }
+        return last;
+    }
+
+    // ── I/O-bound scripts: allocations matter, CPU work is light ────────
+
+    [Benchmark]
+    public async Task<JsValue> IO_NewEngine_10x()
+    {
+        JsValue last = JsValue.Undefined;
+        for (var i = 0; i < 10; i++)
+        {
+            var engine = new Engine(ConfigureEngine);
+            BindIOClrObjects(engine);
+            engine.Execute(_consoleShim);
+            engine.Execute(_utilityLibrary);
+            last = await engine.EvaluateAsync(_ioScript);
+        }
+        return last;
     }
 
     [Benchmark]
-    public JsValue ResetState_WithOptions_WithSetup()
+    public async Task<JsValue> IO_ResetState_10x()
     {
-        _reusableEngineWithOptions.ResetState();
-        _reusableEngineWithOptions.Execute(_setupScript);
-        return _reusableEngineWithOptions.Evaluate(_workScript);
+        JsValue last = JsValue.Undefined;
+        for (var i = 0; i < 10; i++)
+        {
+            _reusableIO.ResetState();
+            BindIOClrObjects(_reusableIO);
+            _reusableIO.Execute(_consoleShim);
+            _reusableIO.Execute(_utilityLibrary);
+            last = await _reusableIO.EvaluateAsync(_ioScript);
+        }
+        return last;
     }
 }

--- a/Jint.Tests/Runtime/EngineResetTests.cs
+++ b/Jint.Tests/Runtime/EngineResetTests.cs
@@ -1,4 +1,5 @@
 using Jint.Native;
+using Jint.Native.Object;
 using Jint.Native.Promise;
 using Jint.Runtime;
 
@@ -612,65 +613,44 @@ public class EngineResetTests
     [Fact]
     public async Task ResetState_StaleAsyncCallbacksDroppedAfterReset()
     {
+        var staleCallbackExecuted = false;
+
         var engine = new Engine(options =>
         {
             options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
+            options.TimeoutInterval(TimeSpan.FromMilliseconds(100));
+            options.Constraints.PromiseTimeout = TimeSpan.FromMilliseconds(100);
         });
 
         var tcs = new TaskCompletionSource<int>();
 
         engine.SetValue("getPendingValue", new Func<Task<int>>(() => tcs.Task));
+        engine.SetValue("setFlag", new Action(() => staleCallbackExecuted = true));
 
-        // Start an async evaluation that will be pending (tcs not yet completed)
-        var evalTask = engine.EvaluateAsync("getPendingValue()");
+        // Start async eval — will timeout because tcs is never completed in time
+        try
+        {
+            await engine.EvaluateAsync("getPendingValue().then(() => setFlag())");
+        }
+        catch
+        {
+            // Expected: timeout
+        }
 
-        // Reset while the Task is still pending — the ContinueWith callback
-        // will fire later and enqueue onto the event loop with a stale generation
+        // Now the async operation is no longer pending — safe to reset
         engine.ResetState();
 
-        // Complete the old task AFTER reset — its callback should be silently dropped
+        // Complete the old task AFTER reset — the settle closure captured the old
+        // generation, so it should be silently dropped
         tcs.SetResult(999);
-
-        // New execution on the reset engine should work cleanly
-        engine.SetValue("getValue", new Func<Task<int>>(() => Task.FromResult(42)));
-        var result = await engine.EvaluateAsync("getValue()");
-        Assert.Equal(42, result.AsNumber());
-    }
-
-    [Fact]
-    public async Task ResetState_MultipleStaleCallbacksAllDropped()
-    {
-        var engine = new Engine(options =>
-        {
-            options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
-        });
-
-        var sources = new List<TaskCompletionSource<int>>();
-
-        for (var i = 0; i < 5; i++)
-        {
-            var tcs = new TaskCompletionSource<int>();
-            sources.Add(tcs);
-            engine.SetValue($"pending{i}", new Func<Task<int>>(() => tcs.Task));
-            _ = engine.EvaluateAsync($"pending{i}()");
-        }
-
-        engine.ResetState();
-
-        // Complete all old tasks after reset
-        for (var i = 0; i < sources.Count; i++)
-        {
-            sources[i].SetResult(i);
-        }
-
-        // Give callbacks a moment to fire and enqueue stale events
         await Task.Delay(200);
 
-        // Engine should be clean — stale events dropped by generation check
-        Assert.Equal(1, engine.Evaluate("1").AsNumber());
+        // Verify the stale callback did NOT execute
+        Assert.False(staleCallbackExecuted);
 
-        var result = await engine.EvaluateAsync("Promise.resolve(77)");
-        Assert.Equal(77, result.AsNumber());
+        // New execution should work cleanly
+        var result = await engine.EvaluateAsync("Promise.resolve(42)");
+        Assert.Equal(42, result.AsNumber());
     }
 
     [Fact]
@@ -705,5 +685,135 @@ public class EngineResetTests
             })()
         ");
         Assert.Equal(6, result.AsNumber());
+    }
+
+    // ── Reviewer-requested tests ────────────────────────────────────────
+
+    [Fact]
+    public async Task ResetState_StaleContinueWithDoesNotExecuteObservableWork()
+    {
+        var staleWorkExecuted = false;
+
+        var engine = new Engine(options =>
+        {
+            options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
+            options.TimeoutInterval(TimeSpan.FromMilliseconds(100));
+            options.Constraints.PromiseTimeout = TimeSpan.FromMilliseconds(100);
+        });
+
+        var tcs = new TaskCompletionSource<int>();
+        engine.SetValue("getPending", new Func<Task<int>>(() => tcs.Task));
+        engine.SetValue("flagStale", new Action(() => staleWorkExecuted = true));
+
+        try
+        {
+            await engine.EvaluateAsync("getPending().then(() => flagStale())");
+        }
+        catch
+        {
+            // Expected: timeout
+        }
+
+        engine.ResetState();
+
+        // Late completion: the settle closure captured the old generation
+        tcs.SetResult(42);
+        await Task.Delay(200);
+
+        // The stale .then(() => flagStale()) must NOT have executed
+        Assert.False(staleWorkExecuted, "Stale ContinueWith callback should have been dropped by generation check");
+    }
+
+    [Fact]
+    public void ResetState_ModulesRegisteredViaConfigureSurviveReset()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Modules.RegisterRequire = true;
+            options.Configure(e => e.Modules.Add("cfgLib", b => b.ExportValue("val", JsNumber.Create(99))));
+        });
+
+        var ns = engine.Modules.Import("cfgLib");
+        Assert.Equal(99, ns.Get("val").AsNumber());
+
+        engine.ResetState();
+
+        // Modules registered via Options.Configure are re-applied on reset
+        ns = engine.Modules.Import("cfgLib");
+        Assert.Equal(99, ns.Get("val").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_ProgrammaticModuleRegistrationsClearedAfterReset()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Modules.RegisterRequire = true;
+        });
+
+        engine.Modules.Add("myLib", builder => builder.ExportValue("version", JsNumber.Create(1)));
+        var ns = engine.Modules.Import("myLib");
+        Assert.Equal(1, ns.Get("version").AsNumber());
+
+        engine.ResetState();
+
+        // Module registration is gone after reset — must re-register
+        engine.Modules.Add("myLib", builder => builder.ExportValue("version", JsNumber.Create(2)));
+        ns = engine.Modules.Import("myLib");
+        Assert.Equal(2, ns.Get("version").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_CustomHostPostInitializeSurvivesReset()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Host.Factory = _ => new TestHostWithPostInit();
+        });
+
+        // PostInitialize should have registered the global
+        Assert.Equal(42, engine.Evaluate("hostGlobal").AsNumber());
+
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        // After reset, PostInitialize is re-called — hostGlobal should be present again
+        Assert.Equal(42, engine.Evaluate("hostGlobal").AsNumber());
+        // But user state should be gone
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("x"));
+    }
+
+    [Fact]
+    public async Task ResetState_ThrowsWhileAsyncEvaluationIsPendingThenRecoverable()
+    {
+        var engine = new Engine(options =>
+        {
+            options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
+        });
+
+        var tcs = new TaskCompletionSource<int>();
+        engine.SetValue("getPending", new Func<Task<int>>(() => tcs.Task));
+
+        var evalTask = engine.EvaluateAsync("getPending()");
+
+        // Cannot reset while async is pending
+        Assert.Throws<InvalidOperationException>(() => engine.ResetState());
+
+        // Complete and await so engine is usable
+        tcs.SetResult(1);
+        var result = await evalTask;
+        Assert.Equal(1, result.AsNumber());
+
+        // Now reset should work
+        engine.ResetState();
+        Assert.Equal(2, engine.Evaluate("2").AsNumber());
+    }
+
+    private sealed class TestHostWithPostInit : Host
+    {
+        protected override void PostInitialize()
+        {
+            Engine.SetValue("hostGlobal", 42);
+        }
     }
 }

--- a/Jint.Tests/Runtime/EngineResetTests.cs
+++ b/Jint.Tests/Runtime/EngineResetTests.cs
@@ -1,0 +1,709 @@
+using Jint.Native;
+using Jint.Native.Promise;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+public class EngineResetTests
+{
+    // ── Sync: Basic State Clearing ──────────────────────────────────────
+
+    [Fact]
+    public void ResetState_ClearsGlobalVariables()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 42;");
+        Assert.Equal(42, engine.Evaluate("x").AsNumber());
+
+        engine.ResetState();
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("x"));
+        Assert.Contains("x", ex.Message);
+    }
+
+    [Fact]
+    public void ResetState_ClearsGlobalFunctions()
+    {
+        var engine = new Engine();
+        engine.Execute("function greet() { return 'hello'; }");
+        Assert.Equal("hello", engine.Evaluate("greet()").AsString());
+
+        engine.ResetState();
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("greet()"));
+        Assert.Contains("greet", ex.Message);
+    }
+
+    [Fact]
+    public void ResetState_ClearsLetAndConst()
+    {
+        var engine = new Engine();
+        engine.Execute("let a = 1; const b = 2;");
+        Assert.Equal(1, engine.Evaluate("a").AsNumber());
+        Assert.Equal(2, engine.Evaluate("b").AsNumber());
+
+        engine.ResetState();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("a"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("b"));
+    }
+
+    [Fact]
+    public void ResetState_ClearsGlobalThisProperties()
+    {
+        var engine = new Engine();
+        engine.Execute("globalThis.myProp = 'test';");
+        Assert.Equal("test", engine.Evaluate("globalThis.myProp").AsString());
+
+        engine.ResetState();
+
+        Assert.True(engine.Evaluate("globalThis.myProp").IsUndefined());
+    }
+
+    // ── Sync: Built-ins Preserved ───────────────────────────────────────
+
+    [Fact]
+    public void ResetState_PreservesBuiltInObjects()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        Assert.Equal(3, engine.Evaluate("Math.max(1, 2, 3)").AsNumber());
+        Assert.Equal("function", engine.Evaluate("typeof Number").AsString());
+        Assert.Equal("function", engine.Evaluate("typeof Array").AsString());
+        Assert.Equal("function", engine.Evaluate("typeof Object").AsString());
+        Assert.Equal("function", engine.Evaluate("typeof JSON.parse").AsString());
+        Assert.Equal("function", engine.Evaluate("typeof Promise").AsString());
+    }
+
+    [Fact]
+    public void ResetState_PreservesBuiltInPrototypeMethods()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        Assert.Equal(3, engine.Evaluate("[1,2,3].length").AsNumber());
+        Assert.Equal("HELLO", engine.Evaluate("'hello'.toUpperCase()").AsString());
+        Assert.Equal(3, engine.Evaluate("JSON.parse('[1,2,3]').length").AsNumber());
+        Assert.Equal("1,2,3", engine.Evaluate("[1,2,3].join(',')").AsString());
+    }
+
+    // ── Sync: Execution After Reset ─────────────────────────────────────
+
+    [Fact]
+    public void ResetState_AllowsNewExecution()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 'old';");
+        engine.ResetState();
+
+        engine.Execute("var x = 'new';");
+        Assert.Equal("new", engine.Evaluate("x").AsString());
+    }
+
+    [Fact]
+    public void ResetState_PreparedScriptsWorkAfterReset()
+    {
+        var prepared = Engine.PrepareScript("function add(a, b) { return a + b; }");
+        var engine = new Engine();
+
+        engine.Execute(prepared);
+        Assert.Equal(5, engine.Evaluate("add(2, 3)").AsNumber());
+
+        engine.ResetState();
+
+        engine.Execute(prepared);
+        Assert.Equal(7, engine.Evaluate("add(3, 4)").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_MultipleCyclesWork()
+    {
+        var engine = new Engine();
+        var prepared = Engine.PrepareScript("var counter = (typeof counter !== 'undefined' ? counter : 0) + 1;");
+
+        for (var i = 0; i < 10; i++)
+        {
+            engine.ResetState();
+            engine.Execute(prepared);
+            Assert.Equal(1, engine.Evaluate("counter").AsNumber());
+        }
+    }
+
+    [Fact]
+    public void ResetState_ChainingWorksAfterReset()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        engine
+            .Execute("var a = 1;")
+            .Execute("var b = 2;")
+            .Execute("var c = a + b;");
+
+        Assert.Equal(3, engine.Evaluate("c").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_SetValueWorksAfterReset()
+    {
+        var engine = new Engine();
+        engine.SetValue("x", 1);
+        Assert.Equal(1, engine.Evaluate("x").AsNumber());
+
+        engine.ResetState();
+
+        engine.SetValue("y", 42);
+        Assert.Equal(42, engine.Evaluate("y").AsNumber());
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("x"));
+    }
+
+    [Fact]
+    public void ResetState_ClrDelegatesWorkAfterReset()
+    {
+        var engine = new Engine();
+        engine.SetValue("add", new Func<int, int, int>((a, b) => a + b));
+        Assert.Equal(5, engine.Evaluate("add(2, 3)").AsNumber());
+
+        engine.ResetState();
+
+        engine.SetValue("multiply", new Func<int, int, int>((a, b) => a * b));
+        Assert.Equal(6, engine.Evaluate("multiply(2, 3)").AsNumber());
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("add(1, 1)"));
+    }
+
+    // ── Sync: Constraints and Error State ───────────────────────────────
+
+    [Fact]
+    public void ResetState_ClearsErrorState()
+    {
+        var engine = new Engine();
+        Assert.Throws<JavaScriptException>(() => engine.Execute("throw new Error('boom');"));
+
+        engine.ResetState();
+
+        Assert.Equal(42, engine.Evaluate("42").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_ConstraintsWork()
+    {
+        var engine = new Engine(options => options.TimeoutInterval(TimeSpan.FromSeconds(5)));
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        Assert.Equal(1, engine.Evaluate("1").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_StrictModePreserved()
+    {
+        var engine = new Engine(options => options.Strict = true);
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        Assert.Throws<JavaScriptException>(() => engine.Execute("y = 1;"));
+    }
+
+    // ── Sync: Symbol Registry and Modules ───────────────────────────────
+
+    [Fact]
+    public void ResetState_ClearsSymbolForRegistry()
+    {
+        var engine = new Engine();
+        engine.Execute("var s = Symbol.for('myKey');");
+        engine.ResetState();
+
+        // Symbol.for with same key should create a new symbol, not return old one
+        // (we can't directly compare, but the engine should not crash)
+        var result = engine.Evaluate("Symbol.for('myKey').toString()").AsString();
+        Assert.Equal("Symbol(myKey)", result);
+    }
+
+    // ── Sync: Object Creation After Reset ───────────────────────────────
+
+    [Fact]
+    public void ResetState_ObjectCreationWorks()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = { a: 1 };");
+        engine.ResetState();
+
+        var result = engine.Evaluate("JSON.stringify({ a: 1, b: [2, 3] })").AsString();
+        Assert.Equal("{\"a\":1,\"b\":[2,3]}", result);
+    }
+
+    [Fact]
+    public void ResetState_RegExpWorks()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        Assert.True(engine.Evaluate("/hello/.test('hello world')").AsBoolean());
+    }
+
+    [Fact]
+    public void ResetState_DateWorks()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        Assert.Equal("number", engine.Evaluate("typeof new Date().getTime()").AsString());
+    }
+
+    [Fact]
+    public void ResetState_MapAndSetWork()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        Assert.Equal(2, engine.Evaluate("var m = new Map(); m.set('a', 1); m.set('b', 2); m.size").AsNumber());
+        Assert.Equal(3, engine.Evaluate("var s = new Set([1,2,3]); s.size").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_ErrorConstructorsWork()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        Assert.Equal("TypeError", engine.Evaluate("new TypeError('test').name").AsString());
+        Assert.Equal("RangeError", engine.Evaluate("new RangeError('test').name").AsString());
+    }
+
+    // ── Async: Basic Async After Reset ──────────────────────────────────
+
+    [Fact]
+    public async Task ResetState_EvaluateAsyncWorksAfterReset()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        var result = await engine.EvaluateAsync("Promise.resolve(42)");
+        Assert.Equal(42, result.AsNumber());
+    }
+
+    [Fact]
+    public async Task ResetState_AsyncFunctionWorksAfterReset()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        var result = await engine.EvaluateAsync("(async () => { return 42; })()");
+        Assert.Equal(42, result.AsNumber());
+    }
+
+    [Fact]
+    public async Task ResetState_PromiseChainWorksAfterReset()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        var result = await engine.EvaluateAsync("Promise.resolve(1).then(x => x + 1).then(x => x * 2)");
+        Assert.Equal(4, result.AsNumber());
+    }
+
+    [Fact]
+    public async Task ResetState_PromiseAllWorksAfterReset()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        var result = await engine.EvaluateAsync("Promise.all([Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)])");
+        Assert.True(result.IsArray());
+    }
+
+    [Fact]
+    public async Task ResetState_InvokeAsyncWorksAfterReset()
+    {
+        var engine = new Engine();
+        engine.Execute("function getValue() { return Promise.resolve(99); }");
+        engine.ResetState();
+
+        engine.Execute("function getValue() { return Promise.resolve(77); }");
+        var result = await engine.InvokeAsync("getValue");
+        Assert.Equal(77, result.AsNumber());
+    }
+
+    [Fact]
+    public async Task ResetState_AsyncRejectionHandledAfterReset()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        await Assert.ThrowsAsync<PromiseRejectedException>(
+            () => engine.EvaluateAsync("Promise.reject('error')"));
+    }
+
+    // ── Async: Task Interop After Reset ─────────────────────────────────
+
+    [Fact]
+    public async Task ResetState_TaskInteropWorksAfterReset()
+    {
+        var engine = new Engine(options =>
+        {
+            options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
+        });
+
+        engine.SetValue("getValueAsync", new Func<Task<int>>(() => Task.FromResult(42)));
+        var result1 = await engine.EvaluateAsync("getValueAsync()");
+        Assert.Equal(42, result1.AsNumber());
+
+        engine.ResetState();
+
+        engine.SetValue("getValueAsync", new Func<Task<string>>(() => Task.FromResult("hello")));
+        var result2 = await engine.EvaluateAsync("getValueAsync()");
+        Assert.Equal("hello", result2.AsString());
+    }
+
+    // ── Async: Multiple Reset Cycles ────────────────────────────────────
+
+    [Fact]
+    public async Task ResetState_MultipleAsyncCyclesWork()
+    {
+        var engine = new Engine();
+
+        for (var i = 0; i < 5; i++)
+        {
+            engine.ResetState();
+
+            engine.SetValue("iteration", i);
+            var result = await engine.EvaluateAsync("Promise.resolve(iteration)");
+            Assert.Equal(i, (int) result.AsNumber());
+        }
+    }
+
+    [Fact]
+    public async Task ResetState_MixedSyncAsyncCycles()
+    {
+        var engine = new Engine();
+        var prepared = Engine.PrepareScript("function compute(n) { return n * 2; }");
+
+        for (var i = 0; i < 5; i++)
+        {
+            engine.ResetState();
+            engine.Execute(prepared);
+
+            // Sync call
+            Assert.Equal(i * 2, (int) engine.Evaluate($"compute({i})").AsNumber());
+
+            // Async call
+            var asyncResult = await engine.EvaluateAsync($"Promise.resolve(compute({i}))");
+            Assert.Equal(i * 2, (int) asyncResult.AsNumber());
+        }
+    }
+
+    // ── Async: Prepared Script + Async ──────────────────────────────────
+
+    [Fact]
+    public async Task ResetState_PreparedScriptWithAsyncExecution()
+    {
+        var setup = Engine.PrepareScript(@"
+            function processData(input) {
+                return JSON.parse(input);
+            }
+        ");
+
+        var engine = new Engine();
+
+        engine.Execute(setup);
+        var result1 = await engine.EvaluateAsync("Promise.resolve(processData('{\"key\":1}'))");
+        Assert.Equal(1, result1.AsObject().Get("key").AsNumber());
+
+        engine.ResetState();
+        engine.Execute(setup);
+
+        var result2 = await engine.EvaluateAsync("Promise.resolve(processData('{\"key\":2}'))");
+        Assert.Equal(2, result2.AsObject().Get("key").AsNumber());
+    }
+
+    // ── Edge Cases ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void ResetState_ImmediateResetOnFreshEngine()
+    {
+        var engine = new Engine();
+        engine.ResetState();
+        Assert.Equal(1, engine.Evaluate("1").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_DoubleReset()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+        engine.ResetState();
+        Assert.Equal(42, engine.Evaluate("42").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_ResetAfterRecursionError()
+    {
+        var engine = new Engine(options => options.Constraints.MaxRecursionDepth = 10);
+
+        Assert.ThrowsAny<Exception>(() =>
+            engine.Execute("function f() { return f(); } f();"));
+
+        engine.ResetState();
+
+        Assert.Equal(1, engine.Evaluate("1").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_CompletionValueCleared()
+    {
+        var engine = new Engine();
+        Assert.Equal(42, engine.Evaluate("42").AsNumber());
+        engine.ResetState();
+
+        // After reset, evaluating undefined should work cleanly
+        Assert.True(engine.Evaluate("undefined").IsUndefined());
+    }
+
+    [Fact]
+    public async Task ResetState_EventLoopCleanAfterReset()
+    {
+        var engine = new Engine();
+
+        // Execute async that creates event loop activity
+        await engine.EvaluateAsync("Promise.resolve(1).then(x => x + 1)");
+
+        engine.ResetState();
+
+        // Fresh async should work without interference from previous event loop state
+        var result = await engine.EvaluateAsync("Promise.resolve(99)");
+        Assert.Equal(99, result.AsNumber());
+    }
+
+    // ── Additional Coverage: eval, closures, CLR objects, modules ───────
+
+    [Fact]
+    public void ResetState_EvalWorksAfterReset()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = eval('1 + 2');");
+        Assert.Equal(3, engine.Evaluate("x").AsNumber());
+
+        engine.ResetState();
+
+        Assert.Equal(7, engine.Evaluate("eval('3 + 4')").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_ClosuresFromPriorExecutionNotAccessible()
+    {
+        var engine = new Engine();
+        engine.Execute(@"
+            var outer = 10;
+            function getClosure() {
+                return function() { return outer; };
+            }
+            var fn = getClosure();
+        ");
+        Assert.Equal(10, engine.Evaluate("fn()").AsNumber());
+
+        engine.ResetState();
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("fn()"));
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("outer"));
+    }
+
+    [Fact]
+    public void ResetState_ClrObjectInteropAfterReset()
+    {
+        var engine = new Engine();
+        engine.SetValue("obj", new { Name = "old", Value = 1 });
+        Assert.Equal("old", engine.Evaluate("obj.Name").AsString());
+
+        engine.ResetState();
+
+        engine.SetValue("obj", new { Name = "new", Value = 2 });
+        Assert.Equal("new", engine.Evaluate("obj.Name").AsString());
+        Assert.Equal(2, engine.Evaluate("obj.Value").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_ClrTypeReferenceAfterReset()
+    {
+        var engine = new Engine(options => options.AllowClr(typeof(Math).Assembly));
+        engine.Execute("var x = System.Math.PI;");
+
+        engine.ResetState();
+
+        var pi = engine.Evaluate("System.Math.PI").AsNumber();
+        Assert.True(System.Math.Abs(pi - System.Math.PI) < 0.0001);
+    }
+
+    [Fact]
+    public void ResetState_ThrowInScriptThenResetThenNewScript()
+    {
+        var engine = new Engine();
+
+        var ex = Assert.Throws<JavaScriptException>(() =>
+            engine.Execute("throw new TypeError('first error');"));
+        Assert.Contains("first error", ex.Message);
+
+        engine.ResetState();
+
+        Assert.Equal("ok", engine.Evaluate("'ok'").AsString());
+
+        var ex2 = Assert.Throws<JavaScriptException>(() =>
+            engine.Execute("throw new RangeError('second error');"));
+        Assert.Contains("second error", ex2.Message);
+
+        engine.ResetState();
+        Assert.Equal(42, engine.Evaluate("42").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_SpreadAndDestructuringAfterReset()
+    {
+        var engine = new Engine();
+        engine.Execute("var [a, ...rest] = [1, 2, 3];");
+        engine.ResetState();
+
+        Assert.Equal(6, engine.Evaluate("var [x, ...y] = [1, 2, 3]; x + y[0] + y[1]").AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_GeneratorsWorkAfterReset()
+    {
+        var engine = new Engine();
+        engine.Execute("function* gen() { yield 1; }");
+        engine.ResetState();
+
+        var result = engine.Evaluate(@"
+            function* counter() { let i = 0; while(true) yield i++; }
+            var g = counter();
+            g.next().value + g.next().value + g.next().value;
+        ");
+        Assert.Equal(3, result.AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_ProxyAndReflectWorkAfterReset()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        var result = engine.Evaluate(@"
+            var target = { a: 1, b: 2 };
+            var handler = { get: function(obj, prop) { return prop in obj ? obj[prop] : 'default'; } };
+            var proxy = new Proxy(target, handler);
+            proxy.a + ',' + proxy.c;
+        ");
+        Assert.Equal("1,default", result.AsString());
+    }
+
+    [Fact]
+    public async Task ResetState_StaleAsyncCallbacksDroppedAfterReset()
+    {
+        var engine = new Engine(options =>
+        {
+            options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
+        });
+
+        var tcs = new TaskCompletionSource<int>();
+
+        engine.SetValue("getPendingValue", new Func<Task<int>>(() => tcs.Task));
+
+        // Start an async evaluation that will be pending (tcs not yet completed)
+        var evalTask = engine.EvaluateAsync("getPendingValue()");
+
+        // Reset while the Task is still pending — the ContinueWith callback
+        // will fire later and enqueue onto the event loop with a stale generation
+        engine.ResetState();
+
+        // Complete the old task AFTER reset — its callback should be silently dropped
+        tcs.SetResult(999);
+
+        // New execution on the reset engine should work cleanly
+        engine.SetValue("getValue", new Func<Task<int>>(() => Task.FromResult(42)));
+        var result = await engine.EvaluateAsync("getValue()");
+        Assert.Equal(42, result.AsNumber());
+    }
+
+    [Fact]
+    public async Task ResetState_MultipleStaleCallbacksAllDropped()
+    {
+        var engine = new Engine(options =>
+        {
+            options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
+        });
+
+        var sources = new List<TaskCompletionSource<int>>();
+
+        for (var i = 0; i < 5; i++)
+        {
+            var tcs = new TaskCompletionSource<int>();
+            sources.Add(tcs);
+            engine.SetValue($"pending{i}", new Func<Task<int>>(() => tcs.Task));
+            _ = engine.EvaluateAsync($"pending{i}()");
+        }
+
+        engine.ResetState();
+
+        // Complete all old tasks after reset
+        for (var i = 0; i < sources.Count; i++)
+        {
+            sources[i].SetResult(i);
+        }
+
+        // Give callbacks a moment to fire and enqueue stale events
+        await Task.Delay(200);
+
+        // Engine should be clean — stale events dropped by generation check
+        Assert.Equal(1, engine.Evaluate("1").AsNumber());
+
+        var result = await engine.EvaluateAsync("Promise.resolve(77)");
+        Assert.Equal(77, result.AsNumber());
+    }
+
+    [Fact]
+    public void ResetState_ThrowsWhenCalledDuringExecution()
+    {
+        var engine = new Engine();
+        InvalidOperationException caught = null!;
+        engine.SetValue("triggerReset", new Action(() =>
+        {
+            try { engine.ResetState(); }
+            catch (InvalidOperationException ex) { caught = ex; }
+        }));
+        engine.Execute("triggerReset()");
+
+        Assert.NotNull(caught);
+        Assert.Contains("executing", caught!.Message);
+    }
+
+    [Fact]
+    public async Task ResetState_AsyncGeneratorWorksAfterReset()
+    {
+        var engine = new Engine();
+        engine.Execute("var x = 1;");
+        engine.ResetState();
+
+        var result = await engine.EvaluateAsync(@"
+            async function* gen() { yield 1; yield 2; yield 3; }
+            (async () => {
+                var sum = 0;
+                for await (var val of gen()) { sum += val; }
+                return sum;
+            })()
+        ");
+        Assert.Equal(6, result.AsNumber());
+    }
+}

--- a/Jint/Engine.Async.cs
+++ b/Jint/Engine.Async.cs
@@ -119,6 +119,8 @@ public partial class Engine
     /// </summary>
     private async Task<JsValue> AwaitPromiseSettlementAsync(JsPromise promise, CancellationToken cancellationToken)
     {
+        Interlocked.Increment(ref _pendingAsyncOperations);
+
         var eventLoop = _eventLoop;
         var timeout = Options.Constraints.PromiseTimeout;
         var hasTimeout = timeout > TimeSpan.Zero;
@@ -178,6 +180,7 @@ public partial class Engine
         }
         finally
         {
+            Interlocked.Decrement(ref _pendingAsyncOperations);
             ownedCts?.Dispose();
         }
 

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -74,12 +74,6 @@ public partial class Engine
 
         internal IModuleLoader ModuleLoader { get; }
 
-        internal void Clear()
-        {
-            _modules.Clear();
-            _builders.Clear();
-        }
-
         internal Module Load(string? referencingModuleLocation, ModuleRequest request)
         {
             var moduleResolution = ModuleLoader.Resolve(referencingModuleLocation, request);

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -74,6 +74,12 @@ public partial class Engine
 
         internal IModuleLoader ModuleLoader { get; }
 
+        internal void Clear()
+        {
+            _modules.Clear();
+            _builders.Clear();
+        }
+
         internal Module Load(string? referencingModuleLocation, ModuleRequest request)
         {
             var moduleResolution = ModuleLoader.Resolve(referencingModuleLocation, request);

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -168,6 +168,92 @@ public sealed partial class Engine : IDisposable
         _host.Initialize(this);
     }
 
+    /// <summary>
+    /// Resets the engine to a clean execution state, keeping Intrinsics and configuration intact.
+    /// This is significantly cheaper than creating a new Engine instance because it avoids
+    /// reconstructing Options, Parser, Intrinsics (Object/Function constructors and their prototypes),
+    /// and all cached CLR metadata.
+    /// </summary>
+    /// <remarks>
+    /// After calling this method the engine is in a state equivalent to a freshly constructed engine
+    /// with the same options — global variables, functions, and modules from prior executions are cleared.
+    /// The built-in prototypes (Array.prototype, Object.prototype, etc.) are preserved as-is; if prior
+    /// scripts mutated them (e.g. <c>Array.prototype.custom = ...</c>), those mutations will persist.
+    /// For sandboxed/trusted scripts that do not modify built-in prototypes, this is safe and fast.
+    /// This method must only be called when no script is executing on the engine (i.e., between
+    /// <see cref="Execute(string, string?)"/> / <see cref="EvaluateAsync(string, string?, System.Threading.CancellationToken)"/> calls).
+    /// Calling it from within a JavaScript callback or during active execution throws <see cref="InvalidOperationException"/>.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">Thrown when called during script execution.</exception>
+    public void ResetState()
+    {
+        if (_activeEvaluationContext is not null)
+        {
+            Throw.InvalidOperationException("ResetState cannot be called while script is executing");
+        }
+
+        // Capture realm before clearing execution context stack
+        var realm = Realm;
+
+        _completionValue = JsValue.Undefined;
+        _activeEvaluationContext = null;
+        _error = null;
+        _lastSyntaxElement = null;
+        _realmInConstruction = null;
+        ModuleAsyncEvaluationCount = 0;
+
+        _executionContexts.Clear();
+        CallStack.Clear();
+        _eventLoop.Reset();
+        _agent.ClearKeptObjects();
+
+        // Set _realmInConstruction so ObjectInstance constructors can resolve the realm
+        // while the execution context stack is still empty (same pattern as Host.CreateRealm)
+        _realmInConstruction = realm;
+        try
+        {
+            var newGlobalObject = _host.CreateGlobalObject(realm);
+            var newGlobalEnv = _host.CreateGlobalEnvironment(newGlobalObject);
+            realm.GlobalObject = newGlobalObject;
+            realm.GlobalEnv = newGlobalEnv;
+            realm._templateMap.Clear();
+        }
+        finally
+        {
+            _realmInConstruction = null;
+        }
+
+        // Re-enter root execution context (same as Host.InitializeHostDefinedRealm)
+        var globalEnv = realm.GlobalEnv;
+        var newContext = new ExecutionContext(
+            scriptOrModule: null,
+            lexicalEnvironment: globalEnv,
+            variableEnvironment: globalEnv,
+            privateEnvironment: null,
+            realm: realm,
+            function: null);
+        _executionContexts.Push(newContext);
+
+        // Clear per-execution caches
+        GlobalSymbolRegistry.Reset();
+        Modules.Clear();
+
+        // Clear object wrapper identity cache
+        if (_objectWrapperCache is not null)
+        {
+#if SUPPORTS_WEAK_TABLE_CLEAR
+            _objectWrapperCache.Clear();
+#else
+            _objectWrapperCache = null;
+#endif
+        }
+
+        // Re-apply options (registers CLR interop globals, require(), etc.)
+        Options.Apply(this);
+
+        ResetConstraints();
+    }
+
     internal ref readonly ExecutionContext ExecutionContext
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -19,6 +19,7 @@ using Jint.Runtime.Interop.Reflection;
 using Jint.Runtime.Interpreter;
 using Jint.Runtime.Interpreter.Expressions;
 using Environment = Jint.Runtime.Environments.Environment;
+using Volatile = System.Threading.Volatile;
 
 namespace Jint;
 
@@ -42,6 +43,21 @@ public sealed partial class Engine : IDisposable
     internal EventLoop EventLoop => _eventLoop;
 
     private readonly Agent _agent = new();
+
+    /// <summary>
+    /// Monotonically increasing generation counter, bumped by <see cref="ResetState"/>.
+    /// Captured by async settle closures at registration time so that late-arriving
+    /// <c>Task.ContinueWith</c> callbacks from a prior execution cycle are silently
+    /// dropped instead of enqueuing stale work onto the event loop.
+    /// </summary>
+    private volatile int _executionGeneration;
+
+    /// <summary>
+    /// Number of outstanding <c>AwaitPromiseSettlementAsync</c> calls.
+    /// Incremented before the async wait loop, decremented in its finally block.
+    /// Checked by <see cref="ResetState"/> to prevent reset while an async evaluation is suspended.
+    /// </summary>
+    internal int _pendingAsyncOperations;
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-IncrementModuleAsyncEvaluationCount
@@ -180,17 +196,31 @@ public sealed partial class Engine : IDisposable
     /// The built-in prototypes (Array.prototype, Object.prototype, etc.) are preserved as-is; if prior
     /// scripts mutated them (e.g. <c>Array.prototype.custom = ...</c>), those mutations will persist.
     /// For sandboxed/trusted scripts that do not modify built-in prototypes, this is safe and fast.
-    /// This method must only be called when no script is executing on the engine (i.e., between
-    /// <see cref="Execute(string, string?)"/> / <see cref="EvaluateAsync(string, string?, System.Threading.CancellationToken)"/> calls).
+    /// If the debugger has been used (<see cref="Debugger"/>), its internal state (breakpoints, step mode)
+    /// is preserved across resets.
+    /// Programmatic module registrations (<see cref="ModuleOperations.Add(string, string)"/>) are cleared;
+    /// re-register them after reset if needed.
+    /// Custom <see cref="Host"/> subclasses should place per-execution setup in
+    /// <see cref="Host.PostInitialize"/> (which is re-invoked on reset), not in
+    /// <see cref="Host.InitializeHostDefinedRealm"/> (which only runs at construction time).
+    /// This method must only be called when no script is executing on the engine and no
+    /// <see cref="EvaluateAsync(string, string?, System.Threading.CancellationToken)"/> Task is pending.
     /// Calling it from within a JavaScript callback or during active execution throws <see cref="InvalidOperationException"/>.
     /// </remarks>
-    /// <exception cref="InvalidOperationException">Thrown when called during script execution.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when called during script execution or while an async evaluation is pending.</exception>
     public void ResetState()
     {
         if (_activeEvaluationContext is not null)
         {
             Throw.InvalidOperationException("ResetState cannot be called while script is executing");
         }
+
+        if (Volatile.Read(ref _pendingAsyncOperations) > 0)
+        {
+            Throw.InvalidOperationException("ResetState cannot be called while an async evaluation (EvaluateAsync/ExecuteAsync/InvokeAsync) is pending");
+        }
+
+        unchecked { _executionGeneration++; }
 
         // Capture realm before clearing execution context stack
         var realm = Realm;
@@ -212,10 +242,7 @@ public sealed partial class Engine : IDisposable
         _realmInConstruction = realm;
         try
         {
-            var newGlobalObject = _host.CreateGlobalObject(realm);
-            var newGlobalEnv = _host.CreateGlobalEnvironment(newGlobalObject);
-            realm.GlobalObject = newGlobalObject;
-            realm.GlobalEnv = newGlobalEnv;
+            _host.RebuildGlobals(realm);
             realm._templateMap.Clear();
         }
         finally
@@ -236,17 +263,8 @@ public sealed partial class Engine : IDisposable
 
         // Clear per-execution caches
         GlobalSymbolRegistry.Reset();
-        Modules.Clear();
 
-        // Clear object wrapper identity cache
-        if (_objectWrapperCache is not null)
-        {
-#if SUPPORTS_WEAK_TABLE_CLEAR
-            _objectWrapperCache.Clear();
-#else
-            _objectWrapperCache = null;
-#endif
-        }
+        ClearObjectWrapperCache();
 
         // Re-apply options (registers CLR interop globals, require(), etc.)
         Options.Apply(this);
@@ -585,9 +603,15 @@ public sealed partial class Engine : IDisposable
 
         var (resolve, reject) = promise.CreateResolvingFunctions();
 
+        var capturedGeneration = _executionGeneration;
 
         Action<JsValue> SettleWith(Function settle) => value =>
         {
+            if (capturedGeneration != _executionGeneration)
+            {
+                return;
+            }
+
             // Enqueue to event loop to ensure thread safety - the settle operation
             // may be called from a background thread (e.g., Task.ContinueWith callback)
             // but JavaScript execution must happen on the thread that owns the Engine.
@@ -623,8 +647,15 @@ public sealed partial class Engine : IDisposable
 
         var (resolve, reject) = promise.CreateResolvingFunctions();
 
+        var capturedGeneration = _executionGeneration;
+
         Action<object?> SettleWithClr(Function settle) => clrValue =>
         {
+            if (capturedGeneration != _executionGeneration)
+            {
+                return;
+            }
+
             // Enqueue to event loop to ensure thread safety - both the FromObject conversion
             // and the settle operation are performed on the main thread, not the background
             // thread that completed the Task.
@@ -1952,6 +1983,11 @@ public sealed partial class Engine : IDisposable
     }
 
     public void Dispose()
+    {
+        ClearObjectWrapperCache();
+    }
+
+    private void ClearObjectWrapperCache()
     {
         if (_objectWrapperCache is null)
         {

--- a/Jint/Native/Symbol/GlobalSymbolRegistry.cs
+++ b/Jint/Native/Symbol/GlobalSymbolRegistry.cs
@@ -36,6 +36,11 @@ public sealed class GlobalSymbolRegistry
         _customSymbolLookup[symbol._value] = symbol;
     }
 
+    internal void Reset()
+    {
+        _customSymbolLookup = null;
+    }
+
     internal static JsSymbol CreateSymbol(JsValue description)
     {
         return new JsSymbol(description);

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -143,6 +143,8 @@ public class Options
     /// </summary>
     internal void Apply(Engine engine)
     {
+        engine.Modules = new Engine.ModuleOperations(engine, Modules.ModuleLoader);
+
         foreach (var configuration in _configurations)
         {
             configuration(engine);
@@ -185,7 +187,6 @@ public class Options
                 PropertyFlag.AllForbidden));
         }
 
-        engine.Modules = new Engine.ModuleOperations(engine, Modules.ModuleLoader);
     }
 
     private static void AttachExtensionMethodsToPrototypes(Engine engine)
@@ -224,6 +225,13 @@ public class Options
             JsValue key = overloads.Key;
             PropertyDescriptor? descriptorWithFallback = null;
             PropertyDescriptor? descriptorWithoutFallback = null;
+
+            if (prototype.HasOwnProperty(key) &&
+                prototype.GetOwnProperty(key).Value is MethodInfoFunction)
+            {
+                // Already attached (e.g., during a previous Options.Apply call) — skip
+                continue;
+            }
 
             if (prototype.HasOwnProperty(key) &&
                 prototype.GetOwnProperty(key).Value is Function functionInstance)

--- a/Jint/Runtime/EventLoop.cs
+++ b/Jint/Runtime/EventLoop.cs
@@ -5,7 +5,7 @@ namespace Jint.Runtime;
 
 internal sealed record EventLoop
 {
-    private readonly ConcurrentQueue<TaggedEvent> _events = new();
+    private readonly ConcurrentQueue<Action> _events = new();
 
     /// <summary>
     /// Tracks whether we are currently processing the event loop.
@@ -30,19 +30,10 @@ internal sealed record EventLoop
     /// </summary>
     private volatile TaskCompletionSource<bool>? _eventAvailable;
 
-    /// <summary>
-    /// Monotonically increasing generation counter. Bumped on <see cref="Reset"/>.
-    /// Events enqueued with a stale generation are silently dropped during processing,
-    /// preventing callbacks from a prior execution cycle (e.g., late-arriving
-    /// Task.ContinueWith callbacks) from running after the engine has been reset.
-    /// </summary>
-    private volatile int _generation;
-
     public bool IsEmpty => _events.IsEmpty;
 
     internal void Reset()
     {
-        Interlocked.Increment(ref _generation);
         while (_events.TryDequeue(out _)) { }
         Interlocked.Exchange(ref _isProcessing, 0);
         _waitingThreadId = -1;
@@ -51,7 +42,7 @@ internal sealed record EventLoop
 
     public void Enqueue(Action continuation)
     {
-        _events.Enqueue(new TaggedEvent(continuation, _generation));
+        _events.Enqueue(continuation);
 
         // Wake any async waiter. Atomically steal the TCS and signal it.
         // This ensures the async loop in WaitForEventAsync wakes up promptly
@@ -136,13 +127,10 @@ internal sealed record EventLoop
 
         try
         {
-            var currentGeneration = _generation;
-            while (_events.TryDequeue(out var taggedEvent))
+            while (_events.TryDequeue(out var nextContinuation))
             {
-                if (taggedEvent.Generation == currentGeneration)
-                {
-                    taggedEvent.Continuation();
-                }
+                // note that continuation can enqueue new events
+                nextContinuation();
             }
         }
         finally
@@ -150,6 +138,4 @@ internal sealed record EventLoop
             Interlocked.Exchange(ref _isProcessing, 0);
         }
     }
-
-    private readonly record struct TaggedEvent(Action Continuation, int Generation);
 }

--- a/Jint/Runtime/EventLoop.cs
+++ b/Jint/Runtime/EventLoop.cs
@@ -5,7 +5,7 @@ namespace Jint.Runtime;
 
 internal sealed record EventLoop
 {
-    private readonly ConcurrentQueue<Action> _events = new();
+    private readonly ConcurrentQueue<TaggedEvent> _events = new();
 
     /// <summary>
     /// Tracks whether we are currently processing the event loop.
@@ -30,11 +30,28 @@ internal sealed record EventLoop
     /// </summary>
     private volatile TaskCompletionSource<bool>? _eventAvailable;
 
+    /// <summary>
+    /// Monotonically increasing generation counter. Bumped on <see cref="Reset"/>.
+    /// Events enqueued with a stale generation are silently dropped during processing,
+    /// preventing callbacks from a prior execution cycle (e.g., late-arriving
+    /// Task.ContinueWith callbacks) from running after the engine has been reset.
+    /// </summary>
+    private volatile int _generation;
+
     public bool IsEmpty => _events.IsEmpty;
+
+    internal void Reset()
+    {
+        Interlocked.Increment(ref _generation);
+        while (_events.TryDequeue(out _)) { }
+        Interlocked.Exchange(ref _isProcessing, 0);
+        _waitingThreadId = -1;
+        Interlocked.Exchange(ref _eventAvailable, null);
+    }
 
     public void Enqueue(Action continuation)
     {
-        _events.Enqueue(continuation);
+        _events.Enqueue(new TaggedEvent(continuation, _generation));
 
         // Wake any async waiter. Atomically steal the TCS and signal it.
         // This ensures the async loop in WaitForEventAsync wakes up promptly
@@ -119,10 +136,13 @@ internal sealed record EventLoop
 
         try
         {
-            while (_events.TryDequeue(out var nextContinuation))
+            var currentGeneration = _generation;
+            while (_events.TryDequeue(out var taggedEvent))
             {
-                // note that continuation can enqueue new events
-                nextContinuation();
+                if (taggedEvent.Generation == currentGeneration)
+                {
+                    taggedEvent.Continuation();
+                }
             }
         }
         finally
@@ -130,4 +150,6 @@ internal sealed record EventLoop
             Interlocked.Exchange(ref _isProcessing, 0);
         }
     }
+
+    private readonly record struct TaggedEvent(Action Continuation, int Generation);
 }

--- a/Jint/Runtime/ExecutionContextStack.cs
+++ b/Jint/Runtime/ExecutionContextStack.cs
@@ -70,6 +70,8 @@ internal sealed class ExecutionContextStack
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Pop() => _stack.PopAndDiscard();
 
+    public void Clear() => _stack.Clear();
+
     public IScriptOrModule? GetActiveScriptOrModule()
     {
         var array = _stack._array;

--- a/Jint/Runtime/Host.cs
+++ b/Jint/Runtime/Host.cs
@@ -65,7 +65,7 @@ public class Host
         return JintEnvironment.NewGlobalEnvironment(Engine, globalObject, globalObject);
     }
 
-    protected virtual ObjectInstance CreateGlobalObject(Realm realm)
+    protected internal virtual ObjectInstance CreateGlobalObject(Realm realm)
     {
         var globalObject = new GlobalObject(Engine, realm);
         // Because the properties might need some of the built-in object

--- a/Jint/Runtime/Host.cs
+++ b/Jint/Runtime/Host.cs
@@ -60,12 +60,27 @@ public class Host
         Engine.EnterExecutionContext(newContext);
     }
 
+    /// <summary>
+    /// Rebuilds the global object and environment for an existing realm, then runs
+    /// <see cref="PostInitialize"/>. Used by <see cref="Engine.ResetState"/> to
+    /// reset execution state without recreating Intrinsics.
+    /// </summary>
+    internal void RebuildGlobals(Realm realm)
+    {
+        var globalObject = CreateGlobalObject(realm);
+        var globalEnv = CreateGlobalEnvironment(globalObject);
+        realm.GlobalObject = globalObject;
+        realm.GlobalEnv = globalEnv;
+
+        PostInitialize();
+    }
+
     internal virtual GlobalEnvironment CreateGlobalEnvironment(ObjectInstance globalObject)
     {
         return JintEnvironment.NewGlobalEnvironment(Engine, globalObject, globalObject);
     }
 
-    protected internal virtual ObjectInstance CreateGlobalObject(Realm realm)
+    protected virtual ObjectInstance CreateGlobalObject(Realm realm)
     {
         var globalObject = new GlobalObject(Engine, realm);
         // Because the properties might need some of the built-in object

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ and many more.
 - Because Jint neither generates any .NET bytecode nor uses the DLR it runs relatively small scripts really fast
 - If you repeatedly run the same script, you should prepare it for execution using `Engine.PrepareScript` or `Engine.PrepareModule`, cache the returned `Prepared<...>` object and feed it to Jint instead of the content string
 - You should prefer running engine in strict mode, it improves performance
+- If you create many engine instances with the same configuration, use `Engine.ResetState()` to reuse an existing engine instead of constructing a new one — it preserves Intrinsics and configuration while clearing all execution state
 
 You can check out [the engine comparison results](Jint.Benchmark), bear in mind that every use case is different and benchmarks might not reflect your real-world usage.
 
@@ -185,7 +186,23 @@ https://docs.microsoft.com/shows/code-conversations/sebastien-ros-on-jint-javasc
 
 ## Thread-safety
 
-Engine instances are not thread-safe and they should not accessed from multiple threads simultaneously. 
+Engine instances are not thread-safe and they should not be accessed from multiple threads simultaneously. However, engines can be reused sequentially across threads via `Engine.ResetState()`, which clears all execution state while preserving Intrinsics and configuration:
+
+```c#
+var engine = pool.Get();
+try
+{
+    engine.Execute(setupScript);
+    var result = await engine.EvaluateAsync("process(21)");
+}
+finally
+{
+    engine.ResetState();
+    pool.Return(engine);
+}
+```
+
+Note: built-in prototype mutations from prior scripts persist after reset. For untrusted scripts that may modify prototypes, create a new engine instead.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- Add `Engine.ResetState()` that resets an engine to a clean execution state while preserving Intrinsics, Options, Parser, and CLR metadata caches
- Capture execution generation at promise registration time so late-arriving `Task.ContinueWith` callbacks from a prior cycle are silently dropped
- Track outstanding async waiters (`_pendingAsyncOperations`) — `ResetState` throws `InvalidOperationException` if called while an `EvaluateAsync` Task is pending
- Add `Host.RebuildGlobals()` internal helper that re-invokes `PostInitialize()` on reset, keeping the `Host` extension point working
- Prevent extension method wrapper chain buildup on repeated resets
- Move `ModuleOperations` initialization before configuration callbacks in `Options.Apply` so `options.Configure(e => e.Modules.Add(...))` works
- Extract `ClearObjectWrapperCache()` private helper (used by both `Dispose()` and `ResetState()`)
- Update README with usage guidance in Performance and Thread-safety sections

## Motivation

When embedding Jint in scenarios that require many short-lived engine instances (e.g., executing user scripts in a server loop, tool dispatch), the cost of constructing a new `Engine` per invocation adds up — especially the Intrinsics (Object/Function constructors + prototypes), Parser, ExtensionMethodCache, and option-derived fields. None of these change between invocations.

`ResetState()` allows callers to reuse an engine instance from a pool by clearing all execution state and rebuilding only the GlobalObject and GlobalEnvironment.

## Benchmark — three workload profiles

Light scripts (tool dispatch: parse args, format output), heavy scripts (5K-record processing), and I/O-bound scripts (async CLR calls — the most realistic server-side pattern):

```
| Method               | Mean          | Gen0       | Gen1      | Allocated   | Alloc Ratio |
|--------------------- |--------------:|-----------:|----------:|------------:|------------:|
| Light_NewEngine_10x  |     293.14 us |    86.9141 |    5.3711 |   713.38 KB |        1.00 |
| Light_ResetState_10x |     242.18 us |    58.5938 |   19.5313 |   479.42 KB |        0.67 |
| Heavy_NewEngine_10x  | 154,994.82 us | 13000.0000 | 5250.0000 | 94338.21 KB |      132.24 |
| Heavy_ResetState_10x | 153,620.74 us | 13250.0000 | 5750.0000 | 93971.49 KB |      131.73 |
| IO_NewEngine_10x     |     141.11 us |    73.2422 |    2.9297 |   605.42 KB |        0.85 |
| IO_ResetState_10x    |      92.73 us |    44.9219 |    4.8828 |   369.95 KB |        0.52 |
```

- **Light scripts**: 17% faster, 33% fewer allocations — setup is a meaningful fraction
- **Heavy scripts**: ~0% difference — script execution completely dominates, setup is noise
- **I/O-bound (async CLR calls)**: 34% faster, 39% fewer allocations — JS CPU work is minimal, engine setup is the main cost

The feature is most valuable for I/O-bound and light workloads where engine construction is a significant fraction of CPU time per invocation.

## What ResetState clears

- Execution state: `_completionValue`, `_activeEvaluationContext`, `_error`, `_lastSyntaxElement`
- Execution context stack and call stack
- Event loop (drains pending events)
- GlobalObject and GlobalEnvironment (rebuilt fresh via `Host.RebuildGlobals`)
- `Host.PostInitialize()` re-invoked
- Realm template map
- Global symbol registry (user-created `Symbol.for()` entries)
- Module cache (via `Options.Apply` which creates fresh `ModuleOperations`)
- Object wrapper identity cache

## What ResetState preserves

- Intrinsics (ObjectConstructor, FunctionConstructor, all lazy-initialized built-in constructors and prototypes)
- Options, Parser, ParserOptions
- ExtensionMethodCache
- TypeCache and reflection accessor cache (deterministic CLR metadata)
- Constraint definitions
- Debugger state (breakpoints, step mode)

## Stale async callback protection

When `ResetState()` is called after an async execution completes, the previous execution's `Task.ContinueWith` callbacks may still fire from background threads. These closures capture the execution generation at promise registration time. If the generation has been bumped by `ResetState`, the settle closure returns early without enqueueing stale work onto the event loop.

## Safety guards

- Throws `InvalidOperationException` if called during synchronous script execution (`_activeEvaluationContext` check)
- Throws `InvalidOperationException` if called while an `EvaluateAsync`/`ExecuteAsync`/`InvokeAsync` Task is still pending (`_pendingAsyncOperations` check)

## Caveats

- Built-in prototype mutations from prior scripts persist (e.g., `Array.prototype.custom = ...`). For untrusted scripts, create a new engine instead.
- Programmatic module registrations (`engine.Modules.Add(...)`) are cleared on reset. Modules registered via `options.Configure(e => e.Modules.Add(...))` are automatically re-applied.
- Custom `Host` subclasses should place per-execution setup in `PostInitialize` (re-invoked on reset), not `InitializeHostDefinedRealm` (construction-only).

## Test plan

- [x] 52 dedicated tests covering sync and async paths
- [x] Global var/let/const/function clearing
- [x] Built-in object and prototype preservation
- [x] Prepared scripts work after reset
- [x] CLR delegates, objects, and type references after reset
- [x] Multiple reset cycles (10 iterations)
- [x] Mixed sync/async cycles
- [x] EvaluateAsync, InvokeAsync, Promise chains, Promise.all
- [x] Task interop (ExperimentalFeature.TaskInterop) after reset
- [x] Stale async callback dropping — observable flag assertion
- [x] Error recovery (throw → reset → new script)
- [x] Recursion overflow recovery
- [x] eval(), closures, generators, async generators, Proxy/Reflect
- [x] Strict mode preservation
- [x] Guard: throws InvalidOperationException during sync execution
- [x] Guard: throws InvalidOperationException during pending async evaluation
- [x] Custom Host with PostInitialize survives reset
- [x] Module registrations via Options.Configure survive reset
- [x] Module registrations via engine.Modules.Add cleared on reset
- [x] Full test suite regression check (2914 passed, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)