### PR TITLE
Extend pooled-accumulator pattern: RegExp split, Iterator.toArray, Object enumeration, builder tuning

### DIFF
--- a/Jint.Benchmark/IteratorToArrayBenchmark.cs
+++ b/Jint.Benchmark/IteratorToArrayBenchmark.cs
@@ -1,0 +1,40 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+[MemoryDiagnoser]
+public class IteratorToArrayBenchmark
+{
+    private const int N = 100;
+
+    private Engine _engine = null!;
+    private Prepared<Script> _arrayValuesToArray;
+    private Prepared<Script> _setValuesToArray;
+    private Prepared<Script> _helperChainToArray;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute("""
+var numbers = [];
+for (var i = 0; i < 1000; i++) {
+    numbers.push(i);
+}
+var set = new Set(numbers);
+""");
+
+        _arrayValuesToArray = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ numbers.values().toArray(); }}");
+        _setValuesToArray = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ set.values().toArray(); }}");
+        _helperChainToArray = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ numbers.values().map(function(x) {{ return x * 2; }}).toArray(); }}");
+    }
+
+    [Benchmark]
+    public void ArrayValuesToArray() => _engine.Execute(_arrayValuesToArray);
+
+    [Benchmark]
+    public void SetValuesToArray() => _engine.Execute(_setValuesToArray);
+
+    [Benchmark]
+    public void HelperChainToArray() => _engine.Execute(_helperChainToArray);
+}

--- a/Jint.Benchmark/ObjectEnumerationBenchmark.cs
+++ b/Jint.Benchmark/ObjectEnumerationBenchmark.cs
@@ -1,0 +1,49 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+[MemoryDiagnoser]
+public class ObjectEnumerationBenchmark
+{
+    private const int N = 100;
+
+    private Engine _engine = null!;
+    private Prepared<Script> _keys;
+    private Prepared<Script> _values;
+    private Prepared<Script> _entries;
+    private Prepared<Script> _keysFiltered;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute("""
+var obj = {};
+for (var i = 0; i < 100; i++) {
+    obj['key' + i] = i;
+}
+var filtered = {};
+for (var i = 0; i < 100; i++) {
+    Object.defineProperty(filtered, 'key' + i, { value: i, enumerable: i % 2 === 0 });
+}
+""");
+
+        _keys = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ Object.keys(obj); }}");
+        _values = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ Object.values(obj); }}");
+        _entries = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ Object.entries(obj); }}");
+        // half the keys are non-enumerable: exercises the filtered/oversized-result path
+        _keysFiltered = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ Object.keys(filtered); }}");
+    }
+
+    [Benchmark]
+    public void Keys() => _engine.Execute(_keys);
+
+    [Benchmark]
+    public void Values() => _engine.Execute(_values);
+
+    [Benchmark]
+    public void Entries() => _engine.Execute(_entries);
+
+    [Benchmark]
+    public void KeysFiltered() => _engine.Execute(_keysFiltered);
+}

--- a/Jint.Benchmark/RegExpSplitBenchmark.cs
+++ b/Jint.Benchmark/RegExpSplitBenchmark.cs
@@ -1,0 +1,41 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+[MemoryDiagnoser]
+public class RegExpSplitBenchmark
+{
+    private const int N = 100;
+
+    private Engine _engine = null!;
+    private Prepared<Script> _split;
+    private Prepared<Script> _splitWithCaptures;
+    private Prepared<Script> _splitUnicode;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute("""
+var text = '';
+for (var i = 0; i < 200; i++) {
+    text += 'word' + i + '; ';
+}
+""");
+
+        // .NET engine fast path
+        _split = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ text.split(/;\\s/); }}");
+        _splitWithCaptures = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ text.split(/(;)\\s/); }}");
+        // unicode flag forces the generic exec loop
+        _splitUnicode = Engine.PrepareScript($"for (var n = 0; n < {N}; n++) {{ text.split(/;\\s/u); }}");
+    }
+
+    [Benchmark]
+    public void Split() => _engine.Execute(_split);
+
+    [Benchmark]
+    public void SplitWithCaptures() => _engine.Execute(_splitWithCaptures);
+
+    [Benchmark]
+    public void SplitUnicode() => _engine.Execute(_splitUnicode);
+}

--- a/Jint.Tests/Runtime/IteratorHelpersTests.cs
+++ b/Jint.Tests/Runtime/IteratorHelpersTests.cs
@@ -1,0 +1,38 @@
+namespace Jint.Tests.Runtime;
+
+public class IteratorHelpersTests
+{
+    [Fact]
+    public void ToArrayCollectsAllValues()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            function* gen() { yield 1; yield 2; yield 3; }
+            JSON.stringify([
+                [1, 2, 3].values().toArray(),
+                gen().toArray(),
+                new Set(['a', 'b']).values().toArray()
+            ]);
+            """).AsString();
+
+        Assert.Equal("[[1,2,3],[1,2,3],[\"a\",\"b\"]]", result);
+    }
+
+    [Fact]
+    public void ToArrayWorksThroughHelperChain()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("JSON.stringify([1, 2, 3, 4, 5].values().drop(1).take(3).map(x => x * 10).toArray())").AsString();
+
+        Assert.Equal("[20,30,40]", result);
+    }
+
+    [Fact]
+    public void ToArrayReturnsPlainArray()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("Array.isArray([].values().toArray()) && [].values().toArray().length === 0").AsBoolean();
+
+        Assert.True(result);
+    }
+}

--- a/Jint.Tests/Runtime/ObjectInstanceTests.cs
+++ b/Jint.Tests/Runtime/ObjectInstanceTests.cs
@@ -5,6 +5,61 @@ namespace Jint.Tests.Runtime;
 public class ObjectInstanceTests
 {
     [Fact]
+    public void KeysValuesEntriesCollectEnumerableStringKeys()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var o = { a: 1, b: 2 };
+            JSON.stringify([Object.keys(o), Object.values(o), Object.entries(o)]);
+            """).AsString();
+
+        Assert.Equal("[[\"a\",\"b\"],[1,2],[[\"a\",1],[\"b\",2]]]", result);
+    }
+
+    [Fact]
+    public void KeysValuesEntriesFilterNonEnumerableAndSymbolKeys()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var o = { a: 1 };
+            Object.defineProperty(o, 'hidden', { value: 2, enumerable: false });
+            o[Symbol('s')] = 3;
+            o.b = 4;
+            JSON.stringify([Object.keys(o), Object.values(o), Object.entries(o).length]);
+            """).AsString();
+
+        Assert.Equal("[[\"a\",\"b\"],[1,4],2]", result);
+    }
+
+    [Fact]
+    public void EntriesPairsAreRealArrays()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var e = Object.entries({ a: 1 })[0];
+            Array.isArray(e) && e.length === 2 && (e.push(3), e.length === 3);
+            """).AsBoolean();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void KeysOnProxyConsultTraps()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var calls = [];
+            var p = new Proxy({ a: 1, b: 2 }, {
+                ownKeys: function (t) { calls.push('ownKeys'); return Reflect.ownKeys(t); },
+                getOwnPropertyDescriptor: function (t, k) { calls.push('gopd:' + k); return Reflect.getOwnPropertyDescriptor(t, k); }
+            });
+            JSON.stringify([Object.keys(p), calls]);
+            """).AsString();
+
+        Assert.Equal("[[\"a\",\"b\"],[\"ownKeys\",\"gopd:a\",\"gopd:b\"]]", result);
+    }
+
+    [Fact]
     public void RemovingFirstPropertyFromObjectInstancePropertiesBucketAndEnumerating()
     {
         var engine = new Engine();

--- a/Jint.Tests/Runtime/RegExpTests.cs
+++ b/Jint.Tests/Runtime/RegExpTests.cs
@@ -34,6 +34,40 @@ public class RegExpTests
         Assert.Equal(3, result);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("u")]
+    public void SplitCollectsSegmentsCapturesAndTail(string flags)
+    {
+        // without flags exercises the .NET fast path, with 'u' the generic exec loop
+        var engine = new Engine();
+        var result = engine.Evaluate($"JSON.stringify('a1b22c'.split(/(\\d+)/{flags}))").AsString();
+
+        Assert.Equal("[\"a\",\"1\",\"b\",\"22\",\"c\"]", result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("u")]
+    public void SplitHonorsLimit(string flags)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($"JSON.stringify(['a,b,c'.split(/,/{flags}, 2), 'a1b2c'.split(/(\\d)/{flags}, 2)])").AsString();
+
+        Assert.Equal("[[\"a\",\"b\"],[\"a\",\"1\"]]", result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("u")]
+    public void SplitKeepsEmptyLeadingAndTrailingSegments(string flags)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($"JSON.stringify([',a,'.split(/,/{flags}), ''.split(/x/{flags}), ''.split(/(?:)/{flags})])").AsString();
+
+        Assert.Equal("[[\"\",\"a\",\"\"],[\"\"],[]]", result);
+    }
+
     private const string TestRegex = "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w\\.-]*)*\\/?$";
     private const string TestedValue = "https://archiverbx.blob.core.windows.net/static/C:/Users/USR/Documents/Projects/PROJ/static/images/full/1234567890.jpg";
 

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -95,7 +95,7 @@ public sealed partial class ArrayConstructor : Constructor
         var iterator = items.GetIterator(_realm, method: usingIterator);
 
         var builder = new JsValueListBuilder(16);
-        var args = _engine._jsValueArrayPool.RentArray(2);
+        var args = callable is not null ? _engine._jsValueArrayPool.RentArray(2) : null;
         try
         {
             var iterations = 0;
@@ -119,7 +119,7 @@ public sealed partial class ArrayConstructor : Constructor
 
                     if (callable is not null)
                     {
-                        args[0] = jsValue;
+                        args![0] = jsValue;
                         args[1] = index;
                         jsValue = callable.Call(thisArg, args);
                     }
@@ -138,7 +138,10 @@ public sealed partial class ArrayConstructor : Constructor
         finally
         {
             builder.Dispose();
-            _engine._jsValueArrayPool.ReturnArray(args);
+            if (args is not null)
+            {
+                _engine._jsValueArrayPool.ReturnArray(args);
+            }
         }
     }
 

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1837,9 +1837,9 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
             // The result is still provably a plain array (same gate as the Map/Filter fast
             // paths); accumulate into a pooled buffer instead of per-element virtual writes.
-            if (CanConcatWithBuilder(thisArr, arguments))
+            if (CanConcatWithBuilder(thisArr, arguments, out var sizeHint))
             {
-                return ConcatPlainTarget(thisArr, arguments);
+                return ConcatPlainTarget(thisArr, arguments, sizeHint);
             }
         }
 
@@ -1903,31 +1903,44 @@ public sealed partial class ArrayPrototype : ArrayInstance
     /// backing (lazy <c>new Array(N)</c>, truncated-backing holey arrays) must stay on the
     /// CopyValues slow path, which keeps such results compact instead of materializing
     /// every hole. The +50 slack mirrors the engine's looks-sparse write heuristic.
-    /// All inspected state is engine-internal, so bailing here is unobservable.
+    /// All inspected state is engine-internal, so bailing here is unobservable; the same
+    /// pass sums the known JsArray lengths into a rent-size hint for the builder.
+    /// Non-array spreadables read their length observably during processing, so they only
+    /// count one slot here and the builder grows if they spread larger.
     /// </summary>
-    private static bool CanConcatWithBuilder(JsArray thisArr, JsCallArguments arguments)
+    private static bool CanConcatWithBuilder(JsArray thisArr, JsCallArguments arguments, out ulong sizeHint)
     {
+        sizeHint = 0;
+
         if (thisArr._dense is null || thisArr.GetLength() > (ulong) thisArr._dense.Length + 50)
         {
             return false;
         }
 
+        sizeHint = thisArr.GetLength();
         for (var i = 0; i < arguments.Length; i++)
         {
-            if (arguments[i] is JsArray ja
-                && (ja._dense is null || ja.GetLength() > (ulong) ja._dense.Length + 50))
+            if (arguments[i] is JsArray ja)
             {
-                return false;
+                if (ja._dense is null || ja.GetLength() > (ulong) ja._dense.Length + 50)
+                {
+                    return false;
+                }
+
+                sizeHint += ja.GetLength();
+            }
+            else
+            {
+                sizeHint++;
             }
         }
 
         return true;
     }
 
-    private JsArray ConcatPlainTarget(JsArray thisArr, JsCallArguments arguments)
+    private JsArray ConcatPlainTarget(JsArray thisArr, JsCallArguments arguments, ulong sizeHint)
     {
-        var initialCapacity = (ulong) thisArr.GetLength() + (ulong) arguments.Length;
-        var builder = new JsValueListBuilder((int) System.Math.Min(initialCapacity, 1024 * 1024));
+        var builder = new JsValueListBuilder((int) System.Math.Min(sizeHint, 1024 * 1024));
         try
         {
             AppendConcatItem(ref builder, thisArr);

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -1,5 +1,6 @@
 using Jint.Native.Object;
 using Jint.Native.Symbol;
+using Jint.Pooling;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
@@ -404,22 +405,37 @@ internal partial class IteratorPrototype : Prototype
         }
 
         var iterated = GetIteratorDirect(o);
-        var items = new JsArray(_engine);
-        while (iterated.TryIteratorStep(out var iteratorResult))
+        var builder = new JsValueListBuilder(16);
+        try
         {
-            try
+            var iterations = 0;
+            while (iterated.TryIteratorStep(out var iteratorResult))
             {
-                var value = iteratorResult.Get(CommonProperties.Value);
-                items.Push(value);
-            }
-            catch
-            {
-                iterated.Close(CompletionType.Throw);
-                throw;
-            }
-        }
+                try
+                {
+                    // Check constraints periodically so a huge (or native-backed) iterator
+                    // cannot run uninterrupted; the catch closes the iterator.
+                    if (++iterations % Engine.ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
 
-        return items;
+                    var value = iteratorResult.Get(CommonProperties.Value);
+                    builder.Add(value);
+                }
+                catch
+                {
+                    iterated.Close(CompletionType.Throw);
+                    throw;
+                }
+            }
+
+            return _engine.Realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+        }
+        finally
+        {
+            builder.Dispose();
+        }
     }
 
     /// <summary>

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1489,8 +1489,19 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     {
         var ownKeys = GetOwnPropertyKeys(Types.String);
 
-        var array = Engine.Realm.Intrinsics.Array.ArrayCreate((uint) ownKeys.Count);
-        uint index = 0;
+        // ArrayCreate would validate this through the constructor; the ownership-taking
+        // constructor used below does not, so keep constraint parity explicitly.
+        if ((uint) ownKeys.Count > _engine.Options.Constraints.MaxArraySize)
+        {
+            ArrayInstance.ThrowMaximumArraySizeReachedException(_engine, (uint) ownKeys.Count);
+        }
+
+        // The output is bounded by (and usually equal to) the key count, so values are
+        // written straight into the final backing array and the result takes ownership
+        // without copying; only when keys get filtered out is an exact-size copy made,
+        // instead of retaining the over-allocated backing.
+        var target = new JsValue[ownKeys.Count];
+        var count = 0;
 
         for (var i = 0; i < ownKeys.Count; i++)
         {
@@ -1512,30 +1523,31 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             {
                 if (kind == EnumerableOwnPropertyNamesKind.Key)
                 {
-                    array.SetIndexValue(index, property, updateLength: false);
+                    target[count++] = property;
                 }
                 else
                 {
                     var value = Get(property);
                     if (kind == EnumerableOwnPropertyNamesKind.Value)
                     {
-                        array.SetIndexValue(index, value, updateLength: false);
+                        target[count++] = value;
                     }
                     else
                     {
-                        var objectInstance = _engine.Realm.Intrinsics.Array.ArrayCreate(2);
-                        objectInstance.SetIndexValue(0, property, updateLength: false);
-                        objectInstance.SetIndexValue(1, value, updateLength: false);
-                        array.SetIndexValue(index, objectInstance, updateLength: false);
+                        target[count++] = new JsArray(_engine, [property, value]);
                     }
                 }
-
-                index++;
             }
         }
 
-        array.SetLength(index);
-        return array;
+        if (count == target.Length)
+        {
+            return new JsArray(_engine, target);
+        }
+
+        var exact = new JsValue[count];
+        System.Array.Copy(target, exact, count);
+        return new JsArray(_engine, exact);
     }
 
     internal enum EnumerableOwnPropertyNamesKind

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -559,7 +559,6 @@ internal sealed partial class RegExpPrototype : Prototype
             rx,
             newFlags
         ]);
-        uint lengthA = 0;
         var lim = limit.IsUndefined() ? NumberConstructor.MaxSafeInteger : TypeConverter.ToUint32(limit);
 
         if (lim == 0)
@@ -590,118 +589,129 @@ internal sealed partial class RegExpPrototype : Prototype
                 return StringPrototype.SplitWithStringSeparator(_engine, _realm, "", s, (uint) s.Length);
             }
 
-            var a = _realm.Intrinsics.Array.Construct(Arguments.Empty);
-
-            int lastIndex = 0;
-            uint index = 0;
-            var matchCount = 0;
-            for (var match = R.Value.Match(s, 0); match.Success; match = match.NextMatch())
+            // the result is a plain array per spec (no species for the result), so segments
+            // accumulate in a pooled buffer and materialize at exact size
+            var builder = new JsValueListBuilder(16);
+            try
             {
-                if (++matchCount % ConstraintCheckInterval == 0)
+                int lastIndex = 0;
+                var matchCount = 0;
+                for (var match = R.Value.Match(s, 0); match.Success; match = match.NextMatch())
+                {
+                    if (++matchCount % ConstraintCheckInterval == 0)
+                    {
+                        _engine.Constraints.Check();
+                    }
+
+                    if (match.Length == 0 && (match.Index == 0 || match.Index == s.Length || match.Index == lastIndex))
+                    {
+                        continue;
+                    }
+
+                    builder.Add(s.Substring(lastIndex, match.Index - lastIndex));
+
+                    if (builder.Length >= lim)
+                    {
+                        return _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+                    }
+
+                    lastIndex = match.Index + match.Length;
+                    var actualGroupCount = GetActualRegexGroupCount(R, match);
+                    for (int i = 1; i < actualGroupCount; i++)
+                    {
+                        var group = match.Groups[i];
+                        var item = Undefined;
+                        if (group.Captures.Count > 0)
+                        {
+                            item = match.Groups[i].Value;
+                        }
+
+                        builder.Add(item);
+
+                        if (builder.Length >= lim)
+                        {
+                            return _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+                        }
+                    }
+                }
+
+                // Add the last part of the split
+                builder.Add(s.Substring(lastIndex));
+
+                return _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+            }
+            finally
+            {
+                builder.Dispose();
+            }
+        }
+
+        return SplitSlow(s, splitter, unicodeMatching, lim);
+    }
+
+    private JsArray SplitSlow(string s, ObjectInstance splitter, bool unicodeMatching, long lim)
+    {
+        var builder = new JsValueListBuilder(16);
+        try
+        {
+            ulong previousStringIndex = 0;
+            ulong currentIndex = 0;
+            var iterations = 0;
+            while (currentIndex < (ulong) s.Length)
+            {
+                if (++iterations % ConstraintCheckInterval == 0)
                 {
                     _engine.Constraints.Check();
                 }
 
-                if (match.Length == 0 && (match.Index == 0 || match.Index == s.Length || match.Index == lastIndex))
+                splitter.Set(JsRegExp.PropertyLastIndex, currentIndex, true);
+                var z = RegExpExec(splitter, s);
+                if (z.IsNull())
                 {
+                    currentIndex = AdvanceStringIndex(s, currentIndex, unicodeMatching);
                     continue;
                 }
 
-                // Add the match results to the array.
-                a.SetIndexValue(index++, s.Substring(lastIndex, match.Index - lastIndex), updateLength: true);
-
-                if (index >= lim)
+                var endIndex = TypeConverter.ToLength(splitter.Get(JsRegExp.PropertyLastIndex));
+                endIndex = System.Math.Min(endIndex, (ulong) s.Length);
+                if (endIndex == previousStringIndex)
                 {
-                    return a;
+                    currentIndex = AdvanceStringIndex(s, currentIndex, unicodeMatching);
+                    continue;
                 }
 
-                lastIndex = match.Index + match.Length;
-                var actualGroupCount = GetActualRegexGroupCount(R, match);
-                for (int i = 1; i < actualGroupCount; i++)
+                var t = s.Substring((int) previousStringIndex, (int) (currentIndex - previousStringIndex));
+                builder.Add(t);
+                if (builder.Length == lim)
                 {
-                    var group = match.Groups[i];
-                    var item = Undefined;
-                    if (group.Captures.Count > 0)
-                    {
-                        item = match.Groups[i].Value;
-                    }
+                    return _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+                }
 
-                    a.SetIndexValue(index++, item, updateLength: true);
-
-                    if (index >= lim)
+                previousStringIndex = endIndex;
+                var numberOfCaptures = (int) TypeConverter.ToLength(z.Get(CommonProperties.Length));
+                numberOfCaptures = System.Math.Max(numberOfCaptures - 1, 0);
+                var i = 1;
+                while (i <= numberOfCaptures)
+                {
+                    var nextCapture = z.Get(i);
+                    builder.Add(nextCapture);
+                    i++;
+                    if (builder.Length == lim)
                     {
-                        return a;
+                        return _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
                     }
                 }
+
+                currentIndex = previousStringIndex;
             }
 
-            // Add the last part of the split
-            a.SetIndexValue(index, s.Substring(lastIndex), updateLength: true);
-
-            return a;
+            builder.Add(s.Substring((int) previousStringIndex, s.Length - (int) previousStringIndex));
+            return _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
         }
-
-        return SplitSlow(s, splitter, unicodeMatching, lengthA, lim);
-    }
-
-    private JsArray SplitSlow(string s, ObjectInstance splitter, bool unicodeMatching, uint lengthA, long lim)
-    {
-        var a = _realm.Intrinsics.Array.ArrayCreate(0);
-        ulong previousStringIndex = 0;
-        ulong currentIndex = 0;
-        var iterations = 0;
-        while (currentIndex < (ulong) s.Length)
+        finally
         {
-            if (++iterations % ConstraintCheckInterval == 0)
-            {
-                _engine.Constraints.Check();
-            }
-
-            splitter.Set(JsRegExp.PropertyLastIndex, currentIndex, true);
-            var z = RegExpExec(splitter, s);
-            if (z.IsNull())
-            {
-                currentIndex = AdvanceStringIndex(s, currentIndex, unicodeMatching);
-                continue;
-            }
-
-            var endIndex = TypeConverter.ToLength(splitter.Get(JsRegExp.PropertyLastIndex));
-            endIndex = System.Math.Min(endIndex, (ulong) s.Length);
-            if (endIndex == previousStringIndex)
-            {
-                currentIndex = AdvanceStringIndex(s, currentIndex, unicodeMatching);
-                continue;
-            }
-
-            var t = s.Substring((int) previousStringIndex, (int) (currentIndex - previousStringIndex));
-            a.SetIndexValue(lengthA, t, updateLength: true);
-            lengthA++;
-            if (lengthA == lim)
-            {
-                return a;
-            }
-
-            previousStringIndex = endIndex;
-            var numberOfCaptures = (int) TypeConverter.ToLength(z.Get(CommonProperties.Length));
-            numberOfCaptures = System.Math.Max(numberOfCaptures - 1, 0);
-            var i = 1;
-            while (i <= numberOfCaptures)
-            {
-                var nextCapture = z.Get(i);
-                a.SetIndexValue(lengthA, nextCapture, updateLength: true);
-                i++;
-                lengthA++;
-                if (lengthA == lim)
-                {
-                    return a;
-                }
-            }
-
-            currentIndex = previousStringIndex;
+            builder.Dispose();
         }
-
-        a.SetIndexValue(lengthA, s.Substring((int) previousStringIndex, s.Length - (int) previousStringIndex), updateLength: true);
-        return a;
     }
 
     private JsValue Flags(JsValue thisObject)


### PR DESCRIPTION
## Summary

Follow-up to #2524: applies the pooled `JsValueListBuilder` pattern to the remaining unknown-size accumulation sites found in a sweep of the codebase, and tunes two things in the merged implementation. Five commits, each independently benchmarked (BenchmarkDotNet default jobs, before/after pairs; full tables in the commit messages).

### 1. Size concat builder rent from known argument lengths (`f6182eb`)

`ConcatPlainTarget` rented from `thisLen + argument COUNT`, ignoring how many elements spreadable array arguments carry, paying avoidable `Grow` copy+clear cycles. `CanConcatWithBuilder` already walks every argument; the same pass now sums known `JsArray` lengths into a rent hint at zero extra cost.

| Case | Mean | Allocated |
|---|---|---|
| Concat_WithPlainObject | 593 → 564 µs (−5%) | same |
| Concat_WithSpreadableObject | 2673 → 2417 µs (−10%) | same |
| Concat_WithHoleyArray | 1130 → 936 µs (**−17%**) | same |
| fast-path cases | noise | same |

### 2. Rent Array.from callback args only when a mapper is present (`0857a8f`)

`ConstructFromIterator` held a 2-element pool array across the whole iteration even for mapper-less `Array.from(iterable)`. Pool-slot hygiene; measured neutral at 1000-element scale as expected (one pooled rent amortizes to nothing).

### 3. Use pooled builder for RegExp `[Symbol.split]` (`dffcc20`)

Both the .NET-engine fast path and the generic exec loop built results via `ArrayCreate(0)` + `SetIndexValue(..., updateLength: true)` — doubling growth plus a length-maintenance pass per write. The spec result is a plain `ArrayCreate` (species applies to the splitter, not the result), so no gate is needed.

| Case | Mean | Allocated |
|---|---|---|
| Split | 2.07 → 2.02 ms | 6.09 → 5.84 MB, Gen1 47→35 |
| SplitWithCaptures | 3.74 → 3.24 ms (**−13%**) | 11.12 → 10.63 MB, Gen1 98→63 |
| SplitUnicode (generic loop) | 26.3 → 23.8 ms (**−10%**) | Gen1 344→250 |

### 4. Use pooled builder for `Iterator.prototype.toArray` (`22b0a98`)

Replaced the `JsArray.Push`-per-item loop (argument handling + length update per value). Also adds the standard periodic constraint check this loop was missing.

| Case | Mean | Allocated |
|---|---|---|
| ArrayValuesToArray | 2.68 → 2.21 ms (**−18%**) | 16.12 → 15.31 MB, Gen1 70→35 |
| SetValuesToArray | 2.50 → 2.20 ms (**−12%**) | 16.12 → 15.31 MB, Gen1 70→35 |
| HelperChainToArray | neutral | Gen1 156→63 |

### 5. Build `Object.keys/values/entries` via exact backing arrays (`7e1f8dd`)

Not the builder — measurement showed the right tool here is different. `EnumerableOwnProperties` now writes values straight into a `JsValue[]` the result takes ownership of (zero-copy, no per-element `SetIndexValue`); filtered results materialize exact-size instead of retaining the over-allocated backing; `entries` pairs are built as two-element ownership arrays. A pooled-builder variant was measured first and **rejected** — it regressed plain keys/values by 5–9% because the old path already wrote into an exact-presized array, so the pooled buffer only added a copy and a clear.

| Case | Mean | Allocated |
|---|---|---|
| Keys | 212 → 191 µs (**−10%**) | same |
| Values | 268 → 249 µs (−7%) | same |
| Entries | 576 → 438 µs (**−24%**) | same |
| KeysFiltered | neutral | retained backing now exact-size |

## Not converted (checked and deliberately skipped)

- **Non-sticky .NET regexp match path** — already a single exact resize; a builder would add a copy.
- **Promise combinators, `AsyncIterator.toArray`, resumable spread** — accumulation spans event-loop ticks / generator suspension; a ref struct cannot.
- **`groupBy` per-group accumulation** — groups live in dictionary values where a ref struct cannot be stored; `ConstructFast(List)` already materializes exact-size.

## Testing

- New unit tests per site: split segments/captures/limits/empty-segment edges on both engine paths, `toArray` through helper chains and generators, keys/values/entries filtering + Proxy trap ordering, entries pairs being real mutable arrays.
- `Jint.Tests` (3120 passed), `Jint.Tests.PublicInterface` (79 passed), full `Jint.Tests.Test262`: 99,259 passed, 1 timing-sensitive Atomics.waitAsync flake that passes in isolation, 0 real failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)