### PR TITLE
Fix MissingMemberException on implicit string coercion of CLR objects

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
+++ b/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
@@ -299,6 +299,66 @@ public partial class InteropTests
         engine.Invoking(e => e.Evaluate("obj.AgeMissing")).Should().Throw<MissingMemberException>();
     }
 
+    private class ClassWithToString
+    {
+        public override string ToString() => "Test";
+    }
+
+    private class ClassWithCustomValueOf
+    {
+        public int ValueOf() => 42;
+        public override string ToString() => "Custom";
+    }
+
+    [Fact]
+    public void ImplicitStringCoercionShouldNotThrowForMissingValueOf()
+    {
+        // default settings — works as before via NullAccessor + prototype fallback
+        var engine = new Engine();
+        engine.SetValue("obj", new ClassWithToString());
+        engine.Evaluate("'prefix' + obj").AsString().Should().Be("prefixTest");
+
+        // bug regression — strict access must NOT block the implicit coercion
+        engine = new Engine(options => options.Interop.ThrowOnUnresolvedMember = true);
+        engine.SetValue("obj", new ClassWithToString());
+        engine.Evaluate("'prefix' + obj").AsString().Should().Be("prefixTest");
+
+        // valueOf via prototype returns the wrapper itself (Object.prototype.valueOf)
+        var wrapped = engine.Evaluate("obj");
+        engine.Evaluate("obj.valueOf()").Should().Be(wrapped);
+
+        // strict access still throws for genuinely missing members
+        engine.Invoking(e => e.Evaluate("obj.AgeMissing")).Should().Throw<MissingMemberException>();
+    }
+
+    [Fact]
+    public void NumericCoercionFallsBackToToStringWithStrictAccess()
+    {
+        // Number(obj): valueOf -> proto returns wrapper (not primitive) -> toString -> CLR ToString -> "Test" -> NaN
+        var engine = new Engine(options => options.Interop.ThrowOnUnresolvedMember = true);
+        engine.SetValue("obj", new ClassWithToString());
+        engine.Evaluate("Number(obj)").AsNumber().Should().Be(double.NaN);
+    }
+
+    [Fact]
+    public void CustomValueOfStillUsedWithStrictAccess()
+    {
+        // CLR ValueOf() resolves via case-insensitive first-char match — must take precedence over prototype's valueOf
+        var engine = new Engine(options => options.Interop.ThrowOnUnresolvedMember = true);
+        engine.SetValue("obj", new ClassWithCustomValueOf());
+        engine.Evaluate("'x' + obj").AsString().Should().Be("x42");
+        engine.Evaluate("Number(obj)").AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void StrictAccessStillThrowsForMissingWrites()
+    {
+        // Set policy unchanged: writing to an unknown member with strict mode throws
+        var engine = new Engine(options => options.Interop.ThrowOnUnresolvedMember = true);
+        engine.SetValue("obj", new ClassWithToString());
+        engine.Invoking(e => e.Evaluate("obj.NewProperty = 5")).Should().Throw<MissingMemberException>();
+    }
+
     public class ClassWithPropertyToHide
     {
         public int x { get; set; } = 2;

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -346,13 +346,23 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         }
 
         // slow path requires us to create a property descriptor that might get cached or not
-        var desc = GetOwnProperty(property, mustBeReadable: true, mustBeWritable: false);
+        // suppress ThrowOnUnresolvedMember here so we can fall back to the prototype chain
+        // (e.g. valueOf/toString from Object.prototype during implicit coercion)
+        var desc = GetOwnProperty(property, mustBeReadable: true, mustBeWritable: false, throwOnError: false);
         if (desc != PropertyDescriptor.Undefined)
         {
             return UnwrapJsValue(desc, receiver);
         }
 
-        return Prototype?.Get(property, receiver) ?? Undefined;
+        var protoResult = Prototype?.Get(property, receiver) ?? Undefined;
+        if (protoResult.IsUndefined()
+            && property is JsString
+            && _engine.Options.Interop.ThrowOnUnresolvedMember)
+        {
+            throw new MissingMemberException($"Cannot access property '{property}' on type '{ClrType.FullName}");
+        }
+
+        return protoResult;
     }
 
     public override List<JsValue> GetOwnPropertyKeys(Types types = Types.Empty | Types.String | Types.Symbol)
@@ -450,7 +460,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         return GetOwnProperty(property, mustBeReadable: false, mustBeWritable: false);
     }
 
-    private PropertyDescriptor GetOwnProperty(JsValue property, bool mustBeReadable, bool mustBeWritable)
+    private PropertyDescriptor GetOwnProperty(JsValue property, bool mustBeReadable, bool mustBeWritable, bool throwOnError = true)
     {
         if (TryGetProperty(property, out var x))
         {
@@ -503,7 +513,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             return new PropertyDescriptor(result, PropertyFlag.OnlyEnumerable);
         }
 
-        var accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, ClrType, member, mustBeReadable, mustBeWritable);
+        var accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, ClrType, member, mustBeReadable, mustBeWritable, throwOnError);
         var actualType = Target.GetType();
         if (ClrType != actualType)
         {
@@ -513,11 +523,11 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             //   that should take precedence over the indexer
             if (accessor == ConstantValueAccessor.NullAccessor)
             {
-                accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, mustBeReadable, mustBeWritable);
+                accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, mustBeReadable, mustBeWritable, throwOnError);
             }
             else if (accessor is IndexerAccessor)
             {
-                var runtimeAccessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, mustBeReadable, mustBeWritable);
+                var runtimeAccessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, mustBeReadable, mustBeWritable, throwOnError);
                 if (runtimeAccessor is not IndexerAccessor && runtimeAccessor != ConstantValueAccessor.NullAccessor)
                 {
                     // Prefer direct property/field/method from runtime type over indexer from declared type
@@ -553,7 +563,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             };
         }
 
-        var accessor = engine.Options.Interop.TypeResolver.GetAccessor(engine, target.GetType(), member.Name, mustBeReadable: false, mustBeWritable: false, Factory);
+        var accessor = engine.Options.Interop.TypeResolver.GetAccessor(engine, target.GetType(), member.Name, mustBeReadable: false, mustBeWritable: false, accessorFactory: Factory);
         return accessor.CreatePropertyDescriptor(engine, target, member.Name);
     }
 

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -76,6 +76,7 @@ public sealed class TypeResolver
         string member,
         bool mustBeReadable,
         bool mustBeWritable,
+        bool throwOnError = true,
         Func<ReflectionAccessor?>? accessorFactory = null)
     {
         var key = new Engine.ClrPropertyDescriptorFactoriesKey(type, member);
@@ -83,10 +84,16 @@ public sealed class TypeResolver
         var factories = engine._reflectionAccessors;
         if (factories.TryGetValue(key, out var accessor))
         {
+            if (throwOnError
+                && ReferenceEquals(accessor, ConstantValueAccessor.NullAccessor)
+                && engine.Options.Interop.ThrowOnUnresolvedMember)
+            {
+                throw new MissingMemberException($"Cannot access property '{member}' on type '{type.FullName}");
+            }
             return accessor;
         }
 
-        accessor = accessorFactory?.Invoke() ?? ResolvePropertyDescriptorFactory(engine, type, member, mustBeReadable, mustBeWritable);
+        accessor = accessorFactory?.Invoke() ?? ResolvePropertyDescriptorFactory(engine, type, member, mustBeReadable, mustBeWritable, throwOnError);
 
         // don't cache if numeric indexer
         if (uint.TryParse(member, out _))
@@ -109,7 +116,8 @@ public sealed class TypeResolver
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)] Type type,
         string memberName,
         bool mustBeReadable,
-        bool mustBeWritable)
+        bool mustBeWritable,
+        bool throwOnError)
     {
         var isInteger = long.TryParse(memberName, NumberStyles.Integer, CultureInfo.InvariantCulture, out _);
 
@@ -260,7 +268,7 @@ public sealed class TypeResolver
             }
         }
 
-        if (engine.Options.Interop.ThrowOnUnresolvedMember)
+        if (throwOnError && engine.Options.Interop.ThrowOnUnresolvedMember)
         {
             throw new MissingMemberException($"Cannot access property '{memberName}' on type '{type.FullName}");
         }


### PR DESCRIPTION
## Summary

Fixes #2430. When `Interop.ThrowOnUnresolvedMember = true`, implicit string coercion of a CLR object via `'x' + obj` threw `MissingMemberException` because `OrdinaryToPrimitive` calls `obj.Get(\"valueOf\")` and the CLR type typically has no `valueOf` member — `TypeResolver` threw before `ObjectWrapper.Get` could fall back to `Object.prototype.valueOf` / `toString`.

## Approach

Refactored the throw out of `TypeResolver` so the strict-access policy lives at the call site:

- `TypeResolver.GetAccessor` and `ResolvePropertyDescriptorFactory` take a new `bool throwOnError = true` parameter. When `false`, missing members return `ConstantValueAccessor.NullAccessor` instead of throwing.
- `ObjectWrapper.Get` calls the private `GetOwnProperty` with `throwOnError: false`, walks the prototype chain, and re-throws `MissingMemberException` only when both own + prototype lookups yield `Undefined`.
- The cache-hit branch in `GetAccessor` still throws when the caller passed `throwOnError: true`, so `Set` / `DefineOwnProperty` semantics are preserved (writing to a missing strict-mode member still throws).
- Symbols are excluded from the new throw (the existing symbol path already returns `Undefined` without consulting `TypeResolver`).

This eliminates the per-access exception cost that a try/catch fix (e.g. #2431) would incur — the cached `NullAccessor` makes repeat reads of `valueOf`/`toString` essentially free, so tight loops doing string concatenation stay fast.

## Closes

Supersedes #2431 (Copilot's try/catch approach), which has the right idea but throws + catches on every access since the cache write happens after the throw site.

## Test plan

- [x] `dotnet build --configuration Release` clean (warnings-as-errors)
- [x] New tests in `InteropTests.MemberAccess.cs`:
  - `ImplicitStringCoercionShouldNotThrowForMissingValueOf` — bug regression (default + strict mode), `obj.valueOf()` returns wrapper via prototype, `obj.AgeMissing` still throws.
  - `NumericCoercionFallsBackToToStringWithStrictAccess` — `Number(obj)` produces `NaN` via valueOf→toString fallback.
  - `CustomValueOfStillUsedWithStrictAccess` — CLR `ValueOf()` (case-insensitive first-char match) takes precedence over the prototype's `valueOf`.
  - `StrictAccessStillThrowsForMissingWrites` — `obj.NewProperty = 5` with strict mode still throws.
- [x] Full `Jint.Tests` passes (2879 net10 / 2832 net472, no regressions).
- [x] `Jint.Tests.PublicInterface` passes (79 / 79).