### PR TITLE
Update test262 suite and fix promise combinator non-thenable handling

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -1,5 +1,5 @@
 {
-  "SuiteGitSha": "4249661388e5d3f92a85186213da140a6481490f",
+  "SuiteGitSha": "05bb032907160d66c212589d345fa0e335e2738c",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Jint.Tests.Test262",

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -346,7 +346,18 @@ internal sealed partial class PromiseConstructor : Constructor
                 }, 1, PropertyFlag.Configurable);
 
                 remainingElementsCount++;
-                _engine.Invoke(nextPromise, "then", [onFulfilled, onRejected]);
+
+                // Perform ? Invoke(nextPromise, "then", « onFulfilled, onRejected »)
+                // Abrupt completions must reject the result capability (IfAbruptRejectPromise in the caller),
+                // so throw a catchable JavaScriptException instead of going through Engine.Invoke.
+                var then = nextPromise.GetV(_realm, "then");
+                if (then is not ICallable thenFunc)
+                {
+                    Throw.TypeError(_realm, $"{then} is not a function");
+                    return;
+                }
+
+                thenFunc.Call(nextPromise, onFulfilled, onRejected);
             }
             else
             {
@@ -367,7 +378,18 @@ internal sealed partial class PromiseConstructor : Constructor
                 }, 1, PropertyFlag.Configurable);
 
                 remainingElementsCount++;
-                _engine.Invoke(nextPromise, "then", [(JsValue) onFulfilled, resultCapability.RejectObj]);
+
+                // Perform ? Invoke(nextPromise, "then", « onFulfilled, resultCapability.[[Reject]] »)
+                // Abrupt completions must reject the result capability (IfAbruptRejectPromise in the caller),
+                // so throw a catchable JavaScriptException instead of going through Engine.Invoke.
+                var then = nextPromise.GetV(_realm, "then");
+                if (then is not ICallable thenFunc)
+                {
+                    Throw.TypeError(_realm, $"{then} is not a function");
+                    return;
+                }
+
+                thenFunc.Call(nextPromise, onFulfilled, resultCapability.RejectObj);
             }
 
             index++;
@@ -814,8 +836,16 @@ internal sealed partial class PromiseConstructor : Constructor
                 var nextPromise = promiseResolve.Call(thisObject, nextValue);
 
                 // i. Perform ? Invoke(nextPromise, "then", « resultCapability.[[Resolve]], resultCapability.[[Reject]] »).
+                // Abrupt completions must reject the result capability (IfAbruptRejectPromise in the caller),
+                // so throw a catchable JavaScriptException instead of going through Engine.Invoke.
+                var then = nextPromise.GetV(_realm, "then");
+                if (then is not ICallable thenFunc)
+                {
+                    Throw.TypeError(_realm, $"{then} is not a function");
+                    return capability.PromiseInstance;
+                }
 
-                _engine.Invoke(nextPromise, "then", [(JsValue) capability.Resolve, capability.RejectObj]);
+                thenFunc.Call(nextPromise, (JsValue) capability.Resolve, capability.RejectObj);
             } while (true);
         }
         catch (JavaScriptException e)


### PR DESCRIPTION
Updates the test262 suite to commit [`05bb0329`](https://github.com/tc39/test262/commit/05bb032907160d66c212589d345fa0e335e2738c). The only new upstream commit ([tc39/test262#5041](https://github.com/tc39/test262/pull/5041)) adds failure-case and edge-case tests for the `await-dictionary` proposal (`Promise.allKeyed` / `Promise.allSettledKeyed`).

## Bug exposed by the new tests

The new `ctx-ctor-constructed.js` tests failed: when a custom constructor''s `resolve` method returns a non-thenable value, `PerformPromiseAllKeyed` invoked `"then"` via `Engine.Invoke`, which throws `TypeErrorException`. That exception type bypasses the `catch (JavaScriptException)` reject path in `Promise.allKeyed` / `Promise.allSettledKeyed`, so the combinator threw synchronously instead of rejecting the result capability promise as required by *IfAbruptRejectPromise*.

`Promise.race` had the same latent bug (no test262 coverage for it today, fixed here as well since it is the identical defect).

## Fix

Perform the spec `Invoke(nextPromise, "then", ...)` inline — `GetV` + `IsCallable` check + `Call` — and throw a realm-aware `TypeError` with the V8-style `kCalledNonCallable` message (`undefined is not a function`), matching how `Promise.all`, `allSettled` and `any` already handle the non-thenable case in this file. Using `GetV` keeps the correct primitive prototype lookup semantics that `Engine.Invoke` had.

## Test results

| Suite | Result |
| --- | --- |
| test262 (full) | 99,260 passed, 0 failed, 133 skipped (configured exclusions) |
| Promise test262 subset | 1,400 passed, 0 failed |
| Jint.Tests (net10.0) | 3,067 passed, 0 failed |
| Jint.Tests (net472) | 3,005 passed, 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)