### PR TITLE
Store function-local numbers unboxed in environment slot bindings

### DIFF
--- a/Jint.Benchmark/FunctionLocalNumberLoopBenchmark.cs
+++ b/Jint.Benchmark/FunctionLocalNumberLoopBenchmark.cs
@@ -1,0 +1,98 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Function-local numeric loop patterns: accumulators and counters held in declarative
+/// environment slots. These are the workloads where transient JsNumber allocations dominate
+/// (values outside the int cache allocate per write), which the rest of the suite under-covers
+/// because its loops live at script top level where bindings are global-object properties.
+/// </summary>
+[MemoryDiagnoser]
+public class FunctionLocalNumberLoopBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _doubleAccumulator;
+    private Prepared<Script> _largeIntCounter;
+    private Prepared<Script> _accumulatorWithCallArg;
+    private Prepared<Script> _mixedArithmetic;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        // pure accumulator: every += result is an uncached double
+        _doubleAccumulator = Engine.PrepareScript("""
+            function f() {
+                var s = 0.5;
+                for (var i = 0; i < 100000; i++) {
+                    s += 0.25;
+                }
+                return s;
+            }
+            f();
+            """);
+
+        // counter beyond the interned-int range with a materializing loop test
+        _largeIntCounter = Engine.PrepareScript("""
+            function f() {
+                var n = 0;
+                for (var i = 0; i < 100000; i++) {
+                    n += 1;
+                }
+                return n;
+            }
+            f();
+            """);
+
+        // unboxed write followed by a materializing read every iteration
+        _accumulatorWithCallArg = Engine.PrepareScript("""
+            function g(v) { return v > 0; }
+            function f() {
+                var s = 0.5;
+                var hits = 0;
+                for (var i = 0; i < 100000; i++) {
+                    s += 0.25;
+                    if (g(s)) { hits++; }
+                }
+                return hits;
+            }
+            f();
+            """);
+
+        // several locals updated per iteration (numeric kernel shape)
+        _mixedArithmetic = Engine.PrepareScript("""
+            function f() {
+                var x = 0.1;
+                var y = 0.2;
+                var sum = 0;
+                for (var i = 0; i < 100000; i++) {
+                    x *= 1.0000001;
+                    y += x;
+                    sum += y;
+                    sum -= x * 0.5;
+                }
+                return sum;
+            }
+            f();
+            """);
+
+        _engine = new Engine();
+        _engine.Evaluate(_doubleAccumulator);
+        _engine.Evaluate(_largeIntCounter);
+        _engine.Evaluate(_accumulatorWithCallArg);
+        _engine.Evaluate(_mixedArithmetic);
+    }
+
+    [Benchmark]
+    public JsValue DoubleAccumulator() => _engine.Evaluate(_doubleAccumulator);
+
+    [Benchmark]
+    public JsValue LargeIntCounter() => _engine.Evaluate(_largeIntCounter);
+
+    [Benchmark]
+    public JsValue AccumulatorWithCallArg() => _engine.Evaluate(_accumulatorWithCallArg);
+
+    [Benchmark]
+    public JsValue MixedArithmetic() => _engine.Evaluate(_mixedArithmetic);
+}

--- a/Jint.Tests/Runtime/CompletionValueTests.cs
+++ b/Jint.Tests/Runtime/CompletionValueTests.cs
@@ -1,0 +1,90 @@
+using Jint.Native;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Guards the completion-value semantics around the function-body elision optimization:
+/// Normal-completion values must stay observable at script/eval/module top level while
+/// function bodies only surface Return/Throw completions.
+/// </summary>
+public class CompletionValueTests
+{
+    private readonly Engine _engine = new();
+
+    [Fact]
+    public void ScriptTopLevelReturnsLastExpressionValue()
+    {
+        Assert.Equal(2d, _engine.Evaluate("1; 2;").AsNumber());
+        Assert.Equal(3d, _engine.Evaluate("var x = 1; x + 2;").AsNumber());
+        Assert.Equal(0.5, _engine.Evaluate("var y = 0.25; y + 0.25;").AsNumber());
+    }
+
+    [Fact]
+    public void EvalReturnsLastExpressionValue()
+    {
+        Assert.Equal(3d, _engine.Evaluate("eval('1;2;3')").AsNumber());
+        Assert.Equal(JsValue.Undefined, _engine.Evaluate("eval('var a = 1;')"));
+    }
+
+    [Fact]
+    public void DirectEvalInsideFunctionReturnsLastExpressionValue()
+    {
+        Assert.Equal(3d, _engine.Evaluate("function f() { return eval('1;2;3'); } f()").AsNumber());
+        Assert.Equal(42d, _engine.Evaluate("function g() { var t = 2; return eval('t; 42'); } g()").AsNumber());
+    }
+
+    [Fact]
+    public void IndirectEvalReturnsLastExpressionValue()
+    {
+        Assert.Equal(7d, _engine.Evaluate("function f() { var e = eval; return e('5;6;7'); } f()").AsNumber());
+    }
+
+    [Fact]
+    public void FunctionWithoutReturnGivesUndefined()
+    {
+        Assert.Equal(JsValue.Undefined, _engine.Evaluate("function f() { 1; 2; 3; } f()"));
+        Assert.Equal(JsValue.Undefined, _engine.Evaluate("(function () { 42; })()"));
+    }
+
+    [Fact]
+    public void FunctionReturnValueFlows()
+    {
+        Assert.Equal(0.75, _engine.Evaluate("function f() { var s = 0; for (var i = 0; i < 3; i++) { s += 0.25; } return s; } f()").AsNumber());
+    }
+
+    [Fact]
+    public void TopLevelLoopProducesLastIterationValue()
+    {
+        Assert.Equal(4d, _engine.Evaluate("for (var i = 0; i < 5; i++) { i; }").AsNumber());
+        Assert.Equal(2.5, _engine.Evaluate("var s = 0; for (var i = 0; i < 5; i++) { s += 0.5; }").AsNumber());
+    }
+
+    [Fact]
+    public void TopLevelBlockAndIfProduceValues()
+    {
+        Assert.Equal(2d, _engine.Evaluate("{ 1; 2; }").AsNumber());
+        Assert.Equal(10d, _engine.Evaluate("if (true) { 10; } else { 20; }").AsNumber());
+        Assert.Equal(5d, _engine.Evaluate("switch (1) { case 1: 5; }").AsNumber());
+    }
+
+    [Fact]
+    public void GeneratorAndAsyncResultsFlow()
+    {
+        Assert.Equal(1d, _engine.Evaluate("function* g() { 41; yield 1; 43; } g().next().value").AsNumber());
+        Assert.Equal(11d, _engine.Evaluate("async function a() { 1; return 11; } a()").UnwrapIfPromise().AsNumber());
+    }
+
+    [Fact]
+    public void ClassStaticBlockValuesAreNotObservable()
+    {
+        Assert.Equal(9d, _engine.Evaluate("class C { static x; static { 123; C.x = 9; } } C.x").AsNumber());
+    }
+
+    [Fact]
+    public void EvalSwitchAndTryProduceValues()
+    {
+        Assert.Equal(3d, _engine.Evaluate("eval('try { 3; } catch (e) { 4; }')").AsNumber());
+        Assert.Equal(4d, _engine.Evaluate("eval('try { throw 1; } catch (e) { 4; }')").AsNumber());
+        Assert.Equal(8d, _engine.Evaluate("eval('switch (2) { case 2: 8; }')").AsNumber());
+    }
+}

--- a/Jint.Tests/Runtime/NumberTests.cs
+++ b/Jint.Tests/Runtime/NumberTests.cs
@@ -212,5 +212,10 @@ public class NumberTests
         Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("var b = 3n; b &= 1;"));
         Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("var b = 3; b &= 1n;"));
         Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("var b = 1n; b >>>= 1n;"));
+
+        // compound assignment to an uninitialized (TDZ) binding must be a ReferenceError,
+        // not a NullReferenceException from the identifier fast path
+        var tdz = Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("(function() { { x += 1; let x; } })()"));
+        Assert.Equal("ReferenceError", tdz.Error.AsObject().Get("constructor").AsObject().Get("name").AsString());
     }
 }

--- a/Jint.Tests/Runtime/NumberTests.cs
+++ b/Jint.Tests/Runtime/NumberTests.cs
@@ -217,5 +217,8 @@ public class NumberTests
         // not a NullReferenceException from the identifier fast path
         var tdz = Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("(function() { { x += 1; let x; } })()"));
         Assert.Equal("ReferenceError", tdz.Error.AsObject().Get("constructor").AsObject().Get("name").AsString());
+
+        var tdzUpdate = Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("(function() { { y++; let y; } })()"));
+        Assert.Equal("ReferenceError", tdzUpdate.Error.AsObject().Get("constructor").AsObject().Get("name").AsString());
     }
 }

--- a/Jint.Tests/Runtime/UnboxedBindingTests.cs
+++ b/Jint.Tests/Runtime/UnboxedBindingTests.cs
@@ -1,0 +1,141 @@
+using Jint.Native;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Guards the unboxed number binding fast paths: numeric read-modify-write statements on
+/// function-local slot bindings store raw doubles; materializing reads must observe exact
+/// JS number semantics (including -0, NaN, infinities and int32 boundaries) and all
+/// non-qualifying shapes must keep their full error/coercion behavior.
+/// </summary>
+public class UnboxedBindingTests
+{
+    private readonly Engine _engine = new();
+
+    [Fact]
+    public void DoubleAccumulatorProducesExactResult()
+    {
+        Assert.Equal(1.0, _engine.Evaluate("function f() { var s = 0.5; s += 0.25; s += 0.25; return s; } f()").AsNumber());
+        Assert.Equal(2500d, _engine.Evaluate("function f() { var s = 0; for (var i = 0; i < 10000; i++) { s += 0.25; } return s; } f()").AsNumber());
+    }
+
+    [Fact]
+    public void AllCompoundOperatorsWork()
+    {
+        Assert.Equal(7d, _engine.Evaluate("function f() { var x = 10; x -= 3; return x; } f()").AsNumber());
+        Assert.Equal(2.5, _engine.Evaluate("function f() { var x = 5; x *= 0.5; return x; } f()").AsNumber());
+        Assert.Equal(2.5, _engine.Evaluate("function f() { var x = 5; x /= 2; return x; } f()").AsNumber());
+        Assert.Equal(1d, _engine.Evaluate("function f() { var x = 7; x %= 3; return x; } f()").AsNumber());
+        Assert.Equal(4d, _engine.Evaluate("function f() { var x = 6; x &= 12; return x; } f()").AsNumber());
+        Assert.Equal(14d, _engine.Evaluate("function f() { var x = 6; x |= 12; return x; } f()").AsNumber());
+        Assert.Equal(10d, _engine.Evaluate("function f() { var x = 6; x ^= 12; return x; } f()").AsNumber());
+        Assert.Equal(24d, _engine.Evaluate("function f() { var x = 6; x <<= 2; return x; } f()").AsNumber());
+        Assert.Equal(1d, _engine.Evaluate("function f() { var x = 6; x >>= 2; return x; } f()").AsNumber());
+        Assert.Equal(1073741822d, _engine.Evaluate("function f() { var x = -6; x >>>= 2; return x; } f()").AsNumber());
+        Assert.Equal(8d, _engine.Evaluate("function f() { var x = 2; x **= 3; return x; } f()").AsNumber());
+    }
+
+    [Fact]
+    public void UpdateExpressionsWork()
+    {
+        Assert.Equal(3d, _engine.Evaluate("function f() { var i = 0; i++; i++; ++i; return i; } f()").AsNumber());
+        Assert.Equal(-3d, _engine.Evaluate("function f() { var i = 0; i--; i--; --i; return i; } f()").AsNumber());
+        Assert.Equal(0.5, _engine.Evaluate("function f() { var i = -0.5; i++; return i; } f()").AsNumber());
+    }
+
+    [Fact]
+    public void Int32BoundaryWidensCorrectly()
+    {
+        Assert.Equal(2147483648d, _engine.Evaluate("function f() { var i = 2147483647; i++; return i; } f()").AsNumber());
+        Assert.Equal(-2147483649d, _engine.Evaluate("function f() { var i = (1<<31)|0; i--; return i; } f()").AsNumber());
+        Assert.Equal(2147483648d, _engine.Evaluate("function f() { var i = (1<<31)|0; i /= -1; return i; } f()").AsNumber());
+    }
+
+    [Fact]
+    public void SpecialValuesSurviveMaterialization()
+    {
+        Assert.True(_engine.Evaluate("function f() { var z = 0; z *= -1; return Object.is(z, -0); } f()").AsBoolean());
+        Assert.True(_engine.Evaluate("function f() { var n = 0; n /= 0; return Number.isNaN(n); } f()").AsBoolean());
+        Assert.Equal(double.PositiveInfinity, _engine.Evaluate("function f() { var x = 1; x /= 0; return x; } f()").AsNumber());
+        Assert.Equal(double.NegativeInfinity, _engine.Evaluate("function f() { var x = -1; x /= 0; return x; } f()").AsNumber());
+        Assert.True(_engine.Evaluate("function f() { var x = -6; x %= 3; return Object.is(x, -0); } f()").AsBoolean());
+    }
+
+    [Fact]
+    public void ReadAfterUnboxedWriteReturnsCorrectValue()
+    {
+        // materializing consumers (call arguments, comparisons, returns) after unboxed writes
+        Assert.Equal(0.75, _engine.Evaluate("function g(v) { return v; } function f() { var s = 0.5; s += 0.25; return g(s); } f()").AsNumber());
+        Assert.True(_engine.Evaluate("function f() { var s = 0.5; s += 0.25; return s === 0.75; } f()").AsBoolean());
+        Assert.Equal("0.75", _engine.Evaluate("function f() { var s = 0.5; s += 0.25; return '' + s; } f()").AsString());
+    }
+
+    [Fact]
+    public void RepeatedReadsReturnSameInstance()
+    {
+        // write-back memoization: two reads of the same unboxed binding observe one value
+        Assert.True(_engine.Evaluate("function f() { var s = 0.5; s += 0.25; var a = s; var b = s; return a === b; } f()").AsBoolean());
+    }
+
+    [Fact]
+    public void NonNumberRightHandSideCompletesCorrectly()
+    {
+        Assert.Equal("0.5x", _engine.Evaluate("function f() { var s = 0.5; s += 'x'; return s; } f()").AsString());
+        Assert.Equal(0.5, _engine.Evaluate("function f() { var s = 1; s *= { valueOf: function() { return 0.5; } }; return s; } f()").AsNumber());
+        Assert.Throws<Jint.Runtime.JavaScriptException>(() => _engine.Evaluate("function f() { var s = 1; s += 1n; return s; } f()"));
+        Assert.Throws<Jint.Runtime.JavaScriptException>(() => _engine.Evaluate("function f() { var s = 1; s &= 1n; return s; } f()"));
+    }
+
+    [Fact]
+    public void ExponentiationKeepsSpecSemantics()
+    {
+        Assert.True(_engine.Evaluate("function f() { var x = 1; x **= Infinity; return Number.isNaN(x); } f()").AsBoolean());
+    }
+
+    [Fact]
+    public void RightHandSideRunsExactlyOnce()
+    {
+        Assert.Equal(1d, _engine.Evaluate("function f() { var calls = 0; function g() { calls++; return 2; } var s = 1; s += g(); return calls; } f()").AsNumber());
+        Assert.Equal("1x|1", _engine.Evaluate("function f() { var calls = 0; function g() { calls++; return 'x'; } var s = 1; s += g(); return s + '|' + calls; } f()").AsString());
+    }
+
+    [Fact]
+    public void ConstAndTdzKeepProperErrors()
+    {
+        Assert.Throws<Jint.Runtime.JavaScriptException>(() => _engine.Evaluate("function f() { 'use strict'; const c = 1.5; c += 1; } f()"));
+        Assert.Throws<Jint.Runtime.JavaScriptException>(() => _engine.Evaluate("function f() { { x += 1.5; let x; } } f()"));
+        Assert.Throws<Jint.Runtime.JavaScriptException>(() => _engine.Evaluate("function f() { { y++; let y; } } f()"));
+
+        // const bindings reject compound assignment in sloppy mode too (binding-level strictness)
+        Assert.Throws<Jint.Runtime.JavaScriptException>(() => _engine.Evaluate("function f() { const c = 2.5; c += 1; return c; } f()"));
+    }
+
+    [Fact]
+    public void ObservableContextsKeepMaterializedResults()
+    {
+        // value-producing positions never take the discard path
+        Assert.Equal(1.5, _engine.Evaluate("function f() { var s = 1; var y = (s += 0.5); return y; } f()").AsNumber());
+        Assert.Equal(2d, _engine.Evaluate("function f() { var i = 1; var y = i++; return i; } f()").AsNumber());
+        Assert.Equal(1d, _engine.Evaluate("function f() { var i = 1; var y = i++; return y; } f()").AsNumber());
+    }
+
+    [Fact]
+    public void GeneratorsAndAsyncKeepFullSemantics()
+    {
+        Assert.Equal(1.5, _engine.Evaluate("function* g() { var s = 1; s += 0.5; yield s; } g().next().value").AsNumber());
+        Assert.Equal(2.5, _engine.Evaluate("async function a() { var s = 2; s += 0.5; return s; } a()").UnwrapIfPromise().AsNumber());
+    }
+
+    [Fact]
+    public void ClosureObservesUnboxedWrites()
+    {
+        Assert.Equal(0.75, _engine.Evaluate("function f() { var s = 0.5; var get = function() { return s; }; s += 0.25; return get(); } f()").AsNumber());
+    }
+
+    [Fact]
+    public void ForLoopCountersStayCorrect()
+    {
+        Assert.Equal(100000d, _engine.Evaluate("function f() { var i; for (i = 0; i < 100000; i++) { } return i; } f()").AsNumber());
+        Assert.Equal(12502500d, _engine.Evaluate("function f() { var s = 0; for (var i = 0; i <= 5000; i++) { s += i * 0.5; } return s * 2; } f()").AsNumber());
+    }
+}

--- a/Jint.Tests/Runtime/UnboxedBindingTests.cs
+++ b/Jint.Tests/Runtime/UnboxedBindingTests.cs
@@ -133,6 +133,44 @@ public class UnboxedBindingTests
     }
 
     [Fact]
+    public void WithStatementDynamicShadowingResolvesPerExecution()
+    {
+        // write paths: the slot-location cache must not skip a with-object that gains
+        // the property after the cache was populated
+        Assert.Equal("2|101", _engine.Evaluate(
+            "function f() { var i = 0; var r = ''; for (var k = 0; k < 3; k++) { var obj = (k === 1) ? { i: 100 } : {}; with (obj) { i++; } if (k === 1) { r = '' + obj.i; } } return i + '|' + r; } f();").AsString());
+
+        Assert.Equal("2|101", _engine.Evaluate(
+            "function g() { var i = 0; var r = ''; for (var k = 0; k < 3; k++) { var obj = (k === 1) ? { i: 100 } : {}; with (obj) { i += 1; } if (k === 1) { r = '' + obj.i; } } return i + '|' + r; } g();").AsString());
+
+        // read path: the identifier slot cache has the same obligation
+        Assert.Equal("42;999;", _engine.Evaluate(
+            "function h() { var i = 42; var out = ''; for (var k = 0; k < 2; k++) { var obj = (k === 1) ? { i: 999 } : {}; with (obj) { out += i + ';'; } } return out; } h();").AsString());
+
+        // a with-object that owns the property from the start
+        Assert.Equal("1|105", _engine.Evaluate(
+            "function w() { var s = 1; var o = { s: 100 }; with (o) { s += 5; } return s + '|' + o.s; } w();").AsString());
+    }
+
+    [Fact]
+    public void SequenceExpressionUpdatesInForLoop()
+    {
+        Assert.Equal("5|5", _engine.Evaluate(
+            "function f() { var i = 0, j = 10; for (; i < j; i++, j--) { } return i + '|' + j; } f();").AsString());
+        Assert.Equal(2.5, _engine.Evaluate(
+            "function f() { var a = 0, b = 0; for (var k = 0; k < 5; k++, a += 0.25, b += 0.25) { } return a + b; } f();").AsNumber());
+    }
+
+    [Fact]
+    public void SwitchBodiesInsideFunctionsStayCorrect()
+    {
+        Assert.Equal(0.75, _engine.Evaluate(
+            "function f() { var s = 0; switch (1) { case 1: s += 0.5; s += 0.25; break; } return s; } f();").AsNumber());
+        Assert.Equal(50d, _engine.Evaluate(
+            "function f() { var acc = 0; for (var i = 0; i < 100; i++) { switch (i % 2) { case 0: acc += 1; break; default: acc -= 0; break; } } return acc; } f();").AsNumber());
+    }
+
+    [Fact]
     public void ForLoopCountersStayCorrect()
     {
         Assert.Equal(100000d, _engine.Evaluate("function f() { var i; for (i = 0; i < 100000; i++) { } return i; } f()").AsNumber());

--- a/Jint/Runtime/Environments/Binding.cs
+++ b/Jint/Runtime/Environments/Binding.cs
@@ -3,30 +3,88 @@ using Jint.Native;
 
 namespace Jint.Runtime.Environments;
 
-[DebuggerDisplay("Mutable: {Mutable}, Strict: {Strict}, CanBeDeleted: {CanBeDeleted}, Value: {Value}")]
+[Flags]
+internal enum BindingFlags : byte
+{
+    None = 0,
+    CanBeDeleted = 1,
+    Mutable = 2,
+    Strict = 4,
+
+    /// <summary>
+    /// The binding holds a raw number in <see cref="Binding._number"/> instead of a materialized
+    /// <see cref="JsValue"/>. Only ever set for slot-stored bindings by the numeric
+    /// read-modify-write fast paths; a materializing read converts back (with write-back caching).
+    /// </summary>
+    UnboxedNumber = 8,
+}
+
+[DebuggerDisplay("Mutable: {Mutable}, Strict: {Strict}, CanBeDeleted: {CanBeDeleted}, Value: {_value}, Unboxed: {IsUnboxedNumber} ({_number})")]
 internal readonly struct Binding
 {
+    private readonly JsValue? _value;
+    private readonly double _number;
+    private readonly BindingFlags _flags;
+
     public Binding(
         JsValue value,
         bool canBeDeleted,
         bool mutable,
         bool strict)
     {
-        Value = value;
-        CanBeDeleted = canBeDeleted;
-        Mutable = mutable;
-        Strict = strict;
+        _value = value;
+        _number = 0;
+        _flags = (canBeDeleted ? BindingFlags.CanBeDeleted : BindingFlags.None)
+                 | (mutable ? BindingFlags.Mutable : BindingFlags.None)
+                 | (strict ? BindingFlags.Strict : BindingFlags.None);
     }
 
-    public readonly JsValue Value;
-    public readonly bool CanBeDeleted;
-    public readonly bool Mutable;
-    public readonly bool Strict;
+    private Binding(JsValue? value, double number, BindingFlags flags)
+    {
+        _value = value;
+        _number = number;
+        _flags = flags;
+    }
+
+    /// <summary>
+    /// The materialized value; readers must check <see cref="HasReferenceValue"/> (or use the
+    /// environment's materializing accessors) so unboxed bindings are not observed as null.
+    /// </summary>
+    public JsValue Value
+    {
+        get
+        {
+            Debug.Assert(_value is not null || !IsUnboxedNumber, "unboxed binding read through Value without materialization");
+            return _value!;
+        }
+    }
+
+    public bool CanBeDeleted => (_flags & BindingFlags.CanBeDeleted) != BindingFlags.None;
+    public bool Mutable => (_flags & BindingFlags.Mutable) != BindingFlags.None;
+    public bool Strict => (_flags & BindingFlags.Strict) != BindingFlags.None;
+
+    public bool IsUnboxedNumber => (_flags & BindingFlags.UnboxedNumber) != BindingFlags.None;
+
+    public bool HasReferenceValue => _value is not null;
+
+    public double UnboxedNumber
+    {
+        get
+        {
+            Debug.Assert(IsUnboxedNumber);
+            return _number;
+        }
+    }
 
     public Binding ChangeValue(JsValue argument)
     {
-        return new Binding(argument, CanBeDeleted, Mutable, Strict);
+        return new Binding(argument, 0, _flags & ~BindingFlags.UnboxedNumber);
     }
 
-    public bool IsInitialized() => Value is not null;
+    public Binding WithUnboxedNumber(double value)
+    {
+        return new Binding(null, value, _flags | BindingFlags.UnboxedNumber);
+    }
+
+    public bool IsInitialized() => _value is not null || (_flags & BindingFlags.UnboxedNumber) != BindingFlags.None;
 }

--- a/Jint/Runtime/Environments/DeclarativeEnvironment.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironment.cs
@@ -61,7 +61,16 @@ internal class DeclarativeEnvironment : Environment
     /// </summary>
     internal bool TryGetNumberSlot(int slotIndex, out double value)
     {
-        ref var binding = ref _slots![slotIndex];
+        // bounds-checked like the identifier slot-cache read path: a cached index is
+        // deterministic per AST node, but a stale/torn cache must fall back, not throw
+        var slots = _slots;
+        if (slots is null || (uint) slotIndex >= (uint) slots.Length)
+        {
+            value = 0;
+            return false;
+        }
+
+        ref var binding = ref slots[slotIndex];
         if (binding.Mutable)
         {
             if (binding.IsUnboxedNumber)

--- a/Jint/Runtime/Environments/DeclarativeEnvironment.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironment.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Jint.Collections;
 using Jint.Native;
@@ -35,6 +36,76 @@ internal class DeclarativeEnvironment : Environment
         return -1;
     }
 
+    /// <summary>
+    /// Materializes an unboxed number binding with write-back caching so subsequent reads
+    /// return the same instance, or returns null when the binding is uninitialized (TDZ).
+    /// Cold by design: it runs at most once per unboxed write.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal static JsValue? MaterializeUnboxedOrNull(ref Binding binding)
+    {
+        if (!binding.IsUnboxedNumber)
+        {
+            return null;
+        }
+
+        var value = JsNumber.Create(binding.UnboxedNumber);
+        binding = binding.ChangeValue(value);
+        return value;
+    }
+
+    /// <summary>
+    /// Reads a slot-stored binding as a raw number for the numeric read-modify-write fast
+    /// paths. Succeeds only for initialized, mutable bindings currently holding a number
+    /// (unboxed or as a JsNumber), so that <see cref="SetNumberSlot"/> may store unchecked.
+    /// </summary>
+    internal bool TryGetNumberSlot(int slotIndex, out double value)
+    {
+        ref var binding = ref _slots![slotIndex];
+        if (binding.Mutable)
+        {
+            if (binding.IsUnboxedNumber)
+            {
+                value = binding.UnboxedNumber;
+                return true;
+            }
+
+            if (binding.HasReferenceValue && binding.Value is JsNumber number)
+            {
+                value = number._value;
+                return true;
+            }
+        }
+
+        value = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// Stores a raw number into a slot previously validated by <see cref="TryGetNumberSlot"/>
+    /// without materializing a JsNumber.
+    /// </summary>
+    internal void SetNumberSlot(int slotIndex, double value)
+    {
+        ref var binding = ref _slots![slotIndex];
+        Debug.Assert(binding.Mutable && binding.IsInitialized());
+        binding = binding.WithUnboxedNumber(value);
+    }
+
+    /// <summary>
+    /// Finds the fixed slot index for a name so callers can cache the location
+    /// (same lifetime guarantees as the identifier slot-binding cache).
+    /// </summary>
+    internal int FindSlotIndex(Key name)
+    {
+        if (_slots is not null && _slotNames is not null)
+        {
+            return SlotIndexOf(name);
+        }
+
+        return -1;
+    }
+
     internal sealed override bool HasBinding(BindingName name) => HasBinding(name.Key);
 
     internal sealed override bool HasBinding(Key name)
@@ -53,14 +124,15 @@ internal class DeclarativeEnvironment : Environment
             var index = SlotIndexOf(name.Key);
             if (index >= 0)
             {
-                value = _slots[index].Value;
+                ref var binding = ref _slots[index];
+                value = binding.HasReferenceValue ? binding.Value : MaterializeUnboxedOrNull(ref binding)!;
                 return true;
             }
         }
 
-        if (_dictionary?.TryGetValue(name.Key, out var binding) == true)
+        if (_dictionary?.TryGetValue(name.Key, out var dictionaryBinding) == true)
         {
-            value = binding.Value;
+            value = dictionaryBinding.Value;
             return true;
         }
 
@@ -244,10 +316,17 @@ internal class DeclarativeEnvironment : Environment
             if (index >= 0)
             {
                 ref var binding = ref _slots[index];
-                if (binding.IsInitialized())
+                if (binding.HasReferenceValue)
                 {
                     return binding.Value;
                 }
+
+                var materialized = MaterializeUnboxedOrNull(ref binding);
+                if (materialized is not null)
+                {
+                    return materialized;
+                }
+
                 ThrowUninitializedBindingError(name);
                 return null!;
             }

--- a/Jint/Runtime/Environments/SlotLocationCache.cs
+++ b/Jint/Runtime/Environments/SlotLocationCache.cs
@@ -1,0 +1,115 @@
+using System.Runtime.CompilerServices;
+
+namespace Jint.Runtime.Environments;
+
+/// <summary>
+/// Per-AST-node cache of a binding's slot location (environment + slot index), shared by the
+/// identifier read fast path and the numeric read-modify-write discard fast paths.
+/// </summary>
+/// <remarks>
+/// Validity reasoning: closure-captured environments cannot be pooled (escape detection
+/// prevents it), so a cached env reference is stable for the lifetime of the function
+/// instance that captured it, and slot indices are immutable for the lifetime of the env.
+/// Slot layout is deterministic per AST node, so a node shared across engines via
+/// <c>Prepared&lt;Script&gt;</c> resolves to the same index everywhere; the engine-identity
+/// gate only avoids wasted walks against another engine's environments.
+/// The chain walk refuses to skip over an <see cref="ObjectEnvironment"/> (a sloppy-mode
+/// <c>with</c> block): a with-object can gain a shadowing property at any time, so only the
+/// full resolution path can decide who owns the binding.
+/// Nodes whose binding can never be slot-stored (global/object/dictionary environments)
+/// disable themselves permanently so failed attempts don't re-walk the chain.
+/// </remarks>
+internal struct SlotLocationCache
+{
+    // Bounded walk: chain depth is typically 1-3 in real code; deeper chains fall through.
+    internal const int MaxChainDepth = 4;
+
+    private DeclarativeEnvironment? _cachedSlotEnv;
+    private int _cachedSlotIndex;
+    private bool _disabled;
+
+    /// <summary>
+    /// Resolves the slot location for <paramref name="name"/> against the current lexical
+    /// environment, using and maintaining the cache. Returns false when the binding is not
+    /// slot-stored, the cached location is not safely reachable, or resolution must go
+    /// through the full materialized path.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryResolve(
+        Engine engine,
+        Environment env,
+        Environment.BindingName name,
+        out DeclarativeEnvironment slotEnv,
+        out int slotIndex)
+    {
+        var cached = _cachedSlotEnv;
+        if (cached is not null && ReferenceEquals(cached._engine, engine))
+        {
+            var search = env;
+            for (var hops = 0; hops < MaxChainDepth && search is not null; hops++)
+            {
+                if (ReferenceEquals(search, cached))
+                {
+                    slotEnv = cached;
+                    slotIndex = _cachedSlotIndex;
+                    return true;
+                }
+
+                if (search is ObjectEnvironment)
+                {
+                    // a with-object between us and the cached slot may shadow the name dynamically
+                    break;
+                }
+
+                search = search._outerEnv;
+            }
+
+            slotEnv = null!;
+            slotIndex = -1;
+            return false;
+        }
+
+        if (_disabled)
+        {
+            slotEnv = null!;
+            slotIndex = -1;
+            return false;
+        }
+
+        return ResolveAndPopulate(env, name, out slotEnv, out slotIndex);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool ResolveAndPopulate(
+        Environment env,
+        Environment.BindingName name,
+        out DeclarativeEnvironment slotEnv,
+        out int slotIndex)
+    {
+        slotEnv = null!;
+        slotIndex = -1;
+
+        if (!JintEnvironment.TryGetIdentifierEnvironmentWithBinding(env, name, out var record))
+        {
+            // unresolvable; the full path produces the proper error
+            return false;
+        }
+
+        if (record is DeclarativeEnvironment declarativeEnvironment)
+        {
+            var index = declarativeEnvironment.FindSlotIndex(name.Key);
+            if (index >= 0)
+            {
+                _cachedSlotEnv = declarativeEnvironment;
+                _cachedSlotIndex = index;
+                slotEnv = declarativeEnvironment;
+                slotIndex = index;
+                return true;
+            }
+        }
+
+        // the binding for this node can never be slot-stored; stop attempting
+        _disabled = true;
+        return false;
+    }
+}

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -57,6 +57,15 @@ internal sealed class EvaluationContext
 
     public readonly bool OperatorOverloadingAllowed;
 
+    /// <summary>
+    /// Whether Normal-completion values of statements are observable in the current frame.
+    /// True at script/module/eval top level (the value feeds Engine.Evaluate / eval results);
+    /// false inside function bodies, where the spec only surfaces Return/Throw completions -
+    /// letting expression statements skip materializing their value.
+    /// Maintained by <see cref="JintStatementList.Execute"/> with save/restore semantics.
+    /// </summary>
+    public bool CompletionValuesObservable = true;
+
     // completion record information
     public string? Target;
     public CompletionType Completion;

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -15,6 +15,16 @@ internal sealed class JintAssignmentExpression : JintExpression
     private readonly JintExpression _right;
     private readonly Operator _operator;
 
+    // Slot-location cache for the discard-mode fast path; same validity reasoning as
+    // JintIdentifierExpression's slot-binding cache: closure-captured envs cannot be
+    // pooled, so the env reference is stable and slot indices are immutable.
+    // _discardFastPathDisabled marks nodes whose binding can never be slot-stored
+    // (global/object/dictionary environments) so failed attempts don't re-walk the chain.
+    private DeclarativeEnvironment? _cachedSlotEnv;
+    private int _cachedSlotIndex = -1;
+    private bool _discardFastPathDisabled;
+    private const int MaxSlotCacheChainDepth = 4;
+
     private JintAssignmentExpression(AssignmentExpression expression) : base(expression)
     {
         _left = Build((Expression) expression.Left);
@@ -323,6 +333,7 @@ internal sealed class JintAssignmentExpression : JintExpression
     {
         var engine = context.Engine;
         if (_leftIdentifier is null
+            || _discardFastPathDisabled
             || context.OperatorOverloadingAllowed
             || engine.ExecutionContext.Suspendable is not null
             || _operator is Operator.NullishCoalescingAssignment or Operator.LogicalAndAssignment or Operator.LogicalOrAssignment)
@@ -330,13 +341,54 @@ internal sealed class JintAssignmentExpression : JintExpression
             return false;
         }
 
-        var name = _leftIdentifier.Identifier;
-        if (!JintEnvironment.TryGetIdentifierEnvironmentWithBinding(
-                engine.ExecutionContext.LexicalEnvironment,
-                name,
-                out var record)
-            || record is not DeclarativeEnvironment declarativeEnvironment
-            || !declarativeEnvironment.TryGetNumberSlot(name.Key, out var slotIndex, out var left))
+        var env = engine.ExecutionContext.LexicalEnvironment;
+        DeclarativeEnvironment declarativeEnvironment;
+        int slotIndex;
+
+        var cachedSlotEnv = _cachedSlotEnv;
+        if (cachedSlotEnv is not null && ReferenceEquals(cachedSlotEnv._engine, engine))
+        {
+            var search = env;
+            var hops = 0;
+            for (; hops < MaxSlotCacheChainDepth && search is not null; hops++)
+            {
+                if (ReferenceEquals(search, cachedSlotEnv))
+                {
+                    break;
+                }
+                search = search._outerEnv;
+            }
+
+            if (search is null || hops == MaxSlotCacheChainDepth || !ReferenceEquals(search, cachedSlotEnv))
+            {
+                return false;
+            }
+
+            declarativeEnvironment = cachedSlotEnv;
+            slotIndex = _cachedSlotIndex;
+        }
+        else
+        {
+            var name = _leftIdentifier.Identifier;
+            if (!JintEnvironment.TryGetIdentifierEnvironmentWithBinding(env, name, out var record))
+            {
+                // unresolvable; the full path produces the proper error
+                return false;
+            }
+
+            if (record is not DeclarativeEnvironment resolved || (slotIndex = resolved.FindSlotIndex(name.Key)) < 0)
+            {
+                // the binding for this node can never be slot-stored; stop attempting
+                _discardFastPathDisabled = true;
+                return false;
+            }
+
+            declarativeEnvironment = resolved;
+            _cachedSlotEnv = resolved;
+            _cachedSlotIndex = slotIndex;
+        }
+
+        if (!declarativeEnvironment.TryGetNumberSlot(slotIndex, out var left))
         {
             return false;
         }
@@ -398,7 +450,7 @@ internal sealed class JintAssignmentExpression : JintExpression
         // cannot apply and the result is always stored.
         var wasMutatedInPlace = false;
         var newLeftValue = ComputeCompound(context, JsNumber.Create(left), rval, ref wasMutatedInPlace);
-        record.SetMutableBinding(name.Key, newLeftValue, StrictModeScope.IsStrictModeCode);
+        declarativeEnvironment.SetMutableBinding(_leftIdentifier.Identifier.Key, newLeftValue, StrictModeScope.IsStrictModeCode);
         return true;
     }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -15,15 +15,9 @@ internal sealed class JintAssignmentExpression : JintExpression
     private readonly JintExpression _right;
     private readonly Operator _operator;
 
-    // Slot-location cache for the discard-mode fast path; same validity reasoning as
-    // JintIdentifierExpression's slot-binding cache: closure-captured envs cannot be
-    // pooled, so the env reference is stable and slot indices are immutable.
-    // _discardFastPathDisabled marks nodes whose binding can never be slot-stored
-    // (global/object/dictionary environments) so failed attempts don't re-walk the chain.
-    private DeclarativeEnvironment? _cachedSlotEnv;
-    private int _cachedSlotIndex = -1;
-    private bool _discardFastPathDisabled;
-    private const int MaxSlotCacheChainDepth = 4;
+    // Slot-location cache for the discard-mode fast path; see SlotLocationCache for the
+    // validity reasoning (with-statement shadowing, pooling, cross-engine sharing).
+    private SlotLocationCache _slotCache;
 
     private JintAssignmentExpression(AssignmentExpression expression) : base(expression)
     {
@@ -308,6 +302,8 @@ internal sealed class JintAssignmentExpression : JintExpression
         }
     }
 
+    internal override bool HasDiscardFastPath => true;
+
     internal override void EvaluateAndDiscard(EvaluationContext context)
     {
         var oldSyntaxElement = context.LastSyntaxElement;
@@ -333,7 +329,6 @@ internal sealed class JintAssignmentExpression : JintExpression
     {
         var engine = context.Engine;
         if (_leftIdentifier is null
-            || _discardFastPathDisabled
             || context.OperatorOverloadingAllowed
             || engine.ExecutionContext.Suspendable is not null
             || _operator is Operator.NullishCoalescingAssignment or Operator.LogicalAndAssignment or Operator.LogicalOrAssignment)
@@ -341,54 +336,8 @@ internal sealed class JintAssignmentExpression : JintExpression
             return false;
         }
 
-        var env = engine.ExecutionContext.LexicalEnvironment;
-        DeclarativeEnvironment declarativeEnvironment;
-        int slotIndex;
-
-        var cachedSlotEnv = _cachedSlotEnv;
-        if (cachedSlotEnv is not null && ReferenceEquals(cachedSlotEnv._engine, engine))
-        {
-            var search = env;
-            var hops = 0;
-            for (; hops < MaxSlotCacheChainDepth && search is not null; hops++)
-            {
-                if (ReferenceEquals(search, cachedSlotEnv))
-                {
-                    break;
-                }
-                search = search._outerEnv;
-            }
-
-            if (search is null || hops == MaxSlotCacheChainDepth || !ReferenceEquals(search, cachedSlotEnv))
-            {
-                return false;
-            }
-
-            declarativeEnvironment = cachedSlotEnv;
-            slotIndex = _cachedSlotIndex;
-        }
-        else
-        {
-            var name = _leftIdentifier.Identifier;
-            if (!JintEnvironment.TryGetIdentifierEnvironmentWithBinding(env, name, out var record))
-            {
-                // unresolvable; the full path produces the proper error
-                return false;
-            }
-
-            if (record is not DeclarativeEnvironment resolved || (slotIndex = resolved.FindSlotIndex(name.Key)) < 0)
-            {
-                // the binding for this node can never be slot-stored; stop attempting
-                _discardFastPathDisabled = true;
-                return false;
-            }
-
-            declarativeEnvironment = resolved;
-            _cachedSlotEnv = resolved;
-            _cachedSlotIndex = slotIndex;
-        }
-
-        if (!declarativeEnvironment.TryGetNumberSlot(slotIndex, out var left))
+        if (!_slotCache.TryResolve(engine, engine.ExecutionContext.LexicalEnvironment, _leftIdentifier.Identifier, out var declarativeEnvironment, out var slotIndex)
+            || !declarativeEnvironment.TryGetNumberSlot(slotIndex, out var left))
         {
             return false;
         }
@@ -428,13 +377,13 @@ internal sealed class JintAssignmentExpression : JintExpression
                     result = TypeConverter.ToInt32(left) ^ TypeConverter.ToInt32(right);
                     break;
                 case Operator.LeftShiftAssignment:
-                    result = TypeConverter.ToInt32(left) << (int) (TypeConverter.ToUint32(rightNumber) & 0x1F);
+                    result = TypeConverter.ToInt32(left) << (int) (TypeConverter.ToUint32(right) & 0x1F);
                     break;
                 case Operator.RightShiftAssignment:
-                    result = TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(rightNumber) & 0x1F);
+                    result = TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(right) & 0x1F);
                     break;
                 case Operator.UnsignedRightShiftAssignment:
-                    result = (uint) TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(rightNumber) & 0x1F);
+                    result = (uint) TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(right) & 0x1F);
                     break;
                 default:
                     Throw.NotImplementedException();

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -62,7 +62,8 @@ internal sealed class JintAssignmentExpression : JintExpression
                 _leftIdentifier.Identifier,
                 strict,
                 out var identifierEnvironment,
-                out var temp))
+                out var temp)
+            && temp is not null) // an uninitialized (TDZ) binding reports null; the Reference path below produces the proper ReferenceError
         {
             originalLeftValue = temp;
             lref = engine._referencePool.Rent(identifierEnvironment, _leftIdentifier.Identifier.Value, strict, thisValue: null);

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -102,216 +102,6 @@ internal sealed class JintAssignmentExpression : JintExpression
         {
             switch (_operator)
             {
-                case Operator.AdditionAssignment:
-                    {
-                        var rval = _right.GetValue(context);
-                        if (context.IsSuspended())
-                        {
-                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
-                            return rval;
-                        }
-
-                        if (AreIntegerOperands(originalLeftValue, rval))
-                        {
-                            newLeftValue = (long) originalLeftValue.AsInteger() + rval.AsInteger();
-                        }
-                        else
-                        {
-                            var lprim = TypeConverter.ToPrimitive(originalLeftValue);
-                            var rprim = TypeConverter.ToPrimitive(rval);
-
-                            if (lprim.IsString() || rprim.IsString())
-                            {
-                                wasMutatedInPlace = lprim is JsString.ConcatenatedString;
-                                if (lprim is not JsString jsString)
-                                {
-                                    jsString = new JsString.ConcatenatedString(TypeConverter.ToString(lprim));
-                                }
-
-                                newLeftValue = jsString.Append(rprim);
-                            }
-                            else if (JintBinaryExpression.AreNonBigIntOperands(originalLeftValue, rval))
-                            {
-                                newLeftValue = TypeConverter.ToNumber(lprim) + TypeConverter.ToNumber(rprim);
-                            }
-                            else
-                            {
-                                JintBinaryExpression.AssertValidBigIntArithmeticOperands(lprim, rprim);
-                                newLeftValue = JsBigInt.Create(TypeConverter.ToBigInt(lprim) + TypeConverter.ToBigInt(rprim));
-                            }
-                        }
-
-                        break;
-                    }
-
-                case Operator.SubtractionAssignment:
-                    {
-                        var rval = _right.GetValue(context);
-                        if (context.IsSuspended())
-                        {
-                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
-                            return rval;
-                        }
-
-                        if (AreIntegerOperands(originalLeftValue, rval))
-                        {
-                            newLeftValue = JsNumber.Create((long) originalLeftValue.AsInteger() - rval.AsInteger());
-                        }
-                        else
-                        {
-                            var leftNumeric = TypeConverter.ToNumeric(originalLeftValue);
-                            var rightNumeric = TypeConverter.ToNumeric(rval);
-
-                            if (JintBinaryExpression.AreNonBigIntOperands(leftNumeric, rightNumeric))
-                            {
-                                newLeftValue = JsNumber.Create(leftNumeric.AsNumber() - rightNumeric.AsNumber());
-                            }
-                            else
-                            {
-                                JintBinaryExpression.AssertValidBigIntArithmeticOperands(leftNumeric, rightNumeric);
-                                newLeftValue = JsBigInt.Create(TypeConverter.ToBigInt(leftNumeric) - TypeConverter.ToBigInt(rightNumeric));
-                            }
-                        }
-
-                        break;
-                    }
-
-                case Operator.MultiplicationAssignment:
-                    {
-                        var rval = _right.GetValue(context);
-                        if (context.IsSuspended())
-                        {
-                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
-                            return rval;
-                        }
-
-                        if (AreIntegerOperands(originalLeftValue, rval))
-                        {
-                            newLeftValue = (long) originalLeftValue.AsInteger() * rval.AsInteger();
-                        }
-                        else
-                        {
-                            var leftNumeric = TypeConverter.ToNumeric(originalLeftValue);
-                            var rightNumeric = TypeConverter.ToNumeric(rval);
-
-                            if (JintBinaryExpression.AreNonBigIntOperands(leftNumeric, rightNumeric))
-                            {
-                                newLeftValue = leftNumeric.AsNumber() * rightNumeric.AsNumber();
-                            }
-                            else
-                            {
-                                JintBinaryExpression.AssertValidBigIntArithmeticOperands(leftNumeric, rightNumeric);
-                                newLeftValue = JsBigInt.Create(TypeConverter.ToBigInt(leftNumeric) * TypeConverter.ToBigInt(rightNumeric));
-                            }
-                        }
-
-                        break;
-                    }
-
-                case Operator.DivisionAssignment:
-                    {
-                        var rval = _right.GetValue(context);
-                        if (context.IsSuspended())
-                        {
-                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
-                            return rval;
-                        }
-
-                        newLeftValue = Divide(context, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval));
-                        break;
-                    }
-
-                case Operator.RemainderAssignment:
-                    {
-                        var rval = _right.GetValue(context);
-                        if (context.IsSuspended())
-                        {
-                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
-                            return rval;
-                        }
-
-                        newLeftValue = Remainder(context, originalLeftValue, rval);
-                        break;
-                    }
-
-                case Operator.BitwiseAndAssignment:
-                    {
-                        var rval = _right.GetValue(context);
-                        if (context.IsSuspended())
-                        {
-                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
-                            return rval;
-                        }
-
-                        newLeftValue = JintBinaryExpression.EvaluateBitwiseOperation(Operator.BitwiseAnd, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
-                        break;
-                    }
-
-                case Operator.BitwiseOrAssignment:
-                    {
-                        var rval = _right.GetValue(context);
-                        if (context.IsSuspended())
-                        {
-                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
-                            return rval;
-                        }
-
-                        newLeftValue = JintBinaryExpression.EvaluateBitwiseOperation(Operator.BitwiseOr, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
-                        break;
-                    }
-
-                case Operator.BitwiseXorAssignment:
-                    {
-                        var rval = _right.GetValue(context);
-                        if (context.IsSuspended())
-                        {
-                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
-                            return rval;
-                        }
-
-                        newLeftValue = JintBinaryExpression.EvaluateBitwiseOperation(Operator.BitwiseXor, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
-                        break;
-                    }
-
-                case Operator.LeftShiftAssignment:
-                    {
-                        var rval = _right.GetValue(context);
-                        if (context.IsSuspended())
-                        {
-                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
-                            return rval;
-                        }
-
-                        newLeftValue = JintBinaryExpression.EvaluateBitwiseOperation(Operator.LeftShift, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
-                        break;
-                    }
-
-                case Operator.RightShiftAssignment:
-                    {
-                        var rval = _right.GetValue(context);
-                        if (context.IsSuspended())
-                        {
-                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
-                            return rval;
-                        }
-
-                        newLeftValue = JintBinaryExpression.EvaluateBitwiseOperation(Operator.RightShift, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
-                        break;
-                    }
-
-                case Operator.UnsignedRightShiftAssignment:
-                    {
-                        var rval = _right.GetValue(context);
-                        if (context.IsSuspended())
-                        {
-                            HandleSuspendedRight(engine, suspendable, lref, originalLeftValue, lhsHasSideEffects);
-                            return rval;
-                        }
-
-                        newLeftValue = JintBinaryExpression.EvaluateBitwiseOperation(Operator.UnsignedRightShift, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
-                        break;
-                    }
-
                 case Operator.NullishCoalescingAssignment:
                     {
                         if (!originalLeftValue.IsNullOrUndefined())
@@ -372,7 +162,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         break;
                     }
 
-                case Operator.ExponentiationAssignment:
+                default:
                     {
                         var rval = _right.GetValue(context);
                         if (context.IsSuspended())
@@ -381,13 +171,9 @@ internal sealed class JintAssignmentExpression : JintExpression
                             return rval;
                         }
 
-                        newLeftValue = JintBinaryExpression.Exponentiate(context, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval));
+                        newLeftValue = ComputeCompound(context, originalLeftValue, rval, ref wasMutatedInPlace);
                         break;
                     }
-
-                default:
-                    Throw.NotImplementedException();
-                    return default;
             }
         }
 
@@ -400,6 +186,220 @@ internal sealed class JintAssignmentExpression : JintExpression
         engine._referencePool.Return(lref);
         suspendable?.Data.Clear(this);
         return newLeftValue!;
+    }
+
+    /// <summary>
+    /// Computes the result of a compound assignment operator (everything except the
+    /// logical/nullish forms, which short-circuit before evaluating the right operand).
+    /// Operands are fully evaluated; shared by the materialized and discard-mode lanes.
+    /// </summary>
+    private JsValue ComputeCompound(EvaluationContext context, JsValue originalLeftValue, JsValue rval, ref bool wasMutatedInPlace)
+    {
+        switch (_operator)
+        {
+            case Operator.AdditionAssignment:
+                {
+                    if (AreIntegerOperands(originalLeftValue, rval))
+                    {
+                        return JsNumber.Create((long) originalLeftValue.AsInteger() + rval.AsInteger());
+                    }
+
+                    var lprim = TypeConverter.ToPrimitive(originalLeftValue);
+                    var rprim = TypeConverter.ToPrimitive(rval);
+
+                    if (lprim.IsString() || rprim.IsString())
+                    {
+                        wasMutatedInPlace = lprim is JsString.ConcatenatedString;
+                        if (lprim is not JsString jsString)
+                        {
+                            jsString = new JsString.ConcatenatedString(TypeConverter.ToString(lprim));
+                        }
+
+                        return jsString.Append(rprim);
+                    }
+
+                    if (JintBinaryExpression.AreNonBigIntOperands(originalLeftValue, rval))
+                    {
+                        return JsNumber.Create(TypeConverter.ToNumber(lprim) + TypeConverter.ToNumber(rprim));
+                    }
+
+                    JintBinaryExpression.AssertValidBigIntArithmeticOperands(lprim, rprim);
+                    return JsBigInt.Create(TypeConverter.ToBigInt(lprim) + TypeConverter.ToBigInt(rprim));
+                }
+
+            case Operator.SubtractionAssignment:
+                {
+                    if (AreIntegerOperands(originalLeftValue, rval))
+                    {
+                        return JsNumber.Create((long) originalLeftValue.AsInteger() - rval.AsInteger());
+                    }
+
+                    var leftNumeric = TypeConverter.ToNumeric(originalLeftValue);
+                    var rightNumeric = TypeConverter.ToNumeric(rval);
+
+                    if (JintBinaryExpression.AreNonBigIntOperands(leftNumeric, rightNumeric))
+                    {
+                        return JsNumber.Create(leftNumeric.AsNumber() - rightNumeric.AsNumber());
+                    }
+
+                    JintBinaryExpression.AssertValidBigIntArithmeticOperands(leftNumeric, rightNumeric);
+                    return JsBigInt.Create(TypeConverter.ToBigInt(leftNumeric) - TypeConverter.ToBigInt(rightNumeric));
+                }
+
+            case Operator.MultiplicationAssignment:
+                {
+                    if (AreIntegerOperands(originalLeftValue, rval))
+                    {
+                        return JsNumber.Create((long) originalLeftValue.AsInteger() * rval.AsInteger());
+                    }
+
+                    var leftNumeric = TypeConverter.ToNumeric(originalLeftValue);
+                    var rightNumeric = TypeConverter.ToNumeric(rval);
+
+                    if (JintBinaryExpression.AreNonBigIntOperands(leftNumeric, rightNumeric))
+                    {
+                        return leftNumeric.AsNumber() * rightNumeric.AsNumber();
+                    }
+
+                    JintBinaryExpression.AssertValidBigIntArithmeticOperands(leftNumeric, rightNumeric);
+                    return JsBigInt.Create(TypeConverter.ToBigInt(leftNumeric) * TypeConverter.ToBigInt(rightNumeric));
+                }
+
+            case Operator.DivisionAssignment:
+                return Divide(context, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval));
+
+            case Operator.RemainderAssignment:
+                return Remainder(context, originalLeftValue, rval);
+
+            case Operator.BitwiseAndAssignment:
+                return JintBinaryExpression.EvaluateBitwiseOperation(Operator.BitwiseAnd, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
+
+            case Operator.BitwiseOrAssignment:
+                return JintBinaryExpression.EvaluateBitwiseOperation(Operator.BitwiseOr, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
+
+            case Operator.BitwiseXorAssignment:
+                return JintBinaryExpression.EvaluateBitwiseOperation(Operator.BitwiseXor, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
+
+            case Operator.LeftShiftAssignment:
+                return JintBinaryExpression.EvaluateBitwiseOperation(Operator.LeftShift, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
+
+            case Operator.RightShiftAssignment:
+                return JintBinaryExpression.EvaluateBitwiseOperation(Operator.RightShift, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
+
+            case Operator.UnsignedRightShiftAssignment:
+                return JintBinaryExpression.EvaluateBitwiseOperation(Operator.UnsignedRightShift, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval), _left._expression);
+
+            case Operator.ExponentiationAssignment:
+                return JintBinaryExpression.Exponentiate(context, TypeConverter.ToNumeric(originalLeftValue), TypeConverter.ToNumeric(rval));
+
+            default:
+                Throw.NotImplementedException();
+                return null!;
+        }
+    }
+
+    internal override void EvaluateAndDiscard(EvaluationContext context)
+    {
+        var oldSyntaxElement = context.LastSyntaxElement;
+        context.PrepareFor(_expression);
+
+        if (!TryCompoundUnboxed(context))
+        {
+            EvaluateInternal(context);
+        }
+
+        context.LastSyntaxElement = oldSyntaxElement;
+    }
+
+    /// <summary>
+    /// Discard-mode fast path: a numeric compound assignment to a slot-stored number binding
+    /// computes on raw doubles and stores unboxed, with no materialization of the old or new
+    /// value. The right-hand side runs exactly once; non-number results complete through the
+    /// shared <see cref="ComputeCompound"/>. Everything that needs the full semantics
+    /// (operator overloading, generators/async, logical/nullish forms, TDZ, const, non-number
+    /// left values, dictionary/global/object environments) falls back before any evaluation.
+    /// </summary>
+    private bool TryCompoundUnboxed(EvaluationContext context)
+    {
+        var engine = context.Engine;
+        if (_leftIdentifier is null
+            || context.OperatorOverloadingAllowed
+            || engine.ExecutionContext.Suspendable is not null
+            || _operator is Operator.NullishCoalescingAssignment or Operator.LogicalAndAssignment or Operator.LogicalOrAssignment)
+        {
+            return false;
+        }
+
+        var name = _leftIdentifier.Identifier;
+        if (!JintEnvironment.TryGetIdentifierEnvironmentWithBinding(
+                engine.ExecutionContext.LexicalEnvironment,
+                name,
+                out var record)
+            || record is not DeclarativeEnvironment declarativeEnvironment
+            || !declarativeEnvironment.TryGetNumberSlot(name.Key, out var slotIndex, out var left))
+        {
+            return false;
+        }
+
+        var rval = _right.GetValue(context);
+
+        if (rval is JsNumber rightNumber && _operator != Operator.ExponentiationAssignment)
+        {
+            var right = rightNumber._value;
+            double result;
+            switch (_operator)
+            {
+                case Operator.AdditionAssignment:
+                    result = left + right;
+                    break;
+                case Operator.SubtractionAssignment:
+                    result = left - right;
+                    break;
+                case Operator.MultiplicationAssignment:
+                    result = left * right;
+                    break;
+                case Operator.DivisionAssignment:
+                    // IEEE 754 division matches the ECMAScript algorithm for all special cases
+                    result = left / right;
+                    break;
+                case Operator.RemainderAssignment:
+                    // IEEE 754 remainder (fmod) matches the ECMAScript algorithm for all special cases
+                    result = left % right;
+                    break;
+                case Operator.BitwiseAndAssignment:
+                    result = TypeConverter.ToInt32(left) & TypeConverter.ToInt32(right);
+                    break;
+                case Operator.BitwiseOrAssignment:
+                    result = TypeConverter.ToInt32(left) | TypeConverter.ToInt32(right);
+                    break;
+                case Operator.BitwiseXorAssignment:
+                    result = TypeConverter.ToInt32(left) ^ TypeConverter.ToInt32(right);
+                    break;
+                case Operator.LeftShiftAssignment:
+                    result = TypeConverter.ToInt32(left) << (int) (TypeConverter.ToUint32(rightNumber) & 0x1F);
+                    break;
+                case Operator.RightShiftAssignment:
+                    result = TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(rightNumber) & 0x1F);
+                    break;
+                case Operator.UnsignedRightShiftAssignment:
+                    result = (uint) TypeConverter.ToInt32(left) >> (int) (TypeConverter.ToUint32(rightNumber) & 0x1F);
+                    break;
+                default:
+                    Throw.NotImplementedException();
+                    return false;
+            }
+
+            declarativeEnvironment.SetNumberSlot(slotIndex, result);
+            return true;
+        }
+
+        // rare: number op= non-number (string concat, BigInt mix error, exponentiation).
+        // The left operand is a number, never a ConcatenatedString, so in-place mutation
+        // cannot apply and the result is always stored.
+        var wasMutatedInPlace = false;
+        var newLeftValue = ComputeCompound(context, JsNumber.Create(left), rval, ref wasMutatedInPlace);
+        record.SetMutableBinding(name.Key, newLeftValue, StrictModeScope.IsStrictModeCode);
+        return true;
     }
 
     private void HandleSuspendedRight(Engine engine, ISuspendable? suspendable, Reference lref, JsValue originalLeftValue, bool lhsHasSideEffects)

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -55,6 +55,13 @@ internal abstract class JintExpression
     protected abstract object EvaluateInternal(EvaluationContext context);
 
     /// <summary>
+    /// True when this expression type overrides <see cref="EvaluateAndDiscard"/> with a
+    /// non-materializing fast path; callers use it to keep every other expression on its
+    /// exact current call sequence.
+    /// </summary>
+    internal virtual bool HasDiscardFastPath => false;
+
+    /// <summary>
     /// Evaluates the expression for its side effects only; the caller guarantees the result
     /// is unobservable (e.g. an expression statement inside a function body). Expression types
     /// with a non-materializing fast path override this; the default matches <see cref="GetValue"/>.

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -55,6 +55,16 @@ internal abstract class JintExpression
     protected abstract object EvaluateInternal(EvaluationContext context);
 
     /// <summary>
+    /// Evaluates the expression for its side effects only; the caller guarantees the result
+    /// is unobservable (e.g. an expression statement inside a function body). Expression types
+    /// with a non-materializing fast path override this; the default matches <see cref="GetValue"/>.
+    /// </summary>
+    internal virtual void EvaluateAndDiscard(EvaluationContext context)
+    {
+        GetValue(context);
+    }
+
+    /// <summary>
     /// Resolves this expression as a boolean value.
     /// Comparison expressions override this to avoid creating a JsBoolean wrapper.
     /// </summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -123,6 +123,14 @@ internal sealed class JintIdentifierExpression : JintExpression
                     }
                     break;
                 }
+
+                if (search is ObjectEnvironment)
+                {
+                    // a with-object between us and the cached slot may shadow the name
+                    // dynamically; only the full resolution can decide who owns the binding
+                    break;
+                }
+
                 search = search._outerEnv;
             }
         }
@@ -157,19 +165,13 @@ internal sealed class JintIdentifierExpression : JintExpression
             // Populate slot-binding cache when the resolved env stores this binding in a fixed slot.
             // Closure-captured envs cannot be pooled (escape detection prevents it), so caching the
             // env reference is safe; slot indices are immutable for the lifetime of the env.
-            if (identifierEnvironment is DeclarativeEnvironment denv
-                && denv._slots is not null
-                && denv._slotNames is { } slotNames)
+            if (identifierEnvironment is DeclarativeEnvironment denv)
             {
-                var key = identifier.Key;
-                for (var i = 0; i < slotNames.Length; i++)
+                var slotIndex = denv.FindSlotIndex(identifier.Key);
+                if (slotIndex >= 0)
                 {
-                    if (slotNames[i] == key)
-                    {
-                        _cachedSlotEnv = denv;
-                        _cachedSlotIndex = i;
-                        break;
-                    }
+                    _cachedSlotEnv = denv;
+                    _cachedSlotIndex = slotIndex;
                 }
             }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -111,7 +111,10 @@ internal sealed class JintIdentifierExpression : JintExpression
                     var idx = _cachedSlotIndex;
                     if (slots is not null && (uint) idx < (uint) slots.Length)
                     {
-                        value = slots[idx].Value;
+                        ref var binding = ref slots[idx];
+                        value = binding.HasReferenceValue
+                            ? binding.Value
+                            : DeclarativeEnvironment.MaterializeUnboxedOrNull(ref binding);
                         if (value is null)
                         {
                             ThrowNotInitialized(engine);

--- a/Jint/Runtime/Interpreter/Expressions/JintSequenceExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintSequenceExpression.cs
@@ -5,6 +5,7 @@ namespace Jint.Runtime.Interpreter.Expressions;
 internal sealed class JintSequenceExpression : JintExpression
 {
     private readonly JintExpression[] _expressions;
+    private readonly bool _hasDiscardFastPath;
 
     public JintSequenceExpression(SequenceExpression expression) : base(expression)
     {
@@ -13,9 +14,34 @@ internal sealed class JintSequenceExpression : JintExpression
         for (var i = 0; i < (uint) temp.Length; i++)
         {
             temp[i] = Build(expressions[i]);
+            _hasDiscardFastPath |= temp[i].HasDiscardFastPath;
         }
 
         _expressions = temp;
+    }
+
+    internal override bool HasDiscardFastPath => _hasDiscardFastPath;
+
+    internal override void EvaluateAndDiscard(EvaluationContext context)
+    {
+        // suspension bookkeeping (resume index) lives in EvaluateInternal; only plain
+        // synchronous frames may forward the discard to operands (e.g. `i++, j--`)
+        if (context.Engine.ExecutionContext.Suspendable is not null)
+        {
+            GetValue(context);
+            return;
+        }
+
+        var oldSyntaxElement = context.LastSyntaxElement;
+        context.PrepareFor(_expression);
+
+        var expressions = _expressions;
+        for (var i = 0; i < expressions.Length; i++)
+        {
+            expressions[i].EvaluateAndDiscard(context);
+        }
+
+        context.LastSyntaxElement = oldSyntaxElement;
     }
 
     protected override object EvaluateInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -14,15 +14,9 @@ internal sealed class JintUpdateExpression : JintExpression
     private readonly JintIdentifierExpression? _leftIdentifier;
     private readonly bool _evalOrArguments;
 
-    // Slot-location cache for the discard-mode fast path; same validity reasoning as
-    // JintIdentifierExpression's slot-binding cache: closure-captured envs cannot be
-    // pooled, so the env reference is stable and slot indices are immutable.
-    // _discardFastPathDisabled marks nodes whose binding can never be slot-stored
-    // (global/object/dictionary environments) so failed attempts don't re-walk the chain.
-    private DeclarativeEnvironment? _cachedSlotEnv;
-    private int _cachedSlotIndex = -1;
-    private bool _discardFastPathDisabled;
-    private const int MaxSlotCacheChainDepth = 4;
+    // Slot-location cache for the discard-mode fast path; see SlotLocationCache for the
+    // validity reasoning (with-statement shadowing, pooling, cross-engine sharing).
+    private SlotLocationCache _slotCache;
 
     public JintUpdateExpression(UpdateExpression expression) : base(expression)
     {
@@ -54,6 +48,8 @@ internal sealed class JintUpdateExpression : JintExpression
         return fastResult ?? UpdateNonIdentifier(context);
     }
 
+    internal override bool HasDiscardFastPath => true;
+
     internal override void EvaluateAndDiscard(EvaluationContext context)
     {
         var oldSyntaxElement = context.LastSyntaxElement;
@@ -77,7 +73,6 @@ internal sealed class JintUpdateExpression : JintExpression
     {
         var engine = context.Engine;
         if (_leftIdentifier is null
-            || _discardFastPathDisabled
             || context.OperatorOverloadingAllowed
             || engine.ExecutionContext.Suspendable is not null)
         {
@@ -90,60 +85,8 @@ internal sealed class JintUpdateExpression : JintExpression
             return false;
         }
 
-        var env = engine.ExecutionContext.LexicalEnvironment;
-
-        var cachedSlotEnv = _cachedSlotEnv;
-        if (cachedSlotEnv is not null)
-        {
-            if (!ReferenceEquals(cachedSlotEnv._engine, engine))
-            {
-                return ResolveSlotAndUpdate(engine, env);
-            }
-
-            var search = env;
-            for (var hops = 0; hops < MaxSlotCacheChainDepth && search is not null; hops++)
-            {
-                if (ReferenceEquals(search, cachedSlotEnv))
-                {
-                    return TryUpdateSlot(cachedSlotEnv, _cachedSlotIndex);
-                }
-                search = search._outerEnv;
-            }
-
-            return false;
-        }
-
-        return ResolveSlotAndUpdate(engine, env);
-    }
-
-    private bool ResolveSlotAndUpdate(Engine engine, Environment env)
-    {
-        var name = _leftIdentifier!.Identifier;
-        if (!JintEnvironment.TryGetIdentifierEnvironmentWithBinding(env, name, out var record))
-        {
-            // unresolvable; the full path produces the proper error
-            return false;
-        }
-
-        if (record is DeclarativeEnvironment declarativeEnvironment)
-        {
-            var slotIndex = declarativeEnvironment.FindSlotIndex(name.Key);
-            if (slotIndex >= 0)
-            {
-                _cachedSlotEnv = declarativeEnvironment;
-                _cachedSlotIndex = slotIndex;
-                return TryUpdateSlot(declarativeEnvironment, slotIndex);
-            }
-        }
-
-        // the binding for this node can never be slot-stored; stop attempting
-        _discardFastPathDisabled = true;
-        return false;
-    }
-
-    private bool TryUpdateSlot(DeclarativeEnvironment environment, int slotIndex)
-    {
-        if (!environment.TryGetNumberSlot(slotIndex, out var value))
+        if (!_slotCache.TryResolve(engine, engine.ExecutionContext.LexicalEnvironment, _leftIdentifier.Identifier, out var environment, out var slotIndex)
+            || !environment.TryGetNumberSlot(slotIndex, out var value))
         {
             return false;
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -1,6 +1,8 @@
 using Jint.Native;
 using Jint.Runtime.Environments;
 
+using Environment = Jint.Runtime.Environments.Environment;
+
 namespace Jint.Runtime.Interpreter.Expressions;
 
 internal sealed class JintUpdateExpression : JintExpression
@@ -11,6 +13,16 @@ internal sealed class JintUpdateExpression : JintExpression
 
     private readonly JintIdentifierExpression? _leftIdentifier;
     private readonly bool _evalOrArguments;
+
+    // Slot-location cache for the discard-mode fast path; same validity reasoning as
+    // JintIdentifierExpression's slot-binding cache: closure-captured envs cannot be
+    // pooled, so the env reference is stable and slot indices are immutable.
+    // _discardFastPathDisabled marks nodes whose binding can never be slot-stored
+    // (global/object/dictionary environments) so failed attempts don't re-walk the chain.
+    private DeclarativeEnvironment? _cachedSlotEnv;
+    private int _cachedSlotIndex = -1;
+    private bool _discardFastPathDisabled;
+    private const int MaxSlotCacheChainDepth = 4;
 
     public JintUpdateExpression(UpdateExpression expression) : base(expression)
     {
@@ -65,6 +77,7 @@ internal sealed class JintUpdateExpression : JintExpression
     {
         var engine = context.Engine;
         if (_leftIdentifier is null
+            || _discardFastPathDisabled
             || context.OperatorOverloadingAllowed
             || engine.ExecutionContext.Suspendable is not null)
         {
@@ -77,18 +90,65 @@ internal sealed class JintUpdateExpression : JintExpression
             return false;
         }
 
-        var name = _leftIdentifier.Identifier;
-        if (!JintEnvironment.TryGetIdentifierEnvironmentWithBinding(
-                engine.ExecutionContext.LexicalEnvironment,
-                name,
-                out var record)
-            || record is not DeclarativeEnvironment declarativeEnvironment
-            || !declarativeEnvironment.TryGetNumberSlot(name.Key, out var slotIndex, out var value))
+        var env = engine.ExecutionContext.LexicalEnvironment;
+
+        var cachedSlotEnv = _cachedSlotEnv;
+        if (cachedSlotEnv is not null)
+        {
+            if (!ReferenceEquals(cachedSlotEnv._engine, engine))
+            {
+                return ResolveSlotAndUpdate(engine, env);
+            }
+
+            var search = env;
+            for (var hops = 0; hops < MaxSlotCacheChainDepth && search is not null; hops++)
+            {
+                if (ReferenceEquals(search, cachedSlotEnv))
+                {
+                    return TryUpdateSlot(cachedSlotEnv, _cachedSlotIndex);
+                }
+                search = search._outerEnv;
+            }
+
+            return false;
+        }
+
+        return ResolveSlotAndUpdate(engine, env);
+    }
+
+    private bool ResolveSlotAndUpdate(Engine engine, Environment env)
+    {
+        var name = _leftIdentifier!.Identifier;
+        if (!JintEnvironment.TryGetIdentifierEnvironmentWithBinding(env, name, out var record))
+        {
+            // unresolvable; the full path produces the proper error
+            return false;
+        }
+
+        if (record is DeclarativeEnvironment declarativeEnvironment)
+        {
+            var slotIndex = declarativeEnvironment.FindSlotIndex(name.Key);
+            if (slotIndex >= 0)
+            {
+                _cachedSlotEnv = declarativeEnvironment;
+                _cachedSlotIndex = slotIndex;
+                return TryUpdateSlot(declarativeEnvironment, slotIndex);
+            }
+        }
+
+        // the binding for this node can never be slot-stored; stop attempting
+        _discardFastPathDisabled = true;
+        return false;
+    }
+
+    private bool TryUpdateSlot(DeclarativeEnvironment environment, int slotIndex)
+    {
+        if (!environment.TryGetNumberSlot(slotIndex, out var value))
         {
             return false;
         }
 
-        declarativeEnvironment.SetNumberSlot(slotIndex, value + _change);
+        environment.SetNumberSlot(slotIndex, value + _change);
         return true;
     }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -42,6 +42,56 @@ internal sealed class JintUpdateExpression : JintExpression
         return fastResult ?? UpdateNonIdentifier(context);
     }
 
+    internal override void EvaluateAndDiscard(EvaluationContext context)
+    {
+        var oldSyntaxElement = context.LastSyntaxElement;
+        context.PrepareFor(_expression);
+
+        if (!TryUpdateUnboxed(context))
+        {
+            EvaluateInternal(context);
+        }
+
+        context.LastSyntaxElement = oldSyntaxElement;
+    }
+
+    /// <summary>
+    /// Discard-mode fast path: increments a slot-stored number binding without materializing
+    /// the old or new value. Anything that needs the full semantics (operator overloading,
+    /// generators/async, TDZ, const, non-number values, dictionary/global/object environments)
+    /// falls back to the materialized path which produces the exact errors and coercions.
+    /// </summary>
+    private bool TryUpdateUnboxed(EvaluationContext context)
+    {
+        var engine = context.Engine;
+        if (_leftIdentifier is null
+            || context.OperatorOverloadingAllowed
+            || engine.ExecutionContext.Suspendable is not null)
+        {
+            return false;
+        }
+
+        if (_evalOrArguments && StrictModeScope.IsStrictModeCode)
+        {
+            // full path raises the proper SyntaxError
+            return false;
+        }
+
+        var name = _leftIdentifier.Identifier;
+        if (!JintEnvironment.TryGetIdentifierEnvironmentWithBinding(
+                engine.ExecutionContext.LexicalEnvironment,
+                name,
+                out var record)
+            || record is not DeclarativeEnvironment declarativeEnvironment
+            || !declarativeEnvironment.TryGetNumberSlot(name.Key, out var slotIndex, out var value))
+        {
+            return false;
+        }
+
+        declarativeEnvironment.SetNumberSlot(slotIndex, value + _change);
+        return true;
+    }
+
     private JsValue UpdateNonIdentifier(EvaluationContext context)
     {
         var engine = context.Engine;

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -117,7 +117,8 @@ internal sealed class JintUpdateExpression : JintExpression
                 name,
                 strict,
                 out var environmentRecord,
-                out var value))
+                out var value)
+            && value is not null) // an uninitialized (TDZ) binding reports null; the Reference path produces the proper ReferenceError
         {
             if (_evalOrArguments && strict)
             {

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -7,11 +7,24 @@ using Jint.Runtime.Interpreter.Statements;
 
 namespace Jint.Runtime.Interpreter;
 
+internal enum CompletionValueObservability : byte
+{
+    /// <summary>Keep the enclosing frame's observability (nested blocks, switch consequents).</summary>
+    Inherit = 0,
+
+    /// <summary>Completion values feed Engine.Evaluate / eval / module results (top-level lists).</summary>
+    Observable = 1,
+
+    /// <summary>Function bodies: only Return/Throw completions surface, Normal values may be elided.</summary>
+    NotObservable = 2,
+}
+
 internal sealed class JintStatementList
 {
     private readonly record struct Pair(JintStatement Statement, JsValue? Value);
 
     private readonly Statement? _statement;
+    private readonly CompletionValueObservability _observability;
 
     private readonly Pair[] _jintStatements;
     private uint _index;
@@ -26,13 +39,19 @@ internal sealed class JintStatementList
     }
 
     public JintStatementList(Program program)
-        : this(null, program.Body)
+        : this(null, program.Body, CompletionValueObservability.Observable)
     {
     }
 
-    public JintStatementList(Statement? statement, in NodeList<Statement> statements)
+    public JintStatementList(Statement? statement, in NodeList<Statement> statements, CompletionValueObservability? observability = null)
     {
         _statement = statement;
+        _observability = observability
+            ?? (statement is FunctionBody
+                ? CompletionValueObservability.NotObservable
+                : statement is null
+                    ? CompletionValueObservability.Observable
+                    : CompletionValueObservability.Inherit);
         var jintStatements = new Pair[statements.Count];
         for (var i = 0; i < jintStatements.Length; i++)
         {
@@ -61,16 +80,13 @@ internal sealed class JintStatementList
 
         // Completion-value elision: inside function bodies Normal-completion values are
         // spec-unobservable (only Return/Throw matter), so expression statements may skip
-        // materializing their value. Top-level lists (_statement == null: script, eval text,
-        // module, switch consequents) must surface real values for Engine.Evaluate/eval results.
+        // materializing their value; top-level lists (script, eval text, module) must surface
+        // real values for Engine.Evaluate/eval results, and nested lists (blocks, switch
+        // consequents) inherit the enclosing frame's observability.
         var oldCompletionValuesObservable = context.CompletionValuesObservable;
-        if (_statement is FunctionBody)
+        if (_observability != CompletionValueObservability.Inherit)
         {
-            context.CompletionValuesObservable = false;
-        }
-        else if (_statement is null)
-        {
-            context.CompletionValuesObservable = true;
+            context.CompletionValuesObservable = _observability == CompletionValueObservability.Observable;
         }
 
         // The value of a StatementList is the value of the last value-producing item in the StatementList

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -59,6 +59,20 @@ internal sealed class JintStatementList
         Completion c = Completion.Empty();
         Completion sl = c;
 
+        // Completion-value elision: inside function bodies Normal-completion values are
+        // spec-unobservable (only Return/Throw matter), so expression statements may skip
+        // materializing their value. Top-level lists (_statement == null: script, eval text,
+        // module, switch consequents) must surface real values for Engine.Evaluate/eval results.
+        var oldCompletionValuesObservable = context.CompletionValuesObservable;
+        if (_statement is FunctionBody)
+        {
+            context.CompletionValuesObservable = false;
+        }
+        else if (_statement is null)
+        {
+            context.CompletionValuesObservable = true;
+        }
+
         // The value of a StatementList is the value of the last value-producing item in the StatementList
         var lastValue = JsEmpty.Instance;
         var i = _index;
@@ -150,6 +164,10 @@ internal sealed class JintStatementList
                 ExceptionDataHelper.TryAttachJavaScriptLocation(ex, context.Engine, locationNode.Location);
                 throw;
             }
+        }
+        finally
+        {
+            context.CompletionValuesObservable = oldCompletionValuesObservable;
         }
 
         // Only apply the final UpdateEmpty(Undefined) at program/script level or function body level.

--- a/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
@@ -10,17 +10,24 @@ internal sealed class JintExpressionStatement : JintStatement<ExpressionStatemen
     // identifiers are queried the most
     private readonly JintIdentifierExpression? _identifierExpression;
 
+    // only these node types have a non-materializing discard path; gating here keeps
+    // every other statement on the exact same call sequence as before
+    private readonly bool _expressionCanDiscard;
+
     public JintExpressionStatement(ExpressionStatement statement) : base(statement)
     {
         _expression = JintExpression.Build(statement.Expression);
         _identifierExpression = _expression as JintIdentifierExpression;
+        _expressionCanDiscard = _expression is JintUpdateExpression or JintAssignmentExpression;
     }
 
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
         // generators/async functions surface suspended values through completions,
         // so elision only applies in plain synchronous frames
-        if (context.CompletionValuesObservable || context.Engine.ExecutionContext.Suspendable is not null)
+        if (!_expressionCanDiscard
+            || context.CompletionValuesObservable
+            || context.Engine.ExecutionContext.Suspendable is not null)
         {
             var value = _identifierExpression is not null
                 ? _identifierExpression.GetValue(context)

--- a/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
@@ -10,7 +10,7 @@ internal sealed class JintExpressionStatement : JintStatement<ExpressionStatemen
     // identifiers are queried the most
     private readonly JintIdentifierExpression? _identifierExpression;
 
-    // only these node types have a non-materializing discard path; gating here keeps
+    // only node types with a non-materializing discard path divert; gating here keeps
     // every other statement on the exact same call sequence as before
     private readonly bool _expressionCanDiscard;
 
@@ -18,7 +18,7 @@ internal sealed class JintExpressionStatement : JintStatement<ExpressionStatemen
     {
         _expression = JintExpression.Build(statement.Expression);
         _identifierExpression = _expression as JintIdentifierExpression;
-        _expressionCanDiscard = _expression is JintUpdateExpression or JintAssignmentExpression;
+        _expressionCanDiscard = _expression.HasDiscardFastPath;
     }
 
     protected override Completion ExecuteInternal(EvaluationContext context)

--- a/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
@@ -1,3 +1,4 @@
+using Jint.Native;
 using Jint.Runtime.Interpreter.Expressions;
 
 namespace Jint.Runtime.Interpreter.Statements;
@@ -17,10 +18,18 @@ internal sealed class JintExpressionStatement : JintStatement<ExpressionStatemen
 
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
-        var value = _identifierExpression is not null
-            ? _identifierExpression.GetValue(context)
-            : _expression.GetValue(context);
+        // generators/async functions surface suspended values through completions,
+        // so elision only applies in plain synchronous frames
+        if (context.CompletionValuesObservable || context.Engine.ExecutionContext.Suspendable is not null)
+        {
+            var value = _identifierExpression is not null
+                ? _identifierExpression.GetValue(context)
+                : _expression.GetValue(context);
 
-        return new Completion(context.Completion, value, _statement);
+            return new Completion(context.Completion, value, _statement);
+        }
+
+        _expression.EvaluateAndDiscard(context);
+        return new Completion(context.Completion, JsValue.Undefined, _statement);
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -15,6 +15,7 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
 
     private readonly JintExpression? _test;
     private readonly JintExpression? _increment;
+    private readonly bool _incrementCanDiscard;
 
     private readonly ProbablyBlockStatement _body;
     private readonly List<Key>? _boundNames;
@@ -60,6 +61,9 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         if (statement.Update != null)
         {
             _increment = JintExpression.Build(statement.Update);
+            // restricted to types whose Evaluate() result is a plain value (never a Reference)
+            // so the discard path matches today's semantics exactly
+            _incrementCanDiscard = _increment is JintUpdateExpression or JintAssignmentExpression;
         }
     }
 
@@ -301,7 +305,16 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
             if (_increment != null)
             {
                 debugHandler?.OnStep(_increment._expression);
-                _increment.Evaluate(context);
+                if (_incrementCanDiscard)
+                {
+                    // update/compound assignment results are unobservable here and these
+                    // node types have non-materializing fast paths
+                    _increment.EvaluateAndDiscard(context);
+                }
+                else
+                {
+                    _increment.Evaluate(context);
+                }
 
                 // Check for suspension in update expression (e.g., yield in the update)
                 if (context.IsSuspended())

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -63,7 +63,7 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
             _increment = JintExpression.Build(statement.Update);
             // restricted to types whose Evaluate() result is a plain value (never a Reference)
             // so the discard path matches today's semantics exactly
-            _incrementCanDiscard = _increment is JintUpdateExpression or JintAssignmentExpression;
+            _incrementCanDiscard = _increment.HasDiscardFastPath;
         }
     }
 

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
@@ -216,7 +216,7 @@ start:
 
         public JintSwitchCase(SwitchCase switchCase)
         {
-            Consequent = new JintStatementList(statement: null, switchCase.Consequent);
+            Consequent = new JintStatementList(statement: null, switchCase.Consequent, CompletionValueObservability.Inherit);
             LexicalDeclarations = DeclarationCacheBuilder.Build(switchCase);
             Range = switchCase.Range;
             TestRange = switchCase.Test?.Range;

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -437,6 +437,20 @@ public static class TypeConverter
     }
 
     /// <summary>
+    /// https://tc39.es/ecma262/#sec-touint32
+    /// </summary>
+    internal static uint ToUint32(double value)
+    {
+        if (value is >= 0.0 and <= uint.MaxValue)
+        {
+            // Double-to-uint cast is correct in this range
+            return (uint) value;
+        }
+
+        return (uint) DoubleToInt32Slow(value);
+    }
+
+    /// <summary>
     /// http://www.ecma-international.org/ecma-262/5.1/#sec-9.5
     /// </summary>
     public static int ToInt32(JsValue o)
@@ -446,14 +460,7 @@ public static class TypeConverter
             return o.AsInteger();
         }
 
-        var doubleVal = ToNumber(o);
-        if (doubleVal >= -(double) int.MinValue && doubleVal <= int.MaxValue)
-        {
-            // Double-to-int cast is correct in this range
-            return (int) doubleVal;
-        }
-
-        return DoubleToInt32Slow(doubleVal);
+        return ToInt32(ToNumber(o));
     }
 
     /// <summary>

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -425,6 +425,20 @@ public static class TypeConverter
     /// <summary>
     /// http://www.ecma-international.org/ecma-262/5.1/#sec-9.5
     /// </summary>
+    internal static int ToInt32(double value)
+    {
+        if (value is >= int.MinValue and <= int.MaxValue)
+        {
+            // Double-to-int cast truncates toward zero, matching the spec in this range
+            return (int) value;
+        }
+
+        return DoubleToInt32Slow(value);
+    }
+
+    /// <summary>
+    /// http://www.ecma-international.org/ecma-262/5.1/#sec-9.5
+    /// </summary>
     public static int ToInt32(JsValue o)
     {
         if (o._type == InternalTypes.Integer)


### PR DESCRIPTION
Numeric read-modify-write statements on function-local bindings (`s += 0.25;`, `i++;` and friends) currently allocate a `JsNumber` per write once values leave the interned-int cache — double accumulators and large counters allocate on every loop iteration. This PR stores such values as raw doubles inside the environment slot and skips materialization entirely when the statement result is unobservable.

The first two commits fix pre-existing `NullReferenceException`s (instead of the spec-required `ReferenceError`) for compound assignment / update expressions on uninitialized (TDZ) bindings, e.g. `{ x += 1; let x; }` — found by this work's test coverage and continuing the theme of #2497.

## Design

**Unboxed slot storage** — `Binding` packs its bools into a flags byte and gains a raw-double field. A slot binding can now be in a third state: *unboxed number*. Reads keep their existing instruction stream — the unboxed check nests inside the pre-existing null/TDZ branch — and a materializing read converts through `JsNumber.Create` with **write-back caching**, so repeated reads observe one instance and read-many patterns never cost more than the one allocation per write the boxed representation already paid. `TryGetNumberSlot` carries the same `(uint)` bounds guard as the identifier read path, so a stale cache falls back instead of throwing.

**Discard lane** — Normal-completion values of statements are spec-observable only at script/eval/module top level. Completion-value observability is an explicit per-list mode (`Observable` for top-level script/eval/module lists, `NotObservable` for function bodies, `Inherit` for nested blocks *and switch-case consequents*), maintained by `JintStatementList` with save/restore on `EvaluationContext.CompletionValuesObservable`. Expression statements in unobservable frames evaluate through a new `JintExpression.EvaluateAndDiscard` virtual whose default matches `GetValue`.

The lane is gated by a `HasDiscardFastPath` capability virtual rather than hardcoded type lists: update and compound assignment expressions override it, and `JintSequenceExpression` forwards the discard to its operands so comma-separated for-loop updates (`for (...; ...; i++, j--)`) reach the fast path too. Everything else keeps its exact current call sequence; generators/async functions always use the materializing path because suspended values flow through completions.

**Producers** — discarded `i++`/`i--` and numeric compound assignments compute on raw doubles and store unboxed. The fast path engages only when every full-semantics trigger is absent (identifier target, no operator overloading, no generator/async frame, slot-stored mutable number binding, non-logical operator). The right-hand side runs exactly once; non-number results complete through `ComputeCompound`, the per-operator computation extracted from `EvaluateInternal` and shared by both lanes. IEEE 754 double division/remainder match the ECMAScript algorithms exactly, so the raw arms need no special cases.

**Slot-location caching** — the per-node cache (environment + slot index) used by the identifier read fast path and both producers now lives in a single `SlotLocationCache` struct. The chain walk validates the cached env by reference equality with an engine-identity gate, **refuses to skip over an `ObjectEnvironment`** (a `with` object can gain a shadowing property at any time — the check sits after the equality test so hop-0 hits pay nothing), and permanently disables itself for nodes whose binding can never be slot-stored (global/object/dictionary environments) so non-qualifying code doesn't pay a second environment walk.

## Bugs found and fixed along the way

- **Dynamic `with`-statement shadowing**: the previous per-node slot caches (and the identifier read cache that already ships in `main`) walked the env chain by reference equality only, so a `with` object that *gained* a shadowing property after the cache was populated kept being bypassed — reads returned the stale local, and the new write fast paths updated the local slot instead of the with-object property (`with (obj) { i++; }`). Fixed for reads, updates and compound assignments via the shared cache; covered by regression tests.
- **Dead `ToInt32(JsValue)` fast path**: its range guard read `doubleVal >= -(double) int.MinValue` (i.e. `>= 2147483648`) combined with `<= int.MaxValue` — unsatisfiable — so every non-Integer bitwise/shift operand engine-wide took `DoubleToInt32Slow`. It now delegates to a corrected double-based `ToInt32`; a `ToUint32(double)` twin keeps raw-double shift counts off the `JsValue` path.

## Benchmarks

Paired back-to-back runs on the same machine (BenchmarkDotNet defaults, `[MemoryDiagnoser]`), final branch head. New `FunctionLocalNumberLoopBenchmark` covers the targeted patterns, which the existing suite under-covers because its loops live at script top level where bindings are global-object properties:

| Benchmark | Base | PR | Time | Allocated |
|---|---|---|---:|---:|
| DoubleAccumulator | 9.21 ms / 5.48 MB | 5.68 ms / 2.74 MB | **−38%** | **−50%** |
| LargeIntCounter | 8.66 ms / 5.48 MB | 5.66 ms / 2.74 MB | **−35%** | **−50%** |
| AccumulatorWithCallArg | 37.59 ms / 12.04 MB | 35.08 ms / 9.30 MB | **−7%** | **−23%** |
| MixedArithmetic | 26.78 ms / 18.0 MB | 18.73 ms / 11.9 MB | **−30%** | **−34%** |

Regression watch (same protocol):

| Benchmark | Base | PR | Time | Allocated |
|---|---|---|---:|---:|
| ForBencmark.ForVar | 79.48 µs / 3.35 KB | 79.17 µs / 3.37 KB | −0.4% | +0.6%¹ |
| ForBencmark.ForLet | 77.47 µs / 3.51 KB | 77.76 µs / 3.53 KB | +0.4% | +0.6%¹ |
| ObjectAccessBenchmark | 136.4 ms / 60.43 MB | 137.0 ms / 60.43 MB | +0.4% | ±0 |
| MathHotPath Warm_AbsTightLoop | 206.9 ns / 49 B | 215.4 ns / 49 B | +4.1%² | ±0 |
| MathHotPath Warm_MaxTightLoop | 196.2 ns / 33 B | 201.5 ns / 33 B | +2.7%² | ±0 |
| Stopwatch classic (prepared) | 217.4 ms / 26.5 MB | 211.8 ms / 26.5 MB | **−2.6%** | ±0 |
| Stopwatch modern (prepared) | 247.8 ms / 26.71 MB | 252.1 ms / 26.72 MB | +1.7%³ | ±0 |
| Dromaeo Cube (classic, prepared) | 13.69 ms / 5.24 MB | 14.26 ms / 5.47 MB | +4.2%³ | +4.4%⁴ |
| Dromaeo Cube (modern, prepared) | 14.57 ms / 5.23 MB | 14.73 ms / 5.46 MB | +1.1% | +4.4%⁴ |
| Dromaeo ObjectString (4 cases) | 150–188 ms / 1272 MB | 152–167 ms / 1272 MB | −12%…+5%³ | −0.7 MB |

¹ node-size growth (the slot-location cache on two expression types), visible only because this benchmark re-parses per execution.
² these two top-level 1000-iteration tight loops bounce ±3–4% between runs of identical code on this machine; the deltas sit inside that band (earlier pairs measured +1.7…+2.2%). The mechanical overhead is the for-update discard detour (~2 ns/iteration).
³ noisy classes: stopwatch-modern's own base varies ±6.5% across runs and ObjectString carries ±7–14 ms StdDev in both builds; the controlled micro equivalents of their hot shapes (ForLet, Stopwatch classic) show no regression. Unprepared Cube cases are bimodal (≈15.3 ↔ ≈18.5 ms) in **both** builds across process restarts and cannot resolve small deltas.
⁴ slot `Binding` grew 16 → 24 bytes; env-churn-heavy code shows it as allocated bytes while time stays within noise.

## Validation

- `Jint.Tests` green on net10.0 and net472, including new `UnboxedBindingTests` (-0/NaN/Infinity through materialization, int32 boundary widening, TDZ/const errors, sloppy-mode semantics, single rhs evaluation, closure visibility, generator/async fallback, observable-context materialization, dynamic `with` shadowing for reads/updates/compound assignments, comma-sequence updates, switch bodies) and `CompletionValueTests` (eval/top-level completion-value semantics test262 does not cover)
- `Jint.Tests.PublicInterface` green (no public API change)
- test262: 99,208 passed, 0 failed (no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
