### PR TITLE
Return zero-copy views from large slice/substring/substr results

### DIFF
--- a/Jint.Benchmark/StringSliceBenchmarks.cs
+++ b/Jint.Benchmark/StringSliceBenchmarks.cs
@@ -1,0 +1,97 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates String.prototype.slice/substring/substr cost over a large (128K char) string —
+/// the dromaeo-object-string shape where large slice results are assigned and discarded
+/// (measured: slice = 89.9%, substring = 9.2% of its 1.26 GB/op allocations).
+/// SliceSmall guards the small-result path; SliceThenRead guards lazy-materialization cost
+/// when the result is actually consumed.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class StringSliceBenchmarks
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _sliceLargeDiscard;
+    private Prepared<Script> _substringLargeDiscard;
+    private Prepared<Script> _sliceSmall;
+    private Prepared<Script> _sliceThenRead;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _sliceLargeDiscard = Engine.PrepareScript("""
+            (function() {
+                var ret = null;
+                for (var i = 0; i < 5000; i++) {
+                    ret = str.slice(0);
+                    ret = str.slice(12000, -1);
+                }
+                return ret.length;
+            })();
+            """, strict: true);
+
+        _substringLargeDiscard = Engine.PrepareScript("""
+            (function() {
+                var ret = null;
+                for (var i = 0; i < 5000; i++) {
+                    ret = str.substring(0);
+                    ret = str.substring(12000, str.length - 1);
+                }
+                return ret.length;
+            })();
+            """, strict: true);
+
+        _sliceSmall = Engine.PrepareScript("""
+            (function() {
+                var ret = null;
+                for (var i = 0; i < 5000; i++) {
+                    ret = str.slice(15000, 15005);
+                    ret = str.slice(-1);
+                    ret = str.substr(12000, 5);
+                }
+                return ret.length;
+            })();
+            """, strict: true);
+
+        _sliceThenRead = Engine.PrepareScript("""
+            (function() {
+                var n = 0;
+                for (var i = 0; i < 5000; i++) {
+                    var t = str.slice(12000, -1);
+                    n += t.length;
+                    n += t.charCodeAt(100);
+                }
+                return n;
+            })();
+            """, strict: true);
+
+        _engine = new Engine(static options => options.Strict());
+        // Build the shared ~128K char base string once (dromaeo-style doubling).
+        _engine.Execute("""
+            var str = "aB3$xQ9pLm0_kEwZ";
+            while (str.length < 131072) {
+                str += str;
+            }
+            """);
+        _engine.Evaluate(_sliceLargeDiscard);
+        _engine.Evaluate(_substringLargeDiscard);
+        _engine.Evaluate(_sliceSmall);
+        _engine.Evaluate(_sliceThenRead);
+    }
+
+    [Benchmark]
+    public JsValue SliceLargeDiscard() => _engine.Evaluate(_sliceLargeDiscard);
+
+    [Benchmark]
+    public JsValue SubstringLargeDiscard() => _engine.Evaluate(_substringLargeDiscard);
+
+    [Benchmark]
+    public JsValue SliceSmall() => _engine.Evaluate(_sliceSmall);
+
+    [Benchmark]
+    public JsValue SliceThenRead() => _engine.Evaluate(_sliceThenRead);
+}

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -203,6 +203,28 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
         return new JsString(value);
     }
 
+    /// <summary>
+    /// Creates a string for a substring of <paramref name="source"/>. Large slices that cover
+    /// most of the source are returned as zero-copy views (<see cref="SlicedString"/>); small
+    /// slices are copied so a short-lived view can never pin a much larger backing string.
+    /// </summary>
+    internal static JsString CreateSliced(string source, int start, int length)
+    {
+        if (start == 0 && length == source.Length)
+        {
+            return new JsString(source);
+        }
+
+        // The view pins the whole source string; only worth it (and safe retention-wise)
+        // when the slice is large and covers at least half of the source.
+        if (length >= 512 && length * 2 >= source.Length)
+        {
+            return new SlicedString(source, start, length);
+        }
+
+        return new JsString(source.Substring(start, length));
+    }
+
     internal static JsString Create(int value)
     {
         var temp = _intToStringJsValue;
@@ -466,6 +488,80 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
         internal override JsValue DoClone()
         {
             return new JsString(ToString());
+        }
+    }
+
+    /// <summary>
+    /// Zero-copy view over a section of a backing string, produced by slice/substring/substr
+    /// for large results. Immutable (unlike <see cref="ConcatenatedString"/>), so it never
+    /// requires cloning; the flat value is materialized lazily on first <see cref="ToString"/>.
+    /// </summary>
+    internal sealed class SlicedString : JsString
+    {
+        private readonly string _source;
+        private readonly int _start;
+        private readonly int _length;
+
+        internal SlicedString(string source, int start, int length)
+            : base(null!, InternalTypes.String)
+        {
+            _source = source;
+            _start = start;
+            _length = length;
+        }
+
+        public override string ToString()
+        {
+            return _value ??= _source.Substring(_start, _length);
+        }
+
+        public override char this[int index] => _source[_start + index];
+
+        public override int Length => _length;
+
+        private ReadOnlySpan<char> AsSpan() => _value is not null ? _value.AsSpan() : _source.AsSpan(_start, _length);
+
+        internal override JsString EnsureCapacity(int capacity)
+        {
+            // base implementation reads _value directly, which may not be materialized yet
+            return new ConcatenatedString(ToString(), capacity);
+        }
+
+        public override bool Equals(string? other)
+        {
+            return other is not null && _length == other.Length && AsSpan().SequenceEqual(other.AsSpan());
+        }
+
+        public override bool Equals(JsString? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (other.Length != _length)
+            {
+                return false;
+            }
+
+            var otherSpan = other is SlicedString otherSlice ? otherSlice.AsSpan() : other.ToString().AsSpan();
+            return AsSpan().SequenceEqual(otherSpan);
+        }
+
+        public override int GetHashCode()
+        {
+#if NETFRAMEWORK || NETSTANDARD2_0 || NETSTANDARD2_1
+            // netstandard2.1 lacks the (ReadOnlySpan<char>, StringComparison) overload
+            return StringComparer.Ordinal.GetHashCode(ToString());
+#else
+            // same hash as the equivalent flat string instance
+            return string.GetHashCode(AsSpan(), StringComparison.Ordinal);
+#endif
         }
     }
 }

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -953,7 +953,7 @@ internal sealed partial class StringPrototype : StringInstance
             return JsString.Create(s[from]);
         }
 
-        return new JsString(s.Substring(from, length));
+        return JsString.CreateSliced(s, from, length);
     }
 
     /// <summary>
@@ -982,7 +982,7 @@ internal sealed partial class StringPrototype : StringInstance
         {
             return TypeConverter.ToString(s[startIndex]);
         }
-        return s.Substring(startIndex, l);
+        return JsString.CreateSliced(s, startIndex, l);
     }
 
     /// <summary>
@@ -1230,7 +1230,13 @@ internal sealed partial class StringPrototype : StringInstance
             return JsString.Create(s[from]);
         }
 
-        return s.Substring(from, span);
+        if (from == 0 && span == len)
+        {
+            // whole-string slice: strings are immutable, the receiver can be returned as-is
+            return s;
+        }
+
+        return JsString.CreateSliced(s.ToString(), from, span);
     }
 
     [JsFunction(Length = 1)]

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -280,7 +280,7 @@ public sealed class TypeReference : Constructor, IObjectWrapper
         }
         else
         {
-            var key = jsString._value;
+            var key = jsString.ToString();
 
             if (_properties?.TryGetValue(key, out var descriptor) != true)
             {


### PR DESCRIPTION
`String.prototype.slice/substring/substr` allocated a full `string.Substring` copy for every result. MemoryProbe attributed **89.9% + 9.2% of dromaeo-object-string''s 1.26 GB/op** to exactly this.

## What

The three methods now route through `JsString.CreateSliced`:
- **whole-string results** share the receiver / backing string outright (no copy, no wrapper for `slice(0)` on a `JsString` receiver);
- **large results covering ≥ half of the source** (and ≥ 512 chars) become `SlicedString` — an immutable lazy view (offset + length) over the backing string, nested beside `ConcatenatedString`. It materializes only on `ToString()` (cached), overrides indexer/`Length`/equality span-based (no materialization for `length`/`charCodeAt`/comparisons), hashes identically to the equivalent flat string, and — being immutable — never requires cloning, so it can be stored into bindings/properties without flattening;
- **small or low-coverage results keep copying**, so a short-lived view can never pin a much larger backing string (bounded retention: a view covers ≥ ½ of its source by construction).

`TypeReference` read `JsString._value` directly (the only such site outside JsString.cs) and now uses `ToString()`.

## Measurements (new `StringSliceBenchmarks`, same-window baselines, 128K char source)

| Benchmark | Before | After | Alloc |
|---|---:|---:|---:|
| SliceLargeDiscard | 140.0 ms | **1.51 ms (−98.9%)** | 1.14 GB → **394 KB** |
| SubstringLargeDiscard | 143.9 ms | **1.89 ms (−98.7%)** | 1.14 GB → 1.0 MB |
| SliceThenRead | 125.5 ms | **1.62 ms** | reads don''t materialize |
| SliceSmall (guard) | 2.18 ms | 2.19 ms | identical |

EngineComparison `dromaeo-object-string`: wall-clock **−53%** (175.1 → 81.8 ms/iter), per-op allocations **1,272 → 136 MB (−89%)** — the remaining MBs are the intentional retention-guard copies. base64/regexp guards unchanged.

## Verification

- `Jint.Tests` 0 failures (net10.0 + net472), PublicInterface green
- Test262: 99,208 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)