### PR TITLE
Fix integer fast path overflows and compound assignment spec divergences

### DIFF
--- a/Jint.Tests/Runtime/NumberTests.cs
+++ b/Jint.Tests/Runtime/NumberTests.cs
@@ -185,4 +185,32 @@ public class NumberTests
         Assert.Equal(-2147483649d, engine.Evaluate("var c = (1<<31)|0; c -= 1; c").AsNumber());
         Assert.Equal(2147483648d, engine.Evaluate("var d = 2147483647; d += 1; d").AsNumber());
     }
+
+    [Fact]
+    public void CompoundAssignmentMatchesBinaryOperatorSemantics()
+    {
+        var engine = new Engine();
+
+        // undefined operands must coerce to NaN, not stay undefined
+        Assert.True(engine.Evaluate("var u; u *= 2; Number.isNaN(u)").AsBoolean());
+        Assert.True(engine.Evaluate("var u; u /= 2; Number.isNaN(u)").AsBoolean());
+        Assert.True(engine.Evaluate("var u; u -= 2; Number.isNaN(u)").AsBoolean());
+
+        // ** has spec semantics that differ from IEEE pow: (+/-1) ** Infinity is NaN
+        Assert.True(engine.Evaluate("var x = 1; x **= Infinity; Number.isNaN(x)").AsBoolean());
+        Assert.True(engine.Evaluate("var x = -1; x **= -Infinity; Number.isNaN(x)").AsBoolean());
+        Assert.Equal(8d, engine.Evaluate("var x = 2; x **= 3; x").AsNumber());
+
+        // compound bitwise/shift operators support BigInt like their binary forms
+        Assert.Equal("1", engine.Evaluate("var b = 3n; b &= 1n; b.toString()").AsString());
+        Assert.Equal("3", engine.Evaluate("var b = 2n; b |= 1n; b.toString()").AsString());
+        Assert.Equal("2", engine.Evaluate("var b = 3n; b ^= 1n; b.toString()").AsString());
+        Assert.Equal("8", engine.Evaluate("var b = 2n; b <<= 2n; b.toString()").AsString());
+        Assert.Equal("2", engine.Evaluate("var b = 8n; b >>= 2n; b.toString()").AsString());
+
+        // mixing BigInt and Number must throw TypeError for compound forms too
+        Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("var b = 3n; b &= 1;"));
+        Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("var b = 3; b &= 1n;"));
+        Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("var b = 1n; b >>>= 1n;"));
+    }
 }

--- a/Jint.Tests/Runtime/NumberTests.cs
+++ b/Jint.Tests/Runtime/NumberTests.cs
@@ -164,4 +164,25 @@ public class NumberTests
         Assert.Equal(double.NegativeInfinity, engine.Evaluate("-'1e1000'").ToObject());
         Assert.Equal("-Infinity", engine.Evaluate("(-'1e1000').toString()").ToObject());
     }
+
+    [Fact]
+    public void Int32BoundaryArithmeticDoesNotOverflow()
+    {
+        var engine = new Engine();
+
+        // internally Integer-tagged int.MinValue / int.MaxValue values must widen
+        // to double on arithmetic instead of wrapping or raising hardware overflows
+        Assert.Equal(2147483648d, engine.Evaluate("var x = (1<<31)|0; -x").AsNumber());
+        Assert.Equal(2147483648d, engine.Evaluate("var x = (1<<31)|0; x / -1").AsNumber());
+        Assert.Equal(0d, engine.Evaluate("var x = (1<<31)|0; x % -1").AsNumber());
+        Assert.True(engine.Evaluate("var x = (1<<31)|0; Object.is(x % -1, -0)").AsBoolean());
+
+        Assert.Equal(2147483648d, engine.Evaluate("var a = 2147483647; a++; a").AsNumber());
+        Assert.Equal(2147483648d, engine.Evaluate("var a = 2147483647; ++a").AsNumber());
+        Assert.Equal(-2147483649d, engine.Evaluate("var b = (1<<31)|0; b--; b").AsNumber());
+        Assert.Equal(-2147483649d, engine.Evaluate("var b = (1<<31)|0; --b").AsNumber());
+
+        Assert.Equal(-2147483649d, engine.Evaluate("var c = (1<<31)|0; c -= 1; c").AsNumber());
+        Assert.Equal(2147483648d, engine.Evaluate("var d = 2147483647; d += 1; d").AsNumber());
+    }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -154,7 +154,7 @@ internal sealed class JintAssignmentExpression : JintExpression
 
                         if (AreIntegerOperands(originalLeftValue, rval))
                         {
-                            newLeftValue = JsNumber.Create(originalLeftValue.AsInteger() - rval.AsInteger());
+                            newLeftValue = JsNumber.Create((long) originalLeftValue.AsInteger() - rval.AsInteger());
                         }
                         else if (JintBinaryExpression.AreNonBigIntOperands(originalLeftValue, rval))
                         {

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -156,14 +156,20 @@ internal sealed class JintAssignmentExpression : JintExpression
                         {
                             newLeftValue = JsNumber.Create((long) originalLeftValue.AsInteger() - rval.AsInteger());
                         }
-                        else if (JintBinaryExpression.AreNonBigIntOperands(originalLeftValue, rval))
-                        {
-                            newLeftValue = JsNumber.Create(TypeConverter.ToNumber(originalLeftValue) - TypeConverter.ToNumber(rval));
-                        }
                         else
                         {
-                            JintBinaryExpression.AssertValidBigIntArithmeticOperands(originalLeftValue, rval);
-                            newLeftValue = JsBigInt.Create(TypeConverter.ToBigInt(originalLeftValue) - TypeConverter.ToBigInt(rval));
+                            var leftNumeric = TypeConverter.ToNumeric(originalLeftValue);
+                            var rightNumeric = TypeConverter.ToNumeric(rval);
+
+                            if (JintBinaryExpression.AreNonBigIntOperands(leftNumeric, rightNumeric))
+                            {
+                                newLeftValue = JsNumber.Create(leftNumeric.AsNumber() - rightNumeric.AsNumber());
+                            }
+                            else
+                            {
+                                JintBinaryExpression.AssertValidBigIntArithmeticOperands(leftNumeric, rightNumeric);
+                                newLeftValue = JsBigInt.Create(TypeConverter.ToBigInt(leftNumeric) - TypeConverter.ToBigInt(rightNumeric));
+                            }
                         }
 
                         break;
@@ -182,18 +188,20 @@ internal sealed class JintAssignmentExpression : JintExpression
                         {
                             newLeftValue = (long) originalLeftValue.AsInteger() * rval.AsInteger();
                         }
-                        else if (originalLeftValue.IsUndefined() || rval.IsUndefined())
-                        {
-                            newLeftValue = JsValue.Undefined;
-                        }
-                        else if (JintBinaryExpression.AreNonBigIntOperands(originalLeftValue, rval))
-                        {
-                            newLeftValue = TypeConverter.ToNumber(originalLeftValue) * TypeConverter.ToNumber(rval);
-                        }
                         else
                         {
-                            JintBinaryExpression.AssertValidBigIntArithmeticOperands(originalLeftValue, rval);
-                            newLeftValue = JsBigInt.Create(TypeConverter.ToBigInt(originalLeftValue) * TypeConverter.ToBigInt(rval));
+                            var leftNumeric = TypeConverter.ToNumeric(originalLeftValue);
+                            var rightNumeric = TypeConverter.ToNumeric(rval);
+
+                            if (JintBinaryExpression.AreNonBigIntOperands(leftNumeric, rightNumeric))
+                            {
+                                newLeftValue = leftNumeric.AsNumber() * rightNumeric.AsNumber();
+                            }
+                            else
+                            {
+                                JintBinaryExpression.AssertValidBigIntArithmeticOperands(leftNumeric, rightNumeric);
+                                newLeftValue = JsBigInt.Create(TypeConverter.ToBigInt(leftNumeric) * TypeConverter.ToBigInt(rightNumeric));
+                            }
                         }
 
                         break;
@@ -208,7 +216,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                             return rval;
                         }
 
-                        newLeftValue = Divide(context, originalLeftValue, rval);
+                        newLeftValue = Divide(context, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval));
                         break;
                     }
 
@@ -234,7 +242,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                             return rval;
                         }
 
-                        newLeftValue = TypeConverter.ToInt32(originalLeftValue) & TypeConverter.ToInt32(rval);
+                        newLeftValue = JintBinaryExpression.EvaluateBitwiseOperation(Operator.BitwiseAnd, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
                         break;
                     }
 
@@ -247,7 +255,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                             return rval;
                         }
 
-                        newLeftValue = TypeConverter.ToInt32(originalLeftValue) | TypeConverter.ToInt32(rval);
+                        newLeftValue = JintBinaryExpression.EvaluateBitwiseOperation(Operator.BitwiseOr, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
                         break;
                     }
 
@@ -260,7 +268,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                             return rval;
                         }
 
-                        newLeftValue = TypeConverter.ToInt32(originalLeftValue) ^ TypeConverter.ToInt32(rval);
+                        newLeftValue = JintBinaryExpression.EvaluateBitwiseOperation(Operator.BitwiseXor, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
                         break;
                     }
 
@@ -273,7 +281,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                             return rval;
                         }
 
-                        newLeftValue = TypeConverter.ToInt32(originalLeftValue) << (int) (TypeConverter.ToUint32(rval) & 0x1F);
+                        newLeftValue = JintBinaryExpression.EvaluateBitwiseOperation(Operator.LeftShift, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
                         break;
                     }
 
@@ -286,7 +294,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                             return rval;
                         }
 
-                        newLeftValue = TypeConverter.ToInt32(originalLeftValue) >> (int) (TypeConverter.ToUint32(rval) & 0x1F);
+                        newLeftValue = JintBinaryExpression.EvaluateBitwiseOperation(Operator.RightShift, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
                         break;
                     }
 
@@ -299,7 +307,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                             return rval;
                         }
 
-                        newLeftValue = (uint) TypeConverter.ToInt32(originalLeftValue) >> (int) (TypeConverter.ToUint32(rval) & 0x1F);
+                        newLeftValue = JintBinaryExpression.EvaluateBitwiseOperation(Operator.UnsignedRightShift, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
                         break;
                     }
 
@@ -372,29 +380,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                             return rval;
                         }
 
-                        if (!originalLeftValue.IsBigInt() && !rval.IsBigInt())
-                        {
-                            newLeftValue = JsNumber.Create(Math.Pow(TypeConverter.ToNumber(originalLeftValue), TypeConverter.ToNumber(rval)));
-                        }
-                        else
-                        {
-                            var exponent = TypeConverter.ToBigInt(rval);
-                            if (exponent < 0)
-                            {
-                                Throw.RangeError(context.Engine.Realm, "Exponent must be positive");
-                            }
-
-                            if (exponent > int.MaxValue)
-                            {
-                                Throw.RangeError(context.Engine.Realm, "Maximum BigInt size exceeded");
-                            }
-
-                            var intExponent = (int) exponent;
-                            var baseValue = TypeConverter.ToBigInt(originalLeftValue);
-                            JintBinaryExpression.ValidateBigIntPowSize(context.Engine.Realm, baseValue, intExponent);
-                            newLeftValue = JsBigInt.Create(BigInteger.Pow(baseValue, intExponent));
-                        }
-
+                        newLeftValue = JintBinaryExpression.Exponentiate(context, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval));
                         break;
                     }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -818,121 +818,130 @@ internal abstract class JintBinaryExpression : JintExpression
             var left = TypeConverter.ToNumeric(leftReference);
             var right = TypeConverter.ToNumeric(rightReference);
 
-            JsValue result;
-            if (AreNonBigIntOperands(left, right))
+            return Exponentiate(context, left, right);
+        }
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-numeric-types-number-exponentiate (+ BigInt variant).
+    /// Operands must already be numeric (ToNumeric applied). Shared by ** and **=.
+    /// </summary>
+    internal static JsValue Exponentiate(EvaluationContext context, JsValue left, JsValue right)
+    {
+        JsValue result;
+        if (AreNonBigIntOperands(left, right))
+        {
+            // validation
+            var baseNumber = (JsNumber) left;
+            var exponentNumber = (JsNumber) right;
+
+            if (exponentNumber.IsNaN())
             {
-                // validation
-                var baseNumber = (JsNumber) left;
-                var exponentNumber = (JsNumber) right;
+                return JsNumber.DoubleNaN;
+            }
 
-                if (exponentNumber.IsNaN())
+            if (exponentNumber.IsZero())
+            {
+                return JsNumber.PositiveOne;
+            }
+
+            if (baseNumber.IsNaN())
+            {
+                return JsNumber.DoubleNaN;
+            }
+
+            var exponentValue = exponentNumber._value;
+            if (baseNumber.IsPositiveInfinity())
+            {
+                return exponentValue > 0 ? JsNumber.DoublePositiveInfinity : JsNumber.PositiveZero;
+            }
+
+            static bool IsOddIntegral(double value) => TypeConverter.IsIntegralNumber(value) && value % 2 != 0;
+
+            if (baseNumber.IsNegativeInfinity())
+            {
+                if (exponentValue > 0)
                 {
-                    return JsNumber.DoubleNaN;
-                }
-
-                if (exponentNumber.IsZero())
-                {
-                    return JsNumber.PositiveOne;
-                }
-
-                if (baseNumber.IsNaN())
-                {
-                    return JsNumber.DoubleNaN;
-                }
-
-                var exponentValue = exponentNumber._value;
-                if (baseNumber.IsPositiveInfinity())
-                {
-                    return exponentValue > 0 ? JsNumber.DoublePositiveInfinity : JsNumber.PositiveZero;
-                }
-
-                static bool IsOddIntegral(double value) => TypeConverter.IsIntegralNumber(value) && value % 2 != 0;
-
-                if (baseNumber.IsNegativeInfinity())
-                {
-                    if (exponentValue > 0)
-                    {
-                        return IsOddIntegral(exponentValue) ? JsNumber.DoubleNegativeInfinity : JsNumber.DoublePositiveInfinity;
-                    }
-
-                    return IsOddIntegral(exponentValue) ? JsNumber.NegativeZero : JsNumber.PositiveZero;
-                }
-
-                if (baseNumber.IsPositiveZero())
-                {
-                    return exponentValue > 0 ? JsNumber.PositiveZero : JsNumber.DoublePositiveInfinity;
-                }
-
-                if (baseNumber.IsNegativeZero())
-                {
-                    if (exponentValue > 0)
-                    {
-                        return IsOddIntegral(exponentValue) ? JsNumber.NegativeZero : JsNumber.PositiveZero;
-                    }
                     return IsOddIntegral(exponentValue) ? JsNumber.DoubleNegativeInfinity : JsNumber.DoublePositiveInfinity;
                 }
 
-                var baseValue = baseNumber._value;
-                if (exponentNumber.IsPositiveInfinity())
-                {
-                    var absBase = Math.Abs(baseValue);
-                    if (absBase > 1)
-                    {
-                        return JsNumber.DoublePositiveInfinity;
-                    }
-                    if (absBase == 1)
-                    {
-                        return JsNumber.DoubleNaN;
-                    }
+                return IsOddIntegral(exponentValue) ? JsNumber.NegativeZero : JsNumber.PositiveZero;
+            }
 
-                    return JsNumber.PositiveZero;
+            if (baseNumber.IsPositiveZero())
+            {
+                return exponentValue > 0 ? JsNumber.PositiveZero : JsNumber.DoublePositiveInfinity;
+            }
+
+            if (baseNumber.IsNegativeZero())
+            {
+                if (exponentValue > 0)
+                {
+                    return IsOddIntegral(exponentValue) ? JsNumber.NegativeZero : JsNumber.PositiveZero;
                 }
+                return IsOddIntegral(exponentValue) ? JsNumber.DoubleNegativeInfinity : JsNumber.DoublePositiveInfinity;
+            }
 
-                if (exponentNumber.IsNegativeInfinity())
+            var baseValue = baseNumber._value;
+            if (exponentNumber.IsPositiveInfinity())
+            {
+                var absBase = Math.Abs(baseValue);
+                if (absBase > 1)
                 {
-                    var absBase = Math.Abs(baseValue);
-                    if (absBase > 1)
-                    {
-                        return JsNumber.PositiveZero;
-                    }
-                    if (absBase == 1)
-                    {
-                        return JsNumber.DoubleNaN;
-                    }
-
                     return JsNumber.DoublePositiveInfinity;
                 }
-
-                if (baseValue < 0 && !TypeConverter.IsIntegralNumber(exponentValue))
+                if (absBase == 1)
                 {
                     return JsNumber.DoubleNaN;
                 }
 
-                result = JsNumber.Create(Math.Pow(baseNumber._value, exponentValue));
+                return JsNumber.PositiveZero;
             }
-            else
+
+            if (exponentNumber.IsNegativeInfinity())
             {
-                AssertValidBigIntArithmeticOperands(left, right);
-
-                var exponent = right.AsBigInt();
-                if (exponent < 0)
+                var absBase = Math.Abs(baseValue);
+                if (absBase > 1)
                 {
-                    Throw.RangeError(context.Engine.Realm, "Exponent must be positive");
+                    return JsNumber.PositiveZero;
+                }
+                if (absBase == 1)
+                {
+                    return JsNumber.DoubleNaN;
                 }
 
-                if (exponent > int.MaxValue)
-                {
-                    Throw.RangeError(context.Engine.Realm, "Maximum BigInt size exceeded");
-                }
-
-                var intExponent = (int) exponent;
-                var baseValue = left.AsBigInt();
-                ValidateBigIntPowSize(context.Engine.Realm, baseValue, intExponent);
-                result = JsBigInt.Create(BigInteger.Pow(baseValue, intExponent));
+                return JsNumber.DoublePositiveInfinity;
             }
 
-            return result;
+            if (baseValue < 0 && !TypeConverter.IsIntegralNumber(exponentValue))
+            {
+                return JsNumber.DoubleNaN;
+            }
+
+            result = JsNumber.Create(Math.Pow(baseNumber._value, exponentValue));
         }
+        else
+        {
+            AssertValidBigIntArithmeticOperands(left, right);
+
+            var exponent = right.AsBigInt();
+            if (exponent < 0)
+            {
+                Throw.RangeError(context.Engine.Realm, "Exponent must be positive");
+            }
+
+            if (exponent > int.MaxValue)
+            {
+                Throw.RangeError(context.Engine.Realm, "Maximum BigInt size exceeded");
+            }
+
+            var intExponent = (int) exponent;
+            var baseValue = left.AsBigInt();
+            ValidateBigIntPowSize(context.Engine.Realm, baseValue, intExponent);
+            result = JsBigInt.Create(BigInteger.Pow(baseValue, intExponent));
+        }
+
+        return result;
     }
 
     private sealed class InBinaryExpression : JintBinaryExpression
@@ -1030,114 +1039,119 @@ internal abstract class JintBinaryExpression : JintExpression
             var lnum = TypeConverter.ToNumeric(lval);
             var rnum = TypeConverter.ToNumeric(rval);
 
-            if (lnum.Type != rnum.Type)
-            {
-                Throw.TypeErrorNoEngine("Cannot mix BigInt and other types, use explicit conversions", _left._expression);
-            }
+            return EvaluateBitwiseOperation(_operator, lnum, rnum, _left._expression);
+        }
+    }
 
-            if (AreIntegerOperands(lnum, rnum))
-            {
-                int leftValue = lnum.AsInteger();
-                int rightValue = rnum.AsInteger();
-
-                JsValue? result = null;
-                switch (_operator)
-                {
-                    case Operator.BitwiseAnd:
-                        result = JsNumber.Create(leftValue & rightValue);
-                        break;
-                    case Operator.BitwiseOr:
-                        result = JsNumber.Create(leftValue | rightValue);
-                        break;
-                    case Operator.BitwiseXor:
-                        result = JsNumber.Create(leftValue ^ rightValue);
-                        break;
-                    case Operator.LeftShift:
-                        result = JsNumber.Create(leftValue << (int) ((uint) rightValue & 0x1F));
-                        break;
-                    case Operator.RightShift:
-                        result = JsNumber.Create(leftValue >> (int) ((uint) rightValue & 0x1F));
-                        break;
-                    case Operator.UnsignedRightShift:
-                        result = JsNumber.Create((uint) leftValue >> (int) ((uint) rightValue & 0x1F));
-                        break;
-                    default:
-                        Throw.ArgumentOutOfRangeException(nameof(_operator), "unknown shift operator");
-                        break;
-                }
-
-                return result;
-            }
-
-            return EvaluateNonInteger(lnum, rnum);
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-numberbitwiseop (+ BigInt variants and shift operators).
+    /// Operands must already be numeric (ToNumeric applied). Shared by the bitwise/shift
+    /// binary operators and their compound assignment forms.
+    /// </summary>
+    internal static JsValue EvaluateBitwiseOperation(Operator op, JsValue left, JsValue right, Node? location)
+    {
+        if (left.Type != right.Type)
+        {
+            Throw.TypeErrorNoEngine("Cannot mix BigInt and other types, use explicit conversions", location);
         }
 
-        private JsValue EvaluateNonInteger(JsValue left, JsValue right)
+        if (AreIntegerOperands(left, right))
         {
-            switch (_operator)
+            int leftValue = left.AsInteger();
+            int rightValue = right.AsInteger();
+
+            JsValue? result = null;
+            switch (op)
             {
                 case Operator.BitwiseAnd:
-                    {
-                        if (!left.IsBigInt())
-                        {
-                            return JsNumber.Create(TypeConverter.ToInt32(left) & TypeConverter.ToInt32(right));
-                        }
-
-                        return JsBigInt.Create(TypeConverter.ToBigInt(left) & TypeConverter.ToBigInt(right));
-                    }
-
+                    result = JsNumber.Create(leftValue & rightValue);
+                    break;
                 case Operator.BitwiseOr:
-                    {
-                        if (!left.IsBigInt())
-                        {
-                            return JsNumber.Create(TypeConverter.ToInt32(left) | TypeConverter.ToInt32(right));
-                        }
-                        return JsBigInt.Create(TypeConverter.ToBigInt(left) | TypeConverter.ToBigInt(right));
-                    }
-
+                    result = JsNumber.Create(leftValue | rightValue);
+                    break;
                 case Operator.BitwiseXor:
-                    {
-                        if (!left.IsBigInt())
-                        {
-                            return JsNumber.Create(TypeConverter.ToInt32(left) ^ TypeConverter.ToInt32(right));
-                        }
-                        return JsBigInt.Create(TypeConverter.ToBigInt(left) ^ TypeConverter.ToBigInt(right));
-                    }
-
+                    result = JsNumber.Create(leftValue ^ rightValue);
+                    break;
                 case Operator.LeftShift:
-                    {
-                        if (!left.IsBigInt())
-                        {
-                            return JsNumber.Create(TypeConverter.ToInt32(left) << (int) (TypeConverter.ToUint32(right) & 0x1F));
-                        }
-                        return JsBigInt.Create(TypeConverter.ToBigInt(left) << (int) TypeConverter.ToBigInt(right));
-                    }
-
+                    result = JsNumber.Create(leftValue << (int) ((uint) rightValue & 0x1F));
+                    break;
                 case Operator.RightShift:
-                    {
-                        if (!left.IsBigInt())
-                        {
-                            return JsNumber.Create(TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(right) & 0x1F));
-                        }
-                        return JsBigInt.Create(TypeConverter.ToBigInt(left) >> (int) TypeConverter.ToBigInt(right));
-                    }
-
+                    result = JsNumber.Create(leftValue >> (int) ((uint) rightValue & 0x1F));
+                    break;
                 case Operator.UnsignedRightShift:
+                    result = JsNumber.Create((uint) leftValue >> (int) ((uint) rightValue & 0x1F));
+                    break;
+                default:
+                    Throw.ArgumentOutOfRangeException(nameof(op), "unknown shift operator");
+                    break;
+            }
+
+            return result!;
+        }
+
+        switch (op)
+        {
+            case Operator.BitwiseAnd:
+                {
+                    if (!left.IsBigInt())
                     {
-                        if (!left.IsBigInt())
-                        {
-                            return JsNumber.Create((uint) TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(right) & 0x1F));
-                        }
-                        Throw.TypeErrorNoEngine("BigInts have no unsigned right shift, use >> instead", _left._expression);
-                        return null;
+                        return JsNumber.Create(TypeConverter.ToInt32(left) & TypeConverter.ToInt32(right));
                     }
 
-                default:
+                    return JsBigInt.Create(TypeConverter.ToBigInt(left) & TypeConverter.ToBigInt(right));
+                }
+
+            case Operator.BitwiseOr:
+                {
+                    if (!left.IsBigInt())
                     {
-                        Throw.ArgumentOutOfRangeException(nameof(_operator), "unknown shift operator");
-                        return null;
+                        return JsNumber.Create(TypeConverter.ToInt32(left) | TypeConverter.ToInt32(right));
                     }
-            }
+                    return JsBigInt.Create(TypeConverter.ToBigInt(left) | TypeConverter.ToBigInt(right));
+                }
+
+            case Operator.BitwiseXor:
+                {
+                    if (!left.IsBigInt())
+                    {
+                        return JsNumber.Create(TypeConverter.ToInt32(left) ^ TypeConverter.ToInt32(right));
+                    }
+                    return JsBigInt.Create(TypeConverter.ToBigInt(left) ^ TypeConverter.ToBigInt(right));
+                }
+
+            case Operator.LeftShift:
+                {
+                    if (!left.IsBigInt())
+                    {
+                        return JsNumber.Create(TypeConverter.ToInt32(left) << (int) (TypeConverter.ToUint32(right) & 0x1F));
+                    }
+                    return JsBigInt.Create(TypeConverter.ToBigInt(left) << (int) TypeConverter.ToBigInt(right));
+                }
+
+            case Operator.RightShift:
+                {
+                    if (!left.IsBigInt())
+                    {
+                        return JsNumber.Create(TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(right) & 0x1F));
+                    }
+                    return JsBigInt.Create(TypeConverter.ToBigInt(left) >> (int) TypeConverter.ToBigInt(right));
+                }
+
+            case Operator.UnsignedRightShift:
+                {
+                    if (!left.IsBigInt())
+                    {
+                        return JsNumber.Create((uint) TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(right) & 0x1F));
+                    }
+                    Throw.TypeErrorNoEngine("BigInts have no unsigned right shift, use >> instead", location);
+                    return null;
+                }
+
+            default:
+                {
+                    Throw.ArgumentOutOfRangeException(nameof(op), "unknown shift operator");
+                    return null;
+                }
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -167,7 +167,8 @@ internal abstract class JintExpression
             }
             else
             {
-                var modulo = leftInteger % rightInteger;
+                // long math: int.MinValue % -1 raises a hardware overflow in 32-bit division
+                var modulo = (long) leftInteger % rightInteger;
                 if (modulo == 0 && leftInteger < 0)
                 {
                     result = JsNumber.NegativeZero;
@@ -278,9 +279,10 @@ internal abstract class JintExpression
             return lN > 0 ? double.PositiveInfinity : double.NegativeInfinity;
         }
 
-        if (lN % rN == 0 && (lN != 0 || rN > 0))
+        // long math: int.MinValue / -1 (and % -1) raises a hardware overflow in 32-bit division
+        if ((long) lN % rN == 0 && (lN != 0 || rN > 0))
         {
-            return JsNumber.Create(lN / rN);
+            return JsNumber.Create((long) lN / rN);
         }
 
         return (double) lN / rN;

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -289,7 +289,8 @@ internal sealed class JintUnaryExpression : JintExpression
             var asInteger = value.AsInteger();
             if (asInteger != 0)
             {
-                return JsNumber.Create(asInteger * -1);
+                // long math: -int.MinValue overflows int32
+                return JsNumber.Create(-(long) asInteger);
             }
         }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -72,7 +72,7 @@ internal sealed class JintUpdateExpression : JintExpression
         {
             if (isInteger)
             {
-                newValue = JsNumber.Create(value.AsInteger() + _change);
+                newValue = JsNumber.Create((long) value.AsInteger() + _change);
             }
             else if (!value.IsBigInt())
             {
@@ -142,7 +142,7 @@ internal sealed class JintUpdateExpression : JintExpression
             {
                 if (isInteger)
                 {
-                    newValue = JsNumber.Create(value.AsInteger() + _change);
+                    newValue = JsNumber.Create((long) value.AsInteger() + _change);
                 }
                 else if (value._type != InternalTypes.BigInt)
                 {


### PR DESCRIPTION
Two related groups of correctness fixes in the interpreter's numeric fast paths, found while auditing the integer-tagged value handling.

## 1. int32 overflow at the int.MinValue/MaxValue boundary

Integer-tagged fast paths performed 32-bit operations that wrap or raise hardware overflow exceptions at the boundary:

| Expression | Before | After (= V8/spec) |
|---|---|---|
| `var x = (1<<31)\|0; -x` | `-2147483648` (wrapped) | `2147483648` |
| `((1<<31)\|0) / -1` | `ArithmeticException` escaping to caller | `2147483648` |
| `((1<<31)\|0) % -1` | `ArithmeticException` escaping to caller | `-0` |
| `var a = 2147483647; a++` | `-2147483648` (wrapped) | `2147483648` |
| `var b = (1<<31)\|0; b--` | `2147483647` (wrapped) | `-2147483649` |
| `var c = (1<<31)\|0; c -= 1` | `2147483647` (wrapped) | `-2147483649` |

Fix: widen to 64-bit math before the operation, matching the pattern the `+`, `-` and `*` binary operator fast paths already used. (`int.MinValue / -1` and `% -1` raise hardware overflow in 32-bit division, so the division/remainder guards now compute through `long`.)

## 2. Compound assignment operators diverged from their binary forms

Compound assignments computed results with simplified logic that didn't match the corresponding binary operators:

| Expression | Before | After (= V8/spec) |
|---|---|---|
| `var u; u *= 2` | `undefined` | `NaN` |
| `var u; u /= 2` | `undefined` | `NaN` |
| `var x = 1; x **= Infinity` | `1` (raw `Math.Pow`) | `NaN` |
| `var b = 3n; b &= 1n` | `TypeError: Cannot convert a BigInt value to a number` | `1n` |
| `var b = 2n; b <<= 2n` (and `\|=`, `^=`, `>>=`) | `TypeError` | works |
| `var b = 3n; b &= 1` | `TypeError` with conversion message | proper "Cannot mix BigInt" `TypeError` |

Fix: the spec defines `x op= y` as `x = x op y`, so the per-operator computation is now shared:
- `**` and `**=` share a new `Exponentiate` helper (the spec-compliant special cases for `±1 ** ±Infinity`, signed zeros etc. previously lived only in the binary operator)
- the bitwise/shift binary operators and their `op=` forms share a new `EvaluateBitwiseOperation` helper (including BigInt support and the `>>>=`-on-BigInt rejection)
- `-=`, `*=` and `/=` now apply `ToNumeric` before branching, like binary `-`, `*`, `/`

## Testing

- New regression tests in `NumberTests` covering all the cases above
- `Jint.Tests` green on net10.0 and net472
- test262 suite: 99,208 passed, 0 failed (no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)