### PR TITLE
Fix async resume through control-flow statements

### DIFF
--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -358,6 +358,60 @@ public class AsyncTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateCompoundAssignmentLhsAfterAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            const obj = { 0: 0 };
+            let i = -1;
+            obj[++i] += await Promise.resolve(5);
+            return { obj, i };
+            """);
+
+        Assert.Equal("""{"obj":{"0":5},"i":0}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluatePropertyAssignmentLhsAfterAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            const obj = { x: 10 };
+            let touches = 0;
+            const accessor = () => (touches++, obj);
+            accessor().x -= await Promise.resolve(3);
+            return { obj, touches };
+            """);
+
+        Assert.Equal("""{"obj":{"x":7},"touches":1}""", result);
+    }
+
+    [Fact]
+    public void ShouldPreserveCompoundAssignmentLhsAcrossNullishCoalescing()
+    {
+        var result = EvaluateAsyncJson("""
+            const obj = { 0: null };
+            let i = -1;
+            obj[++i] ??= await Promise.resolve("filled");
+            return { obj, i };
+            """);
+
+        Assert.Equal("""{"obj":{"0":"filled"},"i":0}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateCompoundAssignmentLhsOnSimpleIdentifierAfterAwait()
+    {
+        // Simple-identifier LHS goes through the fast path (no observable side
+        // effect to preserve), but the result still has to be correct.
+        var result = EvaluateAsyncJson("""
+            let x = 7;
+            x *= await Promise.resolve(3);
+            return { x };
+            """);
+
+        Assert.Equal("""{"x":21}""", result);
+    }
+
+    [Fact]
     public void ShouldTaskConvertedToPromiseInJS()
     {
         Engine engine = new();

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -412,6 +412,63 @@ public class AsyncTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateCallArgumentsBeforeAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            let i = 0;
+            const foo = (a, b, c) => ({ a, b, c });
+            const r = foo(++i, ++i, await Promise.resolve(++i));
+            return { r, i };
+            """);
+
+        Assert.Equal("""{"r":{"a":1,"b":2,"c":3},"i":3}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateCallArgumentsAcrossMultipleAwaits()
+    {
+        var result = EvaluateAsyncJson("""
+            let i = 0;
+            const foo = (a, b, c, d) => ({ a, b, c, d });
+            const r = foo(++i, await Promise.resolve(++i), ++i, await Promise.resolve(++i));
+            return { r, i };
+            """);
+
+        Assert.Equal("""{"r":{"a":1,"b":2,"c":3,"d":4},"i":4}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateNewExpressionArgumentsBeforeAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            let i = 0;
+            class C {
+                constructor(a, b, c) { this.a = a; this.b = b; this.c = c; }
+            }
+            const obj = new C(++i, ++i, await Promise.resolve(++i));
+            return { obj: { a: obj.a, b: obj.b, c: obj.c }, i };
+            """);
+
+        Assert.Equal("""{"obj":{"a":1,"b":2,"c":3},"i":3}""", result);
+    }
+
+    [Fact]
+    public void ShouldHandleCallExpressionWithAwaitOnlyInLastArgument()
+    {
+        // Confirms the suspend-data is cleared after completion: a subsequent
+        // call to the same call site should not see stale state.
+        var result = EvaluateAsyncJson("""
+            let i = 0;
+            const foo = (a, b) => a + b;
+            const first = foo(++i, await Promise.resolve(10));
+            const second = foo(++i, await Promise.resolve(20));
+            return { first, second, i };
+            """);
+
+        Assert.Equal("""{"first":11,"second":22,"i":2}""", result);
+    }
+
+    [Fact]
     public void ShouldTaskConvertedToPromiseInJS()
     {
         Engine engine = new();

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -281,6 +281,83 @@ public class AsyncTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateBinaryLeftOperandAfterAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            let d = 0;
+            const sum = (++d) + (await Promise.resolve(10));
+            return { d, sum };
+            """);
+
+        Assert.Equal("""{"d":1,"sum":11}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateLogicalAndLeftOperandAfterAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            let d = 0;
+            const ok = (++d > 0) && (await Promise.resolve(true));
+            return { d, ok };
+            """);
+
+        Assert.Equal("""{"d":1,"ok":true}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateLogicalOrLeftOperandAfterAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            let d = 0;
+            const ok = (++d <= 0) || (await Promise.resolve(true));
+            return { d, ok };
+            """);
+
+        Assert.Equal("""{"d":1,"ok":true}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateConditionalTestAfterAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            let d = 0;
+            const value = (++d > 0) ? (await Promise.resolve("yes")) : "no";
+            return { d, value };
+            """);
+
+        Assert.Equal("""{"d":1,"value":"yes"}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateConditionalTestWhenAlternateAwaits()
+    {
+        var result = EvaluateAsyncJson("""
+            let d = 0;
+            const value = (++d > 1) ? "yes" : (await Promise.resolve("no"));
+            return { d, value };
+            """);
+
+        Assert.Equal("""{"d":1,"value":"no"}""", result);
+    }
+
+    [Fact]
+    public void ShouldShortCircuitLogicalAndWithoutSavingLeftOperand()
+    {
+        // Left short-circuits to false: right (await) should never run, and a
+        // subsequent expression using the same `&&` should still re-evaluate left.
+        var result = EvaluateAsyncJson("""
+            let d = 0;
+            let awaits = 0;
+            const a = (d > 0) && (await Promise.resolve(++awaits));
+            d = 1;
+            const b = (d > 0) && (await Promise.resolve(++awaits));
+            return { a, b, awaits };
+            """);
+
+        Assert.Equal("""{"a":false,"b":1,"awaits":1}""", result);
+    }
+
+    [Fact]
     public void ShouldTaskConvertedToPromiseInJS()
     {
         Engine engine = new();

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -18,6 +18,269 @@ public class AsyncTests
     }
 
     [Fact]
+    public void ShouldResumeAwaitInsideCatchWithoutReexecutingTryBlock()
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            (async () => {
+                let tries = 0;
+                try {
+                    tries++;
+                    await Promise.reject(new Error("boom"));
+                } catch (e) {
+                    await Promise.resolve();
+                    return tries;
+                }
+            })()
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(1, result.AsNumber());
+    }
+
+    [Fact]
+    public void ShouldNotLeakCatchBindingAfterAwaitInsideCatch()
+    {
+        var result = EvaluateAsyncJson("""
+            try {
+                throw 1;
+            } catch (e) {
+                await Promise.resolve();
+            }
+
+            try {
+                return { leaked: true, value: e };
+            } catch (err) {
+                return { leaked: false, name: err.name };
+            }
+            """);
+
+        Assert.Equal("""{"leaked":false,"name":"ReferenceError"}""", result);
+    }
+
+    [Fact]
+    public void ShouldPreserveCatchBindingAfterAwaitInsideCatch()
+    {
+        var result = EvaluateAsyncJson("""
+            try {
+                throw 42;
+            } catch (e) {
+                await Promise.resolve();
+                return { value: e };
+            }
+            """);
+
+        Assert.Equal("""{"value":42}""", result);
+    }
+
+    [Fact]
+    public void ShouldPreserveCatchReturnAcrossAwaitedFinallyAfterCatchResume()
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            (async () => {
+                try {
+                    throw 1;
+                } catch {
+                    await Promise.resolve();
+                    return 2;
+                } finally {
+                    await Promise.resolve();
+                }
+            })()
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(2, result.AsInteger());
+    }
+
+    [Fact]
+    public void ShouldPreserveCatchThrowAcrossAwaitedFinallyAfterCatchResume()
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            (async () => {
+                try {
+                    throw 1;
+                } catch {
+                    await Promise.resolve();
+                    throw 4;
+                } finally {
+                    await Promise.resolve();
+                }
+            })()
+            """);
+
+        var exception = Assert.Throws<PromiseRejectedException>(() => result.UnwrapIfPromise(TimeSpan.FromSeconds(1)));
+        Assert.Equal(4, exception.RejectedValue.AsInteger());
+    }
+
+    [Fact]
+    public void ShouldResumeAwaitInsideIfWithoutReexecutingTest()
+    {
+        var result = EvaluateAsyncJson("""
+            let tests = 0;
+            if (++tests === 1) {
+                await Promise.resolve();
+                return { tests };
+            }
+            return { tests, fellThrough: true };
+            """);
+
+        Assert.Equal("""{"tests":1}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotExecuteElseWhileIfTestIsSuspended()
+    {
+        var result = EvaluateAsyncJson("""
+            let sideEffects = 0;
+            if (await Promise.resolve(true)) {
+            } else {
+                sideEffects++;
+            }
+            return { sideEffects };
+            """);
+
+        Assert.Equal("""{"sideEffects":0}""", result);
+    }
+
+    [Fact]
+    public void ShouldResumeAwaitInsideWhileBodyWithoutReexecutingTest()
+    {
+        var result = EvaluateAsyncJson("""
+            let tests = 0;
+            let bodies = 0;
+            while (++tests <= 1) {
+                bodies++;
+                await Promise.resolve();
+                return { tests, bodies };
+            }
+            return { tests, bodies, fellThrough: true };
+            """);
+
+        Assert.Equal("""{"tests":1,"bodies":1}""", result);
+    }
+
+    [Fact]
+    public void ShouldResumeAwaitInsideForBodyWithoutReexecutingTest()
+    {
+        var result = EvaluateAsyncJson("""
+            let inits = 0;
+            let tests = 0;
+            let updates = 0;
+            let bodies = 0;
+            for (inits++; ++tests <= 1; updates++) {
+                bodies++;
+                await Promise.resolve();
+                return { inits, tests, updates, bodies };
+            }
+            return { inits, tests, updates, bodies, fellThrough: true };
+            """);
+
+        Assert.Equal("""{"inits":1,"tests":1,"updates":0,"bodies":1}""", result);
+    }
+
+    [Fact]
+    public void ShouldResumeAwaitInsideForUpdateWithoutReexecutingBody()
+    {
+        var result = EvaluateAsyncJson("""
+            let bodies = 0;
+            for (let i = 0; i < 1; i += await Promise.resolve(1)) {
+                bodies++;
+            }
+            return { bodies };
+            """);
+
+        Assert.Equal("""{"bodies":1}""", result);
+    }
+
+    [Fact]
+    public void ShouldResumeAwaitInsideSwitchCaseWithoutReexecutingDiscriminant()
+    {
+        var result = EvaluateAsyncJson("""
+            let discriminants = 0;
+            switch (++discriminants) {
+                case 1:
+                    await Promise.resolve();
+                    return { discriminants };
+                default:
+                    return { discriminants, fellThrough: true };
+            }
+            """);
+
+        Assert.Equal("""{"discriminants":1}""", result);
+    }
+
+    [Fact]
+    public void ShouldResumeAwaitInsideSwitchCaseTestBeforeMatchingCase()
+    {
+        var result = EvaluateAsyncJson("""
+            switch (0) {
+                case await Promise.resolve(1):
+                    return { matched: true };
+                default:
+                    return { matched: false };
+            }
+            """);
+
+        Assert.Equal("""{"matched":false}""", result);
+    }
+
+    [Fact]
+    public void ShouldPreserveSwitchLexicalBindingAfterAwaitInsideCase()
+    {
+        var result = EvaluateAsyncJson("""
+            switch (1) {
+                case 1:
+                    let x = 1;
+                    await Promise.resolve();
+                    return { x };
+                default:
+                    return { x: 0 };
+            }
+            """);
+
+        Assert.Equal("""{"x":1}""", result);
+    }
+
+    [Fact]
+    public void ShouldClearSwitchSuspendDataAfterResumedBreak()
+    {
+        var result = EvaluateAsyncJson("""
+            const values = [];
+            for (let i = 0; i < 2; i++) {
+                switch (1) {
+                    case 1:
+                        let x = i;
+                        await Promise.resolve();
+                        values.push(x);
+                        break;
+                }
+            }
+            return { values };
+            """);
+
+        Assert.Equal("""{"values":[0,1]}""", result);
+    }
+
+    [Fact]
+    public void ShouldResumeAwaitInsideDoWhileTestWithoutReexecutingBody()
+    {
+        var result = EvaluateAsyncJson("""
+            let tests = 0;
+            let bodies = 0;
+            do {
+                bodies++;
+            } while (++tests < await Promise.resolve(1));
+            return { tests, bodies };
+            """);
+
+        Assert.Equal("""{"tests":1,"bodies":1}""", result);
+    }
+
+    [Fact]
     public void ShouldTaskConvertedToPromiseInJS()
     {
         Engine engine = new();
@@ -32,6 +295,16 @@ public class AsyncTests
             Assert.True(true);
             return 1;
         }
+    }
+
+    private static string EvaluateAsyncJson(string body)
+    {
+        var engine = new Engine();
+        return engine.Evaluate($$"""
+            (async () => {
+                {{body}}
+            })().then(JSON.stringify)
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(1)).AsString();
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/GeneratorTests.cs
+++ b/Jint.Tests/Runtime/GeneratorTests.cs
@@ -266,4 +266,258 @@ public class GeneratorTests
         Assert.Equal(1, _engine.Evaluate("sequence.next().value"));
         Assert.Equal(2, _engine.Evaluate("sequence.next().value"));
     }
+
+    // The following tests mirror PR #2469's AsyncTests for control-flow resume but
+    // using yield in a sync generator. The PR's fix is shared infrastructure
+    // (ISuspendable.Data, GetSuspensionNode, IsNodeInsideRange), so these are
+    // regression guards against drift between the async and sync resume paths.
+
+    [Fact]
+    public void ShouldResumeYieldInsideCatchWithoutReexecutingTryBlock()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    let tries = 0;
+                    try {
+                        tries++;
+                        throw 1;
+                    } catch (e) {
+                        yield;
+                        return tries;
+                    }
+                }
+                const g = gen();
+                g.next();
+                return g.next().value;
+            })()
+            """;
+
+        Assert.Equal(1, _engine.Evaluate(Script));
+    }
+
+    [Fact]
+    public void ShouldResumeYieldInsideIfWithoutReexecutingTest()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    let tests = 0;
+                    if (++tests === 1) {
+                        yield;
+                        return tests;
+                    }
+                    return -1;
+                }
+                const g = gen();
+                g.next();
+                return g.next().value;
+            })()
+            """;
+
+        Assert.Equal(1, _engine.Evaluate(Script));
+    }
+
+    [Fact]
+    public void ShouldResumeYieldInsideForBodyWithoutReexecutingTest()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    let inits = 0, tests = 0, updates = 0, bodies = 0;
+                    for (inits++; ++tests <= 1; updates++) {
+                        bodies++;
+                        yield;
+                        return [inits, tests, updates, bodies];
+                    }
+                    return [inits, tests, updates, bodies, "fellThrough"];
+                }
+                const g = gen();
+                g.next();
+                return JSON.stringify(g.next().value);
+            })()
+            """;
+
+        Assert.Equal("[1,1,0,1]", _engine.Evaluate(Script));
+    }
+
+    [Fact]
+    public void ShouldResumeYieldInsideSwitchCaseWithoutReexecutingDiscriminant()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    let discriminants = 0;
+                    switch (++discriminants) {
+                        case 1:
+                            yield;
+                            return discriminants;
+                        default:
+                            return -1;
+                    }
+                }
+                const g = gen();
+                g.next();
+                return g.next().value;
+            })()
+            """;
+
+        Assert.Equal(1, _engine.Evaluate(Script));
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateBinaryLeftOperandAfterYield()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    let d = 0;
+                    const sum = (++d) + (yield 10);
+                    return [d, sum];
+                }
+                const g = gen();
+                g.next();              // yields 10
+                return JSON.stringify(g.next(5).value);  // resume with 5 → sum = 1 + 5 = 6
+            })()
+            """;
+
+        Assert.Equal("[1,6]", _engine.Evaluate(Script));
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateLogicalAndLeftOperandAfterYield()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    let d = 0;
+                    const ok = (++d > 0) && (yield true);
+                    return [d, ok];
+                }
+                const g = gen();
+                g.next();
+                return JSON.stringify(g.next(7).value);
+            })()
+            """;
+
+        Assert.Equal("[1,7]", _engine.Evaluate(Script));
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateCallArgumentsBeforeYield()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    let i = 0;
+                    const foo = (a, b, c) => [a, b, c];
+                    const r = foo(++i, ++i, yield ++i);
+                    return [r, i];
+                }
+                const g = gen();
+                g.next();                          // yields 3
+                return JSON.stringify(g.next("done").value);
+            })()
+            """;
+
+        Assert.Equal("""[[1,2,"done"],3]""", _engine.Evaluate(Script));
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateCompoundAssignmentLhsAfterYield()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    const obj = { 0: 0 };
+                    let i = -1;
+                    obj[++i] += yield;
+                    return [obj, i];
+                }
+                const g = gen();
+                g.next();
+                return JSON.stringify(g.next(5).value);
+            })()
+            """;
+
+        Assert.Equal("""[{"0":5},0]""", _engine.Evaluate(Script));
+    }
+
+    [Fact]
+    public void ShouldPreserveSwitchLexicalBindingAfterYieldInsideCase()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    switch (1) {
+                        case 1:
+                            let x = 1;
+                            yield;
+                            return x;
+                        default:
+                            return 0;
+                    }
+                }
+                const g = gen();
+                g.next();
+                return g.next().value;
+            })()
+            """;
+
+        Assert.Equal(1, _engine.Evaluate(Script));
+    }
+
+    [Fact]
+    public void ShouldClearSwitchSuspendDataAfterResumedBreakInGenerator()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    const values = [];
+                    for (let i = 0; i < 2; i++) {
+                        switch (1) {
+                            case 1:
+                                let x = i;
+                                yield;
+                                values.push(x);
+                                break;
+                        }
+                    }
+                    return values;
+                }
+                const g = gen();
+                g.next();         // yields, x=0 in iter 0
+                g.next();         // resumes, pushes 0; yields, x=1 in iter 1
+                return JSON.stringify(g.next().value);  // resumes, pushes 1; loop exits
+            })()
+            """;
+
+        Assert.Equal("[0,1]", _engine.Evaluate(Script));
+    }
+
+    [Fact]
+    public void ShouldResumeYieldInsideCatchInAsyncGenerator()
+    {
+        // Async generators share ISuspendable.Data with sync generators / async
+        // functions, so the same control-flow resume fixes apply.
+        var result = _engine.Evaluate("""
+            (async () => {
+                async function* gen() {
+                    let tries = 0;
+                    try {
+                        tries++;
+                        throw 1;
+                    } catch (e) {
+                        yield;
+                        return tries;
+                    }
+                }
+                const g = gen();
+                await g.next();
+                return (await g.next()).value;
+            })()
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(1, result.AsNumber());
+    }
 }

--- a/Jint/Runtime/Interpreter/Expressions/ExpressionCache.cs
+++ b/Jint/Runtime/Interpreter/Expressions/ExpressionCache.cs
@@ -60,7 +60,7 @@ internal sealed class ExpressionCache
         }
     }
 
-    public JsValue[] ArgumentListEvaluation(EvaluationContext context, out bool rented)
+    public JsValue[] ArgumentListEvaluation(EvaluationContext context, object key, out bool rented)
     {
         rented = false;
         if (_fullyCached)
@@ -75,18 +75,50 @@ internal sealed class ExpressionCache
             return args.ToArray();
         }
 
-        var arguments = context.Engine._jsValueArrayPool.RentArray(_expressions.Length);
+        var suspendable = context.Engine.ExecutionContext.Suspendable;
+
+        JsValue[] arguments;
+        int startIndex;
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(key, out CallArgumentsSuspendData? suspendData))
+        {
+            // Resume: reuse the partially-filled buffer so already-evaluated
+            // arguments (which may have observable side effects) are not re-evaluated.
+            arguments = suspendData!.Buffer;
+            startIndex = suspendData.NextIndex;
+        }
+        else
+        {
+            arguments = context.Engine._jsValueArrayPool.RentArray(_expressions.Length);
+            startIndex = 0;
+        }
+
+        var nextIndex = BuildArguments(context, arguments, startIndex);
+
+        if (context.IsSuspended())
+        {
+            // Buffer is kept alive in suspend data; caller must NOT return it to the pool.
+            if (suspendable is not null)
+            {
+                var data = suspendable.Data.GetOrCreate<CallArgumentsSuspendData>(key);
+                data.Buffer = arguments;
+                data.NextIndex = nextIndex;
+            }
+
+            return arguments;
+        }
+
+        // Completed normally — caller now owns the array and should return it to the pool.
+        suspendable?.Data.Clear(key);
         rented = true;
-
-        BuildArguments(context, arguments);
-
         return arguments;
     }
 
-    internal void BuildArguments(EvaluationContext context, JsValue[] targetArray)
+    internal int BuildArguments(EvaluationContext context, JsValue[] targetArray, int startIndex = 0)
     {
         var expressions = _expressions;
-        for (uint i = 0; i < (uint) expressions.Length; i++)
+        int i = startIndex;
+        for (; (uint) i < (uint) expressions.Length; i++)
         {
             targetArray[i] = GetValue(context, expressions[i])!;
 
@@ -94,9 +126,11 @@ internal sealed class ExpressionCache
             // This is needed because yield expressions return normally instead of throwing
             if (context.IsSuspended())
             {
-                return;
+                return i;
             }
         }
+
+        return i;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -43,10 +43,21 @@ internal sealed class JintAssignmentExpression : JintExpression
     {
         var engine = context.Engine;
         var strict = StrictModeScope.IsStrictModeCode;
+        var suspendable = engine.ExecutionContext.Suspendable;
 
         JsValue originalLeftValue;
         Reference lref;
-        if (_leftIdentifier is not null && JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(
+        bool lhsHasSideEffects;
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out AssignmentSuspendData? suspendData))
+        {
+            // Resuming: skip LHS re-evaluation. The slow path may have observable
+            // side effects (obj[++i]), so we reuse the saved Reference + original value.
+            lref = suspendData!.Lref;
+            originalLeftValue = suspendData.OriginalLeftValue;
+            lhsHasSideEffects = true;
+        }
+        else if (_leftIdentifier is not null && JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(
                 engine.ExecutionContext.LexicalEnvironment,
                 _leftIdentifier.Identifier,
                 strict,
@@ -55,6 +66,7 @@ internal sealed class JintAssignmentExpression : JintExpression
         {
             originalLeftValue = temp;
             lref = engine._referencePool.Rent(identifierEnvironment, _leftIdentifier.Identifier.Value, strict, thisValue: null);
+            lhsHasSideEffects = false;
         }
         else
         {
@@ -65,6 +77,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                 Throw.ReferenceError(context.Engine.Realm, "Invalid left-hand side in assignment");
             }
             originalLeftValue = context.Engine.GetValue(lref, returnReferenceToPool: false);
+            lhsHasSideEffects = true;
         }
 
         var handledByOverload = false;
@@ -85,7 +98,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -127,7 +140,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -153,7 +166,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -183,7 +196,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -196,7 +209,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -209,7 +222,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -222,7 +235,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -235,7 +248,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -248,7 +261,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -261,7 +274,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -274,7 +287,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -287,13 +300,14 @@ internal sealed class JintAssignmentExpression : JintExpression
                         if (!originalLeftValue.IsNullOrUndefined())
                         {
                             engine._referencePool.Return(lref);
+                            suspendable?.Data.Clear(this);
                             return originalLeftValue;
                         }
 
                         var rval = NamedEvaluation(context, _right);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -306,13 +320,14 @@ internal sealed class JintAssignmentExpression : JintExpression
                         if (!TypeConverter.ToBoolean(originalLeftValue))
                         {
                             engine._referencePool.Return(lref);
+                            suspendable?.Data.Clear(this);
                             return originalLeftValue;
                         }
 
                         var rval = NamedEvaluation(context, _right);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -325,13 +340,14 @@ internal sealed class JintAssignmentExpression : JintExpression
                         if (TypeConverter.ToBoolean(originalLeftValue))
                         {
                             engine._referencePool.Return(lref);
+                            suspendable?.Data.Clear(this);
                             return originalLeftValue;
                         }
 
                         var rval = NamedEvaluation(context, _right);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -344,7 +360,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
                         {
-                            engine._referencePool.Return(lref);
+                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
                             return rval;
                         }
 
@@ -387,7 +403,26 @@ internal sealed class JintAssignmentExpression : JintExpression
         }
 
         engine._referencePool.Return(lref);
+        suspendable?.Data.Clear(this);
         return newLeftValue!;
+    }
+
+    private void HandleSuspendedRight(Engine engine, ISuspendable? suspendable, Reference lref, JsValue originalLeftValue, bool lhsHasSideEffects)
+    {
+        // Only the slow path's LHS can have observable side effects (e.g. obj[++i]).
+        // For that case, hold the Reference + value across the suspension so the next
+        // resume reuses them. For the side-effect-free fast path, return the Reference
+        // to the pool — no benefit in retaining it.
+        if (lhsHasSideEffects && suspendable is not null)
+        {
+            var data = suspendable.Data.GetOrCreate<AssignmentSuspendData>(this);
+            data.Lref = lref;
+            data.OriginalLeftValue = originalLeftValue;
+        }
+        else
+        {
+            engine._referencePool.Return(lref);
+        }
     }
 
     private JsValue? EvaluateOperatorOverloading(EvaluationContext context, JsValue originalLeftValue, JsValue? newLeftValue, ref bool handledByOverload)

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -33,15 +33,35 @@ internal abstract class JintBinaryExpression : JintExpression
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected bool TryEvaluateOperands(EvaluationContext context, out JsValue left, out JsValue right)
     {
-        left = _left.GetValue(context);
-        if (context.IsSuspended())
+        var suspendable = context.Engine?.ExecutionContext.Suspendable;
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out BinaryExpressionSuspendData? suspendData))
         {
-            right = JsValue.Undefined;
-            return false;
+            left = suspendData!.LeftValue;
+        }
+        else
+        {
+            left = _left.GetValue(context);
+            if (context.IsSuspended())
+            {
+                right = JsValue.Undefined;
+                return false;
+            }
         }
 
         right = _right.GetValue(context);
-        return !context.IsSuspended();
+        if (context.IsSuspended())
+        {
+            if (suspendable is not null)
+            {
+                suspendable.Data.GetOrCreate<BinaryExpressionSuspendData>(this).LeftValue = left;
+            }
+
+            return false;
+        }
+
+        suspendable?.Data.Clear(this);
+        return true;
     }
 
     private readonly record struct MethodResolverState(JsCallArguments Arguments);

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -35,7 +35,7 @@ internal abstract class JintBinaryExpression : JintExpression
     {
         var suspendable = context.Engine?.ExecutionContext.Suspendable;
         if (suspendable is { IsResuming: true }
-            && suspendable.Data.TryGet(this, out BinaryExpressionSuspendData? suspendData))
+            && suspendable.Data.TryGet(this, out LeftOperandSuspendData? suspendData))
         {
             left = suspendData!.LeftValue;
         }
@@ -54,7 +54,7 @@ internal abstract class JintBinaryExpression : JintExpression
         {
             if (suspendable is not null)
             {
-                suspendable.Data.GetOrCreate<BinaryExpressionSuspendData>(this).LeftValue = left;
+                suspendable.Data.GetOrCreate<LeftOperandSuspendData>(this).LeftValue = left;
             }
 
             return false;

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -99,11 +99,13 @@ internal sealed class JintCallExpression : JintExpression
             thisObject = JsValue.Undefined;
         }
 
-        var arguments = this._arguments.ArgumentListEvaluation(context, out var rented);
+        var arguments = this._arguments.ArgumentListEvaluation(context, this, out var rented);
 
         // Check for generator suspension after argument evaluation
         if (context.IsSuspended())
         {
+            // When suspended mid-arglist, ExpressionCache keeps the array alive
+            // in suspend data and returns rented=false, so we don't release it here.
             if (rented && arguments is not null)
             {
                 engine._jsValueArrayPool.ReturnArray(arguments);
@@ -189,7 +191,7 @@ internal sealed class JintCallExpression : JintExpression
 
     private JsValue HandleEval(EvaluationContext context, JsValue func, Engine engine, Reference referenceRecord)
     {
-        var argList = _arguments.ArgumentListEvaluation(context, out var rented);
+        var argList = _arguments.ArgumentListEvaluation(context, this, out var rented);
 
         if (argList.Length == 0)
         {
@@ -224,7 +226,7 @@ internal sealed class JintCallExpression : JintExpression
 
         var argList = defaultSuperCall
             ? _arguments.DefaultSuperCallArgumentListEvaluation(context)
-            : _arguments.ArgumentListEvaluation(context, out rented);
+            : _arguments.ArgumentListEvaluation(context, this, out rented);
 
         if (func is null || !func.IsConstructor)
         {

--- a/Jint/Runtime/Interpreter/Expressions/JintConditionalExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintConditionalExpression.cs
@@ -1,3 +1,5 @@
+using Jint.Native;
+
 namespace Jint.Runtime.Interpreter.Expressions;
 
 internal sealed class JintConditionalExpression : JintExpression
@@ -15,16 +17,39 @@ internal sealed class JintConditionalExpression : JintExpression
 
     protected override object EvaluateInternal(EvaluationContext context)
     {
-        var testValue = _test.GetValue(context);
-
-        // Check for generator suspension after evaluating test
-        if (context.IsSuspended())
+        JsValue testValue;
+        var suspendable = context.Engine?.ExecutionContext.Suspendable;
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out LeftOperandSuspendData? suspendData))
         {
-            return testValue;
+            testValue = suspendData!.LeftValue;
+        }
+        else
+        {
+            testValue = _test.GetValue(context);
+
+            // Check for generator suspension after evaluating test
+            if (context.IsSuspended())
+            {
+                return testValue;
+            }
         }
 
-        return TypeConverter.ToBoolean(testValue)
+        var result = TypeConverter.ToBoolean(testValue)
             ? _consequent.GetValue(context)
             : _alternate.GetValue(context);
+
+        if (context.IsSuspended())
+        {
+            if (suspendable is not null)
+            {
+                suspendable.Data.GetOrCreate<LeftOperandSuspendData>(this).LeftValue = testValue;
+            }
+
+            return result;
+        }
+
+        suspendable?.Data.Clear(this);
+        return result;
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintLogicalAndExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLogicalAndExpression.cs
@@ -15,24 +15,48 @@ internal sealed class JintLogicalAndExpression : JintExpression
 
     protected override object EvaluateInternal(EvaluationContext context)
     {
-        var left = _left.GetValue(context);
-
-        // Check for generator suspension after evaluating left operand
-        if (context.IsSuspended())
+        JsValue left;
+        var suspendable = context.Engine?.ExecutionContext.Suspendable;
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out LeftOperandSuspendData? suspendData))
         {
-            return left;
+            left = suspendData!.LeftValue;
+        }
+        else
+        {
+            left = _left.GetValue(context);
+
+            // Check for generator suspension after evaluating left operand
+            if (context.IsSuspended())
+            {
+                return left;
+            }
         }
 
         if (left is JsBoolean b && !b._value)
         {
+            suspendable?.Data.Clear(this);
             return b;
         }
 
         if (!TypeConverter.ToBoolean(left))
         {
+            suspendable?.Data.Clear(this);
             return left;
         }
 
-        return _right.GetValue(context);
+        var right = _right.GetValue(context);
+        if (context.IsSuspended())
+        {
+            if (suspendable is not null)
+            {
+                suspendable.Data.GetOrCreate<LeftOperandSuspendData>(this).LeftValue = left;
+            }
+
+            return right;
+        }
+
+        suspendable?.Data.Clear(this);
+        return right;
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintLogicalOrExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLogicalOrExpression.cs
@@ -15,24 +15,48 @@ internal sealed class JintLogicalOrExpression : JintExpression
 
     protected override object EvaluateInternal(EvaluationContext context)
     {
-        var left = _left.GetValue(context);
-
-        // Check for generator suspension after evaluating left operand
-        if (context.IsSuspended())
+        JsValue left;
+        var suspendable = context.Engine?.ExecutionContext.Suspendable;
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out LeftOperandSuspendData? suspendData))
         {
-            return left;
+            left = suspendData!.LeftValue;
+        }
+        else
+        {
+            left = _left.GetValue(context);
+
+            // Check for generator suspension after evaluating left operand
+            if (context.IsSuspended())
+            {
+                return left;
+            }
         }
 
         if (left is JsBoolean b && b._value)
         {
+            suspendable?.Data.Clear(this);
             return b;
         }
 
         if (TypeConverter.ToBoolean(left))
         {
+            suspendable?.Data.Clear(this);
             return left;
         }
 
-        return _right.GetValue(context);
+        var right = _right.GetValue(context);
+        if (context.IsSuspended())
+        {
+            if (suspendable is not null)
+            {
+                suspendable.Data.GetOrCreate<LeftOperandSuspendData>(this).LeftValue = left;
+            }
+
+            return right;
+        }
+
+        suspendable?.Data.Clear(this);
+        return right;
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
@@ -18,11 +18,23 @@ internal sealed class JintNewExpression : JintExpression
         // todo: optimize by defining a common abstract class or interface
         var jsValue = _calleeExpression.GetValue(context);
 
-        var arguments = _arguments.ArgumentListEvaluation(context, out var rented);
+        if (context.IsSuspended())
+        {
+            return jsValue;
+        }
+
+        var arguments = _arguments.ArgumentListEvaluation(context, this, out var rented);
 
         // Reset the location to the "new" keyword so that if an Error object is
         // constructed below, the stack trace will capture the correct location.
         context.LastSyntaxElement = _expression;
+
+        if (context.IsSuspended())
+        {
+            // Argument list suspended mid-evaluation. ExpressionCache keeps the buffer
+            // alive in suspend data and returns rented=false.
+            return jsValue;
+        }
 
         if (!jsValue.IsConstructor)
         {

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -106,6 +106,15 @@ internal sealed class JintStatementList
 
                 if (c.Type != CompletionType.Normal)
                 {
+                    if (!context.IsSuspended())
+                    {
+                        var asyncFunction = context.Engine.ExecutionContext.AsyncFunction;
+                        if (asyncFunction?._body != this)
+                        {
+                            Reset();
+                        }
+                    }
+
                     return c.UpdateEmpty(sl.Value);
                 }
 

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -23,36 +23,45 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
     {
         JsValue v = JsValue.Undefined;
         bool iterating;
+        var suspensionNode = GetSuspensionNode(context.Engine.ExecutionContext.Suspendable);
+        var skipBodyOnce = suspensionNode is not null && IsNodeInsideRange(suspensionNode, _statement.Test.Range);
 
         do
         {
             context.Engine.ExecutionContext.ClearCompletedAwaitsIfNotResuming();
 
-            var completion = _body.Execute(context);
-            if (!completion.Value.IsEmpty)
+            if (!skipBodyOnce)
             {
-                v = completion.Value;
-            }
-
-            // Check for generator suspension - if the generator is suspended, we need to exit the loop
-            if (context.IsSuspended())
-            {
-                var generator = context.Engine.ExecutionContext.Generator;
-                var suspendedValue = generator?._suspendedValue ?? completion.Value;
-                return new Completion(CompletionType.Return, suspendedValue, _statement);
-            }
-
-            if (completion.Type != CompletionType.Continue || !string.Equals(context.Target, _labelSetName, StringComparison.Ordinal))
-            {
-                if (completion.Type == CompletionType.Break && (context.Target == null || string.Equals(context.Target, _labelSetName, StringComparison.Ordinal)))
+                var completion = _body.Execute(context);
+                if (!completion.Value.IsEmpty)
                 {
-                    return new Completion(CompletionType.Normal, v, _statement);
+                    v = completion.Value;
                 }
 
-                if (completion.Type != CompletionType.Normal)
+                // Check for generator suspension - if the generator is suspended, we need to exit the loop
+                if (context.IsSuspended())
                 {
-                    return completion;
+                    var generator = context.Engine.ExecutionContext.Generator;
+                    var suspendedValue = generator?._suspendedValue ?? completion.Value;
+                    return new Completion(CompletionType.Return, suspendedValue, _statement);
                 }
+
+                if (completion.Type != CompletionType.Continue || !string.Equals(context.Target, _labelSetName, StringComparison.Ordinal))
+                {
+                    if (completion.Type == CompletionType.Break && (context.Target == null || string.Equals(context.Target, _labelSetName, StringComparison.Ordinal)))
+                    {
+                        return new Completion(CompletionType.Normal, v, _statement);
+                    }
+
+                    if (completion.Type != CompletionType.Normal)
+                    {
+                        return completion;
+                    }
+                }
+            }
+            else
+            {
+                skipBodyOnce = false;
             }
 
             if (context.DebugMode)

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -74,20 +74,15 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         // If resuming from init expression, we must re-execute init to complete pending nested awaits
         var suspendable = engine.ExecutionContext.Suspendable;
 
-        // Get the resume node from the unified interface
-        Node? resumeNode = null;
-        if (suspendable is { IsResuming: true, LastSuspensionNode: not null })
-        {
-            // LastSuspensionNode could be a Node directly (yield) or a JintExpression (await)
-            resumeNode = suspendable.LastSuspensionNode as Node
-                ?? (suspendable.LastSuspensionNode as JintExpression)?._expression as Node;
-        }
+        var resumeNode = GetSuspensionNode(suspendable);
 
         // Only skip init when resuming from body/test/update, NOT from init
         var resumingInLoop = resumeNode is not null && IsNodeInsideForStatementExcludingInit(resumeNode);
+        var resumingInBody = resumeNode is not null && IsNodeInsideRange(resumeNode, _statement.Body.Range);
+        var resumingInUpdate = resumeNode is not null && _statement.Update is not null && IsNodeInsideRange(resumeNode, _statement.Update.Range);
 
         ForLoopSuspendData? suspendData = null;
-        if (resumingInLoop && _boundNames != null)
+        if (resumingInLoop)
         {
             suspendable?.Data.TryGet(this, out suspendData);
         }
@@ -152,7 +147,7 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                 }
             }
 
-            completion = ForBodyEvaluation(context);
+            completion = ForBodyEvaluation(context, suspendData?.AccumulatedValue ?? JsValue.Undefined, skipTestOnce: resumingInBody, resumeUpdateOnce: resumingInUpdate);
             return completion;
         }
         finally
@@ -230,11 +225,11 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
     /// <summary>
     /// https://tc39.es/ecma262/#sec-forbodyevaluation
     /// </summary>
-    private Completion ForBodyEvaluation(EvaluationContext context)
+    private Completion ForBodyEvaluation(EvaluationContext context, JsValue initialValue, bool skipTestOnce, bool resumeUpdateOnce)
     {
-        var v = JsValue.Undefined;
+        var v = initialValue;
 
-        if (_shouldCreatePerIterationEnvironment && !_canReuseIterationEnvironment)
+        if (!resumeUpdateOnce && _shouldCreatePerIterationEnvironment && !_canReuseIterationEnvironment)
         {
             CreatePerIterationEnvironment(context);
         }
@@ -245,7 +240,7 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         {
             context.Engine.ExecutionContext.ClearCompletedAwaitsIfNotResuming();
 
-            if (_test != null)
+            if (!resumeUpdateOnce && !skipTestOnce && _test != null)
             {
                 debugHandler?.OnStep(_test._expression);
 
@@ -254,44 +249,54 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                     // Check for async suspension in test expression
                     if (context.IsSuspended())
                     {
+                        SaveAccumulatedValue(context, v);
                         return new Completion(CompletionType.Return, JsValue.Undefined, ((JintStatement) this)._statement);
                     }
 
+                    context.Engine.ExecutionContext.Suspendable?.Data.Clear(this);
                     return new Completion(CompletionType.Normal, v, ((JintStatement) this)._statement);
                 }
             }
 
-            var result = _body.Execute(context);
-            if (!result.Value.IsEmpty)
-            {
-                v = result.Value;
-            }
+            skipTestOnce = false;
 
-            // Check for suspension - if suspended, we need to exit the loop
             var suspendable = context.Engine.ExecutionContext.Suspendable;
-            if (context.IsSuspended())
+            if (!resumeUpdateOnce)
             {
-                var suspendedValue = suspendable?.SuspendedValue ?? result.Value;
-                return new Completion(CompletionType.Return, suspendedValue, ((JintStatement) this)._statement);
-            }
-
-            if (result.Type == CompletionType.Break && (context.Target == null || string.Equals(context.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
-            {
-                return new Completion(CompletionType.Normal, result.Value, ((JintStatement) this)._statement);
-            }
-
-            if (result.Type != CompletionType.Continue || (context.Target != null && !string.Equals(context.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
-            {
-                if (result.Type != CompletionType.Normal)
+                var result = _body.Execute(context);
+                if (!result.Value.IsEmpty)
                 {
-                    return result;
+                    v = result.Value;
+                }
+
+                // Check for suspension - if suspended, we need to exit the loop
+                if (context.IsSuspended())
+                {
+                    SaveAccumulatedValue(context, v);
+                    var suspendedValue = suspendable?.SuspendedValue ?? result.Value;
+                    return new Completion(CompletionType.Return, suspendedValue, ((JintStatement) this)._statement);
+                }
+
+                if (result.Type == CompletionType.Break && (context.Target == null || string.Equals(context.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
+                {
+                    suspendable?.Data.Clear(this);
+                    return new Completion(CompletionType.Normal, result.Value, ((JintStatement) this)._statement);
+                }
+
+                if (result.Type != CompletionType.Continue || (context.Target != null && !string.Equals(context.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
+                {
+                    if (result.Type != CompletionType.Normal)
+                    {
+                        return result;
+                    }
+                }
+
+                if (_shouldCreatePerIterationEnvironment && !_canReuseIterationEnvironment)
+                {
+                    CreatePerIterationEnvironment(context);
                 }
             }
-
-            if (_shouldCreatePerIterationEnvironment && !_canReuseIterationEnvironment)
-            {
-                CreatePerIterationEnvironment(context);
-            }
+            resumeUpdateOnce = false;
 
             if (_increment != null)
             {
@@ -301,6 +306,7 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                 // Check for suspension in update expression (e.g., yield in the update)
                 if (context.IsSuspended())
                 {
+                    SaveAccumulatedValue(context, v);
                     var suspendedValue = suspendable?.SuspendedValue ?? JsValue.Undefined;
                     return new Completion(CompletionType.Return, suspendedValue, ((JintStatement) this)._statement);
                 }
@@ -312,6 +318,15 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                     return new Completion(CompletionType.Return, returnValue, ((JintStatement) this)._statement);
                 }
             }
+        }
+    }
+
+    private void SaveAccumulatedValue(EvaluationContext context, JsValue value)
+    {
+        var suspendable = context.Engine.ExecutionContext.Suspendable;
+        if (suspendable is not null)
+        {
+            suspendable.Data.GetOrCreate<ForLoopSuspendData>(this).AccumulatedValue = value;
         }
     }
 

--- a/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
@@ -24,32 +24,53 @@ internal sealed class JintIfStatement : JintStatement<IfStatement>
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
         Completion result;
-        if (_test.GetBooleanValue(context))
+        var suspensionNode = GetSuspensionNode(context.Engine.ExecutionContext.Suspendable);
+        if (suspensionNode is not null && IsNodeInsideRange(suspensionNode, _statement.Consequent.Range))
         {
-            // B.3.2/B.3.3: IfStatement function declarations need runtime AnnexB handling
-            if (_consequentIsFunctionDecl && !StrictModeScope.IsStrictModeCode)
-            {
-                result = ExecuteAnnexBFunctionDeclaration(context, (FunctionDeclaration) _statement.Consequent);
-            }
-            else
-            {
-                result = _statementConsequent.Execute(context);
-            }
+            result = _statementConsequent.Execute(context);
         }
-        else if (_alternate != null)
+        else if (suspensionNode is not null
+            && _statement.Alternate is not null
+            && IsNodeInsideRange(suspensionNode, _statement.Alternate.Range))
         {
-            if (_alternateIsFunctionDecl && !StrictModeScope.IsStrictModeCode)
-            {
-                result = ExecuteAnnexBFunctionDeclaration(context, (FunctionDeclaration) _statement.Alternate!);
-            }
-            else
-            {
-                result = _alternate.Value.Execute(context);
-            }
+            result = _alternate!.Value.Execute(context);
         }
         else
         {
-            result = Completion.Empty();
+            var testResult = _test.GetBooleanValue(context);
+            if (context.IsSuspended())
+            {
+                var suspendable = context.Engine.ExecutionContext.Suspendable;
+                var suspendedValue = suspendable?.SuspendedValue ?? JsValue.Undefined;
+                result = new Completion(CompletionType.Return, suspendedValue, _statement);
+            }
+            else if (testResult)
+            {
+                // B.3.2/B.3.3: IfStatement function declarations need runtime AnnexB handling
+                if (_consequentIsFunctionDecl && !StrictModeScope.IsStrictModeCode)
+                {
+                    result = ExecuteAnnexBFunctionDeclaration(context, (FunctionDeclaration) _statement.Consequent);
+                }
+                else
+                {
+                    result = _statementConsequent.Execute(context);
+                }
+            }
+            else if (_alternate != null)
+            {
+                if (_alternateIsFunctionDecl && !StrictModeScope.IsStrictModeCode)
+                {
+                    result = ExecuteAnnexBFunctionDeclaration(context, (FunctionDeclaration) _statement.Alternate!);
+                }
+                else
+                {
+                    result = _alternate.Value.Execute(context);
+                }
+            }
+            else
+            {
+                result = Completion.Empty();
+            }
         }
 
         return result.UpdateEmpty(JsValue.Undefined);

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -1,6 +1,8 @@
 using System.Runtime.CompilerServices;
+using Acornima;
 using Jint.Native;
 using Jint.Runtime.Interpreter.Expressions;
+using Range = Acornima.Range;
 
 namespace Jint.Runtime.Interpreter.Statements;
 
@@ -92,5 +94,21 @@ internal abstract class JintStatement
         }
 
         return null;
+    }
+
+    protected internal static Node? GetSuspensionNode(ISuspendable? suspendable)
+    {
+        if (suspendable is not { IsResuming: true, LastSuspensionNode: not null })
+        {
+            return null;
+        }
+
+        return suspendable.LastSuspensionNode as Node
+            ?? (suspendable.LastSuspensionNode as JintExpression)?._expression as Node;
+    }
+
+    protected internal static bool IsNodeInsideRange(Node node, in Range range)
+    {
+        return range.Start <= node.Range.Start && node.Range.End <= range.End;
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -96,7 +96,7 @@ internal abstract class JintStatement
         return null;
     }
 
-    protected internal static Node? GetSuspensionNode(ISuspendable? suspendable)
+    internal static Node? GetSuspensionNode(ISuspendable? suspendable)
     {
         if (suspendable is not { IsResuming: true, LastSuspensionNode: not null })
         {
@@ -107,7 +107,7 @@ internal abstract class JintStatement
             ?? (suspendable.LastSuspensionNode as JintExpression)?._expression as Node;
     }
 
-    protected internal static bool IsNodeInsideRange(Node node, in Range range)
+    internal static bool IsNodeInsideRange(Node node, in Range range)
     {
         return range.Start <= node.Range.Start && node.Range.End <= range.End;
     }

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
@@ -2,81 +2,163 @@ using Jint.Native;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
 using Environment = Jint.Runtime.Environments.Environment;
+using Range = Acornima.Range;
 
 namespace Jint.Runtime.Interpreter.Statements;
 
 internal sealed class JintSwitchBlock
 {
     private readonly JintSwitchCase[] _jintSwitchBlock;
+    private readonly DeclarationCache _lexicalDeclarations;
 
     public JintSwitchBlock(NodeList<SwitchCase> switchBlock)
     {
         _jintSwitchBlock = new JintSwitchCase[switchBlock.Count];
+        List<ScopedDeclaration>? declarations = null;
+        var allLexicalScoped = true;
+
         for (var i = 0; i < _jintSwitchBlock.Length; i++)
         {
-            _jintSwitchBlock[i] = new JintSwitchCase(switchBlock[i]);
+            var switchCase = new JintSwitchCase(switchBlock[i]);
+            _jintSwitchBlock[i] = switchCase;
+
+            if (switchCase.LexicalDeclarations.Declarations.Count > 0)
+            {
+                declarations ??= [];
+                declarations.AddRange(switchCase.LexicalDeclarations.Declarations);
+                allLexicalScoped &= switchCase.LexicalDeclarations.AllLexicalScoped;
+            }
         }
+
+        _lexicalDeclarations = new DeclarationCache(declarations ?? [], allLexicalScoped);
     }
 
     public Completion Execute(EvaluationContext context, JsValue input)
     {
-        var v = JsValue.Undefined;
-        var l = context.LastSyntaxElement;
-        var hit = false;
-        var defaultCaseIndex = -1;
+        return Execute(context, input, startIndex: 0, hit: false, defaultCaseIndex: -1, initialValue: JsValue.Undefined);
+    }
 
-        var i = 0;
+    public Completion? ExecuteResume(EvaluationContext context, Node suspensionNode)
+    {
+        var temp = _jintSwitchBlock;
+        var suspendable = context.Engine.ExecutionContext.Suspendable;
+        SwitchBlockSuspendData? suspendData = null;
+        suspendable?.Data.TryGet(this, out suspendData);
+        for (var i = 0; i < temp.Length; i++)
+        {
+            var clause = temp[i];
+            if (clause.TestRange is { } testRange && JintStatement.IsNodeInsideRange(suspensionNode, testRange))
+            {
+                return Execute(
+                    context,
+                    suspendData?.Input ?? JsValue.Undefined,
+                    i,
+                    hit: false,
+                    defaultCaseIndex: suspendData?.DefaultCaseIndex ?? -1,
+                    initialValue: suspendData?.AccumulatedValue ?? JsValue.Undefined);
+            }
+
+            if (JintStatement.IsNodeInsideRange(suspensionNode, clause.Range))
+            {
+                return Execute(
+                    context,
+                    suspendData?.Input ?? JsValue.Undefined,
+                    i,
+                    hit: true,
+                    defaultCaseIndex: suspendData?.DefaultCaseIndex ?? -1,
+                    initialValue: suspendData?.AccumulatedValue ?? JsValue.Undefined);
+            }
+        }
+
+        return null;
+    }
+
+    private Completion Execute(EvaluationContext context, JsValue input, int startIndex, bool hit, int defaultCaseIndex, JsValue initialValue)
+    {
+        var v = initialValue;
+        var l = context.LastSyntaxElement;
+
+        var i = startIndex;
         Environment? oldEnv = null;
         var temp = _jintSwitchBlock;
+        var suspendable = context.Engine.ExecutionContext.Suspendable;
+        SwitchBlockSuspendData? suspendData = null;
+        suspendable?.Data.TryGet(this, out suspendData);
 
-        DeclarativeEnvironment? blockEnv = null;
+        DeclarativeEnvironment? blockEnv = suspendData?.BlockEnvironment;
 
 start:
         for (; i < temp.Length; i++)
         {
             var clause = temp[i];
-            if (clause.LexicalDeclarations.Declarations.Count > 0 && oldEnv is null)
+            if (_lexicalDeclarations.Declarations.Count > 0 && oldEnv is null)
             {
-                oldEnv = context.Engine.ExecutionContext.LexicalEnvironment;
-                blockEnv ??= JintEnvironment.NewDeclarativeEnvironment(context.Engine, oldEnv);
-                blockEnv.Clear();
-
-                JintStatementList.BlockDeclarationInstantiation(blockEnv, clause.LexicalDeclarations);
-                context.Engine.UpdateLexicalEnvironment(blockEnv);
-            }
-
-            if (clause.Test == null)
-            {
-                defaultCaseIndex = i;
-                if (!hit)
+                oldEnv = suspendData?.OuterEnvironment ?? context.Engine.ExecutionContext.LexicalEnvironment;
+                if (blockEnv is null)
                 {
-                    continue;
+                    blockEnv = JintEnvironment.NewDeclarativeEnvironment(context.Engine, oldEnv);
+                    JintStatementList.BlockDeclarationInstantiation(blockEnv, _lexicalDeclarations);
                 }
-            }
 
-            var clauseSelector = clause.Test?.GetValue(context);
-            if (clauseSelector == input)
-            {
-                hit = true;
+                if (!ReferenceEquals(context.Engine.ExecutionContext.LexicalEnvironment, blockEnv))
+                {
+                    context.Engine.UpdateLexicalEnvironment(blockEnv);
+                }
             }
 
             if (!hit)
             {
-                if (oldEnv is not null)
+                if (clause.Test == null)
                 {
-                    context.Engine.UpdateLexicalEnvironment(oldEnv);
-                    oldEnv = null;
+                    defaultCaseIndex = i;
+                    continue;
                 }
-                continue;
+
+                var clauseSelector = clause.Test.GetValue(context);
+                if (context.IsSuspended())
+                {
+                    SaveSuspendData(context, input, defaultCaseIndex, v, blockEnv, oldEnv);
+                    if (oldEnv is not null)
+                    {
+                        context.Engine.UpdateLexicalEnvironment(oldEnv);
+                    }
+
+                    var suspendedValue = suspendable?.SuspendedValue ?? JsValue.Undefined;
+                    return new Completion(CompletionType.Return, suspendedValue, clause.Test._expression);
+                }
+
+                if (clauseSelector == input)
+                {
+                    hit = true;
+                }
+
+                if (!hit)
+                {
+                    if (oldEnv is not null)
+                    {
+                        context.Engine.UpdateLexicalEnvironment(oldEnv);
+                        oldEnv = null;
+                    }
+                    continue;
+                }
             }
 
             var r = clause.Consequent.Execute(context);
+            if (context.IsSuspended())
+            {
+                SaveSuspendData(context, input, defaultCaseIndex, v, blockEnv, oldEnv);
+            }
 
             if (r.Type != CompletionType.Normal)
             {
                 if (oldEnv is not null)
                 {
                     context.Engine.UpdateLexicalEnvironment(oldEnv);
+                }
+
+                if (!context.IsSuspended())
+                {
+                    suspendable?.Data.Clear(this);
                 }
 
                 return r.UpdateEmpty(v);
@@ -100,7 +182,28 @@ start:
             context.Engine.UpdateLexicalEnvironment(oldEnv);
         }
 
+        context.Engine.ExecutionContext.Suspendable?.Data.Clear(this);
         return new Completion(CompletionType.Normal, v, l);
+    }
+
+    private void SaveSuspendData(
+        EvaluationContext context,
+        JsValue input,
+        int defaultCaseIndex,
+        JsValue value,
+        DeclarativeEnvironment? blockEnv,
+        Environment? oldEnv)
+    {
+        var suspendable = context.Engine.ExecutionContext.Suspendable;
+        if (suspendable is not null)
+        {
+            var data = suspendable.Data.GetOrCreate<SwitchBlockSuspendData>(this);
+            data.Input = input;
+            data.DefaultCaseIndex = defaultCaseIndex;
+            data.AccumulatedValue = value;
+            data.BlockEnvironment = blockEnv;
+            data.OuterEnvironment = oldEnv;
+        }
     }
 
     private sealed class JintSwitchCase
@@ -108,11 +211,15 @@ start:
         internal readonly JintStatementList Consequent;
         internal readonly JintExpression? Test;
         internal readonly DeclarationCache LexicalDeclarations;
+        internal readonly Range Range;
+        internal readonly Range? TestRange;
 
         public JintSwitchCase(SwitchCase switchCase)
         {
             Consequent = new JintStatementList(statement: null, switchCase.Consequent);
             LexicalDeclarations = DeclarationCacheBuilder.Build(switchCase);
+            Range = switchCase.Range;
+            TestRange = switchCase.Test?.Range;
 
             if (switchCase.Test != null)
             {

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchStatement.cs
@@ -18,8 +18,23 @@ internal sealed class JintSwitchStatement : JintStatement<SwitchStatement>
 
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
+        var suspensionNode = GetSuspensionNode(context.Engine.ExecutionContext.Suspendable);
+        if (suspensionNode is not null && IsNodeInsideRange(suspensionNode, _statement.Range))
+        {
+            var resume = _switchBlock.ExecuteResume(context, suspensionNode);
+            if (resume is not null)
+            {
+                return HandleCompletion(context, resume.Value);
+            }
+        }
+
         var value = _discriminant.GetValue(context);
         var r = _switchBlock.Execute(context, value);
+        return HandleCompletion(context, r);
+    }
+
+    private Completion HandleCompletion(EvaluationContext context, Completion r)
+    {
         if (r.Type == CompletionType.Break && string.Equals(context.Target, _statement.LabelSet?.Name, StringComparison.Ordinal))
         {
             return new Completion(CompletionType.Normal, r.Value, ((JintStatement) this)._statement);

--- a/Jint/Runtime/Interpreter/Statements/JintTryStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintTryStatement.cs
@@ -1,6 +1,5 @@
 using Jint.Native;
 using Jint.Runtime.Environments;
-using Range = Acornima.Range;
 
 namespace Jint.Runtime.Interpreter.Statements;
 
@@ -29,7 +28,8 @@ internal sealed class JintTryStatement : JintStatement<TryStatement>
 
         // Check if we're resuming from inside the catch or finally block
         // If so, skip the try block and go directly to the appropriate block
-        if (suspendable is { IsResuming: true, LastSuspensionNode: Node suspensionNode })
+        var suspensionNode = GetSuspensionNode(suspendable);
+        if (suspensionNode is not null)
         {
             if (_statement.Handler is not null && IsNodeInsideRange(suspensionNode, _statement.Handler.Range))
             {
@@ -39,7 +39,7 @@ internal sealed class JintTryStatement : JintStatement<TryStatement>
             if (_statement.Finalizer is not null && IsNodeInsideRange(suspensionNode, _statement.Finalizer.Range))
             {
                 // Resuming from inside finally block - execute finally directly
-                return ExecuteFinallyResume(context, suspendable);
+                return ExecuteFinallyResume(context, suspendable!);
             }
         }
 
@@ -47,7 +47,7 @@ internal sealed class JintTryStatement : JintStatement<TryStatement>
         if (suspendable is { IsResuming: true } && ReferenceEquals(suspendable.CurrentFinallyStatement, this))
         {
             // Resuming from inside finally block - execute finally directly
-            return ExecuteFinallyResume(context, suspendable);
+            return ExecuteFinallyResume(context, suspendable!);
         }
 
         var b = _block.Execute(context);
@@ -64,66 +64,7 @@ internal sealed class JintTryStatement : JintStatement<TryStatement>
             return b;
         }
 
-        if (_finalizer != null)
-        {
-            // Save the pending completion before running finally
-            // This is needed because if finally yields/awaits, we need to remember the
-            // original completion (throw/return) to restore after finally completes
-            if (suspendable is not null && (b.Type == CompletionType.Throw || b.Type == CompletionType.Return))
-            {
-                suspendable.PendingCompletionType = b.Type;
-                suspendable.PendingCompletionValue = b.Value;
-                suspendable.CurrentFinallyStatement = this;
-            }
-
-            // Clear _returnRequested before running finally block.
-            // Per ECMAScript spec, a return in the finally block supersedes any pending return.
-            // If we don't clear this, the finally block's statements will incorrectly use _suspendedValue.
-            var generator = engine.ExecutionContext.Generator;
-            if (generator is not null)
-            {
-                generator._returnRequested = false;
-            }
-
-            var asyncGenerator = engine.ExecutionContext.AsyncGenerator;
-            if (asyncGenerator is not null)
-            {
-                asyncGenerator._returnRequested = false;
-            }
-
-            var f = _finalizer.Execute(context);
-
-            // Check for suspension in finally
-            if (context.IsSuspended())
-            {
-                // Suspended in finally - the pending completion is preserved
-                return f;
-            }
-
-            // Clear the pending completion tracking if we completed normally
-            if (suspendable is not null && ReferenceEquals(suspendable.CurrentFinallyStatement, this))
-            {
-                suspendable.CurrentFinallyStatement = null;
-                suspendable.PendingCompletionType = CompletionType.Normal;
-                suspendable.PendingCompletionValue = null;
-            }
-
-            if (f.Type == CompletionType.Normal)
-            {
-                // Per spec: If F.[[type]] is normal, let F be B.
-                // And step 6: If F.[[value]] is empty, return undefined
-                return b.UpdateEmpty(JsValue.Undefined);
-            }
-
-            return f.UpdateEmpty(JsValue.Undefined);
-        }
-
-        return b.UpdateEmpty(JsValue.Undefined);
-    }
-
-    private static bool IsNodeInsideRange(Node node, in Range range)
-    {
-        return range.Start <= node.Range.Start && node.Range.End <= range.End;
+        return ExecuteFinalizer(context, b, engine, suspendable);
     }
 
     private Completion ExecuteCatchResume(EvaluationContext context)
@@ -139,26 +80,28 @@ internal sealed class JintTryStatement : JintStatement<TryStatement>
             return Completion.Empty();
         }
 
+        var engine = context.Engine;
+        var suspendable = engine.ExecutionContext.Suspendable;
+        var suspendData = GetCatchSuspendData(suspendable);
+        if (suspendData?.CatchEnvironment is not null)
+        {
+            engine.UpdateLexicalEnvironment(suspendData.CatchEnvironment);
+        }
+
         // Execute catch block (it will resume from the saved position)
         var b = _catch.Execute(context);
 
         // If suspended (yield/await), don't run the finally yet
         if (context.IsSuspended())
         {
+            RestoreOuterEnvironmentAfterCatchResume(engine, suspendData);
             return b;
         }
 
-        // Run finally if present
-        if (_finalizer != null)
-        {
-            var f = _finalizer.Execute(context);
-            if (f.Type != CompletionType.Normal)
-            {
-                return f.UpdateEmpty(JsValue.Undefined);
-            }
-        }
+        RestoreOuterEnvironmentAfterCatchResume(engine, suspendData);
+        suspendable?.Data.Clear(this);
 
-        return b.UpdateEmpty(JsValue.Undefined);
+        return ExecuteFinalizer(context, b, engine, suspendable);
     }
 
     private Completion ExecuteFinallyResume(EvaluationContext context, ISuspendable suspendable)
@@ -229,9 +172,100 @@ internal sealed class JintTryStatement : JintStatement<TryStatement>
 
             b = _catch.Execute(context);
 
+            var suspendable = engine.ExecutionContext.Suspendable;
+            if (context.IsSuspended() && suspendable is not null)
+            {
+                var suspendData = suspendable.Data.GetOrCreate<CatchSuspendData>(this);
+                suspendData.CatchEnvironment = catchEnv;
+                suspendData.OuterEnvironment = oldEnv;
+            }
+            else
+            {
+                suspendable?.Data.Clear(this);
+            }
+
             engine.UpdateLexicalEnvironment(oldEnv);
         }
 
         return b;
+    }
+
+    private Completion ExecuteFinalizer(EvaluationContext context, Completion b, Engine engine, ISuspendable? suspendable)
+    {
+        if (_finalizer is null)
+        {
+            return b.UpdateEmpty(JsValue.Undefined);
+        }
+
+        // Save the pending completion before running finally. If finally awaits,
+        // ExecuteFinallyResume restores this completion after the await resumes.
+        if (suspendable is not null && (b.Type == CompletionType.Throw || b.Type == CompletionType.Return))
+        {
+            suspendable.PendingCompletionType = b.Type;
+            suspendable.PendingCompletionValue = b.Value;
+            suspendable.CurrentFinallyStatement = this;
+        }
+
+        // Clear _returnRequested before running finally block.
+        // Per ECMAScript spec, a return in the finally block supersedes any pending return.
+        // If we don't clear this, the finally block's statements will incorrectly use _suspendedValue.
+        var generator = engine.ExecutionContext.Generator;
+        if (generator is not null)
+        {
+            generator._returnRequested = false;
+        }
+
+        var asyncGenerator = engine.ExecutionContext.AsyncGenerator;
+        if (asyncGenerator is not null)
+        {
+            asyncGenerator._returnRequested = false;
+        }
+
+        var f = _finalizer.Execute(context);
+
+        // Check for suspension in finally
+        if (context.IsSuspended())
+        {
+            // Suspended in finally - the pending completion is preserved
+            return f;
+        }
+
+        // Clear the pending completion tracking if we completed normally
+        if (suspendable is not null && ReferenceEquals(suspendable.CurrentFinallyStatement, this))
+        {
+            suspendable.CurrentFinallyStatement = null;
+            suspendable.PendingCompletionType = CompletionType.Normal;
+            suspendable.PendingCompletionValue = null;
+        }
+
+        if (f.Type == CompletionType.Normal)
+        {
+            // Per spec: If F.[[type]] is normal, let F be B.
+            // And step 6: If F.[[value]] is empty, return undefined
+            return b.UpdateEmpty(JsValue.Undefined);
+        }
+
+        return f.UpdateEmpty(JsValue.Undefined);
+    }
+
+    private CatchSuspendData? GetCatchSuspendData(ISuspendable? suspendable)
+    {
+        return suspendable?.Data.TryGet(this, out CatchSuspendData? suspendData) == true
+            ? suspendData
+            : null;
+    }
+
+    private static void RestoreOuterEnvironmentAfterCatchResume(Engine engine, CatchSuspendData? suspendData)
+    {
+        if (suspendData?.OuterEnvironment is not null)
+        {
+            engine.UpdateLexicalEnvironment(suspendData.OuterEnvironment);
+            return;
+        }
+
+        if (engine.ExecutionContext.LexicalEnvironment is DeclarativeEnvironment { _catchEnvironment: true, _outerEnv: { } outerEnv })
+        {
+            engine.UpdateLexicalEnvironment(outerEnv);
+        }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
@@ -22,28 +22,36 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
         var v = JsValue.Undefined;
+        var suspensionNode = GetSuspensionNode(context.Engine.ExecutionContext.Suspendable);
+        var skipTestOnce = suspensionNode is not null && IsNodeInsideRange(suspensionNode, _statement.Body.Range);
+
         while (true)
         {
             context.Engine.ExecutionContext.ClearCompletedAwaitsIfNotResuming();
 
-            if (context.DebugMode)
+            if (!skipTestOnce)
             {
-                context.Engine.Debugger.OnStep(_test._expression);
-            }
-
-            if (!_test.GetBooleanValue(context))
-            {
-                // GetBooleanValue returns false for both actual false condition
-                // and suspended evaluation (async/generator); check which case
-                if (context.IsSuspended())
+                if (context.DebugMode)
                 {
-                    var suspendable = context.Engine.ExecutionContext.Suspendable;
-                    var suspendedValue = suspendable?.SuspendedValue ?? JsValue.Undefined;
-                    return new Completion(CompletionType.Return, suspendedValue, _statement);
+                    context.Engine.Debugger.OnStep(_test._expression);
                 }
 
-                return new Completion(CompletionType.Normal, v, _statement);
+                if (!_test.GetBooleanValue(context))
+                {
+                    // GetBooleanValue returns false for both actual false condition
+                    // and suspended evaluation (async/generator); check which case
+                    if (context.IsSuspended())
+                    {
+                        var suspendable = context.Engine.ExecutionContext.Suspendable;
+                        var suspendedValue = suspendable?.SuspendedValue ?? JsValue.Undefined;
+                        return new Completion(CompletionType.Return, suspendedValue, _statement);
+                    }
+
+                    return new Completion(CompletionType.Normal, v, _statement);
+                }
             }
+
+            skipTestOnce = false;
 
             var completion = _body.Execute(context);
 

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -137,6 +137,19 @@ internal sealed class AssignmentSuspendData : SuspendData
 }
 
 /// <summary>
+/// Stores the in-progress argument buffer and resume index for a call/new
+/// expression when evaluation suspends inside one of the arguments. Reused on
+/// resume so already-evaluated arguments (which may have observable side
+/// effects) are not re-evaluated.
+/// </summary>
+internal sealed class CallArgumentsSuspendData : SuspendData
+{
+    public JsValue[] Buffer { get; set; } = [];
+
+    public int NextIndex { get; set; }
+}
+
+/// <summary>
 /// Stores the state of a for-await-of loop when an async function awaits inside it.
 /// </summary>
 internal sealed class ForAwaitSuspendData : SuspendData

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -102,10 +102,12 @@ internal sealed class SwitchBlockSuspendData : SuspendData
 }
 
 /// <summary>
-/// Stores the left operand of a binary expression when evaluation suspends while
-/// evaluating the right operand.
+/// Stores the already-evaluated left operand of a binary, logical, or conditional
+/// expression when evaluation suspends inside the right operand / branch. Reused
+/// on resume so the left side (which may have observable side effects) is not
+/// re-evaluated.
 /// </summary>
-internal sealed class BinaryExpressionSuspendData : SuspendData
+internal sealed class LeftOperandSuspendData : SuspendData
 {
     public JsValue LeftValue { get; set; } = JsValue.Undefined;
 }

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -124,6 +124,19 @@ internal sealed class CatchSuspendData : SuspendData
 }
 
 /// <summary>
+/// Stores the resolved LHS Reference and pre-mutation value of a compound assignment
+/// (e.g. obj[++i] += await y) when evaluation suspends inside the right-hand side.
+/// Reused on resume so the LHS — which may have observable side effects in its index
+/// or property accessor — is not re-evaluated.
+/// </summary>
+internal sealed class AssignmentSuspendData : SuspendData
+{
+    public Reference Lref { get; set; } = null!;
+
+    public JsValue OriginalLeftValue { get; set; } = JsValue.Undefined;
+}
+
+/// <summary>
 /// Stores the state of a for-await-of loop when an async function awaits inside it.
 /// </summary>
 internal sealed class ForAwaitSuspendData : SuspendData

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -81,6 +81,44 @@ internal sealed class ForLoopSuspendData : SuspendData
     /// The saved values of loop variables (let bindings in for loop init).
     /// </summary>
     public Dictionary<Key, JsValue>? BoundValues { get; set; }
+
+    /// <summary>
+    /// The accumulated completion value from previous iterations.
+    /// </summary>
+    public JsValue AccumulatedValue { get; set; } = JsValue.Undefined;
+}
+
+internal sealed class SwitchBlockSuspendData : SuspendData
+{
+    public JsValue Input { get; set; } = JsValue.Undefined;
+
+    public int DefaultCaseIndex { get; set; } = -1;
+
+    public JsValue AccumulatedValue { get; set; } = JsValue.Undefined;
+
+    public DeclarativeEnvironment? BlockEnvironment { get; set; }
+
+    public Environments.Environment? OuterEnvironment { get; set; }
+}
+
+/// <summary>
+/// Stores the left operand of a binary expression when evaluation suspends while
+/// evaluating the right operand.
+/// </summary>
+internal sealed class BinaryExpressionSuspendData : SuspendData
+{
+    public JsValue LeftValue { get; set; } = JsValue.Undefined;
+}
+
+/// <summary>
+/// Stores the outer lexical environment for a catch clause when execution suspends
+/// inside the catch body.
+/// </summary>
+internal sealed class CatchSuspendData : SuspendData
+{
+    public DeclarativeEnvironment? CatchEnvironment { get; set; }
+
+    public Environments.Environment? OuterEnvironment { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Fix async resume through control-flow statements.

## Details

- Resume async execution inside catch/finally without rerunning the try block or leaking catch bindings.
- Resume selected if/while/do-while/for/switch paths without rerunning already-completed guards, bodies, discriminants, or case tests.
- Preserve accumulated loop/switch completion values and binary-expression left operands across await suspension.
- Add focused AsyncTests coverage for catch/finally, branch, loop, switch, and binary-expression resume behavior.

## Linked issue

Refs #

## Test plan

- [x] Added or updated unit tests in Jint.Tests
- [x] Ran dotnet test --configuration Release locally
- [ ] For ECMAScript spec changes: ran Jint.Tests.Test262 and confirmed no regressions
- [ ] For interop changes: covered in Jint.Tests/Runtime/Interop
- [ ] For perf changes: included before/after numbers from Jint.Benchmark

Additional local validation:

- dotnet test Jint.Tests/Jint.Tests.csproj --filter "FullyQualifiedName~AsyncTests"
- dotnet build Jint/Jint.csproj --configuration Release

## Breaking change?

No.
