### PR TITLE
Update test262 to 673e9bac and fix newly-revealed issues

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -1,5 +1,5 @@
 {
-  "SuiteGitSha": "2b2ecead6e828dd9af13a9ec72065e645724a50f",
+  "SuiteGitSha": "673e9bacbe28590f501e2dcd817aadcc31899191",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Jint.Tests.Test262",

--- a/Jint/Native/ArrayBuffer/ArrayBufferPrototype.cs
+++ b/Jint/Native/ArrayBuffer/ArrayBufferPrototype.cs
@@ -272,15 +272,13 @@ internal sealed partial class ArrayBufferPrototype : Prototype
     private JsValue SliceToImmutable(JsValue thisObject, JsValue start, JsValue end)
     {
         // 1. Let O be the this value.
+        // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+        // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
         var o = thisObject as JsArrayBuffer;
         if (o is null || o.IsSharedArrayBuffer)
         {
             Throw.TypeError(_realm, "Method ArrayBuffer.prototype.sliceToImmutable called on incompatible receiver " + thisObject);
         }
-
-        // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
-        // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-        // (already checked above)
 
         // 4. If IsDetachedBuffer(O) is true, throw a TypeError exception.
         o.AssertNotDetached();
@@ -288,10 +286,9 @@ internal sealed partial class ArrayBufferPrototype : Prototype
         // 5. Let len be O.[[ArrayBufferByteLength]].
         var len = o.ArrayBufferByteLength;
 
-        // 6. Let relativeStart be ? ToIntegerOrInfinity(start).
+        // 6. Let bounds be ? ResolveBounds(len, start, end).
+        // 6.1 Let relativeStart be ? ToIntegerOrInfinity(start).
         var relativeStart = TypeConverter.ToIntegerOrInfinity(start);
-
-        // 7-8. Set first based on relativeStart
         var first = relativeStart switch
         {
             double.NegativeInfinity => 0,
@@ -299,18 +296,8 @@ internal sealed partial class ArrayBufferPrototype : Prototype
             _ => (int) System.Math.Min(relativeStart, len)
         };
 
-        // 9-10. Set relativeEnd based on end
-        double relativeEnd;
-        if (end.IsUndefined())
-        {
-            relativeEnd = len;
-        }
-        else
-        {
-            relativeEnd = TypeConverter.ToIntegerOrInfinity(end);
-        }
-
-        // 11-12. Set final based on relativeEnd
+        // 6.5 If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
+        var relativeEnd = end.IsUndefined() ? len : TypeConverter.ToIntegerOrInfinity(end);
         var final = relativeEnd switch
         {
             double.NegativeInfinity => 0,
@@ -318,28 +305,29 @@ internal sealed partial class ArrayBufferPrototype : Prototype
             _ => (int) System.Math.Min(relativeEnd, len)
         };
 
-        // 13. Let newLen be max(final - first, 0).
-        var newLen = (uint) System.Math.Max(final - first, 0);
-
-        // 14. Let new be ? AllocateArrayBuffer(%ArrayBuffer%, newLen).
-        var newBuffer = _engine.Realm.Intrinsics.ArrayBuffer.AllocateArrayBuffer(_engine.Realm.Intrinsics.ArrayBuffer, newLen);
-
-        // 15. If IsDetachedBuffer(O) is true, throw a TypeError exception.
+        // After coercion, the buffer may have been detached and/or resized — re-check detachment
+        // *before* the currentLen<final bounds check so detach yields TypeError, not RangeError.
         o.AssertNotDetached();
 
-        // 16. Let fromBuf be O.[[ArrayBufferData]].
+        // 9. Let newLen be max(final - first, 0).
+        var newLen = (uint) System.Math.Max(final - first, 0);
+
+        // 12. Let fromBuf be O.[[ArrayBufferData]].
         var fromBuf = o.ArrayBufferData!;
 
-        // 17. Let toBuf be new.[[ArrayBufferData]].
-        var toBuf = newBuffer.ArrayBufferData!;
+        // 13. Let currentLen be O.[[ArrayBufferByteLength]].
+        // 14. If currentLen < final, throw a RangeError exception.
+        if (o.ArrayBufferByteLength < final)
+        {
+            Throw.RangeError(_realm, "ArrayBuffer has shrunk below the resolved end during argument coercion");
+        }
 
-        // 18. Perform CopyDataBlockBytes(toBuf, 0, fromBuf, first, newLen).
-        System.Array.Copy(fromBuf, first, toBuf, 0, newLen);
-
-        // 19. Set new.[[ArrayBufferImmutable]] to true.
+        // 15. Let newBuffer be ? AllocateImmutableArrayBuffer(%ArrayBuffer%, newLen, fromBuf, first, newLen).
+        var newBuffer = _engine.Realm.Intrinsics.ArrayBuffer.AllocateArrayBuffer(_engine.Realm.Intrinsics.ArrayBuffer, newLen);
+        System.Array.Copy(fromBuf, first, newBuffer.ArrayBufferData!, 0, newLen);
         newBuffer._isImmutable = true;
 
-        // 20. Return new.
+        // 16. Return newBuffer.
         return newBuffer;
     }
 

--- a/Jint/Native/FinalizationRegistry/FinalizationRegistryInstance.cs
+++ b/Jint/Native/FinalizationRegistry/FinalizationRegistryInstance.cs
@@ -64,7 +64,16 @@ internal sealed class FinalizationRegistryInstance : ObjectInstance
         ~Observer()
 #pragma warning restore MA0055
         {
-            _callable.Callback.Call(Undefined);
+            try
+            {
+                _callable.Callback.Call(Undefined);
+            }
+            catch
+            {
+                // FinalizationRegistry cleanup callbacks are spec'd to run in a Job
+                // isolated from any calling context. Exceptions must never escape
+                // the GC finalizer thread or they will terminate the host process.
+            }
         }
     }
 }

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayConstructor.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayConstructor.cs
@@ -60,6 +60,7 @@ internal sealed partial class IntrinsicTypedArrayConstructor : Constructor
             var values = TypedArrayConstructor.IterableToList(_realm, source, usingIterator);
             var iteratorLen = values.Count;
             var iteratorTarget = TypedArrayCreate(_realm, (IConstructor) c, [iteratorLen]);
+            iteratorTarget._viewedArrayBuffer.AssertNotImmutable();
             for (var k = 0; k < iteratorLen; ++k)
             {
                 var kValue = values[k];
@@ -82,6 +83,7 @@ internal sealed partial class IntrinsicTypedArrayConstructor : Constructor
 
         var argumentList = new JsValue[] { JsNumber.Create(len) };
         var targetObj = TypedArrayCreate(_realm, (IConstructor) c, argumentList);
+        targetObj._viewedArrayBuffer.AssertNotImmutable();
 
         var mappingArgs = mapping ? new JsValue[2] : null;
         for (uint k = 0; k < len; ++k)
@@ -120,6 +122,7 @@ internal sealed partial class IntrinsicTypedArrayConstructor : Constructor
         }
 
         var newObj = TypedArrayCreate(_realm, (IConstructor) thisObject, [len]);
+        newObj._viewedArrayBuffer.AssertNotImmutable();
 
         for (var k = 0; k < len; k++)
         {

--- a/Jint/Native/TypedArray/TypedArrayConstructor.cs
+++ b/Jint/Native/TypedArray/TypedArrayConstructor.cs
@@ -102,7 +102,7 @@ public abstract partial class TypedArrayConstructor : Constructor
     /// </summary>
     internal static List<JsValue> IterableToList(Realm realm, JsValue items, ICallable? method = null)
     {
-        var iteratorRecord = items.GetIterator(realm);
+        var iteratorRecord = items.GetIterator(realm, method: method);
         var values = new List<JsValue>();
         while (iteratorRecord.TryIteratorStep(out var nextItem))
         {

--- a/Jint/Native/TypedArray/Uint8ArrayPrototype.cs
+++ b/Jint/Native/TypedArray/Uint8ArrayPrototype.cs
@@ -47,6 +47,7 @@ internal sealed partial class Uint8ArrayPrototype : Prototype
         {
             Throw.TypeError(_realm, "TypedArray is out of bounds");
         }
+        into._viewedArrayBuffer.AssertNotImmutable();
 
         var byteLength = taRecord.TypedArrayLength;
         var result = Uint8ArrayConstructor.FromBase64(_engine, s.ToString(), alphabet.ToString(), lastChunkHandling.ToString(), byteLength);
@@ -92,6 +93,7 @@ internal sealed partial class Uint8ArrayPrototype : Prototype
         {
             Throw.TypeError(_realm, "TypedArray is out of bounds");
         }
+        into._viewedArrayBuffer.AssertNotImmutable();
 
         var byteLength = taRecord.TypedArrayLength;
         var result = Uint8ArrayConstructor.FromHex(_engine, s.ToString(), byteLength);

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -232,6 +232,12 @@ public static class TypeConverter
         }
 
         input = StringPrototype.TrimEx(input);
+        if (input.Length == 0)
+        {
+            // The pre-trim IsNullOrWhiteSpace check can miss BOM and other characters
+            // that Jint's TrimEx considers whitespace per the ECMAScript spec.
+            return 0;
+        }
         firstChar = input[0];
 
         const NumberStyles NumberStyles = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign |


### PR DESCRIPTION
## Summary

Bumps the Test262 suite hash from `2b2ecead` to `673e9bac`, which brings stage-4 spec updates for the **immutable-arraybuffer** proposal and a stricter `ArrayBuffer.prototype.sliceToImmutable` algorithm. Twelve previously failing test cases now pass:

- `built-ins/ArrayBuffer/prototype/sliceToImmutable/this-shrinks.js`
- `built-ins/ArrayBuffer/prototype/sliceToImmutable/argument-coercion.js`
- `built-ins/TypedArrayConstructors/from/custom-ctor-returns-immutable-arraybuffer.js`
- `built-ins/TypedArrayConstructors/of/custom-ctor-returns-immutable-arraybuffer.js`
- `built-ins/Uint8Array/prototype/setFromBase64/throws-when-target-is-backed-by-immutable-arraybuffer.js`
- `built-ins/Uint8Array/prototype/setFromHex/throws-when-target-is-backed-by-immutable-arraybuffer.js`

## Fixes

- **`ArrayBufferPrototype.SliceToImmutable`** rewritten to the latest spec. `first`/`final` are still computed from the original `len`, but the detach check now precedes the bounds check, and a `RangeError` is thrown when the buffer has shrunk below `final` during argument coercion.
- **`TypeConverter.ToNumber(string)`** guards against empty input after `TrimEx`. The pre-trim `string.IsNullOrWhiteSpace` check misses BOM (`﻿`) and other characters that the spec-compliant `TrimEx` removes — this previously caused an `IndexOutOfRangeException` on whitespace-padded empty strings (the new `argument-coercion.js` reaches that path).
- **`Uint8Array.prototype.setFromBase64` / `setFromHex`** call `AssertNotImmutable()` on the viewed buffer before writing, per the new spec step.
- **`%TypedArray%.from` / `.of`** call `AssertNotImmutable()` on a custom constructor's result before populating it (the `write` mutability intent in `TypedArrayCreateFromConstructor`).
- **`TypedArrayConstructor.IterableToList`** now passes the already-fetched iterator method through to `GetIterator` instead of re-reading `Symbol.iterator` on the source.

## CI host crash fix

A `FinalizationRegistry` cleanup callback can throw arbitrary exceptions (e.g. `TimeoutException` when engine constraints trip), and they were escaping the GC finalizer thread and aborting the whole test process — visible on [this run](https://github.com/sebastienros/jint/actions/runs/25849551722/job/75952660586). The callback invocation is now wrapped in a swallow-all `try`/`catch`, matching the spec's intent that these callbacks run in an isolated Job.

## Test plan

- [x] Full test262 suite green: 99013 passed, 0 failed, 133 skipped.
- [x] `Jint.Tests` green (2885 passed).
- [x] `Jint.Tests.PublicInterface` green (79 passed).
- [x] `Jint.Tests.CommonScripts` green (28 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)