### PR TITLE
Add compilation cache for repeated eval and new Function sources

### DIFF
--- a/Jint.Benchmark/EvalCacheBenchmarks.cs
+++ b/Jint.Benchmark/EvalCacheBenchmarks.cs
@@ -1,0 +1,70 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates the eval / new Function compile pipeline (dromaeo-core-eval shape).
+/// SameSource variants hit a repeated identical source (cacheable); DistinctSources
+/// variants generate a unique source per call and guard the cache-miss path.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class EvalCacheBenchmarks
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _evalSameSource;
+    private Prepared<Script> _newFunctionSameSource;
+    private Prepared<Script> _evalDistinctSources;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // The eval'd source mirrors dromaeo-core-eval's cmd: parse-heavy relative to its execution.
+        const string Source = """
+            var cmd = "var s='';for(var i=0;i<50;i++){s+='a';}res=s;";
+            """;
+
+        _evalSameSource = Engine.PrepareScript(Source + """
+            var res = null;
+            for (var n = 0; n < 50; n++) {
+                eval(cmd);
+            }
+            res;
+            """, strict: true);
+
+        _newFunctionSameSource = Engine.PrepareScript(Source + """
+            var res = null;
+            for (var n = 0; n < 50; n++) {
+                (new Function(cmd))();
+            }
+            res;
+            """, strict: true);
+
+        // globalThis counter keeps every eval'd source unique across benchmark ops so this
+        // permanently measures the cache-miss path (including any eviction policy).
+        _evalDistinctSources = Engine.PrepareScript("""
+            globalThis.__evalCounter = globalThis.__evalCounter || 0;
+            var res = null;
+            for (var n = 0; n < 50; n++) {
+                var u = ++globalThis.__evalCounter;
+                res = eval("var v" + u + " = " + u + "; v" + u + " + 1;");
+            }
+            res;
+            """, strict: true);
+
+        _engine = new Engine(static options => options.Strict());
+        _engine.Evaluate(_evalSameSource);
+        _engine.Evaluate(_newFunctionSameSource);
+        _engine.Evaluate(_evalDistinctSources);
+    }
+
+    [Benchmark]
+    public JsValue EvalSameSource() => _engine.Evaluate(_evalSameSource);
+
+    [Benchmark]
+    public JsValue NewFunctionSameSource() => _engine.Evaluate(_newFunctionSameSource);
+
+    [Benchmark]
+    public JsValue EvalDistinctSources() => _engine.Evaluate(_evalDistinctSources);
+}

--- a/Jint/Native/Function/EvalFunction.cs
+++ b/Jint/Native/Function/EvalFunction.cs
@@ -11,6 +11,35 @@ public sealed class EvalFunction : Function
 {
     private static readonly JsString _functionName = new("eval");
 
+    // Compilation cache for repeated eval of identical sources (a la V8's compilation cache).
+    // Keyed by source + parse strictness (cheap hash); the parse-affecting ParserOptions are
+    // validated on hit. Entries hold the parsed AST, the prebuilt statement tree and the
+    // static analysis flags. Parse failures are never cached.
+    private const int CacheCapacity = 32;
+    private const int CacheMaxSourceLength = 32 * 1024;
+    private Dictionary<CacheKey, CacheEntry>? _evalCache;
+
+    // Memoized `with`-adjustment of the active parser options (stable instance in steady state).
+    private ParserOptions? _lastBaseParserOptions;
+    private ParserOptions? _lastAdjustedParserOptions;
+
+    // Two-touch promotion: a source enters the cache only when seen twice, so one-shot eval
+    // workloads pay just a failed lookup + key compare instead of an insert per call.
+    private CacheKey _probationKey;
+
+    private readonly record struct CacheKey(string Source, bool StrictParse);
+
+    private sealed class CacheEntry
+    {
+        public required ParserOptions ParserOptions { get; init; }
+        public required Script Script { get; init; }
+        public required JintScript JintScript { get; init; }
+        public required bool ContainsArguments { get; init; }
+        public required bool ContainsNewTarget { get; init; }
+        public required bool ContainsSuperCall { get; init; }
+        public required bool ContainsSuperProperty { get; init; }
+    }
+
     internal EvalFunction(
         Engine engine,
         Realm realm,
@@ -72,34 +101,86 @@ public sealed class EvalFunction : Function
             }
         }
 
-        Script? script = null;
         var parserOptions = _engine.GetActiveParserOptions();
-        var adjustedParserOptions = parserOptions with
+        ParserOptions adjustedParserOptions;
+        if (ReferenceEquals(parserOptions, _lastBaseParserOptions))
         {
-            AllowReturnOutsideFunction = false,
-            AllowNewTargetOutsideFunction = true,
-            AllowSuperOutsideMethod = true,
-            // This is a workaround, just makes some tests pass. Actually, we need these checks (done either by the parser or by the runtime).
-            // TODO: implement a correct solution
-            CheckPrivateFields = false
-        };
-        var parser = _engine.GetParserFor(adjustedParserOptions);
+            adjustedParserOptions = _lastAdjustedParserOptions!;
+        }
+        else
+        {
+            adjustedParserOptions = parserOptions with
+            {
+                AllowReturnOutsideFunction = false,
+                AllowNewTargetOutsideFunction = true,
+                AllowSuperOutsideMethod = true,
+                // This is a workaround, just makes some tests pass. Actually, we need these checks (done either by the parser or by the runtime).
+                // TODO: implement a correct solution
+                CheckPrivateFields = false
+            };
+            _lastBaseParserOptions = parserOptions;
+            _lastAdjustedParserOptions = adjustedParserOptions;
+        }
+
         // For indirect eval, parse in non-strict mode (strictness only from "use strict" in code)
         // For direct eval, inherit caller's strictness
-        script = parser.ParseScriptGuarded(_engine.Realm, x.ToString(), strict: direct && strictCaller);
+        var strictParse = direct && strictCaller;
+        var source = x.ToString();
 
+        var cacheable = source.Length <= CacheMaxSourceLength;
+        var cacheKey = new CacheKey(source, strictParse);
+        if (!cacheable
+            || _evalCache is null
+            || !_evalCache.TryGetValue(cacheKey, out var cached)
+            || !(ReferenceEquals(cached.ParserOptions, adjustedParserOptions) || cached.ParserOptions.Equals(adjustedParserOptions)))
+        {
+            var parser = _engine.GetParserFor(adjustedParserOptions);
+            var parsedScript = parser.ParseScriptGuarded(_engine.Realm, source, strict: strictParse);
+
+            var analyzer = new EvalScriptAnalyzer();
+            analyzer.Visit(parsedScript);
+
+            cached = new CacheEntry
+            {
+                ParserOptions = adjustedParserOptions,
+                Script = parsedScript,
+                JintScript = new JintScript(parsedScript),
+                ContainsArguments = analyzer._containsArguments,
+                ContainsNewTarget = analyzer._containsNewTarget,
+                ContainsSuperCall = analyzer._containsSuperCall,
+                ContainsSuperProperty = analyzer._containsSuperProperty,
+            };
+
+            if (cacheable)
+            {
+                // Promote into the cache only on the second sighting of the same source.
+                if (cacheKey.Equals(_probationKey))
+                {
+                    var cache = _evalCache ??= new Dictionary<CacheKey, CacheEntry>();
+                    if (cache.Count >= CacheCapacity)
+                    {
+                        cache.Clear();
+                    }
+                    cache[cacheKey] = cached;
+                }
+                else
+                {
+                    _probationKey = cacheKey;
+                }
+            }
+        }
+
+        var script = cached.Script;
         var body = script.Body;
         if (body.Count == 0)
         {
             return Undefined;
         }
 
-        var analyzer = new EvalScriptAnalyzer();
-        analyzer.Visit(script);
         if (!inFunction)
         {
             // if body Contains NewTarget, throw a SyntaxError exception.
-            if (analyzer._containsNewTarget)
+            if (cached.ContainsNewTarget)
             {
                 Throw.SyntaxError(evalRealm, "new.target expression is not allowed here");
             }
@@ -108,7 +189,7 @@ public sealed class EvalFunction : Function
         if (!inMethod)
         {
             // if body Contains SuperProperty, throw a SyntaxError exception.
-            if (analyzer._containsSuperProperty)
+            if (cached.ContainsSuperProperty)
             {
                 Throw.SyntaxError(evalRealm, "'super' keyword unexpected here");
             }
@@ -117,7 +198,7 @@ public sealed class EvalFunction : Function
         if (!inDerivedConstructor)
         {
             // if body Contains SuperCall, throw a SyntaxError exception.
-            if (analyzer._containsSuperCall)
+            if (cached.ContainsSuperCall)
             {
                 Throw.SyntaxError(evalRealm, "'super' keyword unexpected here");
             }
@@ -126,7 +207,7 @@ public sealed class EvalFunction : Function
         if (inClassFieldInitializer)
         {
             // if ContainsArguments of body is true, throw a SyntaxError exception.
-            if (analyzer._containsArguments)
+            if (cached.ContainsArguments)
             {
                 Throw.SyntaxError(evalRealm, "'arguments' is not allowed in class field initializer or static initialization block");
             }
@@ -172,7 +253,7 @@ public sealed class EvalFunction : Function
             {
                 Engine.EvalDeclarationInstantiation(script, varEnv, lexEnv, privateEnv, strictEval);
 
-                var statement = new JintScript(script);
+                var statement = cached.JintScript;
                 var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
                 var result = statement.Execute(context);
 

--- a/Jint/Native/Function/FunctionInstance.Dynamic.cs
+++ b/Jint/Native/Function/FunctionInstance.Dynamic.cs
@@ -7,11 +7,27 @@ using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Native.Function;
 
+/// <summary>
+/// Cache key for repeated new Function(...) compilations; the function kind is embedded in
+/// the source prefix so it does not need to be part of the key. Parse-affecting
+/// <see cref="ParserOptions"/> are validated on hit via <see cref="DynamicFunctionCacheEntry"/>.
+/// </summary>
+internal readonly record struct DynamicFunctionCacheKey(string FunctionExpression, bool Strict);
+
+internal sealed class DynamicFunctionCacheEntry
+{
+    public required ParserOptions ParserOptions { get; init; }
+    public required Runtime.Interpreter.JintFunctionDefinition Definition { get; init; }
+}
+
 #pragma warning disable MA0049
 public partial class Function
 #pragma warning restore MA0049
 {
     private static readonly JsString _functionNameAnonymous = new JsString("anonymous");
+
+    private const int DynamicFunctionCacheCapacity = 32;
+    private const int DynamicFunctionCacheMaxSourceLength = 32 * 1024;
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-createdynamicfunction
@@ -75,7 +91,7 @@ public partial class Function
             body = TypeConverter.ToString(arguments[argCount - 1]);
         }
 
-        IFunction? function = null;
+        JintFunctionDefinition? definition = null;
         try
         {
             string? functionExpression = null;
@@ -132,8 +148,44 @@ public partial class Function
             {
                 parserOptions = parserOptions with { AllowReturnOutsideFunction = true };
             }
-            Parser parser = new(parserOptions);
-            function = (IFunction) parser.ParseScriptGuarded(callerRealm, functionExpression, strict: _engine._isStrict).Body[0];
+
+            // Compilation cache for repeated new Function(...) with identical sources: the parsed
+            // function definition is shared (like closures sharing one definition); the resulting
+            // Function object below is always a fresh instance. Parse failures are never cached.
+            var cacheable = functionExpression!.Length <= DynamicFunctionCacheMaxSourceLength;
+            var cacheKey = new DynamicFunctionCacheKey(functionExpression, _engine._isStrict);
+            var cache = _realm._dynamicFunctionCache;
+            if (cacheable
+                && cache is not null
+                && cache.TryGetValue(cacheKey, out var cachedEntry)
+                && (ReferenceEquals(cachedEntry.ParserOptions, parserOptions) || cachedEntry.ParserOptions.Equals(parserOptions)))
+            {
+                definition = cachedEntry.Definition;
+            }
+            else
+            {
+                Parser parser = new(parserOptions);
+                var function = (IFunction) parser.ParseScriptGuarded(callerRealm, functionExpression, strict: _engine._isStrict).Body[0];
+                definition = new JintFunctionDefinition(function);
+
+                if (cacheable)
+                {
+                    // Promote into the cache only on the second sighting of the same source.
+                    if (cacheKey.Equals(_realm._dynamicFunctionProbationKey))
+                    {
+                        cache = _realm._dynamicFunctionCache ??= new Dictionary<DynamicFunctionCacheKey, DynamicFunctionCacheEntry>();
+                        if (cache.Count >= DynamicFunctionCacheCapacity)
+                        {
+                            cache.Clear();
+                        }
+                        cache[cacheKey] = new DynamicFunctionCacheEntry { ParserOptions = parserOptions, Definition = definition };
+                    }
+                    else
+                    {
+                        _realm._dynamicFunctionProbationKey = cacheKey;
+                    }
+                }
+            }
         }
         catch (ParseErrorException ex)
         {
@@ -145,8 +197,7 @@ public partial class Function
         var scope = realmF.GlobalEnv;
         PrivateEnvironment? privateEnv = null;
 
-        var definition = new JintFunctionDefinition(function);
-        Function F = OrdinaryFunctionCreate(proto, definition, function.IsStrict() ? FunctionThisMode.Strict : FunctionThisMode.Global, scope, privateEnv);
+        Function F = OrdinaryFunctionCreate(proto, definition!, definition!.Function.IsStrict() ? FunctionThisMode.Strict : FunctionThisMode.Global, scope, privateEnv);
         F.SetFunctionName(_functionNameAnonymous, force: true);
 
         if (kind == FunctionKind.Generator)

--- a/Jint/Runtime/Realm.cs
+++ b/Jint/Runtime/Realm.cs
@@ -8,6 +8,18 @@ public sealed class Realm
 {
     internal readonly Dictionary<Node, JsArray> _templateMap = new();
 
+    /// <summary>
+    /// Compilation cache for repeated new Function(...) with identical sources,
+    /// see <see cref="Native.Function.Function"/> CreateDynamicFunction.
+    /// </summary>
+    internal Dictionary<Native.Function.DynamicFunctionCacheKey, Native.Function.DynamicFunctionCacheEntry>? _dynamicFunctionCache;
+
+    /// <summary>
+    /// Two-touch promotion slot for <see cref="_dynamicFunctionCache"/>: a source is cached
+    /// only when seen twice, keeping one-shot compilations insert-free.
+    /// </summary>
+    internal Native.Function.DynamicFunctionCacheKey _dynamicFunctionProbationKey;
+
 
     // helps when debugging which nested realm we are in...
 #if DEBUG


### PR DESCRIPTION
Adds a V8-compilation-cache-style cache for repeated `eval` and `new Function(...)` compilations of identical sources.

## What

- **Per-realm caches** on `EvalFunction` (direct/indirect eval) and `Realm` (`new Function`), keyed by source + parse strictness with the parse-affecting `ParserOptions` validated on hit.
- Eval entries hold the parsed AST, the prebuilt `JintScript` statement tree and the static-analysis flags (`new.target`/`super`/`arguments` checks still run per call against the cached flags, since their legality depends on the call site). `EvalDeclarationInstantiation` still runs per call (environment-dependent).
- `new Function` caches the shared `JintFunctionDefinition` — the returned `Function` object is always a **fresh instance per call** (spec identity preserved; `SetFunctionName`/`MakeConstructor` run per call). `EnsureCanCompileStrings` is still consulted on every call before a hit is honored.
- **Two-touch promotion**: a source enters the cache only when seen twice, so one-shot eval workloads pay just a failed lookup + key compare — no insert, no entry retention.
- Bounded: 32 entries / 32 KB max source per cache, cleared on overflow. Parse failures are never cached.

## Measurements (new `EvalCacheBenchmarks`, same-window baseline)

| Benchmark | Before | After | Δ time | Δ alloc |
|---|---:|---:|---:|---:|
| EvalSameSource | 464.2 μs ± 7.2 | 290.2 μs ± 8.5 | **−37.5%** | 353.8 → 80.3 KB (**−77%**) |
| NewFunctionSameSource | 528.0 μs ± 17.4 | 273.3 μs ± 9.2 | **−48.2%** | 435.1 → 76.1 KB (**−82%**) |
| EvalDistinctSources (miss-path guard) | 115.8 μs ± 2.6 | 114.9 μs ± 3.6 | within noise | −1.6% |

Scope note: the EngineComparison `dromaeo-core-eval` row does **not** move — that benchmark constructs a fresh engine per op, and a per-realm cache (like V8''s per-isolate one) never sees a second sighting there. The win applies to the common real-world pattern of a long-lived engine evaluating repeated sources.

## Verification

- `Jint.Tests` 0 failures (net10.0 + net472)
- Test262: 99,208 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)