### PR TITLE
Return pooled temporaries on abrupt completion

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -858,33 +858,39 @@ public sealed partial class Engine : IDisposable
                 items[i] = JsValue.FromObject(this, arguments[i]);
             }
 
-            // ensure logic is in sync between Call, Construct, engine.Invoke and JintCallExpression!
-            JsValue result;
             var thisObject = JsValue.FromObject(this, thisObj);
-            if (callable is Function functionInstance)
+            try
             {
-                var callStack = CallStack;
-                callStack.Push(functionInstance, expression: null, ExecutionContext);
-                try
+                // ensure logic is in sync between Call, Construct, engine.Invoke and JintCallExpression!
+                JsValue result;
+                if (callable is Function functionInstance)
                 {
-                    result = functionInstance.Call(thisObject, items);
-                }
-                finally
-                {
-                    // if call stack was reset due to recursive call to engine or similar, we might not have it anymore
-                    if (callStack.Count > 0)
+                    var callStack = CallStack;
+                    callStack.Push(functionInstance, expression: null, ExecutionContext);
+                    try
                     {
-                        callStack.Pop();
+                        result = functionInstance.Call(thisObject, items);
+                    }
+                    finally
+                    {
+                        // if call stack was reset due to recursive call to engine or similar, we might not have it anymore
+                        if (callStack.Count > 0)
+                        {
+                            callStack.Pop();
+                        }
                     }
                 }
-            }
-            else
-            {
-                result = callable.Call(thisObject, items);
-            }
+                else
+                {
+                    result = callable.Call(thisObject, items);
+                }
 
-            _jsValueArrayPool.ReturnArray(items);
-            return result;
+                return result;
+            }
+            finally
+            {
+                _jsValueArrayPool.ReturnArray(items);
+            }
         }
 
         return ExecuteWithConstraints(Options.Strict, DoInvoke);

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -580,9 +580,14 @@ public static class JsValueExtensions
             var engine = objectInstance.Engine;
             var arguments = engine._jsValueArrayPool.RentArray(1);
             arguments[0] = arg1;
-            var result = engine.Call(value, arguments);
-            engine._jsValueArrayPool.ReturnArray(arguments);
-            return result;
+            try
+            {
+                return engine.Call(value, arguments);
+            }
+            finally
+            {
+                engine._jsValueArrayPool.ReturnArray(arguments);
+            }
         }
 
         return ThrowNotObject(value);
@@ -597,9 +602,14 @@ public static class JsValueExtensions
             var arguments = engine._jsValueArrayPool.RentArray(2);
             arguments[0] = arg1;
             arguments[1] = arg2;
-            var result = engine.Call(value, arguments);
-            engine._jsValueArrayPool.ReturnArray(arguments);
-            return result;
+            try
+            {
+                return engine.Call(value, arguments);
+            }
+            finally
+            {
+                engine._jsValueArrayPool.ReturnArray(arguments);
+            }
         }
 
         return ThrowNotObject(value);
@@ -615,9 +625,14 @@ public static class JsValueExtensions
             arguments[0] = arg1;
             arguments[1] = arg2;
             arguments[2] = arg3;
-            var result = engine.Call(value, arguments);
-            engine._jsValueArrayPool.ReturnArray(arguments);
-            return result;
+            try
+            {
+                return engine.Call(value, arguments);
+            }
+            finally
+            {
+                engine._jsValueArrayPool.ReturnArray(arguments);
+            }
         }
 
         return ThrowNotObject(value);

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -609,26 +609,31 @@ public sealed partial class ArrayConstructor : Constructor
 
         var target = ArrayOperations.For(a, forWrite: true);
         uint n = 0;
-        for (uint i = 0; i < length; i++)
+        try
         {
-            var value = source.Get(i);
+            for (uint i = 0; i < length; i++)
+            {
+                var value = source.Get(i);
+                if (callable is not null)
+                {
+                    args![0] = value;
+                    args[1] = i;
+                    value = callable.Call(thisArg, args);
+
+                    // function can alter data
+                    length = source.GetLength();
+                }
+
+                target.CreateDataPropertyOrThrow(i, value);
+                n++;
+            }
+        }
+        finally
+        {
             if (callable is not null)
             {
-                args![0] = value;
-                args[1] = i;
-                value = callable.Call(thisArg, args);
-
-                // function can alter data
-                length = source.GetLength();
+                _engine._jsValueArrayPool.ReturnArray(args!);
             }
-
-            target.CreateDataPropertyOrThrow(i, value);
-            n++;
-        }
-
-        if (callable is not null)
-        {
-            _engine._jsValueArrayPool.ReturnArray(args!);
         }
 
         target.SetLength(length);
@@ -874,14 +879,20 @@ public sealed partial class ArrayConstructor : Constructor
     {
         var jsArray = Construct(Arguments.Empty);
         var tempArray = _engine._jsValueArrayPool.RentArray(1);
-        foreach (var item in enumerable)
+        try
         {
-            var jsItem = FromObject(Engine, item);
-            tempArray[0] = jsItem;
-            _realm.Intrinsics.Array.PrototypeObject.Push(jsArray, tempArray);
+            foreach (var item in enumerable)
+            {
+                var jsItem = FromObject(Engine, item);
+                tempArray[0] = jsItem;
+                _realm.Intrinsics.Array.PrototypeObject.Push(jsArray, tempArray);
+            }
+        }
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(tempArray);
         }
 
-        _engine._jsValueArrayPool.ReturnArray(tempArray);
         return jsArray;
     }
 

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -1275,25 +1275,31 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         var a = _engine.Realm.Intrinsics.Array.ArrayCreate(len);
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = this;
-        for (uint k = 0; k < len; k++)
+        try
         {
-            if (TryGetValue(k, out var kvalue))
+            for (uint k = 0; k < len; k++)
             {
-                args[0] = kvalue;
-                args[1] = k;
-                var mappedValue = callable.Call(thisArg, args);
-                if (a._dense != null && k < (uint) a._dense.Length)
+                if (TryGetValue(k, out var kvalue))
                 {
-                    a._dense[k] = mappedValue;
-                }
-                else
-                {
-                    a.WriteArrayValue(k, mappedValue);
+                    args[0] = kvalue;
+                    args[1] = k;
+                    var mappedValue = callable.Call(thisArg, args);
+                    if (a._dense != null && k < (uint) a._dense.Length)
+                    {
+                        a._dense[k] = mappedValue;
+                    }
+                    else
+                    {
+                        a.WriteArrayValue(k, mappedValue);
+                    }
                 }
             }
         }
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
 
-        _engine._jsValueArrayPool.ReturnArray(args);
         return a;
     }
 
@@ -1319,48 +1325,52 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = this;
-
-        if (!fromEnd)
+        try
         {
-            for (uint k = 0; k < len; k++)
+            if (!fromEnd)
             {
-                if (TryGetValue(k, out var kvalue) || visitUnassigned)
+                for (uint k = 0; k < len; k++)
                 {
-                    kvalue ??= Undefined;
-                    args[0] = kvalue;
-                    args[1] = k;
-                    var testResult = callable.Call(thisArg, args);
-                    if (TypeConverter.ToBoolean(testResult))
+                    if (TryGetValue(k, out var kvalue) || visitUnassigned)
                     {
-                        index = k;
-                        value = kvalue;
-                        return true;
+                        kvalue ??= Undefined;
+                        args[0] = kvalue;
+                        args[1] = k;
+                        var testResult = callable.Call(thisArg, args);
+                        if (TypeConverter.ToBoolean(testResult))
+                        {
+                            index = k;
+                            value = kvalue;
+                            return true;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                for (long k = len - 1; k >= 0; k--)
+                {
+                    var idx = (uint) k;
+                    if (TryGetValue(idx, out var kvalue) || visitUnassigned)
+                    {
+                        kvalue ??= Undefined;
+                        args[0] = kvalue;
+                        args[1] = idx;
+                        var testResult = callable.Call(thisArg, args);
+                        if (TypeConverter.ToBoolean(testResult))
+                        {
+                            index = idx;
+                            value = kvalue;
+                            return true;
+                        }
                     }
                 }
             }
         }
-        else
+        finally
         {
-            for (long k = len - 1; k >= 0; k--)
-            {
-                var idx = (uint) k;
-                if (TryGetValue(idx, out var kvalue) || visitUnassigned)
-                {
-                    kvalue ??= Undefined;
-                    args[0] = kvalue;
-                    args[1] = idx;
-                    var testResult = callable.Call(thisArg, args);
-                    if (TypeConverter.ToBoolean(testResult))
-                    {
-                        index = idx;
-                        value = kvalue;
-                        return true;
-                    }
-                }
-            }
+            _engine._jsValueArrayPool.ReturnArray(args);
         }
-
-        _engine._jsValueArrayPool.ReturnArray(args);
 
         index = 0;
         value = Undefined;

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -449,23 +449,29 @@ public sealed partial class ArrayPrototype : ArrayInstance
         uint to = 0;
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o.Target;
-        for (uint k = 0; k < len; k++)
+        try
         {
-            if (o.TryGetValue(k, out var kvalue))
+            for (uint k = 0; k < len; k++)
             {
-                args[0] = kvalue;
-                args[1] = k;
-                var selected = callable.Call(thisArg, args);
-                if (TypeConverter.ToBoolean(selected))
+                if (o.TryGetValue(k, out var kvalue))
                 {
-                    operations.CreateDataPropertyOrThrow(to, kvalue);
-                    to++;
+                    args[0] = kvalue;
+                    args[1] = k;
+                    var selected = callable.Call(thisArg, args);
+                    if (TypeConverter.ToBoolean(selected))
+                    {
+                        operations.CreateDataPropertyOrThrow(to, kvalue);
+                        to++;
+                    }
                 }
             }
-        }
 
-        operations.SetLength(to);
-        _engine._jsValueArrayPool.ReturnArray(args);
+            operations.SetLength(to);
+        }
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
 
         return a;
     }
@@ -497,17 +503,24 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var a = ArrayOperations.For(_realm.Intrinsics.Array.ArraySpeciesCreate(TypeConverter.ToObject(_realm, thisObject), (uint) len), forWrite: true);
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o.Target;
-        for (uint k = 0; k < len; k++)
+        try
         {
-            if (o.TryGetValue(k, out var kvalue))
+            for (uint k = 0; k < len; k++)
             {
-                args[0] = kvalue;
-                args[1] = k;
-                var mappedValue = callable.Call(thisArg, args);
-                a.CreateDataPropertyOrThrow(k, mappedValue);
+                if (o.TryGetValue(k, out var kvalue))
+                {
+                    args[0] = kvalue;
+                    args[1] = k;
+                    var mappedValue = callable.Call(thisArg, args);
+                    a.CreateDataPropertyOrThrow(k, mappedValue);
+                }
             }
         }
-        _engine._jsValueArrayPool.ReturnArray(args);
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
+
         return a.Target;
     }
 
@@ -645,16 +658,22 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o.Target;
-        for (uint k = 0; k < len; k++)
+        try
         {
-            if (o.TryGetValue(k, out var kvalue))
+            for (uint k = 0; k < len; k++)
             {
-                args[0] = kvalue;
-                args[1] = k;
-                callable.Call(thisArg, args);
+                if (o.TryGetValue(k, out var kvalue))
+                {
+                    args[0] = kvalue;
+                    args[1] = k;
+                    callable.Call(thisArg, args);
+                }
             }
         }
-        _engine._jsValueArrayPool.ReturnArray(args);
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
 
         return Undefined;
     }
@@ -760,20 +779,26 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o.Target;
-        for (uint k = 0; k < len; k++)
+        try
         {
-            if (o.TryGetValue(k, out var kvalue))
+            for (uint k = 0; k < len; k++)
             {
-                args[0] = kvalue;
-                args[1] = k;
-                var testResult = callable.Call(thisArg, args);
-                if (!TypeConverter.ToBoolean(testResult))
+                if (o.TryGetValue(k, out var kvalue))
                 {
-                    return JsBoolean.False;
+                    args[0] = kvalue;
+                    args[1] = k;
+                    var testResult = callable.Call(thisArg, args);
+                    if (!TypeConverter.ToBoolean(testResult))
+                    {
+                        return JsBoolean.False;
+                    }
                 }
             }
         }
-        _engine._jsValueArrayPool.ReturnArray(args);
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
 
         return JsBoolean.True;
     }

--- a/Jint/Native/Function/BindFunction.cs
+++ b/Jint/Native/Function/BindFunction.cs
@@ -49,10 +49,14 @@ public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
         }
 
         var args = CreateArguments(arguments);
-        var value = f.Call(BoundThis, args);
-        _engine._jsValueArrayPool.ReturnArray(args);
-
-        return value;
+        try
+        {
+            return f.Call(BoundThis, args);
+        }
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
     }
 
     ObjectInstance IConstructor.Construct(JsCallArguments arguments, JsValue newTarget)
@@ -70,10 +74,14 @@ public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
             newTarget = BoundTargetFunction;
         }
 
-        var value = target.Construct(args, newTarget);
-        _engine._jsValueArrayPool.ReturnArray(args);
-
-        return value;
+        try
+        {
+            return target.Construct(args, newTarget);
+        }
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
     }
 
     internal override bool OrdinaryHasInstance(JsValue v)

--- a/Jint/Native/JsMap.cs
+++ b/Jint/Native/JsMap.cs
@@ -94,34 +94,39 @@ public sealed class JsMap : ObjectInstance, IEnumerable<KeyValuePair<JsValue, Js
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = this;
 
-        var i = 0;
-        while (i < _map.Count)
+        try
         {
-            var key = _map.GetKey(i);
-            args[0] = _map[key];
-            args[1] = key;
-            callable.Call(thisArg, args);
+            var i = 0;
+            while (i < _map.Count)
+            {
+                var key = _map.GetKey(i);
+                args[0] = _map[key];
+                args[1] = key;
+                callable.Call(thisArg, args);
 
-            // Adjust position for mutations during callback
-            if (i < _map.Count && ReferenceEquals(_map.GetKey(i), key))
-            {
-                // Common fast path: key still at same position
-                i++;
-            }
-            else if (_map.ContainsKey(key))
-            {
-                var newIndex = _map.IndexOf(key);
-                if (newIndex < i)
+                // Adjust position for mutations during callback
+                if (i < _map.Count && ReferenceEquals(_map.GetKey(i), key))
                 {
-                    // Key moved backward (entries before it were deleted)
-                    i = newIndex + 1;
+                    // Common fast path: key still at same position
+                    i++;
                 }
-                // else: key was deleted and re-added at end, keep i (entries shifted left)
+                else if (_map.ContainsKey(key))
+                {
+                    var newIndex = _map.IndexOf(key);
+                    if (newIndex < i)
+                    {
+                        // Key moved backward (entries before it were deleted)
+                        i = newIndex + 1;
+                    }
+                    // else: key was deleted and re-added at end, keep i (entries shifted left)
+                }
+                // else: key was deleted, entries shifted left so i now points to next entry
             }
-            // else: key was deleted, entries shifted left so i now points to next entry
         }
-
-        _engine._jsValueArrayPool.ReturnArray(args);
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
     }
 
     internal ObjectInstance Iterator() => _realm.Intrinsics.MapIteratorPrototype.ConstructEntryIterator(this);

--- a/Jint/Native/JsSet.cs
+++ b/Jint/Native/JsSet.cs
@@ -61,34 +61,39 @@ public sealed class JsSet : ObjectInstance, IEnumerable<JsValue>
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = this;
 
-        var i = 0;
-        while (i < _set._list.Count)
+        try
         {
-            var value = _set._list[i];
-            args[0] = value;
-            args[1] = value;
-            callable.Call(thisArg, args);
+            var i = 0;
+            while (i < _set._list.Count)
+            {
+                var value = _set._list[i];
+                args[0] = value;
+                args[1] = value;
+                callable.Call(thisArg, args);
 
-            // Adjust position for mutations during callback
-            if (i < _set._list.Count && SameComparison(_set._list[i], value))
-            {
-                // Common fast path: value still at same position
-                i++;
-            }
-            else if (_set.Contains(value))
-            {
-                var newIndex = _set._list.IndexOf(value);
-                if (newIndex < i)
+                // Adjust position for mutations during callback
+                if (i < _set._list.Count && SameComparison(_set._list[i], value))
                 {
-                    // Value moved backward (entries before it were deleted)
-                    i = newIndex + 1;
+                    // Common fast path: value still at same position
+                    i++;
                 }
-                // else: value was deleted and re-added at end, keep i (entries shifted left)
+                else if (_set.Contains(value))
+                {
+                    var newIndex = _set._list.IndexOf(value);
+                    if (newIndex < i)
+                    {
+                        // Value moved backward (entries before it were deleted)
+                        i = newIndex + 1;
+                    }
+                    // else: value was deleted and re-added at end, keep i (entries shifted left)
+                }
+                // else: value was deleted, entries shifted left so i now points to next entry
             }
-            // else: value was deleted, entries shifted left so i now points to next entry
         }
-
-        _engine._jsValueArrayPool.ReturnArray(args);
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
     }
 
     private static bool SameComparison(JsValue a, JsValue b)

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1195,46 +1195,50 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
 
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = this;
-
-        if (!fromEnd)
+        try
         {
-            for (ulong k = 0; k < length; k++)
+            if (!fromEnd)
             {
-                if (TryGetValue(k, out var kvalue) || visitUnassigned)
+                for (ulong k = 0; k < length; k++)
                 {
-                    args[0] = kvalue;
-                    args[1] = k;
-                    var testResult = callable.Call(thisArg, args);
-                    if (TypeConverter.ToBoolean(testResult))
+                    if (TryGetValue(k, out var kvalue) || visitUnassigned)
                     {
-                        index = k;
-                        value = kvalue;
-                        return true;
+                        args[0] = kvalue;
+                        args[1] = k;
+                        var testResult = callable.Call(thisArg, args);
+                        if (TypeConverter.ToBoolean(testResult))
+                        {
+                            index = k;
+                            value = kvalue;
+                            return true;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                for (var k = (long) (length - 1); k >= 0; k--)
+                {
+                    if (TryGetValue((ulong) k, out var kvalue) || visitUnassigned)
+                    {
+                        kvalue ??= Undefined;
+                        args[0] = kvalue;
+                        args[1] = k;
+                        var testResult = callable.Call(thisArg, args);
+                        if (TypeConverter.ToBoolean(testResult))
+                        {
+                            index = (ulong) k;
+                            value = kvalue;
+                            return true;
+                        }
                     }
                 }
             }
         }
-        else
+        finally
         {
-            for (var k = (long) (length - 1); k >= 0; k--)
-            {
-                if (TryGetValue((ulong) k, out var kvalue) || visitUnassigned)
-                {
-                    kvalue ??= Undefined;
-                    args[0] = kvalue;
-                    args[1] = k;
-                    var testResult = callable.Call(thisArg, args);
-                    if (TypeConverter.ToBoolean(testResult))
-                    {
-                        index = (ulong) k;
-                        value = kvalue;
-                        return true;
-                    }
-                }
-            }
+            _engine._jsValueArrayPool.ReturnArray(args);
         }
-
-        _engine._jsValueArrayPool.ReturnArray(args);
 
         index = 0;
         value = Undefined;

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -392,17 +392,22 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o;
-        for (var k = 0; k < len; k++)
+        try
         {
-            args[0] = o[k];
-            args[1] = k;
-            if (!TypeConverter.ToBoolean(predicate.Call(thisArg, args)))
+            for (var k = 0; k < len; k++)
             {
-                return JsBoolean.False;
+                args[0] = o[k];
+                args[1] = k;
+                if (!TypeConverter.ToBoolean(predicate.Call(thisArg, args)))
+                {
+                    return JsBoolean.False;
+                }
             }
         }
-
-        _engine._jsValueArrayPool.ReturnArray(args);
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
 
         return JsBoolean.True;
     }
@@ -499,20 +504,25 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o;
-        for (var k = 0; k < len; k++)
+        try
         {
-            var kValue = o[k];
-            args[0] = kValue;
-            args[1] = k;
-            var selected = callbackfn.Call(thisArg, args);
-            if (TypeConverter.ToBoolean(selected))
+            for (var k = 0; k < len; k++)
             {
-                kept.Add(kValue);
-                captured++;
+                var kValue = o[k];
+                args[0] = kValue;
+                args[1] = k;
+                var selected = callbackfn.Call(thisArg, args);
+                if (TypeConverter.ToBoolean(selected))
+                {
+                    kept.Add(kValue);
+                    captured++;
+                }
             }
         }
-
-        _engine._jsValueArrayPool.ReturnArray(args);
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
 
         var a = _realm.Intrinsics.TypedArray.TypedArraySpeciesCreate(o, [captured]);
         for (var n = 0; n < captured; ++n)
@@ -568,33 +578,40 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o;
-        if (!fromEnd)
+        try
         {
-            for (var k = 0; k < len; k++)
+            if (!fromEnd)
             {
-                var kNumber = JsNumber.Create(k);
-                var kValue = o[k];
-                args[0] = kValue;
-                args[1] = kNumber;
-                if (TypeConverter.ToBoolean(predicate.Call(thisArg, args)))
+                for (var k = 0; k < len; k++)
                 {
-                    return new KeyValuePair<JsValue, JsValue>(kNumber, kValue);
+                    var kNumber = JsNumber.Create(k);
+                    var kValue = o[k];
+                    args[0] = kValue;
+                    args[1] = kNumber;
+                    if (TypeConverter.ToBoolean(predicate.Call(thisArg, args)))
+                    {
+                        return new KeyValuePair<JsValue, JsValue>(kNumber, kValue);
+                    }
+                }
+            }
+            else
+            {
+                for (var k = (int) (len - 1); k >= 0; k--)
+                {
+                    var kNumber = JsNumber.Create(k);
+                    var kValue = o[k];
+                    args[0] = kValue;
+                    args[1] = kNumber;
+                    if (TypeConverter.ToBoolean(predicate.Call(thisArg, args)))
+                    {
+                        return new KeyValuePair<JsValue, JsValue>(kNumber, kValue);
+                    }
                 }
             }
         }
-        else
+        finally
         {
-            for (var k = (int) (len - 1); k >= 0; k--)
-            {
-                var kNumber = JsNumber.Create(k);
-                var kValue = o[k];
-                args[0] = kValue;
-                args[1] = kNumber;
-                if (TypeConverter.ToBoolean(predicate.Call(thisArg, args)))
-                {
-                    return new KeyValuePair<JsValue, JsValue>(kNumber, kValue);
-                }
-            }
+            _engine._jsValueArrayPool.ReturnArray(args);
         }
 
         return new KeyValuePair<JsValue, JsValue>(JsNumber.IntegerNegativeOne, Undefined);
@@ -614,15 +631,20 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o;
-        for (var k = 0; k < len; k++)
+        try
         {
-            var kValue = o[k];
-            args[0] = kValue;
-            args[1] = k;
-            callbackfn.Call(thisArg, args);
+            for (var k = 0; k < len; k++)
+            {
+                var kValue = o[k];
+                args[0] = kValue;
+                args[1] = k;
+                callbackfn.Call(thisArg, args);
+            }
         }
-
-        _engine._jsValueArrayPool.ReturnArray(args);
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
 
         return Undefined;
     }
@@ -857,15 +879,21 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var a = _realm.Intrinsics.TypedArray.TypedArraySpeciesCreate(o, [len]);
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o;
-        for (var k = 0; k < len; k++)
+        try
         {
-            args[0] = o[k];
-            args[1] = k;
-            var mappedValue = callable.Call(thisArg, args);
-            a[k] = mappedValue;
+            for (var k = 0; k < len; k++)
+            {
+                args[0] = o[k];
+                args[1] = k;
+                var mappedValue = callable.Call(thisArg, args);
+                a[k] = mappedValue;
+            }
+        }
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
         }
 
-        _engine._jsValueArrayPool.ReturnArray(args);
         return a;
     }
 
@@ -903,17 +931,22 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         var args = _engine._jsValueArrayPool.RentArray(4);
         args[3] = o;
-        while (k < len)
+        try
         {
-            var kValue = o[k];
-            args[0] = accumulator;
-            args[1] = kValue;
-            args[2] = k;
-            accumulator = callbackfn.Call(Undefined, args);
-            k++;
+            while (k < len)
+            {
+                var kValue = o[k];
+                args[0] = accumulator;
+                args[1] = kValue;
+                args[2] = k;
+                accumulator = callbackfn.Call(Undefined, args);
+                k++;
+            }
         }
-
-        _engine._jsValueArrayPool.ReturnArray(args);
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
 
         return accumulator;
     }
@@ -951,15 +984,21 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         var jsValues = _engine._jsValueArrayPool.RentArray(4);
         jsValues[3] = o;
-        for (; k >= 0; k--)
+        try
         {
-            jsValues[0] = accumulator;
-            jsValues[1] = o[(int) k];
-            jsValues[2] = k;
-            accumulator = callbackfn.Call(Undefined, jsValues);
+            for (; k >= 0; k--)
+            {
+                jsValues[0] = accumulator;
+                jsValues[1] = o[(int) k];
+                jsValues[2] = k;
+                accumulator = callbackfn.Call(Undefined, jsValues);
+            }
+        }
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(jsValues);
         }
 
-        _engine._jsValueArrayPool.ReturnArray(jsValues);
         return accumulator;
     }
 
@@ -1284,17 +1323,23 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o;
-        for (var k = 0; k < len; k++)
+        try
         {
-            args[0] = o[k];
-            args[1] = k;
-            if (TypeConverter.ToBoolean(callbackfn.Call(thisArg, args)))
+            for (var k = 0; k < len; k++)
             {
-                return JsBoolean.True;
+                args[0] = o[k];
+                args[1] = k;
+                if (TypeConverter.ToBoolean(callbackfn.Call(thisArg, args)))
+                {
+                    return JsBoolean.True;
+                }
             }
         }
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
 
-        _engine._jsValueArrayPool.ReturnArray(args);
         return JsBoolean.False;
     }
 

--- a/Jint/Runtime/Environments/FunctionEnvironment.cs
+++ b/Jint/Runtime/Environments/FunctionEnvironment.cs
@@ -226,33 +226,38 @@ internal sealed class FunctionEnvironment : DeclarativeEnvironment
             : null;
 
         var jsValues = _engine._jsValueArrayPool.RentArray(1);
-        foreach (var property in properties)
+        try
         {
-            // Evaluate property access in the current execution context.
-            // The VariableEnvironment has already been set up correctly for eval in FunctionDeclarationInstantiation.
-            if (property is AssignmentProperty p)
+            foreach (var property in properties)
             {
-                var propertyName = p.GetKey(_engine);
-                processedProperties?.Add(propertyName.ToString());
-                jsValues[0] = argumentObject.Get(propertyName);
-                SetFunctionParameter(context, p.Value, jsValues, 0, initiallyEmpty);
-            }
-            else
-            {
-                if (((RestElement) property).Argument is Identifier restIdentifier)
+                // Evaluate property access in the current execution context.
+                // The VariableEnvironment has already been set up correctly for eval in FunctionDeclarationInstantiation.
+                if (property is AssignmentProperty p)
                 {
-                    var rest = _engine.Realm.Intrinsics.Object.Construct((argumentObject.Properties?.Count ?? 0) - processedProperties!.Count);
-                    argumentObject.CopyDataProperties(rest, processedProperties);
-                    SetItemSafely(restIdentifier.Name, rest, initiallyEmpty);
+                    var propertyName = p.GetKey(_engine);
+                    processedProperties?.Add(propertyName.ToString());
+                    jsValues[0] = argumentObject.Get(propertyName);
+                    SetFunctionParameter(context, p.Value, jsValues, 0, initiallyEmpty);
                 }
                 else
                 {
-                    Throw.SyntaxError(_functionObject._realm, "Object rest parameter can only be objects");
+                    if (((RestElement) property).Argument is Identifier restIdentifier)
+                    {
+                        var rest = _engine.Realm.Intrinsics.Object.Construct((argumentObject.Properties?.Count ?? 0) - processedProperties!.Count);
+                        argumentObject.CopyDataProperties(rest, processedProperties);
+                        SetItemSafely(restIdentifier.Name, rest, initiallyEmpty);
+                    }
+                    else
+                    {
+                        Throw.SyntaxError(_functionObject._realm, "Object rest parameter can only be objects");
+                    }
                 }
             }
         }
-
-        _engine._jsValueArrayPool.ReturnArray(jsValues);
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(jsValues);
+        }
     }
 
     private void HandleArrayPattern(EvaluationContext context, bool initiallyEmpty, JsValue argument, ArrayPattern arrayPattern)

--- a/Jint/Runtime/Interpreter/Expressions/ExpressionCache.cs
+++ b/Jint/Runtime/Interpreter/Expressions/ExpressionCache.cs
@@ -78,7 +78,16 @@ internal sealed class ExpressionCache
         var arguments = context.Engine._jsValueArrayPool.RentArray(_expressions.Length);
         rented = true;
 
-        BuildArguments(context, arguments);
+        try
+        {
+            BuildArguments(context, arguments);
+        }
+        catch
+        {
+            context.Engine._jsValueArrayPool.ReturnArray(arguments);
+            rented = false;
+            throw;
+        }
 
         return arguments;
     }

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -111,62 +111,63 @@ internal sealed class JintCallExpression : JintExpression
             return func; // Return any value, caller will check Suspended
         }
 
-        if (!func.IsObject() && !engine._referenceResolver.TryGetCallable(engine, reference, out func))
+        try
         {
-            ThrowMemberIsNotFunction(referenceRecord, reference, engine);
-        }
-
-        var callable = func as ICallable;
-        if (callable is null)
-        {
-            ThrowReferenceNotFunction(referenceRecord, reference, engine);
-        }
-
-        if (tailCall)
-        {
-            // TODO tail call
-            // PrepareForTailCall();
-        }
-
-        // ensure logic is in sync between Call, Construct and JintCallExpression!
-
-        JsValue result;
-        if (callable is Function functionInstance)
-        {
-            var callStack = engine.CallStack;
-            var recursionDepth = callStack.Push(functionInstance, _calleeExpression, engine.ExecutionContext);
-
-            if (recursionDepth > engine.Options.Constraints.MaxRecursionDepth)
+            if (!func.IsObject() && !engine._referenceResolver.TryGetCallable(engine, reference, out func))
             {
-                // automatically pops the current element as it was never reached
-                Throw.RecursionDepthOverflowException(callStack);
+                ThrowMemberIsNotFunction(referenceRecord, reference, engine);
             }
 
-            try
+            var callable = func as ICallable;
+            if (callable is null)
             {
-                result = functionInstance.Call(thisObject, arguments);
+                ThrowReferenceNotFunction(referenceRecord, reference, engine);
             }
-            finally
+
+            if (tailCall)
             {
-                // if call stack was reset due to recursive call to engine or similar, we might not have it anymore
-                if (callStack.Count > 0)
+                // TODO tail call
+                // PrepareForTailCall();
+            }
+
+            // ensure logic is in sync between Call, Construct and JintCallExpression!
+
+            if (callable is Function functionInstance)
+            {
+                var callStack = engine.CallStack;
+                var recursionDepth = callStack.Push(functionInstance, _calleeExpression, engine.ExecutionContext);
+
+                if (recursionDepth > engine.Options.Constraints.MaxRecursionDepth)
                 {
-                    callStack.Pop();
+                    // automatically pops the current element as it was never reached
+                    Throw.RecursionDepthOverflowException(callStack);
+                }
+
+                try
+                {
+                    return functionInstance.Call(thisObject, arguments);
+                }
+                finally
+                {
+                    // if call stack was reset due to recursive call to engine or similar, we might not have it anymore
+                    if (callStack.Count > 0)
+                    {
+                        callStack.Pop();
+                    }
                 }
             }
-        }
-        else
-        {
-            result = callable.Call(thisObject, arguments);
-        }
 
-        if (rented)
-        {
-            engine._jsValueArrayPool.ReturnArray(arguments);
+            return callable.Call(thisObject, arguments);
         }
+        finally
+        {
+            if (rented)
+            {
+                engine._jsValueArrayPool.ReturnArray(arguments);
+            }
 
-        engine._referencePool.Return(referenceRecord);
-        return result;
+            engine._referencePool.Return(referenceRecord);
+        }
     }
 
     [DoesNotReturn]
@@ -193,6 +194,11 @@ internal sealed class JintCallExpression : JintExpression
 
         if (argList.Length == 0)
         {
+            if (rented)
+            {
+                engine._jsValueArrayPool.ReturnArray(argList);
+            }
+            engine._referencePool.Return(referenceRecord);
             return JsValue.Undefined;
         }
 
@@ -201,15 +207,18 @@ internal sealed class JintCallExpression : JintExpression
         var strictCaller = StrictModeScope.IsStrictModeCode;
         var evalRealm = evalFunctionInstance._realm;
         var direct = !_expression.IsOptional();
-        var value = evalFunctionInstance.PerformEval(evalArg, evalRealm, strictCaller, direct);
-
-        if (rented)
+        try
         {
-            engine._jsValueArrayPool.ReturnArray(argList);
+            return evalFunctionInstance.PerformEval(evalArg, evalRealm, strictCaller, direct);
         }
-        engine._referencePool.Return(referenceRecord);
-
-        return value;
+        finally
+        {
+            if (rented)
+            {
+                engine._jsValueArrayPool.ReturnArray(argList);
+            }
+            engine._referencePool.Return(referenceRecord);
+        }
     }
 
     private ObjectInstance SuperCall(EvaluationContext context)
@@ -235,20 +244,25 @@ internal sealed class JintCallExpression : JintExpression
             Throw.TypeError(engine.Realm, "Not a constructor");
         }
 
-        var result = ((IConstructor) func).Construct(argList, newTarget);
-
-        var thisER = (FunctionEnvironment) engine.ExecutionContext.GetThisEnvironment();
-        thisER.BindThisValue(result);
-        var F = thisER._functionObject;
-
-        result.InitializeInstanceElements((ScriptFunction) F);
-
-        if (rented)
+        try
         {
-            engine._jsValueArrayPool.ReturnArray(argList);
-        }
+            var result = ((IConstructor) func).Construct(argList, newTarget);
 
-        return result;
+            var thisER = (FunctionEnvironment) engine.ExecutionContext.GetThisEnvironment();
+            thisER.BindThisValue(result);
+            var F = thisER._functionObject;
+
+            result.InitializeInstanceElements((ScriptFunction) F);
+
+            return result;
+        }
+        finally
+        {
+            if (rented)
+            {
+                engine._jsValueArrayPool.ReturnArray(argList);
+            }
+        }
     }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
@@ -26,17 +26,25 @@ internal sealed class JintNewExpression : JintExpression
 
         if (!jsValue.IsConstructor)
         {
+            if (rented)
+            {
+                engine._jsValueArrayPool.ReturnArray(arguments);
+            }
+
             Throw.TypeError(engine.Realm, $"{_calleeExpression.SourceText} is not a constructor");
         }
 
-        // construct the new instance using the Function's constructor method
-        var instance = engine.Construct(jsValue, arguments, jsValue, _calleeExpression);
-
-        if (rented)
+        try
         {
-            engine._jsValueArrayPool.ReturnArray(arguments);
+            // construct the new instance using the Function's constructor method
+            return engine.Construct(jsValue, arguments, jsValue, _calleeExpression);
         }
-
-        return instance;
+        finally
+        {
+            if (rented)
+            {
+                engine._jsValueArrayPool.ReturnArray(arguments);
+            }
+        }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
@@ -44,11 +44,14 @@ internal sealed class JintTaggedTemplateExpression : JintExpression
             ? reference.Base
             : JsValue.Undefined;
 
-        var result = tagger.Call(thisObject, args);
-
-        engine._jsValueArrayPool.ReturnArray(args);
-
-        return result;
+        try
+        {
+            return tagger.Call(thisObject, args);
+        }
+        finally
+        {
+            engine._jsValueArrayPool.ReturnArray(args);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Return pooled temporary values when evaluation exits abruptly.

## Details

- Wrap rented argument arrays and temporary element buffers in finally blocks so callbacks, constructors, and iterator operations return pooled storage even when they throw.
- Cover array, map, set, typed array, object property, call, new, tagged-template, function environment, and expression-cache paths.
- Keep this independent of native recursion hardening by using the existing call APIs on main.
- This is a resource-lifecycle change; intended JavaScript behavior is unchanged except for avoiding leaked pooled temporaries after abrupt completion.

## Linked issue

Refs #

## Test plan

- [x] Added or updated unit tests in Jint.Tests
- [x] Ran dotnet test --configuration Release locally
- [ ] For ECMAScript spec changes: ran Jint.Tests.Test262 and confirmed no regressions
- [ ] For interop changes: covered in Jint.Tests/Runtime/Interop
- [ ] For perf changes: included before/after numbers from Jint.Benchmark

Additional local validation:

- dotnet test Jint.Tests/Jint.Tests.csproj --filter "FullyQualifiedName!~EngineTests.ShouldSetYearBefore1970"
- dotnet build Jint/Jint.csproj --configuration Release

Note: full dotnet test Jint.Tests/Jint.Tests.csproj also ran; only EngineTests.ShouldSetYearBefore1970 failed locally due the existing timezone-sensitive main-branch test covered separately by nc/date-test-utc.

## Breaking change?

No.
