### PR TITLE
Pool the for-loop iteration environment across loop entries

### DIFF
--- a/Jint.Benchmark/ElementAccessBenchmark.cs
+++ b/Jint.Benchmark/ElementAccessBenchmark.cs
@@ -1,0 +1,71 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates computed dense-array element access (<c>a[i]</c>, <c>a[i] = v</c>, <c>m[i][j]</c>) — the
+/// dromaeo-3d-cube MMulti shape, where chained numeric-index reads/writes previously paid the full
+/// Reference + Engine.GetValue/PutValue pipeline per access. Values are masked to stay in the
+/// small-integer cache so the signal is the access cost, not JsNumber boxing. Arrays are pre-filled
+/// so reads/writes hit existing dense slots (the fast path); the chained case mirrors MMulti's
+/// <c>m[i][j]</c> double-indexing.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class ElementAccessBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _read;
+    private Prepared<Script> _write;
+    private Prepared<Script> _readModifyWrite;
+    private Prepared<Script> _chainedRead;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _read = Engine.PrepareScript("""
+            var a = []; for (var k = 0; k < 1024; k++) a[k] = k;
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) s = (s + a[i & 1023]) & 1023;
+            s;
+            """, strict: true);
+
+        _write = Engine.PrepareScript("""
+            var a = []; for (var k = 0; k < 1024; k++) a[k] = 0;
+            for (var i = 0; i < 1000000; i++) a[i & 1023] = i & 1023;
+            a[0];
+            """, strict: true);
+
+        _readModifyWrite = Engine.PrepareScript("""
+            var a = []; for (var k = 0; k < 1024; k++) a[k] = 0;
+            for (var i = 0; i < 1000000; i++) { var j = i & 1023; a[j] = (a[j] + 1) & 1023; }
+            a[0];
+            """, strict: true);
+
+        _chainedRead = Engine.PrepareScript("""
+            var m = []; for (var r = 0; r < 4; r++) { m[r] = []; for (var c = 0; c < 4; c++) m[r][c] = r * 4 + c; }
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) s = (s + m[i & 3][(i >> 2) & 3]) & 1023;
+            s;
+            """, strict: true);
+
+        _engine = new Engine(static options => options.Strict());
+        _engine.Evaluate(_read);
+        _engine.Evaluate(_write);
+        _engine.Evaluate(_readModifyWrite);
+        _engine.Evaluate(_chainedRead);
+    }
+
+    [Benchmark]
+    public JsValue Read() => _engine.Evaluate(_read);
+
+    [Benchmark]
+    public JsValue Write() => _engine.Evaluate(_write);
+
+    [Benchmark]
+    public JsValue ReadModifyWrite() => _engine.Evaluate(_readModifyWrite);
+
+    [Benchmark]
+    public JsValue ChainedRead() => _engine.Evaluate(_chainedRead);
+}

--- a/Jint.Benchmark/ForBenchmark.cs
+++ b/Jint.Benchmark/ForBenchmark.cs
@@ -11,12 +11,29 @@ var stringArray = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'
 
     private Engine engine;
 
+    // A `for (let j ...)` re-entered 100k times via repeated inner() calls. With loop-env pooling the
+    // inner loop's environment is reset and reused instead of allocated on every entry. Counters stay
+    // in the int cache so the signal is the per-entry environment allocation, not JsNumber boxing.
+    private Prepared<Script> _reenteredInnerLetLoop;
 
     [GlobalSetup]
     public void Setup()
     {
         engine = new Engine();
         engine.Execute(script);
+
+        _reenteredInnerLetLoop = Engine.PrepareScript("""
+            function inner() { var s = 0; for (let j = 0; j < 4; j++) { s += j; } return s; }
+            var total = 0;
+            for (var k = 0; k < 100000; k++) { total = (total + inner()) & 1023; }
+            total;
+            """);
+    }
+
+    [Benchmark]
+    public void ReenteredInnerLetLoop()
+    {
+        engine.Evaluate(_reenteredInnerLetLoop);
     }
 
     [Benchmark]

--- a/Jint.Benchmark/FunctionDeclarationAllocBenchmark.cs
+++ b/Jint.Benchmark/FunctionDeclarationAllocBenchmark.cs
@@ -1,0 +1,47 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates the allocation cost of creating functions that are never used as constructors and whose
+/// <c>.prototype</c> is never read — the linq-js cold-start shape, where hundreds of helper functions
+/// are declared but essentially none are <c>new</c>-ed. With a lazy <c>.prototype</c> each such function
+/// skips its prototype object + two descriptor allocations. <see cref="ConstructEach"/> is the guard:
+/// when the functions ARE used as constructors the prototype must still materialize (no allocation win,
+/// no regression).
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class FunctionDeclarationAllocBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _declareMany;
+    private Prepared<Script> _constructEach;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _declareMany = Engine.PrepareScript("""
+            var arr = [];
+            for (var i = 0; i < 500; i++) { arr.push(function (a, b) { return a + b; }); }
+            arr.length;
+            """, strict: true);
+
+        _constructEach = Engine.PrepareScript("""
+            var arr = [];
+            for (var i = 0; i < 500; i++) { var F = function () { this.x = 1; }; arr.push(new F()); }
+            arr.length;
+            """, strict: true);
+
+        _engine = new Engine(static options => options.Strict());
+        _engine.Evaluate(_declareMany);
+        _engine.Evaluate(_constructEach);
+    }
+
+    [Benchmark]
+    public JsValue DeclareMany() => _engine.Evaluate(_declareMany);
+
+    [Benchmark]
+    public JsValue ConstructEach() => _engine.Evaluate(_constructEach);
+}

--- a/Jint.Benchmark/GlobalAccessBenchmarks.cs
+++ b/Jint.Benchmark/GlobalAccessBenchmarks.cs
@@ -15,6 +15,7 @@ public class GlobalAccessBenchmarks
     private Engine _engine = null!;
     private Prepared<Script> _globalVarLoop;
     private Prepared<Script> _localVarLoop;
+    private Prepared<Script> _globalUpdateLoop;
 
     [GlobalSetup]
     public void Setup()
@@ -41,10 +42,24 @@ public class GlobalAccessBenchmarks
             })();
             """, strict: true);
 
+        // Update-expression heavy: gx++, gy++, and the gi++/go++ loop counters are all global
+        // UpdateExpressions, which #2507 did not cache (it cached reads and simple assignments). The
+        // counters stay in the small-integer cache (reset each outer iteration) so the measurement is
+        // the binding-resolution cost, not JsNumber boxing — the stopwatch.js shape (x<1021, y<383).
+        _globalUpdateLoop = Engine.PrepareScript("""
+            gx = 0; gy = 0;
+            for (var go = 0; go < 1000; go++) {
+                for (var gi = 0; gi < 1000; gi++) { gx++; gy++; }
+                gx = 0; gy = 0;
+            }
+            gx + gy;
+            """, strict: true);
+
         _engine = new Engine(static options => options.Strict());
         _engine.Execute("var gx = 0; var gy = 0; var gz = 0;");
         _engine.Evaluate(_globalVarLoop);
         _engine.Evaluate(_localVarLoop);
+        _engine.Evaluate(_globalUpdateLoop);
     }
 
     [Benchmark]
@@ -52,4 +67,7 @@ public class GlobalAccessBenchmarks
 
     [Benchmark]
     public JsValue LocalVarLoop() => _engine.Evaluate(_localVarLoop);
+
+    [Benchmark]
+    public JsValue GlobalUpdateLoop() => _engine.Evaluate(_globalUpdateLoop);
 }

--- a/Jint.Benchmark/MethodCallBenchmark.cs
+++ b/Jint.Benchmark/MethodCallBenchmark.cs
@@ -1,0 +1,68 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates object method-call dispatch — the stopwatch.js shape where <c>sw.Start()</c>,
+/// <c>sw.Stop()</c> etc. are invoked hundreds of thousands of times. Each call resolves a
+/// literal-named property on an object and invokes the resulting closure. <see cref="MethodCallThis"/>
+/// reads/writes <c>this</c> state; <see cref="MethodCallCaptured"/> reads/writes closure-captured
+/// state (the exact Stopwatch shape). <see cref="FreeFunctionCall"/> is the guard: plain
+/// (non-member) calls must not regress.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class MethodCallBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _methodCallThis;
+    private Prepared<Script> _methodCallCaptured;
+    private Prepared<Script> _freeFunctionCall;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Values are masked to stay in the small-integer cache so JsNumber boxing does not
+        // dominate/perturb the measurement — the signal is the call-dispatch + property
+        // resolution cost, which the fast path removes (Reference rent + descriptor re-resolution).
+        _methodCallThis = Engine.PrepareScript("""
+            var o = { n: 0, tick: function () { this.n = (this.n + 1) & 1023; return this.n; } };
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) { s = (s + o.tick()) & 1023; }
+            s;
+            """, strict: true);
+
+        _methodCallCaptured = Engine.PrepareScript("""
+            function makeCounter() {
+                var n = 0;
+                return { inc: function () { n = (n + 1) & 1023; return n; } };
+            }
+            var c = makeCounter();
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) { s = (s + c.inc()) & 1023; }
+            s;
+            """, strict: true);
+
+        _freeFunctionCall = Engine.PrepareScript("""
+            function f(x) { return (x + 1) & 1023; }
+            var s = 0;
+            for (var i = 0; i < 1000000; i++) { s = f(s); }
+            s;
+            """, strict: true);
+
+        _engine = new Engine(static options => options.Strict());
+        _engine.Evaluate(_methodCallThis);
+        _engine.Evaluate(_methodCallCaptured);
+        _engine.Evaluate(_freeFunctionCall);
+    }
+
+    [Benchmark]
+    public JsValue MethodCallThis() => _engine.Evaluate(_methodCallThis);
+
+    [Benchmark]
+    public JsValue MethodCallCaptured() => _engine.Evaluate(_methodCallCaptured);
+
+    [Benchmark]
+    public JsValue FreeFunctionCall() => _engine.Evaluate(_freeFunctionCall);
+}

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -777,6 +777,49 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         return TryGetValueUnlikely(index, out value);
     }
 
+    /// <summary>
+    /// Fast read of a present dense element: returns true only when <paramref name="index"/> is in
+    /// range and the slot is non-null (a real element, not a hole). Holes and out-of-range indices
+    /// return false so the caller falls back to the full lookup (prototype chain etc.). The caller
+    /// must have already verified <see cref="CanUseFastAccess"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryGetValueFast(uint index, out JsValue value)
+    {
+        var temp = _dense;
+        if (temp is not null && index < (uint) temp.Length)
+        {
+            var v = temp[index];
+            if (v is not null)
+            {
+                value = v;
+                return true;
+            }
+        }
+
+        value = Undefined;
+        return false;
+    }
+
+    /// <summary>
+    /// Fast overwrite of an existing dense element: returns true only when <paramref name="index"/>
+    /// is in range and the slot is already non-null. This never grows the array, fills a hole, or
+    /// changes length, so growing/hole-filling writes return false and defer to the full set path.
+    /// The caller must have already verified <see cref="CanUseFastAccess"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryWriteExistingDense(uint index, JsValue value)
+    {
+        var temp = _dense;
+        if (temp is not null && index < (uint) temp.Length && temp[index] is not null)
+        {
+            temp[index] = value;
+            return true;
+        }
+
+        return false;
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private bool TryGetValueUnlikely(uint index, out JsValue value)
     {

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
 using Environment = Jint.Runtime.Environments.Environment;
@@ -351,13 +352,31 @@ public abstract partial class Function : ObjectInstance, ICallable
         _constructorKind = ConstructorKind.Base;
         if (prototype is null)
         {
-            prototype = new ObjectInstanceWithConstructor(_engine, this)
+            // Lazily create the .prototype object. Functions that are never used as a constructor and
+            // whose .prototype is never read (e.g. the hundreds of helper functions declared by
+            // linq-js) then skip the ObjectInstanceWithConstructor + its two descriptor allocations.
+            // The value is memoized on first access, so .prototype identity is stable. Flags match the
+            // eager descriptor below: writable=writableProperty, enumerable=false, configurable=false.
+            var flags = PropertyFlag.WritableSet | PropertyFlag.EnumerableSet | PropertyFlag.ConfigurableSet;
+            if (writableProperty)
             {
-                _prototype = _realm.Intrinsics.Object.PrototypeObject
-            };
-        }
+                flags |= PropertyFlag.Writable;
+            }
 
-        _prototypeDescriptor = new PropertyDescriptor(prototype, writableProperty, enumerable: false, configurable: false);
+            _prototypeDescriptor = new LazyPropertyDescriptor<Function>(this, static f => f.CreateConstructorPrototype(), flags);
+        }
+        else
+        {
+            _prototypeDescriptor = new PropertyDescriptor(prototype, writableProperty, enumerable: false, configurable: false);
+        }
+    }
+
+    private ObjectInstanceWithConstructor CreateConstructorPrototype()
+    {
+        return new ObjectInstanceWithConstructor(_engine, this)
+        {
+            _prototype = _realm.Intrinsics.Object.PrototypeObject
+        };
     }
 
     internal void SetFunctionLength(JsNumber length)

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using Jint.Native;
+using Jint.Native.Array;
 using Jint.Native.Function;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
@@ -576,6 +577,19 @@ internal sealed class JintAssignmentExpression : JintExpression
 
             // If generator suspended or return requested during right-hand side evaluation, don't assign
             if (context.IsGeneratorAborted())
+            {
+                engine._referencePool.Return(lref);
+                return rval;
+            }
+
+            // Fast path for dense array element overwrite: arr[intIndex] = rval. Only overwrites an
+            // existing in-range slot (TryWriteExistingDense), so it never grows length, fills a hole,
+            // or triggers sparse conversion — those defer to the full PutValue path below.
+            if (lref.Base is JsArray array
+                && array.CanUseFastAccess
+                && lref.ReferencedName is JsNumber indexNumber
+                && ArrayInstance.IsArrayIndex(indexNumber, out var arrayIndex)
+                && array.TryWriteExistingDense(arrayIndex, rval))
             {
                 engine._referencePool.Return(lref);
                 return rval;

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -35,69 +35,108 @@ internal sealed class JintCallExpression : JintExpression
 
         // https://tc39.es/ecma262/#sec-function-calls
 
-        var reference = _calleeExpression.Evaluate(context);
-
-        // Check for generator suspension after evaluating callee
-        if (context.IsSuspended())
-        {
-            return reference as JsValue ?? JsValue.Undefined;
-        }
-
-        if (ReferenceEquals(reference, JsValue.Undefined))
-        {
-            return JsValue.Undefined;
-        }
-
         var engine = context.Engine;
-        var func = engine.GetValue(reference, false);
 
-        if (func.IsNullOrUndefined() && _expression.IsOptional())
-        {
-            return JsValue.Undefined;
-        }
-
-        var referenceRecord = reference as Reference;
-        if (ReferenceEquals(func, engine.Realm.Intrinsics.Eval)
-            && referenceRecord != null
-            && !referenceRecord.IsPropertyReference
-            && CommonProperties.Eval.Equals(referenceRecord.ReferencedName))
-        {
-            return HandleEval(context, func, engine, referenceRecord);
-        }
-
-        var thisCall = (CallExpression) _expression;
-        var tailCall = IsInTailPosition(thisCall);
-
-        // https://tc39.es/ecma262/#sec-evaluatecall
-
+        object reference;
+        Reference? referenceRecord;
+        JsValue func;
         JsValue thisObject;
-        if (referenceRecord is not null)
-        {
-            if (referenceRecord.IsPropertyReference)
-            {
-                thisObject = referenceRecord.ThisValue;
-            }
-            else
-            {
-                var baseValue = referenceRecord.Base;
 
-                // deviation from the spec to support null-propagation helper
-                if (baseValue.IsNullOrUndefined()
-                    && engine._referenceResolver.TryUnresolvableReference(engine, referenceRecord, out var value))
-                {
-                    thisObject = value;
-                }
-                else
-                {
-                    var refEnv = (Environment) baseValue;
-                    thisObject = refEnv.WithBaseObject();
-                }
+        // Fast path: obj.method() / this.method() where the receiver is a plain identifier or `this`
+        // and the property is a literal name. Reuse the member expression's own-property inline cache
+        // to resolve the callee and `this` without renting a Reference. Only callables take the fast
+        // path; a non-callable result falls through to the Reference path so the exact "Property 'x'
+        // of object is not a function" error and this-binding are preserved (the identifier/`this`
+        // receiver is side-effect-free, so re-evaluating it on that rare path is unobservable).
+        JsValue? fastFunc = null;
+        var fastThis = JsValue.Undefined;
+        if (_calleeExpression is JintMemberExpression member
+            && member.IsFastCallEligible
+            && !engine._customResolver)
+        {
+            fastFunc = member.GetCalleeForCall(context, out fastThis);
+            if (context.IsSuspended())
+            {
+                return fastFunc;
             }
+            if (fastFunc is not ICallable)
+            {
+                fastFunc = null;
+            }
+        }
+
+        if (fastFunc is not null)
+        {
+            func = fastFunc;
+            thisObject = fastThis;
+            referenceRecord = null;
+            reference = fastFunc;
         }
         else
         {
-            thisObject = JsValue.Undefined;
+            var calleeReference = _calleeExpression.Evaluate(context);
+
+            // Check for generator suspension after evaluating callee
+            if (context.IsSuspended())
+            {
+                return calleeReference as JsValue ?? JsValue.Undefined;
+            }
+
+            if (ReferenceEquals(calleeReference, JsValue.Undefined))
+            {
+                return JsValue.Undefined;
+            }
+
+            func = engine.GetValue(calleeReference, false);
+
+            if (func.IsNullOrUndefined() && _expression.IsOptional())
+            {
+                return JsValue.Undefined;
+            }
+
+            referenceRecord = calleeReference as Reference;
+            if (ReferenceEquals(func, engine.Realm.Intrinsics.Eval)
+                && referenceRecord != null
+                && !referenceRecord.IsPropertyReference
+                && CommonProperties.Eval.Equals(referenceRecord.ReferencedName))
+            {
+                return HandleEval(context, func, engine, referenceRecord);
+            }
+
+            // https://tc39.es/ecma262/#sec-evaluatecall
+
+            if (referenceRecord is not null)
+            {
+                if (referenceRecord.IsPropertyReference)
+                {
+                    thisObject = referenceRecord.ThisValue;
+                }
+                else
+                {
+                    var baseValue = referenceRecord.Base;
+
+                    // deviation from the spec to support null-propagation helper
+                    if (baseValue.IsNullOrUndefined()
+                        && engine._referenceResolver.TryUnresolvableReference(engine, referenceRecord, out var value))
+                    {
+                        thisObject = value;
+                    }
+                    else
+                    {
+                        var refEnv = (Environment) baseValue;
+                        thisObject = refEnv.WithBaseObject();
+                    }
+                }
+            }
+            else
+            {
+                thisObject = JsValue.Undefined;
+            }
+
+            reference = calleeReference;
         }
+
+        var tailCall = IsInTailPosition((CallExpression) _expression);
 
         var arguments = this._arguments.ArgumentListEvaluation(context, this, out var rented);
 

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -303,4 +303,82 @@ internal sealed class JintMemberExpression : JintExpression
 
         return engine.GetValue(reference, returnReferenceToPool: true);
     }
+
+    /// <summary>
+    /// Whether this member expression can serve as a call's callee via <see cref="GetCalleeForCall"/>
+    /// without renting a <see cref="Reference"/>: a non-computed, non-optional literal-name property
+    /// access on a side-effect-free, never-suspending base (a plain identifier or <c>this</c>). The
+    /// identifier/<c>this</c> restriction guarantees the base evaluates once with no observable side
+    /// effect, so the call's slow-path fallback (taken when the resolved value is not callable) never
+    /// double-evaluates anything observable.
+    /// </summary>
+    internal bool IsFastCallEligible
+        => _propertyExpression is null
+           && _determinedProperty is JsString
+           && !_memberExpression.Optional
+           && !_objectExpressionCanShortCircuit
+           && _objectExpression is JintIdentifierExpression or JintThisExpression;
+
+    /// <summary>
+    /// Resolves the callee value and the call's <c>this</c> binding for an <see cref="IsFastCallEligible"/>
+    /// member call, reusing the same version-gated own-property inline cache as <see cref="GetValue"/> and
+    /// avoiding a <see cref="Reference"/> rent. <paramref name="thisObject"/> is the base value — the base
+    /// object, or for the rare primitive-base call the primitive itself — matching the property-reference
+    /// this-binding the slow path produces.
+    /// </summary>
+    internal JsValue GetCalleeForCall(EvaluationContext context, out JsValue thisObject)
+    {
+        var engine = context.Engine;
+        var determinedProperty = (JsString) _determinedProperty!;
+
+        var baseValue = _objectExpression.GetValue(context);
+        if (context.IsSuspended())
+        {
+            thisObject = JsValue.Undefined;
+            return JsValue.Undefined;
+        }
+
+        context.LastSyntaxElement = _expression;
+        thisObject = baseValue;
+
+        if (baseValue is ObjectInstance baseObject)
+        {
+            if ((baseObject._type & InternalTypes.PlainObject) != InternalTypes.Empty)
+            {
+                if (ReferenceEquals(baseObject, _cachedReadObject)
+                    && baseObject._propertiesVersion == _cachedReadVersion
+                    && _cachedReadDescriptor is not null)
+                {
+                    return ObjectInstance.UnwrapJsValue(_cachedReadDescriptor, baseObject);
+                }
+
+                var ownDescriptor = baseObject.GetOwnProperty(determinedProperty);
+                if (!ReferenceEquals(ownDescriptor, PropertyDescriptor.Undefined))
+                {
+                    _cachedReadObject = baseObject;
+                    _cachedReadVersion = baseObject._propertiesVersion;
+                    _cachedReadDescriptor = ownDescriptor;
+                    return ObjectInstance.UnwrapJsValue(ownDescriptor, baseObject);
+                }
+
+                _cachedReadObject = null;
+                _cachedReadDescriptor = null;
+            }
+
+            return baseObject.Get(determinedProperty, baseObject);
+        }
+
+        if (baseValue.IsNullOrUndefined())
+        {
+            TypeConverter.CheckObjectCoercible(engine, baseValue, _memberExpression.Property, determinedProperty.ToString());
+        }
+
+        // JsString primitive: mirror GetValue's `s.length` fast path to avoid a StringInstance wrapper.
+        if (baseValue is JsString jsString && CommonProperties.Length.Equals(determinedProperty))
+        {
+            return JsNumber.Create((uint) jsString.Length);
+        }
+
+        return baseValue.GetV(engine.Realm, determinedProperty);
+    }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -320,15 +320,14 @@ internal sealed class JintMemberExpression : JintExpression
            && _objectExpression is JintIdentifierExpression or JintThisExpression;
 
     /// <summary>
-    /// Resolves the callee value and the call's <c>this</c> binding for an <see cref="IsFastCallEligible"/>
-    /// member call, reusing the same version-gated own-property inline cache as <see cref="GetValue"/> and
-    /// avoiding a <see cref="Reference"/> rent. <paramref name="thisObject"/> is the base value — the base
-    /// object, or for the rare primitive-base call the primitive itself — matching the property-reference
-    /// this-binding the slow path produces.
+    /// member call when the receiver is an object, reusing the same version-gated own-property inline
+    /// cache as <see cref="GetValue"/> and avoiding a <see cref="Reference"/> rent. <paramref name="thisObject"/>
+    /// is the receiver object, matching the property-reference this-binding the slow path produces. For a
+    /// primitive receiver this returns <see cref="JsValue.Undefined"/> so the caller falls through to the
+    /// Reference path (which never forces lazy-string materialization).
     /// </summary>
     internal JsValue GetCalleeForCall(EvaluationContext context, out JsValue thisObject)
     {
-        var engine = context.Engine;
         var determinedProperty = (JsString) _determinedProperty!;
 
         var baseValue = _objectExpression.GetValue(context);
@@ -339,10 +338,15 @@ internal sealed class JintMemberExpression : JintExpression
         }
 
         context.LastSyntaxElement = _expression;
-        thisObject = baseValue;
 
+        // Only object receivers take the fast path. Primitive receivers (string/number/...) — including
+        // custom JsString subclasses with lazy materialization — return undefined here so the caller
+        // falls through to the Reference path, which resolves them without forcing materialization. The
+        // identifier/`this` receiver is side-effect-free, so re-evaluating it on that path is unobservable.
         if (baseValue is ObjectInstance baseObject)
         {
+            thisObject = baseObject;
+
             if ((baseObject._type & InternalTypes.PlainObject) != InternalTypes.Empty)
             {
                 if (ReferenceEquals(baseObject, _cachedReadObject)
@@ -368,17 +372,7 @@ internal sealed class JintMemberExpression : JintExpression
             return baseObject.Get(determinedProperty, baseObject);
         }
 
-        if (baseValue.IsNullOrUndefined())
-        {
-            TypeConverter.CheckObjectCoercible(engine, baseValue, _memberExpression.Property, determinedProperty.ToString());
-        }
-
-        // JsString primitive: mirror GetValue's `s.length` fast path to avoid a StringInstance wrapper.
-        if (baseValue is JsString jsString && CommonProperties.Length.Equals(determinedProperty))
-        {
-            return JsNumber.Create((uint) jsString.Length);
-        }
-
-        return baseValue.GetV(engine.Realm, determinedProperty);
+        thisObject = JsValue.Undefined;
+        return JsValue.Undefined;
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -1,4 +1,5 @@
 using Jint.Native;
+using Jint.Native.Array;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
@@ -15,6 +16,7 @@ internal sealed class JintMemberExpression : JintExpression
     private readonly JintExpression? _propertyExpression;
     private readonly JsValue? _determinedProperty;
     private readonly bool _objectExpressionCanShortCircuit;
+    private readonly bool _computedReadEligible;
     private ObjectInstance? _cachedReadObject;
     private PropertyDescriptor? _cachedReadDescriptor;
     private uint _cachedReadVersion;
@@ -26,6 +28,13 @@ internal sealed class JintMemberExpression : JintExpression
         _memberExpression = (MemberExpression) _expression;
         _objectExpression = Build(_memberExpression.Object);
         _objectExpressionCanShortCircuit = CanShortCircuit(_memberExpression.Object);
+
+        // Computed reads like a[i] / a[i][j] / a[0] (but not super[i] or optional a?.[i]) can take a
+        // dense-array fast path in GetValue that resolves base+index without a Reference rent.
+        _computedReadEligible = _memberExpression.Computed
+            && !_memberExpression.Optional
+            && !_objectExpressionCanShortCircuit
+            && _objectExpression is not JintSuperExpression;
 
         var determined = _expression.UserData as JsValue ?? InitializeDeterminedProperty(_memberExpression, cache: false);
 
@@ -264,12 +273,49 @@ internal sealed class JintMemberExpression : JintExpression
             return baseValue.GetV(engine.Realm, determinedProperty);
         }
 
+        // Fast path for computed dense-array element reads (a[i], a[i][j], a[0]) in non-suspendable
+        // contexts: resolve the base (recursively via GetValue, so chained reads stay rent-free) and
+        // the index once, then read the dense slot directly. A miss rents a Reference from the
+        // already-resolved operands — no re-evaluation — and completes through the normal path. The
+        // Suspendable==null gate means neither operand can suspend, so no suspend bookkeeping is needed.
+        if (_computedReadEligible
+            && !engine._customResolver
+            && engine.ExecutionContext.Suspendable is null)
+        {
+            var baseValue = _objectExpression.GetValue(context);
+            var property = _determinedProperty ?? _propertyExpression!.GetValue(context);
+            context.LastSyntaxElement = _expression;
+
+            if (baseValue is JsArray fastArray
+                && fastArray.CanUseFastAccess
+                && property is JsNumber fastIndexNumber
+                && ArrayInstance.IsArrayIndex(fastIndexNumber, out var fastIndex)
+                && fastArray.TryGetValueFast(fastIndex, out var fastValue))
+            {
+                return fastValue;
+            }
+
+            var rentedReference = engine._referencePool.Rent(baseValue, property, StrictModeScope.IsStrictModeCode, thisValue: null);
+            return CompleteReadFromReference(context, engine, rentedReference);
+        }
+
         var result = Evaluate(context);
         if (result is not Reference reference)
         {
             return (JsValue) result;
         }
 
+        return CompleteReadFromReference(context, engine, reference);
+    }
+
+    /// <summary>
+    /// Completes a read from an already-resolved <see cref="Reference"/>: string-character and
+    /// dense-array element fast paths, then the null-base coercibility check, then the full
+    /// <see cref="Engine.GetValue(Reference, bool)"/> pipeline. The reference is always returned to
+    /// the pool.
+    /// </summary>
+    private JsValue CompleteReadFromReference(EvaluationContext context, Engine engine, Reference reference)
+    {
         // Fast path for string character access: str[intIndex]
         if (_memberExpression.Computed
             && reference.Base is JsString str
@@ -284,6 +330,20 @@ internal sealed class JintMemberExpression : JintExpression
             }
 
             return JsValue.Undefined;
+        }
+
+        // Fast path for dense array element access: arr[intIndex] with a clean prototype chain.
+        // Skips Engine.GetValue's property pipeline; holes / out-of-range / sparse arrays fall
+        // through (TryGetValueFast returns false) so prototype-chain and length semantics are kept.
+        if (_memberExpression.Computed
+            && reference.Base is JsArray array
+            && array.CanUseFastAccess
+            && reference.ReferencedName is JsNumber arrayIndexNumber
+            && ArrayInstance.IsArrayIndex(arrayIndexNumber, out var arrayIndex)
+            && array.TryGetValueFast(arrayIndex, out var arrayValue))
+        {
+            engine._referencePool.Return(reference);
+            return arrayValue;
         }
 
         // Check if base is null/undefined before calling Engine.GetValue

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -162,6 +162,53 @@ internal sealed class JintUpdateExpression : JintExpression
 
     private JsValue? UpdateIdentifier(EvaluationContext context)
     {
+        var engine = context.Engine;
+
+        // Global-binding fast path: when this identifier resolves to a cached plain writable global
+        // data property, read and write its descriptor value directly — no environment chain walk and
+        // no second SetMutableBinding lookup. Mirrors the read cache in JintIdentifierExpression and the
+        // simple-assignment cache (AssignToCachedGlobalBinding). Operator-overloading-capable contexts
+        // fall through so a CLR op_Increment/op_Decrement is still honored.
+        if (_leftIdentifier!._cachedGlobalEnv is not null && !context.OperatorOverloadingAllowed)
+        {
+            var descriptor = _leftIdentifier.TryGetValidatedGlobalDescriptor(engine, engine.ExecutionContext.LexicalEnvironment);
+            if (descriptor is not null && descriptor._value is { } current)
+            {
+                if (_evalOrArguments && StrictModeScope.IsStrictModeCode)
+                {
+                    Throw.SyntaxError(engine.Realm);
+                }
+
+                JsValue newValue;
+                if (current._type == InternalTypes.Integer)
+                {
+                    newValue = JsNumber.Create((long) current.AsInteger() + _change);
+                }
+                else if (current._type != InternalTypes.BigInt)
+                {
+                    newValue = JsNumber.Create(TypeConverter.ToNumber(current) + _change);
+                }
+                else
+                {
+                    newValue = JsBigInt.Create(TypeConverter.ToBigInt(current) + _change);
+                }
+
+                descriptor._value = newValue;
+
+                if (_prefix)
+                {
+                    return newValue;
+                }
+
+                if (!current.IsBigInt() && !current.IsNumber())
+                {
+                    return JsNumber.Create(TypeConverter.ToNumber(current));
+                }
+
+                return current;
+            }
+        }
+
         var name = _leftIdentifier!.Identifier;
         var strict = StrictModeScope.IsStrictModeCode;
 
@@ -209,6 +256,14 @@ internal sealed class JintUpdateExpression : JintExpression
             }
 
             environmentRecord.SetMutableBinding(name.Key, newValue!, strict);
+
+            // Remember the binding so subsequent updates of this global take the fast path above,
+            // even when the identifier is never read elsewhere (e.g. a write-only counter).
+            if (environmentRecord is GlobalEnvironment globalEnv)
+            {
+                _leftIdentifier.TryRememberGlobalBinding(globalEnv);
+            }
+
             if (_prefix)
             {
                 return newValue;

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Jint.Native;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
@@ -23,6 +24,13 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
     private readonly bool _shouldCreatePerIterationEnvironment;
     private readonly bool _canReuseIterationEnvironment;
 
+    // When the loop env can be reused across iterations AND nothing captures it, it can also be pooled
+    // across loop entries: a fixed-slot environment is reset and reused instead of allocated each entry.
+    private readonly bool _canPoolLoopEnv;
+    private readonly Key[]? _loopSlotNames;
+    private readonly Binding[]? _loopSlotTemplates;
+    private DeclarativeEnvironment? _cachedLoopEnv;
+
     public JintForStatement(ForStatement statement) : base(statement)
     {
         _body = new ProbablyBlockStatement(statement.Body);
@@ -45,6 +53,23 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                 if (_shouldCreatePerIterationEnvironment)
                 {
                     _canReuseIterationEnvironment = !ForLoopMayCapture(statement);
+
+                    // ...and pool that environment across loop entries via fixed slots (let bindings,
+                    // 1-16 names). Re-entries reset and reuse one DeclarativeEnvironment.
+                    if (_canReuseIterationEnvironment && _boundNames!.Count is > 0 and <= 16)
+                    {
+                        var slotNames = new Key[_boundNames.Count];
+                        var slotTemplates = new Binding[_boundNames.Count];
+                        for (var i = 0; i < _boundNames.Count; i++)
+                        {
+                            slotNames[i] = _boundNames[i];
+                            slotTemplates[i] = new Binding(null!, canBeDeleted: false, mutable: true, strict: false);
+                        }
+
+                        _loopSlotNames = slotNames;
+                        _loopSlotTemplates = slotTemplates;
+                        _canPoolLoopEnv = true;
+                    }
                 }
             }
             else
@@ -94,31 +119,57 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         if (_boundNames != null)
         {
             oldEnv = engine.ExecutionContext.LexicalEnvironment;
-            loopEnv = JintEnvironment.NewDeclarativeEnvironment(engine, oldEnv);
-            var loopEnvRec = loopEnv;
-            var kind = _initStatement!._statement.Kind;
-            for (var i = 0; i < _boundNames.Count; i++)
+
+            if (_canPoolLoopEnv && suspendable is null)
             {
-                var name = _boundNames[i];
-                // const, using, and await using all create immutable bindings
-                if (kind is VariableDeclarationKind.Const or VariableDeclarationKind.Using or VariableDeclarationKind.AwaitUsing)
+                // Pooled fixed-slot environment, reset and reused across loop entries. ResetSlots leaves
+                // every binding uninitialized (TDZ re-established); the for-init then initializes them.
+                // Gated on a non-suspendable context so a pooled env never has to round-trip through the
+                // async/generator suspend/resume save-and-restore machinery.
+                var cachedEnv = Interlocked.Exchange(ref _cachedLoopEnv, null);
+                if (cachedEnv is not null && ReferenceEquals(cachedEnv._engine, engine))
                 {
-                    loopEnvRec.CreateImmutableBinding(name);
+                    cachedEnv._outerEnv = oldEnv;
+                    ResetSlots(cachedEnv._slots!, _loopSlotTemplates!);
+                    loopEnv = cachedEnv;
                 }
                 else
                 {
-                    loopEnvRec.CreateMutableBinding(name);
+                    loopEnv = JintEnvironment.NewDeclarativeEnvironment(engine, oldEnv);
+                    loopEnv._slotNames = _loopSlotNames;
+                    loopEnv._slots = (Binding[]) _loopSlotTemplates!.Clone();
                 }
+
+                engine.UpdateLexicalEnvironment(loopEnv);
             }
-
-            engine.UpdateLexicalEnvironment(loopEnv);
-
-            // Restore loop variable values if resuming
-            if (resumingInLoop && suspendData?.BoundValues is not null)
+            else
             {
-                foreach (var kvp in suspendData.BoundValues)
+                loopEnv = JintEnvironment.NewDeclarativeEnvironment(engine, oldEnv);
+                var loopEnvRec = loopEnv;
+                var kind = _initStatement!._statement.Kind;
+                for (var i = 0; i < _boundNames.Count; i++)
                 {
-                    loopEnvRec.InitializeBinding(kvp.Key, kvp.Value, DisposeHint.Normal);
+                    var name = _boundNames[i];
+                    // const, using, and await using all create immutable bindings
+                    if (kind is VariableDeclarationKind.Const or VariableDeclarationKind.Using or VariableDeclarationKind.AwaitUsing)
+                    {
+                        loopEnvRec.CreateImmutableBinding(name);
+                    }
+                    else
+                    {
+                        loopEnvRec.CreateMutableBinding(name);
+                    }
+                }
+
+                engine.UpdateLexicalEnvironment(loopEnv);
+
+                // Restore loop variable values if resuming
+                if (resumingInLoop && suspendData?.BoundValues is not null)
+                {
+                    foreach (var kvp in suspendData.BoundValues)
+                    {
+                        loopEnvRec.InitializeBinding(kvp.Key, kvp.Value, DisposeHint.Normal);
+                    }
                 }
             }
         }
@@ -181,8 +232,37 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                 }
 
                 loopEnv!.DisposeResources(completion);
+
+                // Cache the pooled environment for the next loop entry (only on clean, non-suspended
+                // completion; a suspended loop may still reference it).
+                if (_canPoolLoopEnv && !context.IsSuspended() && loopEnv._slots is not null)
+                {
+                    Interlocked.Exchange(ref _cachedLoopEnv, loopEnv);
+                }
+
                 engine.UpdateLexicalEnvironment(oldEnv);
             }
+        }
+    }
+
+    /// <summary>
+    /// Reset the slots of a reused loop environment to the pre-computed templates (every binding
+    /// uninitialized). Hand-rolled small-array fast path: loop headers hold 1-3 bindings.
+    /// </summary>
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    private static void ResetSlots(Binding[] slots, Binding[] templates)
+    {
+        var len = slots.Length;
+        if (len == templates.Length && len <= 4)
+        {
+            for (var i = 0; i < len; i++)
+            {
+                slots[i] = templates[i];
+            }
+        }
+        else
+        {
+            templates.AsSpan().CopyTo(slots);
         }
     }
 


### PR DESCRIPTION
> Stacked on #2514 → #2512 → #2511 → #2510. Review/merge in order (rebase on merge).

## What

A `for (let ...)` loop allocated a fresh `DeclarativeEnvironment` on **every loop entry**, even when the iteration environment is already reused across iterations (`_canReuseIterationEnvironment` — no closures capture it). For loops re-entered many times — an inner `for (let j)` inside an outer loop, or a loop inside a frequently-called function — that's one allocation per entry.

When the loop env can be reused across iterations (let binding, no captures, 1–16 bound names) **and** execution is non-suspendable, pool a fixed-slot environment across loop **entries**: reset its slots to the templates (re-establishing TDZ) and reuse the same `DeclarativeEnvironment` instead of allocating. This replicates `JintBlockStatement`'s existing `_cachedEnv`/`ResetSlots` pattern (kept `Interlocked.Exchange` for parallel-fixture safety).

Async/generator contexts (`Suspendable != null`) keep the original path, so the suspend/resume save-restore machinery is untouched. The fixed-slot environment also makes the loop variable slot-based (faster reads/writes) instead of dictionary-based, which helps even single-entry loops.

## Benchmarks (default job, stash A/B)

| Benchmark | Baseline | This PR | Δ |
|---|--:|--:|--:|
| ForBencmark.ReenteredInnerLetLoop — Allocated | 28.6 MB | 6.7 MB | **−76.5%** |
| ForBencmark.ReenteredInnerLetLoop — time | 78.4 ms | 66.2 ms | −15.6% |
| ForBencmark.ForLet (single-entry, slot-env) | 78.2 µs | 69.5 µs | −11.2% |
| stopwatch-modern (wall-clock driver) | 239.7 ms/iter | 227.7 ms/iter | **−5.0%** |

`ForVar` / `ForOfVar` / `ForOfLet` / `ForOfConst` guards flat.

## Tests

- Jint.Tests net10 (3067) + net472 (3005) — incl. the `for`-update `await` resume test
- Jint.Tests.PublicInterface net10 (79) + net472 (79)
- Test262: 99260 passed, 0 failed (for/let per-iteration, closure-capture, TDZ suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
