### PR TITLE
Source generator: migrate Promise/WeakMap/WeakRef/FinalizationRegistry prototypes + Symbol/BigInt constructors

### DIFF
--- a/Jint/Native/BigInt/BigIntConstructor.cs
+++ b/Jint/Native/BigInt/BigIntConstructor.cs
@@ -3,14 +3,14 @@ using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.BigInt;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-bigint-constructor
 /// </summary>
-internal sealed class BigIntConstructor : Constructor
+[JsObject]
+internal sealed partial class BigIntConstructor : Constructor
 {
     private static readonly JsString _functionName = new("BigInt");
 
@@ -27,23 +27,16 @@ internal sealed class BigIntConstructor : Constructor
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
     }
 
-    protected override void Initialize()
-    {
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            ["asIntN"] = new(new ClrFunction(Engine, "asIntN", AsIntN, 2, PropertyFlag.Configurable), true, false, true),
-            ["asUintN"] = new(new ClrFunction(Engine, "asUintN", AsUintN, 2, PropertyFlag.Configurable), true, false, true),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-bigint.asintn
     /// </summary>
-    private JsValue AsIntN(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue AsIntN(JsValue thisObject, JsValue bitsValue, JsValue bigintValue)
     {
-        var bits = (int) TypeConverter.ToIndex(_realm, arguments.At(0));
-        var bigint = arguments.At(1).ToBigInteger(_engine);
+        var bits = (int) TypeConverter.ToIndex(_realm, bitsValue);
+        var bigint = bigintValue.ToBigInteger(_engine);
 
         var mod = TypeConverter.BigIntegerModulo(bigint, BigInteger.Pow(2, bits));
         if (bits > 0 && mod >= BigInteger.Pow(2, bits - 1))
@@ -57,10 +50,11 @@ internal sealed class BigIntConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-bigint.asuintn
     /// </summary>
-    private JsValue AsUintN(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue AsUintN(JsValue thisObject, JsValue bitsValue, JsValue bigintValue)
     {
-        var bits = (int) TypeConverter.ToIndex(_realm, arguments.At(0));
-        var bigint = arguments.At(1).ToBigInteger(_engine);
+        var bits = (int) TypeConverter.ToIndex(_realm, bitsValue);
+        var bigint = bigintValue.ToBigInteger(_engine);
 
         var result = TypeConverter.BigIntegerModulo(bigint, BigInteger.Pow(2, bits));
 

--- a/Jint/Native/FinalizationRegistry/FinalizationRegistryPrototype.cs
+++ b/Jint/Native/FinalizationRegistry/FinalizationRegistryPrototype.cs
@@ -1,17 +1,19 @@
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.FinalizationRegistry;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-prototype-object
 /// </summary>
-internal sealed class FinalizationRegistryPrototype : Prototype
+[JsObject]
+internal sealed partial class FinalizationRegistryPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly FinalizationRegistryConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString FinalizationRegistryToStringTag = new("FinalizationRegistry");
 
     public FinalizationRegistryPrototype(
         Engine engine,
@@ -25,29 +27,17 @@ internal sealed class FinalizationRegistryPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.NonEnumerable;
-        var properties = new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            [KnownKeys.Constructor] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["register"] = new PropertyDescriptor(new ClrFunction(Engine, "register", Register, 2, PropertyFlag.Configurable), PropertyFlags),
-            ["unregister"] = new PropertyDescriptor(new ClrFunction(Engine, "unregister", Unregister, 1, PropertyFlag.Configurable), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1) { [GlobalSymbolRegistry.ToStringTag] = new("FinalizationRegistry", PropertyFlag.Configurable) };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-finalization-registry.prototype.register
     /// </summary>
-    private JsValue Register(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue Register(JsValue thisObject, JsValue target, JsValue heldValue, JsValue unregisterToken)
     {
         var finalizationRegistry = AssertFinalizationRegistryInstance(thisObject);
-
-        var target = arguments.At(0);
-        var heldValue = arguments.At(1);
-        var unregisterToken = arguments.At(2);
 
         if (!target.CanBeHeldWeakly(_engine.GlobalSymbolRegistry))
         {
@@ -75,11 +65,10 @@ internal sealed class FinalizationRegistryPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister
     /// </summary>
-    private JsValue Unregister(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Unregister(JsValue thisObject, JsValue unregisterToken)
     {
         var finalizationRegistry = AssertFinalizationRegistryInstance(thisObject);
-
-        var unregisterToken = arguments.At(0);
 
         if (!unregisterToken.CanBeHeldWeakly(_engine.GlobalSymbolRegistry))
         {

--- a/Jint/Native/Promise/PromisePrototype.cs
+++ b/Jint/Native/Promise/PromisePrototype.cs
@@ -1,14 +1,17 @@
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 
 namespace Jint.Native.Promise;
 
-internal sealed class PromisePrototype : Prototype
+[JsObject]
+internal sealed partial class PromisePrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly PromiseConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString PromiseToStringTag = new("Promise");
 
     internal PromisePrototype(
         Engine engine,
@@ -22,22 +25,8 @@ internal sealed class PromisePrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag lengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(5, checkExistingKeys: false)
-        {
-            ["constructor"] = new(_constructor, PropertyFlag.NonEnumerable),
-            ["then"] = new(new ClrFunction(Engine, "then", Then, 2, lengthFlags), propertyFlags),
-            ["catch"] = new(new ClrFunction(Engine, "catch", Catch, 1, lengthFlags), propertyFlags),
-            ["finally"] = new(new ClrFunction(Engine, "finally", Finally, 1, lengthFlags), propertyFlags)
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new(new JsString("Promise"), PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     // https://tc39.es/ecma262/#sec-promise.prototype.then
@@ -49,11 +38,12 @@ internal sealed class PromisePrototype : Prototype
     // 3. Let C be ? SpeciesConstructor(promise, %Promise%).
     // 4. Let resultCapability be ? NewPromiseCapability(C).
     // 5. Return PerformPromiseThen(promise, onFulfilled, onRejected, resultCapability).
-    private JsValue Then(JsValue thisValue, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue Then(JsValue thisObject, JsValue onFulfilled, JsValue onRejected)
     {
         // 1. Let promise be the this value.
         // 2. If IsPromise(promise) is false, throw a TypeError exception.
-        var promise = thisValue as JsPromise;
+        var promise = thisObject as JsPromise;
         if (promise is null)
         {
             Throw.TypeError(_realm, "Method Promise.prototype.then called on incompatible receiver");
@@ -66,7 +56,7 @@ internal sealed class PromisePrototype : Prototype
         var capability = PromiseConstructor.NewPromiseCapability(_engine, (JsValue) ctor);
 
         // 5. Return PerformPromiseThen(promise, onFulfilled, onRejected, resultCapability).
-        return PromiseOperations.PerformPromiseThen(_engine, promise, arguments.At(0), arguments.At(1), capability);
+        return PromiseOperations.PerformPromiseThen(_engine, promise, onFulfilled, onRejected, capability);
     }
 
     // https://tc39.es/ecma262/#sec-promise.prototype.catch
@@ -76,15 +66,17 @@ internal sealed class PromisePrototype : Prototype
     //
     // 1. Let promise be the this value.
     // 2. Return ? Invoke(promise, "then", « undefined, onRejected »).
-    private JsValue Catch(JsValue thisValue, JsCallArguments arguments) =>
-        _engine.Invoke(thisValue, "then", [Undefined, arguments.At(0)]);
+    [JsFunction(Length = 1)]
+    private JsValue Catch(JsValue thisObject, JsValue onRejected) =>
+        _engine.Invoke(thisObject, "then", [Undefined, onRejected]);
 
     // https://tc39.es/ecma262/#sec-promise.prototype.finally
-    private JsValue Finally(JsValue thisValue, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Finally(JsValue thisObject, JsValue onFinally)
     {
         // 1. Let promise be the this value.
         // 2. If Type(promise) is not Object, throw a TypeError exception.
-        var promise = thisValue as ObjectInstance;
+        var promise = thisObject as ObjectInstance;
         if (promise is null)
         {
             Throw.TypeError(_realm, "this passed to Promise.prototype.finally is not an object");
@@ -96,7 +88,6 @@ internal sealed class PromisePrototype : Prototype
 
         JsValue thenFinally;
         JsValue catchFinally;
-        var onFinally = arguments.At(0);
 
         // 5. If IsCallable(onFinally) is false, then
         if (onFinally is not ICallable onFinallyFunc)

--- a/Jint/Native/Symbol/SymbolConstructor.cs
+++ b/Jint/Native/Symbol/SymbolConstructor.cs
@@ -4,7 +4,6 @@ using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Symbol;
 
@@ -12,9 +11,28 @@ namespace Jint.Native.Symbol;
 /// 19.4
 /// http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol-objects
 /// </summary>
-internal sealed class SymbolConstructor : Constructor
+[JsObject]
+internal sealed partial class SymbolConstructor : Constructor
 {
     private static readonly JsString _functionName = new JsString("Symbol");
+
+    // Well-known symbol aliases. Each forwards a JsSymbol from GlobalSymbolRegistry under the
+    // Symbol.X spec name, with PropertyFlag.AllForbidden (non-writable, non-enumerable, non-configurable).
+    [JsProperty(Name = "hasInstance")] private static readonly JsSymbol _hasInstance = GlobalSymbolRegistry.HasInstance;
+    [JsProperty(Name = "isConcatSpreadable")] private static readonly JsSymbol _isConcatSpreadable = GlobalSymbolRegistry.IsConcatSpreadable;
+    [JsProperty(Name = "iterator")] private static readonly JsSymbol _iterator = GlobalSymbolRegistry.Iterator;
+    [JsProperty(Name = "match")] private static readonly JsSymbol _match = GlobalSymbolRegistry.Match;
+    [JsProperty(Name = "matchAll")] private static readonly JsSymbol _matchAll = GlobalSymbolRegistry.MatchAll;
+    [JsProperty(Name = "replace")] private static readonly JsSymbol _replace = GlobalSymbolRegistry.Replace;
+    [JsProperty(Name = "search")] private static readonly JsSymbol _search = GlobalSymbolRegistry.Search;
+    [JsProperty(Name = "species")] private static readonly JsSymbol _species = GlobalSymbolRegistry.Species;
+    [JsProperty(Name = "split")] private static readonly JsSymbol _split = GlobalSymbolRegistry.Split;
+    [JsProperty(Name = "toPrimitive")] private static readonly JsSymbol _toPrimitive = GlobalSymbolRegistry.ToPrimitive;
+    [JsProperty(Name = "toStringTag")] private static readonly JsSymbol _toStringTag = GlobalSymbolRegistry.ToStringTag;
+    [JsProperty(Name = "unscopables")] private static readonly JsSymbol _unscopables = GlobalSymbolRegistry.Unscopables;
+    [JsProperty(Name = "asyncIterator")] private static readonly JsSymbol _asyncIterator = GlobalSymbolRegistry.AsyncIterator;
+    [JsProperty(Name = "dispose")] private static readonly JsSymbol _dispose = GlobalSymbolRegistry.Dispose;
+    [JsProperty(Name = "asyncDispose")] private static readonly JsSymbol _asyncDispose = GlobalSymbolRegistry.AsyncDispose;
 
     internal SymbolConstructor(
         Engine engine,
@@ -31,33 +49,7 @@ internal sealed class SymbolConstructor : Constructor
 
     public SymbolPrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag lengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag propertyFlags = PropertyFlag.AllForbidden;
-
-        var properties = new PropertyDictionary(17, checkExistingKeys: false)
-        {
-            ["for"] = new PropertyDescriptor(new ClrFunction(Engine, "for", For, 1, lengthFlags), PropertyFlag.Writable | PropertyFlag.Configurable),
-            ["keyFor"] = new PropertyDescriptor(new ClrFunction(Engine, "keyFor", KeyFor, 1, lengthFlags), PropertyFlag.Writable | PropertyFlag.Configurable),
-            ["hasInstance"] = new PropertyDescriptor(GlobalSymbolRegistry.HasInstance, propertyFlags),
-            ["isConcatSpreadable"] = new PropertyDescriptor(GlobalSymbolRegistry.IsConcatSpreadable, propertyFlags),
-            ["iterator"] = new PropertyDescriptor(GlobalSymbolRegistry.Iterator, propertyFlags),
-            ["match"] = new PropertyDescriptor(GlobalSymbolRegistry.Match, propertyFlags),
-            ["matchAll"] = new PropertyDescriptor(GlobalSymbolRegistry.MatchAll, propertyFlags),
-            ["replace"] = new PropertyDescriptor(GlobalSymbolRegistry.Replace, propertyFlags),
-            ["search"] = new PropertyDescriptor(GlobalSymbolRegistry.Search, propertyFlags),
-            ["species"] = new PropertyDescriptor(GlobalSymbolRegistry.Species, propertyFlags),
-            ["split"] = new PropertyDescriptor(GlobalSymbolRegistry.Split, propertyFlags),
-            ["toPrimitive"] = new PropertyDescriptor(GlobalSymbolRegistry.ToPrimitive, propertyFlags),
-            ["toStringTag"] = new PropertyDescriptor(GlobalSymbolRegistry.ToStringTag, propertyFlags),
-            ["unscopables"] = new PropertyDescriptor(GlobalSymbolRegistry.Unscopables, propertyFlags),
-            ["asyncIterator"] = new PropertyDescriptor(GlobalSymbolRegistry.AsyncIterator, propertyFlags),
-            ["dispose"] = new PropertyDescriptor(GlobalSymbolRegistry.Dispose, propertyFlags),
-            ["asyncDispose"] = new PropertyDescriptor(GlobalSymbolRegistry.AsyncDispose, propertyFlags),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     /// <summary>
     /// http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol-description
@@ -76,9 +68,10 @@ internal sealed class SymbolConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-symbol.for
     /// </summary>
-    private JsValue For(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1, Name = "for")]
+    private JsValue For(JsValue thisObject, JsValue key)
     {
-        var stringKey = TypeConverter.ToJsString(arguments.At(0));
+        var stringKey = TypeConverter.ToJsString(key);
 
         // 2. ReturnIfAbrupt(stringKey).
 
@@ -94,12 +87,13 @@ internal sealed class SymbolConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-symbol.keyfor
     /// </summary>
-    private JsValue KeyFor(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue KeyFor(JsValue thisObject, JsValue sym)
     {
-        var symbol = arguments.At(0) as JsSymbol;
+        var symbol = sym as JsSymbol;
         if (symbol is null)
         {
-            Throw.TypeError(_realm, $"{arguments.At(0)} is not a symbol");
+            Throw.TypeError(_realm, $"{sym} is not a symbol");
         }
 
         if (_engine.GlobalSymbolRegistry.TryGetSymbol(symbol._value, out var e))

--- a/Jint/Native/WeakMap/WeakMapPrototype.cs
+++ b/Jint/Native/WeakMap/WeakMapPrototype.cs
@@ -1,19 +1,25 @@
 #pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of prototype methods return JsValue
 
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.WeakMap;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-weakmap-objects
 /// </summary>
-internal sealed class WeakMapPrototype : Prototype
+[JsObject]
+internal sealed partial class WeakMapPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly WeakMapConstructor _constructor;
+
+    // Pre-existing quirk: TC39 spec does not require a `length` property on WeakMap.prototype
+    // (length lives on the constructor). Preserved here verbatim from the pre-source-gen Initialize body.
+    [JsProperty(Name = "length", Flags = PropertyFlag.Configurable)] private static readonly JsNumber WeakMapLength = JsNumber.PositiveZero;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString WeakMapToStringTag = new("WeakMap");
 
     internal WeakMapPrototype(
         Engine engine,
@@ -27,47 +33,32 @@ internal sealed class WeakMapPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(8, checkExistingKeys: false)
-        {
-            ["length"] = new PropertyDescriptor(0, PropertyFlag.Configurable),
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["delete"] = new PropertyDescriptor(new ClrFunction(Engine, "delete", Delete, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["get"] = new PropertyDescriptor(new ClrFunction(Engine, "get", Get, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["getOrInsert"] = new PropertyDescriptor(new ClrFunction(Engine, "getOrInsert", GetOrInsert, 2, PropertyFlag.Configurable), PropertyFlags),
-            ["getOrInsertComputed"] = new PropertyDescriptor(new ClrFunction(Engine, "getOrInsertComputed", GetOrInsertComputed, 2, PropertyFlag.Configurable), PropertyFlags),
-            ["has"] = new PropertyDescriptor(new ClrFunction(Engine, "has", Has, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["set"] = new PropertyDescriptor(new ClrFunction(Engine, "set", Set, 2, PropertyFlag.Configurable), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor("WeakMap", false, false, true)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
-    private JsValue Get(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1, Name = "get")]
+    private JsValue MapGet(JsValue thisObject, JsValue key)
     {
         var map = AssertWeakMapInstance(thisObject);
-        return map.WeakMapGet(arguments.At(0));
+        return map.WeakMapGet(key);
     }
 
-    private JsValue GetOrInsert(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue GetOrInsert(JsValue thisObject, JsValue key, JsValue value)
     {
         var map = AssertWeakMapInstance(thisObject);
-        var key = AssertCanBeHeldWeakly(arguments.At(0));
-        var value = arguments.At(1);
-        return map.GetOrInsert(key, value);
+        var checkedKey = AssertCanBeHeldWeakly(key);
+        return map.GetOrInsert(checkedKey, value);
     }
 
-    private JsValue GetOrInsertComputed(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue GetOrInsertComputed(JsValue thisObject, JsValue key, JsValue callbackfn)
     {
         var map = AssertWeakMapInstance(thisObject);
-        var key = AssertCanBeHeldWeakly(arguments.At(0));
-        var callbackfn = arguments.At(1).GetCallable(_realm);
-        return map.GetOrInsertComputed(key, callbackfn);
+        var checkedKey = AssertCanBeHeldWeakly(key);
+        var callable = callbackfn.GetCallable(_realm);
+        return map.GetOrInsertComputed(checkedKey, callable);
     }
 
     private JsValue AssertCanBeHeldWeakly(JsValue key)
@@ -80,23 +71,26 @@ internal sealed class WeakMapPrototype : Prototype
         return key;
     }
 
-    private JsValue Delete(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Delete(JsValue thisObject, JsValue key)
     {
         var map = AssertWeakMapInstance(thisObject);
-        return arguments.Length > 0 && map.WeakMapDelete(arguments.At(0)) ? JsBoolean.True : JsBoolean.False;
+        return map.WeakMapDelete(key) ? JsBoolean.True : JsBoolean.False;
     }
 
-    private JsValue Set(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2, Name = "set")]
+    private JsValue MapSet(JsValue thisObject, JsValue key, JsValue value)
     {
         var map = AssertWeakMapInstance(thisObject);
-        map.WeakMapSet(arguments.At(0), arguments.At(1));
+        map.WeakMapSet(key, value);
         return thisObject;
     }
 
-    private JsValue Has(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Has(JsValue thisObject, JsValue key)
     {
         var map = AssertWeakMapInstance(thisObject);
-        return map.WeakMapHas(arguments.At(0)) ? JsBoolean.True : JsBoolean.False;
+        return map.WeakMapHas(key) ? JsBoolean.True : JsBoolean.False;
     }
 
     private JsWeakMap AssertWeakMapInstance(JsValue thisObject)

--- a/Jint/Native/WeakRef/WeakRefPrototype.cs
+++ b/Jint/Native/WeakRef/WeakRefPrototype.cs
@@ -1,17 +1,19 @@
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.WeakRef;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-prototype-object
 /// </summary>
-internal sealed class WeakRefPrototype : Prototype
+[JsObject]
+internal sealed partial class WeakRefPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly WeakRefConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString WeakRefToStringTag = new("WeakRef");
 
     internal WeakRefPrototype(
         Engine engine,
@@ -25,22 +27,12 @@ internal sealed class WeakRefPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(5, checkExistingKeys: false)
-        {
-            ["constructor"] = new(_constructor, PropertyFlag.NonEnumerable),
-            ["deref"] = new(new ClrFunction(Engine, "deref", Deref, 0, PropertyFlag.Configurable), propertyFlags)
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("WeakRef", false, false, true)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
-    private JsValue Deref(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Deref(JsValue thisObject)
     {
         if (thisObject is JsWeakRef weakRef)
         {


### PR DESCRIPTION
Continues the source-generator expansion from #2421 / #2422 / #2425 to four small prototypes plus the two trivial constructors that pair with the just-merged `Symbol.prototype` / `BigInt.prototype`. No new generator features needed.

## Migrations

| Target | `[JsFunction]` | `[JsProperty]` | `[JsSymbol]` |
|--------|---------------:|---------------:|--------------|
| **Promise.prototype** | 3 (then, catch, finally) | `constructor` | `@@toStringTag = "Promise"` |
| **WeakMap.prototype** | 6 (delete, get, getOrInsert, getOrInsertComputed, has, set) | `constructor`, `length = 0` *(see note)* | `@@toStringTag = "WeakMap"` |
| **WeakRef.prototype** | 1 (deref) | `constructor` | `@@toStringTag = "WeakRef"` |
| **FinalizationRegistry.prototype** | 2 (register, unregister) | `constructor` | `@@toStringTag = "FinalizationRegistry"` |
| **SymbolConstructor** | 2 (for, keyFor) | 15 well-known symbol aliases (hasInstance, iterator, match, replace, search, species, split, toPrimitive, toStringTag, unscopables, isConcatSpreadable, matchAll, asyncIterator, dispose, asyncDispose) | — |
| **BigIntConstructor** | 2 (asIntN, asUintN) | — | — |

## Method signatures

Methods take spec-named `JsValue` parameters (`Then(thisObject, onFulfilled, onRejected)`, `Register(thisObject, target, heldValue, unregisterToken)`, etc.). None of the methods in this batch has the not-present-vs-explicit-undefined distinction that forced `JsCallArguments` on `Reflect.construct/get/set` in #2425.

## Notes

- **`Call()` and `Construct()` overrides on `SymbolConstructor` / `BigIntConstructor` stay user-written.** The source generator handles property registration only; it doesn't interact with the host class's `Function`-derived virtuals.
- **`WeakMap.prototype.length = 0`**: the pre-existing code (also on `MapPrototype`) registers a `length: 0` data property. TC39 spec doesn't require this on `WeakMap.prototype` (length lives on the constructor). Preserved verbatim — fixing the spec deviation is out of scope.
- **`Get` / `Set` rename in WeakMapPrototype**: C# method names are `MapGet` / `MapSet` with explicit `Name = "get"` / `"set"` to avoid colliding with `ObjectInstance.Get` / `ObjectInstance.Set` virtuals when the parameter list moves from `JsCallArguments` to individual `JsValue` arguments.
- **Drive-by gotcha worth knowing for future migrations**: the generator only recognises the receiver parameter when it's named `thisObject` or `thisObj`. The original Promise methods used `thisValue`, which was being unpacked as a regular argument and broke 288 Promise tests until renamed. (The project memory note already documents this; reaffirming.)
- Promise's `ThenFinallyFunctions` / `CatchFinallyFunctions` stay as private helpers — they allocate per-call `ClrFunction` closures that don't fit the declarative attribute model.

## Verification

- All 5 TFMs build clean (net462, netstandard2.0/2.1, net8.0, net10.0)
- `Jint.Tests.SourceGenerators`: 24/24 snapshot tests pass
- `Jint.Tests`: 2,875 (net10) + 2,828 (net472), 0 fail
- Per-area test262: Promise 448/448, plus full sweep covers WeakMap, WeakRef, FinalizationRegistry, Symbol, BigInt
- **Test262 full sweep: 98,959 pass, 0 fail** — matches `upstream/main` baseline exactly

## What's intentionally NOT in this PR

- `MapConstructor`, `SetConstructor`, `WeakMapConstructor`, `WeakSetConstructor`, `WeakRefConstructor`, `FinalizationRegistryConstructor`, `ProxyConstructor` — all override `Construct(JsCallArguments, JsValue newTarget)`. Migrating their `Initialize()` bodies is straightforward, but their full migration is bundled with the future "Construct() override generator support" work.
- Date / String / Array / RegExp constructors — same `newTarget` consideration, deferred from #2422.
- `MapPrototype` / `SetPrototype` — share an `@@iterator`-points-to-`entries` pattern that needs care; deserves a focused PR.
- ArrayBuffer / SharedArrayBuffer / DataView / TypedArray / Atomics / Iterator / AsyncIterator — bigger surface, separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)