### PR TITLE
Source generator: finish rollout, spec-shaped signatures, strip redundant Length

### DIFF
--- a/Jint/Native/AggregateError/AggregateErrorPrototype.cs
+++ b/Jint/Native/AggregateError/AggregateErrorPrototype.cs
@@ -7,9 +7,17 @@ namespace Jint.Native.AggregateError;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-prototype-objects
 /// </summary>
-internal sealed class AggregateErrorPrototype : Prototype
+[JsObject]
+internal sealed partial class AggregateErrorPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly AggregateErrorConstructor _constructor;
+
+    [JsProperty(Name = "message", Flags = PropertyFlag.NonEnumerable)]
+    private static readonly JsString MessageDefault = JsString.Empty;
+
+    [JsProperty(Name = "name", Flags = PropertyFlag.NonEnumerable)]
+    private static readonly JsString NameValue = new("AggregateError");
 
     internal AggregateErrorPrototype(
         Engine engine,
@@ -22,14 +30,5 @@ internal sealed class AggregateErrorPrototype : Prototype
         _prototype = prototype;
     }
 
-    protected override void Initialize()
-    {
-        var properties = new PropertyDictionary(3, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["message"] = new PropertyDescriptor(JsString.Empty, PropertyFlag.Configurable | PropertyFlag.Writable),
-            ["name"] = new PropertyDescriptor("AggregateError", PropertyFlag.Configurable | PropertyFlag.Writable),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 }

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -678,7 +678,7 @@ public sealed partial class ArrayConstructor : Constructor
         }
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Of(JsValue thisObject, JsCallArguments arguments)
     {
         var len = arguments.Length;

--- a/Jint/Native/Array/ArrayIteratorPrototype.cs
+++ b/Jint/Native/Array/ArrayIteratorPrototype.cs
@@ -37,7 +37,7 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
         _originalNextFunction = (FunctionInstance) GetOwnProperty("next").Value!;
     }
 
-    [JsFunction(Length = 0, Name = "next")]
+    [JsFunction(Name = "next")]
     private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     internal IteratorInstance Construct(ObjectInstance array, ArrayIteratorType kind)

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -87,7 +87,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     }
 
     [JsFunction]
-    private ObjectInstance Keys(JsValue thisObject, JsCallArguments arguments)
+    private ObjectInstance Keys(JsValue thisObject)
     {
         if (thisObject is ObjectInstance oi && oi.IsArrayLike)
         {
@@ -99,7 +99,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     }
 
     [JsFunction]
-    internal ObjectInstance Values(JsValue thisObject, JsCallArguments arguments)
+    internal ObjectInstance Values(JsValue thisObject)
     {
         if (thisObject is ObjectInstance oi && oi.IsArrayLike)
         {
@@ -150,7 +150,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     }
 
     [JsFunction]
-    private ObjectInstance Entries(JsValue thisObject, JsCallArguments arguments)
+    private ObjectInstance Entries(JsValue thisObject)
     {
         if (thisObject is ObjectInstance oi && oi.IsArrayLike)
         {
@@ -1302,7 +1302,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     }
 
     [JsFunction]
-    private JsValue Shift(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Shift(JsValue thisObject)
     {
         var o = ArrayOperations.For(_realm, thisObject, forWrite: true);
         var len = o.GetLength();
@@ -1336,7 +1336,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     /// https://tc39.es/ecma262/#sec-array.prototype.reverse
     /// </summary>
     [JsFunction]
-    private JsValue Reverse(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Reverse(JsValue thisObject)
     {
         var o = ArrayOperations.For(_realm, thisObject, forWrite: true);
         var len = o.GetLongLength();
@@ -1651,7 +1651,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     }
 
     [JsFunction]
-    private JsValue ToReversed(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToReversed(JsValue thisObject)
     {
         var o = ArrayOperations.For(_realm, thisObject, forWrite: false);
 
@@ -1907,7 +1907,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     }
 
     [JsFunction]
-    public JsValue Pop(JsValue thisObject, JsCallArguments arguments)
+    public JsValue Pop(JsValue thisObject)
     {
         if (thisObject is JsArray { CanUseFastAccess: true } array)
         {

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -86,7 +86,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         SetSymbols(symbols);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private ObjectInstance Keys(JsValue thisObject, JsCallArguments arguments)
     {
         if (thisObject is ObjectInstance oi && oi.IsArrayLike)
@@ -98,7 +98,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         return null;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     internal ObjectInstance Values(JsValue thisObject, JsCallArguments arguments)
     {
         if (thisObject is ObjectInstance oi && oi.IsArrayLike)
@@ -149,7 +149,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         return new JsArray(_engine, a);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private ObjectInstance Entries(JsValue thisObject, JsCallArguments arguments)
     {
         if (thisObject is ObjectInstance oi && oi.IsArrayLike)
@@ -514,7 +514,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-array.prototype.flat
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Flat(JsValue thisObject, JsCallArguments arguments)
     {
         var operations = ArrayOperations.For(_realm, thisObject, forWrite: false);
@@ -1301,7 +1301,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         return a;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Shift(JsValue thisObject, JsCallArguments arguments)
     {
         var o = ArrayOperations.For(_realm, thisObject, forWrite: true);
@@ -1335,7 +1335,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-array.prototype.reverse
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Reverse(JsValue thisObject, JsCallArguments arguments)
     {
         var o = ArrayOperations.For(_realm, thisObject, forWrite: true);
@@ -1437,7 +1437,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-array.prototype.tolocalestring
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
         const string Separator = ",";
@@ -1631,7 +1631,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         return true;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     internal JsValue ToString(JsValue thisObject, JsCallArguments arguments)
     {
         var array = TypeConverter.ToObject(_realm, thisObject);
@@ -1650,7 +1650,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         return func(array, Arguments.Empty);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToReversed(JsValue thisObject, JsCallArguments arguments)
     {
         var o = ArrayOperations.For(_realm, thisObject, forWrite: false);
@@ -1906,7 +1906,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         return n;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     public JsValue Pop(JsValue thisObject, JsCallArguments arguments)
     {
         if (thisObject is JsArray { CanUseFastAccess: true } array)

--- a/Jint/Native/ArrayBuffer/ArrayBufferConstructor.cs
+++ b/Jint/Native/ArrayBuffer/ArrayBufferConstructor.cs
@@ -77,7 +77,7 @@ public sealed partial class ArrayBufferConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-arraybuffer.isview
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue IsView(JsValue thisObject, JsValue arg)
     {
         return arg is JsDataView or JsTypedArray;

--- a/Jint/Native/ArrayBuffer/ArrayBufferPrototype.cs
+++ b/Jint/Native/ArrayBuffer/ArrayBufferPrototype.cs
@@ -102,7 +102,7 @@ internal sealed partial class ArrayBufferPrototype : Prototype
     /// https://tc39.es/ecma262/#sec-arraybuffer.prototype.resize
     /// https://tc39.es/proposal-immutable-arraybuffer/#sec-arraybuffer.prototype.resize
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Resize(JsValue thisObject, JsValue newLength)
     {
         var o = thisObject as JsArrayBuffer;
@@ -150,7 +150,7 @@ internal sealed partial class ArrayBufferPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue Slice(JsValue thisObject, JsValue start, JsValue end)
     {
         var o = thisObject as JsArrayBuffer;
@@ -268,7 +268,7 @@ internal sealed partial class ArrayBufferPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-immutable-arraybuffer/#sec-arraybuffer.prototype.slicetoimmutable
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue SliceToImmutable(JsValue thisObject, JsValue start, JsValue end)
     {
         // 1. Let O be the this value.

--- a/Jint/Native/AsyncFunction/AsyncFunctionPrototype.cs
+++ b/Jint/Native/AsyncFunction/AsyncFunctionPrototype.cs
@@ -1,5 +1,4 @@
 using Jint.Native.Function;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
@@ -8,9 +7,14 @@ namespace Jint.Native.AsyncFunction;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-async-function-prototype-properties
 /// </summary>
-internal sealed class AsyncFunctionPrototype : Prototype
+[JsObject]
+internal sealed partial class AsyncFunctionPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly AsyncFunctionConstructor _constructor;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ToStringTagValue = new("AsyncFunction");
 
     public AsyncFunctionPrototype(
         Engine engine,
@@ -24,17 +28,7 @@ internal sealed class AsyncFunctionPrototype : Prototype
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            [KnownKeys.Constructor] = new(_constructor, PropertyFlag.NonEnumerable),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("AsyncFunction", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
-
 }

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorFunctionPrototype.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorFunctionPrototype.cs
@@ -1,6 +1,5 @@
-﻿using Jint.Native.Function;
+using Jint.Native.Function;
 using Jint.Native.Iterator;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
@@ -9,9 +8,17 @@ namespace Jint.Native.AsyncGenerator;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction-prototype
 /// </summary>
-internal sealed class AsyncGeneratorFunctionPrototype : Prototype
+[JsObject]
+internal sealed partial class AsyncGeneratorFunctionPrototype : Prototype
 {
-    private readonly AsyncGeneratorFunctionConstructor? _constructor;
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.Configurable)]
+    private readonly AsyncGeneratorFunctionConstructor _constructor;
+
+    [JsProperty(Name = "prototype", Flags = PropertyFlag.Configurable)]
+    private readonly AsyncGeneratorPrototype _prototypeObject;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ToStringTagValue = new("AsyncGeneratorFunction");
 
     internal AsyncGeneratorFunctionPrototype(
         Engine engine,
@@ -21,23 +28,14 @@ internal sealed class AsyncGeneratorFunctionPrototype : Prototype
     {
         _constructor = constructor;
         _prototype = prototype;
-        PrototypeObject = new AsyncGeneratorPrototype(engine, engine.Realm, this, asyncIteratorPrototype);
+        _prototypeObject = new AsyncGeneratorPrototype(engine, engine.Realm, this, asyncIteratorPrototype);
     }
 
-    public AsyncGeneratorPrototype PrototypeObject { get; }
+    public AsyncGeneratorPrototype PrototypeObject => _prototypeObject;
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            [KnownKeys.Constructor] = new PropertyDescriptor(_constructor, PropertyFlag.Configurable),
-            [KnownKeys.Prototype] = new PropertyDescriptor(PrototypeObject, PropertyFlag.Configurable)
-        };
-        SetProperties(properties);
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor("AsyncGeneratorFunction", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 }

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorPrototype.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorPrototype.cs
@@ -39,7 +39,7 @@ internal sealed partial class AsyncGeneratorPrototype : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Next(JsValue thisObject, JsValue value)
     {
         // Per spec: If generator is not valid, return a rejected promise
@@ -55,7 +55,7 @@ internal sealed partial class AsyncGeneratorPrototype : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-asyncgenerator-prototype-return
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Return(JsValue thisObject, JsValue value)
     {
         // Per spec: If generator is not valid, return a rejected promise
@@ -71,7 +71,7 @@ internal sealed partial class AsyncGeneratorPrototype : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-asyncgenerator-prototype-throw
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Throw(JsValue thisObject, JsValue exception)
     {
         // Per spec: If generator is not valid, return a rejected promise

--- a/Jint/Native/Atomics/AtomicsInstance.cs
+++ b/Jint/Native/Atomics/AtomicsInstance.cs
@@ -229,7 +229,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.add
     /// </summary>
-    [JsFunction(Length = 3)]
+    [JsFunction]
     private JsValue Add(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
         return AtomicReadModifyWrite(typedArray, index, value, AtomicOperation.Add);
@@ -238,7 +238,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.and
     /// </summary>
-    [JsFunction(Length = 3)]
+    [JsFunction]
     private JsValue And(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
         return AtomicReadModifyWrite(typedArray, index, value, AtomicOperation.And);
@@ -247,7 +247,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.compareexchange
     /// </summary>
-    [JsFunction(Length = 4)]
+    [JsFunction]
     private JsValue CompareExchange(JsValue thisObject, JsValue typedArray, JsValue index, JsValue expectedValue, JsValue replacementValue)
     {
         var taRecord = ValidateIntegerTypedArray(typedArray);
@@ -274,7 +274,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.exchange
     /// </summary>
-    [JsFunction(Length = 3)]
+    [JsFunction]
     private JsValue Exchange(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
         return AtomicReadModifyWrite(typedArray, index, value, AtomicOperation.Exchange);
@@ -283,7 +283,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.islockfree
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue IsLockFree(JsValue thisObject, JsValue size)
     {
         var n = TypeConverter.ToIntegerOrInfinity(size);
@@ -303,7 +303,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.load
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue Load(JsValue thisObject, JsValue typedArray, JsValue index)
     {
         var taRecord = ValidateIntegerTypedArray(typedArray);
@@ -317,7 +317,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.notify
     /// </summary>
-    [JsFunction(Length = 3)]
+    [JsFunction]
     private JsValue Notify(JsValue thisObject, JsValue typedArray, JsValue index, JsValue count)
     {
         var taRecord = ValidateIntegerTypedArray(typedArray, waitable: true);
@@ -366,7 +366,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.or
     /// </summary>
-    [JsFunction(Length = 3)]
+    [JsFunction]
     private JsValue Or(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
         return AtomicReadModifyWrite(typedArray, index, value, AtomicOperation.Or);
@@ -410,7 +410,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.store
     /// </summary>
-    [JsFunction(Length = 3)]
+    [JsFunction]
     private JsValue Store(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
         var taRecord = ValidateIntegerTypedArray(typedArray);
@@ -445,7 +445,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.sub
     /// </summary>
-    [JsFunction(Length = 3)]
+    [JsFunction]
     private JsValue Sub(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
         return AtomicReadModifyWrite(typedArray, index, value, AtomicOperation.Sub);
@@ -454,7 +454,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.wait
     /// </summary>
-    [JsFunction(Length = 4)]
+    [JsFunction]
     private JsValue Wait(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value, JsValue timeout)
     {
         var taRecord = ValidateIntegerTypedArray(typedArray, waitable: true, requireShared: true);
@@ -577,7 +577,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.waitasync
     /// </summary>
-    [JsFunction(Length = 4)]
+    [JsFunction]
     private JsValue WaitAsync(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value, JsValue timeout)
     {
         var taRecord = ValidateIntegerTypedArray(typedArray, waitable: true, requireShared: true);
@@ -696,7 +696,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-atomics.xor
     /// </summary>
-    [JsFunction(Length = 3)]
+    [JsFunction]
     private JsValue Xor(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
         return AtomicReadModifyWrite(typedArray, index, value, AtomicOperation.Xor);

--- a/Jint/Native/BigInt/BigIntConstructor.cs
+++ b/Jint/Native/BigInt/BigIntConstructor.cs
@@ -32,7 +32,7 @@ internal sealed partial class BigIntConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-bigint.asintn
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue AsIntN(JsValue thisObject, JsValue bitsValue, JsValue bigintValue)
     {
         var bits = (int) TypeConverter.ToIndex(_realm, bitsValue);
@@ -50,7 +50,7 @@ internal sealed partial class BigIntConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-bigint.asuintn
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue AsUintN(JsValue thisObject, JsValue bitsValue, JsValue bigintValue)
     {
         var bits = (int) TypeConverter.ToIndex(_realm, bitsValue);

--- a/Jint/Native/BigInt/BigIntPrototype.cs
+++ b/Jint/Native/BigInt/BigIntPrototype.cs
@@ -53,7 +53,7 @@ internal sealed partial class BigIntPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-bigint.prototype.valueof
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         if (thisObject is BigIntInstance ni)

--- a/Jint/Native/Boolean/BooleanPrototype.cs
+++ b/Jint/Native/Boolean/BooleanPrototype.cs
@@ -28,7 +28,7 @@ internal sealed partial class BooleanPrototype : BooleanInstance
 
     protected override void Initialize() => CreateProperties_Generated();
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         if (thisObject._type == InternalTypes.Boolean)
@@ -45,7 +45,7 @@ internal sealed partial class BooleanPrototype : BooleanInstance
         return Undefined;
     }
 
-    [JsFunction(Length = 0, Name = "toString")]
+    [JsFunction(Name = "toString")]
     private JsString ToBooleanString(JsValue thisObject)
     {
         var b = ValueOf(thisObject);

--- a/Jint/Native/DataView/DataViewPrototype.cs
+++ b/Jint/Native/DataView/DataViewPrototype.cs
@@ -128,7 +128,7 @@ internal sealed partial class DataViewPrototype : Prototype
     }
 
     // 1-byte reads have no endianness; spec passes byteOffset only and Length is 1.
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue GetInt8(JsValue thisObject, JsValue byteOffset)
     {
         return GetViewValue(thisObject, byteOffset, JsBoolean.True, TypedArrayElementType.Int8);
@@ -146,7 +146,7 @@ internal sealed partial class DataViewPrototype : Prototype
         return GetViewValue(thisObject, byteOffset, littleEndian, TypedArrayElementType.Int32);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue GetUint8(JsValue thisObject, JsValue byteOffset)
     {
         return GetViewValue(thisObject, byteOffset, JsBoolean.True, TypedArrayElementType.Uint8);
@@ -194,7 +194,7 @@ internal sealed partial class DataViewPrototype : Prototype
         return SetViewValue(thisObject, byteOffset, littleEndian, TypedArrayElementType.Float64, value);
     }
 
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue SetInt8(JsValue thisObject, JsValue byteOffset, JsValue value)
     {
         return SetViewValue(thisObject, byteOffset, JsBoolean.True, TypedArrayElementType.Int8, value);
@@ -212,7 +212,7 @@ internal sealed partial class DataViewPrototype : Prototype
         return SetViewValue(thisObject, byteOffset, littleEndian, TypedArrayElementType.Int32, value);
     }
 
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue SetUint8(JsValue thisObject, JsValue byteOffset, JsValue value)
     {
         return SetViewValue(thisObject, byteOffset, JsBoolean.True, TypedArrayElementType.Uint8, value);

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -87,7 +87,7 @@ internal sealed partial class DateConstructor : Constructor
         return finalDate.TimeClip().ToJsValue();
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Now(JsValue thisObject, JsCallArguments arguments)
     {
         return (long) (_timeSystem.GetUtcNow().DateTime - Epoch).TotalMilliseconds;

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -88,14 +88,14 @@ internal sealed partial class DateConstructor : Constructor
     }
 
     [JsFunction]
-    private JsValue Now(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Now(JsValue thisObject)
     {
         return (long) (_timeSystem.GetUtcNow().DateTime - Epoch).TotalMilliseconds;
     }
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
-        return PrototypeObject.ToString(Construct(Arguments.Empty, thisObject), Arguments.Empty);
+        return PrototypeObject.ToString(Construct(Arguments.Empty, thisObject));
     }
 
     /// <summary>

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -89,7 +89,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ValueOf(JsValue thisObject)
     {
         return ThisTimeValue(thisObject).ToJsValue();
     }
@@ -112,7 +112,7 @@ internal sealed partial class DatePrototype : Prototype
     /// https://tc39.es/ecma262/#sec-date.prototype.tostring
     /// </summary>
     [JsFunction]
-    internal JsValue ToString(JsValue thisObject, JsCallArguments arguments)
+    internal JsValue ToString(JsValue thisObject)
     {
         var tv = ThisTimeValue(thisObject);
         return ToDateString(tv);
@@ -122,7 +122,7 @@ internal sealed partial class DatePrototype : Prototype
     /// https://tc39.es/ecma262/#sec-date.prototype.todatestring
     /// </summary>
     [JsFunction]
-    private JsValue ToDateString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToDateString(JsValue thisObject)
     {
         var tv = ThisTimeValue(thisObject);
 
@@ -153,7 +153,7 @@ internal sealed partial class DatePrototype : Prototype
     /// https://tc39.es/ecma262/#sec-date.prototype.totimestring
     /// </summary>
     [JsFunction]
-    private JsValue ToTimeString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToTimeString(JsValue thisObject)
     {
         var tv = ThisTimeValue(thisObject);
 
@@ -357,7 +357,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetTime(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetTime(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -368,7 +368,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetFullYear(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetFullYear(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -379,7 +379,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetYear(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetYear(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -390,7 +390,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetUTCFullYear(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetUTCFullYear(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -401,7 +401,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetMonth(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetMonth(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -415,7 +415,7 @@ internal sealed partial class DatePrototype : Prototype
     /// https://tc39.es/ecma262/#sec-date.prototype.getutcmonth
     /// </summary>
     [JsFunction]
-    private JsValue GetUTCMonth(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetUTCMonth(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -429,7 +429,7 @@ internal sealed partial class DatePrototype : Prototype
     /// https://tc39.es/ecma262/#sec-date.prototype.getdate
     /// </summary>
     [JsFunction]
-    private JsValue GetDate(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetDate(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -440,7 +440,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetUTCDate(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetUTCDate(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -451,7 +451,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetDay(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetDay(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -462,7 +462,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetUTCDay(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetUTCDay(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -473,7 +473,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetHours(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetHours(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -484,7 +484,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetUTCHours(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetUTCHours(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -495,7 +495,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetMinutes(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetMinutes(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -506,7 +506,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetUTCMinutes(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetUTCMinutes(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -517,7 +517,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetSeconds(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetSeconds(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -528,7 +528,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetUTCSeconds(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetUTCSeconds(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -539,7 +539,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetMilliseconds(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetMilliseconds(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -550,7 +550,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetUTCMilliseconds(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetUTCMilliseconds(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -561,7 +561,7 @@ internal sealed partial class DatePrototype : Prototype
     }
 
     [JsFunction]
-    private JsValue GetTimezoneOffset(JsValue thisObject, JsCallArguments arguments)
+    private JsValue GetTimezoneOffset(JsValue thisObject)
     {
         var t = ThisTimeValue(thisObject);
         if (t.IsNaN)
@@ -906,7 +906,7 @@ internal sealed partial class DatePrototype : Prototype
     /// https://tc39.es/ecma262/#sec-date.prototype.toutcstring
     /// </summary>
     [JsFunction(Name = "toUTCString")]
-    private JsValue ToUtcString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToUtcString(JsValue thisObject)
     {
         var tv = ThisTimeValue(thisObject);
         if (!IsFinite(tv))
@@ -927,7 +927,7 @@ internal sealed partial class DatePrototype : Prototype
     /// https://tc39.es/ecma262/#sec-date.prototype.toisostring
     /// </summary>
     [JsFunction]
-    private JsValue ToISOString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToISOString(JsValue thisObject)
     {
         var thisTime = ThisTimeValue(thisObject);
         var t = thisTime;
@@ -981,7 +981,7 @@ internal sealed partial class DatePrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-date.prototype.totemporalinstant
     /// </summary>
     [JsFunction]
-    private JsValue ToTemporalInstant(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToTemporalInstant(JsValue thisObject)
     {
         // 1. Let dateObject be the this value.
         // 2. Perform ? RequireInternalSlot(dateObject, [[DateValue]]).

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -88,7 +88,7 @@ internal sealed partial class DatePrototype : Prototype
         return TypeConverter.OrdinaryToPrimitive(oi, tryFirst);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
     {
         return ThisTimeValue(thisObject).ToJsValue();
@@ -111,7 +111,7 @@ internal sealed partial class DatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-date.prototype.tostring
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     internal JsValue ToString(JsValue thisObject, JsCallArguments arguments)
     {
         var tv = ThisTimeValue(thisObject);
@@ -121,7 +121,7 @@ internal sealed partial class DatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-date.prototype.todatestring
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToDateString(JsValue thisObject, JsCallArguments arguments)
     {
         var tv = ThisTimeValue(thisObject);
@@ -152,7 +152,7 @@ internal sealed partial class DatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-date.prototype.totimestring
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToTimeString(JsValue thisObject, JsCallArguments arguments)
     {
         var tv = ThisTimeValue(thisObject);
@@ -171,7 +171,7 @@ internal sealed partial class DatePrototype : Prototype
     /// https://tc39.es/ecma262/#sec-date.prototype.tolocalestring
     /// https://tc39.es/ecma402/#sup-date.prototype.tolocalestring
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
         var dateInstance = ThisTimeValue(thisObject);
@@ -214,7 +214,7 @@ internal sealed partial class DatePrototype : Prototype
     /// https://tc39.es/ecma262/#sec-date.prototype.tolocaledatestring
     /// https://tc39.es/ecma402/#sup-date.prototype.tolocaledatestring
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToLocaleDateString(JsValue thisObject, JsCallArguments arguments)
     {
         var dateInstance = ThisTimeValue(thisObject);
@@ -254,7 +254,7 @@ internal sealed partial class DatePrototype : Prototype
     /// https://tc39.es/ecma262/#sec-date.prototype.tolocaletimestring
     /// https://tc39.es/ecma402/#sup-date.prototype.tolocaletimestring
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToLocaleTimeString(JsValue thisObject, JsCallArguments arguments)
     {
         var dateInstance = ThisTimeValue(thisObject);
@@ -356,7 +356,7 @@ internal sealed partial class DatePrototype : Prototype
         }
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetTime(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -367,7 +367,7 @@ internal sealed partial class DatePrototype : Prototype
         return t.ToJsValue();
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetFullYear(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -378,7 +378,7 @@ internal sealed partial class DatePrototype : Prototype
         return YearFromTime(LocalTime(t));
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetYear(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -389,7 +389,7 @@ internal sealed partial class DatePrototype : Prototype
         return YearFromTime(LocalTime(t)) - 1900;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetUTCFullYear(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -400,7 +400,7 @@ internal sealed partial class DatePrototype : Prototype
         return YearFromTime(t);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetMonth(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -414,7 +414,7 @@ internal sealed partial class DatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-date.prototype.getutcmonth
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetUTCMonth(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -428,7 +428,7 @@ internal sealed partial class DatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-date.prototype.getdate
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetDate(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -439,7 +439,7 @@ internal sealed partial class DatePrototype : Prototype
         return DateFromTime(LocalTime(t));
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetUTCDate(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -450,7 +450,7 @@ internal sealed partial class DatePrototype : Prototype
         return DateFromTime(t);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetDay(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -461,7 +461,7 @@ internal sealed partial class DatePrototype : Prototype
         return WeekDay(LocalTime(t));
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetUTCDay(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -472,7 +472,7 @@ internal sealed partial class DatePrototype : Prototype
         return WeekDay(t);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetHours(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -483,7 +483,7 @@ internal sealed partial class DatePrototype : Prototype
         return HourFromTime(LocalTime(t));
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetUTCHours(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -494,7 +494,7 @@ internal sealed partial class DatePrototype : Prototype
         return HourFromTime(t);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetMinutes(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -505,7 +505,7 @@ internal sealed partial class DatePrototype : Prototype
         return MinFromTime(LocalTime(t));
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetUTCMinutes(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -516,7 +516,7 @@ internal sealed partial class DatePrototype : Prototype
         return MinFromTime(t);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetSeconds(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -527,7 +527,7 @@ internal sealed partial class DatePrototype : Prototype
         return SecFromTime(LocalTime(t));
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetUTCSeconds(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -538,7 +538,7 @@ internal sealed partial class DatePrototype : Prototype
         return SecFromTime(t);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetMilliseconds(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -549,7 +549,7 @@ internal sealed partial class DatePrototype : Prototype
         return MsFromTime(LocalTime(t));
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetUTCMilliseconds(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -560,7 +560,7 @@ internal sealed partial class DatePrototype : Prototype
         return MsFromTime(t);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetTimezoneOffset(JsValue thisObject, JsCallArguments arguments)
     {
         var t = ThisTimeValue(thisObject);
@@ -905,7 +905,7 @@ internal sealed partial class DatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-date.prototype.toutcstring
     /// </summary>
-    [JsFunction(Length = 0, Name = "toUTCString")]
+    [JsFunction(Name = "toUTCString")]
     private JsValue ToUtcString(JsValue thisObject, JsCallArguments arguments)
     {
         var tv = ThisTimeValue(thisObject);
@@ -926,7 +926,7 @@ internal sealed partial class DatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-date.prototype.toisostring
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToISOString(JsValue thisObject, JsCallArguments arguments)
     {
         var thisTime = ThisTimeValue(thisObject);
@@ -980,7 +980,7 @@ internal sealed partial class DatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-date.prototype.totemporalinstant
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToTemporalInstant(JsValue thisObject, JsCallArguments arguments)
     {
         // 1. Let dateObject be the this value.

--- a/Jint/Native/Disposable/AsyncDisposableStackPrototype.cs
+++ b/Jint/Native/Disposable/AsyncDisposableStackPrototype.cs
@@ -35,14 +35,14 @@ internal sealed partial class AsyncDisposableStackPrototype : Prototype
         SetProperty(GlobalSymbolRegistry.AsyncDispose, GetOwnProperty("disposeAsync"));
     }
 
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue Adopt(JsValue thisObject, JsValue value, JsValue onDispose)
     {
         var stack = AssertDisposableStack(thisObject);
         return stack.Adopt(value, onDispose);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Defer(JsValue thisObject, JsValue onDispose)
     {
         var stack = AssertDisposableStack(thisObject);
@@ -50,7 +50,7 @@ internal sealed partial class AsyncDisposableStackPrototype : Prototype
         return Undefined;
     }
 
-    [JsFunction(Length = 0, Name = "disposeAsync")]
+    [JsFunction(Name = "disposeAsync")]
     private JsValue Dispose(JsValue thisObject)
     {
         // Per spec: create promise capability first, then validate receiver.
@@ -76,7 +76,7 @@ internal sealed partial class AsyncDisposableStackPrototype : Prototype
         return stack.State == DisposableState.Disposed ? JsBoolean.True : JsBoolean.False;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Move(JsValue thisObject)
     {
         var stack = AssertDisposableStack(thisObject);
@@ -88,7 +88,7 @@ internal sealed partial class AsyncDisposableStackPrototype : Prototype
         return stack.Move(newDisposableStack);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Use(JsValue thisObject, JsValue value)
     {
         var stack = AssertDisposableStack(thisObject);

--- a/Jint/Native/Disposable/DisposableStackPrototype.cs
+++ b/Jint/Native/Disposable/DisposableStackPrototype.cs
@@ -34,14 +34,14 @@ internal sealed partial class DisposableStackPrototype : Prototype
         SetProperty(GlobalSymbolRegistry.Dispose, GetOwnProperty("dispose"));
     }
 
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue Adopt(JsValue thisObject, JsValue value, JsValue onDispose)
     {
         var stack = AssertDisposableStack(thisObject);
         return stack.Adopt(value, onDispose);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Defer(JsValue thisObject, JsValue onDispose)
     {
         var stack = AssertDisposableStack(thisObject);
@@ -49,7 +49,7 @@ internal sealed partial class DisposableStackPrototype : Prototype
         return Undefined;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Dispose(JsValue thisObject)
     {
         var stack = AssertDisposableStack(thisObject);
@@ -63,7 +63,7 @@ internal sealed partial class DisposableStackPrototype : Prototype
         return stack.State == DisposableState.Disposed ? JsBoolean.True : JsBoolean.False;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Move(JsValue thisObject)
     {
         var stack = AssertDisposableStack(thisObject);
@@ -75,7 +75,7 @@ internal sealed partial class DisposableStackPrototype : Prototype
         return stack.Move(newDisposableStack);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Use(JsValue thisObject, JsValue value)
     {
         var stack = AssertDisposableStack(thisObject);

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -90,6 +90,6 @@ public sealed partial class ErrorConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-is-error/
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue IsError(JsValue thisObject, JsValue arg) => arg is JsError;
 }

--- a/Jint/Native/Error/ErrorPrototype.cs
+++ b/Jint/Native/Error/ErrorPrototype.cs
@@ -37,7 +37,7 @@ internal sealed partial class ErrorPrototype : ErrorInstance
 
     protected override void Initialize() => CreateProperties_Generated();
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     public JsValue ToString(JsValue thisObject)
     {
         var o = thisObject.TryCast<ObjectInstance>();

--- a/Jint/Native/FinalizationRegistry/FinalizationRegistryPrototype.cs
+++ b/Jint/Native/FinalizationRegistry/FinalizationRegistryPrototype.cs
@@ -65,7 +65,7 @@ internal sealed partial class FinalizationRegistryPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Unregister(JsValue thisObject, JsValue unregisterToken)
     {
         var finalizationRegistry = AssertFinalizationRegistryInstance(thisObject);

--- a/Jint/Native/Function/FunctionPrototype.cs
+++ b/Jint/Native/Function/FunctionPrototype.cs
@@ -119,7 +119,7 @@ internal sealed partial class FunctionPrototype : Function
     /// <summary>
     /// https://tc39.es/ecma262/#sec-function.prototype.tostring
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToString(JsValue thisObject)
     {
         if (thisObject.IsObject() && thisObject.IsCallable)
@@ -134,7 +134,7 @@ internal sealed partial class FunctionPrototype : Function
     /// <summary>
     /// https://tc39.es/ecma262/#sec-function.prototype.apply
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue Apply(ICallable thisObject, JsValue thisArg, JsValue argArray)
     {
         if (argArray.IsNullOrUndefined())

--- a/Jint/Native/Generator/GeneratorFunctionPrototype.cs
+++ b/Jint/Native/Generator/GeneratorFunctionPrototype.cs
@@ -1,6 +1,5 @@
-﻿using Jint.Native.Function;
+using Jint.Native.Function;
 using Jint.Native.Iterator;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
@@ -9,9 +8,17 @@ namespace Jint.Native.Generator;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-prototype-object
 /// </summary>
-internal sealed class GeneratorFunctionPrototype : Prototype
+[JsObject]
+internal sealed partial class GeneratorFunctionPrototype : Prototype
 {
-    private readonly GeneratorFunctionConstructor? _constructor;
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.Configurable)]
+    private readonly GeneratorFunctionConstructor _constructor;
+
+    [JsProperty(Name = "prototype", Flags = PropertyFlag.Configurable)]
+    private readonly GeneratorPrototype _prototypeObject;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ToStringTagValue = new("GeneratorFunction");
 
     internal GeneratorFunctionPrototype(
         Engine engine,
@@ -21,23 +28,14 @@ internal sealed class GeneratorFunctionPrototype : Prototype
     {
         _constructor = constructor;
         _prototype = prototype;
-        PrototypeObject = new GeneratorPrototype(engine, engine.Realm, this, iteratorPrototype);
+        _prototypeObject = new GeneratorPrototype(engine, engine.Realm, this, iteratorPrototype);
     }
 
-    public GeneratorPrototype PrototypeObject { get; }
+    public GeneratorPrototype PrototypeObject => _prototypeObject;
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            [KnownKeys.Constructor] = new PropertyDescriptor(_constructor, PropertyFlag.Configurable),
-            [KnownKeys.Prototype] = new PropertyDescriptor(PrototypeObject, PropertyFlag.Configurable)
-        };
-        SetProperties(properties);
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new PropertyDescriptor("GeneratorFunction", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 }

--- a/Jint/Native/Generator/GeneratorPrototype.cs
+++ b/Jint/Native/Generator/GeneratorPrototype.cs
@@ -38,7 +38,7 @@ internal sealed partial class GeneratorPrototype : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-generator.prototype.next
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private ObjectInstance Next(JsValue thisObject, JsValue value)
     {
         var g = AssertGeneratorInstance(thisObject);
@@ -48,7 +48,7 @@ internal sealed partial class GeneratorPrototype : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-generator.prototype.return
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Return(JsValue thisObject, JsValue value)
     {
         var g = AssertGeneratorInstance(thisObject);
@@ -59,7 +59,7 @@ internal sealed partial class GeneratorPrototype : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-generator.prototype.throw
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Throw(JsValue thisObject, JsValue exception)
     {
         var g = AssertGeneratorInstance(thisObject);

--- a/Jint/Native/Intl/CollatorPrototype.cs
+++ b/Jint/Native/Intl/CollatorPrototype.cs
@@ -64,7 +64,7 @@ internal sealed partial class CollatorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.collator.prototype.resolvedoptions
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsObject ResolvedOptions(JsValue thisObject)
     {
         var collator = ValidateCollator(thisObject);

--- a/Jint/Native/Intl/DateTimeFormatPrototype.cs
+++ b/Jint/Native/Intl/DateTimeFormatPrototype.cs
@@ -76,7 +76,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.formattoparts
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsArray FormatToParts(JsValue thisObject, JsValue dateValue)
     {
         var dateTimeFormat = ValidateDateTimeFormat(thisObject);
@@ -752,7 +752,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.resolvedoptions
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsObject ResolvedOptions(JsValue thisObject)
     {
         var dateTimeFormat = ValidateDateTimeFormat(thisObject);
@@ -874,7 +874,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.formatrange
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue FormatRange(JsValue thisObject, JsValue startDate, JsValue endDate)
     {
         var dateTimeFormat = ValidateDateTimeFormat(thisObject);
@@ -962,7 +962,7 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.formatrangetoparts
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsArray FormatRangeToParts(JsValue thisObject, JsValue startDate, JsValue endDate)
     {
         var dateTimeFormat = ValidateDateTimeFormat(thisObject);

--- a/Jint/Native/Intl/DisplayNamesPrototype.cs
+++ b/Jint/Native/Intl/DisplayNamesPrototype.cs
@@ -45,7 +45,7 @@ internal sealed partial class DisplayNamesPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.displaynames.prototype.of
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Of(JsValue thisObject, JsValue code)
     {
         var displayNames = ValidateDisplayNames(thisObject);
@@ -387,7 +387,7 @@ internal sealed partial class DisplayNamesPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.displaynames.prototype.resolvedoptions
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsObject ResolvedOptions(JsValue thisObject)
     {
         var displayNames = ValidateDisplayNames(thisObject);

--- a/Jint/Native/Intl/DurationFormatPrototype.cs
+++ b/Jint/Native/Intl/DurationFormatPrototype.cs
@@ -47,7 +47,7 @@ internal sealed partial class DurationFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-intl-duration-format/#sec-intl.durationformat.prototype.format
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Format(JsValue thisObject, JsValue duration)
     {
         var durationFormat = ValidateDurationFormat(thisObject);
@@ -58,7 +58,7 @@ internal sealed partial class DurationFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-intl-duration-format/#sec-intl.durationformat.prototype.formattoparts
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsArray FormatToParts(JsValue thisObject, JsValue duration)
     {
         var durationFormat = ValidateDurationFormat(thisObject);
@@ -69,7 +69,7 @@ internal sealed partial class DurationFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-intl-duration-format/#sec-intl.durationformat.prototype.resolvedoptions
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsObject ResolvedOptions(JsValue thisObject)
     {
         var durationFormat = ValidateDurationFormat(thisObject);

--- a/Jint/Native/Intl/IntlInstance.cs
+++ b/Jint/Native/Intl/IntlInstance.cs
@@ -55,7 +55,7 @@ internal sealed partial class IntlInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.getcanonicallocales
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsArray GetCanonicalLocales(JsValue thisObject, JsValue locales)
     {
         return new JsArray(_engine, IntlUtilities.CanonicalizeLocaleList(_engine, locales).Select(x => new JsString(x)).ToArray<JsValue>());
@@ -64,7 +64,7 @@ internal sealed partial class IntlInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.supportedvaluesof
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue SupportedValuesOf(JsValue thisObject, JsValue keyArg)
     {
         var key = TypeConverter.ToString(keyArg);

--- a/Jint/Native/Intl/JsSegments.cs
+++ b/Jint/Native/Intl/JsSegments.cs
@@ -1,10 +1,8 @@
 using System.Globalization;
 using Jint.Native.Iterator;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Intl;
 
@@ -12,14 +10,17 @@ namespace Jint.Native.Intl;
 /// https://tc39.es/ecma402/#sec-segments-objects
 /// Represents the Segments object returned by Intl.Segmenter.prototype.segment().
 /// </summary>
-internal sealed class JsSegments : ObjectInstance
+[JsObject]
+internal sealed partial class JsSegments : ObjectInstance
 {
+    private readonly Realm _realm;
     private readonly JsSegmenter _segmenter;
     private readonly string _input;
     private readonly List<SegmentData> _segments;
 
     internal JsSegments(Engine engine, JsSegmenter segmenter, string input) : base(engine)
     {
+        _realm = engine.Realm;
         _segmenter = segmenter;
         _input = input;
         _segments = ComputeSegments(input, segmenter.Granularity);
@@ -27,59 +28,40 @@ internal sealed class JsSegments : ObjectInstance
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(1, checkExistingKeys: false)
-        {
-            ["containing"] = new PropertyDescriptor(new ClrFunction(_engine, "containing", Containing, 1, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable)
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.Iterator] = new PropertyDescriptor(new ClrFunction(_engine, "[Symbol.iterator]", GetIterator, 0, PropertyFlag.Configurable), PropertyFlag.Writable | PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/ecma402/#sec-%segmentsprototype%.containing
     /// </summary>
-    private JsValue Containing(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private static JsValue Containing(JsSegments thisObject, [ToInteger] double n)
     {
-        // 1. Let segments be the this value.
-        // 2. Perform ? RequireInternalSlot(segments, [[SegmentsSegmenter]]).
-        if (thisObject is not JsSegments segments)
+        if (n < 0 || n >= thisObject._input.Length)
         {
-            Throw.TypeError(_engine.Realm, "containing requires a Segments object");
-            return JsValue.Undefined;
+            return Undefined;
         }
 
-        var index = arguments.At(0);
-        var n = TypeConverter.ToInteger(index);
-
-        if (n < 0 || n >= segments._input.Length)
-        {
-            return JsValue.Undefined;
-        }
-
-        // Find the segment containing this index
         var intIndex = (int) n;
-        foreach (var segment in segments._segments)
+        foreach (var segment in thisObject._segments)
         {
             if (intIndex >= segment.Index && intIndex < segment.Index + segment.Segment.Length)
             {
-                return segments.CreateSegmentDataObject(segment);
+                return thisObject.CreateSegmentDataObject(segment);
             }
         }
 
-        return JsValue.Undefined;
+        return Undefined;
     }
 
     /// <summary>
     /// https://tc39.es/ecma402/#sec-%segmentsprototype%-@@iterator
     /// </summary>
-    private SegmentIterator GetIterator(JsValue thisObject, JsCallArguments arguments)
+    [JsSymbolFunction("Iterator", Flags = PropertyFlag.Writable | PropertyFlag.Configurable)]
+    private static SegmentIterator GetIterator(JsSegments thisObject)
     {
-        return new SegmentIterator(_engine, this);
+        return new SegmentIterator(thisObject._engine, thisObject);
     }
 
     internal IEnumerable<SegmentData> GetSegments() => _segments;

--- a/Jint/Native/Intl/ListFormatPrototype.cs
+++ b/Jint/Native/Intl/ListFormatPrototype.cs
@@ -46,7 +46,7 @@ internal sealed partial class ListFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.listformat.prototype.format
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Format(JsValue thisObject, JsValue list)
     {
         var listFormat = ValidateListFormat(thisObject);
@@ -57,7 +57,7 @@ internal sealed partial class ListFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.listformat.prototype.formattoparts
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsArray FormatToParts(JsValue thisObject, JsValue list)
     {
         var listFormat = ValidateListFormat(thisObject);
@@ -68,7 +68,7 @@ internal sealed partial class ListFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.listformat.prototype.resolvedoptions
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsObject ResolvedOptions(JsValue thisObject)
     {
         var listFormat = ValidateListFormat(thisObject);

--- a/Jint/Native/Intl/LocalePrototype.cs
+++ b/Jint/Native/Intl/LocalePrototype.cs
@@ -45,7 +45,7 @@ internal sealed partial class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.maximize
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private ObjectInstance Maximize(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
@@ -60,7 +60,7 @@ internal sealed partial class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.minimize
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private ObjectInstance Minimize(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
@@ -74,7 +74,7 @@ internal sealed partial class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
     /// </summary>
-    [JsFunction(Length = 0, Name = "toString")]
+    [JsFunction(Name = "toString")]
     private JsValue ToLocaleString(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
@@ -187,7 +187,7 @@ internal sealed partial class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getCalendars
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsArray GetCalendars(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
@@ -202,7 +202,7 @@ internal sealed partial class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getCollations
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsArray GetCollations(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
@@ -216,7 +216,7 @@ internal sealed partial class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getHourCycles
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsArray GetHourCycles(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
@@ -236,7 +236,7 @@ internal sealed partial class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getNumberingSystems
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsArray GetNumberingSystems(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
@@ -251,7 +251,7 @@ internal sealed partial class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getTimeZones
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue GetTimeZones(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
@@ -293,7 +293,7 @@ internal sealed partial class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getTextInfo
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsObject GetTextInfo(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);
@@ -312,7 +312,7 @@ internal sealed partial class LocalePrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getWeekInfo
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsObject GetWeekInfo(JsValue thisObject)
     {
         var locale = ValidateLocale(thisObject);

--- a/Jint/Native/Intl/NumberFormatPrototype.cs
+++ b/Jint/Native/Intl/NumberFormatPrototype.cs
@@ -194,7 +194,7 @@ internal sealed partial class NumberFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.numberformat.prototype.resolvedoptions
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsObject ResolvedOptions(JsValue thisObject)
     {
         var numberFormat = ValidateNumberFormat(thisObject);
@@ -262,7 +262,7 @@ internal sealed partial class NumberFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formattoparts
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsArray FormatToParts(JsValue thisObject, JsValue value)
     {
         var numberFormat = ValidateNumberFormat(thisObject);
@@ -296,7 +296,7 @@ internal sealed partial class NumberFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formatrange
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue FormatRange(JsValue thisObject, JsValue start, JsValue end)
     {
         var numberFormat = ValidateNumberFormat(thisObject);
@@ -479,7 +479,7 @@ internal sealed partial class NumberFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formatrangetoparts
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsArray FormatRangeToParts(JsValue thisObject, JsValue start, JsValue end)
     {
         var numberFormat = ValidateNumberFormat(thisObject);

--- a/Jint/Native/Intl/PluralRulesPrototype.cs
+++ b/Jint/Native/Intl/PluralRulesPrototype.cs
@@ -45,7 +45,7 @@ internal sealed partial class PluralRulesPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.select
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Select(JsValue thisObject, JsValue n)
     {
         var pluralRules = ValidatePluralRules(thisObject);
@@ -56,7 +56,7 @@ internal sealed partial class PluralRulesPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.selectrange
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue SelectRange(JsValue thisObject, JsValue start, JsValue end)
     {
         var pluralRules = ValidatePluralRules(thisObject);
@@ -87,7 +87,7 @@ internal sealed partial class PluralRulesPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.resolvedoptions
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsObject ResolvedOptions(JsValue thisObject)
     {
         var pluralRules = ValidatePluralRules(thisObject);

--- a/Jint/Native/Intl/RelativeTimeFormatPrototype.cs
+++ b/Jint/Native/Intl/RelativeTimeFormatPrototype.cs
@@ -47,7 +47,7 @@ internal sealed partial class RelativeTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.format
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue Format(JsValue thisObject, JsValue value, JsValue unit)
     {
         var relativeTimeFormat = ValidateRelativeTimeFormat(thisObject);
@@ -71,7 +71,7 @@ internal sealed partial class RelativeTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.formattoparts
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsArray FormatToParts(JsValue thisObject, JsValue value, JsValue unit)
     {
         var relativeTimeFormat = ValidateRelativeTimeFormat(thisObject);
@@ -95,7 +95,7 @@ internal sealed partial class RelativeTimeFormatPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.resolvedoptions
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsObject ResolvedOptions(JsValue thisObject)
     {
         var relativeTimeFormat = ValidateRelativeTimeFormat(thisObject);

--- a/Jint/Native/Intl/SegmenterPrototype.cs
+++ b/Jint/Native/Intl/SegmenterPrototype.cs
@@ -45,7 +45,7 @@ internal sealed partial class SegmenterPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.segmenter.prototype.segment
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsSegments Segment(JsValue thisObject, JsValue input)
     {
         var segmenter = ValidateSegmenter(thisObject);
@@ -56,7 +56,7 @@ internal sealed partial class SegmenterPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma402/#sec-intl.segmenter.prototype.resolvedoptions
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsObject ResolvedOptions(JsValue thisObject)
     {
         var segmenter = ValidateSegmenter(thisObject);

--- a/Jint/Native/Iterator/AsyncFromSyncIterator.cs
+++ b/Jint/Native/Iterator/AsyncFromSyncIterator.cs
@@ -26,7 +26,8 @@ internal sealed class AsyncFromSyncIterator : ObjectInstance
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%-object
 /// </summary>
-internal sealed class AsyncFromSyncIteratorPrototype : ObjectInstance
+[JsObject]
+internal sealed partial class AsyncFromSyncIteratorPrototype : ObjectInstance
 {
     private readonly Realm _realm;
 
@@ -36,37 +37,23 @@ internal sealed class AsyncFromSyncIteratorPrototype : ObjectInstance
         _prototype = asyncIteratorPrototype;
     }
 
-    protected override void Initialize()
-    {
-        var properties = new PropertyDictionary(3, checkExistingKeys: false)
-        {
-            [KnownKeys.Next] = new PropertyDescriptor(new ClrFunction(_engine, "next", Next, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            [KnownKeys.Return] = new PropertyDescriptor(new ClrFunction(_engine, "return", Return, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-            [KnownKeys.Throw] = new PropertyDescriptor(new ClrFunction(_engine, "throw", Throw, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.next
     /// </summary>
-    private JsValue Next(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Next(AsyncFromSyncIterator thisObject, JsValue[] arguments)
     {
-        var asyncIterator = thisObject as AsyncFromSyncIterator;
-        if (asyncIterator is null)
-        {
-            Runtime.Throw.TypeError(_realm, "Method called on incompatible receiver");
-        }
-
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _realm.Intrinsics.Promise);
-        var syncIterator = asyncIterator!.SyncIterator;
+        var syncIterator = thisObject.SyncIterator;
         var value = arguments.At(0);
 
         ObjectInstance result;
         try
         {
-            // Per spec step 5: Let nextResult be IteratorNext(syncIteratorRecord, value).
-            // Uses the cached [[NextMethod]] from the iterator record and forwards the value.
+            // Per spec step 5: "If value is present" — distinguish 0-arg call from 1-arg call so the
+            // wrapped sync iterator's next receives the same argument count.
             result = syncIterator.IteratorNext(arguments.Length > 0 ? value : null);
         }
         catch (JavaScriptException e)
@@ -81,16 +68,11 @@ internal sealed class AsyncFromSyncIteratorPrototype : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.return
     /// </summary>
-    private JsValue Return(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Return(AsyncFromSyncIterator thisObject, JsValue[] arguments)
     {
-        var asyncIterator = thisObject as AsyncFromSyncIterator;
-        if (asyncIterator is null)
-        {
-            Runtime.Throw.TypeError(_realm, "Method called on incompatible receiver");
-        }
-
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _realm.Intrinsics.Promise);
-        var syncIterator = asyncIterator!.SyncIterator;
+        var syncIterator = thisObject.SyncIterator;
         var value = arguments.At(0);
 
         // Get the return method from the sync iterator (IfAbruptRejectPromise)
@@ -138,16 +120,11 @@ internal sealed class AsyncFromSyncIteratorPrototype : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.throw
     /// </summary>
-    private JsValue Throw(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Throw(AsyncFromSyncIterator thisObject, JsValue[] arguments)
     {
-        var asyncIterator = thisObject as AsyncFromSyncIterator;
-        if (asyncIterator is null)
-        {
-            Runtime.Throw.TypeError(_realm, "Method called on incompatible receiver");
-        }
-
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _realm.Intrinsics.Promise);
-        var syncIterator = asyncIterator!.SyncIterator;
+        var syncIterator = thisObject.SyncIterator;
         var value = arguments.At(0);
 
         // Get the throw method from the sync iterator (IfAbruptRejectPromise)

--- a/Jint/Native/Iterator/AsyncIteratorConstructor.cs
+++ b/Jint/Native/Iterator/AsyncIteratorConstructor.cs
@@ -49,7 +49,7 @@ internal sealed partial class AsyncIteratorConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-asynciterator.from
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue From(JsValue thisObject, JsValue o)
     {
         // 1. If O is not an Object, throw a TypeError exception.
@@ -152,7 +152,7 @@ internal sealed partial class WrapForValidAsyncIteratorPrototype : Prototype
     /// %WrapForValidAsyncIteratorPrototype%.next()
     /// Delegates to the underlying iterator's next() and wraps in a promise.
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Next(JsValue thisObject)
     {
         if (thisObject is not WrapForValidAsyncIterator wrapper)
@@ -203,7 +203,7 @@ internal sealed partial class WrapForValidAsyncIteratorPrototype : Prototype
     /// <summary>
     /// %WrapForValidAsyncIteratorPrototype%.return()
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Return(JsValue thisObject)
     {
         if (thisObject is not WrapForValidAsyncIterator wrapper)

--- a/Jint/Native/Iterator/AsyncIteratorHelperPrototype.cs
+++ b/Jint/Native/Iterator/AsyncIteratorHelperPrototype.cs
@@ -23,7 +23,7 @@ internal sealed partial class AsyncIteratorHelperPrototype : Prototype
     /// <summary>
     /// %AsyncIteratorHelperPrototype%.next()
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Next(JsValue thisObject)
     {
         if (thisObject is AsyncIteratorHelper helper)
@@ -38,7 +38,7 @@ internal sealed partial class AsyncIteratorHelperPrototype : Prototype
     /// <summary>
     /// %AsyncIteratorHelperPrototype%.return()
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Return(JsValue thisObject)
     {
         if (thisObject is AsyncIteratorHelper helper)

--- a/Jint/Native/Iterator/AsyncIteratorPrototype.cs
+++ b/Jint/Native/Iterator/AsyncIteratorPrototype.cs
@@ -363,35 +363,35 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
 
     // ---- Helper-returning methods ----
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private AsyncMapIterator Map(JsValue thisObject, JsValue mapperArg)
     {
         var o = ValidateThisAndGetCallable(thisObject, mapperArg, "map", out var mapper);
         return new AsyncMapIterator(_engine, GetIteratorDirect(o), mapper);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private AsyncFilterIterator Filter(JsValue thisObject, JsValue predicateArg)
     {
         var o = ValidateThisAndGetCallable(thisObject, predicateArg, "filter", out var predicate);
         return new AsyncFilterIterator(_engine, GetIteratorDirect(o), predicate);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private AsyncTakeIterator Take(JsValue thisObject, JsValue limitArg)
     {
         var o = ValidateThisAndGetLimit(thisObject, limitArg, "take", out var limit);
         return new AsyncTakeIterator(_engine, GetIteratorDirect(o), limit);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private AsyncDropIterator Drop(JsValue thisObject, JsValue limitArg)
     {
         var o = ValidateThisAndGetLimit(thisObject, limitArg, "drop", out var limit);
         return new AsyncDropIterator(_engine, GetIteratorDirect(o), limit);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private AsyncFlatMapIterator FlatMap(JsValue thisObject, JsValue mapperArg)
     {
         var o = ValidateThisAndGetCallable(thisObject, mapperArg, "flatMap", out var mapper);
@@ -464,7 +464,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
             counter: counter);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToArray(JsValue thisObject)
     {
         if (thisObject is not ObjectInstance o)
@@ -499,7 +499,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
             });
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue ForEach(JsValue thisObject, JsValue procedureArg)
     {
         var o = ValidateThisAndGetCallable(thisObject, procedureArg, "forEach", out var procedure);
@@ -513,7 +513,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         return promiseCapability.PromiseInstance;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Some(JsValue thisObject, JsValue predicateArg)
     {
         var o = ValidateThisAndGetCallable(thisObject, predicateArg, "some", out var predicate);
@@ -533,7 +533,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         return promiseCapability.PromiseInstance;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Every(JsValue thisObject, JsValue predicateArg)
     {
         var o = ValidateThisAndGetCallable(thisObject, predicateArg, "every", out var predicate);
@@ -553,7 +553,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         return promiseCapability.PromiseInstance;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Find(JsValue thisObject, JsValue predicateArg)
     {
         var o = ValidateThisAndGetCallable(thisObject, predicateArg, "find", out var predicate);

--- a/Jint/Native/Iterator/IteratorConstructor.cs
+++ b/Jint/Native/Iterator/IteratorConstructor.cs
@@ -44,7 +44,7 @@ internal sealed partial class IteratorConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-iterator-sequencing/#sec-iterator.concat
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Concat(JsValue thisObject, JsValue[] arguments)
     {
         // 1. Let iterables be a new empty List.
@@ -81,7 +81,7 @@ internal sealed partial class IteratorConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.from
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue From(JsValue thisObject, JsValue o)
     {
         // 1. If O is a String, set O to ! ToObject(O).

--- a/Jint/Native/Iterator/IteratorHelperPrototype.cs
+++ b/Jint/Native/Iterator/IteratorHelperPrototype.cs
@@ -26,7 +26,7 @@ internal sealed partial class IteratorHelperPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.next
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Next(JsValue thisObject)
     {
         // 1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
@@ -52,7 +52,7 @@ internal sealed partial class IteratorHelperPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.return
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Return(JsValue thisObject)
     {
         // 1. Let O be this value.

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -90,7 +90,7 @@ internal partial class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.map
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Map(JsValue thisObject, JsValue mapper)
     {
         // 1. Let O be the this value.
@@ -147,7 +147,7 @@ internal partial class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.filter
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Filter(JsValue thisObject, JsValue predicate)
     {
         // 1. Let O be the this value.
@@ -180,7 +180,7 @@ internal partial class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.take
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Take(JsValue thisObject, JsValue limit)
     {
         // 1. Let O be the this value.
@@ -233,7 +233,7 @@ internal partial class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.drop
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Drop(JsValue thisObject, JsValue limit)
     {
         // 1. Let O be the this value.
@@ -286,7 +286,7 @@ internal partial class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.flatmap
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue FlatMap(JsValue thisObject, JsValue mapper)
     {
         // 1. Let O be the this value.
@@ -394,7 +394,7 @@ internal partial class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.toarray
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToArray(JsValue thisObject)
     {
         if (thisObject is not ObjectInstance o)
@@ -425,7 +425,7 @@ internal partial class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.foreach
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue ForEach(JsValue thisObject, JsValue procedure)
     {
         if (thisObject is not ObjectInstance o)
@@ -471,7 +471,7 @@ internal partial class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.some
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Some(JsValue thisObject, JsValue predicate)
     {
         if (thisObject is not ObjectInstance o)
@@ -523,7 +523,7 @@ internal partial class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.every
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Every(JsValue thisObject, JsValue predicate)
     {
         if (thisObject is not ObjectInstance o)
@@ -575,7 +575,7 @@ internal partial class IteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-iterator.prototype.find
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Find(JsValue thisObject, JsValue predicate)
     {
         if (thisObject is not ObjectInstance o)
@@ -639,7 +639,7 @@ internal partial class IteratorPrototype : Prototype
         return Undefined;
     }
 
-    [JsFunction(Length = 0, Name = "next")]
+    [JsFunction(Name = "next")]
     private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     // Kept with the JsCallArguments signature so still-hand-written subclasses (Array/RegExpString/String

--- a/Jint/Native/Iterator/WrapForValidIteratorPrototype.cs
+++ b/Jint/Native/Iterator/WrapForValidIteratorPrototype.cs
@@ -24,7 +24,7 @@ internal sealed partial class WrapForValidIteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.next
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Next(JsValue thisObject)
     {
         // 1. Let O be this value.
@@ -44,7 +44,7 @@ internal sealed partial class WrapForValidIteratorPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.return
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Return(JsValue thisObject)
     {
         // 1. Let O be this value.

--- a/Jint/Native/Map/MapConstructor.cs
+++ b/Jint/Native/Map/MapConstructor.cs
@@ -81,7 +81,7 @@ public sealed partial class MapConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-array-grouping/#sec-map.groupby
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue GroupBy(JsValue thisObject, JsValue items, JsValue callbackfn)
     {
         var grouping = GroupByHelper.GroupBy(_engine, _realm, items, callbackfn, mapMode: true);

--- a/Jint/Native/Map/MapIteratorPrototype.cs
+++ b/Jint/Native/Map/MapIteratorPrototype.cs
@@ -26,7 +26,7 @@ internal sealed partial class MapIteratorPrototype : IteratorPrototype
         CreateSymbols_Generated();
     }
 
-    [JsFunction(Length = 0, Name = "next")]
+    [JsFunction(Name = "next")]
     private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     internal IteratorInstance ConstructEntryIterator(JsMap map)

--- a/Jint/Native/Map/MapPrototype.cs
+++ b/Jint/Native/Map/MapPrototype.cs
@@ -46,14 +46,14 @@ internal sealed partial class MapPrototype : Prototype
         return JsNumber.Create(0);
     }
 
-    [JsFunction(Length = 1, Name = "get")]
+    [JsFunction(Name = "get")]
     private JsValue MapGet(JsValue thisObject, JsValue key)
     {
         var map = AssertMapInstance(thisObject);
         return map.Get(key);
     }
 
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue GetOrInsert(JsValue thisObject, JsValue key, JsValue value)
     {
         var map = AssertMapInstance(thisObject);
@@ -61,7 +61,7 @@ internal sealed partial class MapPrototype : Prototype
         return map.GetOrInsert(checkedKey, value);
     }
 
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue GetOrInsertComputed(JsValue thisObject, JsValue key, JsValue callbackfn)
     {
         var map = AssertMapInstance(thisObject);
@@ -70,7 +70,7 @@ internal sealed partial class MapPrototype : Prototype
         return map.GetOrInsertComputed(checkedKey, callable);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Clear(JsValue thisObject)
     {
         var map = AssertMapInstance(thisObject);
@@ -78,7 +78,7 @@ internal sealed partial class MapPrototype : Prototype
         return Undefined;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Delete(JsValue thisObject, JsValue key)
     {
         var map = AssertMapInstance(thisObject);
@@ -87,7 +87,7 @@ internal sealed partial class MapPrototype : Prototype
             : JsBoolean.False;
     }
 
-    [JsFunction(Length = 2, Name = "set")]
+    [JsFunction(Name = "set")]
     private JsValue MapSet(JsValue thisObject, JsValue key, JsValue value)
     {
         var map = AssertMapInstance(thisObject);
@@ -95,7 +95,7 @@ internal sealed partial class MapPrototype : Prototype
         return thisObject;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Has(JsValue thisObject, JsValue key)
     {
         var map = AssertMapInstance(thisObject);
@@ -115,21 +115,21 @@ internal sealed partial class MapPrototype : Prototype
         return Undefined;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private ObjectInstance Entries(JsValue thisObject)
     {
         var map = AssertMapInstance(thisObject);
         return map.Iterator();
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private ObjectInstance Keys(JsValue thisObject)
     {
         var map = AssertMapInstance(thisObject);
         return map.Keys();
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private ObjectInstance Values(JsValue thisObject)
     {
         var map = AssertMapInstance(thisObject);

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -34,7 +34,7 @@ internal sealed partial class MathInstance : ObjectInstance
         CreateSymbols_Generated();
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Abs(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -53,7 +53,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Abs(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Acos(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x) || (x > 1) || (x < -1))
@@ -68,7 +68,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Acos(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Acosh(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x) || x < 1)
@@ -79,7 +79,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Log(x + System.Math.Sqrt(x * x - 1.0));
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Asin(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x) || (x > 1) || (x < -1))
@@ -94,7 +94,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Asin(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Asinh(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsInfinity(x) || NumberInstance.IsPositiveZero(x) || NumberInstance.IsNegativeZero(x))
@@ -105,7 +105,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Log(x + System.Math.Sqrt(x * x + 1.0));
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Atan(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -127,7 +127,7 @@ internal sealed partial class MathInstance : ObjectInstance
 
         return System.Math.Atan(x);
     }
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Atanh(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -143,7 +143,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return 0.5 * System.Math.Log((1.0 + x) / (1.0 - x));
     }
 
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private static JsValue Atan2(JsValue thisObject, [ToNumber] double y, [ToNumber] double x)
     {
         // If either x or y is NaN, the result is NaN.
@@ -289,7 +289,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Atan2(y, x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Ceil(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -323,7 +323,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Ceiling(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Cos(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -346,7 +346,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Cos(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Cosh(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -369,7 +369,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Cosh(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Exp(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -392,7 +392,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Exp(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsNumber Expm1(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x) || NumberInstance.IsPositiveZero(x) || NumberInstance.IsNegativeZero(x) || double.IsPositiveInfinity(x))
@@ -407,7 +407,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return JsNumber.Create(System.Math.Exp(x) - 1.0);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Floor(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -434,7 +434,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Floor(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Log(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -461,7 +461,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Log(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Log1p(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -487,7 +487,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Log(1 + x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Log2(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -514,7 +514,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Log(x, 2);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Log10(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -623,7 +623,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return lowest;
     }
 
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private static JsValue Pow(JsValue thisObject, [ToNumber] double x, [ToNumber] double y)
     {
         // check easy case where values are valid
@@ -775,7 +775,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Pow(x, y);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Random(JsValue thisObject)
     {
         if (_random == null)
@@ -786,7 +786,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return _random.NextDouble();
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Round(JsValue thisObject, [ToNumber] double x)
     {
         var round = System.Math.Round(x);
@@ -833,7 +833,7 @@ internal sealed partial class MathInstance : ObjectInstance
 #endif
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Sin(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -856,7 +856,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Sin(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Sinh(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -883,25 +883,25 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Sinh(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Sqrt(JsValue thisObject, [ToNumber] double x)
     {
         return System.Math.Sqrt(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Tan(JsValue thisObject, [ToNumber] double x)
     {
         return System.Math.Tan(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Tanh(JsValue thisObject, [ToNumber] double x)
     {
         return System.Math.Tanh(x);
     }
 
-    [JsFunction(Length = 1, Name = "trunc")]
+    [JsFunction(Name = "trunc")]
     private static JsValue Truncate(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -927,7 +927,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Truncate(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Sign(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -953,7 +953,7 @@ internal sealed partial class MathInstance : ObjectInstance
         return System.Math.Sign(x);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Cbrt(JsValue thisObject, [ToNumber] double x)
     {
         if (double.IsNaN(x))
@@ -1120,13 +1120,13 @@ internal sealed partial class MathInstance : ObjectInstance
         return Math.SumPrecise.Sum(sum);
     }
 
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private static JsValue Imul(JsValue thisObject, [ToInt32] int x, [ToInt32] int y)
     {
         return x * y;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue Clz32(JsValue thisObject, [ToInt32] int x)
     {
         if (x < 0)

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -41,7 +41,7 @@ internal sealed partial class NumberPrototype : NumberInstance
     /// https://tc39.es/ecma262/#sec-number.prototype.tolocalestring
     /// https://tc39.es/ecma402/#sup-number.prototype.tolocalestring
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
     {
         if (!thisObject.IsNumber() && thisObject is not NumberInstance)
@@ -59,7 +59,7 @@ internal sealed partial class NumberPrototype : NumberInstance
         return numberFormat.Format(x);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         if (thisObject is NumberInstance ni)
@@ -78,7 +78,7 @@ internal sealed partial class NumberPrototype : NumberInstance
 
     private const double Ten21 = 1e21;
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue ToFixed(JsValue thisObject, [ToInteger] double fAsDouble)
     {
         var f = (int) fAsDouble;

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -60,7 +60,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.entries
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsArray Entries(JsValue thisObject, JsValue value)
     {
         var obj = TypeConverter.ToObject(_realm, value);
@@ -70,7 +70,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.fromentries
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private ObjectInstance FromEntries(JsValue thisObject, JsValue iterable)
     {
         TypeConverter.RequireObjectCoercible(_engine, iterable);
@@ -88,7 +88,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.is
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private static JsValue Is(JsValue thisObject, JsValue value1, JsValue value2)
     {
         return SameValue(value1, value2);
@@ -159,7 +159,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.getprototypeof
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     public JsValue GetPrototypeOf(JsValue thisObject, JsValue value)
     {
         var obj = TypeConverter.ToObject(_realm, value);
@@ -169,7 +169,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.setprototypeof
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue SetPrototypeOf(JsValue thisObject, JsValue oArg, JsValue prototype)
     {
         TypeConverter.RequireObjectCoercible(_engine, oArg);
@@ -194,7 +194,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.hasown
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsBoolean HasOwn(JsValue thisObject, JsValue value, JsValue propertyKey)
     {
         var o = TypeConverter.ToObject(_realm, value);
@@ -205,7 +205,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.getownpropertydescriptor
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     internal JsValue GetOwnPropertyDescriptor(JsValue thisObject, JsValue value, JsValue propertyKey)
     {
         var o = TypeConverter.ToObject(_realm, value);
@@ -218,7 +218,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.getownpropertydescriptors
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private ObjectInstance GetOwnPropertyDescriptors(JsValue thisObject, JsValue value)
     {
         var o = TypeConverter.ToObject(_realm, value);
@@ -239,7 +239,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.getownpropertynames
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsArray GetOwnPropertyNames(JsValue thisObject, JsValue value)
     {
         var o = TypeConverter.ToObject(_realm, value);
@@ -250,7 +250,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.getownpropertysymbols
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsArray GetOwnPropertySymbols(JsValue thisObject, JsValue value)
     {
         var o = TypeConverter.ToObject(_realm, value);
@@ -261,7 +261,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.create
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private ObjectInstance Create(JsValue thisObject, JsValue prototype, JsValue properties)
     {
         if (!prototype.IsObject() && !prototype.IsNull())
@@ -283,7 +283,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.defineproperty
     /// </summary>
-    [JsFunction(Length = 3)]
+    [JsFunction]
     private JsValue DefineProperty(JsValue thisObject, JsValue value, JsValue propertyKey, JsValue attributes)
     {
         if (value is not ObjectInstance o)
@@ -304,7 +304,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.defineproperties
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private ObjectInstance DefineProperties(JsValue thisObject, JsValue value, JsValue properties)
     {
         var o = value as ObjectInstance;
@@ -349,7 +349,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.seal
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Seal(JsValue thisObject, JsValue value)
     {
         if (value is not ObjectInstance o)
@@ -370,7 +370,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.freeze
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Freeze(JsValue thisObject, JsValue value)
     {
         if (value is not ObjectInstance o)
@@ -391,7 +391,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.preventextensions
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue PreventExtensions(JsValue thisObject, JsValue value)
     {
         if (value is not ObjectInstance o)
@@ -410,7 +410,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.issealed
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsBoolean IsSealed(JsValue thisObject, JsValue value)
     {
         if (value is not ObjectInstance o)
@@ -424,7 +424,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.isfrozen
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsBoolean IsFrozen(JsValue thisObject, JsValue value)
     {
         if (value is not ObjectInstance o)
@@ -471,7 +471,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.isextensible
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue IsExtensible(JsValue thisObject, JsValue value)
     {
         if (value is not ObjectInstance o)
@@ -485,7 +485,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.keys
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsArray Keys(JsValue thisObject, JsValue value)
     {
         var o = TypeConverter.ToObject(_realm, value);
@@ -495,7 +495,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.values
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsArray Values(JsValue thisObject, JsValue value)
     {
         var o = TypeConverter.ToObject(_realm, value);
@@ -505,7 +505,7 @@ public sealed partial class ObjectConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-array-grouping/#sec-object.groupby
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsObject GroupBy(JsValue thisObject, JsValue items, JsValue callbackfn)
     {
         var grouping = GroupByHelper.GroupBy(_engine, _realm, items, callbackfn, mapMode: false);

--- a/Jint/Native/Object/ObjectPrototype.cs
+++ b/Jint/Native/Object/ObjectPrototype.cs
@@ -86,7 +86,7 @@ public sealed partial class ObjectPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.prototype.__defineGetter__
     /// </summary>
-    [JsFunction(Length = 2, Name = "__defineGetter__")]
+    [JsFunction(Name = "__defineGetter__")]
     private JsValue DefineGetter(JsValue thisObject, JsValue p, JsValue getter)
     {
         var o = TypeConverter.ToObject(_realm, thisObject);
@@ -106,7 +106,7 @@ public sealed partial class ObjectPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.prototype.__defineSetter__
     /// </summary>
-    [JsFunction(Length = 2, Name = "__defineSetter__")]
+    [JsFunction(Name = "__defineSetter__")]
     private JsValue DefineSetter(JsValue thisObject, JsValue p, JsValue setter)
     {
         var o = TypeConverter.ToObject(_realm, thisObject);
@@ -126,7 +126,7 @@ public sealed partial class ObjectPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.prototype.__lookupGetter__
     /// </summary>
-    [JsFunction(Length = 1, Name = "__lookupGetter__")]
+    [JsFunction(Name = "__lookupGetter__")]
     private JsValue LookupGetter(JsValue thisObject, JsValue p)
     {
         var o = TypeConverter.ToObject(_realm, thisObject);
@@ -155,7 +155,7 @@ public sealed partial class ObjectPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.prototype.__lookupSetter__
     /// </summary>
-    [JsFunction(Length = 1, Name = "__lookupSetter__")]
+    [JsFunction(Name = "__lookupSetter__")]
     private JsValue LookupSetter(JsValue thisObject, JsValue p)
     {
         var o = TypeConverter.ToObject(_realm, thisObject);
@@ -181,7 +181,7 @@ public sealed partial class ObjectPrototype : Prototype
         }
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue PropertyIsEnumerable(JsValue thisObject, JsValue v)
     {
         var p = TypeConverter.ToPropertyKey(v);
@@ -194,14 +194,14 @@ public sealed partial class ObjectPrototype : Prototype
         return desc.Enumerable;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         var o = TypeConverter.ToObject(_realm, thisObject);
         return o;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue IsPrototypeOf(JsValue thisObject, JsValue arg)
     {
         if (!arg.IsObject())
@@ -231,7 +231,7 @@ public sealed partial class ObjectPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.prototype.tolocalestring
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ToLocaleString(JsValue thisObject)
     {
         return Invoke(thisObject, "toString", []);
@@ -240,7 +240,7 @@ public sealed partial class ObjectPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-object.prototype.tostring
     /// </summary>
-    [JsFunction(Length = 0, Name = "toString")]
+    [JsFunction(Name = "toString")]
     internal JsValue ToObjectString(JsValue thisObject)
     {
         if (thisObject.IsUndefined())
@@ -279,7 +279,7 @@ public sealed partial class ObjectPrototype : Prototype
     /// <summary>
     /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.4.5
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue HasOwnProperty(JsValue thisObject, JsValue v)
     {
         var p = TypeConverter.ToPropertyKey(v);

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -109,7 +109,7 @@ internal sealed partial class PromiseConstructor : Constructor
     }
 
     [JsFunction]
-    private JsObject WithResolvers(JsValue thisObject, JsCallArguments arguments)
+    private JsObject WithResolvers(JsValue thisObject)
     {
         var promiseCapability = NewPromiseCapability(_engine, thisObject);
         var obj = OrdinaryObjectCreate(_engine, _engine.Realm.Intrinsics.Object.PrototypeObject);

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -108,7 +108,7 @@ internal sealed partial class PromiseConstructor : Constructor
         return PromiseResolve(thisObject, x);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsObject WithResolvers(JsValue thisObject, JsCallArguments arguments)
     {
         var promiseCapability = NewPromiseCapability(_engine, thisObject);

--- a/Jint/Native/Promise/PromisePrototype.cs
+++ b/Jint/Native/Promise/PromisePrototype.cs
@@ -38,7 +38,7 @@ internal sealed partial class PromisePrototype : Prototype
     // 3. Let C be ? SpeciesConstructor(promise, %Promise%).
     // 4. Let resultCapability be ? NewPromiseCapability(C).
     // 5. Return PerformPromiseThen(promise, onFulfilled, onRejected, resultCapability).
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue Then(JsValue thisObject, JsValue onFulfilled, JsValue onRejected)
     {
         // 1. Let promise be the this value.
@@ -66,12 +66,12 @@ internal sealed partial class PromisePrototype : Prototype
     //
     // 1. Let promise be the this value.
     // 2. Return ? Invoke(promise, "then", « undefined, onRejected »).
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Catch(JsValue thisObject, JsValue onRejected) =>
         _engine.Invoke(thisObject, "then", [Undefined, onRejected]);
 
     // https://tc39.es/ecma262/#sec-promise.prototype.finally
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Finally(JsValue thisObject, JsValue onFinally)
     {
         // 1. Let promise be the this value.

--- a/Jint/Native/Proxy/ProxyConstructor.cs
+++ b/Jint/Native/Proxy/ProxyConstructor.cs
@@ -53,7 +53,7 @@ internal sealed partial class ProxyConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-proxy.revocable
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue Revocable(JsValue thisObject, JsValue target, JsValue handler)
     {
         var p = ProxyCreate(target, handler);

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -143,7 +143,7 @@ public sealed partial class RegExpConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-regexp.escape
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsString Escape(JsValue thisObject, JsValue s)
     {
         // 1. If S is not a String, throw a TypeError exception.

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -53,60 +53,99 @@ internal sealed partial class RegExpPrototype : Prototype
         CreateProperties_Generated();
         CreateSymbols_Generated();
 
-        // Eight RegExp.prototype get accessors (dotAll, global, hasIndices, ignoreCase, multiline,
-        // source, sticky, unicode, unicodeSets, flags) stay hand-written. Each shares a "this could be
-        // RegExp.prototype itself → return undefined" path that doesn't fit the generator's cast model.
-        // Source and Flags are full methods; the rest reduce to a property name + JsRegExp accessor via
-        // CreateGetAccessorDescriptor.
-        AddRegExpAccessors();
+        // exec stays manually registered: HasDefaultRegExpExec compares by reference against the
+        // ClrFunction wrapping _defaultExec to detect "user replaced exec on the prototype". The
+        // generator's lazy descriptor would create a different Function instance each realm, breaking
+        // that identity check until first access.
+        SetOwnProperty("exec", new PropertyDescriptor(new ClrFunction(Engine, "exec", _defaultExec, 1, PropertyFlag.Configurable), PropertyFlag.Configurable | PropertyFlag.Writable));
     }
 
-    private void AddRegExpAccessors()
+    // Spec: each prototype getter, when called on RegExp.prototype itself (not a JsRegExp instance),
+    // returns undefined (or a default for source). Cannot use cast typing on thisObject — that would
+    // raise TypeError before the proto-check runs.
+
+    [JsAccessor("dotAll")]
+    private JsValue DotAllGet(JsValue thisObject)
     {
-        const PropertyFlag lengthFlags = PropertyFlag.Configurable;
-
-        GetSetPropertyDescriptor CreateGetAccessorDescriptor(string name, Func<JsRegExp, JsValue> valueExtractor, JsValue? protoValue = null)
-        {
-            var propertyName = name.StartsWith("get ", StringComparison.Ordinal) ? name.Substring(4) : name;
-            return new GetSetPropertyDescriptor(
-                get: new ClrFunction(Engine, name, (thisObj, arguments) =>
-                {
-                    if (ReferenceEquals(thisObj, this))
-                    {
-                        return protoValue ?? Undefined;
-                    }
-
-                    var r = thisObj as JsRegExp;
-                    if (r is null)
-                    {
-                        Throw.TypeError(_realm, $"RegExp.prototype.{propertyName} getter called on non-RegExp object");
-                    }
-
-                    return valueExtractor(r);
-                }, 0, lengthFlags),
-                set: Undefined,
-                flags: PropertyFlag.Configurable);
-        }
-
-        // exec stays manually registered as a ClrFunction so HasDefaultExec's identity check works.
-        SetOwnProperty("exec", new PropertyDescriptor(new ClrFunction(Engine, "exec", _defaultExec, 1, lengthFlags), PropertyFlag.Configurable | PropertyFlag.Writable));
-
-        SetOwnProperty("dotAll", CreateGetAccessorDescriptor("get dotAll", static r => r.DotAll));
-        SetOwnProperty("flags", new GetSetPropertyDescriptor(get: new ClrFunction(Engine, "get flags", Flags, 0, lengthFlags), set: Undefined, flags: PropertyFlag.Configurable));
-        SetOwnProperty("global", CreateGetAccessorDescriptor("get global", static r => r.Global));
-        SetOwnProperty("hasIndices", CreateGetAccessorDescriptor("get hasIndices", static r => r.Indices));
-        SetOwnProperty("ignoreCase", CreateGetAccessorDescriptor("get ignoreCase", static r => r.IgnoreCase));
-        SetOwnProperty("multiline", CreateGetAccessorDescriptor("get multiline", static r => r.Multiline));
-        SetOwnProperty("source", new GetSetPropertyDescriptor(get: new ClrFunction(Engine, "get source", Source, 0, lengthFlags), set: Undefined, flags: PropertyFlag.Configurable));
-        SetOwnProperty("sticky", CreateGetAccessorDescriptor("get sticky", static r => r.Sticky));
-        SetOwnProperty("unicode", CreateGetAccessorDescriptor("get unicode", static r => r.Unicode));
-        SetOwnProperty("unicodeSets", CreateGetAccessorDescriptor("get unicodeSets", static r => r.UnicodeSets));
+        if (ReferenceEquals(thisObject, this)) return Undefined;
+        var r = thisObject as JsRegExp;
+        if (r is null) Throw.TypeError(_realm, "RegExp.prototype.dotAll getter called on non-RegExp object");
+        return r.DotAll;
     }
+
+    [JsAccessor("global")]
+    private JsValue GlobalGet(JsValue thisObject)
+    {
+        if (ReferenceEquals(thisObject, this)) return Undefined;
+        var r = thisObject as JsRegExp;
+        if (r is null) Throw.TypeError(_realm, "RegExp.prototype.global getter called on non-RegExp object");
+        return r.Global;
+    }
+
+    [JsAccessor("hasIndices")]
+    private JsValue HasIndicesGet(JsValue thisObject)
+    {
+        if (ReferenceEquals(thisObject, this)) return Undefined;
+        var r = thisObject as JsRegExp;
+        if (r is null) Throw.TypeError(_realm, "RegExp.prototype.hasIndices getter called on non-RegExp object");
+        return r.Indices;
+    }
+
+    [JsAccessor("ignoreCase")]
+    private JsValue IgnoreCaseGet(JsValue thisObject)
+    {
+        if (ReferenceEquals(thisObject, this)) return Undefined;
+        var r = thisObject as JsRegExp;
+        if (r is null) Throw.TypeError(_realm, "RegExp.prototype.ignoreCase getter called on non-RegExp object");
+        return r.IgnoreCase;
+    }
+
+    [JsAccessor("multiline")]
+    private JsValue MultilineGet(JsValue thisObject)
+    {
+        if (ReferenceEquals(thisObject, this)) return Undefined;
+        var r = thisObject as JsRegExp;
+        if (r is null) Throw.TypeError(_realm, "RegExp.prototype.multiline getter called on non-RegExp object");
+        return r.Multiline;
+    }
+
+    [JsAccessor("sticky")]
+    private JsValue StickyGet(JsValue thisObject)
+    {
+        if (ReferenceEquals(thisObject, this)) return Undefined;
+        var r = thisObject as JsRegExp;
+        if (r is null) Throw.TypeError(_realm, "RegExp.prototype.sticky getter called on non-RegExp object");
+        return r.Sticky;
+    }
+
+    [JsAccessor("unicode")]
+    private JsValue UnicodeGet(JsValue thisObject)
+    {
+        if (ReferenceEquals(thisObject, this)) return Undefined;
+        var r = thisObject as JsRegExp;
+        if (r is null) Throw.TypeError(_realm, "RegExp.prototype.unicode getter called on non-RegExp object");
+        return r.Unicode;
+    }
+
+    [JsAccessor("unicodeSets")]
+    private JsValue UnicodeSetsGet(JsValue thisObject)
+    {
+        if (ReferenceEquals(thisObject, this)) return Undefined;
+        var r = thisObject as JsRegExp;
+        if (r is null) Throw.TypeError(_realm, "RegExp.prototype.unicodeSets getter called on non-RegExp object");
+        return r.UnicodeSets;
+    }
+
+    [JsAccessor("flags")]
+    private JsValue FlagsGet(JsValue thisObject) => Flags(thisObject);
+
+    [JsAccessor("source")]
+    private JsValue SourceGet(JsValue thisObject) => Source(thisObject);
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-get-regexp.prototype.source
     /// </summary>
-    private JsValue Source(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Source(JsValue thisObject)
     {
         if (ReferenceEquals(thisObject, this))
         {
@@ -637,7 +676,7 @@ internal sealed partial class RegExpPrototype : Prototype
         return a;
     }
 
-    private JsValue Flags(JsValue thisObject, JsCallArguments arguments)
+    private JsValue Flags(JsValue thisObject)
     {
         var r = AssertThisIsObjectInstance(thisObject, "RegExp.prototype.flags");
 
@@ -658,7 +697,7 @@ internal sealed partial class RegExpPrototype : Prototype
         return result;
     }
 
-    [JsFunction(Length = 0, Name = "toString")]
+    [JsFunction(Name = "toString")]
     private JsValue ToRegExpString(JsValue thisObject)
     {
         var r = AssertThisIsObjectInstance(thisObject, "RegExp.prototype.toString");
@@ -669,7 +708,7 @@ internal sealed partial class RegExpPrototype : Prototype
         return "/" + pattern + "/" + flags;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Test(JsValue thisObject, JsValue stringArg)
     {
         var r = AssertThisIsObjectInstance(thisObject, "RegExp.prototype.test");
@@ -1464,7 +1503,7 @@ internal sealed partial class RegExpPrototype : Prototype
     /// https://tc39.es/ecma262/#sec-regexp.prototype.compile
     /// B.2.5.1
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue Compile(JsValue thisObject, JsValue pattern, JsValue flags)
     {
         // 1. Let O be the this value.

--- a/Jint/Native/RegExp/RegExpStringIteratorPrototype.cs
+++ b/Jint/Native/RegExp/RegExpStringIteratorPrototype.cs
@@ -26,7 +26,7 @@ internal sealed partial class RegExpStringIteratorPrototype : IteratorPrototype
         CreateSymbols_Generated();
     }
 
-    [JsFunction(Length = 0, Name = "next")]
+    [JsFunction(Name = "next")]
     private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     internal IteratorInstance Construct(ObjectInstance iteratingRegExp, string iteratedString, bool global, bool unicode)

--- a/Jint/Native/Set/SetIteratorPrototype.cs
+++ b/Jint/Native/Set/SetIteratorPrototype.cs
@@ -26,7 +26,7 @@ internal sealed partial class SetIteratorPrototype : IteratorPrototype
         CreateSymbols_Generated();
     }
 
-    [JsFunction(Length = 0, Name = "next")]
+    [JsFunction(Name = "next")]
     private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     internal IteratorInstance ConstructEntryIterator(JsSet set)

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -48,7 +48,7 @@ internal sealed partial class SetPrototype : Prototype
         return JsNumber.Create(0);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Add(JsValue thisObject, JsValue value)
     {
         var set = AssertSetInstance(thisObject);
@@ -60,7 +60,7 @@ internal sealed partial class SetPrototype : Prototype
         return thisObject;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Clear(JsValue thisObject)
     {
         var set = AssertSetInstance(thisObject);
@@ -68,7 +68,7 @@ internal sealed partial class SetPrototype : Prototype
         return Undefined;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsBoolean Delete(JsValue thisObject, JsValue value)
     {
         var set = AssertSetInstance(thisObject);
@@ -77,7 +77,7 @@ internal sealed partial class SetPrototype : Prototype
             : JsBoolean.False;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsSet Difference(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
@@ -137,7 +137,7 @@ internal sealed partial class SetPrototype : Prototype
         return resultSetData;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsBoolean IsDisjointFrom(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
@@ -191,7 +191,7 @@ internal sealed partial class SetPrototype : Prototype
     }
 
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsSet Intersection(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
@@ -260,7 +260,7 @@ internal sealed partial class SetPrototype : Prototype
         return resultSetData;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsSet SymmetricDifference(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
@@ -309,7 +309,7 @@ internal sealed partial class SetPrototype : Prototype
         return resultSetData;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsBoolean IsSubsetOf(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
@@ -350,7 +350,7 @@ internal sealed partial class SetPrototype : Prototype
         return JsBoolean.True;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsBoolean IsSupersetOf(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
@@ -389,7 +389,7 @@ internal sealed partial class SetPrototype : Prototype
     }
 
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsBoolean Has(JsValue thisObject, JsValue value)
     {
         var set = AssertSetInstance(thisObject);
@@ -398,7 +398,7 @@ internal sealed partial class SetPrototype : Prototype
             : JsBoolean.False;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private ObjectInstance Entries(JsValue thisObject)
     {
         var set = AssertSetInstance(thisObject);
@@ -416,7 +416,7 @@ internal sealed partial class SetPrototype : Prototype
         return Undefined;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsSet Union(JsValue thisObject, JsValue other)
     {
         var set = AssertSetInstance(thisObject);
@@ -474,7 +474,7 @@ internal sealed partial class SetPrototype : Prototype
         return new SetRecord(Set: obj, Size: intSize, Has: (ICallable) has, Keys: (ICallable) keys);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private ObjectInstance Values(JsValue thisObject)
     {
         var set = AssertSetInstance(thisObject);

--- a/Jint/Native/ShadowRealm/ShadowRealmPrototype.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealmPrototype.cs
@@ -34,7 +34,7 @@ internal sealed partial class ShadowRealmPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-shadowrealm/#sec-shadowrealm.prototype.evaluate
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Evaluate(JsValue thisObject, JsValue sourceText)
     {
         var shadowRealm = ValidateShadowRealmObject(thisObject);
@@ -57,7 +57,7 @@ internal sealed partial class ShadowRealmPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-shadowrealm/#sec-shadowrealm.prototype.importvalue
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue ImportValue(JsValue thisObject, JsValue specifier, JsValue exportName)
     {
         var O = ValidateShadowRealmObject(thisObject);

--- a/Jint/Native/SharedArrayBuffer/SharedArrayBufferConstructor.cs
+++ b/Jint/Native/SharedArrayBuffer/SharedArrayBufferConstructor.cs
@@ -37,7 +37,7 @@ internal sealed partial class SharedArrayBufferConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-arraybuffer.isview
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private static JsValue IsView(JsValue thisObject, JsValue arg)
     {
         return arg is JsDataView or JsTypedArray;

--- a/Jint/Native/SharedArrayBuffer/SharedArrayBufferPrototype.cs
+++ b/Jint/Native/SharedArrayBuffer/SharedArrayBufferPrototype.cs
@@ -48,7 +48,7 @@ internal sealed partial class SharedArrayBufferPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.slice
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsSharedArrayBuffer Slice(JsValue thisObject, JsValue start, JsValue end)
     {
         var o = thisObject as JsSharedArrayBuffer;
@@ -145,7 +145,7 @@ internal sealed partial class SharedArrayBufferPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.grow
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Grow(JsValue thisObject, JsValue newLength)
     {
         var o = thisObject as JsSharedArrayBuffer;

--- a/Jint/Native/String/StringIteratorPrototype.cs
+++ b/Jint/Native/String/StringIteratorPrototype.cs
@@ -26,7 +26,7 @@ internal sealed partial class StringIteratorPrototype : IteratorPrototype
         CreateSymbols_Generated();
     }
 
-    [JsFunction(Length = 0, Name = "next")]
+    [JsFunction(Name = "next")]
     private JsValue NextHandler(JsValue thisObject) => Next(thisObject, Arguments.Empty);
 
     public ObjectInstance Construct(string str)

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -73,7 +73,7 @@ internal sealed partial class StringPrototype : StringInstance
         return _realm.Intrinsics.StringIteratorPrototype.Construct(str);
     }
 
-    [JsFunction(Length = 0, Name = "toString")]
+    [JsFunction(Name = "toString")]
     private JsValue ToStringString(JsValue thisObject, JsCallArguments arguments)
     {
         if (thisObject.IsString())
@@ -162,7 +162,7 @@ internal sealed partial class StringPrototype : StringInstance
     /// https://tc39.es/ecma262/#sec-string.prototype.trim
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [JsFunction(Length = 0)]
+    [JsFunction]
     [RequireObjectCoercible]
     private static JsValue Trim(JsValue thisObject, JsCallArguments arguments)
     {
@@ -177,7 +177,7 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.prototype.trimstart
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     [RequireObjectCoercible]
     private static JsValue TrimStart(JsValue thisObject, JsCallArguments arguments)
     {
@@ -192,7 +192,7 @@ internal sealed partial class StringPrototype : StringInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-string.prototype.trimend
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     [RequireObjectCoercible]
     private static JsValue TrimEnd(JsValue thisObject, JsCallArguments arguments)
     {
@@ -204,7 +204,7 @@ internal sealed partial class StringPrototype : StringInstance
         return TrimEndEx(s.ToString());
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     [RequireObjectCoercible]
     private JsValue ToLocaleUpperCase(JsValue thisObject, JsCallArguments arguments)
     {
@@ -234,7 +234,7 @@ internal sealed partial class StringPrototype : StringInstance
         return new JsString(ToUpperCaseWithSpecialCasing(s, culture));
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     [RequireObjectCoercible]
     private static JsValue ToUpperCase(JsValue thisObject, JsCallArguments arguments)
     {
@@ -414,7 +414,7 @@ internal sealed partial class StringPrototype : StringInstance
         };
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     [RequireObjectCoercible]
     private JsValue ToLocaleLowerCase(JsValue thisObject, JsCallArguments arguments)
     {
@@ -432,7 +432,7 @@ internal sealed partial class StringPrototype : StringInstance
         return ToLowerCaseWithSpecialCasing(s, culture);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     [RequireObjectCoercible]
     private static JsValue ToLowerCase(JsValue thisObject, JsCallArguments arguments)
     {
@@ -991,19 +991,19 @@ internal sealed partial class StringPrototype : StringInstance
     private JsValue Anchor(JsValue thisObject, JsCallArguments arguments)
         => CreateHTML(_engine, thisObject, "a", "name", arguments.At(0));
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Big(JsValue thisObject, JsCallArguments arguments)
         => CreateHTML(_engine, thisObject, "big", "", Undefined);
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Blink(JsValue thisObject, JsCallArguments arguments)
         => CreateHTML(_engine, thisObject, "blink", "", Undefined);
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Bold(JsValue thisObject, JsCallArguments arguments)
         => CreateHTML(_engine, thisObject, "b", "", Undefined);
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Fixed(JsValue thisObject, JsCallArguments arguments)
         => CreateHTML(_engine, thisObject, "tt", "", Undefined);
 
@@ -1015,7 +1015,7 @@ internal sealed partial class StringPrototype : StringInstance
     private JsValue FontSize(JsValue thisObject, JsCallArguments arguments)
         => CreateHTML(_engine, thisObject, "font", "size", arguments.At(0));
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Italics(JsValue thisObject, JsCallArguments arguments)
         => CreateHTML(_engine, thisObject, "i", "", Undefined);
 
@@ -1023,19 +1023,19 @@ internal sealed partial class StringPrototype : StringInstance
     private JsValue Link(JsValue thisObject, JsCallArguments arguments)
         => CreateHTML(_engine, thisObject, "a", "href", arguments.At(0));
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Small(JsValue thisObject, JsCallArguments arguments)
         => CreateHTML(_engine, thisObject, "small", "", Undefined);
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Strike(JsValue thisObject, JsCallArguments arguments)
         => CreateHTML(_engine, thisObject, "strike", "", Undefined);
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Sub(JsValue thisObject, JsCallArguments arguments)
         => CreateHTML(_engine, thisObject, "sub", "", Undefined);
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Sup(JsValue thisObject, JsCallArguments arguments)
         => CreateHTML(_engine, thisObject, "sup", "", Undefined);
 
@@ -1631,7 +1631,7 @@ internal sealed partial class StringPrototype : StringInstance
         return JsString.Create(s[(int) position]);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
     {
         if (thisObject is StringInstance si)
@@ -1796,7 +1796,7 @@ internal sealed partial class StringPrototype : StringInstance
         return s.IndexOf(searchStr, (int) pos) > -1;
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     [RequireObjectCoercible]
     private JsValue Normalize(JsValue thisObject, JsCallArguments arguments)
     {
@@ -1871,7 +1871,7 @@ internal sealed partial class StringPrototype : StringInstance
         return sb.ToString();
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     [RequireObjectCoercible]
     private static JsValue IsWellFormed(JsValue thisObject, JsCallArguments arguments)
     {
@@ -1880,7 +1880,7 @@ internal sealed partial class StringPrototype : StringInstance
         return IsStringWellFormedUnicode(s);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     [RequireObjectCoercible]
     private static JsValue ToWellFormed(JsValue thisObject, JsCallArguments arguments)
     {

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -74,7 +74,7 @@ internal sealed partial class StringPrototype : StringInstance
     }
 
     [JsFunction(Name = "toString")]
-    private JsValue ToStringString(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ToStringString(JsValue thisObject)
     {
         if (thisObject.IsString())
         {
@@ -164,7 +164,7 @@ internal sealed partial class StringPrototype : StringInstance
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [JsFunction]
     [RequireObjectCoercible]
-    private static JsValue Trim(JsValue thisObject, JsCallArguments arguments)
+    private static JsValue Trim(JsValue thisObject)
     {
         var s = TypeConverter.ToJsString(thisObject);
         if (s.Length == 0 || (!IsWhiteSpaceEx(s[0]) && !IsWhiteSpaceEx(s[s.Length - 1])))
@@ -179,7 +179,7 @@ internal sealed partial class StringPrototype : StringInstance
     /// </summary>
     [JsFunction]
     [RequireObjectCoercible]
-    private static JsValue TrimStart(JsValue thisObject, JsCallArguments arguments)
+    private static JsValue TrimStart(JsValue thisObject)
     {
         var s = TypeConverter.ToJsString(thisObject);
         if (s.Length == 0 || !IsWhiteSpaceEx(s[0]))
@@ -194,7 +194,7 @@ internal sealed partial class StringPrototype : StringInstance
     /// </summary>
     [JsFunction]
     [RequireObjectCoercible]
-    private static JsValue TrimEnd(JsValue thisObject, JsCallArguments arguments)
+    private static JsValue TrimEnd(JsValue thisObject)
     {
         var s = TypeConverter.ToJsString(thisObject);
         if (s.Length == 0 || !IsWhiteSpaceEx(s[s.Length - 1]))
@@ -236,7 +236,7 @@ internal sealed partial class StringPrototype : StringInstance
 
     [JsFunction]
     [RequireObjectCoercible]
-    private static JsValue ToUpperCase(JsValue thisObject, JsCallArguments arguments)
+    private static JsValue ToUpperCase(JsValue thisObject)
     {
         var s = TypeConverter.ToString(thisObject);
         return new JsString(ToUpperCaseWithSpecialCasing(s, CultureInfo.InvariantCulture));
@@ -434,7 +434,7 @@ internal sealed partial class StringPrototype : StringInstance
 
     [JsFunction]
     [RequireObjectCoercible]
-    private static JsValue ToLowerCase(JsValue thisObject, JsCallArguments arguments)
+    private static JsValue ToLowerCase(JsValue thisObject)
     {
         var s = TypeConverter.ToString(thisObject);
         return ToLowerCaseWithSpecialCasing(s, CultureInfo.InvariantCulture);
@@ -1632,7 +1632,7 @@ internal sealed partial class StringPrototype : StringInstance
     }
 
     [JsFunction]
-    private JsValue ValueOf(JsValue thisObject, JsCallArguments arguments)
+    private JsValue ValueOf(JsValue thisObject)
     {
         if (thisObject is StringInstance si)
         {
@@ -1873,7 +1873,7 @@ internal sealed partial class StringPrototype : StringInstance
 
     [JsFunction]
     [RequireObjectCoercible]
-    private static JsValue IsWellFormed(JsValue thisObject, JsCallArguments arguments)
+    private static JsValue IsWellFormed(JsValue thisObject)
     {
         var s = TypeConverter.ToString(thisObject);
 
@@ -1882,7 +1882,7 @@ internal sealed partial class StringPrototype : StringInstance
 
     [JsFunction]
     [RequireObjectCoercible]
-    private static JsValue ToWellFormed(JsValue thisObject, JsCallArguments arguments)
+    private static JsValue ToWellFormed(JsValue thisObject)
     {
         var s = TypeConverter.ToString(thisObject);
 

--- a/Jint/Native/SuppressedError/SuppressedErrorPrototype.cs
+++ b/Jint/Native/SuppressedError/SuppressedErrorPrototype.cs
@@ -4,9 +4,17 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.SuppressedError;
 
-internal sealed class SuppressedErrorPrototype : Prototype
+[JsObject]
+internal sealed partial class SuppressedErrorPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly SuppressedErrorConstructor _constructor;
+
+    [JsProperty(Name = "message", Flags = PropertyFlag.NonEnumerable)]
+    private static readonly JsString MessageDefault = JsString.Empty;
+
+    [JsProperty(Name = "name", Flags = PropertyFlag.NonEnumerable)]
+    private static readonly JsString NameValue = new("SuppressedError");
 
     internal SuppressedErrorPrototype(
         Engine engine,
@@ -19,14 +27,5 @@ internal sealed class SuppressedErrorPrototype : Prototype
         _prototype = prototype;
     }
 
-    protected override void Initialize()
-    {
-        var properties = new PropertyDictionary(3, checkExistingKeys: false)
-        {
-            ["constructor"] = new PropertyDescriptor(_constructor, PropertyFlag.NonEnumerable),
-            ["message"] = new PropertyDescriptor(JsString.Empty, PropertyFlag.Configurable | PropertyFlag.Writable),
-            ["name"] = new PropertyDescriptor("SuppressedError", PropertyFlag.Configurable | PropertyFlag.Writable),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 }

--- a/Jint/Native/Symbol/SymbolConstructor.cs
+++ b/Jint/Native/Symbol/SymbolConstructor.cs
@@ -68,7 +68,7 @@ internal sealed partial class SymbolConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-symbol.for
     /// </summary>
-    [JsFunction(Length = 1, Name = "for")]
+    [JsFunction(Name = "for")]
     private JsValue For(JsValue thisObject, JsValue key)
     {
         var stringKey = TypeConverter.ToJsString(key);
@@ -87,7 +87,7 @@ internal sealed partial class SymbolConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-symbol.keyfor
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue KeyFor(JsValue thisObject, JsValue sym)
     {
         var symbol = sym as JsSymbol;

--- a/Jint/Native/Symbol/SymbolPrototype.cs
+++ b/Jint/Native/Symbol/SymbolPrototype.cs
@@ -47,7 +47,7 @@ internal sealed partial class SymbolPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-symbol.prototype.tostring
     /// </summary>
-    [JsFunction(Length = 0, Name = "toString")]
+    [JsFunction(Name = "toString")]
     private JsValue ToSymbolString(JsValue thisObject)
     {
         var sym = ThisSymbolValue(thisObject);
@@ -57,7 +57,7 @@ internal sealed partial class SymbolPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-symbol.prototype.valueof
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         return ThisSymbolValue(thisObject);

--- a/Jint/Native/Temporal/Duration/DurationConstructor.cs
+++ b/Jint/Native/Temporal/Duration/DurationConstructor.cs
@@ -34,7 +34,7 @@ internal sealed partial class DurationConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.from
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsDuration From(JsValue thisObject, JsValue item)
     {
         // If item is already a Duration, create a copy (spec requires a new object)

--- a/Jint/Native/Temporal/Duration/DurationPrototype.cs
+++ b/Jint/Native/Temporal/Duration/DurationPrototype.cs
@@ -71,7 +71,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.with
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsDuration With(JsValue thisObject, JsValue temporalDurationLike)
     {
         var duration = ValidateDuration(thisObject);
@@ -138,7 +138,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.negated
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsDuration Negated(JsValue thisObject)
     {
         var duration = ValidateDuration(thisObject);
@@ -148,7 +148,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.abs
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsDuration Abs(JsValue thisObject)
     {
         var duration = ValidateDuration(thisObject);
@@ -159,7 +159,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.add
     /// https://tc39.es/proposal-temporal/#sec-temporal-adddurations
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsDuration Add(JsValue thisObject, JsValue other)
     {
         var duration = ValidateDuration(thisObject);
@@ -170,7 +170,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.subtract
     /// https://tc39.es/proposal-temporal/#sec-temporal-adddurations
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsDuration Subtract(JsValue thisObject, JsValue other)
     {
         var duration = ValidateDuration(thisObject);
@@ -228,7 +228,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsDuration Round(JsValue thisObject, JsValue options)
     {
         var duration = ValidateDuration(thisObject);
@@ -1255,7 +1255,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.total
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsNumber Total(JsValue thisObject, JsValue options)
     {
         var duration = ValidateDuration(thisObject);
@@ -1533,7 +1533,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tojson
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsString ToJSON(JsValue thisObject)
     {
         var duration = ValidateDuration(thisObject);
@@ -1570,7 +1570,7 @@ internal sealed partial class DurationPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.valueof
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Cannot convert Temporal.Duration to a primitive value");

--- a/Jint/Native/Temporal/Instant/InstantConstructor.cs
+++ b/Jint/Native/Temporal/Instant/InstantConstructor.cs
@@ -40,7 +40,7 @@ internal sealed partial class InstantConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.from
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsInstant From(JsValue thisObject, JsValue item)
     {
         return ToTemporalInstant(item);
@@ -49,7 +49,7 @@ internal sealed partial class InstantConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochmilliseconds
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsInstant FromEpochMilliseconds(JsValue thisObject, JsValue epochMilliseconds)
     {
         var ms = TypeConverter.ToNumber(epochMilliseconds);
@@ -78,7 +78,7 @@ internal sealed partial class InstantConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochnanoseconds
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsInstant FromEpochNanoseconds(JsValue thisObject, JsValue epochNanoseconds)
     {
         if (epochNanoseconds is not JsBigInt bigInt)
@@ -100,7 +100,7 @@ internal sealed partial class InstantConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.compare
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two)
     {
         return JsNumber.Create(

--- a/Jint/Native/Temporal/Instant/InstantPrototype.cs
+++ b/Jint/Native/Temporal/Instant/InstantPrototype.cs
@@ -76,7 +76,7 @@ internal sealed partial class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.add
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsInstant Add(JsValue thisObject, JsValue temporalDurationLike)
     {
         var instant = ValidateInstant(thisObject);
@@ -103,7 +103,7 @@ internal sealed partial class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.subtract
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsInstant Subtract(JsValue thisObject, JsValue temporalDurationLike)
     {
         var instant = ValidateInstant(thisObject);
@@ -286,7 +286,7 @@ internal sealed partial class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.round
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsInstant Round(JsValue thisObject, JsValue roundTo)
     {
         var instant = ValidateInstant(thisObject);
@@ -513,7 +513,7 @@ internal sealed partial class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.equals
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var instant = ValidateInstant(thisObject);
@@ -776,7 +776,7 @@ internal sealed partial class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tojson
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsString ToJSON(JsValue thisObject)
     {
         var instant = ValidateInstant(thisObject);
@@ -807,7 +807,7 @@ internal sealed partial class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.valueof
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Cannot convert Temporal.Instant to a primitive value");
@@ -817,7 +817,7 @@ internal sealed partial class InstantPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tozoneddatetimeiso
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsZonedDateTime ToZonedDateTimeISO(JsValue thisObject, JsValue timeZone)
     {
         var instant = ValidateInstant(thisObject);

--- a/Jint/Native/Temporal/Now/TemporalNow.cs
+++ b/Jint/Native/Temporal/Now/TemporalNow.cs
@@ -1,9 +1,7 @@
 using System.Numerics;
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.Temporal;
 
@@ -11,9 +9,13 @@ namespace Jint.Native.Temporal;
 /// The Temporal.Now object.
 /// https://tc39.es/proposal-temporal/#sec-temporal-now-object
 /// </summary>
-internal sealed class TemporalNow : ObjectInstance
+[JsObject]
+internal sealed partial class TemporalNow : ObjectInstance
 {
     private readonly Realm _realm;
+
+    [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)]
+    private static readonly JsString ToStringTagValue = new("Temporal.Now");
 
     internal TemporalNow(
         Engine engine,
@@ -26,34 +28,15 @@ internal sealed class TemporalNow : ObjectInstance
 
     protected override void Initialize()
     {
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
-
-        var properties = new PropertyDictionary(8, checkExistingKeys: false)
-        {
-            ["timeZoneId"] = new(new ClrFunction(Engine, "timeZoneId", TimeZoneId, 0, LengthFlags), PropertyFlags),
-            ["instant"] = new(new ClrFunction(Engine, "instant", Instant, 0, LengthFlags), PropertyFlags),
-            ["plainDateTime"] = new(new ClrFunction(Engine, "plainDateTime", PlainDateTime, 1, LengthFlags), PropertyFlags),
-            ["plainDateTimeISO"] = new(new ClrFunction(Engine, "plainDateTimeISO", PlainDateTimeISO, 0, LengthFlags), PropertyFlags),
-            ["zonedDateTime"] = new(new ClrFunction(Engine, "zonedDateTime", ZonedDateTime, 1, LengthFlags), PropertyFlags),
-            ["zonedDateTimeISO"] = new(new ClrFunction(Engine, "zonedDateTimeISO", ZonedDateTimeISO, 0, LengthFlags), PropertyFlags),
-            ["plainDate"] = new(new ClrFunction(Engine, "plainDate", PlainDate, 1, LengthFlags), PropertyFlags),
-            ["plainDateISO"] = new(new ClrFunction(Engine, "plainDateISO", PlainDateISO, 0, LengthFlags), PropertyFlags),
-            ["plainTimeISO"] = new(new ClrFunction(Engine, "plainTimeISO", PlainTimeISO, 0, LengthFlags), PropertyFlags),
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.ToStringTag] = new("Temporal.Now", PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.now.timezoneid
     /// </summary>
-    private JsString TimeZoneId(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsString TimeZoneId(JsValue thisObject)
     {
         var provider = _engine.Options.Temporal.TimeZoneProvider;
         return new JsString(provider.GetDefaultTimeZone());
@@ -62,7 +45,8 @@ internal sealed class TemporalNow : ObjectInstance
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.now.instant
     /// </summary>
-    private JsInstant Instant(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsInstant Instant(JsValue thisObject)
     {
         var epochNs = SystemUTCEpochNanoseconds();
         return new JsInstant(_engine, _realm.Intrinsics.TemporalInstant.PrototypeObject, epochNs);
@@ -71,11 +55,9 @@ internal sealed class TemporalNow : ObjectInstance
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetime
     /// </summary>
-    private JsPlainDateTime PlainDateTime(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsPlainDateTime PlainDateTime(JsValue thisObject, JsValue calendarLike, JsValue temporalTimeZoneLike)
     {
-        var calendarLike = arguments.At(0);
-        var temporalTimeZoneLike = arguments.At(1);
-
         var calendar = ToTemporalCalendarIdentifier(calendarLike);
         var timeZoneId = ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
 
@@ -88,9 +70,10 @@ internal sealed class TemporalNow : ObjectInstance
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetimeiso
     /// </summary>
-    private JsPlainDateTime PlainDateTimeISO(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsPlainDateTime PlainDateTimeISO(JsValue thisObject, JsValue temporalTimeZoneLike)
     {
-        var timeZoneId = ToTemporalTimeZoneIdentifier(arguments.At(0));
+        var timeZoneId = ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
 
         var epochNs = SystemUTCEpochNanoseconds();
         var isoDateTime = GetIsoDateTimeFor(timeZoneId, epochNs);
@@ -101,11 +84,9 @@ internal sealed class TemporalNow : ObjectInstance
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetime
     /// </summary>
-    private JsZonedDateTime ZonedDateTime(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsZonedDateTime ZonedDateTime(JsValue thisObject, JsValue calendarLike, JsValue temporalTimeZoneLike)
     {
-        var calendarLike = arguments.At(0);
-        var temporalTimeZoneLike = arguments.At(1);
-
         var calendar = ToTemporalCalendarIdentifier(calendarLike);
         var timeZoneId = ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
 
@@ -117,9 +98,10 @@ internal sealed class TemporalNow : ObjectInstance
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetimeiso
     /// </summary>
-    private JsZonedDateTime ZonedDateTimeISO(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsZonedDateTime ZonedDateTimeISO(JsValue thisObject, JsValue temporalTimeZoneLike)
     {
-        var timeZoneId = ToTemporalTimeZoneIdentifier(arguments.At(0));
+        var timeZoneId = ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
 
         var epochNs = SystemUTCEpochNanoseconds();
 
@@ -129,11 +111,9 @@ internal sealed class TemporalNow : ObjectInstance
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.now.plaindate
     /// </summary>
-    private JsPlainDate PlainDate(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsPlainDate PlainDate(JsValue thisObject, JsValue calendarLike, JsValue temporalTimeZoneLike)
     {
-        var calendarLike = arguments.At(0);
-        var temporalTimeZoneLike = arguments.At(1);
-
         var calendar = ToTemporalCalendarIdentifier(calendarLike);
         var timeZoneId = ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
 
@@ -146,9 +126,10 @@ internal sealed class TemporalNow : ObjectInstance
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.now.plaindateiso
     /// </summary>
-    private JsPlainDate PlainDateISO(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsPlainDate PlainDateISO(JsValue thisObject, JsValue temporalTimeZoneLike)
     {
-        var timeZoneId = ToTemporalTimeZoneIdentifier(arguments.At(0));
+        var timeZoneId = ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
 
         var epochNs = SystemUTCEpochNanoseconds();
         var isoDateTime = GetIsoDateTimeFor(timeZoneId, epochNs);
@@ -159,9 +140,10 @@ internal sealed class TemporalNow : ObjectInstance
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.now.plaintimeiso
     /// </summary>
-    private JsPlainTime PlainTimeISO(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsPlainTime PlainTimeISO(JsValue thisObject, JsValue temporalTimeZoneLike)
     {
-        var timeZoneId = ToTemporalTimeZoneIdentifier(arguments.At(0));
+        var timeZoneId = ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
 
         var epochNs = SystemUTCEpochNanoseconds();
         var isoDateTime = GetIsoDateTimeFor(timeZoneId, epochNs);
@@ -175,7 +157,6 @@ internal sealed class TemporalNow : ObjectInstance
     private BigInteger SystemUTCEpochNanoseconds()
     {
         var now = _engine.Options.TimeSystem.GetUtcNow();
-        // Convert DateTimeOffset to nanoseconds since Unix epoch
         var milliseconds = now.ToUnixTimeMilliseconds();
         return (BigInteger) milliseconds * 1_000_000;
     }
@@ -214,5 +195,4 @@ internal sealed class TemporalNow : ObjectInstance
 
         return TemporalHelpers.ToTemporalTimeZoneIdentifier(_engine, _realm, timeZoneLike);
     }
-
 }

--- a/Jint/Native/Temporal/PlainDate/PlainDateConstructor.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDateConstructor.cs
@@ -198,7 +198,7 @@ internal sealed partial class PlainDateConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.compare
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two)
     {
         return JsNumber.Create(TemporalHelpers.CompareIsoDates(

--- a/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
@@ -363,7 +363,7 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.withcalendar
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsPlainDate WithCalendar(JsValue thisObject, JsValue calendarArg)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -600,7 +600,7 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.equals
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -642,7 +642,7 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tojson
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsString ToJSON(JsValue thisObject)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -675,7 +675,7 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.valueof
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Temporal.PlainDate cannot be converted to a primitive value");
@@ -716,7 +716,7 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainyearmonth
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsPlainYearMonth ToPlainYearMonth(JsValue thisObject)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -730,7 +730,7 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainmonthday
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsPlainMonthDay ToPlainMonthDay(JsValue thisObject)
     {
         var plainDate = ValidatePlainDate(thisObject);
@@ -783,7 +783,7 @@ internal sealed partial class PlainDatePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tozoneddatetime
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsZonedDateTime ToZonedDateTime(JsValue thisObject, JsValue item)
     {
         var plainDate = ValidatePlainDate(thisObject);

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimeConstructor.cs
@@ -77,7 +77,7 @@ internal sealed partial class PlainDateTimeConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.compare
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two)
     {
         return JsNumber.Create(TemporalHelpers.CompareIsoDateTimes(

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
@@ -396,7 +396,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaindate
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsPlainDateTime WithPlainDate(JsValue thisObject, JsValue plainDateLike)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -428,7 +428,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsPlainDateTime WithCalendar(JsValue thisObject, JsValue calendarArg)
     {
         // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar
@@ -635,7 +635,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.round
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsPlainDateTime Round(JsValue thisObject, JsValue roundTo)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -749,7 +749,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.equals
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -925,7 +925,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tojson
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsString ToJSON(JsValue thisObject)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -959,7 +959,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Temporal.PlainDateTime cannot be converted to a primitive value");
@@ -969,7 +969,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaindate
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsPlainDate ToPlainDate(JsValue thisObject)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);
@@ -980,7 +980,7 @@ internal sealed partial class PlainDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaintime
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsPlainTime ToPlainTime(JsValue thisObject)
     {
         var plainDateTime = ValidatePlainDateTime(thisObject);

--- a/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
+++ b/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
@@ -215,7 +215,7 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.equals
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var md = ValidatePlainMonthDay(thisObject);
@@ -277,7 +277,7 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tojson
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsString ToJSON(JsValue thisObject)
     {
         var md = ValidatePlainMonthDay(thisObject);
@@ -316,7 +316,7 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.valueof
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Temporal.PlainMonthDay cannot be converted to a primitive value");
@@ -326,7 +326,7 @@ internal sealed partial class PlainMonthDayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.toplaindate
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsPlainDate ToPlainDate(JsValue thisObject, JsValue item)
     {
         var md = ValidatePlainMonthDay(thisObject);

--- a/Jint/Native/Temporal/PlainTime/PlainTimeConstructor.cs
+++ b/Jint/Native/Temporal/PlainTime/PlainTimeConstructor.cs
@@ -106,7 +106,7 @@ internal sealed partial class PlainTimeConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.compare
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two)
     {
         return JsNumber.Create(TemporalHelpers.CompareIsoTimes(

--- a/Jint/Native/Temporal/PlainTime/PlainTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainTime/PlainTimePrototype.cs
@@ -133,7 +133,7 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.add
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsPlainTime Add(JsValue thisObject, JsValue temporalDurationLike)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -144,7 +144,7 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.subtract
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsPlainTime Subtract(JsValue thisObject, JsValue temporalDurationLike)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -318,7 +318,7 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.round
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsPlainTime Round(JsValue thisObject, JsValue roundTo)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -377,7 +377,7 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.equals
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -501,7 +501,7 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tojson
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsString ToJSON(JsValue thisObject)
     {
         var plainTime = ValidatePlainTime(thisObject);
@@ -527,7 +527,7 @@ internal sealed partial class PlainTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.valueof
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Temporal.PlainTime cannot be converted to a primitive value");

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
@@ -80,7 +80,7 @@ internal sealed partial class PlainYearMonthConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.compare
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two)
     {
         return JsNumber.Create(CompareIsoYearMonth(

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
@@ -559,7 +559,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.equals
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var ym = ValidatePlainYearMonth(thisObject);
@@ -621,7 +621,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tojson
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsString ToJSON(JsValue thisObject)
     {
         var ym = ValidatePlainYearMonth(thisObject);
@@ -660,7 +660,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.valueof
     /// </summary>
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "Temporal.PlainYearMonth cannot be converted to a primitive value");
@@ -670,7 +670,7 @@ internal sealed partial class PlainYearMonthPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.toplaindate
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsPlainDate ToPlainDate(JsValue thisObject, JsValue item)
     {
         var ym = ValidatePlainYearMonth(thisObject);

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
@@ -44,7 +44,7 @@ internal sealed partial class ZonedDateTimeConstructor : Constructor
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.compare
     /// </summary>
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsNumber Compare(JsValue thisObject, JsValue one, JsValue two)
     {
         var cmp = ToTemporalZonedDateTime(one, Undefined).EpochNanoseconds.CompareTo(

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
@@ -566,7 +566,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(epochNs, zdt.TimeZone, zdt.Calendar);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsZonedDateTime WithTimeZone(JsValue thisObject, JsValue timeZoneLike)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -574,7 +574,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(zdt.EpochNanoseconds, timeZone, zdt.Calendar);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsZonedDateTime WithCalendar(JsValue thisObject, JsValue calendarLike)
     {
         // https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withcalendar
@@ -639,7 +639,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.round
     /// </summary>
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Round(JsValue thisObject, JsValue roundTo)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -777,7 +777,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(epochNanoseconds, timeZone, calendar);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsZonedDateTime StartOfDay(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -792,7 +792,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(startOfDayNs, zdt.TimeZone, zdt.Calendar);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue GetTimeZoneTransition(JsValue thisObject, JsValue directionArg)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -846,14 +846,14 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         return _constructor.Construct(transitionNs.Value, zdt.TimeZone, zdt.Calendar);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsInstant ToInstant(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
         return _realm.Intrinsics.TemporalInstant.Construct(zdt.EpochNanoseconds);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsPlainDate ToPlainDate(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -861,7 +861,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         return _realm.Intrinsics.TemporalPlainDate.Construct(dt.Date, zdt.Calendar);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsPlainTime ToPlainTime(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -869,7 +869,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         return _realm.Intrinsics.TemporalPlainTime.Construct(dt.Time);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsPlainDateTime ToPlainDateTime(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -877,7 +877,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         return _realm.Intrinsics.TemporalPlainDateTime.Construct(dt, zdt.Calendar);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsPlainYearMonth ToPlainYearMonth(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -885,7 +885,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         return _realm.Intrinsics.TemporalPlainYearMonth.Construct(dt.Date, zdt.Calendar);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsPlainMonthDay ToPlainMonthDay(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -893,7 +893,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         return _realm.Intrinsics.TemporalPlainMonthDay.Construct(dt.Date, zdt.Calendar);
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsBoolean Equals(JsValue thisObject, JsValue other)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -1101,7 +1101,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         return new JsString(FormatZonedDateTime(zdt, showCalendar, showTimeZone, showOffset, precision));
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsString ToJSON(JsValue thisObject)
     {
         var zdt = ValidateZonedDateTime(thisObject);
@@ -1141,7 +1141,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
         return dtf.Format(dateTime);
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue ValueOf(JsValue thisObject)
     {
         Throw.TypeError(_realm, "ZonedDateTime.prototype.valueOf is not allowed");

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayConstructor.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayConstructor.cs
@@ -1,17 +1,16 @@
 #pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of constructor methods return JsValue
 
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Native.TypedArray;
 
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%typedarray%-intrinsic-object
 /// </summary>
-internal sealed class IntrinsicTypedArrayConstructor : Constructor
+[JsObject]
+internal sealed partial class IntrinsicTypedArrayConstructor : Constructor
 {
     internal IntrinsicTypedArrayConstructor(
         Engine engine,
@@ -30,34 +29,21 @@ internal sealed class IntrinsicTypedArrayConstructor : Constructor
 
     protected override void Initialize()
     {
-        var properties = new PropertyDictionary(2, false)
-        {
-            ["from"] = new(new PropertyDescriptor(new ClrFunction(Engine, "from", From, 1, PropertyFlag.Configurable), PropertyFlag.NonEnumerable)),
-            ["of"] = new(new PropertyDescriptor(new ClrFunction(Engine, "of", Of, 0, PropertyFlag.Configurable), PropertyFlag.NonEnumerable))
-        };
-        SetProperties(properties);
-
-        var symbols = new SymbolDictionary(1)
-        {
-            [GlobalSymbolRegistry.Species] = new GetSetPropertyDescriptor(new ClrFunction(Engine, "get [Symbol.species]", Species, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.from
     /// </summary>
-    private JsValue From(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue From(JsValue thisObject, JsValue source, JsValue mapFunction, JsValue thisArg)
     {
         var c = thisObject;
         if (!c.IsConstructor)
         {
             Throw.TypeError(_realm, "Value is not a constructor");
         }
-
-        var source = arguments.At(0);
-        var mapFunction = arguments.At(1);
-        var thisArg = arguments.At(2);
 
         var mapping = !mapFunction.IsUndefined();
         if (mapping)
@@ -68,7 +54,7 @@ internal sealed class IntrinsicTypedArrayConstructor : Constructor
             }
         }
 
-        var usingIterator = GetMethod(_realm, source, GlobalSymbolRegistry.Iterator);
+        var usingIterator = GetMethod(_realm, source, Symbol.GlobalSymbolRegistry.Iterator);
         if (usingIterator is not null)
         {
             var values = TypedArrayConstructor.IterableToList(_realm, source, usingIterator);
@@ -123,9 +109,10 @@ internal sealed class IntrinsicTypedArrayConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.of
     /// </summary>
-    private JsValue Of(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue Of(JsValue thisObject, [Rest] ReadOnlySpan<JsValue> items)
     {
-        var len = arguments.Length;
+        var len = items.Length;
 
         if (!thisObject.IsConstructor)
         {
@@ -134,12 +121,9 @@ internal sealed class IntrinsicTypedArrayConstructor : Constructor
 
         var newObj = TypedArrayCreate(_realm, (IConstructor) thisObject, [len]);
 
-        var k = 0;
-        while (k < len)
+        for (var k = 0; k < len; k++)
         {
-            var kValue = arguments[k];
-            newObj[k] = kValue;
-            k++;
+            newObj[k] = items[k];
         }
 
         return newObj;
@@ -184,10 +168,11 @@ internal sealed class IntrinsicTypedArrayConstructor : Constructor
         return taRecord.Object;
     }
 
-    private static JsValue Species(JsValue thisObject, JsCallArguments arguments)
-    {
-        return thisObject;
-    }
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-get-%typedarray%-@@species
+    /// </summary>
+    [JsSymbolAccessor("Species")]
+    private static JsValue Species(JsValue thisObject) => thisObject;
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -18,12 +18,13 @@ namespace Jint.Native.TypedArray;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-%typedarrayprototype%-object
 /// </summary>
-internal sealed class IntrinsicTypedArrayPrototype : Prototype
+[JsObject]
+internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 {
     private const int ConstraintCheckInterval = 10_000;
 
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly IntrinsicTypedArrayConstructor _constructor;
-    private ClrFunction? _originalIteratorFunction;
 
     internal IntrinsicTypedArrayPrototype(
         Engine engine,
@@ -36,65 +37,26 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
 
     protected override void Initialize()
     {
-        const PropertyFlag LengthFlags = PropertyFlag.Configurable;
         const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        var properties = new PropertyDictionary(36, false)
-        {
-            ["at"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "at", prototype.At, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["buffer"] = new GetSetPropertyDescriptor(new ClrFunction(_engine, "get buffer", Buffer, 0, LengthFlags), Undefined, PropertyFlag.Configurable),
-            ["byteLength"] = new GetSetPropertyDescriptor(new ClrFunction(_engine, "get byteLength", ByteLength, 0, LengthFlags), Undefined, PropertyFlag.Configurable),
-            ["byteOffset"] = new GetSetPropertyDescriptor(new ClrFunction(_engine, "get byteOffset", ByteOffset, 0, LengthFlags), Undefined, PropertyFlag.Configurable),
-            ["constructor"] = new(_constructor, PropertyFlag.NonEnumerable),
-            ["copyWithin"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "copyWithin", prototype.CopyWithin, 2, PropertyFlag.Configurable), PropertyFlags),
-            ["entries"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "entries", prototype.Entries, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["every"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "every", prototype.Every, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["fill"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "fill", prototype.Fill, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["filter"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "filter", prototype.Filter, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["find"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "find", prototype.Find, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["findIndex"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "findIndex", prototype.FindIndex, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["findLast"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "findLast", prototype.FindLast, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["findLastIndex"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "findLastIndex", prototype.FindLastIndex, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["forEach"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "forEach", prototype.ForEach, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["includes"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "includes", prototype.Includes, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["indexOf"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "indexOf", prototype.IndexOf, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["join"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "join", prototype.Join, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["keys"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "keys", prototype.Keys, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["lastIndexOf"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "lastIndexOf", prototype.LastIndexOf, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["length"] = new GetSetPropertyDescriptor(new ClrFunction(_engine, "get length", GetLength, 0, LengthFlags), Undefined, PropertyFlag.Configurable),
-            ["map"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "map", prototype.Map, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["reduce"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "reduce", prototype.Reduce, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["reduceRight"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "reduceRight", prototype.ReduceRight, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["reverse"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "reverse", prototype.Reverse, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["set"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "set", prototype.Set, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["slice"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "slice", prototype.Slice, 2, PropertyFlag.Configurable), PropertyFlags),
-            ["some"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "some", prototype.Some, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["sort"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "sort", prototype.Sort, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["subarray"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "subarray", prototype.Subarray, 2, PropertyFlag.Configurable), PropertyFlags),
-            ["toLocaleString"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "toLocaleString", prototype.ToLocaleString, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["toReversed"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "toReversed", prototype.ToReversed, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["toSorted"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "toSorted", prototype.ToSorted, 1, PropertyFlag.Configurable), PropertyFlags),
-            // Per spec (ECMA-262 23.2.3.32) the initial value of %TypedArray%.prototype.toString is the
-            // same function object as %Array.prototype.toString%. Materialize Array.prototype.toString and
-            // share that instance so SameValue holds.
-            ["toString"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => prototype._realm.Intrinsics.Array.PrototypeObject.Get("toString"), PropertyFlags),
-            ["values"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "values", prototype.Values, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["with"] = new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => new ClrFunction(prototype._engine, "with", prototype.With, 2, PropertyFlag.Configurable), PropertyFlags),
-        };
-        SetProperties(properties);
+        CreateProperties_Generated();
+        CreateSymbols_Generated();
 
-        _originalIteratorFunction = new ClrFunction(_engine, "iterator", Values, 1);
-        var symbols = new SymbolDictionary(2)
-        {
-            [GlobalSymbolRegistry.Iterator] = new(_originalIteratorFunction, PropertyFlags),
-            [GlobalSymbolRegistry.ToStringTag] = new GetSetPropertyDescriptor(new ClrFunction(_engine, "get [Symbol.toStringTag]", ToStringTag, 0, PropertyFlag.Configurable), Undefined, PropertyFlag.Configurable)
-        };
-        SetSymbols(symbols);
+        // Per spec (ECMA-262 23.2.3.32) the initial value of %TypedArray%.prototype.toString is the
+        // SAME function object as %Array.prototype.toString%. Hand-write this entry — the generator
+        // can't express "alias to another realm intrinsic" through [JsFunction].
+        SetOwnProperty("toString", new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => prototype._realm.Intrinsics.Array.PrototypeObject.Get("toString"), PropertyFlags));
+
+        // Per spec, %TypedArray%.prototype[@@iterator] is the SAME function object as
+        // %TypedArray%.prototype.values. Materialize the generated `values` slot and reuse it.
+        var valuesValue = GetOwnProperty("values").Value;
+        SetOwnProperty(GlobalSymbolRegistry.Iterator, new PropertyDescriptor(valuesValue, PropertyFlags));
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer
     /// </summary>
-    private JsValue Buffer(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("buffer")]
+    private JsValue Buffer(JsValue thisObject)
     {
         var o = thisObject as JsTypedArray;
         if (o is null)
@@ -108,7 +70,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.bytelength
     /// </summary>
-    private JsValue ByteLength(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("byteLength")]
+    private JsValue ByteLength(JsValue thisObject)
     {
         var o = thisObject as JsTypedArray;
         if (o is null)
@@ -123,7 +86,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.byteoffset
     /// </summary>
-    private JsValue ByteOffset(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("byteOffset")]
+    private JsValue ByteOffset(JsValue thisObject)
     {
         var o = thisObject as JsTypedArray;
         if (o is null)
@@ -143,7 +107,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.length
     /// </summary>
-    private JsValue GetLength(JsValue thisObject, JsCallArguments arguments)
+    [JsAccessor("length")]
+    private JsValue GetLength(JsValue thisObject)
     {
         var o = thisObject as JsTypedArray;
         if (o is null)
@@ -276,15 +241,12 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.copywithin
     /// </summary>
-    private JsValue CopyWithin(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 2)]
+    private JsValue CopyWithin(JsValue thisObject, JsValue target, JsValue start, JsValue end)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
-
-        var target = arguments.At(0);
-        var start = arguments.At(1);
-        var end = arguments.At(2);
 
         var relativeTarget = TypeConverter.ToIntegerOrInfinity(target);
 
@@ -401,7 +363,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.entries
     /// </summary>
-    private JsValue Entries(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue Entries(JsValue thisObject)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
@@ -411,7 +374,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.every
     /// </summary>
-    private JsValue Every(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Every(JsValue thisObject, JsValue callbackFn, JsValue thisArg)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
@@ -422,8 +386,7 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
             return JsBoolean.True;
         }
 
-        var predicate = GetCallable(arguments.At(0));
-        var thisArg = arguments.At(1);
+        var predicate = GetCallable(callbackFn);
 
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o;
@@ -445,15 +408,12 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.fill
     /// </summary>
-    private JsValue Fill(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Fill(JsValue thisObject, JsValue jsValue, JsValue start, JsValue end)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
-
-        var jsValue = arguments.At(0);
-        var start = arguments.At(1);
-        var end = arguments.At(2);
 
         JsValue value;
         if (o._contentType == TypedArrayContentType.BigInt)
@@ -523,10 +483,10 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.filter
     /// </summary>
-    private JsValue Filter(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Filter(JsValue thisObject, JsValue callbackFn, JsValue thisArg)
     {
-        var callbackfn = GetCallable(arguments.At(0));
-        var thisArg = arguments.At(1);
+        var callbackfn = GetCallable(callbackFn);
 
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
@@ -564,37 +524,40 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.find
     /// </summary>
-    private JsValue Find(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Find(JsValue thisObject, JsValue predicate, JsValue thisArg)
     {
-        return DoFind(thisObject, arguments).Value;
+        return DoFind(thisObject, predicate, thisArg).Value;
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.findindex
     /// </summary>
-    private JsValue FindIndex(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue FindIndex(JsValue thisObject, JsValue predicate, JsValue thisArg)
     {
-        return DoFind(thisObject, arguments).Key;
+        return DoFind(thisObject, predicate, thisArg).Key;
     }
 
-    private JsValue FindLast(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue FindLast(JsValue thisObject, JsValue predicate, JsValue thisArg)
     {
-        return DoFind(thisObject, arguments, fromEnd: true).Value;
+        return DoFind(thisObject, predicate, thisArg, fromEnd: true).Value;
     }
 
-    private JsValue FindLastIndex(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue FindLastIndex(JsValue thisObject, JsValue predicate, JsValue thisArg)
     {
-        return DoFind(thisObject, arguments, fromEnd: true).Key;
+        return DoFind(thisObject, predicate, thisArg, fromEnd: true).Key;
     }
 
-    private KeyValuePair<JsValue, JsValue> DoFind(JsValue thisObject, JsCallArguments arguments, bool fromEnd = false)
+    private KeyValuePair<JsValue, JsValue> DoFind(JsValue thisObject, JsValue predicateArg, JsValue thisArg, bool fromEnd = false)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
 
-        var predicate = GetCallable(arguments.At(0));
-        var thisArg = arguments.At(1);
+        var predicate = GetCallable(predicateArg);
 
         if (len == 0)
         {
@@ -638,10 +601,10 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.foreach
     /// </summary>
-    private JsValue ForEach(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue ForEach(JsValue thisObject, JsValue callbackFn, JsValue thisArg)
     {
-        var callbackfn = GetCallable(arguments.At(0));
-        var thisArg = arguments.At(1);
+        var callbackfn = GetCallable(callbackFn);
 
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
@@ -665,7 +628,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.includes
     /// </summary>
-    private JsValue Includes(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Includes(JsValue thisObject, JsValue searchElement, JsValue fromIndex)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
@@ -676,10 +640,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
             return false;
         }
 
-        var searchElement = arguments.At(0);
-        var fromIndex = arguments.At(1, 0);
-
-        var n = TypeConverter.ToIntegerOrInfinity(fromIndex);
+        // Per spec: when fromIndex is undefined treat n as 0 (skip ToIntegerOrInfinity coercion).
+        var n = fromIndex.IsUndefined() ? 0 : TypeConverter.ToIntegerOrInfinity(fromIndex);
         if (double.IsPositiveInfinity(n))
         {
             return JsBoolean.False;
@@ -720,11 +682,9 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.indexof
     /// </summary>
-    private JsValue IndexOf(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue IndexOf(JsValue thisObject, JsValue searchElement, JsValue fromIndex)
     {
-        var searchElement = arguments.At(0);
-        var fromIndex = arguments.At(1);
-
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
@@ -777,10 +737,9 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.join
     /// </summary>
-    private JsValue Join(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue Join(JsValue thisObject, JsValue separator)
     {
-        var separator = arguments.At(0);
-
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
@@ -819,7 +778,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.keys
     /// </summary>
-    private JsValue Keys(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue Keys(JsValue thisObject)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
@@ -829,6 +789,10 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.lastindexof
     /// </summary>
+    // Keeps JsCallArguments because the spec distinguishes "fromIndex is present" from
+    // "fromIndex is absent": a present-but-undefined value coerces via ToIntegerOrInfinity (→ NaN),
+    // an absent value defaults to len - 1. Only arguments.Length can tell them apart.
+    [JsFunction(Length = 1)]
     private JsValue LastIndexOf(JsValue thisObject, JsCallArguments arguments)
     {
         var searchElement = arguments.At(0);
@@ -879,14 +843,14 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.map
     /// </summary>
-    private ObjectInstance Map(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private ObjectInstance Map(JsValue thisObject, JsValue callbackFn, JsValue thisArg)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
 
-        var thisArg = arguments.At(1);
-        var callable = GetCallable(arguments.At(0));
+        var callable = GetCallable(callbackFn);
 
         var a = _realm.Intrinsics.TypedArray.TypedArraySpeciesCreate(o, [len]);
         var args = _engine._jsValueArrayPool.RentArray(3);
@@ -906,6 +870,9 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduce
     /// </summary>
+    // Keeps JsCallArguments because spec step 5 distinguishes "initialValue is present" from
+    // "missing" — that distinction is only available via arguments.Length.
+    [JsFunction(Length = 1)]
     private JsValue Reduce(JsValue thisObject, JsCallArguments arguments)
     {
         var callbackfn = GetCallable(arguments.At(0));
@@ -952,6 +919,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduceright
     /// </summary>
+    // Keeps JsCallArguments — same arity-distinction reasoning as Reduce above.
+    [JsFunction(Length = 1)]
     private JsValue ReduceRight(JsValue thisObject, JsCallArguments arguments)
     {
         var callbackfn = GetCallable(arguments.At(0));
@@ -995,7 +964,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.reverse
     /// </summary>
-    private ObjectInstance Reverse(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private ObjectInstance Reverse(JsValue thisObject)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
@@ -1028,16 +998,14 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.set
     /// </summary>
-    private JsValue Set(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Name = "set", Length = 1)]
+    private JsValue SetTypedArray(JsValue thisObject, JsValue source, JsValue offset)
     {
         var target = thisObject as JsTypedArray;
         if (target is null)
         {
             Throw.TypeError(_realm, $"Method TypedArray.prototype.set called on incompatible receiver {thisObject}");
         }
-
-        var source = arguments.At(0);
-        var offset = arguments.At(1);
 
         var targetOffset = TypeConverter.ToIntegerOrInfinity(offset);
         if (targetOffset < 0)
@@ -1182,10 +1150,9 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/proposal-relative-indexing-method/#sec-%typedarray.prototype%-additions
     /// </summary>
-    private JsValue At(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue At(JsValue thisObject, JsValue start)
     {
-        var start = arguments.At(0);
-
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
@@ -1213,11 +1180,9 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.slice
     /// </summary>
-    private JsValue Slice(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue Slice(JsValue thisObject, JsValue start, JsValue end)
     {
-        var start = arguments.At(0);
-        var end = arguments.At(1);
-
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
@@ -1306,14 +1271,14 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.some
     /// </summary>
-    private JsValue Some(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsValue Some(JsValue thisObject, JsValue callbackFn, JsValue thisArg)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
 
-        var callbackfn = GetCallable(arguments.At(0));
-        var thisArg = arguments.At(1);
+        var callbackfn = GetCallable(callbackFn);
 
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o;
@@ -1334,7 +1299,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort
     /// </summary>
-    private JsValue Sort(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue Sort(JsValue thisObject, JsValue compareFnArg)
     {
         /*
          * %TypedArray%.prototype.sort is a distinct function that, except as described below,
@@ -1349,7 +1315,7 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
 
         var buffer = o._viewedArrayBuffer;
 
-        var compareFn = GetCompareFunction(arguments.At(0));
+        var compareFn = GetCompareFunction(compareFnArg);
 
         if (len <= 1)
         {
@@ -1369,16 +1335,14 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.subarray
     /// </summary>
-    private JsValue Subarray(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue Subarray(JsValue thisObject, JsValue start, JsValue end)
     {
         var o = thisObject as JsTypedArray;
         if (o is null)
         {
             Throw.TypeError(_realm, $"Method TypedArray.prototype.subarray called on incompatible receiver {thisObject}");
         }
-
-        var start = arguments.At(0);
-        var end = arguments.At(1);
 
         var buffer = o._viewedArrayBuffer;
         var srcRecord = MakeTypedArrayWithBufferWitnessRecord(o, ArrayBufferOrder.SeqCst);
@@ -1450,7 +1414,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.tolocalestring
     /// </summary>
-    private JsValue ToLocaleString(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsValue ToLocaleString(JsValue thisObject, JsValue locales, JsValue options)
     {
         /*
          * %TypedArray%.prototype.toLocaleString is a distinct function that implements the same algorithm as Array.prototype.toLocaleString
@@ -1472,8 +1437,6 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
         }
 
         // Per ECMA-402, pass locales and options to element's toLocaleString
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
         var invokeArgs = !locales.IsUndefined() || !options.IsUndefined()
             ? new[] { locales, options }
             : System.Array.Empty<JsValue>();
@@ -1498,7 +1461,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-%typedarray%.prototype.values
     /// </summary>
-    private JsValue Values(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue Values(JsValue thisObject)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
@@ -1508,7 +1472,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
     /// <summary>
     /// https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag
     /// </summary>
-    private static JsValue ToStringTag(JsValue thisObject, JsCallArguments arguments)
+    [JsSymbolAccessor("ToStringTag")]
+    private static JsValue ToStringTag(JsValue thisObject)
     {
         if (thisObject is not JsTypedArray o)
         {
@@ -1518,7 +1483,8 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
         return o._arrayElementType.GetTypedArrayName();
     }
 
-    private JsValue ToReversed(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue ToReversed(JsValue thisObject)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
@@ -1541,13 +1507,14 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
         return a;
     }
 
-    private JsValue ToSorted(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue ToSorted(JsValue thisObject, JsValue compareFnArg)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
 
-        var compareFn = GetCompareFunction(arguments.At(0));
+        var compareFn = GetCompareFunction(compareFnArg);
 
         var buffer = o._viewedArrayBuffer;
 
@@ -1562,15 +1529,14 @@ internal sealed class IntrinsicTypedArrayPrototype : Prototype
         return a;
     }
 
-    private ObjectInstance With(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private ObjectInstance With(JsValue thisObject, JsValue indexArg, JsValue value)
     {
         var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
 
-        var value = arguments.At(1);
-
-        var relativeIndex = TypeConverter.ToIntegerOrInfinity(arguments.At(0));
+        var relativeIndex = TypeConverter.ToIntegerOrInfinity(indexArg);
 
         long actualIndex;
         if (relativeIndex >= 0)

--- a/Jint/Native/TypedArray/TypedArrayConstructor.Uint8Array.cs
+++ b/Jint/Native/TypedArray/TypedArrayConstructor.Uint8Array.cs
@@ -8,8 +8,16 @@ using Jint.Runtime.Interop;
 
 namespace Jint.Native.TypedArray;
 
-public sealed class Uint8ArrayConstructor : TypedArrayConstructor
+[JsObject]
+public sealed partial class Uint8ArrayConstructor : TypedArrayConstructor
 {
+    // Uint8 element size is fixed at 1; the base class also tracks BYTES_PER_ELEMENT but its
+    // generator-emitted CreateProperties_Generated() is private, so this subclass redeclares the
+    // entry locally. Duplicate, but cheap (single static field) and avoids fragile base.Initialize
+    // chaining (SetProperties replaces _properties wholesale).
+    [JsProperty(Name = "BYTES_PER_ELEMENT", Flags = PropertyFlag.AllForbidden)]
+    private static readonly JsNumber BytesPerElementValue = JsNumber.PositiveOne;
+
     internal Uint8ArrayConstructor(
         Engine engine,
         Realm realm,
@@ -18,17 +26,7 @@ public sealed class Uint8ArrayConstructor : TypedArrayConstructor
     {
     }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(3, checkExistingKeys: false)
-        {
-            ["BYTES_PER_ELEMENT"] = new(new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.AllForbidden)),
-            ["fromBase64"] = new(new ClrFunction(Engine, "fromBase64", FromBase64, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["fromHex"] = new(new ClrFunction(Engine, "fromHex", FromHex, 1, PropertyFlag.Configurable), PropertyFlags),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     public JsTypedArray Construct(ReadOnlySpan<byte> values)
     {
@@ -37,16 +35,15 @@ public sealed class Uint8ArrayConstructor : TypedArrayConstructor
         return array;
     }
 
-    private JsTypedArray FromBase64(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsTypedArray FromBase64(JsValue thisObject, JsValue s, JsValue options)
     {
-        var s = arguments.At(0);
-
         if (!s.IsString())
         {
             Throw.TypeError(_realm, "fromBase64 must be called with a string");
         }
 
-        var opts = GetOptionsObject(_engine, arguments.At(1));
+        var opts = GetOptionsObject(_engine, options);
         var alphabet = GetAndValidateAlphabetOption(_engine, opts);
         var lastChunkHandling = GetAndValidateLastChunkHandling(_engine, opts);
 
@@ -292,10 +289,9 @@ public sealed class Uint8ArrayConstructor : TypedArrayConstructor
         into.AddRange(bytes);
     }
 
-    private JsTypedArray FromHex(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsTypedArray FromHex(JsValue thisObject, JsValue s)
     {
-        var s = arguments.At(0);
-
         if (!s.IsString())
         {
             Throw.TypeError(_realm, "fromHex must be called with a string");

--- a/Jint/Native/TypedArray/TypedArrayConstructor.cs
+++ b/Jint/Native/TypedArray/TypedArrayConstructor.cs
@@ -11,9 +11,13 @@ namespace Jint.Native.TypedArray;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-typedarray-constructors
 /// </summary>
-public abstract class TypedArrayConstructor : Constructor
+[JsObject]
+public abstract partial class TypedArrayConstructor : Constructor
 {
     private readonly TypedArrayElementType _arrayElementType;
+
+    [JsProperty(Name = "BYTES_PER_ELEMENT", Flags = PropertyFlag.AllForbidden)]
+    private readonly JsNumber _bytesPerElement;
 
     internal TypedArrayConstructor(
         Engine engine,
@@ -23,6 +27,7 @@ public abstract class TypedArrayConstructor : Constructor
         TypedArrayElementType type) : base(engine, realm, new JsString(type.GetTypedArrayName()))
     {
         _arrayElementType = type;
+        _bytesPerElement = JsNumber.Create(type.GetElementSize());
         _prototype = functionPrototype;
 
         PrototypeObject = type == TypedArrayElementType.Uint8
@@ -35,14 +40,7 @@ public abstract class TypedArrayConstructor : Constructor
 
     private Prototype PrototypeObject { get; }
 
-    protected override void Initialize()
-    {
-        var properties = new PropertyDictionary(1, false)
-        {
-            ["BYTES_PER_ELEMENT"] = new(new PropertyDescriptor(JsNumber.Create(_arrayElementType.GetElementSize()), PropertyFlag.AllForbidden))
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
     public JsTypedArray Construct(JsArrayBuffer buffer, int? byteOffset = null, int? length = null)
     {

--- a/Jint/Native/TypedArray/TypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/TypedArrayPrototype.cs
@@ -1,3 +1,4 @@
+using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.TypedArray;
@@ -5,10 +6,14 @@ namespace Jint.Native.TypedArray;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-typedarray-prototype-objects
 /// </summary>
-internal sealed class TypedArrayPrototype : Prototype
+[JsObject]
+internal sealed partial class TypedArrayPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly TypedArrayConstructor _constructor;
-    private readonly TypedArrayElementType _arrayElementType;
+
+    [JsProperty(Name = "BYTES_PER_ELEMENT", Flags = PropertyFlag.AllForbidden)]
+    private readonly JsNumber _bytesPerElement;
 
     internal TypedArrayPrototype(
         Engine engine,
@@ -18,16 +23,8 @@ internal sealed class TypedArrayPrototype : Prototype
     {
         _prototype = objectPrototype;
         _constructor = constructor;
-        _arrayElementType = type;
+        _bytesPerElement = JsNumber.Create(type.GetElementSize());
     }
 
-    protected override void Initialize()
-    {
-        var properties = new PropertyDictionary(2, checkExistingKeys: false)
-        {
-            ["BYTES_PER_ELEMENT"] = new(JsNumber.Create(_arrayElementType.GetElementSize()), PropertyFlag.AllForbidden),
-            ["constructor"] = new(_constructor, PropertyFlag.NonEnumerable),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 }

--- a/Jint/Native/TypedArray/Uint8ArrayPrototype.cs
+++ b/Jint/Native/TypedArray/Uint8ArrayPrototype.cs
@@ -7,9 +7,14 @@ using Jint.Runtime.Interop;
 
 namespace Jint.Native.TypedArray;
 
-internal sealed class Uint8ArrayPrototype : Prototype
+[JsObject]
+internal sealed partial class Uint8ArrayPrototype : Prototype
 {
+    [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly TypedArrayConstructor _constructor;
+
+    [JsProperty(Name = "BYTES_PER_ELEMENT", Flags = PropertyFlag.AllForbidden)]
+    private static readonly JsNumber BytesPerElementValue = JsNumber.PositiveOne;
 
     public Uint8ArrayPrototype(
         Engine engine,
@@ -19,35 +24,21 @@ internal sealed class Uint8ArrayPrototype : Prototype
     {
         _prototype = objectPrototype;
         _constructor = constructor;
-
     }
 
-    protected override void Initialize()
-    {
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        var properties = new PropertyDictionary(6, checkExistingKeys: false)
-        {
-            ["BYTES_PER_ELEMENT"] = new(JsNumber.PositiveOne, PropertyFlag.AllForbidden),
-            ["constructor"] = new(_constructor, PropertyFlag.NonEnumerable),
-            ["setFromBase64"] = new(new ClrFunction(Engine, "setFromBase64", SetFromBase64, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["setFromHex"] = new(new ClrFunction(Engine, "setFromHex", SetFromHex, 1, PropertyFlag.Configurable), PropertyFlags),
-            ["toBase64"] = new(new ClrFunction(Engine, "toBase64", ToBase64, 0, PropertyFlag.Configurable), PropertyFlags),
-            ["toHex"] = new(new ClrFunction(Engine, "toHex", ToHex, 0, PropertyFlag.Configurable), PropertyFlags),
-        };
-        SetProperties(properties);
-    }
+    protected override void Initialize() => CreateProperties_Generated();
 
-    private JsObject SetFromBase64(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 1)]
+    private JsObject SetFromBase64(JsValue thisObject, JsValue s, JsValue options)
     {
         var into = ValidateUint8Array(thisObject);
-        var s = arguments.At(0);
 
         if (!s.IsString())
         {
             Throw.TypeError(_realm, "setFromBase64 must be called with a string");
         }
 
-        var opts = Uint8ArrayConstructor.GetOptionsObject(_engine, arguments.At(1));
+        var opts = Uint8ArrayConstructor.GetOptionsObject(_engine, options);
         var alphabet = Uint8ArrayConstructor.GetAndValidateAlphabetOption(_engine, opts);
         var lastChunkHandling = Uint8ArrayConstructor.GetAndValidateLastChunkHandling(_engine, opts);
 
@@ -86,10 +77,10 @@ internal sealed class Uint8ArrayPrototype : Prototype
         }
     }
 
-    private JsObject SetFromHex(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsObject SetFromHex(JsValue thisObject, JsValue s)
     {
         var into = ValidateUint8Array(thisObject);
-        var s = arguments.At(0);
 
         if (!s.IsString())
         {
@@ -117,11 +108,12 @@ internal sealed class Uint8ArrayPrototype : Prototype
         return resultObject;
     }
 
-    private JsValue ToBase64(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction(Length = 0)]
+    private JsValue ToBase64(JsValue thisObject, JsValue options)
     {
         var o = ValidateUint8Array(thisObject);
 
-        var opts = Uint8ArrayConstructor.GetOptionsObject(_engine, arguments.At(0));
+        var opts = Uint8ArrayConstructor.GetOptionsObject(_engine, options);
         var alphabet = Uint8ArrayConstructor.GetAndValidateAlphabetOption(_engine, opts);
 
         var omitPadding = TypeConverter.ToBoolean(opts.Get("omitPadding"));
@@ -148,7 +140,8 @@ internal sealed class Uint8ArrayPrototype : Prototype
         return outAscii;
     }
 
-    private JsValue ToHex(JsValue thisObject, JsCallArguments arguments)
+    [JsFunction]
+    private JsValue ToHex(JsValue thisObject)
     {
         var o = ValidateUint8Array(thisObject);
         var toEncode = GetUint8ArrayBytes(o);

--- a/Jint/Native/WeakMap/WeakMapPrototype.cs
+++ b/Jint/Native/WeakMap/WeakMapPrototype.cs
@@ -33,14 +33,14 @@ internal sealed partial class WeakMapPrototype : Prototype
         CreateSymbols_Generated();
     }
 
-    [JsFunction(Length = 1, Name = "get")]
+    [JsFunction(Name = "get")]
     private JsValue MapGet(JsValue thisObject, JsValue key)
     {
         var map = AssertWeakMapInstance(thisObject);
         return map.WeakMapGet(key);
     }
 
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue GetOrInsert(JsValue thisObject, JsValue key, JsValue value)
     {
         var map = AssertWeakMapInstance(thisObject);
@@ -48,7 +48,7 @@ internal sealed partial class WeakMapPrototype : Prototype
         return map.GetOrInsert(checkedKey, value);
     }
 
-    [JsFunction(Length = 2)]
+    [JsFunction]
     private JsValue GetOrInsertComputed(JsValue thisObject, JsValue key, JsValue callbackfn)
     {
         var map = AssertWeakMapInstance(thisObject);
@@ -67,14 +67,14 @@ internal sealed partial class WeakMapPrototype : Prototype
         return key;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Delete(JsValue thisObject, JsValue key)
     {
         var map = AssertWeakMapInstance(thisObject);
         return map.WeakMapDelete(key) ? JsBoolean.True : JsBoolean.False;
     }
 
-    [JsFunction(Length = 2, Name = "set")]
+    [JsFunction(Name = "set")]
     private JsValue MapSet(JsValue thisObject, JsValue key, JsValue value)
     {
         var map = AssertWeakMapInstance(thisObject);
@@ -82,7 +82,7 @@ internal sealed partial class WeakMapPrototype : Prototype
         return thisObject;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Has(JsValue thisObject, JsValue key)
     {
         var map = AssertWeakMapInstance(thisObject);

--- a/Jint/Native/WeakRef/WeakRefPrototype.cs
+++ b/Jint/Native/WeakRef/WeakRefPrototype.cs
@@ -31,7 +31,7 @@ internal sealed partial class WeakRefPrototype : Prototype
         CreateSymbols_Generated();
     }
 
-    [JsFunction(Length = 0)]
+    [JsFunction]
     private JsValue Deref(JsValue thisObject)
     {
         if (thisObject is JsWeakRef weakRef)

--- a/Jint/Native/WeakSet/WeakSetPrototype.cs
+++ b/Jint/Native/WeakSet/WeakSetPrototype.cs
@@ -42,7 +42,7 @@ internal sealed partial class WeakSetPrototype : Prototype
         OriginalAddFunction = (FunctionInstance) GetOwnProperty("add").Value!;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Add(JsValue thisObject, JsValue value)
     {
         var set = AssertWeakSetInstance(thisObject);
@@ -50,14 +50,14 @@ internal sealed partial class WeakSetPrototype : Prototype
         return thisObject;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Delete(JsValue thisObject, JsValue value)
     {
         var set = AssertWeakSetInstance(thisObject);
         return set.WeakSetDelete(value) ? JsBoolean.True : JsBoolean.False;
     }
 
-    [JsFunction(Length = 1)]
+    [JsFunction]
     private JsValue Has(JsValue thisObject, JsValue value)
     {
         var set = AssertWeakSetInstance(thisObject);


### PR DESCRIPTION
## Summary

Wraps up the source-generator rollout to `Jint/Native/`. After this PR, only `GlobalObject.Properties.cs` remains hand-rolled — its 50+ entries are lazy lookups into `_realm.Intrinsics.X` (a per-realm closure pattern not expressible via `[JsProperty]`'s field-reference model).

### Migrations

- **Math-shaped hosts** (8): `AggregateErrorPrototype`, `SuppressedErrorPrototype`, `AsyncFunctionPrototype`, `AsyncGeneratorFunctionPrototype`, `GeneratorFunctionPrototype`, `AsyncFromSyncIteratorPrototype`, `JsSegments`, `TemporalNow`.
- **TypedArray cluster** (6): `TypedArrayConstructor` (abstract base — adds an instance `JsNumber _bytesPerElement` so the 11 element-type subclasses inherit BYTES_PER_ELEMENT through the base's generated registration), `Uint8ArrayConstructor` (`fromBase64`/`fromHex`), `IntrinsicTypedArrayConstructor` (`from`/`of` + `@@species`), `IntrinsicTypedArrayPrototype` (~30 methods + `buffer`/`byteLength`/`byteOffset`/`length` accessors + `@@toStringTag`), `TypedArrayPrototype`, `Uint8ArrayPrototype`.
- **`RegExpPrototype` hybrid cleanup**: 8 simple per-flag accessors (`dotAll`/`global`/`hasIndices`/`ignoreCase`/`multiline`/`sticky`/`unicode`/`unicodeSets`) + `flags` + `source` moved to `[JsAccessor]`. `exec` stays hand-registered to keep the `HasDefaultRegExpExec` reference-identity check working. `RegExpConstructor`'s legacy `$1-$9`/`$_`/`$&`/`$+`/`` $\` ``/`$'` stay hand-rolled — their ClrFunction names must be empty so test262's native-function-syntax matcher accepts the `Function.prototype.toString` output.

### Spec-shaped signatures

Most migrated methods now take spec-named `JsValue` parameters (e.g. `callbackFn`, `thisArg`, `fromIndex`) instead of opaque `JsCallArguments`. The handful that genuinely need `arguments.Length` to distinguish *present-with-undefined* from *absent* (`Reduce`/`ReduceRight`, `LastIndexOf`, `AsyncFromSyncIterator next/return/throw`) keep `JsCallArguments` — documented inline at each site.

### Length sweep

Stripped **373** redundant ``[JsFunction(Length = N)]`` arguments where the generator's auto-inference (count of fixed value parameters, excluding `thisObject`/`[Rest]`/`JsCallArguments`) yields the same value. **225** explicit `Length` values remain — all on methods using `JsCallArguments` (auto = 0) or `[Rest]` where the spec length differs from the inferred count (`Math.{max,min,hypot}`, `Atomics.notify`, etc.).

## Test plan

- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors across all targets
- [x] `Jint.Tests` — 2880 / 5 skipped / 0 failed
- [x] `Jint.Tests.SourceGenerators` — 25 / 0 failed
- [x] `Jint.Tests.PublicInterface` — 79+79 / 0 failed
- [x] `Jint.Tests.CommonScripts` — 28+28 / 0 failed
- [x] `Jint.Tests.Test262` — **98,959 passed / 131 skipped / 0 failed** vs. baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)