### PR TITLE
Source generator: migrate JSON, Reflect, Symbol, BigInt prototypes

### DIFF
--- a/Jint.Tests/Runtime/ReflectTests.cs
+++ b/Jint.Tests/Runtime/ReflectTests.cs
@@ -1,0 +1,58 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+public class ReflectTests
+{
+    // Regression tests for the spec's "argument is not present" vs "argument is undefined"
+    // distinction in Reflect.construct / get / set. Per ECMA-262, "not present" defaults to
+    // target / undefined-target paths, but explicit `undefined` is preserved and reaches the
+    // downstream operation (IsConstructor check, [[Set]] receiver-not-Object branch, accessor
+    // `this`).
+
+    [Fact]
+    public void ReflectConstructExplicitUndefinedNewTargetThrows()
+    {
+        var engine = new Engine();
+        engine.Execute("class C { constructor() {} }");
+
+        // newTarget not present — defaults to target, succeeds
+        engine.Evaluate("Reflect.construct(C, [])");
+
+        // newTarget explicitly undefined — IsConstructor(undefined) is false, throws TypeError
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("Reflect.construct(C, [], undefined)"));
+        Assert.Equal("TypeError", ex.Error.Get("name").AsString());
+    }
+
+    [Fact]
+    public void ReflectSetExplicitUndefinedReceiverReturnsFalse()
+    {
+        var engine = new Engine();
+
+        // receiver not present — defaults to target, set succeeds
+        Assert.True(engine.Evaluate("Reflect.set({}, 'p', 1)").AsBoolean());
+
+        // receiver explicitly undefined — non-Object receiver, [[Set]] returns false
+        Assert.False(engine.Evaluate("Reflect.set({}, 'p', 1, undefined)").AsBoolean());
+    }
+
+    [Fact]
+    public void ReflectGetExplicitUndefinedReceiverPropagatesToAccessor()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            "use strict";
+            var seen;
+            var obj = {};
+            Object.defineProperty(obj, 'p', { get: function() { seen = this; return 1; } });
+        """);
+
+        // receiver not present — defaults to target, getter sees `this === obj`
+        engine.Evaluate("Reflect.get(obj, 'p')");
+        Assert.True(engine.Evaluate("seen === obj").AsBoolean());
+
+        // receiver explicitly undefined — getter sees `this === undefined`
+        engine.Evaluate("Reflect.get(obj, 'p', undefined)");
+        Assert.True(engine.Evaluate("seen === undefined").AsBoolean());
+    }
+}

--- a/Jint/Native/BigInt/BigIntPrototype.cs
+++ b/Jint/Native/BigInt/BigIntPrototype.cs
@@ -39,11 +39,8 @@ internal sealed partial class BigIntPrototype : Prototype
     /// https://tc39.es/ecma402/#sup-bigint.prototype.tolocalestring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToLocaleString(JsValue thisObject, JsValue locales, JsValue options)
     {
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
-
         var x = ThisBigIntValue(thisObject);
 
         // Use Intl.NumberFormat for locale-aware formatting
@@ -57,7 +54,7 @@ internal sealed partial class BigIntPrototype : Prototype
     /// https://tc39.es/ecma262/#sec-bigint.prototype.valueof
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ValueOf(JsValue thisObject)
     {
         if (thisObject is BigIntInstance ni)
         {
@@ -77,11 +74,9 @@ internal sealed partial class BigIntPrototype : Prototype
     /// https://tc39.es/ecma262/#sec-bigint.prototype.tostring
     /// </summary>
     [JsFunction(Length = 0, Name = "toString")]
-    private JsValue ToBigIntString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToBigIntString(JsValue thisObject, JsValue radix)
     {
         var x = ThisBigIntValue(thisObject);
-
-        var radix = arguments.At(0);
 
         var radixMV = radix.IsUndefined()
             ? 10

--- a/Jint/Native/BigInt/BigIntPrototype.cs
+++ b/Jint/Native/BigInt/BigIntPrototype.cs
@@ -3,19 +3,21 @@ using System.Numerics;
 using System.Text;
 using Jint.Native.Intl;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.BigInt;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-bigint-prototype-object
 /// </summary>
-internal sealed class BigIntPrototype : Prototype
+[JsObject]
+internal sealed partial class BigIntPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly BigIntConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString BigIntToStringTag = new("BigInt");
 
     internal BigIntPrototype(
         Engine engine,
@@ -29,25 +31,14 @@ internal sealed class BigIntPrototype : Prototype
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            ["constructor"] = new(_constructor, true, false, true),
-            ["toString"] = new(new ClrFunction(Engine, "toString", ToBigIntString, 0, PropertyFlag.Configurable), true, false, true),
-            ["toLocaleString"] = new(new ClrFunction(Engine, "toLocaleString", ToLocaleString, 0, PropertyFlag.Configurable), true, false, true),
-            ["valueOf"] = new(new ClrFunction(Engine, "valueOf", ValueOf, 0, PropertyFlag.Configurable), true, false, true),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("BigInt", false, false, true)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/ecma402/#sup-bigint.prototype.tolocalestring
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
         var locales = arguments.At(0);
@@ -65,6 +56,7 @@ internal sealed class BigIntPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-bigint.prototype.valueof
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
     {
         if (thisObject is BigIntInstance ni)
@@ -84,6 +76,7 @@ internal sealed class BigIntPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-bigint.prototype.tostring
     /// </summary>
+    [JsFunction(Length = 0, Name = "toString")]
     private JsValue ToBigIntString(JsValue thisObject, JsCallArguments arguments)
     {
         var x = ThisBigIntValue(thisObject);

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -1,14 +1,15 @@
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Json;
 
-internal sealed class JsonInstance : ObjectInstance
+[JsObject]
+internal sealed partial class JsonInstance : ObjectInstance
 {
     private readonly Realm _realm;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString JsonToStringTag = new("JSON");
 
     internal JsonInstance(
         Engine engine,
@@ -22,25 +23,14 @@ internal sealed class JsonInstance : ObjectInstance
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            ["parse"] = new PropertyDescriptor(new ClrFunction(Engine, "parse", Parse, 2, PropertyFlag.Configurable), true, false, true),
-            ["stringify"] = new PropertyDescriptor(new ClrFunction(Engine, "stringify", Stringify, 3, PropertyFlag.Configurable), true, false, true),
-            ["rawJSON"] = new PropertyDescriptor(new ClrFunction(Engine, "rawJSON", RawJSON, 1, PropertyFlag.Configurable), true, false, true),
-            ["isRawJSON"] = new PropertyDescriptor(new ClrFunction(Engine, "isRawJSON", IsRawJSON, 1, PropertyFlag.Configurable), true, false, true)
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor("JSON", false, false, true),
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/proposal-json-parse-with-source/#sec-json.israwjson
     /// </summary>
+    [JsFunction(Length = 1)]
     private static JsValue IsRawJSON(JsValue thisObject, JsCallArguments arguments)
     {
         var o = arguments.At(0);
@@ -52,6 +42,7 @@ internal sealed class JsonInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/proposal-json-parse-with-source/#sec-json.rawjson
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsValue RawJSON(JsValue thisObject, JsCallArguments arguments)
     {
         var text = arguments.At(0);
@@ -186,6 +177,7 @@ internal sealed class JsonInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-json.parse
     /// </summary>
+    [JsFunction(Length = 2)]
     private JsValue Parse(JsValue thisObject, JsCallArguments arguments)
     {
         var jsonString = TypeConverter.ToString(arguments.At(0));
@@ -209,6 +201,7 @@ internal sealed class JsonInstance : ObjectInstance
         }
     }
 
+    [JsFunction(Length = 3)]
     private JsValue Stringify(JsValue thisObject, JsCallArguments arguments)
     {
         var value = arguments.At(0);

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -30,10 +30,9 @@ internal sealed partial class JsonInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/proposal-json-parse-with-source/#sec-json.israwjson
     /// </summary>
-    [JsFunction(Length = 1)]
-    private static JsValue IsRawJSON(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private static JsValue IsRawJSON(JsValue thisObject, JsValue o)
     {
-        var o = arguments.At(0);
         // If Type(O) is Object and O has an [[IsRawJSON]] internal slot, return true.
         // Return false otherwise.
         return o is JsRawJson;
@@ -42,11 +41,9 @@ internal sealed partial class JsonInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/proposal-json-parse-with-source/#sec-json.rawjson
     /// </summary>
-    [JsFunction(Length = 1)]
-    private JsValue RawJSON(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue RawJSON(JsValue thisObject, JsValue text)
     {
-        var text = arguments.At(0);
-
         // 1. Let jsonString be ? ToString(text).
         var jsonString = TypeConverter.ToString(text);
 
@@ -177,11 +174,10 @@ internal sealed partial class JsonInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-json.parse
     /// </summary>
-    [JsFunction(Length = 2)]
-    private JsValue Parse(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue Parse(JsValue thisObject, JsValue text, JsValue reviver)
     {
-        var jsonString = TypeConverter.ToString(arguments.At(0));
-        var reviver = arguments.At(1);
+        var jsonString = TypeConverter.ToString(text);
 
         var parser = new JsonParser(_engine);
 
@@ -201,13 +197,9 @@ internal sealed partial class JsonInstance : ObjectInstance
         }
     }
 
-    [JsFunction(Length = 3)]
-    private JsValue Stringify(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue Stringify(JsValue thisObject, JsValue value, JsValue replacer, JsValue space)
     {
-        var value = arguments.At(0);
-        var replacer = arguments.At(1);
-        var space = arguments.At(2);
-
         if (value.IsUndefined() && replacer.IsUndefined())
         {
             return Undefined;

--- a/Jint/Native/Reflect/ReflectInstance.cs
+++ b/Jint/Native/Reflect/ReflectInstance.cs
@@ -2,19 +2,20 @@
 
 using Jint.Native.Function;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Reflect;
 
 /// <summary>
 /// https://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect-object
 /// </summary>
-internal sealed class ReflectInstance : ObjectInstance
+[JsObject]
+internal sealed partial class ReflectInstance : ObjectInstance
 {
     private readonly Realm _realm;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString ReflectToStringTag = new("Reflect");
 
     internal ReflectInstance(
         Engine engine,
@@ -27,31 +28,11 @@ internal sealed class ReflectInstance : ObjectInstance
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(14, checkExistingKeys: false)
-        {
-            ["apply"] = new PropertyDescriptor(new ClrFunction(Engine, "apply", Apply, 3, PropertyFlag.Configurable), true, false, true),
-            ["construct"] = new PropertyDescriptor(new ClrFunction(Engine, "construct", Construct, 2, PropertyFlag.Configurable), true, false, true),
-            ["defineProperty"] = new PropertyDescriptor(new ClrFunction(Engine, "defineProperty", DefineProperty, 3, PropertyFlag.Configurable), true, false, true),
-            ["deleteProperty"] = new PropertyDescriptor(new ClrFunction(Engine, "deleteProperty", DeleteProperty, 2, PropertyFlag.Configurable), true, false, true),
-            ["get"] = new PropertyDescriptor(new ClrFunction(Engine, "get", Get, 2, PropertyFlag.Configurable), true, false, true),
-            ["getOwnPropertyDescriptor"] = new PropertyDescriptor(new ClrFunction(Engine, "getOwnPropertyDescriptor", GetOwnPropertyDescriptor, 2, PropertyFlag.Configurable), true, false, true),
-            ["getPrototypeOf"] = new PropertyDescriptor(new ClrFunction(Engine, "getPrototypeOf", GetPrototypeOf, 1, PropertyFlag.Configurable), true, false, true),
-            ["has"] = new PropertyDescriptor(new ClrFunction(Engine, "has", Has, 2, PropertyFlag.Configurable), true, false, true),
-            ["isExtensible"] = new PropertyDescriptor(new ClrFunction(Engine, "isExtensible", IsExtensible, 1, PropertyFlag.Configurable), true, false, true),
-            ["ownKeys"] = new PropertyDescriptor(new ClrFunction(Engine, "ownKeys", OwnKeys, 1, PropertyFlag.Configurable), true, false, true),
-            ["preventExtensions"] = new PropertyDescriptor(new ClrFunction(Engine, "preventExtensions", PreventExtensions, 1, PropertyFlag.Configurable), true, false, true),
-            ["set"] = new PropertyDescriptor(new ClrFunction(Engine, "set", Set, 3, PropertyFlag.Configurable), true, false, true),
-            ["setPrototypeOf"] = new PropertyDescriptor(new ClrFunction(Engine, "setPrototypeOf", SetPrototypeOf, 2, PropertyFlag.Configurable), true, false, true),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor("Reflect", false, false, true)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
+    [JsFunction(Length = 3)]
     private JsValue Apply(JsValue thisObject, JsCallArguments arguments)
     {
         var target = arguments.At(0);
@@ -73,6 +54,7 @@ internal sealed class ReflectInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-reflect.construct
     /// </summary>
+    [JsFunction(Length = 2)]
     private JsValue Construct(JsValue thisObject, JsCallArguments arguments)
     {
         var target = AssertConstructor(_engine, arguments.At(0));
@@ -88,6 +70,7 @@ internal sealed class ReflectInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-reflect.defineproperty
     /// </summary>
+    [JsFunction(Length = 3)]
     private JsValue DefineProperty(JsValue thisObject, JsCallArguments arguments)
     {
         var target = arguments.At(0) as ObjectInstance;
@@ -105,6 +88,7 @@ internal sealed class ReflectInstance : ObjectInstance
         return target.DefineOwnProperty(key, desc);
     }
 
+    [JsFunction(Length = 2)]
     private JsValue DeleteProperty(JsValue thisObject, JsCallArguments arguments)
     {
         var o = arguments.At(0) as ObjectInstance;
@@ -117,6 +101,7 @@ internal sealed class ReflectInstance : ObjectInstance
         return o.Delete(property) ? JsBoolean.True : JsBoolean.False;
     }
 
+    [JsFunction(Length = 2)]
     private JsValue Has(JsValue thisObject, JsCallArguments arguments)
     {
         var o = arguments.At(0) as ObjectInstance;
@@ -129,6 +114,7 @@ internal sealed class ReflectInstance : ObjectInstance
         return o.HasProperty(property) ? JsBoolean.True : JsBoolean.False;
     }
 
+    [JsFunction(Length = 3)]
     private JsValue Set(JsValue thisObject, JsCallArguments arguments)
     {
         var target = arguments.At(0);
@@ -145,6 +131,7 @@ internal sealed class ReflectInstance : ObjectInstance
         return o.Set(property, value, receiver);
     }
 
+    [JsFunction(Length = 2)]
     private JsValue Get(JsValue thisObject, JsCallArguments arguments)
     {
         var target = arguments.At(0);
@@ -159,6 +146,7 @@ internal sealed class ReflectInstance : ObjectInstance
         return o.Get(property, receiver);
     }
 
+    [JsFunction(Length = 2)]
     private JsValue GetOwnPropertyDescriptor(JsValue thisObject, JsCallArguments arguments)
     {
         if (!arguments.At(0).IsObject())
@@ -168,6 +156,7 @@ internal sealed class ReflectInstance : ObjectInstance
         return _realm.Intrinsics.Object.GetOwnPropertyDescriptor(Undefined, arguments);
     }
 
+    [JsFunction(Length = 1)]
     private JsValue OwnKeys(JsValue thisObject, JsCallArguments arguments)
     {
         var o = arguments.At(0) as ObjectInstance;
@@ -180,6 +169,7 @@ internal sealed class ReflectInstance : ObjectInstance
         return _realm.Intrinsics.Array.CreateArrayFromList(keys);
     }
 
+    [JsFunction(Length = 1)]
     private JsValue IsExtensible(JsValue thisObject, JsCallArguments arguments)
     {
         var o = arguments.At(0) as ObjectInstance;
@@ -191,6 +181,7 @@ internal sealed class ReflectInstance : ObjectInstance
         return o.Extensible;
     }
 
+    [JsFunction(Length = 1)]
     private JsValue PreventExtensions(JsValue thisObject, JsCallArguments arguments)
     {
         var o = arguments.At(0) as ObjectInstance;
@@ -202,6 +193,7 @@ internal sealed class ReflectInstance : ObjectInstance
         return o.PreventExtensions();
     }
 
+    [JsFunction(Length = 1)]
     private JsValue GetPrototypeOf(JsValue thisObject, JsCallArguments arguments)
     {
         var target = arguments.At(0);
@@ -214,6 +206,7 @@ internal sealed class ReflectInstance : ObjectInstance
         return _realm.Intrinsics.Object.GetPrototypeOf(Undefined, arguments);
     }
 
+    [JsFunction(Length = 2)]
     private JsValue SetPrototypeOf(JsValue thisObject, JsCallArguments arguments)
     {
         var target = arguments.At(0);

--- a/Jint/Native/Reflect/ReflectInstance.cs
+++ b/Jint/Native/Reflect/ReflectInstance.cs
@@ -50,18 +50,21 @@ internal sealed partial class ReflectInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-reflect.construct
     /// </summary>
+    // Spec distinguishes "newTarget is not present" (defaults to target) from "newTarget is undefined"
+    // (must throw via IsConstructor). The arguments-array form is the only way to detect that
+    // difference; the source generator's per-parameter unpacking always passes Undefined for missing
+    // positions, conflating the two cases.
     [JsFunction(Length = 2)]
-    private JsValue Construct(JsValue thisObject, JsValue target, JsValue argumentsList, JsValue newTarget)
+    private JsValue Construct(JsValue thisObject, JsCallArguments arguments)
     {
-        var targetCtor = AssertConstructor(_engine, target);
+        var target = AssertConstructor(_engine, arguments.At(0));
 
-        // If newTarget is not present, set newTarget to target.
-        var newTargetArgument = newTarget.IsUndefined() ? target : newTarget;
+        var newTargetArgument = arguments.At(2, arguments[0]);
         AssertConstructor(_engine, newTargetArgument);
 
-        var args = FunctionPrototype.CreateListFromArrayLike(_realm, argumentsList);
+        var args = FunctionPrototype.CreateListFromArrayLike(_realm, arguments.At(1));
 
-        return targetCtor.Construct(args, newTargetArgument);
+        return target.Construct(args, newTargetArgument);
     }
 
     /// <summary>
@@ -108,41 +111,41 @@ internal sealed partial class ReflectInstance : ObjectInstance
         return o.HasProperty(property) ? JsBoolean.True : JsBoolean.False;
     }
 
+    // "receiver is not present" defaults to target; "receiver is undefined" is preserved and
+    // forwarded to [[Set]] (where, per spec, a non-Object receiver causes the set to return false).
+    // Generator-unpacked params can't represent "not present", so this method takes the array form.
     [JsFunction(Length = 3)]
-    private JsValue Set(JsValue thisObject, JsValue target, JsValue propertyKey, JsValue value, JsValue receiver)
+    private JsValue Set(JsValue thisObject, JsCallArguments arguments)
     {
+        var target = arguments.At(0);
+        var property = TypeConverter.ToPropertyKey(arguments.At(1));
+        var value = arguments.At(2);
+        var receiver = arguments.At(3, target);
+
         var o = target as ObjectInstance;
         if (o is null)
         {
             Throw.TypeError(_realm, "Reflect.set called on non-object");
         }
 
-        // If receiver is not present, set receiver to target.
-        if (receiver.IsUndefined())
-        {
-            receiver = target;
-        }
-
-        var property = TypeConverter.ToPropertyKey(propertyKey);
         return o.Set(property, value, receiver);
     }
 
+    // Same not-present-vs-undefined distinction as Set: receiver defaults to target only when the
+    // caller didn't pass a third argument. Explicit undefined is preserved and reaches [[Get]] /
+    // accessor invocation as the receiver.
     [JsFunction(Length = 2)]
-    private JsValue Get(JsValue thisObject, JsValue target, JsValue propertyKey, JsValue receiver)
+    private JsValue Get(JsValue thisObject, JsCallArguments arguments)
     {
+        var target = arguments.At(0);
         var o = target as ObjectInstance;
         if (o is null)
         {
             Throw.TypeError(_realm, "Reflect.get called on non-object");
         }
 
-        // If receiver is not present, set receiver to target.
-        if (receiver.IsUndefined())
-        {
-            receiver = target;
-        }
-
-        var property = TypeConverter.ToPropertyKey(propertyKey);
+        var receiver = arguments.At(2, target);
+        var property = TypeConverter.ToPropertyKey(arguments.At(1));
         return o.Get(property, receiver);
     }
 

--- a/Jint/Native/Reflect/ReflectInstance.cs
+++ b/Jint/Native/Reflect/ReflectInstance.cs
@@ -32,13 +32,9 @@ internal sealed partial class ReflectInstance : ObjectInstance
         CreateSymbols_Generated();
     }
 
-    [JsFunction(Length = 3)]
-    private JsValue Apply(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue Apply(JsValue thisObject, JsValue target, JsValue thisArgument, JsValue argumentsList)
     {
-        var target = arguments.At(0);
-        var thisArgument = arguments.At(1);
-        var argumentsList = arguments.At(2);
-
         if (!target.IsCallable)
         {
             Throw.TypeError(_realm, "Reflect.apply requires the first argument to be a function");
@@ -55,124 +51,128 @@ internal sealed partial class ReflectInstance : ObjectInstance
     /// https://tc39.es/ecma262/#sec-reflect.construct
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsValue Construct(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Construct(JsValue thisObject, JsValue target, JsValue argumentsList, JsValue newTarget)
     {
-        var target = AssertConstructor(_engine, arguments.At(0));
+        var targetCtor = AssertConstructor(_engine, target);
 
-        var newTargetArgument = arguments.At(2, arguments[0]);
+        // If newTarget is not present, set newTarget to target.
+        var newTargetArgument = newTarget.IsUndefined() ? target : newTarget;
         AssertConstructor(_engine, newTargetArgument);
 
-        var args = FunctionPrototype.CreateListFromArrayLike(_realm, arguments.At(1));
+        var args = FunctionPrototype.CreateListFromArrayLike(_realm, argumentsList);
 
-        return target.Construct(args, newTargetArgument);
+        return targetCtor.Construct(args, newTargetArgument);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-reflect.defineproperty
     /// </summary>
-    [JsFunction(Length = 3)]
-    private JsValue DefineProperty(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue DefineProperty(JsValue thisObject, JsValue target, JsValue propertyKey, JsValue attributes)
     {
-        var target = arguments.At(0) as ObjectInstance;
-        if (target is null)
+        var o = target as ObjectInstance;
+        if (o is null)
         {
             Throw.TypeError(_realm, "Reflect.defineProperty called on non-object");
         }
 
-        var propertyKey = arguments.At(1);
-        var attributes = arguments.At(2);
-
         var key = TypeConverter.ToPropertyKey(propertyKey);
         var desc = PropertyDescriptor.ToPropertyDescriptor(_realm, attributes);
 
-        return target.DefineOwnProperty(key, desc);
+        return o.DefineOwnProperty(key, desc);
     }
 
-    [JsFunction(Length = 2)]
-    private JsValue DeleteProperty(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue DeleteProperty(JsValue thisObject, JsValue target, JsValue propertyKey)
     {
-        var o = arguments.At(0) as ObjectInstance;
+        var o = target as ObjectInstance;
         if (o is null)
         {
             Throw.TypeError(_realm, "Reflect.deleteProperty called on non-object");
         }
 
-        var property = TypeConverter.ToPropertyKey(arguments.At(1));
+        var property = TypeConverter.ToPropertyKey(propertyKey);
         return o.Delete(property) ? JsBoolean.True : JsBoolean.False;
     }
 
-    [JsFunction(Length = 2)]
-    private JsValue Has(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue Has(JsValue thisObject, JsValue target, JsValue propertyKey)
     {
-        var o = arguments.At(0) as ObjectInstance;
+        var o = target as ObjectInstance;
         if (o is null)
         {
             Throw.TypeError(_realm, "Reflect.has called on non-object");
         }
 
-        var property = TypeConverter.ToPropertyKey(arguments.At(1));
+        var property = TypeConverter.ToPropertyKey(propertyKey);
         return o.HasProperty(property) ? JsBoolean.True : JsBoolean.False;
     }
 
     [JsFunction(Length = 3)]
-    private JsValue Set(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Set(JsValue thisObject, JsValue target, JsValue propertyKey, JsValue value, JsValue receiver)
     {
-        var target = arguments.At(0);
-        var property = TypeConverter.ToPropertyKey(arguments.At(1));
-        var value = arguments.At(2);
-        var receiver = arguments.At(3, target);
-
         var o = target as ObjectInstance;
         if (o is null)
         {
             Throw.TypeError(_realm, "Reflect.set called on non-object");
         }
 
+        // If receiver is not present, set receiver to target.
+        if (receiver.IsUndefined())
+        {
+            receiver = target;
+        }
+
+        var property = TypeConverter.ToPropertyKey(propertyKey);
         return o.Set(property, value, receiver);
     }
 
     [JsFunction(Length = 2)]
-    private JsValue Get(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Get(JsValue thisObject, JsValue target, JsValue propertyKey, JsValue receiver)
     {
-        var target = arguments.At(0);
         var o = target as ObjectInstance;
         if (o is null)
         {
             Throw.TypeError(_realm, "Reflect.get called on non-object");
         }
 
-        var receiver = arguments.At(2, target);
-        var property = TypeConverter.ToPropertyKey(arguments.At(1));
+        // If receiver is not present, set receiver to target.
+        if (receiver.IsUndefined())
+        {
+            receiver = target;
+        }
+
+        var property = TypeConverter.ToPropertyKey(propertyKey);
         return o.Get(property, receiver);
     }
 
-    [JsFunction(Length = 2)]
-    private JsValue GetOwnPropertyDescriptor(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue GetOwnPropertyDescriptor(JsValue thisObject, JsValue target, JsValue propertyKey)
     {
-        if (!arguments.At(0).IsObject())
+        if (!target.IsObject())
         {
             Throw.TypeError(_realm, "Reflect.getOwnPropertyDescriptor called on non-object");
         }
-        return _realm.Intrinsics.Object.GetOwnPropertyDescriptor(Undefined, arguments);
+        return _realm.Intrinsics.Object.GetOwnPropertyDescriptor(Undefined, [target, propertyKey]);
     }
 
-    [JsFunction(Length = 1)]
-    private JsValue OwnKeys(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue OwnKeys(JsValue thisObject, JsValue target)
     {
-        var o = arguments.At(0) as ObjectInstance;
+        var o = target as ObjectInstance;
         if (o is null)
         {
-            Throw.TypeError(_realm, "Reflect.get called on non-object");
+            Throw.TypeError(_realm, "Reflect.ownKeys called on non-object");
         }
 
         var keys = o.GetOwnPropertyKeys();
         return _realm.Intrinsics.Array.CreateArrayFromList(keys);
     }
 
-    [JsFunction(Length = 1)]
-    private JsValue IsExtensible(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue IsExtensible(JsValue thisObject, JsValue target)
     {
-        var o = arguments.At(0) as ObjectInstance;
+        var o = target as ObjectInstance;
         if (o is null)
         {
             Throw.TypeError(_realm, "Reflect.isExtensible called on non-object");
@@ -181,10 +181,10 @@ internal sealed partial class ReflectInstance : ObjectInstance
         return o.Extensible;
     }
 
-    [JsFunction(Length = 1)]
-    private JsValue PreventExtensions(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue PreventExtensions(JsValue thisObject, JsValue target)
     {
-        var o = arguments.At(0) as ObjectInstance;
+        var o = target as ObjectInstance;
         if (o is null)
         {
             Throw.TypeError(_realm, "Reflect.preventExtensions called on non-object");
@@ -193,31 +193,26 @@ internal sealed partial class ReflectInstance : ObjectInstance
         return o.PreventExtensions();
     }
 
-    [JsFunction(Length = 1)]
-    private JsValue GetPrototypeOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue GetPrototypeOf(JsValue thisObject, JsValue target)
     {
-        var target = arguments.At(0);
-
         if (!target.IsObject())
         {
             Throw.TypeError(_realm, "Reflect.getPrototypeOf called on non-object");
         }
 
-        return _realm.Intrinsics.Object.GetPrototypeOf(Undefined, arguments);
+        return _realm.Intrinsics.Object.GetPrototypeOf(Undefined, [target]);
     }
 
-    [JsFunction(Length = 2)]
-    private JsValue SetPrototypeOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue SetPrototypeOf(JsValue thisObject, JsValue target, JsValue prototype)
     {
-        var target = arguments.At(0);
-
         var o = target as ObjectInstance;
         if (o is null)
         {
             Throw.TypeError(_realm, "Reflect.setPrototypeOf called on non-object");
         }
 
-        var prototype = arguments.At(1);
         if (!prototype.IsObject() && !prototype.IsNull())
         {
             Throw.TypeError(_realm, $"Object prototype may only be an Object or null: {prototype}");

--- a/Jint/Native/Symbol/SymbolPrototype.cs
+++ b/Jint/Native/Symbol/SymbolPrototype.cs
@@ -3,16 +3,19 @@
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Symbol;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-symbol-prototype-object
 /// </summary>
-internal sealed class SymbolPrototype : Prototype
+[JsObject]
+internal sealed partial class SymbolPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly SymbolConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString SymbolToStringTag = new("Symbol");
 
     internal SymbolPrototype(
         Engine engine,
@@ -27,28 +30,15 @@ internal sealed class SymbolPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag lengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag propertyFlags = PropertyFlag.Configurable;
-        SetProperties(new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.Configurable | PropertyFlag.Writable),
-            ["description"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "description", Description, 0, lengthFlags), Undefined, propertyFlags),
-            ["toString"] = new PropertyDescriptor(new ClrFunction(Engine, "toString", ToSymbolString, 0, lengthFlags), PropertyFlag.Configurable | PropertyFlag.Writable),
-            ["valueOf"] = new PropertyDescriptor(new ClrFunction(Engine, "valueOf", ValueOf, 0, lengthFlags), PropertyFlag.Configurable | PropertyFlag.Writable)
-        });
-
-        SetSymbols(new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToPrimitive] = new PropertyDescriptor(new ClrFunction(Engine, "[Symbol.toPrimitive]", ToPrimitive, 1, lengthFlags), propertyFlags),
-            [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor(new JsString("Symbol"), propertyFlags)
-        }
-        );
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-symbol.prototype.description
     /// </summary>
-    private JsValue Description(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("description")]
+    private JsValue Description(JsValue thisObject)
     {
         var sym = ThisSymbolValue(thisObject);
         return sym._value;
@@ -57,7 +47,8 @@ internal sealed class SymbolPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-symbol.prototype.tostring
     /// </summary>
-    private JsValue ToSymbolString(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0, Name = "toString")]
+    private JsValue ToSymbolString(JsValue thisObject)
     {
         var sym = ThisSymbolValue(thisObject);
         return new JsString(sym.ToString());
@@ -66,7 +57,8 @@ internal sealed class SymbolPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-symbol.prototype.valueof
     /// </summary>
-    private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsValue ValueOf(JsValue thisObject)
     {
         return ThisSymbolValue(thisObject);
     }
@@ -74,7 +66,8 @@ internal sealed class SymbolPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-symbol.prototype-@@toprimitive
     /// </summary>
-    private JsValue ToPrimitive(JsValue thisObject, JsCallArguments arguments)
+    [JsSymbolFunction("ToPrimitive", Length = 1, Flags = PropertyFlag.Configurable)]
+    private JsValue ToPrimitive(JsValue thisObject)
     {
         return ThisSymbolValue(thisObject);
     }


### PR DESCRIPTION
Continues the source-generator expansion from #2421 and #2422 to four small, accessor-light built-ins. No new generator features are needed: `[JsObject]`, `[JsFunction]`, `[JsAccessor]`, `[JsSymbolFunction]`, and `[JsSymbol]` were all already shipped.

## Migrations

| Target | `[JsFunction]` | Accessors | Symbols |
|--------|---------------:|----------:|---------|
| **JSON** (`JsonInstance`) | 4 (parse, stringify, rawJSON, isRawJSON) | 0 | `@@toStringTag = "JSON"` |
| **Reflect** (`ReflectInstance`) | 13 (apply, construct, defineProperty, deleteProperty, get, getOwnPropertyDescriptor, getPrototypeOf, has, isExtensible, ownKeys, preventExtensions, set, setPrototypeOf) | 0 | `@@toStringTag = "Reflect"` |
| **Symbol.prototype** | 2 (toString, valueOf) + 1 `[JsSymbolFunction]` (`@@toPrimitive`) | 1 (`description` getter) | `@@toStringTag = "Symbol"` + `constructor` |
| **BigInt.prototype** | 3 (toString, toLocaleString, valueOf) | 0 | `@@toStringTag = "BigInt"` + `constructor` |

## Method signatures

Methods take the spec's named `JsValue` parameters instead of `JsCallArguments arguments` — the source generator emits per-parameter `Arguments.At(arguments, i)` at the dispatcher boundary, so call-site bookkeeping like `var x = arguments.At(0)` disappears from method bodies.

**Three exceptions retain the array form:** `Reflect.construct`, `Reflect.get`, `Reflect.set`. Per ECMA-262 these methods distinguish "argument is not present" (defaults to target / target-as-receiver) from "argument is explicit undefined" (preserved — `IsConstructor(undefined)` throws, `[[Set]]` receiver-not-Object returns false, accessor `this` is undefined). The generator-unpacked form passes `Undefined` for both missing and explicit-undefined positions, so these three keep `JsCallArguments` and use `arguments.Length`-based defaults. New `ReflectTests` cover all three cases as regression locks.

## Other notes

- `SymbolPrototype._constructor` flags moved from `Configurable | Writable` to `PropertyFlag.NonEnumerable` to match Boolean / Error / Number / Function / Object. Functionally identical (both produce a non-enumerable, configurable, writable descriptor — verified by reading `PropertyFlag.cs:6-29`).
- Drive-by fix: `Reflect.ownKeys` non-Object error message was `"Reflect.get called on non-object"` (copy-paste bug). Now reads `"Reflect.ownKeys called on non-object"`.
- The generator's first-char lowercasing handles `RawJSON` → `rawJSON`, `IsRawJSON` → `isRawJSON`, `GetPrototypeOf` → `getPrototypeOf`, etc., so explicit `Name = ...` is only needed when the C# method name doesn't match (`ToBigIntString` → `toString`, `ToSymbolString` → `toString`).

## Verification

- All 5 TFMs build clean (net462, netstandard2.0/2.1, net8.0, net10.0)
- `Jint.Tests.SourceGenerators`: 24/24 snapshot tests pass
- `Jint.Tests`: 2,875 (net10) + 2,828 (net472), 0 fail (3 new ReflectTests added)
- **Test262 full sweep: 98,959 pass, 0 fail** — zero regressions

## What's intentionally NOT in this PR

- `SymbolConstructor`, `BigIntConstructor` — small but distinct review surface; can ship as a "constructors batch" later
- The four constructors deferred from #2422 (Date/String/Array/RegExp) — `newTarget` handling out of scope for the prototype generator
- Map/Set/WeakMap/WeakSet — share the `@@iterator`-points-to-`entries` pattern; deserves its own focused PR
- Promise, ArrayBuffer/SharedArrayBuffer, DataView, TypedArray, Atomics, Iterator/AsyncIterator — bigger surface, separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)