### PR TITLE
Extend zero-copy string slice views to bounded-waste substrings

### DIFF
--- a/Jint.Benchmark/StringSliceBenchmarks.cs
+++ b/Jint.Benchmark/StringSliceBenchmarks.cs
@@ -5,8 +5,10 @@ namespace Jint.Benchmark;
 
 /// <summary>
 /// Isolates String.prototype.slice/substring/substr cost over a large (128K char) string —
-/// the dromaeo-object-string shape where large slice results are assigned and discarded
-/// (measured: slice = 89.9%, substring = 9.2% of its 1.26 GB/op allocations).
+/// the dromaeo-object-string shape where large slice results are assigned and discarded.
+/// Both SliceLargeDiscard and SubstringLargeDiscard use the actual dromaeo arguments
+/// (start, -1): substring clamps the -1 to 0 and swaps, producing a 12000-char result that
+/// previously fell below the zero-copy retention guard and copied on every call.
 /// SliceSmall guards the small-result path; SliceThenRead guards lazy-materialization cost
 /// when the result is actually consumed.
 /// </summary>
@@ -39,7 +41,7 @@ public class StringSliceBenchmarks
                 var ret = null;
                 for (var i = 0; i < 5000; i++) {
                     ret = str.substring(0);
-                    ret = str.substring(12000, str.length - 1);
+                    ret = str.substring(12000, -1);
                 }
                 return ret.length;
             })();

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -203,10 +203,18 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
         return new JsString(value);
     }
 
+    // A zero-copy view pins the whole source string, so a slice only becomes a view when retention
+    // stays bounded: either it covers at least half the source (≤ 2× the result is pinned), or the
+    // bytes it pins but never uses (source.Length - length) stay within this fixed budget. The latter
+    // catches a moderate slice of a large source — e.g. substring(12000, -1) of a ~128K string, the
+    // dromaeo-object-string shape — which otherwise copies on every call.
+    private const int SliceViewMaxWastedChars = 128 * 1024;
+
     /// <summary>
-    /// Creates a string for a substring of <paramref name="source"/>. Large slices that cover
-    /// most of the source are returned as zero-copy views (<see cref="SlicedString"/>); small
-    /// slices are copied so a short-lived view can never pin a much larger backing string.
+    /// Creates a string for a substring of <paramref name="source"/>. Large slices that cover most of
+    /// the source, or moderate slices whose unused pinned remainder stays within
+    /// <see cref="SliceViewMaxWastedChars"/>, are returned as zero-copy views (<see cref="SlicedString"/>);
+    /// smaller slices are copied so a short-lived view can never pin a much larger backing string.
     /// </summary>
     internal static JsString CreateSliced(string source, int start, int length)
     {
@@ -215,9 +223,8 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
             return new JsString(source);
         }
 
-        // The view pins the whole source string; only worth it (and safe retention-wise)
-        // when the slice is large and covers at least half of the source.
-        if (length >= 512 && length * 2 >= source.Length)
+        if (length >= 512
+            && (length * 2 >= source.Length || source.Length - length <= SliceViewMaxWastedChars))
         {
             return new SlicedString(source, start, length);
         }


### PR DESCRIPTION
## What

`String.prototype.substring(start, end)` clamps a negative `end` to 0 and then **swaps** so the larger index is the end. So `str.substring(12000, -1)` on a 131072-char string yields a **12000-char** result whose pinned backing-string remainder (119072 chars) exceeded `JsString.CreateSliced`'s zero-copy retention guard (`length*2 >= source.Length` → 24000 < 131072), forcing a **full `string.Substring` copy on every call**. The visually-identical `str.slice(12000, -1)` resolves `-1` relative to length without swapping → a 119071-char span → passes the guard → zero-copy view. That asymmetry is why `slice` was ~1% of `dromaeo-object-string`'s allocation while **`substring` was 89.85% (116 MB/iter)**.

This adds an **absolute-waste cap** to the guard: a slice also becomes a `SlicedString` view when the bytes it pins but never uses (`source.Length - length`) stay within `SliceViewMaxWastedChars` (128K chars). So a moderate slice of a large source avoids the per-call copy while retention stays bounded (≤ result + 256 KB). Small slices still copy.

The PR also **corrects `StringSliceBenchmarks.SubstringLargeDiscard`**, which used `substring(12000, str.length - 1)` (positive args, no swap → already a view) and so never measured the dromaeo shape that copies — the reason #2506's benchmark reported substring as a small fraction.

## Benchmarks (default job, stash A/B)

| Benchmark | Baseline | This PR | Δ |
|---|--:|--:|--:|
| `SubstringLargeDiscard` — Allocated | 117,776 KB | 550 KB | **−99.5%** |
| `SubstringLargeDiscard` — time | 6.39 ms | 1.96 ms | −69% |
| `SliceSmall` (must still copy) | 628.57 KB | 628.57 KB | flat |
| `SliceThenRead` / `SliceLargeDiscard` | — | — | flat |

End-to-end **`dromaeo-object-string` allocation 129 MB → 14.6 MB (−88.7%)** (substring 116 MB → 1.6 MB), via MemoryProbe. Jint stays rank #1 on object-string by time.

## Tests

- Jint.Tests net10 (3067) + net472 (3005)
- Jint.Tests.PublicInterface net10 (79) + net472 (79)
- Test262: 99260 passed, 0 failed (substring/substr/slice suites + the indexOf/startsWith/split/equality consumers that operate on the returned view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
