### PR TITLE
Add object method-call fast path reusing the member inline cache

### DIFF
--- a/Jint.Benchmark/MethodCallBenchmark.cs
+++ b/Jint.Benchmark/MethodCallBenchmark.cs
@@ -1,0 +1,68 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates object method-call dispatch — the stopwatch.js shape where <c>sw.Start()</c>,
+/// <c>sw.Stop()</c> etc. are invoked hundreds of thousands of times. Each call resolves a
+/// literal-named property on an object and invokes the resulting closure. <see cref="MethodCallThis"/>
+/// reads/writes <c>this</c> state; <see cref="MethodCallCaptured"/> reads/writes closure-captured
+/// state (the exact Stopwatch shape). <see cref="FreeFunctionCall"/> is the guard: plain
+/// (non-member) calls must not regress.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class MethodCallBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _methodCallThis;
+    private Prepared<Script> _methodCallCaptured;
+    private Prepared<Script> _freeFunctionCall;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Values are masked to stay in the small-integer cache so JsNumber boxing does not
+        // dominate/perturb the measurement — the signal is the call-dispatch + property
+        // resolution cost, which the fast path removes (Reference rent + descriptor re-resolution).
+        _methodCallThis = Engine.PrepareScript("""
+            var o = { n: 0, tick: function () { this.n = (this.n + 1) & 1023; return this.n; } };
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) { s = (s + o.tick()) & 1023; }
+            s;
+            """, strict: true);
+
+        _methodCallCaptured = Engine.PrepareScript("""
+            function makeCounter() {
+                var n = 0;
+                return { inc: function () { n = (n + 1) & 1023; return n; } };
+            }
+            var c = makeCounter();
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) { s = (s + c.inc()) & 1023; }
+            s;
+            """, strict: true);
+
+        _freeFunctionCall = Engine.PrepareScript("""
+            function f(x) { return (x + 1) & 1023; }
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) { s = f(s); }
+            s;
+            """, strict: true);
+
+        _engine = new Engine(static options => options.Strict());
+        _engine.Evaluate(_methodCallThis);
+        _engine.Evaluate(_methodCallCaptured);
+        _engine.Evaluate(_freeFunctionCall);
+    }
+
+    [Benchmark]
+    public JsValue MethodCallThis() => _engine.Evaluate(_methodCallThis);
+
+    [Benchmark]
+    public JsValue MethodCallCaptured() => _engine.Evaluate(_methodCallCaptured);
+
+    [Benchmark]
+    public JsValue FreeFunctionCall() => _engine.Evaluate(_freeFunctionCall);
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -35,69 +35,108 @@ internal sealed class JintCallExpression : JintExpression
 
         // https://tc39.es/ecma262/#sec-function-calls
 
-        var reference = _calleeExpression.Evaluate(context);
-
-        // Check for generator suspension after evaluating callee
-        if (context.IsSuspended())
-        {
-            return reference as JsValue ?? JsValue.Undefined;
-        }
-
-        if (ReferenceEquals(reference, JsValue.Undefined))
-        {
-            return JsValue.Undefined;
-        }
-
         var engine = context.Engine;
-        var func = engine.GetValue(reference, false);
 
-        if (func.IsNullOrUndefined() && _expression.IsOptional())
-        {
-            return JsValue.Undefined;
-        }
-
-        var referenceRecord = reference as Reference;
-        if (ReferenceEquals(func, engine.Realm.Intrinsics.Eval)
-            && referenceRecord != null
-            && !referenceRecord.IsPropertyReference
-            && CommonProperties.Eval.Equals(referenceRecord.ReferencedName))
-        {
-            return HandleEval(context, func, engine, referenceRecord);
-        }
-
-        var thisCall = (CallExpression) _expression;
-        var tailCall = IsInTailPosition(thisCall);
-
-        // https://tc39.es/ecma262/#sec-evaluatecall
-
+        object reference;
+        Reference? referenceRecord;
+        JsValue func;
         JsValue thisObject;
-        if (referenceRecord is not null)
-        {
-            if (referenceRecord.IsPropertyReference)
-            {
-                thisObject = referenceRecord.ThisValue;
-            }
-            else
-            {
-                var baseValue = referenceRecord.Base;
 
-                // deviation from the spec to support null-propagation helper
-                if (baseValue.IsNullOrUndefined()
-                    && engine._referenceResolver.TryUnresolvableReference(engine, referenceRecord, out var value))
-                {
-                    thisObject = value;
-                }
-                else
-                {
-                    var refEnv = (Environment) baseValue;
-                    thisObject = refEnv.WithBaseObject();
-                }
+        // Fast path: obj.method() / this.method() where the receiver is a plain identifier or `this`
+        // and the property is a literal name. Reuse the member expression's own-property inline cache
+        // to resolve the callee and `this` without renting a Reference. Only callables take the fast
+        // path; a non-callable result falls through to the Reference path so the exact "Property 'x'
+        // of object is not a function" error and this-binding are preserved (the identifier/`this`
+        // receiver is side-effect-free, so re-evaluating it on that rare path is unobservable).
+        JsValue? fastFunc = null;
+        var fastThis = JsValue.Undefined;
+        if (_calleeExpression is JintMemberExpression member
+            && member.IsFastCallEligible
+            && !engine._customResolver)
+        {
+            fastFunc = member.GetCalleeForCall(context, out fastThis);
+            if (context.IsSuspended())
+            {
+                return fastFunc;
             }
+            if (fastFunc is not ICallable)
+            {
+                fastFunc = null;
+            }
+        }
+
+        if (fastFunc is not null)
+        {
+            func = fastFunc;
+            thisObject = fastThis;
+            referenceRecord = null;
+            reference = fastFunc;
         }
         else
         {
-            thisObject = JsValue.Undefined;
+            var calleeReference = _calleeExpression.Evaluate(context);
+
+            // Check for generator suspension after evaluating callee
+            if (context.IsSuspended())
+            {
+                return calleeReference as JsValue ?? JsValue.Undefined;
+            }
+
+            if (ReferenceEquals(calleeReference, JsValue.Undefined))
+            {
+                return JsValue.Undefined;
+            }
+
+            func = engine.GetValue(calleeReference, false);
+
+            if (func.IsNullOrUndefined() && _expression.IsOptional())
+            {
+                return JsValue.Undefined;
+            }
+
+            referenceRecord = calleeReference as Reference;
+            if (ReferenceEquals(func, engine.Realm.Intrinsics.Eval)
+                && referenceRecord != null
+                && !referenceRecord.IsPropertyReference
+                && CommonProperties.Eval.Equals(referenceRecord.ReferencedName))
+            {
+                return HandleEval(context, func, engine, referenceRecord);
+            }
+
+            // https://tc39.es/ecma262/#sec-evaluatecall
+
+            if (referenceRecord is not null)
+            {
+                if (referenceRecord.IsPropertyReference)
+                {
+                    thisObject = referenceRecord.ThisValue;
+                }
+                else
+                {
+                    var baseValue = referenceRecord.Base;
+
+                    // deviation from the spec to support null-propagation helper
+                    if (baseValue.IsNullOrUndefined()
+                        && engine._referenceResolver.TryUnresolvableReference(engine, referenceRecord, out var value))
+                    {
+                        thisObject = value;
+                    }
+                    else
+                    {
+                        var refEnv = (Environment) baseValue;
+                        thisObject = refEnv.WithBaseObject();
+                    }
+                }
+            }
+            else
+            {
+                thisObject = JsValue.Undefined;
+            }
+
+            reference = calleeReference;
         }
+
+        var tailCall = IsInTailPosition((CallExpression) _expression);
 
         var arguments = this._arguments.ArgumentListEvaluation(context, this, out var rented);
 

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -303,4 +303,82 @@ internal sealed class JintMemberExpression : JintExpression
 
         return engine.GetValue(reference, returnReferenceToPool: true);
     }
+
+    /// <summary>
+    /// Whether this member expression can serve as a call's callee via <see cref="GetCalleeForCall"/>
+    /// without renting a <see cref="Reference"/>: a non-computed, non-optional literal-name property
+    /// access on a side-effect-free, never-suspending base (a plain identifier or <c>this</c>). The
+    /// identifier/<c>this</c> restriction guarantees the base evaluates once with no observable side
+    /// effect, so the call's slow-path fallback (taken when the resolved value is not callable) never
+    /// double-evaluates anything observable.
+    /// </summary>
+    internal bool IsFastCallEligible
+        => _propertyExpression is null
+           && _determinedProperty is JsString
+           && !_memberExpression.Optional
+           && !_objectExpressionCanShortCircuit
+           && _objectExpression is JintIdentifierExpression or JintThisExpression;
+
+    /// <summary>
+    /// Resolves the callee value and the call's <c>this</c> binding for an <see cref="IsFastCallEligible"/>
+    /// member call, reusing the same version-gated own-property inline cache as <see cref="GetValue"/> and
+    /// avoiding a <see cref="Reference"/> rent. <paramref name="thisObject"/> is the base value — the base
+    /// object, or for the rare primitive-base call the primitive itself — matching the property-reference
+    /// this-binding the slow path produces.
+    /// </summary>
+    internal JsValue GetCalleeForCall(EvaluationContext context, out JsValue thisObject)
+    {
+        var engine = context.Engine;
+        var determinedProperty = (JsString) _determinedProperty!;
+
+        var baseValue = _objectExpression.GetValue(context);
+        if (context.IsSuspended())
+        {
+            thisObject = JsValue.Undefined;
+            return JsValue.Undefined;
+        }
+
+        context.LastSyntaxElement = _expression;
+        thisObject = baseValue;
+
+        if (baseValue is ObjectInstance baseObject)
+        {
+            if ((baseObject._type & InternalTypes.PlainObject) != InternalTypes.Empty)
+            {
+                if (ReferenceEquals(baseObject, _cachedReadObject)
+                    && baseObject._propertiesVersion == _cachedReadVersion
+                    && _cachedReadDescriptor is not null)
+                {
+                    return ObjectInstance.UnwrapJsValue(_cachedReadDescriptor, baseObject);
+                }
+
+                var ownDescriptor = baseObject.GetOwnProperty(determinedProperty);
+                if (!ReferenceEquals(ownDescriptor, PropertyDescriptor.Undefined))
+                {
+                    _cachedReadObject = baseObject;
+                    _cachedReadVersion = baseObject._propertiesVersion;
+                    _cachedReadDescriptor = ownDescriptor;
+                    return ObjectInstance.UnwrapJsValue(ownDescriptor, baseObject);
+                }
+
+                _cachedReadObject = null;
+                _cachedReadDescriptor = null;
+            }
+
+            return baseObject.Get(determinedProperty, baseObject);
+        }
+
+        if (baseValue.IsNullOrUndefined())
+        {
+            TypeConverter.CheckObjectCoercible(engine, baseValue, _memberExpression.Property, determinedProperty.ToString());
+        }
+
+        // JsString primitive: mirror GetValue's `s.length` fast path to avoid a StringInstance wrapper.
+        if (baseValue is JsString jsString && CommonProperties.Length.Equals(determinedProperty))
+        {
+            return JsNumber.Create((uint) jsString.Length);
+        }
+
+        return baseValue.GetV(engine.Realm, determinedProperty);
+    }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -320,15 +320,14 @@ internal sealed class JintMemberExpression : JintExpression
            && _objectExpression is JintIdentifierExpression or JintThisExpression;
 
     /// <summary>
-    /// Resolves the callee value and the call's <c>this</c> binding for an <see cref="IsFastCallEligible"/>
-    /// member call, reusing the same version-gated own-property inline cache as <see cref="GetValue"/> and
-    /// avoiding a <see cref="Reference"/> rent. <paramref name="thisObject"/> is the base value — the base
-    /// object, or for the rare primitive-base call the primitive itself — matching the property-reference
-    /// this-binding the slow path produces.
+    /// member call when the receiver is an object, reusing the same version-gated own-property inline
+    /// cache as <see cref="GetValue"/> and avoiding a <see cref="Reference"/> rent. <paramref name="thisObject"/>
+    /// is the receiver object, matching the property-reference this-binding the slow path produces. For a
+    /// primitive receiver this returns <see cref="JsValue.Undefined"/> so the caller falls through to the
+    /// Reference path (which never forces lazy-string materialization).
     /// </summary>
     internal JsValue GetCalleeForCall(EvaluationContext context, out JsValue thisObject)
     {
-        var engine = context.Engine;
         var determinedProperty = (JsString) _determinedProperty!;
 
         var baseValue = _objectExpression.GetValue(context);
@@ -339,10 +338,15 @@ internal sealed class JintMemberExpression : JintExpression
         }
 
         context.LastSyntaxElement = _expression;
-        thisObject = baseValue;
 
+        // Only object receivers take the fast path. Primitive receivers (string/number/...) — including
+        // custom JsString subclasses with lazy materialization — return undefined here so the caller
+        // falls through to the Reference path, which resolves them without forcing materialization. The
+        // identifier/`this` receiver is side-effect-free, so re-evaluating it on that path is unobservable.
         if (baseValue is ObjectInstance baseObject)
         {
+            thisObject = baseObject;
+
             if ((baseObject._type & InternalTypes.PlainObject) != InternalTypes.Empty)
             {
                 if (ReferenceEquals(baseObject, _cachedReadObject)
@@ -368,17 +372,7 @@ internal sealed class JintMemberExpression : JintExpression
             return baseObject.Get(determinedProperty, baseObject);
         }
 
-        if (baseValue.IsNullOrUndefined())
-        {
-            TypeConverter.CheckObjectCoercible(engine, baseValue, _memberExpression.Property, determinedProperty.ToString());
-        }
-
-        // JsString primitive: mirror GetValue's `s.length` fast path to avoid a StringInstance wrapper.
-        if (baseValue is JsString jsString && CommonProperties.Length.Equals(determinedProperty))
-        {
-            return JsNumber.Create((uint) jsString.Length);
-        }
-
-        return baseValue.GetV(engine.Realm, determinedProperty);
+        thisObject = JsValue.Undefined;
+        return JsValue.Undefined;
     }
 }


### PR DESCRIPTION
## What

`obj.method()` / `this.method()` where the receiver is a plain identifier or `this` and the property is a literal name now resolves the callee **and** the `this` binding through the member expression's existing version-gated own-property inline cache (`JintMemberExpression.GetCalleeForCall`), avoiding the per-call `Reference` rent and the property re-resolution the call path previously paid on every invocation.

Previously the callee went through `JintExpression.Evaluate` → `JintMemberExpression.EvaluateInternal`, which rents a `Reference`, and then `Engine.GetValue` re-resolved the property. The version-gated inline cache only lived in the `GetValue` override, which the call path never reached. This routes the common eligible shape through that same cache.

Non-callable results and every other callee shape (computed, optional, `super`, private names, custom reference resolver, primitive base) fall through to the unchanged `Reference` path. The identifier/`this` receiver is side-effect-free, so that fallback never double-evaluates anything observable.

## Why

The `stopwatch` EngineComparison row and OO-heavy JS generally spend a large fraction of time in method-call dispatch. This removes a per-call `Reference` rent + a property dictionary lookup.

## Benchmarks (new `MethodCallBenchmark`, default job, stash A/B in one window)

| Method | Baseline | This PR | Δ |
|---|--:|--:|--:|
| MethodCallThis | 381.9 ms | 343.7 ms | **−10.0%** |
| MethodCallCaptured | 372.1 ms | 340.3 ms | **−8.5%** |
| FreeFunctionCall (guard) | 358.5 ms | 362.6 ms | +1.1% (StdDev overlaps → noise) |

Allocated flat at 68.36 MB across all three.

Guard scripts (wall-clock driver, 3-run medians) — flat:

| Guard | Baseline | This PR |
|---|--:|--:|
| dromaeo-object-array | 24.49 ms/iter | 23.96 ms/iter |
| array-stress | 6.95 ms/iter | 6.86 ms/iter |

## Tests

- Jint.Tests net10.0: 3067 passed, 0 failed
- Jint.Tests net472: 3005 passed, 0 failed
- Test262: 99260 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
