### PR TITLE
Fix async for-of destructuring resume

### DIFF
--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -2108,6 +2108,26 @@ public class AsyncTests
         Assert.Equal("10,20,30", result.AsString());
     }
 
+    [Fact]
+    public void AwaitInsideForOfLoopShouldWorkWithHeadDestructuring()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (async function() {
+                var results = [];
+                var items = { a: 1, b: 2 };
+                for (const [key, value] of Object.entries(items)) {
+                    var r = await Promise.resolve(value * 10);
+                    results.push(key + ":" + r);
+                }
+                return results.join(",");
+            })()
+            """);
+
+        result = result.UnwrapIfPromise();
+        Assert.Equal("a:10,b:20", result.AsString());
+    }
+
     class TestAsyncClass
     {
         private readonly ConcurrentBag<string> _values = new();

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -455,6 +455,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     context.Engine.Debugger.OnStep(_leftNode);
                 }
 
+                var valueForResume = nextValue;
                 var status = CompletionType.Normal;
                 if (!destructuring)
                 {
@@ -482,13 +483,10 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 }
                 else
                 {
-                    // Save the original iterator value before destructuring (for potential resume)
-                    var iteratorValue = nextValue;
-
                     nextValue = DestructuringPatternAssignmentExpression.ProcessPatterns(
                         context,
                         _assignmentPattern!,
-                        iteratorValue,
+                        valueForResume,
                         iterationEnv,
                         checkPatternPropertyReference: _lhsKind != LhsKind.VarBinding);
 
@@ -500,7 +498,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                         if (_iterationKind == IterationKind.AsyncIterate && suspendable is not null)
                         {
                             var asyncSD = suspendable.Data.GetOrCreate<ForAwaitSuspendData>(this);
-                            asyncSD.CurrentValue = iteratorValue;
+                            asyncSD.CurrentValue = valueForResume;
                             asyncSD.AccumulatedValue = v;
                         }
                         completionType = CompletionType.Return;
@@ -561,7 +559,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 {
                     var data = generator.Data.GetOrCreate<ForOfSuspendData>(this, iteratorRecord);
                     data.AccumulatedValue = v;
-                    data.CurrentValue = nextValue;
+                    data.CurrentValue = valueForResume;
                     data.IterationEnv = iterationEnv;
                     data.OuterEnv = oldEnv;
                 }
@@ -574,7 +572,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 {
                     var asyncData = asyncFnBody.Data.GetOrCreate<ForOfSuspendData>(this, iteratorRecord);
                     asyncData.AccumulatedValue = v;
-                    asyncData.CurrentValue = nextValue;
+                    asyncData.CurrentValue = valueForResume;
                     asyncData.IterationEnv = iterationEnv;
                     asyncData.OuterEnv = oldEnv;
                 }


### PR DESCRIPTION
<!-- Thanks for contributing to Jint! Please fill in the sections below. -->

## Summary

Resuming from await inside a for-of loop where the loop var is destructured would fail with 'cannot destructure property of undefined' because loop resume value was set to destructured member instead of original value

## Details

Added test and fix

## Linked issue

<!-- Use "Fixes #1234" or "Closes #1234" so the issue is auto-closed on merge. For discussion-only changes use "Refs #1234". -->

Fixes #

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally
- [-] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [-] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [-] For perf changes: included before/after numbers from `Jint.Benchmark`

## Breaking change?

No
