### PR TITLE
Add computed-index dense-array fast path for reads and writes

### DIFF
--- a/Jint.Benchmark/ElementAccessBenchmark.cs
+++ b/Jint.Benchmark/ElementAccessBenchmark.cs
@@ -1,0 +1,71 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates computed dense-array element access (<c>a[i]</c>, <c>a[i] = v</c>, <c>m[i][j]</c>) — the
+/// dromaeo-3d-cube MMulti shape, where chained numeric-index reads/writes previously paid the full
+/// Reference + Engine.GetValue/PutValue pipeline per access. Values are masked to stay in the
+/// small-integer cache so the signal is the access cost, not JsNumber boxing. Arrays are pre-filled
+/// so reads/writes hit existing dense slots (the fast path); the chained case mirrors MMulti's
+/// <c>m[i][j]</c> double-indexing.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class ElementAccessBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _read;
+    private Prepared<Script> _write;
+    private Prepared<Script> _readModifyWrite;
+    private Prepared<Script> _chainedRead;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _read = Engine.PrepareScript("""
+            var a = []; for (var k = 0; k < 1024; k++) a[k] = k;
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) s = (s + a[i & 1023]) & 1023;
+            s;
+            """, strict: true);
+
+        _write = Engine.PrepareScript("""
+            var a = []; for (var k = 0; k < 1024; k++) a[k] = 0;
+            for (var i = 0; i < 1000000; i++) a[i & 1023] = i & 1023;
+            a[0];
+            """, strict: true);
+
+        _readModifyWrite = Engine.PrepareScript("""
+            var a = []; for (var k = 0; k < 1024; k++) a[k] = 0;
+            for (var i = 0; i < 1000000; i++) { var j = i & 1023; a[j] = (a[j] + 1) & 1023; }
+            a[0];
+            """, strict: true);
+
+        _chainedRead = Engine.PrepareScript("""
+            var m = []; for (var r = 0; r < 4; r++) { m[r] = []; for (var c = 0; c < 4; c++) m[r][c] = r * 4 + c; }
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) s = (s + m[i & 3][(i >> 2) & 3]) & 1023;
+            s;
+            """, strict: true);
+
+        _engine = new Engine(static options => options.Strict());
+        _engine.Evaluate(_read);
+        _engine.Evaluate(_write);
+        _engine.Evaluate(_readModifyWrite);
+        _engine.Evaluate(_chainedRead);
+    }
+
+    [Benchmark]
+    public JsValue Read() => _engine.Evaluate(_read);
+
+    [Benchmark]
+    public JsValue Write() => _engine.Evaluate(_write);
+
+    [Benchmark]
+    public JsValue ReadModifyWrite() => _engine.Evaluate(_readModifyWrite);
+
+    [Benchmark]
+    public JsValue ChainedRead() => _engine.Evaluate(_chainedRead);
+}

--- a/Jint.Benchmark/MethodCallBenchmark.cs
+++ b/Jint.Benchmark/MethodCallBenchmark.cs
@@ -1,0 +1,68 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates object method-call dispatch — the stopwatch.js shape where <c>sw.Start()</c>,
+/// <c>sw.Stop()</c> etc. are invoked hundreds of thousands of times. Each call resolves a
+/// literal-named property on an object and invokes the resulting closure. <see cref="MethodCallThis"/>
+/// reads/writes <c>this</c> state; <see cref="MethodCallCaptured"/> reads/writes closure-captured
+/// state (the exact Stopwatch shape). <see cref="FreeFunctionCall"/> is the guard: plain
+/// (non-member) calls must not regress.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class MethodCallBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _methodCallThis;
+    private Prepared<Script> _methodCallCaptured;
+    private Prepared<Script> _freeFunctionCall;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Values are masked to stay in the small-integer cache so JsNumber boxing does not
+        // dominate/perturb the measurement — the signal is the call-dispatch + property
+        // resolution cost, which the fast path removes (Reference rent + descriptor re-resolution).
+        _methodCallThis = Engine.PrepareScript("""
+            var o = { n: 0, tick: function () { this.n = (this.n + 1) & 1023; return this.n; } };
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) { s = (s + o.tick()) & 1023; }
+            s;
+            """, strict: true);
+
+        _methodCallCaptured = Engine.PrepareScript("""
+            function makeCounter() {
+                var n = 0;
+                return { inc: function () { n = (n + 1) & 1023; return n; } };
+            }
+            var c = makeCounter();
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) { s = (s + c.inc()) & 1023; }
+            s;
+            """, strict: true);
+
+        _freeFunctionCall = Engine.PrepareScript("""
+            function f(x) { return (x + 1) & 1023; }
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) { s = f(s); }
+            s;
+            """, strict: true);
+
+        _engine = new Engine(static options => options.Strict());
+        _engine.Evaluate(_methodCallThis);
+        _engine.Evaluate(_methodCallCaptured);
+        _engine.Evaluate(_freeFunctionCall);
+    }
+
+    [Benchmark]
+    public JsValue MethodCallThis() => _engine.Evaluate(_methodCallThis);
+
+    [Benchmark]
+    public JsValue MethodCallCaptured() => _engine.Evaluate(_methodCallCaptured);
+
+    [Benchmark]
+    public JsValue FreeFunctionCall() => _engine.Evaluate(_freeFunctionCall);
+}

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -777,6 +777,49 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         return TryGetValueUnlikely(index, out value);
     }
 
+    /// <summary>
+    /// Fast read of a present dense element: returns true only when <paramref name="index"/> is in
+    /// range and the slot is non-null (a real element, not a hole). Holes and out-of-range indices
+    /// return false so the caller falls back to the full lookup (prototype chain etc.). The caller
+    /// must have already verified <see cref="CanUseFastAccess"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryGetValueFast(uint index, out JsValue value)
+    {
+        var temp = _dense;
+        if (temp is not null && index < (uint) temp.Length)
+        {
+            var v = temp[index];
+            if (v is not null)
+            {
+                value = v;
+                return true;
+            }
+        }
+
+        value = Undefined;
+        return false;
+    }
+
+    /// <summary>
+    /// Fast overwrite of an existing dense element: returns true only when <paramref name="index"/>
+    /// is in range and the slot is already non-null. This never grows the array, fills a hole, or
+    /// changes length, so growing/hole-filling writes return false and defer to the full set path.
+    /// The caller must have already verified <see cref="CanUseFastAccess"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryWriteExistingDense(uint index, JsValue value)
+    {
+        var temp = _dense;
+        if (temp is not null && index < (uint) temp.Length && temp[index] is not null)
+        {
+            temp[index] = value;
+            return true;
+        }
+
+        return false;
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private bool TryGetValueUnlikely(uint index, out JsValue value)
     {

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using Jint.Native;
+using Jint.Native.Array;
 using Jint.Native.Function;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
@@ -576,6 +577,19 @@ internal sealed class JintAssignmentExpression : JintExpression
 
             // If generator suspended or return requested during right-hand side evaluation, don't assign
             if (context.IsGeneratorAborted())
+            {
+                engine._referencePool.Return(lref);
+                return rval;
+            }
+
+            // Fast path for dense array element overwrite: arr[intIndex] = rval. Only overwrites an
+            // existing in-range slot (TryWriteExistingDense), so it never grows length, fills a hole,
+            // or triggers sparse conversion — those defer to the full PutValue path below.
+            if (lref.Base is JsArray array
+                && array.CanUseFastAccess
+                && lref.ReferencedName is JsNumber indexNumber
+                && ArrayInstance.IsArrayIndex(indexNumber, out var arrayIndex)
+                && array.TryWriteExistingDense(arrayIndex, rval))
             {
                 engine._referencePool.Return(lref);
                 return rval;

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -35,69 +35,108 @@ internal sealed class JintCallExpression : JintExpression
 
         // https://tc39.es/ecma262/#sec-function-calls
 
-        var reference = _calleeExpression.Evaluate(context);
-
-        // Check for generator suspension after evaluating callee
-        if (context.IsSuspended())
-        {
-            return reference as JsValue ?? JsValue.Undefined;
-        }
-
-        if (ReferenceEquals(reference, JsValue.Undefined))
-        {
-            return JsValue.Undefined;
-        }
-
         var engine = context.Engine;
-        var func = engine.GetValue(reference, false);
 
-        if (func.IsNullOrUndefined() && _expression.IsOptional())
-        {
-            return JsValue.Undefined;
-        }
-
-        var referenceRecord = reference as Reference;
-        if (ReferenceEquals(func, engine.Realm.Intrinsics.Eval)
-            && referenceRecord != null
-            && !referenceRecord.IsPropertyReference
-            && CommonProperties.Eval.Equals(referenceRecord.ReferencedName))
-        {
-            return HandleEval(context, func, engine, referenceRecord);
-        }
-
-        var thisCall = (CallExpression) _expression;
-        var tailCall = IsInTailPosition(thisCall);
-
-        // https://tc39.es/ecma262/#sec-evaluatecall
-
+        object reference;
+        Reference? referenceRecord;
+        JsValue func;
         JsValue thisObject;
-        if (referenceRecord is not null)
-        {
-            if (referenceRecord.IsPropertyReference)
-            {
-                thisObject = referenceRecord.ThisValue;
-            }
-            else
-            {
-                var baseValue = referenceRecord.Base;
 
-                // deviation from the spec to support null-propagation helper
-                if (baseValue.IsNullOrUndefined()
-                    && engine._referenceResolver.TryUnresolvableReference(engine, referenceRecord, out var value))
-                {
-                    thisObject = value;
-                }
-                else
-                {
-                    var refEnv = (Environment) baseValue;
-                    thisObject = refEnv.WithBaseObject();
-                }
+        // Fast path: obj.method() / this.method() where the receiver is a plain identifier or `this`
+        // and the property is a literal name. Reuse the member expression's own-property inline cache
+        // to resolve the callee and `this` without renting a Reference. Only callables take the fast
+        // path; a non-callable result falls through to the Reference path so the exact "Property 'x'
+        // of object is not a function" error and this-binding are preserved (the identifier/`this`
+        // receiver is side-effect-free, so re-evaluating it on that rare path is unobservable).
+        JsValue? fastFunc = null;
+        var fastThis = JsValue.Undefined;
+        if (_calleeExpression is JintMemberExpression member
+            && member.IsFastCallEligible
+            && !engine._customResolver)
+        {
+            fastFunc = member.GetCalleeForCall(context, out fastThis);
+            if (context.IsSuspended())
+            {
+                return fastFunc;
             }
+            if (fastFunc is not ICallable)
+            {
+                fastFunc = null;
+            }
+        }
+
+        if (fastFunc is not null)
+        {
+            func = fastFunc;
+            thisObject = fastThis;
+            referenceRecord = null;
+            reference = fastFunc;
         }
         else
         {
-            thisObject = JsValue.Undefined;
+            var calleeReference = _calleeExpression.Evaluate(context);
+
+            // Check for generator suspension after evaluating callee
+            if (context.IsSuspended())
+            {
+                return calleeReference as JsValue ?? JsValue.Undefined;
+            }
+
+            if (ReferenceEquals(calleeReference, JsValue.Undefined))
+            {
+                return JsValue.Undefined;
+            }
+
+            func = engine.GetValue(calleeReference, false);
+
+            if (func.IsNullOrUndefined() && _expression.IsOptional())
+            {
+                return JsValue.Undefined;
+            }
+
+            referenceRecord = calleeReference as Reference;
+            if (ReferenceEquals(func, engine.Realm.Intrinsics.Eval)
+                && referenceRecord != null
+                && !referenceRecord.IsPropertyReference
+                && CommonProperties.Eval.Equals(referenceRecord.ReferencedName))
+            {
+                return HandleEval(context, func, engine, referenceRecord);
+            }
+
+            // https://tc39.es/ecma262/#sec-evaluatecall
+
+            if (referenceRecord is not null)
+            {
+                if (referenceRecord.IsPropertyReference)
+                {
+                    thisObject = referenceRecord.ThisValue;
+                }
+                else
+                {
+                    var baseValue = referenceRecord.Base;
+
+                    // deviation from the spec to support null-propagation helper
+                    if (baseValue.IsNullOrUndefined()
+                        && engine._referenceResolver.TryUnresolvableReference(engine, referenceRecord, out var value))
+                    {
+                        thisObject = value;
+                    }
+                    else
+                    {
+                        var refEnv = (Environment) baseValue;
+                        thisObject = refEnv.WithBaseObject();
+                    }
+                }
+            }
+            else
+            {
+                thisObject = JsValue.Undefined;
+            }
+
+            reference = calleeReference;
         }
+
+        var tailCall = IsInTailPosition((CallExpression) _expression);
 
         var arguments = this._arguments.ArgumentListEvaluation(context, this, out var rented);
 

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -303,4 +303,82 @@ internal sealed class JintMemberExpression : JintExpression
 
         return engine.GetValue(reference, returnReferenceToPool: true);
     }
+
+    /// <summary>
+    /// Whether this member expression can serve as a call's callee via <see cref="GetCalleeForCall"/>
+    /// without renting a <see cref="Reference"/>: a non-computed, non-optional literal-name property
+    /// access on a side-effect-free, never-suspending base (a plain identifier or <c>this</c>). The
+    /// identifier/<c>this</c> restriction guarantees the base evaluates once with no observable side
+    /// effect, so the call's slow-path fallback (taken when the resolved value is not callable) never
+    /// double-evaluates anything observable.
+    /// </summary>
+    internal bool IsFastCallEligible
+        => _propertyExpression is null
+           && _determinedProperty is JsString
+           && !_memberExpression.Optional
+           && !_objectExpressionCanShortCircuit
+           && _objectExpression is JintIdentifierExpression or JintThisExpression;
+
+    /// <summary>
+    /// Resolves the callee value and the call's <c>this</c> binding for an <see cref="IsFastCallEligible"/>
+    /// member call, reusing the same version-gated own-property inline cache as <see cref="GetValue"/> and
+    /// avoiding a <see cref="Reference"/> rent. <paramref name="thisObject"/> is the base value — the base
+    /// object, or for the rare primitive-base call the primitive itself — matching the property-reference
+    /// this-binding the slow path produces.
+    /// </summary>
+    internal JsValue GetCalleeForCall(EvaluationContext context, out JsValue thisObject)
+    {
+        var engine = context.Engine;
+        var determinedProperty = (JsString) _determinedProperty!;
+
+        var baseValue = _objectExpression.GetValue(context);
+        if (context.IsSuspended())
+        {
+            thisObject = JsValue.Undefined;
+            return JsValue.Undefined;
+        }
+
+        context.LastSyntaxElement = _expression;
+        thisObject = baseValue;
+
+        if (baseValue is ObjectInstance baseObject)
+        {
+            if ((baseObject._type & InternalTypes.PlainObject) != InternalTypes.Empty)
+            {
+                if (ReferenceEquals(baseObject, _cachedReadObject)
+                    && baseObject._propertiesVersion == _cachedReadVersion
+                    && _cachedReadDescriptor is not null)
+                {
+                    return ObjectInstance.UnwrapJsValue(_cachedReadDescriptor, baseObject);
+                }
+
+                var ownDescriptor = baseObject.GetOwnProperty(determinedProperty);
+                if (!ReferenceEquals(ownDescriptor, PropertyDescriptor.Undefined))
+                {
+                    _cachedReadObject = baseObject;
+                    _cachedReadVersion = baseObject._propertiesVersion;
+                    _cachedReadDescriptor = ownDescriptor;
+                    return ObjectInstance.UnwrapJsValue(ownDescriptor, baseObject);
+                }
+
+                _cachedReadObject = null;
+                _cachedReadDescriptor = null;
+            }
+
+            return baseObject.Get(determinedProperty, baseObject);
+        }
+
+        if (baseValue.IsNullOrUndefined())
+        {
+            TypeConverter.CheckObjectCoercible(engine, baseValue, _memberExpression.Property, determinedProperty.ToString());
+        }
+
+        // JsString primitive: mirror GetValue's `s.length` fast path to avoid a StringInstance wrapper.
+        if (baseValue is JsString jsString && CommonProperties.Length.Equals(determinedProperty))
+        {
+            return JsNumber.Create((uint) jsString.Length);
+        }
+
+        return baseValue.GetV(engine.Realm, determinedProperty);
+    }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -320,15 +320,14 @@ internal sealed class JintMemberExpression : JintExpression
            && _objectExpression is JintIdentifierExpression or JintThisExpression;
 
     /// <summary>
-    /// Resolves the callee value and the call's <c>this</c> binding for an <see cref="IsFastCallEligible"/>
-    /// member call, reusing the same version-gated own-property inline cache as <see cref="GetValue"/> and
-    /// avoiding a <see cref="Reference"/> rent. <paramref name="thisObject"/> is the base value — the base
-    /// object, or for the rare primitive-base call the primitive itself — matching the property-reference
-    /// this-binding the slow path produces.
+    /// member call when the receiver is an object, reusing the same version-gated own-property inline
+    /// cache as <see cref="GetValue"/> and avoiding a <see cref="Reference"/> rent. <paramref name="thisObject"/>
+    /// is the receiver object, matching the property-reference this-binding the slow path produces. For a
+    /// primitive receiver this returns <see cref="JsValue.Undefined"/> so the caller falls through to the
+    /// Reference path (which never forces lazy-string materialization).
     /// </summary>
     internal JsValue GetCalleeForCall(EvaluationContext context, out JsValue thisObject)
     {
-        var engine = context.Engine;
         var determinedProperty = (JsString) _determinedProperty!;
 
         var baseValue = _objectExpression.GetValue(context);
@@ -339,10 +338,15 @@ internal sealed class JintMemberExpression : JintExpression
         }
 
         context.LastSyntaxElement = _expression;
-        thisObject = baseValue;
 
+        // Only object receivers take the fast path. Primitive receivers (string/number/...) — including
+        // custom JsString subclasses with lazy materialization — return undefined here so the caller
+        // falls through to the Reference path, which resolves them without forcing materialization. The
+        // identifier/`this` receiver is side-effect-free, so re-evaluating it on that path is unobservable.
         if (baseValue is ObjectInstance baseObject)
         {
+            thisObject = baseObject;
+
             if ((baseObject._type & InternalTypes.PlainObject) != InternalTypes.Empty)
             {
                 if (ReferenceEquals(baseObject, _cachedReadObject)
@@ -368,17 +372,7 @@ internal sealed class JintMemberExpression : JintExpression
             return baseObject.Get(determinedProperty, baseObject);
         }
 
-        if (baseValue.IsNullOrUndefined())
-        {
-            TypeConverter.CheckObjectCoercible(engine, baseValue, _memberExpression.Property, determinedProperty.ToString());
-        }
-
-        // JsString primitive: mirror GetValue's `s.length` fast path to avoid a StringInstance wrapper.
-        if (baseValue is JsString jsString && CommonProperties.Length.Equals(determinedProperty))
-        {
-            return JsNumber.Create((uint) jsString.Length);
-        }
-
-        return baseValue.GetV(engine.Realm, determinedProperty);
+        thisObject = JsValue.Undefined;
+        return JsValue.Undefined;
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -1,4 +1,5 @@
 using Jint.Native;
+using Jint.Native.Array;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
@@ -15,6 +16,7 @@ internal sealed class JintMemberExpression : JintExpression
     private readonly JintExpression? _propertyExpression;
     private readonly JsValue? _determinedProperty;
     private readonly bool _objectExpressionCanShortCircuit;
+    private readonly bool _computedReadEligible;
     private ObjectInstance? _cachedReadObject;
     private PropertyDescriptor? _cachedReadDescriptor;
     private uint _cachedReadVersion;
@@ -26,6 +28,13 @@ internal sealed class JintMemberExpression : JintExpression
         _memberExpression = (MemberExpression) _expression;
         _objectExpression = Build(_memberExpression.Object);
         _objectExpressionCanShortCircuit = CanShortCircuit(_memberExpression.Object);
+
+        // Computed reads like a[i] / a[i][j] / a[0] (but not super[i] or optional a?.[i]) can take a
+        // dense-array fast path in GetValue that resolves base+index without a Reference rent.
+        _computedReadEligible = _memberExpression.Computed
+            && !_memberExpression.Optional
+            && !_objectExpressionCanShortCircuit
+            && _objectExpression is not JintSuperExpression;
 
         var determined = _expression.UserData as JsValue ?? InitializeDeterminedProperty(_memberExpression, cache: false);
 
@@ -264,12 +273,49 @@ internal sealed class JintMemberExpression : JintExpression
             return baseValue.GetV(engine.Realm, determinedProperty);
         }
 
+        // Fast path for computed dense-array element reads (a[i], a[i][j], a[0]) in non-suspendable
+        // contexts: resolve the base (recursively via GetValue, so chained reads stay rent-free) and
+        // the index once, then read the dense slot directly. A miss rents a Reference from the
+        // already-resolved operands — no re-evaluation — and completes through the normal path. The
+        // Suspendable==null gate means neither operand can suspend, so no suspend bookkeeping is needed.
+        if (_computedReadEligible
+            && !engine._customResolver
+            && engine.ExecutionContext.Suspendable is null)
+        {
+            var baseValue = _objectExpression.GetValue(context);
+            var property = _determinedProperty ?? _propertyExpression!.GetValue(context);
+            context.LastSyntaxElement = _expression;
+
+            if (baseValue is JsArray fastArray
+                && fastArray.CanUseFastAccess
+                && property is JsNumber fastIndexNumber
+                && ArrayInstance.IsArrayIndex(fastIndexNumber, out var fastIndex)
+                && fastArray.TryGetValueFast(fastIndex, out var fastValue))
+            {
+                return fastValue;
+            }
+
+            var rentedReference = engine._referencePool.Rent(baseValue, property, StrictModeScope.IsStrictModeCode, thisValue: null);
+            return CompleteReadFromReference(context, engine, rentedReference);
+        }
+
         var result = Evaluate(context);
         if (result is not Reference reference)
         {
             return (JsValue) result;
         }
 
+        return CompleteReadFromReference(context, engine, reference);
+    }
+
+    /// <summary>
+    /// Completes a read from an already-resolved <see cref="Reference"/>: string-character and
+    /// dense-array element fast paths, then the null-base coercibility check, then the full
+    /// <see cref="Engine.GetValue(Reference, bool)"/> pipeline. The reference is always returned to
+    /// the pool.
+    /// </summary>
+    private JsValue CompleteReadFromReference(EvaluationContext context, Engine engine, Reference reference)
+    {
         // Fast path for string character access: str[intIndex]
         if (_memberExpression.Computed
             && reference.Base is JsString str
@@ -284,6 +330,20 @@ internal sealed class JintMemberExpression : JintExpression
             }
 
             return JsValue.Undefined;
+        }
+
+        // Fast path for dense array element access: arr[intIndex] with a clean prototype chain.
+        // Skips Engine.GetValue's property pipeline; holes / out-of-range / sparse arrays fall
+        // through (TryGetValueFast returns false) so prototype-chain and length semantics are kept.
+        if (_memberExpression.Computed
+            && reference.Base is JsArray array
+            && array.CanUseFastAccess
+            && reference.ReferencedName is JsNumber arrayIndexNumber
+            && ArrayInstance.IsArrayIndex(arrayIndexNumber, out var arrayIndex)
+            && array.TryGetValueFast(arrayIndex, out var arrayValue))
+        {
+            engine._referencePool.Return(reference);
+            return arrayValue;
         }
 
         // Check if base is null/undefined before calling Engine.GetValue


### PR DESCRIPTION
> Stacked on #2510 — the diff includes that PR's commit until it merges. Review/merge after #2510 (rebase on merge).

## What

Computed element access `a[i]` / `a[i][j]` / `a[0]` previously rented a `Reference` and went through the full `Engine.GetValue`/`PutValue` pipeline on every access. This adds a dense-array fast path:

- **Reads** (`JintMemberExpression.GetValue`): in non-suspendable contexts, resolve the base **recursively via `GetValue`** (so chained `a[i][j]` reads stay rent-free at *every* level) and the index once, then read the dense slot directly via `ArrayInstance.TryGetValueFast`. A miss rents a `Reference` from the already-resolved operands — no re-evaluation — and completes through the normal path (factored into `CompleteReadFromReference`). Gated on `Suspendable == null`, so neither operand can suspend and no suspend bookkeeping is needed.
- **Writes** (`SimpleAssignmentExpression.SetValue`): overwrite an existing in-range dense slot via `ArrayInstance.TryWriteExistingDense` before `PutValue`. Growing/hole-filling writes return false and defer to the full path, so `length` and sparse semantics are unchanged.

Guarded by `ArrayInstance.CanUseFastAccess` (clean prototype chain, default data descriptors). `JsArray` is `sealed`, so typed arrays, `arguments`, and `Proxy` are excluded by construction. Holes and out-of-range indices fall through to the prototype-chain lookup.

## Why

`dromaeo-3d-cube`'s `MMulti` does chained `m[i][k]` reads in a tight loop; computed indexing had no fast path (only literal-name reads and post-Reference string-char access did).

## Benchmarks (new `ElementAccessBenchmark`, default job, stash A/B in one window)

| Method | Baseline | This PR | Δ |
|---|--:|--:|--:|
| ChainedRead (`m[i][j]`) | 204.6 ms | 162.9 ms | **−20.4%** |
| ReadModifyWrite | 216.0 ms | 193.2 ms | −10.6% |
| Read | 136.3 ms | 126.7 ms | −7.0% |
| Write | 124.3 ms | 115.8 ms | −6.8% |

Allocated flat across all. Guard set (`array-stress`, `dromaeo-object-array`, `dromaeo-string-base64`, `dromaeo-object-regexp`, wall-clock driver) flat.

## Tests

- Jint.Tests net10 (3067) + net472 (3005)
- Jint.Tests.PublicInterface net10 (79) + net472 (79)
- Test262: 99260 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
