### PR TITLE
Include target type, arguments and candidate signatures in interop resolution errors

### DIFF
--- a/Jint.Tests/Runtime/GenericMethodTests.cs
+++ b/Jint.Tests/Runtime/GenericMethodTests.cs
@@ -64,7 +64,9 @@ public class GenericMethodTests
                 ");
         });
 
-        Assert.Equal("No public methods with the specified arguments were found.", argException.Message);
+        Assert.StartsWith("No public methods with the specified arguments were found.", argException.Message);
+        Assert.Contains("TestGenericClass", argException.Message);
+        Assert.Contains("Fancy", argException.Message);
     }
 
     // TPC: TODO: tldr; typescript transpiled to javascript does not include the types in the constructors - JINT should allow you to use generics without specifying type

--- a/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
+++ b/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
@@ -1,0 +1,99 @@
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+using Jint.Tests.Runtime.Domain;
+using Jint.Tests.Runtime.ExtensionMethods;
+
+namespace Jint.Tests.Runtime;
+
+public partial class InteropTests
+{
+    [Fact]
+    public void FailedMethodResolutionReportsTargetTypeArgumentsAndCandidates()
+    {
+        var engine = new Engine();
+        engine.SetValue("speaker", new Speaker());
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+
+        Assert.Equal(
+            "No public methods with the specified arguments were found. Target: Jint.Tests.Runtime.Speaker.Say; provided arguments: (string, string); candidate signatures: Say(String message)",
+            ex.Message);
+    }
+
+    [Fact]
+    public void FailedMethodResolutionDescribesArgumentKinds()
+    {
+        var engine = new Engine();
+        engine.SetValue("speaker", new Speaker());
+        engine.SetValue("other", new Speaker());
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate(
+            "speaker.Say(null, undefined, [1, 2, 3], x => x, {}, new Date(), other)"));
+
+        Assert.Contains("(null, undefined, Array, function, object, Date, Speaker)", ex.Message);
+    }
+
+    [Fact]
+    public void FailedMethodResolutionCapsReportedCandidates()
+    {
+        var engine = new Engine();
+        engine.SetValue("picker", new OverloadPicker());
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("picker.Pick()"));
+
+        Assert.StartsWith("No public methods with the specified arguments were found.", ex.Message);
+        Assert.Contains("Pick(Int32 a)", ex.Message);
+        Assert.Contains(" and 2 more", ex.Message);
+    }
+
+    [Fact]
+    public void FailedExtensionMethodResolutionReportsDeclaringTypeAndReceiver()
+    {
+        var options = new Options();
+        options.AddExtensionMethods(typeof(PersonExtensions));
+
+        var engine = new Engine(options);
+        engine.SetValue("person", new Person());
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("person.MultiplyAge()"));
+
+        Assert.StartsWith("No public methods with the specified arguments were found.", ex.Message);
+        Assert.Contains("PersonExtensions.MultiplyAge(this Person person, Int32 factor)", ex.Message);
+    }
+
+    [Fact]
+    public void FailedConstructorResolutionReportsArgumentsAndCandidates()
+    {
+        var engine = new Engine();
+        engine.SetValue("CtorFails", TypeReference.CreateTypeReference<CtorFails>(engine));
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CtorFails(1, 2)"));
+
+        Assert.StartsWith("Could not resolve a constructor for type Jint.Tests.Runtime.CtorFails for given arguments", ex.Message);
+        Assert.Contains("provided arguments: (number, number)", ex.Message);
+        Assert.Contains("candidate signatures: CtorFails(String name)", ex.Message);
+    }
+}
+
+public class Speaker
+{
+    public string Say(string message) => $"Speaker says: {message}";
+}
+
+public class OverloadPicker
+{
+    public void Pick(int a) { }
+    public void Pick(int a, int b) { }
+    public void Pick(int a, int b, int c) { }
+    public void Pick(int a, int b, int c, int d) { }
+    public void Pick(int a, int b, int c, int d, int e) { }
+    public void Pick(int a, int b, int c, int d, int e, int f) { }
+    public void Pick(int a, int b, int c, int d, int e, int f, int g) { }
+}
+
+public class CtorFails
+{
+    public CtorFails(string name)
+    {
+    }
+}

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -3132,7 +3132,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         var engine = new Engine(options => options.AllowClr());
         engine.SetValue("IntValueInput", TypeReference.CreateTypeReference(engine, typeof(IntValueInput)));
         var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("new IntValueInput().testFunc(NaN);").AsString());
-        Assert.Equal("No public methods with the specified arguments were found.", ex.Message);
+        Assert.StartsWith("No public methods with the specified arguments were found.", ex.Message);
+        Assert.Contains("IntValueInput", ex.Message);
 
         Assert.Equal(123, engine.Evaluate("new IntValueInput().testFunc(123);").AsNumber());
     }

--- a/Jint/Runtime/Interop/InteropErrorHelper.cs
+++ b/Jint/Runtime/Interop/InteropErrorHelper.cs
@@ -1,0 +1,99 @@
+using System.Text;
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Native.Object;
+
+namespace Jint.Runtime.Interop;
+
+/// <summary>
+/// Builds detailed error messages for failed interop member resolution. Cold path only,
+/// invoked right before throwing.
+/// </summary>
+internal static class InteropErrorHelper
+{
+    private const int MaxCandidatesToReport = 5;
+
+    public static string CreateNoMatchingMethodMessage(Type targetType, string name, JsCallArguments arguments, MethodDescriptor[] methods)
+    {
+        var sb = new StringBuilder("No public methods with the specified arguments were found. Target: ");
+        sb.Append(targetType).Append('.').Append(name);
+        AppendArguments(sb, arguments);
+        AppendCandidates(sb, methods);
+        return sb.ToString();
+    }
+
+    public static string CreateNoMatchingConstructorMessage(Type type, JsCallArguments arguments, MethodDescriptor[]? constructors)
+    {
+        var sb = new StringBuilder("Could not resolve a constructor for type ");
+        sb.Append(type).Append(" for given arguments");
+        AppendArguments(sb, arguments);
+        AppendCandidates(sb, constructors ?? []);
+        return sb.ToString();
+    }
+
+    private static void AppendArguments(StringBuilder sb, JsCallArguments arguments)
+    {
+        sb.Append("; provided arguments: (");
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+            sb.Append(DescribeArgument(arguments[i]));
+        }
+        sb.Append(')');
+    }
+
+    private static void AppendCandidates(StringBuilder sb, MethodDescriptor[] methods)
+    {
+        sb.Append("; candidate signatures: ");
+        if (methods.Length == 0)
+        {
+            sb.Append("none");
+            return;
+        }
+
+        var reported = Math.Min(methods.Length, MaxCandidatesToReport);
+        for (var i = 0; i < reported; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+            sb.Append(methods[i]);
+        }
+
+        if (methods.Length > reported)
+        {
+            sb.Append(" and ").Append(methods.Length - reported).Append(" more");
+        }
+    }
+
+    /// <summary>
+    /// Describes an argument without calling ToObject(), which can invoke getters and
+    /// deep-convert objects - unwanted side effects on an error path.
+    /// </summary>
+    private static string DescribeArgument(JsValue value)
+    {
+        return value switch
+        {
+            null => "<missing>",
+            JsUndefined => "undefined",
+            JsNull => "null",
+            JsBoolean => "boolean",
+            JsString => "string",
+            JsNumber => "number",
+            JsBigInt => "bigint",
+            JsSymbol => "symbol",
+            // TypeReference implements IObjectWrapper with Target == the Type itself, match it first
+            TypeReference typeReference => typeReference.ReferenceType.Name,
+            IObjectWrapper wrapper => wrapper.Target?.GetType().Name ?? "null",
+            JsArray => "Array",
+            JsDate => "Date",
+            Function => "function",
+            ObjectInstance => "object",
+            _ => value.Type.ToString(),
+        };
+    }
+}

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -1,6 +1,7 @@
 using Jint.Native;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Jint.Extensions;
 
 #pragma warning disable IL2072
@@ -175,6 +176,106 @@ internal sealed class MethodDescriptor
         Array.Sort(descriptors, CreateComparison);
 
         return descriptors;
+    }
+
+    /// <summary>
+    /// Renders a C#-like signature for error messages, e.g. "Say(String message)" or
+    /// "PersonExtensions.FizzBuzz(this Person person)". Cold path only.
+    /// </summary>
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        if (Method is ConstructorInfo)
+        {
+            sb.Append(GetTypeName(Method.DeclaringType!));
+        }
+        else
+        {
+            if (IsExtensionMethod)
+            {
+                sb.Append(GetTypeName(Method.DeclaringType!)).Append('.');
+            }
+
+            sb.Append(Method.Name);
+
+            if (Method.IsGenericMethodDefinition)
+            {
+                sb.Append('<');
+                var genericArguments = Method.GetGenericArguments();
+                for (var i = 0; i < genericArguments.Length; i++)
+                {
+                    if (i > 0)
+                    {
+                        sb.Append(", ");
+                    }
+                    sb.Append(genericArguments[i].Name);
+                }
+                sb.Append('>');
+            }
+        }
+
+        sb.Append('(');
+        for (var i = 0; i < Parameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+
+            var parameter = Parameters[i];
+            if (i == 0 && IsExtensionMethod)
+            {
+                sb.Append("this ");
+            }
+            else if (HasParams && i == Parameters.Length - 1 && parameter.ParameterType.IsArray)
+            {
+                sb.Append("params ");
+            }
+
+            sb.Append(GetTypeName(parameter.ParameterType)).Append(' ').Append(parameter.Name);
+
+            if (parameter.HasDefaultValue)
+            {
+                sb.Append(" = ").Append(parameter.DefaultValue ?? "null");
+            }
+        }
+        sb.Append(')');
+
+        return sb.ToString();
+    }
+
+    private static string GetTypeName(Type type)
+    {
+        if (type.IsArray)
+        {
+            return GetTypeName(type.GetElementType()!) + "[]";
+        }
+
+        if (Nullable.GetUnderlyingType(type) is { } underlyingType)
+        {
+            return GetTypeName(underlyingType) + "?";
+        }
+
+        if (type.IsGenericType)
+        {
+            var name = type.Name;
+            var tickIndex = name.IndexOf('`');
+            var sb = new StringBuilder(tickIndex > 0 ? name.Substring(0, tickIndex) : name);
+            sb.Append('<');
+            var genericArguments = type.GetGenericArguments();
+            for (var i = 0; i < genericArguments.Length; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(", ");
+                }
+                sb.Append(GetTypeName(genericArguments[i]));
+            }
+            sb.Append('>');
+            return sb.ToString();
+        }
+
+        return type.Name;
     }
 
     public JsValue Call(Engine engine, object? instance, JsCallArguments arguments)

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -189,7 +189,7 @@ internal sealed class MethodInfoFunction : Function
             return _fallbackFunctionInstance.Call(thisObject, jsArguments);
         }
 
-        Throw.TypeError(_engine.Realm, "No public methods with the specified arguments were found.");
+        Throw.TypeError(_engine.Realm, InteropErrorHelper.CreateNoMatchingMethodMessage(_targetType, _name, jsArguments, _methods));
         return null;
     }
 

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -67,6 +67,7 @@ public sealed class TypeReference : Constructor, IObjectWrapper
 
             var fromOptionsCreator = engine.Options.Interop.CreateTypeReferenceObject(engine, referenceType, arguments);
             ObjectInstance? result = null;
+            MethodDescriptor[]? constructors = null;
             if (fromOptionsCreator is not null)
             {
                 result = TypeConverter.ToObject(realm, FromObject(engine, fromOptionsCreator));
@@ -78,7 +79,7 @@ public sealed class TypeReference : Constructor, IObjectWrapper
             }
             else
             {
-                var constructors = _constructorCache.GetOrAdd(
+                constructors = _constructorCache.GetOrAdd(
                     referenceType,
                     t =>
                     {
@@ -198,7 +199,7 @@ public sealed class TypeReference : Constructor, IObjectWrapper
 
             if (result is null)
             {
-                Throw.TypeError(realm, $"Could not resolve a constructor for type {referenceType} for given arguments");
+                Throw.TypeError(realm, InteropErrorHelper.CreateNoMatchingConstructorMessage(referenceType, arguments, constructors));
             }
 
             result.SetPrototypeOf(state.TypeReference);


### PR DESCRIPTION
Improves the error messages thrown when CLR interop method or constructor resolution fails, as raised in discussion #2523: previously the message gave no indication of which CLR type was involved.

**Before:**
```
No public methods with the specified arguments were found.
```

**After:**
```
No public methods with the specified arguments were found. Target: MyApp.Person.Say; provided arguments: (string, string); candidate signatures: Say(String message)
```

Constructor resolution failures get the same treatment:
```
Could not resolve a constructor for type MyApp.CtorFails for given arguments; provided arguments: (number, number); candidate signatures: CtorFails(String name)
```

### Details

- New internal `InteropErrorHelper` builds the messages; `MethodDescriptor` gets a `ToString()` override rendering C#-like signatures (extension methods render as `PersonExtensions.MultiplyAge(this Person person, Int32 factor)`, params arrays as `params String[] values`, generic definitions as `Fancy<T>(...)`, optionals with their defaults).
- Argument types are described from the JsValue side without calling `ToObject()` (avoids getter side effects on the error path); wrapped CLR objects report their `Target` type name, which is what the host wants to see.
- The candidate list is capped at 5 (+ `and N more`) — `MethodDescriptor` ordering already puts the most plausible matches first.
- Both legacy message texts are preserved verbatim as prefixes, so any consumer matching with `StartsWith`/`Contains` keeps working; only exact-equality matchers see a change.
- The headline shows the JS-visible member name while candidates show CLR names — these can differ in casing when a naming convention is applied, which is intentional.

All on a cold error path, no hot-path changes.

### Tests

- New `InteropTests.ErrorMessages.cs` covering: the discussion scenario (exact message pin), argument-kind rendering (`null`, `undefined`, `Array`, `function`, `object`, `Date`, wrapped CLR object), the 5-candidate cap, extension-method rendering, and constructor failures.
- Two existing exact-equality assertions relaxed to prefix + contains.
- Full Jint.Tests (3112 + 3050) and Jint.Tests.PublicInterface (79 + 79) green on net10.0 and net472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)