### PR TITLE
Allow hosts to hide selected global built-ins

### DIFF
--- a/Jint.Tests/Runtime/GlobalTests.cs
+++ b/Jint.Tests/Runtime/GlobalTests.cs
@@ -3,6 +3,64 @@ namespace Jint.Tests.Runtime;
 public class GlobalTests
 {
     [Fact]
+    public void CanDisableSelectedGlobalBuiltIns()
+    {
+        var engine = new Engine(options => options.DisableGlobalBuiltIns(
+            GlobalBuiltIn.ArrayBuffer
+            | GlobalBuiltIn.SharedArrayBuffer
+            | GlobalBuiltIn.DataView
+            | GlobalBuiltIn.TypedArray
+            | GlobalBuiltIn.Atomics
+            | GlobalBuiltIn.ShadowRealm));
+
+        var result = engine.Evaluate("""
+            [
+                typeof ArrayBuffer,
+                typeof SharedArrayBuffer,
+                typeof DataView,
+                typeof TypedArray,
+                typeof BigInt64Array,
+                typeof BigUint64Array,
+                typeof Float16Array,
+                typeof Float32Array,
+                typeof Float64Array,
+                typeof Int8Array,
+                typeof Int16Array,
+                typeof Int32Array,
+                typeof Uint8Array,
+                typeof Uint8ClampedArray,
+                typeof Uint16Array,
+                typeof Uint32Array,
+                typeof Atomics,
+                typeof ShadowRealm,
+                typeof Array,
+                typeof Object
+            ].join(',')
+            """).AsString();
+
+        Assert.Equal(
+            "undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,undefined,function,function",
+            result);
+    }
+
+    [Fact]
+    public void DisablingOneGlobalBuiltInDoesNotDisableRelatedBuiltIns()
+    {
+        var engine = new Engine(options => options.DisableGlobalBuiltIns(GlobalBuiltIn.ArrayBuffer));
+
+        var result = engine.Evaluate("""
+            [
+                typeof ArrayBuffer,
+                typeof DataView,
+                typeof Uint8Array,
+                typeof SharedArrayBuffer
+            ].join(',')
+            """).AsString();
+
+        Assert.Equal("undefined,function,function,function", result);
+    }
+
+    [Fact]
     public void UnescapeAtEndOfString()
     {
         var e = new Engine();

--- a/Jint/Native/Global/GlobalObject.Properties.cs
+++ b/Jint/Native/Global/GlobalObject.Properties.cs
@@ -85,6 +85,7 @@ public partial class GlobalObject
         const PropertyFlag LengthFlags = PropertyFlag.Configurable;
 
         CreateProperties_Generated();
+        HideDisabledGlobalBuiltIns();
 
         // After CreateProperties_Generated, _properties is the HybridDictionary wrapper around the
         // generator-built StringDictionarySlim. AddDangerous skips both duplicate-key lookup and
@@ -102,5 +103,59 @@ public partial class GlobalObject
         _properties!.AddDangerous("parseInt", new LazyPropertyDescriptor<GlobalObject>(this, static global => new ClrFunction(global._engine, "parseInt", ParseInt, 2, LengthFlags), PropertyFlags));
         _properties.AddDangerous("parseFloat", new LazyPropertyDescriptor<GlobalObject>(this, static global => new ClrFunction(global._engine, "parseFloat", ParseFloat, 1, LengthFlags), PropertyFlags));
         _properties.AddDangerous("globalThis", new PropertyDescriptor(this, PropertyFlags));
+    }
+
+    private void HideDisabledGlobalBuiltIns()
+    {
+        var disabledBuiltIns = _engine.Options.Builtins.DisabledGlobalBuiltIns;
+        if (disabledBuiltIns == GlobalBuiltIn.None)
+        {
+            return;
+        }
+
+        void Remove(string name) => _properties!.Remove(name);
+        bool IsDisabled(GlobalBuiltIn builtIn) => (disabledBuiltIns & builtIn) != GlobalBuiltIn.None;
+
+        if (IsDisabled(GlobalBuiltIn.ArrayBuffer))
+        {
+            Remove("ArrayBuffer");
+        }
+
+        if (IsDisabled(GlobalBuiltIn.Atomics))
+        {
+            Remove("Atomics");
+        }
+
+        if (IsDisabled(GlobalBuiltIn.DataView))
+        {
+            Remove("DataView");
+        }
+
+        if (IsDisabled(GlobalBuiltIn.ShadowRealm))
+        {
+            Remove("ShadowRealm");
+        }
+
+        if (IsDisabled(GlobalBuiltIn.SharedArrayBuffer))
+        {
+            Remove("SharedArrayBuffer");
+        }
+
+        if (IsDisabled(GlobalBuiltIn.TypedArray))
+        {
+            Remove("BigInt64Array");
+            Remove("BigUint64Array");
+            Remove("Float16Array");
+            Remove("Float32Array");
+            Remove("Float64Array");
+            Remove("Int16Array");
+            Remove("Int32Array");
+            Remove("Int8Array");
+            Remove("TypedArray");
+            Remove("Uint16Array");
+            Remove("Uint32Array");
+            Remove("Uint8Array");
+            Remove("Uint8ClampedArray");
+        }
     }
 }

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -110,6 +110,15 @@ public static class OptionsExtensions
         return options;
     }
 
+    /// <summary>
+    /// Hides selected built-ins from the global object.
+    /// </summary>
+    public static Options DisableGlobalBuiltIns(this Options options, GlobalBuiltIn builtIns)
+    {
+        options.Builtins.DisabledGlobalBuiltIns |= builtIns;
+        return options;
+    }
+
     public static Options AddExtensionMethods(this Options options, params Type[] types)
     {
         options.Interop.ExtensionMethodTypes.AddRange(types);

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -57,6 +57,11 @@ public class Options
     public HostOptions Host { get; } = new();
 
     /// <summary>
+    /// JavaScript built-in object options.
+    /// </summary>
+    public BuiltinOptions Builtins { get; } = new();
+
+    /// <summary>
     /// Module options
     /// </summary>
     public ModuleOptions Modules { get; } = new();
@@ -520,6 +525,14 @@ public class Options
         public Func<Function, Node, string?> FunctionToStringHandler { get; set; } = (_, _) => null;
     }
 
+    public class BuiltinOptions
+    {
+        /// <summary>
+        /// Global built-ins that should not be exposed as properties on the global object.
+        /// </summary>
+        public GlobalBuiltIn DisabledGlobalBuiltIns { get; set; }
+    }
+
     /// <summary>
     /// Module related customization
     /// </summary>
@@ -624,6 +637,48 @@ public enum ValueCoercionType
     /// All coercion rules enabled.
     /// </summary>
     All = Boolean | Number | String
+}
+
+/// <summary>
+/// JavaScript built-ins that can be hidden from the global object.
+/// </summary>
+[Flags]
+public enum GlobalBuiltIn
+{
+    /// <summary>
+    /// No global built-ins.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The ArrayBuffer global constructor.
+    /// </summary>
+    ArrayBuffer = 1 << 0,
+
+    /// <summary>
+    /// The SharedArrayBuffer global constructor.
+    /// </summary>
+    SharedArrayBuffer = 1 << 1,
+
+    /// <summary>
+    /// The DataView global constructor.
+    /// </summary>
+    DataView = 1 << 2,
+
+    /// <summary>
+    /// The TypedArray abstract constructor and concrete typed array global constructors.
+    /// </summary>
+    TypedArray = 1 << 3,
+
+    /// <summary>
+    /// The Atomics global object.
+    /// </summary>
+    Atomics = 1 << 4,
+
+    /// <summary>
+    /// The ShadowRealm global constructor.
+    /// </summary>
+    ShadowRealm = 1 << 5
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Allow hosts to hide selected built-ins from globalThis.

## Details

- Add Options.Builtins.DisabledGlobalBuiltIns and a fluent DisableGlobalBuiltIns helper.
- Add GlobalBuiltIn flags for ArrayBuffer, SharedArrayBuffer, DataView, TypedArray constructors, Atomics, and ShadowRealm.
- Remove disabled generated global properties after globalThis source-generated initialization.
- Keep each flag independent so disabling ArrayBuffer does not implicitly hide DataView, typed arrays, or SharedArrayBuffer.

## Linked issue

Refs #

## Test plan

- [x] Added or updated unit tests in Jint.Tests
- [ ] Ran dotnet test --configuration Release locally
- [ ] For ECMAScript spec changes: ran Jint.Tests.Test262 and confirmed no regressions
- [ ] For interop changes: covered in Jint.Tests/Runtime/Interop
- [ ] For perf changes: included before/after numbers from Jint.Benchmark

Additional local validation:

- dotnet test Jint.Tests/Jint.Tests.csproj --filter "FullyQualifiedName~GlobalTests"
- dotnet build Jint/Jint.csproj --configuration Release

## Breaking change?

No.
