### PR TITLE
Guard native recursion and stack recovery paths

### DIFF
--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -1,7 +1,10 @@
 #if !NETFRAMEWORK
 
 using System.Text;
+using Jint.Native;
+using Jint.Native.Function;
 using Jint.Runtime;
+using Jint.Runtime.Interop;
 
 namespace Jint.Tests.Runtime;
 
@@ -65,6 +68,277 @@ public class EngineLimitTests
         }
     }
 
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenConstructorStackGuardExceeds()
+    {
+        var script = GenerateConstructorChain(static i => $"return new C{i + 1}();", "new C0();");
+
+        AssertMaximumCallStackExceeded(script);
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenSuperConstructorStackGuardExceeds()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"class C{ConstructorChainCount} {{ constructor() {{ }} }}");
+        for (var i = ConstructorChainCount - 1; i >= 0; i--)
+        {
+            sb.Append("class C").Append(i).Append(" extends C").Append(i + 1)
+                .AppendLine(" { constructor() { super(); } }");
+        }
+        sb.AppendLine("new C0();");
+
+        AssertMaximumCallStackExceeded(sb.ToString());
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenReflectConstructStackGuardExceeds()
+    {
+        var script = GenerateConstructorChain(static i => $"return Reflect.construct(C{i + 1}, []);", "new C0();");
+
+        AssertMaximumCallStackExceeded(script);
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenBoundConstructorStackGuardExceeds()
+    {
+        var script = GenerateConstructorChain(
+            static i => $"return new B{i + 1}();",
+            "new B0();",
+            afterConstructors: sb =>
+            {
+                for (var i = 0; i <= ConstructorChainCount; i++)
+                {
+                    sb.Append("const B").Append(i).Append(" = C").Append(i).AppendLine(".bind(null);");
+                }
+            });
+
+        AssertMaximumCallStackExceeded(script);
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenProxyConstructorStackGuardExceeds()
+    {
+        var script = GenerateConstructorChain(
+            static i => $"return new P{i + 1}();",
+            "new P0();",
+            afterConstructors: sb =>
+            {
+                for (var i = 0; i <= ConstructorChainCount; i++)
+                {
+                    sb.Append("const P").Append(i).Append(" = new Proxy(C").Append(i).AppendLine(", {});");
+                }
+            });
+
+        AssertMaximumCallStackExceeded(script);
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenBoundConstructorWrapperDepthExceeds()
+    {
+        AssertMaximumCallStackExceeded(
+            """
+            let f = function() {};
+            for (let i = 0; i < 32; i++) {
+              f = f.bind(null);
+            }
+            new f();
+            """,
+            static options => options.Constraints.MaxBuiltInRecursionDepth = ConstructorStackGuardLimit);
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenProxyConstructorWrapperDepthExceeds()
+    {
+        AssertMaximumCallStackExceeded(
+            """
+            let f = function() {};
+            for (let i = 0; i < 32; i++) {
+              f = new Proxy(f, {});
+            }
+            new f();
+            """,
+            static options => options.Constraints.MaxBuiltInRecursionDepth = ConstructorStackGuardLimit);
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenProxyCallWrapperDepthExceeds()
+    {
+        AssertMaximumCallStackExceeded(
+            """
+            let f = function() { return 1; };
+            for (let i = 0; i < 32; i++) {
+              f = new Proxy(f, {});
+            }
+            f();
+            """,
+            static options => options.Constraints.MaxBuiltInRecursionDepth = ConstructorStackGuardLimit);
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenReflectApplyProxyWrapperDepthExceeds()
+    {
+        AssertMaximumCallStackExceeded(
+            """
+            let f = function() { return 1; };
+            for (let i = 0; i < 32; i++) {
+              f = new Proxy(f, {});
+            }
+            Reflect.apply(f, undefined, []);
+            """,
+            static options => options.Constraints.MaxBuiltInRecursionDepth = ConstructorStackGuardLimit);
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenNativeFunctionCallWrapperDepthExceeds()
+    {
+        var engine = new Engine(static options =>
+        {
+            options.Constraints.MaxBuiltInRecursionDepth = ConstructorStackGuardLimit;
+        });
+
+        ClrFunction function = null!;
+        function = new ClrFunction(
+            engine,
+            "recurse",
+            (_, _) => ((ICallable) function).Call(JsValue.Undefined, Arguments.Empty));
+
+        var exception = Assert.Throws<JavaScriptException>(
+            () => ((ICallable) function).Call(JsValue.Undefined, Arguments.Empty));
+
+        Assert.Equal("Maximum call stack size exceeded", exception.Message);
+    }
+
+    [Fact]
+    public void ShouldAllowNativeCallsWhenBuiltInRecursionGuardIsDisabled()
+    {
+        var engine = new Engine(static options =>
+        {
+            options.Constraints.MaxBuiltInRecursionDepth = -1;
+        });
+
+        var result = engine.Evaluate("""
+            const applyResult = (function (value) { return value; }).apply(null, [1]);
+
+            const proxy = new Proxy(function (value) { return value + 1; }, {});
+            const proxyResult = proxy(1);
+
+            function C(value) { this.value = value; }
+            const Bound = C.bind(null, 3);
+            const boundResult = new Bound().value;
+
+            applyResult + proxyResult + boundResult;
+            """);
+
+        Assert.Equal(6, result.AsNumber());
+    }
+
+    [Fact]
+    public void ShouldThrowCyclicReferenceWhenJsonCycleIsReachedAtBuiltInRecursionLimit()
+    {
+        var engine = new Engine(static options =>
+        {
+            options.Constraints.MaxBuiltInRecursionDepth = ConstructorStackGuardLimit;
+        });
+
+        var script = """
+            const root = {};
+            let node = root;
+            for (let i = 1; i < LIMIT; i++) {
+                node.next = {};
+                node = node.next;
+            }
+            node.next = root;
+            JSON.stringify(root);
+            """.Replace("LIMIT", ConstructorStackGuardLimit.ToString());
+
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Execute(script));
+        Assert.Equal("Cyclic reference detected.", exception.Message);
+    }
+
+    [Fact]
+    public void ShouldThrowRangeErrorWhenJsonDepthExceedsBuiltInRecursionLimit()
+    {
+        var engine = new Engine(static options =>
+        {
+            options.Constraints.MaxBuiltInRecursionDepth = ConstructorStackGuardLimit;
+        });
+
+        var script = """
+            const root = {};
+            let node = root;
+            for (let i = 0; i <= LIMIT; i++) {
+                node.next = {};
+                node = node.next;
+            }
+            JSON.stringify(root);
+            """.Replace("LIMIT", ConstructorStackGuardLimit.ToString());
+
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Execute(script));
+        Assert.Equal($"JSON serialization exceeds maximum depth of {ConstructorStackGuardLimit}", exception.Message);
+        Assert.True(exception.Error.InstanceofOperator(engine.Intrinsics.RangeError));
+    }
+
+    [Fact]
+    public void ShouldTreatArrayToLocaleStringCyclesAsEmptyWhenCycleIsReachedAtBuiltInRecursionLimit()
+    {
+        var engine = new Engine(static options =>
+        {
+            options.Constraints.MaxBuiltInRecursionDepth = 1;
+        });
+
+        var result = engine.Evaluate("""
+            const a = [];
+            a[0] = a;
+            a.toLocaleString();
+            """);
+
+        Assert.Equal("", result.AsString());
+    }
+
+    [Fact]
+    public void ShouldThrowRangeErrorWhenArrayToLocaleStringDepthExceedsBuiltInRecursionLimit()
+    {
+        var engine = new Engine(static options =>
+        {
+            options.Constraints.MaxBuiltInRecursionDepth = 1;
+        });
+
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Execute("""
+            const a = [[1]];
+            a.toLocaleString();
+            """));
+
+        Assert.Equal("Array string conversion exceeds maximum depth of 1", exception.Message);
+        Assert.True(exception.Error.InstanceofOperator(engine.Intrinsics.RangeError));
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenArrayConstructorStackGuardExceeds()
+    {
+        var fromScript = GenerateConstructorChain(static i => $"return new C{i + 1}();", "Array.from.call(C0, [1]);");
+        var ofScript = GenerateConstructorChain(static i => $"return new C{i + 1}();", "Array.of.call(C0, 1);");
+
+        AssertMaximumCallStackExceeded(fromScript);
+        AssertMaximumCallStackExceeded(ofScript);
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenTypedArrayConstructorStackGuardExceeds()
+    {
+        var script = GenerateConstructorChain(static i => $"return new C{i + 1}();", "Uint8Array.from.call(C0, [1]);");
+
+        AssertMaximumCallStackExceeded(script);
+    }
+
+    [Fact]
+    public void ShouldThrowJavascriptExceptionWhenPromiseConstructorStackGuardExceeds()
+    {
+        var script = GenerateConstructorChain(static i => $"return new C{i + 1}();", "Promise.resolve.call(C0, 1);");
+
+        AssertMaximumCallStackExceeded(script);
+    }
+
     private string GenerateCallTree(int functionNestingCount)
     {
         var sb = new StringBuilder();
@@ -89,6 +363,45 @@ public class EngineLimitTests
             sb.AppendLine();
         }
         return sb.ToString();
+    }
+
+    private const int ConstructorChainCount = 32;
+    private const int ConstructorStackGuardLimit = 10;
+
+    private static string GenerateConstructorChain(
+        Func<int, string> recursiveBody,
+        string entry,
+        Action<StringBuilder> afterConstructors = null)
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < ConstructorChainCount; i++)
+        {
+            sb.Append("function C").Append(i).Append("() { ")
+                .Append(recursiveBody(i))
+                .AppendLine(" }");
+        }
+        sb.Append("function C").Append(ConstructorChainCount).AppendLine("() { }");
+        afterConstructors?.Invoke(sb);
+        sb.AppendLine(entry);
+        return sb.ToString();
+    }
+
+    private static void AssertMaximumCallStackExceeded(string script)
+    {
+        AssertMaximumCallStackExceeded(
+            script,
+            static options => options.Constraints.MaxExecutionStackCount = ConstructorStackGuardLimit);
+    }
+
+    private static void AssertMaximumCallStackExceeded(string script, Action<Options> configure)
+    {
+        var engine = new Engine(options =>
+        {
+            configure(options);
+        });
+
+        var exception = Assert.Throws<JavaScriptException>(() => engine.Execute(script));
+        Assert.Equal("Maximum call stack size exceeded", exception.Message);
     }
 }
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -37,6 +37,7 @@ public sealed partial class Engine : IDisposable
     private JsValue _completionValue = JsValue.Undefined;
     internal EvaluationContext? _activeEvaluationContext;
     internal ErrorDispatchInfo? _error;
+    private int _nativeCallDepth;
 
     private readonly EventLoop _eventLoop = new();
     internal EventLoop EventLoop => _eventLoop;
@@ -858,31 +859,8 @@ public sealed partial class Engine : IDisposable
                 items[i] = JsValue.FromObject(this, arguments[i]);
             }
 
-            // ensure logic is in sync between Call, Construct, engine.Invoke and JintCallExpression!
-            JsValue result;
             var thisObject = JsValue.FromObject(this, thisObj);
-            if (callable is Function functionInstance)
-            {
-                var callStack = CallStack;
-                callStack.Push(functionInstance, expression: null, ExecutionContext);
-                try
-                {
-                    result = functionInstance.Call(thisObject, items);
-                }
-                finally
-                {
-                    // if call stack was reset due to recursive call to engine or similar, we might not have it anymore
-                    if (callStack.Count > 0)
-                    {
-                        callStack.Pop();
-                    }
-                }
-            }
-            else
-            {
-                result = callable.Call(thisObject, items);
-            }
-
+            var result = Call(callable, thisObject, items, expression: null);
             _jsValueArrayPool.ReturnArray(items);
             return result;
         }
@@ -931,7 +909,7 @@ public sealed partial class Engine : IDisposable
                 Throw.TypeErrorNoEngine("Can only invoke functions");
             }
 
-            return callable.Call(v, arguments);
+            return CallFromNative(callable, v, arguments);
         }
         finally
         {
@@ -1734,7 +1712,70 @@ public sealed partial class Engine : IDisposable
             return Call(functionInstance, thisObject, arguments, expression);
         }
 
-        return callable.Call(thisObject, arguments);
+        if (!_stackGuard.TryEnterOnCurrentStack())
+        {
+            return StackGuard.RunOnEmptyStack(static state =>
+            {
+                return state.Item1.Call(state.Item2, state.Item3, state.Item4, state.Item5);
+            }, Tuple.Create(this, callable, thisObject, arguments, expression));
+        }
+
+        EnterNativeCall();
+        try
+        {
+            return callable.Call(thisObject, arguments);
+        }
+        finally
+        {
+            LeaveNativeCall();
+        }
+    }
+
+    internal JsValue CallFromNative(ICallable callable, JsValue thisObject, JsCallArguments arguments)
+    {
+        if (callable is Function functionInstance)
+        {
+            return CallFromNative(functionInstance, thisObject, arguments);
+        }
+
+        if (!_stackGuard.TryEnterOnCurrentStack())
+        {
+            return StackGuard.RunOnEmptyStack(static state =>
+            {
+                return state.Item1.CallFromNative(state.Item2, state.Item3, state.Item4);
+            }, Tuple.Create(this, callable, thisObject, arguments));
+        }
+
+        EnterNativeCall();
+        try
+        {
+            return callable.Call(thisObject, arguments);
+        }
+        finally
+        {
+            LeaveNativeCall();
+        }
+    }
+
+    internal JsValue CallFromNative(Function function, JsValue thisObject, JsCallArguments arguments)
+    {
+        if (!_stackGuard.TryEnterOnCurrentStack())
+        {
+            return StackGuard.RunOnEmptyStack(static state =>
+            {
+                return state.Item1.CallFromNative(state.Item2, state.Item3, state.Item4);
+            }, Tuple.Create(this, function, thisObject, arguments));
+        }
+
+        EnterNativeCall();
+        try
+        {
+            return function.Call(thisObject, arguments);
+        }
+        finally
+        {
+            LeaveNativeCall();
+        }
     }
 
     /// <summary>
@@ -1776,12 +1817,38 @@ public sealed partial class Engine : IDisposable
         JsValue newTarget,
         JintExpression? expression)
     {
+        return Construct((IConstructor) constructor, arguments, newTarget, expression);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ObjectInstance Construct(
+        IConstructor constructor,
+        JsCallArguments arguments,
+        JsValue newTarget,
+        JintExpression? expression)
+    {
         if (constructor is Function functionInstance)
         {
             return Construct(functionInstance, arguments, newTarget, expression);
         }
 
-        return ((IConstructor) constructor).Construct(arguments, newTarget);
+        if (!_stackGuard.TryEnterOnCurrentStack())
+        {
+            return StackGuard.RunOnEmptyStack(static state =>
+            {
+                return state.Item1.Construct(state.Item2, state.Item3, state.Item4, state.Item5);
+            }, Tuple.Create(this, constructor, arguments, newTarget, expression));
+        }
+
+        EnterNativeCall();
+        try
+        {
+            return constructor.Construct(arguments, newTarget);
+        }
+        finally
+        {
+            LeaveNativeCall();
+        }
     }
 
     internal JsValue Call(Function function, JsValue thisObject)
@@ -1794,6 +1861,14 @@ public sealed partial class Engine : IDisposable
         JintExpression? expression)
     {
         // ensure logic is in sync between Call, Construct, engine.Invoke and JintCallExpression!
+
+        if (!_stackGuard.TryEnterOnCurrentStack())
+        {
+            return StackGuard.RunOnEmptyStack(static state =>
+            {
+                return state.Item1.Call(state.Item2, state.Item3, state.Item4, state.Item5);
+            }, Tuple.Create(this, function, thisObject, arguments, expression));
+        }
 
         var recursionDepth = CallStack.Push(function, expression, ExecutionContext);
 
@@ -1828,6 +1903,14 @@ public sealed partial class Engine : IDisposable
     {
         // ensure logic is in sync between Call, Construct, engine.Invoke and JintCallExpression!
 
+        if (!_stackGuard.TryEnterOnCurrentStack())
+        {
+            return StackGuard.RunOnEmptyStack(static state =>
+            {
+                return state.Item1.Construct(state.Item2, state.Item3, state.Item4, state.Item5);
+            }, Tuple.Create(this, function, arguments, newTarget, expression));
+        }
+
         var recursionDepth = CallStack.Push(function, expression, ExecutionContext);
 
         if (recursionDepth > Options.Constraints.MaxRecursionDepth)
@@ -1843,10 +1926,29 @@ public sealed partial class Engine : IDisposable
         }
         finally
         {
-            CallStack.Pop();
+            if (CallStack.Count > 0)
+            {
+                CallStack.Pop();
+            }
         }
 
         return result;
+    }
+
+    private void EnterNativeCall()
+    {
+        var maxDepth = Options.Constraints.MaxBuiltInRecursionDepth;
+        if (maxDepth >= 0 && _nativeCallDepth >= maxDepth)
+        {
+            Throw.RangeError(Realm, "Maximum call stack size exceeded");
+        }
+
+        _nativeCallDepth++;
+    }
+
+    private void LeaveNativeCall()
+    {
+        _nativeCallDepth--;
     }
 
     internal void SignalError(ErrorDispatchInfo error)

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -61,7 +61,7 @@ public sealed partial class ArrayConstructor : Constructor
             ObjectInstance instance;
             if (!ReferenceEquals(this, thisObject) && thisObject is IConstructor constructor)
             {
-                instance = constructor.Construct([], thisObject);
+                instance = _engine.Construct(constructor, [], thisObject, expression: null);
             }
             else
             {
@@ -192,7 +192,7 @@ public sealed partial class ArrayConstructor : Constructor
         ObjectInstance instance;
         if (!ReferenceEquals(this, c) && c is IConstructor constructor)
         {
-            instance = constructor.Construct([], c);
+            instance = _engine.Construct(constructor, [], c, expression: null);
         }
         else
         {
@@ -443,7 +443,7 @@ public sealed partial class ArrayConstructor : Constructor
             ObjectInstance a;
             if (!ReferenceEquals(c, this) && c is IConstructor constructor)
             {
-                a = constructor.Construct([(JsNumber) longLen], c);
+                a = _engine.Construct(constructor, [(JsNumber) longLen], c, expression: null);
             }
             else
             {
@@ -596,7 +596,7 @@ public sealed partial class ArrayConstructor : Constructor
         if (!ReferenceEquals(thisObj, this) && thisObj is IConstructor constructor)
         {
             var argumentsList = new JsValue[] { length };
-            a = Construct(constructor, argumentsList);
+            a = _engine.Construct(constructor, argumentsList, (JsValue) constructor, expression: null);
         }
         else
         {
@@ -685,7 +685,7 @@ public sealed partial class ArrayConstructor : Constructor
         ObjectInstance a;
         if (thisObject.IsConstructor)
         {
-            a = ((IConstructor) thisObject).Construct([len], thisObject);
+            a = _engine.Construct((IConstructor) thisObject, [len], thisObject, expression: null);
         }
         else
         {
@@ -944,7 +944,7 @@ public sealed partial class ArrayConstructor : Constructor
             Throw.TypeError(_realm, $"{c} is not a constructor");
         }
 
-        return ((IConstructor) c).Construct([JsNumber.Create(length)], c);
+        return _engine.Construct((IConstructor) c, [JsNumber.Create(length)], c, expression: null);
     }
 
     internal JsArray CreateArrayFromList<T>(List<T> values) where T : JsValue

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -28,6 +28,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     private readonly ArrayConstructor _constructor;
 
     private readonly ObjectTraverseStack _joinStack;
+    private int _joinDepth;
     internal JsValue? _originalIteratorFunction;
 
     internal ArrayPrototype(
@@ -568,8 +569,15 @@ public sealed partial class ArrayPrototype : ArrayInstance
         ulong start,
         double depth,
         ICallable? mapperFunction = null,
-        JsValue? thisArg = null)
+        JsValue? thisArg = null,
+        int recursionDepth = 0)
     {
+        var maxDepth = _engine.Options.Constraints.MaxBuiltInRecursionDepth;
+        if (maxDepth >= 0 && recursionDepth > maxDepth)
+        {
+            Throw.RangeError(_realm, $"Array flattening exceeds maximum depth of {maxDepth}");
+        }
+
         var targetIndex = start;
         ulong sourceIndex = 0;
 
@@ -580,56 +588,67 @@ public sealed partial class ArrayPrototype : ArrayInstance
             callArguments[2] = source.Target;
         }
 
-        while (sourceIndex < sourceLen)
+        try
         {
-            var exists = source.HasProperty(sourceIndex);
-            if (exists)
+            while (sourceIndex < sourceLen)
             {
-                var element = source.Get(sourceIndex);
-                if (mapperFunction is not null)
+                var exists = source.HasProperty(sourceIndex);
+                if (exists)
                 {
-                    callArguments[0] = element;
-                    callArguments[1] = JsNumber.Create(sourceIndex);
-                    element = mapperFunction.Call(thisArg ?? Undefined, callArguments);
-                }
-
-                var shouldFlatten = false;
-                if (depth > 0)
-                {
-                    shouldFlatten = element.IsArray();
-                }
-
-                if (shouldFlatten)
-                {
-                    var newDepth = double.IsPositiveInfinity(depth)
-                        ? depth
-                        : depth - 1;
-
-                    var objectInstance = (ObjectInstance) element;
-                    var elementLen = objectInstance.GetLength();
-                    targetIndex = FlattenIntoArray(target, ArrayOperations.For(objectInstance, forWrite: false), elementLen, targetIndex, newDepth);
-                }
-                else
-                {
-                    if (targetIndex >= NumberConstructor.MaxSafeInteger)
+                    var element = source.Get(sourceIndex);
+                    if (mapperFunction is not null)
                     {
-                        Throw.TypeError(_realm, "Invalid array length");
+                        callArguments[0] = element;
+                        callArguments[1] = JsNumber.Create(sourceIndex);
+                        element = mapperFunction.Call(thisArg ?? Undefined, callArguments);
                     }
 
-                    target.CreateDataPropertyOrThrow(targetIndex, element);
-                    targetIndex += 1;
+                    var shouldFlatten = false;
+                    if (depth > 0)
+                    {
+                        shouldFlatten = element.IsArray();
+                    }
+
+                    if (shouldFlatten)
+                    {
+                        var newDepth = double.IsPositiveInfinity(depth)
+                            ? depth
+                            : depth - 1;
+
+                        var objectInstance = (ObjectInstance) element;
+                        var elementLen = objectInstance.GetLength();
+                        targetIndex = FlattenIntoArray(
+                            target,
+                            ArrayOperations.For(objectInstance, forWrite: false),
+                            elementLen,
+                            targetIndex,
+                            newDepth,
+                            recursionDepth: recursionDepth + 1);
+                    }
+                    else
+                    {
+                        if (targetIndex >= NumberConstructor.MaxSafeInteger)
+                        {
+                            Throw.TypeError(_realm, "Invalid array length");
+                        }
+
+                        target.CreateDataPropertyOrThrow(targetIndex, element);
+                        targetIndex += 1;
+                    }
                 }
+
+                sourceIndex++;
             }
 
-            sourceIndex++;
+            return targetIndex;
         }
-
-        if (mapperFunction is not null)
+        finally
         {
-            _engine._jsValueArrayPool.ReturnArray(callArguments);
+            if (mapperFunction is not null)
+            {
+                _engine._jsValueArrayPool.ReturnArray(callArguments);
+            }
         }
-
-        return targetIndex;
     }
 
     [JsFunction(Length = 1)]
@@ -1492,38 +1511,43 @@ public sealed partial class ArrayPrototype : ArrayInstance
             return JsString.Empty;
         }
 
-        if (!_joinStack.TryEnter(thisObject))
+        if (!TryEnterJoin(thisObject))
         {
             return JsString.Empty;
         }
 
-        static string StringFromJsValue(JsValue value)
+        try
         {
-            return value.IsNullOrUndefined()
-                ? ""
-                : TypeConverter.ToString(value);
-        }
-
-        var s = StringFromJsValue(o.Get(0));
-        if (len == 1)
-        {
-            _joinStack.Exit();
-            return s;
-        }
-
-        using var sb = new ValueStringBuilder();
-        sb.Append(s);
-        for (uint k = 1; k < len; k++)
-        {
-            if (sep != "")
+            static string StringFromJsValue(JsValue value)
             {
-                sb.Append(sep);
+                return value.IsNullOrUndefined()
+                    ? ""
+                    : TypeConverter.ToString(value);
             }
-            sb.Append(StringFromJsValue(o.Get(k)));
-        }
-        _joinStack.Exit();
 
-        return sb.ToString();
+            var s = StringFromJsValue(o.Get(0));
+            if (len == 1)
+            {
+                return s;
+            }
+
+            using var sb = new ValueStringBuilder();
+            sb.Append(s);
+            for (uint k = 1; k < len; k++)
+            {
+                if (sep != "")
+                {
+                    sb.Append(sep);
+                }
+                sb.Append(StringFromJsValue(o.Get(k)));
+            }
+
+            return sb.ToString();
+        }
+        finally
+        {
+            ExitJoin();
+        }
     }
 
     /// <summary>
@@ -1541,32 +1565,62 @@ public sealed partial class ArrayPrototype : ArrayInstance
             return JsString.Empty;
         }
 
-        if (!_joinStack.TryEnter(thisObject))
+        if (!TryEnterJoin(thisObject))
         {
             return JsString.Empty;
         }
 
-        // Per ECMA-402, always pass locales and options to element's toLocaleString
-        var locales = arguments.At(0);
-        var options = arguments.At(1);
-        var invokeArgs = new[] { locales, options };
-
-        using var r = new ValueStringBuilder();
-        for (uint k = 0; k < len; k++)
+        try
         {
-            if (k > 0)
-            {
-                r.Append(Separator);
-            }
-            if (array.TryGetValue(k, out var nextElement) && !nextElement.IsNullOrUndefined())
-            {
-                var s = TypeConverter.ToString(Invoke(nextElement, "toLocaleString", invokeArgs));
-                r.Append(s);
-            }
-        }
-        _joinStack.Exit();
+            // Per ECMA-402, always pass locales and options to element's toLocaleString
+            var locales = arguments.At(0);
+            var options = arguments.At(1);
+            var invokeArgs = new[] { locales, options };
 
-        return r.ToString();
+            using var r = new ValueStringBuilder();
+            for (uint k = 0; k < len; k++)
+            {
+                if (k > 0)
+                {
+                    r.Append(Separator);
+                }
+                if (array.TryGetValue(k, out var nextElement) && !nextElement.IsNullOrUndefined())
+                {
+                    var s = TypeConverter.ToString(Invoke(nextElement, "toLocaleString", invokeArgs));
+                    r.Append(s);
+                }
+            }
+
+            return r.ToString();
+        }
+        finally
+        {
+            ExitJoin();
+        }
+    }
+
+    private bool TryEnterJoin(JsValue value)
+    {
+        if (!_joinStack.TryEnter(value))
+        {
+            return false;
+        }
+
+        var maxDepth = _engine.Options.Constraints.MaxBuiltInRecursionDepth;
+        if (maxDepth >= 0 && _joinDepth >= maxDepth)
+        {
+            _joinStack.Exit();
+            Throw.RangeError(_realm, $"Array string conversion exceeds maximum depth of {maxDepth}");
+        }
+
+        _joinDepth++;
+        return true;
+    }
+
+    private void ExitJoin()
+    {
+        _joinStack.Exit();
+        _joinDepth--;
     }
 
     /// <summary>

--- a/Jint/Native/Function/BindFunction.cs
+++ b/Jint/Native/Function/BindFunction.cs
@@ -49,10 +49,14 @@ public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
         }
 
         var args = CreateArguments(arguments);
-        var value = f.Call(BoundThis, args);
-        _engine._jsValueArrayPool.ReturnArray(args);
-
-        return value;
+        try
+        {
+            return _engine.CallFromNative(f, BoundThis, args);
+        }
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
     }
 
     ObjectInstance IConstructor.Construct(JsCallArguments arguments, JsValue newTarget)
@@ -70,7 +74,7 @@ public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
             newTarget = BoundTargetFunction;
         }
 
-        var value = target.Construct(args, newTarget);
+        var value = _engine.Construct(target, args, newTarget, expression: null);
         _engine._jsValueArrayPool.ReturnArray(args);
 
         return value;

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -74,7 +74,8 @@ public abstract partial class Function : ObjectInstance, ICallable
 
     internal override bool IsCallable => true;
 
-    JsValue ICallable.Call(JsValue thisObject, params JsCallArguments arguments) => Call(thisObject, arguments);
+    JsValue ICallable.Call(JsValue thisObject, params JsCallArguments arguments)
+        => _engine.CallFromNative(this, thisObject, arguments);
 
     /// <summary>
     /// Executed when a function object is used as a function

--- a/Jint/Native/Function/FunctionPrototype.cs
+++ b/Jint/Native/Function/FunctionPrototype.cs
@@ -139,12 +139,12 @@ internal sealed partial class FunctionPrototype : Function
     {
         if (argArray.IsNullOrUndefined())
         {
-            return thisObject.Call(thisArg, Arguments.Empty);
+            return Engine.CallFromNative(thisObject, thisArg, Arguments.Empty);
         }
 
         var argList = CreateListFromArrayLike(_realm, argArray);
 
-        var result = thisObject.Call(thisArg, argList);
+        var result = Engine.CallFromNative(thisObject, thisArg, argList);
 
         return result;
     }
@@ -168,7 +168,7 @@ internal sealed partial class FunctionPrototype : Function
     /// https://tc39.es/ecma262/#sec-function.prototype.call
     /// </summary>
     [JsFunction(Length = 1, Name = "call")]
-    private static JsValue CallImpl(ICallable thisObject, JsCallArguments arguments)
+    private JsValue CallImpl(ICallable thisObject, JsCallArguments arguments)
     {
         JsValue[] values = [];
         if (arguments.Length > 1)
@@ -177,7 +177,7 @@ internal sealed partial class FunctionPrototype : Function
             System.Array.Copy(arguments, 1, values, 0, arguments.Length - 1);
         }
 
-        var result = thisObject.Call(arguments.At(0), values);
+        var result = Engine.CallFromNative(thisObject, arguments.At(0), values);
 
         return result;
     }

--- a/Jint/Native/JsProxy.cs
+++ b/Jint/Native/JsProxy.cs
@@ -60,7 +60,7 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
             Throw.TypeError(_engine.Realm, _target + " is not a function");
         }
 
-        return callable.Call(thisObject, arguments);
+        return _engine.CallFromNative(callable, thisObject, arguments);
     }
 
     /// <summary>
@@ -82,7 +82,7 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
             {
                 Throw.TypeError(_engine.Realm);
             }
-            return constructor.Construct(arguments, newTarget);
+            return _engine.Construct(constructor, arguments, newTarget, expression: null);
         }
 
         var oi = result as ObjectInstance;
@@ -596,7 +596,7 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
                 Throw.TypeError(_engine.Realm, $"{_handler} returned for property '{propertyName}' of object '{_target}' is not a function");
             }
 
-            result = callable.Call(_handler, arguments);
+            result = _engine.CallFromNative(callable, _handler, arguments);
             return true;
         }
 

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -21,6 +21,7 @@ public sealed class JsonSerializer
     private string _gap = string.Empty;
     private List<JsValue>? _propertyList;
     private JsValue _replacerFunction = JsValue.Undefined;
+    private int _serializeDepth;
 
     private static readonly JsString toJsonProperty = new("toJSON");
 
@@ -37,6 +38,7 @@ public sealed class JsonSerializer
     public JsValue Serialize(JsValue value, JsValue replacer, JsValue space)
     {
         _stack = new ObjectTraverseStack(_engine);
+        _serializeDepth = 0;
 
         // for JSON.stringify(), any function passed as the first argument will return undefined
         // if the replacer is not defined. The function is not called either.
@@ -429,58 +431,61 @@ public sealed class JsonSerializer
             return;
         }
 
-        _stack.Enter(value);
+        EnterSerializeNode(value);
         var stepback = _indent;
-        if (_gap.Length > 0)
+        try
         {
-            _indent += _gap;
-        }
-
-        const char separator = ',';
-        bool hasPrevious = false;
-
-        for (int i = 0; i < len; i++)
-        {
-            if (hasPrevious)
+            if (_gap.Length > 0)
             {
-                json.Append(separator);
+                _indent += _gap;
             }
-            else
+
+            const char separator = ',';
+            bool hasPrevious = false;
+
+            for (int i = 0; i < len; i++)
             {
-                json.Append('[');
+                if (hasPrevious)
+                {
+                    json.Append(separator);
+                }
+                else
+                {
+                    json.Append('[');
+                }
+
+                if (_gap.Length > 0)
+                {
+                    json.Append('\n');
+                    json.Append(_indent);
+                }
+
+                if (SerializeJSONProperty(i, value, ref json) == SerializeResult.Undefined)
+                {
+                    json.Append("null");
+                }
+
+                hasPrevious = true;
+            }
+
+            if (!hasPrevious)
+            {
+                json.Append("[]");
+                return;
             }
 
             if (_gap.Length > 0)
             {
                 json.Append('\n');
-                json.Append(_indent);
+                json.Append(stepback);
             }
-
-            if (SerializeJSONProperty(i, value, ref json) == SerializeResult.Undefined)
-            {
-                json.Append("null");
-            }
-
-            hasPrevious = true;
+            json.Append(']');
         }
-
-        if (!hasPrevious)
+        finally
         {
-            _stack.Exit();
             _indent = stepback;
-            json.Append("[]");
-            return;
+            ExitSerializeNode();
         }
-
-        if (_gap.Length > 0)
-        {
-            json.Append('\n');
-            json.Append(stepback);
-        }
-        json.Append(']');
-
-        _stack.Exit();
-        _indent = stepback;
     }
 
     /// <summary>
@@ -497,69 +502,92 @@ public sealed class JsonSerializer
             return;
         }
 
-        _stack.Enter(value);
+        EnterSerializeNode(value);
         var stepback = _indent;
-        if (_gap.Length > 0)
+        try
         {
-            _indent += _gap;
-        }
-
-        const char separator = ',';
-        var hasPrevious = false;
-        for (var i = 0; i < enumeration.Keys.Count; i++)
-        {
-            var p = enumeration.Keys[i];
-            int position = json.Length;
-
-            if (hasPrevious)
+            if (_gap.Length > 0)
             {
-                json.Append(separator);
+                _indent += _gap;
             }
-            else
+
+            const char separator = ',';
+            var hasPrevious = false;
+            for (var i = 0; i < enumeration.Keys.Count; i++)
             {
-                json.Append('{');
+                var p = enumeration.Keys[i];
+                int position = json.Length;
+
+                if (hasPrevious)
+                {
+                    json.Append(separator);
+                }
+                else
+                {
+                    json.Append('{');
+                }
+
+                if (_gap.Length > 0)
+                {
+                    json.Append('\n');
+                    json.Append(_indent);
+                }
+
+                QuoteJSONString(p.ToString(), ref json);
+                json.Append(':');
+                if (_gap.Length > 0)
+                {
+                    json.Append(' ');
+                }
+
+                if (SerializeJSONProperty(p, value, ref json) == SerializeResult.Undefined)
+                {
+                    json.Length = position;
+                }
+                else
+                {
+                    hasPrevious = true;
+                }
+            }
+
+            if (!hasPrevious)
+            {
+                json.Append("{}");
+                return;
             }
 
             if (_gap.Length > 0)
             {
                 json.Append('\n');
-                json.Append(_indent);
+                json.Append(stepback);
             }
-
-            QuoteJSONString(p.ToString(), ref json);
-            json.Append(':');
-            if (_gap.Length > 0)
-            {
-                json.Append(' ');
-            }
-
-            if (SerializeJSONProperty(p, value, ref json) == SerializeResult.Undefined)
-            {
-                json.Length = position;
-            }
-            else
-            {
-                hasPrevious = true;
-            }
+            json.Append('}');
         }
+        finally
+        {
+            _indent = stepback;
+            ExitSerializeNode();
+        }
+    }
 
-        if (!hasPrevious)
+    private void EnterSerializeNode(ObjectInstance value)
+    {
+        _stack.Enter(value);
+
+        var maxDepth = _engine.Options.Constraints.MaxBuiltInRecursionDepth;
+        if (maxDepth >= 0 && _serializeDepth >= maxDepth)
         {
             _stack.Exit();
-            _indent = stepback;
-            json.Append("{}");
-            return;
+            Throw.RangeError(_engine.Realm, $"JSON serialization exceeds maximum depth of {maxDepth}");
         }
 
-        if (_gap.Length > 0)
-        {
-            json.Append('\n');
-            json.Append(stepback);
-        }
-        json.Append('}');
+        _serializeDepth++;
+    }
 
+    private void ExitSerializeNode()
+    {
         _stack.Exit();
-        _indent = stepback;
+        _serializeDepth--;
     }
 
     private enum SerializeResult

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -108,17 +108,17 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     internal static ObjectInstance Construct(IConstructor f, IConstructor? newTarget, JsCallArguments argumentsList)
     {
         newTarget ??= f;
-        return f.Construct(argumentsList, (JsValue) newTarget);
+        return ((ObjectInstance) f).Engine.Construct(f, argumentsList, (JsValue) newTarget, expression: null);
     }
 
     internal static ObjectInstance Construct(IConstructor f, JsCallArguments argumentsList)
     {
-        return f.Construct(argumentsList, (JsValue) f);
+        return ((ObjectInstance) f).Engine.Construct(f, argumentsList, (JsValue) f, expression: null);
     }
 
     internal static ObjectInstance Construct(IConstructor f)
     {
-        return f.Construct([], (JsValue) f);
+        return ((ObjectInstance) f).Engine.Construct(f, [], (JsValue) f, expression: null);
     }
 
 
@@ -1637,7 +1637,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             return default;
         }
 
-        return callable.Call(v, arguments);
+        return _engine.CallFromNative(callable, v, arguments);
     }
 
 

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -908,7 +908,7 @@ internal sealed partial class PromiseConstructor : Constructor
 
         var executor = new ClrFunction(engine, "", Executor, 2, PropertyFlag.Configurable);
 
-        var instance = ctor.Construct([executor], c);
+        var instance = engine.Construct(ctor, [executor], c, expression: null);
 
         ICallable? resolve = null;
         ICallable? reject = null;

--- a/Jint/Native/Reflect/ReflectInstance.cs
+++ b/Jint/Native/Reflect/ReflectInstance.cs
@@ -44,7 +44,7 @@ internal sealed partial class ReflectInstance : ObjectInstance
 
         // 3. Perform PrepareForTailCall().
 
-        return ((ICallable) target).Call(thisArgument, args);
+        return _engine.CallFromNative((ICallable) target, thisArgument, args);
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ internal sealed partial class ReflectInstance : ObjectInstance
 
         var args = FunctionPrototype.CreateListFromArrayLike(_realm, arguments.At(1));
 
-        return target.Construct(args, newTargetArgument);
+        return _engine.Construct(target, args, newTargetArgument, expression: null);
     }
 
     /// <summary>

--- a/Jint/Native/ShadowRealm/ShadowRealm.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealm.cs
@@ -377,7 +377,7 @@ public sealed class ShadowRealm : ObjectInstance
             JsValue result;
             try
             {
-                result = target.Call(wrappedThisArgument, wrappedArgs);
+                result = target.Engine.CallFromNative((ICallable) target, wrappedThisArgument, wrappedArgs);
             }
             catch (JavaScriptException ex)
             {

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -16,6 +16,8 @@ namespace Jint.Native.String;
 [JsObject]
 internal sealed partial class StringConstructor : Constructor
 {
+    private const int MaxStackallocChars = 256;
+
     private static readonly JsString _functionName = new JsString("String");
 
     public StringConstructor(
@@ -54,7 +56,7 @@ internal sealed partial class StringConstructor : Constructor
         }
 
 #if SUPPORTS_SPAN_PARSE
-        var elements = length < 512 ? stackalloc char[length] : new char[length];
+        var elements = length <= MaxStackallocChars ? stackalloc char[length] : new char[length];
 #else
         var elements = new char[length];
 #endif

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -445,6 +445,8 @@ public class Options
 
     public class ConstraintOptions
     {
+        public const int DefaultBuiltInRecursionDepth = 256;
+
         /// <summary>
         /// Registered constraints.
         /// </summary>
@@ -464,6 +466,12 @@ public class Options
         /// When max stack size to be exceeded, Engine throws an exception <see cref="JavaScriptException" />.
         /// </remarks>
         public int MaxExecutionStackCount { get; set; } = StackGuard.Disabled;
+
+        /// <summary>
+        /// Maximum recursion depth allowed inside recursive native built-in implementations,
+        /// separate from JavaScript function recursion.
+        /// </summary>
+        public int MaxBuiltInRecursionDepth { get; set; } = DefaultBuiltInRecursionDepth;
 
         /// <summary>
         /// Maximum time a Regex is allowed to run, defaults to 10 seconds.

--- a/Jint/Runtime/CallStack/StackGuard.cs
+++ b/Jint/Runtime/CallStack/StackGuard.cs
@@ -21,9 +21,15 @@ internal sealed class StackGuard
 
     public bool TryEnterOnCurrentStack()
     {
-        if (_engine.Options.Constraints.MaxExecutionStackCount == Disabled)
+        var maxExecutionStackCount = _engine.Options.Constraints.MaxExecutionStackCount;
+        if (maxExecutionStackCount == Disabled)
         {
             return true;
+        }
+
+        if (_engine.CallStack.Count > maxExecutionStackCount)
+        {
+            Throw.RangeError(_engine.Realm, "Maximum call stack size exceeded");
         }
 
 #if NETFRAMEWORK || NETSTANDARD2_0
@@ -42,7 +48,7 @@ internal sealed class StackGuard
         }
 #endif
 
-        if (_engine.CallStack.Count > _engine.Options.Constraints.MaxExecutionStackCount)
+        if (_engine.CallStack.Count > maxExecutionStackCount)
         {
             Throw.RangeError(_engine.Realm, "Maximum call stack size exceeded");
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -157,7 +157,7 @@ internal sealed class JintCallExpression : JintExpression
         }
         else
         {
-            result = callable.Call(thisObject, arguments);
+            result = engine.Call(callable, thisObject, arguments, _calleeExpression);
         }
 
         if (rented)
@@ -235,7 +235,7 @@ internal sealed class JintCallExpression : JintExpression
             Throw.TypeError(engine.Realm, "Not a constructor");
         }
 
-        var result = ((IConstructor) func).Construct(argList, newTarget);
+        var result = engine.Construct((IConstructor) func, argList, newTarget, _calleeExpression);
 
         var thisER = (FunctionEnvironment) engine.ExecutionContext.GetThisEnvironment();
         thisER.BindThisValue(result);


### PR DESCRIPTION
## Summary

Guard native recursion paths against unbounded CLR stack growth.

## Details

- Add MaxBuiltInRecursionDepth for recursive native built-ins and native callback/constructor paths.
- Limit recursive Array.flat, Array.join/toString/toLocaleString, and JSON.stringify traversal.
- Route native callable and constructor dispatch through guarded Engine helpers, including Function.prototype.call/apply, proxies, Reflect, bound functions, ShadowRealm wrappers, species constructors, and promises.
- Fall back to StackGuard.RunOnEmptyStack when the CLR stack is low, while keeping net462 compatibility by avoiding value-tuple callback state.
- Add EngineLimit coverage for regular calls, constructors, super constructors, Reflect.construct, bound constructors, proxy constructors, species constructors, typed arrays, promises, and native built-ins.

## Linked issue

Refs #

## Test plan

- [x] Added or updated unit tests in Jint.Tests
- [x] Ran dotnet test --configuration Release locally
- [ ] For ECMAScript spec changes: ran Jint.Tests.Test262 and confirmed no regressions
- [ ] For interop changes: covered in Jint.Tests/Runtime/Interop
- [ ] For perf changes: included before/after numbers from Jint.Benchmark

Additional local validation:

- dotnet test Jint.Tests/Jint.Tests.csproj --filter "FullyQualifiedName~EngineLimitTests"
- dotnet test Jint.Tests/Jint.Tests.csproj --filter "FullyQualifiedName!~EngineTests.ShouldSetYearBefore1970"
- dotnet build Jint/Jint.csproj --configuration Release

Note: EngineTests.ShouldSetYearBefore1970 is excluded locally because this branch intentionally stays independent from the nc/date-test-utc test-only branch.

## Breaking change?

No.
