### PR TITLE
Add version-gated inline cache for global variable bindings

### DIFF
--- a/Jint.Benchmark/GlobalAccessBenchmarks.cs
+++ b/Jint.Benchmark/GlobalAccessBenchmarks.cs
@@ -1,0 +1,55 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates top-level (global binding) variable access — the stopwatch.js shape where loop
+/// counters and state live as global-object properties and every read/write pays a property
+/// dictionary lookup. LocalVarLoop is the fixed-slot ceiling/guard for the same operations.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class GlobalAccessBenchmarks
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _globalVarLoop;
+    private Prepared<Script> _localVarLoop;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _globalVarLoop = Engine.PrepareScript("""
+            gx = 0; gy = 0; gz = 0;
+            for (var gi = 0; gi < 200000; gi++) {
+                gz = gx ^ gy;
+                gx = (gx + 1) & 1023;
+                gy = (gy + (gz & 3)) & 2047;
+            }
+            gz;
+            """, strict: true);
+
+        _localVarLoop = Engine.PrepareScript("""
+            (function() {
+                var x = 0, y = 0, z = 0;
+                for (var i = 0; i < 200000; i++) {
+                    z = x ^ y;
+                    x = (x + 1) & 1023;
+                    y = (y + (z & 3)) & 2047;
+                }
+                return z;
+            })();
+            """, strict: true);
+
+        _engine = new Engine(static options => options.Strict());
+        _engine.Execute("var gx = 0; var gy = 0; var gz = 0;");
+        _engine.Evaluate(_globalVarLoop);
+        _engine.Evaluate(_localVarLoop);
+    }
+
+    [Benchmark]
+    public JsValue GlobalVarLoop() => _engine.Evaluate(_globalVarLoop);
+
+    [Benchmark]
+    public JsValue LocalVarLoop() => _engine.Evaluate(_localVarLoop);
+}

--- a/Jint/Runtime/Environments/GlobalEnvironment.cs
+++ b/Jint/Runtime/Environments/GlobalEnvironment.cs
@@ -25,10 +25,14 @@ internal sealed class GlobalEnvironment : Environment
     internal readonly ObjectInstance _global;
 
     // we expect it to be GlobalObject, but need to allow to something host-defined, like Window
-    private readonly GlobalObject? _globalObject;
+    internal readonly GlobalObject? _globalObject;
 
     // Environment records are needed by debugger
     internal readonly GlobalDeclarativeEnvironment _declarativeRecord;
+
+    // Bumped whenever the SET of lexical (let/const) declarations changes; lets identifier
+    // nodes cache resolved global-object bindings and detect later shadowing declarations.
+    internal int _lexicalMutations;
 
     public GlobalEnvironment(Engine engine, ObjectInstance global) : base(engine)
     {
@@ -124,6 +128,7 @@ internal sealed class GlobalEnvironment : Environment
             ThrowAlreadyDeclaredException(name);
         }
 
+        _lexicalMutations++;
         _declarativeRecord.CreateMutableBinding(name, canBeDeleted);
     }
 
@@ -137,6 +142,7 @@ internal sealed class GlobalEnvironment : Environment
             ThrowAlreadyDeclaredException(name);
         }
 
+        _lexicalMutations++;
         _declarativeRecord.CreateImmutableBinding(name, strict);
     }
 
@@ -249,6 +255,7 @@ internal sealed class GlobalEnvironment : Environment
     {
         if (_declarativeRecord.HasBinding(name))
         {
+            _lexicalMutations++;
             return _declarativeRecord.DeleteBinding(name);
         }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Native.Function;
+using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
 
 using Environment = Jint.Runtime.Environments.Environment;
@@ -597,6 +599,19 @@ internal sealed class JintAssignmentExpression : JintExpression
             var env = engine.ExecutionContext.LexicalEnvironment;
             var strict = StrictModeScope.IsStrictModeCode;
             var identifier = left.Identifier;
+
+            // Global-binding fast path: write directly through the cached plain writable
+            // MutableBinding data descriptor. The null pre-check keeps the cost for non-global
+            // identifiers to a single field test; the rest stays out-of-line.
+            if (left._cachedGlobalEnv is not null)
+            {
+                var cachedGlobalDescriptor = left.TryGetValidatedGlobalDescriptor(engine, env);
+                if (cachedGlobalDescriptor is not null)
+                {
+                    return AssignToCachedGlobalBinding(context, left, right, cachedGlobalDescriptor, hasEvalOrArguments, nameAnonymousFunction, strict);
+                }
+            }
+
             if (JintEnvironment.TryGetIdentifierEnvironmentWithBinding(
                     env,
                     identifier,
@@ -636,10 +651,74 @@ internal sealed class JintAssignmentExpression : JintExpression
                 }
 
                 environmentRecord.SetMutableBinding(identifier, rval, strict);
+
+                // Populate the global-binding cache from the write side too, so write-first
+                // patterns benefit from the next access on. Must run after the set: the set
+                // may have created the property (bumping the shape version).
+                if (ReferenceEquals(environmentRecord, env) && environmentRecord is GlobalEnvironment globalEnv)
+                {
+                    left.TryRememberGlobalBinding(globalEnv);
+                }
+
                 return rval;
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// The cached-global-binding arm of <see cref="AssignToIdentifier"/>; semantics are
+        /// identical to its slow path with the final store mirroring
+        /// GlobalObject.SetFromMutableBinding's writable MutableBinding data-property fast path.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static JsValue AssignToCachedGlobalBinding(
+            EvaluationContext context,
+            JintIdentifierExpression left,
+            JintExpression right,
+            PropertyDescriptor descriptor,
+            bool hasEvalOrArguments,
+            bool nameAnonymousFunction,
+            bool strict)
+        {
+            var engine = context.Engine;
+            var identifier = left.Identifier;
+
+            if (strict && hasEvalOrArguments && identifier.Key != KnownKeys.Eval)
+            {
+                Throw.SyntaxError(engine.Realm, "Invalid assignment target");
+            }
+
+            JsValue completion;
+            if (nameAnonymousFunction && right is JintClassExpression classExpression && right._expression.IsAnonymousFunctionDefinition())
+            {
+                completion = classExpression.EvaluateWithName(context, identifier.Value.ToString());
+            }
+            else
+            {
+                completion = right.GetValue(context);
+            }
+
+            if (context.IsAbrupt())
+            {
+                return completion;
+            }
+
+            // If generator suspended or return requested during right-hand side evaluation, don't assign
+            if (context.IsGeneratorAborted())
+            {
+                return completion;
+            }
+
+            var rval = completion.Clone();
+
+            if (nameAnonymousFunction && right._expression.IsFunctionDefinition() && right is not JintClassExpression)
+            {
+                ((Function) rval).SetFunctionName(identifier.Value);
+            }
+
+            descriptor._value = rval;
+            return rval;
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -23,6 +23,16 @@ internal sealed class JintIdentifierExpression : JintExpression
     private DeclarativeEnvironment? _cachedSlotEnv;
     private int _cachedSlotIndex = -1;
 
+    // Version-based inline cache for global bindings: when top-level code (current lexical
+    // env IS the global env) resolves to a plain writable MutableBinding data property on the
+    // real GlobalObject, remember the descriptor. Valid while the global object's own-property
+    // shape and the set of global lexical declarations are unchanged — value writes mutate the
+    // descriptor in place and bump neither version. Mirrors JintMemberExpression's read cache.
+    internal GlobalEnvironment? _cachedGlobalEnv;
+    private Runtime.Descriptors.PropertyDescriptor? _cachedGlobalDescriptor;
+    private uint _cachedGlobalShapeVersion;
+    private int _cachedGlobalLexicalVersion;
+
     // Bounded walk: chain depth is typically 1-3 in real code; deeper chains fall through.
     private const int MaxSlotCacheChainDepth = 4;
 
@@ -136,6 +146,24 @@ internal sealed class JintIdentifierExpression : JintExpression
         }
 
 
+        // Global-binding fast path: top-level identifier reads hit the cached descriptor
+        // directly, skipping the property dictionary lookup entirely. The null pre-check keeps
+        // the cost for non-global identifiers to a single field test; the out-of-line validator
+        // keeps this method's code size unaffected.
+        if (_cachedGlobalEnv is not null)
+        {
+            var cachedGlobalDescriptor = TryGetValidatedGlobalDescriptor(engine, env);
+            if (cachedGlobalDescriptor is not null)
+            {
+                value = cachedGlobalDescriptor._value;
+                if (value is null)
+                {
+                    ThrowNotInitialized(engine);
+                }
+                return MaterializeIfArguments(value);
+            }
+        }
+
         if (ReferenceEquals(env, _cachedEnvironment)
             && _cachedStrict == strict
             && env.TryGetBinding(identifier, strict, out value))
@@ -174,6 +202,10 @@ internal sealed class JintIdentifierExpression : JintExpression
                     _cachedSlotIndex = slotIndex;
                 }
             }
+            else if (ReferenceEquals(identifierEnvironment, env) && identifierEnvironment is GlobalEnvironment globalEnv)
+            {
+                TryRememberGlobalBinding(globalEnv);
+            }
 
             if (value is null)
             {
@@ -187,6 +219,54 @@ internal sealed class JintIdentifierExpression : JintExpression
         }
 
         return MaterializeIfArguments(value);
+    }
+
+    /// <summary>
+    /// Validates the global-binding cache for the current environment: the current lexical env
+    /// must be the cached GlobalEnvironment itself (top-level code) and neither the global
+    /// object's own-property shape nor the global lexical declaration set may have changed.
+    /// Returns the cached plain writable data descriptor, or null on miss.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal Runtime.Descriptors.PropertyDescriptor? TryGetValidatedGlobalDescriptor(Engine engine, Environment env)
+    {
+        var cachedGlobalEnv = _cachedGlobalEnv;
+        if (cachedGlobalEnv is not null
+            && ReferenceEquals(env, cachedGlobalEnv)
+            && ReferenceEquals(cachedGlobalEnv._engine, engine)
+            && cachedGlobalEnv._global._propertiesVersion == _cachedGlobalShapeVersion
+            && cachedGlobalEnv._lexicalMutations == _cachedGlobalLexicalVersion)
+        {
+            return _cachedGlobalDescriptor;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Caches the resolved global binding when it is a plain writable MutableBinding data
+    /// property on the real GlobalObject and no lexical declaration shadows it. Both reads
+    /// and writes may then operate on the descriptor directly while the versions hold.
+    /// </summary>
+    internal void TryRememberGlobalBinding(GlobalEnvironment globalEnv)
+    {
+        var identifier = _identifier;
+        if (globalEnv._globalObject is not { } globalObject
+            || globalEnv._declarativeRecord.HasBinding(identifier.Key))
+        {
+            return;
+        }
+
+        if (globalObject._properties!.TryGetValue(identifier.Key, out var descriptor)
+            && descriptor.IsDataDescriptor()
+            && descriptor.Writable
+            && (descriptor._flags & Runtime.Descriptors.PropertyFlag.MutableBinding) != Runtime.Descriptors.PropertyFlag.None)
+        {
+            _cachedGlobalEnv = globalEnv;
+            _cachedGlobalDescriptor = descriptor;
+            _cachedGlobalShapeVersion = globalObject._propertiesVersion;
+            _cachedGlobalLexicalVersion = globalEnv._lexicalMutations;
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Top-level identifier reads and writes paid a global-object property dictionary lookup on every access (writes: chain resolution **plus** a second lookup in `SetMutableBinding`). Loop-heavy top-level code — the `stopwatch` comparison benchmark shape — pays this hundreds of thousands of times per run.

## What

`JintIdentifierExpression` now carries a version-gated inline cache for global bindings, engaging when the current lexical env **is** the global env (top-level code) and the binding resolved to a plain writable `MutableBinding` data property on the real `GlobalObject` with no global lexical declaration shadowing it. Validity:

- the global object''s own-property shape version (`_propertiesVersion` — bumped on add/remove/redefine, not on value writes), and
- a new `GlobalEnvironment._lexicalMutations` counter, bumped when the set of global let/const declarations changes (create/delete), so a later shadowing declaration invalidates cached object-record bindings.

Hits read/write the descriptor value directly, mirroring `GlobalObject.SetFromMutableBinding`''s existing writable-MutableBinding fast path. The cache fills from both read and write resolutions.

Inlining shape was measured, not guessed: a null pre-check on the cache field keeps the cost for non-global identifiers to a single field test, while the validator and the write arm are `NoInlining` — inlining them taxed local-variable loops ~7% through code growth in `GetValue`/`AssignToIdentifier`.

## Measurements (new `GlobalAccessBenchmarks`, tight same-window A/B)

| Benchmark | Before | After |
|---|---:|---:|
| GlobalVarLoop (200k iterations, 3 reads + 3 writes each) | 58.40 ms | **43.26 ms (−25.9%)** |
| LocalVarLoop (fixed-slot guard) | 53.20 ms | 50.89 ms (clean) |

EngineComparison `stopwatch` wall-clock: **207.5 → 186.0 ms/iter (−10.4%)**.

## Verification

- `Jint.Tests` 0 failures (net10.0 + net472), PublicInterface green
- Test262: 99,208 passed / 0 failed (incl. the global let/const shadowing, delete, redefine and TDZ suites that exercise the invalidation paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)