### PR TITLE
Serialize Atomics.waitAsync test262 group instead of excluding it

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="SourceMaps" Version="0.3.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.45.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.8" />
-    <PackageVersion Include="Test262Harness" Version="1.0.5" />
+    <PackageVersion Include="Test262Harness" Version="1.0.6" />
     <PackageVersion Include="xunit.v3.mtp-off" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
     <PackageVersion Include="YantraJS.Core" Version="1.2.366" />

--- a/Jint.Tests.Test262/.config/dotnet-tools.json
+++ b/Jint.Tests.Test262/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "test262harness.console": {
-      "version": "1.0.4",
+      "version": "1.0.6",
       "commands": [
         "test262"
       ]

--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -97,15 +97,17 @@
     "intl402/Temporal/ZonedDateTime/prototype/daysInYear/basic-islamic-umalqura.js",
     "intl402/Temporal/ZonedDateTime/prototype/inLeapYear/basic-islamic-umalqura.js",
     "intl402/Temporal/ZonedDateTime/prototype/with/basic-islamic-umalqura.js",
-    "intl402/Temporal/ZonedDateTime/prototype/withCalendar/extreme-dates.js",
+    "intl402/Temporal/ZonedDateTime/prototype/withCalendar/extreme-dates.js"
 
-    // === ATOMICS WAITASYNC TIMING FLAKES ===
-    // The no-spurious-wakeup-* siblings all assert `lapse >= TIMEOUT` where
-    // TIMEOUT is $262.agent.timeouts.small (200ms). On slow/loaded Windows CI
-    // runners, Task.Delay-driven timeout resolution can complete a few ms shy
-    // of the requested interval (Windows timer-tick granularity), producing
-    // a non-deterministic failure even though the implementation is correct.
-    "built-ins/Atomics/waitAsync/no-spurious-wakeup-on-exchange.js"
-
+  ],
+  // Timing-sensitive suites: serialise the whole generated test method instead of
+  // disabling individual cases. The Atomics.waitAsync no-spurious-wakeup-* tests
+  // assert `lapse >= TIMEOUT` where TIMEOUT is $262.agent.timeouts.small (200ms);
+  // under [Parallelizable(ParallelScope.All)] on loaded Windows CI runners,
+  // Task.Delay-driven timeout resolution can complete a few ms shy of the
+  // requested interval (timer-tick granularity), producing non-deterministic
+  // failures even though the implementation is correct.
+  "NonParallelFeatures": [
+    "Atomics.waitAsync"
   ]
 }


### PR DESCRIPTION
## Summary

- Bump `Test262Harness` package + `test262harness.console` tool manifest from 1.0.5/1.0.4 to **1.0.6**, which introduces the `NonParallel{Features,Flags,Files}` settings (see lahma/test262-harness-dotnet#142). Matches emit `[NonParallelizable]` on the generated NUnit method, overriding the inherited `[Parallelizable(ParallelScope.All)]`.
- Use `"NonParallelFeatures": ["Atomics.waitAsync"]` to serialise the whole Atomics.waitAsync test group rather than excluding individual timing-sensitive cases. This restores coverage of `built-ins/Atomics/waitAsync/no-spurious-wakeup-on-exchange.js`, which was disabled in f71c1ba because `Task.Delay`-driven timeout resolution on loaded Windows runners can complete a few ms shy of the requested `$262.agent.timeouts.small` (200ms), tripping the `lapse >= TIMEOUT` assertion when the test ran alongside other CPU-bound suites.

## Verification

Regenerated suite after the bump:

- `[NonParallelizable]` appears on exactly **two** generated methods — `Atomics/waitAsync` root and the `bigint` subdirectory variant — and nowhere else in `built-ins`/`annexB`/`intl402`/`language`.
- The previously-excluded `built-ins/Atomics/waitAsync/no-spurious-wakeup-on-exchange.js` is back in the suite (`TestCase` lines for both strict and non-strict modes).

## Test plan

- [ ] CI green on Windows runners (waitAsync no-spurious-wakeup cases pass without re-flaking)
- [ ] No regression in total runtime — only the small Atomics.waitAsync group is serialised; the other ~99k cases stay parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)