### PR TITLE
Reduce CLR interop method dispatch overhead and allocations

### DIFF
--- a/Jint.Benchmark/InteropBulkConversionBenchmark.cs
+++ b/Jint.Benchmark/InteropBulkConversionBenchmark.cs
@@ -1,0 +1,45 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Bulk JS-array → CLR collection argument conversion — exercises DefaultTypeConverter's
+/// object[]-to-generic-collection path (Activator.CreateInstance(List&lt;&gt;) + per-element
+/// recursive Convert).
+/// </summary>
+[MemoryDiagnoser]
+public class InteropBulkConversionBenchmark
+{
+    public sealed class Sink
+    {
+        public int Count { get; private set; }
+
+        public void TakeList(List<int> values) => Count = values.Count;
+        public void TakeArray(int[] values) => Count = values.Length;
+    }
+
+    private Engine _engine = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _engine = new Engine();
+        _engine.SetValue("sink", new Sink());
+        _engine.Execute("const data = []; for (let i = 0; i < 1000; i++) data.push(i);");
+
+        // Warm the conversion caches.
+        _engine.Execute("sink.TakeList(data); sink.TakeArray(data);");
+    }
+
+    [Benchmark]
+    public void JsArrayToListOfInt()
+    {
+        _engine.Execute("sink.TakeList(data)");
+    }
+
+    [Benchmark]
+    public void JsArrayToIntArray()
+    {
+        _engine.Execute("sink.TakeArray(data)");
+    }
+}

--- a/Jint.Benchmark/InteropColdTypeBenchmark.cs
+++ b/Jint.Benchmark/InteropColdTypeBenchmark.cs
@@ -1,0 +1,32 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Cold-cache first-touch of a CLR type: fresh engine per operation, single property read.
+/// Captures TypeResolver.ResolvePropertyDescriptorFactory + TypeDescriptor analysis cost.
+/// Regression guard so warm-path caching changes don't inflate first-touch cost.
+/// (TypeDescriptor's static per-process cache stays warm across iterations; the per-engine
+/// reflection-accessor cache is what gets rebuilt here.)
+/// </summary>
+[MemoryDiagnoser]
+public class InteropColdTypeBenchmark
+{
+    public sealed class ColdPoco
+    {
+        public int Number { get; set; }
+        public string Text { get; set; } = string.Empty;
+
+        public int Bump(int delta) => Number + delta;
+    }
+
+    private readonly ColdPoco _instance = new() { Number = 1, Text = "x" };
+
+    [Benchmark]
+    public void ColdFirstTouch_NewType()
+    {
+        var engine = new Engine();
+        engine.SetValue("p", _instance);
+        engine.Execute("p.Number; p.Text; p.Bump(1);");
+    }
+}

--- a/Jint.Benchmark/InteropConstructorBenchmark.cs
+++ b/Jint.Benchmark/InteropConstructorBenchmark.cs
@@ -1,0 +1,73 @@
+#nullable enable
+using BenchmarkDotNet.Attributes;
+using Jint.Runtime.Interop;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// CLR constructor invocation from JS via TypeReference — the MethodDescriptor.Call path
+/// (TypeReference.Construct → InteropHelper.FindBestMatch → MethodDescriptor.Call), which has
+/// its own per-call object[] parameter array and reflective ConstructorInfo.Invoke.
+/// </summary>
+[MemoryDiagnoser]
+public class InteropConstructorBenchmark
+{
+    private const int OperationsPerInvoke = 1_000;
+
+    public sealed class RefTarget
+    {
+        public RefTarget()
+        {
+        }
+
+        public RefTarget(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public int Id { get; }
+        public string? Name { get; }
+    }
+
+    public readonly struct ValueTarget
+    {
+        public ValueTarget(int id)
+        {
+            Id = id;
+        }
+
+        public int Id { get; }
+    }
+
+    private Engine _engine = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _engine = new Engine(cfg => cfg.AllowClr(typeof(RefTarget).Assembly));
+        _engine.SetValue("RefTarget", TypeReference.CreateTypeReference<RefTarget>(_engine));
+        _engine.SetValue("ValueTarget", TypeReference.CreateTypeReference<ValueTarget>(_engine));
+
+        // Warm constructor caches.
+        _engine.Execute("new RefTarget(); new RefTarget(1, 'x'); new ValueTarget(1)");
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void Construct_NoArg()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engine.Execute("new RefTarget()");
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void Construct_TwoArgs()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engine.Execute("new RefTarget(1, 'x')");
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void Construct_ValueType_OneArg()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engine.Execute("new ValueTarget(1)");
+    }
+}

--- a/Jint.Benchmark/InteropMethodDispatchBenchmark.cs
+++ b/Jint.Benchmark/InteropMethodDispatchBenchmark.cs
@@ -1,0 +1,131 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// CLR interop method-dispatch micro-benchmarks. These isolate the per-call cost of
+/// MethodInfoFunction.Call: FindBestMatch iterator + overload scoring, the per-call
+/// object[] parameter array, argument coercion and the reflective MethodBase.Invoke.
+///
+/// Warm engines (caches populated in GlobalSetup) so the numbers reflect the steady-state
+/// dispatch cost, not first-touch type resolution (see InteropColdTypeBenchmark for that).
+/// </summary>
+[MemoryDiagnoser]
+public class InteropMethodDispatchBenchmark
+{
+    private const int OperationsPerInvoke = 1_000;
+
+    public sealed class Target
+    {
+        private int _counter;
+
+        // single-overload methods (the dominant real-world shape)
+        public int Ping() => _counter;
+        public int AddPoints(int delta) { _counter += delta; return _counter; }
+        public double SetRatio(double ratio) => ratio;
+        public string SetName(string name) => name;
+        public string Combine(int count, string name) => name;
+
+        // overload group with mixed argument types
+        public string Do(int x) => "int";
+        public string Do(string x) => "string";
+        public string Do(double x, double y) => "double,double";
+        public string Do(object x) => "object";
+
+        // params method
+        public int Sum(params int[] values)
+        {
+            var sum = 0;
+            foreach (var value in values)
+            {
+                sum += value;
+            }
+
+            return sum;
+        }
+    }
+
+    private Engine _engineNoArg = null!;
+    private Engine _engineOneInt = null!;
+    private Engine _engineOneDouble = null!;
+    private Engine _engineOneString = null!;
+    private Engine _engineTwoArgs = null!;
+    private Engine _engineOverloaded = null!;
+    private Engine _engineParams = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        // One engine per scenario keeps member-access caches monomorphic per benchmark.
+        static Engine CreateEngine()
+        {
+            var engine = new Engine();
+            engine.SetValue("t", new Target());
+            return engine;
+        }
+
+        _engineNoArg = CreateEngine();
+        _engineOneInt = CreateEngine();
+        _engineOneDouble = CreateEngine();
+        _engineOneString = CreateEngine();
+        _engineTwoArgs = CreateEngine();
+        _engineOverloaded = CreateEngine();
+        _engineParams = CreateEngine();
+
+        // Warm the dispatch caches.
+        _engineNoArg.Execute("t.Ping()");
+        _engineOneInt.Execute("t.AddPoints(1)");
+        _engineOneDouble.Execute("t.SetRatio(1.5)");
+        _engineOneString.Execute("t.SetName('x')");
+        _engineTwoArgs.Execute("t.Combine(1, 'x')");
+        _engineOverloaded.Execute("t.Do(1); t.Do('x'); t.Do(1.5, 2.5); t.Do({})");
+        _engineParams.Execute("t.Sum(1, 2, 3)");
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void SingleOverload_NoArg()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineNoArg.Execute("t.Ping()");
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void SingleOverload_OneIntArg()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineOneInt.Execute("t.AddPoints(1)");
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void SingleOverload_OneDoubleArg()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineOneDouble.Execute("t.SetRatio(1.5)");
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void SingleOverload_OneStringArg()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineOneString.Execute("t.SetName('x')");
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void SingleOverload_TwoArgs_IntString()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineTwoArgs.Execute("t.Combine(1, 'x')");
+    }
+
+    /// <summary>
+    /// Calls into a 4-method overload group with alternating argument types; guards that
+    /// single-overload fast paths don't change multi-overload resolution behavior or speed.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void Overloaded_MixedArgs()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineOverloaded.Execute("t.Do(1); t.Do('x'); t.Do(1.5, 2.5)");
+    }
+
+    /// <summary>Guards the HasParams / ProcessParamsArrays path.</summary>
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void ParamsMethod_Spread()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineParams.Execute("t.Sum(1, 2, 3)");
+    }
+}

--- a/Jint/Runtime/Interop/InteropHelper.cs
+++ b/Jint/Runtime/Interop/InteropHelper.cs
@@ -327,13 +327,110 @@ internal sealed class InteropHelper
         return !type.IsValueType || Nullable.GetUnderlyingType(type) != null;
     }
 
+    // (double) long.MaxValue rounds up to 2^63 which overflows long, the bound must be exclusive
+    private const double LongMaxValueExclusiveUpperBound = 9223372036854775808d;
+
+    /// <summary>
+    /// Fast conversion for the dominant numeric argument shapes, avoiding the generic
+    /// converter and Convert.ChangeType. Only converts when the result is bit-exact with
+    /// the general conversion path; otherwise declines and the caller falls back.
+    /// </summary>
+    internal static bool TryConvertNumberFast(double value, Type parameterType, out object? converted)
+    {
+        if (parameterType == typeof(double))
+        {
+            converted = value;
+            return true;
+        }
+
+        if (TypeConverter.IsIntegralNumber(value))
+        {
+            if (parameterType == typeof(int))
+            {
+                if (value is >= int.MinValue and <= int.MaxValue)
+                {
+                    converted = (int) value;
+                    return true;
+                }
+            }
+            else if (parameterType == typeof(long))
+            {
+                if (value is >= long.MinValue and < LongMaxValueExclusiveUpperBound)
+                {
+                    converted = (long) value;
+                    return true;
+                }
+            }
+        }
+
+        converted = null;
+        return false;
+    }
+
 
     internal readonly record struct MethodMatch(MethodDescriptor Method, JsCallArguments Arguments, int Score = 0) : IComparable<MethodMatch>
     {
         public int CompareTo(MethodMatch other) => Score.CompareTo(other.Score);
     }
 
-    internal static IEnumerable<MethodMatch> FindBestMatch<TState>(
+    /// <summary>
+    /// Match candidates in preference order: either a single perfect match or a score-sorted
+    /// candidate list. A struct with a struct enumerator so the common single-match case does
+    /// not allocate; only the ambiguous multi-candidate case carries a list.
+    /// </summary>
+    internal readonly struct MethodMatches
+    {
+        private readonly MethodMatch _single;
+        private readonly List<MethodMatch>? _list;
+        private readonly bool _hasSingle;
+
+        private MethodMatches(in MethodMatch single, List<MethodMatch>? list, bool hasSingle)
+        {
+            _single = single;
+            _list = list;
+            _hasSingle = hasSingle;
+        }
+
+        public static MethodMatches Empty => default;
+
+        public static MethodMatches Single(in MethodMatch match) => new(match, list: null, hasSingle: true);
+
+        public static MethodMatches Sorted(List<MethodMatch> list) => new(default, list, hasSingle: false);
+
+        public MethodMatch FirstOrDefault()
+        {
+            if (_hasSingle)
+            {
+                return _single;
+            }
+
+            return _list is { Count: > 0 } ? _list[0] : default;
+        }
+
+        public Enumerator GetEnumerator() => new(this);
+
+        internal struct Enumerator
+        {
+            private readonly MethodMatches _matches;
+            private int _index;
+
+            internal Enumerator(in MethodMatches matches)
+            {
+                _matches = matches;
+                _index = -1;
+            }
+
+            public readonly MethodMatch Current => _matches._list is not null ? _matches._list[_index] : _matches._single;
+
+            public bool MoveNext()
+            {
+                var count = _matches._list?.Count ?? (_matches._hasSingle ? 1 : 0);
+                return ++_index < count;
+            }
+        }
+    }
+
+    internal static MethodMatches FindBestMatch<TState>(
         Engine engine,
         MethodDescriptor[] methods,
         Func<MethodDescriptor, TState, JsValue[]> argumentProvider,
@@ -350,9 +447,8 @@ internal sealed class InteropHelper
                 var score = CalculateMethodScore(engine, method, arguments);
                 if (score == 0)
                 {
-                    // perfect match
-                    yield return new MethodMatch(method, arguments);
-                    yield break;
+                    // perfect match, earlier non-perfect candidates are discarded
+                    return MethodMatches.Single(new MethodMatch(method, arguments));
                 }
 
                 if (score < 0)
@@ -368,7 +464,7 @@ internal sealed class InteropHelper
 
         if (matchingByParameterCount == null)
         {
-            yield break;
+            return MethodMatches.Empty;
         }
 
         if (matchingByParameterCount.Count > 1)
@@ -376,9 +472,6 @@ internal sealed class InteropHelper
             matchingByParameterCount.Sort();
         }
 
-        foreach (var match in matchingByParameterCount)
-        {
-            yield return match;
-        }
+        return MethodMatches.Sorted(matchingByParameterCount);
     }
 }

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -36,6 +36,80 @@ internal sealed class MethodDescriptor
     public int ParameterDefaultValuesCount { get; }
     public bool IsExtensionMethod { get; }
 
+#if NET8_0_OR_GREATER
+    // lazily initialized fast invokers, benign race - last writer wins
+    private MethodInvoker? _methodInvoker;
+    private ConstructorInvoker? _constructorInvoker;
+#endif
+
+    /// <summary>
+    /// Invokes the method using a cached fast invoker when available. Target exceptions are
+    /// normalized to <see cref="TargetInvocationException"/> to match MethodBase.Invoke behavior.
+    /// </summary>
+    public object? Invoke(object? instance, object?[] parameters)
+    {
+#if NET8_0_OR_GREATER
+        return Invoke(instance, parameters.AsSpan());
+#else
+        return Method switch
+        {
+            MethodInfo m => m.Invoke(instance, parameters),
+            ConstructorInfo c => c.Invoke(parameters),
+            _ => throw new NotSupportedException("Method is unknown type"),
+        };
+#endif
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Invokes the method using a cached fast invoker; the span may be a slice of a pooled,
+    /// oversized buffer. Target exceptions are normalized to <see cref="TargetInvocationException"/>.
+    /// </summary>
+    public object? Invoke(object? instance, Span<object?> parameters)
+    {
+        // MethodInvoker/ConstructorInvoker don't perform Type.Missing default-value
+        // substitution, fall back to MethodBase.Invoke when optional arguments are elided
+        if (ParameterDefaultValuesCount > 0)
+        {
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                if (ReferenceEquals(parameters[i], System.Type.Missing))
+                {
+                    return Method switch
+                    {
+                        MethodInfo m => m.Invoke(instance, parameters.ToArray()),
+                        ConstructorInfo c => c.Invoke(parameters.ToArray()),
+                        _ => throw new NotSupportedException("Method is unknown type"),
+                    };
+                }
+            }
+        }
+
+        try
+        {
+            if (Method is MethodInfo methodInfo)
+            {
+                var invoker = _methodInvoker ??= MethodInvoker.Create(methodInfo);
+                return invoker.Invoke(instance, parameters);
+            }
+
+            if (Method is ConstructorInfo constructorInfo)
+            {
+                var invoker = _constructorInvoker ??= ConstructorInvoker.Create(constructorInfo);
+                return invoker.Invoke(parameters);
+            }
+        }
+        catch (Exception e) when (e is not TargetInvocationException)
+        {
+            // MethodBase.Invoke wraps exceptions thrown by the invoked member, the fast
+            // invokers rethrow them as-is - normalize so callers see the legacy shape
+            throw new TargetInvocationException(e);
+        }
+
+        throw new NotSupportedException("Method is unknown type");
+    }
+#endif
+
     public static MethodDescriptor[] Build<T>(List<T> source) where T : MethodBase
     {
         var descriptors = new MethodDescriptor[source.Count];
@@ -105,7 +179,7 @@ internal sealed class MethodDescriptor
 
     public JsValue Call(Engine engine, object? instance, JsCallArguments arguments)
     {
-        var parameters = new object?[arguments.Length];
+        object?[] parameters = arguments.Length == 0 ? [] : new object?[arguments.Length];
         var methodParameters = Parameters;
         var valueCoercionType = engine.Options.Interop.ValueCoercion;
 
@@ -127,6 +201,10 @@ internal sealed class MethodDescriptor
                     // undefined is considered missing, null is considered explicit value
                     converted = methodParameter.DefaultValue;
                 }
+                else if (value is JsNumber jsNumber && InteropHelper.TryConvertNumberFast(jsNumber._value, parameterType, out converted))
+                {
+                    // common numeric argument converted without the generic converter
+                }
                 else if (!ReflectionExtensions.TryConvertViaTypeCoercion(parameterType, valueCoercionType, value, out converted))
                 {
                     converted = engine.TypeConverter.Convert(
@@ -138,12 +216,7 @@ internal sealed class MethodDescriptor
                 parameters[i] = converted;
             }
 
-            var retVal = Method switch
-            {
-                MethodInfo m => m.Invoke(instance, parameters),
-                ConstructorInfo c => c.Invoke(parameters),
-                _ => throw new NotSupportedException("Method is unknown type"),
-            };
+            var retVal = Invoke(instance, parameters);
             return JsValue.FromObject(engine, retVal);
         }
         catch (TargetInvocationException exception)

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -154,112 +155,32 @@ internal sealed class MethodInfoFunction : Function
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments jsArguments)
     {
-        static JsCallArguments ArgumentProvider(MethodDescriptor method, MethodResolverState state)
-        {
-            if (method.IsExtensionMethod)
-            {
-                var jsArgumentsTemp = new JsValue[1 + state.Arguments.Length];
-                jsArgumentsTemp[0] = state.This;
-                Array.Copy(state.Arguments, 0, jsArgumentsTemp, 1, state.Arguments.Length);
-                return method.HasParams
-                    ? ProcessParamsArrays(state.Engine, method, jsArgumentsTemp)
-                    : jsArgumentsTemp;
-            }
-
-            return method.HasParams
-                ? ProcessParamsArrays(state.Engine, method, state.Arguments)
-                : state.Arguments;
-        }
-
         var converter = Engine.TypeConverter;
         var thisObj = thisObject.ToObject() ?? _target;
-        object?[]? parameters = null;
         var state = new MethodResolverState(_engine, thisObject, jsArguments);
-        foreach (var (method, arguments, _) in InteropHelper.FindBestMatch(_engine, _methods, ArgumentProvider, state))
+
+        if (_methods.Length == 1)
         {
-            var methodParameters = method.Parameters;
-            if (parameters == null || parameters.Length != methodParameters.Length)
+            // single candidate, no overload resolution needed - bind directly and skip scoring
+            var method = _methods[0];
+            var parameterInfos = method.Parameters;
+            var arguments = ArgumentProvider(method, state);
+            if (arguments.Length <= parameterInfos.Length
+                && arguments.Length >= parameterInfos.Length - method.ParameterDefaultValuesCount
+                && CanBindNullArguments(parameterInfos, arguments)
+                && TryCall(method, arguments, thisObj, converter, out var fastResult))
             {
-                parameters = new object[methodParameters.Length];
+                return fastResult;
             }
-
-            var argumentsMatch = true;
-            var resolvedMethod = ResolveMethod(method.Method, methodParameters, arguments);
-            // We only need to call GetParameters it if this ends up being a generic method (i.e. they will be different in that scenario)
-            if (resolvedMethod.IsGenericMethod)
+        }
+        else
+        {
+            foreach (var (method, arguments, _) in InteropHelper.FindBestMatch(_engine, _methods, static (method, state) => ArgumentProvider(method, state), state))
             {
-                methodParameters = resolvedMethod.GetParameters();
-            }
-            for (var i = 0; i < parameters.Length; i++)
-            {
-                var methodParameter = methodParameters[i];
-                var parameterType = methodParameter.ParameterType;
-                var argument = arguments.Length > i ? arguments[i] : null;
-                object? argumentObject = null;
-
-                if (typeof(JsValue).IsAssignableFrom(parameterType))
+                if (TryCall(method, arguments, thisObj, converter, out var result))
                 {
-                    parameters[i] = argument;
+                    return result;
                 }
-                else if (argument is null)
-                {
-                    // optional
-                    parameters[i] = System.Type.Missing;
-                }
-                else if (IsGenericParameter(argumentObject = argument.ToObject(), parameterType)) // don't think we need the condition preface of (argument == null) because of earlier condition
-                {
-                    // ^ this is the best way I could think of to only eval argument.ToObject() when needed.
-                    // But it's very cursed, I'm sorry.
-                    parameters[i] = argumentObject;
-                }
-                else if (parameterType == typeof(JsValue[]) && argument.IsArray())
-                {
-                    // Handle specific case of F(params JsValue[])
-                    var arrayInstance = argument.AsArray();
-                    var len = TypeConverter.ToInt32(arrayInstance.Get(CommonProperties.Length, this));
-                    var result = new JsValue[len];
-                    for (uint k = 0; k < len; k++)
-                    {
-                        result[k] = arrayInstance.TryGetValue(k, out var value) ? value : Undefined;
-                    }
-
-                    parameters[i] = result;
-                }
-                else
-                {
-                    if (!ReflectionExtensions.TryConvertViaTypeCoercion(parameterType, _engine.Options.Interop.ValueCoercion, argument, out parameters[i])
-                        && !converter.TryConvert(argumentObject, parameterType, CultureInfo.InvariantCulture, out parameters[i]))
-                    {
-                        argumentsMatch = false;
-                        break;
-                    }
-
-                    if (parameters[i] is LambdaExpression lambdaExpression)
-                    {
-                        parameters[i] = lambdaExpression.Compile();
-                    }
-                }
-            }
-
-            if (!argumentsMatch)
-            {
-                continue;
-            }
-
-            // todo: cache method info
-            try
-            {
-                if (method.Method is MethodInfo { IsGenericMethodDefinition: true })
-                {
-                    var result = resolvedMethod.Invoke(thisObj, parameters);
-                    return FromObjectWithType(Engine, result, type: (resolvedMethod as MethodInfo)?.ReturnType);
-                }
-
-                return FromObjectWithType(Engine, method.Method.Invoke(thisObj, parameters), type: (method.Method as MethodInfo)?.ReturnType);
-            }
-            catch (TargetInvocationException exception)
-            {
-                Throw.MeaningfulException(_engine, exception);
             }
         }
 
@@ -270,6 +191,144 @@ internal sealed class MethodInfoFunction : Function
 
         Throw.TypeError(_engine.Realm, "No public methods with the specified arguments were found.");
         return null;
+    }
+
+    private static JsCallArguments ArgumentProvider(MethodDescriptor method, in MethodResolverState state)
+    {
+        if (method.IsExtensionMethod)
+        {
+            var jsArgumentsTemp = new JsValue[1 + state.Arguments.Length];
+            jsArgumentsTemp[0] = state.This;
+            Array.Copy(state.Arguments, 0, jsArgumentsTemp, 1, state.Arguments.Length);
+            return method.HasParams
+                ? ProcessParamsArrays(state.Engine, method, jsArgumentsTemp)
+                : jsArgumentsTemp;
+        }
+
+        return method.HasParams
+            ? ProcessParamsArrays(state.Engine, method, state.Arguments)
+            : state.Arguments;
+    }
+
+    /// <summary>
+    /// Mirrors the null/undefined rejection rule of overload scoring: null cannot bind to a
+    /// non-optional parameter of non-nullable value type (even when value coercion could
+    /// otherwise produce a value).
+    /// </summary>
+    private static bool CanBindNullArguments(ParameterInfo[] parameterInfos, JsCallArguments arguments)
+    {
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            if (arguments[i].IsNullOrUndefined())
+            {
+                var parameter = parameterInfos[i];
+                if (!parameter.IsOptional && !InteropHelper.TypeIsNullable(parameter.ParameterType))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private bool TryCall(
+        MethodDescriptor method,
+        JsCallArguments arguments,
+        object? thisObj,
+        ITypeConverter converter,
+        [NotNullWhen(true)] out JsValue? callResult)
+    {
+        callResult = null;
+
+        var methodParameters = method.Parameters;
+        var resolvedMethod = ResolveMethod(method.Method, methodParameters, arguments);
+        // We only need to call GetParameters it if this ends up being a generic method (i.e. they will be different in that scenario)
+        var isGenericDefinition = false;
+        if (resolvedMethod.IsGenericMethod)
+        {
+            methodParameters = resolvedMethod.GetParameters();
+            isGenericDefinition = method.Method is MethodInfo { IsGenericMethodDefinition: true };
+        }
+
+        // NOTE: pooling this buffer via ArrayPool was measured slower than allocation (tiny
+        // gen0 arrays), keep the plain exact-size allocation
+        var parameterCount = methodParameters.Length;
+        object?[] parameters = parameterCount == 0 ? [] : new object[parameterCount];
+
+        for (var i = 0; i < parameterCount; i++)
+        {
+            var methodParameter = methodParameters[i];
+            var parameterType = methodParameter.ParameterType;
+            var argument = arguments.Length > i ? arguments[i] : null;
+            object? argumentObject = null;
+
+            if (typeof(JsValue).IsAssignableFrom(parameterType))
+            {
+                parameters[i] = argument;
+            }
+            else if (argument is null)
+            {
+                // optional
+                parameters[i] = System.Type.Missing;
+            }
+            else if (IsGenericParameter(argumentObject = argument.ToObject(), parameterType)) // don't think we need the condition preface of (argument == null) because of earlier condition
+            {
+                // ^ this is the best way I could think of to only eval argument.ToObject() when needed.
+                // But it's very cursed, I'm sorry.
+                parameters[i] = argumentObject;
+            }
+            else if (parameterType == typeof(JsValue[]) && argument.IsArray())
+            {
+                // Handle specific case of F(params JsValue[])
+                var arrayInstance = argument.AsArray();
+                var len = TypeConverter.ToInt32(arrayInstance.Get(CommonProperties.Length, this));
+                var result = new JsValue[len];
+                for (uint k = 0; k < len; k++)
+                {
+                    result[k] = arrayInstance.TryGetValue(k, out var value) ? value : Undefined;
+                }
+
+                parameters[i] = result;
+            }
+            else if (argument is JsNumber jsNumber && InteropHelper.TryConvertNumberFast(jsNumber._value, parameterType, out parameters[i]))
+            {
+                // common numeric argument converted without the generic converter
+            }
+            else
+            {
+                if (!ReflectionExtensions.TryConvertViaTypeCoercion(parameterType, _engine.Options.Interop.ValueCoercion, argument, out parameters[i])
+                    && !converter.TryConvert(argumentObject, parameterType, CultureInfo.InvariantCulture, out parameters[i]))
+                {
+                    // arguments don't match this method
+                    return false;
+                }
+
+                if (parameters[i] is LambdaExpression lambdaExpression)
+                {
+                    parameters[i] = lambdaExpression.Compile();
+                }
+            }
+        }
+
+        try
+        {
+            if (isGenericDefinition)
+            {
+                // the resolved generic method differs per call, cannot use the cached invoker
+                var result = resolvedMethod.Invoke(thisObj, parameters);
+                callResult = FromObjectWithType(Engine, result, type: (resolvedMethod as MethodInfo)?.ReturnType);
+                return true;
+            }
+
+            callResult = FromObjectWithType(Engine, method.Invoke(thisObj, parameters), type: (method.Method as MethodInfo)?.ReturnType);
+            return true;
+        }
+        catch (TargetInvocationException exception)
+        {
+            Throw.MeaningfulException(_engine, exception);
+            return false;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Reduces per-call CPU time and allocations when JavaScript code calls .NET methods and constructors. Five changes that share the same dispatch path:

- **`InteropHelper.FindBestMatch` no longer allocates an enumerator state machine per call** — it returns a `readonly struct` result (single match inline, score-sorted list only in the ambiguous multi-candidate case) with a struct enumerator. Same scan order, gate, early-exit and sort as before.
- **Single-overload methods skip overload scoring entirely** and bind directly. This also removes a hidden cost: scoring called `ToObject()` per argument, which for a JS array argument materialized a duplicate `object[]` + boxed elements on every call (visible in the bulk conversion rows below). The null/undefined → non-optional, non-nullable value-type rejection rule from scoring is preserved explicitly (`CanBindNullArguments`), so behavior is unchanged even when `ValueCoercion.Number` is enabled.
- **`Array.Empty` for parameterless calls** in both `MethodInfoFunction` and `MethodDescriptor` instead of `new object[0]`.
- **Cached `MethodInvoker`/`ConstructorInvoker` per `MethodDescriptor` on net8+** (lazy, benign-racy init). Two correctness points handled: the fast invokers rethrow target exceptions unwrapped, so they're normalized back to `TargetInvocationException` to keep `Throw.MeaningfulException`/`ExceptionHandler` routing identical; and they don't support `Type.Missing` default-value substitution, so elided optional arguments fall back to `MethodBase.Invoke`. Older TFMs keep the existing reflection path unchanged.
- **Fast path for `JsNumber` → `double`/`int`/`long` argument conversion** before the general converter (previously a `double` parameter went through `ToObject` + `Convert.ChangeType` on every call). Only fires when the result is bit-exact with the existing pipeline; NaN/Infinity/fractional-to-int cases fall through to the existing logic. The `long` upper bound is exclusive 2^63 because `(double)long.MaxValue` rounds up.

Also adds interop dispatch/constructor/bulk-conversion/cold-start micro-benchmarks used to gate this work.

### Benchmarks

AMD Ryzen 9 5950X, .NET 10.0.8, BenchmarkDotNet v0.15.8 default job, `[MemoryDiagnoser]`. Before = `main` baseline, after = this branch in isolation.

| Benchmark | Mean before | Mean after | Allocated before | Allocated after |
|---|---:|---:|---:|---:|
| SingleOverload_NoArg | 894.6 ns | 839.0 ns | 1,848 B | 1,638 B |
| SingleOverload_OneIntArg | 1,144.6 ns | 1,016.7 ns | 2,144 B | 1,935 B |
| SingleOverload_OneStringArg | 1,123.4 ns | 1,121.5 ns | 2,048 B | 1,863 B |
| SingleOverload_TwoArgs_IntString | 1,316.9 ns | 1,245 ns | 2,224 B | 2,017 B |
| Overloaded_MixedArgs (3 calls) | 5,409.3 ns | 5,294 ns | 5,632 B | 5,018 B |
| ParamsMethod_Spread | 1,902.1 ns | 1,702.3 ns | 3,224 B | 2,765 B |
| MethodInvoke_NoArgs | 942.1 ns | 919.1 ns | 1,904 B | 1,700 B |
| MethodInvoke_OneArg | 1,113.9 ns | 1,064.6 ns | 2,144 B | 1,935 B |
| GenericMethods | 4,061.9 ns | 4,032.7 ns | 6,272 B | 5,878 B |
| Construct_NoArg | 966.1 ns | 910.3 ns | 1,760 B | 1,567 B |
| Construct_TwoArgs | 1,275.0 ns | 1,273.4 ns | 2,168 B | 1,997 B |
| Construct_ValueType_OneArg | 1,051.8 ns | 1,067.8 ns | 2,024 B | 1,853 B |
| JsArrayToListOfInt (1000 elems) | 42.3 µs | 39.7 µs | 155,179 B | 122,778 B (−21%) |
| JsArrayToIntArray (1000 elems) | 41.0 µs | 38.5 µs | 158,466 B | 126,106 B (−20%) |
| ColdFirstTouch_NewType (guard) | 5,609 ns | 5,857 ns | 22,688 B | 22,682 B |

Time deltas under ~5% are within run-to-run variance on this machine; the allocation column is deterministic. The bulk-conversion rows improve because single-overload binding no longer materializes the JS array twice (once for scoring, once for conversion).

Notes:
- An `ArrayPool` variant for the N-arg parameter buffer was also tried and measured **slower** (+2–4% time for −30–40 B) — pool rent/clear/return costs more than a tiny gen0 array, so the plain exact-size allocation stays.
- Full `Jint.Tests` pass on net10.0 and net472 on this branch; the combined campaign tree additionally passed Test262 (99,260/0), `Jint.Tests.PublicInterface` and the AOT example build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)