### PR TITLE
Update test262 suite and implement newly-surfaced features

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -1,5 +1,5 @@
 {
-  "SuiteGitSha": "673e9bacbe28590f501e2dcd817aadcc31899191",
+  "SuiteGitSha": "4249661388e5d3f92a85186213da140a6481490f",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Jint.Tests.Test262",
@@ -12,6 +12,15 @@
   "ExcludedDirectories": [
   ],
   "ExcludedFiles": [
+
+    // %TypedArray%.prototype.slice creates its destination via TypedArraySpeciesCreate(..., write), which
+    // (correctly) rejects an immutable backing buffer — see the passing slice/speciesctor-destination-
+    // backed-by-immutable-buffer.js. This test was broadened to run against every buffer-arg factory
+    // (including makeImmutableArrayBuffer) yet still expects the element copy to succeed, so when the
+    // source — and therefore the same-buffer species destination — is immutable, a spec-conformant slice
+    // throws instead of producing the expected array. The test does not declare the immutable-arraybuffer
+    // feature; it is incompatible with an engine that implements it.
+    "built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js",
 
     // === INTL402 EXCLUSIONS ===
     // The following tests require full CLDR locale data support which is not available in the default provider.
@@ -97,7 +106,17 @@
     "intl402/Temporal/ZonedDateTime/prototype/daysInYear/basic-islamic-umalqura.js",
     "intl402/Temporal/ZonedDateTime/prototype/inLeapYear/basic-islamic-umalqura.js",
     "intl402/Temporal/ZonedDateTime/prototype/with/basic-islamic-umalqura.js",
-    "intl402/Temporal/ZonedDateTime/prototype/withCalendar/extreme-dates.js"
+    "intl402/Temporal/ZonedDateTime/prototype/withCalendar/extreme-dates.js",
+
+    // === SOURCE-PHASE IMPORT RE-EXPORT ===
+    // These exercise re-exporting a source-phase import (`import source x from '<module source>'; export { x }`).
+    // The `<module source>` specifier must resolve to a module that exposes a [[ModuleSource]] (i.e. a
+    // WebAssembly module). Jint has no WebAssembly module support, so the import cannot be loaded and the
+    // re-exported binding can never become an %AbstractModuleSource% instance. The basic source-phase
+    // rejection behaviour (import-source.js) is still covered and passes.
+    "language/module-code/source-phase-import/reexport-source-binding-named-import.js",
+    "language/module-code/source-phase-import/reexport-source-binding-namespace-get.js",
+    "language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-import-source-and-export.js"
 
   ],
   // Timing-sensitive suites: serialise the whole generated test method instead of

--- a/Jint.Tests/Runtime/ErrorTests.cs
+++ b/Jint.Tests/Runtime/ErrorTests.cs
@@ -186,10 +186,22 @@ var b = function(v) {
     }
 
     [Fact]
-    public void ErrorObjectHasOwnPropertyStack()
+    public void ErrorObjectHasStackAccessorOnPrototype()
     {
-        var res = new Engine().Evaluate(@"Error().hasOwnProperty('stack')").AsBoolean();
-        Assert.True(res);
+        var engine = new Engine();
+
+        // Per the error-stack-accessor proposal, "stack" is an accessor property on Error.prototype,
+        // not an own data property of the instance.
+        Assert.False(engine.Evaluate(@"Error().hasOwnProperty('stack')").AsBoolean());
+
+        Assert.True(engine.Evaluate(@"Error.prototype.hasOwnProperty('stack')").AsBoolean());
+
+        var descriptorType = engine.Evaluate(
+            @"typeof Object.getOwnPropertyDescriptor(Error.prototype, 'stack').get").AsString();
+        Assert.Equal("function", descriptorType);
+
+        // The inherited accessor still produces a string for an error instance.
+        Assert.Equal("string", engine.Evaluate(@"typeof Error().stack").AsString());
     }
 
     private class Folder

--- a/Jint/Native/AggregateError/AggregateErrorConstructor.cs
+++ b/Jint/Native/AggregateError/AggregateErrorConstructor.cs
@@ -46,6 +46,8 @@ internal sealed class AggregateErrorConstructor : Constructor
             static intrinsics => intrinsics.AggregateError.PrototypeObject,
             static (Engine engine, Realm _, object? _) => new JsError(engine));
 
+        o._stack = ErrorConstructor.BuildStackTraceString(_engine, this);
+
         if (!message.IsUndefined())
         {
             var msg = TypeConverter.ToString(message);

--- a/Jint/Native/Atomics/AtomicsInstance.cs
+++ b/Jint/Native/Atomics/AtomicsInstance.cs
@@ -250,7 +250,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     [JsFunction]
     private JsValue CompareExchange(JsValue thisObject, JsValue typedArray, JsValue index, JsValue expectedValue, JsValue replacementValue)
     {
-        var taRecord = ValidateIntegerTypedArray(typedArray);
+        var taRecord = ValidateIntegerTypedArray(typedArray, isWrite: true);
         var byteIndexInBuffer = ValidateAtomicAccess(taRecord, index);
         var ta = taRecord.Object;
 
@@ -413,7 +413,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     [JsFunction]
     private JsValue Store(JsValue thisObject, JsValue typedArray, JsValue index, JsValue value)
     {
-        var taRecord = ValidateIntegerTypedArray(typedArray);
+        var taRecord = ValidateIntegerTypedArray(typedArray, isWrite: true);
         var byteIndexInBuffer = ValidateAtomicAccess(taRecord, index);
         var ta = taRecord.Object;
 
@@ -705,9 +705,9 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// <summary>
     /// https://tc39.es/ecma262/#sec-validateintegertypedarray
     /// </summary>
-    private IntrinsicTypedArrayPrototype.TypedArrayWithBufferWitnessRecord ValidateIntegerTypedArray(JsValue typedArray, bool waitable = false, bool requireShared = false)
+    private IntrinsicTypedArrayPrototype.TypedArrayWithBufferWitnessRecord ValidateIntegerTypedArray(JsValue typedArray, bool waitable = false, bool requireShared = false, bool isWrite = false)
     {
-        var taRecord = typedArray.ValidateTypedArray(_realm, ArrayBufferOrder.Unordered);
+        var taRecord = typedArray.ValidateTypedArray(_realm, ArrayBufferOrder.Unordered, isWrite: isWrite);
         var ta = taRecord.Object;
         var type = ta._arrayElementType;
 
@@ -789,7 +789,7 @@ internal sealed partial class AtomicsInstance : ObjectInstance
     /// </summary>
     private JsValue AtomicReadModifyWrite(JsValue typedArrayValue, JsValue index, JsValue value, AtomicOperation op)
     {
-        var taRecord = ValidateIntegerTypedArray(typedArrayValue);
+        var taRecord = ValidateIntegerTypedArray(typedArrayValue, isWrite: true);
         var byteIndexInBuffer = ValidateAtomicAccess(taRecord, index);
         var ta = taRecord.Object;
 

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -55,12 +55,10 @@ public sealed partial class ErrorConstructor : Constructor
             o.CreateNonEnumerableDataPropertyOrThrow(CommonProperties.Message, msg);
         }
 
-        var stackString = BuildStackString();
-        if (stackString is not null)
-        {
-            var stackDesc = new PropertyDescriptor(stackString, PropertyFlag.NonEnumerable);
-            o.DefinePropertyOrThrow(CommonProperties.Stack, stackDesc);
-        }
+        // Per the error-stack-accessor proposal, "stack" is no longer an own data property of the
+        // instance; it is exposed via the get/set accessor on %Error.prototype%. The captured trace
+        // is stored in the [[ErrorData]]-bearing instance and returned by that getter.
+        o._stack = BuildStackTraceString(_engine, this);
 
         var options = arguments.At(1);
         if (!options.IsUndefined())
@@ -69,22 +67,26 @@ public sealed partial class ErrorConstructor : Constructor
         }
 
         return o;
+    }
 
-        JsValue? BuildStackString()
+    /// <summary>
+    /// Builds the implementation-defined stack trace string for an error being constructed by
+    /// <paramref name="constructor"/>. Returns <c>null</c> when there is no active script location.
+    /// </summary>
+    internal static JsValue? BuildStackTraceString(Engine engine, JsValue constructor)
+    {
+        var lastSyntaxNode = engine.GetLastSyntaxElement();
+        if (lastSyntaxNode == null)
         {
-            var lastSyntaxNode = _engine.GetLastSyntaxElement();
-            if (lastSyntaxNode == null)
-            {
-                return null;
-            }
-
-            var callStack = _engine.CallStack;
-            var currentFunction = callStack.TryPeek(out var element) ? element.Function : null;
-
-            // If the current function is the ErrorConstructor itself (i.e. "throw new Error(...)" was called
-            // from script), exclude it from the stack trace, because the trace should begin at the throw point.
-            return callStack.BuildCallStackString(_engine, lastSyntaxNode.Location, currentFunction == this ? 1 : 0);
+            return null;
         }
+
+        var callStack = engine.CallStack;
+        var currentFunction = callStack.TryPeek(out var element) ? element.Function : null;
+
+        // If the current function is the error constructor itself (i.e. "throw new Error(...)" was called
+        // from script), exclude it from the stack trace, because the trace should begin at the throw point.
+        return callStack.BuildCallStackString(engine, lastSyntaxNode.Location, currentFunction == constructor ? 1 : 0);
     }
 
     /// <summary>

--- a/Jint/Native/Error/ErrorPrototype.cs
+++ b/Jint/Native/Error/ErrorPrototype.cs
@@ -35,7 +35,106 @@ internal sealed partial class ErrorPrototype : ErrorInstance
         _prototype = prototype;
     }
 
-    protected override void Initialize() => CreateProperties_Generated();
+    protected override void Initialize()
+    {
+        CreateProperties_Generated();
+
+        // The "stack" accessor is an own property of the intrinsic %Error.prototype% only; the
+        // NativeError prototypes (TypeError.prototype, RangeError.prototype, ...) inherit it through
+        // the prototype chain. The source generator adds it to every ErrorPrototype instance, so
+        // remove it from the non-root prototypes — those whose [[Prototype]] is itself an ErrorPrototype
+        // (i.e. %Error.prototype%), whereas the root's [[Prototype]] is %Object.prototype%.
+        if (_prototype is ErrorPrototype)
+        {
+            RemoveOwnProperty(CommonProperties.Stack);
+        }
+    }
+
+    /// <summary>
+    /// https://tc39.es/proposal-error-stacks/#sec-get-error.prototype-stack
+    /// </summary>
+    [JsAccessor("stack")]
+    private JsValue StackGet(JsValue thisObject)
+    {
+        // 1. Let E be the this value.
+        // 2. If E is not an Object, throw a TypeError exception.
+        if (thisObject is not ObjectInstance)
+        {
+            Throw.TypeError(_realm, "get Error.prototype.stack called on non-object");
+            return Undefined;
+        }
+
+        // 3. If E does not have an [[ErrorData]] internal slot, return undefined.
+        if (thisObject is not JsError error)
+        {
+            return Undefined;
+        }
+
+        // 4. Return an implementation-defined string that represents the stack trace of E.
+        return error._stack ?? JsString.Empty;
+    }
+
+    /// <summary>
+    /// https://tc39.es/proposal-error-stacks/#sec-set-error.prototype-stack
+    /// </summary>
+    [JsAccessor("stack", AccessorKind.Set)]
+    private JsValue StackSet(JsValue thisObject, JsValue value)
+    {
+        // 1. Let E be the this value.
+        // 2. If E is not an Object, throw a TypeError exception.
+        if (thisObject is not ObjectInstance)
+        {
+            Throw.TypeError(_realm, "set Error.prototype.stack called on non-object");
+            return Undefined;
+        }
+
+        // 3. If v is not a String, throw a TypeError exception.
+        if (!value.IsString())
+        {
+            Throw.TypeError(_realm, "set Error.prototype.stack called with a non-string value");
+            return Undefined;
+        }
+
+        // 4. Perform ? SetterThatIgnoresPrototypeProperties(this value, %Error.prototype%, "stack", v).
+        SetterThatIgnoresPrototypeProperties(thisObject, this, CommonProperties.Stack, value);
+
+        // 5. Return undefined.
+        return Undefined;
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-setterthatignoresprototypeproperties
+    /// </summary>
+    private void SetterThatIgnoresPrototypeProperties(JsValue thisValue, ObjectInstance home, JsValue p, JsValue v)
+    {
+        // 1. If this is not an Object, throw a TypeError exception.
+        if (thisValue is not ObjectInstance objectInstance)
+        {
+            Throw.TypeError(_realm, "Error.prototype.stack setter called on non-object");
+            return;
+        }
+
+        // 2. If SameValue(this, home) is true, throw a TypeError exception.
+        if (SameValue(thisValue, home))
+        {
+            Throw.TypeError(_realm, "Cannot set the \"stack\" property directly on %Error.prototype%");
+            return;
+        }
+
+        // 3. Let desc be ? this.[[GetOwnProperty]](p).
+        var desc = objectInstance.GetOwnProperty(p);
+
+        // 4. If desc is undefined, perform ? CreateDataPropertyOrThrow(this, p, v).
+        if (desc == PropertyDescriptor.Undefined)
+        {
+            objectInstance.CreateDataPropertyOrThrow(p, v);
+        }
+        else
+        {
+            // 5. Else, perform ? Set(this, p, v, true).
+            objectInstance.Set(p, v, throwOnError: true);
+        }
+    }
 
     [JsFunction]
     public JsValue ToString(JsValue thisObject)

--- a/Jint/Native/Intl/CollatorConstructor.cs
+++ b/Jint/Native/Intl/CollatorConstructor.cs
@@ -66,6 +66,8 @@ internal sealed partial class CollatorConstructor : Constructor
     /// </summary>
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
+        // Intl.Collator has no normative-optional legacy-constructor (ChainCollator) behaviour — unlike
+        // NumberFormat/DateTimeFormat it always returns a fresh instance and ignores the this value.
         return Construct(arguments, this);
     }
 

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -72,7 +72,11 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
     /// </summary>
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
-        return Construct(arguments, this);
+        var dateTimeFormat = Construct(arguments, this);
+
+        // Normative-optional ChainDateTimeFormat: when called as a plain function on a DateTimeFormat
+        // receiver, stash the formatter under %Intl%.[[FallbackSymbol]] and return the receiver.
+        return IntlUtilities.ChainLegacyConstructor(_realm, this, thisObject, dateTimeFormat);
     }
 
     /// <summary>

--- a/Jint/Native/Intl/DateTimeFormatPrototype.cs
+++ b/Jint/Native/Intl/DateTimeFormatPrototype.cs
@@ -40,6 +40,14 @@ internal sealed partial class DateTimeFormatPrototype : Prototype
             return dateTimeFormat;
         }
 
+        // UnwrapDateTimeFormat: a legacy-constructed wrapper keeps the real formatter under the
+        // per-realm %Intl%.[[FallbackSymbol]] property.
+        var unwrapped = IntlUtilities.UnwrapLegacyConstructor(_realm, _realm.Intrinsics.DateTimeFormat, thisObject);
+        if (unwrapped is JsDateTimeFormat unwrappedDateTimeFormat)
+        {
+            return unwrappedDateTimeFormat;
+        }
+
         Throw.TypeError(_realm, "Value is not an Intl.DateTimeFormat");
         return null!; // Never reached
     }

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -1,9 +1,11 @@
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Jint.Native.Function;
 using Jint.Native.Intl.Data;
 using Jint.Native.Object;
 using Jint.Runtime;
+using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Intl;
 
@@ -13,6 +15,41 @@ namespace Jint.Native.Intl;
 /// </summary>
 internal static class IntlUtilities
 {
+    /// <summary>
+    /// Implements the normative-optional legacy-constructor chaining behaviour shared by
+    /// Intl.Collator, Intl.DateTimeFormat and Intl.NumberFormat (ChainCollator / ChainDateTimeFormat /
+    /// ChainNumberFormat). When the constructor is invoked as a plain function (NewTarget is undefined)
+    /// and the receiver is an instance of the constructor, the freshly created formatter is stashed on
+    /// the receiver under the per-realm %Intl%.[[FallbackSymbol]] and the receiver is returned.
+    /// https://tc39.es/ecma402/#sec-chaindatetimeformat
+    /// </summary>
+    internal static JsValue ChainLegacyConstructor(Realm realm, Constructor constructor, JsValue thisObject, ObjectInstance instance)
+    {
+        if (thisObject is ObjectInstance receiver && constructor.OrdinaryHasInstance(thisObject))
+        {
+            var fallbackSymbol = realm.Intrinsics.IntlLegacyConstructedSymbol;
+            receiver.DefinePropertyOrThrow(fallbackSymbol, new PropertyDescriptor(instance, PropertyFlag.AllForbidden));
+            return receiver;
+        }
+
+        return instance;
+    }
+
+    /// <summary>
+    /// Implements the unwrap step shared by UnwrapCollator / UnwrapDateTimeFormat / UnwrapNumberFormat:
+    /// when <paramref name="thisObject"/> is an instance of the constructor that lacks the internal slot
+    /// (i.e. it is a legacy-constructed wrapper rather than a real formatter), the actual formatter is
+    /// read from the per-realm %Intl%.[[FallbackSymbol]] property. Returns the value to validate.
+    /// </summary>
+    internal static JsValue UnwrapLegacyConstructor(Realm realm, Constructor constructor, JsValue thisObject)
+    {
+        if (thisObject is ObjectInstance && constructor.OrdinaryHasInstance(thisObject))
+        {
+            return thisObject.Get(realm.Intrinsics.IntlLegacyConstructedSymbol);
+        }
+
+        return thisObject;
+    }
     // Cache for CultureInfo instances to avoid repeated allocations.
     // CultureInfo with useUserOverride:false is immutable, safe to cache and share.
     private static readonly ConcurrentDictionary<string, CultureInfo?> _cultureCache = new(StringComparer.OrdinalIgnoreCase);

--- a/Jint/Native/Intl/JsPluralRules.cs
+++ b/Jint/Native/Intl/JsPluralRules.cs
@@ -15,6 +15,7 @@ internal sealed class JsPluralRules : ObjectInstance
         string locale,
         string pluralRuleType,
         string notation,
+        string? compactDisplay,
         int minimumIntegerDigits,
         int? minimumFractionDigits,
         int? maximumFractionDigits,
@@ -30,6 +31,7 @@ internal sealed class JsPluralRules : ObjectInstance
         Locale = locale;
         PluralRuleType = pluralRuleType;
         Notation = notation;
+        CompactDisplay = compactDisplay;
         MinimumIntegerDigits = minimumIntegerDigits;
         MinimumFractionDigits = minimumFractionDigits;
         MaximumFractionDigits = maximumFractionDigits;
@@ -56,6 +58,12 @@ internal sealed class JsPluralRules : ObjectInstance
     /// The notation style: "standard", "compact", "scientific", or "engineering".
     /// </summary>
     internal string Notation { get; }
+
+    /// <summary>
+    /// The compact display form ("short" or "long"); only set when <see cref="Notation"/> is "compact",
+    /// otherwise null per the [[CompactDisplay]] internal slot semantics.
+    /// </summary>
+    internal string? CompactDisplay { get; }
 
     /// <summary>
     /// Minimum integer digits.

--- a/Jint/Native/Intl/NumberFormatConstructor.cs
+++ b/Jint/Native/Intl/NumberFormatConstructor.cs
@@ -51,7 +51,11 @@ internal sealed partial class NumberFormatConstructor : Constructor
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
         // Per spec: If NewTarget is undefined, let newTarget be the active function object
-        return Construct(arguments, this);
+        var numberFormat = Construct(arguments, this);
+
+        // Normative-optional ChainNumberFormat: when called as a plain function on a NumberFormat
+        // receiver, stash the formatter under %Intl%.[[FallbackSymbol]] and return the receiver.
+        return IntlUtilities.ChainLegacyConstructor(_realm, this, thisObject, numberFormat);
     }
 
     /// <summary>

--- a/Jint/Native/Intl/NumberFormatPrototype.cs
+++ b/Jint/Native/Intl/NumberFormatPrototype.cs
@@ -42,6 +42,14 @@ internal sealed partial class NumberFormatPrototype : Prototype
             return numberFormat;
         }
 
+        // UnwrapNumberFormat: a legacy-constructed wrapper keeps the real formatter under the
+        // per-realm %Intl%.[[FallbackSymbol]] property.
+        var unwrapped = IntlUtilities.UnwrapLegacyConstructor(_realm, _realm.Intrinsics.NumberFormat, thisObject);
+        if (unwrapped is JsNumberFormat unwrappedNumberFormat)
+        {
+            return unwrappedNumberFormat;
+        }
+
         Throw.TypeError(_realm, "Value is not an Intl.NumberFormat");
         return null!; // Never reached
     }

--- a/Jint/Native/Intl/PluralRulesConstructor.cs
+++ b/Jint/Native/Intl/PluralRulesConstructor.cs
@@ -18,6 +18,7 @@ internal sealed partial class PluralRulesConstructor : Constructor
     private static readonly StringSearchValues LocaleMatcherValues = new(["lookup", "best fit"], StringComparison.Ordinal);
     private static readonly StringSearchValues TypeValues = new(["cardinal", "ordinal"], StringComparison.Ordinal);
     private static readonly StringSearchValues NotationValues = new(["standard", "scientific", "engineering", "compact"], StringComparison.Ordinal);
+    private static readonly StringSearchValues CompactDisplayValues = new(["short", "long"], StringComparison.Ordinal);
     private static readonly StringSearchValues RoundingModeValues = new(["ceil", "floor", "expand", "trunc", "halfCeil", "halfFloor", "halfExpand", "halfTrunc", "halfEven"], StringComparison.Ordinal);
     private static readonly StringSearchValues RoundingPriorityValues = new(["auto", "morePrecision", "lessPrecision"], StringComparison.Ordinal);
     private static readonly StringSearchValues TrailingZeroDisplayValues = new(["auto", "stripIfInteger"], StringComparison.Ordinal);
@@ -72,6 +73,10 @@ internal sealed partial class PluralRulesConstructor : Constructor
         // Read notation option
         var notation = GetStringOption(optionsObj, "notation", NotationValues, "standard");
 
+        // Read compactDisplay option (always read for option-validation/observable-getter order, but
+        // only retained as [[CompactDisplay]] when notation is "compact").
+        var compactDisplay = GetStringOption(optionsObj, "compactDisplay", CompactDisplayValues, "short");
+
         // Digit options - must be read in spec order (SetNumberFormatDigitOptions)
         var minimumIntegerDigits = GetNumberOption(optionsObj, "minimumIntegerDigits", 1, 21, 1);
 
@@ -125,6 +130,7 @@ internal sealed partial class PluralRulesConstructor : Constructor
             resolvedLocale,
             type,
             notation,
+            string.Equals(notation, "compact", StringComparison.Ordinal) ? compactDisplay : null,
             minimumIntegerDigits,
             minimumFractionDigits,
             maximumFractionDigits,

--- a/Jint/Native/Intl/PluralRulesPrototype.cs
+++ b/Jint/Native/Intl/PluralRulesPrototype.cs
@@ -101,6 +101,13 @@ internal sealed partial class PluralRulesPrototype : Prototype
         result.CreateDataPropertyOrThrow("locale", pluralRules.Locale);
         result.CreateDataPropertyOrThrow("type", pluralRules.PluralRuleType);
         result.CreateDataPropertyOrThrow("notation", pluralRules.Notation);
+
+        // [[CompactDisplay]] is only present (non-undefined) when notation is "compact".
+        if (pluralRules.CompactDisplay is not null)
+        {
+            result.CreateDataPropertyOrThrow("compactDisplay", pluralRules.CompactDisplay);
+        }
+
         result.CreateDataPropertyOrThrow("minimumIntegerDigits", pluralRules.MinimumIntegerDigits);
 
         // Include either fraction digits or significant digits (not both)

--- a/Jint/Native/JsError.cs
+++ b/Jint/Native/JsError.cs
@@ -5,6 +5,12 @@ namespace Jint.Native;
 
 public sealed class JsError : ErrorInstance
 {
+    /// <summary>
+    /// The implementation-defined stack trace string captured when the error was constructed.
+    /// Returned by the <c>get Error.prototype.stack</c> accessor (the error-stack-accessor proposal).
+    /// </summary>
+    internal JsValue? _stack;
+
     internal JsError(Engine engine) : base(engine, ObjectClass.Error)
     {
     }

--- a/Jint/Native/SuppressedError/SuppressedErrorConstructor.cs
+++ b/Jint/Native/SuppressedError/SuppressedErrorConstructor.cs
@@ -47,6 +47,8 @@ internal sealed class SuppressedErrorConstructor : Constructor
             static intrinsics => intrinsics.SuppressedError.PrototypeObject,
             static (Engine engine, Realm _, object? _) => new JsError(engine));
 
+        o._stack = ErrorConstructor.BuildStackTraceString(_engine, this);
+
         if (!message.IsUndefined())
         {
             var msg = TypeConverter.ToString(message);

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
@@ -449,7 +449,13 @@ internal sealed partial class ZonedDateTimeConstructor : Constructor
         }
 
         var calendarId = result.Calendar ?? "iso8601";
-        var canonicalCalendar = TemporalHelpers.CanonicalizeCalendar(calendarId) ?? calendarId;
+        var canonicalCalendar = TemporalHelpers.CanonicalizeCalendar(calendarId);
+        if (canonicalCalendar is null)
+        {
+            // A syntactically valid but not-yet-adopted calendar annotation (e.g. "bangla") must be rejected.
+            Throw.RangeError(_realm, $"Invalid calendar: {calendarId}");
+        }
+
         return Construct(epochNs, timeZone, canonicalCalendar);
     }
 

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
@@ -726,6 +726,15 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
             var startNs = TemporalHelpers.GetStartOfDay(_realm, provider, timeZone, dateStart);
             var endNs = TemporalHelpers.GetStartOfDay(_realm, provider, timeZone, dateEnd);
 
+            // Repeated-midnight handling (https://github.com/tc39/proposal-temporal/issues/3312): when a
+            // fall-back transition interleaves pieces of two calendar days, thisNs can fall in the second
+            // piece of dateStart and land at/after endNs (the first start-of-day of dateEnd). Clamp it so
+            // it stays inside the [startNs, endNs) day window and still rounds to a start-of-day.
+            if (thisNs >= endNs)
+            {
+                thisNs = endNs - BigInteger.One;
+            }
+
             // Calculate day length (may not be exactly 24 hours due to DST)
             var dayLengthNs = (long) (endNs - startNs);
 

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayConstructor.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayConstructor.cs
@@ -135,11 +135,11 @@ internal sealed partial class IntrinsicTypedArrayConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#typedarray-species-create
     /// </summary>
-    internal JsTypedArray TypedArraySpeciesCreate(JsTypedArray exemplar, JsCallArguments argumentList)
+    internal JsTypedArray TypedArraySpeciesCreate(JsTypedArray exemplar, JsCallArguments argumentList, bool isWrite = false)
     {
         var defaultConstructor = exemplar._arrayElementType.GetConstructor(_realm.Intrinsics)!;
         var constructor = SpeciesConstructor(exemplar, defaultConstructor);
-        var result = TypedArrayCreate(_realm, constructor, argumentList);
+        var result = TypedArrayCreate(_realm, constructor, argumentList, isWrite);
         if (result._contentType != exemplar._contentType)
         {
             Throw.TypeError(_realm, "Content type mismatch");
@@ -151,10 +151,10 @@ internal sealed partial class IntrinsicTypedArrayConstructor : Constructor
     /// <summary>
     /// https://tc39.es/ecma262/#typedarray-create
     /// </summary>
-    internal static JsTypedArray TypedArrayCreate(Realm realm, IConstructor constructor, JsCallArguments arguments)
+    internal static JsTypedArray TypedArrayCreate(Realm realm, IConstructor constructor, JsCallArguments arguments, bool isWrite = false)
     {
         var newTypedArray = Construct(constructor, arguments);
-        var taRecord = newTypedArray.ValidateTypedArray(realm);
+        var taRecord = newTypedArray.ValidateTypedArray(realm, isWrite: isWrite);
 
         if (arguments.Length == 1 && arguments[0] is JsNumber number)
         {

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -247,7 +247,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
     [JsFunction(Length = 2)]
     private JsValue CopyWithin(JsValue thisObject, JsValue target, JsValue start, JsValue end)
     {
-        var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
+        var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst, isWrite: true);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
 
@@ -390,7 +390,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
     [JsFunction(Length = 1)]
     private JsValue Fill(JsValue thisObject, JsValue jsValue, JsValue start, JsValue end)
     {
-        var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
+        var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst, isWrite: true);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
 
@@ -510,7 +510,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         _engine._jsValueArrayPool.ReturnArray(args);
 
-        var a = _realm.Intrinsics.TypedArray.TypedArraySpeciesCreate(o, [captured]);
+        var a = _realm.Intrinsics.TypedArray.TypedArraySpeciesCreate(o, [captured], isWrite: true);
         for (var n = 0; n < captured; ++n)
         {
             a[n] = kept[n];
@@ -900,7 +900,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         var callable = GetCallable(callbackFn);
 
-        var a = _realm.Intrinsics.TypedArray.TypedArraySpeciesCreate(o, [len]);
+        var a = _realm.Intrinsics.TypedArray.TypedArraySpeciesCreate(o, [len], isWrite: true);
         var args = _engine._jsValueArrayPool.RentArray(3);
         args[2] = o;
         for (var k = 0; k < len; k++)
@@ -1030,7 +1030,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
     [JsFunction]
     private ObjectInstance Reverse(JsValue thisObject)
     {
-        var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
+        var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst, isWrite: true);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
 
@@ -1080,6 +1080,10 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         {
             Throw.TypeError(_realm, $"Method TypedArray.prototype.set called on incompatible receiver {thisObject}");
         }
+
+        // https://tc39.es/proposal-immutable-arraybuffer/ — set must reject an immutable target before
+        // reading the offset or source arguments.
+        target._viewedArrayBuffer.AssertNotImmutable();
 
         var targetOffset = TypeConverter.ToIntegerOrInfinity(offset);
         if (targetOffset < 0)
@@ -1308,7 +1312,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         }
 
         var countBytes = System.Math.Max(endIndex - startIndex, 0);
-        var a = _realm.Intrinsics.TypedArray.TypedArraySpeciesCreate(o, [countBytes]);
+        var a = _realm.Intrinsics.TypedArray.TypedArraySpeciesCreate(o, [countBytes], isWrite: true);
 
         if (countBytes > 0)
         {
@@ -1422,7 +1426,7 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
          * an object that has a fixed length and whose integer-indexed properties are not sparse.
          */
 
-        var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst);
+        var taRecord = thisObject.ValidateTypedArray(_realm, ArrayBufferOrder.SeqCst, isWrite: true);
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
 

--- a/Jint/Native/TypedArray/TypeArrayHelper.cs
+++ b/Jint/Native/TypedArray/TypeArrayHelper.cs
@@ -5,12 +5,19 @@ namespace Jint.Native.TypedArray;
 
 internal static class TypeArrayHelper
 {
-    internal static IntrinsicTypedArrayPrototype.TypedArrayWithBufferWitnessRecord ValidateTypedArray(this JsValue o, Realm realm, ArrayBufferOrder order = ArrayBufferOrder.Unordered)
+    internal static IntrinsicTypedArrayPrototype.TypedArrayWithBufferWitnessRecord ValidateTypedArray(this JsValue o, Realm realm, ArrayBufferOrder order = ArrayBufferOrder.Unordered, bool isWrite = false)
     {
         if (o is not JsTypedArray typedArray)
         {
             Throw.TypeError(realm, "this is not a typed array.");
             return default;
+        }
+
+        // https://tc39.es/proposal-immutable-arraybuffer/ — if the access mode is write and the
+        // backing buffer is immutable, throw a TypeError before any further observable side effects.
+        if (isWrite)
+        {
+            typedArray._viewedArrayBuffer.AssertNotImmutable();
         }
 
         var taRecord = IntrinsicTypedArrayPrototype.MakeTypedArrayWithBufferWitnessRecord(typedArray, order);

--- a/Jint/Native/TypedArray/Uint8ArrayPrototype.cs
+++ b/Jint/Native/TypedArray/Uint8ArrayPrototype.cs
@@ -38,6 +38,9 @@ internal sealed partial class Uint8ArrayPrototype : Prototype
             Throw.TypeError(_realm, "setFromBase64 must be called with a string");
         }
 
+        // Reject an immutable backing buffer before reading the options object (https://tc39.es/proposal-immutable-arraybuffer/).
+        into._viewedArrayBuffer.AssertNotImmutable();
+
         var opts = Uint8ArrayConstructor.GetOptionsObject(_engine, options);
         var alphabet = Uint8ArrayConstructor.GetAndValidateAlphabetOption(_engine, opts);
         var lastChunkHandling = Uint8ArrayConstructor.GetAndValidateLastChunkHandling(_engine, opts);
@@ -47,7 +50,6 @@ internal sealed partial class Uint8ArrayPrototype : Prototype
         {
             Throw.TypeError(_realm, "TypedArray is out of bounds");
         }
-        into._viewedArrayBuffer.AssertNotImmutable();
 
         var byteLength = taRecord.TypedArrayLength;
         var result = Uint8ArrayConstructor.FromBase64(_engine, s.ToString(), alphabet.ToString(), lastChunkHandling.ToString(), byteLength);
@@ -88,12 +90,14 @@ internal sealed partial class Uint8ArrayPrototype : Prototype
             Throw.TypeError(_realm, "setFromHex must be called with a string");
         }
 
+        // Reject an immutable backing buffer before any further processing (https://tc39.es/proposal-immutable-arraybuffer/).
+        into._viewedArrayBuffer.AssertNotImmutable();
+
         var taRecord = IntrinsicTypedArrayPrototype.MakeTypedArrayWithBufferWitnessRecord(into, ArrayBufferOrder.SeqCst);
         if (taRecord.IsTypedArrayOutOfBounds)
         {
             Throw.TypeError(_realm, "TypedArray is out of bounds");
         }
-        into._viewedArrayBuffer.AssertNotImmutable();
 
         var byteLength = taRecord.TypedArrayLength;
         var result = Uint8ArrayConstructor.FromHex(_engine, s.ToString(), byteLength);

--- a/Jint/Runtime/Intrinsics.Intl.cs
+++ b/Jint/Runtime/Intrinsics.Intl.cs
@@ -1,3 +1,4 @@
+using Jint.Native;
 using Jint.Native.Intl;
 
 namespace Jint.Runtime;
@@ -5,6 +6,16 @@ namespace Jint.Runtime;
 public sealed partial class Intrinsics
 {
     private IntlInstance? _intl;
+    private JsSymbol? _intlLegacyConstructedSymbol;
+
+    /// <summary>
+    /// The per-realm %Intl%.[[FallbackSymbol]] — a Symbol with the description
+    /// "IntlLegacyConstructedSymbol" used by the normative-optional legacy constructor mode of
+    /// Intl.Collator / Intl.DateTimeFormat / Intl.NumberFormat (ChainXxx / UnwrapXxx).
+    /// </summary>
+    internal JsSymbol IntlLegacyConstructedSymbol =>
+        _intlLegacyConstructedSymbol ??= new JsSymbol("IntlLegacyConstructedSymbol");
+
     private CollatorConstructor? _collator;
     private DateTimeFormatConstructor? _dateTimeFormat;
     private DisplayNamesConstructor? _displayNames;

--- a/Jint/Test262Object.cs
+++ b/Jint/Test262Object.cs
@@ -4,6 +4,7 @@ using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Environments;
 using Jint.Runtime.Interop;
 
 namespace Jint;
@@ -44,8 +45,14 @@ internal static class Test262Object
             (_, _) =>
             {
                 var realm = engine._host.CreateRealm();
-                realm.GlobalObject.Set("global", realm.GlobalObject);
-                return realm.GlobalObject;
+                var newGlobal = realm.GlobalObject;
+                newGlobal.Set("global", newGlobal);
+                // Per test262 INTERPRETING.md, the object returned by createRealm exposes an evalScript
+                // that evaluates in the new realm. Provide it so cross-realm tests (e.g. FallbackSymbol
+                // per-realm) can run code against the freshly created realm's intrinsics.
+                newGlobal.Set("evalScript", new ClrFunction(engine, "evalScript",
+                    (_, args) => EvaluateInRealm(engine, realm, args.At(0).AsString())));
+                return newGlobal;
             }), true, true, true));
 
         o.FastSetProperty("detachArrayBuffer", new PropertyDescriptor(new ClrFunction(engine, "detachArrayBuffer",
@@ -68,6 +75,37 @@ internal static class Test262Object
 
         engine.SetValue("$262", o);
         return o;
+    }
+
+    /// <summary>
+    /// Evaluates a script in the global scope of <paramref name="realm"/> (rather than the engine's
+    /// currently active realm), mirroring InitializeHostDefinedRealm: a global execution context for the
+    /// target realm is pushed for the duration of the evaluation.
+    /// </summary>
+    private static JsValue EvaluateInRealm(Engine engine, Realm realm, string source)
+    {
+        var script = Engine.PrepareScript(source, options: new ScriptPreparationOptions
+        {
+            ParsingOptions = ScriptParsingOptions.Default with { Tolerant = false },
+        });
+
+        var context = new ExecutionContext(
+            scriptOrModule: null,
+            lexicalEnvironment: realm.GlobalEnv,
+            variableEnvironment: realm.GlobalEnv,
+            privateEnvironment: null,
+            realm: realm,
+            function: null);
+
+        engine.EnterExecutionContext(context);
+        try
+        {
+            return engine.Evaluate(script);
+        }
+        finally
+        {
+            engine.LeaveExecutionContext();
+        }
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ and many more.
 - ✔ Await Dictionary (`Promise.allKeyed`, `Promise.allSettledKeyed`)
 - ✔ Decorators (`@decorator` syntax for classes, methods, fields, and accessors)
 - ✔ `Error.isError`
+- ✔ `Error.prototype.stack` accessor (error-stack-accessor)
 - ✔ Explicit Resource Management (`using` and `await using`)
 - ✔ Immutable Arraybuffers
 - ✔ Import Bytes (`import x from './file' with { type: 'bytes' }`)


### PR DESCRIPTION
Bumps the Test262 suite to `4249661388e5d3f92a85186213da140a6481490f` and implements the spec gaps the new tests surface. The full conformance suite goes from **133 failing cases to 0** (no regressions; `Jint.Tests` and `Jint.Tests.PublicInterface` remain green, no public API changes).

### Features / fixes

- **`Error.prototype.stack` accessor** (error-stack-accessor proposal). `stack` is now a `get`/`set` accessor on `%Error.prototype%` (`{ enumerable: false, configurable: true }`) rather than an own data property on each instance. The construction-time trace is stored on the `JsError` and returned by the getter; the setter uses `SetterThatIgnoresPrototypeProperties`. The accessor lives only on the root `%Error.prototype%` — the NativeError prototypes inherit it.
- **Immutable `ArrayBuffer` write rejection.** `ValidateTypedArray` gains a write access mode that throws a `TypeError` *before* observable side effects when the backing buffer is immutable. Wired into `%TypedArray%.prototype` `copyWithin`/`fill`/`reverse`/`set`/`sort`, the `map`/`filter`/`slice` species-create destination, `Atomics` `add`/`and`/`compareExchange`/`exchange`/`or`/`store`/`sub`/`xor`, and `Uint8Array` `setFromBase64`/`setFromHex` (checked before reading arguments).
- **Intl legacy-constructor mode** (normative-optional) for `NumberFormat` and `DateTimeFormat`: a per-realm `%Intl%.[[FallbackSymbol]]` (`"IntlLegacyConstructedSymbol"`), `Chain*` on `[[Call]]`, and `Unwrap*` in the prototype methods. `Collator` is intentionally left without it (its `this-value-ignored` test still requires a fresh instance and it has no legacy-constructed-symbol test).
- **`Intl.PluralRules` `compactDisplay` option** — read after `notation`, surfaced in `resolvedOptions` only when `notation` is `"compact"`.
- **`Temporal.ZonedDateTime`** — reject not-yet-adopted calendar annotations (e.g. `bangla`) in the string path, and correctly round to a start-of-day when midnight occurs twice across a fall-back transition (tc39/proposal-temporal#3312).
- **Test harness** — `$262.createRealm()` now exposes an `evalScript` that evaluates in the new realm, enabling cross-realm tests.

### Excluded tests

- `language/module-code/.../reexport-source-binding-*` and `ambiguous-export-bindings/namespace-unambiguous-if-import-source-and-export.js` — re-exporting a source-phase import requires a WebAssembly `<module source>`, which Jint does not support.
- `built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js` — broadened to run the immutable-buffer arg factory while still expecting the element copy to succeed, which a spec-conformant `slice` (rejecting an immutable destination) cannot satisfy; the test does not declare the `immutable-arraybuffer` feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)