### PR TITLE
Fix prepared scripts executing slower than re-parsed source

### DIFF
--- a/Jint.Benchmark/PreparedAnomalyBenchmarks.cs
+++ b/Jint.Benchmark/PreparedAnomalyBenchmarks.cs
@@ -1,0 +1,70 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates the prepared-script execution anomaly: a Prepared&lt;Script&gt; shared across
+/// fresh engine instances has been consistently slower than re-parsing the source on
+/// call-heavy workloads (stopwatch shape), despite saving the parse. The script here is
+/// closure-call heavy with a negligible parse cost, so the delta is pure execution.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class PreparedAnomalyBenchmarks
+{
+    private const string Source = """
+        function Counter() {
+            var c = 0;
+            var on = false;
+            this.start = function () { if (on) return; on = true; };
+            this.stop = function () { if (!on) return; on = false; };
+            this.bump = function () { c = c + 1; };
+            this.value = function () { return c; };
+        }
+        var k = new Counter();
+        k.start();
+        for (var x = 0; x < 200; x++) {
+            for (var y = 0; y < 250; y++) {
+                var z = x ^ y;
+                if (z % 2 == 0) k.start();
+                else if (z % 3 == 0) k.stop();
+                else if (z % 5 == 0) k.bump();
+                var v = k.value;
+                var r = k.bump;
+            }
+        }
+        k.stop();
+        """;
+
+    private Prepared<Script> _prepared;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _prepared = Engine.PrepareScript(Source, strict: true);
+    }
+
+    [Benchmark(Baseline = true)]
+    public void SourcePerOp()
+    {
+        var engine = new Engine(static options => options.Strict());
+        engine.Execute(Source);
+    }
+
+    [Benchmark]
+    public void PreparedShared()
+    {
+        var engine = new Engine(static options => options.Strict());
+        engine.Execute(_prepared);
+    }
+
+    // Diagnostic arm: prepared tree built fresh per op (never shared). Distinguishes
+    // "shared across engines" from "prepared-tree shape" as the cause of the anomaly.
+    [Benchmark]
+    public void PreparedPerOp()
+    {
+        var prepared = Engine.PrepareScript(Source, strict: true);
+        var engine = new Engine(static options => options.Strict());
+        engine.Execute(prepared);
+    }
+}

--- a/Jint/Engine.Ast.cs
+++ b/Jint/Engine.Ast.cs
@@ -87,7 +87,13 @@ public partial class Engine
 
                     if (!_bindingNames.TryGetValue(name, out var bindingName))
                     {
-                        _bindingNames[name] = bindingName = new Environment.BindingName(JsString.CachedCreate(name));
+                        // Build the binding name from the parser's own (deduplicated) string
+                        // instance: environment binding storage is keyed by Keys created from
+                        // the same parse, so Key comparisons stay on the reference-equality
+                        // fast path of string.Equals. Routing through a process-wide JsString
+                        // cache here would substitute string instances from unrelated parses
+                        // and force every lookup onto the memcmp path.
+                        _bindingNames[name] = bindingName = new Environment.BindingName(name);
                     }
 
                     node.UserData = bindingName;


### PR DESCRIPTION
Fixes `Prepared<Script>` consistently executing **slower** than re-parsing the source on call-heavy workloads (+4.8% on `stopwatch`, +12.4% on `stopwatch-modern` wall-clock; reproduced at 1.07–1.10× with the new `PreparedAnomalyBenchmarks`), despite saving the parse.

## Root cause

`AstAnalyzer` built prepared identifier `BindingName`s via `JsString.CachedCreate(name)`. That process-wide cache returns string instances originating from unrelated earlier parses (or from the single-char `JsString` cache), while environment binding storage is keyed by `Key`s created from the **current parse''s deduplicated strings**. `Key` equality relies on `string.Equals`, whose reference-equality fast path then fails for every identifier lookup, degrading each one to a length+memcmp compare — hundreds of thousands of times per run on call-heavy scripts.

The fix builds `BindingName` from the parser''s own string instance, so identifier Keys and binding-storage Keys stay reference-equal (also across engines sharing one prepared script, since both sides then come from the same parse).

Found by bisecting the `AstAnalyzer` UserData attachments with an env-var-gated visitor; a `PreparedPerOp` benchmark arm (tree built fresh per op) separated tree-shape effects from sharing effects. A competing hypothesis — `Interlocked` contention on the shared `State` pool fields — was implemented and benchmarked first and showed **no effect** (ratio unchanged), so it was discarded; the pool design is not the bottleneck.

## Measurements

`PreparedAnomalyBenchmarks` (closure-call-heavy script, negligible parse cost, fresh engine per op):

| Arm | Before | After |
|---|---:|---:|
| SourcePerOp (baseline) | 19.78 ms | 20.12 ms (1.00) |
| PreparedShared | 21.09 ms (**1.07×**) | 20.11 ms (**1.00×**) |
| PreparedPerOp | 20.88 ms (1.06×) | 20.01 ms (0.99×) |

EngineComparison wall-clock (prepared vs source, same window): `stopwatch` +4.8% → +1.3%; `stopwatch-modern` +12.4% → parity. Parse-heavy workloads (`dromaeo-object-regexp` etc.) keep their existing prepared advantage.

## Verification

- `Jint.Tests` 0 failures (net10.0 + net472)
- Test262: 99,208 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)