### PR TITLE
Use direct IndexOf scan in String.prototype.split with string separator

### DIFF
--- a/Jint.Benchmark/StringSplitBenchmark.cs
+++ b/Jint.Benchmark/StringSplitBenchmark.cs
@@ -1,0 +1,98 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates String.prototype.split with a string separator over a large (~1M char) string —
+/// the dromaeo-object-string "String Split on Char" shape (<c>tmpstr.split("a")</c>), which
+/// produces tens of thousands of short segments. The non-empty-separator path previously routed
+/// through <see cref="string.Split(string[], StringSplitOptions)"/>, allocating a throwaway
+/// <c>string[]</c> result plus an internal match-position buffer on every call.
+/// SplitOnChar/SplitOnMultiChar guard the segment-production cost; SplitEmpty guards the
+/// already-optimal single-char branch (cached single-char JsStrings); SplitThenJoin guards the
+/// consume-the-result case (segments are materialized) so the production change stays neutral there.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class StringSplitBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _splitOnChar;
+    private Prepared<Script> _splitOnMultiChar;
+    private Prepared<Script> _splitEmpty;
+    private Prepared<Script> _splitThenJoin;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _splitOnChar = Engine.PrepareScript("""
+            (function() {
+                var ret = null;
+                for (var i = 0; i < 20; i++) {
+                    ret = bigstr.split("a");
+                }
+                return ret.length;
+            })();
+            """, strict: true);
+
+        _splitOnMultiChar = Engine.PrepareScript("""
+            (function() {
+                var ret = null;
+                for (var i = 0; i < 20; i++) {
+                    ret = bigstr.split("xy");
+                }
+                return ret.length;
+            })();
+            """, strict: true);
+
+        _splitEmpty = Engine.PrepareScript("""
+            (function() {
+                var ret = null;
+                for (var i = 0; i < 5; i++) {
+                    ret = bigstr.split("");
+                }
+                return ret.length;
+            })();
+            """, strict: true);
+
+        _splitThenJoin = Engine.PrepareScript("""
+            (function() {
+                var ret = null;
+                for (var i = 0; i < 20; i++) {
+                    ret = bigstr.split("a").join("a");
+                }
+                return ret.length;
+            })();
+            """, strict: true);
+
+        _engine = new Engine(static options => options.Strict());
+        // Deterministic ~1M char source cycling 'a'..'y' (dromaeo-style: 'a' every 25 chars,
+        // average 24-char segments; "xy" also appears once per cycle).
+        _engine.Execute("""
+            var bigstr = "";
+            for (var i = 0; i < 16384; i++) {
+                bigstr += String.fromCharCode(97 + (i % 25));
+            }
+            while (bigstr.length < 1048576) {
+                bigstr += bigstr;
+            }
+            """);
+        _engine.Evaluate(_splitOnChar);
+        _engine.Evaluate(_splitOnMultiChar);
+        _engine.Evaluate(_splitEmpty);
+        _engine.Evaluate(_splitThenJoin);
+    }
+
+    [Benchmark]
+    public JsValue SplitOnChar() => _engine.Evaluate(_splitOnChar);
+
+    [Benchmark]
+    public JsValue SplitOnMultiChar() => _engine.Evaluate(_splitOnMultiChar);
+
+    [Benchmark]
+    public JsValue SplitEmpty() => _engine.Evaluate(_splitEmpty);
+
+    [Benchmark]
+    public JsValue SplitThenJoin() => _engine.Evaluate(_splitThenJoin);
+}

--- a/Jint/Native/String/StringExecutionContext.cs
+++ b/Jint/Native/String/StringExecutionContext.cs
@@ -10,15 +10,12 @@ internal sealed class StringExecutionContext
     private static readonly ThreadLocal<StringExecutionContext> _executionContext = new ThreadLocal<StringExecutionContext>(() => new StringExecutionContext());
 
     private List<string>? _splitSegmentList;
-    private string[]? _splitArray1;
 
     private StringExecutionContext()
     {
     }
 
     public List<string> SplitSegmentList => _splitSegmentList ??= new List<string>();
-
-    public string[] SplitArray1 => _splitArray1 ??= new string[1];
 
     public static StringExecutionContext Current => _executionContext.Value!;
 }

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -1139,9 +1139,30 @@ internal sealed partial class StringPrototype : StringInstance
         }
         else
         {
-            var array = StringExecutionContext.Current.SplitArray1;
-            array[0] = sep;
-            segments.AddRange(s.Split(array, StringSplitOptions.None));
+            // Direct scan instead of string.Split: avoids the throwaway result array
+            // string.Split allocates on every call, and stops scanning once lim
+            // segments have been collected.
+            var start = 0;
+            while ((uint) segments.Count < lim)
+            {
+                if (segments.Count > 0 && segments.Count % ConstraintCheckInterval == 0)
+                {
+                    engine.Constraints.Check();
+                }
+
+                var index = sep.Length == 1
+                    ? s.IndexOf(sep[0], start)
+                    : s.IndexOf(sep, start, StringComparison.Ordinal);
+
+                if (index < 0)
+                {
+                    segments.Add(start == 0 ? s : s.Substring(start));
+                    break;
+                }
+
+                segments.Add(s.Substring(start, index - start));
+                start = index + sep.Length;
+            }
         }
 
         var length = (uint) System.Math.Min(segments.Count, lim);


### PR DESCRIPTION
## Summary

`SplitWithStringSeparator` (the `String.prototype.split` path for non-empty string separators) routed through `string.Split(string[], StringSplitOptions)`, which allocates a throwaway result `string[]` on every call — ~320 KB straight to the LOH when splitting a ~1M char string into ~40K segments (the dromaeo-object-string *String Split on Char* shape) — only for the contents to be copied into the pooled segment list and the array discarded.

This PR replaces it with a direct `IndexOf` scan that appends segments straight into the pooled list:

- no intermediate result array,
- the vectorized `IndexOf(char, int)` overload for single-character separators (the common case),
- scanning stops once `lim` segments have been collected instead of always splitting the entire string (`"a,b,c,…".split(",", 1)` no longer pays for the full scan),
- the loop is interruptible via the established `ConstraintCheckInterval` idiom (the old single `string.Split` call was an uninterruptible block),
- the now-unused `SplitArray1` scratch field is removed from `StringExecutionContext`.

Observable behavior is unchanged: same ordinal matching, same `StringSplitOptions.None` semantics (empty segments preserved, trailing empty segment included), same `lim` truncation results.

## Benchmarks

`StringSplitBenchmark` (added in this PR; default job, splitting a ~1M char string with average 24-char segments):

| Method | Before | After | Time | Alloc before | after | Δ |
|---|---:|---:|---:|---:|---:|---:|
| SplitOnChar | 118.83 ms | 81.87 ms | **−31.1%** | 96.06 MB | 89.66 MB | −6.7% |
| SplitOnMultiChar | 124.37 ms | 85.80 ms | **−31.0%** | 95.98 MB | 89.58 MB | −6.7% |
| SplitEmpty (guard, untouched branch) | 48.57 ms | 49.03 ms | flat | 40.01 MB | 40.01 MB | flat |
| SplitThenJoin | 127.21 ms | 94.56 ms | **−25.7%** | 136.07 MB | 129.66 MB | −4.7% |

Whole-workload `DromaeoBenchmark.ObjectString` (all four Modern × Prepared combos): allocations down in every row (e.g. Modern=true/Prepared=false 21.63 → 21.10 MB), time flat-to-better on the tight-variance prepared rows (47.21 → 46.27 ms). A deterministic per-subtest A/B (fixed-seed content) attributes the win precisely: *String Split on Char* −30%, every other subtest unchanged.

## Verification

- `dotnet build Jint/Jint.csproj -c Release` — all TFMs clean
- `Jint.Tests` net10.0 + net472 green
- `Jint.Tests.PublicInterface` net10.0 + net472 green
- Test262: 99260 passed, 0 failed, 133 skipped (exact baseline)
- Split edge cases spot-checked against V8 semantics: limits, empty string, consecutive separators, separator == whole string, no-match, regexp separators (unaffected path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
