### PR TITLE
Fix one-shot iterable head destructuring on async for-of body resume

### DIFF
--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -2128,6 +2128,46 @@ public class AsyncTests
         Assert.Equal("a:10,b:20", result.AsString());
     }
 
+    [Fact]
+    public void AwaitInsideForOfLoopShouldPreserveOneShotIteratorDestructuring()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (async function() {
+                function* gen() { yield 1; }
+                var out = [];
+                for (const [x] of [gen()]) {
+                    await Promise.resolve();
+                    out.push(x);
+                }
+                return out.join(",");
+            })()
+            """);
+
+        result = result.UnwrapIfPromise();
+        Assert.Equal("1", result.AsString());
+    }
+
+    [Fact]
+    public void AwaitInsideForOfLoopShouldPreserveOneShotIteratorDestructuringAcrossIterations()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (async function() {
+                function* gen(n) { yield n; }
+                var out = [];
+                for (const [x] of [gen(1), gen(2), gen(3)]) {
+                    await Promise.resolve();
+                    out.push(x);
+                }
+                return out.join(",");
+            })()
+            """);
+
+        result = result.UnwrapIfPromise();
+        Assert.Equal("1,2,3", result.AsString());
+    }
+
     class TestAsyncClass
     {
         private readonly ConcurrentBag<string> _values = new();

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -2168,6 +2168,47 @@ public class AsyncTests
         Assert.Equal("1,2,3", result.AsString());
     }
 
+    [Fact]
+    public void AwaitInsideForOfLoopShouldPreserveOneShotIteratorDestructuringWithLetBinding()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (async function() {
+                function* gen() { yield 42; }
+                var out = [];
+                for (let [x] of [gen()]) {
+                    await Promise.resolve();
+                    out.push(x);
+                }
+                return out.join(",");
+            })()
+            """);
+
+        result = result.UnwrapIfPromise();
+        Assert.Equal("42", result.AsString());
+    }
+
+    [Fact]
+    public void AwaitInsideForOfLoopShouldPreserveOneShotIteratorDestructuringWithAssignmentTarget()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (async function() {
+                function* gen() { yield 7; }
+                var out = [];
+                var x;
+                for ([x] of [gen()]) {
+                    await Promise.resolve();
+                    out.push(x);
+                }
+                return out.join(",");
+            })()
+            """);
+
+        result = result.UnwrapIfPromise();
+        Assert.Equal("7", result.AsString());
+    }
+
     class TestAsyncClass
     {
         private readonly ConcurrentBag<string> _values = new();

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -303,6 +303,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
 
                 DeclarativeEnvironment? iterationEnv = null;
                 JsValue nextValue;
+                var skipLhsSetup = false;
 
                 // Skip TryIteratorStep if we're resuming and already have a current value
                 // (this happens when yield occurred during body execution or destructuring)
@@ -310,7 +311,9 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 {
                     nextValue = suspendData.CurrentValue;
                     iterationEnv = suspendData.IterationEnv;
+                    skipLhsSetup = suspendData.LhsBindingComplete;
                     suspendData.CurrentValue = null; // Clear after use
+                    suspendData.LhsBindingComplete = false; // Save block re-sets if body re-suspends
                     resuming = false; // Only skip step on first iteration after resume
 
                     // Restore the iteration environment if it was saved
@@ -425,113 +428,120 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
 
                 close = true;
 
-                object lhsRef = null!;
-                if (lhsKind != LhsKind.LexicalBinding)
-                {
-                    if (!destructuring)
-                    {
-                        lhsRef = lhs!.Evaluate(context);
-                    }
-                }
-                else
-                {
-                    iterationEnv = JintEnvironment.NewDeclarativeEnvironment(engine, oldEnv);
-                    if (_tdzNames != null)
-                    {
-                        BindingInstantiation(iterationEnv);
-                    }
-                    engine.UpdateLexicalEnvironment(iterationEnv);
-
-                    if (!destructuring)
-                    {
-                        var identifier = (Identifier) ((VariableDeclaration) _leftNode).Declarations[0].Id;
-                        lhsName ??= identifier.Name;
-                        lhsRef = engine.ResolveBinding(lhsName);
-                    }
-                }
-
-                if (context.DebugMode)
-                {
-                    context.Engine.Debugger.OnStep(_leftNode);
-                }
-
                 var valueForResume = nextValue;
                 var status = CompletionType.Normal;
-                if (!destructuring)
+
+                // Skip lhs setup (env creation, BindingInstantiation, destructuring/init) on body
+                // resume — bindings already exist in the restored iterationEnv. Re-running
+                // destructuring against `valueForResume` would consume a one-shot iterator twice.
+                if (!skipLhsSetup)
                 {
-                    if (context.IsAbrupt())
+                    object lhsRef = null!;
+                    if (lhsKind != LhsKind.LexicalBinding)
                     {
-                        close = true;
-                        status = context.Completion;
+                        if (!destructuring)
+                        {
+                            lhsRef = lhs!.Evaluate(context);
+                        }
                     }
                     else
                     {
-                        var reference = lhsRef as Reference;
-                        if (reference is null)
+                        iterationEnv = JintEnvironment.NewDeclarativeEnvironment(engine, oldEnv);
+                        if (_tdzNames != null)
                         {
-                            Throw.ReferenceError(engine.Realm, "Invalid left-hand side in assignment");
+                            BindingInstantiation(iterationEnv);
                         }
-                        if (lhsKind == LhsKind.LexicalBinding || _leftNode.Type == NodeType.Identifier && !reference.IsUnresolvableReference)
+                        engine.UpdateLexicalEnvironment(iterationEnv);
+
+                        if (!destructuring)
                         {
-                            reference.InitializeReferencedBinding(nextValue, _disposeHint);
+                            var identifier = (Identifier) ((VariableDeclaration) _leftNode).Declarations[0].Id;
+                            lhsName ??= identifier.Name;
+                            lhsRef = engine.ResolveBinding(lhsName);
+                        }
+                    }
+
+                    if (context.DebugMode)
+                    {
+                        context.Engine.Debugger.OnStep(_leftNode);
+                    }
+
+                    if (!destructuring)
+                    {
+                        if (context.IsAbrupt())
+                        {
+                            close = true;
+                            status = context.Completion;
                         }
                         else
                         {
-                            engine.PutValue(reference, nextValue);
+                            var reference = lhsRef as Reference;
+                            if (reference is null)
+                            {
+                                Throw.ReferenceError(engine.Realm, "Invalid left-hand side in assignment");
+                            }
+                            if (lhsKind == LhsKind.LexicalBinding || _leftNode.Type == NodeType.Identifier && !reference.IsUnresolvableReference)
+                            {
+                                reference.InitializeReferencedBinding(nextValue, _disposeHint);
+                            }
+                            else
+                            {
+                                engine.PutValue(reference, nextValue);
+                            }
                         }
-                    }
-                }
-                else
-                {
-                    nextValue = DestructuringPatternAssignmentExpression.ProcessPatterns(
-                        context,
-                        _assignmentPattern!,
-                        valueForResume,
-                        iterationEnv,
-                        checkPatternPropertyReference: _lhsKind != LhsKind.VarBinding);
-
-                    // Check for suspension after destructuring (yield inside pattern)
-                    if (context.IsSuspended())
-                    {
-                        close = false; // Don't close iterator, we'll resume later
-                        // Save the ORIGINAL iterator value for replay when resuming
-                        if (_iterationKind == IterationKind.AsyncIterate && suspendable is not null)
-                        {
-                            var asyncSD = suspendable.Data.GetOrCreate<ForAwaitSuspendData>(this);
-                            asyncSD.CurrentValue = valueForResume;
-                            asyncSD.AccumulatedValue = v;
-                        }
-                        completionType = CompletionType.Return;
-                        return new Completion(CompletionType.Return, suspendable?.SuspendedValue ?? nextValue, _statement!);
-                    }
-
-                    // Check for return request after destructuring (e.g., generator.return() was called)
-                    if (suspendable?.ReturnRequested == true)
-                    {
-                        completionType = CompletionType.Return;
-                        close = false; // Prevent double-close in finally
-                        suspendable.Data.Clear(this);
-                        iteratorRecord.Close(completionType);
-                        var returnValue = suspendable.SuspendedValue ?? nextValue;
-                        return new Completion(CompletionType.Return, returnValue, _statement!);
-                    }
-
-                    status = context.Completion;
-
-                    if (lhsKind == LhsKind.Assignment)
-                    {
-                        // DestructuringAssignmentEvaluation of assignmentPattern using nextValue as the argument.
-                    }
-#pragma warning disable MA0140
-                    else if (lhsKind == LhsKind.VarBinding)
-                    {
-                        // BindingInitialization for lhs passing nextValue and undefined as the arguments.
                     }
                     else
                     {
-                        // BindingInitialization for lhs passing nextValue and iterationEnv as arguments
-                    }
+                        nextValue = DestructuringPatternAssignmentExpression.ProcessPatterns(
+                            context,
+                            _assignmentPattern!,
+                            valueForResume,
+                            iterationEnv,
+                            checkPatternPropertyReference: _lhsKind != LhsKind.VarBinding);
+
+                        // Check for suspension after destructuring (yield inside pattern)
+                        if (context.IsSuspended())
+                        {
+                            close = false; // Don't close iterator, we'll resume later
+                            // Save the ORIGINAL iterator value for replay when resuming
+                            if (_iterationKind == IterationKind.AsyncIterate && suspendable is not null)
+                            {
+                                var asyncSD = suspendable.Data.GetOrCreate<ForAwaitSuspendData>(this);
+                                asyncSD.CurrentValue = valueForResume;
+                                asyncSD.AccumulatedValue = v;
+                            }
+                            completionType = CompletionType.Return;
+                            return new Completion(CompletionType.Return, suspendable?.SuspendedValue ?? nextValue, _statement!);
+                        }
+
+                        // Check for return request after destructuring (e.g., generator.return() was called)
+                        if (suspendable?.ReturnRequested == true)
+                        {
+                            completionType = CompletionType.Return;
+                            close = false; // Prevent double-close in finally
+                            suspendable.Data.Clear(this);
+                            iteratorRecord.Close(completionType);
+                            var returnValue = suspendable.SuspendedValue ?? nextValue;
+                            return new Completion(CompletionType.Return, returnValue, _statement!);
+                        }
+
+                        status = context.Completion;
+
+                        if (lhsKind == LhsKind.Assignment)
+                        {
+                            // DestructuringAssignmentEvaluation of assignmentPattern using nextValue as the argument.
+                        }
+#pragma warning disable MA0140
+                        else if (lhsKind == LhsKind.VarBinding)
+                        {
+                            // BindingInitialization for lhs passing nextValue and undefined as the arguments.
+                        }
+                        else
+                        {
+                            // BindingInitialization for lhs passing nextValue and iterationEnv as arguments
+                        }
 #pragma warning restore MA0140
+                    }
                 }
 
                 if (status != CompletionType.Normal)
@@ -562,6 +572,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     data.CurrentValue = valueForResume;
                     data.IterationEnv = iterationEnv;
                     data.OuterEnv = oldEnv;
+                    data.LhsBindingComplete = true;
                 }
 
                 // For async functions with sync iterators, save state so that if an await
@@ -575,6 +586,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     asyncData.CurrentValue = valueForResume;
                     asyncData.IterationEnv = iterationEnv;
                     asyncData.OuterEnv = oldEnv;
+                    asyncData.LhsBindingComplete = true;
                 }
 
                 var result = stmt.Execute(context);

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -60,6 +60,15 @@ internal sealed class ForOfSuspendData : SuspendData
     /// block-scoped environment from let declarations inside the loop body.
     /// </summary>
     public Environments.Environment? OuterEnv { get; set; }
+
+    /// <summary>
+    /// True when the iteration's lhs setup (iteration env creation, BindingInstantiation,
+    /// destructuring/simple-binding initialization) had already completed for the current
+    /// value before suspension occurred (i.e. suspension happened inside the loop body, not
+    /// inside destructuring). On resume, the lhs setup must be skipped to avoid re-running
+    /// destructuring against a one-shot iterator that has already been consumed.
+    /// </summary>
+    public bool LhsBindingComplete { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Follow-up to #2453: preserve destructured bindings instead of replaying the head against the saved (already-consumed) source value when an async function body `await`s after a destructuring head over a one-shot inner iterable.

## Details

PR #2453 saved the original iterator value (`valueForResume`) into `ForOfSuspendData.CurrentValue` so the loop could re-run destructuring on resume. That worked for the test in #2453 (`Object.entries(items)` yields re-iterable arrays), but for a one-shot inner value like a generator instance the second call to `DestructuringPatternAssignmentExpression.ProcessPatterns` calls `GetIterator` on the same already-consumed source, observes `done=true`, and binds `undefined`.

P2 issue raised in [Codex bot review](https://github.com/sebastienros/jint/pull/2453#discussion_r3195196379), acknowledged by @nfcampos as a separate pre-existing bug.

Failing repro before this PR (produces `[undefined]`, expected `[1]`):

```js
(async function() {
    function* gen() { yield 1; }
    var out = [];
    for (const [x] of [gen()]) {
        await Promise.resolve();
        out.push(x);
    }
    return out;
})()
```

### Fix

Added `ForOfSuspendData.LhsBindingComplete`. Body-suspend save sites set it to `true` (destructuring/binding init had completed). On resume, the loop skips the lhs-setup block (env recreation, `BindingInstantiation`, destructuring/init). The saved `IterationEnv` already has fully-initialized bindings; the resume path already restores it via `UpdateLexicalEnvironment`.

Mirrors the existing `BlockSuspendData.DisposalComplete` "skip already-done work on resume" pattern.

The destructuring-suspend path (`ForAwaitSuspendData.CurrentValue`, line 322-330) is untouched — its replay is legitimate (destructuring was interrupted mid-flight, bindings are not yet complete). The `for await (...)` body-suspend path saves before lhs setup runs, so it doesn't have this bug either.

### Behavior nuance: debugger stepping

The wrapped lhs-setup block contains `Debugger.OnStep(_leftNode)`. With the skip, `OnStep` is intentionally **not** re-fired on body-await resume past the head — the binding step already happened pre-suspend, so re-stepping into it would be misleading. Reviewers using the debugger may want to flag this.

## Linked issue

Refs #2453

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`:
    - `AwaitInsideForOfLoopShouldPreserveOneShotIteratorDestructuring` — Codex bot's repro (`const [x]`, single one-shot generator)
    - `AwaitInsideForOfLoopShouldPreserveOneShotIteratorDestructuringAcrossIterations` — three sequential one-shot generators
    - `AwaitInsideForOfLoopShouldPreserveOneShotIteratorDestructuringWithLetBinding` — `let [x]` (alternate `LhsKind.LexicalBinding` spelling)
    - `AwaitInsideForOfLoopShouldPreserveOneShotIteratorDestructuringWithAssignmentTarget` — `for ([x] of …)` (`LhsKind.Assignment`, no `iterationEnv` path)
- [x] Ran `dotnet test --configuration Release` locally — Jint.Tests AsyncTests 7/7 matching tests on net472 + net10
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions — 3873/3873 forOf/forOf_dstr/forAwaitOf, 1919/1919 asyncFunction/asyncGenerator/generators
- [-] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [-] For perf changes: included before/after numbers from `Jint.Benchmark`

## Breaking change?

No. Internal-only flag on internal `ForOfSuspendData`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)