### PR TITLE
Convert oversize CLR inputs to RangeError

### DIFF
--- a/Jint.Tests/Runtime/BigIntTests.cs
+++ b/Jint.Tests/Runtime/BigIntTests.cs
@@ -124,4 +124,34 @@ public class BigIntTests
         var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("2n ** -1n"));
         Assert.Contains("Exponent must be positive", ex.Message);
     }
+
+    [Theory]
+    [InlineData("BigInt.asIntN(2147483648, 1n)")]
+    [InlineData("BigInt.asUintN(2147483648, 1n)")]
+    public void FixedWidthBigIntOperationsRejectUnsupportedBitCounts(string expression)
+    {
+        var engine = new Engine();
+
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Evaluate(expression));
+
+        Assert.True(exception.Error.InstanceofOperator(engine.Intrinsics.RangeError));
+    }
+
+    [Theory]
+    [InlineData("BigInt.asIntN")]
+    [InlineData("BigInt.asUintN")]
+    public void FixedWidthBigIntOperationsConvertBigIntOperandBeforeRejectingUnsupportedBitCounts(string operation)
+    {
+        var engine = new Engine();
+
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Evaluate($$"""
+            {{operation}}(2147483648, {
+                [Symbol.toPrimitive]() {
+                    throw new Error('boom');
+                }
+            });
+            """));
+
+        Assert.Equal("boom", exception.Error.AsObject().Get("message").AsString());
+    }
 }

--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -17,6 +17,40 @@ public class FunctionTests
     }
 
     [Fact]
+    public void ApplyRejectsArrayLikeArgumentsThatCannotBeMaterialized()
+    {
+        var engine = new Engine();
+        var length = ClrLimits.MaxArrayLength + 1UL;
+
+        var exception = Assert.Throws<JavaScriptException>(
+            () => engine.Evaluate($"(function(){{}}).apply(null, {{ length: {length} }});"));
+
+        Assert.True(exception.Error.InstanceofOperator(engine.Intrinsics.RangeError));
+    }
+
+    [Fact]
+    public void FunctionPrototypeApplyThrowsRangeErrorFromTheFunctionsRealm()
+    {
+        var engine = new Engine();
+        var otherGlobal = engine._host.CreateRealm().GlobalObject;
+        otherGlobal.Set("global", otherGlobal);
+        engine.SetValue("other", otherGlobal);
+        var length = ClrLimits.MaxArrayLength + 1UL;
+
+        var script = @"
+            var threw = false;
+            try {
+                other.Function.prototype.apply.call(function () {}, null, { length: LENGTH });
+            } catch (e) {
+                threw = (e instanceof other.RangeError) && !(e instanceof RangeError);
+            }
+            threw
+        ".Replace("LENGTH", length.ToString());
+
+        Assert.True(((JsBoolean) engine.Evaluate(script))._value);
+    }
+
+    [Fact]
     public void FunctionPrototypeApplyThrowsTypeErrorFromTheFunctionsRealm()
     {
         // Regression for the source-gen [JsFunction]/ICallable cast precondition: when

--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -1,3 +1,5 @@
+using Jint.Runtime;
+
 namespace Jint.Tests.Runtime;
 
 public class StringTests
@@ -78,6 +80,18 @@ bar += 'bar';
         var engine = new Engine();
         Assert.Equal(0, engine.Evaluate("''.indexOf('', 0)"));
         Assert.Equal(0, engine.Evaluate("''.indexOf('', 1)"));
+    }
+
+    [Fact]
+    public void RepeatRejectsCountsThatCannotFitInClrStringCapacity()
+    {
+        var engine = new Engine();
+        var repeatCount = ClrLimits.MaxArrayLength / 2 + 1UL;
+
+        var exception = Assert.Throws<JavaScriptException>(
+            () => engine.Evaluate($"'xx'.repeat({repeatCount});"));
+
+        Assert.True(exception.Error.InstanceofOperator(engine.Intrinsics.RangeError));
     }
 
     [Fact]

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -80,12 +80,19 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
     public virtual JsValue[] GetAll(
         Types elementTypes = Types.Undefined | Types.Null | Types.Boolean | Types.String | Types.Symbol | Types.Number | Types.BigInt | Types.Object,
-        bool skipHoles = false)
+        bool skipHoles = false,
+        Realm? errorRealm = null)
     {
         uint writeIndex = 0;
-        var n = (int) GetLength();
+        var length = GetLongLength();
+        if (length > ClrLimits.MaxArrayLength)
+        {
+            Throw.RangeError(errorRealm ?? Target.Engine.Realm, "Invalid array-like length");
+        }
+
+        var n = (int) length;
         var jsValues = new JsValue[n];
-        for (uint i = 0; i < (uint) jsValues.Length; i++)
+        for (uint i = 0; i < (uint) n; i++)
         {
             var jsValue = skipHoles && !HasProperty(i) ? JsValue.Undefined : Get(i);
             if ((jsValue.Type & elementTypes) == Types.Empty)
@@ -267,13 +274,18 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         public override JsValue[] GetAll(
             Types elementTypes = Types.Empty | Types.Undefined | Types.Null | Types.Boolean | Types.String | Types.Number | Types.Symbol | Types.BigInt | Types.Object,
-            bool skipHoles = false)
+            bool skipHoles = false,
+            Realm? errorRealm = null)
         {
             var n = _target.GetLength();
+            if (n > ClrLimits.MaxArrayLength)
+            {
+                Throw.RangeError(errorRealm ?? _target.Engine.Realm, "Invalid array-like length");
+            }
 
             if (_target._dense == null || _target._dense.Length < n)
             {
-                return base.GetAll(elementTypes, skipHoles);
+                return base.GetAll(elementTypes, skipHoles, errorRealm);
             }
 
             // optimized

--- a/Jint/Native/BigInt/BigIntConstructor.cs
+++ b/Jint/Native/BigInt/BigIntConstructor.cs
@@ -35,13 +35,14 @@ internal sealed partial class BigIntConstructor : Constructor
     [JsFunction]
     private JsValue AsIntN(JsValue thisObject, JsValue bitsValue, JsValue bigintValue)
     {
-        var bits = (int) TypeConverter.ToIndex(_realm, bitsValue);
+        var bits = TypeConverter.ToIndex(_realm, bitsValue);
         var bigint = bigintValue.ToBigInteger(_engine);
+        var supportedBits = ToSupportedBitCount(bits);
 
-        var mod = TypeConverter.BigIntegerModulo(bigint, BigInteger.Pow(2, bits));
-        if (bits > 0 && mod >= BigInteger.Pow(2, bits - 1))
+        var mod = TypeConverter.BigIntegerModulo(bigint, BigInteger.Pow(2, supportedBits));
+        if (supportedBits > 0 && mod >= BigInteger.Pow(2, supportedBits - 1))
         {
-            return (mod - BigInteger.Pow(2, bits));
+            return (mod - BigInteger.Pow(2, supportedBits));
         }
 
         return mod;
@@ -53,12 +54,23 @@ internal sealed partial class BigIntConstructor : Constructor
     [JsFunction]
     private JsValue AsUintN(JsValue thisObject, JsValue bitsValue, JsValue bigintValue)
     {
-        var bits = (int) TypeConverter.ToIndex(_realm, bitsValue);
+        var bits = TypeConverter.ToIndex(_realm, bitsValue);
         var bigint = bigintValue.ToBigInteger(_engine);
+        var supportedBits = ToSupportedBitCount(bits);
 
-        var result = TypeConverter.BigIntegerModulo(bigint, BigInteger.Pow(2, bits));
+        var result = TypeConverter.BigIntegerModulo(bigint, BigInteger.Pow(2, supportedBits));
 
         return result;
+    }
+
+    private int ToSupportedBitCount(ulong bits)
+    {
+        if (bits > int.MaxValue)
+        {
+            Throw.RangeError(_realm, "Invalid bit count");
+        }
+
+        return (int) bits;
     }
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)

--- a/Jint/Native/Function/FunctionPrototype.cs
+++ b/Jint/Native/Function/FunctionPrototype.cs
@@ -160,7 +160,9 @@ internal sealed partial class FunctionPrototype : Function
             Throw.TypeError(realm, "CreateListFromArrayLike called on non-object");
         }
         var operations = ArrayOperations.For(argArrayObj, forWrite: false);
-        var argList = elementTypes is null ? operations.GetAll() : operations.GetAll(elementTypes.Value);
+        var argList = elementTypes is null
+            ? operations.GetAll(errorRealm: realm)
+            : operations.GetAll(elementTypes.Value, errorRealm: realm);
         return argList;
     }
 

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -1861,12 +1861,18 @@ internal sealed partial class StringPrototype : StringInstance
             return JsString.Empty;
         }
 
+        var resultLength = n * s.Length;
+        if (resultLength > ClrLimits.MaxArrayLength)
+        {
+            Throw.RangeError(_realm, "Invalid string length");
+        }
+
         if (s.Length == 1)
         {
             return new string(s[0], (int) n);
         }
 
-        var sb = new ValueStringBuilder((int) (n * s.Length));
+        var sb = new ValueStringBuilder((int) resultLength);
         for (var i = 0; i < n; ++i)
         {
             sb.Append(s);

--- a/Jint/Pooling/ValueStringBuilder.cs
+++ b/Jint/Pooling/ValueStringBuilder.cs
@@ -340,13 +340,11 @@ internal ref struct ValueStringBuilder
         Debug.Assert(additionalCapacityBeyondPos > 0);
         Debug.Assert(_pos > _chars.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
 
-        const uint ArrayMaxLength = 0x7FFFFFC7; // same as Array.MaxLength
-
         // Increase to at least the required size (_pos + additionalCapacityBeyondPos), but try
         // to double the size if possible, bounding the doubling to not go beyond the max array length.
         int newCapacity = (int) Math.Max(
             (uint) (_pos + additionalCapacityBeyondPos),
-            Math.Min((uint) _chars.Length * 2, ArrayMaxLength));
+            Math.Min((uint) _chars.Length * 2, global::Jint.Runtime.ClrLimits.MaxArrayLength));
 
         // Make sure to let Rent throw an exception if the caller has a bug and the desired capacity is negative.
         // This could also go negative if the actual required length wraps around.

--- a/Jint/Runtime/ClrLimits.cs
+++ b/Jint/Runtime/ClrLimits.cs
@@ -1,0 +1,6 @@
+namespace Jint.Runtime;
+
+internal static class ClrLimits
+{
+    internal const uint MaxArrayLength = 0x7FFFFFC7; // same as Array.MaxLength
+}


### PR DESCRIPTION
## Summary

Convert oversize CLR-backed inputs to JavaScript RangeError.

## Details

- Reject BigInt.asIntN/asUintN bit counts that exceed the CLR Int32 range before calling BigInteger.Pow.
- Reject array-like lengths that cannot be materialized as a CLR array before Function.prototype.apply builds the argument list.
- Reject String.prototype.repeat results that would exceed CLR string capacity before allocating the result buffer.
- Keep the checks at the CLR boundary so ordinary ECMAScript validation remains unchanged.

## Linked issue

Refs #

## Test plan

- [x] Added or updated unit tests in Jint.Tests
- [x] Ran dotnet test --configuration Release locally
- [ ] For ECMAScript spec changes: ran Jint.Tests.Test262 and confirmed no regressions
- [ ] For interop changes: covered in Jint.Tests/Runtime/Interop
- [ ] For perf changes: included before/after numbers from Jint.Benchmark

Additional local validation:

- dotnet test Jint.Tests/Jint.Tests.csproj --filter "FullyQualifiedName~BigIntTests|FullyQualifiedName~FunctionTests|FullyQualifiedName~StringTests"
- dotnet build Jint/Jint.csproj --configuration Release

## Breaking change?

No.
