### PR TITLE
Honor prepare-time RegexTimeout for custom-engine regex literals (#2454)

### DIFF
--- a/Jint.Tests/Runtime/RegExpTests.cs
+++ b/Jint.Tests/Runtime/RegExpTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Jint.Native;
 
 namespace Jint.Tests.Runtime;
@@ -155,5 +156,81 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate("/[^]?(:[rp][el]a[\\w-]+)[^]/.test(':reagent-')").AsBoolean();
         Assert.True(result);
+    }
+
+    // Regression tests for https://github.com/sebastienros/jint/issues/2454
+    //
+    // The TestRegex pattern triggers Jint's custom (QuickJS-port) regex engine via
+    // RegExpConstructor.NeedCustomEngine — that engine has no built-in match timeout
+    // (unlike .NET Regex which embeds MatchTimeout), so each prototype method must
+    // honor the prepare-time RegexTimeout when calling the custom engine.
+
+    [Theory]
+    // RegExp.prototype[@@match] without /g → slow path (RegExpExec → CustomEngineBuiltinExec).
+    [InlineData("'{0}'.match(/{1}/)")]
+    // RegExp.prototype[@@match] with /g → custom-engine fast loop in Match().
+    [InlineData("'{0}'.match(/{1}/g)")]
+    // RegExp.prototype[@@replace] with /g → custom-engine fast loop in Replace().
+    [InlineData("'{0}'.replace(/{1}/g, 'X')")]
+    // RegExp.prototype.test() → custom-engine IsMatch fast path.
+    [InlineData("/{1}/.test('{0}')")]
+    // RegExp.prototype[@@search] → custom-engine Execute fast path.
+    [InlineData("'{0}'.search(/{1}/)")]
+    public void PreparedScriptHonorsRegexTimeoutForCustomEngine(string scriptTemplate)
+    {
+        var script = scriptTemplate.Replace("{0}", TestedValue).Replace("{1}", TestRegex);
+        AssertPrepareTimeRegexTimeoutFires(script);
+    }
+
+    [Fact]
+    public void PreparedModuleHonorsRegexTimeoutForCustomEngine()
+    {
+        var preparationOptions = ModulePreparationOptions.Default with
+        {
+            ParsingOptions = ModulePreparationOptions.Default.ParsingOptions with
+            {
+                RegexTimeout = TimeSpan.FromSeconds(1),
+            },
+        };
+
+        var preparedModule = Engine.PrepareModule(
+            $"export default '{TestedValue}'.match(/{TestRegex}/)",
+            options: preparationOptions);
+
+        // Engine has no RegexTimeoutInterval set (defaults to 10s) — only the prepare-time
+        // 1s timeout should apply. The 5s upper bound catches a regression to the 10s default.
+        var engine = new Engine();
+        engine.Modules.Add("__main__", x => x.AddModule(preparedModule));
+
+        var sw = Stopwatch.StartNew();
+        Assert.Throws<RegexMatchTimeoutException>(() => engine.Modules.Import("__main__"));
+        sw.Stop();
+
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
+            $"Expected RegexMatchTimeoutException within 5s, took {sw.Elapsed.TotalSeconds:F1}s");
+    }
+
+    private static void AssertPrepareTimeRegexTimeoutFires(string script)
+    {
+        var preparationOptions = ScriptPreparationOptions.Default with
+        {
+            ParsingOptions = ScriptPreparationOptions.Default.ParsingOptions with
+            {
+                RegexTimeout = TimeSpan.FromSeconds(1),
+            },
+        };
+
+        var preparedScript = Engine.PrepareScript(script, options: preparationOptions);
+
+        // Engine has no RegexTimeoutInterval set (defaults to 10s) — only the prepare-time
+        // 1s timeout should apply. The 5s upper bound catches a regression to the 10s default.
+        var engine = new Engine();
+
+        var sw = Stopwatch.StartNew();
+        Assert.Throws<RegexMatchTimeoutException>(() => engine.Execute(preparedScript));
+        sw.Stop();
+
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5),
+            $"Expected RegexMatchTimeoutException within 5s, took {sw.Elapsed.TotalSeconds:F1}s");
     }
 }

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -218,7 +218,7 @@ internal sealed partial class RegExpPrototype : Prototype
 
             while (count < maxCount && searchStart <= s.Length)
             {
-                var result = customEngine.Execute(s, searchStart);
+                var result = ExecuteWithTimeout(customRei, customEngine, s, searchStart);
                 if (!result.Success)
                 {
                     break;
@@ -723,7 +723,7 @@ internal sealed partial class RegExpPrototype : Prototype
                 var customEngine = R.CustomEngine!;
                 if (!R.Sticky && !R.Global)
                 {
-                    return customEngine.IsMatch(s, 0);
+                    return IsMatchWithTimeout(R, customEngine, s, 0);
                 }
 
                 var lastIndex = (int) TypeConverter.ToLength(R.Get(JsRegExp.PropertyLastIndex));
@@ -734,7 +734,7 @@ internal sealed partial class RegExpPrototype : Prototype
                 }
 
                 // For global/sticky, we need the match position to update lastIndex
-                var result = customEngine.Execute(s, lastIndex);
+                var result = ExecuteWithTimeout(R, customEngine, s, lastIndex);
                 if (!result.Success || (R.Sticky && result.Index != lastIndex))
                 {
                     R.Set(JsRegExp.PropertyLastIndex, 0, throwOnError: true);
@@ -792,7 +792,7 @@ internal sealed partial class RegExpPrototype : Prototype
         // Fast path for custom engine: only need the index, skip full result array
         if (rx is JsRegExp { HasDefaultRegExpExec: true, UsesDotNetEngine: false } customR)
         {
-            var searchResult = customR.CustomEngine!.Execute(s, 0);
+            var searchResult = ExecuteWithTimeout(customR, customR.CustomEngine!, s, 0);
             var currentLastIndex2 = rx.Get(JsRegExp.PropertyLastIndex);
             if (!SameValue(currentLastIndex2, previousLastIndex))
             {
@@ -846,7 +846,7 @@ internal sealed partial class RegExpPrototype : Prototype
             int lastIndex = 0;
             while (lastIndex <= s.Length)
             {
-                var result = customEngine.Execute(s, lastIndex);
+                var result = ExecuteWithTimeout(rei, customEngine, s, lastIndex);
                 if (!result.Success)
                 {
                     break;
@@ -1138,24 +1138,7 @@ internal sealed partial class RegExpPrototype : Prototype
             return Null;
         }
 
-        var regexTimeout = R.Engine.Options.Constraints.RegexTimeout;
-        RegExpMatchResult result;
-        if (regexTimeout.TotalMilliseconds > 0 && regexTimeout != Timeout.InfiniteTimeSpan)
-        {
-            using var cts = new CancellationTokenSource(regexTimeout);
-            try
-            {
-                result = customEngine.Execute(s, (int) lastIndex, cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                throw new RegexMatchTimeoutException(s, R.Source ?? "", regexTimeout);
-            }
-        }
-        else
-        {
-            result = customEngine.Execute(s, (int) lastIndex);
-        }
+        var result = ExecuteWithTimeout(R, customEngine, s, (int) lastIndex);
         var success = result.Success && (!sticky || result.Index == (int) lastIndex);
 
         if (!success)
@@ -1175,6 +1158,59 @@ internal sealed partial class RegExpPrototype : Prototype
         }
 
         return CreateReturnValueArrayFromCustom(R, result, s, hasIndices);
+    }
+
+    /// <summary>
+    /// Effective per-match timeout for a custom-engine regex. Prefers the prepare-time value
+    /// carried via <see cref="RegExpParseResult.AdditionalData"/>; falls back to the engine's
+    /// configured constraint for runtime-built regexes (where the same value was used at compile time).
+    /// </summary>
+    private static TimeSpan GetCustomEngineTimeout(JsRegExp R) =>
+        (R.ParseResult.AdditionalData as Engine.RegexConversionOptions)?.Timeout
+        ?? R.Engine.Options.Constraints.RegexTimeout;
+
+    /// <summary>
+    /// Runs the custom regex engine with timeout enforcement. Throws <see cref="RegexMatchTimeoutException"/>
+    /// when the configured timeout elapses — mirrors how <see cref="Regex.Match(string,int)"/> uses
+    /// <see cref="Regex.MatchTimeout"/> on the .NET path.
+    /// </summary>
+    private static RegExpMatchResult ExecuteWithTimeout(JsRegExp R, JintRegExpEngine engine, string s, int startIndex)
+    {
+        var timeout = GetCustomEngineTimeout(R);
+        if (timeout.TotalMilliseconds > 0 && timeout != Timeout.InfiniteTimeSpan)
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            try
+            {
+                return engine.Execute(s, startIndex, cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                throw new RegexMatchTimeoutException(s, R.Source ?? "", timeout);
+            }
+        }
+        return engine.Execute(s, startIndex);
+    }
+
+    /// <summary>
+    /// IsMatch counterpart of <see cref="ExecuteWithTimeout"/>.
+    /// </summary>
+    private static bool IsMatchWithTimeout(JsRegExp R, JintRegExpEngine engine, string s, int startIndex)
+    {
+        var timeout = GetCustomEngineTimeout(R);
+        if (timeout.TotalMilliseconds > 0 && timeout != Timeout.InfiniteTimeSpan)
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            try
+            {
+                return engine.IsMatch(s, startIndex, cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                throw new RegexMatchTimeoutException(s, R.Source ?? "", timeout);
+            }
+        }
+        return engine.IsMatch(s, startIndex);
     }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -101,7 +101,10 @@ internal sealed class JintLiteralExpression : JintExpression
             var customEngine = RegExpConstructor.TryCompileWithCustomEngine(context.Engine.Realm,
                 pattern, flags, conversionOptions.Timeout);
 
-            cachedParseResult = RegExpParseResult.ForSuccess(customEngine);
+            // Carry the conversion options forward so CustomEngineBuiltinExec can honor
+            // the prepare-time RegexTimeout instead of falling back to engine constraints
+            // (the .NET Regex path embeds the timeout in MatchTimeout, the custom engine has no such carrier).
+            cachedParseResult = RegExpParseResult.ForSuccess(customEngine, additionalData: conversionOptions);
             regExpLiteral.UserData = cachedParseResult; // cache for next evaluation
             return regExpConstructor.Construct(cachedParseResult, pattern, flags);
         }


### PR DESCRIPTION
## Summary

Fixes #2454.

`RegexTimeout` set on `ScriptPreparationOptions.ParsingOptions` (or `ModulePreparationOptions.ParsingOptions`) was being ignored for regex literals whose pattern routes through Jint's custom (QuickJS-port) regex engine. Two related bugs caused this:

1. **Timeout dropped between compile and execution.** `JintLiteralExpression.ResolveValue` created the custom-engine `RegExpParseResult` without forwarding the prepare-time `RegexConversionOptions` through `AdditionalData`, so the timeout was no longer reachable from the resulting `JsRegExp`. `CustomEngineBuiltinExec` then fell back to `Engine.Options.Constraints.RegexTimeout` (10s default) — fine for runtime-built regexes, wrong for prepared-script literals.

2. **Fast paths bypassed timeout entirely.** The custom-engine fast paths in `RegExpPrototype` for `test()`, `search()`, `match(/.../g)` and `replace(/.../g, ...)` called `customEngine.Execute` / `IsMatch` with **no cancellation token** — meaning a catastrophic-backtracking pattern hit through any of these methods would run unbounded regardless of any configured timeout.

(The .NET Regex path already worked correctly because `Regex.MatchTimeout` is baked into the `Regex` object by `Tokenizer.AdaptRegExp` and used automatically by `Regex.Match`. This PR brings the custom engine in line with the same semantics.)

### Fix

- Forward `conversionOptions` via `RegExpParseResult.AdditionalData` so the `JsRegExp` carries the compile-time timeout (`Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs`).
- Add `GetCustomEngineTimeout` / `ExecuteWithTimeout` / `IsMatchWithTimeout` helpers on `RegExpPrototype` that prefer the prepare-time timeout and fall back to the engine constraint. Wire them into the five fast paths (`Replace`, `Test` non-sticky, `Test` sticky/global, `Search`, `Match` `/g` loop) and refactor `CustomEngineBuiltinExec` to use them too.

## Test plan

- [x] `dotnet build --configuration Release` — clean
- [x] `dotnet test --configuration Release Jint.Tests/Jint.Tests.csproj` — **2919 passed / 0 failed** on net10.0 and **2872 / 0** on net472
- [x] New regression tests in `Jint.Tests/Runtime/RegExpTests.cs`:
  - `[Theory] PreparedScriptHonorsRegexTimeoutForCustomEngine` — five inline cases covering `match`, `match`+`/g`, `replace`+`/g`, `test`, `search`
  - `[Fact] PreparedModuleHonorsRegexTimeoutForCustomEngine`

Each test prepares with a 1s `RegexTimeout` on a default-configured engine (10s) and asserts `RegexMatchTimeoutException` fires within 5s — the 5s bound comfortably catches a regression to the 10s engine default while leaving room for slow CI.