### PR TITLE
Parenthesize expressions to correctly pre-allocate `List<T>`

### DIFF
--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -315,7 +315,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         }
 
         var temp = _dense;
-        var properties = new List<JsValue>((temp?.Length ?? 0) + 1);
+        var properties = new List<JsValue>((temp?.Length ?? _sparse!.Count) + 1);
         if (temp != null)
         {
             var length = System.Math.Min(temp.Length, GetLength());

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -315,7 +315,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         }
 
         var temp = _dense;
-        var properties = new List<JsValue>(temp?.Length ?? 0 + 1);
+        var properties = new List<JsValue>((temp?.Length ?? 0) + 1);
         if (temp != null)
         {
             var length = System.Math.Min(temp.Length, GetLength());

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -305,7 +305,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
 
     private List<JsValue> GetOwnPropertyKeysSorted(List<JsValue> initialOwnPropertyKeys, bool returningStringKeys, bool returningSymbols)
     {
-        var keys = new List<JsValue>(_properties?.Count ?? 0 + _symbols?.Count ?? 0 + initialOwnPropertyKeys.Count);
+        var keys = new List<JsValue>((_properties?.Count ?? 0) + (_symbols?.Count ?? 0) + initialOwnPropertyKeys.Count);
         if (returningStringKeys && _properties != null)
         {
             foreach (var pair in _properties)

--- a/Jint/Runtime/Environments/GlobalEnvironment.cs
+++ b/Jint/Runtime/Environments/GlobalEnvironment.cs
@@ -380,7 +380,7 @@ internal sealed class GlobalEnvironment : Environment
         // JT: Rather than introduce a new method for the debugger, I'm reusing this one,
         // which - in spite of the very general name - is actually only used by the debugger
         // at this point.
-        var names = new List<string>(_global._properties?.Count ?? 0 + _declarativeRecord._dictionary?.Count ?? 0);
+        var names = new List<string>((_global._properties?.Count ?? 0) + (_declarativeRecord._dictionary?.Count ?? 0));
         foreach (var name in _global.GetOwnProperties())
         {
             names.Add(name.Key.ToString());


### PR DESCRIPTION
<!-- Thanks for contributing to Jint! Please fill in the sections below. -->

## Summary

<!-- One short sentence (under 80 characters) describing the change. -->
Parenthesize expressions to correctly pre-allocate `List<T>`.

## Details

As `+` binds stronger than `??` this PR parenthesizes the coalescing parts.

See this [SharpLab Example](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEUCuA7AHwAEAmARgFgAoIgBgAIiyUBua6pgTgAoBZWgIbcA2gF009MgEopbGmR79gI8ZJlyAlngz1+QgDIaAzhgA8WjAD56AiRfrAp9ALzWBAfgB0AYQj4d7u70DADUDpraurTKhibm2m52kY4u1twePn6RgcFOYcByHArcsuzyimRCYhLCZKLqRRXK1fS19aVU9ryV3LFmFon0ffFWDk6uNl6+/vQ5oQ5TWQFBtBE63THG/Qk2EsMDY6n06Yszc3nHwKfZK7JAA) for how missing parentheses affect the result.

<!--
- What changed and why
- Anything reviewers should pay extra attention to
- Notable implementation choices or trade-offs
-->

## Linked issue

<!-- Use "Fixes #1234" or "Closes #1234" so the issue is auto-closed on merge. For discussion-only changes use "Refs #1234". -->

## Test plan

- [N/A] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally
- [N/A] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [N/A] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark`
  - Can you advice which benchmark to run?


## Breaking change?

<!-- Yes / No. If yes, describe the public-API impact and any migration steps. -->
No
