### PR TITLE
Async resume: close residual gaps across all expression types after #2469

### DIFF
--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -506,6 +506,67 @@ public class AsyncTests
     }
 
     [Fact]
+    public void ShouldNotReiterateOneShotSpreadIteratorAcrossAwaitInArrayLiteral()
+    {
+        // A custom iterator stored in `g` is drained on first pass. Without
+        // preservation, the spread re-iterates `g` on resume and gets nothing.
+        var result = EvaluateAsyncJson("""
+            function* gen() { yield "a"; yield "b"; yield "c"; }
+            const g = gen();
+            const r = [...g, await Promise.resolve("d")];
+            return { r };
+            """);
+
+        Assert.Equal("""{"r":["a","b","c","d"]}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReiterateOneShotSpreadIteratorAcrossAwaitInCallArguments()
+    {
+        var result = EvaluateAsyncJson("""
+            function* gen() { yield 1; yield 2; yield 3; }
+            const g = gen();
+            const sum = (...vals) => vals.reduce((a, b) => a + b, 0);
+            const total = sum(...g, await Promise.resolve(10));
+            return { total };
+            """);
+
+        Assert.Equal("""{"total":16}""", result);
+    }
+
+    [Fact]
+    public void ShouldPreserveTargetAcrossMultipleSuspensionsInSpreadArguments()
+    {
+        var result = EvaluateAsyncJson("""
+            function* gen() { yield "x"; yield "y"; }
+            const g = gen();
+            const a = [
+                await Promise.resolve("start"),
+                ...g,
+                await Promise.resolve("end")
+            ];
+            return { a };
+            """);
+
+        Assert.Equal("""{"a":["start","x","y","end"]}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotEvaluateLaterArgumentsAfterSuspensionInSpread()
+    {
+        // Without the IsSuspended-check-before-Add fix, `++j` would run during
+        // the suspended pass after the await sentinel is appended.
+        var result = EvaluateAsyncJson("""
+            let j = 0;
+            const arr = [1];
+            const r = [...arr, await Promise.resolve("mid"), ++j];
+            return { r, j };
+            """);
+
+        Assert.Equal("""{"r":[1,"mid",1],"j":1}""", result);
+    }
+
+    [Fact]
     public void ShouldTaskConvertedToPromiseInJS()
     {
         Engine engine = new();

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -469,6 +469,43 @@ public class AsyncTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateArrayLiteralElementsBeforeAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            let i = 0;
+            const a = [++i, ++i, await Promise.resolve(++i)];
+            return { a, i };
+            """);
+
+        Assert.Equal("""{"a":[1,2,3],"i":3}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateArrayLiteralAcrossMultipleAwaits()
+    {
+        var result = EvaluateAsyncJson("""
+            let i = 0;
+            const a = [++i, await Promise.resolve(++i), ++i, await Promise.resolve(++i)];
+            return { a, i };
+            """);
+
+        Assert.Equal("""{"a":[1,2,3,4],"i":4}""", result);
+    }
+
+    [Fact]
+    public void ShouldClearArrayLiteralSuspendDataBetweenCalls()
+    {
+        var result = EvaluateAsyncJson("""
+            let i = 0;
+            const first = [++i, await Promise.resolve(10)];
+            const second = [++i, await Promise.resolve(20)];
+            return { first, second, i };
+            """);
+
+        Assert.Equal("""{"first":[1,10],"second":[2,20],"i":2}""", result);
+    }
+
+    [Fact]
     public void ShouldTaskConvertedToPromiseInJS()
     {
         Engine engine = new();

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -608,6 +608,48 @@ public class AsyncTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateObjectLiteralPropertiesBeforeAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            let i = 0;
+            const o = { a: ++i, b: ++i, c: await Promise.resolve(++i) };
+            return { o, i };
+            """);
+
+        Assert.Equal("""{"o":{"a":1,"b":2,"c":3},"i":3}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateObjectLiteralPropertiesAcrossMultipleAwaits()
+    {
+        var result = EvaluateAsyncJson("""
+            let i = 0;
+            const o = {
+                a: ++i,
+                b: await Promise.resolve(++i),
+                c: ++i,
+                d: await Promise.resolve(++i)
+            };
+            return { o, i };
+            """);
+
+        Assert.Equal("""{"o":{"a":1,"b":2,"c":3,"d":4},"i":4}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateComputedKeyAcrossAwaitInObjectLiteral()
+    {
+        var result = EvaluateAsyncJson("""
+            let i = 0;
+            const k = () => "k" + (++i);
+            const o = { [k()]: 1, value: await Promise.resolve("done") };
+            return { o, i };
+            """);
+
+        Assert.Equal("""{"o":{"k1":1,"value":"done"},"i":1}""", result);
+    }
+
+    [Fact]
     public void ShouldTaskConvertedToPromiseInJS()
     {
         Engine engine = new();

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -580,6 +580,34 @@ public class AsyncTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateMemberExpressionObjectAcrossPropertyAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            let calls = 0;
+            const obj = { val: 1 };
+            const get = () => (calls++, obj);
+            const v = get()[await Promise.resolve("val")];
+            return { v, calls };
+            """);
+
+        Assert.Equal("""{"v":1,"calls":1}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateMemberExpressionObjectAcrossAwaitInChain()
+    {
+        var result = EvaluateAsyncJson("""
+            let calls = 0;
+            const obj = { foo: { bar: 42 } };
+            const get = () => (calls++, obj);
+            const v = get().foo[await Promise.resolve("bar")];
+            return { v, calls };
+            """);
+
+        Assert.Equal("""{"v":42,"calls":1}""", result);
+    }
+
+    [Fact]
     public void ShouldTaskConvertedToPromiseInJS()
     {
         Engine engine = new();

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -567,6 +567,19 @@ public class AsyncTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateNullishCoalescingLeftOperandAfterAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            let d = 0;
+            const getNullish = () => (++d, null);
+            const v = getNullish() ?? (await Promise.resolve("filled"));
+            return { d, v };
+            """);
+
+        Assert.Equal("""{"d":1,"v":"filled"}""", result);
+    }
+
+    [Fact]
     public void ShouldTaskConvertedToPromiseInJS()
     {
         Engine engine = new();

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -650,6 +650,45 @@ public class AsyncTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateTemplateLiteralInterpolationsBeforeAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            let i = 0;
+            const s = `${++i}-${await Promise.resolve("x")}-${++i}`;
+            return { s, i };
+            """);
+
+        Assert.Equal("""{"s":"1-x-2","i":2}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotEvaluateLaterInterpolationsAfterSuspensionInTemplateLiteral()
+    {
+        // Without the IsSuspended-break inside the interpolation loop, `++j` would
+        // also run during the suspended pass, doubling its side effect on resume.
+        var result = EvaluateAsyncJson("""
+            let j = 0;
+            const s = `${await Promise.resolve("mid")}-${++j}`;
+            return { s, j };
+            """);
+
+        Assert.Equal("""{"s":"mid-1","j":1}""", result);
+    }
+
+    [Fact]
+    public void ShouldNotReevaluateTaggedTemplateInterpolationsBeforeAwait()
+    {
+        var result = EvaluateAsyncJson("""
+            let i = 0;
+            const tag = (strings, ...values) => values.join("|");
+            const s = tag`${++i}-${await Promise.resolve("x")}-${++i}`;
+            return { s, i };
+            """);
+
+        Assert.Equal("""{"s":"1|x|2","i":2}""", result);
+    }
+
+    [Fact]
     public void ShouldTaskConvertedToPromiseInJS()
     {
         Engine engine = new();

--- a/Jint.Tests/Runtime/GeneratorTests.cs
+++ b/Jint.Tests/Runtime/GeneratorTests.cs
@@ -515,6 +515,26 @@ public class GeneratorTests
     }
 
     [Fact]
+    public void ShouldNotReiterateOneShotSpreadIteratorAcrossYield()
+    {
+        const string Script = """
+            (function () {
+                function* inner() { yield "a"; yield "b"; yield "c"; }
+                function* outer() {
+                    const g = inner();
+                    const r = [...g, yield "wait"];
+                    return r;
+                }
+                const o = outer();
+                o.next();
+                return JSON.stringify(o.next("d").value);
+            })()
+            """;
+
+        Assert.Equal("""["a","b","c","d"]""", _engine.Evaluate(Script));
+    }
+
+    [Fact]
     public void ShouldResumeYieldInsideCatchInAsyncGenerator()
     {
         // Async generators share ISuspendable.Data with sync generators / async

--- a/Jint.Tests/Runtime/GeneratorTests.cs
+++ b/Jint.Tests/Runtime/GeneratorTests.cs
@@ -535,6 +535,25 @@ public class GeneratorTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateTemplateLiteralInterpolationsBeforeYield()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    let i = 0;
+                    const s = `${++i}-${yield "wait"}-${++i}`;
+                    return [s, i];
+                }
+                const g = gen();
+                g.next();
+                return JSON.stringify(g.next("X").value);
+            })()
+            """;
+
+        Assert.Equal("""["1-X-2",2]""", _engine.Evaluate(Script));
+    }
+
+    [Fact]
     public void ShouldNotReevaluateObjectLiteralPropertiesBeforeYield()
     {
         const string Script = """

--- a/Jint.Tests/Runtime/GeneratorTests.cs
+++ b/Jint.Tests/Runtime/GeneratorTests.cs
@@ -535,6 +535,27 @@ public class GeneratorTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateMemberObjectAcrossPropertyYield()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    let calls = 0;
+                    const obj = { val: 1 };
+                    const get = () => (calls++, obj);
+                    const v = get()[yield "wait"];
+                    return [v, calls];
+                }
+                const g = gen();
+                g.next();
+                return JSON.stringify(g.next("val").value);
+            })()
+            """;
+
+        Assert.Equal("[1,1]", _engine.Evaluate(Script));
+    }
+
+    [Fact]
     public void ShouldNotReevaluateNullishCoalescingLeftOperandAfterYield()
     {
         const string Script = """

--- a/Jint.Tests/Runtime/GeneratorTests.cs
+++ b/Jint.Tests/Runtime/GeneratorTests.cs
@@ -535,6 +535,25 @@ public class GeneratorTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateObjectLiteralPropertiesBeforeYield()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    let i = 0;
+                    const o = { a: ++i, b: ++i, c: yield ++i };
+                    return [o, i];
+                }
+                const g = gen();
+                g.next();
+                return JSON.stringify(g.next("done").value);
+            })()
+            """;
+
+        Assert.Equal("""[{"a":1,"b":2,"c":"done"},3]""", _engine.Evaluate(Script));
+    }
+
+    [Fact]
     public void ShouldNotReevaluateMemberObjectAcrossPropertyYield()
     {
         const string Script = """

--- a/Jint.Tests/Runtime/GeneratorTests.cs
+++ b/Jint.Tests/Runtime/GeneratorTests.cs
@@ -535,6 +535,26 @@ public class GeneratorTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateNullishCoalescingLeftOperandAfterYield()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    let d = 0;
+                    const getNullish = () => (++d, null);
+                    const v = getNullish() ?? (yield "wait");
+                    return [d, v];
+                }
+                const g = gen();
+                g.next();
+                return JSON.stringify(g.next("done").value);
+            })()
+            """;
+
+        Assert.Equal("""[1,"done"]""", _engine.Evaluate(Script));
+    }
+
+    [Fact]
     public void ShouldResumeYieldInsideCatchInAsyncGenerator()
     {
         // Async generators share ISuspendable.Data with sync generators / async

--- a/Jint.Tests/Runtime/GeneratorTests.cs
+++ b/Jint.Tests/Runtime/GeneratorTests.cs
@@ -496,6 +496,25 @@ public class GeneratorTests
     }
 
     [Fact]
+    public void ShouldNotReevaluateArrayLiteralElementsBeforeYield()
+    {
+        const string Script = """
+            (function () {
+                function* gen() {
+                    let i = 0;
+                    const a = [++i, ++i, yield ++i];
+                    return [a, i];
+                }
+                const g = gen();
+                g.next();
+                return JSON.stringify(g.next("done").value);
+            })()
+            """;
+
+        Assert.Equal("""[[1,2,"done"],3]""", _engine.Evaluate(Script));
+    }
+
+    [Fact]
     public void ShouldResumeYieldInsideCatchInAsyncGenerator()
     {
         // Async generators share ISuspendable.Data with sync generators / async

--- a/Jint.Tests/Runtime/OperatorOverloadingTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadingTests.cs
@@ -368,4 +368,28 @@ public class OperatorOverloadingTests
         Assert.Equal("(1, 2)", engine.Evaluate("new String(v1)").As<StringInstance>().StringData.ToString());
         Assert.Equal("### (1, 2) ###", engine.Evaluate("'### ' + v1 + ' ###'"));
     }
+
+    [Fact]
+    public void ShouldNotDoubleEvaluateRhsOnSuspensionWithOperatorOverloading()
+    {
+        var sideEffectCount = 0;
+        _engine.SetValue("incrementCounter", new Func<int>(() => System.Threading.Interlocked.Increment(ref sideEffectCount)));
+
+        var result = _engine.Evaluate("""
+            (async () => {
+                let v = new Vector2(1, 2);
+                v += await Promise.resolve(new Vector2(incrementCounter(), 10));
+                return [v.X, v.Y, incrementCounter];
+            })().then(r => r.slice(0, 2))
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(1));
+
+        // The RHS expression (Promise.resolve(new Vector2(++counter, 10))) must run
+        // exactly once even though _right.GetValue is structurally called twice
+        // (once in EvaluateOperatorOverloading, once in the operator switch).
+        Assert.Equal(1, sideEffectCount);
+
+        var arr = result.As<Native.JsArray>();
+        Assert.Equal(2.0, arr.Get(0).AsNumber());   // v.X = 1 + 1 = 2
+        Assert.Equal(12.0, arr.Get(1).AsNumber());  // v.Y = 2 + 10 = 12
+    }
 }

--- a/Jint/Runtime/Interpreter/Expressions/ExpressionCache.cs
+++ b/Jint/Runtime/Interpreter/Expressions/ExpressionCache.cs
@@ -70,8 +70,7 @@ internal sealed class ExpressionCache
 
         if (HasSpreads)
         {
-            var args = new List<JsValue>(_expressions.Length);
-            BuildArgumentsWithSpreads(context, args);
+            var args = ArgumentListEvaluationWithSpreadsResumable(context, key);
             return args.ToArray();
         }
 
@@ -184,19 +183,31 @@ internal sealed class ExpressionCache
         return args.ToArray();
     }
 
-    internal void BuildArgumentsWithSpreads(EvaluationContext context, List<JsValue> target)
+    /// <summary>
+    /// Iterates argument expressions, expanding spreads into <paramref name="target"/>.
+    /// Returns the next expression index to resume at if suspension occurs; otherwise
+    /// <c>_expressions.Length</c>. Suspension inside iterator <c>.next()</c> calls is
+    /// not possible (spread protocol is synchronous); suspension can only happen at:
+    /// - The <c>_argument</c> of a spread (e.g. <c>...(await fn())</c>) — captured before iteration starts.
+    /// - A non-spread element's <c>GetValue</c> — captured before <c>target.Add</c>.
+    /// </summary>
+    internal int BuildArgumentsWithSpreads(EvaluationContext context, List<JsValue> target, int startIndex = 0)
     {
-        foreach (var expression in _expressions)
+        var expressions = _expressions;
+        int i = startIndex;
+        for (; (uint) i < (uint) expressions.Length; i++)
         {
+            var expression = expressions[i];
             if (expression is JintSpreadExpression jse)
             {
                 jse.GetValueAndCheckIterator(context, out var objectInstance, out var iterator);
 
                 // If generator suspended during spread expression evaluation, stop processing
-                // The iterator will be null because we haven't started iteration yet
+                // The iterator will be null because we haven't started iteration yet.
+                // Resume re-evaluates the spread (the await inside is cached).
                 if (context.IsSuspended())
                 {
-                    return;
+                    return i;
                 }
 
                 // optimize for array unless someone has touched the iterator
@@ -217,15 +228,62 @@ internal sealed class ExpressionCache
             }
             else
             {
-                target.Add(GetValue(context, expression)!);
+                var value = GetValue(context, expression)!;
 
-                // Check for generator suspension after each expression evaluation
+                // Check for generator suspension BEFORE appending — so resume doesn't see
+                // a leftover sentinel value at this index.
                 if (context.IsSuspended())
                 {
-                    return;
+                    return i;
                 }
+
+                target.Add(value);
             }
         }
+
+        return i;
+    }
+
+    /// <summary>
+    /// Resume-aware variant of <see cref="BuildArgumentsWithSpreads"/> for use by callers
+    /// that build an argument list with possible spread elements. The buffer list and
+    /// next-expression index are preserved across suspension in
+    /// <see cref="SpreadArgumentsSuspendData"/> keyed by <paramref name="key"/>.
+    /// </summary>
+    internal List<JsValue> ArgumentListEvaluationWithSpreadsResumable(EvaluationContext context, object key)
+    {
+        var suspendable = context.Engine.ExecutionContext.Suspendable;
+        List<JsValue> target;
+        int startIndex;
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(key, out SpreadArgumentsSuspendData? suspendData))
+        {
+            target = suspendData!.Target;
+            startIndex = suspendData.NextExpressionIndex;
+        }
+        else
+        {
+            target = new List<JsValue>(_expressions.Length);
+            startIndex = 0;
+        }
+
+        var nextIndex = BuildArgumentsWithSpreads(context, target, startIndex);
+
+        if (context.IsSuspended())
+        {
+            if (suspendable is not null)
+            {
+                var data = suspendable.Data.GetOrCreate<SpreadArgumentsSuspendData>(key);
+                data.Target = target;
+                data.NextExpressionIndex = nextIndex;
+            }
+        }
+        else
+        {
+            suspendable?.Data.Clear(key);
+        }
+
+        return target;
     }
 
     private sealed class ArraySpreadProtocol : IteratorProtocol

--- a/Jint/Runtime/Interpreter/Expressions/ExpressionCache.cs
+++ b/Jint/Runtime/Interpreter/Expressions/ExpressionCache.cs
@@ -80,7 +80,7 @@ internal sealed class ExpressionCache
         JsValue[] arguments;
         int startIndex;
         if (suspendable is { IsResuming: true }
-            && suspendable.Data.TryGet(key, out CallArgumentsSuspendData? suspendData))
+            && suspendable.Data.TryGet(key, out ExpressionBufferSuspendData? suspendData))
         {
             // Resume: reuse the partially-filled buffer so already-evaluated
             // arguments (which may have observable side effects) are not re-evaluated.
@@ -100,7 +100,7 @@ internal sealed class ExpressionCache
             // Buffer is kept alive in suspend data; caller must NOT return it to the pool.
             if (suspendable is not null)
             {
-                var data = suspendable.Data.GetOrCreate<CallArgumentsSuspendData>(key);
+                var data = suspendable.Data.GetOrCreate<ExpressionBufferSuspendData>(key);
                 data.Buffer = arguments;
                 data.NextIndex = nextIndex;
             }

--- a/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
@@ -60,10 +60,10 @@ internal sealed class JintArrayExpression : JintExpression
             return new JsArray(engine, values);
         }
 
-        var array = new List<JsValue>();
-        _arguments.BuildArgumentsWithSpreads(context, array);
+        var array = _arguments.ArgumentListEvaluationWithSpreadsResumable(context, this);
 
-        // If generator suspended during argument evaluation, return undefined
+        // If generator suspended during argument evaluation, the partial target
+        // is preserved in suspend data; on resume we continue from there.
         if (context.IsSuspended())
         {
             return JsValue.Undefined;

--- a/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintArrayExpression.cs
@@ -24,16 +24,39 @@ internal sealed class JintArrayExpression : JintExpression
         var engine = context.Engine;
         if (!_arguments.HasSpreads)
         {
-            var values = new JsValue[expressions.Length];
-            _arguments.BuildArguments(context, values);
+            var suspendable = engine.ExecutionContext.Suspendable;
+            JsValue[] values;
+            int startIndex;
+            if (suspendable is { IsResuming: true }
+                && suspendable.Data.TryGet(this, out ExpressionBufferSuspendData? suspendData))
+            {
+                // Resume: reuse the partially-filled buffer so already-evaluated
+                // elements (which may have observable side effects) are not re-evaluated.
+                values = suspendData!.Buffer;
+                startIndex = suspendData.NextIndex;
+            }
+            else
+            {
+                values = new JsValue[expressions.Length];
+                startIndex = 0;
+            }
 
-            // If generator suspended during argument evaluation, return undefined
-            // The expression will be re-evaluated on resume
+            var nextIndex = _arguments.BuildArguments(context, values, startIndex);
+
+            // If generator suspended during element evaluation, stow the partial
+            // buffer in suspend data so resume continues from the right index.
             if (context.IsSuspended())
             {
+                if (suspendable is not null)
+                {
+                    var data = suspendable.Data.GetOrCreate<ExpressionBufferSuspendData>(this);
+                    data.Buffer = values;
+                    data.NextIndex = nextIndex;
+                }
                 return JsValue.Undefined;
             }
 
+            suspendable?.Data.Clear(this);
             return new JsArray(engine, values);
         }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -86,6 +86,14 @@ internal sealed class JintAssignmentExpression : JintExpression
         if (context.OperatorOverloadingAllowed)
         {
             newLeftValue = EvaluateOperatorOverloading(context, originalLeftValue, newLeftValue, ref handledByOverload);
+
+            // RHS suspended during the overloading attempt; save LHS state and bail
+            // so the operator-switch below doesn't double-evaluate _right.
+            if (context.IsSuspended())
+            {
+                HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
+                return newLeftValue!;
+            }
         }
 
         var wasMutatedInPlace = false;
@@ -472,6 +480,17 @@ internal sealed class JintAssignmentExpression : JintExpression
         if (operatorClrName != null)
         {
             var rval = _right.GetValue(context);
+
+            // If RHS suspended, return immediately so the caller can detect
+            // IsSuspended and save state. Without this, the operator-switch
+            // below would call _right.GetValue again, re-running side effects
+            // inside the await argument and registering a second pair of
+            // promise handlers.
+            if (context.IsSuspended())
+            {
+                return rval;
+            }
+
             if (JintBinaryExpression.TryOperatorOverloading(context, originalLeftValue, rval, operatorClrName, out var result))
             {
                 newLeftValue = JsValue.FromObject(context.Engine, result);

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -82,61 +82,102 @@ internal sealed class JintMemberExpression : JintExpression
 
         var engine = context.Engine;
         var strict = StrictModeScope.IsStrictModeCode;
-        if (_objectExpression is JintIdentifierExpression identifierExpression)
-        {
-            var identifier = identifierExpression.Identifier;
-            baseReferenceName = identifier.Key.Name;
-            var env = engine.ExecutionContext.LexicalEnvironment;
-            JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(
-                env,
-                identifier,
-                strict,
-                out _,
-                out baseValue);
-        }
-        else if (_objectExpression is JintThisExpression thisExpression)
-        {
-            baseValue = (JsValue?) thisExpression.GetValue(context);
-        }
-        else if (_objectExpression is JintSuperExpression)
-        {
-            var env = (FunctionEnvironment) engine.ExecutionContext.GetThisEnvironment();
-            actualThis = env.GetThisBinding();
-            baseValue = env.GetSuperBase();
-        }
+        var suspendable = engine.ExecutionContext.Suspendable;
 
-        if (baseValue is null)
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out MemberExpressionSuspendData? suspendData))
         {
-            // fast checks failed
-            var baseReference = _objectExpression.Evaluate(context);
-            if (ReferenceEquals(JsValue.Undefined, baseReference))
+            // Resume: reuse the previously-resolved object state so a side-effectful
+            // object expression (e.g. getObj()[await x]) doesn't run twice.
+            baseValue = suspendData!.BaseValue;
+            baseReferenceName = suspendData.BaseReferenceName;
+            actualThis = suspendData.ActualThis;
+        }
+        else
+        {
+            if (_objectExpression is JintIdentifierExpression identifierExpression)
+            {
+                var identifier = identifierExpression.Identifier;
+                baseReferenceName = identifier.Key.Name;
+                var env = engine.ExecutionContext.LexicalEnvironment;
+                JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(
+                    env,
+                    identifier,
+                    strict,
+                    out _,
+                    out baseValue);
+            }
+            else if (_objectExpression is JintThisExpression thisExpression)
+            {
+                baseValue = (JsValue?) thisExpression.GetValue(context);
+            }
+            else if (_objectExpression is JintSuperExpression)
+            {
+                var env = (FunctionEnvironment) engine.ExecutionContext.GetThisEnvironment();
+                actualThis = env.GetThisBinding();
+                baseValue = env.GetSuperBase();
+            }
+
+            if (baseValue is null)
+            {
+                // fast checks failed
+                var baseReference = _objectExpression.Evaluate(context);
+                if (context.IsSuspended())
+                {
+                    // The object-side expression itself suspended (e.g. it's a call
+                    // expression with an awaiting argument). Do NOT save suspend data:
+                    // on resume we re-evaluate _objectExpression so it produces the
+                    // real result via its own resume mechanism. Returning a sentinel
+                    // Reference here matches previous behavior; the caller's IsSuspended
+                    // check bails before use.
+                    return context.Engine._referencePool.Rent(JsValue.Undefined, JsValue.Undefined, StrictModeScope.IsStrictModeCode, thisValue: null);
+                }
+                if (ReferenceEquals(JsValue.Undefined, baseReference))
+                {
+                    return JsValue.Undefined;
+                }
+                if (baseReference is Reference reference)
+                {
+                    baseReferenceName = reference.ReferencedName;
+                    baseValue = engine.GetValue(reference, returnReferenceToPool: true);
+                }
+                else
+                {
+                    baseValue = engine.GetValue(baseReference, returnReferenceToPool: false);
+                }
+            }
+
+            if (baseValue.IsNullOrUndefined() && (_memberExpression.Optional || _objectExpression._expression.IsOptional()))
             {
                 return JsValue.Undefined;
             }
-            if (baseReference is Reference reference)
-            {
-                baseReferenceName = reference.ReferencedName;
-                baseValue = engine.GetValue(reference, returnReferenceToPool: true);
-            }
-            else
-            {
-                baseValue = engine.GetValue(baseReference, returnReferenceToPool: false);
-            }
-        }
-
-        if (baseValue.IsNullOrUndefined() && (_memberExpression.Optional || _objectExpression._expression.IsOptional()))
-        {
-            return JsValue.Undefined;
         }
 
         var property = _determinedProperty ?? _propertyExpression!.GetValue(context);
 
-        if (property.IsPrivateName())
+        if (context.IsSuspended())
         {
-            return MakePrivateReference(engine, baseValue, property);
+            // Property-side suspended. Save the resolved object state so resume
+            // doesn't re-evaluate the (potentially side-effectful) object side.
+            if (suspendable is not null)
+            {
+                var data = suspendable.Data.GetOrCreate<MemberExpressionSuspendData>(this);
+                data.BaseValue = baseValue!;
+                data.BaseReferenceName = baseReferenceName;
+                data.ActualThis = actualThis;
+            }
+        }
+        else
+        {
+            suspendable?.Data.Clear(this);
         }
 
-        return context.Engine._referencePool.Rent(baseValue, property, StrictModeScope.IsStrictModeCode, thisValue: actualThis);
+        if (property.IsPrivateName())
+        {
+            return MakePrivateReference(engine, baseValue!, property);
+        }
+
+        return context.Engine._referencePool.Rent(baseValue!, property, StrictModeScope.IsStrictModeCode, thisValue: actualThis);
     }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -130,9 +130,26 @@ internal sealed class JintObjectExpression : JintExpression
     private JsValue BuildObjectFast(EvaluationContext context)
     {
         var engine = context.Engine;
-        var obj = new JsObject(engine);
-        var properties = new PropertyDictionary(_properties.Length, checkExistingKeys: true);
-        for (var i = 0; i < _properties.Length; i++)
+        var suspendable = engine.ExecutionContext.Suspendable;
+
+        ObjectInstance obj;
+        PropertyDictionary properties;
+        int startIndex;
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out ObjectExpressionSuspendData? suspendData))
+        {
+            obj = suspendData!.Target!;
+            properties = suspendData.FastProperties!;
+            startIndex = suspendData.NextIndex;
+        }
+        else
+        {
+            obj = new JsObject(engine);
+            properties = new PropertyDictionary(_properties.Length, checkExistingKeys: true);
+            startIndex = 0;
+        }
+
+        for (var i = startIndex; i < _properties.Length; i++)
         {
             var objectProperty = _properties[i];
             var propValue = _valueExpressions.GetValue(context, i);
@@ -140,6 +157,13 @@ internal sealed class JintObjectExpression : JintExpression
             // Check for generator suspension after each property evaluation
             if (context.IsSuspended())
             {
+                if (suspendable is not null)
+                {
+                    var data = suspendable.Data.GetOrCreate<ObjectExpressionSuspendData>(this);
+                    data.Target = obj;
+                    data.FastProperties = properties;
+                    data.NextIndex = i;
+                }
                 return JsValue.Undefined;
             }
 
@@ -147,6 +171,7 @@ internal sealed class JintObjectExpression : JintExpression
         }
 
         obj.SetProperties(properties);
+        suspendable?.Data.Clear(this);
         return obj;
     }
 
@@ -156,9 +181,23 @@ internal sealed class JintObjectExpression : JintExpression
     private object BuildObjectNormal(EvaluationContext context)
     {
         var engine = context.Engine;
-        var obj = engine.Realm.Intrinsics.Object.Construct(_properties.Length);
+        var suspendable = engine.ExecutionContext.Suspendable;
 
-        for (var i = 0; i < _properties.Length; i++)
+        ObjectInstance obj;
+        int startIndex;
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out ObjectExpressionSuspendData? suspendData))
+        {
+            obj = suspendData!.Target!;
+            startIndex = suspendData.NextIndex;
+        }
+        else
+        {
+            obj = engine.Realm.Intrinsics.Object.Construct(_properties.Length);
+            startIndex = 0;
+        }
+
+        for (var i = startIndex; i < _properties.Length; i++)
         {
             var objectProperty = _properties[i];
 
@@ -170,6 +209,7 @@ internal sealed class JintObjectExpression : JintExpression
                 // Check for generator suspension
                 if (context.IsSuspended())
                 {
+                    SaveObjectExpressionSuspendState(suspendable, obj, i);
                     return JsValue.Undefined;
                 }
 
@@ -201,6 +241,7 @@ internal sealed class JintObjectExpression : JintExpression
                 // Check for generator suspension after evaluating computed property key
                 if (context.IsSuspended())
                 {
+                    SaveObjectExpressionSuspendState(suspendable, obj, i);
                     return value;
                 }
 
@@ -218,6 +259,7 @@ internal sealed class JintObjectExpression : JintExpression
                 // Check for generator suspension
                 if (context.IsSuspended())
                 {
+                    SaveObjectExpressionSuspendState(suspendable, obj, i);
                     return JsValue.Undefined;
                 }
 
@@ -260,7 +302,18 @@ internal sealed class JintObjectExpression : JintExpression
             }
         }
 
+        suspendable?.Data.Clear(this);
         return obj;
+    }
+
+    private void SaveObjectExpressionSuspendState(ISuspendable? suspendable, ObjectInstance obj, int nextIndex)
+    {
+        if (suspendable is not null)
+        {
+            var data = suspendable.Data.GetOrCreate<ObjectExpressionSuspendData>(this);
+            data.Target = obj;
+            data.NextIndex = nextIndex;
+        }
     }
 
     internal sealed class JintEmptyObjectExpression : JintExpression

--- a/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
@@ -20,33 +20,72 @@ internal sealed class JintTaggedTemplateExpression : JintExpression
     protected override object EvaluateInternal(EvaluationContext context)
     {
         var engine = context.Engine;
-
-        var identifier = _tagIdentifier.Evaluate(context);
-        var tagger = engine.GetValue(identifier) as ICallable;
-        if (tagger is null)
-        {
-            Throw.TypeError(engine.Realm, "Argument must be callable");
-        }
-
+        var suspendable = engine.ExecutionContext.Suspendable;
         ref readonly var expressions = ref _quasi._expressions;
 
-        var args = engine._jsValueArrayPool.RentArray(expressions.Length + 1);
+        ICallable tagger;
+        JsValue thisObject;
+        JsValue[] args;
+        int startIndex;
 
-        var template = GetTemplateObject(context);
-        args[0] = template;
-
-        for (var i = 0; i < expressions.Length; ++i)
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out TaggedTemplateSuspendData? suspendData))
         {
-            args[i + 1] = expressions[i].GetValue(context);
+            tagger = suspendData!.Tagger;
+            thisObject = suspendData.ThisObject;
+            args = suspendData.Args;
+            startIndex = suspendData.NextExpressionIndex;
+        }
+        else
+        {
+            var identifier = _tagIdentifier.Evaluate(context);
+            if (context.IsSuspended())
+            {
+                // _tagIdentifier (e.g. a member expression) suspended; that expression
+                // owns its own resume handling. Don't proceed with sentinel data.
+                return JsValue.Undefined;
+            }
+
+            var taggerCandidate = engine.GetValue(identifier) as ICallable;
+            if (taggerCandidate is null)
+            {
+                Throw.TypeError(engine.Realm, "Argument must be callable");
+            }
+            tagger = taggerCandidate;
+
+            thisObject = identifier is Reference reference && reference.IsPropertyReference
+                ? reference.Base
+                : JsValue.Undefined;
+
+            args = engine._jsValueArrayPool.RentArray(expressions.Length + 1);
+            args[0] = GetTemplateObject(context);
+            startIndex = 0;
         }
 
-        var thisObject = identifier is Reference reference && reference.IsPropertyReference
-            ? reference.Base
-            : JsValue.Undefined;
+        for (var i = startIndex; i < expressions.Length; ++i)
+        {
+            args[i + 1] = expressions[i].GetValue(context);
+
+            // Without this break, side effects in interpolations after a suspended
+            // one would continue to run during the suspended pass.
+            if (context.IsSuspended())
+            {
+                if (suspendable is not null)
+                {
+                    var data = suspendable.Data.GetOrCreate<TaggedTemplateSuspendData>(this);
+                    data.Tagger = tagger;
+                    data.ThisObject = thisObject;
+                    data.Args = args;
+                    data.NextExpressionIndex = i;
+                }
+                return JsValue.Undefined;
+            }
+        }
 
         var result = tagger.Call(thisObject, args);
 
         engine._jsValueArrayPool.ReturnArray(args);
+        suspendable?.Data.Clear(this);
 
         return result;
     }

--- a/Jint/Runtime/Interpreter/Expressions/JintTemplateLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTemplateLiteralExpression.cs
@@ -21,19 +21,53 @@ internal sealed class JintTemplateLiteralExpression : JintExpression
 
     protected override object EvaluateInternal(EvaluationContext context)
     {
+        var suspendable = context.Engine.ExecutionContext.Suspendable;
+
         using var sb = new ValueStringBuilder();
         ref readonly var elements = ref _templateLiteralExpression.Quasis;
-        for (var i = 0; i < elements.Count; i++)
+
+        int startIndex = 0;
+        bool resumeMidIteration = false;
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out TemplateLiteralSuspendData? suspendData))
         {
-            var quasi = elements[i];
-            sb.Append(quasi.Value.Cooked);
+            // The saved accumulator already includes the quasi at startIndex (we
+            // appended it before evaluating the interpolation that suspended).
+            sb.Append(suspendData!.Accumulator.ToString());
+            startIndex = suspendData.NextExpressionIndex;
+            resumeMidIteration = true;
+        }
+
+        for (var i = startIndex; i < elements.Count; i++)
+        {
+            // Skip the quasi append for the resume iteration — it's already in sb.
+            if (!(i == startIndex && resumeMidIteration))
+            {
+                sb.Append(elements[i].Value.Cooked);
+            }
+
             if (i < _expressions.Length)
             {
                 var value = _expressions[i].GetValue(context);
+
+                // Without this break, side effects in interpolations after a suspended
+                // one would continue to run during the suspended pass.
+                if (context.IsSuspended())
+                {
+                    if (suspendable is not null)
+                    {
+                        var data = suspendable.Data.GetOrCreate<TemplateLiteralSuspendData>(this);
+                        data.Accumulator = new StringBuilder(sb.ToString());
+                        data.NextExpressionIndex = i;
+                    }
+                    return JsString.Empty;
+                }
+
                 sb.Append(TypeConverter.ToString(value));
             }
         }
 
+        suspendable?.Data.Clear(this);
         return JsString.Create(sb.ToString());
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/NullishCoalescingExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/NullishCoalescingExpression.cs
@@ -39,16 +39,48 @@ internal sealed class NullishCoalescingExpression : JintExpression
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private JsValue EvaluateConstantOrExpression(EvaluationContext context)
     {
-        var left = _left.GetValue(context);
-
-        // Check for generator suspension after evaluating left operand
-        if (context.IsSuspended())
+        JsValue left;
+        var suspendable = context.Engine?.ExecutionContext.Suspendable;
+        if (suspendable is { IsResuming: true }
+            && suspendable.Data.TryGet(this, out LeftOperandSuspendData? suspendData))
         {
+            left = suspendData!.LeftValue;
+        }
+        else
+        {
+            left = _left.GetValue(context);
+
+            // Check for generator suspension after evaluating left operand
+            if (context.IsSuspended())
+            {
+                return left;
+            }
+        }
+
+        if (!left.IsNullOrUndefined())
+        {
+            suspendable?.Data.Clear(this);
             return left;
         }
 
-        return !left.IsNullOrUndefined()
-            ? left
-            : _constant ?? _right!.GetValue(context);
+        if (_constant is not null)
+        {
+            suspendable?.Data.Clear(this);
+            return _constant;
+        }
+
+        var right = _right!.GetValue(context);
+        if (context.IsSuspended())
+        {
+            if (suspendable is not null)
+            {
+                suspendable.Data.GetOrCreate<LeftOperandSuspendData>(this).LeftValue = left;
+            }
+
+            return right;
+        }
+
+        suspendable?.Data.Clear(this);
+        return right;
     }
 }

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -163,6 +163,21 @@ internal sealed class SpreadArgumentsSuspendData : SuspendData
 }
 
 /// <summary>
+/// Stores the resolved object-side state of a member expression (e.g.
+/// <c>getObj()[await x]</c>) so that, when the property side suspends, the
+/// object expression — which may have observable side effects — is not
+/// re-evaluated on resume.
+/// </summary>
+internal sealed class MemberExpressionSuspendData : SuspendData
+{
+    public JsValue BaseValue { get; set; } = JsValue.Undefined;
+
+    public object? BaseReferenceName { get; set; }
+
+    public JsValue? ActualThis { get; set; }
+}
+
+/// <summary>
 /// Stores the state of a for-await-of loop when an async function awaits inside it.
 /// </summary>
 internal sealed class ForAwaitSuspendData : SuspendData

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -178,6 +178,25 @@ internal sealed class MemberExpressionSuspendData : SuspendData
 }
 
 /// <summary>
+/// Stores the partially-built object and resume index for an object literal
+/// (e.g. <c>{ a: ++i, b: await x, c: ++j }</c>) when evaluation suspends.
+/// Without preservation, the leading properties would re-evaluate on resume,
+/// doubling their side effects.
+/// </summary>
+internal sealed class ObjectExpressionSuspendData : SuspendData
+{
+    public ObjectInstance? Target { get; set; }
+
+    /// <summary>
+    /// Used by the fast-path builder, which accumulates into a separate
+    /// PropertyDictionary that's installed on Target at the end.
+    /// </summary>
+    public PropertyDictionary? FastProperties { get; set; }
+
+    public int NextIndex { get; set; }
+}
+
+/// <summary>
 /// Stores the state of a for-await-of loop when an async function awaits inside it.
 /// </summary>
 internal sealed class ForAwaitSuspendData : SuspendData

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -150,6 +150,19 @@ internal sealed class ExpressionBufferSuspendData : SuspendData
 }
 
 /// <summary>
+/// Stores the partial target list and next expression index for an argument
+/// list that contains spread elements (call/new/array-literal). Without
+/// preservation, one-shot iterators (e.g. generators) would be re-iterated
+/// on resume and yield empty — producing the wrong result.
+/// </summary>
+internal sealed class SpreadArgumentsSuspendData : SuspendData
+{
+    public List<JsValue> Target { get; set; } = new();
+
+    public int NextExpressionIndex { get; set; }
+}
+
+/// <summary>
 /// Stores the state of a for-await-of loop when an async function awaits inside it.
 /// </summary>
 internal sealed class ForAwaitSuspendData : SuspendData

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -137,12 +137,12 @@ internal sealed class AssignmentSuspendData : SuspendData
 }
 
 /// <summary>
-/// Stores the in-progress argument buffer and resume index for a call/new
-/// expression when evaluation suspends inside one of the arguments. Reused on
-/// resume so already-evaluated arguments (which may have observable side
-/// effects) are not re-evaluated.
+/// Stores an in-progress JsValue buffer and the next index to resume at when
+/// evaluation of a sequence of sibling expressions (call/new arguments, array
+/// literal elements) suspends. Reused on resume so already-evaluated entries
+/// — which may have observable side effects — are not re-evaluated.
 /// </summary>
-internal sealed class CallArgumentsSuspendData : SuspendData
+internal sealed class ExpressionBufferSuspendData : SuspendData
 {
     public JsValue[] Buffer { get; set; } = [];
 

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -197,6 +197,36 @@ internal sealed class ObjectExpressionSuspendData : SuspendData
 }
 
 /// <summary>
+/// Stores the partially-built template literal accumulator and next interpolation
+/// index. The accumulator includes the quasi text up to and including the one at
+/// <see cref="NextExpressionIndex"/> (which was appended just before the
+/// interpolation that suspended).
+/// </summary>
+internal sealed class TemplateLiteralSuspendData : SuspendData
+{
+    public System.Text.StringBuilder Accumulator { get; set; } = new();
+
+    public int NextExpressionIndex { get; set; }
+}
+
+/// <summary>
+/// Stores the resolved tag callable, this binding, and partially-evaluated
+/// arguments array for a tagged template expression. <c>Args[0]</c> is the
+/// template object; <c>Args[1..]</c> are the already-evaluated interpolation
+/// values up to (but not including) <see cref="NextExpressionIndex"/>.
+/// </summary>
+internal sealed class TaggedTemplateSuspendData : SuspendData
+{
+    public ICallable Tagger { get; set; } = null!;
+
+    public JsValue ThisObject { get; set; } = JsValue.Undefined;
+
+    public JsValue[] Args { get; set; } = [];
+
+    public int NextExpressionIndex { get; set; }
+}
+
+/// <summary>
 /// Stores the state of a for-await-of loop when an async function awaits inside it.
 /// </summary>
 internal sealed class ForAwaitSuspendData : SuspendData


### PR DESCRIPTION
## Summary

Follow-up to #2469 (now merged). The audit triggered by the review of #2469 identified eight residual gaps where the same bug shape it fixed for `if`/`for`/`switch`/`try-catch-finally`/binary/logical/conditional/assignment/call/new also affected other expression types. This PR closes every one of them.

The bug is the same in each case: when `await` (or `yield`) suspends inside a compound expression, the surrounding sibling sub-expressions with observable side effects re-run on resume. The fix is the same in each case: per-expression suspend-data (`ISuspendable.Data`, identity-keyed by the Jint expression instance) carrying the already-evaluated sub-results plus the next index to resume from.

## What's fixed

| # | Site | Failing shape (before) |
|---|---|---|
| 1 | Array literals | `[++i, ++i, await x]` re-ran `++i`s |
| 2 | Spread arguments in call/new/array | `foo(...iter, await x)` re-iterated one-shot iterators (and re-ran later non-spread side effects mid-suspend) |
| 3 | `NullishCoalescingExpression` | `getX() ?? (await y)` re-ran `getX()` |
| 4 | `JintMemberExpression` (slow path) | `getObj()[await x]` re-ran `getObj()` |
| 5 | `JintObjectExpression` (both fast and normal paths) | `{ a: ++i, b: await x }` re-ran `++i` |
| 6 | `JintTemplateLiteralExpression` | `` `${++i} ${await x} ${++j}` `` — no `IsSuspended` break so `++j` ran during the suspended pass; on resume `++i` ran again |
| 7 | `JintTaggedTemplateExpression` | same as 6 |
| 8 | `JintAssignmentExpression.EvaluateOperatorOverloading` | `clrObj += await fn(counter++)` — `_right.GetValue` ran twice on the same pass (once in the overloading helper, once in the operator switch), evaluating side effects in the awaited expression twice and registering a second pair of promise handlers |

For #6 and #7, the fix also adds the missing `IsSuspended` break inside the interpolation loop so post-suspension side effects don't run.

## Commits

| | SHA | |
|---|---|---|
| 1 | `973ddb7ff` | Rename `CallArgumentsSuspendData` → `ExpressionBufferSuspendData` (mechanical) |
| 2 | `6105f3790` | Array literal non-spread elements |
| 3 | `11d821245` | Spread arguments (call/new/array-literal-spread) |
| 4 | `3a16f2a99` | NullishCoalescingExpression left preservation |
| 5 | `ec3fc0418` | JintMemberExpression resolved-object preservation |
| 6 | `86098545a` | JintObjectExpression property preservation |
| 7 | `d1b099ebb` | Template literal + tagged template |
| 8 | `6f394e8ca` | Compound assignment operator-overloading double-eval |

Each commit is independently testable with focused unit tests.

## New suspend-data types

In `Jint/Runtime/SuspendData.cs`:
- `ExpressionBufferSuspendData` — renamed from `CallArgumentsSuspendData`, now backs both call/new args and array literal elements
- `SpreadArgumentsSuspendData` — partial target list + next expression index
- `MemberExpressionSuspendData` — resolved (BaseValue, BaseReferenceName, ActualThis)
- `ObjectExpressionSuspendData` — partially-built `ObjectInstance` (+ `PropertyDictionary` for the fast path) + next index
- `TemplateLiteralSuspendData` — `StringBuilder` accumulator + next interpolation index
- `TaggedTemplateSuspendData` — resolved tagger + thisObject + partial args + next index

`LeftOperandSuspendData` (from #2469) is reused for nullish-coalescing.

## Verification

- `dotnet build --configuration Release` — clean, warnings-as-errors.
- `dotnet test Jint.Tests/Jint.Tests.csproj` — 2996 / 0 / 5 (net10.0); 2948 / 0 / 5 (net472). New tests: ~30 across `AsyncTests`, `GeneratorTests`, `OperatorOverloadingTests`.
- `dotnet test Jint.Tests.Test262/Jint.Tests.Test262.csproj` — **99013 / 0 / 133**, +56 newly-passing vs main (`8dd17e953`).

## Test plan

- [x] Added or updated unit tests in Jint.Tests
- [x] Ran dotnet test --configuration Release locally
- [x] For ECMAScript spec changes: ran Jint.Tests.Test262 and confirmed no regressions (+56 newly-passing)
- [ ] For interop changes: covered in Jint.Tests/Runtime/Interop — one new test in OperatorOverloadingTests
- [ ] For perf changes: n/a

## Breaking change?

No.