### PR TITLE
Don't throw on missing dictionary keys with ThrowOnUnresolvedMember

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
+++ b/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
@@ -359,6 +359,45 @@ public partial class InteropTests
         engine.Invoking(e => e.Evaluate("obj.NewProperty = 5")).Should().Throw<MissingMemberException>();
     }
 
+    [Fact]
+    public void StrictAccessReturnsUndefinedForMissingDictionaryKey()
+    {
+        // dictionaries are key-value stores — missing keys return undefined even with strict access,
+        // matching ordinary JS object semantics (regression test for #2445)
+        var engine = new Engine(options => options.Interop.ThrowOnUnresolvedMember = true);
+        engine.SetValue("dict", new Dictionary<string, string> { ["Foo"] = "bar" });
+
+        engine.Evaluate("dict['Foo']").AsString().Should().Be("bar");
+        engine.Evaluate("dict['Missing']").Should().Be(JsValue.Undefined);
+
+        // real CLR members on the dictionary still resolve
+        engine.Evaluate("dict.Count").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void StrictAccessReturnsUndefinedForMissingNonGenericDictionaryKey()
+    {
+        // covers the IsDictionary && !IsStringKeyedGenericDictionary branch (Hashtable etc.)
+        var engine = new Engine(options => options.Interop.ThrowOnUnresolvedMember = true);
+        var hashtable = new Hashtable { ["Foo"] = "bar" };
+        engine.SetValue("dict", hashtable);
+
+        engine.Evaluate("dict['Foo']").AsString().Should().Be("bar");
+        engine.Evaluate("dict['Missing']").Should().Be(JsValue.Undefined);
+    }
+
+    [Fact]
+    public void StrictAccessReturnsUndefinedForMissingReadOnlyDictionaryKey()
+    {
+        // IReadOnlyDictionary<string, T> goes through the same string-keyed-generic path
+        var engine = new Engine(options => options.Interop.ThrowOnUnresolvedMember = true);
+        IReadOnlyDictionary<string, int> dict = new Dictionary<string, int> { ["answer"] = 42 };
+        engine.SetValue("dict", dict);
+
+        engine.Evaluate("dict['answer']").AsNumber().Should().Be(42);
+        engine.Evaluate("dict['missing']").Should().Be(JsValue.Undefined);
+    }
+
     public class ClassWithPropertyToHide
     {
         public int x { get; set; } = 2;

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -357,6 +357,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         var protoResult = Prototype?.Get(property, receiver) ?? Undefined;
         if (protoResult.IsUndefined()
             && property is JsString
+            && !_typeDescriptor.IsDictionary
             && _engine.Options.Interop.ThrowOnUnresolvedMember)
         {
             throw new MissingMemberException($"Cannot access property '{property}' on type '{ClrType.FullName}");


### PR DESCRIPTION
## Summary
- #2439 moved the `ThrowOnUnresolvedMember` throw in `ObjectWrapper.Get` to *after* the prototype walk so implicit coercion (`'x' + obj`) could fall back to `Object.prototype.valueOf`/`toString`. The new throw unintentionally fires on `IDictionary` key misses: `IndexerAccessor.CreatePropertyDescriptor` correctly reports a missing key as `Undefined` via `ContainsKey`, the prototype walk also yields `Undefined`, and the guard then throws — even though missing-key semantics in JS are "return undefined".
- Skip the throw when the wrapped type is a dictionary. `TypeDescriptor.IsDictionary` covers `IDictionary<,>`, `IReadOnlyDictionary<,>`, and non-generic `IDictionary` with one check.
- Plain CLR objects retain the strict-access throw — `CanConfigureStrictAccess` and `StrictAccessStillThrowsForMissingWrites` still pass unchanged.

Fixes #2445.

## Test plan
- [x] New test `StrictAccessReturnsUndefinedForMissingDictionaryKey` (`Dictionary<string, string>`) — also asserts `dict.Count` still resolves so the relaxation isn't over-broad
- [x] New test `StrictAccessReturnsUndefinedForMissingNonGenericDictionaryKey` (`Hashtable`) — covers the `IsDictionary && !IsStringKeyedGenericDictionary` branch
- [x] New test `StrictAccessReturnsUndefinedForMissingReadOnlyDictionaryKey` (`IReadOnlyDictionary<string, int>`)
- [x] All 257 `Jint.Tests.Runtime.InteropTests` pass on net10.0 and net472, including the existing strict-access cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)