### PR TITLE
Fix #2477: spec-compliant async suspension for await using dispose

### DIFF
--- a/Jint.Benchmark/AsyncFunctionExitBenchmark.cs
+++ b/Jint.Benchmark/AsyncFunctionExitBenchmark.cs
@@ -1,0 +1,61 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Measures async-function and async-generator EXIT cost in two shapes:
+///   - "Plain": no `await using` declarations in scope; the dispose state machine
+///     is skipped via the HasDisposeResources fast path. Goal: zero allocation
+///     beyond the function/promise plumbing itself.
+///   - "WithSyncUsing": one `using` declaration with a sync dispose method; the
+///     state machine runs but never suspends.
+/// Compares against the pre-PR-2478 "everything inline-disposes" code path by
+/// running many iterations so per-call allocation differences dominate.
+/// </summary>
+[MemoryDiagnoser]
+public class AsyncFunctionExitBenchmark
+{
+    private Prepared<Script> _plainAsyncExits;
+    private Prepared<Script> _asyncExitsWithSyncUsing;
+    private Prepared<Script> _asyncGenExitsPlain;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Plain async function exit, no using — exercises the HasDisposeResources fast path.
+        _plainAsyncExits = Engine.PrepareScript("""
+            async function f(n) { return n + 1; }
+            for (let i = 0; i < 1000; i++) f(i);
+            """);
+
+        // Async function with a sync `using` — state machine runs but never suspends.
+        _asyncExitsWithSyncUsing = Engine.PrepareScript("""
+            const sentinel = { [Symbol.dispose]() {} };
+            async function f(n) {
+                using d = sentinel;
+                return n + 1;
+            }
+            for (let i = 0; i < 1000; i++) f(i);
+            """);
+
+        // Plain async generator exit, no using — covers the AsyncGenerator fast path.
+        _asyncGenExitsPlain = Engine.PrepareScript("""
+            async function* g(n) { yield n; yield n + 1; }
+            for (let i = 0; i < 500; i++) {
+                const it = g(i);
+                it.next();
+                it.next();
+                it.next();
+            }
+            """);
+    }
+
+    [Benchmark]
+    public void PlainAsyncFunctionExit_1000() => new Engine().Execute(_plainAsyncExits);
+
+    [Benchmark]
+    public void AsyncFunctionWithSyncUsing_1000() => new Engine().Execute(_asyncExitsWithSyncUsing);
+
+    [Benchmark]
+    public void PlainAsyncGeneratorExit_500() => new Engine().Execute(_asyncGenExitsPlain);
+}

--- a/Jint.Tests/Runtime/InteropDisposeTests.cs
+++ b/Jint.Tests/Runtime/InteropDisposeTests.cs
@@ -264,6 +264,101 @@ public class InteropDisposeTests
     }
 
     /// <summary>
+    /// TLA module with a genuinely-async dispose (Task.Delay). Confirms the module's
+    /// execution context is correctly popped before dispatching the dispose chain so
+    /// the Promise.then callbacks don't run with the module context still on the
+    /// engine stack.
+    /// </summary>
+    [Fact]
+    public void ShouldAsyncDisposeInTopLevelAwaitModuleWithGenuinelyAsyncTask()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var disposable = new DelayedAsyncDisposable();
+        engine.SetValue("getAsync", () => disposable);
+
+        engine.Modules.Add("tla-dispose-delayed", "await using d = getAsync();");
+        engine.Modules.Import("tla-dispose-delayed");
+
+        disposable.Disposed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// `for (await using x of arr)` inside an async function with a genuinely-async
+    /// DisposeAsync, single iteration. Exercises JintForInForOfStatement's
+    /// per-iteration dispose state-machine drive.
+    /// </summary>
+    [Fact]
+    public async Task ShouldAsyncDisposeInForOfWithGenuinelyAsyncTask_SingleIteration()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var order = new List<string>();
+        engine.SetValue("make", new Func<string, DelayedTrackedDisposable>(name => new DelayedTrackedDisposable(name, order)));
+
+        await engine.EvaluateAsync("""
+            (async () => {
+                for (await using x of [make('A')]) {
+                    // body intentionally empty
+                }
+            })()
+            """);
+
+        order.Should().Equal("A");
+    }
+
+    /// <summary>
+    /// `for (await using x of arr)` inside an async function with a genuinely-async
+    /// DisposeAsync. Exercises JintForInForOfStatement's per-iteration dispose
+    /// state-machine drive — the spec-mandated Await between iterations must
+    /// consume a real microtask tick and must not deadlock the way #2477 did.
+    /// </summary>
+    [Fact]
+    public async Task ShouldAsyncDisposeInForOfWithGenuinelyAsyncTask()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var order = new List<string>();
+        engine.SetValue("make", new Func<string, DelayedTrackedDisposable>(name => new DelayedTrackedDisposable(name, order)));
+
+        await engine.EvaluateAsync("""
+            (async () => {
+                for (await using x of [make('A'), make('B'), make('C')]) {
+                    // body intentionally empty — dispose-only test
+                }
+            })()
+            """);
+
+        order.Should().Equal("A", "B", "C");
+    }
+
+    /// <summary>
+    /// `for (await using x of arr)` where the dispose method rejects. Confirms
+    /// the rejection from a per-iteration dispose surfaces as the loop's
+    /// rejection and stops further iterations.
+    /// </summary>
+    [Fact]
+    public async Task ShouldAsyncDisposeInForOfPropagatesRejection()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var order = new List<string>();
+        engine.SetValue("makeOk", new Func<string, DelayedTrackedDisposable>(name => new DelayedTrackedDisposable(name, order)));
+        engine.SetValue("makeBad", new Func<FaultingAsyncDisposable>(() => new FaultingAsyncDisposable()));
+
+        await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+        {
+            await engine.EvaluateAsync("""
+                (async () => {
+                    for (await using x of [makeOk('A'), makeBad(), makeOk('C')]) {
+                        // body intentionally empty
+                    }
+                })()
+                """);
+        });
+
+        // 'A' disposed first (LIFO of one), then 'makeBad' threw — 'C' should not be
+        // reached because the loop's iteration aborts on dispose rejection.
+        order.Should().Equal("A");
+    }
+
+    /// <summary>
     /// `await using` inside an async generator body — exercises the Pattern B
     /// refactor in AsyncGeneratorInstance.
     /// </summary>
@@ -326,6 +421,24 @@ public class InteropDisposeTests
         {
             _order.Add(_name);
             return default;
+        }
+    }
+
+    private class DelayedTrackedDisposable : IAsyncDisposable
+    {
+        private readonly string _name;
+        private readonly List<string> _order;
+
+        public DelayedTrackedDisposable(string name, List<string> order)
+        {
+            _name = name;
+            _order = order;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Task.Delay(5).ConfigureAwait(false);
+            _order.Add(_name);
         }
     }
 

--- a/Jint.Tests/Runtime/InteropDisposeTests.cs
+++ b/Jint.Tests/Runtime/InteropDisposeTests.cs
@@ -1,3 +1,5 @@
+using Jint.Runtime;
+
 namespace Jint.Tests.Runtime;
 
 public class InteropDisposeTests
@@ -50,6 +52,170 @@ public class InteropDisposeTests
         _asyncDisposable.Disposed.Should().BeTrue();
     }
 
+    /// <summary>
+    /// Regression test for https://github.com/sebastienros/jint/issues/2477:
+    /// EvaluateAsync + IAsyncDisposable obtained via an awaited Task must complete,
+    /// not deadlock. Previously hung for 10s and threw a timeout PromiseRejectedException.
+    /// </summary>
+    [Fact]
+    public async Task ShouldAsyncDisposeAfterAwait_EvaluateAsync()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var disposable = new AsyncDisposable();
+        engine.SetValue("makeDisposable", new Func<Task<AsyncDisposable>>(() =>
+            Task.FromResult(disposable)));
+
+        await engine.EvaluateAsync("""
+            (async () => {
+                await using d = await makeDisposable();
+            })()
+            """);
+
+        disposable.Disposed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Confirms the state machine truly suspends and resumes — not just that
+    /// synchronously-completed ValueTasks happen to work. Uses Task.Delay so
+    /// the dispose await crosses a real async boundary.
+    /// </summary>
+    [Fact]
+    public async Task ShouldAsyncDisposeWithGenuinelyAsyncTask()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var disposable = new DelayedAsyncDisposable();
+        engine.SetValue("makeDisposable", new Func<Task<DelayedAsyncDisposable>>(() =>
+            Task.FromResult(disposable)));
+
+        await engine.EvaluateAsync("""
+            (async () => {
+                await using d = await makeDisposable();
+            })()
+            """);
+
+        disposable.Disposed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Two await-using declarations in the same block dispose LIFO across two suspensions.
+    /// </summary>
+    [Fact]
+    public async Task ShouldAsyncDisposeMultipleResourcesLifoOrder()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var order = new List<string>();
+        engine.SetValue("makeA", new Func<TrackedAsyncDisposable>(() => new TrackedAsyncDisposable("A", order)));
+        engine.SetValue("makeB", new Func<TrackedAsyncDisposable>(() => new TrackedAsyncDisposable("B", order)));
+
+        await engine.EvaluateAsync("""
+            (async () => {
+                await using a = makeA();
+                await using b = makeB();
+            })()
+            """);
+
+        order.Should().Equal("B", "A");
+    }
+
+    /// <summary>
+    /// Nested async functions: dispose suspension must work across function boundaries.
+    /// </summary>
+    [Fact]
+    public async Task ShouldAsyncDisposeNestedAcrossAsyncFunctions()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var disposable = new AsyncDisposable();
+        engine.SetValue("makeDisposable", new Func<Task<AsyncDisposable>>(() =>
+            Task.FromResult(disposable)));
+
+        await engine.EvaluateAsync("""
+            async function inner() {
+                await using d = await makeDisposable();
+            }
+            async function outer() {
+                await inner();
+            }
+            outer();
+            """);
+
+        disposable.Disposed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Body throws AND dispose rejects: completion must be a SuppressedError per spec.
+    /// </summary>
+    [Fact]
+    public async Task ShouldAsyncDisposeChainsSuppressedError()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var disposable = new FaultingAsyncDisposable();
+        engine.SetValue("makeDisposable", new Func<FaultingAsyncDisposable>(() => disposable));
+
+        var error = await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+        {
+            await engine.EvaluateAsync("""
+                (async () => {
+                    await using d = makeDisposable();
+                    throw new Error("body error");
+                })()
+                """);
+        });
+
+        // The rejected value should be a SuppressedError. .error is the (later) dispose
+        // failure — a .NET AggregateException wrapper since the Task was faulted, so its
+        // message starts with "One or more errors occurred." and contains "dispose fault".
+        // .suppressed is the (earlier) body error with the verbatim message.
+        var rejected = error.RejectedValue.AsObject();
+        rejected.Get("name").AsString().Should().Be("SuppressedError");
+        rejected.Get("error").AsObject().Get("message").AsString().Should().Contain("dispose fault");
+        rejected.Get("suppressed").AsObject().Get("message").AsString().Should().Be("body error");
+    }
+
+    /// <summary>
+    /// await using at top level of an async function body — exercises
+    /// JintFunctionDefinition.AsyncBlockStart's Pattern B dispose path.
+    /// </summary>
+    [Fact]
+    public async Task ShouldAsyncDisposeAtAsyncFunctionExit()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var disposable = new AsyncDisposable();
+        engine.SetValue("getAsync", () => disposable);
+
+        await engine.EvaluateAsync("""
+            (async function () {
+                await using d = getAsync();
+            })()
+            """);
+
+        disposable.Disposed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Async function body throws — dispose must still run, and the resulting
+    /// rejection must carry the original throw (no SuppressedError since dispose succeeds).
+    /// </summary>
+    [Fact]
+    public async Task ShouldAsyncDisposeAfterUnhandledThrow()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var disposable = new AsyncDisposable();
+        engine.SetValue("makeDisposable", new Func<AsyncDisposable>(() => disposable));
+
+        var error = await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+        {
+            await engine.EvaluateAsync("""
+                (async () => {
+                    await using d = makeDisposable();
+                    throw new Error("body error");
+                })()
+                """);
+        });
+
+        error.RejectedValue.AsObject().Get("message").AsString().Should().Be("body error");
+        disposable.Disposed.Should().BeTrue();
+    }
+
     private class AsyncDisposable : IAsyncDisposable
     {
         public bool Disposed { get; private set; }
@@ -58,6 +224,43 @@ public class InteropDisposeTests
         {
             Disposed = true;
             return default;
+        }
+    }
+
+    private class DelayedAsyncDisposable : IAsyncDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Task.Delay(20).ConfigureAwait(false);
+            Disposed = true;
+        }
+    }
+
+    private class TrackedAsyncDisposable : IAsyncDisposable
+    {
+        private readonly string _name;
+        private readonly List<string> _order;
+
+        public TrackedAsyncDisposable(string name, List<string> order)
+        {
+            _name = name;
+            _order = order;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _order.Add(_name);
+            return default;
+        }
+    }
+
+    private class FaultingAsyncDisposable : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync()
+        {
+            return new ValueTask(Task.FromException(new InvalidOperationException("dispose fault")));
         }
     }
 #endif

--- a/Jint.Tests/Runtime/InteropDisposeTests.cs
+++ b/Jint.Tests/Runtime/InteropDisposeTests.cs
@@ -216,6 +216,79 @@ public class InteropDisposeTests
         disposable.Disposed.Should().BeTrue();
     }
 
+    /// <summary>
+    /// AsyncDisposableStack.prototype.disposeAsync must consume the spec-mandated
+    /// Await(undefined) microtask tick even when the only resource is null. The
+    /// expected interleaving puts 'job 1' (two ticks deep) before 'dispose' (also
+    /// two ticks deep: one for the Await(undefined), one for the .then handler).
+    /// Without the tick, 'dispose' would fire synchronously and produce
+    /// ['dispose', 'job 1', 'job 2'] instead.
+    /// Mirrors built-ins/AsyncDisposableStack/prototype/disposeAsync/
+    /// explicit-await-for-null.js from Test262.
+    /// </summary>
+    [Fact]
+    public async Task ShouldAsyncDisposableStackConsumeAwaitTickForNull()
+    {
+        var engine = new Engine();
+        var result = await engine.EvaluateAsync("""
+            (async function () {
+                const stack = new AsyncDisposableStack();
+                const sequence = [];
+                stack.use(null);
+                await Promise.all([
+                    Promise.resolve().then(() => 0).then(() => { sequence.push('job 1'); }),
+                    stack.disposeAsync().then(() => { sequence.push('dispose'); }),
+                    Promise.resolve().then(() => 0).then(() => { sequence.push('job 2'); })
+                ]);
+                return sequence.join(',');
+            })()
+            """);
+        result.AsString().Should().Be("job 1,dispose,job 2");
+    }
+
+    /// <summary>
+    /// Top-level `await using` in a module — exercises the Pattern B refactor in
+    /// SourceTextModule's TLA execution path.
+    /// </summary>
+    [Fact]
+    public void ShouldAsyncDisposeInTopLevelAwaitModule()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var disposable = new AsyncDisposable();
+        engine.SetValue("getAsync", () => disposable);
+
+        engine.Modules.Add("tla-dispose", "await using d = getAsync();");
+        engine.Modules.Import("tla-dispose");
+
+        disposable.Disposed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// `await using` inside an async generator body — exercises the Pattern B
+    /// refactor in AsyncGeneratorInstance.
+    /// </summary>
+    [Fact]
+    public async Task ShouldAsyncDisposeInAsyncGenerator()
+    {
+        var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
+        var disposable = new AsyncDisposable();
+        engine.SetValue("getAsync", () => disposable);
+
+        await engine.EvaluateAsync("""
+            (async () => {
+                async function* gen() {
+                    await using d = getAsync();
+                    yield 1;
+                }
+                const it = gen();
+                await it.next();
+                await it.next();
+            })()
+            """);
+
+        disposable.Disposed.Should().BeTrue();
+    }
+
     private class AsyncDisposable : IAsyncDisposable
     {
         public bool Disposed { get; private set; }

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
@@ -261,7 +261,12 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
         }
         catch (JavaScriptException ex)
         {
+            // Leave context up front so any async dispose work below runs (and its
+            // Promise.then callbacks fire) without the generator's execution context
+            // still on the stack — otherwise outer `await`s in the caller would
+            // mis-route through SuspendForAwaitInAsyncGenerator.
             var env = _engine.ExecutionContext.LexicalEnvironment;
+            _engine.LeaveExecutionContext();
             if (!env.HasDisposeResources)
             {
                 SettleResumeRejection(ex.Error, promiseCapability);
@@ -295,8 +300,12 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
             return;
         }
 
-        // Generator body completed — dispose resources before leaving context.
+        // Generator body completed — leave the generator's execution context BEFORE
+        // dispatching dispose so its async Promise.then chain doesn't run with the
+        // generator's context still on the stack. Settlement helpers below assume
+        // the context has already been popped.
         var lexEnv = _engine.ExecutionContext.LexicalEnvironment;
+        _engine.LeaveExecutionContext();
         if (!lexEnv.HasDisposeResources)
         {
             SettleResumeCompletion(result, promiseCapability);
@@ -308,7 +317,8 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
 
     private void SettleResumeRejection(JsValue error, PromiseCapability promiseCapability)
     {
-        _engine.LeaveExecutionContext();
+        // Note: caller (ResumeExecution / its callback) has already left the
+        // generator's execution context.
         _currentPromiseCapability = null;
         _asyncGeneratorState = AsyncGeneratorState.Completed;
         _completedAwaits = null;
@@ -318,7 +328,6 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
 
     private void SettleResumeCompletion(Completion final, PromiseCapability promiseCapability)
     {
-        _engine.LeaveExecutionContext();
         _currentPromiseCapability = null;
 
         if (final.Type == CompletionType.Throw)
@@ -473,8 +482,10 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
                 return;
             }
 
-            // Generator completed — dispose resources before leaving context.
+            // Generator completed — leave the generator's execution context BEFORE
+            // dispatching dispose (see ResumeExecution for the same rationale).
             var lexEnv = _engine.ExecutionContext.LexicalEnvironment;
+            _engine.LeaveExecutionContext();
             if (!lexEnv.HasDisposeResources)
             {
                 SettleDelegationCompletion(bodyResult, promiseCapability);
@@ -486,6 +497,7 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
         catch (JavaScriptException ex)
         {
             var env = _engine.ExecutionContext.LexicalEnvironment;
+            _engine.LeaveExecutionContext();
             if (!env.HasDisposeResources)
             {
                 SettleDelegationRejection(ex.Error, promiseCapability);
@@ -501,8 +513,7 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
 
     private void SettleDelegationCompletion(Completion final, PromiseCapability? promiseCapability)
     {
-        _engine.LeaveExecutionContext();
-
+        // Note: caller has already left the generator's execution context.
         _currentPromiseCapability = null;
 
         if (final.Type == CompletionType.Throw)
@@ -529,7 +540,7 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
 
     private void SettleDelegationRejection(JsValue error, PromiseCapability? promiseCapability)
     {
-        _engine.LeaveExecutionContext();
+        // Note: caller has already left the generator's execution context.
         _currentPromiseCapability = null;
         _asyncGeneratorState = AsyncGeneratorState.Completed;
         _completedAwaits = null;

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
@@ -262,19 +262,16 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
         catch (JavaScriptException ex)
         {
             var env = _engine.ExecutionContext.LexicalEnvironment;
+            if (!env.HasDisposeResources)
+            {
+                SettleResumeRejection(ex.Error, promiseCapability);
+                return;
+            }
             DisposeResourcesHelper.DisposeAndThen(
                 _engine,
                 env,
                 new Completion(CompletionType.Throw, ex.Error, null!),
-                final =>
-                {
-                    _engine.LeaveExecutionContext();
-                    _currentPromiseCapability = null;
-                    _asyncGeneratorState = AsyncGeneratorState.Completed;
-                    _completedAwaits = null;
-                    AsyncGeneratorReject(final.Value, promiseCapability);
-                    AsyncGeneratorResumeNext();
-                });
+                final => SettleResumeRejection(final.Value, promiseCapability));
             return;
         }
 
@@ -300,44 +297,61 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
 
         // Generator body completed — dispose resources before leaving context.
         var lexEnv = _engine.ExecutionContext.LexicalEnvironment;
-        DisposeResourcesHelper.DisposeAndThen(_engine, lexEnv, result, final =>
+        if (!lexEnv.HasDisposeResources)
         {
-            _engine.LeaveExecutionContext();
+            SettleResumeCompletion(result, promiseCapability);
+            return;
+        }
+        DisposeResourcesHelper.DisposeAndThen(_engine, lexEnv, result,
+            final => SettleResumeCompletion(final, promiseCapability));
+    }
 
-            _currentPromiseCapability = null;
+    private void SettleResumeRejection(JsValue error, PromiseCapability promiseCapability)
+    {
+        _engine.LeaveExecutionContext();
+        _currentPromiseCapability = null;
+        _asyncGeneratorState = AsyncGeneratorState.Completed;
+        _completedAwaits = null;
+        AsyncGeneratorReject(error, promiseCapability);
+        AsyncGeneratorResumeNext();
+    }
 
-            if (final.Type == CompletionType.Throw)
+    private void SettleResumeCompletion(Completion final, PromiseCapability promiseCapability)
+    {
+        _engine.LeaveExecutionContext();
+        _currentPromiseCapability = null;
+
+        if (final.Type == CompletionType.Throw)
+        {
+            _asyncGeneratorState = AsyncGeneratorState.Completed;
+            _completedAwaits = null;
+            AsyncGeneratorReject(final.Value, promiseCapability);
+        }
+        else if (final.Type == CompletionType.Return)
+        {
+            // Per spec 13.10.1: "return;" (no expression) does NOT await the return value,
+            // but "return expr;" does call Await(exprValue) before returning.
+            // When the return statement has no argument, we can resolve directly.
+            if (final._source is ReturnStatement { Argument: null })
             {
                 _asyncGeneratorState = AsyncGeneratorState.Completed;
                 _completedAwaits = null;
-                AsyncGeneratorReject(final.Value, promiseCapability);
+                AsyncGeneratorResolve(final.Value, true, promiseCapability);
             }
-            else if (final.Type == CompletionType.Return)
+            else
             {
-                // Per spec 13.10.1: "return;" (no expression) does NOT await the return value,
-                // but "return expr;" does call Await(exprValue) before returning.
-                // When the return statement has no argument, we can resolve directly.
-                if (final._source is ReturnStatement { Argument: null })
-                {
-                    _asyncGeneratorState = AsyncGeneratorState.Completed;
-                    _completedAwaits = null;
-                    AsyncGeneratorResolve(final.Value, true, promiseCapability);
-                }
-                else
-                {
-                    _asyncGeneratorState = AsyncGeneratorState.AwaitingReturn;
-                    AsyncGeneratorAwaitReturn(final.Value, promiseCapability);
-                }
+                _asyncGeneratorState = AsyncGeneratorState.AwaitingReturn;
+                AsyncGeneratorAwaitReturn(final.Value, promiseCapability);
             }
-            else if (final.Type == CompletionType.Normal)
-            {
-                _asyncGeneratorState = AsyncGeneratorState.Completed;
-                _completedAwaits = null;
-                AsyncGeneratorResolve(Undefined, true, promiseCapability);
-            }
+        }
+        else if (final.Type == CompletionType.Normal)
+        {
+            _asyncGeneratorState = AsyncGeneratorState.Completed;
+            _completedAwaits = null;
+            AsyncGeneratorResolve(Undefined, true, promiseCapability);
+        }
 
-            AsyncGeneratorResumeNext();
-        });
+        AsyncGeneratorResumeNext();
     }
 
     /// <summary>
@@ -461,54 +475,69 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
 
             // Generator completed — dispose resources before leaving context.
             var lexEnv = _engine.ExecutionContext.LexicalEnvironment;
-            DisposeResourcesHelper.DisposeAndThen(_engine, lexEnv, bodyResult, final =>
+            if (!lexEnv.HasDisposeResources)
             {
-                _engine.LeaveExecutionContext();
-
-                _currentPromiseCapability = null;
-
-                if (final.Type == CompletionType.Throw)
-                {
-                    _asyncGeneratorState = AsyncGeneratorState.Completed;
-                    _completedAwaits = null;
-                    if (promiseCapability is not null)
-                    {
-                        AsyncGeneratorReject(final.Value, promiseCapability);
-                    }
-                }
-                else
-                {
-                    _asyncGeneratorState = AsyncGeneratorState.Completed;
-                    _completedAwaits = null;
-                    if (promiseCapability is not null)
-                    {
-                        var completionValue = final.Type == CompletionType.Return ? final.Value : Undefined;
-                        AsyncGeneratorResolve(completionValue, true, promiseCapability);
-                    }
-                }
-                AsyncGeneratorResumeNext();
-            });
+                SettleDelegationCompletion(bodyResult, promiseCapability);
+                return;
+            }
+            DisposeResourcesHelper.DisposeAndThen(_engine, lexEnv, bodyResult,
+                final => SettleDelegationCompletion(final, promiseCapability));
         }
         catch (JavaScriptException ex)
         {
             var env = _engine.ExecutionContext.LexicalEnvironment;
+            if (!env.HasDisposeResources)
+            {
+                SettleDelegationRejection(ex.Error, promiseCapability);
+                return;
+            }
             DisposeResourcesHelper.DisposeAndThen(
                 _engine,
                 env,
                 new Completion(CompletionType.Throw, ex.Error, null!),
-                final =>
-                {
-                    _engine.LeaveExecutionContext();
-                    _currentPromiseCapability = null;
-                    _asyncGeneratorState = AsyncGeneratorState.Completed;
-                    _completedAwaits = null;
-                    if (promiseCapability is not null)
-                    {
-                        AsyncGeneratorReject(final.Value, promiseCapability);
-                    }
-                    AsyncGeneratorResumeNext();
-                });
+                final => SettleDelegationRejection(final.Value, promiseCapability));
         }
+    }
+
+    private void SettleDelegationCompletion(Completion final, PromiseCapability? promiseCapability)
+    {
+        _engine.LeaveExecutionContext();
+
+        _currentPromiseCapability = null;
+
+        if (final.Type == CompletionType.Throw)
+        {
+            _asyncGeneratorState = AsyncGeneratorState.Completed;
+            _completedAwaits = null;
+            if (promiseCapability is not null)
+            {
+                AsyncGeneratorReject(final.Value, promiseCapability);
+            }
+        }
+        else
+        {
+            _asyncGeneratorState = AsyncGeneratorState.Completed;
+            _completedAwaits = null;
+            if (promiseCapability is not null)
+            {
+                var completionValue = final.Type == CompletionType.Return ? final.Value : Undefined;
+                AsyncGeneratorResolve(completionValue, true, promiseCapability);
+            }
+        }
+        AsyncGeneratorResumeNext();
+    }
+
+    private void SettleDelegationRejection(JsValue error, PromiseCapability? promiseCapability)
+    {
+        _engine.LeaveExecutionContext();
+        _currentPromiseCapability = null;
+        _asyncGeneratorState = AsyncGeneratorState.Completed;
+        _completedAwaits = null;
+        if (promiseCapability is not null)
+        {
+            AsyncGeneratorReject(error, promiseCapability);
+        }
+        AsyncGeneratorResumeNext();
     }
 
     /// <summary>

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
@@ -1,3 +1,4 @@
+using Jint.Native.Disposable;
 using Jint.Native.Iterator;
 using Jint.Native.Object;
 using Jint.Native.Promise;
@@ -261,13 +262,19 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
         catch (JavaScriptException ex)
         {
             var env = _engine.ExecutionContext.LexicalEnvironment;
-            var disposeResult = env.DisposeResources(new Completion(CompletionType.Throw, ex.Error, null!));
-            _engine.LeaveExecutionContext();
-            _currentPromiseCapability = null;
-            _asyncGeneratorState = AsyncGeneratorState.Completed;
-            _completedAwaits = null;
-            AsyncGeneratorReject(disposeResult.Value, promiseCapability);
-            AsyncGeneratorResumeNext();
+            DisposeResourcesHelper.DisposeAndThen(
+                _engine,
+                env,
+                new Completion(CompletionType.Throw, ex.Error, null!),
+                final =>
+                {
+                    _engine.LeaveExecutionContext();
+                    _currentPromiseCapability = null;
+                    _asyncGeneratorState = AsyncGeneratorState.Completed;
+                    _completedAwaits = null;
+                    AsyncGeneratorReject(final.Value, promiseCapability);
+                    AsyncGeneratorResumeNext();
+                });
             return;
         }
 
@@ -291,45 +298,46 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
             return;
         }
 
-        // Generator body completed — dispose resources before leaving context
+        // Generator body completed — dispose resources before leaving context.
         var lexEnv = _engine.ExecutionContext.LexicalEnvironment;
-        result = lexEnv.DisposeResources(result);
-
-        _engine.LeaveExecutionContext();
-
-        _currentPromiseCapability = null;
-
-        if (result.Type == CompletionType.Throw)
+        DisposeResourcesHelper.DisposeAndThen(_engine, lexEnv, result, final =>
         {
-            _asyncGeneratorState = AsyncGeneratorState.Completed;
-            _completedAwaits = null;
-            AsyncGeneratorReject(result.Value, promiseCapability);
-        }
-        else if (result.Type == CompletionType.Return)
-        {
-            // Per spec 13.10.1: "return;" (no expression) does NOT await the return value,
-            // but "return expr;" does call Await(exprValue) before returning.
-            // When the return statement has no argument, we can resolve directly.
-            if (result._source is ReturnStatement { Argument: null })
+            _engine.LeaveExecutionContext();
+
+            _currentPromiseCapability = null;
+
+            if (final.Type == CompletionType.Throw)
             {
                 _asyncGeneratorState = AsyncGeneratorState.Completed;
                 _completedAwaits = null;
-                AsyncGeneratorResolve(result.Value, true, promiseCapability);
+                AsyncGeneratorReject(final.Value, promiseCapability);
             }
-            else
+            else if (final.Type == CompletionType.Return)
             {
-                _asyncGeneratorState = AsyncGeneratorState.AwaitingReturn;
-                AsyncGeneratorAwaitReturn(result.Value, promiseCapability);
+                // Per spec 13.10.1: "return;" (no expression) does NOT await the return value,
+                // but "return expr;" does call Await(exprValue) before returning.
+                // When the return statement has no argument, we can resolve directly.
+                if (final._source is ReturnStatement { Argument: null })
+                {
+                    _asyncGeneratorState = AsyncGeneratorState.Completed;
+                    _completedAwaits = null;
+                    AsyncGeneratorResolve(final.Value, true, promiseCapability);
+                }
+                else
+                {
+                    _asyncGeneratorState = AsyncGeneratorState.AwaitingReturn;
+                    AsyncGeneratorAwaitReturn(final.Value, promiseCapability);
+                }
             }
-        }
-        else if (result.Type == CompletionType.Normal)
-        {
-            _asyncGeneratorState = AsyncGeneratorState.Completed;
-            _completedAwaits = null;
-            AsyncGeneratorResolve(Undefined, true, promiseCapability);
-        }
+            else if (final.Type == CompletionType.Normal)
+            {
+                _asyncGeneratorState = AsyncGeneratorState.Completed;
+                _completedAwaits = null;
+                AsyncGeneratorResolve(Undefined, true, promiseCapability);
+            }
 
-        AsyncGeneratorResumeNext();
+            AsyncGeneratorResumeNext();
+        });
     }
 
     /// <summary>
@@ -451,48 +459,55 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
                 return;
             }
 
-            // Generator completed — dispose resources before leaving context
+            // Generator completed — dispose resources before leaving context.
             var lexEnv = _engine.ExecutionContext.LexicalEnvironment;
-            bodyResult = lexEnv.DisposeResources(bodyResult);
-
-            _engine.LeaveExecutionContext();
-
-            _currentPromiseCapability = null;
-
-            if (bodyResult.Type == CompletionType.Throw)
+            DisposeResourcesHelper.DisposeAndThen(_engine, lexEnv, bodyResult, final =>
             {
-                _asyncGeneratorState = AsyncGeneratorState.Completed;
-                _completedAwaits = null;
-                if (promiseCapability is not null)
+                _engine.LeaveExecutionContext();
+
+                _currentPromiseCapability = null;
+
+                if (final.Type == CompletionType.Throw)
                 {
-                    AsyncGeneratorReject(bodyResult.Value, promiseCapability);
+                    _asyncGeneratorState = AsyncGeneratorState.Completed;
+                    _completedAwaits = null;
+                    if (promiseCapability is not null)
+                    {
+                        AsyncGeneratorReject(final.Value, promiseCapability);
+                    }
                 }
-            }
-            else
-            {
-                _asyncGeneratorState = AsyncGeneratorState.Completed;
-                _completedAwaits = null;
-                if (promiseCapability is not null)
+                else
                 {
-                    var completionValue = bodyResult.Type == CompletionType.Return ? bodyResult.Value : Undefined;
-                    AsyncGeneratorResolve(completionValue, true, promiseCapability);
+                    _asyncGeneratorState = AsyncGeneratorState.Completed;
+                    _completedAwaits = null;
+                    if (promiseCapability is not null)
+                    {
+                        var completionValue = final.Type == CompletionType.Return ? final.Value : Undefined;
+                        AsyncGeneratorResolve(completionValue, true, promiseCapability);
+                    }
                 }
-            }
-            AsyncGeneratorResumeNext();
+                AsyncGeneratorResumeNext();
+            });
         }
         catch (JavaScriptException ex)
         {
             var env = _engine.ExecutionContext.LexicalEnvironment;
-            var disposeResult = env.DisposeResources(new Completion(CompletionType.Throw, ex.Error, null!));
-            _engine.LeaveExecutionContext();
-            _currentPromiseCapability = null;
-            _asyncGeneratorState = AsyncGeneratorState.Completed;
-            _completedAwaits = null;
-            if (promiseCapability is not null)
-            {
-                AsyncGeneratorReject(disposeResult.Value, promiseCapability);
-            }
-            AsyncGeneratorResumeNext();
+            DisposeResourcesHelper.DisposeAndThen(
+                _engine,
+                env,
+                new Completion(CompletionType.Throw, ex.Error, null!),
+                final =>
+                {
+                    _engine.LeaveExecutionContext();
+                    _currentPromiseCapability = null;
+                    _asyncGeneratorState = AsyncGeneratorState.Completed;
+                    _completedAwaits = null;
+                    if (promiseCapability is not null)
+                    {
+                        AsyncGeneratorReject(final.Value, promiseCapability);
+                    }
+                    AsyncGeneratorResumeNext();
+                });
         }
     }
 

--- a/Jint/Native/Disposable/AsyncDisposableStackPrototype.cs
+++ b/Jint/Native/Disposable/AsyncDisposableStackPrototype.cs
@@ -59,8 +59,31 @@ internal sealed partial class AsyncDisposableStackPrototype : Prototype
         try
         {
             var stack = AssertDisposableStack(thisObject);
-            var result = stack.Dispose();
-            capability.Resolve.Call(Undefined, result);
+            if (!stack.TryMarkDisposed())
+            {
+                // Already disposed — resolve with undefined.
+                capability.Resolve.Call(Undefined, Undefined);
+                return capability.PromiseInstance;
+            }
+
+            // Drive the dispose state machine via Promise.then chains so each
+            // spec-defined Await(...) consumes a real microtask tick. Settlement
+            // of the returned promise is deferred until the dispose chain finishes.
+            DisposeResourcesHelper.DisposeAndThen(
+                _engine,
+                stack.DisposeCapability,
+                new Completion(CompletionType.Normal, Undefined, _engine.GetLastSyntaxElement()),
+                final =>
+                {
+                    if (final.Type == CompletionType.Throw)
+                    {
+                        capability.Reject.Call(Undefined, final.Value);
+                    }
+                    else
+                    {
+                        capability.Resolve.Call(Undefined, Undefined);
+                    }
+                });
         }
         catch (JavaScriptException e)
         {

--- a/Jint/Native/Disposable/DisposableStack.cs
+++ b/Jint/Native/Disposable/DisposableStack.cs
@@ -24,6 +24,12 @@ internal sealed class DisposableStack : ObjectInstance
 
     public DisposableState State { get; private set; }
 
+    /// <summary>
+    /// Exposes the internal dispose capability so async callers (AsyncDisposableStack)
+    /// can drive the state machine via <see cref="DisposeResourcesHelper"/>.
+    /// </summary>
+    internal DisposeCapability DisposeCapability => _disposeCapability;
+
     public JsValue Dispose()
     {
         if (State == DisposableState.Disposed)
@@ -38,6 +44,23 @@ internal sealed class DisposableStack : ObjectInstance
             Throw.JavaScriptException(_engine, completion.Value, completion);
         }
         return completion.Value;
+    }
+
+    /// <summary>
+    /// Marks the stack disposed and returns the dispose state machine's initial step
+    /// for the async path. The caller (AsyncDisposableStack.prototype.disposeAsync)
+    /// drives the state machine via <see cref="DisposeResourcesHelper"/> so that each
+    /// spec-defined Await consumes a real microtask tick.
+    /// Returns null if the stack was already disposed.
+    /// </summary>
+    internal bool TryMarkDisposed()
+    {
+        if (State == DisposableState.Disposed)
+        {
+            return false;
+        }
+        State = DisposableState.Disposed;
+        return true;
     }
 
     public void Defer(JsValue onDispose)

--- a/Jint/Native/Disposable/DisposeCapability.cs
+++ b/Jint/Native/Disposable/DisposeCapability.cs
@@ -46,6 +46,12 @@ internal sealed class DisposeCapability
         _engine = engine;
     }
 
+    /// <summary>
+    /// Fast check used by callers to avoid allocating dispose-completion closures
+    /// when nothing is registered.
+    /// </summary>
+    public bool HasResources => _disposableResourceStack.Count > 0;
+
     public void AddDisposableResource(JsValue v, DisposeHint hint, ICallable? method = null)
     {
         DisposableResource resource;

--- a/Jint/Native/Disposable/DisposeCapability.cs
+++ b/Jint/Native/Disposable/DisposeCapability.cs
@@ -34,7 +34,10 @@ internal sealed class DisposeCapability
     private readonly Engine _engine;
     private readonly List<DisposableResource> _disposableResourceStack = [];
 
-    // State preserved across suspensions (3.e.ii.1, 3.d.i, 4.a).
+    // State preserved across suspensions (3.e.ii.1, 3.d.i, 4.a). Not reentrant —
+    // a single DisposeCapability instance can only drive one in-flight dispose at a
+    // time. This matches the engine's single-thread-per-Engine assumption: a JS
+    // dispose method cannot synchronously re-enter dispose on its own capability.
     private int _disposeIndex;
     private bool _disposeHasAwaited;
     private bool _disposeNeedsAwait;
@@ -212,12 +215,6 @@ internal sealed class DisposeCapability
                 catch (JavaScriptException e)
                 {
                     HandleDisposeException(e.Error);
-                    _disposeIndex--;
-                    continue;
-                }
-                catch (PromiseRejectedException e)
-                {
-                    HandleDisposeException(e.RejectedValue);
                     _disposeIndex--;
                     continue;
                 }

--- a/Jint/Native/Disposable/DisposeCapability.cs
+++ b/Jint/Native/Disposable/DisposeCapability.cs
@@ -1,17 +1,45 @@
+using System.Runtime.InteropServices;
 using Jint.Runtime;
 
 namespace Jint.Native.Disposable;
+
+/// <summary>
+/// Result of a single step of <see cref="DisposeCapability"/>'s state machine.
+/// Either the dispose finished (<see cref="IsDone"/> with <see cref="CompletedResult"/>)
+/// or it needs to await a promise (<see cref="PendingPromise"/>) before continuing.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct DisposeStepResult(
+    bool IsDone,
+    Completion CompletedResult,
+    JsValue? PendingPromise)
+{
+    public static DisposeStepResult Done(Completion c) => new(true, c, null);
+    public static DisposeStepResult Suspend(JsValue promise) => new(false, default, promise);
+}
+
+/// <summary>
+/// Tracks where in the spec algorithm we suspended, so the next
+/// <see cref="DisposeCapability.ContinueDispose"/> call applies the right rules.
+/// </summary>
+internal enum DisposeResumePoint
+{
+    None,
+    AfterMethodAwait,   // resumed after step 3.e.ii.1
+    AfterImplicitAwait, // resumed after step 3.d.i or 4.a
+}
 
 internal sealed class DisposeCapability
 {
     private readonly Engine _engine;
     private readonly List<DisposableResource> _disposableResourceStack = [];
 
-    /// <summary>
-    /// Set to true after DisposeResources if an async-dispose resource with no method
-    /// was encountered, indicating the caller should introduce an Await tick per spec.
-    /// </summary>
-    public bool NeedsAsyncTick { get; private set; }
+    // State preserved across suspensions (3.e.ii.1, 3.d.i, 4.a).
+    private int _disposeIndex;
+    private bool _disposeHasAwaited;
+    private bool _disposeNeedsAwait;
+    private Completion _disposeCompletion;
+    private DisposeResumePoint _disposeResume;
 
     public DisposeCapability(Engine engine)
     {
@@ -66,80 +94,184 @@ internal sealed class DisposeCapability
         return new DisposableResource(v, hint, method);
     }
 
+    /// <summary>
+    /// Legacy synchronous entry point. Drives the state machine to completion,
+    /// sync-waiting via <see cref="JsValueExtensions.UnwrapIfPromise(JsValue, TimeSpan)"/>
+    /// on every suspension. Used by callers that can't suspend their own context
+    /// (sync function bodies, module loading). After all async-context call sites
+    /// migrated to <see cref="BeginDispose"/> / <see cref="ContinueDispose"/>, this
+    /// only runs for contexts where await-using is syntactically illegal, so no
+    /// async-dispose resource can actually be in the stack and the loop exits in
+    /// a single Done step without ever calling UnwrapIfPromise.
+    /// </summary>
     public Completion DisposeResources(Completion c)
     {
-        var needsAwait = false;
-        var hasAwaited = false;
-
-        for (var i = _disposableResourceStack.Count - 1; i >= 0; i--)
+        var step = BeginDispose(c);
+        while (!step.IsDone)
         {
-            var (value, hint, method) = _disposableResourceStack[i];
-
-            if (hint == DisposeHint.Sync && needsAwait && !hasAwaited)
+            var pending = step.PendingPromise!;
+            JsValue resolved;
+            bool threw = false;
+            try
             {
-                _engine.RunAvailableContinuations();
-                needsAwait = false;
+                resolved = pending.UnwrapIfPromise(_engine.Options.Constraints.PromiseTimeout);
+            }
+            catch (PromiseRejectedException e)
+            {
+                resolved = e.RejectedValue;
+                threw = true;
+            }
+            catch (JavaScriptException e)
+            {
+                resolved = e.Error;
+                threw = true;
+            }
+            step = ContinueDispose(resolved, threw);
+        }
+        return step.CompletedResult;
+    }
+
+    /// <summary>
+    /// Initialize the dispose state machine and run until the first suspension or completion.
+    /// </summary>
+    public DisposeStepResult BeginDispose(Completion c)
+    {
+        _disposeIndex = _disposableResourceStack.Count - 1;
+        _disposeHasAwaited = false;
+        _disposeNeedsAwait = false;
+        _disposeCompletion = c;
+        _disposeResume = DisposeResumePoint.None;
+        return Advance();
+    }
+
+    /// <summary>
+    /// Continue the dispose state machine after a suspended Await settles.
+    /// </summary>
+    public DisposeStepResult ContinueDispose(JsValue awaitResult, bool awaitThrew)
+    {
+        switch (_disposeResume)
+        {
+            case DisposeResumePoint.AfterMethodAwait:
+                // Spec step 3.e.ii.1 just settled. Promote rejection per 3.e.iii.
+                if (awaitThrew)
+                {
+                    HandleDisposeException(awaitResult);
+                }
+                _disposeIndex--;
+                break;
+
+            case DisposeResumePoint.AfterImplicitAwait:
+                // Spec step 3.d.i or 4.a — Await(undefined) has no error path.
+                if (_disposeIndex < 0)
+                {
+                    // We were on step 4.a (final implicit tick).
+                    return Finish();
+                }
+                // Otherwise we were on step 3.d.i — fall through to process
+                // the current resource (no decrement).
+                break;
+        }
+
+        _disposeResume = DisposeResumePoint.None;
+        return Advance();
+    }
+
+    private DisposeStepResult Advance()
+    {
+        while (_disposeIndex >= 0)
+        {
+            var resource = _disposableResourceStack[_disposeIndex];
+            var value = resource.ResourceValue;
+            var hint = resource.Hint;
+            var method = resource.DisposeMethod;
+
+            // Step 3.d: implicit Await tick when a sync-dispose follows pending async resources.
+            if (hint == DisposeHint.Sync && _disposeNeedsAwait && !_disposeHasAwaited)
+            {
+                _disposeHasAwaited = true;
+                _disposeNeedsAwait = false;
+                _disposeResume = DisposeResumePoint.AfterImplicitAwait;
+                // Don't decrement — current resource will be processed after resume.
+                return DisposeStepResult.Suspend(CreateResolvedUndefinedPromise());
             }
 
+            // Step 3.e: call the dispose method.
             if (method is not null)
             {
-                var result = JsValue.Undefined;
-                JavaScriptException? exception = null;
+                JsValue methodResult;
                 try
                 {
-                    result = method.Call(value);
-                    if (hint == DisposeHint.Async)
-                    {
-                        hasAwaited = true;
-                        try
-                        {
-                            result = result.UnwrapIfPromise(_engine.Options.Constraints.PromiseTimeout);
-                        }
-                        catch (PromiseRejectedException e)
-                        {
-                            exception = new JavaScriptException(e.RejectedValue);
-                        }
-                        catch (JavaScriptException e)
-                        {
-                            exception = e;
-                        }
-                    }
+                    methodResult = method.Call(value);
                 }
                 catch (JavaScriptException e)
                 {
-                    exception = e;
+                    HandleDisposeException(e.Error);
+                    _disposeIndex--;
+                    continue;
+                }
+                catch (PromiseRejectedException e)
+                {
+                    HandleDisposeException(e.RejectedValue);
+                    _disposeIndex--;
+                    continue;
                 }
 
-                if (exception is not null)
+                if (hint == DisposeHint.Async)
                 {
-                    if (c.Type == CompletionType.Throw)
-                    {
-                        var error = _engine.Intrinsics.SuppressedError.Construct(_engine.Intrinsics.SuppressedError, "", exception.Error, c.Value);
-                        c = new Completion(CompletionType.Throw, error, c._source);
-                    }
-                    else
-                    {
-                        c = new Completion(CompletionType.Throw, exception.Error, c._source);
-                    }
+                    // Step 3.e.ii.1: Await the result before continuing.
+                    _disposeHasAwaited = true;
+                    _disposeResume = DisposeResumePoint.AfterMethodAwait;
+                    return DisposeStepResult.Suspend(methodResult);
                 }
             }
             else
             {
-                // Assert: hint is "async-dispose"
-                needsAwait = true;
+                // Step 3.f: null/undefined async-dispose resource — accumulates needsAwait.
+                _disposeNeedsAwait = true;
             }
+
+            _disposeIndex--;
         }
 
-        if (needsAwait && !hasAwaited)
+        // Step 4: final implicit Await(undefined) if needsAwait was set but never satisfied.
+        if (_disposeNeedsAwait && !_disposeHasAwaited)
         {
-            NeedsAsyncTick = true;
-            _engine.RunAvailableContinuations();
+            _disposeHasAwaited = true;
+            _disposeNeedsAwait = false;
+            _disposeResume = DisposeResumePoint.AfterImplicitAwait;
+            // _disposeIndex is already -1; ContinueDispose will Finish on resume.
+            return DisposeStepResult.Suspend(CreateResolvedUndefinedPromise());
         }
 
+        return Finish();
+    }
+
+    private DisposeStepResult Finish()
+    {
+        var result = _disposeCompletion;
         _disposableResourceStack.Clear();
-        return c;
+        _disposeResume = DisposeResumePoint.None;
+        return DisposeStepResult.Done(result);
+    }
+
+    private void HandleDisposeException(JsValue error)
+    {
+        if (_disposeCompletion.Type == CompletionType.Throw)
+        {
+            var suppressed = _engine.Intrinsics.SuppressedError.Construct(
+                _engine.Intrinsics.SuppressedError, "", error, _disposeCompletion.Value);
+            _disposeCompletion = new Completion(CompletionType.Throw, suppressed, _disposeCompletion._source);
+        }
+        else
+        {
+            _disposeCompletion = new Completion(CompletionType.Throw, error, _disposeCompletion._source);
+        }
+    }
+
+    private JsValue CreateResolvedUndefinedPromise()
+    {
+        return _engine.Realm.Intrinsics.Promise.PromiseResolve(JsValue.Undefined);
     }
 
     private readonly record struct DisposableResource(JsValue ResourceValue, DisposeHint Hint, ICallable? DisposeMethod);
 }
-

--- a/Jint/Native/Disposable/DisposeResourcesHelper.cs
+++ b/Jint/Native/Disposable/DisposeResourcesHelper.cs
@@ -1,0 +1,60 @@
+using Jint.Native.Promise;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+using Environment = Jint.Runtime.Environments.Environment;
+
+namespace Jint.Native.Disposable;
+
+/// <summary>
+/// Drives <see cref="DisposeCapability"/>'s state machine for call sites where the
+/// async function/generator body has already finished — so we don't need to suspend
+/// the function itself, only defer settlement of its return promise. Each
+/// state-machine Suspend is chained via <c>Promise.then</c>, and the caller-provided
+/// <c>continueWith</c> callback fires when the full dispose chain has completed.
+/// </summary>
+internal static class DisposeResourcesHelper
+{
+    public static void DisposeAndThen(
+        Engine engine,
+        Environment env,
+        Completion initial,
+        Action<Completion> continueWith)
+    {
+        var step = env.BeginDisposeResources(initial);
+        DriveAsync(engine, env, step, continueWith);
+    }
+
+    private static void DriveAsync(
+        Engine engine,
+        Environment env,
+        DisposeStepResult step,
+        Action<Completion> continueWith)
+    {
+        while (!step.IsDone)
+        {
+            var pending = step.PendingPromise!;
+            var promise = pending as JsPromise
+                ?? (JsPromise) engine.Realm.Intrinsics.Promise.PromiseResolve(pending);
+
+            var onFulfilled = new ClrFunction(engine, "", (_, args) =>
+            {
+                var next = env.ContinueDisposeResources(args.At(0), awaitThrew: false);
+                DriveAsync(engine, env, next, continueWith);
+                return JsValue.Undefined;
+            }, 1, PropertyFlag.Configurable);
+
+            var onRejected = new ClrFunction(engine, "", (_, args) =>
+            {
+                var next = env.ContinueDisposeResources(args.At(0), awaitThrew: true);
+                DriveAsync(engine, env, next, continueWith);
+                return JsValue.Undefined;
+            }, 1, PropertyFlag.Configurable);
+
+            PromiseOperations.PerformPromiseThen(engine, promise, onFulfilled, onRejected, null!);
+            return; // suspended — onFulfilled/onRejected will continue the drive
+        }
+
+        continueWith(step.CompletedResult);
+    }
+}

--- a/Jint/Native/Disposable/DisposeResourcesHelper.cs
+++ b/Jint/Native/Disposable/DisposeResourcesHelper.cs
@@ -8,8 +8,8 @@ namespace Jint.Native.Disposable;
 
 /// <summary>
 /// Drives <see cref="DisposeCapability"/>'s state machine for call sites where the
-/// async function/generator body has already finished — so we don't need to suspend
-/// the function itself, only defer settlement of its return promise. Each
+/// async function/generator/module body has already finished — so we don't need to
+/// suspend the function itself, only defer settlement of its return promise. Each
 /// state-machine Suspend is chained via <c>Promise.then</c>, and the caller-provided
 /// <c>continueWith</c> callback fires when the full dispose chain has completed.
 /// </summary>
@@ -21,15 +21,23 @@ internal static class DisposeResourcesHelper
         Completion initial,
         Action<Completion> continueWith)
     {
-        var step = env.BeginDisposeResources(initial);
-        DriveAsync(engine, env, step, continueWith);
+        Drive(engine, env.BeginDisposeResources(initial), continueWith, env.ContinueDisposeResources);
     }
 
-    private static void DriveAsync(
+    public static void DisposeAndThen(
         Engine engine,
-        Environment env,
-        DisposeStepResult step,
+        DisposeCapability capability,
+        Completion initial,
         Action<Completion> continueWith)
+    {
+        Drive(engine, capability.BeginDispose(initial), continueWith, capability.ContinueDispose);
+    }
+
+    private static void Drive(
+        Engine engine,
+        DisposeStepResult step,
+        Action<Completion> continueWith,
+        Func<JsValue, bool, DisposeStepResult> continueDispose)
     {
         while (!step.IsDone)
         {
@@ -39,15 +47,15 @@ internal static class DisposeResourcesHelper
 
             var onFulfilled = new ClrFunction(engine, "", (_, args) =>
             {
-                var next = env.ContinueDisposeResources(args.At(0), awaitThrew: false);
-                DriveAsync(engine, env, next, continueWith);
+                var next = continueDispose(args.At(0), false);
+                Drive(engine, next, continueWith, continueDispose);
                 return JsValue.Undefined;
             }, 1, PropertyFlag.Configurable);
 
             var onRejected = new ClrFunction(engine, "", (_, args) =>
             {
-                var next = env.ContinueDisposeResources(args.At(0), awaitThrew: true);
-                DriveAsync(engine, env, next, continueWith);
+                var next = continueDispose(args.At(0), true);
+                Drive(engine, next, continueWith, continueDispose);
                 return JsValue.Undefined;
             }, 1, PropertyFlag.Configurable);
 

--- a/Jint/Runtime/Environments/DeclarativeEnvironment.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironment.cs
@@ -343,10 +343,19 @@ internal class DeclarativeEnvironment : Environment
     internal sealed override Completion DisposeResources(Completion c) => _disposeCapability?.DisposeResources(c) ?? c;
 
     /// <summary>
-    /// True if the last DisposeResources call encountered an async-dispose resource
-    /// with no method (null/undefined value), requiring an implicit Await tick per spec.
+    /// Begin dispose via the state machine. Returns either Done with the final Completion,
+    /// or Suspend with a Promise the caller must await before calling
+    /// <see cref="ContinueDisposeResources"/>. If no resources are registered, returns
+    /// Done immediately.
     /// </summary>
-    internal bool NeedsAsyncDisposeTick => _disposeCapability?.NeedsAsyncTick == true;
+    internal sealed override DisposeStepResult BeginDisposeResources(Completion c)
+        => _disposeCapability?.BeginDispose(c) ?? DisposeStepResult.Done(c);
+
+    /// <summary>
+    /// Continue dispose after a suspended Await settles. Returns either Done or the next Suspend.
+    /// </summary>
+    internal sealed override DisposeStepResult ContinueDisposeResources(JsValue awaitResult, bool awaitThrew)
+        => _disposeCapability!.ContinueDispose(awaitResult, awaitThrew);
 
     public void Clear()
     {

--- a/Jint/Runtime/Environments/DeclarativeEnvironment.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironment.cs
@@ -342,6 +342,8 @@ internal class DeclarativeEnvironment : Environment
 
     internal sealed override Completion DisposeResources(Completion c) => _disposeCapability?.DisposeResources(c) ?? c;
 
+    internal sealed override bool HasDisposeResources => _disposeCapability?.HasResources == true;
+
     /// <summary>
     /// Begin dispose via the state machine. Returns either Done with the final Completion,
     /// or Suspend with a Promise the caller must await before calling

--- a/Jint/Runtime/Environments/Environment.cs
+++ b/Jint/Runtime/Environments/Environment.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Jint.Native;
+using Jint.Native.Disposable;
 
 namespace Jint.Runtime.Environments;
 
@@ -108,6 +109,22 @@ internal abstract class Environment : JsValue
     internal JsValue? NewTarget { get; set; }
 
     internal virtual Completion DisposeResources(Completion c) => c;
+
+    /// <summary>
+    /// Begin dispose via the state machine. Default returns Done immediately for
+    /// environments that don't track disposable resources.
+    /// </summary>
+    internal virtual DisposeStepResult BeginDisposeResources(Completion c) => DisposeStepResult.Done(c);
+
+    /// <summary>
+    /// Continue dispose after an awaited promise settled. Must not be called on
+    /// an environment that didn't return a Suspend from BeginDisposeResources.
+    /// </summary>
+    internal virtual DisposeStepResult ContinueDisposeResources(JsValue awaitResult, bool awaitThrew)
+    {
+        Throw.InvalidOperationException("ContinueDisposeResources called without a pending Suspend.");
+        return default;
+    }
 
     /// <summary>
     /// Helper to cache JsString/Key when environments use different lookups.

--- a/Jint/Runtime/Environments/Environment.cs
+++ b/Jint/Runtime/Environments/Environment.cs
@@ -111,6 +111,13 @@ internal abstract class Environment : JsValue
     internal virtual Completion DisposeResources(Completion c) => c;
 
     /// <summary>
+    /// Fast bool check for whether this environment has any disposable resources to
+    /// process. Lets callers skip allocating a continueWith closure when there's no
+    /// dispose work to do — the dispose hot path on every async function/generator exit.
+    /// </summary>
+    internal virtual bool HasDisposeResources => false;
+
+    /// <summary>
     /// Begin dispose via the state machine. Default returns Done immediately for
     /// environments that don't track disposable resources.
     /// </summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
@@ -1,6 +1,7 @@
 using Jint.Native;
 using Jint.Native.AsyncFunction;
 using Jint.Native.AsyncGenerator;
+using Jint.Native.Disposable;
 using Jint.Native.Promise;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
@@ -242,10 +243,16 @@ internal sealed class JintAwaitExpression : JintExpression
         catch (JavaScriptException e)
         {
             var env = engine.ExecutionContext.LexicalEnvironment;
-            var disposeResult = env.DisposeResources(new Completion(CompletionType.Throw, e.Error, null!));
-            engine.LeaveExecutionContext();
-            asyncInstance._state = AsyncFunctionState.Completed;
-            asyncInstance._capability.Reject.Call(JsValue.Undefined, disposeResult.Value);
+            DisposeResourcesHelper.DisposeAndThen(
+                engine,
+                env,
+                new Completion(CompletionType.Throw, e.Error, null!),
+                final =>
+                {
+                    engine.LeaveExecutionContext();
+                    asyncInstance._state = AsyncFunctionState.Completed;
+                    asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
+                });
             return;
         }
 
@@ -256,23 +263,23 @@ internal sealed class JintAwaitExpression : JintExpression
         }
 
         var lexEnv = engine.ExecutionContext.LexicalEnvironment;
-        result = lexEnv.DisposeResources(result);
-
-        engine.LeaveExecutionContext();
-
-        asyncInstance._state = AsyncFunctionState.Completed;
-
-        if (result.Type == CompletionType.Throw)
+        DisposeResourcesHelper.DisposeAndThen(engine, lexEnv, result, final =>
         {
-            asyncInstance._capability.Reject.Call(JsValue.Undefined, result.Value);
-        }
-        else if (result.Type == CompletionType.Return)
-        {
-            asyncInstance._capability.Resolve.Call(JsValue.Undefined, result.Value);
-        }
-        else
-        {
-            asyncInstance._capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
-        }
+            engine.LeaveExecutionContext();
+            asyncInstance._state = AsyncFunctionState.Completed;
+
+            if (final.Type == CompletionType.Throw)
+            {
+                asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
+            }
+            else if (final.Type == CompletionType.Return)
+            {
+                asyncInstance._capability.Resolve.Call(JsValue.Undefined, final.Value);
+            }
+            else
+            {
+                asyncInstance._capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
+            }
+        });
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
@@ -243,16 +243,18 @@ internal sealed class JintAwaitExpression : JintExpression
         catch (JavaScriptException e)
         {
             var env = engine.ExecutionContext.LexicalEnvironment;
+            if (!env.HasDisposeResources)
+            {
+                engine.LeaveExecutionContext();
+                asyncInstance._state = AsyncFunctionState.Completed;
+                asyncInstance._capability.Reject.Call(JsValue.Undefined, e.Error);
+                return;
+            }
             DisposeResourcesHelper.DisposeAndThen(
                 engine,
                 env,
                 new Completion(CompletionType.Throw, e.Error, null!),
-                final =>
-                {
-                    engine.LeaveExecutionContext();
-                    asyncInstance._state = AsyncFunctionState.Completed;
-                    asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
-                });
+                final => SettleAsyncResumeCompletion(engine, asyncInstance, final));
             return;
         }
 
@@ -263,23 +265,31 @@ internal sealed class JintAwaitExpression : JintExpression
         }
 
         var lexEnv = engine.ExecutionContext.LexicalEnvironment;
-        DisposeResourcesHelper.DisposeAndThen(engine, lexEnv, result, final =>
+        if (!lexEnv.HasDisposeResources)
         {
-            engine.LeaveExecutionContext();
-            asyncInstance._state = AsyncFunctionState.Completed;
+            SettleAsyncResumeCompletion(engine, asyncInstance, result);
+            return;
+        }
+        DisposeResourcesHelper.DisposeAndThen(engine, lexEnv, result,
+            final => SettleAsyncResumeCompletion(engine, asyncInstance, final));
+    }
 
-            if (final.Type == CompletionType.Throw)
-            {
-                asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
-            }
-            else if (final.Type == CompletionType.Return)
-            {
-                asyncInstance._capability.Resolve.Call(JsValue.Undefined, final.Value);
-            }
-            else
-            {
-                asyncInstance._capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
-            }
-        });
+    private static void SettleAsyncResumeCompletion(Engine engine, AsyncFunctionInstance asyncInstance, Completion final)
+    {
+        engine.LeaveExecutionContext();
+        asyncInstance._state = AsyncFunctionState.Completed;
+
+        if (final.Type == CompletionType.Throw)
+        {
+            asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
+        }
+        else if (final.Type == CompletionType.Return)
+        {
+            asyncInstance._capability.Resolve.Call(JsValue.Undefined, final.Value);
+        }
+        else
+        {
+            asyncInstance._capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
+        }
     }
 }

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -3,6 +3,7 @@ using Jint.Native;
 using Jint.Native.Function;
 using Jint.Native.AsyncFunction;
 using Jint.Native.AsyncGenerator;
+using Jint.Native.Disposable;
 using Jint.Native.Generator;
 using Jint.Native.Promise;
 using Jint.Runtime.Environments;
@@ -177,11 +178,18 @@ internal sealed class JintFunctionDefinition
         }
         catch (JavaScriptException e)
         {
-            // Per spec: DisposeResources before rejecting
+            // Per spec: DisposeResources before rejecting. Use the helper so async-dispose
+            // resources are awaited via the state machine instead of sync-blocking.
             var env = engine.ExecutionContext.LexicalEnvironment;
-            var disposeResult = env.DisposeResources(new Completion(CompletionType.Throw, e.Error, null!));
-            asyncInstance._state = AsyncFunctionState.Completed;
-            asyncInstance._capability.Reject.Call(JsValue.Undefined, disposeResult.Value);
+            DisposeResourcesHelper.DisposeAndThen(
+                engine,
+                env,
+                new Completion(CompletionType.Throw, e.Error, null!),
+                final =>
+                {
+                    asyncInstance._state = AsyncFunctionState.Completed;
+                    asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
+                });
             return;
         }
 
@@ -193,29 +201,31 @@ internal sealed class JintFunctionDefinition
             return;
         }
 
-        // Per spec AsyncBlockStart step 3.f: DisposeResources after body completes
+        // Per spec AsyncBlockStart step 3.f: DisposeResources after body completes.
+        // Settlement of the function's return promise is deferred until the dispose chain
+        // (which may itself await) finishes.
         var lexEnv = engine.ExecutionContext.LexicalEnvironment;
-        result = lexEnv.DisposeResources(result);
+        DisposeResourcesHelper.DisposeAndThen(engine, lexEnv, result, final =>
+        {
+            asyncInstance._state = AsyncFunctionState.Completed;
 
-        // Completed - resolve or reject the async function's return promise
-        asyncInstance._state = AsyncFunctionState.Completed;
-
-        if (result.Type == CompletionType.Throw)
-        {
-            asyncInstance._capability.Reject.Call(JsValue.Undefined, result.Value);
-        }
-        else if (result.Type == CompletionType.Normal)
-        {
-            asyncInstance._capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
-        }
-        else if (result.Type == CompletionType.Return)
-        {
-            asyncInstance._capability.Resolve.Call(JsValue.Undefined, result.Value);
-        }
-        else
-        {
-            asyncInstance._capability.Reject.Call(JsValue.Undefined, result.Value);
-        }
+            if (final.Type == CompletionType.Throw)
+            {
+                asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
+            }
+            else if (final.Type == CompletionType.Normal)
+            {
+                asyncInstance._capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
+            }
+            else if (final.Type == CompletionType.Return)
+            {
+                asyncInstance._capability.Resolve.Call(JsValue.Undefined, final.Value);
+            }
+            else
+            {
+                asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
+            }
+        });
     }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -179,8 +179,15 @@ internal sealed class JintFunctionDefinition
         catch (JavaScriptException e)
         {
             // Per spec: DisposeResources before rejecting. Use the helper so async-dispose
-            // resources are awaited via the state machine instead of sync-blocking.
+            // resources are awaited via the state machine instead of sync-blocking. Skip
+            // the helper entirely if the env has no disposables — common-case hot path.
             var env = engine.ExecutionContext.LexicalEnvironment;
+            if (!env.HasDisposeResources)
+            {
+                asyncInstance._state = AsyncFunctionState.Completed;
+                asyncInstance._capability.Reject.Call(JsValue.Undefined, e.Error);
+                return;
+            }
             DisposeResourcesHelper.DisposeAndThen(
                 engine,
                 env,
@@ -203,29 +210,36 @@ internal sealed class JintFunctionDefinition
 
         // Per spec AsyncBlockStart step 3.f: DisposeResources after body completes.
         // Settlement of the function's return promise is deferred until the dispose chain
-        // (which may itself await) finishes.
+        // (which may itself await) finishes. Fast-path skip when no disposables registered.
         var lexEnv = engine.ExecutionContext.LexicalEnvironment;
-        DisposeResourcesHelper.DisposeAndThen(engine, lexEnv, result, final =>
+        if (!lexEnv.HasDisposeResources)
         {
-            asyncInstance._state = AsyncFunctionState.Completed;
+            SettleAsyncFunctionCompletion(asyncInstance, result);
+            return;
+        }
+        DisposeResourcesHelper.DisposeAndThen(engine, lexEnv, result, final => SettleAsyncFunctionCompletion(asyncInstance, final));
+    }
 
-            if (final.Type == CompletionType.Throw)
-            {
-                asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
-            }
-            else if (final.Type == CompletionType.Normal)
-            {
-                asyncInstance._capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
-            }
-            else if (final.Type == CompletionType.Return)
-            {
-                asyncInstance._capability.Resolve.Call(JsValue.Undefined, final.Value);
-            }
-            else
-            {
-                asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
-            }
-        });
+    private static void SettleAsyncFunctionCompletion(AsyncFunctionInstance asyncInstance, Completion final)
+    {
+        asyncInstance._state = AsyncFunctionState.Completed;
+
+        if (final.Type == CompletionType.Throw)
+        {
+            asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
+        }
+        else if (final.Type == CompletionType.Normal)
+        {
+            asyncInstance._capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
+        }
+        else if (final.Type == CompletionType.Return)
+        {
+            asyncInstance._capability.Resolve.Call(JsValue.Undefined, final.Value);
+        }
+        else
+        {
+            asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
+        }
     }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -163,6 +163,8 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
         ISuspendable suspendable)
     {
         var engine = context.Engine;
+        // suspendable.IsResuming setter delegates to asyncFn._isResuming, so this
+        // single assignment clears both the interface flag and the underlying field.
         suspendable.IsResuming = false;
 
         var asyncFn = engine.ExecutionContext.AsyncFunction!;
@@ -170,7 +172,6 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
         var awaitThrew = asyncFn._resumeWithThrow;
         asyncFn._resumeValue = null;
         asyncFn._resumeWithThrow = false;
-        asyncFn._isResuming = false;
         asyncFn._lastAwaitNode = null;
 
         // Use the env captured at suspend time, in case the env-setup branch above

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -1,5 +1,7 @@
 using System.Threading;
 using Jint.Native;
+using Jint.Native.AsyncFunction;
+using Jint.Native.Disposable;
 using Jint.Native.Promise;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
@@ -102,20 +104,13 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
 
         Completion blockValue;
 
-        // If resuming from a disposal-caused suspension (await-using with null/undefined),
-        // skip re-executing the body — the block body already completed, we're just
-        // resuming after the implicit Await tick from DisposeResources.
+        // Resuming from a dispose-driven suspension: don't re-execute the body — advance
+        // the dispose state machine from where it suspended.
         if (suspendable is { IsResuming: true }
             && suspendable.Data.TryGet(this, out BlockSuspendData? disposeResumeData)
-            && disposeResumeData?.DisposalComplete == true)
+            && disposeResumeData?.DisposeInProgress == true)
         {
-            suspendable.IsResuming = false;
-            suspendable.Data.Clear(this);
-            if (oldEnv is not null)
-            {
-                engine.UpdateLexicalEnvironment(oldEnv);
-            }
-            return new Completion(CompletionType.Normal, JsValue.Undefined, _statement);
+            return ResumeDispose(context, blockEnv, oldEnv, disposeResumeData, suspendable);
         }
 
         if (_singleStatement is not null)
@@ -140,53 +135,12 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
             }
             else
             {
-                // Return environment to cache for reuse (slots only exist when CanReuseEnvironment=true)
-                if (blockEnv._slots is not null)
-                {
-                    Interlocked.Exchange(ref blockState._cachedEnv, blockEnv);
-                }
-
-                blockValue = blockEnv.DisposeResources(blockValue);
-
-                // Per spec Dispose step 3.a: await-using with null/undefined value requires
-                // an implicit Await tick. Suspend the async function to introduce the tick.
-                if (blockEnv.NeedsAsyncDisposeTick)
-                {
-                    var asyncFn = engine.ExecutionContext.AsyncFunction;
-                    if (asyncFn is not null)
-                    {
-                        var promise = (JsPromise) engine.Realm.Intrinsics.Promise.PromiseResolve(JsValue.Undefined);
-
-                        asyncFn._lastAwaitNode = this;
-                        asyncFn._state = Native.AsyncFunction.AsyncFunctionState.SuspendedAwait;
-                        asyncFn._savedContext = engine.ExecutionContext;
-
-                        var onFulfilled = new ClrFunction(engine, "", (_, args) =>
-                        {
-                            asyncFn._resumeValue = JsValue.Undefined;
-                            asyncFn._resumeWithThrow = false;
-                            JintAwaitExpression.AsyncFunctionResume(engine, asyncFn);
-                            return JsValue.Undefined;
-                        }, 1, PropertyFlag.Configurable);
-
-                        PromiseOperations.PerformPromiseThen(engine, promise, onFulfilled, null!, null!);
-
-                        if (suspendable is not null)
-                        {
-                            var data = suspendable.Data.GetOrCreate<BlockSuspendData>(this);
-                            data.BlockEnvironment = blockEnv;
-                            data.OuterEnvironment = oldEnv;
-                            data.DisposalComplete = true;
-                        }
-                        if (oldEnv is not null)
-                        {
-                            engine.UpdateLexicalEnvironment(oldEnv);
-                        }
-                        return blockValue;
-                    }
-                }
-
-                suspendable?.Data.Clear(this);
+                return CompleteDispose(
+                    context,
+                    blockEnv,
+                    oldEnv,
+                    suspendable,
+                    blockEnv.BeginDisposeResources(blockValue));
             }
         }
 
@@ -196,6 +150,140 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
         }
 
         return blockValue;
+    }
+
+    /// <summary>
+    /// Resume the dispose state machine after an awaited dispose promise settled.
+    /// </summary>
+    private Completion ResumeDispose(
+        EvaluationContext context,
+        DeclarativeEnvironment? blockEnv,
+        Environment? oldEnv,
+        BlockSuspendData data,
+        ISuspendable suspendable)
+    {
+        var engine = context.Engine;
+        suspendable.IsResuming = false;
+
+        var asyncFn = engine.ExecutionContext.AsyncFunction!;
+        var awaitResult = asyncFn._resumeValue ?? JsValue.Undefined;
+        var awaitThrew = asyncFn._resumeWithThrow;
+        asyncFn._resumeValue = null;
+        asyncFn._resumeWithThrow = false;
+        asyncFn._isResuming = false;
+        asyncFn._lastAwaitNode = null;
+
+        // Use the env captured at suspend time, in case the env-setup branch above
+        // didn't run on this re-entry (no declarations path).
+        blockEnv ??= data.BlockEnvironment!;
+        oldEnv ??= data.OuterEnvironment;
+        engine.UpdateLexicalEnvironment(blockEnv);
+
+        return CompleteDispose(
+            context,
+            blockEnv,
+            oldEnv,
+            suspendable,
+            blockEnv.ContinueDisposeResources(awaitResult, awaitThrew));
+    }
+
+    /// <summary>
+    /// Drives the dispose state machine to completion. For each suspension, suspends
+    /// the surrounding async function (via the same machinery as <c>await</c>); when
+    /// the dispose promise settles, the function resumes and the block re-enters
+    /// <see cref="ExecuteBlock"/> with the dispose-in-progress flag set.
+    /// </summary>
+    private Completion CompleteDispose(
+        EvaluationContext context,
+        DeclarativeEnvironment blockEnv,
+        Environment? oldEnv,
+        ISuspendable? suspendable,
+        DisposeStepResult step)
+    {
+        var engine = context.Engine;
+
+        while (!step.IsDone)
+        {
+            var pending = step.PendingPromise!;
+            var asyncFn = engine.ExecutionContext.AsyncFunction;
+
+            if (asyncFn is null)
+            {
+                // Non-async context fallback. `await using` is syntactically only valid
+                // in async, so this path is reached only by unusual hosts. Sync wait.
+                JsValue resolved;
+                bool threw = false;
+                try
+                {
+                    resolved = pending.UnwrapIfPromise(engine.Options.Constraints.PromiseTimeout);
+                }
+                catch (PromiseRejectedException e)
+                {
+                    resolved = e.RejectedValue;
+                    threw = true;
+                }
+                step = blockEnv.ContinueDisposeResources(resolved, threw);
+                continue;
+            }
+
+            SetupDisposeSuspension(engine, asyncFn, pending);
+
+            var data = suspendable!.Data.GetOrCreate<BlockSuspendData>(this);
+            data.BlockEnvironment = blockEnv;
+            data.OuterEnvironment = oldEnv;
+            data.DisposeInProgress = true;
+
+            if (oldEnv is not null)
+            {
+                engine.UpdateLexicalEnvironment(oldEnv);
+            }
+            return new Completion(CompletionType.Normal, JsValue.Undefined, _statement);
+        }
+
+        // Dispose finished — finalize: cache env, restore outer env, return.
+        suspendable?.Data.Clear(this);
+        if (blockEnv._slots is not null)
+        {
+            Interlocked.Exchange(ref _blockState._cachedEnv, blockEnv);
+        }
+        if (oldEnv is not null)
+        {
+            engine.UpdateLexicalEnvironment(oldEnv);
+        }
+        return step.CompletedResult;
+    }
+
+    /// <summary>
+    /// Mirror of <see cref="JintAwaitExpression.SuspendForAwait"/> for the dispose path:
+    /// suspends the async function on the pending dispose promise, with handlers that
+    /// resume the function (which re-enters this block via <see cref="ResumeDispose"/>).
+    /// </summary>
+    private void SetupDisposeSuspension(Engine engine, AsyncFunctionInstance asyncFn, JsValue pendingPromise)
+    {
+        var promise = pendingPromise as JsPromise
+            ?? (JsPromise) engine.Realm.Intrinsics.Promise.PromiseResolve(pendingPromise);
+
+        asyncFn._lastAwaitNode = this;
+        asyncFn._state = AsyncFunctionState.SuspendedAwait;
+        asyncFn._savedContext = engine.ExecutionContext;
+
+        var onFulfilled = new ClrFunction(engine, "", (_, args) =>
+        {
+            asyncFn._resumeValue = args.At(0);
+            asyncFn._resumeWithThrow = false;
+            JintAwaitExpression.AsyncFunctionResume(engine, asyncFn);
+            return JsValue.Undefined;
+        }, 1, PropertyFlag.Configurable);
+
+        var onRejected = new ClrFunction(engine, "", (_, args) =>
+        {
+            asyncFn._resumeValue = args.At(0);
+            asyncFn._resumeWithThrow = true;
+            JintAwaitExpression.AsyncFunctionResume(engine, asyncFn);
+            return JsValue.Undefined;
+        }, 1, PropertyFlag.Configurable);
+
+        PromiseOperations.PerformPromiseThen(engine, promise, onFulfilled, onRejected, null!);
     }
 
     private Completion ExecuteSingle(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Jint.Native;
 using Jint.Native.AsyncFunction;
+using Jint.Native.Disposable;
 using Jint.Native.Iterator;
 using Jint.Native.Object;
 using Jint.Native.Promise;
@@ -141,13 +142,22 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
             // Try sync for-of suspend data first (generators)
             if (suspendable.Data.TryGet(this, out suspendData))
             {
+                if (suspendData!.DisposeInProgress)
+                {
+                    return ResumeFromDispose(context, suspendable, suspendData);
+                }
                 // We're resuming into this for-of loop - use the saved iterator
-                keyResult = suspendData!.Iterator;
+                keyResult = suspendData.Iterator;
                 resuming = true;
             }
             // Try async for-await-of suspend data
             else if (suspendable.Data.TryGet(this, out forAwaitSuspendData))
             {
+                if (forAwaitSuspendData!.DisposeInProgress)
+                {
+                    return ResumeFromDispose(context, suspendable, forAwaitSuspendData);
+                }
+
                 // Check if we're resuming from a rejection in an async function - if so, throw the error
                 var asyncFunction = engine.ExecutionContext.AsyncFunction;
                 if (asyncFunction is not null && asyncFunction._lastAwaitNode == this && asyncFunction._resumeWithThrow)
@@ -163,7 +173,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 }
 
                 // Check if we're resuming from a rejection in an async generator - if so, throw the error
-                if (forAwaitSuspendData!.RejectedValue is { } rejectedValue)
+                if (forAwaitSuspendData.RejectedValue is { } rejectedValue)
                 {
                     suspendable.IsResuming = false;
                     suspendable.Data.Clear(this);
@@ -173,7 +183,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 }
 
                 // We're resuming into this for-await-of loop - use the saved iterator
-                keyResult = forAwaitSuspendData!.Iterator;
+                keyResult = forAwaitSuspendData.Iterator;
                 resuming = true;
                 // Only clear IsResuming if NOT resuming from yield inside destructuring
                 // (yield needs IsResuming to be true to return the resume value)
@@ -600,7 +610,41 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     }
                 }
 
-                result = iterationEnv?.DisposeResources(result) ?? result;
+                // Dispose iteration env's resources. If the env has async-dispose
+                // resources and we're in an async function (and the body didn't
+                // suspend), drive the spec-mandated Await(...) suspensions via the
+                // state machine and suspend the async function on each pending
+                // promise — same pattern as JintBlockStatement. Sync/already-suspended
+                // contexts use the legacy drive (which sync-waits via UnwrapIfPromise).
+                if (iterationEnv?.HasDisposeResources == true
+                    && !context.IsSuspended()
+                    && engine.ExecutionContext.AsyncFunction is { } disposeAsyncFn)
+                {
+                    var disposeStep = iterationEnv.BeginDisposeResources(result);
+                    var suspendedCompletion = DriveDispose(
+                        context,
+                        suspendable,
+                        disposeAsyncFn,
+                        iterationEnv,
+                        oldEnv,
+                        v,
+                        iteratorRecord,
+                        iteratorKind,
+                        disposeStep,
+                        out var disposeFinal);
+                    if (suspendedCompletion is { } suspended)
+                    {
+                        // Prevent the finally block from clearing the suspend data we
+                        // just stored and from closing the iterator — we'll resume.
+                        close = false;
+                        return suspended;
+                    }
+                    result = disposeFinal;
+                }
+                else
+                {
+                    result = iterationEnv?.DisposeResources(result) ?? result;
+                }
                 engine.UpdateLexicalEnvironment(oldEnv);
 
                 if (!result.Value.IsEmpty)
@@ -839,6 +883,251 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 Throw.JavaScriptException(engine, e.RejectedValue, _statement!.Location);
                 return default;
             }
+        }
+    }
+
+    /// <summary>
+    /// Drives the iteration env's dispose state machine. If the next step is a
+    /// suspend (await), suspends the surrounding async function on the pending
+    /// promise — same machinery as a JS <c>await</c> — and returns a completion
+    /// indicating the for-of has handed control back to the async runtime. On
+    /// resume, <see cref="ResumeFromDispose"/> picks up where we left off.
+    /// Returns null when the state machine completes synchronously; the caller
+    /// then uses <paramref name="finalCompletion"/> as the post-dispose result.
+    /// </summary>
+    private Completion? DriveDispose(
+        EvaluationContext context,
+        ISuspendable? suspendable,
+        AsyncFunctionInstance asyncFn,
+        DeclarativeEnvironment iterationEnv,
+        Environment oldEnv,
+        JsValue v,
+        IteratorInstance iteratorRecord,
+        IteratorKind iteratorKind,
+        DisposeStepResult step,
+        out Completion finalCompletion)
+    {
+        var engine = context.Engine;
+        if (step.IsDone)
+        {
+            finalCompletion = step.CompletedResult;
+            return null;
+        }
+
+        SetupDisposeSuspension(engine, asyncFn, step.PendingPromise!);
+        SaveDisposeSuspendState(suspendable, iterationEnv, oldEnv, v, iteratorRecord, iteratorKind);
+        engine.UpdateLexicalEnvironment(oldEnv);
+        finalCompletion = default;
+        return new Completion(CompletionType.Normal, JsValue.Undefined, _statement!);
+    }
+
+    /// <summary>
+    /// Resume entry point when the async function was suspended mid-dispose.
+    /// Advances the iteration env's dispose state machine with the awaited result.
+    /// If the state machine suspends again, re-suspends the function. When the
+    /// state machine completes, applies the same post-dispose handling the main
+    /// loop applies (update accumulator, propagate abrupt completions) and either
+    /// continues with the next iteration via <see cref="BodyEvaluation"/>, or
+    /// returns the abrupt completion.
+    /// </summary>
+    private Completion ResumeFromDispose(EvaluationContext context, ISuspendable suspendable, SuspendData data)
+    {
+        var engine = context.Engine;
+        var asyncFn = engine.ExecutionContext.AsyncFunction;
+        var resumeValue = asyncFn?._resumeValue ?? JsValue.Undefined;
+        var resumeThrew = asyncFn?._resumeWithThrow ?? false;
+        if (asyncFn is not null)
+        {
+            asyncFn._resumeValue = null;
+            asyncFn._resumeWithThrow = false;
+            asyncFn._lastAwaitNode = null;
+        }
+        suspendable.IsResuming = false;
+
+        DeclarativeEnvironment iterationEnv;
+        Environment oldEnv;
+        JsValue v;
+        IteratorInstance iteratorRecord;
+        IteratorKind iteratorKind;
+        if (data is ForOfSuspendData syncData)
+        {
+            iterationEnv = syncData.IterationEnv!;
+            oldEnv = syncData.OuterEnv!;
+            v = syncData.AccumulatedValue;
+            iteratorRecord = syncData.Iterator!;
+            iteratorKind = IteratorKind.Sync;
+            syncData.DisposeInProgress = false;
+        }
+        else if (data is ForAwaitSuspendData asyncData)
+        {
+            iterationEnv = asyncData.IterationEnv!;
+            oldEnv = asyncData.OuterEnv!;
+            v = asyncData.AccumulatedValue;
+            iteratorRecord = asyncData.Iterator!;
+            iteratorKind = IteratorKind.Async;
+            asyncData.DisposeInProgress = false;
+        }
+        else
+        {
+            Throw.InvalidOperationException("Unexpected suspend data type for dispose resume.");
+            return default;
+        }
+
+        engine.UpdateLexicalEnvironment(iterationEnv);
+        var step = iterationEnv.ContinueDisposeResources(resumeValue, resumeThrew);
+
+        // The state machine may suspend again — handle that with the same Pattern A
+        // hand-off. We can only re-suspend on AsyncFunctionInstance; if for some
+        // reason it's gone, sync-wait via UnwrapIfPromise as a fallback.
+        while (!step.IsDone)
+        {
+            if (asyncFn is not null)
+            {
+                SetupDisposeSuspension(engine, asyncFn, step.PendingPromise!);
+                SaveDisposeSuspendState(suspendable, iterationEnv, oldEnv, v, iteratorRecord, iteratorKind);
+                engine.UpdateLexicalEnvironment(oldEnv);
+                return new Completion(CompletionType.Normal, JsValue.Undefined, _statement!);
+            }
+            try
+            {
+                var resolved = step.PendingPromise!.UnwrapIfPromise(engine.Options.Constraints.PromiseTimeout);
+                step = iterationEnv.ContinueDisposeResources(resolved, false);
+            }
+            catch (PromiseRejectedException e)
+            {
+                step = iterationEnv.ContinueDisposeResources(e.RejectedValue, true);
+            }
+            catch (JavaScriptException e)
+            {
+                step = iterationEnv.ContinueDisposeResources(e.Error, true);
+            }
+        }
+
+        var result = step.CompletedResult;
+        engine.UpdateLexicalEnvironment(oldEnv);
+        if (!result.Value.IsEmpty)
+        {
+            v = result.Value;
+        }
+
+        // Post-dispose abrupt handling — mirrors the inline code in BodyEvaluation.
+        if (result.Type == CompletionType.Throw)
+        {
+            suspendable.Data.Clear(this);
+            TryCloseIterator(iteratorRecord, CompletionType.Throw);
+            Throw.JavaScriptException(engine, result.Value, _statement!.Location);
+            return default;
+        }
+
+        if (result.Type == CompletionType.Break
+            && (context.Target is null || string.Equals(context.Target, _statement?.LabelSet?.Name, StringComparison.Ordinal)))
+        {
+            suspendable.Data.Clear(this);
+            TryCloseIterator(iteratorRecord, CompletionType.Normal);
+            return new Completion(CompletionType.Normal, v, _statement!);
+        }
+
+        if (result.Type == CompletionType.Return)
+        {
+            suspendable.Data.Clear(this);
+            TryCloseIterator(iteratorRecord, CompletionType.Return);
+            return result;
+        }
+
+        if (result.IsAbrupt() && result.Type != CompletionType.Continue)
+        {
+            suspendable.Data.Clear(this);
+            TryCloseIterator(iteratorRecord, result.Type);
+            return result;
+        }
+
+        // Normal / Continue → next iteration. Clear dispose-specific state but
+        // pass the accumulator forward via a fresh ForOfSuspendData (read by
+        // BodyEvaluation's `v` init).
+        suspendable.Data.Clear(this);
+        var carrier = new ForOfSuspendData { Iterator = iteratorRecord, AccumulatedValue = v };
+        return BodyEvaluation(context, _expr, _body, iteratorRecord, _iterationKind, _lhsKind, carrier, resuming: false, iteratorKind);
+    }
+
+    /// <summary>
+    /// Mirror of <see cref="JintAwaitExpression.SuspendForAwait"/> for the dispose
+    /// path: suspends the async function on the pending dispose promise so the
+    /// next event-loop tick resumes us via <see cref="ResumeFromDispose"/>.
+    /// </summary>
+    private void SetupDisposeSuspension(Engine engine, AsyncFunctionInstance asyncFn, JsValue pendingPromise)
+    {
+        var promise = pendingPromise as JsPromise
+            ?? (JsPromise) engine.Realm.Intrinsics.Promise.PromiseResolve(pendingPromise);
+
+        asyncFn._lastAwaitNode = this;
+        asyncFn._state = AsyncFunctionState.SuspendedAwait;
+        asyncFn._savedContext = engine.ExecutionContext;
+
+        var onFulfilled = new ClrFunction(engine, "", (_, args) =>
+        {
+            asyncFn._resumeValue = args.At(0);
+            asyncFn._resumeWithThrow = false;
+            JintAwaitExpression.AsyncFunctionResume(engine, asyncFn);
+            return JsValue.Undefined;
+        }, 1, PropertyFlag.Configurable);
+
+        var onRejected = new ClrFunction(engine, "", (_, args) =>
+        {
+            asyncFn._resumeValue = args.At(0);
+            asyncFn._resumeWithThrow = true;
+            JintAwaitExpression.AsyncFunctionResume(engine, asyncFn);
+            return JsValue.Undefined;
+        }, 1, PropertyFlag.Configurable);
+
+        PromiseOperations.PerformPromiseThen(engine, promise, onFulfilled, onRejected, null!);
+    }
+
+    private void SaveDisposeSuspendState(
+        ISuspendable? suspendable,
+        DeclarativeEnvironment iterationEnv,
+        Environment oldEnv,
+        JsValue v,
+        IteratorInstance iteratorRecord,
+        IteratorKind iteratorKind)
+    {
+        if (suspendable is null)
+        {
+            return;
+        }
+
+        // Clear any pre-existing suspend data for this statement so the dispose
+        // resume isn't ambiguous with a body-await resume of a different shape.
+        suspendable.Data.Clear(this);
+
+        if (iteratorKind == IteratorKind.Async)
+        {
+            var data = suspendable.Data.GetOrCreate<ForAwaitSuspendData>(this, iteratorRecord);
+            data.Iterator = iteratorRecord;
+            data.IterationEnv = iterationEnv;
+            data.OuterEnv = oldEnv;
+            data.AccumulatedValue = v;
+            data.DisposeInProgress = true;
+        }
+        else
+        {
+            var data = suspendable.Data.GetOrCreate<ForOfSuspendData>(this, iteratorRecord);
+            data.Iterator = iteratorRecord;
+            data.IterationEnv = iterationEnv;
+            data.OuterEnv = oldEnv;
+            data.AccumulatedValue = v;
+            data.DisposeInProgress = true;
+        }
+    }
+
+    private static void TryCloseIterator(IteratorInstance iterator, CompletionType completionType)
+    {
+        try
+        {
+            iterator.Close(completionType);
+        }
+        catch
+        {
+            // Best-effort close on abrupt — main path already has its own completion.
         }
     }
 

--- a/Jint/Runtime/Modules/SourceTextModule.cs
+++ b/Jint/Runtime/Modules/SourceTextModule.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using Jint.Native;
 using Jint.Native.AsyncFunction;
+using Jint.Native.Disposable;
 using Jint.Native.Object;
 using Jint.Native.Promise;
 using Jint.Runtime.Environments;
@@ -406,11 +407,17 @@ internal class SourceTextModule : CyclicModule
                 }
                 catch (JavaScriptException e)
                 {
-                    result = _environment.DisposeResources(new Completion(CompletionType.Throw, e.Error, null!));
-                    _engine.LeaveExecutionContext();
-                    _tlaAsyncInstance._state = AsyncFunctionState.Completed;
-                    capability!.Reject.Call(JsValue.Undefined, e.Error);
-                    return result;
+                    DisposeResourcesHelper.DisposeAndThen(
+                        _engine,
+                        _environment,
+                        new Completion(CompletionType.Throw, e.Error, null!),
+                        final =>
+                        {
+                            _engine.LeaveExecutionContext();
+                            _tlaAsyncInstance._state = AsyncFunctionState.Completed;
+                            capability!.Reject.Call(JsValue.Undefined, final.Value);
+                        });
+                    return new Completion(CompletionType.Normal, JsValue.Undefined, null!);
                 }
 
                 // Check if we suspended at an await
@@ -422,26 +429,29 @@ internal class SourceTextModule : CyclicModule
                     return new Completion(CompletionType.Normal, JsValue.Undefined, null!);
                 }
 
-                result = _environment.DisposeResources(result);
-                _engine.LeaveExecutionContext();
-
-                // Completed - resolve or reject via the capability
-                _tlaAsyncInstance._state = AsyncFunctionState.Completed;
-
-                if (result.Type == CompletionType.Normal)
+                // Module body complete - dispose any (potentially async-dispose) resources
+                // before settling the capability. Settlement is deferred until the dispose
+                // chain finishes so top-level `await using` can suspend correctly.
+                DisposeResourcesHelper.DisposeAndThen(_engine, _environment, result, final =>
                 {
-                    capability!.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
-                }
-                else if (result.Type == CompletionType.Throw)
-                {
-                    capability!.Reject.Call(JsValue.Undefined, result.Value);
-                }
-                else
-                {
-                    capability!.Resolve.Call(JsValue.Undefined, result.Value);
-                }
+                    _engine.LeaveExecutionContext();
+                    _tlaAsyncInstance._state = AsyncFunctionState.Completed;
 
-                return result;
+                    if (final.Type == CompletionType.Normal)
+                    {
+                        capability!.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
+                    }
+                    else if (final.Type == CompletionType.Throw)
+                    {
+                        capability!.Reject.Call(JsValue.Undefined, final.Value);
+                    }
+                    else
+                    {
+                        capability!.Resolve.Call(JsValue.Undefined, final.Value);
+                    }
+                });
+
+                return new Completion(CompletionType.Normal, JsValue.Undefined, null!);
             }
         }
     }

--- a/Jint/Runtime/Modules/SourceTextModule.cs
+++ b/Jint/Runtime/Modules/SourceTextModule.cs
@@ -407,17 +407,24 @@ internal class SourceTextModule : CyclicModule
                 }
                 catch (JavaScriptException e)
                 {
-                    if (!_environment.HasDisposeResources)
+                    // Leave the module's execution context up front so the dispose chain's
+                    // Promise.then callbacks don't run with it still on the stack — same
+                    // rationale as the AsyncGenerator path (see AsyncGeneratorInstance).
+                    var env = _environment;
+                    _engine.LeaveExecutionContext();
+                    _tlaAsyncInstance!._state = AsyncFunctionState.Completed;
+                    var cap = capability!;
+                    if (!env.HasDisposeResources)
                     {
-                        SettleTlaRejection(capability!, e.Error);
+                        cap.Reject.Call(JsValue.Undefined, e.Error);
                     }
                     else
                     {
                         DisposeResourcesHelper.DisposeAndThen(
                             _engine,
-                            _environment,
+                            env,
                             new Completion(CompletionType.Throw, e.Error, null!),
-                            final => SettleTlaRejection(capability!, final.Value));
+                            final => cap.Reject.Call(JsValue.Undefined, final.Value));
                     }
                     return new Completion(CompletionType.Normal, JsValue.Undefined, null!);
                 }
@@ -431,17 +438,24 @@ internal class SourceTextModule : CyclicModule
                     return new Completion(CompletionType.Normal, JsValue.Undefined, null!);
                 }
 
-                // Module body complete - dispose any (potentially async-dispose) resources
-                // before settling the capability. Settlement is deferred until the dispose
-                // chain finishes so top-level `await using` can suspend correctly.
-                if (!_environment.HasDisposeResources)
+                // Module body complete. Leave context BEFORE dispatching the dispose chain
+                // so its Promise.then callbacks run with the caller's context on top, not
+                // the module's — otherwise a later sync await would mis-route via this
+                // module's _tlaAsyncInstance.
                 {
-                    SettleTlaCompletion(capability!, result);
-                }
-                else
-                {
-                    DisposeResourcesHelper.DisposeAndThen(_engine, _environment, result,
-                        final => SettleTlaCompletion(capability!, final));
+                    var env = _environment;
+                    _engine.LeaveExecutionContext();
+                    _tlaAsyncInstance._state = AsyncFunctionState.Completed;
+                    var cap = capability!;
+                    if (!env.HasDisposeResources)
+                    {
+                        SettleTla(cap, result);
+                    }
+                    else
+                    {
+                        DisposeResourcesHelper.DisposeAndThen(_engine, env, result,
+                            final => SettleTla(cap, final));
+                    }
                 }
 
                 return new Completion(CompletionType.Normal, JsValue.Undefined, null!);
@@ -449,11 +463,8 @@ internal class SourceTextModule : CyclicModule
         }
     }
 
-    private void SettleTlaCompletion(PromiseCapability capability, Completion final)
+    private static void SettleTla(PromiseCapability capability, Completion final)
     {
-        _engine.LeaveExecutionContext();
-        _tlaAsyncInstance!._state = AsyncFunctionState.Completed;
-
         if (final.Type == CompletionType.Normal)
         {
             capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
@@ -466,12 +477,5 @@ internal class SourceTextModule : CyclicModule
         {
             capability.Resolve.Call(JsValue.Undefined, final.Value);
         }
-    }
-
-    private void SettleTlaRejection(PromiseCapability capability, JsValue error)
-    {
-        _engine.LeaveExecutionContext();
-        _tlaAsyncInstance!._state = AsyncFunctionState.Completed;
-        capability.Reject.Call(JsValue.Undefined, error);
     }
 }

--- a/Jint/Runtime/Modules/SourceTextModule.cs
+++ b/Jint/Runtime/Modules/SourceTextModule.cs
@@ -407,16 +407,18 @@ internal class SourceTextModule : CyclicModule
                 }
                 catch (JavaScriptException e)
                 {
-                    DisposeResourcesHelper.DisposeAndThen(
-                        _engine,
-                        _environment,
-                        new Completion(CompletionType.Throw, e.Error, null!),
-                        final =>
-                        {
-                            _engine.LeaveExecutionContext();
-                            _tlaAsyncInstance._state = AsyncFunctionState.Completed;
-                            capability!.Reject.Call(JsValue.Undefined, final.Value);
-                        });
+                    if (!_environment.HasDisposeResources)
+                    {
+                        SettleTlaRejection(capability!, e.Error);
+                    }
+                    else
+                    {
+                        DisposeResourcesHelper.DisposeAndThen(
+                            _engine,
+                            _environment,
+                            new Completion(CompletionType.Throw, e.Error, null!),
+                            final => SettleTlaRejection(capability!, final.Value));
+                    }
                     return new Completion(CompletionType.Normal, JsValue.Undefined, null!);
                 }
 
@@ -432,27 +434,44 @@ internal class SourceTextModule : CyclicModule
                 // Module body complete - dispose any (potentially async-dispose) resources
                 // before settling the capability. Settlement is deferred until the dispose
                 // chain finishes so top-level `await using` can suspend correctly.
-                DisposeResourcesHelper.DisposeAndThen(_engine, _environment, result, final =>
+                if (!_environment.HasDisposeResources)
                 {
-                    _engine.LeaveExecutionContext();
-                    _tlaAsyncInstance._state = AsyncFunctionState.Completed;
-
-                    if (final.Type == CompletionType.Normal)
-                    {
-                        capability!.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
-                    }
-                    else if (final.Type == CompletionType.Throw)
-                    {
-                        capability!.Reject.Call(JsValue.Undefined, final.Value);
-                    }
-                    else
-                    {
-                        capability!.Resolve.Call(JsValue.Undefined, final.Value);
-                    }
-                });
+                    SettleTlaCompletion(capability!, result);
+                }
+                else
+                {
+                    DisposeResourcesHelper.DisposeAndThen(_engine, _environment, result,
+                        final => SettleTlaCompletion(capability!, final));
+                }
 
                 return new Completion(CompletionType.Normal, JsValue.Undefined, null!);
             }
         }
+    }
+
+    private void SettleTlaCompletion(PromiseCapability capability, Completion final)
+    {
+        _engine.LeaveExecutionContext();
+        _tlaAsyncInstance!._state = AsyncFunctionState.Completed;
+
+        if (final.Type == CompletionType.Normal)
+        {
+            capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
+        }
+        else if (final.Type == CompletionType.Throw)
+        {
+            capability.Reject.Call(JsValue.Undefined, final.Value);
+        }
+        else
+        {
+            capability.Resolve.Call(JsValue.Undefined, final.Value);
+        }
+    }
+
+    private void SettleTlaRejection(PromiseCapability capability, JsValue error)
+    {
+        _engine.LeaveExecutionContext();
+        _tlaAsyncInstance!._state = AsyncFunctionState.Completed;
+        capability.Reject.Call(JsValue.Undefined, error);
     }
 }

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -69,6 +69,19 @@ internal sealed class ForOfSuspendData : SuspendData
     /// destructuring against a one-shot iterator that has already been consumed.
     /// </summary>
     public bool LhsBindingComplete { get; set; }
+
+    /// <summary>
+    /// True while the iteration's async-dispose chain is in flight. On resume, the
+    /// for-of statement must read <see cref="DisposeResult"/> and act on it instead
+    /// of resuming the body.
+    /// </summary>
+    public bool DisposeInProgress { get; set; }
+
+    /// <summary>
+    /// The final completion of the dispose chain (body+dispose), set by the dispose
+    /// chain's continueWith callback just before the async function is resumed.
+    /// </summary>
+    public Completion DisposeResult { get; set; }
 }
 
 /// <summary>
@@ -252,6 +265,32 @@ internal sealed class ForAwaitSuspendData : SuspendData
     /// When set, the resume should skip the iterator step and use this value.
     /// </summary>
     public JsValue? CurrentValue { get; set; }
+
+    /// <summary>
+    /// The iteration environment for the current iteration, retained across an
+    /// async-dispose suspension so the dispose state machine can advance on resume.
+    /// </summary>
+    public DeclarativeEnvironment? IterationEnv { get; set; }
+
+    /// <summary>
+    /// The outer environment of the for-of loop body evaluation, restored on
+    /// resume from an async-dispose suspension.
+    /// </summary>
+    public Environments.Environment? OuterEnv { get; set; }
+
+    /// <summary>
+    /// True while the iteration's async-dispose chain is in flight. On resume,
+    /// the for-of statement must read <see cref="DisposeResult"/> and act on it
+    /// instead of awaiting the next iterator result.
+    /// </summary>
+    public bool DisposeInProgress { get; set; }
+
+    /// <summary>
+    /// The final completion of the dispose chain (body+dispose), set by the
+    /// dispose chain's continueWith callback just before the async function
+    /// is resumed.
+    /// </summary>
+    public Completion DisposeResult { get; set; }
 }
 
 /// <summary>

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -270,10 +270,11 @@ internal sealed class BlockSuspendData : SuspendData
     public Jint.Runtime.Environments.Environment? OuterEnvironment { get; set; }
 
     /// <summary>
-    /// Whether DisposeResources has already been called for this block.
-    /// When true, resumption should skip disposal and just continue.
+    /// True while this block is suspended mid-dispose. On resume, the block
+    /// must not re-execute its body — it must call ContinueDisposeResources
+    /// to advance the dispose state machine.
     /// </summary>
-    public bool DisposalComplete { get; set; }
+    public bool DisposeInProgress { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- Refactor `DisposeCapability.DisposeResources` into a coroutine-style state machine (`BeginDispose` / `ContinueDispose`) so the three spec-defined `Await(...)` suspension points in *Explicit Resource Management* (3.d.i, 3.e.ii.1, 4.a) become real Promise hand-offs instead of a single synchronous `UnwrapIfPromise` block.
- Drive the state machine from two integration patterns: **Pattern A** in `JintBlockStatement` (suspend the async function via the same machinery as a JS `await`), and **Pattern B** (a new `DisposeResourcesHelper.DisposeAndThen` that chains `Promise.then` so the function/generator/module return promise is settled only when the dispose chain completes). Pattern B is wired into `JintFunctionDefinition.AsyncBlockStart`, `JintAwaitExpression.AsyncFunctionResume`, both `AsyncGeneratorInstance` resume paths, and `SourceTextModule` top-level-await execution.

Fixes #2477.

## Why

The repro in the issue:

```csharp
var engine = new Engine(o => o.ExperimentalFeatures = ExperimentalFeature.TaskInterop);
engine.SetValue(\"makeDisposable\", new Func<Task<MyDisposable>>(() =>
    Task.FromResult(new MyDisposable())));
await engine.EvaluateAsync(\"\"\"
    (async () => {
        await using d = await makeDisposable();
    })()
    \"\"\");
```

hangs and throws `PromiseRejectedException: Timeout of 00:00:10 reached` even though `DisposeAsync()` is invoked and completes. The cause is a re-entrancy deadlock between `DisposeCapability` and `EventLoop.RunAvailableContinuations`:

1. `EvaluateAsync` → `UnwrapResultAsync` fast-path enters `RunAvailableContinuations` and claims `_isProcessing`.
2. Draining queues runs the `makeDisposable` settle, which resumes the async function inline.
3. Body finishes; `JintBlockStatement` calls `DisposeResources`. The `asyncDispose` `ClrFunction` wraps `ValueTask.CompletedTask` via `ConvertAwaitableToPromise`; `RegisterPromiseWithClrValue` enqueues the resolve, so the promise is still pending.
4. `DisposeResources` calls `UnwrapIfPromise`, which polls `RunAvailableContinuations` — that nested call returns early because `_isProcessing == 1`. The settle never executes; 10s later the polling loop throws.

Rather than patch the event-loop re-entry guard, this PR makes every async-context `DisposeResources` call site suspend properly per spec, so no path inside an event-loop continuation needs `UnwrapIfPromise` on a dispose result.

## Test plan

- [x] New `Jint.Tests.Runtime.InteropDisposeTests` covering: the user's repro via `EvaluateAsync`, genuinely-async `DisposeAsync` (`Task.Delay`), LIFO ordering with multiple `await using`, nested `await using` across async functions, `SuppressedError` chaining, dispose at async function exit, and dispose after unhandled throw.
- [x] Existing `ShouldAsyncDispose` (sync `Evaluate + UnwrapIfPromise` entry path) still passes.
- [x] Full Jint.Tests suite: 3004 passed / 0 failed.
- [x] Test262: 184/184 `Statements_awaitUsing` pass; the broader async/dispose/for-loop sweep shows 3233 pass with only 4 pre-existing failures (`AsyncDisposableStack_prototype_disposeAsync`) that exist on `main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)