### PR TITLE
Source generator: migrate Map + Set prototypes + IteratorPrototype family

### DIFF
--- a/Jint.SourceGenerators/Attributes.cs
+++ b/Jint.SourceGenerators/Attributes.cs
@@ -12,6 +12,14 @@ internal static class Attributes
         [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
         internal sealed class JsObjectAttribute : global::System.Attribute
         {
+            /// <summary>
+            /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+            /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+            /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+            /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+            /// to avoid the list→hash transition during init.
+            /// </summary>
+            public int ExtraCapacity { get; set; }
         }
 
         [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.SourceGenerators/Emitter.cs
+++ b/Jint.SourceGenerators/Emitter.cs
@@ -115,16 +115,19 @@ internal static class Emitter
               .Append(obj.Name).Append("Function.Slot.").Append(fn.ClrName).Append("), ").Append(fn.FlagsExpression).AppendLine(");");
         }
 
-        // Accessors: GetSetPropertyDescriptor wrapping eagerly-allocated dispatcher slots.
+        // Accessors: LazyGetSetPropertyDescriptor — dispatcher Functions allocate on first read,
+        // so prototypes with many never-read accessors (Temporal date/time has 10-20 each) skip the
+        // up-front allocations. The shape mirrors the data-property [JsFunction] emission above.
         var accessorNames = new List<string>(accessorsByName.Keys);
         accessorNames.Sort(StringComparer.Ordinal);
         foreach (var name in accessorNames)
         {
             var (getFn, setFn, flagsExpr) = accessorsByName[name];
-            sb.Append("        properties[\"").Append(EscapeStringLit(name)).Append("\"] = new global::Jint.Runtime.Descriptors.GetSetPropertyDescriptor(");
+            sb.Append("        properties[\"").Append(EscapeStringLit(name)).Append("\"] = new global::Jint.Runtime.Descriptors.Specialized.LazyGetSetPropertyDescriptor<")
+              .Append(obj.Name).Append(">(this, ");
             if (getFn is not null)
             {
-                sb.Append("new __").Append(obj.Name).Append("Function(this, __").Append(obj.Name).Append("Function.Slot.").Append(getFn.ClrName).Append(')');
+                sb.Append("static host => new __").Append(obj.Name).Append("Function(host, __").Append(obj.Name).Append("Function.Slot.").Append(getFn.ClrName).Append(')');
             }
             else
             {
@@ -133,7 +136,7 @@ internal static class Emitter
             sb.Append(", ");
             if (setFn is not null)
             {
-                sb.Append("new __").Append(obj.Name).Append("Function(this, __").Append(obj.Name).Append("Function.Slot.").Append(setFn.ClrName).Append(')');
+                sb.Append("static host => new __").Append(obj.Name).Append("Function(host, __").Append(obj.Name).Append("Function.Slot.").Append(setFn.ClrName).Append(')');
             }
             else
             {
@@ -384,17 +387,18 @@ internal static class Emitter
               .Append(obj.Name).Append("Function.Slot.").Append(fn.ClrName).Append("), ").Append(fn.FlagsExpression).AppendLine(");");
         }
 
-        // Symbol-keyed accessors: GetSetPropertyDescriptor wrapping eagerly-allocated dispatcher slots,
-        // registered under GlobalSymbolRegistry.<SymbolName>.
+        // Symbol-keyed accessors: LazyGetSetPropertyDescriptor — dispatcher Functions allocate on
+        // first read, registered under GlobalSymbolRegistry.<SymbolName>.
         var symbolAccessorNames = new List<string>(symbolAccessorsByName.Keys);
         symbolAccessorNames.Sort(StringComparer.Ordinal);
         foreach (var name in symbolAccessorNames)
         {
             var (getFn, setFn, flagsExpr) = symbolAccessorsByName[name];
-            sb.Append("        symbols[global::Jint.Native.Symbol.GlobalSymbolRegistry.").Append(name).Append("] = new global::Jint.Runtime.Descriptors.GetSetPropertyDescriptor(");
+            sb.Append("        symbols[global::Jint.Native.Symbol.GlobalSymbolRegistry.").Append(name).Append("] = new global::Jint.Runtime.Descriptors.Specialized.LazyGetSetPropertyDescriptor<")
+              .Append(obj.Name).Append(">(this, ");
             if (getFn is not null)
             {
-                sb.Append("new __").Append(obj.Name).Append("Function(this, __").Append(obj.Name).Append("Function.Slot.").Append(getFn.ClrName).Append(')');
+                sb.Append("static host => new __").Append(obj.Name).Append("Function(host, __").Append(obj.Name).Append("Function.Slot.").Append(getFn.ClrName).Append(')');
             }
             else
             {
@@ -403,7 +407,7 @@ internal static class Emitter
             sb.Append(", ");
             if (setFn is not null)
             {
-                sb.Append("new __").Append(obj.Name).Append("Function(this, __").Append(obj.Name).Append("Function.Slot.").Append(setFn.ClrName).Append(')');
+                sb.Append("static host => new __").Append(obj.Name).Append("Function(host, __").Append(obj.Name).Append("Function.Slot.").Append(setFn.ClrName).Append(')');
             }
             else
             {

--- a/Jint.SourceGenerators/Emitter.cs
+++ b/Jint.SourceGenerators/Emitter.cs
@@ -179,12 +179,16 @@ internal static class Emitter
         sb.AppendLine("        private readonly Slot _slot;");
         sb.AppendLine();
 
+        // Use host._realm — the realm captured at host construction time (= host's home realm) — not
+        // host.Engine.Realm, which is the *currently active* realm. Lazy descriptors materialize on
+        // first read; if first access is cross-realm (e.g. via ShadowRealm), Engine.Realm would be the
+        // wrong realm and the dispatcher Function would carry the wrong [[Realm]] internal slot.
         sb.Append("        internal ").Append(typeName).Append("(").Append(obj.Name).AppendLine(" host, Slot slot)");
-        sb.AppendLine("            : base(host.Engine, host.Engine.Realm, GetName(slot))");
+        sb.AppendLine("            : base(host.Engine, host._realm, GetName(slot))");
         sb.AppendLine("        {");
         sb.AppendLine("            _host = host;");
         sb.AppendLine("            _slot = slot;");
-        sb.AppendLine("            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;");
+        sb.AppendLine("            _prototype = host._realm.Intrinsics.Function.PrototypeObject;");
         sb.AppendLine("            _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);");
         sb.AppendLine("        }");
         sb.AppendLine();

--- a/Jint.SourceGenerators/Emitter.cs
+++ b/Jint.SourceGenerators/Emitter.cs
@@ -88,15 +88,18 @@ internal static class Emitter
         sb.AppendLine("    private void CreateProperties_Generated()");
         sb.AppendLine("    {");
 
-        if (totalEntries == 0)
+        if (totalEntries == 0 && obj.ExtraCapacity == 0)
         {
             sb.AppendLine("        // no [JsFunction] / [JsProperty] / [JsAccessor] / [JsThrowerAccessor] members");
             sb.AppendLine("    }");
             return;
         }
 
+        // [JsObject(ExtraCapacity=N)] presizes the dictionary for post-CreateProperties_Generated
+        // SetProperty calls (e.g. cross-realm constructor refs in IntlInstance/TemporalInstance) so
+        // the dictionary doesn't grow + transition list→hash during init.
         sb.Append("        var properties = new global::Jint.Collections.HybridDictionary<global::Jint.Runtime.Descriptors.PropertyDescriptor>(")
-          .Append(totalEntries)
+          .Append(totalEntries + obj.ExtraCapacity)
           .AppendLine(", checkExistingKeys: false);");
 
         foreach (var prop in obj.Properties)

--- a/Jint.SourceGenerators/Models.cs
+++ b/Jint.SourceGenerators/Models.cs
@@ -32,6 +32,7 @@ internal sealed record class ObjectDefinition(
     string Name,
     string Accessibility,
     bool IsSealed,
+    int ExtraCapacity,
     EquatableArray<FunctionDefinition> Functions,
     EquatableArray<PropertyDefinition> Properties,
     EquatableArray<SymbolDefinition> Symbols,
@@ -94,6 +95,17 @@ internal sealed record class ObjectDefinition(
         var ns = typeSymbol.ContainingNamespace.IsGlobalNamespace
             ? string.Empty
             : typeSymbol.ContainingNamespace.ToDisplayString();
+
+        // Read [JsObject(ExtraCapacity = N)] for hosts that add properties post-CreateProperties_Generated.
+        var extraCapacity = 0;
+        foreach (var attr in typeSymbol.GetAttributes())
+        {
+            if (attr.AttributeClass?.Name != "JsObjectAttribute") continue;
+            foreach (var named in attr.NamedArguments)
+            {
+                if (named.Key == "ExtraCapacity" && named.Value.Value is int v) extraCapacity = v;
+            }
+        }
 
         var functions = new List<FunctionDefinition>();
         var properties = new List<PropertyDefinition>();
@@ -288,6 +300,7 @@ internal sealed record class ObjectDefinition(
             Name: typeSymbol.Name,
             Accessibility: AccessibilityToString(typeSymbol.DeclaredAccessibility),
             IsSealed: typeSymbol.IsSealed,
+            ExtraCapacity: extraCapacity,
             Functions: functions.ToEquatableArray(),
             Properties: properties.ToEquatableArray(),
             Symbols: symbols.ToEquatableArray(),

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#Sample.Foo.g.verified.cs
@@ -10,7 +10,7 @@ internal sealed partial class Foo
     private void CreateProperties_Generated()
     {
         var properties = new global::Jint.Collections.HybridDictionary<global::Jint.Runtime.Descriptors.PropertyDescriptor>(1, checkExistingKeys: false);
-        properties["__proto__"] = new global::Jint.Runtime.Descriptors.GetSetPropertyDescriptor(new __FooFunction(this, __FooFunction.Slot.ProtoGet), new __FooFunction(this, __FooFunction.Slot.ProtoSet), global::Jint.Runtime.Descriptors.PropertyFlag.EnumerableSet | global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
+        properties["__proto__"] = new global::Jint.Runtime.Descriptors.Specialized.LazyGetSetPropertyDescriptor<Foo>(this, static host => new __FooFunction(host, __FooFunction.Slot.ProtoGet), static host => new __FooFunction(host, __FooFunction.Slot.ProtoSet), global::Jint.Runtime.Descriptors.PropertyFlag.EnumerableSet | global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         SetProperties(properties);
     }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#Sample.Foo.g.verified.cs
@@ -26,11 +26,11 @@ internal sealed partial class Foo
         private readonly Slot _slot;
 
         internal __FooFunction(Foo host, Slot slot)
-            : base(host.Engine, host.Engine.Realm, GetName(slot))
+            : base(host.Engine, host._realm, GetName(slot))
         {
             _host = host;
             _slot = slot;
-            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;
+            _prototype = host._realm.Intrinsics.Function.PrototypeObject;
             _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#Sample.Foo.g.verified.cs
@@ -25,11 +25,11 @@ internal sealed partial class Foo
         private readonly Slot _slot;
 
         internal __FooFunction(Foo host, Slot slot)
-            : base(host.Engine, host.Engine.Realm, GetName(slot))
+            : base(host.Engine, host._realm, GetName(slot))
         {
             _host = host;
             _slot = slot;
-            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;
+            _prototype = host._realm.Intrinsics.Function.PrototypeObject;
             _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#Sample.Foo.g.verified.cs
@@ -10,7 +10,7 @@ internal sealed partial class Foo
     private void CreateProperties_Generated()
     {
         var properties = new global::Jint.Collections.HybridDictionary<global::Jint.Runtime.Descriptors.PropertyDescriptor>(1, checkExistingKeys: false);
-        properties["size"] = new global::Jint.Runtime.Descriptors.GetSetPropertyDescriptor(new __FooFunction(this, __FooFunction.Slot.SizeGet), null, global::Jint.Runtime.Descriptors.PropertyFlag.EnumerableSet | global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
+        properties["size"] = new global::Jint.Runtime.Descriptors.Specialized.LazyGetSetPropertyDescriptor<Foo>(this, static host => new __FooFunction(host, __FooFunction.Slot.SizeGet), null, global::Jint.Runtime.Descriptors.PropertyFlag.EnumerableSet | global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         SetProperties(properties);
     }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#Sample.Foo.g.verified.cs
@@ -25,11 +25,11 @@ internal sealed partial class Foo
         private readonly Slot _slot;
 
         internal __FooFunction(Foo host, Slot slot)
-            : base(host.Engine, host.Engine.Realm, GetName(slot))
+            : base(host.Engine, host._realm, GetName(slot))
         {
             _host = host;
             _slot = slot;
-            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;
+            _prototype = host._realm.Intrinsics.Function.PrototypeObject;
             _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#Sample.Foo.g.verified.cs
@@ -27,11 +27,11 @@ internal sealed partial class Foo
         private readonly Slot _slot;
 
         internal __FooFunction(Foo host, Slot slot)
-            : base(host.Engine, host.Engine.Realm, GetName(slot))
+            : base(host.Engine, host._realm, GetName(slot))
         {
             _host = host;
             _slot = slot;
-            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;
+            _prototype = host._realm.Intrinsics.Function.PrototypeObject;
             _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#Sample.Foo.g.verified.cs
@@ -25,11 +25,11 @@ internal sealed partial class Foo
         private readonly Slot _slot;
 
         internal __FooFunction(Foo host, Slot slot)
-            : base(host.Engine, host.Engine.Realm, GetName(slot))
+            : base(host.Engine, host._realm, GetName(slot))
         {
             _host = host;
             _slot = slot;
-            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;
+            _prototype = host._realm.Intrinsics.Function.PrototypeObject;
             _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#Sample.Foo.g.verified.cs
@@ -25,11 +25,11 @@ internal sealed partial class Foo
         private readonly Slot _slot;
 
         internal __FooFunction(Foo host, Slot slot)
-            : base(host.Engine, host.Engine.Realm, GetName(slot))
+            : base(host.Engine, host._realm, GetName(slot))
         {
             _host = host;
             _slot = slot;
-            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;
+            _prototype = host._realm.Intrinsics.Function.PrototypeObject;
             _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#Sample.Foo.g.verified.cs
@@ -33,11 +33,11 @@ internal sealed partial class Foo
         private readonly Slot _slot;
 
         internal __FooFunction(Foo host, Slot slot)
-            : base(host.Engine, host.Engine.Realm, GetName(slot))
+            : base(host.Engine, host._realm, GetName(slot))
         {
             _host = host;
             _slot = slot;
-            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;
+            _prototype = host._realm.Intrinsics.Function.PrototypeObject;
             _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#Sample.Foo.g.verified.cs
@@ -31,11 +31,11 @@ internal sealed partial class Foo
         private readonly Slot _slot;
 
         internal __FooFunction(Foo host, Slot slot)
-            : base(host.Engine, host.Engine.Realm, GetName(slot))
+            : base(host.Engine, host._realm, GetName(slot))
         {
             _host = host;
             _slot = slot;
-            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;
+            _prototype = host._realm.Intrinsics.Function.PrototypeObject;
             _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#Sample.Foo.g.verified.cs
@@ -16,7 +16,7 @@ internal sealed partial class Foo
     private void CreateSymbols_Generated()
     {
         var symbols = new global::Jint.Collections.DictionarySlim<global::Jint.Native.JsSymbol, global::Jint.Runtime.Descriptors.PropertyDescriptor>(1);
-        symbols[global::Jint.Native.Symbol.GlobalSymbolRegistry.Species] = new global::Jint.Runtime.Descriptors.GetSetPropertyDescriptor(new __FooFunction(this, __FooFunction.Slot.Species), null, global::Jint.Runtime.Descriptors.PropertyFlag.EnumerableSet | global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
+        symbols[global::Jint.Native.Symbol.GlobalSymbolRegistry.Species] = new global::Jint.Runtime.Descriptors.Specialized.LazyGetSetPropertyDescriptor<Foo>(this, static host => new __FooFunction(host, __FooFunction.Slot.Species), null, global::Jint.Runtime.Descriptors.PropertyFlag.EnumerableSet | global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         SetSymbols(symbols);
     }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#Sample.Foo.g.verified.cs
@@ -31,11 +31,11 @@ internal sealed partial class Foo
         private readonly Slot _slot;
 
         internal __FooFunction(Foo host, Slot slot)
-            : base(host.Engine, host.Engine.Realm, GetName(slot))
+            : base(host.Engine, host._realm, GetName(slot))
         {
             _host = host;
             _slot = slot;
-            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;
+            _prototype = host._realm.Intrinsics.Function.PrototypeObject;
             _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#Sample.Foo.g.verified.cs
@@ -25,11 +25,11 @@ internal sealed partial class Foo
         private readonly Slot _slot;
 
         internal __FooFunction(Foo host, Slot slot)
-            : base(host.Engine, host.Engine.Realm, GetName(slot))
+            : base(host.Engine, host._realm, GetName(slot))
         {
             _host = host;
             _slot = slot;
-            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;
+            _prototype = host._realm.Intrinsics.Function.PrototypeObject;
             _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#Sample.Foo.g.verified.cs
@@ -25,11 +25,11 @@ internal sealed partial class Foo
         private readonly Slot _slot;
 
         internal __FooFunction(Foo host, Slot slot)
-            : base(host.Engine, host.Engine.Realm, GetName(slot))
+            : base(host.Engine, host._realm, GetName(slot))
         {
             _host = host;
             _slot = slot;
-            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;
+            _prototype = host._realm.Intrinsics.Function.PrototypeObject;
             _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#Sample.Foo.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#Sample.Foo.g.verified.cs
@@ -27,11 +27,11 @@ internal sealed partial class Foo
         private readonly Slot _slot;
 
         internal __FooFunction(Foo host, Slot slot)
-            : base(host.Engine, host.Engine.Realm, GetName(slot))
+            : base(host.Engine, host._realm, GetName(slot))
         {
             _host = host;
             _slot = slot;
-            _prototype = host.Engine.Realm.Intrinsics.Function.PrototypeObject;
+            _prototype = host._realm.Intrinsics.Function.PrototypeObject;
             _length = new global::Jint.Runtime.Descriptors.PropertyDescriptor(global::Jint.Native.JsNumber.Create(GetLength(slot)), global::Jint.Runtime.Descriptors.PropertyFlag.Configurable);
         }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -8,6 +8,14 @@ namespace Jint;
 [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
 internal sealed class JsObjectAttribute : global::System.Attribute
 {
+    /// <summary>
+    /// Extra capacity to add to the generated property dictionary's initial size, on top of the
+    /// statically declared [JsFunction]/[JsAccessor]/[JsProperty] entries. Use when the host's
+    /// Initialize() body adds further properties post-CreateProperties_Generated() (e.g. cross-realm
+    /// constructor references in IntlInstance / TemporalInstance) — presizes the HybridDictionary
+    /// to avoid the list→hash transition during init.
+    /// </summary>
+    public int ExtraCapacity { get; set; }
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -13,7 +13,8 @@ using Jint.Runtime.Interop;
 
 namespace Jint.Native.Array;
 
-public sealed class ArrayConstructor : Constructor
+[JsObject]
+public sealed partial class ArrayConstructor : Constructor
 {
     private static readonly JsString _functionName = new JsString("Array");
 
@@ -34,25 +35,14 @@ public sealed class ArrayConstructor : Constructor
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            ["from"] = new PropertyDescriptor(new PropertyDescriptor(new ClrFunction(Engine, "from", From, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable)),
-            ["fromAsync"] = new PropertyDescriptor(new PropertyDescriptor(new ClrFunction(Engine, "fromAsync", FromAsync, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable)),
-            ["isArray"] = new PropertyDescriptor(new PropertyDescriptor(new ClrFunction(Engine, "isArray", IsArray, 1), PropertyFlag.NonEnumerable)),
-            ["of"] = new PropertyDescriptor(new PropertyDescriptor(new ClrFunction(Engine, "of", Of, 0, PropertyFlag.Configurable), PropertyFlag.NonEnumerable))
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.Species] = new GetSetPropertyDescriptor(get: new ClrFunction(Engine, "get [Symbol.species]", Species, 0, PropertyFlag.Configurable), set: Undefined, PropertyFlag.Configurable),
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-array.from
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsValue From(JsValue thisObject, JsCallArguments arguments)
     {
         var items = arguments.At(0);
@@ -96,6 +86,7 @@ public sealed class ArrayConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-array.fromasync
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsValue FromAsync(JsValue thisObject, JsCallArguments arguments)
     {
         var asyncItems = arguments.At(0);
@@ -687,6 +678,7 @@ public sealed class ArrayConstructor : Constructor
         }
     }
 
+    [JsFunction(Length = 0)]
     private JsValue Of(JsValue thisObject, JsCallArguments arguments)
     {
         var len = arguments.Length;
@@ -725,11 +717,10 @@ public sealed class ArrayConstructor : Constructor
         return a;
     }
 
-    private static JsValue Species(JsValue thisObject, JsCallArguments arguments)
-    {
-        return thisObject;
-    }
+    [JsSymbolAccessor("Species")]
+    private static JsValue Species(JsValue thisObject) => thisObject;
 
+    [JsFunction(Length = 1)]
     private static JsValue IsArray(JsValue thisObject, JsCallArguments arguments)
     {
         var o = arguments.At(0);

--- a/Jint/Native/Array/ArrayIteratorPrototype.cs
+++ b/Jint/Native/Array/ArrayIteratorPrototype.cs
@@ -1,20 +1,24 @@
 using Jint.Native.ArrayBuffer;
 using Jint.Native.Iterator;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Native.TypedArray;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
+using FunctionInstance = Jint.Native.Function.Function;
 
 namespace Jint.Native.Array;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-object
 /// </summary>
-internal sealed class ArrayIteratorPrototype : IteratorPrototype
+[JsObject]
+internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
 {
-    private ClrFunction? _originalNextFunction;
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString ArrayIteratorToStringTag = new("Array Iterator");
+
+    // Captured once Initialize runs; HasOriginalNext below identity-compares against this snapshot
+    // to detect whether user code has overridden `next` on the prototype.
+    private FunctionInstance _originalNextFunction = null!;
 
     internal ArrayIteratorPrototype(
         Engine engine,
@@ -25,19 +29,16 @@ internal sealed class ArrayIteratorPrototype : IteratorPrototype
 
     protected override void Initialize()
     {
-        _originalNextFunction = new ClrFunction(Engine, "next", Next, 0, PropertyFlag.Configurable);
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            [KnownKeys.Next] = new(_originalNextFunction, PropertyFlag.NonEnumerable)
-        };
-        SetProperties(properties);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
 
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Array Iterator", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        // Snapshot the prototype's `next` function before any user code can replace it,
+        // so HasOriginalNext can detect overrides via ReferenceEquals.
+        _originalNextFunction = (FunctionInstance) GetOwnProperty("next").Value!;
     }
+
+    [JsFunction(Length = 0, Name = "next")]
+    private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     internal IteratorInstance Construct(ObjectInstance array, ArrayIteratorType kind)
     {

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorFunctionPrototype.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorFunctionPrototype.cs
@@ -21,7 +21,7 @@ internal sealed class AsyncGeneratorFunctionPrototype : Prototype
     {
         _constructor = constructor;
         _prototype = prototype;
-        PrototypeObject = new AsyncGeneratorPrototype(engine, this, asyncIteratorPrototype);
+        PrototypeObject = new AsyncGeneratorPrototype(engine, engine.Realm, this, asyncIteratorPrototype);
     }
 
     public AsyncGeneratorPrototype PrototypeObject { get; }

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorPrototype.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorPrototype.cs
@@ -1,19 +1,21 @@
 using Jint.Native.Iterator;
 using Jint.Native.Object;
 using Jint.Native.Promise;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.AsyncGenerator;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-asyncgenerator-prototype-object
 /// </summary>
-internal sealed class AsyncGeneratorPrototype : ObjectInstance
+[JsObject]
+internal sealed partial class AsyncGeneratorPrototype : ObjectInstance
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.Configurable)]
     private readonly AsyncGeneratorFunctionPrototype _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString AsyncGeneratorToStringTag = new("AsyncGenerator");
 
     internal AsyncGeneratorPrototype(
         Engine engine,
@@ -26,28 +28,15 @@ internal sealed class AsyncGeneratorPrototype : ObjectInstance
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        var properties = new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            [KnownKeys.Constructor] = new(_constructor, PropertyFlag.Configurable),
-            [KnownKeys.Next] = new(new ClrFunction(Engine, "next", Next, 1, LengthFlags), PropertyFlags),
-            [KnownKeys.Return] = new(new ClrFunction(Engine, "return", Return, 1, LengthFlags), PropertyFlags),
-            [KnownKeys.Throw] = new(new ClrFunction(Engine, "throw", Throw, 1, LengthFlags), PropertyFlags)
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("AsyncGenerator", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next
     /// </summary>
-    private JsValue Next(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Next(JsValue thisObject, JsValue value)
     {
         // Per spec: If generator is not valid, return a rejected promise
         if (!TryGetAsyncGeneratorInstance(thisObject, out var g))
@@ -55,7 +44,6 @@ internal sealed class AsyncGeneratorPrototype : ObjectInstance
             return CreateRejectedPromiseWithTypeError("object must be an AsyncGenerator instance");
         }
 
-        var value = arguments.At(0);
         var completion = new Completion(CompletionType.Normal, value, null!);
         return g.AsyncGeneratorEnqueue(completion);
     }
@@ -63,7 +51,8 @@ internal sealed class AsyncGeneratorPrototype : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-asyncgenerator-prototype-return
     /// </summary>
-    private JsValue Return(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Return(JsValue thisObject, JsValue value)
     {
         // Per spec: If generator is not valid, return a rejected promise
         if (!TryGetAsyncGeneratorInstance(thisObject, out var g))
@@ -71,7 +60,6 @@ internal sealed class AsyncGeneratorPrototype : ObjectInstance
             return CreateRejectedPromiseWithTypeError("object must be an AsyncGenerator instance");
         }
 
-        var value = arguments.At(0);
         var completion = new Completion(CompletionType.Return, value, null!);
         return g.AsyncGeneratorEnqueue(completion);
     }
@@ -79,7 +67,8 @@ internal sealed class AsyncGeneratorPrototype : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-asyncgenerator-prototype-throw
     /// </summary>
-    private JsValue Throw(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Throw(JsValue thisObject, JsValue exception)
     {
         // Per spec: If generator is not valid, return a rejected promise
         if (!TryGetAsyncGeneratorInstance(thisObject, out var g))
@@ -87,7 +76,6 @@ internal sealed class AsyncGeneratorPrototype : ObjectInstance
             return CreateRejectedPromiseWithTypeError("object must be an AsyncGenerator instance");
         }
 
-        var exception = arguments.At(0);
         var completion = new Completion(CompletionType.Throw, exception, null!);
         return g.AsyncGeneratorEnqueue(completion);
     }

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorPrototype.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorPrototype.cs
@@ -12,6 +12,8 @@ namespace Jint.Native.AsyncGenerator;
 [JsObject]
 internal sealed partial class AsyncGeneratorPrototype : ObjectInstance
 {
+    private readonly Realm _realm;
+
     [JsProperty(Name = "constructor", Flags = PropertyFlag.Configurable)]
     private readonly AsyncGeneratorFunctionPrototype _constructor;
 
@@ -19,9 +21,11 @@ internal sealed partial class AsyncGeneratorPrototype : ObjectInstance
 
     internal AsyncGeneratorPrototype(
         Engine engine,
+        Realm realm,
         AsyncGeneratorFunctionPrototype constructor,
         AsyncIteratorPrototype asyncIteratorPrototype) : base(engine)
     {
+        _realm = realm;
         _constructor = constructor;
         _prototype = asyncIteratorPrototype;
     }
@@ -92,8 +96,8 @@ internal sealed partial class AsyncGeneratorPrototype : ObjectInstance
     /// </summary>
     private JsValue CreateRejectedPromiseWithTypeError(string message)
     {
-        var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
-        var error = _engine.Realm.Intrinsics.TypeError.Construct(message);
+        var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _realm.Intrinsics.Promise);
+        var error = _realm.Intrinsics.TypeError.Construct(message);
         promiseCapability.Reject.Call(Undefined, new[] { error });
         return promiseCapability.PromiseInstance;
     }

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -4,14 +4,14 @@ using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Date;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-date-constructor
 /// </summary>
-internal sealed class DateConstructor : Constructor
+[JsObject]
+internal sealed partial class DateConstructor : Constructor
 {
     internal static readonly DateTime Epoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     private static readonly JsString _functionName = new JsString("Date");
@@ -33,23 +33,12 @@ internal sealed class DateConstructor : Constructor
 
     internal DatePrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-
-        var properties = new PropertyDictionary(3, checkExistingKeys: false)
-        {
-            ["parse"] = new(new ClrFunction(Engine, "parse", Parse, 1, LengthFlags), PropertyFlags),
-            ["UTC"] = new(new ClrFunction(Engine, "UTC", Utc, 7, LengthFlags), PropertyFlags),
-            ["now"] = new(new ClrFunction(Engine, "now", Now, 0, LengthFlags), PropertyFlags)
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-date.parse
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsValue Parse(JsValue thisObject, JsCallArguments arguments)
     {
         var dateString = TypeConverter.ToString(arguments.At(0));
@@ -74,6 +63,7 @@ internal sealed class DateConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-date.utc
     /// </summary>
+    [JsFunction(Length = 7, Name = "UTC")]
     private static JsValue Utc(JsValue thisObject, JsCallArguments arguments)
     {
         var y = TypeConverter.ToNumber(arguments.At(0));
@@ -97,6 +87,7 @@ internal sealed class DateConstructor : Constructor
         return finalDate.TimeClip().ToJsValue();
     }
 
+    [JsFunction(Length = 0)]
     private JsValue Now(JsValue thisObject, JsCallArguments arguments)
     {
         return (long) (_timeSystem.GetUtcNow().DateTime - Epoch).TotalMilliseconds;

--- a/Jint/Native/Disposable/AsyncDisposableStackPrototype.cs
+++ b/Jint/Native/Disposable/AsyncDisposableStackPrototype.cs
@@ -3,13 +3,16 @@ using Jint.Native.Promise;
 using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Disposable;
 
-internal sealed class AsyncDisposableStackPrototype : Prototype
+[JsObject]
+internal sealed partial class AsyncDisposableStackPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly AsyncDisposableStackConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString AsyncDisposableStackToStringTag = new("AsyncDisposableStack");
 
     internal AsyncDisposableStackPrototype(
         Engine engine,
@@ -23,44 +26,32 @@ internal sealed class AsyncDisposableStackPrototype : Prototype
 
     protected override void Initialize()
     {
-        var disposeFunction = new ClrFunction(Engine, "disposeAsync", Dispose, 0, PropertyFlag.Configurable);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
 
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(8, checkExistingKeys: false)
-        {
-            ["length"] = new PropertyDescriptor(0, PropertyFlag.Configurable),
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["adopt"] = new PropertyDescriptor(new ClrFunction(Engine, "adopt", Adopt, 2, PropertyFlag.Configurable), PropertyFlags),
-            ["defer"] = new PropertyDescriptor(new ClrFunction(Engine, "defer", Defer, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["disposeAsync"] = new PropertyDescriptor(disposeFunction, PropertyFlags),
-            ["disposed"] = new GetSetPropertyDescriptor(get: new ClrFunction(Engine, "get disposed", Disposed, 0, PropertyFlag.Configurable), set: Undefined, PropertyFlags),
-            ["move"] = new PropertyDescriptor(new ClrFunction(Engine, "move", Move, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["use"] = new PropertyDescriptor(new ClrFunction(Engine, "use", Use, 1, PropertyFlag.Configurable), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(2)
-        {
-            [GlobalSymbolRegistry.AsyncDispose] = new PropertyDescriptor(disposeFunction, PropertyFlags),
-            [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor("AsyncDisposableStack", PropertyFlag.Configurable),
-        };
-        SetSymbols(symbols);
+        // Spec requires AsyncDisposableStack.prototype[@@asyncDispose] to be the same function object
+        // as AsyncDisposableStack.prototype.disposeAsync. Alias the descriptor here so the
+        // @@asyncDispose slot shares the same materialized function as `disposeAsync`.
+        SetProperty(GlobalSymbolRegistry.AsyncDispose, GetOwnProperty("disposeAsync"));
     }
 
-    private JsValue Adopt(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue Adopt(JsValue thisObject, JsValue value, JsValue onDispose)
     {
         var stack = AssertDisposableStack(thisObject);
-        return stack.Adopt(arguments.At(0), arguments.At(1));
+        return stack.Adopt(value, onDispose);
     }
 
-    private JsValue Defer(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Defer(JsValue thisObject, JsValue onDispose)
     {
         var stack = AssertDisposableStack(thisObject);
-        stack.Defer(arguments.At(0));
+        stack.Defer(onDispose);
         return Undefined;
     }
 
-    private JsValue Dispose(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0, Name = "disposeAsync")]
+    private JsValue Dispose(JsValue thisObject)
     {
         // Per spec: create promise capability first, then validate receiver.
         // If validation fails, reject the promise instead of throwing synchronously.
@@ -78,13 +69,15 @@ internal sealed class AsyncDisposableStackPrototype : Prototype
         return capability.PromiseInstance;
     }
 
-    private JsValue Disposed(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("disposed")]
+    private JsBoolean Disposed(JsValue thisObject)
     {
         var stack = AssertDisposableStack(thisObject);
-        return stack.State == DisposableState.Disposed;
+        return stack.State == DisposableState.Disposed ? JsBoolean.True : JsBoolean.False;
     }
 
-    private JsValue Move(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Move(JsValue thisObject)
     {
         var stack = AssertDisposableStack(thisObject);
         var newDisposableStack = _engine.Intrinsics.Function.OrdinaryCreateFromConstructor(
@@ -95,10 +88,11 @@ internal sealed class AsyncDisposableStackPrototype : Prototype
         return stack.Move(newDisposableStack);
     }
 
-    private JsValue Use(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Use(JsValue thisObject, JsValue value)
     {
         var stack = AssertDisposableStack(thisObject);
-        return stack.Use(arguments.At(0));
+        return stack.Use(value);
     }
 
     private DisposableStack AssertDisposableStack(JsValue thisObject)

--- a/Jint/Native/Disposable/DisposableStackPrototype.cs
+++ b/Jint/Native/Disposable/DisposableStackPrototype.cs
@@ -2,13 +2,16 @@ using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Disposable;
 
-internal sealed class DisposableStackPrototype : Prototype
+[JsObject]
+internal sealed partial class DisposableStackPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly DisposableStackConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString DisposableStackToStringTag = new("DisposableStack");
 
     internal DisposableStackPrototype(
         Engine engine,
@@ -22,57 +25,46 @@ internal sealed class DisposableStackPrototype : Prototype
 
     protected override void Initialize()
     {
-        var disposeFunction = new ClrFunction(Engine, "dispose", Dispose, 0, PropertyFlag.Configurable);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
 
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(8, checkExistingKeys: false)
-        {
-            ["length"] = new PropertyDescriptor(0, PropertyFlag.Configurable),
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["adopt"] = new PropertyDescriptor(new ClrFunction(Engine, "adopt", Adopt, 2, PropertyFlag.Configurable), PropertyFlags),
-            ["defer"] = new PropertyDescriptor(new ClrFunction(Engine, "defer", Defer, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["dispose"] = new PropertyDescriptor(disposeFunction, PropertyFlags),
-            ["disposed"] = new GetSetPropertyDescriptor(get: new ClrFunction(Engine, "get disposed", Disposed, 0, PropertyFlag.Configurable), set: Undefined, PropertyFlags),
-            ["move"] = new PropertyDescriptor(new ClrFunction(Engine, "move", Move, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["use"] = new PropertyDescriptor(new ClrFunction(Engine, "use", Use, 1, PropertyFlag.Configurable), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(2)
-        {
-            [GlobalSymbolRegistry.Dispose] = new PropertyDescriptor(disposeFunction, PropertyFlags),
-            [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor("DisposableStack", PropertyFlag.Configurable),
-        };
-        SetSymbols(symbols);
+        // Spec requires DisposableStack.prototype[@@dispose] to be the same function object as
+        // DisposableStack.prototype.dispose. Alias the descriptor here so the @@dispose slot shares
+        // the same materialized function as `dispose` rather than emitting a separate dispatcher.
+        SetProperty(GlobalSymbolRegistry.Dispose, GetOwnProperty("dispose"));
     }
 
-
-    private JsValue Adopt(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue Adopt(JsValue thisObject, JsValue value, JsValue onDispose)
     {
         var stack = AssertDisposableStack(thisObject);
-        return stack.Adopt(arguments.At(0), arguments.At(1));
+        return stack.Adopt(value, onDispose);
     }
 
-    private JsValue Defer(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Defer(JsValue thisObject, JsValue onDispose)
     {
         var stack = AssertDisposableStack(thisObject);
-        stack.Defer(arguments.At(0));
+        stack.Defer(onDispose);
         return Undefined;
     }
 
-    private JsValue Dispose(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Dispose(JsValue thisObject)
     {
         var stack = AssertDisposableStack(thisObject);
         return stack.Dispose();
     }
 
-    private JsValue Disposed(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("disposed")]
+    private JsBoolean Disposed(JsValue thisObject)
     {
         var stack = AssertDisposableStack(thisObject);
-        return stack.State == DisposableState.Disposed;
+        return stack.State == DisposableState.Disposed ? JsBoolean.True : JsBoolean.False;
     }
 
-    private JsValue Move(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Move(JsValue thisObject)
     {
         var stack = AssertDisposableStack(thisObject);
         var newDisposableStack = _engine.Intrinsics.Function.OrdinaryCreateFromConstructor(
@@ -83,10 +75,11 @@ internal sealed class DisposableStackPrototype : Prototype
         return stack.Move(newDisposableStack);
     }
 
-    private JsValue Use(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Use(JsValue thisObject, JsValue value)
     {
         var stack = AssertDisposableStack(thisObject);
-        return stack.Use(arguments.At(0));
+        return stack.Use(value);
     }
 
     private DisposableStack AssertDisposableStack(JsValue thisObject)

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -1,11 +1,11 @@
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Error;
 
-public sealed class ErrorConstructor : Constructor
+[JsObject]
+public sealed partial class ErrorConstructor : Constructor
 {
     private readonly Func<Intrinsics, ObjectInstance> _intrinsicDefaultProto;
 
@@ -26,14 +26,7 @@ public sealed class ErrorConstructor : Constructor
 
     internal ErrorPrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        var properties = new PropertyDictionary(3, checkExistingKeys: false)
-        {
-            ["isError"] = new PropertyDescriptor(new PropertyDescriptor(new ClrFunction(Engine, "isError", IsError, 1), PropertyFlag.NonEnumerable)),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
@@ -97,8 +90,6 @@ public sealed class ErrorConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-is-error/
     /// </summary>
-    private static JsValue IsError(JsValue? thisObj, JsCallArguments arguments)
-    {
-        return arguments.At(0) is JsError;
-    }
+    [JsFunction(Length = 1)]
+    private static JsValue IsError(JsValue thisObject, JsValue arg) => arg is JsError;
 }

--- a/Jint/Native/Generator/GeneratorFunctionPrototype.cs
+++ b/Jint/Native/Generator/GeneratorFunctionPrototype.cs
@@ -21,7 +21,7 @@ internal sealed class GeneratorFunctionPrototype : Prototype
     {
         _constructor = constructor;
         _prototype = prototype;
-        PrototypeObject = new GeneratorPrototype(engine, this, iteratorPrototype);
+        PrototypeObject = new GeneratorPrototype(engine, engine.Realm, this, iteratorPrototype);
     }
 
     public GeneratorPrototype PrototypeObject { get; }

--- a/Jint/Native/Generator/GeneratorPrototype.cs
+++ b/Jint/Native/Generator/GeneratorPrototype.cs
@@ -1,18 +1,20 @@
-﻿using Jint.Native.Iterator;
+using Jint.Native.Iterator;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Generator;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-generator-objects
 /// </summary>
-internal sealed class GeneratorPrototype : ObjectInstance
+[JsObject]
+internal sealed partial class GeneratorPrototype : ObjectInstance
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.Configurable)]
     private readonly GeneratorFunctionPrototype _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString GeneratorToStringTag = new("Generator");
 
     internal GeneratorPrototype(
         Engine engine,
@@ -25,41 +27,27 @@ internal sealed class GeneratorPrototype : ObjectInstance
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        var properties = new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            [KnownKeys.Constructor] = new(_constructor, PropertyFlag.Configurable),
-            [KnownKeys.Next] = new(new ClrFunction(Engine, "next", Next, 1, LengthFlags), PropertyFlags),
-            [KnownKeys.Return] = new(new ClrFunction(Engine, "return", Return, 1, LengthFlags), PropertyFlags),
-            [KnownKeys.Throw] = new(new ClrFunction(Engine, "throw", Throw, 1, LengthFlags), PropertyFlags)
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Generator", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-generator.prototype.next
     /// </summary>
-    private ObjectInstance Next(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private ObjectInstance Next(JsValue thisObject, JsValue value)
     {
         var g = AssertGeneratorInstance(thisObject);
-        var value = arguments.At(0, null!);
         return g.GeneratorResume(value, null);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-generator.prototype.return
     /// </summary>
-    private JsValue Return(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Return(JsValue thisObject, JsValue value)
     {
         var g = AssertGeneratorInstance(thisObject);
-        var value = arguments.At(0);
         var C = new Completion(CompletionType.Return, value, null!);
         return g.GeneratorResumeAbrupt(C, null);
     }
@@ -67,10 +55,10 @@ internal sealed class GeneratorPrototype : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-generator.prototype.throw
     /// </summary>
-    private JsValue Throw(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Throw(JsValue thisObject, JsValue exception)
     {
         var g = AssertGeneratorInstance(thisObject);
-        var exception = arguments.At(0);
         var C = new Completion(CompletionType.Throw, exception, null!);
         return g.GeneratorResumeAbrupt(C, null);
     }

--- a/Jint/Native/Generator/GeneratorPrototype.cs
+++ b/Jint/Native/Generator/GeneratorPrototype.cs
@@ -11,6 +11,8 @@ namespace Jint.Native.Generator;
 [JsObject]
 internal sealed partial class GeneratorPrototype : ObjectInstance
 {
+    private readonly Realm _realm;
+
     [JsProperty(Name = "constructor", Flags = PropertyFlag.Configurable)]
     private readonly GeneratorFunctionPrototype _constructor;
 
@@ -18,9 +20,11 @@ internal sealed partial class GeneratorPrototype : ObjectInstance
 
     internal GeneratorPrototype(
         Engine engine,
+        Realm realm,
         GeneratorFunctionPrototype constructor,
         IteratorPrototype iteratorPrototype) : base(engine)
     {
+        _realm = realm;
         _constructor = constructor;
         _prototype = iteratorPrototype;
     }
@@ -68,7 +72,7 @@ internal sealed partial class GeneratorPrototype : ObjectInstance
         var generatorInstance = thisObj as GeneratorInstance;
         if (generatorInstance is null)
         {
-            Runtime.Throw.TypeError(_engine.Realm, "object must be a Generator instance");
+            Runtime.Throw.TypeError(_realm, "object must be a Generator instance");
         }
 
         return generatorInstance;

--- a/Jint/Native/Intl/CollatorConstructor.cs
+++ b/Jint/Native/Intl/CollatorConstructor.cs
@@ -11,7 +11,8 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-the-intl-collator-constructor
 /// </summary>
-internal sealed class CollatorConstructor : Constructor
+[JsObject]
+internal sealed partial class CollatorConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Collator");
     private static readonly StringSearchValues LocaleMatcherValues = new(["lookup", "best fit"], StringComparison.Ordinal);
@@ -58,15 +59,7 @@ internal sealed class CollatorConstructor : Constructor
 
     private CollatorPrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            ["supportedLocalesOf"] = new(new ClrFunction(Engine, "supportedLocalesOf", SupportedLocalesOf, 1, PropertyFlag.Configurable), PropertyFlags)
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     /// <summary>
     /// Called when Intl.Collator is invoked without `new`.
@@ -422,10 +415,9 @@ internal sealed class CollatorConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.collator.supportedlocalesof
     /// </summary>
-    private JsArray SupportedLocalesOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray SupportedLocalesOf(JsValue thisObject, JsValue locales, JsValue options)
     {
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
 
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
         var availableLocales = IntlUtilities.GetAvailableLocales();

--- a/Jint/Native/Intl/CollatorPrototype.cs
+++ b/Jint/Native/Intl/CollatorPrototype.cs
@@ -1,5 +1,4 @@
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
@@ -9,9 +8,13 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-the-intl-collator-prototype-object
 /// </summary>
-internal sealed class CollatorPrototype : Prototype
+[JsObject]
+internal sealed partial class CollatorPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly CollatorConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString CollatorToStringTag = new("Intl.Collator");
 
     public CollatorPrototype(Engine engine,
         Realm realm,
@@ -24,32 +27,8 @@ internal sealed class CollatorPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["resolvedOptions"] = new PropertyDescriptor(new ClrFunction(Engine, "resolvedOptions", ResolvedOptions, 0, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        // compare is an accessor property - accessor properties don't have writable attribute
-        SetAccessor("compare", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get compare", GetCompare, 0, LengthFlags),
-            Undefined,
-            PropertyFlag.Configurable));
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Intl.Collator", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
-    }
-
-    private void SetAccessor(string name, GetSetPropertyDescriptor descriptor)
-    {
-        SetProperty(name, descriptor);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     private JsCollator ValidateCollator(JsValue thisObject)
@@ -66,7 +45,8 @@ internal sealed class CollatorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.collator.prototype.compare
     /// </summary>
-    private ClrFunction GetCompare(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("compare")]
+    private ClrFunction GetCompare(JsValue thisObject)
     {
         var collator = ValidateCollator(thisObject);
 
@@ -84,7 +64,8 @@ internal sealed class CollatorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.collator.prototype.resolvedoptions
     /// </summary>
-    private JsObject ResolvedOptions(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsObject ResolvedOptions(JsValue thisObject)
     {
         var collator = ValidateCollator(thisObject);
 

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -23,7 +23,8 @@ internal enum DateTimeDefaults { Date, Time, YearMonth, MonthDay, ZonedDateTime,
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor
 /// </summary>
-internal sealed class DateTimeFormatConstructor : Constructor
+[JsObject]
+internal sealed partial class DateTimeFormatConstructor : Constructor
 {
     private static readonly JsString _functionName = new("DateTimeFormat");
     private static readonly StringSearchValues LocaleMatcherValues = new(["lookup", "best fit"], StringComparison.Ordinal);
@@ -62,15 +63,7 @@ internal sealed class DateTimeFormatConstructor : Constructor
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
     }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            ["supportedLocalesOf"] = new(new ClrFunction(Engine, "supportedLocalesOf", SupportedLocalesOf, 1, PropertyFlag.Configurable), PropertyFlags)
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     public DateTimeFormatPrototype PrototypeObject { get; }
 
@@ -703,10 +696,9 @@ internal sealed class DateTimeFormatConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.datetimeformat.supportedlocalesof
     /// </summary>
-    private JsArray SupportedLocalesOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray SupportedLocalesOf(JsValue thisObject, JsValue locales, JsValue options)
     {
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
 
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
         var availableLocales = IntlUtilities.GetAvailableLocales();

--- a/Jint/Native/Intl/DateTimeFormatPrototype.cs
+++ b/Jint/Native/Intl/DateTimeFormatPrototype.cs
@@ -1,6 +1,5 @@
 using System.Numerics;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Native.Temporal;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
@@ -11,9 +10,13 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-datetimeformat-prototype-object
 /// </summary>
-internal sealed class DateTimeFormatPrototype : Prototype
+[JsObject]
+internal sealed partial class DateTimeFormatPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly DateTimeFormatConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString DateTimeFormatToStringTag = new("Intl.DateTimeFormat");
 
     public DateTimeFormatPrototype(Engine engine,
         Realm realm,
@@ -26,35 +29,8 @@ internal sealed class DateTimeFormatPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(5, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["resolvedOptions"] = new PropertyDescriptor(new ClrFunction(Engine, "resolvedOptions", ResolvedOptions, 0, LengthFlags), PropertyFlags),
-            ["formatToParts"] = new PropertyDescriptor(new ClrFunction(Engine, "formatToParts", FormatToParts, 1, LengthFlags), PropertyFlags),
-            ["formatRange"] = new PropertyDescriptor(new ClrFunction(Engine, "formatRange", FormatRange, 2, LengthFlags), PropertyFlags),
-            ["formatRangeToParts"] = new PropertyDescriptor(new ClrFunction(Engine, "formatRangeToParts", FormatRangeToParts, 2, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        // format is an accessor property - accessor properties don't have writable attribute
-        SetAccessor("format", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get format", GetFormat, 0, LengthFlags),
-            Undefined,
-            PropertyFlag.Configurable));
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Intl.DateTimeFormat", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
-    }
-
-    private void SetAccessor(string name, GetSetPropertyDescriptor descriptor)
-    {
-        SetProperty(name, descriptor);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     private JsDateTimeFormat ValidateDateTimeFormat(JsValue thisObject)
@@ -71,7 +47,8 @@ internal sealed class DateTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.format
     /// </summary>
-    private ClrFunction GetFormat(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("format")]
+    private ClrFunction GetFormat(JsValue thisObject)
     {
         var dateTimeFormat = ValidateDateTimeFormat(thisObject);
 
@@ -99,10 +76,10 @@ internal sealed class DateTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.formattoparts
     /// </summary>
-    private JsArray FormatToParts(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray FormatToParts(JsValue thisObject, JsValue dateValue)
     {
         var dateTimeFormat = ValidateDateTimeFormat(thisObject);
-        var dateValue = arguments.At(0);
         var formattable = ToDateTimeFormattable(dateValue);
 
         List<JsDateTimeFormat.DateTimePart> parts;
@@ -775,7 +752,8 @@ internal sealed class DateTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.resolvedoptions
     /// </summary>
-    private JsObject ResolvedOptions(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsObject ResolvedOptions(JsValue thisObject)
     {
         var dateTimeFormat = ValidateDateTimeFormat(thisObject);
 
@@ -896,12 +874,10 @@ internal sealed class DateTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.formatrange
     /// </summary>
-    private JsValue FormatRange(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue FormatRange(JsValue thisObject, JsValue startDate, JsValue endDate)
     {
         var dateTimeFormat = ValidateDateTimeFormat(thisObject);
-
-        var startDate = arguments.At(0);
-        var endDate = arguments.At(1);
 
         // Validate arguments
         if (startDate.IsUndefined() || endDate.IsUndefined())
@@ -986,12 +962,10 @@ internal sealed class DateTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.formatrangetoparts
     /// </summary>
-    private JsArray FormatRangeToParts(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsArray FormatRangeToParts(JsValue thisObject, JsValue startDate, JsValue endDate)
     {
         var dateTimeFormat = ValidateDateTimeFormat(thisObject);
-
-        var startDate = arguments.At(0);
-        var endDate = arguments.At(1);
 
         // Validate arguments
         if (startDate.IsUndefined() || endDate.IsUndefined())

--- a/Jint/Native/Intl/DisplayNamesConstructor.cs
+++ b/Jint/Native/Intl/DisplayNamesConstructor.cs
@@ -11,7 +11,8 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-displaynames-constructor
 /// </summary>
-internal sealed class DisplayNamesConstructor : Constructor
+[JsObject]
+internal sealed partial class DisplayNamesConstructor : Constructor
 {
     private static readonly JsString _functionName = new("DisplayNames");
     private static readonly StringSearchValues LocaleMatcherValues = new(["lookup", "best fit"], StringComparison.Ordinal);
@@ -32,15 +33,7 @@ internal sealed class DisplayNamesConstructor : Constructor
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
     }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            ["supportedLocalesOf"] = new(new ClrFunction(Engine, "supportedLocalesOf", SupportedLocalesOf, 1, PropertyFlag.Configurable), PropertyFlags)
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     public DisplayNamesPrototype PrototypeObject { get; }
 
@@ -146,10 +139,9 @@ internal sealed class DisplayNamesConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.displaynames.supportedlocalesof
     /// </summary>
-    private JsArray SupportedLocalesOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray SupportedLocalesOf(JsValue thisObject, JsValue locales, JsValue options)
     {
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
 
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
         var availableLocales = IntlUtilities.GetAvailableLocales();

--- a/Jint/Native/Intl/DisplayNamesPrototype.cs
+++ b/Jint/Native/Intl/DisplayNamesPrototype.cs
@@ -1,19 +1,22 @@
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Intl;
 
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-displaynames-prototype-object
 /// </summary>
-internal sealed class DisplayNamesPrototype : Prototype
+[JsObject]
+internal sealed partial class DisplayNamesPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly DisplayNamesConstructor _constructor;
 
-    public DisplayNamesPrototype(Engine engine,
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString DisplayNamesToStringTag = new("Intl.DisplayNames");
+
+    public DisplayNamesPrototype(
+        Engine engine,
         Realm realm,
         DisplayNamesConstructor constructor,
         ObjectPrototype objectPrototype) : base(engine, realm)
@@ -24,22 +27,8 @@ internal sealed class DisplayNamesPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(3, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["of"] = new PropertyDescriptor(new ClrFunction(Engine, "of", Of, 1, LengthFlags), PropertyFlags),
-            ["resolvedOptions"] = new PropertyDescriptor(new ClrFunction(Engine, "resolvedOptions", ResolvedOptions, 0, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Intl.DisplayNames", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     private JsDisplayNames ValidateDisplayNames(JsValue thisObject)
@@ -56,10 +45,10 @@ internal sealed class DisplayNamesPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.displaynames.prototype.of
     /// </summary>
-    private JsValue Of(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Of(JsValue thisObject, JsValue code)
     {
         var displayNames = ValidateDisplayNames(thisObject);
-        var code = arguments.At(0);
 
         // code argument is required
         if (code.IsUndefined())
@@ -398,7 +387,8 @@ internal sealed class DisplayNamesPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.displaynames.prototype.resolvedoptions
     /// </summary>
-    private JsObject ResolvedOptions(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsObject ResolvedOptions(JsValue thisObject)
     {
         var displayNames = ValidateDisplayNames(thisObject);
 

--- a/Jint/Native/Intl/DurationFormatConstructor.cs
+++ b/Jint/Native/Intl/DurationFormatConstructor.cs
@@ -11,7 +11,8 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/proposal-intl-duration-format/
 /// </summary>
-internal sealed class DurationFormatConstructor : Constructor
+[JsObject]
+internal sealed partial class DurationFormatConstructor : Constructor
 {
     private static readonly JsString _functionName = new("DurationFormat");
     private static readonly string[] LocaleMatcherValues = ["lookup", "best fit"];
@@ -33,15 +34,7 @@ internal sealed class DurationFormatConstructor : Constructor
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
     }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            ["supportedLocalesOf"] = new(new ClrFunction(Engine, "supportedLocalesOf", SupportedLocalesOf, 1, PropertyFlag.Configurable), PropertyFlags)
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     public DurationFormatPrototype PrototypeObject { get; }
 
@@ -338,10 +331,9 @@ internal sealed class DurationFormatConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-intl-duration-format/#sec-intl.durationformat.supportedlocalesof
     /// </summary>
-    private JsArray SupportedLocalesOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray SupportedLocalesOf(JsValue thisObject, JsValue locales, JsValue options)
     {
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
 
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
         var availableLocales = IntlUtilities.GetAvailableLocales();

--- a/Jint/Native/Intl/DurationFormatPrototype.cs
+++ b/Jint/Native/Intl/DurationFormatPrototype.cs
@@ -1,19 +1,21 @@
 using System.Numerics;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Native.Temporal;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Intl;
 
 /// <summary>
 /// https://tc39.es/proposal-intl-duration-format/
 /// </summary>
-internal sealed class DurationFormatPrototype : Prototype
+[JsObject]
+internal sealed partial class DurationFormatPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly DurationFormatConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString DurationFormatToStringTag = new("Intl.DurationFormat");
 
     public DurationFormatPrototype(
         Engine engine,
@@ -27,23 +29,8 @@ internal sealed class DurationFormatPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["format"] = new PropertyDescriptor(new ClrFunction(Engine, "format", Format, 1, LengthFlags), PropertyFlags),
-            ["formatToParts"] = new PropertyDescriptor(new ClrFunction(Engine, "formatToParts", FormatToParts, 1, LengthFlags), PropertyFlags),
-            ["resolvedOptions"] = new PropertyDescriptor(new ClrFunction(Engine, "resolvedOptions", ResolvedOptions, 0, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Intl.DurationFormat", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     private JsDurationFormat ValidateDurationFormat(JsValue thisObject)
@@ -60,11 +47,10 @@ internal sealed class DurationFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-intl-duration-format/#sec-intl.durationformat.prototype.format
     /// </summary>
-    private JsValue Format(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Format(JsValue thisObject, JsValue duration)
     {
         var durationFormat = ValidateDurationFormat(thisObject);
-        var duration = arguments.At(0);
-
         var durationRecord = ToDurationRecord(duration);
         return durationFormat.Format(durationRecord);
     }
@@ -72,11 +58,10 @@ internal sealed class DurationFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-intl-duration-format/#sec-intl.durationformat.prototype.formattoparts
     /// </summary>
-    private JsArray FormatToParts(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray FormatToParts(JsValue thisObject, JsValue duration)
     {
         var durationFormat = ValidateDurationFormat(thisObject);
-        var duration = arguments.At(0);
-
         var durationRecord = ToDurationRecord(duration);
         return durationFormat.FormatToParts(_engine, durationRecord);
     }
@@ -84,7 +69,8 @@ internal sealed class DurationFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-intl-duration-format/#sec-intl.durationformat.prototype.resolvedoptions
     /// </summary>
-    private JsObject ResolvedOptions(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsObject ResolvedOptions(JsValue thisObject)
     {
         var durationFormat = ValidateDurationFormat(thisObject);
 

--- a/Jint/Native/Intl/IntlInstance.cs
+++ b/Jint/Native/Intl/IntlInstance.cs
@@ -1,18 +1,19 @@
 using System.Linq;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Intl;
 
 /// <summary>
 /// https://tc39.es/ecma402/#intl-object
 /// </summary>
-internal sealed class IntlInstance : ObjectInstance
+[JsObject]
+internal sealed partial class IntlInstance : ObjectInstance
 {
     private readonly Realm _realm;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString IntlToStringTag = new("Intl");
 
     internal IntlInstance(
         Engine engine,
@@ -30,47 +31,40 @@ internal sealed class IntlInstance : ObjectInstance
 
     protected override void Initialize()
     {
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+
+        // Constructor references aren't generator-friendly (they pull from _realm.Intrinsics);
+        // register them after generated properties to avoid a separate generator feature.
         const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(13, checkExistingKeys: false)
-        {
-            ["Collator"] = new(_realm.Intrinsics.Collator, PropertyFlags),
-            ["DateTimeFormat"] = new(_realm.Intrinsics.DateTimeFormat, PropertyFlags),
-            ["DisplayNames"] = new(_realm.Intrinsics.DisplayNames, PropertyFlags),
-            ["DurationFormat"] = new(_realm.Intrinsics.DurationFormat, PropertyFlags),
-            ["ListFormat"] = new(_realm.Intrinsics.ListFormat, PropertyFlags),
-            ["Locale"] = new(_realm.Intrinsics.Locale, PropertyFlags),
-            ["NumberFormat"] = new(_realm.Intrinsics.NumberFormat, PropertyFlags),
-            ["PluralRules"] = new(_realm.Intrinsics.PluralRules, PropertyFlags),
-            ["RelativeTimeFormat"] = new(_realm.Intrinsics.RelativeTimeFormat, PropertyFlags),
-            ["Segmenter"] = new(_realm.Intrinsics.Segmenter, PropertyFlags),
-            ["getCanonicalLocales"] = new(new ClrFunction(Engine, "getCanonicalLocales", GetCanonicalLocales, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["supportedValuesOf"] = new(new ClrFunction(Engine, "supportedValuesOf", SupportedValuesOf, 1, PropertyFlag.Configurable), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Intl", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        SetProperty("Collator", new PropertyDescriptor(_realm.Intrinsics.Collator, PropertyFlags));
+        SetProperty("DateTimeFormat", new PropertyDescriptor(_realm.Intrinsics.DateTimeFormat, PropertyFlags));
+        SetProperty("DisplayNames", new PropertyDescriptor(_realm.Intrinsics.DisplayNames, PropertyFlags));
+        SetProperty("DurationFormat", new PropertyDescriptor(_realm.Intrinsics.DurationFormat, PropertyFlags));
+        SetProperty("ListFormat", new PropertyDescriptor(_realm.Intrinsics.ListFormat, PropertyFlags));
+        SetProperty("Locale", new PropertyDescriptor(_realm.Intrinsics.Locale, PropertyFlags));
+        SetProperty("NumberFormat", new PropertyDescriptor(_realm.Intrinsics.NumberFormat, PropertyFlags));
+        SetProperty("PluralRules", new PropertyDescriptor(_realm.Intrinsics.PluralRules, PropertyFlags));
+        SetProperty("RelativeTimeFormat", new PropertyDescriptor(_realm.Intrinsics.RelativeTimeFormat, PropertyFlags));
+        SetProperty("Segmenter", new PropertyDescriptor(_realm.Intrinsics.Segmenter, PropertyFlags));
     }
 
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.getcanonicallocales
     /// </summary>
-    private JsArray GetCanonicalLocales(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray GetCanonicalLocales(JsValue thisObject, JsValue locales)
     {
-        var locales = arguments.At(0);
         return new JsArray(_engine, IntlUtilities.CanonicalizeLocaleList(_engine, locales).Select(x => new JsString(x)).ToArray<JsValue>());
     }
 
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.supportedvaluesof
     /// </summary>
-    private JsValue SupportedValuesOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue SupportedValuesOf(JsValue thisObject, JsValue keyArg)
     {
-        var key = TypeConverter.ToString(arguments.At(0));
+        var key = TypeConverter.ToString(keyArg);
 
         string[] values;
         switch (key)

--- a/Jint/Native/Intl/IntlInstance.cs
+++ b/Jint/Native/Intl/IntlInstance.cs
@@ -8,7 +8,10 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#intl-object
 /// </summary>
-[JsObject]
+// ExtraCapacity = 10 covers the post-Initialize SetProperty calls below for the 10 sub-namespace
+// constructor refs (Collator/DateTimeFormat/.../Segmenter), which can't be expressed via [JsProperty]
+// because they read from _realm.Intrinsics.X (not generator-friendly).
+[JsObject(ExtraCapacity = 10)]
 internal sealed partial class IntlInstance : ObjectInstance
 {
     private readonly Realm _realm;

--- a/Jint/Native/Intl/ListFormatConstructor.cs
+++ b/Jint/Native/Intl/ListFormatConstructor.cs
@@ -11,7 +11,8 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-listformat-constructor
 /// </summary>
-internal sealed class ListFormatConstructor : Constructor
+[JsObject]
+internal sealed partial class ListFormatConstructor : Constructor
 {
     private static readonly JsString _functionName = new("ListFormat");
     private static readonly StringSearchValues LocaleMatcherValues = new(["lookup", "best fit"], StringComparison.Ordinal);
@@ -30,15 +31,7 @@ internal sealed class ListFormatConstructor : Constructor
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
     }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            ["supportedLocalesOf"] = new(new ClrFunction(Engine, "supportedLocalesOf", SupportedLocalesOf, 1, PropertyFlag.Configurable), PropertyFlags)
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     public ListFormatPrototype PrototypeObject { get; }
 
@@ -119,10 +112,9 @@ internal sealed class ListFormatConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.listformat.supportedlocalesof
     /// </summary>
-    private JsArray SupportedLocalesOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray SupportedLocalesOf(JsValue thisObject, JsValue locales, JsValue options)
     {
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
 
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
         var availableLocales = IntlUtilities.GetAvailableLocales();

--- a/Jint/Native/Intl/ListFormatPrototype.cs
+++ b/Jint/Native/Intl/ListFormatPrototype.cs
@@ -2,18 +2,22 @@ using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Intl;
 
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-listformat-prototype-object
 /// </summary>
-internal sealed class ListFormatPrototype : Prototype
+[JsObject]
+internal sealed partial class ListFormatPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly ListFormatConstructor _constructor;
 
-    public ListFormatPrototype(Engine engine,
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString ListFormatToStringTag = new("Intl.ListFormat");
+
+    public ListFormatPrototype(
+        Engine engine,
         Realm realm,
         ListFormatConstructor constructor,
         ObjectPrototype objectPrototype) : base(engine, realm)
@@ -24,23 +28,8 @@ internal sealed class ListFormatPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["format"] = new PropertyDescriptor(new ClrFunction(Engine, "format", Format, 1, LengthFlags), PropertyFlags),
-            ["formatToParts"] = new PropertyDescriptor(new ClrFunction(Engine, "formatToParts", FormatToParts, 1, LengthFlags), PropertyFlags),
-            ["resolvedOptions"] = new PropertyDescriptor(new ClrFunction(Engine, "resolvedOptions", ResolvedOptions, 0, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Intl.ListFormat", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     private JsListFormat ValidateListFormat(JsValue thisObject)
@@ -57,11 +46,10 @@ internal sealed class ListFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.listformat.prototype.format
     /// </summary>
-    private JsValue Format(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Format(JsValue thisObject, JsValue list)
     {
         var listFormat = ValidateListFormat(thisObject);
-        var list = arguments.At(0);
-
         var stringList = StringListFromIterable(list);
         return listFormat.Format(stringList);
     }
@@ -69,11 +57,10 @@ internal sealed class ListFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.listformat.prototype.formattoparts
     /// </summary>
-    private JsArray FormatToParts(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray FormatToParts(JsValue thisObject, JsValue list)
     {
         var listFormat = ValidateListFormat(thisObject);
-        var list = arguments.At(0);
-
         var stringList = StringListFromIterable(list);
         return listFormat.FormatToParts(Engine, stringList);
     }
@@ -81,7 +68,8 @@ internal sealed class ListFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.listformat.prototype.resolvedoptions
     /// </summary>
-    private JsObject ResolvedOptions(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsObject ResolvedOptions(JsValue thisObject)
     {
         var listFormat = ValidateListFormat(thisObject);
 

--- a/Jint/Native/Intl/LocalePrototype.cs
+++ b/Jint/Native/Intl/LocalePrototype.cs
@@ -1,18 +1,20 @@
 using Jint.Native.Intl.Data;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Intl;
 
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-locale-prototype-object
 /// </summary>
-internal sealed class LocalePrototype : Prototype
+[JsObject]
+internal sealed partial class LocalePrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly LocaleConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString LocaleToStringTag = new("Intl.Locale");
 
     public LocalePrototype(Engine engine,
         Realm realm,
@@ -25,97 +27,8 @@ internal sealed class LocalePrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag AccessorFlags = PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(11, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["maximize"] = new PropertyDescriptor(new ClrFunction(Engine, "maximize", Maximize, 0, LengthFlags), PropertyFlags),
-            ["minimize"] = new PropertyDescriptor(new ClrFunction(Engine, "minimize", Minimize, 0, LengthFlags), PropertyFlags),
-            ["toString"] = new PropertyDescriptor(new ClrFunction(Engine, "toString", ToLocaleString, 0, LengthFlags), PropertyFlags),
-            ["getCalendars"] = new PropertyDescriptor(new ClrFunction(Engine, "getCalendars", GetCalendars, 0, LengthFlags), PropertyFlags),
-            ["getCollations"] = new PropertyDescriptor(new ClrFunction(Engine, "getCollations", GetCollations, 0, LengthFlags), PropertyFlags),
-            ["getHourCycles"] = new PropertyDescriptor(new ClrFunction(Engine, "getHourCycles", GetHourCycles, 0, LengthFlags), PropertyFlags),
-            ["getNumberingSystems"] = new PropertyDescriptor(new ClrFunction(Engine, "getNumberingSystems", GetNumberingSystems, 0, LengthFlags), PropertyFlags),
-            ["getTimeZones"] = new PropertyDescriptor(new ClrFunction(Engine, "getTimeZones", GetTimeZones, 0, LengthFlags), PropertyFlags),
-            ["getTextInfo"] = new PropertyDescriptor(new ClrFunction(Engine, "getTextInfo", GetTextInfo, 0, LengthFlags), PropertyFlags),
-            ["getWeekInfo"] = new PropertyDescriptor(new ClrFunction(Engine, "getWeekInfo", GetWeekInfo, 0, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        // Accessor properties - accessor properties don't have writable attribute
-        SetAccessor("baseName", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get baseName", GetBaseName, 0, LengthFlags),
-            Undefined,
-            AccessorFlags));
-
-        SetAccessor("calendar", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get calendar", GetCalendar, 0, LengthFlags),
-            Undefined,
-            AccessorFlags));
-
-        SetAccessor("caseFirst", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get caseFirst", GetCaseFirst, 0, LengthFlags),
-            Undefined,
-            AccessorFlags));
-
-        SetAccessor("collation", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get collation", GetCollation, 0, LengthFlags),
-            Undefined,
-            AccessorFlags));
-
-        SetAccessor("hourCycle", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get hourCycle", GetHourCycle, 0, LengthFlags),
-            Undefined,
-            AccessorFlags));
-
-        SetAccessor("language", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get language", GetLanguage, 0, LengthFlags),
-            Undefined,
-            AccessorFlags));
-
-        SetAccessor("numberingSystem", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get numberingSystem", GetNumberingSystem, 0, LengthFlags),
-            Undefined,
-            AccessorFlags));
-
-        SetAccessor("numeric", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get numeric", GetNumeric, 0, LengthFlags),
-            Undefined,
-            AccessorFlags));
-
-        SetAccessor("region", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get region", GetRegion, 0, LengthFlags),
-            Undefined,
-            AccessorFlags));
-
-        SetAccessor("script", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get script", GetScript, 0, LengthFlags),
-            Undefined,
-            AccessorFlags));
-
-        SetAccessor("firstDayOfWeek", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get firstDayOfWeek", GetFirstDayOfWeek, 0, LengthFlags),
-            Undefined,
-            AccessorFlags));
-
-        SetAccessor("variants", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get variants", GetVariants, 0, LengthFlags),
-            Undefined,
-            AccessorFlags));
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Intl.Locale", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
-    }
-
-    private void SetAccessor(string name, GetSetPropertyDescriptor descriptor)
-    {
-        SetProperty(name, descriptor);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     private JsLocale ValidateLocale(JsValue thisObject)
@@ -132,7 +45,8 @@ internal sealed class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.maximize
     /// </summary>
-    private ObjectInstance Maximize(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private ObjectInstance Maximize(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
 
@@ -146,7 +60,8 @@ internal sealed class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.minimize
     /// </summary>
-    private ObjectInstance Minimize(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private ObjectInstance Minimize(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
 
@@ -159,67 +74,78 @@ internal sealed class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
     /// </summary>
-    private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0, Name = "toString")]
+    private JsValue ToLocaleString(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         return locale.Locale;
     }
 
-    private JsValue GetBaseName(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("baseName")]
+    private JsValue GetBaseName(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         return locale.BaseName;
     }
 
-    private JsValue GetCalendar(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("calendar")]
+    private JsValue GetCalendar(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         return locale.Calendar ?? Undefined;
     }
 
-    private JsValue GetCaseFirst(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("caseFirst")]
+    private JsValue GetCaseFirst(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         return locale.CaseFirst ?? Undefined;
     }
 
-    private JsValue GetCollation(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("collation")]
+    private JsValue GetCollation(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         return locale.Collation ?? Undefined;
     }
 
-    private JsValue GetHourCycle(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("hourCycle")]
+    private JsValue GetHourCycle(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         return locale.HourCycle ?? Undefined;
     }
 
-    private JsValue GetLanguage(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("language")]
+    private JsValue GetLanguage(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         return locale.Language;
     }
 
-    private JsValue GetNumberingSystem(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("numberingSystem")]
+    private JsValue GetNumberingSystem(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         return locale.NumberingSystem ?? Undefined;
     }
 
-    private JsBoolean GetNumeric(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("numeric")]
+    private JsBoolean GetNumeric(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         return locale.Numeric.HasValue ? (locale.Numeric.Value ? JsBoolean.True : JsBoolean.False) : JsBoolean.False;
     }
 
-    private JsValue GetRegion(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("region")]
+    private JsValue GetRegion(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         return locale.Region ?? Undefined;
     }
 
-    private JsValue GetScript(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("script")]
+    private JsValue GetScript(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         return locale.Script ?? Undefined;
@@ -229,7 +155,8 @@ internal sealed class LocalePrototype : Prototype
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.variants
     /// Returns hyphen-separated variants string or undefined if no variants.
     /// </summary>
-    private JsValue GetVariants(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("variants")]
+    private JsValue GetVariants(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         var variants = locale.Variants;
@@ -242,7 +169,8 @@ internal sealed class LocalePrototype : Prototype
         return string.Join("-", variants);
     }
 
-    private JsValue GetFirstDayOfWeek(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("firstDayOfWeek")]
+    private JsValue GetFirstDayOfWeek(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
 
@@ -259,7 +187,8 @@ internal sealed class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getCalendars
     /// </summary>
-    private JsArray GetCalendars(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsArray GetCalendars(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
 
@@ -273,7 +202,8 @@ internal sealed class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getCollations
     /// </summary>
-    private JsArray GetCollations(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsArray GetCollations(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
 
@@ -286,7 +216,8 @@ internal sealed class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getHourCycles
     /// </summary>
-    private JsArray GetHourCycles(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsArray GetHourCycles(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         var culture = locale.CultureInfo;
@@ -305,7 +236,8 @@ internal sealed class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getNumberingSystems
     /// </summary>
-    private JsArray GetNumberingSystems(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsArray GetNumberingSystems(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
 
@@ -319,7 +251,8 @@ internal sealed class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getTimeZones
     /// </summary>
-    private JsValue GetTimeZones(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsValue GetTimeZones(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
 
@@ -360,7 +293,8 @@ internal sealed class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getTextInfo
     /// </summary>
-    private JsObject GetTextInfo(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsObject GetTextInfo(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         var culture = locale.CultureInfo;
@@ -378,7 +312,8 @@ internal sealed class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getWeekInfo
     /// </summary>
-    private JsObject GetWeekInfo(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsObject GetWeekInfo(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
         var region = locale.Region;

--- a/Jint/Native/Intl/NumberFormatConstructor.cs
+++ b/Jint/Native/Intl/NumberFormatConstructor.cs
@@ -12,7 +12,8 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-numberformat-constructor
 /// </summary>
-internal sealed class NumberFormatConstructor : Constructor
+[JsObject]
+internal sealed partial class NumberFormatConstructor : Constructor
 {
     private static readonly JsString _functionName = new("NumberFormat");
     private static readonly string[] LocaleMatcherValues = ["lookup", "best fit"];
@@ -39,15 +40,7 @@ internal sealed class NumberFormatConstructor : Constructor
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
     }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            ["supportedLocalesOf"] = new(new ClrFunction(Engine, "supportedLocalesOf", SupportedLocalesOf, 1, PropertyFlag.Configurable), PropertyFlags)
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     public NumberFormatPrototype PrototypeObject { get; }
 
@@ -901,10 +894,9 @@ internal sealed class NumberFormatConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.numberformat.supportedlocalesof
     /// </summary>
-    private JsArray SupportedLocalesOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray SupportedLocalesOf(JsValue thisObject, JsValue locales, JsValue options)
     {
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
 
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
         var availableLocales = IntlUtilities.GetAvailableLocales();

--- a/Jint/Native/Intl/NumberFormatPrototype.cs
+++ b/Jint/Native/Intl/NumberFormatPrototype.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using System.Numerics;
 using Jint.Native.BigInt;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
@@ -12,9 +11,13 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-numberformat-prototype-object
 /// </summary>
-internal sealed class NumberFormatPrototype : Prototype
+[JsObject]
+internal sealed partial class NumberFormatPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly NumberFormatConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString NumberFormatToStringTag = new("Intl.NumberFormat");
 
     public NumberFormatPrototype(
         Engine engine,
@@ -28,35 +31,8 @@ internal sealed class NumberFormatPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(5, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["resolvedOptions"] = new PropertyDescriptor(new ClrFunction(Engine, "resolvedOptions", ResolvedOptions, 0, LengthFlags), PropertyFlags),
-            ["formatToParts"] = new PropertyDescriptor(new ClrFunction(Engine, "formatToParts", FormatToParts, 1, LengthFlags), PropertyFlags),
-            ["formatRange"] = new PropertyDescriptor(new ClrFunction(Engine, "formatRange", FormatRange, 2, LengthFlags), PropertyFlags),
-            ["formatRangeToParts"] = new PropertyDescriptor(new ClrFunction(Engine, "formatRangeToParts", FormatRangeToParts, 2, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        // format is an accessor property - accessor properties don't have writable attribute
-        SetAccessor("format", new GetSetPropertyDescriptor(
-            new ClrFunction(Engine, "get format", GetFormat, 0, LengthFlags),
-            Undefined,
-            PropertyFlag.Configurable));
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Intl.NumberFormat", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
-    }
-
-    private void SetAccessor(string name, GetSetPropertyDescriptor descriptor)
-    {
-        SetProperty(name, descriptor);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     private JsNumberFormat ValidateNumberFormat(JsValue thisObject)
@@ -73,7 +49,8 @@ internal sealed class NumberFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.numberformat.prototype.format
     /// </summary>
-    private ClrFunction GetFormat(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("format")]
+    private ClrFunction GetFormat(JsValue thisObject)
     {
         var numberFormat = ValidateNumberFormat(thisObject);
 
@@ -217,7 +194,8 @@ internal sealed class NumberFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.numberformat.prototype.resolvedoptions
     /// </summary>
-    private JsObject ResolvedOptions(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsObject ResolvedOptions(JsValue thisObject)
     {
         var numberFormat = ValidateNumberFormat(thisObject);
 
@@ -284,10 +262,10 @@ internal sealed class NumberFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formattoparts
     /// </summary>
-    private JsArray FormatToParts(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray FormatToParts(JsValue thisObject, JsValue value)
     {
         var numberFormat = ValidateNumberFormat(thisObject);
-        var value = arguments.At(0);
 
         double number;
         if (value.IsUndefined())
@@ -318,12 +296,10 @@ internal sealed class NumberFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formatrange
     /// </summary>
-    private JsValue FormatRange(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue FormatRange(JsValue thisObject, JsValue start, JsValue end)
     {
         var numberFormat = ValidateNumberFormat(thisObject);
-
-        var start = arguments.At(0);
-        var end = arguments.At(1);
 
         // Validate arguments
         if (start.IsUndefined() || end.IsUndefined())
@@ -503,12 +479,10 @@ internal sealed class NumberFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formatrangetoparts
     /// </summary>
-    private JsArray FormatRangeToParts(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsArray FormatRangeToParts(JsValue thisObject, JsValue start, JsValue end)
     {
         var numberFormat = ValidateNumberFormat(thisObject);
-
-        var start = arguments.At(0);
-        var end = arguments.At(1);
 
         // Validate arguments
         if (start.IsUndefined() || end.IsUndefined())

--- a/Jint/Native/Intl/PluralRulesConstructor.cs
+++ b/Jint/Native/Intl/PluralRulesConstructor.cs
@@ -11,7 +11,8 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-pluralrules-constructor
 /// </summary>
-internal sealed class PluralRulesConstructor : Constructor
+[JsObject]
+internal sealed partial class PluralRulesConstructor : Constructor
 {
     private static readonly JsString _functionName = new("PluralRules");
     private static readonly StringSearchValues LocaleMatcherValues = new(["lookup", "best fit"], StringComparison.Ordinal);
@@ -33,15 +34,7 @@ internal sealed class PluralRulesConstructor : Constructor
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
     }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            ["supportedLocalesOf"] = new(new ClrFunction(Engine, "supportedLocalesOf", SupportedLocalesOf, 1, PropertyFlag.Configurable), PropertyFlags)
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     public PluralRulesPrototype PrototypeObject { get; }
 
@@ -204,11 +197,9 @@ internal sealed class PluralRulesConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.pluralrules.supportedlocalesof
     /// </summary>
-    private JsArray SupportedLocalesOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray SupportedLocalesOf(JsValue thisObject, JsValue locales, JsValue options)
     {
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
-
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
         var availableLocales = IntlUtilities.GetAvailableLocales();
 

--- a/Jint/Native/Intl/PluralRulesPrototype.cs
+++ b/Jint/Native/Intl/PluralRulesPrototype.cs
@@ -1,17 +1,19 @@
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Intl;
 
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-pluralrules-prototype-object
 /// </summary>
-internal sealed class PluralRulesPrototype : Prototype
+[JsObject]
+internal sealed partial class PluralRulesPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly PluralRulesConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString PluralRulesToStringTag = new("Intl.PluralRules");
 
     public PluralRulesPrototype(
         Engine engine,
@@ -25,23 +27,8 @@ internal sealed class PluralRulesPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["select"] = new PropertyDescriptor(new ClrFunction(Engine, "select", Select, 1, LengthFlags), PropertyFlags),
-            ["selectRange"] = new PropertyDescriptor(new ClrFunction(Engine, "selectRange", SelectRange, 2, LengthFlags), PropertyFlags),
-            ["resolvedOptions"] = new PropertyDescriptor(new ClrFunction(Engine, "resolvedOptions", ResolvedOptions, 0, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Intl.PluralRules", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     private JsPluralRules ValidatePluralRules(JsValue thisObject)
@@ -58,11 +45,10 @@ internal sealed class PluralRulesPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.select
     /// </summary>
-    private JsValue Select(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Select(JsValue thisObject, JsValue n)
     {
         var pluralRules = ValidatePluralRules(thisObject);
-        var n = arguments.At(0);
-
         var x = TypeConverter.ToNumber(n);
         return pluralRules.Select(x);
     }
@@ -70,11 +56,10 @@ internal sealed class PluralRulesPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.selectrange
     /// </summary>
-    private JsValue SelectRange(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue SelectRange(JsValue thisObject, JsValue start, JsValue end)
     {
         var pluralRules = ValidatePluralRules(thisObject);
-        var start = arguments.At(0);
-        var end = arguments.At(1);
 
         if (start.IsUndefined())
         {
@@ -102,7 +87,8 @@ internal sealed class PluralRulesPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.resolvedoptions
     /// </summary>
-    private JsObject ResolvedOptions(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsObject ResolvedOptions(JsValue thisObject)
     {
         var pluralRules = ValidatePluralRules(thisObject);
 

--- a/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
@@ -10,7 +10,8 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-relativetimeformat-constructor
 /// </summary>
-internal sealed class RelativeTimeFormatConstructor : Constructor
+[JsObject]
+internal sealed partial class RelativeTimeFormatConstructor : Constructor
 {
     private static readonly JsString _functionName = new("RelativeTimeFormat");
     private static readonly string[] LocaleMatcherValues = ["lookup", "best fit"];
@@ -29,15 +30,7 @@ internal sealed class RelativeTimeFormatConstructor : Constructor
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
     }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            ["supportedLocalesOf"] = new(new ClrFunction(Engine, "supportedLocalesOf", SupportedLocalesOf, 1, PropertyFlag.Configurable), PropertyFlags)
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     public RelativeTimeFormatPrototype PrototypeObject { get; }
 
@@ -349,10 +342,9 @@ internal sealed class RelativeTimeFormatConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.relativetimeformat.supportedlocalesof
     /// </summary>
-    private JsArray SupportedLocalesOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray SupportedLocalesOf(JsValue thisObject, JsValue locales, JsValue options)
     {
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
 
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
         var availableLocales = IntlUtilities.GetAvailableLocales();

--- a/Jint/Native/Intl/RelativeTimeFormatPrototype.cs
+++ b/Jint/Native/Intl/RelativeTimeFormatPrototype.cs
@@ -1,19 +1,21 @@
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Intl;
 
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-relativetimeformat-prototype-object
 /// </summary>
-internal sealed class RelativeTimeFormatPrototype : Prototype
+[JsObject]
+internal sealed partial class RelativeTimeFormatPrototype : Prototype
 {
     private static readonly string[] ValidUnits = ["second", "seconds", "minute", "minutes", "hour", "hours", "day", "days", "week", "weeks", "month", "months", "quarter", "quarters", "year", "years"];
 
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly RelativeTimeFormatConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString RelativeTimeFormatToStringTag = new("Intl.RelativeTimeFormat");
 
     public RelativeTimeFormatPrototype(
         Engine engine,
@@ -27,23 +29,8 @@ internal sealed class RelativeTimeFormatPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["format"] = new PropertyDescriptor(new ClrFunction(Engine, "format", Format, 2, LengthFlags), PropertyFlags),
-            ["formatToParts"] = new PropertyDescriptor(new ClrFunction(Engine, "formatToParts", FormatToParts, 2, LengthFlags), PropertyFlags),
-            ["resolvedOptions"] = new PropertyDescriptor(new ClrFunction(Engine, "resolvedOptions", ResolvedOptions, 0, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Intl.RelativeTimeFormat", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     private JsRelativeTimeFormat ValidateRelativeTimeFormat(JsValue thisObject)
@@ -60,11 +47,10 @@ internal sealed class RelativeTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.format
     /// </summary>
-    private JsValue Format(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue Format(JsValue thisObject, JsValue value, JsValue unit)
     {
         var relativeTimeFormat = ValidateRelativeTimeFormat(thisObject);
-        var value = arguments.At(0);
-        var unit = arguments.At(1);
 
         var numericValue = TypeConverter.ToNumber(value);
         if (double.IsNaN(numericValue) || double.IsInfinity(numericValue))
@@ -85,11 +71,10 @@ internal sealed class RelativeTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.formattoparts
     /// </summary>
-    private JsArray FormatToParts(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsArray FormatToParts(JsValue thisObject, JsValue value, JsValue unit)
     {
         var relativeTimeFormat = ValidateRelativeTimeFormat(thisObject);
-        var value = arguments.At(0);
-        var unit = arguments.At(1);
 
         var numericValue = TypeConverter.ToNumber(value);
         if (double.IsNaN(numericValue) || double.IsInfinity(numericValue))
@@ -110,7 +95,8 @@ internal sealed class RelativeTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.resolvedoptions
     /// </summary>
-    private JsObject ResolvedOptions(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsObject ResolvedOptions(JsValue thisObject)
     {
         var relativeTimeFormat = ValidateRelativeTimeFormat(thisObject);
 

--- a/Jint/Native/Intl/SegmenterConstructor.cs
+++ b/Jint/Native/Intl/SegmenterConstructor.cs
@@ -10,7 +10,8 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-segmenter-constructor
 /// </summary>
-internal sealed class SegmenterConstructor : Constructor
+[JsObject]
+internal sealed partial class SegmenterConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Segmenter");
     private static readonly string[] LocaleMatcherValues = ["lookup", "best fit"];
@@ -28,15 +29,7 @@ internal sealed class SegmenterConstructor : Constructor
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
     }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            ["supportedLocalesOf"] = new(new ClrFunction(Engine, "supportedLocalesOf", SupportedLocalesOf, 1, PropertyFlag.Configurable), PropertyFlags)
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     private SegmenterPrototype PrototypeObject { get; }
 
@@ -120,10 +113,9 @@ internal sealed class SegmenterConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.segmenter.supportedlocalesof
     /// </summary>
-    private JsArray SupportedLocalesOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsArray SupportedLocalesOf(JsValue thisObject, JsValue locales, JsValue options)
     {
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
 
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
         var availableLocales = IntlUtilities.GetAvailableLocales();

--- a/Jint/Native/Intl/SegmenterPrototype.cs
+++ b/Jint/Native/Intl/SegmenterPrototype.cs
@@ -1,17 +1,19 @@
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Intl;
 
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-segmenter-prototype-object
 /// </summary>
-internal sealed class SegmenterPrototype : Prototype
+[JsObject]
+internal sealed partial class SegmenterPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly SegmenterConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString SegmenterToStringTag = new("Intl.Segmenter");
 
     public SegmenterPrototype(
         Engine engine,
@@ -25,22 +27,8 @@ internal sealed class SegmenterPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(3, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["segment"] = new PropertyDescriptor(new ClrFunction(Engine, "segment", Segment, 1, LengthFlags), PropertyFlags),
-            ["resolvedOptions"] = new PropertyDescriptor(new ClrFunction(Engine, "resolvedOptions", ResolvedOptions, 0, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Intl.Segmenter", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     private JsSegmenter ValidateSegmenter(JsValue thisObject)
@@ -57,11 +45,10 @@ internal sealed class SegmenterPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.segmenter.prototype.segment
     /// </summary>
-    private JsSegments Segment(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsSegments Segment(JsValue thisObject, JsValue input)
     {
         var segmenter = ValidateSegmenter(thisObject);
-        var input = arguments.At(0);
-
         var stringInput = TypeConverter.ToString(input);
         return segmenter.Segment(_engine, stringInput);
     }
@@ -69,7 +56,8 @@ internal sealed class SegmenterPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.segmenter.prototype.resolvedoptions
     /// </summary>
-    private JsObject ResolvedOptions(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsObject ResolvedOptions(JsValue thisObject)
     {
         var segmenter = ValidateSegmenter(thisObject);
 

--- a/Jint/Native/Iterator/AsyncIteratorConstructor.cs
+++ b/Jint/Native/Iterator/AsyncIteratorConstructor.cs
@@ -11,7 +11,8 @@ namespace Jint.Native.Iterator;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-asynciterator-constructor
 /// </summary>
-internal sealed class AsyncIteratorConstructor : Constructor
+[JsObject]
+internal sealed partial class AsyncIteratorConstructor : Constructor
 {
     private static readonly JsString _functionName = new("AsyncIterator");
 
@@ -30,16 +31,7 @@ internal sealed class AsyncIteratorConstructor : Constructor
 
     internal AsyncIteratorPrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            ["from"] = new(new PropertyDescriptor(new ClrFunction(Engine, "from", From, 1, LengthFlags), PropertyFlags)),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     public override ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
     {
@@ -57,10 +49,9 @@ internal sealed class AsyncIteratorConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-asynciterator.from
     /// </summary>
-    private JsValue From(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue From(JsValue thisObject, JsValue o)
     {
-        var o = arguments.At(0);
-
         // 1. If O is not an Object, throw a TypeError exception.
         if (o is not ObjectInstance obj)
         {
@@ -144,7 +135,8 @@ internal sealed class WrapForValidAsyncIterator : ObjectInstance
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%wrapforvalidasynciteratorprototype%-object
 /// </summary>
-internal sealed class WrapForValidAsyncIteratorPrototype : Prototype
+[JsObject]
+internal sealed partial class WrapForValidAsyncIteratorPrototype : Prototype
 {
     internal WrapForValidAsyncIteratorPrototype(
         Engine engine,
@@ -154,21 +146,14 @@ internal sealed class WrapForValidAsyncIteratorPrototype : Prototype
         _prototype = asyncIteratorPrototype;
     }
 
-    protected override void Initialize()
-    {
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            [KnownKeys.Next] = new PropertyDescriptor(new ClrFunction(_engine, "next", Next, 0, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            [KnownKeys.Return] = new PropertyDescriptor(new ClrFunction(_engine, "return", Return, 0, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     /// <summary>
     /// %WrapForValidAsyncIteratorPrototype%.next()
     /// Delegates to the underlying iterator's next() and wraps in a promise.
     /// </summary>
-    private JsValue Next(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Next(JsValue thisObject)
     {
         if (thisObject is not WrapForValidAsyncIterator wrapper)
         {
@@ -218,7 +203,8 @@ internal sealed class WrapForValidAsyncIteratorPrototype : Prototype
     /// <summary>
     /// %WrapForValidAsyncIteratorPrototype%.return()
     /// </summary>
-    private JsValue Return(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Return(JsValue thisObject)
     {
         if (thisObject is not WrapForValidAsyncIterator wrapper)
         {

--- a/Jint/Native/Iterator/AsyncIteratorHelperPrototype.cs
+++ b/Jint/Native/Iterator/AsyncIteratorHelperPrototype.cs
@@ -1,6 +1,5 @@
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Iterator;
 
@@ -8,7 +7,8 @@ namespace Jint.Native.Iterator;
 /// https://tc39.es/ecma262/#sec-%asynciteratorhelperprototype%-object
 /// The %AsyncIteratorHelperPrototype% object is the prototype of async iterator helper objects.
 /// </summary>
-internal sealed class AsyncIteratorHelperPrototype : Prototype
+[JsObject]
+internal sealed partial class AsyncIteratorHelperPrototype : Prototype
 {
     internal AsyncIteratorHelperPrototype(
         Engine engine,
@@ -18,20 +18,13 @@ internal sealed class AsyncIteratorHelperPrototype : Prototype
         _prototype = asyncIteratorPrototype;
     }
 
-    protected override void Initialize()
-    {
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            [KnownKeys.Next] = new PropertyDescriptor(new ClrFunction(_engine, "next", Next, 0, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            [KnownKeys.Return] = new PropertyDescriptor(new ClrFunction(_engine, "return", Return, 0, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     /// <summary>
     /// %AsyncIteratorHelperPrototype%.next()
     /// </summary>
-    private JsValue Next(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Next(JsValue thisObject)
     {
         if (thisObject is AsyncIteratorHelper helper)
         {
@@ -45,7 +38,8 @@ internal sealed class AsyncIteratorHelperPrototype : Prototype
     /// <summary>
     /// %AsyncIteratorHelperPrototype%.return()
     /// </summary>
-    private JsValue Return(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Return(JsValue thisObject)
     {
         if (thisObject is AsyncIteratorHelper helper)
         {

--- a/Jint/Native/Iterator/AsyncIteratorPrototype.cs
+++ b/Jint/Native/Iterator/AsyncIteratorPrototype.cs
@@ -116,7 +116,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
     /// Validates thisObject is an ObjectInstance and extracts a callable argument.
     /// Closes the iterator on validation failure.
     /// </summary>
-    private ObjectInstance ValidateThisAndGetCallable(JsValue thisObject, JsValue[] arguments, string methodName, out ICallable callable)
+    private ObjectInstance ValidateThisAndGetCallable(JsValue thisObject, JsValue arg, string methodName, out ICallable callable)
     {
         if (thisObject is not ObjectInstance o)
         {
@@ -127,7 +127,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
 
         try
         {
-            callable = GetCallable(arguments.At(0));
+            callable = GetCallable(arg);
         }
         catch
         {
@@ -142,7 +142,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
     /// Validates thisObject and extracts a numeric limit argument.
     /// Closes the iterator on validation failure.
     /// </summary>
-    private ObjectInstance ValidateThisAndGetLimit(JsValue thisObject, JsValue[] arguments, string methodName, out long limit)
+    private ObjectInstance ValidateThisAndGetLimit(JsValue thisObject, JsValue arg, string methodName, out long limit)
     {
         if (thisObject is not ObjectInstance o)
         {
@@ -154,7 +154,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         double numLimit;
         try
         {
-            numLimit = TypeConverter.ToNumber(arguments.At(0));
+            numLimit = TypeConverter.ToNumber(arg);
         }
         catch
         {
@@ -364,46 +364,46 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
     // ---- Helper-returning methods ----
 
     [JsFunction(Length = 1)]
-    private AsyncMapIterator Map(JsValue thisObject, JsValue[] arguments)
+    private AsyncMapIterator Map(JsValue thisObject, JsValue mapperArg)
     {
-        var o = ValidateThisAndGetCallable(thisObject, arguments, "map", out var mapper);
+        var o = ValidateThisAndGetCallable(thisObject, mapperArg, "map", out var mapper);
         return new AsyncMapIterator(_engine, GetIteratorDirect(o), mapper);
     }
 
     [JsFunction(Length = 1)]
-    private AsyncFilterIterator Filter(JsValue thisObject, JsValue[] arguments)
+    private AsyncFilterIterator Filter(JsValue thisObject, JsValue predicateArg)
     {
-        var o = ValidateThisAndGetCallable(thisObject, arguments, "filter", out var predicate);
+        var o = ValidateThisAndGetCallable(thisObject, predicateArg, "filter", out var predicate);
         return new AsyncFilterIterator(_engine, GetIteratorDirect(o), predicate);
     }
 
     [JsFunction(Length = 1)]
-    private AsyncTakeIterator Take(JsValue thisObject, JsValue[] arguments)
+    private AsyncTakeIterator Take(JsValue thisObject, JsValue limitArg)
     {
-        var o = ValidateThisAndGetLimit(thisObject, arguments, "take", out var limit);
+        var o = ValidateThisAndGetLimit(thisObject, limitArg, "take", out var limit);
         return new AsyncTakeIterator(_engine, GetIteratorDirect(o), limit);
     }
 
     [JsFunction(Length = 1)]
-    private AsyncDropIterator Drop(JsValue thisObject, JsValue[] arguments)
+    private AsyncDropIterator Drop(JsValue thisObject, JsValue limitArg)
     {
-        var o = ValidateThisAndGetLimit(thisObject, arguments, "drop", out var limit);
+        var o = ValidateThisAndGetLimit(thisObject, limitArg, "drop", out var limit);
         return new AsyncDropIterator(_engine, GetIteratorDirect(o), limit);
     }
 
     [JsFunction(Length = 1)]
-    private AsyncFlatMapIterator FlatMap(JsValue thisObject, JsValue[] arguments)
+    private AsyncFlatMapIterator FlatMap(JsValue thisObject, JsValue mapperArg)
     {
-        var o = ValidateThisAndGetCallable(thisObject, arguments, "flatMap", out var mapper);
+        var o = ValidateThisAndGetCallable(thisObject, mapperArg, "flatMap", out var mapper);
         return new AsyncFlatMapIterator(_engine, GetIteratorDirect(o), mapper);
     }
 
     // ---- Consuming methods (return promises) ----
 
     [JsFunction(Length = 1)]
-    private JsValue Reduce(JsValue thisObject, JsValue[] arguments)
+    private JsValue Reduce(JsValue thisObject, JsCallArguments arguments)
     {
-        var o = ValidateThisAndGetCallable(thisObject, arguments, "reduce", out var reducer);
+        var o = ValidateThisAndGetCallable(thisObject, arguments.At(0), "reduce", out var reducer);
         var iterated = GetIteratorDirect(o);
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
         var hasInitialValue = arguments.Length >= 2;
@@ -465,7 +465,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
     }
 
     [JsFunction(Length = 0)]
-    private JsValue ToArray(JsValue thisObject, JsValue[] arguments)
+    private JsValue ToArray(JsValue thisObject)
     {
         if (thisObject is not ObjectInstance o)
         {
@@ -500,9 +500,9 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
     }
 
     [JsFunction(Length = 1)]
-    private JsValue ForEach(JsValue thisObject, JsValue[] arguments)
+    private JsValue ForEach(JsValue thisObject, JsValue procedureArg)
     {
-        var o = ValidateThisAndGetCallable(thisObject, arguments, "forEach", out var procedure);
+        var o = ValidateThisAndGetCallable(thisObject, procedureArg, "forEach", out var procedure);
         var iterated = GetIteratorDirect(o);
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
 
@@ -514,9 +514,9 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
     }
 
     [JsFunction(Length = 1)]
-    private JsValue Some(JsValue thisObject, JsValue[] arguments)
+    private JsValue Some(JsValue thisObject, JsValue predicateArg)
     {
-        var o = ValidateThisAndGetCallable(thisObject, arguments, "some", out var predicate);
+        var o = ValidateThisAndGetCallable(thisObject, predicateArg, "some", out var predicate);
         var iterated = GetIteratorDirect(o);
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
 
@@ -534,9 +534,9 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
     }
 
     [JsFunction(Length = 1)]
-    private JsValue Every(JsValue thisObject, JsValue[] arguments)
+    private JsValue Every(JsValue thisObject, JsValue predicateArg)
     {
-        var o = ValidateThisAndGetCallable(thisObject, arguments, "every", out var predicate);
+        var o = ValidateThisAndGetCallable(thisObject, predicateArg, "every", out var predicate);
         var iterated = GetIteratorDirect(o);
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
 
@@ -554,9 +554,9 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
     }
 
     [JsFunction(Length = 1)]
-    private JsValue Find(JsValue thisObject, JsValue[] arguments)
+    private JsValue Find(JsValue thisObject, JsValue predicateArg)
     {
-        var o = ValidateThisAndGetCallable(thisObject, arguments, "find", out var predicate);
+        var o = ValidateThisAndGetCallable(thisObject, predicateArg, "find", out var predicate);
         var iterated = GetIteratorDirect(o);
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
 

--- a/Jint/Native/Iterator/AsyncIteratorPrototype.cs
+++ b/Jint/Native/Iterator/AsyncIteratorPrototype.cs
@@ -10,8 +10,11 @@ namespace Jint.Native.Iterator;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-asynciteratorprototype
 /// </summary>
-internal sealed class AsyncIteratorPrototype : Prototype
+[JsObject]
+internal sealed partial class AsyncIteratorPrototype : Prototype
 {
+    private static readonly JsString AsyncIteratorToStringTag = new("AsyncIterator");
+
     internal AsyncIteratorPrototype(
         Engine engine,
         Realm realm,
@@ -22,46 +25,40 @@ internal sealed class AsyncIteratorPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag Flags = PropertyFlag.Writable | PropertyFlag.Configurable;
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
 
-        var properties = new PropertyDictionary(12, checkExistingKeys: false)
-        {
-            [KnownKeys.Constructor] = new GetSetPropertyDescriptor(
-                get: new ClrFunction(_engine, "get constructor", (_, _) => _engine.Intrinsics.AsyncIterator, 0, PropertyFlag.Configurable),
-                set: new ClrFunction(_engine, "set constructor", (thisObject, arguments) =>
-                {
-                    SetterThatIgnoresPrototypeProperties(thisObject, _engine.Intrinsics.AsyncIterator.PrototypeObject, CommonProperties.Constructor, arguments.At(0));
-                    return Undefined;
-                }, 1, PropertyFlag.Configurable),
-                PropertyFlag.Configurable),
-            ["map"] = new(new ClrFunction(_engine, "map", Map, 1, PropertyFlag.Configurable), Flags),
-            ["filter"] = new(new ClrFunction(_engine, "filter", Filter, 1, PropertyFlag.Configurable), Flags),
-            ["take"] = new(new ClrFunction(_engine, "take", Take, 1, PropertyFlag.Configurable), Flags),
-            ["drop"] = new(new ClrFunction(_engine, "drop", Drop, 1, PropertyFlag.Configurable), Flags),
-            ["flatMap"] = new(new ClrFunction(_engine, "flatMap", FlatMap, 1, PropertyFlag.Configurable), Flags),
-            ["reduce"] = new(new ClrFunction(_engine, "reduce", Reduce, 1, PropertyFlag.Configurable), Flags),
-            ["toArray"] = new(new ClrFunction(_engine, "toArray", ToArray, 0, PropertyFlag.Configurable), Flags),
-            ["forEach"] = new(new ClrFunction(_engine, "forEach", ForEach, 1, PropertyFlag.Configurable), Flags),
-            ["some"] = new(new ClrFunction(_engine, "some", Some, 1, PropertyFlag.Configurable), Flags),
-            ["every"] = new(new ClrFunction(_engine, "every", Every, 1, PropertyFlag.Configurable), Flags),
-            ["find"] = new(new ClrFunction(_engine, "find", Find, 1, PropertyFlag.Configurable), Flags),
-        };
-        SetProperties(properties);
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-get-asynciteratorprototype-constructor
+    /// </summary>
+    [JsAccessor("constructor")]
+    private AsyncIteratorConstructor ConstructorGet(JsValue thisObject) => _engine.Intrinsics.AsyncIterator;
 
-        var symbols = new SymbolDictionary(3)
-        {
-            [GlobalSymbolRegistry.AsyncIterator] = new(new ClrFunction(Engine, "[Symbol.asyncIterator]", AsyncIterator, 0, PropertyFlag.Configurable), Flags),
-            [GlobalSymbolRegistry.AsyncDispose] = new(new ClrFunction(Engine, "[Symbol.asyncDispose]", AsyncDispose, 0, PropertyFlag.Configurable), Flags),
-            [GlobalSymbolRegistry.ToStringTag] = new GetSetPropertyDescriptor(
-                get: new ClrFunction(_engine, "get [Symbol.toStringTag]", (_, _) => "AsyncIterator", 0, PropertyFlag.Configurable),
-                set: new ClrFunction(_engine, "set [Symbol.toStringTag]", (thisObject, arguments) =>
-                {
-                    SetterThatIgnoresPrototypeProperties(thisObject, _engine.Intrinsics.AsyncIterator.PrototypeObject, GlobalSymbolRegistry.ToStringTag, arguments.At(0));
-                    return Undefined;
-                }, 0, PropertyFlag.Configurable),
-                PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-set-asynciteratorprototype-constructor
+    /// </summary>
+    [JsAccessor("constructor", AccessorKind.Set)]
+    private JsValue ConstructorSet(JsValue thisObject, JsValue value)
+    {
+        SetterThatIgnoresPrototypeProperties(thisObject, _engine.Intrinsics.AsyncIterator.PrototypeObject, CommonProperties.Constructor, value);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-get-asynciteratorprototype-@@tostringtag
+    /// </summary>
+    [JsSymbolAccessor("ToStringTag")]
+    private static JsString ToStringTagGet(JsValue thisObject) => AsyncIteratorToStringTag;
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-set-asynciteratorprototype-@@tostringtag
+    /// </summary>
+    [JsSymbolAccessor("ToStringTag", AccessorKind.Set)]
+    private JsValue ToStringTagSet(JsValue thisObject, JsValue value)
+    {
+        SetterThatIgnoresPrototypeProperties(thisObject, _engine.Intrinsics.AsyncIterator.PrototypeObject, GlobalSymbolRegistry.ToStringTag, value);
+        return Undefined;
     }
 
     /// <summary>
@@ -306,15 +303,14 @@ internal sealed class AsyncIteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-asynciteratorprototype-asynciterator
     /// </summary>
-    private static JsValue AsyncIterator(JsValue thisObject, JsCallArguments arguments)
-    {
-        return thisObject;
-    }
+    [JsSymbolFunction("AsyncIterator", Length = 0, Flags = PropertyFlag.Configurable | PropertyFlag.Writable)]
+    private static JsValue AsyncIterator(JsValue thisObject) => thisObject;
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%asynciteratorprototype%-@@asyncDispose
     /// </summary>
-    private JsValue AsyncDispose(JsValue thisObject, JsCallArguments arguments)
+    [JsSymbolFunction("AsyncDispose", Length = 0, Flags = PropertyFlag.Configurable | PropertyFlag.Writable)]
+    private JsValue AsyncDispose(JsValue thisObject)
     {
         var o = thisObject;
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
@@ -367,30 +363,35 @@ internal sealed class AsyncIteratorPrototype : Prototype
 
     // ---- Helper-returning methods ----
 
+    [JsFunction(Length = 1)]
     private AsyncMapIterator Map(JsValue thisObject, JsValue[] arguments)
     {
         var o = ValidateThisAndGetCallable(thisObject, arguments, "map", out var mapper);
         return new AsyncMapIterator(_engine, GetIteratorDirect(o), mapper);
     }
 
+    [JsFunction(Length = 1)]
     private AsyncFilterIterator Filter(JsValue thisObject, JsValue[] arguments)
     {
         var o = ValidateThisAndGetCallable(thisObject, arguments, "filter", out var predicate);
         return new AsyncFilterIterator(_engine, GetIteratorDirect(o), predicate);
     }
 
+    [JsFunction(Length = 1)]
     private AsyncTakeIterator Take(JsValue thisObject, JsValue[] arguments)
     {
         var o = ValidateThisAndGetLimit(thisObject, arguments, "take", out var limit);
         return new AsyncTakeIterator(_engine, GetIteratorDirect(o), limit);
     }
 
+    [JsFunction(Length = 1)]
     private AsyncDropIterator Drop(JsValue thisObject, JsValue[] arguments)
     {
         var o = ValidateThisAndGetLimit(thisObject, arguments, "drop", out var limit);
         return new AsyncDropIterator(_engine, GetIteratorDirect(o), limit);
     }
 
+    [JsFunction(Length = 1)]
     private AsyncFlatMapIterator FlatMap(JsValue thisObject, JsValue[] arguments)
     {
         var o = ValidateThisAndGetCallable(thisObject, arguments, "flatMap", out var mapper);
@@ -399,6 +400,7 @@ internal sealed class AsyncIteratorPrototype : Prototype
 
     // ---- Consuming methods (return promises) ----
 
+    [JsFunction(Length = 1)]
     private JsValue Reduce(JsValue thisObject, JsValue[] arguments)
     {
         var o = ValidateThisAndGetCallable(thisObject, arguments, "reduce", out var reducer);
@@ -462,6 +464,7 @@ internal sealed class AsyncIteratorPrototype : Prototype
             counter: counter);
     }
 
+    [JsFunction(Length = 0)]
     private JsValue ToArray(JsValue thisObject, JsValue[] arguments)
     {
         if (thisObject is not ObjectInstance o)
@@ -496,6 +499,7 @@ internal sealed class AsyncIteratorPrototype : Prototype
             });
     }
 
+    [JsFunction(Length = 1)]
     private JsValue ForEach(JsValue thisObject, JsValue[] arguments)
     {
         var o = ValidateThisAndGetCallable(thisObject, arguments, "forEach", out var procedure);
@@ -509,6 +513,7 @@ internal sealed class AsyncIteratorPrototype : Prototype
         return promiseCapability.PromiseInstance;
     }
 
+    [JsFunction(Length = 1)]
     private JsValue Some(JsValue thisObject, JsValue[] arguments)
     {
         var o = ValidateThisAndGetCallable(thisObject, arguments, "some", out var predicate);
@@ -528,6 +533,7 @@ internal sealed class AsyncIteratorPrototype : Prototype
         return promiseCapability.PromiseInstance;
     }
 
+    [JsFunction(Length = 1)]
     private JsValue Every(JsValue thisObject, JsValue[] arguments)
     {
         var o = ValidateThisAndGetCallable(thisObject, arguments, "every", out var predicate);
@@ -547,6 +553,7 @@ internal sealed class AsyncIteratorPrototype : Prototype
         return promiseCapability.PromiseInstance;
     }
 
+    [JsFunction(Length = 1)]
     private JsValue Find(JsValue thisObject, JsValue[] arguments)
     {
         var o = ValidateThisAndGetCallable(thisObject, arguments, "find", out var predicate);

--- a/Jint/Native/Iterator/IteratorConstructor.cs
+++ b/Jint/Native/Iterator/IteratorConstructor.cs
@@ -3,11 +3,11 @@ using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Iterator;
 
-internal sealed class IteratorConstructor : Constructor
+[JsObject]
+internal sealed partial class IteratorConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Iterator");
 
@@ -26,19 +26,7 @@ internal sealed class IteratorConstructor : Constructor
 
     internal IteratorPrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        var properties = new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            ["concat"] = new(new PropertyDescriptor(new ClrFunction(Engine, "concat", Concat, 0, LengthFlags), PropertyFlags)),
-            ["from"] = new(new PropertyDescriptor(new ClrFunction(Engine, "from", From, 1, LengthFlags), PropertyFlags)),
-            ["zip"] = new(new PropertyDescriptor(new ClrFunction(Engine, "zip", Zip, 1, LengthFlags), PropertyFlags)),
-            ["zipKeyed"] = new(new PropertyDescriptor(new ClrFunction(Engine, "zipKeyed", ZipKeyed, 1, LengthFlags), PropertyFlags)),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     public override ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
     {
@@ -56,6 +44,7 @@ internal sealed class IteratorConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-iterator-sequencing/#sec-iterator.concat
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue Concat(JsValue thisObject, JsValue[] arguments)
     {
         // 1. Let iterables be a new empty List.
@@ -92,10 +81,10 @@ internal sealed class IteratorConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.from
     /// </summary>
-    private JsValue From(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue From(JsValue thisObject, JsValue o)
     {
         // 1. If O is a String, set O to ! ToObject(O).
-        var o = arguments.At(0);
 
         // 2. Let iteratorRecord be ? GetIteratorFlattenable(O, iterate-strings).
         var iteratorRecord = GetIteratorFlattenable(o, StringHandlingType.IterateStrings, out var underlyingIterator);
@@ -196,11 +185,9 @@ internal sealed class IteratorConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-joint-iteration/#sec-iterator.zip
     /// </summary>
-    private JsValue Zip(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Zip(JsValue thisObject, JsValue iterables, JsValue options)
     {
-        var iterables = arguments.At(0);
-        var options = arguments.At(1);
-
         // 1. If iterables is not an Object, throw a TypeError exception.
         if (iterables is not ObjectInstance iterablesObj)
         {
@@ -397,11 +384,9 @@ internal sealed class IteratorConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-joint-iteration/#sec-iterator.zipkeyed
     /// </summary>
-    private JsValue ZipKeyed(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue ZipKeyed(JsValue thisObject, JsValue iterables, JsValue options)
     {
-        var iterables = arguments.At(0);
-        var options = arguments.At(1);
-
         // 1. If iterables is not an Object, throw a TypeError exception.
         if (iterables is not ObjectInstance iterablesObj)
         {

--- a/Jint/Native/Iterator/IteratorHelperPrototype.cs
+++ b/Jint/Native/Iterator/IteratorHelperPrototype.cs
@@ -1,6 +1,5 @@
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Iterator;
 
@@ -8,7 +7,8 @@ namespace Jint.Native.Iterator;
 /// https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-object
 /// The %IteratorHelperPrototype% object is the prototype of iterator helper objects.
 /// </summary>
-internal sealed class IteratorHelperPrototype : Prototype
+[JsObject]
+internal sealed partial class IteratorHelperPrototype : Prototype
 {
     private readonly IteratorPrototype _iteratorPrototype;
 
@@ -21,20 +21,13 @@ internal sealed class IteratorHelperPrototype : Prototype
         _prototype = iteratorPrototype;
     }
 
-    protected override void Initialize()
-    {
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            [KnownKeys.Next] = new PropertyDescriptor(new ClrFunction(_engine, "next", Next, 0, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            [KnownKeys.Return] = new PropertyDescriptor(new ClrFunction(_engine, "return", Return, 0, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.next
     /// </summary>
-    private JsValue Next(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Next(JsValue thisObject)
     {
         // 1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
         if (thisObject is IteratorHelper helper)
@@ -59,7 +52,8 @@ internal sealed class IteratorHelperPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.return
     /// </summary>
-    private JsValue Return(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Return(JsValue thisObject)
     {
         // 1. Let O be this value.
         // 2. Perform ? RequireInternalSlot(O, [[UnderlyingIterator]]).

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -2,14 +2,14 @@ using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Iterator;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%iteratorprototype%-object
 /// </summary>
-internal class IteratorPrototype : Prototype
+[JsObject]
+internal partial class IteratorPrototype : Prototype
 {
     internal IteratorPrototype(
         Engine engine,
@@ -21,45 +21,42 @@ internal class IteratorPrototype : Prototype
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(12, checkExistingKeys: false)
-        {
-            [KnownKeys.Constructor] = new GetSetPropertyDescriptor(
-                get: new ClrFunction(_engine, "get constructor", (_, _) => _engine.Intrinsics.Iterator, 0, PropertyFlag.Configurable),
-                set: new ClrFunction(_engine, "set constructor", (thisObject, arguments) =>
-                {
-                    SetterThatIgnoresPrototypeProperties(thisObject, _engine.Intrinsics.IteratorPrototype, CommonProperties.Constructor, arguments.At(0));
-                    return Undefined;
-                }, 1, PropertyFlag.Configurable),
-                PropertyFlag.Configurable),
-            ["map"] = new(new ClrFunction(_engine, "map", Map, 1, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            ["filter"] = new(new ClrFunction(_engine, "filter", Filter, 1, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            ["take"] = new(new ClrFunction(_engine, "take", Take, 1, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            ["drop"] = new(new ClrFunction(_engine, "drop", Drop, 1, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            ["flatMap"] = new(new ClrFunction(_engine, "flatMap", FlatMap, 1, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            ["reduce"] = new(new ClrFunction(_engine, "reduce", Reduce, 1, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            ["toArray"] = new(new ClrFunction(_engine, "toArray", ToArray, 0, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            ["forEach"] = new(new ClrFunction(_engine, "forEach", ForEach, 1, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            ["some"] = new(new ClrFunction(_engine, "some", Some, 1, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            ["every"] = new(new ClrFunction(_engine, "every", Every, 1, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            ["find"] = new(new ClrFunction(_engine, "find", Find, 1, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-        };
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+    }
 
-        SetProperties(properties);
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-get-iteratorprototype-constructor
+    /// </summary>
+    [JsAccessor("constructor")]
+    private IteratorConstructor ConstructorGet(JsValue thisObject) => _engine.Intrinsics.Iterator;
 
-        var symbols = new SymbolDictionary(3)
-        {
-            [GlobalSymbolRegistry.Iterator] = new(new ClrFunction(Engine, "[Symbol.iterator]", ToIterator, 0, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            [GlobalSymbolRegistry.Dispose] = new(new ClrFunction(Engine, "[Symbol.dispose]", Dispose, 0, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            [GlobalSymbolRegistry.ToStringTag] = new GetSetPropertyDescriptor(
-                get: new ClrFunction(_engine, "get [Symbol.toStringTag]", (_, _) => "Iterator", 0, PropertyFlag.Configurable),
-                set: new ClrFunction(_engine, "set [Symbol.toStringTag]", (thisObject, arguments) =>
-                {
-                    SetterThatIgnoresPrototypeProperties(thisObject, _engine.Intrinsics.IteratorPrototype, GlobalSymbolRegistry.ToStringTag, arguments.At(0));
-                    return Undefined;
-                }, 0, PropertyFlag.Configurable),
-                PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-set-iteratorprototype-constructor
+    /// </summary>
+    [JsAccessor("constructor", AccessorKind.Set)]
+    private JsValue ConstructorSet(JsValue thisObject, JsValue value)
+    {
+        SetterThatIgnoresPrototypeProperties(thisObject, _engine.Intrinsics.IteratorPrototype, CommonProperties.Constructor, value);
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-get-iteratorprototype-@@tostringtag
+    /// </summary>
+    private static readonly JsString IteratorToStringTag = new("Iterator");
+
+    [JsSymbolAccessor("ToStringTag")]
+    private static JsString ToStringTagGet(JsValue thisObject) => IteratorToStringTag;
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-set-iteratorprototype-@@tostringtag
+    /// </summary>
+    [JsSymbolAccessor("ToStringTag", AccessorKind.Set)]
+    private JsValue ToStringTagSet(JsValue thisObject, JsValue value)
+    {
+        SetterThatIgnoresPrototypeProperties(thisObject, _engine.Intrinsics.IteratorPrototype, GlobalSymbolRegistry.ToStringTag, value);
+        return Undefined;
     }
 
     /// <summary>
@@ -93,7 +90,8 @@ internal class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.map
     /// </summary>
-    private JsValue Map(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Map(JsValue thisObject, JsValue mapper)
     {
         // 1. Let O be the this value.
         // 2. If O is not an Object, throw a TypeError exception.
@@ -104,10 +102,10 @@ internal class IteratorPrototype : Prototype
         }
 
         // 3. If IsCallable(mapper) is false, throw a TypeError exception.
-        ICallable mapper;
+        ICallable mapperCallable;
         try
         {
-            mapper = GetCallable(arguments.At(0));
+            mapperCallable = GetCallable(mapper);
         }
         catch
         {
@@ -119,7 +117,7 @@ internal class IteratorPrototype : Prototype
         var iterated = GetIteratorDirect(o);
 
         // Create and return map iterator
-        return new MapIterator(_engine, iterated, mapper);
+        return new MapIterator(_engine, iterated, mapperCallable);
     }
 
     private static IteratorInstance.ObjectIterator GetIteratorDirect(ObjectInstance objectInstance) => new(objectInstance);
@@ -149,7 +147,8 @@ internal class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.filter
     /// </summary>
-    private JsValue Filter(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Filter(JsValue thisObject, JsValue predicate)
     {
         // 1. Let O be the this value.
         // 2. If O is not an Object, throw a TypeError exception.
@@ -160,10 +159,10 @@ internal class IteratorPrototype : Prototype
         }
 
         // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-        ICallable predicate;
+        ICallable predicateCallable;
         try
         {
-            predicate = GetCallable(arguments.At(0));
+            predicateCallable = GetCallable(predicate);
         }
         catch
         {
@@ -175,13 +174,14 @@ internal class IteratorPrototype : Prototype
         var iterated = GetIteratorDirect(o);
 
         // Create and return filter iterator
-        return new FilterIterator(_engine, iterated, predicate);
+        return new FilterIterator(_engine, iterated, predicateCallable);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.take
     /// </summary>
-    private JsValue Take(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Take(JsValue thisObject, JsValue limit)
     {
         // 1. Let O be the this value.
         // 2. If O is not an Object, throw a TypeError exception.
@@ -195,7 +195,7 @@ internal class IteratorPrototype : Prototype
         double numLimit;
         try
         {
-            numLimit = TypeConverter.ToNumber(arguments.At(0));
+            numLimit = TypeConverter.ToNumber(limit);
         }
         catch
         {
@@ -226,14 +226,15 @@ internal class IteratorPrototype : Prototype
         var iterated = GetIteratorDirect(o);
 
         // Create and return take iterator
-        var limit = double.IsPositiveInfinity(integerLimit) ? long.MaxValue : (long) integerLimit;
-        return new TakeIterator(_engine, iterated, limit);
+        var lim = double.IsPositiveInfinity(integerLimit) ? long.MaxValue : (long) integerLimit;
+        return new TakeIterator(_engine, iterated, lim);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.drop
     /// </summary>
-    private JsValue Drop(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Drop(JsValue thisObject, JsValue limit)
     {
         // 1. Let O be the this value.
         // 2. If O is not an Object, throw a TypeError exception.
@@ -247,7 +248,7 @@ internal class IteratorPrototype : Prototype
         double numLimit;
         try
         {
-            numLimit = TypeConverter.ToNumber(arguments.At(0));
+            numLimit = TypeConverter.ToNumber(limit);
         }
         catch
         {
@@ -278,14 +279,15 @@ internal class IteratorPrototype : Prototype
         var iterated = GetIteratorDirect(o);
 
         // Create and return drop iterator
-        var limit = double.IsPositiveInfinity(integerLimit) ? long.MaxValue : (long) integerLimit;
-        return new DropIterator(_engine, iterated, limit);
+        var lim = double.IsPositiveInfinity(integerLimit) ? long.MaxValue : (long) integerLimit;
+        return new DropIterator(_engine, iterated, lim);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.flatmap
     /// </summary>
-    private JsValue FlatMap(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue FlatMap(JsValue thisObject, JsValue mapper)
     {
         // 1. Let O be the this value.
         // 2. If O is not an Object, throw a TypeError exception.
@@ -296,10 +298,10 @@ internal class IteratorPrototype : Prototype
         }
 
         // 3. If IsCallable(mapper) is false, throw a TypeError exception.
-        ICallable mapper;
+        ICallable mapperCallable;
         try
         {
-            mapper = GetCallable(arguments.At(0));
+            mapperCallable = GetCallable(mapper);
         }
         catch
         {
@@ -311,13 +313,14 @@ internal class IteratorPrototype : Prototype
         var iterated = GetIteratorDirect(o);
 
         // Create and return flatMap iterator
-        return new FlatMapIterator(_engine, iterated, mapper);
+        return new FlatMapIterator(_engine, iterated, mapperCallable);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.reduce
     /// </summary>
-    private JsValue Reduce(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Reduce(JsValue thisObject, JsCallArguments arguments)
     {
         // 1. Let O be the this value.
         // 2. If O is not an Object, throw a TypeError exception.
@@ -391,7 +394,8 @@ internal class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.toarray
     /// </summary>
-    private JsValue ToArray(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 0)]
+    private JsValue ToArray(JsValue thisObject)
     {
         if (thisObject is not ObjectInstance o)
         {
@@ -421,7 +425,8 @@ internal class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.foreach
     /// </summary>
-    private JsValue ForEach(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue ForEach(JsValue thisObject, JsValue procedure)
     {
         if (thisObject is not ObjectInstance o)
         {
@@ -430,10 +435,10 @@ internal class IteratorPrototype : Prototype
         }
 
         // Validate predicate first, close on failure
-        ICallable procedure;
+        ICallable procedureCallable;
         try
         {
-            procedure = GetCallable(arguments.At(0));
+            procedureCallable = GetCallable(procedure);
         }
         catch
         {
@@ -450,7 +455,7 @@ internal class IteratorPrototype : Prototype
             try
             {
                 var value = iteratorResult.Get(CommonProperties.Value);
-                procedure.Call(Undefined, [value, counter]);
+                procedureCallable.Call(Undefined, [value, counter]);
                 counter++;
             }
             catch
@@ -466,7 +471,8 @@ internal class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.some
     /// </summary>
-    private JsValue Some(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Some(JsValue thisObject, JsValue predicate)
     {
         if (thisObject is not ObjectInstance o)
         {
@@ -475,10 +481,10 @@ internal class IteratorPrototype : Prototype
         }
 
         // Validate predicate first, close on failure
-        ICallable predicate;
+        ICallable predicateCallable;
         try
         {
-            predicate = GetCallable(arguments.At(0));
+            predicateCallable = GetCallable(predicate);
         }
         catch
         {
@@ -495,7 +501,7 @@ internal class IteratorPrototype : Prototype
             try
             {
                 var value = iteratorResult.Get(CommonProperties.Value);
-                var result = predicate.Call(Undefined, [value, counter]);
+                var result = predicateCallable.Call(Undefined, [value, counter]);
                 if (TypeConverter.ToBoolean(result))
                 {
                     iterated.Close(CompletionType.Normal);
@@ -517,7 +523,8 @@ internal class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.every
     /// </summary>
-    private JsValue Every(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Every(JsValue thisObject, JsValue predicate)
     {
         if (thisObject is not ObjectInstance o)
         {
@@ -526,10 +533,10 @@ internal class IteratorPrototype : Prototype
         }
 
         // Validate predicate first, close on failure
-        ICallable predicate;
+        ICallable predicateCallable;
         try
         {
-            predicate = GetCallable(arguments.At(0));
+            predicateCallable = GetCallable(predicate);
         }
         catch
         {
@@ -546,7 +553,7 @@ internal class IteratorPrototype : Prototype
             try
             {
                 var value = iteratorResult.Get(CommonProperties.Value);
-                var result = predicate.Call(Undefined, [value, counter]);
+                var result = predicateCallable.Call(Undefined, [value, counter]);
                 if (!TypeConverter.ToBoolean(result))
                 {
                     iterated.Close(CompletionType.Normal);
@@ -568,7 +575,8 @@ internal class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.find
     /// </summary>
-    private JsValue Find(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Find(JsValue thisObject, JsValue predicate)
     {
         if (thisObject is not ObjectInstance o)
         {
@@ -577,10 +585,10 @@ internal class IteratorPrototype : Prototype
         }
 
         // Validate predicate first, close on failure
-        ICallable predicate;
+        ICallable predicateCallable;
         try
         {
-            predicate = GetCallable(arguments.At(0));
+            predicateCallable = GetCallable(predicate);
         }
         catch
         {
@@ -597,7 +605,7 @@ internal class IteratorPrototype : Prototype
             try
             {
                 var value = iteratorResult.Get(CommonProperties.Value);
-                var result = predicate.Call(Undefined, [value, counter]);
+                var result = predicateCallable.Call(Undefined, [value, counter]);
                 if (TypeConverter.ToBoolean(result))
                 {
                     iterated.Close(CompletionType.Normal);
@@ -616,22 +624,26 @@ internal class IteratorPrototype : Prototype
         return Undefined;
     }
 
-    private static JsValue ToIterator(JsValue thisObject, JsCallArguments arguments)
-    {
-        return thisObject;
-    }
+    [JsSymbolFunction("Iterator", Length = 0, Flags = PropertyFlag.NonEnumerable)]
+    private static JsValue ToIterator(JsValue thisObject) => thisObject;
 
-    private static JsValue Dispose(JsValue thisObject, JsCallArguments arguments)
+    [JsSymbolFunction("Dispose", Length = 0, Flags = PropertyFlag.NonEnumerable)]
+    private static JsValue Dispose(JsValue thisObject)
     {
         var method = thisObject.AsObject().GetMethod(CommonProperties.Return);
         if (method is not null)
         {
-            method.Call(thisObject, arguments);
+            method.Call(thisObject, Arguments.Empty);
         }
 
         return Undefined;
     }
 
+    [JsFunction(Length = 0, Name = "next")]
+    private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
+
+    // Kept with the JsCallArguments signature so still-hand-written subclasses (Array/RegExpString/String
+    // IteratorPrototype) can pass it as a ClrFunction delegate from their Initialize bodies.
     internal JsValue Next(JsValue thisObject, JsCallArguments arguments)
     {
         var iterator = thisObject as IteratorInstance;

--- a/Jint/Native/Iterator/WrapForValidIteratorPrototype.cs
+++ b/Jint/Native/Iterator/WrapForValidIteratorPrototype.cs
@@ -1,7 +1,6 @@
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Iterator;
 
@@ -9,7 +8,8 @@ namespace Jint.Native.Iterator;
 /// https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%-object
 /// The %WrapForValidIteratorPrototype% object is the prototype of wrapped iterator objects from Iterator.from.
 /// </summary>
-internal sealed class WrapForValidIteratorPrototype : Prototype
+[JsObject]
+internal sealed partial class WrapForValidIteratorPrototype : Prototype
 {
     internal WrapForValidIteratorPrototype(
         Engine engine,
@@ -19,20 +19,13 @@ internal sealed class WrapForValidIteratorPrototype : Prototype
         _prototype = iteratorPrototype;
     }
 
-    protected override void Initialize()
-    {
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            [KnownKeys.Next] = new PropertyDescriptor(new ClrFunction(_engine, "next", Next, 0, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-            [KnownKeys.Return] = new PropertyDescriptor(new ClrFunction(_engine, "return", Return, 0, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.next
     /// </summary>
-    private JsValue Next(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Next(JsValue thisObject)
     {
         // 1. Let O be this value.
         // 2. Perform ? RequireInternalSlot(O, [[Iterated]]).
@@ -51,7 +44,8 @@ internal sealed class WrapForValidIteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.return
     /// </summary>
-    private JsValue Return(JsValue thisObject, JsValue[] arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Return(JsValue thisObject)
     {
         // 1. Let O be this value.
         // 2. Perform ? RequireInternalSlot(O, [[Iterated]]).

--- a/Jint/Native/Map/MapIteratorPrototype.cs
+++ b/Jint/Native/Map/MapIteratorPrototype.cs
@@ -1,17 +1,18 @@
 using Jint.Native.Iterator;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Map;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%mapiteratorprototype%-object
 /// </summary>
-internal sealed class MapIteratorPrototype : IteratorPrototype
+[JsObject]
+internal sealed partial class MapIteratorPrototype : IteratorPrototype
 {
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString MapIteratorToStringTag = new("Map Iterator");
+
     internal MapIteratorPrototype(
         Engine engine,
         Realm realm,
@@ -21,18 +22,12 @@ internal sealed class MapIteratorPrototype : IteratorPrototype
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            [KnownKeys.Next] = new(new ClrFunction(Engine, "next", Next, 0, PropertyFlag.Configurable), true, false, true)
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Map Iterator", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
+    [JsFunction(Length = 0, Name = "next")]
+    private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     internal IteratorInstance ConstructEntryIterator(JsMap map)
     {

--- a/Jint/Native/Map/MapPrototype.cs
+++ b/Jint/Native/Map/MapPrototype.cs
@@ -16,10 +16,6 @@ internal sealed partial class MapPrototype : Prototype
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly MapConstructor _mapConstructor;
 
-    // Pre-existing quirk: TC39 spec does not require a `length` property on Map.prototype
-    // (length lives on the constructor). Preserved here verbatim from the pre-source-gen Initialize body.
-    [JsProperty(Name = "length", Flags = PropertyFlag.Configurable)] private static readonly JsNumber MapLength = JsNumber.PositiveZero;
-
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString MapToStringTag = new("Map");
 
     internal MapPrototype(

--- a/Jint/Native/Map/MapPrototype.cs
+++ b/Jint/Native/Map/MapPrototype.cs
@@ -4,16 +4,23 @@ using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Map;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-map-objects
 /// </summary>
-internal sealed class MapPrototype : Prototype
+[JsObject]
+internal sealed partial class MapPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly MapConstructor _mapConstructor;
+
+    // Pre-existing quirk: TC39 spec does not require a `length` property on Map.prototype
+    // (length lives on the constructor). Preserved here verbatim from the pre-source-gen Initialize body.
+    [JsProperty(Name = "length", Flags = PropertyFlag.Configurable)] private static readonly JsNumber MapLength = JsNumber.PositiveZero;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString MapToStringTag = new("Map");
 
     internal MapPrototype(
         Engine engine,
@@ -27,98 +34,84 @@ internal sealed class MapPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(14, checkExistingKeys: false)
-        {
-            ["length"] = new PropertyDescriptor(0, PropertyFlag.Configurable),
-            ["constructor"] = new PropertyDescriptor(_mapConstructor, PropertyFlag.NonEnumerable),
-            ["clear"] = new PropertyDescriptor(new ClrFunction(Engine, "clear", Clear, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["delete"] = new PropertyDescriptor(new ClrFunction(Engine, "delete", Delete, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["entries"] = new PropertyDescriptor(new ClrFunction(Engine, "entries", Entries, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["forEach"] = new PropertyDescriptor(new ClrFunction(Engine, "forEach", ForEach, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["get"] = new PropertyDescriptor(new ClrFunction(Engine, "get", Get, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["getOrInsert"] = new PropertyDescriptor(new ClrFunction(Engine, "getOrInsert", GetOrInsert, 2, PropertyFlag.Configurable), PropertyFlags),
-            ["getOrInsertComputed"] = new PropertyDescriptor(new ClrFunction(Engine, "getOrInsertComputed", GetOrInsertComputed, 2, PropertyFlag.Configurable), PropertyFlags),
-            ["has"] = new PropertyDescriptor(new ClrFunction(Engine, "has", Has, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["keys"] = new PropertyDescriptor(new ClrFunction(Engine, "keys", Keys, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["set"] = new PropertyDescriptor(new ClrFunction(Engine, "set", Set, 2, PropertyFlag.Configurable), PropertyFlags),
-            ["values"] = new PropertyDescriptor(new ClrFunction(Engine, "values", Values, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["size"] = new GetSetPropertyDescriptor(get: new ClrFunction(Engine, "get size", Size, 0, PropertyFlag.Configurable), set: null, PropertyFlag.Configurable)
-        };
-        SetProperties(properties);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
 
-        var symbols = new SymbolDictionary(2)
-        {
-            [GlobalSymbolRegistry.Iterator] = new PropertyDescriptor(new ClrFunction(Engine, "iterator", Entries, 1, PropertyFlag.Configurable), PropertyFlags),
-            [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor("Map", false, false, true),
-        };
-        SetSymbols(symbols);
+        // Spec requires Map.prototype[@@iterator] to be the same function object as Map.prototype.entries
+        // (function identity, observable via ===). Alias the descriptor here so the @@iterator slot
+        // shares the same materialized function as `entries` rather than emitting a separate dispatcher.
+        SetProperty(GlobalSymbolRegistry.Iterator, GetOwnProperty("entries"));
     }
 
-    private JsValue Size(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("size")]
+    private JsValue Size(JsValue thisObject)
     {
         AssertMapInstance(thisObject);
         return JsNumber.Create(0);
     }
 
-    private JsValue Get(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1, Name = "get")]
+    private JsValue MapGet(JsValue thisObject, JsValue key)
     {
         var map = AssertMapInstance(thisObject);
-        return map.Get(arguments.At(0));
+        return map.Get(key);
     }
 
-    private JsValue GetOrInsert(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue GetOrInsert(JsValue thisObject, JsValue key, JsValue value)
     {
         var map = AssertMapInstance(thisObject);
-        var key = arguments.At(0).CanonicalizeKeyedCollectionKey();
-        var value = arguments.At(1);
-        return map.GetOrInsert(key, value);
+        var checkedKey = key.CanonicalizeKeyedCollectionKey();
+        return map.GetOrInsert(checkedKey, value);
     }
 
-    private JsValue GetOrInsertComputed(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue GetOrInsertComputed(JsValue thisObject, JsValue key, JsValue callbackfn)
     {
         var map = AssertMapInstance(thisObject);
-        var key = arguments.At(0).CanonicalizeKeyedCollectionKey();
-        var callbackfn = arguments.At(1).GetCallable(_realm);
-        return map.GetOrInsertComputed(key, callbackfn);
+        var checkedKey = key.CanonicalizeKeyedCollectionKey();
+        var callable = callbackfn.GetCallable(_realm);
+        return map.GetOrInsertComputed(checkedKey, callable);
     }
 
-    private JsValue Clear(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Clear(JsValue thisObject)
     {
         var map = AssertMapInstance(thisObject);
         map.Clear();
         return Undefined;
     }
 
-    private JsValue Delete(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Delete(JsValue thisObject, JsValue key)
     {
         var map = AssertMapInstance(thisObject);
-        return map.Remove(arguments.At(0))
+        return map.Remove(key)
             ? JsBoolean.True
             : JsBoolean.False;
     }
 
-    private JsValue Set(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2, Name = "set")]
+    private JsValue MapSet(JsValue thisObject, JsValue key, JsValue value)
     {
         var map = AssertMapInstance(thisObject);
-        map.Set(arguments.At(0), arguments.At(1));
+        map.Set(key, value);
         return thisObject;
     }
 
-    private JsValue Has(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Has(JsValue thisObject, JsValue key)
     {
         var map = AssertMapInstance(thisObject);
-        return map.Has(arguments.At(0))
+        return map.Has(key)
             ? JsBoolean.True
             : JsBoolean.False;
     }
 
-    private JsValue ForEach(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue ForEach(JsValue thisObject, JsValue callbackfn, JsValue thisArg)
     {
         var map = AssertMapInstance(thisObject);
-        var callbackfn = arguments.At(0);
-        var thisArg = arguments.At(1);
-
         var callable = GetCallable(callbackfn);
 
         map.ForEach(callable, thisArg);
@@ -126,19 +119,22 @@ internal sealed class MapPrototype : Prototype
         return Undefined;
     }
 
-    private ObjectInstance Entries(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private ObjectInstance Entries(JsValue thisObject)
     {
         var map = AssertMapInstance(thisObject);
         return map.Iterator();
     }
 
-    private ObjectInstance Keys(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private ObjectInstance Keys(JsValue thisObject)
     {
         var map = AssertMapInstance(thisObject);
         return map.Keys();
     }
 
-    private ObjectInstance Values(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private ObjectInstance Values(JsValue thisObject)
     {
         var map = AssertMapInstance(thisObject);
         return map.Values();
@@ -158,6 +154,8 @@ internal sealed class MapPrototype : Prototype
     private static string MapMethodName(string callerName) => callerName switch
     {
         "Size" => "get size",
+        "MapGet" => "get",
+        "MapSet" => "set",
         _ => char.ToLowerInvariant(callerName[0]) + callerName.Substring(1)
     };
 }

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -8,6 +8,7 @@ namespace Jint.Native.Math;
 [JsObject]
 internal sealed partial class MathInstance : ObjectInstance
 {
+    private readonly Realm _realm;
     private Random? _random;
 
     [JsProperty(Name = "E", Flags = PropertyFlag.AllForbidden)] private static readonly JsNumber EValue = new(System.Math.E);
@@ -21,8 +22,9 @@ internal sealed partial class MathInstance : ObjectInstance
 
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString MathToStringTag = new("Math");
 
-    internal MathInstance(Engine engine, ObjectPrototype objectPrototype) : base(engine)
+    internal MathInstance(Engine engine, Realm realm, ObjectPrototype objectPrototype) : base(engine)
     {
+        _realm = realm;
         _prototype = objectPrototype;
     }
 
@@ -1036,10 +1038,10 @@ internal sealed partial class MathInstance : ObjectInstance
         var items = arguments.At(0);
         if (items.IsNullOrUndefined())
         {
-            Throw.TypeError(_engine.Realm);
+            Throw.TypeError(_realm);
         }
 
-        var iteratorRecord = items.GetIterator(_engine.Realm);
+        var iteratorRecord = items.GetIterator(_realm);
         var state = JsNumber.NegativeZero._value;
         List<double> sum = [];
         long count = 0;
@@ -1052,12 +1054,12 @@ internal sealed partial class MathInstance : ObjectInstance
                 count++;
                 if (count > 9007199254740992)
                 {
-                    Throw.RangeError(_engine.Realm);
+                    Throw.RangeError(_realm);
                 }
 
                 if (value is not JsNumber jsNumber)
                 {
-                    Throw.TypeError(_engine.Realm, "Input is not a number: " + next);
+                    Throw.TypeError(_realm, "Input is not a number: " + next);
                     return default;
                 }
 

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -543,16 +543,24 @@ internal sealed partial class MathInstance : ObjectInstance
     /// https://tc39.es/ecma262/#sec-math.max
     /// </summary>
     [JsFunction(Length = 2)]
-    private static JsValue Max(JsValue thisObject, JsCallArguments arguments)
+    private static JsValue Max(JsValue thisObject, [Rest] ReadOnlySpan<JsValue> values)
     {
-        if (arguments.Length == 0)
+        if (values.Length == 0)
         {
             return JsNumber.DoubleNegativeInfinity;
         }
 
-        var highest = double.NegativeInfinity;
-        foreach (var number in Coerced(arguments))
+        // Spec requires ToNumber on every element before scanning (observable via valueOf).
+        Span<double> coerced = values.Length <= 16 ? stackalloc double[values.Length] : new double[values.Length];
+        for (var i = 0; i < values.Length; i++)
         {
+            coerced[i] = TypeConverter.ToNumber(values[i]);
+        }
+
+        var highest = double.NegativeInfinity;
+        for (var i = 0; i < coerced.Length; i++)
+        {
+            var number = coerced[i];
             if (double.IsNaN(number))
             {
                 return JsNumber.DoubleNaN;
@@ -576,16 +584,24 @@ internal sealed partial class MathInstance : ObjectInstance
     /// https://tc39.es/ecma262/#sec-math.min
     /// </summary>
     [JsFunction(Length = 2)]
-    private static JsValue Min(JsValue thisObject, JsCallArguments arguments)
+    private static JsValue Min(JsValue thisObject, [Rest] ReadOnlySpan<JsValue> values)
     {
-        if (arguments.Length == 0)
+        if (values.Length == 0)
         {
             return JsNumber.DoublePositiveInfinity;
         }
 
-        var lowest = double.PositiveInfinity;
-        foreach (var number in Coerced(arguments))
+        // Spec requires ToNumber on every element before scanning (observable via valueOf).
+        Span<double> coerced = values.Length <= 16 ? stackalloc double[values.Length] : new double[values.Length];
+        for (var i = 0; i < values.Length; i++)
         {
+            coerced[i] = TypeConverter.ToNumber(values[i]);
+        }
+
+        var lowest = double.PositiveInfinity;
+        for (var i = 0; i < coerced.Length; i++)
+        {
+            var number = coerced[i];
             if (double.IsNaN(number))
             {
                 return JsNumber.DoubleNaN;
@@ -967,13 +983,19 @@ internal sealed partial class MathInstance : ObjectInstance
     /// https://tc39.es/ecma262/#sec-math.hypot
     /// </summary>
     [JsFunction(Length = 2)]
-    private static JsValue Hypot(JsValue thisObject, JsCallArguments arguments)
+    private static JsValue Hypot(JsValue thisObject, [Rest] ReadOnlySpan<JsValue> values)
     {
-        var coerced = Coerced(arguments);
-
-        foreach (var number in coerced)
+        // Spec requires ToNumber on every element before scanning. Any Infinity returns +Infinity
+        // (even if a later value is NaN); otherwise NaN; otherwise sum-of-squares root.
+        Span<double> coerced = values.Length <= 16 ? stackalloc double[values.Length] : new double[values.Length];
+        for (var i = 0; i < values.Length; i++)
         {
-            if (double.IsInfinity(number))
+            coerced[i] = TypeConverter.ToNumber(values[i]);
+        }
+
+        for (var i = 0; i < coerced.Length; i++)
+        {
+            if (double.IsInfinity(coerced[i]))
             {
                 return JsNumber.DoublePositiveInfinity;
             }
@@ -981,8 +1003,9 @@ internal sealed partial class MathInstance : ObjectInstance
 
         var onlyZero = true;
         double y = 0;
-        foreach (var number in coerced)
+        for (var i = 0; i < coerced.Length; i++)
         {
+            var number = coerced[i];
             if (double.IsNaN(number))
             {
                 return JsNumber.DoubleNaN;
@@ -1093,19 +1116,6 @@ internal sealed partial class MathInstance : ObjectInstance
         }
 
         return Math.SumPrecise.Sum(sum);
-    }
-
-    private static double[] Coerced(JsCallArguments arguments)
-    {
-        // TODO stackalloc
-        var coerced = new double[arguments.Length];
-        for (var i = 0; i < arguments.Length; i++)
-        {
-            var argument = arguments[i];
-            coerced[i] = TypeConverter.ToNumber(argument);
-        }
-
-        return coerced;
     }
 
     [JsFunction(Length = 2)]

--- a/Jint/Native/Number/NumberConstructor.cs
+++ b/Jint/Native/Number/NumberConstructor.cs
@@ -10,12 +10,22 @@ namespace Jint.Native.Number;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-number-constructor
 /// </summary>
-internal sealed class NumberConstructor : Constructor
+[JsObject]
+internal sealed partial class NumberConstructor : Constructor
 {
     private static readonly JsString _functionName = new JsString("Number");
 
     private const long MinSafeInteger = -9007199254740991;
     internal const long MaxSafeInteger = 9007199254740991;
+
+    [JsProperty(Name = "MAX_VALUE", Flags = PropertyFlag.AllForbidden)] private static readonly JsNumber MaxValue = new(double.MaxValue);
+    [JsProperty(Name = "MIN_VALUE", Flags = PropertyFlag.AllForbidden)] private static readonly JsNumber MinValueField = new(double.Epsilon);
+    [JsProperty(Name = "NaN", Flags = PropertyFlag.AllForbidden)] private static readonly JsNumber NaNField = JsNumber.DoubleNaN;
+    [JsProperty(Name = "NEGATIVE_INFINITY", Flags = PropertyFlag.AllForbidden)] private static readonly JsNumber NegativeInfinityField = JsNumber.DoubleNegativeInfinity;
+    [JsProperty(Name = "POSITIVE_INFINITY", Flags = PropertyFlag.AllForbidden)] private static readonly JsNumber PositiveInfinityField = JsNumber.DoublePositiveInfinity;
+    [JsProperty(Name = "EPSILON", Flags = PropertyFlag.AllForbidden)] private static readonly JsNumber Epsilon = new(JsNumber.JavaScriptEpsilon);
+    [JsProperty(Name = "MIN_SAFE_INTEGER", Flags = PropertyFlag.AllForbidden)] private static readonly JsNumber MinSafeIntegerField = new(MinSafeInteger);
+    [JsProperty(Name = "MAX_SAFE_INTEGER", Flags = PropertyFlag.AllForbidden)] private static readonly JsNumber MaxSafeIntegerField = new(MaxSafeInteger);
 
     public NumberConstructor(
         Engine engine,
@@ -32,26 +42,18 @@ internal sealed class NumberConstructor : Constructor
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(15, checkExistingKeys: false)
-        {
-            ["MAX_VALUE"] = new PropertyDescriptor(new PropertyDescriptor(double.MaxValue, PropertyFlag.AllForbidden)),
-            ["MIN_VALUE"] = new PropertyDescriptor(new PropertyDescriptor(double.Epsilon, PropertyFlag.AllForbidden)),
-            ["NaN"] = new PropertyDescriptor(new PropertyDescriptor(double.NaN, PropertyFlag.AllForbidden)),
-            ["NEGATIVE_INFINITY"] = new PropertyDescriptor(new PropertyDescriptor(double.NegativeInfinity, PropertyFlag.AllForbidden)),
-            ["POSITIVE_INFINITY"] = new PropertyDescriptor(new PropertyDescriptor(double.PositiveInfinity, PropertyFlag.AllForbidden)),
-            ["EPSILON"] = new PropertyDescriptor(new PropertyDescriptor(JsNumber.JavaScriptEpsilon, PropertyFlag.AllForbidden)),
-            ["MIN_SAFE_INTEGER"] = new PropertyDescriptor(new PropertyDescriptor(MinSafeInteger, PropertyFlag.AllForbidden)),
-            ["MAX_SAFE_INTEGER"] = new PropertyDescriptor(new PropertyDescriptor(MaxSafeInteger, PropertyFlag.AllForbidden)),
-            ["isFinite"] = new PropertyDescriptor(new ClrFunction(Engine, "isFinite", IsFinite, 1, PropertyFlag.Configurable), true, false, true),
-            ["isInteger"] = new PropertyDescriptor(new ClrFunction(Engine, "isInteger", IsInteger, 1, PropertyFlag.Configurable), true, false, true),
-            ["isNaN"] = new PropertyDescriptor(new ClrFunction(Engine, "isNaN", IsNaN, 1, PropertyFlag.Configurable), true, false, true),
-            ["isSafeInteger"] = new PropertyDescriptor(new ClrFunction(Engine, "isSafeInteger", IsSafeInteger, 1, PropertyFlag.Configurable), true, false, true),
-            ["parseFloat"] = new PropertyDescriptor(new ClrFunction(Engine, "parseFloat", GlobalObject.ParseFloat, 0, PropertyFlag.Configurable), true, false, true),
-            ["parseInt"] = new PropertyDescriptor(new ClrFunction(Engine, "parseInt", GlobalObject.ParseInt, 0, PropertyFlag.Configurable), true, false, true)
-        };
-        SetProperties(properties);
+        CreateProperties_Generated();
+
+        // Per spec, Number.parseInt and Number.parseFloat are the same function objects as the global
+        // parseInt / parseFloat. Pre-source-gen Jint's behaviour relied on ClrFunction.Equals comparing
+        // the underlying delegate; the source generator's per-method dispatcher would break that
+        // identity, so register parseInt/parseFloat hand-rolled and let them keep the same delegate.
+        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
+        SetProperty("parseInt", new PropertyDescriptor(new ClrFunction(Engine, "parseInt", GlobalObject.ParseInt, 0, PropertyFlag.Configurable), PropertyFlags));
+        SetProperty("parseFloat", new PropertyDescriptor(new ClrFunction(Engine, "parseFloat", GlobalObject.ParseFloat, 0, PropertyFlag.Configurable), PropertyFlags));
     }
 
+    [JsFunction(Length = 1)]
     private static JsValue IsFinite(JsValue thisObject, JsCallArguments arguments)
     {
         if (!(arguments.At(0) is JsNumber num))
@@ -62,6 +64,7 @@ internal sealed class NumberConstructor : Constructor
         return double.IsInfinity(num._value) || double.IsNaN(num._value) ? JsBoolean.False : JsBoolean.True;
     }
 
+    [JsFunction(Length = 1)]
     private static JsValue IsInteger(JsValue thisObject, JsCallArguments arguments)
     {
         if (!(arguments.At(0) is JsNumber num))
@@ -79,6 +82,7 @@ internal sealed class NumberConstructor : Constructor
         return integer == num._value;
     }
 
+    [JsFunction(Length = 1)]
     private static JsValue IsNaN(JsValue thisObject, JsCallArguments arguments)
     {
         if (!(arguments.At(0) is JsNumber num))
@@ -89,6 +93,7 @@ internal sealed class NumberConstructor : Constructor
         return double.IsNaN(num._value);
     }
 
+    [JsFunction(Length = 1)]
     private static JsValue IsSafeInteger(JsValue thisObject, JsCallArguments arguments)
     {
         if (!(arguments.At(0) is JsNumber num))

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -3,11 +3,11 @@
 using Jint.Native.Iterator;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Object;
 
-public sealed class ObjectConstructor : Constructor
+[JsObject]
+public sealed partial class ObjectConstructor : Constructor
 {
     private static readonly JsString _name = new JsString("Object");
 
@@ -26,41 +26,13 @@ public sealed class ObjectConstructor : Constructor
     protected override void Initialize()
     {
         _prototype = _realm.Intrinsics.Function.PrototypeObject;
-
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        var properties = new PropertyDictionary(16, checkExistingKeys: false)
-        {
-            ["assign"] = new PropertyDescriptor(new ClrFunction(Engine, "assign", Assign, 2, LengthFlags), PropertyFlags),
-            ["entries"] = new PropertyDescriptor(new ClrFunction(Engine, "entries", Entries, 1, LengthFlags), PropertyFlags),
-            ["fromEntries"] = new PropertyDescriptor(new ClrFunction(Engine, "fromEntries", FromEntries, 1, LengthFlags), PropertyFlags),
-            ["getPrototypeOf"] = new PropertyDescriptor(new ClrFunction(Engine, "getPrototypeOf", GetPrototypeOf, 1), PropertyFlags),
-            ["getOwnPropertyDescriptor"] = new PropertyDescriptor(new ClrFunction(Engine, "getOwnPropertyDescriptor", GetOwnPropertyDescriptor, 2, LengthFlags), PropertyFlags),
-            ["getOwnPropertyDescriptors"] = new PropertyDescriptor(new ClrFunction(Engine, "getOwnPropertyDescriptors", GetOwnPropertyDescriptors, 1, LengthFlags), PropertyFlags),
-            ["getOwnPropertyNames"] = new PropertyDescriptor(new ClrFunction(Engine, "getOwnPropertyNames", GetOwnPropertyNames, 1), PropertyFlags),
-            ["getOwnPropertySymbols"] = new PropertyDescriptor(new ClrFunction(Engine, "getOwnPropertySymbols", GetOwnPropertySymbols, 1, LengthFlags), PropertyFlags),
-            ["groupBy"] = new PropertyDescriptor(new ClrFunction(Engine, "groupBy", GroupBy, 2, PropertyFlag.Configurable), PropertyFlags),
-            ["create"] = new PropertyDescriptor(new ClrFunction(Engine, "create", Create, 2), PropertyFlags),
-            ["defineProperty"] = new PropertyDescriptor(new ClrFunction(Engine, "defineProperty", DefineProperty, 3), PropertyFlags),
-            ["defineProperties"] = new PropertyDescriptor(new ClrFunction(Engine, "defineProperties", DefineProperties, 2), PropertyFlags),
-            ["is"] = new PropertyDescriptor(new ClrFunction(Engine, "is", Is, 2, LengthFlags), PropertyFlags),
-            ["seal"] = new PropertyDescriptor(new ClrFunction(Engine, "seal", Seal, 1, LengthFlags), PropertyFlags),
-            ["freeze"] = new PropertyDescriptor(new ClrFunction(Engine, "freeze", Freeze, 1), PropertyFlags),
-            ["preventExtensions"] = new PropertyDescriptor(new ClrFunction(Engine, "preventExtensions", PreventExtensions, 1), PropertyFlags),
-            ["isSealed"] = new PropertyDescriptor(new ClrFunction(Engine, "isSealed", IsSealed, 1), PropertyFlags),
-            ["isFrozen"] = new PropertyDescriptor(new ClrFunction(Engine, "isFrozen", IsFrozen, 1), PropertyFlags),
-            ["isExtensible"] = new PropertyDescriptor(new ClrFunction(Engine, "isExtensible", IsExtensible, 1), PropertyFlags),
-            ["keys"] = new PropertyDescriptor(new ClrFunction(Engine, "keys", Keys, 1, LengthFlags), PropertyFlags),
-            ["values"] = new PropertyDescriptor(new ClrFunction(Engine, "values", Values, 1, LengthFlags), PropertyFlags),
-            ["setPrototypeOf"] = new PropertyDescriptor(new ClrFunction(Engine, "setPrototypeOf", SetPrototypeOf, 2, LengthFlags), PropertyFlags),
-            ["hasOwn"] = new PropertyDescriptor(new ClrFunction(Engine, "hasOwn", HasOwn, 2, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
+        CreateProperties_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.assign
     /// </summary>
+    [JsFunction(Length = 2)]
     private JsValue Assign(JsValue thisObject, JsCallArguments arguments)
     {
         var to = TypeConverter.ToObject(_realm, arguments.At(0));
@@ -95,9 +67,10 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.entries
     /// </summary>
-    private JsValue Entries(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Entries(JsValue thisObject, JsValue value)
     {
-        var obj = TypeConverter.ToObject(_realm, arguments.At(0));
+        var obj = TypeConverter.ToObject(_realm, value);
         var nameList = obj.EnumerableOwnProperties(EnumerableOwnPropertyNamesKind.KeyValue);
         return nameList;
     }
@@ -105,15 +78,15 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.fromentries
     /// </summary>
-    private JsValue FromEntries(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue FromEntries(JsValue thisObject, JsValue iterable)
     {
-        var iterable = arguments.At(0);
         TypeConverter.RequireObjectCoercible(_engine, iterable);
 
         var obj = _realm.Intrinsics.Object.Construct(0);
 
         var adder = CreateDataPropertyOnObject.Instance;
-        var iterator = arguments.At(0).GetIterator(_realm);
+        var iterator = iterable.GetIterator(_realm);
 
         IteratorProtocol.AddEntriesFromIterable(obj, iterator, adder);
 
@@ -123,9 +96,10 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.is
     /// </summary>
-    private static JsValue Is(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private static JsValue Is(JsValue thisObject, JsValue value1, JsValue value2)
     {
-        return SameValue(arguments.At(0), arguments.At(1));
+        return SameValue(value1, value2);
     }
 
     /// <summary>
@@ -193,21 +167,21 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.getprototypeof
     /// </summary>
-    public JsValue GetPrototypeOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    public JsValue GetPrototypeOf(JsValue thisObject, JsValue value)
     {
-        var obj = TypeConverter.ToObject(_realm, arguments.At(0));
+        var obj = TypeConverter.ToObject(_realm, value);
         return obj.Prototype ?? Null;
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.setprototypeof
     /// </summary>
-    private JsValue SetPrototypeOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue SetPrototypeOf(JsValue thisObject, JsValue oArg, JsValue prototype)
     {
-        var oArg = arguments.At(0);
         TypeConverter.RequireObjectCoercible(_engine, oArg);
 
-        var prototype = arguments.At(1);
         if (!prototype.IsObject() && !prototype.IsNull())
         {
             Throw.TypeError(_realm, $"Object prototype may only be an Object or null: {prototype}");
@@ -228,22 +202,22 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.hasown
     /// </summary>
-    private JsValue HasOwn(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue HasOwn(JsValue thisObject, JsValue value, JsValue propertyKey)
     {
-        var o = TypeConverter.ToObject(_realm, arguments.At(0));
-        var property = TypeConverter.ToPropertyKey(arguments.At(1));
+        var o = TypeConverter.ToObject(_realm, value);
+        var property = TypeConverter.ToPropertyKey(propertyKey);
         return o.HasOwnProperty(property) ? JsBoolean.True : JsBoolean.False;
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.getownpropertydescriptor
     /// </summary>
-    internal JsValue GetOwnPropertyDescriptor(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    internal JsValue GetOwnPropertyDescriptor(JsValue thisObject, JsValue value, JsValue propertyKey)
     {
-        var o = TypeConverter.ToObject(_realm, arguments.At(0));
-
-        var p = arguments.At(1);
-        var name = TypeConverter.ToPropertyKey(p);
+        var o = TypeConverter.ToObject(_realm, value);
+        var name = TypeConverter.ToPropertyKey(propertyKey);
 
         var desc = o.GetOwnProperty(name);
         return PropertyDescriptor.FromPropertyDescriptor(Engine, desc);
@@ -252,9 +226,10 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.getownpropertydescriptors
     /// </summary>
-    private JsValue GetOwnPropertyDescriptors(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue GetOwnPropertyDescriptors(JsValue thisObject, JsValue value)
     {
-        var o = TypeConverter.ToObject(_realm, arguments.At(0));
+        var o = TypeConverter.ToObject(_realm, value);
         var ownKeys = o.GetOwnPropertyKeys();
         var descriptors = _realm.Intrinsics.Object.Construct(0);
         foreach (var key in ownKeys)
@@ -272,9 +247,10 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.getownpropertynames
     /// </summary>
-    private JsValue GetOwnPropertyNames(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue GetOwnPropertyNames(JsValue thisObject, JsValue value)
     {
-        var o = TypeConverter.ToObject(_realm, arguments.At(0));
+        var o = TypeConverter.ToObject(_realm, value);
         var names = o.GetOwnPropertyKeys(Types.String);
         return _realm.Intrinsics.Array.ConstructFast(names);
     }
@@ -282,9 +258,10 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.getownpropertysymbols
     /// </summary>
-    private JsValue GetOwnPropertySymbols(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue GetOwnPropertySymbols(JsValue thisObject, JsValue value)
     {
-        var o = TypeConverter.ToObject(_realm, arguments.At(0));
+        var o = TypeConverter.ToObject(_realm, value);
         var keys = o.GetOwnPropertyKeys(Types.Symbol);
         return _realm.Intrinsics.Array.ConstructFast(keys);
     }
@@ -292,9 +269,9 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.create
     /// </summary>
-    private JsValue Create(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue Create(JsValue thisObject, JsValue prototype, JsValue properties)
     {
-        var prototype = arguments.At(0);
         if (!prototype.IsObject() && !prototype.IsNull())
         {
             Throw.TypeError(_realm, "Object prototype may only be an Object or null: " + prototype);
@@ -303,7 +280,6 @@ public sealed class ObjectConstructor : Constructor
         var obj = Engine.Realm.Intrinsics.Object.Construct(Arguments.Empty);
         obj._prototype = prototype.IsNull() ? null : prototype.AsObject();
 
-        var properties = arguments.At(1);
         if (!properties.IsUndefined())
         {
             ObjectDefineProperties(obj, properties);
@@ -315,37 +291,36 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.defineproperty
     /// </summary>
-    private JsValue DefineProperty(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 3)]
+    private JsValue DefineProperty(JsValue thisObject, JsValue value, JsValue propertyKey, JsValue attributes)
     {
-        if (arguments.At(0) is not ObjectInstance o)
+        if (value is not ObjectInstance o)
         {
             Throw.TypeError(_realm, "Object.defineProperty called on non-object");
             return null;
         }
 
-        var p = arguments.At(1);
-        var name = TypeConverter.ToPropertyKey(p);
+        var name = TypeConverter.ToPropertyKey(propertyKey);
 
-        var attributes = arguments.At(2);
         var desc = PropertyDescriptor.ToPropertyDescriptor(_realm, attributes);
 
         o.DefinePropertyOrThrow(name, desc);
 
-        return arguments.At(0);
+        return value;
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.defineproperties
     /// </summary>
-    private JsValue DefineProperties(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue DefineProperties(JsValue thisObject, JsValue value, JsValue properties)
     {
-        var o = arguments.At(0) as ObjectInstance;
+        var o = value as ObjectInstance;
         if (o is null)
         {
             Throw.TypeError(_realm, "Object.defineProperties called on non-object");
         }
 
-        var properties = arguments.At(1);
         return ObjectDefineProperties(o, properties);
     }
 
@@ -382,11 +357,12 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.seal
     /// </summary>
-    private JsValue Seal(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Seal(JsValue thisObject, JsValue value)
     {
-        if (arguments.At(0) is not ObjectInstance o)
+        if (value is not ObjectInstance o)
         {
-            return arguments.At(0);
+            return value;
         }
 
         var status = o.SetIntegrityLevel(IntegrityLevel.Sealed);
@@ -402,11 +378,12 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.freeze
     /// </summary>
-    private JsValue Freeze(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Freeze(JsValue thisObject, JsValue value)
     {
-        if (arguments.At(0) is not ObjectInstance o)
+        if (value is not ObjectInstance o)
         {
-            return arguments.At(0);
+            return value;
         }
 
         var status = o.SetIntegrityLevel(IntegrityLevel.Frozen);
@@ -422,11 +399,12 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.preventextensions
     /// </summary>
-    private JsValue PreventExtensions(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue PreventExtensions(JsValue thisObject, JsValue value)
     {
-        if (arguments.At(0) is not ObjectInstance o)
+        if (value is not ObjectInstance o)
         {
-            return arguments.At(0);
+            return value;
         }
 
         if (!o.PreventExtensions())
@@ -440,9 +418,10 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.issealed
     /// </summary>
-    private static JsValue IsSealed(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private static JsValue IsSealed(JsValue thisObject, JsValue value)
     {
-        if (arguments.At(0) is not ObjectInstance o)
+        if (value is not ObjectInstance o)
         {
             return JsBoolean.True;
         }
@@ -453,9 +432,10 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.isfrozen
     /// </summary>
-    private static JsValue IsFrozen(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private static JsValue IsFrozen(JsValue thisObject, JsValue value)
     {
-        if (arguments.At(0) is not ObjectInstance o)
+        if (value is not ObjectInstance o)
         {
             return JsBoolean.True;
         }
@@ -499,9 +479,10 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.isextensible
     /// </summary>
-    private static JsValue IsExtensible(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private static JsValue IsExtensible(JsValue thisObject, JsValue value)
     {
-        if (arguments.At(0) is not ObjectInstance o)
+        if (value is not ObjectInstance o)
         {
             return JsBoolean.False;
         }
@@ -512,28 +493,29 @@ public sealed class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.keys
     /// </summary>
-    private JsValue Keys(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Keys(JsValue thisObject, JsValue value)
     {
-        var o = TypeConverter.ToObject(_realm, arguments.At(0));
+        var o = TypeConverter.ToObject(_realm, value);
         return o.EnumerableOwnProperties(EnumerableOwnPropertyNamesKind.Key);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.values
     /// </summary>
-    private JsValue Values(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Values(JsValue thisObject, JsValue value)
     {
-        var o = TypeConverter.ToObject(_realm, arguments.At(0));
+        var o = TypeConverter.ToObject(_realm, value);
         return o.EnumerableOwnProperties(EnumerableOwnPropertyNamesKind.Value);
     }
 
     /// <summary>
     /// https://tc39.es/proposal-array-grouping/#sec-object.groupby
     /// </summary>
-    private JsValue GroupBy(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue GroupBy(JsValue thisObject, JsValue items, JsValue callbackfn)
     {
-        var items = arguments.At(0);
-        var callbackfn = arguments.At(1);
         var grouping = GroupByHelper.GroupBy(_engine, _realm, items, callbackfn, mapMode: false);
 
         var obj = OrdinaryObjectCreate(_engine, null);

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of constructor methods return JsValue
-
 using Jint.Native.Iterator;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
@@ -33,7 +31,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.assign
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsValue Assign(JsValue thisObject, JsValue target, [Rest] ReadOnlySpan<JsValue> sources)
+    private ObjectInstance Assign(JsValue thisObject, JsValue target, [Rest] ReadOnlySpan<JsValue> sources)
     {
         var to = TypeConverter.ToObject(_realm, target);
         for (var i = 0; i < sources.Length; i++)
@@ -63,18 +61,17 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.entries
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsValue Entries(JsValue thisObject, JsValue value)
+    private JsArray Entries(JsValue thisObject, JsValue value)
     {
         var obj = TypeConverter.ToObject(_realm, value);
-        var nameList = obj.EnumerableOwnProperties(EnumerableOwnPropertyNamesKind.KeyValue);
-        return nameList;
+        return obj.EnumerableOwnProperties(EnumerableOwnPropertyNamesKind.KeyValue);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.fromentries
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsValue FromEntries(JsValue thisObject, JsValue iterable)
+    private ObjectInstance FromEntries(JsValue thisObject, JsValue iterable)
     {
         TypeConverter.RequireObjectCoercible(_engine, iterable);
 
@@ -198,7 +195,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.hasown
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsValue HasOwn(JsValue thisObject, JsValue value, JsValue propertyKey)
+    private JsBoolean HasOwn(JsValue thisObject, JsValue value, JsValue propertyKey)
     {
         var o = TypeConverter.ToObject(_realm, value);
         var property = TypeConverter.ToPropertyKey(propertyKey);
@@ -222,7 +219,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.getownpropertydescriptors
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsValue GetOwnPropertyDescriptors(JsValue thisObject, JsValue value)
+    private ObjectInstance GetOwnPropertyDescriptors(JsValue thisObject, JsValue value)
     {
         var o = TypeConverter.ToObject(_realm, value);
         var ownKeys = o.GetOwnPropertyKeys();
@@ -243,7 +240,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.getownpropertynames
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsValue GetOwnPropertyNames(JsValue thisObject, JsValue value)
+    private JsArray GetOwnPropertyNames(JsValue thisObject, JsValue value)
     {
         var o = TypeConverter.ToObject(_realm, value);
         var names = o.GetOwnPropertyKeys(Types.String);
@@ -254,7 +251,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.getownpropertysymbols
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsValue GetOwnPropertySymbols(JsValue thisObject, JsValue value)
+    private JsArray GetOwnPropertySymbols(JsValue thisObject, JsValue value)
     {
         var o = TypeConverter.ToObject(_realm, value);
         var keys = o.GetOwnPropertyKeys(Types.Symbol);
@@ -265,7 +262,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.create
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsValue Create(JsValue thisObject, JsValue prototype, JsValue properties)
+    private ObjectInstance Create(JsValue thisObject, JsValue prototype, JsValue properties)
     {
         if (!prototype.IsObject() && !prototype.IsNull())
         {
@@ -308,7 +305,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.defineproperties
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsValue DefineProperties(JsValue thisObject, JsValue value, JsValue properties)
+    private ObjectInstance DefineProperties(JsValue thisObject, JsValue value, JsValue properties)
     {
         var o = value as ObjectInstance;
         if (o is null)
@@ -322,7 +319,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-objectdefineproperties
     /// </summary>
-    private JsValue ObjectDefineProperties(ObjectInstance o, JsValue properties)
+    private ObjectInstance ObjectDefineProperties(ObjectInstance o, JsValue properties)
     {
         var props = TypeConverter.ToObject(_realm, properties);
         var keys = props.GetOwnPropertyKeys();
@@ -414,7 +411,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.issealed
     /// </summary>
     [JsFunction(Length = 1)]
-    private static JsValue IsSealed(JsValue thisObject, JsValue value)
+    private static JsBoolean IsSealed(JsValue thisObject, JsValue value)
     {
         if (value is not ObjectInstance o)
         {
@@ -428,7 +425,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.isfrozen
     /// </summary>
     [JsFunction(Length = 1)]
-    private static JsValue IsFrozen(JsValue thisObject, JsValue value)
+    private static JsBoolean IsFrozen(JsValue thisObject, JsValue value)
     {
         if (value is not ObjectInstance o)
         {
@@ -441,7 +438,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-testintegritylevel
     /// </summary>
-    private static JsValue TestIntegrityLevel(ObjectInstance o, IntegrityLevel level)
+    private static JsBoolean TestIntegrityLevel(ObjectInstance o, IntegrityLevel level)
     {
         if (o.Extensible)
         {
@@ -489,7 +486,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.keys
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsValue Keys(JsValue thisObject, JsValue value)
+    private JsArray Keys(JsValue thisObject, JsValue value)
     {
         var o = TypeConverter.ToObject(_realm, value);
         return o.EnumerableOwnProperties(EnumerableOwnPropertyNamesKind.Key);
@@ -499,7 +496,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.values
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsValue Values(JsValue thisObject, JsValue value)
+    private JsArray Values(JsValue thisObject, JsValue value)
     {
         var o = TypeConverter.ToObject(_realm, value);
         return o.EnumerableOwnProperties(EnumerableOwnPropertyNamesKind.Value);
@@ -509,7 +506,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/proposal-array-grouping/#sec-object.groupby
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsValue GroupBy(JsValue thisObject, JsValue items, JsValue callbackfn)
+    private JsObject GroupBy(JsValue thisObject, JsValue items, JsValue callbackfn)
     {
         var grouping = GroupByHelper.GroupBy(_engine, _realm, items, callbackfn, mapMode: false);
 

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -33,17 +33,12 @@ public sealed partial class ObjectConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-object.assign
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsValue Assign(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Assign(JsValue thisObject, JsValue target, [Rest] ReadOnlySpan<JsValue> sources)
     {
-        var to = TypeConverter.ToObject(_realm, arguments.At(0));
-        if (arguments.Length < 2)
+        var to = TypeConverter.ToObject(_realm, target);
+        for (var i = 0; i < sources.Length; i++)
         {
-            return to;
-        }
-
-        for (var i = 1; i < arguments.Length; i++)
-        {
-            var nextSource = arguments[i];
+            var nextSource = sources[i];
             if (nextSource.IsNullOrUndefined())
             {
                 continue;

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -1,7 +1,6 @@
 using Jint.Native.Function;
 using Jint.Native.Iterator;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
@@ -15,7 +14,8 @@ internal sealed record PromiseCapability(
     JsValue ResolveObj,
     JsValue RejectObj);
 
-internal sealed class PromiseConstructor : Constructor
+[JsObject]
+internal sealed partial class PromiseConstructor : Constructor
 {
     private static readonly JsString _functionName = new JsString("Promise");
 
@@ -36,31 +36,12 @@ internal sealed class PromiseConstructor : Constructor
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        var properties = new PropertyDictionary(10, checkExistingKeys: false)
-        {
-            ["all"] = new(new PropertyDescriptor(new ClrFunction(Engine, "all", All, 1, LengthFlags), PropertyFlags)),
-            ["allKeyed"] = new(new PropertyDescriptor(new ClrFunction(Engine, "allKeyed", AllKeyed, 1, LengthFlags), PropertyFlags)),
-            ["allSettled"] = new(new PropertyDescriptor(new ClrFunction(Engine, "allSettled", AllSettled, 1, LengthFlags), PropertyFlags)),
-            ["allSettledKeyed"] = new(new PropertyDescriptor(new ClrFunction(Engine, "allSettledKeyed", AllSettledKeyed, 1, LengthFlags), PropertyFlags)),
-            ["any"] = new(new PropertyDescriptor(new ClrFunction(Engine, "any", Any, 1, LengthFlags), PropertyFlags)),
-            ["race"] = new(new PropertyDescriptor(new ClrFunction(Engine, "race", Race, 1, LengthFlags), PropertyFlags)),
-            ["reject"] = new(new PropertyDescriptor(new ClrFunction(Engine, "reject", Reject, 1, LengthFlags), PropertyFlags)),
-            ["resolve"] = new(new PropertyDescriptor(new ClrFunction(Engine, "resolve", Resolve, 1, LengthFlags), PropertyFlags)),
-            ["try"] = new(new PropertyDescriptor(new ClrFunction(Engine, "try", Try, 1, LengthFlags), PropertyFlags)),
-            ["withResolvers"] = new(new PropertyDescriptor(new ClrFunction(Engine, "withResolvers", WithResolvers, 0, LengthFlags), PropertyFlags)),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.Species] = new GetSetPropertyDescriptor(
-                get: new ClrFunction(_engine, "get [Symbol.species]", (thisObj, _) => thisObj, 0, PropertyFlag.Configurable),
-                set: Undefined, PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
+    [JsSymbolAccessor("Species")]
+    private static JsValue Species(JsValue thisObject) => thisObject;
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-promise-executor
@@ -110,6 +91,7 @@ internal sealed class PromiseConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-promise.resolve
     /// </summary>
+    [JsFunction(Length = 1, Name = "resolve")]
     internal JsValue Resolve(JsValue thisObject, JsCallArguments arguments)
     {
         if (!thisObject.IsObject())
@@ -126,6 +108,7 @@ internal sealed class PromiseConstructor : Constructor
         return PromiseResolve(thisObject, x);
     }
 
+    [JsFunction(Length = 0)]
     private JsObject WithResolvers(JsValue thisObject, JsCallArguments arguments)
     {
         var promiseCapability = NewPromiseCapability(_engine, thisObject);
@@ -162,6 +145,7 @@ internal sealed class PromiseConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-promise.reject
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsValue Reject(JsValue thisObject, JsCallArguments arguments)
     {
         if (!thisObject.IsObject())
@@ -186,6 +170,7 @@ internal sealed class PromiseConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-promise-try/
     /// </summary>
+    [JsFunction(Length = 1, Name = "try")]
     private JsValue Try(JsValue thisObject, JsCallArguments arguments)
     {
         if (!thisObject.IsObject())
@@ -210,6 +195,7 @@ internal sealed class PromiseConstructor : Constructor
     }
 
     // https://tc39.es/proposal-await-dictionary/#sec-promise.allkeyed
+    [JsFunction(Length = 1)]
     private JsValue AllKeyed(JsValue thisObject, JsCallArguments arguments)
     {
         if (!thisObject.IsObject())
@@ -249,6 +235,7 @@ internal sealed class PromiseConstructor : Constructor
     }
 
     // https://tc39.es/proposal-await-dictionary/#sec-promise.allsettledkeyed
+    [JsFunction(Length = 1)]
     private JsValue AllSettledKeyed(JsValue thisObject, JsCallArguments arguments)
     {
         if (!thisObject.IsObject())
@@ -458,6 +445,7 @@ internal sealed class PromiseConstructor : Constructor
     }
 
     // https://tc39.es/ecma262/#sec-promise.all
+    [JsFunction(Length = 1)]
     private JsValue All(JsValue thisObject, JsCallArguments arguments)
     {
         if (!TryGetPromiseCapabilityAndIterator(thisObject, arguments, "Promise.all", out var capability, out var promiseResolve, out var iterator))
@@ -559,6 +547,7 @@ internal sealed class PromiseConstructor : Constructor
     }
 
     // https://tc39.es/ecma262/#sec-promise.allsettled
+    [JsFunction(Length = 1)]
     private JsValue AllSettled(JsValue thisObject, JsCallArguments arguments)
     {
         if (!TryGetPromiseCapabilityAndIterator(thisObject, arguments, "Promise.allSettled", out var capability, out var promiseResolve, out var iterator))
@@ -682,6 +671,7 @@ internal sealed class PromiseConstructor : Constructor
     }
 
     // https://tc39.es/ecma262/#sec-promise.any
+    [JsFunction(Length = 1)]
     private JsValue Any(JsValue thisObject, JsCallArguments arguments)
     {
         if (!TryGetPromiseCapabilityAndIterator(thisObject, arguments, "Promise.any", out var capability, out var promiseResolve, out var iterator))
@@ -792,6 +782,7 @@ internal sealed class PromiseConstructor : Constructor
     }
 
     // https://tc39.es/ecma262/#sec-promise.race
+    [JsFunction(Length = 1)]
     private JsValue Race(JsValue thisObject, JsCallArguments arguments)
     {
         if (!TryGetPromiseCapabilityAndIterator(thisObject, arguments, "Promise.race", out var capability, out var promiseResolve, out var iterator))

--- a/Jint/Native/Reflect/ReflectInstance.cs
+++ b/Jint/Native/Reflect/ReflectInstance.cs
@@ -156,7 +156,7 @@ internal sealed partial class ReflectInstance : ObjectInstance
         {
             Throw.TypeError(_realm, "Reflect.getOwnPropertyDescriptor called on non-object");
         }
-        return _realm.Intrinsics.Object.GetOwnPropertyDescriptor(Undefined, [target, propertyKey]);
+        return _realm.Intrinsics.Object.GetOwnPropertyDescriptor(Undefined, target, propertyKey);
     }
 
     [JsFunction]
@@ -204,7 +204,7 @@ internal sealed partial class ReflectInstance : ObjectInstance
             Throw.TypeError(_realm, "Reflect.getPrototypeOf called on non-object");
         }
 
-        return _realm.Intrinsics.Object.GetPrototypeOf(Undefined, [target]);
+        return _realm.Intrinsics.Object.GetPrototypeOf(Undefined, target);
     }
 
     [JsFunction]

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using Jint.Collections;
 using Jint.Native.Function;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
@@ -12,7 +11,8 @@ using Jint.Runtime.RegExp;
 
 namespace Jint.Native.RegExp;
 
-public sealed class RegExpConstructor : Constructor
+[JsObject]
+public sealed partial class RegExpConstructor : Constructor
 {
     private static readonly JsString _functionName = new JsString("RegExp");
     private static readonly Regex DummyRegex = new("(?:)", RegexOptions.None, TimeSpan.FromSeconds(1));
@@ -57,11 +57,24 @@ public sealed class RegExpConstructor : Constructor
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
+        AddLegacyAccessors();
+    }
 
-        // B.2.4 Legacy static accessor helpers
-        JsValue LegacyGetter(Func<RegExpConstructor, string> getter, JsValue thisObj, JsCallArguments _)
+    [JsSymbolAccessor("Species")]
+    private static JsValue Species(JsValue thisObject) => thisObject;
+
+    // B.2.4 Legacy static accessors. Kept hand-rolled (rather than [JsAccessor]) because the
+    // accessor function names are non-identifier strings like "$&" / "$_" / "$1" / "$`" — when
+    // the source generator names the underlying function "get $&", `Function.prototype.toString`
+    // returns text that fails test262's native-function-syntax matcher. Building the accessors
+    // here with empty-named ClrFunctions preserves the pre-source-gen behaviour.
+    private void AddLegacyAccessors()
+    {
+        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
+
+        JsValue LegacyGetter(Func<RegExpConstructor, string> getter, JsValue thisObj)
         {
             if (!ReferenceEquals(thisObj, this))
             {
@@ -73,12 +86,12 @@ public sealed class RegExpConstructor : Constructor
         GetSetPropertyDescriptor CreateLegacyReadOnlyAccessor(Func<RegExpConstructor, string> getter)
         {
             return new GetSetPropertyDescriptor(
-                get: new ClrFunction(Engine, "", (thisObj, args) => LegacyGetter(getter, thisObj, args), 0, LengthFlags),
+                get: new ClrFunction(Engine, "", (thisObj, _) => LegacyGetter(getter, thisObj), 0, LengthFlags),
                 set: Undefined,
                 flags: PropertyFlag.Configurable);
         }
 
-        // input/$_ - readable and writable
+        // input/$_ — readable and writable
         var inputGetter = new ClrFunction(Engine, "get input", (thisObj, _) =>
         {
             if (!ReferenceEquals(thisObj, this)) Throw.TypeError(_realm, "Getter called on non-RegExp constructor");
@@ -92,7 +105,7 @@ public sealed class RegExpConstructor : Constructor
         }, 1, LengthFlags);
         var inputAccessor = new GetSetPropertyDescriptor(get: inputGetter, set: inputSetter, flags: PropertyFlag.Configurable);
 
-        // $1-$9 - readable, [[Set]]: undefined per B.2.4
+        // $1-$9 — readable, [[Set]]: undefined per B.2.4
         GetSetPropertyDescriptor CreateParenAccessor(int index)
         {
             var i = index;
@@ -106,42 +119,31 @@ public sealed class RegExpConstructor : Constructor
                 flags: PropertyFlag.Configurable);
         }
 
-        var properties = new PropertyDictionary(20, checkExistingKeys: false)
-        {
-            ["escape"] = new PropertyDescriptor(new ClrFunction(Engine, "escape", Escape, 1, LengthFlags), PropertyFlags),
-            // B.2.4 Legacy static accessors
-            ["input"] = inputAccessor,
-            ["$_"] = inputAccessor,
-            ["lastMatch"] = CreateLegacyReadOnlyAccessor(static c => c._legacyLastMatch),
-            ["$&"] = CreateLegacyReadOnlyAccessor(static c => c._legacyLastMatch),
-            ["lastParen"] = CreateLegacyReadOnlyAccessor(static c => c._legacyLastParen),
-            ["$+"] = CreateLegacyReadOnlyAccessor(static c => c._legacyLastParen),
-            ["leftContext"] = CreateLegacyReadOnlyAccessor(static c => c._legacyLeftContext),
-            ["$`"] = CreateLegacyReadOnlyAccessor(static c => c._legacyLeftContext),
-            ["rightContext"] = CreateLegacyReadOnlyAccessor(static c => c._legacyRightContext),
-            ["$'"] = CreateLegacyReadOnlyAccessor(static c => c._legacyRightContext),
-            ["$1"] = CreateParenAccessor(0),
-            ["$2"] = CreateParenAccessor(1),
-            ["$3"] = CreateParenAccessor(2),
-            ["$4"] = CreateParenAccessor(3),
-            ["$5"] = CreateParenAccessor(4),
-            ["$6"] = CreateParenAccessor(5),
-            ["$7"] = CreateParenAccessor(6),
-            ["$8"] = CreateParenAccessor(7),
-            ["$9"] = CreateParenAccessor(8),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.Species] = new GetSetPropertyDescriptor(get: new ClrFunction(_engine, "get [Symbol.species]", (thisObj, _) => thisObj, 0, PropertyFlag.Configurable), set: Undefined, PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        SetProperty("input", inputAccessor);
+        SetProperty("$_", inputAccessor);
+        SetProperty("lastMatch", CreateLegacyReadOnlyAccessor(static c => c._legacyLastMatch));
+        SetProperty("$&", CreateLegacyReadOnlyAccessor(static c => c._legacyLastMatch));
+        SetProperty("lastParen", CreateLegacyReadOnlyAccessor(static c => c._legacyLastParen));
+        SetProperty("$+", CreateLegacyReadOnlyAccessor(static c => c._legacyLastParen));
+        SetProperty("leftContext", CreateLegacyReadOnlyAccessor(static c => c._legacyLeftContext));
+        SetProperty("$`", CreateLegacyReadOnlyAccessor(static c => c._legacyLeftContext));
+        SetProperty("rightContext", CreateLegacyReadOnlyAccessor(static c => c._legacyRightContext));
+        SetProperty("$'", CreateLegacyReadOnlyAccessor(static c => c._legacyRightContext));
+        SetProperty("$1", CreateParenAccessor(0));
+        SetProperty("$2", CreateParenAccessor(1));
+        SetProperty("$3", CreateParenAccessor(2));
+        SetProperty("$4", CreateParenAccessor(3));
+        SetProperty("$5", CreateParenAccessor(4));
+        SetProperty("$6", CreateParenAccessor(5));
+        SetProperty("$7", CreateParenAccessor(6));
+        SetProperty("$8", CreateParenAccessor(7));
+        SetProperty("$9", CreateParenAccessor(8));
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-regexp.escape
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsString Escape(JsValue thisObject, JsCallArguments arguments)
     {
         var s = arguments.At(0);

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -144,10 +144,8 @@ public sealed partial class RegExpConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-regexp.escape
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsString Escape(JsValue thisObject, JsCallArguments arguments)
+    private JsString Escape(JsValue thisObject, JsValue s)
     {
-        var s = arguments.At(0);
-
         // 1. If S is not a String, throw a TypeError exception.
         if (!s.IsString())
         {

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -135,12 +135,11 @@ internal sealed partial class RegExpPrototype : Prototype
     /// https://tc39.es/ecma262/#sec-regexp.prototype-@@replace
     /// </summary>
     [JsSymbolFunction("Replace", Length = 2, Flags = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable | global::Jint.Runtime.Descriptors.PropertyFlag.Writable)]
-    private JsValue Replace(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Replace(JsValue thisObject, JsValue stringArg, JsValue replaceValue)
     {
         var rx = AssertThisIsObjectInstance(thisObject, "RegExp.prototype.replace");
-        var s = TypeConverter.ToString(arguments.At(0));
+        var s = TypeConverter.ToString(stringArg);
         var lengthS = s.Length;
-        var replaceValue = arguments.At(1);
         var functionalReplace = replaceValue is ICallable;
 
         // we need heavier logic if we have named captures
@@ -493,11 +492,10 @@ internal sealed partial class RegExpPrototype : Prototype
     /// https://tc39.es/ecma262/#sec-regexp.prototype-@@split
     /// </summary>
     [JsSymbolFunction("Split", Length = 2, Flags = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable | global::Jint.Runtime.Descriptors.PropertyFlag.Writable)]
-    private JsValue Split(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Split(JsValue thisObject, JsValue stringArg, JsValue limit)
     {
         var rx = AssertThisIsObjectInstance(thisObject, "RegExp.prototype.split");
-        var s = TypeConverter.ToString(arguments.At(0));
-        var limit = arguments.At(1);
+        var s = TypeConverter.ToString(stringArg);
         var c = SpeciesConstructor(rx, _realm.Intrinsics.RegExp);
         var flags = TypeConverter.ToJsString(rx.Get(PropertyFlags));
         var unicodeMatching = flags.Contains('u') || flags.Contains('v');
@@ -661,7 +659,7 @@ internal sealed partial class RegExpPrototype : Prototype
     }
 
     [JsFunction(Length = 0, Name = "toString")]
-    private JsValue ToRegExpString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToRegExpString(JsValue thisObject)
     {
         var r = AssertThisIsObjectInstance(thisObject, "RegExp.prototype.toString");
 
@@ -672,10 +670,10 @@ internal sealed partial class RegExpPrototype : Prototype
     }
 
     [JsFunction(Length = 1)]
-    private JsValue Test(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Test(JsValue thisObject, JsValue stringArg)
     {
         var r = AssertThisIsObjectInstance(thisObject, "RegExp.prototype.test");
-        var s = TypeConverter.ToString(arguments.At(0));
+        var s = TypeConverter.ToString(stringArg);
 
         if (r is JsRegExp R && R.HasDefaultRegExpExec)
         {
@@ -740,11 +738,11 @@ internal sealed partial class RegExpPrototype : Prototype
     /// https://tc39.es/ecma262/#sec-regexp.prototype-@@search
     /// </summary>
     [JsSymbolFunction("Search", Length = 1, Flags = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable | global::Jint.Runtime.Descriptors.PropertyFlag.Writable)]
-    private JsValue Search(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Search(JsValue thisObject, JsValue stringArg)
     {
         var rx = AssertThisIsObjectInstance(thisObject, "RegExp.prototype.search");
 
-        var s = TypeConverter.ToString(arguments.At(0));
+        var s = TypeConverter.ToString(stringArg);
         var previousLastIndex = rx.Get(JsRegExp.PropertyLastIndex);
         if (!SameValue(previousLastIndex, 0))
         {
@@ -783,11 +781,11 @@ internal sealed partial class RegExpPrototype : Prototype
     /// https://tc39.es/ecma262/#sec-regexp.prototype-@@match
     /// </summary>
     [JsSymbolFunction("Match", Length = 1, Flags = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable | global::Jint.Runtime.Descriptors.PropertyFlag.Writable)]
-    private JsValue Match(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Match(JsValue thisObject, JsValue stringArg)
     {
         var rx = AssertThisIsObjectInstance(thisObject, "RegExp.prototype.match");
 
-        var s = TypeConverter.ToString(arguments.At(0));
+        var s = TypeConverter.ToString(stringArg);
         var flags = TypeConverter.ToString(rx.Get(PropertyFlags));
         var global = flags.Contains('g');
         if (!global)
@@ -909,11 +907,11 @@ internal sealed partial class RegExpPrototype : Prototype
     /// https://tc39.es/ecma262/#sec-regexp-prototype-matchall
     /// </summary>
     [JsSymbolFunction("MatchAll", Length = 1, Flags = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable | global::Jint.Runtime.Descriptors.PropertyFlag.Writable)]
-    private JsValue MatchAll(JsValue thisObject, JsCallArguments arguments)
+    private JsValue MatchAll(JsValue thisObject, JsValue stringArg)
     {
         var r = AssertThisIsObjectInstance(thisObject, "RegExp.prototype.matchAll");
 
-        var s = TypeConverter.ToString(arguments.At(0));
+        var s = TypeConverter.ToString(stringArg);
         var c = SpeciesConstructor(r, _realm.Intrinsics.RegExp);
 
         var flags = TypeConverter.ToJsString(r.Get(PropertyFlags));
@@ -1467,7 +1465,7 @@ internal sealed partial class RegExpPrototype : Prototype
     /// B.2.5.1
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsValue Compile(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Compile(JsValue thisObject, JsValue pattern, JsValue flags)
     {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[RegExpMatcher]]).
@@ -1485,9 +1483,6 @@ internal sealed partial class RegExpPrototype : Prototype
             Throw.TypeError(_realm, "RegExp.prototype.compile cannot be used on RegExp subclass or cross-realm instances");
             return default!;
         }
-
-        var pattern = arguments.At(0);
-        var flags = arguments.At(1);
 
         JsValue p;
         JsValue f;

--- a/Jint/Native/RegExp/RegExpStringIteratorPrototype.cs
+++ b/Jint/Native/RegExp/RegExpStringIteratorPrototype.cs
@@ -1,17 +1,18 @@
 using Jint.Native.Iterator;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.RegExp;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%-object
 /// </summary>
-internal sealed class RegExpStringIteratorPrototype : IteratorPrototype
+[JsObject]
+internal sealed partial class RegExpStringIteratorPrototype : IteratorPrototype
 {
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString RegExpStringIteratorToStringTag = new("RegExp String Iterator");
+
     internal RegExpStringIteratorPrototype(
         Engine engine,
         Realm realm,
@@ -21,18 +22,12 @@ internal sealed class RegExpStringIteratorPrototype : IteratorPrototype
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            [KnownKeys.Next] = new(new ClrFunction(Engine, "next", Next, 0, PropertyFlag.Configurable), true, false, true)
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("RegExp String Iterator", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
+    [JsFunction(Length = 0, Name = "next")]
+    private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     internal IteratorInstance Construct(ObjectInstance iteratingRegExp, string iteratedString, bool global, bool unicode)
     {

--- a/Jint/Native/Set/SetIteratorPrototype.cs
+++ b/Jint/Native/Set/SetIteratorPrototype.cs
@@ -1,17 +1,18 @@
 using Jint.Native.Iterator;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Set;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%setiteratorprototype%-object
 /// </summary>
-internal sealed class SetIteratorPrototype : IteratorPrototype
+[JsObject]
+internal sealed partial class SetIteratorPrototype : IteratorPrototype
 {
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString SetIteratorToStringTag = new("Set Iterator");
+
     internal SetIteratorPrototype(
         Engine engine,
         Realm realm,
@@ -21,18 +22,12 @@ internal sealed class SetIteratorPrototype : IteratorPrototype
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            [KnownKeys.Next] = new(new ClrFunction(Engine, "next", Next, 0, PropertyFlag.Configurable), true, false, true)
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Set Iterator", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
+    [JsFunction(Length = 0, Name = "next")]
+    private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     internal IteratorInstance ConstructEntryIterator(JsSet set)
     {

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -1,17 +1,26 @@
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of prototype methods return JsValue
+
 using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Set;
 
 /// <summary>
 /// https://www.ecma-international.org/ecma-262/6.0/#sec-set-objects
 /// </summary>
-internal sealed class SetPrototype : Prototype
+[JsObject]
+internal sealed partial class SetPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly SetConstructor _constructor;
+
+    // Pre-existing quirk: TC39 spec does not require a `length` property on Set.prototype
+    // (length lives on the constructor). Preserved here verbatim from the pre-source-gen Initialize body.
+    [JsProperty(Name = "length", Flags = PropertyFlag.Configurable)] private static readonly JsNumber SetLength = JsNumber.PositiveZero;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString SetToStringTag = new("Set");
 
     internal SetPrototype(
         Engine engine,
@@ -25,47 +34,28 @@ internal sealed class SetPrototype : Prototype
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(12, checkExistingKeys: false)
-        {
-            ["length"] = new(0, PropertyFlag.Configurable),
-            ["constructor"] = new(_constructor, PropertyFlag.NonEnumerable),
-            ["add"] = new(new ClrFunction(Engine, "add", Add, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["clear"] = new(new ClrFunction(Engine, "clear", Clear, 0, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["delete"] = new(new ClrFunction(Engine, "delete", Delete, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["difference"] = new(new ClrFunction(Engine, "difference", Difference, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["entries"] = new(new ClrFunction(Engine, "entries", Entries, 0, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["forEach"] = new(new ClrFunction(Engine, "forEach", ForEach, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["has"] = new(new ClrFunction(Engine, "has", Has, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["intersection"] = new(new ClrFunction(Engine, "intersection", Intersection, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["isDisjointFrom"] = new(new ClrFunction(Engine, "isDisjointFrom", IsDisjointFrom, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["isSubsetOf"] = new(new ClrFunction(Engine, "isSubsetOf", IsSubsetOf, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["isSupersetOf"] = new(new ClrFunction(Engine, "isSupersetOf", IsSupersetOf, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["keys"] = new(new ClrFunction(Engine, "keys", Values, 0, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["values"] = new(new ClrFunction(Engine, "values", Values, 0, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["size"] = new GetSetPropertyDescriptor(get: new ClrFunction(Engine, "get size", Size, 0, PropertyFlag.Configurable), set: null, PropertyFlag.Configurable),
-            ["symmetricDifference"] = new(new ClrFunction(Engine, "symmetricDifference", SymmetricDifference, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            ["union"] = new(new ClrFunction(Engine, "union", Union, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable)
-        };
-        SetProperties(properties);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
 
-        var symbols = new SymbolDictionary(2)
-        {
-            [GlobalSymbolRegistry.Iterator] = new(new ClrFunction(Engine, "iterator", Values, 1, PropertyFlag.Configurable), true, false, true),
-            [GlobalSymbolRegistry.ToStringTag] = new("Set", false, false, true)
-        };
-        SetSymbols(symbols);
+        // Spec requires Set.prototype.keys, Set.prototype.values, and Set.prototype[@@iterator] to all be
+        // the same function object (function identity, observable via ===). Alias the descriptors here
+        // so they share the same materialized function as `values` rather than emitting separate dispatchers.
+        var valuesDesc = GetOwnProperty("values");
+        SetProperty("keys", valuesDesc);
+        SetProperty(GlobalSymbolRegistry.Iterator, valuesDesc);
     }
 
-    private JsNumber Size(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("size")]
+    private JsNumber Size(JsValue thisObject)
     {
         AssertSetInstance(thisObject);
         return JsNumber.Create(0);
     }
 
-    private JsValue Add(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Add(JsValue thisObject, JsValue value)
     {
         var set = AssertSetInstance(thisObject);
-        var value = arguments.At(0);
         if (value is JsNumber number && number.IsNegativeZero())
         {
             value = JsNumber.PositiveZero;
@@ -74,25 +64,27 @@ internal sealed class SetPrototype : Prototype
         return thisObject;
     }
 
-    private JsValue Clear(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsValue Clear(JsValue thisObject)
     {
         var set = AssertSetInstance(thisObject);
         set.Clear();
         return Undefined;
     }
 
-    private JsBoolean Delete(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsBoolean Delete(JsValue thisObject, JsValue value)
     {
         var set = AssertSetInstance(thisObject);
-        return set.Delete(arguments.At(0))
+        return set.Delete(value)
             ? JsBoolean.True
             : JsBoolean.False;
     }
 
-    private JsSet Difference(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsSet Difference(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
-        var other = arguments.At(0);
         var otherRec = GetSetRecord(other);
         var resultSetData = new JsSet(_engine, new OrderedSet<JsValue>(set._set._set));
 
@@ -149,10 +141,10 @@ internal sealed class SetPrototype : Prototype
         return resultSetData;
     }
 
-    private JsBoolean IsDisjointFrom(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsBoolean IsDisjointFrom(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
-        var other = arguments.At(0);
         var otherRec = GetSetRecord(other);
 
         if (set.Size <= otherRec.Size)
@@ -203,10 +195,10 @@ internal sealed class SetPrototype : Prototype
     }
 
 
-    private JsSet Intersection(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsSet Intersection(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
-        var other = arguments.At(0);
 
         var otherRec = GetSetRecord(other);
         var resultSetData = new JsSet(_engine);
@@ -272,10 +264,10 @@ internal sealed class SetPrototype : Prototype
         return resultSetData;
     }
 
-    private JsSet SymmetricDifference(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsSet SymmetricDifference(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
-        var other = arguments.At(0);
 
         if (other is JsSet otherSet)
         {
@@ -321,10 +313,10 @@ internal sealed class SetPrototype : Prototype
         return resultSetData;
     }
 
-    private JsBoolean IsSubsetOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsBoolean IsSubsetOf(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
-        var other = arguments.At(0);
 
         if (other is JsSet otherSet)
         {
@@ -362,10 +354,10 @@ internal sealed class SetPrototype : Prototype
         return JsBoolean.True;
     }
 
-    private JsBoolean IsSupersetOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsBoolean IsSupersetOf(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
-        var other = arguments.At(0);
 
         if (other is JsSet otherSet)
         {
@@ -401,25 +393,25 @@ internal sealed class SetPrototype : Prototype
     }
 
 
-    private JsBoolean Has(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsBoolean Has(JsValue thisObject, JsValue value)
     {
         var set = AssertSetInstance(thisObject);
-        return set.Has(arguments.At(0))
+        return set.Has(value)
             ? JsBoolean.True
             : JsBoolean.False;
     }
 
-    private ObjectInstance Entries(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private ObjectInstance Entries(JsValue thisObject)
     {
         var set = AssertSetInstance(thisObject);
         return set.Entries();
     }
 
-    private JsValue ForEach(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue ForEach(JsValue thisObject, JsValue callbackfn, JsValue thisArg)
     {
-        var callbackfn = arguments.At(0);
-        var thisArg = arguments.At(1);
-
         var set = AssertSetInstance(thisObject);
         var callable = GetCallable(callbackfn);
 
@@ -428,10 +420,10 @@ internal sealed class SetPrototype : Prototype
         return Undefined;
     }
 
-    private JsSet Union(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsSet Union(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
-        var other = arguments.At(0);
         var otherRec = GetSetRecord(other);
         var keysIter = otherRec.Set.GetIteratorFromMethod(_realm, otherRec.Keys);
         var resultSetData = set._set.Clone();
@@ -486,7 +478,8 @@ internal sealed class SetPrototype : Prototype
         return new SetRecord(Set: obj, Size: intSize, Has: (ICallable) has, Keys: (ICallable) keys);
     }
 
-    private ObjectInstance Values(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private ObjectInstance Values(JsValue thisObject)
     {
         var set = AssertSetInstance(thisObject);
         return set.Values();

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -16,10 +16,6 @@ internal sealed partial class SetPrototype : Prototype
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly SetConstructor _constructor;
 
-    // Pre-existing quirk: TC39 spec does not require a `length` property on Set.prototype
-    // (length lives on the constructor). Preserved here verbatim from the pre-source-gen Initialize body.
-    [JsProperty(Name = "length", Flags = PropertyFlag.Configurable)] private static readonly JsNumber SetLength = JsNumber.PositiveZero;
-
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString SetToStringTag = new("Set");
 
     internal SetPrototype(

--- a/Jint/Native/ShadowRealm/ShadowRealmPrototype.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealmPrototype.cs
@@ -1,17 +1,19 @@
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.ShadowRealm;
 
 /// <summary>
 /// https://tc39.es/proposal-shadowrealm/#sec-properties-of-the-shadowrealm-prototype-object
 /// </summary>
-internal sealed class ShadowRealmPrototype : Prototype
+[JsObject]
+internal sealed partial class ShadowRealmPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly ShadowRealmConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString ShadowRealmToStringTag = new("ShadowRealm");
 
     internal ShadowRealmPrototype(
         Engine engine,
@@ -25,27 +27,17 @@ internal sealed class ShadowRealmPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag propertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(5, checkExistingKeys: false)
-        {
-            ["length"] = new PropertyDescriptor(0, PropertyFlag.Configurable),
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["evaluate"] = new PropertyDescriptor(new ClrFunction(Engine, "evaluate", Evaluate, 1, PropertyFlag.Configurable), propertyFlags),
-            ["importValue"] = new PropertyDescriptor(new ClrFunction(Engine, "importValue", ImportValue, 2, PropertyFlag.Configurable), propertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1) { [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor("ShadowRealm", false, false, true) };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/proposal-shadowrealm/#sec-shadowrealm.prototype.evaluate
     /// </summary>
-    private JsValue Evaluate(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Evaluate(JsValue thisObject, JsValue sourceText)
     {
         var shadowRealm = ValidateShadowRealmObject(thisObject);
-        var sourceText = arguments.At(0);
 
         if (!sourceText.IsString())
         {
@@ -65,11 +57,9 @@ internal sealed class ShadowRealmPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-shadowrealm/#sec-shadowrealm.prototype.importvalue
     /// </summary>
-    private JsValue ImportValue(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue ImportValue(JsValue thisObject, JsValue specifier, JsValue exportName)
     {
-        var specifier = arguments.At(0);
-        var exportName = arguments.At(1);
-
         var O = ValidateShadowRealmObject(thisObject);
         var specifierString = TypeConverter.ToJsString(specifier);
         if (!specifier.IsString())

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -6,7 +6,6 @@ using Jint.Native.Function;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 using Jint.Runtime.Interpreter.Expressions;
 
 namespace Jint.Native.String;
@@ -14,7 +13,8 @@ namespace Jint.Native.String;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-string-constructor
 /// </summary>
-internal sealed class StringConstructor : Constructor
+[JsObject]
+internal sealed partial class StringConstructor : Constructor
 {
     private static readonly JsString _functionName = new JsString("String");
 
@@ -33,21 +33,13 @@ internal sealed class StringConstructor : Constructor
 
     public StringPrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        var properties = new PropertyDictionary(3, checkExistingKeys: false)
-        {
-            ["fromCharCode"] = new PropertyDescriptor(new PropertyDescriptor(new ClrFunction(Engine, "fromCharCode", FromCharCode, 1), PropertyFlag.NonEnumerable)),
-            ["fromCodePoint"] = new PropertyDescriptor(new PropertyDescriptor(new ClrFunction(Engine, "fromCodePoint", FromCodePoint, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable)),
-            ["raw"] = new PropertyDescriptor(new PropertyDescriptor(new ClrFunction(Engine, "raw", Raw, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable))
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.fromcharcode
     /// </summary>
-    private static JsValue FromCharCode(JsValue? thisObj, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private static JsValue FromCharCode(JsValue thisObject, JsCallArguments arguments)
     {
         var length = arguments.Length;
 
@@ -78,6 +70,7 @@ internal sealed class StringConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.fromcodepoint
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsValue FromCodePoint(JsValue thisObject, JsCallArguments arguments)
     {
         JsNumber codePoint;
@@ -130,6 +123,7 @@ rangeError:
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.raw
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsValue Raw(JsValue thisObject, JsCallArguments arguments)
     {
         var cooked = TypeConverter.ToObject(_realm, arguments.At(0));

--- a/Jint/Native/String/StringIteratorPrototype.cs
+++ b/Jint/Native/String/StringIteratorPrototype.cs
@@ -1,17 +1,18 @@
 using Jint.Native.Iterator;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.String;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%stringiteratorprototype%-object
 /// </summary>
-internal sealed class StringIteratorPrototype : IteratorPrototype
+[JsObject]
+internal sealed partial class StringIteratorPrototype : IteratorPrototype
 {
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString StringIteratorToStringTag = new("String Iterator");
+
     internal StringIteratorPrototype(
         Engine engine,
         Realm realm,
@@ -21,18 +22,12 @@ internal sealed class StringIteratorPrototype : IteratorPrototype
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            [KnownKeys.Next] = new(new ClrFunction(Engine, "next", Next, 0, PropertyFlag.Configurable), true, false, true)
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("String Iterator", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
+    [JsFunction(Length = 0, Name = "next")]
+    private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     public ObjectInstance Construct(string str)
     {

--- a/Jint/Native/Temporal/Duration/DurationConstructor.cs
+++ b/Jint/Native/Temporal/Duration/DurationConstructor.cs
@@ -49,15 +49,12 @@ internal sealed partial class DurationConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1, JsValue options)
+    private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two, JsValue options)
     {
-        var one = ToTemporalDuration(arg0);
-        var two = ToTemporalDuration(arg1);
+        var d1 = ToTemporalDuration(one).DurationRecord;
+        var d2 = ToTemporalDuration(two).DurationRecord;
         var optionsObj = TemporalHelpers.GetOptionsObject(_realm, options);
         var relativeToResult = TemporalHelpers.GetTemporalRelativeToOption(_engine, _realm, optionsObj);
-
-        var d1 = one.DurationRecord;
-        var d2 = two.DurationRecord;
 
         // Step 5: If all components are equal, return +0
         if (d1.Years == d2.Years && d1.Months == d2.Months && d1.Weeks == d2.Weeks &&

--- a/Jint/Native/Temporal/Duration/DurationConstructor.cs
+++ b/Jint/Native/Temporal/Duration/DurationConstructor.cs
@@ -35,9 +35,8 @@ internal sealed partial class DurationConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.from
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration From(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration From(JsValue thisObject, JsValue item)
     {
-        var item = arguments.At(0);
         // If item is already a Duration, create a copy (spec requires a new object)
         if (item is JsDuration duration)
         {
@@ -50,12 +49,10 @@ internal sealed partial class DurationConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
+    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1, JsValue options)
     {
-        var one = ToTemporalDuration(arguments.At(0));
-        var two = ToTemporalDuration(arguments.At(1));
-        var options = arguments.At(2);
-
+        var one = ToTemporalDuration(arg0);
+        var two = ToTemporalDuration(arg1);
         var optionsObj = TemporalHelpers.GetOptionsObject(_realm, options);
         var relativeToResult = TemporalHelpers.GetTemporalRelativeToOption(_engine, _realm, optionsObj);
 

--- a/Jint/Native/Temporal/Duration/DurationConstructor.cs
+++ b/Jint/Native/Temporal/Duration/DurationConstructor.cs
@@ -9,7 +9,8 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.duration
 /// </summary>
-internal sealed class DurationConstructor : Constructor
+[JsObject]
+internal sealed partial class DurationConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Duration");
 
@@ -27,22 +28,13 @@ internal sealed class DurationConstructor : Constructor
 
     public DurationPrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
+    protected override void Initialize() => CreateProperties_Generated();
 
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            ["from"] = new(new ClrFunction(Engine, "from", From, 1, LengthFlags), PropertyFlags),
-            ["compare"] = new(new ClrFunction(Engine, "compare", Compare, 2, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-    }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.from
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration From(JsValue thisObject, JsCallArguments arguments)
     {
         var item = arguments.At(0);
@@ -57,6 +49,7 @@ internal sealed class DurationConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.compare
     /// </summary>
+    [JsFunction(Length = 2)]
     private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
     {
         var one = ToTemporalDuration(arguments.At(0));

--- a/Jint/Native/Temporal/Duration/DurationPrototype.cs
+++ b/Jint/Native/Temporal/Duration/DurationPrototype.cs
@@ -72,11 +72,9 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.with
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration With(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration With(JsValue thisObject, JsValue temporalDurationLike)
     {
         var duration = ValidateDuration(thisObject);
-        var temporalDurationLike = arguments.At(0);
-
         if (!temporalDurationLike.IsObject())
         {
             Throw.TypeError(_realm, "Duration-like object expected");
@@ -141,7 +139,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.negated
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsDuration Negated(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Negated(JsValue thisObject)
     {
         var duration = ValidateDuration(thisObject);
         return _constructor.Construct(duration.DurationRecord.Negated());
@@ -151,7 +149,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.abs
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsDuration Abs(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Abs(JsValue thisObject)
     {
         var duration = ValidateDuration(thisObject);
         return _constructor.Construct(duration.DurationRecord.Abs());
@@ -162,10 +160,9 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal-adddurations
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Add(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Add(JsValue thisObject, JsValue other)
     {
         var duration = ValidateDuration(thisObject);
-        var other = arguments.At(0);
         return AddDurations(1, duration, other);
     }
 
@@ -174,10 +171,9 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal-adddurations
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Subtract(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Subtract(JsValue thisObject, JsValue other)
     {
         var duration = ValidateDuration(thisObject);
-        var other = arguments.At(0);
         return AddDurations(-1, duration, other);
     }
 
@@ -233,11 +229,9 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Round(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Round(JsValue thisObject, JsValue options)
     {
         var duration = ValidateDuration(thisObject);
-        var options = arguments.At(0);
-
         if (options.IsUndefined())
         {
             Throw.TypeError(_realm, "Options argument is required");
@@ -1262,11 +1256,9 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.total
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsNumber Total(JsValue thisObject, JsCallArguments arguments)
+    private JsNumber Total(JsValue thisObject, JsValue options)
     {
         var duration = ValidateDuration(thisObject);
-        var options = arguments.At(0);
-
         if (options.IsUndefined())
         {
             Throw.TypeError(_realm, "Options argument is required");
@@ -1363,11 +1355,9 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tostring
     /// </summary>
     [JsFunction(Length = 0, Name = "toString")]
-    private JsString ToStringMethod(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToStringMethod(JsValue thisObject, JsValue options)
     {
         var duration = ValidateDuration(thisObject);
-        var options = arguments.At(0);
-
         // Default: auto precision, trunc rounding, no rounding needed
         int precision = -1; // -1 means "auto"
         string roundingMode = "trunc";
@@ -1544,7 +1534,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tojson
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToJSON(JsValue thisObject)
     {
         var duration = ValidateDuration(thisObject);
         return new JsString(TemporalHelpers.FormatDuration(duration.DurationRecord));
@@ -1554,12 +1544,9 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tolocalestring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToLocaleString(JsValue thisObject, JsValue locales, JsValue options)
     {
         var duration = ValidateDuration(thisObject);
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
-
         // Per spec: new Intl.DurationFormat(locales, options).format(this)
         var durationFormat = (Intl.JsDurationFormat) _realm.Intrinsics.DurationFormat.Construct([locales, options], Undefined);
         // Convert Temporal DurationRecord to Intl DurationRecord
@@ -1584,7 +1571,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.valueof
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Cannot convert Temporal.Duration to a primitive value");
         return Undefined;

--- a/Jint/Native/Temporal/Duration/DurationPrototype.cs
+++ b/Jint/Native/Temporal/Duration/DurationPrototype.cs
@@ -10,9 +10,13 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-duration-prototype-object
 /// </summary>
-internal sealed class DurationPrototype : Prototype
+[JsObject]
+internal sealed partial class DurationPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly DurationConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString DurationToStringTag = new("Temporal.Duration");
 
     internal DurationPrototype(
         Engine engine,
@@ -26,44 +30,10 @@ internal sealed class DurationPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(24, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["with"] = new(new ClrFunction(Engine, "with", With, 1, LengthFlags), PropertyFlags),
-            ["negated"] = new(new ClrFunction(Engine, "negated", Negated, 0, LengthFlags), PropertyFlags),
-            ["abs"] = new(new ClrFunction(Engine, "abs", Abs, 0, LengthFlags), PropertyFlags),
-            ["add"] = new(new ClrFunction(Engine, "add", Add, 1, LengthFlags), PropertyFlags),
-            ["subtract"] = new(new ClrFunction(Engine, "subtract", Subtract, 1, LengthFlags), PropertyFlags),
-            ["round"] = new(new ClrFunction(Engine, "round", Round, 1, LengthFlags), PropertyFlags),
-            ["total"] = new(new ClrFunction(Engine, "total", Total, 1, LengthFlags), PropertyFlags),
-            ["toString"] = new(new ClrFunction(Engine, "toString", ToStringMethod, 0, LengthFlags), PropertyFlags),
-            ["toJSON"] = new(new ClrFunction(Engine, "toJSON", ToJSON, 0, LengthFlags), PropertyFlags),
-            ["toLocaleString"] = new(new ClrFunction(Engine, "toLocaleString", ToLocaleString, 0, LengthFlags), PropertyFlags),
-            ["valueOf"] = new(new ClrFunction(Engine, "valueOf", ValueOf, 0, LengthFlags), PropertyFlags),
-            ["years"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get years", GetYears, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["months"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get months", GetMonths, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["weeks"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get weeks", GetWeeks, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["days"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get days", GetDays, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["hours"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get hours", GetHours, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["minutes"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get minutes", GetMinutes, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["seconds"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get seconds", GetSeconds, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["milliseconds"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get milliseconds", GetMilliseconds, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["microseconds"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get microseconds", GetMicroseconds, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["nanoseconds"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get nanoseconds", GetNanoseconds, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["sign"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get sign", GetSign, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["blank"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get blank", GetBlank, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Temporal.Duration", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
 
     private JsDuration ValidateDuration(JsValue thisObject)
     {
@@ -73,22 +43,35 @@ internal sealed class DurationPrototype : Prototype
         return null!;
     }
 
-    private JsNumber GetYears(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidateDuration(thisObject).Years);
-    private JsNumber GetMonths(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidateDuration(thisObject).Months);
-    private JsNumber GetWeeks(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidateDuration(thisObject).Weeks);
-    private JsNumber GetDays(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidateDuration(thisObject).Days);
-    private JsNumber GetHours(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidateDuration(thisObject).Hours);
-    private JsNumber GetMinutes(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidateDuration(thisObject).Minutes);
-    private JsNumber GetSeconds(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidateDuration(thisObject).Seconds);
-    private JsNumber GetMilliseconds(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidateDuration(thisObject).Milliseconds);
-    private JsNumber GetMicroseconds(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidateDuration(thisObject).Microseconds);
-    private JsNumber GetNanoseconds(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidateDuration(thisObject).Nanoseconds);
-    private JsNumber GetSign(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidateDuration(thisObject).DurationRecord.Sign());
-    private JsBoolean GetBlank(JsValue thisObject, JsCallArguments arguments) => ValidateDuration(thisObject).DurationRecord.IsZero() ? JsBoolean.True : JsBoolean.False;
+    [JsAccessor("years")]
+    private JsNumber GetYears(JsValue thisObject) => JsNumber.Create(ValidateDuration(thisObject).Years);
+    [JsAccessor("months")]
+    private JsNumber GetMonths(JsValue thisObject) => JsNumber.Create(ValidateDuration(thisObject).Months);
+    [JsAccessor("weeks")]
+    private JsNumber GetWeeks(JsValue thisObject) => JsNumber.Create(ValidateDuration(thisObject).Weeks);
+    [JsAccessor("days")]
+    private JsNumber GetDays(JsValue thisObject) => JsNumber.Create(ValidateDuration(thisObject).Days);
+    [JsAccessor("hours")]
+    private JsNumber GetHours(JsValue thisObject) => JsNumber.Create(ValidateDuration(thisObject).Hours);
+    [JsAccessor("minutes")]
+    private JsNumber GetMinutes(JsValue thisObject) => JsNumber.Create(ValidateDuration(thisObject).Minutes);
+    [JsAccessor("seconds")]
+    private JsNumber GetSeconds(JsValue thisObject) => JsNumber.Create(ValidateDuration(thisObject).Seconds);
+    [JsAccessor("milliseconds")]
+    private JsNumber GetMilliseconds(JsValue thisObject) => JsNumber.Create(ValidateDuration(thisObject).Milliseconds);
+    [JsAccessor("microseconds")]
+    private JsNumber GetMicroseconds(JsValue thisObject) => JsNumber.Create(ValidateDuration(thisObject).Microseconds);
+    [JsAccessor("nanoseconds")]
+    private JsNumber GetNanoseconds(JsValue thisObject) => JsNumber.Create(ValidateDuration(thisObject).Nanoseconds);
+    [JsAccessor("sign")]
+    private JsNumber GetSign(JsValue thisObject) => JsNumber.Create(ValidateDuration(thisObject).DurationRecord.Sign());
+    [JsAccessor("blank")]
+    private JsBoolean GetBlank(JsValue thisObject) => ValidateDuration(thisObject).DurationRecord.IsZero() ? JsBoolean.True : JsBoolean.False;
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.with
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration With(JsValue thisObject, JsCallArguments arguments)
     {
         var duration = ValidateDuration(thisObject);
@@ -157,6 +140,7 @@ internal sealed class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.negated
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsDuration Negated(JsValue thisObject, JsCallArguments arguments)
     {
         var duration = ValidateDuration(thisObject);
@@ -166,6 +150,7 @@ internal sealed class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.abs
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsDuration Abs(JsValue thisObject, JsCallArguments arguments)
     {
         var duration = ValidateDuration(thisObject);
@@ -176,6 +161,7 @@ internal sealed class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.add
     /// https://tc39.es/proposal-temporal/#sec-temporal-adddurations
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Add(JsValue thisObject, JsCallArguments arguments)
     {
         var duration = ValidateDuration(thisObject);
@@ -187,6 +173,7 @@ internal sealed class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.subtract
     /// https://tc39.es/proposal-temporal/#sec-temporal-adddurations
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Subtract(JsValue thisObject, JsCallArguments arguments)
     {
         var duration = ValidateDuration(thisObject);
@@ -245,6 +232,7 @@ internal sealed class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Round(JsValue thisObject, JsCallArguments arguments)
     {
         var duration = ValidateDuration(thisObject);
@@ -1273,6 +1261,7 @@ internal sealed class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.total
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsNumber Total(JsValue thisObject, JsCallArguments arguments)
     {
         var duration = ValidateDuration(thisObject);
@@ -1373,6 +1362,7 @@ internal sealed class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tostring
     /// </summary>
+    [JsFunction(Length = 0, Name = "toString")]
     private JsString ToStringMethod(JsValue thisObject, JsCallArguments arguments)
     {
         var duration = ValidateDuration(thisObject);
@@ -1553,6 +1543,7 @@ internal sealed class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tojson
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
     {
         var duration = ValidateDuration(thisObject);
@@ -1562,6 +1553,7 @@ internal sealed class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tolocalestring
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
         var duration = ValidateDuration(thisObject);
@@ -1591,6 +1583,7 @@ internal sealed class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.valueof
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
     {
         Throw.TypeError(_realm, "Cannot convert Temporal.Duration to a primitive value");

--- a/Jint/Native/Temporal/Instant/InstantConstructor.cs
+++ b/Jint/Native/Temporal/Instant/InstantConstructor.cs
@@ -11,7 +11,8 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.instant
 /// </summary>
-internal sealed class InstantConstructor : Constructor
+[JsObject]
+internal sealed partial class InstantConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Instant");
 
@@ -33,24 +34,13 @@ internal sealed class InstantConstructor : Constructor
 
     public InstantPrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
+    protected override void Initialize() => CreateProperties_Generated();
 
-        var properties = new PropertyDictionary(4, checkExistingKeys: false)
-        {
-            ["from"] = new(new ClrFunction(Engine, "from", From, 1, LengthFlags), PropertyFlags),
-            ["fromEpochMilliseconds"] = new(new ClrFunction(Engine, "fromEpochMilliseconds", FromEpochMilliseconds, 1, LengthFlags), PropertyFlags),
-            ["fromEpochNanoseconds"] = new(new ClrFunction(Engine, "fromEpochNanoseconds", FromEpochNanoseconds, 1, LengthFlags), PropertyFlags),
-            ["compare"] = new(new ClrFunction(Engine, "compare", Compare, 2, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-    }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.from
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsInstant From(JsValue thisObject, JsCallArguments arguments)
     {
         var item = arguments.At(0);
@@ -60,6 +50,7 @@ internal sealed class InstantConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochmilliseconds
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsInstant FromEpochMilliseconds(JsValue thisObject, JsCallArguments arguments)
     {
         var epochMilliseconds = arguments.At(0);
@@ -89,6 +80,7 @@ internal sealed class InstantConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochnanoseconds
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsInstant FromEpochNanoseconds(JsValue thisObject, JsCallArguments arguments)
     {
         var epochNanoseconds = arguments.At(0);
@@ -112,6 +104,7 @@ internal sealed class InstantConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.compare
     /// </summary>
+    [JsFunction(Length = 2)]
     private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
     {
         var one = ToTemporalInstant(arguments.At(0));

--- a/Jint/Native/Temporal/Instant/InstantConstructor.cs
+++ b/Jint/Native/Temporal/Instant/InstantConstructor.cs
@@ -41,9 +41,8 @@ internal sealed partial class InstantConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.from
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsInstant From(JsValue thisObject, JsCallArguments arguments)
+    private JsInstant From(JsValue thisObject, JsValue item)
     {
-        var item = arguments.At(0);
         return ToTemporalInstant(item);
     }
 
@@ -51,9 +50,8 @@ internal sealed partial class InstantConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochmilliseconds
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsInstant FromEpochMilliseconds(JsValue thisObject, JsCallArguments arguments)
+    private JsInstant FromEpochMilliseconds(JsValue thisObject, JsValue epochMilliseconds)
     {
-        var epochMilliseconds = arguments.At(0);
         var ms = TypeConverter.ToNumber(epochMilliseconds);
 
         // NumberToBigInt: must be an integral number
@@ -81,10 +79,8 @@ internal sealed partial class InstantConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochnanoseconds
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsInstant FromEpochNanoseconds(JsValue thisObject, JsCallArguments arguments)
+    private JsInstant FromEpochNanoseconds(JsValue thisObject, JsValue epochNanoseconds)
     {
-        var epochNanoseconds = arguments.At(0);
-
         if (epochNanoseconds is not JsBigInt bigInt)
         {
             Throw.TypeError(_realm, "epochNanoseconds must be a BigInt");
@@ -105,10 +101,10 @@ internal sealed partial class InstantConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
+    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
-        var one = ToTemporalInstant(arguments.At(0));
-        var two = ToTemporalInstant(arguments.At(1));
+        var one = ToTemporalInstant(arg0);
+        var two = ToTemporalInstant(arg1);
 
         return JsNumber.Create(one.EpochNanoseconds.CompareTo(two.EpochNanoseconds));
     }

--- a/Jint/Native/Temporal/Instant/InstantConstructor.cs
+++ b/Jint/Native/Temporal/Instant/InstantConstructor.cs
@@ -101,12 +101,10 @@ internal sealed partial class InstantConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1)
+    private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two)
     {
-        var one = ToTemporalInstant(arg0);
-        var two = ToTemporalInstant(arg1);
-
-        return JsNumber.Create(one.EpochNanoseconds.CompareTo(two.EpochNanoseconds));
+        return JsNumber.Create(
+            ToTemporalInstant(one).EpochNanoseconds.CompareTo(ToTemporalInstant(two).EpochNanoseconds));
     }
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)

--- a/Jint/Native/Temporal/Instant/InstantPrototype.cs
+++ b/Jint/Native/Temporal/Instant/InstantPrototype.cs
@@ -514,12 +514,11 @@ internal sealed partial class InstantPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.equals
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsValue arg0)
+    private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var instant = ValidateInstant(thisObject);
-        var other = _constructor.ToTemporalInstant(arg0);
-
-        return instant.EpochNanoseconds == other.EpochNanoseconds ? JsBoolean.True : JsBoolean.False;
+        return instant.EpochNanoseconds == _constructor.ToTemporalInstant(other).EpochNanoseconds
+            ? JsBoolean.True : JsBoolean.False;
     }
 
     /// <summary>
@@ -819,10 +818,10 @@ internal sealed partial class InstantPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tozoneddatetimeiso
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsZonedDateTime ToZonedDateTimeISO(JsValue thisObject, JsValue arg0)
+    private JsZonedDateTime ToZonedDateTimeISO(JsValue thisObject, JsValue timeZone)
     {
         var instant = ValidateInstant(thisObject);
-        var timeZoneId = TemporalHelpers.ToTemporalTimeZoneIdentifier(_engine, _realm, arg0);
+        var timeZoneId = TemporalHelpers.ToTemporalTimeZoneIdentifier(_engine, _realm, timeZone);
 
         return new JsZonedDateTime(_engine, _realm.Intrinsics.TemporalZonedDateTime.PrototypeObject,
             instant.EpochNanoseconds, timeZoneId, "iso8601");

--- a/Jint/Native/Temporal/Instant/InstantPrototype.cs
+++ b/Jint/Native/Temporal/Instant/InstantPrototype.cs
@@ -12,9 +12,13 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-instant-prototype-object
 /// </summary>
-internal sealed class InstantPrototype : Prototype
+[JsObject]
+internal sealed partial class InstantPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly InstantConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString InstantToStringTag = new("Temporal.Instant");
 
     internal InstantPrototype(
         Engine engine,
@@ -28,34 +32,10 @@ internal sealed class InstantPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(14, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["add"] = new(new ClrFunction(Engine, "add", Add, 1, LengthFlags), PropertyFlags),
-            ["subtract"] = new(new ClrFunction(Engine, "subtract", Subtract, 1, LengthFlags), PropertyFlags),
-            ["until"] = new(new ClrFunction(Engine, "until", Until, 1, LengthFlags), PropertyFlags),
-            ["since"] = new(new ClrFunction(Engine, "since", Since, 1, LengthFlags), PropertyFlags),
-            ["round"] = new(new ClrFunction(Engine, "round", Round, 1, LengthFlags), PropertyFlags),
-            ["equals"] = new(new ClrFunction(Engine, "equals", Equals, 1, LengthFlags), PropertyFlags),
-            ["toString"] = new(new ClrFunction(Engine, "toString", ToStringMethod, 0, LengthFlags), PropertyFlags),
-            ["toJSON"] = new(new ClrFunction(Engine, "toJSON", ToJSON, 0, LengthFlags), PropertyFlags),
-            ["toLocaleString"] = new(new ClrFunction(Engine, "toLocaleString", ToLocaleString, 0, LengthFlags), PropertyFlags),
-            ["valueOf"] = new(new ClrFunction(Engine, "valueOf", ValueOf, 0, LengthFlags), PropertyFlags),
-            ["toZonedDateTimeISO"] = new(new ClrFunction(Engine, "toZonedDateTimeISO", ToZonedDateTimeISO, 1, LengthFlags), PropertyFlags),
-            ["epochMilliseconds"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get epochMilliseconds", GetEpochMilliseconds, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["epochNanoseconds"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get epochNanoseconds", GetEpochNanoseconds, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Temporal.Instant", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
 
     private JsInstant ValidateInstant(JsValue thisObject)
     {
@@ -65,7 +45,8 @@ internal sealed class InstantPrototype : Prototype
         return null!;
     }
 
-    private JsNumber GetEpochMilliseconds(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("epochMilliseconds")]
+    private JsNumber GetEpochMilliseconds(JsValue thisObject)
     {
         var instant = ValidateInstant(thisObject);
         // Floor division for negative numbers (spec requires floor, not truncation)
@@ -85,7 +66,8 @@ internal sealed class InstantPrototype : Prototype
         return result;
     }
 
-    private JsBigInt GetEpochNanoseconds(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("epochNanoseconds")]
+    private JsBigInt GetEpochNanoseconds(JsValue thisObject)
     {
         var instant = ValidateInstant(thisObject);
         return JsBigInt.Create(instant.EpochNanoseconds);
@@ -94,6 +76,7 @@ internal sealed class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.add
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsInstant Add(JsValue thisObject, JsCallArguments arguments)
     {
         var instant = ValidateInstant(thisObject);
@@ -122,6 +105,7 @@ internal sealed class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.subtract
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsInstant Subtract(JsValue thisObject, JsCallArguments arguments)
     {
         var instant = ValidateInstant(thisObject);
@@ -150,6 +134,7 @@ internal sealed class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.until
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Until(JsValue thisObject, JsCallArguments arguments)
     {
         return DifferenceTemporalInstant(thisObject, arguments, isSince: false);
@@ -158,6 +143,7 @@ internal sealed class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.since
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Since(JsValue thisObject, JsCallArguments arguments)
     {
         return DifferenceTemporalInstant(thisObject, arguments, isSince: true);
@@ -304,6 +290,7 @@ internal sealed class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.round
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsInstant Round(JsValue thisObject, JsCallArguments arguments)
     {
         var instant = ValidateInstant(thisObject);
@@ -532,6 +519,7 @@ internal sealed class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.equals
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
     {
         var instant = ValidateInstant(thisObject);
@@ -543,6 +531,7 @@ internal sealed class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tostring
     /// </summary>
+    [JsFunction(Length = 0, Name = "toString")]
     private JsString ToStringMethod(JsValue thisObject, JsCallArguments arguments)
     {
         var instant = ValidateInstant(thisObject);
@@ -796,6 +785,7 @@ internal sealed class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tojson
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
     {
         var instant = ValidateInstant(thisObject);
@@ -805,6 +795,7 @@ internal sealed class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sup-temporal.instant.prototype.tolocalestring
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
         var instant = ValidateInstant(thisObject);
@@ -828,6 +819,7 @@ internal sealed class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.valueof
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
     {
         Throw.TypeError(_realm, "Cannot convert Temporal.Instant to a primitive value");
@@ -837,6 +829,7 @@ internal sealed class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tozoneddatetimeiso
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsZonedDateTime ToZonedDateTimeISO(JsValue thisObject, JsCallArguments arguments)
     {
         var instant = ValidateInstant(thisObject);

--- a/Jint/Native/Temporal/Instant/InstantPrototype.cs
+++ b/Jint/Native/Temporal/Instant/InstantPrototype.cs
@@ -77,11 +77,9 @@ internal sealed partial class InstantPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.add
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsInstant Add(JsValue thisObject, JsCallArguments arguments)
+    private JsInstant Add(JsValue thisObject, JsValue temporalDurationLike)
     {
         var instant = ValidateInstant(thisObject);
-        var temporalDurationLike = arguments.At(0);
-
         var duration = _realm.Intrinsics.TemporalDuration.ToTemporalDuration(temporalDurationLike);
         var d = duration.DurationRecord;
 
@@ -106,11 +104,9 @@ internal sealed partial class InstantPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.subtract
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsInstant Subtract(JsValue thisObject, JsCallArguments arguments)
+    private JsInstant Subtract(JsValue thisObject, JsValue temporalDurationLike)
     {
         var instant = ValidateInstant(thisObject);
-        var temporalDurationLike = arguments.At(0);
-
         var duration = _realm.Intrinsics.TemporalDuration.ToTemporalDuration(temporalDurationLike);
         var d = duration.DurationRecord;
 
@@ -291,11 +287,9 @@ internal sealed partial class InstantPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.round
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsInstant Round(JsValue thisObject, JsCallArguments arguments)
+    private JsInstant Round(JsValue thisObject, JsValue roundTo)
     {
         var instant = ValidateInstant(thisObject);
-        var roundTo = arguments.At(0);
-
         // Step 3: If roundTo is undefined, throw TypeError
         if (roundTo.IsUndefined())
         {
@@ -520,10 +514,10 @@ internal sealed partial class InstantPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.equals
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
+    private JsBoolean Equals(JsValue thisObject, JsValue arg0)
     {
         var instant = ValidateInstant(thisObject);
-        var other = _constructor.ToTemporalInstant(arguments.At(0));
+        var other = _constructor.ToTemporalInstant(arg0);
 
         return instant.EpochNanoseconds == other.EpochNanoseconds ? JsBoolean.True : JsBoolean.False;
     }
@@ -532,11 +526,9 @@ internal sealed partial class InstantPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tostring
     /// </summary>
     [JsFunction(Length = 0, Name = "toString")]
-    private JsString ToStringMethod(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToStringMethod(JsValue thisObject, JsValue options)
     {
         var instant = ValidateInstant(thisObject);
-        var options = arguments.At(0);
-
         // Step 2: GetOptionsObject
         ObjectInstance? optionsObj = null;
         if (!options.IsUndefined())
@@ -786,7 +778,7 @@ internal sealed partial class InstantPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tojson
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToJSON(JsValue thisObject)
     {
         var instant = ValidateInstant(thisObject);
         return new JsString(FormatInstant(instant.EpochNanoseconds, "UTC", -1));
@@ -796,12 +788,9 @@ internal sealed partial class InstantPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sup-temporal.instant.prototype.tolocalestring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToLocaleString(JsValue thisObject, JsValue locales, JsValue options)
     {
         var instant = ValidateInstant(thisObject);
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
-
         // Per spec: CreateDateTimeFormat with required=~any~, defaults=~all~
         var dtf = _realm.Intrinsics.DateTimeFormat.CreateDateTimeFormat(
             locales, options, required: Intl.DateTimeRequired.Any, defaults: Intl.DateTimeDefaults.All);
@@ -820,7 +809,7 @@ internal sealed partial class InstantPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.valueof
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Cannot convert Temporal.Instant to a primitive value");
         return Undefined;
@@ -830,10 +819,10 @@ internal sealed partial class InstantPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tozoneddatetimeiso
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsZonedDateTime ToZonedDateTimeISO(JsValue thisObject, JsCallArguments arguments)
+    private JsZonedDateTime ToZonedDateTimeISO(JsValue thisObject, JsValue arg0)
     {
         var instant = ValidateInstant(thisObject);
-        var timeZoneId = TemporalHelpers.ToTemporalTimeZoneIdentifier(_engine, _realm, arguments.At(0));
+        var timeZoneId = TemporalHelpers.ToTemporalTimeZoneIdentifier(_engine, _realm, arg0);
 
         return new JsZonedDateTime(_engine, _realm.Intrinsics.TemporalZonedDateTime.PrototypeObject,
             instant.EpochNanoseconds, timeZoneId, "iso8601");

--- a/Jint/Native/Temporal/PlainDate/PlainDateConstructor.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDateConstructor.cs
@@ -10,7 +10,8 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate
 /// </summary>
-internal sealed class PlainDateConstructor : Constructor
+[JsObject]
+internal sealed partial class PlainDateConstructor : Constructor
 {
     private static readonly JsString _functionName = new("PlainDate");
 
@@ -28,22 +29,13 @@ internal sealed class PlainDateConstructor : Constructor
 
     public PlainDatePrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
+    protected override void Initialize() => CreateProperties_Generated();
 
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            ["from"] = new(new ClrFunction(Engine, "from", From, 1, LengthFlags), PropertyFlags),
-            ["compare"] = new(new ClrFunction(Engine, "compare", Compare, 2, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-    }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.from
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDate From(JsValue thisObject, JsCallArguments arguments)
     {
         var item = arguments.At(0);
@@ -209,6 +201,7 @@ internal sealed class PlainDateConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.compare
     /// </summary>
+    [JsFunction(Length = 2)]
     private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
     {
         var one = ToTemporalDate(arguments.At(0), "constrain");

--- a/Jint/Native/Temporal/PlainDate/PlainDateConstructor.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDateConstructor.cs
@@ -36,11 +36,8 @@ internal sealed partial class PlainDateConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.from
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDate From(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDate From(JsValue thisObject, JsValue item, JsValue optionsValue)
     {
-        var item = arguments.At(0);
-        var optionsValue = arguments.At(1);
-
         // For PlainDate/PlainDateTime/ZonedDateTime, validate options first (for observable side effects) then convert
         if (item is JsPlainDate || item is JsPlainDateTime || item is JsZonedDateTime)
         {
@@ -202,10 +199,10 @@ internal sealed partial class PlainDateConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
+    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
-        var one = ToTemporalDate(arguments.At(0), "constrain");
-        var two = ToTemporalDate(arguments.At(1), "constrain");
+        var one = ToTemporalDate(arg0, "constrain");
+        var two = ToTemporalDate(arg1, "constrain");
         return JsNumber.Create(TemporalHelpers.CompareIsoDates(one.IsoDate, two.IsoDate));
     }
 

--- a/Jint/Native/Temporal/PlainDate/PlainDateConstructor.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDateConstructor.cs
@@ -199,11 +199,11 @@ internal sealed partial class PlainDateConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1)
+    private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two)
     {
-        var one = ToTemporalDate(arg0, "constrain");
-        var two = ToTemporalDate(arg1, "constrain");
-        return JsNumber.Create(TemporalHelpers.CompareIsoDates(one.IsoDate, two.IsoDate));
+        return JsNumber.Create(TemporalHelpers.CompareIsoDates(
+            ToTemporalDate(one, "constrain").IsoDate,
+            ToTemporalDate(two, "constrain").IsoDate));
     }
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)

--- a/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
@@ -148,7 +148,7 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.with
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDate With(JsValue thisObject, JsValue temporalDateLike, JsValue optionsArg)
+    private JsPlainDate With(JsValue thisObject, JsValue temporalDateLike, JsValue options)
     {
         var plainDate = ValidatePlainDate(thisObject);
         if (!temporalDateLike.IsObject())
@@ -238,10 +238,10 @@ internal sealed partial class PlainDatePrototype : Prototype
             Throw.TypeError(_realm, "Temporal date-like object must have at least one temporal property");
         }
 
-        // Read options BEFORE any validation (per spec: abstractops.html)
-        // All options must be read before algorithmic validation
-        var options = GetOptionsObject(optionsArg);
-        var overflow = TemporalHelpers.GetOverflowOption(_realm, (JsValue?) options ?? JsValue.Undefined);
+        // Read resolvedOptions BEFORE any validation (per spec: abstractops.html)
+        // All resolvedOptions must be read before algorithmic validation
+        var resolvedOptions = GetOptionsObject(options);
+        var overflow = TemporalHelpers.GetOverflowOption(_realm, (JsValue?) resolvedOptions ?? JsValue.Undefined);
 
         // Handle non-ISO calendars
         if (NonIsoCalendars.IsNonIsoCalendar(plainDate.Calendar))
@@ -376,12 +376,12 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.add
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDate Add(JsValue thisObject, JsValue temporalDurationLike, JsValue optionsArg)
+    private JsPlainDate Add(JsValue thisObject, JsValue temporalDurationLike, JsValue options)
     {
         var plainDate = ValidatePlainDate(thisObject);
         var duration = ToTemporalDurationRecord(temporalDurationLike);
-        var options = GetOptionsObject(optionsArg);
-        var overflow = TemporalHelpers.GetOverflowOption(_realm, (JsValue?) options ?? JsValue.Undefined);
+        var resolvedOptions = GetOptionsObject(options);
+        var overflow = TemporalHelpers.GetOverflowOption(_realm, (JsValue?) resolvedOptions ?? JsValue.Undefined);
         return AddDurationToDate(plainDate, duration, overflow);
     }
 
@@ -389,12 +389,12 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.subtract
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDate Subtract(JsValue thisObject, JsValue temporalDurationLike, JsValue optionsArg)
+    private JsPlainDate Subtract(JsValue thisObject, JsValue temporalDurationLike, JsValue options)
     {
         var plainDate = ValidatePlainDate(thisObject);
         var duration = ToTemporalDurationRecord(temporalDurationLike);
-        var options = GetOptionsObject(optionsArg);
-        var overflow = TemporalHelpers.GetOverflowOption(_realm, (JsValue?) options ?? JsValue.Undefined);
+        var resolvedOptions = GetOptionsObject(options);
+        var overflow = TemporalHelpers.GetOverflowOption(_realm, (JsValue?) resolvedOptions ?? JsValue.Undefined);
 
         // Negate the duration
         var negated = new DurationRecord(

--- a/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
@@ -432,13 +432,13 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.until
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Until(JsValue thisObject, JsValue arg0, JsValue optionsArg)
+    private JsDuration Until(JsValue thisObject, JsValue other, JsValue options)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var other = _constructor.ToTemporalDate(arg0, "constrain");
+        var otherDate = _constructor.ToTemporalDate(other, "constrain");
 
         // Step 3: Calendar equality check (before reading options per spec)
-        if (!string.Equals(plainDate.Calendar, other.Calendar, StringComparison.Ordinal))
+        if (!string.Equals(plainDate.Calendar, otherDate.Calendar, StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, "Calendars must match for date difference operations");
         }
@@ -452,7 +452,7 @@ internal sealed partial class PlainDatePrototype : Prototype
 
         var settings = TemporalHelpers.GetDifferenceSettings(
             _realm,
-            optionsArg,
+            options,
             "until",
             fallbackSmallestUnit,
             fallbackLargestUnit,
@@ -467,20 +467,20 @@ internal sealed partial class PlainDatePrototype : Prototype
 
         ValidateUnitRange(largestUnit, settings.SmallestUnit);
 
-        return DifferenceTemporalPlainDate(plainDate, other, largestUnit, settings.SmallestUnit, settings.RoundingIncrement, settings.RoundingMode, negate: false);
+        return DifferenceTemporalPlainDate(plainDate, otherDate, largestUnit, settings.SmallestUnit, settings.RoundingIncrement, settings.RoundingMode, negate: false);
     }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.since
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Since(JsValue thisObject, JsValue arg0, JsValue optionsArg)
+    private JsDuration Since(JsValue thisObject, JsValue other, JsValue options)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var other = _constructor.ToTemporalDate(arg0, "constrain");
+        var otherDate = _constructor.ToTemporalDate(other, "constrain");
 
         // Step 3: Calendar equality check (before reading options per spec)
-        if (!string.Equals(plainDate.Calendar, other.Calendar, StringComparison.Ordinal))
+        if (!string.Equals(plainDate.Calendar, otherDate.Calendar, StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, "Calendars must match for date difference operations");
         }
@@ -495,7 +495,7 @@ internal sealed partial class PlainDatePrototype : Prototype
 
         var settings = TemporalHelpers.GetDifferenceSettings(
             _realm,
-            optionsArg,
+            options,
             "since",
             fallbackSmallestUnit,
             fallbackLargestUnit,
@@ -510,7 +510,7 @@ internal sealed partial class PlainDatePrototype : Prototype
 
         ValidateUnitRange(largestUnit, settings.SmallestUnit);
 
-        return DifferenceTemporalPlainDate(plainDate, other, largestUnit, settings.SmallestUnit, settings.RoundingIncrement, settings.RoundingMode, negate: true);
+        return DifferenceTemporalPlainDate(plainDate, otherDate, largestUnit, settings.SmallestUnit, settings.RoundingIncrement, settings.RoundingMode, negate: true);
     }
 
     /// <summary>
@@ -601,12 +601,12 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.equals
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsValue arg0)
+    private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var other = _constructor.ToTemporalDate(arg0, "constrain");
-        var result = TemporalHelpers.CompareIsoDates(plainDate.IsoDate, other.IsoDate) == 0 &&
-                     string.Equals(plainDate.Calendar, other.Calendar, StringComparison.Ordinal);
+        var otherDate = _constructor.ToTemporalDate(other, "constrain");
+        var result = TemporalHelpers.CompareIsoDates(plainDate.IsoDate, otherDate.IsoDate) == 0 &&
+                     string.Equals(plainDate.Calendar, otherDate.Calendar, StringComparison.Ordinal);
         return result ? JsBoolean.True : JsBoolean.False;
     }
 

--- a/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
@@ -148,12 +148,9 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.with
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDate With(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDate With(JsValue thisObject, JsValue temporalDateLike, JsValue optionsArg)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var temporalDateLike = arguments.At(0);
-        var optionsArg = arguments.At(1);
-
         if (!temporalDateLike.IsObject())
         {
             Throw.TypeError(_realm, "Temporal date-like must be an object");
@@ -367,10 +364,9 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.withcalendar
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDate WithCalendar(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDate WithCalendar(JsValue thisObject, JsValue calendarArg)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var calendarArg = arguments.At(0);
         var calendar = ToTemporalCalendarIdentifier(calendarArg);
 
         return _constructor.Construct(plainDate.IsoDate, calendar);
@@ -380,11 +376,9 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.add
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDate Add(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDate Add(JsValue thisObject, JsValue temporalDurationLike, JsValue optionsArg)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var temporalDurationLike = arguments.At(0);
-        var optionsArg = arguments.At(1);
         var duration = ToTemporalDurationRecord(temporalDurationLike);
         var options = GetOptionsObject(optionsArg);
         var overflow = TemporalHelpers.GetOverflowOption(_realm, (JsValue?) options ?? JsValue.Undefined);
@@ -395,11 +389,9 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.subtract
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDate Subtract(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDate Subtract(JsValue thisObject, JsValue temporalDurationLike, JsValue optionsArg)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var temporalDurationLike = arguments.At(0);
-        var optionsArg = arguments.At(1);
         var duration = ToTemporalDurationRecord(temporalDurationLike);
         var options = GetOptionsObject(optionsArg);
         var overflow = TemporalHelpers.GetOverflowOption(_realm, (JsValue?) options ?? JsValue.Undefined);
@@ -440,18 +432,16 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.until
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Until(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Until(JsValue thisObject, JsValue arg0, JsValue optionsArg)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var other = _constructor.ToTemporalDate(arguments.At(0), "constrain");
+        var other = _constructor.ToTemporalDate(arg0, "constrain");
 
         // Step 3: Calendar equality check (before reading options per spec)
         if (!string.Equals(plainDate.Calendar, other.Calendar, StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, "Calendars must match for date difference operations");
         }
-
-        var optionsArg = arguments.At(1);
 
         // Date units for PlainDate operations (no time units allowed)
         var dateUnits = new[] { "year", "month", "week", "day" };
@@ -484,18 +474,16 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.since
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Since(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Since(JsValue thisObject, JsValue arg0, JsValue optionsArg)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var other = _constructor.ToTemporalDate(arguments.At(0), "constrain");
+        var other = _constructor.ToTemporalDate(arg0, "constrain");
 
         // Step 3: Calendar equality check (before reading options per spec)
         if (!string.Equals(plainDate.Calendar, other.Calendar, StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, "Calendars must match for date difference operations");
         }
-
-        var optionsArg = arguments.At(1);
 
         // Date units for PlainDate operations (no time units allowed)
         var dateUnits = new[] { "year", "month", "week", "day" };
@@ -613,10 +601,10 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.equals
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
+    private JsBoolean Equals(JsValue thisObject, JsValue arg0)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var other = _constructor.ToTemporalDate(arguments.At(0), "constrain");
+        var other = _constructor.ToTemporalDate(arg0, "constrain");
         var result = TemporalHelpers.CompareIsoDates(plainDate.IsoDate, other.IsoDate) == 0 &&
                      string.Equals(plainDate.Calendar, other.Calendar, StringComparison.Ordinal);
         return result ? JsBoolean.True : JsBoolean.False;
@@ -626,11 +614,9 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tostring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToString(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToString(JsValue thisObject, JsValue optionsValue)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var optionsValue = arguments.At(0);
-
         var calendarName = "auto";
 
         if (!optionsValue.IsUndefined())
@@ -657,7 +643,7 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tojson
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToJSON(JsValue thisObject)
     {
         var plainDate = ValidatePlainDate(thisObject);
         return new JsString(FormatDate(plainDate.IsoDate, plainDate.Calendar));
@@ -667,12 +653,9 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sup-temporal.plaindate.prototype.tolocalestring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToLocaleString(JsValue thisObject, JsValue locales, JsValue options)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
-
         // Per spec: CreateDateTimeFormat with required=~date~, defaults=~date~
         var dtf = _realm.Intrinsics.DateTimeFormat.CreateDateTimeFormat(
             locales, options, required: Intl.DateTimeRequired.Date, defaults: Intl.DateTimeDefaults.Date);
@@ -693,7 +676,7 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.valueof
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Temporal.PlainDate cannot be converted to a primitive value");
         return Undefined;
@@ -703,11 +686,9 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplaindatetime
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsPlainDateTime ToPlainDateTime(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDateTime ToPlainDateTime(JsValue thisObject, JsValue temporalTime)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var temporalTime = arguments.At(0);
-
         IsoTime time;
         if (temporalTime.IsUndefined())
         {
@@ -736,7 +717,7 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainyearmonth
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsPlainYearMonth ToPlainYearMonth(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainYearMonth ToPlainYearMonth(JsValue thisObject)
     {
         var plainDate = ValidatePlainDate(thisObject);
         // Use the first day of the calendar month for the reference day; for non-ISO calendars
@@ -750,7 +731,7 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainmonthday
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsPlainMonthDay ToPlainMonthDay(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainMonthDay ToPlainMonthDay(JsValue thisObject)
     {
         var plainDate = ValidatePlainDate(thisObject);
 
@@ -803,11 +784,9 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tozoneddatetime
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsZonedDateTime ToZonedDateTime(JsValue thisObject, JsCallArguments arguments)
+    private JsZonedDateTime ToZonedDateTime(JsValue thisObject, JsValue item)
     {
         var plainDate = ValidatePlainDate(thisObject);
-        var item = arguments.At(0);
-
         string timeZone;
         JsValue plainTimeValue;
 

--- a/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
@@ -12,9 +12,13 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaindate-prototype-object
 /// </summary>
-internal sealed class PlainDatePrototype : Prototype
+[JsObject]
+internal sealed partial class PlainDatePrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly PlainDateConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString PlainDateToStringTag = new("Temporal.PlainDate");
 
     internal PlainDatePrototype(
         Engine engine,
@@ -28,52 +32,10 @@ internal sealed class PlainDatePrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(32, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["with"] = new(new ClrFunction(Engine, "with", With, 1, LengthFlags), PropertyFlags),
-            ["withCalendar"] = new(new ClrFunction(Engine, "withCalendar", WithCalendar, 1, LengthFlags), PropertyFlags),
-            ["add"] = new(new ClrFunction(Engine, "add", Add, 1, LengthFlags), PropertyFlags),
-            ["subtract"] = new(new ClrFunction(Engine, "subtract", Subtract, 1, LengthFlags), PropertyFlags),
-            ["until"] = new(new ClrFunction(Engine, "until", Until, 1, LengthFlags), PropertyFlags),
-            ["since"] = new(new ClrFunction(Engine, "since", Since, 1, LengthFlags), PropertyFlags),
-            ["equals"] = new(new ClrFunction(Engine, "equals", Equals, 1, LengthFlags), PropertyFlags),
-            ["toString"] = new(new ClrFunction(Engine, "toString", ToString, 0, LengthFlags), PropertyFlags),
-            ["toJSON"] = new(new ClrFunction(Engine, "toJSON", ToJSON, 0, LengthFlags), PropertyFlags),
-            ["toLocaleString"] = new(new ClrFunction(Engine, "toLocaleString", ToLocaleString, 0, LengthFlags), PropertyFlags),
-            ["valueOf"] = new(new ClrFunction(Engine, "valueOf", ValueOf, 0, LengthFlags), PropertyFlags),
-            ["toPlainDateTime"] = new(new ClrFunction(Engine, "toPlainDateTime", ToPlainDateTime, 0, LengthFlags), PropertyFlags),
-            ["toPlainYearMonth"] = new(new ClrFunction(Engine, "toPlainYearMonth", ToPlainYearMonth, 0, LengthFlags), PropertyFlags),
-            ["toPlainMonthDay"] = new(new ClrFunction(Engine, "toPlainMonthDay", ToPlainMonthDay, 0, LengthFlags), PropertyFlags),
-            ["toZonedDateTime"] = new(new ClrFunction(Engine, "toZonedDateTime", ToZonedDateTime, 1, LengthFlags), PropertyFlags),
-            ["calendarId"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get calendarId", GetCalendarId, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["era"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get era", GetEra, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["eraYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get eraYear", GetEraYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["year"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get year", GetYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["month"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get month", GetMonth, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["monthCode"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get monthCode", GetMonthCode, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["day"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get day", GetDay, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["dayOfWeek"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get dayOfWeek", GetDayOfWeek, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["dayOfYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get dayOfYear", GetDayOfYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["weekOfYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get weekOfYear", GetWeekOfYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["yearOfWeek"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get yearOfWeek", GetYearOfWeek, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["daysInWeek"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get daysInWeek", GetDaysInWeek, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["daysInMonth"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get daysInMonth", GetDaysInMonth, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["daysInYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get daysInYear", GetDaysInYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["monthsInYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get monthsInYear", GetMonthsInYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["inLeapYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get inLeapYear", GetInLeapYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Temporal.PlainDate", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
 
     private JsPlainDate ValidatePlainDate(JsValue thisObject)
     {
@@ -83,84 +45,100 @@ internal sealed class PlainDatePrototype : Prototype
         return null!;
     }
 
-    private JsString GetCalendarId(JsValue thisObject, JsCallArguments arguments) => new JsString(ValidatePlainDate(thisObject).Calendar);
+    [JsAccessor("calendarId")]
+    private JsString GetCalendarId(JsValue thisObject) => new JsString(ValidatePlainDate(thisObject).Calendar);
 
-    private JsValue GetEra(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("era")]
+    private JsValue GetEra(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         var era = TemporalHelpers.CalendarEra(pd.Calendar, pd.IsoDate);
         return era is not null ? new JsString(era) : Undefined;
     }
 
-    private JsValue GetEraYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("eraYear")]
+    private JsValue GetEraYear(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         var eraYear = TemporalHelpers.CalendarEraYear(pd.Calendar, pd.IsoDate);
         return eraYear.HasValue ? JsNumber.Create(eraYear.Value) : Undefined;
     }
 
-    private JsNumber GetYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("year")]
+    private JsNumber GetYear(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarYear(pd.Calendar, pd.IsoDate, _engine));
     }
-    private JsNumber GetMonth(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("month")]
+    private JsNumber GetMonth(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarMonth(pd.Calendar, pd.IsoDate, _engine));
     }
-    private JsString GetMonthCode(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("monthCode")]
+    private JsString GetMonthCode(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         return new JsString(TemporalHelpers.CalendarMonthCode(pd.Calendar, pd.IsoDate, _engine));
     }
-    private JsNumber GetDay(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("day")]
+    private JsNumber GetDay(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDay(pd.Calendar, pd.IsoDate, _engine));
     }
-    private JsNumber GetDayOfWeek(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainDate(thisObject).IsoDate.DayOfWeek());
-    private JsNumber GetDayOfYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("dayOfWeek")]
+    private JsNumber GetDayOfWeek(JsValue thisObject) => JsNumber.Create(ValidatePlainDate(thisObject).IsoDate.DayOfWeek());
+    [JsAccessor("dayOfYear")]
+    private JsNumber GetDayOfYear(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDayOfYear(pd.Calendar, pd.IsoDate, _engine));
     }
-    private JsValue GetWeekOfYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("weekOfYear")]
+    private JsValue GetWeekOfYear(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         return string.Equals(pd.Calendar, "iso8601", StringComparison.Ordinal) ? JsNumber.Create(pd.IsoDate.WeekOfYear()) : Undefined;
     }
 
-    private JsValue GetYearOfWeek(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("yearOfWeek")]
+    private JsValue GetYearOfWeek(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         return string.Equals(pd.Calendar, "iso8601", StringComparison.Ordinal) ? JsNumber.Create(pd.IsoDate.YearOfWeek()) : Undefined;
     }
 
-    private JsNumber GetDaysInWeek(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("daysInWeek")]
+    private JsNumber GetDaysInWeek(JsValue thisObject)
     {
         ValidatePlainDate(thisObject);
         return JsNumber.Create(7);
     }
 
-    private JsNumber GetDaysInMonth(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("daysInMonth")]
+    private JsNumber GetDaysInMonth(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDaysInMonth(pd.Calendar, pd.IsoDate, _engine));
     }
-    private JsNumber GetDaysInYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("daysInYear")]
+    private JsNumber GetDaysInYear(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDaysInYear(pd.Calendar, pd.IsoDate, _engine));
     }
 
-    private JsNumber GetMonthsInYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("monthsInYear")]
+    private JsNumber GetMonthsInYear(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarMonthsInYear(pd.Calendar, pd.IsoDate, _engine));
     }
 
-    private JsBoolean GetInLeapYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("inLeapYear")]
+    private JsBoolean GetInLeapYear(JsValue thisObject)
     {
         var pd = ValidatePlainDate(thisObject);
         return TemporalHelpers.CalendarInLeapYear(pd.Calendar, pd.IsoDate, _engine) ? JsBoolean.True : JsBoolean.False;
@@ -169,6 +147,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.with
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDate With(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -387,6 +366,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.withcalendar
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDate WithCalendar(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -399,6 +379,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.add
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDate Add(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -413,6 +394,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.subtract
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDate Subtract(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -457,6 +439,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.until
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Until(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -500,6 +483,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.since
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Since(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -628,6 +612,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.equals
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -640,6 +625,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tostring
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsString ToString(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -670,6 +656,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tojson
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -679,6 +666,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sup-temporal.plaindate.prototype.tolocalestring
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -704,6 +692,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.valueof
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
     {
         Throw.TypeError(_realm, "Temporal.PlainDate cannot be converted to a primitive value");
@@ -713,6 +702,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplaindatetime
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsPlainDateTime ToPlainDateTime(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -745,6 +735,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainyearmonth
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsPlainYearMonth ToPlainYearMonth(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -758,6 +749,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainmonthday
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsPlainMonthDay ToPlainMonthDay(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -810,6 +802,7 @@ internal sealed class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tozoneddatetime
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsZonedDateTime ToZonedDateTime(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDate = ValidatePlainDate(thisObject);

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimeConstructor.cs
@@ -35,11 +35,8 @@ internal sealed partial class PlainDateTimeConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.from
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDateTime From(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDateTime From(JsValue thisObject, JsValue item, JsValue optionsValue)
     {
-        var item = arguments.At(0);
-        var optionsValue = arguments.At(1);
-
         // For existing Temporal types (cloning), validate options first then convert
         if (item is JsPlainDateTime || item is JsPlainDate || item is JsZonedDateTime)
         {
@@ -81,10 +78,10 @@ internal sealed partial class PlainDateTimeConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
+    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
-        var one = ToTemporalDateTime(arguments.At(0), "constrain");
-        var two = ToTemporalDateTime(arguments.At(1), "constrain");
+        var one = ToTemporalDateTime(arg0, "constrain");
+        var two = ToTemporalDateTime(arg1, "constrain");
         return JsNumber.Create(TemporalHelpers.CompareIsoDateTimes(one.IsoDateTime, two.IsoDateTime));
     }
 

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimeConstructor.cs
@@ -9,7 +9,8 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime
 /// </summary>
-internal sealed class PlainDateTimeConstructor : Constructor
+[JsObject]
+internal sealed partial class PlainDateTimeConstructor : Constructor
 {
     private static readonly JsString _functionName = new("PlainDateTime");
 
@@ -27,22 +28,13 @@ internal sealed class PlainDateTimeConstructor : Constructor
 
     public PlainDateTimePrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
+    protected override void Initialize() => CreateProperties_Generated();
 
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            ["from"] = new(new ClrFunction(Engine, "from", From, 1, LengthFlags), PropertyFlags),
-            ["compare"] = new(new ClrFunction(Engine, "compare", Compare, 2, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-    }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.from
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDateTime From(JsValue thisObject, JsCallArguments arguments)
     {
         var item = arguments.At(0);
@@ -88,6 +80,7 @@ internal sealed class PlainDateTimeConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.compare
     /// </summary>
+    [JsFunction(Length = 2)]
     private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
     {
         var one = ToTemporalDateTime(arguments.At(0), "constrain");

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimeConstructor.cs
@@ -78,11 +78,11 @@ internal sealed partial class PlainDateTimeConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1)
+    private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two)
     {
-        var one = ToTemporalDateTime(arg0, "constrain");
-        var two = ToTemporalDateTime(arg1, "constrain");
-        return JsNumber.Create(TemporalHelpers.CompareIsoDateTimes(one.IsoDateTime, two.IsoDateTime));
+        return JsNumber.Create(TemporalHelpers.CompareIsoDateTimes(
+            ToTemporalDateTime(one, "constrain").IsoDateTime,
+            ToTemporalDateTime(two, "constrain").IsoDateTime));
     }
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
@@ -160,7 +160,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.with
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDateTime With(JsValue thisObject, JsValue temporalDateTimeLike, JsValue optionsArg)
+    private JsPlainDateTime With(JsValue thisObject, JsValue temporalDateTimeLike, JsValue options)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
         // IsPartialTemporalObject (spec: abstractops.html#sec-temporal-ispartialtemporalobject)
@@ -341,7 +341,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
 
         // Read options AFTER reading fields but BEFORE algorithmic validation
         // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.with
-        var overflow = TemporalHelpers.GetOverflowOption(_realm, optionsArg);
+        var overflow = TemporalHelpers.GetOverflowOption(_realm, options);
 
         // Process monthCode (after reading options, before algorithmic validation)
         int? monthFromCode = null;
@@ -763,7 +763,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tostring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToString(JsValue thisObject, JsValue optionsArg)
+    private JsString ToString(JsValue thisObject, JsValue options)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
         var calendarName = "auto";
@@ -771,14 +771,12 @@ internal sealed partial class PlainDateTimePrototype : Prototype
         var roundingMode = "trunc";
         var isoDateTime = plainDateTime.IsoDateTime;
 
-        if (!optionsArg.IsUndefined())
+        if (!options.IsUndefined())
         {
-            if (!optionsArg.IsObject())
+            if (!options.IsObject())
             {
                 Throw.TypeError(_realm, "Options must be an object");
             }
-
-            var options = optionsArg.AsObject();
 
             // Read options in strict alphabetical order per spec:
             // calendarName, fractionalSecondDigits, roundingMode, smallestUnit
@@ -994,7 +992,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tozoneddatetime
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsZonedDateTime ToZonedDateTime(JsValue thisObject, JsValue timeZoneLike, JsValue optionsArg)
+    private JsZonedDateTime ToZonedDateTime(JsValue thisObject, JsValue timeZoneLike, JsValue options)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
         // Validate time zone
@@ -1002,14 +1000,14 @@ internal sealed partial class PlainDateTimePrototype : Prototype
 
         // Get disambiguation option
         var disambiguation = "compatible";
-        if (!optionsArg.IsUndefined())
+        if (!options.IsUndefined())
         {
-            if (!optionsArg.IsObject())
+            if (!options.IsObject())
             {
                 Throw.TypeError(_realm, "Options must be an object");
             }
 
-            var disValue = optionsArg.AsObject().Get("disambiguation");
+            var disValue = options.AsObject().Get("disambiguation");
             if (!disValue.IsUndefined())
             {
                 disambiguation = TypeConverter.ToString(disValue);

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
@@ -160,12 +160,9 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.with
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDateTime With(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDateTime With(JsValue thisObject, JsValue temporalDateTimeLike, JsValue optionsArg)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var temporalDateTimeLike = arguments.At(0);
-        var optionsArg = arguments.At(1);
-
         // IsPartialTemporalObject (spec: abstractops.html#sec-temporal-ispartialtemporalobject)
         // Step 1: If value is not an Object, return false
         if (!temporalDateTimeLike.IsObject())
@@ -400,10 +397,10 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaindate
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDateTime WithPlainDate(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDateTime WithPlainDate(JsValue thisObject, JsValue arg0)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var plainDate = _realm.Intrinsics.TemporalPlainDate.ToTemporalDate(arguments.At(0), "constrain");
+        var plainDate = _realm.Intrinsics.TemporalPlainDate.ToTemporalDate(arg0, "constrain");
         return _constructor.Construct(new IsoDateTime(plainDate.IsoDate, plainDateTime.IsoDateTime.Time), plainDate.Calendar);
     }
 
@@ -411,11 +408,9 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaintime
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsPlainDateTime WithPlainTime(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDateTime WithPlainTime(JsValue thisObject, JsValue timeArg)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var timeArg = arguments.At(0);
-
         IsoTime time;
         if (timeArg.IsUndefined())
         {
@@ -434,12 +429,10 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDateTime WithCalendar(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDateTime WithCalendar(JsValue thisObject, JsValue calendarArg)
     {
         // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var calendarArg = arguments.At(0);
-
         // Use ToTemporalCalendarIdentifier for spec-compliant conversion (handles Temporal objects)
         var calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarArg);
 
@@ -450,11 +443,9 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.add
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDateTime Add(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDateTime Add(JsValue thisObject, JsValue temporalDurationLike, JsValue options)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var temporalDurationLike = arguments.At(0);
-        var options = arguments.At(1);
         // Read duration fields first, then options (per spec order)
         var duration = ToDurationRecord(temporalDurationLike);
         var overflow = TemporalHelpers.GetOverflowOption(_realm, options);
@@ -465,11 +456,9 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.subtract
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDateTime Subtract(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDateTime Subtract(JsValue thisObject, JsValue temporalDurationLike, JsValue options)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var temporalDurationLike = arguments.At(0);
-        var options = arguments.At(1);
         // Read duration fields first, then options (per spec order)
         var duration = ToDurationRecord(temporalDurationLike);
         var overflow = TemporalHelpers.GetOverflowOption(_realm, options);
@@ -515,18 +504,16 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.until
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Until(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Until(JsValue thisObject, JsValue arg0, JsValue optionsArg)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var other = _constructor.ToTemporalDateTime(arguments.At(0), "constrain");
+        var other = _constructor.ToTemporalDateTime(arg0, "constrain");
 
         // Calendar equality check (before reading options per spec)
         if (!string.Equals(plainDateTime.Calendar, other.Calendar, StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, "Calendars must match for date-time difference operations");
         }
-
-        var optionsArg = arguments.At(1);
 
         // All temporal units allowed for PlainDateTime operations
         var allUnits = new[] { "year", "month", "week", "day", "hour", "minute", "second", "millisecond", "microsecond", "nanosecond" };
@@ -557,18 +544,16 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.since
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Since(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Since(JsValue thisObject, JsValue arg0, JsValue optionsArg)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var other = _constructor.ToTemporalDateTime(arguments.At(0), "constrain");
+        var other = _constructor.ToTemporalDateTime(arg0, "constrain");
 
         // Calendar equality check (before reading options per spec)
         if (!string.Equals(plainDateTime.Calendar, other.Calendar, StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, "Calendars must match for date-time difference operations");
         }
-
-        var optionsArg = arguments.At(1);
 
         // All temporal units allowed for PlainDateTime operations
         var allUnits = new[] { "year", "month", "week", "day", "hour", "minute", "second", "millisecond", "microsecond", "nanosecond" };
@@ -651,11 +636,9 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.round
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDateTime Round(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDateTime Round(JsValue thisObject, JsValue roundTo)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var roundTo = arguments.At(0);
-
         if (roundTo.IsUndefined())
         {
             Throw.TypeError(_realm, "Options required");
@@ -767,10 +750,10 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.equals
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
+    private JsBoolean Equals(JsValue thisObject, JsValue arg0)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var other = _constructor.ToTemporalDateTime(arguments.At(0), "constrain");
+        var other = _constructor.ToTemporalDateTime(arg0, "constrain");
         var result = TemporalHelpers.CompareIsoDateTimes(plainDateTime.IsoDateTime, other.IsoDateTime) == 0 &&
                      string.Equals(plainDateTime.Calendar, other.Calendar, StringComparison.Ordinal);
         return result ? JsBoolean.True : JsBoolean.False;
@@ -780,11 +763,9 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tostring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToString(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToString(JsValue thisObject, JsValue optionsArg)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var optionsArg = arguments.At(0);
-
         var calendarName = "auto";
         var precision = -1; // -1 means "auto"
         var roundingMode = "trunc";
@@ -947,7 +928,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tojson
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToJSON(JsValue thisObject)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
         return new JsString(FormatDateTime(plainDateTime.IsoDateTime, plainDateTime.Calendar));
@@ -957,12 +938,9 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sup-temporal.plaindatetime.prototype.tolocalestring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToLocaleString(JsValue thisObject, JsValue locales, JsValue options)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
-
         // Per spec: CreateDateTimeFormat with required=~any~, defaults=~all~
         var dtf = _realm.Intrinsics.DateTimeFormat.CreateDateTimeFormat(
             locales, options, required: Intl.DateTimeRequired.Any, defaults: Intl.DateTimeDefaults.All);
@@ -984,7 +962,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Temporal.PlainDateTime cannot be converted to a primitive value");
         return Undefined;
@@ -994,7 +972,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaindate
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsPlainDate ToPlainDate(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDate ToPlainDate(JsValue thisObject)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
         return new JsPlainDate(_engine, _realm.Intrinsics.TemporalPlainDate.PrototypeObject,
@@ -1005,7 +983,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaintime
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsPlainTime ToPlainTime(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainTime ToPlainTime(JsValue thisObject)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
         return new JsPlainTime(_engine, _realm.Intrinsics.TemporalPlainTime.PrototypeObject,
@@ -1016,12 +994,9 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tozoneddatetime
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsZonedDateTime ToZonedDateTime(JsValue thisObject, JsCallArguments arguments)
+    private JsZonedDateTime ToZonedDateTime(JsValue thisObject, JsValue timeZoneLike, JsValue optionsArg)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var timeZoneLike = arguments.At(0);
-        var optionsArg = arguments.At(1);
-
         // Validate time zone
         var timeZone = ToTemporalTimeZoneIdentifier(timeZoneLike);
 

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
@@ -397,10 +397,10 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaindate
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDateTime WithPlainDate(JsValue thisObject, JsValue arg0)
+    private JsPlainDateTime WithPlainDate(JsValue thisObject, JsValue plainDateLike)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var plainDate = _realm.Intrinsics.TemporalPlainDate.ToTemporalDate(arg0, "constrain");
+        var plainDate = _realm.Intrinsics.TemporalPlainDate.ToTemporalDate(plainDateLike, "constrain");
         return _constructor.Construct(new IsoDateTime(plainDate.IsoDate, plainDateTime.IsoDateTime.Time), plainDate.Calendar);
     }
 
@@ -504,13 +504,13 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.until
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Until(JsValue thisObject, JsValue arg0, JsValue optionsArg)
+    private JsDuration Until(JsValue thisObject, JsValue other, JsValue options)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var other = _constructor.ToTemporalDateTime(arg0, "constrain");
+        var otherDateTime = _constructor.ToTemporalDateTime(other, "constrain");
 
         // Calendar equality check (before reading options per spec)
-        if (!string.Equals(plainDateTime.Calendar, other.Calendar, StringComparison.Ordinal))
+        if (!string.Equals(plainDateTime.Calendar, otherDateTime.Calendar, StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, "Calendars must match for date-time difference operations");
         }
@@ -524,7 +524,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
 
         var settings = TemporalHelpers.GetDifferenceSettings(
             _realm,
-            optionsArg,
+            options,
             "until",
             fallbackSmallestUnit,
             fallbackLargestUnit,
@@ -537,20 +537,20 @@ internal sealed partial class PlainDateTimePrototype : Prototype
             largestUnit = TemporalHelpers.LargerOfTwoTemporalUnits(settings.SmallestUnit, "day");
         }
 
-        return DifferenceTemporalPlainDateTime(plainDateTime, other, largestUnit, settings.SmallestUnit, settings.RoundingIncrement, settings.RoundingMode, negate: false);
+        return DifferenceTemporalPlainDateTime(plainDateTime, otherDateTime, largestUnit, settings.SmallestUnit, settings.RoundingIncrement, settings.RoundingMode, negate: false);
     }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.since
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Since(JsValue thisObject, JsValue arg0, JsValue optionsArg)
+    private JsDuration Since(JsValue thisObject, JsValue other, JsValue options)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var other = _constructor.ToTemporalDateTime(arg0, "constrain");
+        var otherDateTime = _constructor.ToTemporalDateTime(other, "constrain");
 
         // Calendar equality check (before reading options per spec)
-        if (!string.Equals(plainDateTime.Calendar, other.Calendar, StringComparison.Ordinal))
+        if (!string.Equals(plainDateTime.Calendar, otherDateTime.Calendar, StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, "Calendars must match for date-time difference operations");
         }
@@ -564,7 +564,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
 
         var settings = TemporalHelpers.GetDifferenceSettings(
             _realm,
-            optionsArg,
+            options,
             "since",
             fallbackSmallestUnit,
             fallbackLargestUnit,
@@ -577,7 +577,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
             largestUnit = TemporalHelpers.LargerOfTwoTemporalUnits(settings.SmallestUnit, "day");
         }
 
-        return DifferenceTemporalPlainDateTime(plainDateTime, other, largestUnit, settings.SmallestUnit, settings.RoundingIncrement, settings.RoundingMode, negate: true);
+        return DifferenceTemporalPlainDateTime(plainDateTime, otherDateTime, largestUnit, settings.SmallestUnit, settings.RoundingIncrement, settings.RoundingMode, negate: true);
     }
 
     /// <summary>
@@ -750,12 +750,12 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.equals
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsValue arg0)
+    private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
-        var other = _constructor.ToTemporalDateTime(arg0, "constrain");
-        var result = TemporalHelpers.CompareIsoDateTimes(plainDateTime.IsoDateTime, other.IsoDateTime) == 0 &&
-                     string.Equals(plainDateTime.Calendar, other.Calendar, StringComparison.Ordinal);
+        var otherDateTime = _constructor.ToTemporalDateTime(other, "constrain");
+        var result = TemporalHelpers.CompareIsoDateTimes(plainDateTime.IsoDateTime, otherDateTime.IsoDateTime) == 0 &&
+                     string.Equals(plainDateTime.Calendar, otherDateTime.Calendar, StringComparison.Ordinal);
         return result ? JsBoolean.True : JsBoolean.False;
     }
 

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
@@ -12,9 +12,13 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaindatetime-prototype-object
 /// </summary>
-internal sealed class PlainDateTimePrototype : Prototype
+[JsObject]
+internal sealed partial class PlainDateTimePrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly PlainDateTimeConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString PlainDateTimeToStringTag = new("Temporal.PlainDateTime");
 
     internal PlainDateTimePrototype(
         Engine engine,
@@ -28,60 +32,10 @@ internal sealed class PlainDateTimePrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(40, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["with"] = new(new ClrFunction(Engine, "with", With, 1, LengthFlags), PropertyFlags),
-            ["withPlainDate"] = new(new ClrFunction(Engine, "withPlainDate", WithPlainDate, 1, LengthFlags), PropertyFlags),
-            ["withPlainTime"] = new(new ClrFunction(Engine, "withPlainTime", WithPlainTime, 0, LengthFlags), PropertyFlags),
-            ["withCalendar"] = new(new ClrFunction(Engine, "withCalendar", WithCalendar, 1, LengthFlags), PropertyFlags),
-            ["add"] = new(new ClrFunction(Engine, "add", Add, 1, LengthFlags), PropertyFlags),
-            ["subtract"] = new(new ClrFunction(Engine, "subtract", Subtract, 1, LengthFlags), PropertyFlags),
-            ["until"] = new(new ClrFunction(Engine, "until", Until, 1, LengthFlags), PropertyFlags),
-            ["since"] = new(new ClrFunction(Engine, "since", Since, 1, LengthFlags), PropertyFlags),
-            ["round"] = new(new ClrFunction(Engine, "round", Round, 1, LengthFlags), PropertyFlags),
-            ["equals"] = new(new ClrFunction(Engine, "equals", Equals, 1, LengthFlags), PropertyFlags),
-            ["toString"] = new(new ClrFunction(Engine, "toString", ToString, 0, LengthFlags), PropertyFlags),
-            ["toJSON"] = new(new ClrFunction(Engine, "toJSON", ToJSON, 0, LengthFlags), PropertyFlags),
-            ["toLocaleString"] = new(new ClrFunction(Engine, "toLocaleString", ToLocaleString, 0, LengthFlags), PropertyFlags),
-            ["valueOf"] = new(new ClrFunction(Engine, "valueOf", ValueOf, 0, LengthFlags), PropertyFlags),
-            ["toPlainDate"] = new(new ClrFunction(Engine, "toPlainDate", ToPlainDate, 0, LengthFlags), PropertyFlags),
-            ["toPlainTime"] = new(new ClrFunction(Engine, "toPlainTime", ToPlainTime, 0, LengthFlags), PropertyFlags),
-            ["toZonedDateTime"] = new(new ClrFunction(Engine, "toZonedDateTime", ToZonedDateTime, 1, LengthFlags), PropertyFlags),
-            ["calendarId"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get calendarId", GetCalendarId, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["era"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get era", GetEra, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["eraYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get eraYear", GetEraYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["year"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get year", GetYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["month"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get month", GetMonth, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["monthCode"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get monthCode", GetMonthCode, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["day"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get day", GetDay, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["hour"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get hour", GetHour, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["minute"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get minute", GetMinute, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["second"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get second", GetSecond, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["millisecond"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get millisecond", GetMillisecond, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["microsecond"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get microsecond", GetMicrosecond, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["nanosecond"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get nanosecond", GetNanosecond, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["dayOfWeek"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get dayOfWeek", GetDayOfWeek, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["dayOfYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get dayOfYear", GetDayOfYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["weekOfYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get weekOfYear", GetWeekOfYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["yearOfWeek"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get yearOfWeek", GetYearOfWeek, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["daysInWeek"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get daysInWeek", GetDaysInWeek, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["daysInMonth"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get daysInMonth", GetDaysInMonth, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["daysInYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get daysInYear", GetDaysInYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["monthsInYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get monthsInYear", GetMonthsInYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["inLeapYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get inLeapYear", GetInLeapYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Temporal.PlainDateTime", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
 
     private JsPlainDateTime ValidatePlainDateTime(JsValue thisObject)
     {
@@ -91,90 +45,112 @@ internal sealed class PlainDateTimePrototype : Prototype
         return null!;
     }
 
-    private JsString GetCalendarId(JsValue thisObject, JsCallArguments arguments) => new JsString(ValidatePlainDateTime(thisObject).Calendar);
+    [JsAccessor("calendarId")]
+    private JsString GetCalendarId(JsValue thisObject) => new JsString(ValidatePlainDateTime(thisObject).Calendar);
 
-    private JsValue GetEra(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("era")]
+    private JsValue GetEra(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         var era = TemporalHelpers.CalendarEra(pdt.Calendar, pdt.IsoDateTime.Date);
         return era is not null ? new JsString(era) : Undefined;
     }
 
-    private JsValue GetEraYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("eraYear")]
+    private JsValue GetEraYear(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         var eraYear = TemporalHelpers.CalendarEraYear(pdt.Calendar, pdt.IsoDateTime.Date);
         return eraYear.HasValue ? JsNumber.Create(eraYear.Value) : Undefined;
     }
 
-    private JsNumber GetYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("year")]
+    private JsNumber GetYear(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarYear(pdt.Calendar, pdt.IsoDateTime.Date, _engine));
     }
-    private JsNumber GetMonth(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("month")]
+    private JsNumber GetMonth(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarMonth(pdt.Calendar, pdt.IsoDateTime.Date, _engine));
     }
-    private JsString GetMonthCode(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("monthCode")]
+    private JsString GetMonthCode(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         return new JsString(TemporalHelpers.CalendarMonthCode(pdt.Calendar, pdt.IsoDateTime.Date, _engine));
     }
-    private JsNumber GetDay(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("day")]
+    private JsNumber GetDay(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDay(pdt.Calendar, pdt.IsoDateTime.Date, _engine));
     }
-    private JsNumber GetHour(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Hour);
-    private JsNumber GetMinute(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Minute);
-    private JsNumber GetSecond(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Second);
-    private JsNumber GetMillisecond(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Millisecond);
-    private JsNumber GetMicrosecond(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Microsecond);
-    private JsNumber GetNanosecond(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Nanosecond);
-    private JsNumber GetDayOfWeek(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Date.DayOfWeek());
-    private JsNumber GetDayOfYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("hour")]
+    private JsNumber GetHour(JsValue thisObject) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Hour);
+    [JsAccessor("minute")]
+    private JsNumber GetMinute(JsValue thisObject) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Minute);
+    [JsAccessor("second")]
+    private JsNumber GetSecond(JsValue thisObject) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Second);
+    [JsAccessor("millisecond")]
+    private JsNumber GetMillisecond(JsValue thisObject) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Millisecond);
+    [JsAccessor("microsecond")]
+    private JsNumber GetMicrosecond(JsValue thisObject) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Microsecond);
+    [JsAccessor("nanosecond")]
+    private JsNumber GetNanosecond(JsValue thisObject) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Nanosecond);
+    [JsAccessor("dayOfWeek")]
+    private JsNumber GetDayOfWeek(JsValue thisObject) => JsNumber.Create(ValidatePlainDateTime(thisObject).IsoDateTime.Date.DayOfWeek());
+    [JsAccessor("dayOfYear")]
+    private JsNumber GetDayOfYear(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDayOfYear(pdt.Calendar, pdt.IsoDateTime.Date, _engine));
     }
-    private JsValue GetWeekOfYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("weekOfYear")]
+    private JsValue GetWeekOfYear(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         return string.Equals(pdt.Calendar, "iso8601", StringComparison.Ordinal) ? JsNumber.Create(pdt.IsoDateTime.Date.WeekOfYear()) : Undefined;
     }
 
-    private JsValue GetYearOfWeek(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("yearOfWeek")]
+    private JsValue GetYearOfWeek(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         return string.Equals(pdt.Calendar, "iso8601", StringComparison.Ordinal) ? JsNumber.Create(pdt.IsoDateTime.Date.YearOfWeek()) : Undefined;
     }
 
-    private JsNumber GetDaysInWeek(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("daysInWeek")]
+    private JsNumber GetDaysInWeek(JsValue thisObject)
     {
         ValidatePlainDateTime(thisObject);
         return JsNumber.Create(7);
     }
 
-    private JsNumber GetDaysInMonth(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("daysInMonth")]
+    private JsNumber GetDaysInMonth(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDaysInMonth(pdt.Calendar, pdt.IsoDateTime.Date, _engine));
     }
-    private JsNumber GetDaysInYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("daysInYear")]
+    private JsNumber GetDaysInYear(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDaysInYear(pdt.Calendar, pdt.IsoDateTime.Date, _engine));
     }
 
-    private JsNumber GetMonthsInYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("monthsInYear")]
+    private JsNumber GetMonthsInYear(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarMonthsInYear(pdt.Calendar, pdt.IsoDateTime.Date, _engine));
     }
 
-    private JsBoolean GetInLeapYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("inLeapYear")]
+    private JsBoolean GetInLeapYear(JsValue thisObject)
     {
         var pdt = ValidatePlainDateTime(thisObject);
         return TemporalHelpers.CalendarInLeapYear(pdt.Calendar, pdt.IsoDateTime.Date, _engine) ? JsBoolean.True : JsBoolean.False;
@@ -183,6 +159,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.with
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDateTime With(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -422,6 +399,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaindate
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDateTime WithPlainDate(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -432,6 +410,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaintime
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsPlainDateTime WithPlainTime(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -454,6 +433,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDateTime WithCalendar(JsValue thisObject, JsCallArguments arguments)
     {
         // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar
@@ -469,6 +449,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.add
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDateTime Add(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -483,6 +464,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.subtract
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDateTime Subtract(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -532,6 +514,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.until
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Until(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -573,6 +556,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.since
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Since(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -666,6 +650,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.round
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDateTime Round(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -781,6 +766,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.equals
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -793,6 +779,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tostring
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsString ToString(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -959,6 +946,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tojson
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -968,6 +956,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sup-temporal.plaindatetime.prototype.tolocalestring
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -994,6 +983,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
     {
         Throw.TypeError(_realm, "Temporal.PlainDateTime cannot be converted to a primitive value");
@@ -1003,6 +993,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaindate
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsPlainDate ToPlainDate(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -1013,6 +1004,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaintime
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsPlainTime ToPlainTime(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -1023,6 +1015,7 @@ internal sealed class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tozoneddatetime
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsZonedDateTime ToZonedDateTime(JsValue thisObject, JsCallArguments arguments)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);

--- a/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayConstructor.cs
+++ b/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayConstructor.cs
@@ -10,7 +10,8 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday
 /// </summary>
-internal sealed class PlainMonthDayConstructor : Constructor
+[JsObject]
+internal sealed partial class PlainMonthDayConstructor : Constructor
 {
     private static readonly JsString _functionName = new("PlainMonthDay");
     private static readonly char[] TimeSuffixChars = { 'T', ' ', '[' };
@@ -29,21 +30,13 @@ internal sealed class PlainMonthDayConstructor : Constructor
 
     public PlainMonthDayPrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
+    protected override void Initialize() => CreateProperties_Generated();
 
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            ["from"] = new(new ClrFunction(Engine, "from", From, 1, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-    }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.from
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainMonthDay From(JsValue thisObject, JsCallArguments arguments)
     {
         var item = arguments.At(0);

--- a/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayConstructor.cs
+++ b/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayConstructor.cs
@@ -37,11 +37,8 @@ internal sealed partial class PlainMonthDayConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.from
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainMonthDay From(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainMonthDay From(JsValue thisObject, JsValue item, JsValue optionsValue)
     {
-        var item = arguments.At(0);
-        var optionsValue = arguments.At(1);
-
         // For existing PlainMonthDay (cloning), validate options first then convert
         if (item is JsPlainMonthDay)
         {

--- a/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
+++ b/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
@@ -62,7 +62,7 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.with
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainMonthDay With(JsValue thisObject, JsValue temporalMonthDayLike, JsValue optionsArg)
+    private JsPlainMonthDay With(JsValue thisObject, JsValue temporalMonthDayLike, JsValue options)
     {
         var md = ValidatePlainMonthDay(thisObject);
         if (!temporalMonthDayLike.IsObject())
@@ -149,7 +149,7 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
         }
 
         // Read options BEFORE any validation (per spec)
-        var overflow = TemporalHelpers.GetOverflowOption(_realm, optionsArg);
+        var overflow = TemporalHelpers.GetOverflowOption(_realm, options);
 
         // For non-ISO calendars, monthCode is required when month is provided
         if (!string.Equals(md.Calendar, "iso8601", StringComparison.Ordinal) &&

--- a/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
+++ b/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
@@ -62,12 +62,9 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.with
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainMonthDay With(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainMonthDay With(JsValue thisObject, JsValue temporalMonthDayLike, JsValue optionsArg)
     {
         var md = ValidatePlainMonthDay(thisObject);
-        var temporalMonthDayLike = arguments.At(0);
-        var optionsArg = arguments.At(1);
-
         if (!temporalMonthDayLike.IsObject())
         {
             Throw.TypeError(_realm, "with argument must be an object");
@@ -219,10 +216,10 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.equals
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
+    private JsBoolean Equals(JsValue thisObject, JsValue arg0)
     {
         var md = ValidatePlainMonthDay(thisObject);
-        var other = _constructor.ToTemporalMonthDay(arguments.At(0), "constrain");
+        var other = _constructor.ToTemporalMonthDay(arg0, "constrain");
 
         return md.IsoDate.Year == other.IsoDate.Year &&
                md.IsoDate.Month == other.IsoDate.Month &&
@@ -236,10 +233,9 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tostring
     /// </summary>
     [JsFunction(Length = 0, Name = "toString")]
-    private JsString ToTemporalString(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToTemporalString(JsValue thisObject, JsValue optionsValue)
     {
         var md = ValidatePlainMonthDay(thisObject);
-        var optionsValue = arguments.At(0);
         var options = TemporalHelpers.GetOptionsObject(_realm, optionsValue);
         var showCalendar = GetCalendarNameOption(options);
 
@@ -282,7 +278,7 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tojson
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToJSON(JsValue thisObject)
     {
         var md = ValidatePlainMonthDay(thisObject);
         // toJSON uses "auto" for calendarName: include year+calendar for non-ISO
@@ -299,12 +295,9 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sup-temporal.plainmonthday.prototype.tolocalestring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToLocaleString(JsValue thisObject, JsValue locales, JsValue options)
     {
         var md = ValidatePlainMonthDay(thisObject);
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
-
         // Per spec: CreateDateTimeFormat with required=~date~, defaults=~date~
         // But for PlainMonthDay, we use month-day specific defaults (no year)
         var dtf = _realm.Intrinsics.DateTimeFormat.CreateDateTimeFormat(
@@ -324,7 +317,7 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.valueof
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Temporal.PlainMonthDay cannot be converted to a primitive value");
         return Undefined;
@@ -334,11 +327,9 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.toplaindate
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDate ToPlainDate(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDate ToPlainDate(JsValue thisObject, JsValue item)
     {
         var md = ValidatePlainMonthDay(thisObject);
-        var item = arguments.At(0);
-
         if (!item.IsObject())
         {
             Throw.TypeError(_realm, "toPlainDate requires an object argument");

--- a/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
+++ b/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
@@ -9,9 +9,13 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plainmonthday-prototype-object
 /// </summary>
-internal sealed class PlainMonthDayPrototype : Prototype
+[JsObject]
+internal sealed partial class PlainMonthDayPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly PlainMonthDayConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString PlainMonthDayToStringTag = new("Temporal.PlainMonthDay");
 
     internal PlainMonthDayPrototype(
         Engine engine,
@@ -25,31 +29,10 @@ internal sealed class PlainMonthDayPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(11, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["with"] = new(new ClrFunction(Engine, "with", With, 1, LengthFlags), PropertyFlags),
-            ["equals"] = new(new ClrFunction(Engine, "equals", Equals, 1, LengthFlags), PropertyFlags),
-            ["toString"] = new(new ClrFunction(Engine, "toString", ToTemporalString, 0, LengthFlags), PropertyFlags),
-            ["toJSON"] = new(new ClrFunction(Engine, "toJSON", ToJSON, 0, LengthFlags), PropertyFlags),
-            ["toLocaleString"] = new(new ClrFunction(Engine, "toLocaleString", ToLocaleString, 0, LengthFlags), PropertyFlags),
-            ["valueOf"] = new(new ClrFunction(Engine, "valueOf", ValueOf, 0, LengthFlags), PropertyFlags),
-            ["toPlainDate"] = new(new ClrFunction(Engine, "toPlainDate", ToPlainDate, 1, LengthFlags), PropertyFlags),
-            ["calendarId"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get calendarId", GetCalendarId, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["monthCode"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get monthCode", GetMonthCode, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["day"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get day", GetDay, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Temporal.PlainMonthDay", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
 
     private JsPlainMonthDay ValidatePlainMonthDay(JsValue thisObject)
     {
@@ -60,13 +43,16 @@ internal sealed class PlainMonthDayPrototype : Prototype
     }
 
     // Getters
-    private JsString GetCalendarId(JsValue thisObject, JsCallArguments arguments) => new JsString(ValidatePlainMonthDay(thisObject).Calendar);
-    private JsString GetMonthCode(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("calendarId")]
+    private JsString GetCalendarId(JsValue thisObject) => new JsString(ValidatePlainMonthDay(thisObject).Calendar);
+    [JsAccessor("monthCode")]
+    private JsString GetMonthCode(JsValue thisObject)
     {
         var md = ValidatePlainMonthDay(thisObject);
         return new JsString(TemporalHelpers.CalendarMonthCode(md.Calendar, md.IsoDate, _engine));
     }
-    private JsNumber GetDay(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("day")]
+    private JsNumber GetDay(JsValue thisObject)
     {
         var md = ValidatePlainMonthDay(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDay(md.Calendar, md.IsoDate, _engine));
@@ -75,6 +61,7 @@ internal sealed class PlainMonthDayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.with
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainMonthDay With(JsValue thisObject, JsCallArguments arguments)
     {
         var md = ValidatePlainMonthDay(thisObject);
@@ -231,6 +218,7 @@ internal sealed class PlainMonthDayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.equals
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
     {
         var md = ValidatePlainMonthDay(thisObject);
@@ -247,6 +235,7 @@ internal sealed class PlainMonthDayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tostring
     /// </summary>
+    [JsFunction(Length = 0, Name = "toString")]
     private JsString ToTemporalString(JsValue thisObject, JsCallArguments arguments)
     {
         var md = ValidatePlainMonthDay(thisObject);
@@ -292,6 +281,7 @@ internal sealed class PlainMonthDayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tojson
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
     {
         var md = ValidatePlainMonthDay(thisObject);
@@ -308,6 +298,7 @@ internal sealed class PlainMonthDayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sup-temporal.plainmonthday.prototype.tolocalestring
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
         var md = ValidatePlainMonthDay(thisObject);
@@ -332,6 +323,7 @@ internal sealed class PlainMonthDayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.valueof
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
     {
         Throw.TypeError(_realm, "Temporal.PlainMonthDay cannot be converted to a primitive value");
@@ -341,6 +333,7 @@ internal sealed class PlainMonthDayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.toplaindate
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDate ToPlainDate(JsValue thisObject, JsCallArguments arguments)
     {
         var md = ValidatePlainMonthDay(thisObject);

--- a/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
+++ b/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
@@ -216,15 +216,15 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.equals
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsValue arg0)
+    private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var md = ValidatePlainMonthDay(thisObject);
-        var other = _constructor.ToTemporalMonthDay(arg0, "constrain");
+        var otherMd = _constructor.ToTemporalMonthDay(other, "constrain");
 
-        return md.IsoDate.Year == other.IsoDate.Year &&
-               md.IsoDate.Month == other.IsoDate.Month &&
-               md.IsoDate.Day == other.IsoDate.Day &&
-               string.Equals(md.Calendar, other.Calendar, StringComparison.Ordinal)
+        return md.IsoDate.Year == otherMd.IsoDate.Year &&
+               md.IsoDate.Month == otherMd.IsoDate.Month &&
+               md.IsoDate.Day == otherMd.IsoDate.Day &&
+               string.Equals(md.Calendar, otherMd.Calendar, StringComparison.Ordinal)
             ? JsBoolean.True
             : JsBoolean.False;
     }

--- a/Jint/Native/Temporal/PlainTime/PlainTimeConstructor.cs
+++ b/Jint/Native/Temporal/PlainTime/PlainTimeConstructor.cs
@@ -107,11 +107,11 @@ internal sealed partial class PlainTimeConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1)
+    private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two)
     {
-        var one = ToTemporalTime(arg0, "constrain");
-        var two = ToTemporalTime(arg1, "constrain");
-        return JsNumber.Create(TemporalHelpers.CompareIsoTimes(one.IsoTime, two.IsoTime));
+        return JsNumber.Create(TemporalHelpers.CompareIsoTimes(
+            ToTemporalTime(one, "constrain").IsoTime,
+            ToTemporalTime(two, "constrain").IsoTime));
     }
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)

--- a/Jint/Native/Temporal/PlainTime/PlainTimeConstructor.cs
+++ b/Jint/Native/Temporal/PlainTime/PlainTimeConstructor.cs
@@ -10,7 +10,8 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime
 /// </summary>
-internal sealed class PlainTimeConstructor : Constructor
+[JsObject]
+internal sealed partial class PlainTimeConstructor : Constructor
 {
     private static readonly JsString _functionName = new("PlainTime");
 
@@ -28,22 +29,13 @@ internal sealed class PlainTimeConstructor : Constructor
 
     public PlainTimePrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
+    protected override void Initialize() => CreateProperties_Generated();
 
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            ["from"] = new(new ClrFunction(Engine, "from", From, 1, LengthFlags), PropertyFlags),
-            ["compare"] = new(new ClrFunction(Engine, "compare", Compare, 2, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-    }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.from
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainTime From(JsValue thisObject, JsCallArguments arguments)
     {
         var item = arguments.At(0);
@@ -117,6 +109,7 @@ internal sealed class PlainTimeConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.compare
     /// </summary>
+    [JsFunction(Length = 2)]
     private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
     {
         var one = ToTemporalTime(arguments.At(0), "constrain");

--- a/Jint/Native/Temporal/PlainTime/PlainTimeConstructor.cs
+++ b/Jint/Native/Temporal/PlainTime/PlainTimeConstructor.cs
@@ -36,11 +36,8 @@ internal sealed partial class PlainTimeConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.from
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainTime From(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainTime From(JsValue thisObject, JsValue item, JsValue options)
     {
-        var item = arguments.At(0);
-        var options = arguments.At(1);
-
         // For existing Temporal types (cloning), validate options first then convert
         if (item is JsPlainTime || item is JsPlainDateTime || item is JsZonedDateTime)
         {
@@ -110,10 +107,10 @@ internal sealed partial class PlainTimeConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
+    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
-        var one = ToTemporalTime(arguments.At(0), "constrain");
-        var two = ToTemporalTime(arguments.At(1), "constrain");
+        var one = ToTemporalTime(arg0, "constrain");
+        var two = ToTemporalTime(arg1, "constrain");
         return JsNumber.Create(TemporalHelpers.CompareIsoTimes(one.IsoTime, two.IsoTime));
     }
 

--- a/Jint/Native/Temporal/PlainTime/PlainTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainTime/PlainTimePrototype.cs
@@ -62,12 +62,9 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.with
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainTime With(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainTime With(JsValue thisObject, JsValue temporalTimeLike, JsValue optionsArg)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var temporalTimeLike = arguments.At(0);
-        var optionsArg = arguments.At(1);
-
         if (!temporalTimeLike.IsObject())
         {
             Throw.TypeError(_realm, "Temporal time-like must be an object");
@@ -137,10 +134,9 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.add
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainTime Add(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainTime Add(JsValue thisObject, JsValue temporalDurationLike)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var temporalDurationLike = arguments.At(0);
         var duration = ToTemporalDurationRecord(temporalDurationLike);
         return AddDurationToTime(plainTime.IsoTime, duration, 1);
     }
@@ -149,10 +145,9 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.subtract
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainTime Subtract(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainTime Subtract(JsValue thisObject, JsValue temporalDurationLike)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var temporalDurationLike = arguments.At(0);
         var duration = ToTemporalDurationRecord(temporalDurationLike);
         return AddDurationToTime(plainTime.IsoTime, duration, -1);
     }
@@ -183,12 +178,10 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.until
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Until(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Until(JsValue thisObject, JsValue arg0, JsValue optionsArg)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var other = _constructor.ToTemporalTime(arguments.At(0), "constrain");
-        var optionsArg = arguments.At(1);
-
+        var other = _constructor.ToTemporalTime(arg0, "constrain");
         // Time units for PlainTime operations
         var timeUnits = new[] { "hour", "minute", "second", "millisecond", "microsecond", "nanosecond" };
 
@@ -221,12 +214,10 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.since
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Since(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Since(JsValue thisObject, JsValue arg0, JsValue optionsArg)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var other = _constructor.ToTemporalTime(arguments.At(0), "constrain");
-        var optionsArg = arguments.At(1);
-
+        var other = _constructor.ToTemporalTime(arg0, "constrain");
         // Time units for PlainTime operations
         var timeUnits = new[] { "hour", "minute", "second", "millisecond", "microsecond", "nanosecond" };
 
@@ -328,11 +319,9 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.round
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainTime Round(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainTime Round(JsValue thisObject, JsValue roundTo)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var roundTo = arguments.At(0);
-
         if (roundTo.IsUndefined())
         {
             Throw.TypeError(_realm, "Options required");
@@ -389,10 +378,10 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.equals
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
+    private JsBoolean Equals(JsValue thisObject, JsValue arg0)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var other = _constructor.ToTemporalTime(arguments.At(0), "constrain");
+        var other = _constructor.ToTemporalTime(arg0, "constrain");
         var result = TemporalHelpers.CompareIsoTimes(plainTime.IsoTime, other.IsoTime) == 0;
         return result ? JsBoolean.True : JsBoolean.False;
     }
@@ -401,10 +390,10 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tostring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToString(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToString(JsValue thisObject, JsValue arg0)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var options = GetOptionsObject(arguments.At(0));
+        var options = GetOptionsObject(arg0);
 
         // Default precision: auto (show subsecond digits as needed)
         var precision = -1; // -1 means auto
@@ -512,7 +501,7 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tojson
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToJSON(JsValue thisObject)
     {
         var plainTime = ValidatePlainTime(thisObject);
         return new JsString(FormatTime(plainTime.IsoTime, -1));
@@ -522,12 +511,9 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sup-temporal.plaintime.prototype.tolocalestring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToLocaleString(JsValue thisObject, JsValue locales, JsValue options)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
-
         // Per spec: CreateDateTimeFormat with required=~time~, defaults=~time~
         var dtf = _realm.Intrinsics.DateTimeFormat.CreateDateTimeFormat(
             locales, options, required: Intl.DateTimeRequired.Time, defaults: Intl.DateTimeDefaults.Time);
@@ -541,7 +527,7 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.valueof
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Temporal.PlainTime cannot be converted to a primitive value");
         return Undefined;

--- a/Jint/Native/Temporal/PlainTime/PlainTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainTime/PlainTimePrototype.cs
@@ -12,9 +12,13 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaintime-prototype-object
 /// </summary>
-internal sealed class PlainTimePrototype : Prototype
+[JsObject]
+internal sealed partial class PlainTimePrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly PlainTimeConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString PlainTimeToStringTag = new("Temporal.PlainTime");
 
     internal PlainTimePrototype(
         Engine engine,
@@ -28,38 +32,10 @@ internal sealed class PlainTimePrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(18, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["with"] = new(new ClrFunction(Engine, "with", With, 1, LengthFlags), PropertyFlags),
-            ["add"] = new(new ClrFunction(Engine, "add", Add, 1, LengthFlags), PropertyFlags),
-            ["subtract"] = new(new ClrFunction(Engine, "subtract", Subtract, 1, LengthFlags), PropertyFlags),
-            ["until"] = new(new ClrFunction(Engine, "until", Until, 1, LengthFlags), PropertyFlags),
-            ["since"] = new(new ClrFunction(Engine, "since", Since, 1, LengthFlags), PropertyFlags),
-            ["round"] = new(new ClrFunction(Engine, "round", Round, 1, LengthFlags), PropertyFlags),
-            ["equals"] = new(new ClrFunction(Engine, "equals", Equals, 1, LengthFlags), PropertyFlags),
-            ["toString"] = new(new ClrFunction(Engine, "toString", ToString, 0, LengthFlags), PropertyFlags),
-            ["toJSON"] = new(new ClrFunction(Engine, "toJSON", ToJSON, 0, LengthFlags), PropertyFlags),
-            ["toLocaleString"] = new(new ClrFunction(Engine, "toLocaleString", ToLocaleString, 0, LengthFlags), PropertyFlags),
-            ["valueOf"] = new(new ClrFunction(Engine, "valueOf", ValueOf, 0, LengthFlags), PropertyFlags),
-            ["hour"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get hour", GetHour, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["minute"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get minute", GetMinute, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["second"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get second", GetSecond, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["millisecond"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get millisecond", GetMillisecond, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["microsecond"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get microsecond", GetMicrosecond, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["nanosecond"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get nanosecond", GetNanosecond, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Temporal.PlainTime", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
 
     private JsPlainTime ValidatePlainTime(JsValue thisObject)
     {
@@ -69,16 +45,23 @@ internal sealed class PlainTimePrototype : Prototype
         return null!;
     }
 
-    private JsNumber GetHour(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainTime(thisObject).IsoTime.Hour);
-    private JsNumber GetMinute(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainTime(thisObject).IsoTime.Minute);
-    private JsNumber GetSecond(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainTime(thisObject).IsoTime.Second);
-    private JsNumber GetMillisecond(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainTime(thisObject).IsoTime.Millisecond);
-    private JsNumber GetMicrosecond(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainTime(thisObject).IsoTime.Microsecond);
-    private JsNumber GetNanosecond(JsValue thisObject, JsCallArguments arguments) => JsNumber.Create(ValidatePlainTime(thisObject).IsoTime.Nanosecond);
+    [JsAccessor("hour")]
+    private JsNumber GetHour(JsValue thisObject) => JsNumber.Create(ValidatePlainTime(thisObject).IsoTime.Hour);
+    [JsAccessor("minute")]
+    private JsNumber GetMinute(JsValue thisObject) => JsNumber.Create(ValidatePlainTime(thisObject).IsoTime.Minute);
+    [JsAccessor("second")]
+    private JsNumber GetSecond(JsValue thisObject) => JsNumber.Create(ValidatePlainTime(thisObject).IsoTime.Second);
+    [JsAccessor("millisecond")]
+    private JsNumber GetMillisecond(JsValue thisObject) => JsNumber.Create(ValidatePlainTime(thisObject).IsoTime.Millisecond);
+    [JsAccessor("microsecond")]
+    private JsNumber GetMicrosecond(JsValue thisObject) => JsNumber.Create(ValidatePlainTime(thisObject).IsoTime.Microsecond);
+    [JsAccessor("nanosecond")]
+    private JsNumber GetNanosecond(JsValue thisObject) => JsNumber.Create(ValidatePlainTime(thisObject).IsoTime.Nanosecond);
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.with
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainTime With(JsValue thisObject, JsCallArguments arguments)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -153,6 +136,7 @@ internal sealed class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.add
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainTime Add(JsValue thisObject, JsCallArguments arguments)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -164,6 +148,7 @@ internal sealed class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.subtract
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainTime Subtract(JsValue thisObject, JsCallArguments arguments)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -197,6 +182,7 @@ internal sealed class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.until
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Until(JsValue thisObject, JsCallArguments arguments)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -234,6 +220,7 @@ internal sealed class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.since
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Since(JsValue thisObject, JsCallArguments arguments)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -340,6 +327,7 @@ internal sealed class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.round
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainTime Round(JsValue thisObject, JsCallArguments arguments)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -400,6 +388,7 @@ internal sealed class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.equals
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -411,6 +400,7 @@ internal sealed class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tostring
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsString ToString(JsValue thisObject, JsCallArguments arguments)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -521,6 +511,7 @@ internal sealed class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tojson
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -530,6 +521,7 @@ internal sealed class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sup-temporal.plaintime.prototype.tolocalestring
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -548,6 +540,7 @@ internal sealed class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.valueof
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
     {
         Throw.TypeError(_realm, "Temporal.PlainTime cannot be converted to a primitive value");

--- a/Jint/Native/Temporal/PlainTime/PlainTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainTime/PlainTimePrototype.cs
@@ -62,7 +62,7 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.with
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainTime With(JsValue thisObject, JsValue temporalTimeLike, JsValue optionsArg)
+    private JsPlainTime With(JsValue thisObject, JsValue temporalTimeLike, JsValue options)
     {
         var plainTime = ValidatePlainTime(thisObject);
         if (!temporalTimeLike.IsObject())
@@ -110,16 +110,16 @@ internal sealed partial class PlainTimePrototype : Prototype
         }
 
         // Check for fundamentally invalid values (negative, would never be valid)
-        // This ensures RangeError is thrown before TypeError for options
+        // This ensures RangeError is thrown before TypeError for resolvedOptions
         if (hour < 0 || minute < 0 || second < 0 ||
             millisecond < 0 || microsecond < 0 || nanosecond < 0)
         {
             Throw.RangeError(_realm, "Invalid time");
         }
 
-        // Get options via GetOptionsObject (after validating partial values)
-        var options = GetOptionsObject(optionsArg);
-        var overflow = TemporalHelpers.GetOverflowOption(_realm, (JsValue?) options ?? Undefined);
+        // Get resolvedOptions via GetOptionsObject (after validating partial values)
+        var resolvedOptions = GetOptionsObject(options);
+        var overflow = TemporalHelpers.GetOverflowOption(_realm, (JsValue?) resolvedOptions ?? Undefined);
 
         var time = TemporalHelpers.RegulateIsoTime(hour, minute, second, millisecond, microsecond, nanosecond, overflow);
         if (time is null)
@@ -391,19 +391,19 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tostring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToString(JsValue thisObject, JsValue optionsArg)
+    private JsString ToString(JsValue thisObject, JsValue options)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var options = GetOptionsObject(optionsArg);
+        var resolvedOptions = GetOptionsObject(options);
 
         // Default precision: auto (show subsecond digits as needed)
         var precision = -1; // -1 means auto
 
-        if (options is not null)
+        if (resolvedOptions is not null)
         {
             // Read properties in spec order: fractionalSecondDigits, roundingMode, smallestUnit
             // 1. Read fractionalSecondDigits first
-            var fsdValue = options.Get("fractionalSecondDigits");
+            var fsdValue = resolvedOptions.Get("fractionalSecondDigits");
             if (!fsdValue.IsUndefined())
             {
                 if (fsdValue.IsNumber())
@@ -435,10 +435,10 @@ internal sealed partial class PlainTimePrototype : Prototype
             }
 
             // 2. Read roundingMode
-            var roundingMode = TemporalHelpers.GetRoundingModeOption(_realm, options, "trunc");
+            var roundingMode = TemporalHelpers.GetRoundingModeOption(_realm, resolvedOptions, "trunc");
 
             // 3. Read smallestUnit (ALWAYS overrides fractionalSecondDigits when present)
-            var smallestUnitValue = options.Get("smallestUnit");
+            var smallestUnitValue = resolvedOptions.Get("smallestUnit");
             if (!smallestUnitValue.IsUndefined())
             {
                 var str = TypeConverter.ToString(smallestUnitValue);

--- a/Jint/Native/Temporal/PlainTime/PlainTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainTime/PlainTimePrototype.cs
@@ -178,10 +178,10 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.until
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Until(JsValue thisObject, JsValue arg0, JsValue optionsArg)
+    private JsDuration Until(JsValue thisObject, JsValue other, JsValue options)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var other = _constructor.ToTemporalTime(arg0, "constrain");
+        var otherTime = _constructor.ToTemporalTime(other, "constrain");
         // Time units for PlainTime operations
         var timeUnits = new[] { "hour", "minute", "second", "millisecond", "microsecond", "nanosecond" };
 
@@ -191,7 +191,7 @@ internal sealed partial class PlainTimePrototype : Prototype
 
         var settings = TemporalHelpers.GetDifferenceSettings(
             _realm,
-            optionsArg,
+            options,
             "until",
             fallbackSmallestUnit,
             fallbackLargestUnit,
@@ -207,17 +207,17 @@ internal sealed partial class PlainTimePrototype : Prototype
         ValidateUnitRange(largestUnit, settings.SmallestUnit);
         ValidateRoundingIncrement(settings.SmallestUnit, settings.RoundingIncrement);
 
-        return DifferenceTemporalPlainTime(plainTime, other, largestUnit, settings.SmallestUnit, settings.RoundingMode, settings.RoundingIncrement, negate: false);
+        return DifferenceTemporalPlainTime(plainTime, otherTime, largestUnit, settings.SmallestUnit, settings.RoundingMode, settings.RoundingIncrement, negate: false);
     }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.since
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Since(JsValue thisObject, JsValue arg0, JsValue optionsArg)
+    private JsDuration Since(JsValue thisObject, JsValue other, JsValue options)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var other = _constructor.ToTemporalTime(arg0, "constrain");
+        var otherTime = _constructor.ToTemporalTime(other, "constrain");
         // Time units for PlainTime operations
         var timeUnits = new[] { "hour", "minute", "second", "millisecond", "microsecond", "nanosecond" };
 
@@ -228,7 +228,7 @@ internal sealed partial class PlainTimePrototype : Prototype
 
         var settings = TemporalHelpers.GetDifferenceSettings(
             _realm,
-            optionsArg,
+            options,
             "since",
             fallbackSmallestUnit,
             fallbackLargestUnit,
@@ -244,7 +244,7 @@ internal sealed partial class PlainTimePrototype : Prototype
         ValidateUnitRange(largestUnit, settings.SmallestUnit);
         ValidateRoundingIncrement(settings.SmallestUnit, settings.RoundingIncrement);
 
-        return DifferenceTemporalPlainTime(plainTime, other, largestUnit, settings.SmallestUnit, settings.RoundingMode, settings.RoundingIncrement, negate: true);
+        return DifferenceTemporalPlainTime(plainTime, otherTime, largestUnit, settings.SmallestUnit, settings.RoundingMode, settings.RoundingIncrement, negate: true);
     }
 
     /// <summary>
@@ -378,11 +378,12 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.equals
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsValue arg0)
+    private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var other = _constructor.ToTemporalTime(arg0, "constrain");
-        var result = TemporalHelpers.CompareIsoTimes(plainTime.IsoTime, other.IsoTime) == 0;
+        var result = TemporalHelpers.CompareIsoTimes(
+            plainTime.IsoTime,
+            _constructor.ToTemporalTime(other, "constrain").IsoTime) == 0;
         return result ? JsBoolean.True : JsBoolean.False;
     }
 
@@ -390,10 +391,10 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tostring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToString(JsValue thisObject, JsValue arg0)
+    private JsString ToString(JsValue thisObject, JsValue optionsArg)
     {
         var plainTime = ValidatePlainTime(thisObject);
-        var options = GetOptionsObject(arg0);
+        var options = GetOptionsObject(optionsArg);
 
         // Default precision: auto (show subsecond digits as needed)
         var precision = -1; // -1 means auto

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
@@ -81,11 +81,11 @@ internal sealed partial class PlainYearMonthConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1)
+    private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two)
     {
-        var one = ToTemporalYearMonth(arg0, "constrain");
-        var two = ToTemporalYearMonth(arg1, "constrain");
-        return JsNumber.Create(CompareIsoYearMonth(one.IsoDate, two.IsoDate));
+        return JsNumber.Create(CompareIsoYearMonth(
+            ToTemporalYearMonth(one, "constrain").IsoDate,
+            ToTemporalYearMonth(two, "constrain").IsoDate));
     }
 
     private static int CompareIsoYearMonth(IsoDate one, IsoDate two)

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
@@ -37,11 +37,8 @@ internal sealed partial class PlainYearMonthConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.from
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainYearMonth From(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainYearMonth From(JsValue thisObject, JsValue item, JsValue optionsValue)
     {
-        var item = arguments.At(0);
-        var optionsValue = arguments.At(1);
-
         // For PlainYearMonth, validate options first (for observable side effects) then convert
         if (item is JsPlainYearMonth)
         {
@@ -84,10 +81,10 @@ internal sealed partial class PlainYearMonthConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
+    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
-        var one = ToTemporalYearMonth(arguments.At(0), "constrain");
-        var two = ToTemporalYearMonth(arguments.At(1), "constrain");
+        var one = ToTemporalYearMonth(arg0, "constrain");
+        var two = ToTemporalYearMonth(arg1, "constrain");
         return JsNumber.Create(CompareIsoYearMonth(one.IsoDate, two.IsoDate));
     }
 

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
@@ -10,7 +10,8 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth
 /// </summary>
-internal sealed class PlainYearMonthConstructor : Constructor
+[JsObject]
+internal sealed partial class PlainYearMonthConstructor : Constructor
 {
     private static readonly JsString _functionName = new("PlainYearMonth");
     private static readonly char[] DateTimeSeparators = { '-', 'T', ' ', '[' };
@@ -29,22 +30,13 @@ internal sealed class PlainYearMonthConstructor : Constructor
 
     public PlainYearMonthPrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
+    protected override void Initialize() => CreateProperties_Generated();
 
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            ["from"] = new(new ClrFunction(Engine, "from", From, 1, LengthFlags), PropertyFlags),
-            ["compare"] = new(new ClrFunction(Engine, "compare", Compare, 2, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-    }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.from
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainYearMonth From(JsValue thisObject, JsCallArguments arguments)
     {
         var item = arguments.At(0);
@@ -91,6 +83,7 @@ internal sealed class PlainYearMonthConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.compare
     /// </summary>
+    [JsFunction(Length = 2)]
     private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
     {
         var one = ToTemporalYearMonth(arguments.At(0), "constrain");

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
@@ -106,12 +106,9 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.with
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainYearMonth With(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainYearMonth With(JsValue thisObject, JsValue temporalYearMonthLike, JsValue options)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var temporalYearMonthLike = arguments.At(0);
-        var options = arguments.At(1);
-
         if (!temporalYearMonthLike.IsObject())
         {
             Throw.TypeError(_realm, "with argument must be an object");
@@ -330,11 +327,10 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.add
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainYearMonth Add(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainYearMonth Add(JsValue thisObject, JsValue arg0, JsValue options)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var duration = ToDurationRecord(arguments.At(0));
-        var options = arguments.At(1);
+        var duration = ToDurationRecord(arg0);
         var overflow = TemporalHelpers.GetOverflowOption(_realm, options);
 
         return AddDurationToYearMonth(ym, duration, overflow);
@@ -344,11 +340,10 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.subtract
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainYearMonth Subtract(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainYearMonth Subtract(JsValue thisObject, JsValue arg0, JsValue options)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var duration = ToDurationRecord(arguments.At(0));
-        var options = arguments.At(1);
+        var duration = ToDurationRecord(arg0);
         var overflow = TemporalHelpers.GetOverflowOption(_realm, options);
 
         // Negate the duration
@@ -393,18 +388,16 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.until
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Until(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Until(JsValue thisObject, JsValue arg0, JsValue optionsArg)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var other = _constructor.ToTemporalYearMonth(arguments.At(0), "constrain");
+        var other = _constructor.ToTemporalYearMonth(arg0, "constrain");
 
         // Calendar equality check (before reading options per spec)
         if (!string.Equals(ym.Calendar, other.Calendar, StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, "Calendars must match for year-month difference operations");
         }
-
-        var optionsArg = arguments.At(1);
 
         // Only year and month units allowed for PlainYearMonth
         var yearMonthUnits = new[] { "year", "month" };
@@ -435,18 +428,16 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.since
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Since(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Since(JsValue thisObject, JsValue arg0, JsValue optionsArg)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var other = _constructor.ToTemporalYearMonth(arguments.At(0), "constrain");
+        var other = _constructor.ToTemporalYearMonth(arg0, "constrain");
 
         // Calendar equality check (before reading options per spec)
         if (!string.Equals(ym.Calendar, other.Calendar, StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, "Calendars must match for year-month difference operations");
         }
-
-        var optionsArg = arguments.At(1);
 
         // Only year and month units allowed for PlainYearMonth
         var yearMonthUnits = new[] { "year", "month" };
@@ -569,10 +560,10 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.equals
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
+    private JsBoolean Equals(JsValue thisObject, JsValue arg0)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var other = _constructor.ToTemporalYearMonth(arguments.At(0), "constrain");
+        var other = _constructor.ToTemporalYearMonth(arg0, "constrain");
 
         return ym.IsoDate.Year == other.IsoDate.Year &&
                ym.IsoDate.Month == other.IsoDate.Month &&
@@ -586,10 +577,9 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tostring
     /// </summary>
     [JsFunction(Length = 0, Name = "toString")]
-    private JsString ToTemporalString(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToTemporalString(JsValue thisObject, JsValue optionsValue)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var optionsValue = arguments.At(0);
         var options = TemporalHelpers.GetOptionsObject(_realm, optionsValue);
         var showCalendar = GetCalendarNameOption(options);
 
@@ -632,7 +622,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tojson
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToJSON(JsValue thisObject)
     {
         var ym = ValidatePlainYearMonth(thisObject);
         var yearStr = TemporalHelpers.PadIsoYear(ym.IsoDate.Year);
@@ -649,12 +639,9 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sup-temporal.plainyearmonth.prototype.tolocalestring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToLocaleString(JsValue thisObject, JsValue locales, JsValue options)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
-
         // Per spec: CreateDateTimeFormat with required=~date~, defaults=~date~
         // But for PlainYearMonth, we use year-month specific defaults (no day)
         var dtf = _realm.Intrinsics.DateTimeFormat.CreateDateTimeFormat(
@@ -674,7 +661,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.valueof
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Temporal.PlainYearMonth cannot be converted to a primitive value");
         return Undefined;
@@ -684,11 +671,9 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.toplaindate
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainDate ToPlainDate(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDate ToPlainDate(JsValue thisObject, JsValue item)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var item = arguments.At(0);
-
         if (!item.IsObject())
         {
             Throw.TypeError(_realm, "toPlainDate requires an object argument");

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
@@ -327,10 +327,10 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.add
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainYearMonth Add(JsValue thisObject, JsValue arg0, JsValue options)
+    private JsPlainYearMonth Add(JsValue thisObject, JsValue temporalDurationLike, JsValue options)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var duration = ToDurationRecord(arg0);
+        var duration = ToDurationRecord(temporalDurationLike);
         var overflow = TemporalHelpers.GetOverflowOption(_realm, options);
 
         return AddDurationToYearMonth(ym, duration, overflow);
@@ -340,10 +340,10 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.subtract
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsPlainYearMonth Subtract(JsValue thisObject, JsValue arg0, JsValue options)
+    private JsPlainYearMonth Subtract(JsValue thisObject, JsValue temporalDurationLike, JsValue options)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var duration = ToDurationRecord(arg0);
+        var duration = ToDurationRecord(temporalDurationLike);
         var overflow = TemporalHelpers.GetOverflowOption(_realm, options);
 
         // Negate the duration
@@ -388,13 +388,13 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.until
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Until(JsValue thisObject, JsValue arg0, JsValue optionsArg)
+    private JsDuration Until(JsValue thisObject, JsValue other, JsValue options)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var other = _constructor.ToTemporalYearMonth(arg0, "constrain");
+        var otherYm = _constructor.ToTemporalYearMonth(other, "constrain");
 
         // Calendar equality check (before reading options per spec)
-        if (!string.Equals(ym.Calendar, other.Calendar, StringComparison.Ordinal))
+        if (!string.Equals(ym.Calendar, otherYm.Calendar, StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, "Calendars must match for year-month difference operations");
         }
@@ -408,7 +408,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
 
         var settings = TemporalHelpers.GetDifferenceSettings(
             _realm,
-            optionsArg,
+            options,
             "until",
             fallbackSmallestUnit,
             fallbackLargestUnit,
@@ -421,20 +421,20 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
             largestUnit = TemporalHelpers.LargerOfTwoTemporalUnits(settings.SmallestUnit, "year");
         }
 
-        return DifferenceYearMonth(ym, other, largestUnit, settings.SmallestUnit, settings.RoundingMode, settings.RoundingIncrement, negate: false);
+        return DifferenceYearMonth(ym, otherYm, largestUnit, settings.SmallestUnit, settings.RoundingMode, settings.RoundingIncrement, negate: false);
     }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.since
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsDuration Since(JsValue thisObject, JsValue arg0, JsValue optionsArg)
+    private JsDuration Since(JsValue thisObject, JsValue other, JsValue options)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var other = _constructor.ToTemporalYearMonth(arg0, "constrain");
+        var otherYm = _constructor.ToTemporalYearMonth(other, "constrain");
 
         // Calendar equality check (before reading options per spec)
-        if (!string.Equals(ym.Calendar, other.Calendar, StringComparison.Ordinal))
+        if (!string.Equals(ym.Calendar, otherYm.Calendar, StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, "Calendars must match for year-month difference operations");
         }
@@ -449,7 +449,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
 
         var settings = TemporalHelpers.GetDifferenceSettings(
             _realm,
-            optionsArg,
+            options,
             "since",
             fallbackSmallestUnit,
             fallbackLargestUnit,
@@ -462,7 +462,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
             largestUnit = TemporalHelpers.LargerOfTwoTemporalUnits(settings.SmallestUnit, "year");
         }
 
-        return DifferenceYearMonth(ym, other, largestUnit, settings.SmallestUnit, settings.RoundingMode, settings.RoundingIncrement, negate: true);
+        return DifferenceYearMonth(ym, otherYm, largestUnit, settings.SmallestUnit, settings.RoundingMode, settings.RoundingIncrement, negate: true);
     }
 
     /// <summary>
@@ -560,15 +560,15 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.equals
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsValue arg0)
+    private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var ym = ValidatePlainYearMonth(thisObject);
-        var other = _constructor.ToTemporalYearMonth(arg0, "constrain");
+        var otherYm = _constructor.ToTemporalYearMonth(other, "constrain");
 
-        return ym.IsoDate.Year == other.IsoDate.Year &&
-               ym.IsoDate.Month == other.IsoDate.Month &&
-               ym.IsoDate.Day == other.IsoDate.Day &&
-               string.Equals(ym.Calendar, other.Calendar, StringComparison.Ordinal)
+        return ym.IsoDate.Year == otherYm.IsoDate.Year &&
+               ym.IsoDate.Month == otherYm.IsoDate.Month &&
+               ym.IsoDate.Day == otherYm.IsoDate.Day &&
+               string.Equals(ym.Calendar, otherYm.Calendar, StringComparison.Ordinal)
             ? JsBoolean.True
             : JsBoolean.False;
     }

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
@@ -9,9 +9,13 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plainyearmonth-prototype-object
 /// </summary>
-internal sealed class PlainYearMonthPrototype : Prototype
+[JsObject]
+internal sealed partial class PlainYearMonthPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly PlainYearMonthConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString PlainYearMonthToStringTag = new("Temporal.PlainYearMonth");
 
     internal PlainYearMonthPrototype(
         Engine engine,
@@ -25,42 +29,10 @@ internal sealed class PlainYearMonthPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(22, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["with"] = new(new ClrFunction(Engine, "with", With, 1, LengthFlags), PropertyFlags),
-            ["add"] = new(new ClrFunction(Engine, "add", Add, 1, LengthFlags), PropertyFlags),
-            ["subtract"] = new(new ClrFunction(Engine, "subtract", Subtract, 1, LengthFlags), PropertyFlags),
-            ["until"] = new(new ClrFunction(Engine, "until", Until, 1, LengthFlags), PropertyFlags),
-            ["since"] = new(new ClrFunction(Engine, "since", Since, 1, LengthFlags), PropertyFlags),
-            ["equals"] = new(new ClrFunction(Engine, "equals", Equals, 1, LengthFlags), PropertyFlags),
-            ["toString"] = new(new ClrFunction(Engine, "toString", ToTemporalString, 0, LengthFlags), PropertyFlags),
-            ["toJSON"] = new(new ClrFunction(Engine, "toJSON", ToJSON, 0, LengthFlags), PropertyFlags),
-            ["toLocaleString"] = new(new ClrFunction(Engine, "toLocaleString", ToLocaleString, 0, LengthFlags), PropertyFlags),
-            ["valueOf"] = new(new ClrFunction(Engine, "valueOf", ValueOf, 0, LengthFlags), PropertyFlags),
-            ["toPlainDate"] = new(new ClrFunction(Engine, "toPlainDate", ToPlainDate, 1, LengthFlags), PropertyFlags),
-            ["calendarId"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get calendarId", GetCalendarId, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["year"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get year", GetYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["month"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get month", GetMonth, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["monthCode"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get monthCode", GetMonthCode, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["daysInMonth"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get daysInMonth", GetDaysInMonth, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["daysInYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get daysInYear", GetDaysInYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["monthsInYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get monthsInYear", GetMonthsInYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["inLeapYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get inLeapYear", GetInLeapYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["eraYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get eraYear", GetEraYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["era"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get era", GetEra, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Temporal.PlainYearMonth", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
 
     private JsPlainYearMonth ValidatePlainYearMonth(JsValue thisObject)
     {
@@ -71,49 +43,59 @@ internal sealed class PlainYearMonthPrototype : Prototype
     }
 
     // Getters
-    private JsString GetCalendarId(JsValue thisObject, JsCallArguments arguments) => new JsString(ValidatePlainYearMonth(thisObject).Calendar);
-    private JsNumber GetYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("calendarId")]
+    private JsString GetCalendarId(JsValue thisObject) => new JsString(ValidatePlainYearMonth(thisObject).Calendar);
+    [JsAccessor("year")]
+    private JsNumber GetYear(JsValue thisObject)
     {
         var ym = ValidatePlainYearMonth(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarYear(ym.Calendar, ym.IsoDate, _engine));
     }
-    private JsNumber GetMonth(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("month")]
+    private JsNumber GetMonth(JsValue thisObject)
     {
         var ym = ValidatePlainYearMonth(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarMonth(ym.Calendar, ym.IsoDate, _engine));
     }
-    private JsString GetMonthCode(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("monthCode")]
+    private JsString GetMonthCode(JsValue thisObject)
     {
         var ym = ValidatePlainYearMonth(thisObject);
         return new JsString(TemporalHelpers.CalendarMonthCode(ym.Calendar, ym.IsoDate, _engine));
     }
-    private JsNumber GetDaysInMonth(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("daysInMonth")]
+    private JsNumber GetDaysInMonth(JsValue thisObject)
     {
         var ym = ValidatePlainYearMonth(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDaysInMonth(ym.Calendar, ym.IsoDate, _engine));
     }
-    private JsNumber GetDaysInYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("daysInYear")]
+    private JsNumber GetDaysInYear(JsValue thisObject)
     {
         var ym = ValidatePlainYearMonth(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDaysInYear(ym.Calendar, ym.IsoDate, _engine));
     }
-    private JsNumber GetMonthsInYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("monthsInYear")]
+    private JsNumber GetMonthsInYear(JsValue thisObject)
     {
         var ym = ValidatePlainYearMonth(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarMonthsInYear(ym.Calendar, ym.IsoDate, _engine));
     }
-    private JsBoolean GetInLeapYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("inLeapYear")]
+    private JsBoolean GetInLeapYear(JsValue thisObject)
     {
         var ym = ValidatePlainYearMonth(thisObject);
         return TemporalHelpers.CalendarInLeapYear(ym.Calendar, ym.IsoDate, _engine) ? JsBoolean.True : JsBoolean.False;
     }
-    private JsValue GetEraYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("eraYear")]
+    private JsValue GetEraYear(JsValue thisObject)
     {
         var ym = ValidatePlainYearMonth(thisObject);
         var eraYear = TemporalHelpers.CalendarEraYear(ym.Calendar, ym.IsoDate);
         return eraYear.HasValue ? JsNumber.Create(eraYear.Value) : Undefined;
     }
-    private JsValue GetEra(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("era")]
+    private JsValue GetEra(JsValue thisObject)
     {
         var ym = ValidatePlainYearMonth(thisObject);
         var era = TemporalHelpers.CalendarEra(ym.Calendar, ym.IsoDate);
@@ -123,6 +105,7 @@ internal sealed class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.with
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainYearMonth With(JsValue thisObject, JsCallArguments arguments)
     {
         var ym = ValidatePlainYearMonth(thisObject);
@@ -346,6 +329,7 @@ internal sealed class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.add
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainYearMonth Add(JsValue thisObject, JsCallArguments arguments)
     {
         var ym = ValidatePlainYearMonth(thisObject);
@@ -359,6 +343,7 @@ internal sealed class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.subtract
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainYearMonth Subtract(JsValue thisObject, JsCallArguments arguments)
     {
         var ym = ValidatePlainYearMonth(thisObject);
@@ -407,6 +392,7 @@ internal sealed class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.until
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Until(JsValue thisObject, JsCallArguments arguments)
     {
         var ym = ValidatePlainYearMonth(thisObject);
@@ -448,6 +434,7 @@ internal sealed class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.since
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsDuration Since(JsValue thisObject, JsCallArguments arguments)
     {
         var ym = ValidatePlainYearMonth(thisObject);
@@ -581,6 +568,7 @@ internal sealed class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.equals
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
     {
         var ym = ValidatePlainYearMonth(thisObject);
@@ -597,6 +585,7 @@ internal sealed class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tostring
     /// </summary>
+    [JsFunction(Length = 0, Name = "toString")]
     private JsString ToTemporalString(JsValue thisObject, JsCallArguments arguments)
     {
         var ym = ValidatePlainYearMonth(thisObject);
@@ -642,6 +631,7 @@ internal sealed class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tojson
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
     {
         var ym = ValidatePlainYearMonth(thisObject);
@@ -658,6 +648,7 @@ internal sealed class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sup-temporal.plainyearmonth.prototype.tolocalestring
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
         var ym = ValidatePlainYearMonth(thisObject);
@@ -682,6 +673,7 @@ internal sealed class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.valueof
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
     {
         Throw.TypeError(_realm, "Temporal.PlainYearMonth cannot be converted to a primitive value");
@@ -691,6 +683,7 @@ internal sealed class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.toplaindate
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsPlainDate ToPlainDate(JsValue thisObject, JsCallArguments arguments)
     {
         var ym = ValidatePlainYearMonth(thisObject);

--- a/Jint/Native/Temporal/TemporalInstance.cs
+++ b/Jint/Native/Temporal/TemporalInstance.cs
@@ -1,5 +1,4 @@
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
@@ -9,9 +8,12 @@ namespace Jint.Native.Temporal;
 /// The Temporal namespace object.
 /// https://tc39.es/proposal-temporal/#sec-temporal-objects
 /// </summary>
-internal sealed class TemporalInstance : ObjectInstance
+[JsObject]
+internal sealed partial class TemporalInstance : ObjectInstance
 {
     private readonly Realm _realm;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString TemporalToStringTag = new("Temporal");
 
     internal TemporalInstance(
         Engine engine,
@@ -24,26 +26,19 @@ internal sealed class TemporalInstance : ObjectInstance
 
     protected override void Initialize()
     {
+        CreateSymbols_Generated();
+
+        // Constructor references aren't generator-friendly (they pull from _realm.Intrinsics);
+        // wire them after generated symbols.
         const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(10, checkExistingKeys: false)
-        {
-            ["Duration"] = new(_realm.Intrinsics.TemporalDuration, PropertyFlags),
-            ["Instant"] = new(_realm.Intrinsics.TemporalInstant, PropertyFlags),
-            ["PlainDate"] = new(_realm.Intrinsics.TemporalPlainDate, PropertyFlags),
-            ["PlainDateTime"] = new(_realm.Intrinsics.TemporalPlainDateTime, PropertyFlags),
-            ["PlainMonthDay"] = new(_realm.Intrinsics.TemporalPlainMonthDay, PropertyFlags),
-            ["PlainTime"] = new(_realm.Intrinsics.TemporalPlainTime, PropertyFlags),
-            ["PlainYearMonth"] = new(_realm.Intrinsics.TemporalPlainYearMonth, PropertyFlags),
-            ["ZonedDateTime"] = new(_realm.Intrinsics.TemporalZonedDateTime, PropertyFlags),
-            ["Now"] = new(_realm.Intrinsics.TemporalNow, PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Temporal", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        SetProperty("Duration", new PropertyDescriptor(_realm.Intrinsics.TemporalDuration, PropertyFlags));
+        SetProperty("Instant", new PropertyDescriptor(_realm.Intrinsics.TemporalInstant, PropertyFlags));
+        SetProperty("PlainDate", new PropertyDescriptor(_realm.Intrinsics.TemporalPlainDate, PropertyFlags));
+        SetProperty("PlainDateTime", new PropertyDescriptor(_realm.Intrinsics.TemporalPlainDateTime, PropertyFlags));
+        SetProperty("PlainMonthDay", new PropertyDescriptor(_realm.Intrinsics.TemporalPlainMonthDay, PropertyFlags));
+        SetProperty("PlainTime", new PropertyDescriptor(_realm.Intrinsics.TemporalPlainTime, PropertyFlags));
+        SetProperty("PlainYearMonth", new PropertyDescriptor(_realm.Intrinsics.TemporalPlainYearMonth, PropertyFlags));
+        SetProperty("ZonedDateTime", new PropertyDescriptor(_realm.Intrinsics.TemporalZonedDateTime, PropertyFlags));
+        SetProperty("Now", new PropertyDescriptor(_realm.Intrinsics.TemporalNow, PropertyFlags));
     }
 }

--- a/Jint/Native/Temporal/TemporalInstance.cs
+++ b/Jint/Native/Temporal/TemporalInstance.cs
@@ -8,7 +8,9 @@ namespace Jint.Native.Temporal;
 /// The Temporal namespace object.
 /// https://tc39.es/proposal-temporal/#sec-temporal-objects
 /// </summary>
-[JsObject]
+// ExtraCapacity = 9 covers the post-Initialize SetProperty calls below for Duration/Instant/PlainDate/
+// PlainDateTime/PlainMonthDay/PlainTime/PlainYearMonth/ZonedDateTime/Now (cross-realm references).
+[JsObject(ExtraCapacity = 9)]
 internal sealed partial class TemporalInstance : ObjectInstance
 {
     private readonly Realm _realm;
@@ -26,6 +28,7 @@ internal sealed partial class TemporalInstance : ObjectInstance
 
     protected override void Initialize()
     {
+        CreateProperties_Generated();
         CreateSymbols_Generated();
 
         // Constructor references aren't generator-friendly (they pull from _realm.Intrinsics);

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
@@ -45,12 +45,10 @@ internal sealed partial class ZonedDateTimeConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1)
+    private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two)
     {
-        var one = ToTemporalZonedDateTime(arg0, Undefined);
-        var two = ToTemporalZonedDateTime(arg1, Undefined);
-
-        var cmp = one.EpochNanoseconds.CompareTo(two.EpochNanoseconds);
+        var cmp = ToTemporalZonedDateTime(one, Undefined).EpochNanoseconds.CompareTo(
+            ToTemporalZonedDateTime(two, Undefined).EpochNanoseconds);
         return JsNumber.Create(cmp < 0 ? -1 : cmp > 0 ? 1 : 0);
     }
 

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
@@ -36,10 +36,8 @@ internal sealed partial class ZonedDateTimeConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.from
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsZonedDateTime From(JsValue thisObject, JsCallArguments arguments)
+    private JsZonedDateTime From(JsValue thisObject, JsValue item, JsValue options)
     {
-        var item = arguments.At(0);
-        var options = arguments.At(1);
         return ToTemporalZonedDateTime(item, options);
     }
 
@@ -47,10 +45,10 @@ internal sealed partial class ZonedDateTimeConstructor : Constructor
     /// https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.compare
     /// </summary>
     [JsFunction(Length = 2)]
-    private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
+    private JsNumber Compare(JsValue thisObject, JsValue arg0, JsValue arg1)
     {
-        var one = ToTemporalZonedDateTime(arguments.At(0), Undefined);
-        var two = ToTemporalZonedDateTime(arguments.At(1), Undefined);
+        var one = ToTemporalZonedDateTime(arg0, Undefined);
+        var two = ToTemporalZonedDateTime(arg1, Undefined);
 
         var cmp = one.EpochNanoseconds.CompareTo(two.EpochNanoseconds);
         return JsNumber.Create(cmp < 0 ? -1 : cmp > 0 ? 1 : 0);

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
@@ -10,7 +10,8 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime
 /// </summary>
-internal sealed class ZonedDateTimeConstructor : Constructor
+[JsObject]
+internal sealed partial class ZonedDateTimeConstructor : Constructor
 {
     private static readonly JsString _functionName = new("ZonedDateTime");
 
@@ -28,22 +29,13 @@ internal sealed class ZonedDateTimeConstructor : Constructor
 
     public ZonedDateTimePrototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
+    protected override void Initialize() => CreateProperties_Generated();
 
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            ["from"] = new(new ClrFunction(Engine, "from", From, 1, LengthFlags), PropertyFlags),
-            ["compare"] = new(new ClrFunction(Engine, "compare", Compare, 2, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-    }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.from
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsZonedDateTime From(JsValue thisObject, JsCallArguments arguments)
     {
         var item = arguments.At(0);
@@ -54,6 +46,7 @@ internal sealed class ZonedDateTimeConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.compare
     /// </summary>
+    [JsFunction(Length = 2)]
     private JsNumber Compare(JsValue thisObject, JsCallArguments arguments)
     {
         var one = ToTemporalZonedDateTime(arguments.At(0), Undefined);

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
@@ -264,12 +264,9 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
 
     // Methods
     [JsFunction(Length = 1)]
-    private JsZonedDateTime With(JsValue thisObject, JsCallArguments arguments)
+    private JsZonedDateTime With(JsValue thisObject, JsValue temporalZonedDateTimeLike, JsValue options)
     {
         var zdt = ValidateZonedDateTime(thisObject);
-        var temporalZonedDateTimeLike = arguments.At(0);
-        var options = arguments.At(1);
-
         if (!temporalZonedDateTimeLike.IsObject())
         {
             Throw.TypeError(_realm, "with requires an object argument");
@@ -538,11 +535,10 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 0)]
-    private JsZonedDateTime WithPlainTime(JsValue thisObject, JsCallArguments arguments)
+    private JsZonedDateTime WithPlainTime(JsValue thisObject, JsValue plainTimeLike)
     {
         // https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withplaintime
         var zdt = ValidateZonedDateTime(thisObject);
-        var plainTimeLike = arguments.At(0);
         var provider = _engine.Options.Temporal.TimeZoneProvider;
 
         BigInteger epochNs;
@@ -571,23 +567,19 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 1)]
-    private JsZonedDateTime WithTimeZone(JsValue thisObject, JsCallArguments arguments)
+    private JsZonedDateTime WithTimeZone(JsValue thisObject, JsValue timeZoneLike)
     {
         var zdt = ValidateZonedDateTime(thisObject);
-        var timeZoneLike = arguments.At(0);
-
         var timeZone = ToTemporalTimeZoneIdentifier(timeZoneLike);
         return _constructor.Construct(zdt.EpochNanoseconds, timeZone, zdt.Calendar);
     }
 
     [JsFunction(Length = 1)]
-    private JsZonedDateTime WithCalendar(JsValue thisObject, JsCallArguments arguments)
+    private JsZonedDateTime WithCalendar(JsValue thisObject, JsValue calendarLike)
     {
         // https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withcalendar
         // Step 1-2: Validate this value
         var zdt = ValidateZonedDateTime(thisObject);
-        var calendarLike = arguments.At(0);
-
         // Step 3: Let calendar be ? ToTemporalCalendarIdentifier(calendarLike)
         var calendar = TemporalHelpers.ToTemporalCalendarIdentifier(_realm, calendarLike);
 
@@ -596,12 +588,9 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 1)]
-    private JsZonedDateTime Add(JsValue thisObject, JsCallArguments arguments)
+    private JsZonedDateTime Add(JsValue thisObject, JsValue temporalDurationLike, JsValue options)
     {
         var zdt = ValidateZonedDateTime(thisObject);
-        var temporalDurationLike = arguments.At(0);
-        var options = arguments.At(1);
-
         var duration = ToDurationRecord(temporalDurationLike);
         var overflow = TemporalHelpers.GetOverflowOption(_realm, options);
 
@@ -615,12 +604,9 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 1)]
-    private JsZonedDateTime Subtract(JsValue thisObject, JsCallArguments arguments)
+    private JsZonedDateTime Subtract(JsValue thisObject, JsValue temporalDurationLike, JsValue options)
     {
         var zdt = ValidateZonedDateTime(thisObject);
-        var temporalDurationLike = arguments.At(0);
-        var options = arguments.At(1);
-
         var duration = ToDurationRecord(temporalDurationLike);
         var negatedDuration = duration.Negated();
         var overflow = TemporalHelpers.GetOverflowOption(_realm, options);
@@ -635,23 +621,17 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 1)]
-    private JsDuration Until(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Until(JsValue thisObject, JsValue other, JsValue options)
     {
         var zdt = ValidateZonedDateTime(thisObject);
-        var other = arguments.At(0);
-        var options = arguments.At(1);
-
         var otherZdt = _constructor.ToTemporalZonedDateTime(other, Undefined);
         return DifferenceZonedDateTime(zdt, otherZdt, options, "until");
     }
 
     [JsFunction(Length = 1)]
-    private JsDuration Since(JsValue thisObject, JsCallArguments arguments)
+    private JsDuration Since(JsValue thisObject, JsValue other, JsValue options)
     {
         var zdt = ValidateZonedDateTime(thisObject);
-        var other = arguments.At(0);
-        var options = arguments.At(1);
-
         var otherZdt = _constructor.ToTemporalZonedDateTime(other, Undefined);
         return DifferenceZonedDateTime(zdt, otherZdt, options, "since");
     }
@@ -660,11 +640,9 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.round
     /// </summary>
     [JsFunction(Length = 1)]
-    private JsValue Round(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Round(JsValue thisObject, JsValue roundTo)
     {
         var zdt = ValidateZonedDateTime(thisObject);
-        var roundTo = arguments.At(0);
-
         if (roundTo.IsUndefined())
         {
             Throw.TypeError(_realm, "roundTo is required");
@@ -800,7 +778,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 0)]
-    private JsZonedDateTime StartOfDay(JsValue thisObject, JsCallArguments arguments)
+    private JsZonedDateTime StartOfDay(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var provider = _engine.Options.Temporal.TimeZoneProvider;
@@ -815,11 +793,9 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 1)]
-    private JsValue GetTimeZoneTransition(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetTimeZoneTransition(JsValue thisObject, JsValue directionArg)
     {
         var zdt = ValidateZonedDateTime(thisObject);
-        var directionArg = arguments.At(0);
-
         if (directionArg.IsUndefined())
         {
             Throw.TypeError(_realm, "direction is required");
@@ -871,14 +847,14 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 0)]
-    private JsInstant ToInstant(JsValue thisObject, JsCallArguments arguments)
+    private JsInstant ToInstant(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         return _realm.Intrinsics.TemporalInstant.Construct(zdt.EpochNanoseconds);
     }
 
     [JsFunction(Length = 0)]
-    private JsPlainDate ToPlainDate(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDate ToPlainDate(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var dt = zdt.GetIsoDateTime();
@@ -886,7 +862,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 0)]
-    private JsPlainTime ToPlainTime(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainTime ToPlainTime(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var dt = zdt.GetIsoDateTime();
@@ -894,7 +870,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 0)]
-    private JsPlainDateTime ToPlainDateTime(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainDateTime ToPlainDateTime(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var dt = zdt.GetIsoDateTime();
@@ -902,7 +878,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 0)]
-    private JsPlainYearMonth ToPlainYearMonth(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainYearMonth ToPlainYearMonth(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var dt = zdt.GetIsoDateTime();
@@ -910,7 +886,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 0)]
-    private JsPlainMonthDay ToPlainMonthDay(JsValue thisObject, JsCallArguments arguments)
+    private JsPlainMonthDay ToPlainMonthDay(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var dt = zdt.GetIsoDateTime();
@@ -918,11 +894,9 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 1)]
-    private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
+    private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var zdt = ValidateZonedDateTime(thisObject);
-        var other = arguments.At(0);
-
         var otherZdt = _constructor.ToTemporalZonedDateTime(other, Undefined);
 
         var sameEpoch = zdt.EpochNanoseconds == otherZdt.EpochNanoseconds;
@@ -933,11 +907,9 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 0, Name = "toString")]
-    private JsString ToStringMethod(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToStringMethod(JsValue thisObject, JsValue options)
     {
         var zdt = ValidateZonedDateTime(thisObject);
-        var options = arguments.At(0);
-
         // Validate options parameter
         if (!options.IsUndefined() && !options.IsObject())
         {
@@ -1130,7 +1102,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 0)]
-    private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
+    private JsString ToJSON(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         return new JsString(FormatZonedDateTime(zdt, "auto", "auto", "auto", null));
@@ -1140,12 +1112,9 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sup-temporal.zoneddatetime.prototype.tolocalestring
     /// </summary>
     [JsFunction(Length = 0)]
-    private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToLocaleString(JsValue thisObject, JsValue locales, JsValue options)
     {
         var zdt = ValidateZonedDateTime(thisObject);
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
-
         // Per spec: CreateDateTimeFormat with required=~any~, defaults=~all~, toLocaleStringTimeZone=ZDT.[[TimeZone]]
         // Uses ZonedDateTime defaults which include timeZoneName: "short"
         // This will throw TypeError if user passes a timeZone option
@@ -1173,7 +1142,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     }
 
     [JsFunction(Length = 0)]
-    private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "ZonedDateTime.prototype.valueOf is not allowed");
         return Undefined;

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
@@ -10,9 +10,13 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-zoneddatetime-prototype-object
 /// </summary>
-internal sealed class ZonedDateTimePrototype : Prototype
+[JsObject]
+internal sealed partial class ZonedDateTimePrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly ZonedDateTimeConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString ZonedDateTimeToStringTag = new("Temporal.ZonedDateTime");
 
     internal ZonedDateTimePrototype(
         Engine engine,
@@ -26,73 +30,10 @@ internal sealed class ZonedDateTimePrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(53, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["with"] = new(new ClrFunction(Engine, "with", With, 1, LengthFlags), PropertyFlags),
-            ["withPlainTime"] = new(new ClrFunction(Engine, "withPlainTime", WithPlainTime, 0, LengthFlags), PropertyFlags),
-            ["withTimeZone"] = new(new ClrFunction(Engine, "withTimeZone", WithTimeZone, 1, LengthFlags), PropertyFlags),
-            ["withCalendar"] = new(new ClrFunction(Engine, "withCalendar", WithCalendar, 1, LengthFlags), PropertyFlags),
-            ["add"] = new(new ClrFunction(Engine, "add", Add, 1, LengthFlags), PropertyFlags),
-            ["subtract"] = new(new ClrFunction(Engine, "subtract", Subtract, 1, LengthFlags), PropertyFlags),
-            ["until"] = new(new ClrFunction(Engine, "until", Until, 1, LengthFlags), PropertyFlags),
-            ["since"] = new(new ClrFunction(Engine, "since", Since, 1, LengthFlags), PropertyFlags),
-            ["round"] = new(new ClrFunction(Engine, "round", Round, 1, LengthFlags), PropertyFlags),
-            ["startOfDay"] = new(new ClrFunction(Engine, "startOfDay", StartOfDay, 0, LengthFlags), PropertyFlags),
-            ["getTimeZoneTransition"] = new(new ClrFunction(Engine, "getTimeZoneTransition", GetTimeZoneTransition, 1, LengthFlags), PropertyFlags),
-            ["toInstant"] = new(new ClrFunction(Engine, "toInstant", ToInstant, 0, LengthFlags), PropertyFlags),
-            ["toPlainDate"] = new(new ClrFunction(Engine, "toPlainDate", ToPlainDate, 0, LengthFlags), PropertyFlags),
-            ["toPlainTime"] = new(new ClrFunction(Engine, "toPlainTime", ToPlainTime, 0, LengthFlags), PropertyFlags),
-            ["toPlainDateTime"] = new(new ClrFunction(Engine, "toPlainDateTime", ToPlainDateTime, 0, LengthFlags), PropertyFlags),
-            ["toPlainYearMonth"] = new(new ClrFunction(Engine, "toPlainYearMonth", ToPlainYearMonth, 0, LengthFlags), PropertyFlags),
-            ["toPlainMonthDay"] = new(new ClrFunction(Engine, "toPlainMonthDay", ToPlainMonthDay, 0, LengthFlags), PropertyFlags),
-            ["equals"] = new(new ClrFunction(Engine, "equals", Equals, 1, LengthFlags), PropertyFlags),
-            ["toString"] = new(new ClrFunction(Engine, "toString", ToStringMethod, 0, LengthFlags), PropertyFlags),
-            ["toJSON"] = new(new ClrFunction(Engine, "toJSON", ToJSON, 0, LengthFlags), PropertyFlags),
-            ["toLocaleString"] = new(new ClrFunction(Engine, "toLocaleString", ToLocaleString, 0, LengthFlags), PropertyFlags),
-            ["valueOf"] = new(new ClrFunction(Engine, "valueOf", ValueOf, 0, LengthFlags), PropertyFlags),
-            ["calendarId"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get calendarId", GetCalendarId, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["timeZoneId"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get timeZoneId", GetTimeZoneId, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["era"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get era", GetEra, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["eraYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get eraYear", GetEraYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["year"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get year", GetYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["month"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get month", GetMonth, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["monthCode"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get monthCode", GetMonthCode, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["day"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get day", GetDay, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["hour"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get hour", GetHour, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["minute"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get minute", GetMinute, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["second"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get second", GetSecond, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["millisecond"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get millisecond", GetMillisecond, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["microsecond"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get microsecond", GetMicrosecond, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["nanosecond"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get nanosecond", GetNanosecond, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["epochMilliseconds"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get epochMilliseconds", GetEpochMilliseconds, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["epochMicroseconds"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get epochMicroseconds", GetEpochMicroseconds, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["epochSeconds"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get epochSeconds", GetEpochSeconds, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["epochNanoseconds"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get epochNanoseconds", GetEpochNanoseconds, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["dayOfWeek"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get dayOfWeek", GetDayOfWeek, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["dayOfYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get dayOfYear", GetDayOfYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["weekOfYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get weekOfYear", GetWeekOfYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["yearOfWeek"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get yearOfWeek", GetYearOfWeek, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["daysInWeek"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get daysInWeek", GetDaysInWeek, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["daysInMonth"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get daysInMonth", GetDaysInMonth, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["daysInYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get daysInYear", GetDaysInYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["monthsInYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get monthsInYear", GetMonthsInYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["inLeapYear"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get inLeapYear", GetInLeapYear, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["hoursInDay"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get hoursInDay", GetHoursInDay, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["offset"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get offset", GetOffset, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-            ["offsetNanoseconds"] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get offsetNanoseconds", GetOffsetNanoseconds, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Temporal.ZonedDateTime", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
+
 
     private JsZonedDateTime ValidateZonedDateTime(JsValue thisObject)
     {
@@ -103,13 +44,16 @@ internal sealed class ZonedDateTimePrototype : Prototype
     }
 
     // Property accessors
-    private JsString GetCalendarId(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("calendarId")]
+    private JsString GetCalendarId(JsValue thisObject) =>
         new JsString(ValidateZonedDateTime(thisObject).Calendar);
 
-    private JsString GetTimeZoneId(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("timeZoneId")]
+    private JsString GetTimeZoneId(JsValue thisObject) =>
         new JsString(ValidateZonedDateTime(thisObject).TimeZone);
 
-    private JsValue GetEra(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("era")]
+    private JsValue GetEra(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var isoDateTime = zdt.GetIsoDateTime();
@@ -117,7 +61,8 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return era is not null ? new JsString(era) : Undefined;
     }
 
-    private JsValue GetEraYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("eraYear")]
+    private JsValue GetEraYear(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var isoDateTime = zdt.GetIsoDateTime();
@@ -125,53 +70,65 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return eraYear.HasValue ? JsNumber.Create(eraYear.Value) : Undefined;
     }
 
-    private JsNumber GetYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("year")]
+    private JsNumber GetYear(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var isoDateTime = zdt.GetIsoDateTime();
         return JsNumber.Create(TemporalHelpers.CalendarYear(zdt.Calendar, isoDateTime.Date, _engine));
     }
 
-    private JsNumber GetMonth(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("month")]
+    private JsNumber GetMonth(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarMonth(zdt.Calendar, zdt.GetIsoDateTime().Date, _engine));
     }
 
-    private JsString GetMonthCode(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("monthCode")]
+    private JsString GetMonthCode(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         return new JsString(TemporalHelpers.CalendarMonthCode(zdt.Calendar, zdt.GetIsoDateTime().Date, _engine));
     }
 
-    private JsNumber GetDay(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("day")]
+    private JsNumber GetDay(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDay(zdt.Calendar, zdt.GetIsoDateTime().Date, _engine));
     }
 
-    private JsNumber GetHour(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("hour")]
+    private JsNumber GetHour(JsValue thisObject) =>
         JsNumber.Create(ValidateZonedDateTime(thisObject).GetIsoDateTime().Hour);
 
-    private JsNumber GetMinute(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("minute")]
+    private JsNumber GetMinute(JsValue thisObject) =>
         JsNumber.Create(ValidateZonedDateTime(thisObject).GetIsoDateTime().Minute);
 
-    private JsNumber GetSecond(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("second")]
+    private JsNumber GetSecond(JsValue thisObject) =>
         JsNumber.Create(ValidateZonedDateTime(thisObject).GetIsoDateTime().Second);
 
-    private JsNumber GetMillisecond(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("millisecond")]
+    private JsNumber GetMillisecond(JsValue thisObject) =>
         JsNumber.Create(ValidateZonedDateTime(thisObject).GetIsoDateTime().Millisecond);
 
-    private JsNumber GetMicrosecond(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("microsecond")]
+    private JsNumber GetMicrosecond(JsValue thisObject) =>
         JsNumber.Create(ValidateZonedDateTime(thisObject).GetIsoDateTime().Microsecond);
 
-    private JsNumber GetNanosecond(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("nanosecond")]
+    private JsNumber GetNanosecond(JsValue thisObject) =>
         JsNumber.Create(ValidateZonedDateTime(thisObject).GetIsoDateTime().Nanosecond);
 
-    private JsNumber GetEpochSeconds(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("epochSeconds")]
+    private JsNumber GetEpochSeconds(JsValue thisObject) =>
         JsNumber.Create((double) FloorDivide(ValidateZonedDateTime(thisObject).EpochNanoseconds, 1_000_000_000));
 
-    private JsNumber GetEpochMilliseconds(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("epochMilliseconds")]
+    private JsNumber GetEpochMilliseconds(JsValue thisObject) =>
         JsNumber.Create((double) FloorDivide(ValidateZonedDateTime(thisObject).EpochNanoseconds, 1_000_000));
 
     private static BigInteger FloorDivide(BigInteger dividend, long divisor)
@@ -185,23 +142,28 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return result;
     }
 
-    private JsBigInt GetEpochMicroseconds(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("epochMicroseconds")]
+    private JsBigInt GetEpochMicroseconds(JsValue thisObject) =>
         JsBigInt.Create(ValidateZonedDateTime(thisObject).EpochNanoseconds / 1_000);
 
-    private JsBigInt GetEpochNanoseconds(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("epochNanoseconds")]
+    private JsBigInt GetEpochNanoseconds(JsValue thisObject) =>
         JsBigInt.Create(ValidateZonedDateTime(thisObject).EpochNanoseconds);
 
-    private JsNumber GetDayOfWeek(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("dayOfWeek")]
+    private JsNumber GetDayOfWeek(JsValue thisObject) =>
         JsNumber.Create(ValidateZonedDateTime(thisObject).GetIsoDateTime().Date.DayOfWeek());
 
-    private JsNumber GetDayOfYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("dayOfYear")]
+    private JsNumber GetDayOfYear(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var date = zdt.GetIsoDateTime().Date;
         return JsNumber.Create(TemporalHelpers.CalendarDayOfYear(zdt.Calendar, date, _engine));
     }
 
-    private JsValue GetWeekOfYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("weekOfYear")]
+    private JsValue GetWeekOfYear(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         if (!string.Equals(zdt.Calendar, "iso8601", StringComparison.Ordinal))
@@ -213,7 +175,8 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return JsNumber.Create(date.WeekOfYear());
     }
 
-    private JsValue GetYearOfWeek(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("yearOfWeek")]
+    private JsValue GetYearOfWeek(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         if (!string.Equals(zdt.Calendar, "iso8601", StringComparison.Ordinal))
@@ -225,37 +188,43 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return JsNumber.Create(date.YearOfWeek());
     }
 
-    private JsNumber GetDaysInWeek(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("daysInWeek")]
+    private JsNumber GetDaysInWeek(JsValue thisObject)
     {
         ValidateZonedDateTime(thisObject);
         return JsNumber.Create(7); // ISO 8601 always has 7 days in a week
     }
 
-    private JsNumber GetDaysInMonth(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("daysInMonth")]
+    private JsNumber GetDaysInMonth(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDaysInMonth(zdt.Calendar, zdt.GetIsoDateTime().Date, _engine));
     }
 
-    private JsNumber GetDaysInYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("daysInYear")]
+    private JsNumber GetDaysInYear(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarDaysInYear(zdt.Calendar, zdt.GetIsoDateTime().Date, _engine));
     }
 
-    private JsNumber GetMonthsInYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("monthsInYear")]
+    private JsNumber GetMonthsInYear(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         return JsNumber.Create(TemporalHelpers.CalendarMonthsInYear(zdt.Calendar, zdt.GetIsoDateTime().Date, _engine));
     }
 
-    private JsBoolean GetInLeapYear(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("inLeapYear")]
+    private JsBoolean GetInLeapYear(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         return TemporalHelpers.CalendarInLeapYear(zdt.Calendar, zdt.GetIsoDateTime().Date, _engine) ? JsBoolean.True : JsBoolean.False;
     }
 
-    private JsNumber GetHoursInDay(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("hoursInDay")]
+    private JsNumber GetHoursInDay(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var provider = _engine.Options.Temporal.TimeZoneProvider;
@@ -281,17 +250,20 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return JsNumber.Create(hours);
     }
 
-    private JsString GetOffset(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("offset")]
+    private JsString GetOffset(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var offsetNs = zdt.OffsetNanoseconds;
         return new JsString(TemporalHelpers.FormatOffsetString(offsetNs));
     }
 
-    private JsNumber GetOffsetNanoseconds(JsValue thisObject, JsCallArguments arguments) =>
+    [JsAccessor("offsetNanoseconds")]
+    private JsNumber GetOffsetNanoseconds(JsValue thisObject) =>
         JsNumber.Create(ValidateZonedDateTime(thisObject).OffsetNanoseconds);
 
     // Methods
+    [JsFunction(Length = 1)]
     private JsZonedDateTime With(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -565,6 +537,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(epochNs, zdt.TimeZone, zdt.Calendar);
     }
 
+    [JsFunction(Length = 0)]
     private JsZonedDateTime WithPlainTime(JsValue thisObject, JsCallArguments arguments)
     {
         // https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withplaintime
@@ -597,6 +570,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(epochNs, zdt.TimeZone, zdt.Calendar);
     }
 
+    [JsFunction(Length = 1)]
     private JsZonedDateTime WithTimeZone(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -606,6 +580,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(zdt.EpochNanoseconds, timeZone, zdt.Calendar);
     }
 
+    [JsFunction(Length = 1)]
     private JsZonedDateTime WithCalendar(JsValue thisObject, JsCallArguments arguments)
     {
         // https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withcalendar
@@ -620,6 +595,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(zdt.EpochNanoseconds, zdt.TimeZone, calendar);
     }
 
+    [JsFunction(Length = 1)]
     private JsZonedDateTime Add(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -638,6 +614,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(newEpochNs, zdt.TimeZone, zdt.Calendar);
     }
 
+    [JsFunction(Length = 1)]
     private JsZonedDateTime Subtract(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -657,6 +634,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(newEpochNs, zdt.TimeZone, zdt.Calendar);
     }
 
+    [JsFunction(Length = 1)]
     private JsDuration Until(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -667,6 +645,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return DifferenceZonedDateTime(zdt, otherZdt, options, "until");
     }
 
+    [JsFunction(Length = 1)]
     private JsDuration Since(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -680,6 +659,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.round
     /// </summary>
+    [JsFunction(Length = 1)]
     private JsValue Round(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -819,6 +799,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(epochNanoseconds, timeZone, calendar);
     }
 
+    [JsFunction(Length = 0)]
     private JsZonedDateTime StartOfDay(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -833,6 +814,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(startOfDayNs, zdt.TimeZone, zdt.Calendar);
     }
 
+    [JsFunction(Length = 1)]
     private JsValue GetTimeZoneTransition(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -888,12 +870,14 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(transitionNs.Value, zdt.TimeZone, zdt.Calendar);
     }
 
+    [JsFunction(Length = 0)]
     private JsInstant ToInstant(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         return _realm.Intrinsics.TemporalInstant.Construct(zdt.EpochNanoseconds);
     }
 
+    [JsFunction(Length = 0)]
     private JsPlainDate ToPlainDate(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -901,6 +885,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _realm.Intrinsics.TemporalPlainDate.Construct(dt.Date, zdt.Calendar);
     }
 
+    [JsFunction(Length = 0)]
     private JsPlainTime ToPlainTime(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -908,6 +893,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _realm.Intrinsics.TemporalPlainTime.Construct(dt.Time);
     }
 
+    [JsFunction(Length = 0)]
     private JsPlainDateTime ToPlainDateTime(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -915,6 +901,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _realm.Intrinsics.TemporalPlainDateTime.Construct(dt, zdt.Calendar);
     }
 
+    [JsFunction(Length = 0)]
     private JsPlainYearMonth ToPlainYearMonth(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -922,6 +909,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _realm.Intrinsics.TemporalPlainYearMonth.Construct(dt.Date, zdt.Calendar);
     }
 
+    [JsFunction(Length = 0)]
     private JsPlainMonthDay ToPlainMonthDay(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -929,6 +917,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return _realm.Intrinsics.TemporalPlainMonthDay.Construct(dt.Date, zdt.Calendar);
     }
 
+    [JsFunction(Length = 1)]
     private JsBoolean Equals(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -943,6 +932,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return sameEpoch && sameTimeZone && sameCalendar ? JsBoolean.True : JsBoolean.False;
     }
 
+    [JsFunction(Length = 0, Name = "toString")]
     private JsString ToStringMethod(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -1139,6 +1129,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return new JsString(FormatZonedDateTime(zdt, showCalendar, showTimeZone, showOffset, precision));
     }
 
+    [JsFunction(Length = 0)]
     private JsString ToJSON(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -1148,6 +1139,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sup-temporal.zoneddatetime.prototype.tolocalestring
     /// </summary>
+    [JsFunction(Length = 0)]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -1180,6 +1172,7 @@ internal sealed class ZonedDateTimePrototype : Prototype
         return dtf.Format(dateTime);
     }
 
+    [JsFunction(Length = 0)]
     private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
     {
         Throw.TypeError(_realm, "ZonedDateTime.prototype.valueOf is not allowed");

--- a/Jint/Native/WeakMap/WeakMapPrototype.cs
+++ b/Jint/Native/WeakMap/WeakMapPrototype.cs
@@ -15,10 +15,6 @@ internal sealed partial class WeakMapPrototype : Prototype
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly WeakMapConstructor _constructor;
 
-    // Pre-existing quirk: TC39 spec does not require a `length` property on WeakMap.prototype
-    // (length lives on the constructor). Preserved here verbatim from the pre-source-gen Initialize body.
-    [JsProperty(Name = "length", Flags = PropertyFlag.Configurable)] private static readonly JsNumber WeakMapLength = JsNumber.PositiveZero;
-
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString WeakMapToStringTag = new("WeakMap");
 
     internal WeakMapPrototype(

--- a/Jint/Native/WeakSet/WeakSetPrototype.cs
+++ b/Jint/Native/WeakSet/WeakSetPrototype.cs
@@ -16,10 +16,6 @@ internal sealed partial class WeakSetPrototype : Prototype
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly WeakSetConstructor _constructor;
 
-    // Pre-existing quirk: TC39 spec does not require a `length` property on WeakSet.prototype
-    // (length lives on the constructor). Preserved here verbatim from the pre-source-gen Initialize body.
-    [JsProperty(Name = "length", Flags = PropertyFlag.Configurable)] private static readonly JsNumber WeakSetLength = JsNumber.PositiveZero;
-
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString WeakSetToStringTag = new("WeakSet");
 
     // Captured once Initialize runs; the WeakSet constructor's array fast path

--- a/Jint/Runtime/Descriptors/Specialized/LazyGetSetPropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/LazyGetSetPropertyDescriptor.cs
@@ -1,0 +1,35 @@
+using System.Runtime.CompilerServices;
+using Jint.Native;
+
+namespace Jint.Runtime.Descriptors.Specialized;
+
+/// <summary>
+/// Accessor counterpart to <see cref="LazyPropertyDescriptor{T}"/>: defers allocation of the
+/// get and/or set <see cref="JsValue"/> instances until first access. The source generator emits
+/// this for <c>[JsAccessor]</c> / <c>[JsSymbolAccessor]</c> slots, so prototypes with many never-read
+/// accessors (e.g. Temporal date/time prototypes with 10-20 each) avoid allocating the dispatcher
+/// <c>Function</c> per slot at <c>Initialize()</c> time.
+/// </summary>
+internal sealed class LazyGetSetPropertyDescriptor<T> : PropertyDescriptor where T : class
+{
+    private readonly T _state;
+    private readonly Func<T, JsValue>? _getResolver;
+    private readonly Func<T, JsValue>? _setResolver;
+    private JsValue? _get;
+    private JsValue? _set;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal LazyGetSetPropertyDescriptor(T state, Func<T, JsValue>? getResolver, Func<T, JsValue>? setResolver, PropertyFlag flags)
+        : base(null, flags)
+    {
+        _flags |= PropertyFlag.NonData;
+        _flags &= ~PropertyFlag.WritableSet;
+        _flags &= ~PropertyFlag.Writable;
+        _state = state;
+        _getResolver = getResolver;
+        _setResolver = setResolver;
+    }
+
+    public override JsValue? Get => _getResolver is null ? null : (_get ??= _getResolver(_state));
+    public override JsValue? Set => _setResolver is null ? null : (_set ??= _setResolver(_state));
+}

--- a/Jint/Runtime/Intrinsics.cs
+++ b/Jint/Runtime/Intrinsics.cs
@@ -284,7 +284,7 @@ public sealed partial class Intrinsics
         _date ??= new DateConstructor(_engine, _realm, Function.PrototypeObject, Object.PrototypeObject);
 
     internal MathInstance Math =>
-        _math ??= new MathInstance(_engine, Object.PrototypeObject);
+        _math ??= new MathInstance(_engine, _realm, Object.PrototypeObject);
 
     internal JsonInstance Json =>
         _json ??= new JsonInstance(_engine, _realm, Object.PrototypeObject);


### PR DESCRIPTION
## Summary

Closes most of the remaining built-in surface for the source generator. **23 commits.** Roughly **94 [JsObject] hosts** are now generator-driven — Map/Set/Iterator/AsyncIterator/Generator/AsyncGenerator/ShadowRealm/DisposableStack family plus most constructors (Promise/Number/Date/Error/Array/String/RegExp/Iterator/AsyncIterator/Object) and the entire Intl (10 prototypes + 8 constructors + IntlInstance) and Temporal (8 prototypes + 8 constructors + TemporalInstance) surfaces. Full test262 sweep matches `upstream/main` baseline at **98,959 / 0**.

## Performance & correctness work (review follow-ups)

The bulk of the migration is in commits 1-16. Commits 17-23 address two rounds of code review focused on optimal generator usage and correctness:

| # | Commit | Subject |
|---|--------|---------|
| 17 | `2a7468949` | **Emit `LazyGetSetPropertyDescriptor` for accessors** — defers dispatcher Function allocation to first read; saves ~100 startup allocations per realm for Temporal date/time prototypes alone |
| 18 | `c9cc47b5e` | **Adopt `[Rest] ReadOnlySpan<JsValue>`** — Object.assign + Math.max/min/hypot now use the existing-but-unused `[Rest]` attribute; the Math methods drop a `double[]` allocation per call (uses `stackalloc` for arity ≤16) |
| 19 | `75df7a61a` | Spec-aligned param names in Temporal Compare/Equals/Until/Since (one/two/other/options) |
| 20 | `0200f56ba` | Tighten 13 `ObjectConstructor` return types; drop file-wide CA1859 pragma |
| 21 | `149fb2e2e` | **Capture host's home realm in dispatcher** — fixes a latent cross-realm correctness bug where lazy-materialized Functions could capture the *currently active* realm instead of the host's home realm under ShadowRealm/cross-realm boundaries |
| 22 | `cc21a787c` | Rename `optionsArg`→`options` in 9 Temporal With/ToString methods |
| 23 | `0f3f92e91` | **Add `[JsObject(ExtraCapacity=N)]`** — presizes the generated property dictionary for hosts with post-Initialize SetProperty calls (IntlInstance/TemporalInstance), avoiding the list→hash transition during init |

### Highlights

#### Cross-realm correctness fix (commit 21)

Pre-fix, the generated dispatcher passed `host.Engine.Realm` to its `Function` base — `Engine.Realm` returns the **currently active** execution-context realm, not the host's home realm. Because `[JsAccessor]`/`[JsFunction]` descriptors are now lazy, first-touch can happen from a different realm (e.g. ShadowRealm or cross-realm property reads). The dispatcher would permanently bind to the wrong realm and the wrong `%Function.prototype%` prototype.

Now uses `host._realm` consistently. Required adding the missing `_realm` field to three hosts (`MathInstance`, `GeneratorPrototype`, `AsyncGeneratorPrototype`) — those now route their throw paths through the captured realm too, fixing latent cross-realm `TypeError` realm misattribution.

#### `[JsObject(ExtraCapacity = N)]` (commit 23)

Adds a single attribute parameter that pads the generator's dictionary capacity. `IntlInstance` declares 2 statically-known methods plus 10 cross-realm constructor refs added in `Initialize()`; without this the dictionary went `2 → 3 → 5 → 9 → list-to-hash transition → 10`. With `ExtraCapacity = 10` it goes straight to a 12-slot hashtable. `TemporalInstance` had no static properties at all (only a `[JsSymbol]`), so `CreateProperties_Generated` was previously empty; it now creates a 9-slot dictionary upfront.

The cross-realm constructor refs themselves can't be cleanly expressed via `[JsProperty]` because they read from `_realm.Intrinsics.X` — that's a future generator feature.

## Migration commits 1-16

| # | Commit | Subject |
|---|--------|---------|
| 1 | `a9ed3afe3` | Migrate Map + Set prototypes + IteratorPrototype family |
| 2 | `da2128834` | Drop non-spec `length=0` property from Map/Set/WeakMap/WeakSet prototypes |
| 3 | `6ce68b5db` | Migrate Array/String/RegExpString iterator prototypes |
| 4 | `9fbb72b42` | Migrate StringConstructor |
| 5 | `cc9581d36` | Migrate ArrayConstructor |
| 6 | `aede07fc0` | Migrate RegExpConstructor |
| 7 | `274ec8056` | Migrate AsyncIteratorPrototype |
| 8 | `3ec34b0e6` | Migrate PromiseConstructor |
| 9 | `b56944570` | Migrate Number/Date/Error constructors |
| 10 | `8f80b7263` | Migrate Iterator/AsyncIterator constructors + helpers |
| 11 | `a86cb8b50` | Refactor AsyncIteratorPrototype methods to spec-named JsValue parameters |
| 12 | `46b1aa690` | Migrate Generator/AsyncGenerator/ShadowRealm/Disposable prototypes |
| 13 | `b5ba537b4` | Migrate Intl prototypes and constructors |
| 14 | `c62911ef2` | Migrate Temporal prototypes and constructors |
| 15 | `5043ef0e4` | Migrate ObjectConstructor |
| 16 | `6797b275b` | Refactor JsCallArguments to spec-named JsValue parameters in RegExp/Temporal |

## Earlier-batch highlights

### `IteratorPrototype` is the first non-sealed `[JsObject]` host

5 subclasses; the generator only processes the host's own `[JsFunction]` methods, so subclasses kept their `Initialize()` until commit 3 migrated all of them. The internal `Next(JsValue, JsCallArguments)` is preserved with its old signature so any future subclass referencing it as a `ClrFunction` delegate keeps compiling.

### Function-identity preserved by post-`CreateProperties_Generated` aliasing

Spec sometimes requires two property names on the same prototype to point at the *same* function object — pre-source-gen Jint satisfied this accidentally via `ClrFunction.Equals` comparing the underlying delegate. Commits 1, 9, 12 alias the materialized descriptor inside `Initialize()`:

- `Map.prototype[@@iterator] === Map.prototype.entries`
- `Set.prototype.keys === Set.prototype.values === Set.prototype[@@iterator]`
- `DisposableStack.prototype[@@dispose] === DisposableStack.prototype.dispose`
- `AsyncDisposableStack.prototype[@@asyncDispose] === AsyncDisposableStack.prototype.disposeAsync`

`Number.parseInt === parseInt` / `Number.parseFloat === parseFloat` is preserved differently — by keeping those two members hand-rolled (commit 9) so they share the underlying `GlobalObject.ParseInt/ParseFloat` delegate.

### `RegExpConstructor` legacy accessors

The B.2.4 legacy static accessors (`input`/`$_`, `lastMatch`/`$&`, `lastParen`/`$+`, `leftContext`/`` $` ``, `rightContext`/`$'`, `$1`-`$9`) stay hand-rolled. test262's native-function-syntax matcher rejects names like `get $&` that the source generator would emit; preserving the original empty-named ClrFunction setup keeps `Function.prototype.toString` output spec-conformant.

### Map's `Get`/`Set` rename

The dispatcher's static call to `host.Get(thisObject, key)` collides with `ObjectInstance.Get(JsValue property, JsValue receiver)`. Renamed C# methods to `MapGet`/`MapSet` with explicit `Name = "get"`/`Name = "set"`.

### `length=0` prototype quirk dropped

TC39 doesn't put a `length` property on Map/Set/WeakMap/WeakSet/ShadowRealm/DisposableStack/AsyncDisposableStack prototypes — it lives on the constructor. Pre-source-gen Jint emitted it; commit 2 plus the new prototype migrations align with the spec.

## Verification

- **Source-generator snapshot tests**: 25 / 25
- **Jint.Tests** (xUnit): 2,875 / 0 (net10.0), 2,828 / 0 (net472)
- **Test262 — full sweep**: **98,959 passed / 0 failed** (matches upstream/main baseline)

## What's intentionally NOT in this PR

- TypedArray family (`IntrinsicTypedArrayPrototype` 36 methods, plus per-type prototypes)
- AsyncFunction / AsyncGeneratorFunction / GeneratorFunction constructors and prototypes
- TemporalNow (still hand-rolled)
- A future `[JsLazyProperty]`/`[JsAlias]`/`[JsRealmIntrinsicProperty]` attribute set that would subsume the remaining post-Initialize boilerplate (5 identity-aliasing sites + 19 cross-realm sub-namespace lines). Architectural addition deserving its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
