### PR TITLE
Fix runtime type member writes for CLR wrappers

### DIFF
--- a/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
+++ b/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
@@ -22,6 +22,16 @@ public class InteropExplicitTypeTests
         string I1.Name { get; } = "CI1 as I1";
     }
 
+    public class BaseValue
+    {
+        public string BaseOnly { get; } = "base";
+    }
+
+    public class DerivedValue : BaseValue
+    {
+        public int DerivedOnlyProperty { get; set; }
+    }
+
     public class Indexer<T>
     {
         private readonly T t;
@@ -65,6 +75,11 @@ public class InteropExplicitTypeTests
         public Indexer<I1> IndexerI1 { get; }
         public Indexer<Super> IndexerSuper { get; }
 
+    }
+
+    public class BaseValueHolder
+    {
+        public BaseValue Value { get; } = new DerivedValue();
     }
 
     private readonly Engine _engine;
@@ -143,6 +158,18 @@ public class InteropExplicitTypeTests
     public void SuperClassFromIndexer()
     {
         Assert.Equal(holder.IndexerSuper[0].Name, _engine.Evaluate("holder.IndexerSuper[0].Name"));
+    }
+
+    [Fact]
+    public void DerivedRuntimePropertyFromBaseDeclaredProperty()
+    {
+        var engine = new Engine(options => options.Interop.ThrowOnUnresolvedMember = true);
+        var holder = new BaseValueHolder();
+        engine.SetValue("holder", holder);
+
+        Assert.Equal("base", engine.Evaluate("holder.Value.BaseOnly"));
+        engine.Execute("const obj = holder.Value; obj.DerivedOnlyProperty = 123;");
+        Assert.Equal(123, ((DerivedValue) holder.Value).DerivedOnlyProperty);
     }
 
     public struct NullabeStruct : I1

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -215,7 +215,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             if (_properties is null || !_properties.ContainsKey(member))
             {
                 // can try utilize fast path
-                var accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, ClrType, member, mustBeReadable: false, mustBeWritable: true);
+                var accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, ClrType, member, mustBeReadable: false, mustBeWritable: true, throwOnError: false);
                 var actualType = Target.GetType();
                 if (ClrType != actualType)
                 {
@@ -224,7 +224,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                     // that should take precedence over the indexer
                     if (accessor is IndexerAccessor)
                     {
-                        var runtimeAccessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, mustBeReadable: false, mustBeWritable: true);
+                        var runtimeAccessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, mustBeReadable: false, mustBeWritable: true, throwOnError: false);
                         if (runtimeAccessor is not IndexerAccessor && runtimeAccessor != ConstantValueAccessor.NullAccessor)
                         {
                             accessor = runtimeAccessor;
@@ -232,12 +232,17 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                     }
                     else if (ReferenceEquals(accessor, ConstantValueAccessor.NullAccessor))
                     {
-                        accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, mustBeReadable: false, mustBeWritable: true);
+                        accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, mustBeReadable: false, mustBeWritable: true, throwOnError: false);
                     }
                 }
 
                 if (ReferenceEquals(accessor, ConstantValueAccessor.NullAccessor))
                 {
+                    if (_engine.Options.Interop.ThrowOnUnresolvedMember)
+                    {
+                        throw new MissingMemberException($"Cannot access property '{member}' on type '{ClrType.FullName}");
+                    }
+
                     // there's no such property, but we can allow extending by calling base
                     // which will add properties, this allows for example JS class to extend a CLR type
                     return base.Set(property, value, receiver);


### PR DESCRIPTION
<!-- Thanks for contributing to Jint! Please fill in the sections below. -->

## Summary

Fix writes to runtime-derived CLR wrapper members.

## Details

- Updates `ObjectWrapper.Set` to probe both declared and runtime CLR types before deciding a member write is unresolved.
- Preserves strict unresolved-member behavior when neither type can satisfy the write.
- Adds regression coverage for a base-declared property that returns a derived runtime object.

## Linked issue

Fixes #2494

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally
- N/A - For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [x] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- N/A - For perf changes: included before/after numbers from `Jint.Benchmark`

Focused validation:

```bash
docker run --rm -v "$PWD":/work -w /work mcr.microsoft.com/dotnet/sdk:10.0 dotnet test --configuration Release Jint.Tests/Jint.Tests.csproj --filter "FullyQualifiedName~Jint.Tests.Runtime.InteropExplicitTypeTests.DerivedRuntimePropertyFromBaseDeclaredProperty|FullyQualifiedName~Jint.Tests.Runtime.InteropTests.StrictAccessStillThrowsForMissingWrites"
```

```text
Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 1 s - Jint.Tests.dll (net10.0)
```

## Breaking change?

No
