### PR TITLE
Make bulk built-ins interruptible by execution constraints (#2486)

### DIFF
--- a/Jint.Tests/Runtime/ExecutionConstraintTests.cs
+++ b/Jint.Tests/Runtime/ExecutionConstraintTests.cs
@@ -356,6 +356,87 @@ myarr[0](0);
         Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("var arr = new Uint8Array(100000000); arr.with(0, 1);"));
     }
 
+    // https://github.com/sebastienros/jint/issues/2486
+    [Fact]
+    public void ShouldThrowRangeErrorWhenPadStartExceedsMaxStringLength()
+    {
+        // The result length (2147483647) exceeds ClrLimits.MaxArrayLength, so the size cap converts
+        // a would-be OutOfMemoryException into a catchable RangeError without any constraints set.
+        var engine = new Engine();
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("'x'.padStart(2147483647)"));
+        Assert.Contains("Invalid string length", ex.Message);
+    }
+
+    // https://github.com/sebastienros/jint/issues/2486
+    [Fact]
+    public void ShouldLimitStringSizeForPadEnd()
+    {
+        // The result (536870911) is below the size cap, so it must be built incrementally and the
+        // memory limit must be able to interrupt it instead of allocating ~1 GB up front.
+        var engine = new Engine(o => o.LimitMemory(4_000_000));
+        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("'x'.padEnd(536870911, 'ab')"));
+    }
+
+    // https://github.com/sebastienros/jint/issues/2486
+    [Fact]
+    public void ShouldLimitArraySizeForArrayFrom()
+    {
+        var engine = new Engine(o => o.LimitMemory(4_000_000));
+        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("Array.from({ length: 50000000 });"));
+    }
+
+    [Fact]
+    public void ShouldLimitStringSizeForStringRaw()
+    {
+        var engine = new Engine(o => o.LimitMemory(4_000_000));
+        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("String.raw({ raw: { length: 50000000 } });"));
+    }
+
+    [Fact]
+    public void ShouldLimitArraySizeForSort()
+    {
+        // The element-collection loop in sort is interruptible: a low statement budget aborts it.
+        var engine = new Engine(o => o.MaxStatements(1_000));
+        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("new Array(50000000).sort();"));
+    }
+
+    [Fact]
+    public void ShouldLimitArraySizeForForEachWithEmptyCallback()
+    {
+        // Even an empty callback must not let a huge array run uninterrupted.
+        var engine = new Engine(o => o.MaxStatements(1_000));
+        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("new Array(50000000).fill(0).forEach(function () {});"));
+    }
+
+    [Fact]
+    public void PadStartAndPadEndProduceCorrectResults()
+    {
+        var engine = new Engine();
+        Assert.Equal("005", engine.Evaluate("'5'.padStart(3, '0')").AsString());
+        Assert.Equal("500", engine.Evaluate("'5'.padEnd(3, '0')").AsString());
+        Assert.Equal("ab", engine.Evaluate("'ab'.padStart(1)").AsString());
+        Assert.Equal("    x", engine.Evaluate("'x'.padStart(5)").AsString());
+        Assert.Equal("x    ", engine.Evaluate("'x'.padEnd(5)").AsString());
+        // Empty fill string returns the input unchanged.
+        Assert.Equal("x", engine.Evaluate("'x'.padEnd(5, '')").AsString());
+        Assert.Equal("1231231abc", engine.Evaluate("'abc'.padStart(10, '123')").AsString());
+        Assert.Equal("abc1231231", engine.Evaluate("'abc'.padEnd(10, '123')").AsString());
+    }
+
+    [Fact]
+    public void PadStartEvaluatesFillStringAfterLengthCheck()
+    {
+        // Per spec (https://tc39.es/ecma262/#sec-stringpad) the fillString is resolved only after the
+        // maxLength <= stringLength early return, so its ToString side effect must not run here.
+        var engine = new Engine();
+        var result = engine.Evaluate(
+            "var sideEffect = false;" +
+            "var fill = { toString() { sideEffect = true; return '0'; } };" +
+            "'abc'.padStart(2, fill);" +
+            "sideEffect;");
+        Assert.False(result.AsBoolean());
+    }
+
     [Fact]
     public void ShouldConsiderConstraintsWhenCallingInvoke()
     {

--- a/Jint.Tests/Runtime/ExecutionConstraintTests.cs
+++ b/Jint.Tests/Runtime/ExecutionConstraintTests.cs
@@ -1,3 +1,4 @@
+using Jint.Constraints;
 using Jint.Native.Function;
 using Jint.Runtime;
 
@@ -401,11 +402,13 @@ myarr[0](0);
     }
 
     [Fact]
-    public void ShouldLimitArraySizeForForEachWithEmptyCallback()
+    public void ShouldLimitArraySizeForForEach()
     {
-        // Even an empty callback must not let a huge array run uninterrupted.
+        // forEach over a huge (sparse) array must be interruptible even though the callback never
+        // runs for holes. A sparse array is used so the guard exercised is forEach's own loop, not
+        // fill's (fill on a dense 50M array would trip the limit before forEach was ever reached).
         var engine = new Engine(o => o.MaxStatements(1_000));
-        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("new Array(50000000).fill(0).forEach(function () {});"));
+        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("new Array(50000000).forEach(function () {});"));
     }
 
     [Fact]
@@ -435,6 +438,68 @@ myarr[0](0);
             "'abc'.padStart(2, fill);" +
             "sideEffect;");
         Assert.False(result.AsBoolean());
+    }
+
+    [Fact]
+    public void JoinReleasesJoinStackWhenInterrupted()
+    {
+        // Regression: when a constraint interrupts a large join mid-loop, the array must not be left
+        // on the engine's long-lived join stack — otherwise a later join of the same array would
+        // wrongly return "" via false cyclic-reference detection.
+        var engine = new Engine(o => o.MaxStatements(10_000_000));
+        engine.Evaluate("var a = []; for (var i = 0; i < 20000; i++) a[i] = i;");
+
+        var maxStatements = engine.Constraints.Find<MaxStatementsConstraint>()!;
+        maxStatements.MaxStatements = 1;
+        engine.Constraints.Reset();
+        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("a.join(',')"));
+
+        // With a generous budget the same array must join correctly (not the empty string).
+        maxStatements.MaxStatements = 10_000_000;
+        engine.Constraints.Reset();
+        Assert.StartsWith("0,1,2,3,", engine.Evaluate("a.join(',')").AsString());
+    }
+
+    [Fact]
+    public void ShouldLimitArrayFromWithNativeIterator()
+    {
+        // Array.from over a native (statement-free) string iterator must be interruptible via the
+        // shared iterator-protocol guard; the string iterator runs no JS statements per element.
+        var engine = new Engine(o => o.MaxStatements(10_000_000));
+        engine.Evaluate("var s = 'x'; for (var i = 0; i < 17; i++) s += s;"); // 131072 chars
+
+        var maxStatements = engine.Constraints.Find<MaxStatementsConstraint>()!;
+        maxStatements.MaxStatements = 1;
+        engine.Constraints.Reset();
+        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("Array.from(s);"));
+    }
+
+    [Fact]
+    public void ShouldLimitObjectKeysForLargeArray()
+    {
+        // Object.keys is a pure native enumeration with no JS callback to self-throttle; it must be
+        // interruptible by the constraint check in EnumerableOwnProperties.
+        var engine = new Engine(o => o.MaxStatements(10_000_000));
+        engine.Evaluate("var a = []; for (var i = 0; i < 30000; i++) a[i] = i;");
+
+        var maxStatements = engine.Constraints.Find<MaxStatementsConstraint>()!;
+        maxStatements.MaxStatements = 1;
+        engine.Constraints.Reset();
+        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("Object.keys(a);"));
+    }
+
+    [Fact]
+    public void ShouldLimitMapForEachWithNativeCallback()
+    {
+        // A native (CLR) callback does not self-throttle via statement checks, so Map.prototype.forEach
+        // must be interruptible by its own constraint check.
+        var engine = new Engine(o => o.MaxStatements(10_000_000));
+        engine.Evaluate("var m = new Map(); for (var i = 0; i < 30000; i++) m.set(i, i);");
+
+        var maxStatements = engine.Constraints.Find<MaxStatementsConstraint>()!;
+        maxStatements.MaxStatements = 1;
+        engine.Constraints.Reset();
+        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("m.forEach(Math.max);"));
     }
 
     [Fact]

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -28,6 +28,13 @@ namespace Jint;
 [DebuggerTypeProxy(typeof(EngineDebugView))]
 public sealed partial class Engine : IDisposable
 {
+    /// <summary>
+    /// How often (in loop iterations) bulk built-in operations should call <see cref="ConstraintOperations.Check"/>
+    /// so that long native loops over JS-controlled sizes remain interruptible by execution constraints.
+    /// Single source of truth shared by every built-in that uses the periodic-check idiom.
+    /// </summary>
+    internal const int ConstraintCheckInterval = 10_000;
+
     private static readonly Options _defaultEngineOptions = new();
 
     private readonly Parser _defaultParser;

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -16,6 +16,8 @@ namespace Jint.Native.Array;
 [JsObject]
 public sealed partial class ArrayConstructor : Constructor
 {
+    private const int ConstraintCheckInterval = 10_000;
+
     private static readonly JsString _functionName = new JsString("Array");
 
     internal ArrayConstructor(
@@ -611,6 +613,12 @@ public sealed partial class ArrayConstructor : Constructor
         uint n = 0;
         for (uint i = 0; i < length; i++)
         {
+            // Check constraints periodically so a huge array-like length cannot run uninterrupted.
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var value = source.Get(i);
             if (callable is not null)
             {
@@ -874,8 +882,16 @@ public sealed partial class ArrayConstructor : Constructor
     {
         var jsArray = Construct(Arguments.Empty);
         var tempArray = _engine._jsValueArrayPool.RentArray(1);
+        long count = 0;
         foreach (var item in enumerable)
         {
+            // Check constraints periodically so a huge enumerable cannot run uninterrupted.
+            if (count > 0 && count % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+            count++;
+
             var jsItem = FromObject(Engine, item);
             tempArray[0] = jsItem;
             _realm.Intrinsics.Array.PrototypeObject.Push(jsArray, tempArray);

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -16,7 +16,7 @@ namespace Jint.Native.Array;
 [JsObject]
 public sealed partial class ArrayConstructor : Constructor
 {
-    private const int ConstraintCheckInterval = 10_000;
+    private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;
 
     private static readonly JsString _functionName = new JsString("Array");
 
@@ -882,22 +882,29 @@ public sealed partial class ArrayConstructor : Constructor
     {
         var jsArray = Construct(Arguments.Empty);
         var tempArray = _engine._jsValueArrayPool.RentArray(1);
-        long count = 0;
-        foreach (var item in enumerable)
+        // try/finally so the rented pool array is returned even when a periodic Check() throws.
+        try
         {
-            // Check constraints periodically so a huge enumerable cannot run uninterrupted.
-            if (count > 0 && count % ConstraintCheckInterval == 0)
+            long count = 0;
+            foreach (var item in enumerable)
             {
-                _engine.Constraints.Check();
-            }
-            count++;
+                // Check constraints periodically so a huge enumerable cannot run uninterrupted.
+                if (count > 0 && count % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+                count++;
 
-            var jsItem = FromObject(Engine, item);
-            tempArray[0] = jsItem;
-            _realm.Intrinsics.Array.PrototypeObject.Push(jsArray, tempArray);
+                var jsItem = FromObject(Engine, item);
+                tempArray[0] = jsItem;
+                _realm.Intrinsics.Array.PrototypeObject.Push(jsArray, tempArray);
+            }
+        }
+        finally
+        {
+            _engine._jsValueArrayPool.ReturnArray(tempArray);
         }
 
-        _engine._jsValueArrayPool.ReturnArray(tempArray);
         return jsArray;
     }
 

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -1320,10 +1320,16 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = this;
 
+        const int ConstraintCheckInterval = 10_000;
         if (!fromEnd)
         {
             for (uint k = 0; k < len; k++)
             {
+                if (k > 0 && k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 if (TryGetValue(k, out var kvalue) || visitUnassigned)
                 {
                     kvalue ??= Undefined;
@@ -1343,6 +1349,11 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         {
             for (long k = len - 1; k >= 0; k--)
             {
+                if (k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 var idx = (uint) k;
                 if (TryGetValue(idx, out var kvalue) || visitUnassigned)
                 {

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -1320,58 +1320,64 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = this;
 
-        const int ConstraintCheckInterval = 10_000;
-        if (!fromEnd)
+        // try/finally so the rented pool array is returned on every exit path: the early
+        // return-on-match below and a periodic Check() throw both previously leaked it.
+        try
         {
-            for (uint k = 0; k < len; k++)
+            if (!fromEnd)
             {
-                if (k > 0 && k % ConstraintCheckInterval == 0)
+                for (uint k = 0; k < len; k++)
                 {
-                    _engine.Constraints.Check();
-                }
-
-                if (TryGetValue(k, out var kvalue) || visitUnassigned)
-                {
-                    kvalue ??= Undefined;
-                    args[0] = kvalue;
-                    args[1] = k;
-                    var testResult = callable.Call(thisArg, args);
-                    if (TypeConverter.ToBoolean(testResult))
+                    if (k > 0 && k % Engine.ConstraintCheckInterval == 0)
                     {
-                        index = k;
-                        value = kvalue;
-                        return true;
+                        _engine.Constraints.Check();
+                    }
+
+                    if (TryGetValue(k, out var kvalue) || visitUnassigned)
+                    {
+                        kvalue ??= Undefined;
+                        args[0] = kvalue;
+                        args[1] = k;
+                        var testResult = callable.Call(thisArg, args);
+                        if (TypeConverter.ToBoolean(testResult))
+                        {
+                            index = k;
+                            value = kvalue;
+                            return true;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                for (long k = len - 1; k >= 0; k--)
+                {
+                    if (k % Engine.ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
+                    var idx = (uint) k;
+                    if (TryGetValue(idx, out var kvalue) || visitUnassigned)
+                    {
+                        kvalue ??= Undefined;
+                        args[0] = kvalue;
+                        args[1] = idx;
+                        var testResult = callable.Call(thisArg, args);
+                        if (TypeConverter.ToBoolean(testResult))
+                        {
+                            index = idx;
+                            value = kvalue;
+                            return true;
+                        }
                     }
                 }
             }
         }
-        else
+        finally
         {
-            for (long k = len - 1; k >= 0; k--)
-            {
-                if (k % ConstraintCheckInterval == 0)
-                {
-                    _engine.Constraints.Check();
-                }
-
-                var idx = (uint) k;
-                if (TryGetValue(idx, out var kvalue) || visitUnassigned)
-                {
-                    kvalue ??= Undefined;
-                    args[0] = kvalue;
-                    args[1] = idx;
-                    var testResult = callable.Call(thisArg, args);
-                    if (TypeConverter.ToBoolean(testResult))
-                    {
-                        index = idx;
-                        value = kvalue;
-                        return true;
-                    }
-                }
-            }
+            _engine._jsValueArrayPool.ReturnArray(args);
         }
-
-        _engine._jsValueArrayPool.ReturnArray(args);
 
         index = 0;
         value = Undefined;

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -94,6 +94,13 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
         var jsValues = new JsValue[n];
         for (uint i = 0; i < (uint) n; i++)
         {
+            // Slow array-like expansion (e.g. Function.prototype.apply / Reflect.apply on a huge
+            // {length} object): per-element property Get; check constraints periodically.
+            if (i > 0 && i % Engine.ConstraintCheckInterval == 0)
+            {
+                Target.Engine.Constraints.Check();
+            }
+
             var jsValue = skipHoles && !HasProperty(i) ? JsValue.Undefined : Get(i);
             if ((jsValue.Type & elementTypes) == Types.Empty)
             {

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -347,6 +347,12 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var i = (ulong) k;
         for (; ; i--)
         {
+            // Slow scan over a (possibly huge) length; check constraints periodically.
+            if (i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var kPresent = o.HasProperty(i);
             if (kPresent)
             {
@@ -396,6 +402,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
             var kPresent = false;
             while (kPresent == false && k < len)
             {
+                if (k > 0 && k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 if (kPresent = o.TryGetValue((uint) k, out var temp))
                 {
                     accumulator = temp;
@@ -414,6 +425,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         args[3] = o.Target;
         while (k < len)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var i = (uint) k;
             if (o.TryGetValue(i, out var kvalue))
             {
@@ -451,6 +467,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         args[2] = o.Target;
         for (uint k = 0; k < len; k++)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             if (o.TryGetValue(k, out var kvalue))
             {
                 args[0] = kvalue;
@@ -499,6 +520,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         args[2] = o.Target;
         for (uint k = 0; k < len; k++)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             if (o.TryGetValue(k, out var kvalue))
             {
                 args[0] = kvalue;
@@ -582,6 +608,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         while (sourceIndex < sourceLen)
         {
+            if (sourceIndex > 0 && sourceIndex % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var exists = source.HasProperty(sourceIndex);
             if (exists)
             {
@@ -647,6 +678,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         args[2] = o.Target;
         for (uint k = 0; k < len; k++)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             if (o.TryGetValue(k, out var kvalue))
             {
                 args[0] = kvalue;
@@ -723,6 +759,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         while (k < len)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var value = o.Get((ulong) k);
             if (SameValueZeroComparer.Equals(value, searchElement))
             {
@@ -762,6 +803,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         args[2] = o.Target;
         for (uint k = 0; k < len; k++)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             if (o.TryGetValue(k, out var kvalue))
             {
                 args[0] = kvalue;
@@ -847,6 +893,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         for (; k < len; k++)
         {
+            if (k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var kPresent = o.HasProperty(k);
             if (kPresent)
             {
@@ -1051,6 +1102,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         for (uint k = 0; k < actualDeleteCount; k++)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var index = actualStart + k;
             if (o.HasProperty(index))
             {
@@ -1066,6 +1122,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         {
             for (ulong k = actualStart; k < len - actualDeleteCount; k++)
             {
+                if (k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 var from = k + actualDeleteCount;
                 var to = k + (ulong) items.Length;
                 if (o.HasProperty(from))
@@ -1081,6 +1142,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
             for (var k = len; k > len - actualDeleteCount + (ulong) items.Length; k--)
             {
+                if (k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 o.DeletePropertyOrThrow(k - 1);
             }
         }
@@ -1088,6 +1154,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         {
             for (var k = len - actualDeleteCount; k > actualStart; k--)
             {
+                if (k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 var from = k + actualDeleteCount - 1;
                 var to = k + (ulong) items.Length - 1;
                 if (o.HasProperty(from))
@@ -1159,6 +1230,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var minIndex = o.GetSmallestIndex(len);
         for (var k = len; k > minIndex; k--)
         {
+            if (k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var from = k - 1;
             var to = k + argCount - 1;
             if (o.TryGetValue(from, out var fromValue))
@@ -1199,6 +1275,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var items = new List<JsValue>((int) System.Math.Min(1024, len));
         for (ulong k = 0; k < len; ++k)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             if (obj.TryGetValue(k, out var kValue))
             {
                 items.Add(kValue);
@@ -1231,12 +1312,22 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
             for (uint j = 0; j < itemCount; j++)
             {
+                if (j > 0 && j % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 obj.Set(j, items[(int) j], updateLength: false, throwOnError: true);
             }
 
             // Holes (TryGetValue returned false) only need clearing when the input had holes.
             for (uint j = (uint) itemCount; j < len; ++j)
             {
+                if (j % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 obj.DeletePropertyOrThrow(j);
             }
         }
@@ -1253,7 +1344,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
     /// per comparison, which is O(n log n) ToString allocations. Cache the coerced key once per
     /// element (Schwartzian transform), then sort indices stably (tiebreak by original index).
     /// </summary>
-    private static void SortByCachedStringKeys(List<JsValue> items)
+    private void SortByCachedStringKeys(List<JsValue> items)
     {
         var itemCount = items.Count;
         if (itemCount <= 1)
@@ -1264,6 +1355,12 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var keys = new string?[itemCount];
         for (var i = 0; i < itemCount; i++)
         {
+            // ToString coercion per element can be costly; check constraints periodically.
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var v = items[i];
             // Spec: undefined elements sort to the end and are not coerced via ToString.
             keys[i] = v.IsUndefined() ? null : TypeConverter.ToString(v);
@@ -1373,6 +1470,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
             var operations = ArrayOperations.For(a, forWrite: true);
             for (uint n = 0; k < final; k++, n++)
             {
+                if (n > 0 && n % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 if (o.TryGetValue(k, out var kValue))
                 {
                     operations.CreateDataPropertyOrThrow(n, kValue);
@@ -1407,6 +1509,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var firstSlow = o.Get(0);
         for (uint k = 1; k < len; k++)
         {
+            if (k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var to = k - 1;
             if (o.TryGetValue(k, out var fromVal))
             {
@@ -1515,6 +1622,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         sb.Append(s);
         for (uint k = 1; k < len; k++)
         {
+            if (k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             if (sep != "")
             {
                 sb.Append(sep);
@@ -1556,6 +1668,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         {
             if (k > 0)
             {
+                if (k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 r.Append(Separator);
             }
             if (array.TryGetValue(k, out var nextElement) && !nextElement.IsNullOrUndefined())
@@ -1614,6 +1731,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
                     for (uint k = 0; k < len; k++)
                     {
+                        if (k > 0 && k % ConstraintCheckInterval == 0)
+                        {
+                            _engine.Constraints.Check();
+                        }
+
                         operations.TryGetValue(k, out var subElement);
                         aOperations.CreateDataPropertyOrThrow(n, subElement);
                         n++;
@@ -1856,6 +1978,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         while (i < actualStart)
         {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             a.SetIndexValue(i, o.Get(i), updateLength: false);
             i++;
         }
@@ -1868,6 +1995,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         while (i < newLen)
         {
+            if (i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var fromValue = o.Get(r);
             a.SetIndexValue(i, fromValue, updateLength: false);
 
@@ -1939,6 +2071,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
             var kPresent = false;
             while (kPresent == false && k >= 0)
             {
+                if (k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 if ((kPresent = o.TryGetValue((ulong) k, out var temp)))
                 {
                     accumulator = temp;
@@ -1957,6 +2094,11 @@ public sealed partial class ArrayPrototype : ArrayInstance
         jsValues[3] = o.Target;
         for (; k >= 0; k--)
         {
+            if (k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             if (o.TryGetValue((ulong) k, out var kvalue))
             {
                 jsValues[0] = accumulator;

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -20,7 +20,7 @@ namespace Jint.Native.Array;
 [JsObject]
 public sealed partial class ArrayPrototype : ArrayInstance
 {
-    private const int ConstraintCheckInterval = 10_000;
+    private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;
 
     private readonly Realm _realm;
 
@@ -1611,31 +1611,38 @@ public sealed partial class ArrayPrototype : ArrayInstance
                 : TypeConverter.ToString(value);
         }
 
-        var s = StringFromJsValue(o.Get(0));
-        if (len == 1)
+        // try/finally so a Constraints.Check() throw inside the loop cannot leak the entry on the
+        // long-lived join stack (which would corrupt cyclic-join detection for later calls).
+        try
+        {
+            var s = StringFromJsValue(o.Get(0));
+            if (len == 1)
+            {
+                return s;
+            }
+
+            using var sb = new ValueStringBuilder();
+            sb.Append(s);
+            for (uint k = 1; k < len; k++)
+            {
+                if (k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
+                if (sep != "")
+                {
+                    sb.Append(sep);
+                }
+                sb.Append(StringFromJsValue(o.Get(k)));
+            }
+
+            return sb.ToString();
+        }
+        finally
         {
             _joinStack.Exit();
-            return s;
         }
-
-        using var sb = new ValueStringBuilder();
-        sb.Append(s);
-        for (uint k = 1; k < len; k++)
-        {
-            if (k % ConstraintCheckInterval == 0)
-            {
-                _engine.Constraints.Check();
-            }
-
-            if (sep != "")
-            {
-                sb.Append(sep);
-            }
-            sb.Append(StringFromJsValue(o.Get(k)));
-        }
-        _joinStack.Exit();
-
-        return sb.ToString();
     }
 
     /// <summary>
@@ -1663,27 +1670,35 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var options = arguments.At(1);
         var invokeArgs = new[] { locales, options };
 
-        using var r = new ValueStringBuilder();
-        for (uint k = 0; k < len; k++)
+        // try/finally so a Constraints.Check() throw inside the loop cannot leak the entry on the
+        // long-lived join stack (which would corrupt cyclic-join detection for later calls).
+        try
         {
-            if (k > 0)
+            using var r = new ValueStringBuilder();
+            for (uint k = 0; k < len; k++)
             {
-                if (k % ConstraintCheckInterval == 0)
+                if (k > 0)
                 {
-                    _engine.Constraints.Check();
+                    if (k % ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
+                    r.Append(Separator);
                 }
+                if (array.TryGetValue(k, out var nextElement) && !nextElement.IsNullOrUndefined())
+                {
+                    var s = TypeConverter.ToString(Invoke(nextElement, "toLocaleString", invokeArgs));
+                    r.Append(s);
+                }
+            }
 
-                r.Append(Separator);
-            }
-            if (array.TryGetValue(k, out var nextElement) && !nextElement.IsNullOrUndefined())
-            {
-                var s = TypeConverter.ToString(Invoke(nextElement, "toLocaleString", invokeArgs));
-                r.Append(s);
-            }
+            return r.ToString();
         }
-        _joinStack.Exit();
-
-        return r.ToString();
+        finally
+        {
+            _joinStack.Exit();
+        }
     }
 
     /// <summary>

--- a/Jint/Native/Iterator/IteratorProtocol.cs
+++ b/Jint/Native/Iterator/IteratorProtocol.cs
@@ -26,10 +26,18 @@ internal abstract class IteratorProtocol
     {
         var args = _engine._jsValueArrayPool.RentArray(_argCount);
         var done = false;
+        var iterations = 0;
         try
         {
             while (ShouldContinue)
             {
+                // Check constraints periodically so a huge (or native-backed) iterator cannot run
+                // uninterrupted; the surrounding try closes the iterator and returns the pool array.
+                if (++iterations % Engine.ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 if (!_iterator.TryIteratorStep(out var item))
                 {
                     done = true;
@@ -79,10 +87,18 @@ internal abstract class IteratorProtocol
         var args = target.Engine._jsValueArrayPool.RentArray(2);
 
         var skipClose = true;
+        var iterations = 0;
         try
         {
             do
             {
+                // Check constraints periodically so a huge (or native-backed) iterable cannot run
+                // uninterrupted (covers new Map/WeakMap and Object.fromEntries).
+                if (++iterations % Engine.ConstraintCheckInterval == 0)
+                {
+                    target.Engine.Constraints.Check();
+                }
+
                 if (!iterable.TryIteratorStep(out var nextItem))
                 {
                     return;

--- a/Jint/Native/JsMap.cs
+++ b/Jint/Native/JsMap.cs
@@ -95,8 +95,15 @@ public sealed class JsMap : ObjectInstance, IEnumerable<KeyValuePair<JsValue, Js
         args[2] = this;
 
         var i = 0;
+        var iterations = 0;
         while (i < _map.Count)
         {
+            // A native (CLR) callback does not self-throttle via statement checks; check periodically.
+            if (++iterations % Engine.ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var key = _map.GetKey(i);
             args[0] = _map[key];
             args[1] = key;

--- a/Jint/Native/JsSet.cs
+++ b/Jint/Native/JsSet.cs
@@ -62,8 +62,15 @@ public sealed class JsSet : ObjectInstance, IEnumerable<JsValue>
         args[2] = this;
 
         var i = 0;
+        var iterations = 0;
         while (i < _set._list.Count)
         {
+            // A native (CLR) callback does not self-throttle via statement checks; check periodically.
+            if (++iterations % Engine.ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var value = _set._list[i];
             args[0] = value;
             args[1] = value;

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -39,7 +39,7 @@ internal readonly struct JsonParseResult
 
 public sealed class JsonParser
 {
-    private const int ConstraintCheckInterval = 10_000;
+    private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;
 
     private readonly Engine _engine;
     private readonly int _maxDepth;

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -39,6 +39,8 @@ internal readonly struct JsonParseResult
 
 public sealed class JsonParser
 {
+    private const int ConstraintCheckInterval = 10_000;
+
     private readonly Engine _engine;
     private readonly int _maxDepth;
 
@@ -338,8 +340,14 @@ public sealed class JsonParser
         ++_index;
 
         using var sb = new ValueStringBuilder(stackalloc char[64]);
+        var scanned = 0;
         while (_index < _length)
         {
+            if (++scanned % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             char ch = _source[_index++];
 
             if (ch == quote)
@@ -563,8 +571,14 @@ public sealed class JsonParser
         JsValue[] buffer = ArrayPool<JsValue>.Shared.Rent(16);
         try
         {
+            var elementCount = 0;
             while (!Match(']'))
             {
+                if (++elementCount % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 buffer[bufferIndex++] = ParseJsonValue(ref state);
 
                 if (!Match(']'))
@@ -638,8 +652,14 @@ public sealed class JsonParser
 
         var obj = new JsObject(_engine);
 
+        var memberCount = 0;
         while (!Match('}'))
         {
+            if (++memberCount % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             Tokens type = _lookahead.Type;
             if (type != Tokens.String)
             {
@@ -816,8 +836,14 @@ public sealed class JsonParser
         JsValue[] buffer = ArrayPool<JsValue>.Shared.Rent(16);
         try
         {
+            var elementCount = 0;
             while (!Match(']'))
             {
+                if (++elementCount % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 var elementResult = ParseJsonValueWithSourceInfo(ref state);
                 buffer[bufferIndex++] = elementResult.Value;
                 if (elementResult.Node != null)
@@ -900,8 +926,14 @@ public sealed class JsonParser
 
         var obj = new JsObject(_engine);
 
+        var memberCount = 0;
         while (!Match('}'))
         {
+            if (++memberCount % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             Tokens type = _lookahead.Type;
             if (type != Tokens.String)
             {

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -15,7 +15,7 @@ namespace Jint.Native.Json;
 
 public sealed class JsonSerializer
 {
-    private const int ConstraintCheckInterval = 10_000;
+    private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;
 
     private readonly Engine _engine;
     private ObjectTraverseStack _stack = null!;

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -15,6 +15,8 @@ namespace Jint.Native.Json;
 
 public sealed class JsonSerializer
 {
+    private const int ConstraintCheckInterval = 10_000;
+
     private readonly Engine _engine;
     private ObjectTraverseStack _stack = null!;
     private string? _indent;
@@ -87,6 +89,11 @@ public sealed class JsonSerializer
                 var k = 0;
                 while (k < len)
                 {
+                    if (k > 0 && k % ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
                     var prop = JsString.Create(k);
                     var v = replacer.Get(prop);
                     var item = JsValue.Undefined;
@@ -441,6 +448,11 @@ public sealed class JsonSerializer
 
         for (int i = 0; i < len; i++)
         {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             if (hasPrevious)
             {
                 json.Append(separator);
@@ -508,6 +520,11 @@ public sealed class JsonSerializer
         var hasPrevious = false;
         for (var i = 0; i < enumeration.Keys.Count; i++)
         {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var p = enumeration.Keys[i];
             int position = json.Length;
 

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -44,8 +44,16 @@ public sealed partial class ObjectConstructor : Constructor
 
             var from = TypeConverter.ToObject(_realm, nextSource);
             var keys = from.GetOwnPropertyKeys();
+            var processed = 0;
             foreach (var nextKey in keys)
             {
+                // Pure native key copy over a JS-controlled key count; check constraints periodically.
+                if (processed > 0 && processed % Engine.ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+                processed++;
+
                 var desc = from.GetOwnProperty(nextKey);
                 if (desc != PropertyDescriptor.Undefined && desc.Enumerable)
                 {

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1196,56 +1196,62 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = this;
 
-        const int ConstraintCheckInterval = 10_000;
-        if (!fromEnd)
+        // try/finally so the rented pool array is returned on every exit path: the early
+        // return-on-match below and a periodic Check() throw both previously leaked it.
+        try
         {
-            for (ulong k = 0; k < length; k++)
+            if (!fromEnd)
             {
-                if (k > 0 && k % ConstraintCheckInterval == 0)
+                for (ulong k = 0; k < length; k++)
                 {
-                    _engine.Constraints.Check();
-                }
-
-                if (TryGetValue(k, out var kvalue) || visitUnassigned)
-                {
-                    args[0] = kvalue;
-                    args[1] = k;
-                    var testResult = callable.Call(thisArg, args);
-                    if (TypeConverter.ToBoolean(testResult))
+                    if (k > 0 && k % Engine.ConstraintCheckInterval == 0)
                     {
-                        index = k;
-                        value = kvalue;
-                        return true;
+                        _engine.Constraints.Check();
+                    }
+
+                    if (TryGetValue(k, out var kvalue) || visitUnassigned)
+                    {
+                        args[0] = kvalue;
+                        args[1] = k;
+                        var testResult = callable.Call(thisArg, args);
+                        if (TypeConverter.ToBoolean(testResult))
+                        {
+                            index = k;
+                            value = kvalue;
+                            return true;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                for (var k = (long) (length - 1); k >= 0; k--)
+                {
+                    if (k % Engine.ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
+                    if (TryGetValue((ulong) k, out var kvalue) || visitUnassigned)
+                    {
+                        kvalue ??= Undefined;
+                        args[0] = kvalue;
+                        args[1] = k;
+                        var testResult = callable.Call(thisArg, args);
+                        if (TypeConverter.ToBoolean(testResult))
+                        {
+                            index = (ulong) k;
+                            value = kvalue;
+                            return true;
+                        }
                     }
                 }
             }
         }
-        else
+        finally
         {
-            for (var k = (long) (length - 1); k >= 0; k--)
-            {
-                if (k % ConstraintCheckInterval == 0)
-                {
-                    _engine.Constraints.Check();
-                }
-
-                if (TryGetValue((ulong) k, out var kvalue) || visitUnassigned)
-                {
-                    kvalue ??= Undefined;
-                    args[0] = kvalue;
-                    args[1] = k;
-                    var testResult = callable.Call(thisArg, args);
-                    if (TypeConverter.ToBoolean(testResult))
-                    {
-                        index = (ulong) k;
-                        value = kvalue;
-                        return true;
-                    }
-                }
-            }
+            _engine._jsValueArrayPool.ReturnArray(args);
         }
-
-        _engine._jsValueArrayPool.ReturnArray(args);
 
         index = 0;
         value = Undefined;
@@ -1488,6 +1494,12 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
 
         for (var i = 0; i < ownKeys.Count; i++)
         {
+            // Pure native enumeration over a JS-controlled key count; check constraints periodically.
+            if (i > 0 && i % Engine.ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var property = ownKeys[i];
 
             if (!property.IsString())

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1196,10 +1196,16 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = this;
 
+        const int ConstraintCheckInterval = 10_000;
         if (!fromEnd)
         {
             for (ulong k = 0; k < length; k++)
             {
+                if (k > 0 && k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 if (TryGetValue(k, out var kvalue) || visitUnassigned)
                 {
                     args[0] = kvalue;
@@ -1218,6 +1224,11 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         {
             for (var k = (long) (length - 1); k >= 0; k--)
             {
+                if (k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 if (TryGetValue((ulong) k, out var kvalue) || visitUnassigned)
                 {
                     kvalue ??= Undefined;

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -17,6 +17,8 @@ namespace Jint.Native.RegExp;
 [JsObject(ExtraCapacity = 1)]
 internal sealed partial class RegExpPrototype : Prototype
 {
+    private const int ConstraintCheckInterval = 10_000;
+
     private static readonly JsString PropertyExec = new("exec");
     private static readonly JsString PropertyIndex = new("index");
     private static readonly JsString PropertyInput = new("input");
@@ -214,6 +216,11 @@ internal sealed partial class RegExpPrototype : Prototype
 
             while (count < maxCount && searchStart <= s.Length)
             {
+                if (count > 0 && count % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 var result = ExecuteWithTimeout(customRei, customEngine, s, searchStart);
                 if (!result.Success)
                 {
@@ -303,8 +310,14 @@ internal sealed partial class RegExpPrototype : Prototype
 
         var results = new List<ObjectInstance>();
 
+        var matchCount = 0;
         while (true)
         {
+            if (++matchCount % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var result = RegExpExec(rx, s);
             if (result.IsNull())
             {
@@ -332,6 +345,11 @@ internal sealed partial class RegExpPrototype : Prototype
         var captures = new List<string>();
         for (var i = 0; i < results.Count; i++)
         {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var result = results[i];
             var nCaptures = (int) result.GetLength();
             nCaptures = System.Math.Max(nCaptures - 1, 0);
@@ -568,15 +586,21 @@ internal sealed partial class RegExpPrototype : Prototype
             if (string.Equals(R.Source, JsRegExp.regExpForMatchingAllCharacters, StringComparison.Ordinal))
             {
                 // if empty string, just a string split
-                return StringPrototype.SplitWithStringSeparator(_realm, "", s, (uint) s.Length);
+                return StringPrototype.SplitWithStringSeparator(_engine, _realm, "", s, (uint) s.Length);
             }
 
             var a = _realm.Intrinsics.Array.Construct(Arguments.Empty);
 
             int lastIndex = 0;
             uint index = 0;
+            var matchCount = 0;
             for (var match = R.Value.Match(s, 0); match.Success; match = match.NextMatch())
             {
+                if (++matchCount % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 if (match.Length == 0 && (match.Index == 0 || match.Index == s.Length || match.Index == lastIndex))
                 {
                     continue;
@@ -624,8 +648,14 @@ internal sealed partial class RegExpPrototype : Prototype
         var a = _realm.Intrinsics.Array.ArrayCreate(0);
         ulong previousStringIndex = 0;
         ulong currentIndex = 0;
+        var iterations = 0;
         while (currentIndex < (ulong) s.Length)
         {
+            if (++iterations % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             splitter.Set(JsRegExp.PropertyLastIndex, currentIndex, true);
             var z = RegExpExec(splitter, s);
             if (z.IsNull())
@@ -842,6 +872,11 @@ internal sealed partial class RegExpPrototype : Prototype
             int lastIndex = 0;
             while (lastIndex <= s.Length)
             {
+                if (n > 0 && n % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 var result = ExecuteWithTimeout(rei, customEngine, s, lastIndex);
                 if (!result.Success)
                 {
@@ -884,6 +919,11 @@ internal sealed partial class RegExpPrototype : Prototype
                 uint li = 0;
                 while (true)
                 {
+                    if (li > 0 && li % ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
                     match = match.NextMatch();
                     if (!match.Success || match.Index != ++li)
                         break;
@@ -904,6 +944,11 @@ internal sealed partial class RegExpPrototype : Prototype
                 a.SetLength((uint) matches.Count);
                 for (var i = 0; i < matches.Count; i++)
                 {
+                    if (i > 0 && i % ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
                     a.SetIndexValue((uint) i, matches[i].Value, updateLength: false);
                 }
                 return a;
@@ -919,6 +964,11 @@ internal sealed partial class RegExpPrototype : Prototype
         uint n = 0;
         while (true)
         {
+            if (n > 0 && n % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var result = RegExpExec(rx, s);
             if (result.IsNull())
             {
@@ -1074,8 +1124,14 @@ internal sealed partial class RegExpPrototype : Prototype
         }
 
         var startAt = (int) lastIndex;
+        var iterations = 0;
         while (true)
         {
+            if (++iterations % ConstraintCheckInterval == 0)
+            {
+                R.Engine.Constraints.Check();
+            }
+
             match = R.Value.Match(s, startAt);
 
             // The conversion of Unicode regex patterns to .NET Regex has some flaws:

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -17,7 +17,7 @@ namespace Jint.Native.RegExp;
 [JsObject(ExtraCapacity = 1)]
 internal sealed partial class RegExpPrototype : Prototype
 {
-    private const int ConstraintCheckInterval = 10_000;
+    private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;
 
     private static readonly JsString PropertyExec = new("exec");
     private static readonly JsString PropertyIndex = new("index");

--- a/Jint/Native/Set/SetConstructor.cs
+++ b/Jint/Native/Set/SetConstructor.cs
@@ -50,8 +50,15 @@ public sealed partial class SetConstructor : Constructor
             try
             {
                 var args = new JsValue[1];
+                var iterations = 0;
                 do
                 {
+                    // Check constraints periodically so a huge (or native-backed) iterable cannot run uninterrupted.
+                    if (++iterations % Engine.ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
                     if (!iterable.TryIteratorStep(out var next))
                     {
                         return set;

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -16,7 +16,7 @@ namespace Jint.Native.String;
 [JsObject]
 internal sealed partial class StringConstructor : Constructor
 {
-    private const int ConstraintCheckInterval = 10_000;
+    private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;
 
     private static readonly JsString _functionName = new JsString("String");
 
@@ -55,12 +55,8 @@ internal sealed partial class StringConstructor : Constructor
             return JsString.Create((char) TypeConverter.ToUint16(arguments[0]));
         }
 
-        // Convert a would-be OutOfMemoryException into a catchable RangeError, mirroring repeat.
-        if ((uint) length > ClrLimits.MaxArrayLength)
-        {
-            Throw.RangeError(_realm, "Invalid string length");
-        }
-
+        // length is arguments.Length, already bounded by the materialized arguments array, so no
+        // size cap is needed here (unlike padStart/repeat whose length comes from a JS number).
 #if SUPPORTS_SPAN_PARSE
         var elements = length < 512 ? stackalloc char[length] : new char[length];
 #else

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -16,6 +16,8 @@ namespace Jint.Native.String;
 [JsObject]
 internal sealed partial class StringConstructor : Constructor
 {
+    private const int ConstraintCheckInterval = 10_000;
+
     private static readonly JsString _functionName = new JsString("String");
 
     public StringConstructor(
@@ -39,7 +41,7 @@ internal sealed partial class StringConstructor : Constructor
     /// https://tc39.es/ecma262/#sec-string.fromcharcode
     /// </summary>
     [JsFunction(Length = 1)]
-    private static JsValue FromCharCode(JsValue thisObject, JsCallArguments arguments)
+    private JsValue FromCharCode(JsValue thisObject, JsCallArguments arguments)
     {
         var length = arguments.Length;
 
@@ -53,6 +55,12 @@ internal sealed partial class StringConstructor : Constructor
             return JsString.Create((char) TypeConverter.ToUint16(arguments[0]));
         }
 
+        // Convert a would-be OutOfMemoryException into a catchable RangeError, mirroring repeat.
+        if ((uint) length > ClrLimits.MaxArrayLength)
+        {
+            Throw.RangeError(_realm, "Invalid string length");
+        }
+
 #if SUPPORTS_SPAN_PARSE
         var elements = length < 512 ? stackalloc char[length] : new char[length];
 #else
@@ -60,6 +68,12 @@ internal sealed partial class StringConstructor : Constructor
 #endif
         for (var i = 0; i < elements.Length; i++)
         {
+            // Spread can inflate the argument count; check constraints periodically.
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var nextCu = TypeConverter.ToUint16(arguments[i]);
             elements[i] = (char) nextCu;
         }
@@ -75,8 +89,16 @@ internal sealed partial class StringConstructor : Constructor
     {
         JsNumber codePoint;
         using var result = new ValueStringBuilder(stackalloc char[128]);
+        var processed = 0;
         foreach (var a in arguments)
         {
+            // Spread can inflate the argument count; check constraints periodically.
+            if (processed > 0 && processed % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+            processed++;
+
             int point;
             codePoint = TypeConverter.ToJsNumber(a);
             if (codePoint.IsInteger())
@@ -139,8 +161,14 @@ rangeError:
         using var result = new ValueStringBuilder();
         for (var i = 0; i < length; i++)
         {
+            // Check constraints periodically so a huge raw.length cannot run uninterrupted.
             if (i > 0)
             {
+                if (i % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 if (i < arguments.Length && !arguments[i].IsUndefined())
                 {
                     result.Append(TypeConverter.ToString(arguments[i]));

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -22,7 +22,7 @@ namespace Jint.Native.String;
 [JsObject(ExtraCapacity = 2)]
 internal sealed partial class StringPrototype : StringInstance
 {
-    private const int ConstraintCheckInterval = 10_000;
+    private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;
 
     private readonly Realm _realm;
 
@@ -1739,7 +1739,8 @@ internal sealed partial class StringPrototype : StringInstance
         // Build incrementally: do not pre-rent the full (possibly huge) target up front, and check
         // the engine constraints periodically so timeout/memory/statements limits can interrupt a
         // large fill instead of allocating until the CLR throws OutOfMemoryException.
-        var sb = new ValueStringBuilder(System.Math.Min(targetLength, ConstraintCheckInterval));
+        // 'using' so the pooled buffer is returned even when a periodic Check() throws mid-fill.
+        using var sb = new ValueStringBuilder(System.Math.Min(targetLength, ConstraintCheckInterval));
         if (!padStart)
         {
             sb.Append(sourceString);
@@ -1939,7 +1940,8 @@ internal sealed partial class StringPrototype : StringInstance
             return new string(s[0], (int) n);
         }
 
-        var sb = new ValueStringBuilder((int) resultLength);
+        // 'using' so the pooled buffer is returned even when a periodic Check() throws mid-build.
+        using var sb = new ValueStringBuilder((int) resultLength);
         for (var i = 0; i < n; ++i)
         {
             if (i > 0 && i % ConstraintCheckInterval == 0)
@@ -1971,7 +1973,8 @@ internal sealed partial class StringPrototype : StringInstance
         var strLen = s.Length;
         var k = 0;
 
-        var result = new ValueStringBuilder();
+        // 'using' so the pooled buffer is returned even when a periodic Check() throws mid-build.
+        using var result = new ValueStringBuilder();
         while (k < strLen)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -22,6 +22,8 @@ namespace Jint.Native.String;
 [JsObject(ExtraCapacity = 2)]
 internal sealed partial class StringPrototype : StringInstance
 {
+    private const int ConstraintCheckInterval = 10_000;
+
     private readonly Realm _realm;
 
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
@@ -240,7 +242,7 @@ internal sealed partial class StringPrototype : StringInstance
 
     [JsFunction]
     [RequireObjectCoercible]
-    private static JsValue ToUpperCase(JsValue thisObject)
+    private JsValue ToUpperCase(JsValue thisObject)
     {
         var s = TypeConverter.ToString(thisObject);
         return new JsString(ToUpperCaseWithSpecialCasing(s, CultureInfo.InvariantCulture));
@@ -251,7 +253,7 @@ internal sealed partial class StringPrototype : StringInstance
     /// expansions (e.g. ß → SS, ﬀ → FF, Greek titlecase → upper + Ι).
     /// https://www.unicode.org/Public/UCD/latest/ucd/SpecialCasing.txt
     /// </summary>
-    private static string ToUpperCaseWithSpecialCasing(string s, CultureInfo culture)
+    private string ToUpperCaseWithSpecialCasing(string s, CultureInfo culture)
     {
         // Fast path: no codepoint in the string has a SpecialCasing expansion.
         if (!NeedsUpperSpecialCasing(s))
@@ -264,6 +266,11 @@ internal sealed partial class StringPrototype : StringInstance
         var sb = new ValueStringBuilder(stackBuffer);
         for (var i = 0; i < s.Length; i++)
         {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var c = s[i];
             var mapped = GetSpecialUpperCasing(c);
             if (mapped is not null)
@@ -438,7 +445,7 @@ internal sealed partial class StringPrototype : StringInstance
 
     [JsFunction]
     [RequireObjectCoercible]
-    private static JsValue ToLowerCase(JsValue thisObject)
+    private JsValue ToLowerCase(JsValue thisObject)
     {
         var s = TypeConverter.ToString(thisObject);
         return ToLowerCaseWithSpecialCasing(s, CultureInfo.InvariantCulture);
@@ -449,7 +456,7 @@ internal sealed partial class StringPrototype : StringInstance
     /// Handles Final_Sigma, Turkish/Azeri I-dot, Lithuanian soft-dotted, and İ decomposition.
     /// https://unicode.org/reports/tr21/tr21-5.html#SpecialCasing
     /// </summary>
-    private static string ToLowerCaseWithSpecialCasing(string s, CultureInfo culture)
+    private string ToLowerCaseWithSpecialCasing(string s, CultureInfo culture)
     {
         var langName = culture.TwoLetterISOLanguageName;
         var isTurkishOrAzeri = string.Equals(langName, "tr", StringComparison.Ordinal) ||
@@ -468,6 +475,11 @@ internal sealed partial class StringPrototype : StringInstance
 
         for (var i = 0; i < s.Length; i++)
         {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var c = s[i];
 
             // Greek Final_Sigma (all locales)
@@ -1099,10 +1111,10 @@ internal sealed partial class StringPrototype : StringInstance
             return arrayInstance;
         }
 
-        return SplitWithStringSeparator(_realm, separator, s, lim);
+        return SplitWithStringSeparator(_engine, _realm, separator, s, lim);
     }
 
-    internal static JsValue SplitWithStringSeparator(Realm realm, JsValue separator, string s, uint lim)
+    internal static JsValue SplitWithStringSeparator(Engine engine, Realm realm, JsValue separator, string s, uint lim)
     {
         var segments = StringExecutionContext.Current.SplitSegmentList;
         segments.Clear();
@@ -1117,6 +1129,11 @@ internal sealed partial class StringPrototype : StringInstance
 
             for (var i = 0; i < s.Length; i++)
             {
+                if (i > 0 && i % ConstraintCheckInterval == 0)
+                {
+                    engine.Constraints.Check();
+                }
+
                 segments.Add(TypeConverter.ToString(s[i]));
             }
         }
@@ -1131,6 +1148,11 @@ internal sealed partial class StringPrototype : StringInstance
         var a = realm.Intrinsics.Array.ArrayCreate(length);
         for (int i = 0; i < length; i++)
         {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                engine.Constraints.Check();
+            }
+
             a.SetIndexValue((uint) i, segments[i], updateLength: false);
         }
 
@@ -1353,9 +1375,15 @@ internal sealed partial class StringPrototype : StringInstance
         var endOfLastMatch = 0;
         using var result = new ValueStringBuilder();
 
+        var matchCount = 0;
         var position = StringIndexOf(thisString, searchString, 0);
         while (position != -1)
         {
+            if (++matchCount % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             string replacement;
             var preserved = thisString.Substring(endOfLastMatch, position - endOfLastMatch);
             if (functionalReplace)
@@ -1657,9 +1685,9 @@ internal sealed partial class StringPrototype : StringInstance
     /// </summary>
     [JsFunction(Length = 1)]
     [RequireObjectCoercible]
-    private static JsValue PadStart(JsValue thisObject, JsCallArguments arguments)
+    private JsValue PadStart(JsValue thisObject, JsCallArguments arguments)
     {
-        return StringPad(thisObject, arguments, true);
+        return StringPad(thisObject, arguments, padStart: true);
     }
 
     /// <summary>
@@ -1667,39 +1695,78 @@ internal sealed partial class StringPrototype : StringInstance
     /// </summary>
     [JsFunction(Length = 1)]
     [RequireObjectCoercible]
-    private static JsValue PadEnd(JsValue thisObject, JsCallArguments arguments)
+    private JsValue PadEnd(JsValue thisObject, JsCallArguments arguments)
     {
-        return StringPad(thisObject, arguments, false);
+        return StringPad(thisObject, arguments, padStart: false);
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-stringpad
     /// </summary>
-    private static JsValue StringPad(JsValue thisObject, JsCallArguments arguments, bool padStart)
+    private JsValue StringPad(JsValue thisObject, JsCallArguments arguments, bool padStart)
     {
         var s = TypeConverter.ToJsString(thisObject);
 
-        var targetLength = TypeConverter.ToInt32(arguments.At(0));
-        var padStringValue = arguments.At(1);
-
-        var padString = padStringValue.IsUndefined()
-            ? " "
-            : TypeConverter.ToString(padStringValue);
-
-        if (s.Length > targetLength || padString.Length == 0)
+        // ToLength (not ToInt32) so large values don't wrap and bypass the size cap below.
+        var intMaxLength = TypeConverter.ToLength(arguments.At(0));
+        if (intMaxLength <= (ulong) s.Length)
         {
             return s;
         }
 
-        targetLength -= s.Length;
-        if (targetLength > padString.Length)
+        // Per spec the fill string is resolved (and its ToString side effect runs) only after the
+        // length check above; the previous implementation evaluated it too early.
+        var padStringValue = arguments.At(1);
+        var padString = padStringValue.IsUndefined()
+            ? " "
+            : TypeConverter.ToString(padStringValue);
+
+        if (padString.Length == 0)
         {
-            padString = string.Join("", System.Linq.Enumerable.Repeat(padString, (targetLength / padString.Length) + 1));
+            return s;
         }
 
-        return padStart
-            ? $"{padString.Substring(0, targetLength)}{s}"
-            : $"{s}{padString.Substring(0, targetLength)}";
+        // Convert a would-be OutOfMemoryException into a catchable RangeError, mirroring repeat.
+        if (intMaxLength > ClrLimits.MaxArrayLength)
+        {
+            Throw.RangeError(_realm, "Invalid string length");
+        }
+
+        var targetLength = (int) intMaxLength;
+        var sourceString = s.ToString();
+        var fillLength = targetLength - sourceString.Length;
+
+        // Build incrementally: do not pre-rent the full (possibly huge) target up front, and check
+        // the engine constraints periodically so timeout/memory/statements limits can interrupt a
+        // large fill instead of allocating until the CLR throws OutOfMemoryException.
+        var sb = new ValueStringBuilder(System.Math.Min(targetLength, ConstraintCheckInterval));
+        if (!padStart)
+        {
+            sb.Append(sourceString);
+        }
+
+        var remaining = fillLength;
+        var sinceCheck = 0;
+        var padSpan = padString.AsSpan();
+        while (remaining > 0)
+        {
+            var take = System.Math.Min(padSpan.Length, remaining);
+            sb.Append(take == padSpan.Length ? padSpan : padSpan.Slice(0, take));
+            remaining -= take;
+            sinceCheck += take;
+            if (sinceCheck >= ConstraintCheckInterval && remaining > 0)
+            {
+                sinceCheck = 0;
+                _engine.Constraints.Check();
+            }
+        }
+
+        if (padStart)
+        {
+            sb.Append(sourceString);
+        }
+
+        return sb.ToString();
     }
 
     /// <summary>
@@ -1875,6 +1942,11 @@ internal sealed partial class StringPrototype : StringInstance
         var sb = new ValueStringBuilder((int) resultLength);
         for (var i = 0; i < n; ++i)
         {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             sb.Append(s);
         }
 
@@ -1892,7 +1964,7 @@ internal sealed partial class StringPrototype : StringInstance
 
     [JsFunction]
     [RequireObjectCoercible]
-    private static JsValue ToWellFormed(JsValue thisObject)
+    private JsValue ToWellFormed(JsValue thisObject)
     {
         var s = TypeConverter.ToString(thisObject);
 
@@ -1902,6 +1974,11 @@ internal sealed partial class StringPrototype : StringInstance
         var result = new ValueStringBuilder();
         while (k < strLen)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var cp = CodePointAt(s, k);
             if (cp.IsUnpairedSurrogate)
             {

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -394,6 +394,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         args[2] = o;
         for (var k = 0; k < len; k++)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             args[0] = o[k];
             args[1] = k;
             if (!TypeConverter.ToBoolean(predicate.Call(thisArg, args)))
@@ -501,6 +506,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         args[2] = o;
         for (var k = 0; k < len; k++)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var kValue = o[k];
             args[0] = kValue;
             args[1] = k;
@@ -572,6 +582,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         {
             for (var k = 0; k < len; k++)
             {
+                if (k > 0 && k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 var kNumber = JsNumber.Create(k);
                 var kValue = o[k];
                 args[0] = kValue;
@@ -586,6 +601,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         {
             for (var k = (int) (len - 1); k >= 0; k--)
             {
+                if (k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 var kNumber = JsNumber.Create(k);
                 var kValue = o[k];
                 args[0] = kValue;
@@ -616,6 +636,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         args[2] = o;
         for (var k = 0; k < len; k++)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var kValue = o[k];
             args[0] = kValue;
             args[1] = k;
@@ -669,6 +694,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         while (k < len)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var value = o[(int) k];
             if (SameValueZeroComparer.Equals(value, searchElement))
             {
@@ -722,6 +752,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         for (; k < len; k++)
         {
+            if (k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var kPresent = o.HasProperty(k);
             if (kPresent)
             {
@@ -770,6 +805,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         result.Append(s);
         for (var k = 1; k < len; k++)
         {
+            if (k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             result.Append(sep);
             result.Append(StringFromJsValue(o[k]));
         }
@@ -828,6 +868,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         for (; k >= 0; k--)
         {
+            if (k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var kPresent = o.HasProperty(k);
             if (kPresent)
             {
@@ -859,6 +904,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         args[2] = o;
         for (var k = 0; k < len; k++)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             args[0] = o[k];
             args[1] = k;
             var mappedValue = callable.Call(thisArg, args);
@@ -905,6 +955,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         args[3] = o;
         while (k < len)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var kValue = o[k];
             args[0] = accumulator;
             args[1] = kValue;
@@ -953,6 +1008,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         jsValues[3] = o;
         for (; k >= 0; k--)
         {
+            if (k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             jsValues[0] = accumulator;
             jsValues[1] = o[(int) k];
             jsValues[2] = k;
@@ -1089,6 +1149,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var targetByteIndex = (int) (targetOffset * targetElementSize + targetByteOffset);
         var limit = targetByteIndex + targetElementSize * srcLength;
 
+        var processed = 0;
         if (srcType == targetType)
         {
             // NOTE: If srcType and targetType are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
@@ -1098,6 +1159,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
                 targetBuffer.SetValueInBuffer(targetByteIndex, TypedArrayElementType.Uint8, value, isTypedArray: true, ArrayBufferOrder.Unordered);
                 srcByteIndex += 1;
                 targetByteIndex += 1;
+
+                if (++processed % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
             }
         }
         else
@@ -1108,6 +1174,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
                 targetBuffer.SetValueInBuffer(targetByteIndex, targetType, value, isTypedArray: true, ArrayBufferOrder.Unordered);
                 srcByteIndex += srcElementSize;
                 targetByteIndex += targetElementSize;
+
+                if (++processed % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
             }
         }
     }
@@ -1143,6 +1214,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var k = 0;
         while (k < srcLength)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             var jsValue = src.Get((ulong) k);
             target.IntegerIndexedElementSet(targetOffset + k, jsValue);
             k++;
@@ -1242,6 +1318,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
                 var n = 0;
                 while (startIndex < endIndex)
                 {
+                    if (n > 0 && n % ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
                     var kValue = o[startIndex];
                     a[n] = kValue;
                     startIndex++;
@@ -1257,12 +1338,18 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
                 var targetByteIndex = a._byteOffset;
                 var srcByteIndex = (int) startIndex * elementSize + srcByteOffset;
                 var limit = targetByteIndex + countBytes * elementSize;
+                var copied = 0;
                 while (targetByteIndex < limit)
                 {
                     var value = srcBuffer.GetValueFromBuffer(srcByteIndex, TypedArrayElementType.Uint8, true, ArrayBufferOrder.Unordered);
                     targetBuffer.SetValueInBuffer(targetByteIndex, TypedArrayElementType.Uint8, value, true, ArrayBufferOrder.Unordered);
                     srcByteIndex++;
                     targetByteIndex++;
+
+                    if (++copied % ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
                 }
             }
         }
@@ -1286,6 +1373,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         args[2] = o;
         for (var k = 0; k < len; k++)
         {
+            if (k > 0 && k % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             args[0] = o[k];
             args[1] = k;
             if (TypeConverter.ToBoolean(callbackfn.Call(thisArg, args)))
@@ -1328,6 +1420,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         for (var i = 0; i < (uint) array.Length; ++i)
         {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             o[i] = array[i];
         }
 
@@ -1448,6 +1545,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         {
             if (k > 0)
             {
+                if (k % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
                 r.Append(Separator);
             }
             if (array.TryGetValue(k, out var nextElement) && !nextElement.IsNullOrUndefined())
@@ -1525,6 +1627,11 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var array = SortArray(buffer, compareFn, o);
         for (var i = 0; (uint) i < (uint) array.Length; ++i)
         {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
             a[i] = array[i];
         }
 

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -21,7 +21,7 @@ namespace Jint.Native.TypedArray;
 [JsObject(ExtraCapacity = 1)]
 internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 {
-    private const int ConstraintCheckInterval = 10_000;
+    private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;
 
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
     private readonly IntrinsicTypedArrayConstructor _constructor;

--- a/Jint/Native/WeakSet/WeakSetConstructor.cs
+++ b/Jint/Native/WeakSet/WeakSetConstructor.cs
@@ -44,8 +44,16 @@ internal sealed class WeakSetConstructor : Constructor
             // check fast path
             if (arg1 is JsArray array && ReferenceEquals(adder, _engine.Realm.Intrinsics.WeakSet.PrototypeObject.OriginalAddFunction))
             {
+                var index = 0;
                 foreach (var value in array)
                 {
+                    // Check constraints periodically so a huge source array cannot run uninterrupted.
+                    if (index > 0 && index % Engine.ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+                    index++;
+
                     set.WeakSetAdd(value);
                 }
 
@@ -62,8 +70,15 @@ internal sealed class WeakSetConstructor : Constructor
             try
             {
                 var args = new JsValue[1];
+                var iterations = 0;
                 do
                 {
+                    // Check constraints periodically so a huge (or native-backed) iterable cannot run uninterrupted.
+                    if (++iterations % Engine.ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
                     if (!iterable.TryIteratorStep(out var next))
                     {
                         return set;


### PR DESCRIPTION
Fixes #2486.

## Problem

Several built-ins perform a full bulk operation in a single CLR call **without per-step constraint checks**, so a configured `TimeoutInterval` / `MaxStatements` / `LimitMemory` cannot interrupt them. For large inputs they either hang for seconds (no constraint can fire until the call returns) or the CLR throws `System.OutOfMemoryException` — which is **not** one of Jint's catchable constraint exceptions (`TimeoutException`, `MemoryLimitExceededException`, `StatementsCountOverflowException`).

The cases from the issue:

```js
'x'.padStart(2147483647)        // hang, then OOM
'x'.padEnd(536870911, 'ab')     // hang, then OOM
Array.from({ length: 50000000 })// hang
```

This is the same fix class as #2349 (BigInt `**`) and #2465 (`String.prototype.repeat`, `BigInt.asIntN/asUintN`, `Function.prototype.apply`). The reporter and maintainer asked to also cover `String.raw`, `Array.prototype.join`, `Array.prototype.sort`, **and any other affected sites**, so this PR does the full sweep.

## Approach

Two complementary mechanisms already present in the codebase are reused:

1. **Hard size cap** — `ClrLimits.MaxArrayLength` (`0x7FFFFFC7`). Converts a would-be `OutOfMemoryException` into a catchable `RangeError`, exactly as `String.prototype.repeat` already does.
2. **Periodic constraint check** — the established `ConstraintCheckInterval = 10_000` idiom (already used by `Array.prototype.fill`/`reverse`/`with`, etc.):
   ```csharp
   if (k > 0 && k % ConstraintCheckInterval == 0) _engine.Constraints.Check();
   ```
   A periodic `Check()` in a native loop lets **all three** constraints fire: time (stopwatch), memory (allocations accumulate as the structure grows), and statements (the counter increments per `Check()`).

A single giant up-front allocation can't be interrupted before it OOMs, so it is either pre-capped (mechanism 1) or built incrementally with periodic checks (mechanism 2).

## Changes

**`String.prototype.padStart` / `padEnd`** (the issue) — rewritten:
- Use `ToLength` instead of `ToInt32` so a large `maxLength` can't wrap and slip past the size cap (spec step 2).
- Resolve `fillString` (and run its `ToString`) **only after** the `maxLength <= stringLength` early return — fixes an observable side-effect-ordering bug.
- Throw a catchable `RangeError("Invalid string length")` when the result exceeds `MaxArrayLength`.
- Build incrementally with a bounded initial capacity + periodic checks, instead of `Enumerable.Repeat` + `string.Join` + `Substring` + interpolation (~3× transient allocation).

**`Array.from`** (the issue) — periodic checks in `ConstructArrayFromArrayLike` and `ConstructArrayFromIEnumerable`.

**`String.raw` / `fromCharCode` / `fromCodePoint`** — periodic checks in the element/char loops; size cap added to `fromCharCode`.

**`Array.prototype` & `%TypedArray%.prototype` bulk loops** — `join`, `sort` (collection/write-back), `map`, `filter`, `forEach`, `reduce`/`reduceRight`, `find*` (via `FindWithCallback`), `slice`, `splice`, `unshift`, `shift`, `concat`, `toSpliced`, `toLocaleString`, `set`, and the **slow** `indexOf`/`lastIndexOf`/`includes` scans. **Dense primitive fast-path scans are intentionally left unguarded** (they're tight, bounded by `MaxArraySize`, and the one place a per-iteration check would actually cost).

**`RegExp.prototype`** — `@@replace` / `@@split` / `@@match` outer match-collection loops.

**`JSON`** — `JSON.stringify` breadth (array/object/replacer) and `JSON.parse` array/object/string-literal loops (depth was already capped; breadth was not).

### Not changed (already covered / fast paths)
- `ArrayBuffer`/`TypedArray` constructors — already capped at `int.MaxValue`.
- `String.prototype.repeat` single-char path, `new Array(N)` — already capped/lazy.
- Dense array fast-path scans — fast and `MaxArraySize`-bounded.

## Performance

Reuses the `% ConstraintCheckInterval` idiom (RyuJIT lowers `% const` to a multiply+shift; the branch is predicted not-taken 9999/10000). The predicate is added only to loops whose body is already heavy (a JS call, property `Get`/`Set`, `ToString`, regex `NextMatch`), and the common small-input case runs the predicate a handful of times.

Measured with BenchmarkDotNet (`--job short`, net10.0, 1000 ops/benchmark), base (`main`) vs this branch:

| Benchmark (1000 ops) | Mean before | Mean after | Alloc before | Alloc after |
| --- | ---: | ---: | ---: | ---: |
| `padStart` (small) | 223.6 µs | 186.9 µs | 188.7 KB | **71.5 KB** |
| `padEnd` (small) | 231.2 µs | 194.4 µs | 204.3 KB | **79.3 KB** |
| `filter` (1000-elem) | 138,494 µs | 120,107 µs | 48,095 KB | 48,095 KB |
| `forEach` (1000-elem) | 142,163 µs | 150,465 µs | 66,525 KB | 66,525 KB |
| `join` (1000-elem) | 7,230 µs | 7,966 µs | 7,688 KB | 7,688 KB |

- **`padStart`/`padEnd`**: ~60% fewer allocations and slightly faster — the rewrite removes the old 3× transient allocation.
- **Guarded array methods**: allocation counts are **identical** (the guard allocates nothing). The time deltas are within the noise of the `ShortRun` config — between two baseline runs `filter` alone varied 119,636 → 138,494 µs (±16%), which is larger than any of the before/after deltas.

## Testing
- Full **Test262**: 99,015 passed, 0 failed (no regressions). The 70 `padStart`/`padEnd` conformance tests pass, confirming the `ToLength` + side-effect-ordering changes are spec-correct.
- **Jint.Tests**: 3024 passed, 0 failed, including new tests in `ExecutionConstraintTests` for the three issue repros plus `String.raw`, `sort`, an empty-callback `forEach`, `padStart`/`padEnd` correctness, and the fill-string side-effect ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
