### PR TITLE
Skip FunctionDeclarationInstantiation entirely when there is nothing to do

### DIFF
--- a/Jint.Benchmark/ClosureCallBenchmarks.cs
+++ b/Jint.Benchmark/ClosureCallBenchmarks.cs
@@ -1,0 +1,88 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates the per-call cost of closure-style methods (the stopwatch.js shape):
+/// EmptyClosureCall = 0-param/0-var closures where FunctionDeclarationInstantiation should be a no-op;
+/// CapturedVarReadWrite = closures reading/writing captured variables (environment-chain resolution);
+/// ParamLocalCall = guard for the existing fixed-slot fast-FDI path.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class ClosureCallBenchmarks
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _emptyClosureCall;
+    private Prepared<Script> _capturedVarReadWrite;
+    private Prepared<Script> _paramLocalCall;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _emptyClosureCall = Engine.PrepareScript("""
+            (function() {
+                function Box() {
+                    this.nop = function () { };
+                }
+                var b = new Box();
+                for (var i = 0; i < 100000; i++) {
+                    b.nop();
+                    b.nop();
+                    b.nop();
+                }
+                return b;
+            })();
+            """, strict: true);
+
+        _capturedVarReadWrite = Engine.PrepareScript("""
+            (function() {
+                function Box() {
+                    var on = false;
+                    var count = 0;
+                    this.enable = function () { on = true; };
+                    this.toggle = function () { on = !on; };
+                    this.bump = function () { count = count + 1; return on; };
+                }
+                var b = new Box();
+                for (var i = 0; i < 100000; i++) {
+                    b.enable();
+                    b.toggle();
+                    b.bump();
+                }
+                return b;
+            })();
+            """, strict: true);
+
+        _paramLocalCall = Engine.PrepareScript("""
+            (function() {
+                function add(a, b) {
+                    var sum = a + b;
+                    return sum;
+                }
+                var acc = 0;
+                for (var i = 0; i < 100000; i++) {
+                    acc = add(acc, 1);
+                    acc = add(acc, 2);
+                    acc = add(acc, 3);
+                }
+                return acc;
+            })();
+            """, strict: true);
+
+        _engine = new Engine(static options => options.Strict());
+        _engine.Evaluate(_emptyClosureCall);
+        _engine.Evaluate(_capturedVarReadWrite);
+        _engine.Evaluate(_paramLocalCall);
+    }
+
+    [Benchmark]
+    public JsValue EmptyClosureCall() => _engine.Evaluate(_emptyClosureCall);
+
+    [Benchmark]
+    public JsValue CapturedVarReadWrite() => _engine.Evaluate(_capturedVarReadWrite);
+
+    [Benchmark]
+    public JsValue ParamLocalCall() => _engine.Evaluate(_paramLocalCall);
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1187,6 +1187,13 @@ public sealed partial class Engine : IDisposable
         var func = function._functionDefinition;
         var configuration = func!.Initialize();
 
+        // Fastest path: nothing to instantiate at all (no parameters, vars, lexical declarations,
+        // inner function declarations, arguments object or eval context).
+        if (configuration.CanUseEmptyFDI && !_isDebugMode)
+        {
+            return null;
+        }
+
         // Fast path for simple functions with fixed-slot storage
         if (configuration.CanUseFastFDI && !_isDebugMode)
         {

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -331,6 +331,12 @@ internal sealed class JintFunctionDefinition
         public int ParameterSlotCount;
         public int VarSlotCount;
         public bool CanUseFastFDI;
+        /// <summary>
+        /// True when FunctionDeclarationInstantiation has nothing to do at all: no parameters,
+        /// no vars, no lexical declarations, no inner function declarations, no arguments object
+        /// and no eval context. Lets calls skip FDI entirely (common for tiny closure methods).
+        /// </summary>
+        public bool CanUseEmptyFDI;
         public bool EnvironmentMayEscape;
         // True when the function body contains a direct call to itself by name. For tight
         // recursion (e.g. fib/ack/tak), the per-call pool fields below add atomic-op overhead
@@ -590,6 +596,19 @@ internal sealed class JintFunctionDefinition
                 state.CanUseFastFDI = lexicalBindingCount == 0;
             }
         }
+
+        // Empty-FDI: instantiation is a complete no-op. Common for tiny closure methods like
+        // `this.start = function () { ... }` that only touch captured or global state.
+        // IsSimpleParameterList is required because rest/pattern parameters bind via
+        // AddFunctionParameters from the AST and may not appear in ParameterNames
+        // (e.g. the synthesized default derived constructor `constructor(...args)`).
+        state.CanUseEmptyFDI = state.IsSimpleParameterList
+            && state.ParameterNames.Length == 0
+            && !state.NeedsEvalContext
+            && !state.ArgumentsObjectNeeded
+            && state.FunctionsToInitialize is null
+            && varsToInitialize.Count == 0
+            && state.LexicalDeclarations is null;
 
         // Compute EnvironmentMayEscape unconditionally so consumers (e.g. FunctionEnvironment pooling)
         // can rely on it without first checking UseFixedSlots. Generators / async functions / direct eval


### PR DESCRIPTION
Wave 1 of the engine-comparison gap work: functions with nothing to instantiate now skip `FunctionDeclarationInstantiation` entirely.

## What

Functions with a **simple empty parameter list, no vars, no lexical or inner function declarations, no `arguments` object and no eval context** return from FDI immediately. This shape is common for tiny closure methods (`this.start = function () { ... }`) that only touch captured or global state — the dominant call pattern in the `stopwatch` comparison benchmark.

`IsSimpleParameterList` is a required part of the gate: rest/pattern parameters bind via `AddFunctionParameters` from the AST and may not appear in `ParameterNames` — notably the synthesized default derived constructor `constructor(...args) { super(...args); }`. (Caught by the test suite during development: 14 failures without it.)

## Measurements (new `ClosureCallBenchmarks`, same-window baseline)

| Benchmark | Before | After | Δ |
|---|---:|---:|---:|
| EmptyClosureCall | 59.38 ms ± 1.15 | 51.38 ms ± 0.93 | **−13.5%** |
| CapturedVarReadWrite | 84.23 ms ± 1.79 | 73.37 ms ± 4.58 | **−12.9%** |
| ParamLocalCall (guard, fast-FDI path) | 121.93 ms ± 3.78 | 121.01 ms ± 2.98 | unchanged |

Allocations unchanged on all three. EngineComparison `stopwatch` wall-clock: **−5.1%** (242.4 → 230.0 ms/iter median, tight same-window A/B).

## Verification

- `Jint.Tests` 0 failures (net10.0 + net472)
- Test262: 99,208 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)