### PR TITLE
Add option to prefer JS prototype methods over CLR on wrapped objects

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -3260,6 +3260,106 @@ public partial class InteropTests : IDisposable
     }
 
     [Fact]
+    public void ListReverseDefaultsToClrSemantics()
+    {
+        // Default: List<T>.Reverse() (void) wins over Array.prototype.reverse — locks in current behavior.
+        // CLR void is exposed to JS as null (not undefined), and the list is reversed in place.
+        var engine = new Jint.Engine();
+        var list = new List<int> { 1, 2, 3 };
+        engine.SetValue("list", list);
+
+        var result = engine.Evaluate("list.reverse()");
+        Assert.True(result.IsNull());
+        Assert.Equal(new[] { 3, 2, 1 }, list);
+    }
+
+    [Fact]
+    public void PreferJsPrototypeMethodsMakesArrayReverseWin()
+    {
+        var engine = new Jint.Engine(cfg => cfg.PreferJsPrototypeMethods());
+        var list = new List<int> { 1, 2, 3 };
+        engine.SetValue("list", list);
+
+        Assert.True(engine.Evaluate("list.reverse() === list").AsBoolean());
+        Assert.Equal(new[] { 3, 2, 1 }, list);
+    }
+
+    [Fact]
+    public void PreferJsPrototypeMethodsMakesArraySortWin()
+    {
+        // Without the flag List<int>.Sort gives ascending int sort and returns void.
+        // With the flag, Array.prototype.sort returns the array and uses JS string-compare semantics
+        // ([10, 2, 1] -> [1, 10, 2] because "10" < "2" lexicographically).
+        var engine = new Jint.Engine(cfg => cfg.PreferJsPrototypeMethods());
+        var list = new List<int> { 10, 2, 1 };
+        engine.SetValue("list", list);
+
+        Assert.Equal("[1,10,2]", engine.Evaluate("JSON.stringify(list.sort())").AsString());
+    }
+
+    [Fact]
+    public void PreferJsPrototypeMethodsLeavesNonClashingClrMethodsAlone()
+    {
+        // Methods without an Array.prototype counterpart must still resolve to CLR.
+        var engine = new Jint.Engine(cfg => cfg.PreferJsPrototypeMethods());
+        var list = new List<string> { "A", "B" };
+        engine.SetValue("list", list);
+
+        engine.Evaluate("list.Add('C')");
+        Assert.Equal(3, list.Count);
+        Assert.Equal("C", list[2]);
+
+        engine.Evaluate("list.RemoveAt(0)");
+        Assert.Equal(new[] { "B", "C" }, list);
+    }
+
+    [Fact]
+    public void PreferJsPrototypeMethodsKeepsLengthMappedToCount()
+    {
+        // length is served by the fast path in ObjectWrapper.Get — must be unaffected.
+        var engine = new Jint.Engine(cfg => cfg.PreferJsPrototypeMethods());
+        var list = new List<int> { 10, 20, 30, 40 };
+        engine.SetValue("list", list);
+
+        Assert.Equal(4, engine.Evaluate("list.length").AsNumber());
+    }
+
+    [Fact]
+    public void PreferJsPrototypeMethodsDoesNotAffectPlainObjectWrapper()
+    {
+        // POCOs get Object.prototype, which the check explicitly skips, so CLR ToString still wins.
+        var engine = new Jint.Engine(cfg => cfg.PreferJsPrototypeMethods());
+        engine.SetValue("obj", new ClassWithToString());
+
+        Assert.Equal("Test", engine.Evaluate("obj.toString()").AsString());
+    }
+
+    [Fact]
+    public void ListReverseCanBeFixedTodayWithMemberFilter()
+    {
+        // Documents the workaround that works without the new flag, on existing Jint versions.
+        var engine = new Jint.Engine(options => options.SetTypeResolver(new TypeResolver
+        {
+            MemberFilter = m =>
+            {
+                if (m is System.Reflection.MethodInfo mi
+                    && mi.DeclaringType is { } dt
+                    && typeof(System.Collections.IList).IsAssignableFrom(dt))
+                {
+                    return mi.Name is not ("Reverse" or "Sort");
+                }
+                return true;
+            }
+        }));
+
+        var list = new List<int> { 1, 2, 3 };
+        engine.SetValue("list", list);
+
+        Assert.True(engine.Evaluate("list.reverse() === list").AsBoolean());
+        Assert.Equal(new[] { 3, 2, 1 }, list);
+    }
+
+    [Fact]
     public void ShouldBeJavaScriptException()
     {
         var engine = new Engine(cfg => cfg.AllowClr().AllowOperatorOverloading().CatchClrExceptions());

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -269,6 +269,18 @@ public static class OptionsExtensions
     }
 
     /// <summary>
+    /// When enabled, JavaScript prototype methods take precedence over CLR methods of the same name on wrapped CLR objects
+    /// whose prototype is not the default Object prototype (e.g. <c>Array.prototype</c> attached to wrapped <see cref="System.Collections.Generic.IList{T}"/>).
+    /// Avoids semantic mismatches such as <c>List&lt;T&gt;.Reverse()</c> returning <c>void</c> while
+    /// <c>Array.prototype.reverse</c> returns the array.
+    /// </summary>
+    public static Options PreferJsPrototypeMethods(this Options options, bool prefer = true)
+    {
+        options.Interop.PreferJsPrototypeMethods = prefer;
+        return options;
+    }
+
+    /// <summary>
     /// Registers some custom logic to apply on an <see cref="Engine"/> instance when the options
     /// are loaded.
     /// </summary>

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -407,6 +407,15 @@ public class Options
         public bool AttachArrayPrototype { get; set; } = true;
 
         /// <summary>
+        /// When true, JavaScript prototype methods take precedence over CLR methods of the same name on wrapped CLR objects
+        /// whose prototype is not the default Object prototype (e.g. <c>Array.prototype</c> attached to wrapped <see cref="System.Collections.Generic.IList{T}"/>).
+        /// Avoids semantic mismatches such as <c>List&lt;T&gt;.Reverse()</c> returning <c>void</c> while
+        /// <c>Array.prototype.reverse</c> returns the array. Has no effect when no JS prototype is attached
+        /// (i.e. <see cref="AttachArrayPrototype"/> is false or the wrapped type is not array-like). Defaults to false for backward compatibility.
+        /// </summary>
+        public bool PreferJsPrototypeMethods { get; set; }
+
+        /// <summary>
         /// Whether the engine should throw an error when a member is not found on a CLR object. Defaults to false.
         /// </summary>
         public bool ThrowOnUnresolvedMember { get; set; }

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -507,6 +507,18 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             }
         }
 
+        if (!isDictionary
+            && _engine.Options.Interop.PreferJsPrototypeMethods
+            && _prototype is not null
+            && !ReferenceEquals(_prototype, _engine.Realm.Intrinsics.Object.PrototypeObject)
+            && _prototype.Get(property, this) is { } protoValue
+            && protoValue.IsCallable)
+        {
+            // Let outer Get fall through to the attached prototype (Array.prototype, etc.)
+            // rather than dispatching to a same-named CLR method whose semantics may differ.
+            return PropertyDescriptor.Undefined;
+        }
+
         var result = Engine.Options.Interop.MemberAccessor(Engine, Target, member);
         if (result is not null)
         {


### PR DESCRIPTION
## Summary
- Closes #2432.
- Wrapped `IList<T>` / `IList` already get `Array.prototype` attached (default `AttachArrayPrototype = true`), but `ObjectWrapper.GetOwnProperty` resolves CLR members before walking the prototype chain — so `list.reverse()` calls `List<T>.Reverse()` (void → JS `null`), `list.sort()` calls `List<T>.Sort()` (also void), and any user type with a same-named CLR method shadows its JS counterpart.
- Adds `Options.Interop.PreferJsPrototypeMethods` (opt-in, default `false`). When set, `ObjectWrapper.GetOwnProperty` short-circuits to the existing prototype-fallback path if the attached prototype has a callable for the requested name and that prototype is not `Object.prototype`, so plain POCO wrappers are unaffected. Includes the matching `OptionsExtensions.PreferJsPrototypeMethods()` fluent helper.
- The same fix is also reachable today on existing versions via `TypeResolver.MemberFilter`; the PR documents and regression-protects that path with a test, so users who can't take the new option still have a clear answer.

## Test plan
- [x] `dotnet test Jint.Tests` — 2886 / 2839 passed (net10 / net472), 0 failed
- [x] `dotnet test Jint.Tests.PublicInterface` — 79 / 79 passed on both targets
- [x] New tests covering: default behavior locked in, flag-on `reverse` returns the list, flag-on `sort` uses JS string-compare semantics, CLR-only methods (`Add` / `RemoveAt`) still resolve, `length` fast path still maps to `Count`, plain `ObjectWrapper` (Object.prototype) unaffected, and the `MemberFilter`-based workaround
- [x] No public-API surface change beyond the new opt-in option and fluent helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)