### PR TITLE
Switch FluentAssertions to AwesomeAssertions, update test deps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ Split into a separate file when:
 
 - **Jint.Tests/**: Main test suite using xUnit v3
   - Organized by topic (Runtime/, Parser/, Debugger/, etc.)
-  - Uses FluentAssertions for readable assertions
+  - Uses AwesomeAssertions for readable assertions
   - Embedded test scripts in Runtime/Scripts/ and Parser/Scripts/
   - Use timeout of 30 seconds when invoking test runner
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,18 +8,18 @@
     <PackageVersion Include="Acornima.Extras" Version="1.6.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.TestAdapter" Version="0.13.12" />
-    <PackageVersion Include="FluentAssertions" Version="[7.2.2]" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Flurl.Http.Signed" Version="4.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
     <PackageVersion Include="ICU4N" Version="60.1.0-alpha.439" />
     <PackageVersion Include="Jurassic" Version="3.2.9" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.78" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.84" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
     <PackageVersion Include="Verify.NUnit" Version="31.16.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="MongoDB.Bson.signed" Version="2.19.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
@@ -30,7 +30,7 @@
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="SourceMaps" Version="0.3.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.45.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
     <PackageVersion Include="Test262Harness" Version="1.0.5" />
     <PackageVersion Include="xunit.v3.mtp-off" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />

--- a/Jint.Tests.PublicInterface/FunctionToStringTest.cs
+++ b/Jint.Tests.PublicInterface/FunctionToStringTest.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace Jint.Tests.PublicInterface;
 

--- a/Jint.Tests.PublicInterface/InteropTests.Json.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.Json.cs
@@ -1,6 +1,6 @@
 using System.Dynamic;
 using System.Text;
-using FluentAssertions;
+using AwesomeAssertions;
 using Jint.Runtime.Interop;
 
 namespace Jint.Tests.PublicInterface;

--- a/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+++ b/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Acornima.Extras" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Flurl.Http.Signed" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/Jint.Tests.PublicInterface/MapTests.cs
+++ b/Jint.Tests.PublicInterface/MapTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Jint.Native;
 
 namespace Jint.Tests.Runtime;

--- a/Jint.Tests.PublicInterface/SetTests.cs
+++ b/Jint.Tests.PublicInterface/SetTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Jint.Native;
 
 namespace Jint.Tests.Runtime;

--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Acornima.Extras" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Flurl.Http.Signed" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="FluentAssertions" />
+    <Using Include="AwesomeAssertions" />
     <Using Include="Xunit" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Replace FluentAssertions 7.2.2 with the API-compatible community fork AwesomeAssertions 9.4.0 (resolves the licensing/maintenance concerns that prompted the fork; same `Should()` surface)
- Bump test/analyzer dependencies via `dotnet outdated -u`:
  - Meziantou.Analyzer 3.0.78 → 3.0.84
  - Microsoft.Extensions.DependencyInjection 10.0.7 → 10.0.8
  - Microsoft.Extensions.TimeProvider.Testing 10.5.0 → 10.6.0
  - System.Text.Json 10.0.1 → 10.0.8

## Test plan
- [x] `dotnet build --configuration Release` (0 warnings, 0 errors)
- [x] `dotnet test Jint.Tests/Jint.Tests.csproj --framework net10.0` — 2932 passed, 5 skipped
- [x] `dotnet test Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj --framework net10.0` — 79 passed
- [ ] CI: net472 + Test262 conformance

🤖 Generated with [Claude Code](https://claude.com/claude-code)