### PR TITLE
Fix completion value clobbered by re-entrant Evaluate() during module execution

### DIFF
--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -2874,6 +2874,30 @@ x.test = {
     }
 
     [Fact]
+    public void NestedEvaluateDuringContinuationDrainDoesNotClobberOuterResult()
+    {
+        // Regression test for https://github.com/sebastienros/jint/issues/2492
+        // A queued microtask, drained while a nested Evaluate() is running, used to overwrite
+        // the engine-level completion value that the nested Evaluate() was about to return.
+        var engine = new Engine();
+        engine.SetValue("evalB", new Func<JsValue>(() => engine.Evaluate("'B'")));
+        engine.SetValue("evalC", new Func<JsValue>(() => engine.Evaluate("'C'")));
+
+        // Promise.resolve().then(evalC) queues a microtask. evalB()'s nested Evaluate drains it
+        // (RunAvailableContinuations), running evalC() -> a deeper Evaluate that completes with 'C'.
+        // Pre-fix, 'C' leaked into the shared field that evalB()'s Evaluate read back, so the
+        // outer script observed 'C' instead of 'B'.
+        var result = engine.Evaluate(@"
+            var captured;
+            Promise.resolve().then(() => { evalC(); });
+            captured = evalB();
+            captured;
+        ");
+
+        Assert.Equal("B", result.AsString());
+    }
+
+    [Fact]
     public void MemberExpressionInObjectProperty()
     {
         var engine = new Engine();

--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -122,6 +122,60 @@ public class ModuleTests
     }
 
     [Fact]
+    public void NestedEvaluateFromModuleExecutionDoesNotClobberCompletionValue()
+    {
+        // Regression test for https://github.com/sebastienros/jint/issues/2492
+        // A CLR function (importLibrary) calls back into engine.Evaluate(). While that nested
+        // Evaluate() drains the event loop, an awaited dynamic import runs module-two, which also
+        // calls importLibrary() -> a deeper Evaluate(). Pre-fix, the deeper completion value
+        // leaked into the field the first importLibrary('library-one') call read back, so it
+        // returned library-two's object and "firstLibrary.TextFunctions" was undefined.
+        var engine = new Engine();
+
+        const string libraryOne = @"(function () {
+            var $export = {};
+            $export.TextFunctions = { generateRandomText: function (length) { return ''; } };
+            return $export;
+        })();";
+
+        const string libraryTwo = @"(function () {
+            var $export = {};
+            $export.DateFunctions = { getCurrentDate: function () { return new Date(); } };
+            return $export;
+        })();";
+
+        engine.SetValue("importLibrary", new Func<string, JsValue>(name => name switch
+        {
+            "library-one" => engine.Evaluate(libraryOne),
+            "library-two" => engine.Evaluate(libraryTwo),
+            _ => JsValue.Undefined
+        }));
+
+        engine.Modules.Add("module-one", "export async function fetchSamplePost() { return new Promise((resolve) => { }); }");
+        engine.Modules.Add("module-two", @"
+            import * as bl from 'module-one';
+            export async function sample() {
+                const lib2 = importLibrary('library-two');
+                globalThis.currentDateFromLib2 = lib2.DateFunctions.getCurrentDate();
+                return await bl.fetchSamplePost();
+            }");
+
+        var result = engine.Evaluate(@"
+            var result = {};
+            (async () => {
+                const m2 = await import('module-two');
+                const obj = await m2.sample();
+                result.obj = obj;
+            })();
+            const firstLibrary = importLibrary('library-one');
+            result.someText = firstLibrary.TextFunctions.generateRandomText(10);
+            result;
+        ").AsObject();
+
+        Assert.Equal("", result.Get("someText").AsString());
+    }
+
+    [Fact]
     public void ShouldPropagateParseError()
     {
         _engine.Modules.Add("imported", "export const invalid;");

--- a/Jint/Engine.Async.cs
+++ b/Jint/Engine.Async.cs
@@ -47,7 +47,7 @@ public partial class Engine
     /// <returns>The engine instance for chaining, after all async work completes.</returns>
     public async Task<Engine> ExecuteAsync(string code, string? source = null, CancellationToken cancellationToken = default)
     {
-        var result = Execute(code, source)._completionValue;
+        var result = Evaluate(code, source);
         if (result is JsPromise)
         {
             await UnwrapResultAsync(result, cancellationToken).ConfigureAwait(false);

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -41,7 +41,16 @@ public sealed partial class Engine : IDisposable
     private ParserOptions? _defaultModuleParserOptions; // cache default ParserOptions for ModuleBuilder instances
 
     private readonly ExecutionContextStack _executionContexts;
-    private JsValue _completionValue = JsValue.Undefined;
+
+    // Invariant for engine-level ambient mutable fields (e.g. _activeEvaluationContext, _error,
+    // _lastSyntaxElement): they must not hold an in-flight result across a call that can re-enter
+    // the engine (anything that may run RunAvailableContinuations, or a CLR callback that calls
+    // Evaluate/Execute/Invoke). Either save-and-restore around the re-entrant region (see the
+    // ownsContext pattern in ExecuteWithConstraints and ShadowRealm), or carry the value out-of-band
+    // rather than in a field. A script's completion value used to live here as a field and was
+    // clobbered by a re-entrant drain (https://github.com/sebastienros/jint/issues/2492); it is now
+    // returned from ScriptEvaluation as a per-frame local. _error and _lastSyntaxElement are safe
+    // because they are produced and consumed synchronously with no re-entrant drain in between.
     internal EvaluationContext? _activeEvaluationContext;
     internal ErrorDispatchInfo? _error;
 
@@ -385,7 +394,7 @@ public sealed partial class Engine : IDisposable
     /// Evaluates code and returns last return value.
     /// </summary>
     public JsValue Evaluate(in Prepared<Script> preparedScript)
-        => Execute(preparedScript)._completionValue;
+        => ExecuteForCompletion(preparedScript);
 
     /// <summary>
     /// Executes code into engine and returns the engine instance (useful for chaining).
@@ -417,6 +426,17 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     public Engine Execute(in Prepared<Script> preparedScript)
     {
+        ExecuteForCompletion(preparedScript);
+        return this;
+    }
+
+    /// <summary>
+    /// Shared core for <see cref="Execute(in Prepared{Script})"/> and <see cref="Evaluate(in Prepared{Script})"/>.
+    /// Returns the script's completion value directly (a per-frame local), so a re-entrant drain
+    /// during <see cref="RunAvailableContinuations"/> cannot clobber it via shared engine state.
+    /// </summary>
+    private JsValue ExecuteForCompletion(in Prepared<Script> preparedScript)
+    {
         if (!preparedScript.IsValid)
         {
             Throw.InvalidPreparedScriptArgumentException(nameof(preparedScript));
@@ -425,15 +445,14 @@ public sealed partial class Engine : IDisposable
         var script = preparedScript.Program;
         var parserOptions = preparedScript.ParserOptions;
         var strict = _isStrict || script.Strict;
-        ExecuteWithConstraints(strict, () => ScriptEvaluation(new ScriptRecord(Realm, script, script.Location.SourceFile), parserOptions));
-
-        return this;
+        // The lambda captures the locals (script, parserOptions), never the `in` parameter.
+        return ExecuteWithConstraints(strict, () => ScriptEvaluation(new ScriptRecord(Realm, script, script.Location.SourceFile), parserOptions));
     }
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-runtime-semantics-scriptevaluation
     /// </summary>
-    private Engine ScriptEvaluation(ScriptRecord scriptRecord, ParserOptions parserOptions)
+    private JsValue ScriptEvaluation(ScriptRecord scriptRecord, ParserOptions parserOptions)
     {
         Debugger.OnBeforeEvaluate(scriptRecord.EcmaScriptCode);
 
@@ -474,12 +493,17 @@ public sealed partial class Engine : IDisposable
                 throw ex;
             }
 
-            _completionValue = result.GetValueOrDefault();
+            // Capture into a local BEFORE draining the event loop. RunAvailableContinuations can
+            // re-enter the engine (e.g. an awaited dynamic import that invokes a CLR callback which
+            // calls Evaluate()); a deeper ScriptEvaluation must not be able to clobber this frame's
+            // result. A local is per-frame, so it survives re-entrancy (#2492). A completed script's
+            // value is fixed by its last statement — continuations cannot change it.
+            var completionValue = result.GetValueOrDefault();
 
             // TODO what about callstack and thrown exceptions?
             RunAvailableContinuations();
 
-            return this;
+            return completionValue;
         }
         finally
         {


### PR DESCRIPTION
## Summary

Fixes #2492 — a regression where a script's completion value could be clobbered by a re-entrant `Evaluate()` triggered from module execution, so a previous evaluation returned the wrong object (reported as `Cannot read property 'generateRandomText' of undefined`).

## Root cause

`Engine.ScriptEvaluation` stored the script's completion value in the engine-level `_completionValue` field and **then** drained the shared event loop:

```csharp
_completionValue = result.GetValueOrDefault();
RunAvailableContinuations();   // can re-enter the engine
return this;                   // caller then reads engine._completionValue
```

`RunAvailableContinuations()` can re-enter the engine: an awaited dynamic `import()` runs a module whose body calls a CLR function that itself calls `Evaluate()`. Because the event loop has an `_isProcessing` re-entrancy guard, the **middle** `Evaluate()` is the active drainer; the **deeper** `Evaluate()` writes `_completionValue` before the middle frame reads it back — so the middle `Evaluate()` returns the deeper frame's value. (Surfaces only when the imported module has its own `import`, which shifts microtask timing.)

## Fix

Carry the completion value out as a **per-frame local** instead of a shared field — a local is immune to re-entrancy by construction:

- `ScriptEvaluation` now returns the `JsValue` (captured before the drain, returned after).
- `Evaluate(in Prepared<Script>)` and `Execute(in Prepared<Script>)` funnel through a shared `ExecuteForCompletion(...)` helper.
- `ExecuteAsync(string,...)` reads via `Evaluate(...)`.
- The `_completionValue` field is **removed**.
- The invariant for the remaining ambient fields (`_error`, `_lastSyntaxElement`) is documented; they are safe because they're produced and consumed synchronously with no re-entrant drain in between.

No public API signatures change.

## Tests

Two regression tests, both verified **red on `main`, green after**:
- `EngineTests.NestedEvaluateDuringContinuationDrainDoesNotClobberOuterResult` — minimal deterministic repro (`Promise.resolve().then` queues a microtask drained by a nested `Evaluate()`); no modules needed.
- `ModuleTests.NestedEvaluateFromModuleExecutionDoesNotClobberCompletionValue` — faithful repro of the issue (dynamic `import` + `import * as` + an `importLibrary` CLR callback).

Full `Jint.Tests` passes (3030); Test262 unchanged (99,206 passed; only the pre-existing timing-flaky `Atomics.waitAsync` differs, confirmed flaky on `main` too).

## Performance

The change **removes** a field rather than growing any hot struct (e.g. `ExecutionContext`, which is full-copied on every push / scope change), so no regression is expected. `MinimalScriptBenchmark` (BenchmarkDotNet ShortRun, net10.0), base vs fix:

| Method | Base Mean | Fix Mean | Base Alloc | Fix Alloc |
|---|---|---|---|---|
| Execute | 2.892 us | 2.917 us | 17.24 KB | 17.23 KB |
| Execute_ParsedScript | 1.792 us | 1.766 us | 15.33 KB | 15.32 KB |

Means are within the measurement error; allocations are flat-to-marginally-lower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)