### PR TITLE
Source generator: migrate Atomics + WeakSetPrototype + SetConstructor

### DIFF
--- a/Jint/Native/Atomics/AtomicsInstance.cs
+++ b/Jint/Native/Atomics/AtomicsInstance.cs
@@ -7,20 +7,21 @@ using System.Threading;
 using Jint.Native.ArrayBuffer;
 using Jint.Native.Object;
 using Jint.Native.Promise;
-using Jint.Native.Symbol;
 using Jint.Native.TypedArray;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Atomics;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-atomics-object
 /// </summary>
-internal sealed class AtomicsInstance : ObjectInstance
+[JsObject]
+internal sealed partial class AtomicsInstance : ObjectInstance
 {
     private readonly Realm _realm;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString AtomicsToStringTag = new("Atomics");
 
     /// <summary>
     /// Global waiters list for Atomics.wait/notify.
@@ -221,67 +222,34 @@ internal sealed class AtomicsInstance : ObjectInstance
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        var properties = new PropertyDictionary(14, checkExistingKeys: false)
-        {
-            ["add"] = new(new ClrFunction(Engine, "add", Add, 3, LengthFlags), true, false, true),
-            ["and"] = new(new ClrFunction(Engine, "and", And, 3, LengthFlags), true, false, true),
-            ["compareExchange"] = new(new ClrFunction(Engine, "compareExchange", CompareExchange, 4, LengthFlags), true, false, true),
-            ["exchange"] = new(new ClrFunction(Engine, "exchange", Exchange, 3, LengthFlags), true, false, true),
-            ["isLockFree"] = new(new ClrFunction(Engine, "isLockFree", IsLockFree, 1, LengthFlags), true, false, true),
-            ["load"] = new(new ClrFunction(Engine, "load", Load, 2, LengthFlags), true, false, true),
-            ["notify"] = new(new ClrFunction(Engine, "notify", Notify, 3, LengthFlags), true, false, true),
-            ["or"] = new(new ClrFunction(Engine, "or", Or, 3, LengthFlags), true, false, true),
-            ["pause"] = new(new ClrFunction(Engine, "pause", Pause, 0, LengthFlags), true, false, true),
-            ["store"] = new(new ClrFunction(Engine, "store", Store, 3, LengthFlags), true, false, true),
-            ["sub"] = new(new ClrFunction(Engine, "sub", Sub, 3, LengthFlags), true, false, true),
-            ["wait"] = new(new ClrFunction(Engine, "wait", Wait, 4, LengthFlags), true, false, true),
-            ["waitAsync"] = new(new ClrFunction(Engine, "waitAsync", WaitAsync, 4, LengthFlags), true, false, true),
-            ["xor"] = new(new ClrFunction(Engine, "xor", Xor, 3, LengthFlags), true, false, true),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor("Atomics", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.add
     /// </summary>
-    private JsValue Add(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 3)]
+    private JsValue Add(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
-        var typedArray = arguments.At(0);
-        var index = arguments.At(1);
-        var value = arguments.At(2);
-
         return AtomicReadModifyWrite(typedArray, index, value, AtomicOperation.Add);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.and
     /// </summary>
-    private JsValue And(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 3)]
+    private JsValue And(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
-        var typedArray = arguments.At(0);
-        var index = arguments.At(1);
-        var value = arguments.At(2);
-
         return AtomicReadModifyWrite(typedArray, index, value, AtomicOperation.And);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.compareexchange
     /// </summary>
-    private JsValue CompareExchange(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 4)]
+    private JsValue CompareExchange(JsValue thisObject, JsValue typedArray, JsValue index, JsValue expectedValue, JsValue replacementValue)
     {
-        var typedArray = arguments.At(0);
-        var index = arguments.At(1);
-        var expectedValue = arguments.At(2);
-        var replacementValue = arguments.At(3);
-
         var taRecord = ValidateIntegerTypedArray(typedArray);
         var byteIndexInBuffer = ValidateAtomicAccess(taRecord, index);
         var ta = taRecord.Object;
@@ -306,21 +274,18 @@ internal sealed class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.exchange
     /// </summary>
-    private JsValue Exchange(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 3)]
+    private JsValue Exchange(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
-        var typedArray = arguments.At(0);
-        var index = arguments.At(1);
-        var value = arguments.At(2);
-
         return AtomicReadModifyWrite(typedArray, index, value, AtomicOperation.Exchange);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.islockfree
     /// </summary>
-    private static JsValue IsLockFree(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private static JsValue IsLockFree(JsValue thisObject, JsValue size)
     {
-        var size = arguments.At(0);
         var n = TypeConverter.ToIntegerOrInfinity(size);
 
         // Per spec: size 1, 2, 8 are implementation-defined, size 4 must return true
@@ -338,11 +303,9 @@ internal sealed class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.load
     /// </summary>
-    private JsValue Load(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue Load(JsValue thisObject, JsValue typedArray, JsValue index)
     {
-        var typedArray = arguments.At(0);
-        var index = arguments.At(1);
-
         var taRecord = ValidateIntegerTypedArray(typedArray);
         var byteIndexInBuffer = ValidateAtomicAccess(taRecord, index);
         var ta = taRecord.Object;
@@ -354,12 +317,9 @@ internal sealed class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.notify
     /// </summary>
-    private JsValue Notify(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 3)]
+    private JsValue Notify(JsValue thisObject, JsValue typedArray, JsValue index, JsValue count)
     {
-        var typedArray = arguments.At(0);
-        var index = arguments.At(1);
-        var count = arguments.At(2);
-
         var taRecord = ValidateIntegerTypedArray(typedArray, waitable: true);
         var byteIndexInBuffer = ValidateAtomicAccess(taRecord, index);
         var ta = taRecord.Object;
@@ -406,21 +366,18 @@ internal sealed class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.or
     /// </summary>
-    private JsValue Or(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 3)]
+    private JsValue Or(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
-        var typedArray = arguments.At(0);
-        var index = arguments.At(1);
-        var value = arguments.At(2);
-
         return AtomicReadModifyWrite(typedArray, index, value, AtomicOperation.Or);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.pause
     /// </summary>
-    private JsValue Pause(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Pause(JsValue thisObject, JsValue iterationNumber)
     {
-        var iterationNumber = arguments.At(0);
         if (!iterationNumber.IsUndefined())
         {
             if (!iterationNumber.IsNumber())
@@ -453,12 +410,9 @@ internal sealed class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.store
     /// </summary>
-    private JsValue Store(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 3)]
+    private JsValue Store(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
-        var typedArray = arguments.At(0);
-        var index = arguments.At(1);
-        var value = arguments.At(2);
-
         var taRecord = ValidateIntegerTypedArray(typedArray);
         var byteIndexInBuffer = ValidateAtomicAccess(taRecord, index);
         var ta = taRecord.Object;
@@ -491,25 +445,18 @@ internal sealed class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.sub
     /// </summary>
-    private JsValue Sub(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 3)]
+    private JsValue Sub(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
-        var typedArray = arguments.At(0);
-        var index = arguments.At(1);
-        var value = arguments.At(2);
-
         return AtomicReadModifyWrite(typedArray, index, value, AtomicOperation.Sub);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.wait
     /// </summary>
-    private JsValue Wait(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 4)]
+    private JsValue Wait(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value, JsValue timeout)
     {
-        var typedArray = arguments.At(0);
-        var index = arguments.At(1);
-        var value = arguments.At(2);
-        var timeout = arguments.At(3);
-
         var taRecord = ValidateIntegerTypedArray(typedArray, waitable: true, requireShared: true);
         var byteIndexInBuffer = ValidateAtomicAccess(taRecord, index);
         var ta = taRecord.Object;
@@ -630,13 +577,9 @@ internal sealed class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.waitasync
     /// </summary>
-    private JsValue WaitAsync(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 4)]
+    private JsValue WaitAsync(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value, JsValue timeout)
     {
-        var typedArray = arguments.At(0);
-        var index = arguments.At(1);
-        var value = arguments.At(2);
-        var timeout = arguments.At(3);
-
         var taRecord = ValidateIntegerTypedArray(typedArray, waitable: true, requireShared: true);
         var byteIndexInBuffer = ValidateAtomicAccess(taRecord, index);
         var ta = taRecord.Object;
@@ -753,12 +696,9 @@ internal sealed class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.xor
     /// </summary>
-    private JsValue Xor(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 3)]
+    private JsValue Xor(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
-        var typedArray = arguments.At(0);
-        var index = arguments.At(1);
-        var value = arguments.At(2);
-
         return AtomicReadModifyWrite(typedArray, index, value, AtomicOperation.Xor);
     }
 

--- a/Jint/Native/Set/SetConstructor.cs
+++ b/Jint/Native/Set/SetConstructor.cs
@@ -1,13 +1,12 @@
 using Jint.Native.Function;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Set;
 
-public sealed class SetConstructor : Constructor
+[JsObject]
+public sealed partial class SetConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Set");
 
@@ -26,15 +25,7 @@ public sealed class SetConstructor : Constructor
 
     internal SetPrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.Species] = new GetSetPropertyDescriptor(get: new ClrFunction(_engine, "get [Symbol.species]", Species, 0, PropertyFlag.Configurable), set: Undefined, PropertyFlag.Configurable)
-        };
-
-        SetSymbols(symbols);
-    }
+    protected override void Initialize() => CreateSymbols_Generated();
 
     public JsSet Construct() => ConstructSet(this);
 
@@ -103,7 +94,8 @@ public sealed class SetConstructor : Constructor
         return set;
     }
 
-    private static JsValue Species(JsValue thisObject, JsCallArguments arguments)
+    [JsSymbolAccessor("Species")]
+    private static JsValue Species(JsValue thisObject)
     {
         return thisObject;
     }

--- a/Jint/Native/WeakSet/WeakSetConstructor.cs
+++ b/Jint/Native/WeakSet/WeakSetConstructor.cs
@@ -42,7 +42,7 @@ internal sealed class WeakSetConstructor : Constructor
             var adder = set.Get("add") as ICallable;
 
             // check fast path
-            if (arg1 is JsArray array && ReferenceEquals(adder, _engine.Realm.Intrinsics.WeakSet.PrototypeObject._originalAddFunction))
+            if (arg1 is JsArray array && ReferenceEquals(adder, _engine.Realm.Intrinsics.WeakSet.PrototypeObject.OriginalAddFunction))
             {
                 foreach (var value in array)
                 {

--- a/Jint/Native/WeakSet/WeakSetPrototype.cs
+++ b/Jint/Native/WeakSet/WeakSetPrototype.cs
@@ -1,20 +1,30 @@
 #pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of prototype methods return JsValue
 
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
+using FunctionInstance = Jint.Native.Function.Function;
 
 namespace Jint.Native.WeakSet;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-weakset-objects
 /// </summary>
-internal sealed class WeakSetPrototype : Prototype
+[JsObject]
+internal sealed partial class WeakSetPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly WeakSetConstructor _constructor;
-    internal ClrFunction _originalAddFunction = null!;
+
+    // Pre-existing quirk: TC39 spec does not require a `length` property on WeakSet.prototype
+    // (length lives on the constructor). Preserved here verbatim from the pre-source-gen Initialize body.
+    [JsProperty(Name = "length", Flags = PropertyFlag.Configurable)] private static readonly JsNumber WeakSetLength = JsNumber.PositiveZero;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString WeakSetToStringTag = new("WeakSet");
+
+    // Captured once Initialize runs; the WeakSet constructor's array fast path
+    // identity-compares against this snapshot to detect a user-overridden `add`.
+    internal FunctionInstance OriginalAddFunction { get; private set; } = null!;
 
     internal WeakSetPrototype(
         Engine engine,
@@ -28,43 +38,34 @@ internal sealed class WeakSetPrototype : Prototype
 
     protected override void Initialize()
     {
-        _originalAddFunction = new ClrFunction(Engine, "add", Add, 1, PropertyFlag.Configurable);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
 
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(5, checkExistingKeys: false)
-        {
-            ["length"] = new(0, PropertyFlag.Configurable),
-            ["constructor"] = new(_constructor, PropertyFlag.NonEnumerable),
-            ["delete"] = new(new ClrFunction(Engine, "delete", Delete, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["add"] = new(_originalAddFunction, PropertyFlags),
-            ["has"] = new(new ClrFunction(Engine, "has", Has, 1, PropertyFlag.Configurable), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("WeakSet", false, false, true)
-        };
-        SetSymbols(symbols);
+        // Snapshot the prototype's `add` function before any user code can replace it,
+        // so the constructor's array fast path can detect overrides via ReferenceEquals.
+        OriginalAddFunction = (FunctionInstance) GetOwnProperty("add").Value!;
     }
 
-    private JsValue Add(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Add(JsValue thisObject, JsValue value)
     {
         var set = AssertWeakSetInstance(thisObject);
-        set.WeakSetAdd(arguments.At(0));
+        set.WeakSetAdd(value);
         return thisObject;
     }
 
-    private JsValue Delete(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Delete(JsValue thisObject, JsValue value)
     {
         var set = AssertWeakSetInstance(thisObject);
-        return set.WeakSetDelete(arguments.At(0)) ? JsBoolean.True : JsBoolean.False;
+        return set.WeakSetDelete(value) ? JsBoolean.True : JsBoolean.False;
     }
 
-    private JsValue Has(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Has(JsValue thisObject, JsValue value)
     {
         var set = AssertWeakSetInstance(thisObject);
-        return set.WeakSetHas(arguments.At(0)) ? JsBoolean.True : JsBoolean.False;
+        return set.WeakSetHas(value) ? JsBoolean.True : JsBoolean.False;
     }
 
     private JsWeakSet AssertWeakSetInstance(JsValue thisObject)


### PR DESCRIPTION
## Summary

Closes out the small remaining built-ins that fit the existing source-generator surface — bringing the migrated total to **30 built-ins**. No new generator features were needed; all three targets ride on attributes that already shipped (`[JsObject]`, `[JsFunction]`, `[JsSymbol]`, `[JsProperty]`, `[JsSymbolAccessor]` from #2434).

| Target | `[JsFunction]` | `[JsSymbolAccessor]` | `[JsSymbol]` | `[JsProperty]` |
|--------|---------------:|---------------------:|--------------|----------------|
| `AtomicsInstance` | 14 | — | `@@toStringTag = "Atomics"` | — |
| `WeakSetPrototype` | 3 | — | `@@toStringTag = "WeakSet"` | `constructor`, `length` |
| `SetConstructor` | — | 1 (`@@species`) | — | — |

Net: **17 method registrations + 1 symbol accessor + 2 toStringTags**, replacing three hand-written `Initialize()` bodies. `-135/+68` lines.

### Atomics + Set: standard pattern
- `AtomicsInstance` follows the static-namespace template (Math/JSON/Reflect): all 14 methods now take spec-named `JsValue` parameters instead of `JsCallArguments`. The `_realm` field is preserved for the methods that need it.
- `SetConstructor` had a single hand-built `@@species` accessor; the lambda was extracted into `private static JsValue Species(JsValue thisObject)` and annotated with `[JsSymbolAccessor("Species")]`.

### WeakSetPrototype: keeping the constructor's array fast path

`WeakSetConstructor` has an established fast path: when constructing `new WeakSet([...])` over a plain `JsArray`, it skips the iterator protocol and calls `WeakSetAdd` directly — but **only** if `prototype.add` hasn't been replaced. The check is an identity comparison against the prototype's original `add` function, which the pre-source-gen code captured eagerly into a field during `Initialize()`.

The generator emits `LazyPropertyDescriptor<T>` for properties, which would defer that allocation until first access — but the snapshot has to happen **before any user code can replace `prototype.add`**, otherwise the fast path either crashes (when the user sets `add = null`) or fires incorrectly against the user's override (when the user installs a counter).

Fix: snapshot the function at the end of `Initialize()` (which already runs before any script can touch the prototype), expose it as `OriginalAddFunction`, and update `WeakSetConstructor:45` to read through the property. Type widens from `ClrFunction` → `Function` since the lazy descriptor materialises a `Function` subtype, but `ReferenceEquals` semantics are unchanged.

## Verification

- **Source-generator snapshot tests**: 25 / 25
- **Jint.Tests** (xUnit): 2,875 passed / 0 failed (net10.0), 2,828 passed / 0 failed (net472)
- **Test262 — targeted areas** (.NET 10):
  - `BuiltInsTests.Atomics`: 764 / 0
  - `BuiltInsTests.WeakSet`: 170 / 0
  - `BuiltInsTests.Set` (includes WeakSet by prefix): 786 / 0
- **Test262 — full sweep**: **98,959 passed / 0 failed** (matches the upstream/main baseline)

## What's intentionally NOT in this PR

The remaining migration targets are larger and warrant their own batches:
- Map/Set prototypes (iterators, callback protocols, lots of methods)
- PromiseConstructor (executor coordination, multi-method)
- IteratorPrototype (helpers + generic)
- TypedArray family (constructor + prototype, large surface)
- Date/String/Array/RegExp constructors

## Test plan

- [x] `dotnet build --configuration Release Jint/Jint.csproj` (all 5 TFMs)
- [x] `dotnet test --configuration Release Jint.Tests.SourceGenerators/Jint.Tests.SourceGenerators.csproj`
- [x] `dotnet test --configuration Release Jint.Tests/Jint.Tests.csproj`
- [x] `dotnet test --configuration Release Jint.Tests.Test262/Jint.Tests.Test262.csproj` (full sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)