### PR TITLE
Allow customizing reported property keys for CLR objects (enables for..in)

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -3390,6 +3390,75 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     }
 
     [Fact]
+    public void ForInEnumeratesClrObjectUsingReportedPropertyKeys()
+    {
+        // https://github.com/sebastienros/jint/discussions/2513
+        var people = new ReportedKeysPeople(new[]
+        {
+            new ReportedKeysPerson("person1"),
+            new ReportedKeysPerson("person2"),
+        });
+
+        var engine = new Engine(cfg => cfg.Interop.ObjectWrapperReportedPropertyKeys =
+            static (_, target) => target is ReportedKeysPeople p ? p.Names.Select(n => (JsValue) n) : null);
+        engine.SetValue("people", people);
+
+        // indexer access keeps working
+        Assert.Equal("person1", engine.Evaluate("people['person1'].Name").AsString());
+
+        // for...in now enumerates the reported keys and the body resolves values via the indexer
+        var forIn = engine.Evaluate(@"
+            var result = '';
+            for (var p in people) { result += people[p].Name + ' '; }
+            result.trim();
+        ").AsString();
+        Assert.Equal("person1 person2", forIn);
+
+        // Object.keys shares the same enumeration path
+        Assert.Equal("person1,person2", engine.Evaluate("Object.keys(people).join(',')").AsString());
+
+        // regular CLR members remain accessible alongside the reported keys
+        Assert.Equal(2d, engine.Evaluate("people.Count").AsNumber());
+    }
+
+    [Fact]
+    public void ReportedPropertyKeysDefaultsToExistingEnumeration()
+    {
+        var engine = new Engine();
+        engine.SetValue("dictionary", new Dictionary<string, object>
+        {
+            { "foo", 1 },
+            { "bar", 2 },
+        });
+
+        // default delegate returns null, so dictionary enumeration is unchanged
+        Assert.Equal("foo,bar", engine.Evaluate("Object.keys(dictionary).join(',')").AsString());
+
+        var forIn = engine.Evaluate(@"
+            var keys = [];
+            for (var k in dictionary) keys.push(k);
+            keys.join(',');
+        ").AsString();
+        Assert.Equal("foo,bar", forIn);
+    }
+
+    public sealed class ReportedKeysPerson(string name)
+    {
+        public string Name => name;
+    }
+
+    public sealed class ReportedKeysPeople(IEnumerable<ReportedKeysPerson> people)
+    {
+        private readonly List<ReportedKeysPerson> _people = people.ToList();
+
+        public ReportedKeysPerson this[JsValue name] => _people.FirstOrDefault(p => p.Name == name.ToString());
+
+        public int Count => _people.Count;
+
+        public IEnumerable<string> Names => _people.Select(p => p.Name);
+    }
+
+    [Fact]
     public void CanCheckIfCallable()
     {
         var engine = new Engine();

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -36,6 +36,8 @@ public class Options
 
     public delegate string SerializeToJsonDelegate(object? target, string space, string? currentIndent);
 
+    public delegate IEnumerable<JsValue>? ReportedPropertyKeysDelegate(Engine engine, object target);
+
     /// <summary>
     /// Execution constraints for the engine.
     /// </summary>
@@ -441,6 +443,16 @@ public class Options
         /// Reported member binding flags when reflecting, defaults to <see cref="BindingFlags.Instance" /> | <see cref="BindingFlags.Public" /> | <see cref="BindingFlags.Static" />.
         /// </summary>
         public BindingFlags ObjectWrapperReportedMethodBindingFlags { get; set; } = BindingFlags.Instance | BindingFlags.Public | BindingFlags.Static;
+
+        /// <summary>
+        /// Customizes the property keys reported by <see cref="ObjectWrapper"/> when a wrapped CLR object is
+        /// enumerated (JavaScript <c>for..in</c>, <c>Object.keys</c>, object spread, <c>JSON.stringify</c>).
+        /// When the delegate returns a non-null sequence, those keys replace the default reflected/dictionary
+        /// keys for the given target; returning <c>null</c> keeps the default behavior. Reported keys must be
+        /// resolvable through the wrapper's normal member/indexer access for their values to be readable.
+        /// Defaults to returning <c>null</c>.
+        /// </summary>
+        public ReportedPropertyKeysDelegate ObjectWrapperReportedPropertyKeys { get; set; } = static (_, _) => null;
     }
 
     public class ConstraintOptions

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -495,6 +495,20 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
     {
         // prefer object order, add possible other properties after
         var includeStrings = (types & Types.String) != Types.Empty;
+
+        if (includeStrings)
+        {
+            var customKeys = _engine.Options.Interop.ObjectWrapperReportedPropertyKeys(_engine, Target);
+            if (customKeys is not null)
+            {
+                foreach (var key in customKeys)
+                {
+                    yield return key;
+                }
+                yield break; // non-null replaces the default key set
+            }
+        }
+
         if (includeStrings && _typeDescriptor.IsStringKeyedGenericDictionary) // expando object for instance
         {
             var keys = (ICollection<string>) _typeDescriptor.KeysAccessor!.GetValue(Target)!;


### PR DESCRIPTION
Addresses the scenario raised in discussion #2513.

## Problem

JavaScript `for..in` (and `Object.keys`, object spread, `JSON.stringify`) over a wrapped CLR object enumerates the keys reported by `ObjectWrapper`, which today are limited to:

- string-keyed dictionary keys, or
- reflected public **non-indexer** properties/fields/methods.

A collection whose logical keys are exposed only through a custom indexer (e.g. `Person this[JsValue name]`) therefore reports **no keys**, so `for..in` yields nothing. The only previous workaround — inheriting `ObjectInstance` and calling `FastSetDataProperty` — makes the object lose all of its CLR members, so there was no way to get both enumeration and CLR access.

## Change

Adds `Options.Interop.ObjectWrapperReportedPropertyKeys`, a delegate the host can set to supply the property keys reported when a CLR object is enumerated:

```csharp
public delegate IEnumerable<JsValue>? ReportedPropertyKeysDelegate(Engine engine, object target);
```

- Returning a non-null sequence **replaces** the default reflected/dictionary keys for that target.
- Returning `null` (the default) keeps the existing behavior, so the feature is fully opt-in and non-breaking.

Value lookup already worked through the existing indexer/member resolution, and indexer-resolved descriptors are already enumerable, so the only missing piece was reporting the keys. The hook is added at the top of `ObjectWrapper.EnumerateOwnPropertyKeys`, which every enumeration path (`for..in`, `Object.keys`, spread, `JSON.stringify`) funnels through.

## Usage

```csharp
var engine = new Engine(cfg => cfg.Interop.ObjectWrapperReportedPropertyKeys =
    static (_, target) => target is People p ? p.Names.Select(n => (JsValue) n) : null);
engine.SetValue("people", people);

// for (const k in people) people[k].Name   -> works
// Object.keys(people)                      -> ["person1", "person2"]
// people.Count, people["person1"].Name     -> CLR member/indexer still work
```

Reported keys must be resolvable through the wrapper's normal member/indexer access for their values to be readable.

## Tests

- `ForInEnumeratesClrObjectUsingReportedPropertyKeys` — reproduces the discussion: `for..in`, `Object.keys`, indexer access and a plain CLR member all work together.
- `ReportedPropertyKeysDefaultsToExistingEnumeration` — with the default (unset) delegate, dictionary enumeration is unchanged.

Full `InteropTests` and `Jint.Tests.PublicInterface` suites pass on net10.0 and net472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
