### PR TITLE
Reduce intermediate allocations in array-building built-ins with a pooled accumulator

### DIFF
--- a/Jint.Benchmark/ArrayConcatBenchmark.cs
+++ b/Jint.Benchmark/ArrayConcatBenchmark.cs
@@ -24,16 +24,31 @@ var e100 = makeArr(100);
     private Prepared<Script> _twoArrays;
     private Prepared<Script> _fiveArrays;
     private Prepared<Script> _withScalar;
+    private Prepared<Script> _withPlainObject;
+    private Prepared<Script> _withSpreadableObject;
+    private Prepared<Script> _withHoleyArray;
 
     [GlobalSetup]
     public void Setup()
     {
         _engine = new Engine();
         _engine.Execute(SetupScript);
+        _engine.Execute("""
+var spreadable100 = { length: 100 };
+spreadable100[Symbol.isConcatSpreadable] = true;
+for (var i = 0; i < 100; i++) spreadable100[i] = i;
+var holey500 = makeArr(500);
+delete holey500[100];
+delete holey500[200];
+""");
 
         _twoArrays = Engine.PrepareScript("for (var n = 0; n < 1000; n++) { a500.concat(b500); }");
         _fiveArrays = Engine.PrepareScript("for (var n = 0; n < 1000; n++) { a100.concat(b100, c100, d100, e100); }");
         _withScalar = Engine.PrepareScript("for (var n = 0; n < 1000; n++) { a500.concat('x', b500); }");
+        // the following all bail the all-JsArray fast path into the slow/builder path
+        _withPlainObject = Engine.PrepareScript("for (var n = 0; n < 1000; n++) { a500.concat({}); }");
+        _withSpreadableObject = Engine.PrepareScript("for (var n = 0; n < 1000; n++) { a500.concat(spreadable100); }");
+        _withHoleyArray = Engine.PrepareScript("for (var n = 0; n < 1000; n++) { a500.concat(holey500, {}); }");
     }
 
     [Benchmark]
@@ -44,4 +59,13 @@ var e100 = makeArr(100);
 
     [Benchmark]
     public void Concat_WithScalar() => _engine.Execute(_withScalar);
+
+    [Benchmark]
+    public void Concat_WithPlainObject() => _engine.Execute(_withPlainObject);
+
+    [Benchmark]
+    public void Concat_WithSpreadableObject() => _engine.Execute(_withSpreadableObject);
+
+    [Benchmark]
+    public void Concat_WithHoleyArray() => _engine.Execute(_withHoleyArray);
 }

--- a/Jint.Benchmark/ArrayFilterBenchmark.cs
+++ b/Jint.Benchmark/ArrayFilterBenchmark.cs
@@ -1,0 +1,37 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+[MemoryDiagnoser]
+public class ArrayFilterBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _filter;
+
+    [Params(100, 10_000)]
+    public int Size { get; set; }
+
+    /// <summary>
+    /// Share of source elements that pass the predicate: 0 exercises the empty-result path,
+    /// 50 the growth path, 100 the full-copy worst case.
+    /// </summary>
+    [Params(0, 50, 100)]
+    public int SelectivityPercent { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute($$"""
+var testArray = [];
+for (var i = 0; i < {{Size}}; i++) {
+    testArray.push(i);
+}
+var threshold = {{Size}} * {{SelectivityPercent}} / 100;
+""");
+        _filter = Engine.PrepareScript("testArray.filter(function(x) { return x < threshold; });");
+    }
+
+    [Benchmark]
+    public void Filter() => _engine.Execute(_filter);
+}

--- a/Jint.Benchmark/ArrayFlatBenchmark.cs
+++ b/Jint.Benchmark/ArrayFlatBenchmark.cs
@@ -1,0 +1,48 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+[MemoryDiagnoser]
+public class ArrayFlatBenchmark
+{
+    private const int N = 100;
+
+    private Engine _engine = null!;
+    private Prepared<Script> _flatShallow;
+    private Prepared<Script> _flatDeep;
+    private Prepared<Script> _flatMap;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute("""
+var nested = [];
+for (var i = 0; i < 100; i++) {
+    var inner = [];
+    for (var j = 0; j < 10; j++) {
+        inner.push(i * 10 + j);
+    }
+    nested.push(inner);
+}
+var deep = [1, [2, [3, [4, [5, [6, [7, [8, [9, [10]]]]]]]]]];
+var flatArray = [];
+for (var i = 0; i < 1000; i++) {
+    flatArray.push(i);
+}
+""");
+
+        _flatShallow = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ nested.flat(); }}");
+        _flatDeep = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ deep.flat(Infinity); }}");
+        _flatMap = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ flatArray.flatMap(function(x) {{ return [x, x]; }}); }}");
+    }
+
+    [Benchmark]
+    public void FlatShallow() => _engine.Execute(_flatShallow);
+
+    [Benchmark]
+    public void FlatDeep() => _engine.Execute(_flatDeep);
+
+    [Benchmark]
+    public void FlatMap() => _engine.Execute(_flatMap);
+}

--- a/Jint.Benchmark/ArrayFromBenchmark.cs
+++ b/Jint.Benchmark/ArrayFromBenchmark.cs
@@ -1,0 +1,40 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+[MemoryDiagnoser]
+public class ArrayFromBenchmark
+{
+    private const int N = 100;
+
+    private Engine _engine = null!;
+    private Prepared<Script> _fromSet;
+    private Prepared<Script> _fromArray;
+    private Prepared<Script> _fromSetWithMapper;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute("""
+var numbers = [];
+for (var i = 0; i < 1000; i++) {
+    numbers.push(i);
+}
+var set = new Set(numbers);
+""");
+
+        _fromSet = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ Array.from(set); }}");
+        _fromArray = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ Array.from(numbers); }}");
+        _fromSetWithMapper = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ Array.from(set, function(x) {{ return x * 2; }}); }}");
+    }
+
+    [Benchmark]
+    public void FromSet() => _engine.Execute(_fromSet);
+
+    [Benchmark]
+    public void FromArray() => _engine.Execute(_fromArray);
+
+    [Benchmark]
+    public void FromSetWithMapper() => _engine.Execute(_fromSetWithMapper);
+}

--- a/Jint.Benchmark/RegExpMatchBenchmark.cs
+++ b/Jint.Benchmark/RegExpMatchBenchmark.cs
@@ -1,0 +1,36 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+[MemoryDiagnoser]
+public class RegExpMatchBenchmark
+{
+    private const int N = 100;
+
+    private Engine _engine = null!;
+    private Prepared<Script> _matchGlobal;
+    private Prepared<Script> _matchGlobalUnicode;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute("""
+var text = '';
+for (var i = 0; i < 100; i++) {
+    text += 'word' + i + ' number ' + (i * 37) + '; ';
+}
+""");
+
+        // non-sticky .NET engine path (already exact-sized, regression canary)
+        _matchGlobal = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ text.match(/\\d+/g); }}");
+        // unicode flag forces the MatchSlow exec loop
+        _matchGlobalUnicode = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ text.match(/\\d+/gu); }}");
+    }
+
+    [Benchmark]
+    public void MatchGlobal() => _engine.Execute(_matchGlobal);
+
+    [Benchmark]
+    public void MatchGlobalUnicode() => _engine.Execute(_matchGlobalUnicode);
+}

--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -118,6 +118,47 @@ public class ArrayTests
     }
 
     [Fact]
+    public void ConcatGenericSpreadableAbsentIndicesBecomeUndefinedProperties()
+    {
+        // mirrors the long-standing slow-path deviation: absent indices of a generic
+        // spreadable are written as undefined-valued own properties, not holes
+        var result = _engine.Evaluate("""
+            var obj = { length: 3, 0: 'a', 2: 'c' };
+            obj[Symbol.isConcatSpreadable] = true;
+            var r = [].concat(obj);
+            JSON.stringify([r.length, 1 in r, r[0], r[2]]);
+            """).AsString();
+
+        Assert.Equal("[3,true,\"a\",\"c\"]", result);
+    }
+
+    [Fact]
+    public void ConcatMixedHoleyArrayAndSpreadableObject()
+    {
+        var result = _engine.Evaluate("""
+            var obj = { length: 3, 0: 'a', 2: 'c' };
+            obj[Symbol.isConcatSpreadable] = true;
+            var r = ['x'].concat([1, , 3], obj, 'tail');
+            JSON.stringify([r.length, 2 in r, 5 in r, r[0], r[1], r[3], r[4], r[6], r[7]]);
+            """).AsString();
+
+        Assert.Equal("[8,false,true,\"x\",1,3,\"a\",\"c\",\"tail\"]", result);
+    }
+
+    [Fact]
+    public void ConcatOwnConstructorPropertyFallsBackToSlowPath()
+    {
+        var result = _engine.Evaluate("""
+            var a = ['x'];
+            a.constructor = Array;
+            var r = a.concat([1, , 3]);
+            JSON.stringify([r.length, 2 in r, r[0], r[1], r[3]]);
+            """).AsString();
+
+        Assert.Equal("[4,false,\"x\",1,3]", result);
+    }
+
+    [Fact]
     public void ConcatSparseModeReceiverDoesNotCrash()
     {
         var result = _engine.Evaluate("""

--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -118,6 +118,32 @@ public class ArrayTests
     }
 
     [Fact]
+    public void ConcatSparseModeReceiverDoesNotCrash()
+    {
+        var result = _engine.Evaluate("""
+            var s = [];
+            s[5000000] = 1;
+            var r = s.concat([2]);
+            JSON.stringify([r.length, r[5000000], r[5000001], 0 in r]);
+            """).AsString();
+
+        Assert.Equal("[5000002,1,2,false]", result);
+    }
+
+    [Fact]
+    public void ConcatSparseModeArgumentDoesNotCrash()
+    {
+        var result = _engine.Evaluate("""
+            var s = [];
+            s[5000000] = 1;
+            var r = ['x'].concat(s);
+            JSON.stringify([r.length, r[0], r[5000001], 1 in r]);
+            """).AsString();
+
+        Assert.Equal("[5000002,\"x\",1,false]", result);
+    }
+
+    [Fact]
     public void ArrayPrototypeToStringWithArray()
     {
         var result = _engine.Evaluate("Array.prototype.toString.call([1,2,3]);").AsString();

--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -185,6 +185,59 @@ public class ArrayTests
     }
 
     [Fact]
+    public void ArrayFromIteratorCollectsAllValues()
+    {
+        var result = _engine.Evaluate("""
+            var fromSet = Array.from(new Set([1, 2, 3, 2, 1]));
+            function* gen() { yield 'a'; yield 'b'; }
+            var fromGen = Array.from(gen());
+            JSON.stringify([fromSet, fromGen]);
+            """).AsString();
+
+        Assert.Equal("[[1,2,3],[\"a\",\"b\"]]", result);
+    }
+
+    [Fact]
+    public void ArrayFromIteratorWithMapperPassesIndices()
+    {
+        var result = _engine.Evaluate("JSON.stringify(Array.from(new Set(['a', 'b']), function (v, i) { return v + i; }))").AsString();
+
+        Assert.Equal("[\"a0\",\"b1\"]", result);
+    }
+
+    [Fact]
+    public void ArrayFromThrowingMapperClosesIterator()
+    {
+        var result = _engine.Evaluate("""
+            var closed = false;
+            var iterable = {};
+            iterable[Symbol.iterator] = function () {
+                var i = 0;
+                return {
+                    next: function () { return { value: i++, done: i > 5 }; },
+                    return: function () { closed = true; return { done: true }; }
+                };
+            };
+            try { Array.from(iterable, function (x) { if (x === 2) { throw new Error('boom'); } return x; }); } catch (e) { }
+            closed;
+            """).AsBoolean();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ArrayFromSubclassUsesConstructor()
+    {
+        var result = _engine.Evaluate("""
+            class A extends Array {}
+            var a = A.from(new Set([1, 2]));
+            a instanceof A && a.length === 2 && a[0] === 1 && a[1] === 2;
+            """).AsBoolean();
+
+        Assert.True(result);
+    }
+
+    [Fact]
     public void ArrayPrototypeToStringWithArray()
     {
         var result = _engine.Evaluate("Array.prototype.toString.call([1,2,3]);").AsString();

--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -80,6 +80,44 @@ public class ArrayTests
     }
 
     [Fact]
+    public void FlatSkipsNestedHoles()
+    {
+        var result = _engine.Evaluate("JSON.stringify([1, [2, , 3], , [4]].flat())").AsString();
+
+        Assert.Equal("[1,2,3,4]", result);
+    }
+
+    [Fact]
+    public void FlatInfiniteDepth()
+    {
+        var result = _engine.Evaluate("JSON.stringify([1, [2, [3, [4, [5]]]]].flat(Infinity))").AsString();
+
+        Assert.Equal("[1,2,3,4,5]", result);
+    }
+
+    [Fact]
+    public void FlatSubclassUsesSpecies()
+    {
+        var result = _engine.Evaluate("""
+            class A extends Array {}
+            var a = A.from([[1], [2]]);
+            var flattened = a.flat();
+            flattened instanceof A && flattened.length === 2;
+            """).AsBoolean();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void FlatMapThrowingMapperLeavesEngineUsable()
+    {
+        Assert.Throws<JavaScriptException>(() => _engine.Evaluate("[1, 2, 3].flatMap(function(x) { if (x === 2) { throw new Error('boom'); } return [x]; })"));
+
+        var result = _engine.Evaluate("JSON.stringify([1, 2].flatMap(function(x) { return [x, x * 10]; }))").AsString();
+        Assert.Equal("[1,10,2,20]", result);
+    }
+
+    [Fact]
     public void ArrayPrototypeToStringWithArray()
     {
         var result = _engine.Evaluate("Array.prototype.toString.call([1,2,3]);").AsString();

--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -1,4 +1,5 @@
 using Jint.Native;
+using Jint.Runtime;
 using Jint.Runtime.Interop;
 
 namespace Jint.Tests.Runtime;
@@ -13,6 +14,69 @@ public class ArrayTests
             .SetValue("log", new Action<object>(Console.WriteLine))
             .SetValue("assert", new Action<bool>(Assert.True))
             .SetValue("equal", new Action<object, object>(Assert.Equal));
+    }
+
+    [Fact]
+    public void FilterSkipsHoles()
+    {
+        var result = _engine.Evaluate("JSON.stringify([1,,3].filter(function(x) { return true; }))").AsString();
+
+        Assert.Equal("[1,3]", result);
+    }
+
+    [Fact]
+    public void FilterSubclassUsesSpecies()
+    {
+        var result = _engine.Evaluate("""
+            class A extends Array {}
+            var a = A.from([1, 2, 3, 4]);
+            var filtered = a.filter(x => x % 2 === 0);
+            filtered instanceof A && filtered.length === 2 && filtered[0] === 2 && filtered[1] === 4;
+            """).AsBoolean();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void FilterRespectsOwnConstructorProperty()
+    {
+        var result = _engine.Evaluate("""
+            var a = [1, 2, 3, 4];
+            var captured = null;
+            a.constructor = function(len) { captured = len; return new Array(len); };
+            a.constructor[Symbol.species] = a.constructor;
+            var filtered = a.filter(x => x > 2);
+            captured === 0 && filtered.length === 2 && filtered[0] === 3 && filtered[1] === 4;
+            """).AsBoolean();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void FilterThrowingCallbackLeavesEngineUsable()
+    {
+        Assert.Throws<JavaScriptException>(() => _engine.Evaluate("[1, 2, 3].filter(function(x) { if (x === 2) { throw new Error('boom'); } return true; })"));
+
+        var result = _engine.Evaluate("JSON.stringify([1, 2, 3, 4].filter(function(x) { return x % 2 === 0; }))").AsString();
+        Assert.Equal("[2,4]", result);
+    }
+
+    [Fact]
+    public void FilterCallbackMutatingSource()
+    {
+        // elements appended during iteration are not visited (len captured up front),
+        // shrinking makes the tail absent
+        var grow = _engine.Evaluate("""
+            var a = [1, 2, 3];
+            JSON.stringify(a.filter(function(x) { a.push(x * 10); return true; }));
+            """).AsString();
+        Assert.Equal("[1,2,3]", grow);
+
+        var shrink = _engine.Evaluate("""
+            var b = [1, 2, 3, 4, 5];
+            JSON.stringify(b.filter(function(x) { b.length = 2; return true; }));
+            """).AsString();
+        Assert.Equal("[1,2]", shrink);
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/JsValueListBuilderTests.cs
+++ b/Jint.Tests/Runtime/JsValueListBuilderTests.cs
@@ -1,0 +1,134 @@
+using Jint.Native;
+using Jint.Pooling;
+
+namespace Jint.Tests.Runtime;
+
+public class JsValueListBuilderTests
+{
+    [Fact]
+    public void AccumulatesAndMaterializesExactSize()
+    {
+        var builder = new JsValueListBuilder(4);
+        try
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                builder.Add(JsNumber.Create(i));
+            }
+
+            Assert.Equal(1000, builder.Length);
+
+            var array = builder.ToArray();
+            Assert.Equal(1000, array.Length);
+            for (var i = 0; i < array.Length; i++)
+            {
+                Assert.Equal(i, ((JsNumber) array[i]).AsNumber());
+            }
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void GrowsAcrossManyPoolBuckets()
+    {
+        var builder = new JsValueListBuilder(4);
+        try
+        {
+            const int Count = 100_000;
+            for (var i = 0; i < Count; i++)
+            {
+                builder.Add(JsNumber.Create(i % 7));
+            }
+
+            var array = builder.ToArray();
+            Assert.Equal(Count, array.Length);
+            Assert.Equal(0, ((JsNumber) array[0]).AsNumber());
+            Assert.Equal((Count - 1) % 7, ((JsNumber) array[Count - 1]).AsNumber());
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void HolesArePreservedAsNulls()
+    {
+        var builder = new JsValueListBuilder(4);
+        try
+        {
+            builder.Add(JsNumber.Create(1));
+            builder.AddHole();
+            builder.Add(JsNumber.Create(3));
+
+            Assert.Equal(3, builder.Length);
+            Assert.NotNull(builder[0]);
+            Assert.Null(builder[1]);
+            Assert.NotNull(builder[2]);
+
+            var array = builder.ToArray();
+            Assert.Equal(3, array.Length);
+            Assert.Null(array[1]);
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AddRangePreservesNullsAndGrows()
+    {
+        var builder = new JsValueListBuilder(4);
+        try
+        {
+            var source = new JsValue[100];
+            for (var i = 0; i < source.Length; i += 2)
+            {
+                source[i] = JsNumber.Create(i);
+            }
+
+            builder.Add(JsNumber.Create(-1));
+            builder.AddRange(source);
+
+            Assert.Equal(101, builder.Length);
+
+            var array = builder.ToArray();
+            Assert.Equal(-1, ((JsNumber) array[0]).AsNumber());
+            Assert.Equal(2, ((JsNumber) array[3]).AsNumber());
+            Assert.Null(array[2]);
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void EmptyBuilderMaterializesSharedEmptyArray()
+    {
+        var builder = new JsValueListBuilder(0);
+        try
+        {
+            var array = builder.ToArray();
+            Assert.Empty(array);
+            Assert.Same(System.Array.Empty<JsValue>(), array);
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void DoubleDisposeIsSafe()
+    {
+        var builder = new JsValueListBuilder(4);
+        builder.Add(JsNumber.Create(1));
+        builder.Dispose();
+        builder.Dispose();
+    }
+}

--- a/Jint.Tests/Runtime/JsonTests.cs
+++ b/Jint.Tests/Runtime/JsonTests.cs
@@ -8,6 +8,48 @@ namespace Jint.Tests.Runtime;
 public class JsonTests
 {
     [Theory]
+    [InlineData(0)]
+    [InlineData(15)]
+    [InlineData(16)]
+    [InlineData(17)]
+    [InlineData(1000)]
+    public void CanParseArraysOfAnySize(int size)
+    {
+        var engine = new Engine();
+        var json = "[" + string.Join(",", Enumerable.Range(0, size)) + "]";
+        var ok = engine.Evaluate($"var a = JSON.parse('{json}'); a.length === {size} && ({size} === 0 || a[{size - 1}] === {size - 1})").AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(15)]
+    [InlineData(16)]
+    [InlineData(17)]
+    [InlineData(1000)]
+    public void CanParseArraysOfAnySizeWithReviver(int size)
+    {
+        var engine = new Engine();
+        var json = "[" + string.Join(",", Enumerable.Range(0, size)) + "]";
+        var ok = engine.Evaluate($"var a = JSON.parse('{json}', function (k, v) {{ return v; }}); a.length === {size} && ({size} === 0 || a[{size - 1}] === {size - 1})").AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void CanParseNestedArrays()
+    {
+        var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var a = JSON.parse('[[1,2,3],[4,5,[6,7,[8]]],9]');
+            JSON.stringify(a) === '[[1,2,3],[4,5,[6,7,[8]]],9]';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Theory]
     [InlineData(@"JSON.parse(""{\""abc\\tdef\"": \""42\""}"");", "abc\tdef")]
     [InlineData(@"JSON.parse(""{\""abc\\ndef\"": \""42\""}"");", "abc\ndef")]
     [InlineData(@"JSON.parse(""{\""abc\\fdef\"": \""42\""}"");", "abc\fdef")]

--- a/Jint.Tests/Runtime/RegExpTests.cs
+++ b/Jint.Tests/Runtime/RegExpTests.cs
@@ -6,6 +6,34 @@ namespace Jint.Tests.Runtime;
 
 public class RegExpTests
 {
+    [Fact]
+    public void MatchGlobalUnicodeNoMatchesReturnsNull()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("'abc'.match(/\\d/gu) === null").AsBoolean();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void MatchGlobalUnicodeCollectsAllMatches()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("JSON.stringify('a1b22c333'.match(/\\d+/gu))").AsString();
+
+        Assert.Equal("[\"1\",\"22\",\"333\"]", result);
+    }
+
+    [Fact]
+    public void MatchGlobalUnicodeEmptyMatchesAdvanceByCodePoint()
+    {
+        var engine = new Engine();
+        // 2 astral code points (4 UTF-16 units): empty matches at positions 0, 2, 4
+        var result = engine.Evaluate("'\\u{1F600}\\u{1F600}'.match(/(?:)/gu).length").AsNumber();
+
+        Assert.Equal(3, result);
+    }
+
     private const string TestRegex = "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w\\.-]*)*\\/?$";
     private const string TestedValue = "https://archiverbx.blob.core.windows.net/static/C:/Users/USR/Documents/Projects/PROJ/static/images/full/1234567890.jpg";
 

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -61,20 +61,16 @@ public sealed partial class ArrayConstructor : Constructor
         var usingIterator = GetMethod(_realm, items, GlobalSymbolRegistry.Iterator);
         if (usingIterator is not null)
         {
-            ObjectInstance instance;
             if (!ReferenceEquals(this, thisObject) && thisObject is IConstructor constructor)
             {
-                instance = constructor.Construct([], thisObject);
-            }
-            else
-            {
-                instance = ArrayCreate(0);
+                var instance = constructor.Construct([], thisObject);
+                var iterator = items.GetIterator(_realm, method: usingIterator);
+                var protocol = new ArrayProtocol(_engine, thisArg, instance, iterator, callable);
+                protocol.Execute();
+                return instance;
             }
 
-            var iterator = items.GetIterator(_realm, method: usingIterator);
-            var protocol = new ArrayProtocol(_engine, thisArg, instance, iterator, callable);
-            protocol.Execute();
-            return instance;
+            return ConstructFromIterator(items, usingIterator, callable, thisArg);
         }
 
         if (items is IObjectWrapper { Target: IEnumerable enumerable })
@@ -84,6 +80,66 @@ public sealed partial class ArrayConstructor : Constructor
 
         var source = ArrayOperations.For(_realm, items, forWrite: false);
         return ConstructArrayFromArrayLike(thisObject, source, callable, thisArg);
+    }
+
+    /// <summary>
+    /// Iterator branch of Array.from for the plain-array result: accumulates into a pooled
+    /// builder and materializes an exact-size dense array instead of per-item
+    /// CreateDataPropertyOrThrow writes. The loop structure mirrors
+    /// <see cref="IteratorProtocol.Execute"/>, including closing the iterator on abrupt
+    /// completion; materialization happens after the loop so a length-related throw does
+    /// not trigger an extra iterator close.
+    /// </summary>
+    private JsArray ConstructFromIterator(JsValue items, ICallable usingIterator, ICallable? callable, JsValue thisArg)
+    {
+        var iterator = items.GetIterator(_realm, method: usingIterator);
+
+        var builder = new JsValueListBuilder(16);
+        var args = _engine._jsValueArrayPool.RentArray(2);
+        try
+        {
+            var iterations = 0;
+            long index = -1;
+            try
+            {
+                while (true)
+                {
+                    if (++iterations % ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
+                    if (!iterator.TryIteratorStep(out var item))
+                    {
+                        break;
+                    }
+
+                    var jsValue = item.Get(CommonProperties.Value);
+                    index++;
+
+                    if (callable is not null)
+                    {
+                        args[0] = jsValue;
+                        args[1] = index;
+                        jsValue = callable.Call(thisArg, args);
+                    }
+
+                    builder.Add(jsValue);
+                }
+            }
+            catch
+            {
+                iterator.Close(CompletionType.Throw);
+                throw;
+            }
+
+            return ConstructFromBuilder(ref builder);
+        }
+        finally
+        {
+            builder.Dispose();
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
     }
 
     /// <summary>

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -7,6 +7,7 @@ using Jint.Native.Iterator;
 using Jint.Native.Object;
 using Jint.Native.Promise;
 using Jint.Native.Symbol;
+using Jint.Pooling;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
@@ -920,6 +921,47 @@ public sealed partial class ArrayConstructor : Constructor
         var array = new JsValue[contents.Count];
         contents.CopyTo(array);
         return new JsArray(_engine, array);
+    }
+
+    /// <summary>
+    /// Materializes accumulated builder contents into a plain array instance via an
+    /// exact-size backing array the result takes ownership of. The caller still owns
+    /// the builder and is responsible for disposing it.
+    /// </summary>
+    internal JsArray ConstructFromBuilder(ref JsValueListBuilder builder)
+    {
+        var length = (uint) builder.Length;
+
+        // The ownership-taking constructor skips capacity validation; the incremental
+        // write path enforced MaxArraySize through EnsureCapacity, so keep parity here.
+        if (length > _engine.Options.Constraints.MaxArraySize)
+        {
+            ArrayInstance.ThrowMaximumArraySizeReachedException(_engine, length);
+        }
+
+        if (length < ArrayInstance.MaxDenseArrayLengthInternal)
+        {
+            return new JsArray(_engine, builder.ToArray());
+        }
+
+        // The incremental write path would have converted an array this large to sparse
+        // backing; preserve that policy by replaying the values into a sparse-backed array.
+        var a = ArrayCreate(length);
+        for (uint i = 0; i < length; i++)
+        {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
+            var value = builder[(int) i];
+            if (value is not null)
+            {
+                a.SetIndexValue(i, value, updateLength: false);
+            }
+        }
+
+        return a;
     }
 
     /// <summary>

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Jint.Native.Object;
 using Jint.Native.Symbol;
+using Jint.Pooling;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
@@ -1340,6 +1341,54 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         return a;
     }
 
+    internal JsArray Filter(JsCallArguments arguments)
+    {
+        var callbackfn = arguments.At(0);
+        var thisArg = arguments.At(1);
+
+        var len = GetLength();
+
+        var callable = GetCallable(callbackfn);
+
+        // Output size is unknown (only bounded by len); accumulate into a pooled buffer and
+        // materialize an exact-size result instead of growing the result's dense backing by
+        // doubling. Capped initial rent so a large low-selectivity source doesn't rent ~len slots.
+        var builder = new JsValueListBuilder((int) System.Math.Min(len, 1024));
+        var args = _engine._jsValueArrayPool.RentArray(3);
+        args[2] = this;
+
+        // try/finally so the rented args array and the pooled builder buffer are released
+        // when the callback or a periodic Check() throws.
+        try
+        {
+            for (uint k = 0; k < len; k++)
+            {
+                if (k > 0 && k % Engine.ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
+                if (TryGetValue(k, out var kvalue))
+                {
+                    args[0] = kvalue;
+                    args[1] = k;
+                    var selected = callable.Call(thisArg, args);
+                    if (TypeConverter.ToBoolean(selected))
+                    {
+                        builder.Add(kvalue);
+                    }
+                }
+            }
+
+            return _engine.Realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+        }
+        finally
+        {
+            builder.Dispose();
+            _engine._jsValueArrayPool.ReturnArray(args);
+        }
+    }
+
     /// <inheritdoc />
     internal sealed override bool FindWithCallback(
         JsCallArguments arguments,
@@ -1531,7 +1580,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         return "(" + (_length?._value!.AsNumber() ?? 0) + ")[]";
     }
 
-    private static void ThrowMaximumArraySizeReachedException(Engine engine, uint capacity)
+    internal static void ThrowMaximumArraySizeReachedException(Engine engine, uint capacity)
     {
         Throw.MemoryLimitExceededException(
             $"The array size {capacity} is larger than maximum allowed ({engine.Options.Constraints.MaxArraySize})"

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -7,6 +7,7 @@ using Jint.Native.Iterator;
 using Jint.Native.Number;
 using Jint.Native.Object;
 using Jint.Native.Symbol;
+using Jint.Pooling;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Descriptors.Specialized;
@@ -563,6 +564,23 @@ public sealed partial class ArrayPrototype : ArrayInstance
             depthNum = 0;
         }
 
+        if (thisObject is JsArray { CanUseFastAccess: true } jsArray
+            && !jsArray.HasOwnProperty(CommonProperties.Constructor))
+        {
+            // ArraySpeciesCreate would provably return a plain array; accumulate into a
+            // pooled buffer and materialize an exact-size result instead.
+            var builder = new JsValueListBuilder((int) System.Math.Min(sourceLen, 1024));
+            try
+            {
+                FlattenIntoArrayDense(ref builder, operations, sourceLen, depthNum);
+                return _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+            }
+            finally
+            {
+                builder.Dispose();
+            }
+        }
+
         var A = _realm.Intrinsics.Array.ArraySpeciesCreate(operations.Target, 0);
         FlattenIntoArray(A, operations, sourceLen, 0, depthNum);
         return A;
@@ -583,6 +601,21 @@ public sealed partial class ArrayPrototype : ArrayInstance
         if (!mapperFunction.IsCallable)
         {
             Throw.TypeError(_realm, $"{mapperFunction} is not a function");
+        }
+
+        if (thisObject is JsArray { CanUseFastAccess: true } jsArray
+            && !jsArray.HasOwnProperty(CommonProperties.Constructor))
+        {
+            var builder = new JsValueListBuilder((int) System.Math.Min(sourceLen, 1024));
+            try
+            {
+                FlattenIntoArrayDense(ref builder, O, sourceLen, 1, (ICallable) mapperFunction, thisArg);
+                return _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+            }
+            finally
+            {
+                builder.Dispose();
+            }
         }
 
         var A = _realm.Intrinsics.Array.ArraySpeciesCreate(O.Target, 0);
@@ -667,6 +700,84 @@ public sealed partial class ArrayPrototype : ArrayInstance
         }
 
         return targetIndex;
+    }
+
+    /// <summary>
+    /// <see cref="FlattenIntoArray"/> variant for a provably plain array result: appends
+    /// into the pooled builder instead of writing per element through the target object.
+    /// The textual structure is kept parallel to the generic variant; the target index is
+    /// implicit in the builder length and holes are skipped per spec (the exists check),
+    /// so the MaxSafeInteger target-index guard has no int-bounded equivalent here.
+    /// </summary>
+    private void FlattenIntoArrayDense(
+        ref JsValueListBuilder builder,
+        ArrayOperations source,
+        uint sourceLen,
+        double depth,
+        ICallable? mapperFunction = null,
+        JsValue? thisArg = null)
+    {
+        ulong sourceIndex = 0;
+
+        var callArguments = System.Array.Empty<JsValue>();
+        if (mapperFunction is not null)
+        {
+            callArguments = _engine._jsValueArrayPool.RentArray(3);
+            callArguments[2] = source.Target;
+        }
+
+        try
+        {
+            while (sourceIndex < sourceLen)
+            {
+                if (sourceIndex > 0 && sourceIndex % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
+
+                var exists = source.HasProperty(sourceIndex);
+                if (exists)
+                {
+                    var element = source.Get(sourceIndex);
+                    if (mapperFunction is not null)
+                    {
+                        callArguments[0] = element;
+                        callArguments[1] = JsNumber.Create(sourceIndex);
+                        element = mapperFunction.Call(thisArg ?? Undefined, callArguments);
+                    }
+
+                    var shouldFlatten = false;
+                    if (depth > 0)
+                    {
+                        shouldFlatten = element.IsArray();
+                    }
+
+                    if (shouldFlatten)
+                    {
+                        var newDepth = double.IsPositiveInfinity(depth)
+                            ? depth
+                            : depth - 1;
+
+                        var objectInstance = (ObjectInstance) element;
+                        var elementLen = objectInstance.GetLength();
+                        FlattenIntoArrayDense(ref builder, ArrayOperations.For(objectInstance, forWrite: false), elementLen, newDepth);
+                    }
+                    else
+                    {
+                        builder.Add(element);
+                    }
+                }
+
+                sourceIndex++;
+            }
+        }
+        finally
+        {
+            if (mapperFunction is not null)
+            {
+                _engine._jsValueArrayPool.ReturnArray(callArguments);
+            }
+        }
     }
 
     [JsFunction(Length = 1)]

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1893,8 +1893,9 @@ public sealed partial class ArrayPrototype : ArrayInstance
         result = null!;
 
         // CanUseFastAccess does not catch a custom @@isConcatSpreadable symbol, so we still
-        // have to consult IsConcatSpreadable for each input.
-        if (!thisArr.IsConcatSpreadable)
+        // have to consult IsConcatSpreadable for each input. A sparse-mode receiver can also
+        // still be fast-access; it has no dense backing to bulk-copy from.
+        if (thisArr._dense is null || !thisArr.IsConcatSpreadable)
         {
             return false;
         }
@@ -1907,7 +1908,7 @@ public sealed partial class ArrayPrototype : ArrayInstance
         for (var i = 0; i < arguments.Length; i++)
         {
             var e = arguments[i];
-            if (e is JsArray { CanUseFastAccess: true } ja && ja.IsConcatSpreadable)
+            if (e is JsArray { CanUseFastAccess: true } ja && ja._dense is not null && ja.IsConcatSpreadable)
             {
                 argInfo![i] = true;
                 totalLen += ja.GetLength();

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1828,10 +1828,19 @@ public sealed partial class ArrayPrototype : ArrayInstance
         // Pre-sum total length so the output is allocated once at exact size and each source
         // can be copied via Array.Copy instead of element-by-element CreateDataPropertyOrThrow.
         if (thisObject is JsArray { CanUseFastAccess: true } thisArr
-            && !thisArr.HasOwnProperty(CommonProperties.Constructor)
-            && TryConcatAllJsArrayFast(thisArr, arguments, out var fastResult))
+            && !thisArr.HasOwnProperty(CommonProperties.Constructor))
         {
-            return fastResult;
+            if (TryConcatAllJsArrayFast(thisArr, arguments, out var fastResult))
+            {
+                return fastResult;
+            }
+
+            // The result is still provably a plain array (same gate as the Map/Filter fast
+            // paths); accumulate into a pooled buffer instead of per-element virtual writes.
+            if (CanConcatWithBuilder(thisArr, arguments))
+            {
+                return ConcatPlainTarget(thisArr, arguments);
+            }
         }
 
         var o = TypeConverter.ToObject(_realm, thisObject);
@@ -1886,6 +1895,100 @@ public sealed partial class ArrayPrototype : ArrayInstance
         a.DefineOwnProperty(CommonProperties.Length, new PropertyDescriptor(n, PropertyFlag.OnlyWritable));
 
         return a;
+    }
+
+    /// <summary>
+    /// JsArray sources are appended from their dense backing, so sparse-mode arrays (no
+    /// backing at all) and arrays whose declared length grossly exceeds the physical
+    /// backing (lazy <c>new Array(N)</c>, truncated-backing holey arrays) must stay on the
+    /// CopyValues slow path, which keeps such results compact instead of materializing
+    /// every hole. The +50 slack mirrors the engine's looks-sparse write heuristic.
+    /// All inspected state is engine-internal, so bailing here is unobservable.
+    /// </summary>
+    private static bool CanConcatWithBuilder(JsArray thisArr, JsCallArguments arguments)
+    {
+        if (thisArr._dense is null || thisArr.GetLength() > (ulong) thisArr._dense.Length + 50)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            if (arguments[i] is JsArray ja
+                && (ja._dense is null || ja.GetLength() > (ulong) ja._dense.Length + 50))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private JsArray ConcatPlainTarget(JsArray thisArr, JsCallArguments arguments)
+    {
+        var initialCapacity = (ulong) thisArr.GetLength() + (ulong) arguments.Length;
+        var builder = new JsValueListBuilder((int) System.Math.Min(initialCapacity, 1024 * 1024));
+        try
+        {
+            AppendConcatItem(ref builder, thisArr);
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                AppendConcatItem(ref builder, arguments[i]);
+            }
+
+            return _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    private void AppendConcatItem(ref JsValueListBuilder builder, JsValue e)
+    {
+        if (e is ObjectInstance { IsConcatSpreadable: true } oi)
+        {
+            if (oi is JsArray eArray)
+            {
+                // CanConcatWithBuilder guarantees a dense backing with at most +50 logical
+                // tail; raw null entries flow through AddRange as holes, like CopyValues.
+                var len = eArray.GetLength();
+                var dense = eArray._dense!;
+                var copyLen = (int) System.Math.Min((uint) dense.Length, len);
+                builder.AddRange(dense.AsSpan(0, copyLen));
+                for (var k = (uint) copyLen; k < len; k++)
+                {
+                    builder.AddHole();
+                }
+            }
+            else
+            {
+                var operations = ArrayOperations.For(oi, forWrite: false);
+                var len = operations.GetLongLength();
+
+                if ((ulong) builder.Length + len > ArrayOperations.MaxArrayLikeLength)
+                {
+                    Throw.TypeError(_realm, "Invalid array length");
+                }
+
+                for (uint k = 0; k < len; k++)
+                {
+                    if (k > 0 && k % ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
+                    // mirrors the generic slow path: absent indices append as undefined
+                    // (TryGetValue surfaces Undefined for them), they do not stay holes
+                    operations.TryGetValue(k, out var subElement);
+                    builder.Add(subElement);
+                }
+            }
+        }
+        else
+        {
+            builder.Add(e);
+        }
     }
 
     private bool TryConcatAllJsArrayFast(JsArray thisArr, JsCallArguments arguments, out JsArray result)

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -451,6 +451,12 @@ public sealed partial class ArrayPrototype : ArrayInstance
     [JsFunction(Length = 1)]
     private JsValue Filter(JsValue thisObject, JsCallArguments arguments)
     {
+        if (thisObject is JsArray { CanUseFastAccess: true } arrayInstance
+            && !arrayInstance.HasOwnProperty(CommonProperties.Constructor))
+        {
+            return arrayInstance.Filter(arguments);
+        }
+
         var callbackfn = arguments.At(0);
         var thisArg = arguments.At(1);
 

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -1,9 +1,9 @@
-using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using Jint.Pooling;
 using Jint.Runtime;
 
 namespace Jint.Native.Json;
@@ -545,30 +545,11 @@ public sealed class JsonParser
             ThrowDepthLimitReached(_lookahead);
         }
 
-        /*
-         To speed up performance, the list allocation is deferred.
-
-         First the elements are stored within an array received
-         from the .NET array pool.
-
-         If a list contains less elements that the size that array,
-         a Jint array is constructed with the values stored in that
-         array.
-
-         When the number of elements exceed the buffer size,
-         The elements-array gets created and filled with the content
-         of the array. The array will then turn into an
-         intermediate buffer which gets flushed to the list
-         when its full.
-        */
-        List<JsValue>? elements = null;
-
         Expect(ref state, '[');
 
-        int bufferIndex = 0;
-        JsArray? result = null;
-
-        JsValue[] buffer = ArrayPool<JsValue>.Shared.Rent(16);
+        // Elements accumulate in a pooled buffer and materialize as an exact-size dense
+        // array; nested arrays rent their own builders during the recursion.
+        var builder = new JsValueListBuilder(16);
         try
         {
             var elementCount = 0;
@@ -579,66 +560,23 @@ public sealed class JsonParser
                     _engine.Constraints.Check();
                 }
 
-                buffer[bufferIndex++] = ParseJsonValue(ref state);
+                builder.Add(ParseJsonValue(ref state));
 
                 if (!Match(']'))
                 {
                     Expect(ref state, ',');
                 }
-
-                if (bufferIndex >= buffer.Length)
-                {
-                    if (elements is null)
-                    {
-                        elements = new List<JsValue>(buffer);
-                    }
-                    else
-                    {
-                        elements.AddRange(buffer);
-                    }
-                    bufferIndex = 0;
-                }
             }
 
-            // BufferIndex = 0 has two meanings
-            // * Empty JSON array (elements will be null)
-            // * The buffer array has just been flushed (elements will NOT be null)
-            if (bufferIndex > 0)
-            {
-                if (elements is null)
-                {
-                    // No element list has been created, all values did fit into the array.
-                    // The Jint-Array can get constructed from that array.
-                    var data = new JsValue[bufferIndex];
-                    System.Array.Copy(buffer, data, length: bufferIndex);
-                    result = new JsArray(_engine, data);
-                }
-                else
-                {
-                    // An element list has been created. Flush the
-                    // remaining added items within the array to that list.
-                    for (var i = 0; i < bufferIndex; ++i)
-                    {
-                        elements.Add(buffer[i]);
-                    }
-                }
-            }
-            else if (elements is null)
-            {
-                // the JSON array did not have any elements
-                // aka: []
-                result = new JsArray(_engine);
-            }
+            Expect(ref state, ']');
+            state.CurrentDepth--;
+
+            return _engine.Realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
         }
         finally
         {
-            ArrayPool<JsValue>.Shared.Return(buffer);
+            builder.Dispose();
         }
-
-        Expect(ref state, ']');
-        state.CurrentDepth--;
-
-        return result ?? new JsArray(_engine, elements!.ToArray());
     }
 
     private JsObject ParseJsonObject(ref State state)
@@ -826,14 +764,10 @@ public sealed class JsonParser
 
         var startPos = _lookahead.Range.Start;
         var elements = new List<JsonParseNode>();
-        List<JsValue>? valueList = null;
 
         Expect(ref state, '[');
 
-        int bufferIndex = 0;
-        JsArray? result = null;
-
-        JsValue[] buffer = ArrayPool<JsValue>.Shared.Rent(16);
+        var builder = new JsValueListBuilder(16);
         try
         {
             var elementCount = 0;
@@ -845,7 +779,7 @@ public sealed class JsonParser
                 }
 
                 var elementResult = ParseJsonValueWithSourceInfo(ref state);
-                buffer[bufferIndex++] = elementResult.Value;
+                builder.Add(elementResult.Value);
                 if (elementResult.Node != null)
                 {
                     elements.Add(elementResult.Node);
@@ -855,61 +789,27 @@ public sealed class JsonParser
                 {
                     Expect(ref state, ',');
                 }
-
-                if (bufferIndex >= buffer.Length)
-                {
-                    if (valueList is null)
-                    {
-                        valueList = new List<JsValue>(buffer);
-                    }
-                    else
-                    {
-                        valueList.AddRange(buffer);
-                    }
-                    bufferIndex = 0;
-                }
             }
 
-            if (bufferIndex > 0)
+            Expect(ref state, ']');
+            var endPos = _index;
+            state.CurrentDepth--;
+
+            var arrayValue = _engine.Realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+            var arrayNode = new JsonParseNode
             {
-                if (valueList is null)
-                {
-                    var data = new JsValue[bufferIndex];
-                    System.Array.Copy(buffer, data, length: bufferIndex);
-                    result = new JsArray(_engine, data);
-                }
-                else
-                {
-                    for (var i = 0; i < bufferIndex; ++i)
-                    {
-                        valueList.Add(buffer[i]);
-                    }
-                }
-            }
-            else if (valueList is null)
-            {
-                result = new JsArray(_engine);
-            }
+                Start = startPos,
+                End = endPos,
+                IsPrimitive = false,
+                Elements = elements
+            };
+
+            return new JsonParseResult(arrayValue, arrayNode);
         }
         finally
         {
-            ArrayPool<JsValue>.Shared.Return(buffer);
+            builder.Dispose();
         }
-
-        Expect(ref state, ']');
-        var endPos = _index;
-        state.CurrentDepth--;
-
-        var arrayValue = result ?? new JsArray(_engine, valueList!.ToArray());
-        var arrayNode = new JsonParseNode
-        {
-            Start = startPos,
-            End = endPos,
-            IsPrimitive = false,
-            Elements = elements
-        };
-
-        return new JsonParseResult(arrayValue, arrayNode);
     }
 
     private JsonParseResult ParseJsonObjectWithSourceInfo(ref State state)

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -7,6 +7,7 @@ using Jint.Native.Number;
 using Jint.Native.Object;
 using Jint.Native.String;
 using Jint.Native.Symbol;
+using Jint.Pooling;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
@@ -867,38 +868,41 @@ internal sealed partial class RegExpPrototype : Prototype
             // fast path for custom engine: call Execute directly, skip building
             // full JS result arrays per match (saves 15-20 allocations per match)
             var customEngine = rei.CustomEngine!;
-            var a = _realm.Intrinsics.Array.ArrayCreate(0);
-            uint n = 0;
-            int lastIndex = 0;
-            while (lastIndex <= s.Length)
+            var builder = new JsValueListBuilder(16);
+            try
             {
-                if (n > 0 && n % ConstraintCheckInterval == 0)
+                int lastIndex = 0;
+                while (lastIndex <= s.Length)
                 {
-                    _engine.Constraints.Check();
+                    if (builder.Length > 0 && builder.Length % ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
+                    var result = ExecuteWithTimeout(rei, customEngine, s, lastIndex);
+                    if (!result.Success)
+                    {
+                        break;
+                    }
+
+                    builder.Add(result.Value);
+
+                    if (result.Length == 0)
+                    {
+                        lastIndex = (int) AdvanceStringIndex(s, (ulong) result.Index, fullUnicode);
+                    }
+                    else
+                    {
+                        lastIndex = result.Index + result.Length;
+                    }
                 }
 
-                var result = ExecuteWithTimeout(rei, customEngine, s, lastIndex);
-                if (!result.Success)
-                {
-                    break;
-                }
-
-                a.SetIndexValue(n, result.Value, updateLength: false);
-
-                if (result.Length == 0)
-                {
-                    lastIndex = (int) AdvanceStringIndex(s, (ulong) result.Index, fullUnicode);
-                }
-                else
-                {
-                    lastIndex = result.Index + result.Length;
-                }
-
-                n++;
+                return builder.Length == 0 ? Null : _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
             }
-
-            a.SetLength(n);
-            return n == 0 ? Null : a;
+            finally
+            {
+                builder.Dispose();
+            }
         }
 
         if (!fullUnicode
@@ -960,32 +964,35 @@ internal sealed partial class RegExpPrototype : Prototype
 
     private JsValue MatchSlow(ObjectInstance rx, string s, bool fullUnicode)
     {
-        var a = _realm.Intrinsics.Array.ArrayCreate(0);
-        uint n = 0;
-        while (true)
+        var builder = new JsValueListBuilder(16);
+        try
         {
-            if (n > 0 && n % ConstraintCheckInterval == 0)
+            while (true)
             {
-                _engine.Constraints.Check();
-            }
+                if (builder.Length > 0 && builder.Length % ConstraintCheckInterval == 0)
+                {
+                    _engine.Constraints.Check();
+                }
 
-            var result = RegExpExec(rx, s);
-            if (result.IsNull())
-            {
-                a.SetLength(n);
-                return n == 0 ? Null : a;
-            }
+                var result = RegExpExec(rx, s);
+                if (result.IsNull())
+                {
+                    return builder.Length == 0 ? Null : _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+                }
 
-            var matchStr = TypeConverter.ToString(result.Get(JsString.NumberZeroString));
-            a.SetIndexValue(n, matchStr, updateLength: false);
-            if (matchStr == "")
-            {
-                var thisIndex = TypeConverter.ToLength(rx.Get(JsRegExp.PropertyLastIndex));
-                var nextIndex = AdvanceStringIndex(s, thisIndex, fullUnicode);
-                rx.Set(JsRegExp.PropertyLastIndex, nextIndex, true);
+                var matchStr = TypeConverter.ToString(result.Get(JsString.NumberZeroString));
+                builder.Add(matchStr);
+                if (matchStr == "")
+                {
+                    var thisIndex = TypeConverter.ToLength(rx.Get(JsRegExp.PropertyLastIndex));
+                    var nextIndex = AdvanceStringIndex(s, thisIndex, fullUnicode);
+                    rx.Set(JsRegExp.PropertyLastIndex, nextIndex, true);
+                }
             }
-
-            n++;
+        }
+        finally
+        {
+            builder.Dispose();
         }
     }
 

--- a/Jint/Pooling/JsValueListBuilder.cs
+++ b/Jint/Pooling/JsValueListBuilder.cs
@@ -1,0 +1,140 @@
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Pooling;
+
+/// <summary>
+/// Pooled, growable accumulator for building array contents of unknown final size.
+/// Hand the result off via <see cref="ToArray"/> (exact-size copy that <see cref="JsArray"/>
+/// can take ownership of) and always call <see cref="Dispose"/> from a finally block so the
+/// rented buffer returns to the pool. Holes use the dense-array convention: null entries.
+/// </summary>
+internal ref struct JsValueListBuilder
+{
+    private JsValue?[] _array;
+    private int _pos;
+
+    public JsValueListBuilder(int initialCapacity)
+    {
+        _array = ArrayPool<JsValue?>.Shared.Rent(System.Math.Max(initialCapacity, 4));
+        _pos = 0;
+    }
+
+    public readonly int Length => _pos;
+
+    public readonly JsValue? this[int index]
+    {
+        get
+        {
+            Debug.Assert((uint) index < (uint) _pos);
+            return _array[index];
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Add(JsValue value)
+    {
+        var pos = _pos;
+        var array = _array;
+        if ((uint) pos < (uint) array.Length)
+        {
+            array[pos] = value;
+            _pos = pos + 1;
+        }
+        else
+        {
+            GrowAndAdd(value);
+        }
+    }
+
+    /// <summary>
+    /// Appends a hole; materialized arrays keep the index absent (null dense entry).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void AddHole()
+    {
+        var pos = _pos;
+        var array = _array;
+        if ((uint) pos < (uint) array.Length)
+        {
+            array[pos] = null;
+            _pos = pos + 1;
+        }
+        else
+        {
+            GrowAndAdd(null);
+        }
+    }
+
+    public void AddRange(ReadOnlySpan<JsValue?> values)
+    {
+        var pos = _pos;
+        if (pos > _array.Length - values.Length)
+        {
+            Grow(values.Length);
+        }
+
+        values.CopyTo(_array.AsSpan(pos));
+        _pos = pos + values.Length;
+    }
+
+    /// <summary>
+    /// Returns an exact-size copy of the accumulated values; null entries (holes) are
+    /// preserved. Does not dispose, so a caller's finally-block <see cref="Dispose"/>
+    /// stays valid on every exit path.
+    /// </summary>
+    public readonly JsValue[] ToArray()
+    {
+        var pos = _pos;
+        if (pos == 0)
+        {
+            return [];
+        }
+
+        var result = new JsValue[pos];
+        System.Array.Copy(_array, result, pos);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void GrowAndAdd(JsValue? value)
+    {
+        Grow(1);
+        _array[_pos++] = value;
+    }
+
+    private void Grow(int additionalCapacityBeyondPos)
+    {
+        Debug.Assert(additionalCapacityBeyondPos > 0);
+
+        var newCapacity = (int) System.Math.Max(
+            (uint) (_pos + additionalCapacityBeyondPos),
+            System.Math.Min((uint) _array.Length * 2, ClrLimits.MaxArrayLength));
+
+        var newArray = ArrayPool<JsValue?>.Shared.Rent(newCapacity);
+        System.Array.Copy(_array, newArray, _pos);
+
+        var toReturn = _array;
+        _array = newArray;
+
+        // The used range must be cleared before returning: retained JsValue references
+        // in a pooled buffer would root arbitrarily large engine object graphs.
+        System.Array.Clear(toReturn, 0, _pos);
+        ArrayPool<JsValue?>.Shared.Return(toReturn);
+    }
+
+    public void Dispose()
+    {
+        var toReturn = _array;
+        var pos = _pos;
+        this = default; // safe double-dispose; further Adds fail fast instead of corrupting the pool
+        if (toReturn is not null)
+        {
+            System.Array.Clear(toReturn, 0, pos);
+            ArrayPool<JsValue?>.Shared.Return(toReturn);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Built-ins that accumulate result elements of unknown final size (filter, flat/flatMap, concat slow path, RegExp match, JSON arrays, Array.from with iterators) previously created a size-0 result array and wrote per element through virtual `CreateDataPropertyOrThrow`, growing the dense backing by doubling. That produced intermediate garbage arrays on every growth step, per-element virtual dispatch, and a permanently oversized final `_dense` buffer.

This PR introduces `JsValueListBuilder`, an internal `ref struct` accumulator backed by `ArrayPool<JsValue?>.Shared` (modeled on the existing `ValueStringBuilder`). Built-ins append into the pooled buffer and materialize the result through `ArrayConstructor.ConstructFromBuilder`, which copies into an exact-size backing array handed zero-copy to the ownership-taking `JsArray(Engine, JsValue[])` constructor. The used buffer range is cleared before pool return so pooled `JsValue` references cannot root engine object graphs.

Fast paths are gated on the established precedent from the Map/Concat fast paths (`CanUseFastAccess` + no own `constructor` property); subclasses, species overrides and exotic receivers keep the spec-observable slow paths. `ConstructFromBuilder` restores the `MaxArraySize` constraint (the ownership ctor skips capacity validation) and preserves the ≥10M dense→sparse conversion policy.

Also includes a standalone fix (separate commit, cherry-pickable): `TryConcatAllJsArrayFast` crashed with `NullReferenceException` when the receiver or an argument was a sparse-mode array (`var s = []; s[5000000] = 1; s.concat([2])`), because sparse-mode arrays still report `CanUseFastAccess` while `_dense` is null.

## Results (BenchmarkDotNet default jobs, before → after; full tables in commit messages)

| Benchmark | Time | Allocated |
|---|---|---|
| Flat (100×10 nested) | 3765 → 882 µs (−77%) | 16.5 → 1.0 MB (−94%) |
| FlatMap (x => [x,x], 1000 elem) | 27.8 → 17.6 ms (−37%) | 57.9 → 25.9 MB (−55%), Gen2 3000→0 |
| Concat with plain-object arg | 2680 → 592 µs (−78%) | 4.35 → 4.08 MB |
| Concat with spreadable object | 4959 → 2731 µs (−45%) | 12.1 → 4.8 MB (−61%) |
| Concat holey-array mixed | 5333 → 1159 µs (−78%) | 12.1 → 7.9 MB (−35%) |
| Filter (1000 strings, selective) | 12.3 → 10.3 ms (−16%) | ~same |
| Filter 10000/100% selected | 1441 → 1297 µs (−10%) | 649 → 470 KB (−28%), Gen1/2 41→0 |
| JSON.parse array round-trip | 499 → 485 µs | 720 → 520 KB (−28%) |
| RegExp match (u-flag slow path) | neutral | 6.07 → 5.82 MB (−4%) |
| Array.from(set/array, 1000 elem) | neutral | 16.1 → 15.3 MB (−5%), Gen1 70→35 |

Fast-path canaries (Map, dense-dense concat, non-sticky regexp match) are unchanged.

## Not converted (deliberately)

- **Promise.all / spread-element accumulation**: accumulation survives event-loop ticks / generator suspension — a ref struct cannot.
- **Sticky+global `[Symbol.match]` .NET path**: left untouched because it currently returns wrong results (match position confused with match count plus an off-by-one truncation, e.g. `"aaa".match(/a/gy)` → `["a","a"]`); will be fixed in a separate PR rather than burying a behavior change here.
- **Non-sticky .NET regexp match path**: already resizes exactly once.

## Testing

- Unit tests for the builder (growth across pool buckets, hole preservation, dispose idempotence) plus pinning tests for the pre-existing concat hole/undefined semantics (verified identical against base before the change), species/subclass fallbacks, throwing callbacks, and JSON buffer boundaries.
- `Jint.Tests` (3107 passed), `Jint.Tests.PublicInterface` (79 passed), full `Jint.Tests.Test262`: **99,260 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)