### PR TITLE
Avoid per-access parameter array allocation in interop indexer reads

### DIFF
--- a/Jint.Benchmark/InteropIndexerBenchmark.cs
+++ b/Jint.Benchmark/InteropIndexerBenchmark.cs
@@ -1,0 +1,71 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Custom-indexer access from JS — the IndexerAccessor reflection path. Plain List&lt;T&gt; and
+/// string-keyed generic dictionaries take specialized wrapper paths (GenericListWrapper /
+/// TypeDescriptor) and never hit IndexerAccessor; a custom this[string] / this[int] type does.
+/// </summary>
+[MemoryDiagnoser]
+public class InteropIndexerBenchmark
+{
+    private const int OperationsPerInvoke = 1_000;
+
+    public sealed class StringIndexedBag
+    {
+        private readonly Dictionary<string, int> _data = new() { ["alpha"] = 1, ["beta"] = 2 };
+
+        public int this[string key]
+        {
+            get => _data[key];
+            set => _data[key] = value;
+        }
+
+        public bool ContainsKey(string key) => _data.ContainsKey(key);
+    }
+
+    public sealed class IntIndexedBag
+    {
+        private readonly int[] _data = [1, 2, 3, 4];
+
+        public int this[int index]
+        {
+            get => _data[index];
+            set => _data[index] = value;
+        }
+    }
+
+    private Engine _engineString = null!;
+    private Engine _engineInt = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _engineString = new Engine();
+        _engineString.SetValue("bag", new StringIndexedBag());
+        _engineString.Execute("bag['alpha']; bag['alpha'] = 1;");
+
+        _engineInt = new Engine();
+        _engineInt.SetValue("bag", new IntIndexedBag());
+        _engineInt.Execute("bag[1]; bag[1] = 2;");
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void IndexerGet_StringKey()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineString.Execute("bag['alpha']");
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void IndexerSet_StringKey()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineString.Execute("bag['alpha'] = 1");
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void IndexerGet_IntKey()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineInt.Execute("bag[1]");
+    }
+}

--- a/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/IndexerAccessor.cs
@@ -14,6 +14,9 @@ internal sealed class IndexerAccessor : ReflectionAccessor
 {
     private readonly object _key;
 
+    // the key never changes, safe to share between getter/ContainsKey invocations (contents are never mutated)
+    private readonly object[] _keyParameters;
+
     private readonly MethodInfo? _getter;
     private readonly MethodInfo? _setter;
     private readonly MethodInfo? _containsKey;
@@ -25,6 +28,7 @@ internal sealed class IndexerAccessor : ReflectionAccessor
 
         _containsKey = containsKey;
         _key = key;
+        _keyParameters = [key];
 
         _getter = indexer.GetGetMethod();
         _setter = indexer.GetSetMethod();
@@ -185,7 +189,7 @@ internal sealed class IndexerAccessor : ReflectionAccessor
             return null;
         }
 
-        object[] parameters = [_key];
+        var parameters = _keyParameters;
 
         if (_containsKey != null)
         {
@@ -220,7 +224,7 @@ internal sealed class IndexerAccessor : ReflectionAccessor
     {
         if (_containsKey != null)
         {
-            if (_containsKey.Invoke(target, [_key]) as bool? != true)
+            if (_containsKey.Invoke(target, _keyParameters) as bool? != true)
             {
                 return PropertyDescriptor.Undefined;
             }


### PR DESCRIPTION
`IndexerAccessor` allocated a fresh `object[] { _key }` for every indexer read (`DoGetValue` and `CreatePropertyDescriptor`'s `ContainsKey` probe). The key is immutable per accessor instance — accessors are cached per `(type, propertyName)` — so the single-element argument array can be created once in the constructor and shared. Sharing is re-entrancy-safe because the array contents are never mutated. The setter keeps its per-call array since it carries the written value.

This path is hit by custom indexer types (e.g. `this[string]` on non-dictionary classes, `JsonNode`); plain `List<T>`/string-keyed dictionaries use the specialized wrapper paths and are unaffected. Adds an `InteropIndexerBenchmark` covering exactly this path.

### Benchmarks

AMD Ryzen 9 5950X, .NET 10.0.8, BenchmarkDotNet v0.15.8 default job, `[MemoryDiagnoser]`. Isolated A/B of this change.

| Benchmark | Mean before | Mean after | Allocated before | Allocated after |
|---|---:|---:|---:|---:|
| IndexerGet_StringKey | 840.6 ns | 839.1 ns | 1,649 B | 1,618 B |
| IndexerGet_IntKey | 783.6 ns | 774.9 ns | 1,516 B | 1,485 B |
| IndexerSet_StringKey (unchanged path) | 1,074.9 ns | 1,080.4 ns | 1,894 B | 1,894 B |

One `object[1]` (32 B) removed per indexer read; time flat to slightly better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)