### PR TITLE
Stabilize pre-1970 setYear test

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2009,8 +2009,9 @@ var prep = function (fn) { fn(); };
     [Fact]
     public void ShouldSetYearBefore1970()
     {
-
-        RunTest(@"
+        new Engine(options => options.LocalTimeZone(TimeZoneInfo.Utc))
+            .SetValue("equal", new Action<object, object>(Assert.Equal))
+            .Execute(@"
                 var d = new Date('1969-01-01T08:17:00Z');
                 d.setYear(2015);
                 equal('2015-01-01T08:17:00.000Z', d.toISOString());


### PR DESCRIPTION
## Summary

Pin the pre-1970 setYear test to UTC.

## Details

- Run ShouldSetYearBefore1970 with an explicit UTC local timezone.
- Avoid dependence on the machine default timezone when asserting the resulting ISO timestamp.
- Leave runtime date behavior unchanged; this is a test-only stability fix.

## Linked issue

Refs #

## Test plan

- [x] Added or updated unit tests in Jint.Tests
- [x] Ran dotnet test --configuration Release locally
- [ ] For ECMAScript spec changes: ran Jint.Tests.Test262 and confirmed no regressions
- [ ] For interop changes: covered in Jint.Tests/Runtime/Interop
- [ ] For perf changes: included before/after numbers from Jint.Benchmark

Additional local validation:

- dotnet test Jint.Tests/Jint.Tests.csproj --filter "FullyQualifiedName~EngineTests.ShouldSetYearBefore1970"

## Breaking change?

No.
