### PR TITLE
Fix flag v bugs in custom regex engine

### DIFF
--- a/Jint.Tests/Runtime/RegExpTests.cs
+++ b/Jint.Tests/Runtime/RegExpTests.cs
@@ -151,6 +151,30 @@ public class RegExpTests
     }
 
     [Fact]
+    public void ShouldAllowClassSetSyntaxCharacterOutsideClassSetForFlagV()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(@"new RegExp('/-', 'v').test('/-')");
+        Assert.True(result.AsBoolean());
+    }
+
+    [Fact]
+    public void ShouldAllowClassSetReservedDoublePunctuatorCharactersOutsideClassSetForFlagV()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(@"new RegExp('&&!!##%%,,::;;<<==>>@@``~~', 'v').test('&&!!##%%,,::;;<<==>>@@``~~')");
+        Assert.True(result.AsBoolean());
+    }
+
+    [Fact]
+    public void ShouldAllowEscapedClassSetReservedPunctuatorsForFlagV()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate(@"new RegExp('[\\!\\#\\%\\&\\,\\-\\:\\;\\<\\=\\>\\@\\`\\~]{14}', 'v').test('!#%&,-:;<=>@`~')");
+        Assert.True(result.AsBoolean());
+    }
+
+    [Fact]
     public void Issue506()
     {
         var engine = new Engine();

--- a/Jint/Runtime/RegExp/RegExpCompiler.cs
+++ b/Jint/Runtime/RegExp/RegExpCompiler.cs
@@ -1241,7 +1241,16 @@ default_escape:
                                     else
                                     {
                                         _pos = savedPos;
-                                        if (IsUnicode)
+                                        if (IsUnicode
+                                            && (!UnicodeSets
+                                                || !inclass
+                                                || _pattern[_pos] is not
+                                                (
+                                                    '!' or '#' or '%' or '&'
+                                                    or ',' or '-' or ':' or ';'
+                                                    or '<' or '=' or '>' or '@'
+                                                    or '`' or '~'
+                                                )))
                                         {
                                             throw new RegExpSyntaxException("invalid escape sequence in regular expression");
                                         }
@@ -1274,7 +1283,7 @@ default_escape:
                 case '^':
                 case '`':
                 case '~':
-                    if (UnicodeSets && _pos + 1 < _patternEnd && _pattern[_pos + 1] == c)
+                    if (UnicodeSets && inclass && _pos + 1 < _patternEnd && _pattern[_pos + 1] == c)
                     {
                         // Forbidden double characters in unicode-sets mode
                         throw new RegExpSyntaxException("invalid class set operation in regular expression");
@@ -1290,7 +1299,7 @@ default_escape:
                 case '/':
                 case '-':
                 case '|':
-                    if (UnicodeSets)
+                    if (UnicodeSets && inclass)
                     {
                         throw new RegExpSyntaxException("invalid character in class in regular expression");
                     }


### PR DESCRIPTION
## Summary
This PR makes some minor corrections to the custom regexp engine failing to execute some valid regexp patterns.

## Details
The custom engine incorrectly rejects some regexp constructs in flag v patterns:
- [ClassSetSyntaxCharacter](https://tc39.es/ecma262/#prod-ClassSetSyntaxCharacter) outside class sets, e.g. `/-/v`,
- [ClassSetReservedDoublePunctuator](https://tc39.es/ecma262/#prod-ClassSetReservedDoublePunctuator) outside class sets, e.g. `/&&/v`
- escaped [ClassSetReservedPunctuator](https://tc39.es/ecma262/#prod-ClassSetReservedPunctuator) inside class sets, e.g. `/[\!]/v`

## Linked issue
n/a

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark`

## Breaking change?
No