### PR TITLE
Gate detailed interop resolution error messages; expose CLR type to host

### DIFF
--- a/Jint.Tests/Runtime/GenericMethodTests.cs
+++ b/Jint.Tests/Runtime/GenericMethodTests.cs
@@ -64,9 +64,8 @@ public class GenericMethodTests
                 ");
         });
 
-        Assert.StartsWith("No public methods with the specified arguments were found.", argException.Message);
-        Assert.Contains("TestGenericClass", argException.Message);
-        Assert.Contains("Fancy", argException.Message);
+        // detailed resolution errors are off by default, so the terse message is used
+        Assert.Equal("No public methods with the specified arguments were found.", argException.Message);
     }
 
     // TPC: TODO: tldr; typescript transpiled to javascript does not include the types in the constructors - JINT should allow you to use generics without specifying type

--- a/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
+++ b/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
@@ -7,10 +7,13 @@ namespace Jint.Tests.Runtime;
 
 public partial class InteropTests
 {
+    private static Engine DetailedErrorsEngine() =>
+        new Engine(options => options.Interop.ExposeDetailedResolutionErrors = true);
+
     [Fact]
     public void FailedMethodResolutionReportsTargetTypeArgumentsAndCandidates()
     {
-        var engine = new Engine();
+        var engine = DetailedErrorsEngine();
         engine.SetValue("speaker", new Speaker());
 
         var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
@@ -23,7 +26,7 @@ public partial class InteropTests
     [Fact]
     public void FailedMethodResolutionDescribesArgumentKinds()
     {
-        var engine = new Engine();
+        var engine = DetailedErrorsEngine();
         engine.SetValue("speaker", new Speaker());
         engine.SetValue("other", new Speaker());
 
@@ -36,7 +39,7 @@ public partial class InteropTests
     [Fact]
     public void FailedMethodResolutionCapsReportedCandidates()
     {
-        var engine = new Engine();
+        var engine = DetailedErrorsEngine();
         engine.SetValue("picker", new OverloadPicker());
 
         var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("picker.Pick()"));
@@ -50,6 +53,7 @@ public partial class InteropTests
     public void FailedExtensionMethodResolutionReportsDeclaringTypeAndReceiver()
     {
         var options = new Options();
+        options.Interop.ExposeDetailedResolutionErrors = true;
         options.AddExtensionMethods(typeof(PersonExtensions));
 
         var engine = new Engine(options);
@@ -64,7 +68,7 @@ public partial class InteropTests
     [Fact]
     public void FailedConstructorResolutionReportsArgumentsAndCandidates()
     {
-        var engine = new Engine();
+        var engine = DetailedErrorsEngine();
         engine.SetValue("CtorFails", TypeReference.CreateTypeReference<CtorFails>(engine));
 
         var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CtorFails(1, 2)"));
@@ -72,6 +76,63 @@ public partial class InteropTests
         Assert.StartsWith("Could not resolve a constructor for type Jint.Tests.Runtime.CtorFails for given arguments", ex.Message);
         Assert.Contains("provided arguments: (number, number)", ex.Message);
         Assert.Contains("candidate signatures: CtorFails(String name)", ex.Message);
+    }
+
+    [Fact]
+    public void DefaultMethodResolutionErrorIsTerseAndHidesClrDetail()
+    {
+        var engine = new Engine();
+        engine.SetValue("speaker", new Speaker());
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+
+        // the script-visible message must not leak the CLR type, member, argument types or signatures
+        Assert.Equal("No public methods with the specified arguments were found.", ex.Message);
+    }
+
+    [Fact]
+    public void DefaultConstructorResolutionErrorIsTerse()
+    {
+        var engine = new Engine();
+        engine.SetValue("CtorFails", TypeReference.CreateTypeReference<CtorFails>(engine));
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CtorFails(1, 2)"));
+
+        // historical terse text (names the type, as it always has) but none of the added detail
+        Assert.Equal("Could not resolve a constructor for type Jint.Tests.Runtime.CtorFails for given arguments", ex.Message);
+        Assert.DoesNotContain("provided arguments", ex.Message);
+        Assert.DoesNotContain("candidate signatures", ex.Message);
+    }
+
+    [Fact]
+    public void ClrTypeIsAvailableHostSideUnderSafeDefault()
+    {
+        // no options set: detailed messages are off, but the host can still recover the CLR type
+        var engine = new Engine();
+        engine.SetValue("speaker", new Speaker());
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+
+        Assert.True(JintException.TryGetClrType(ex, out var type));
+        Assert.Equal(typeof(Speaker), type);
+
+        Assert.True(JintException.TryGetClrMemberName(ex, out var member));
+        Assert.Equal("Say", member);
+    }
+
+    [Fact]
+    public void ClrTypeIsAvailableForConstructorFailures()
+    {
+        var engine = new Engine();
+        engine.SetValue("CtorFails", TypeReference.CreateTypeReference<CtorFails>(engine));
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CtorFails(1, 2)"));
+
+        Assert.True(JintException.TryGetClrType(ex, out var type));
+        Assert.Equal(typeof(CtorFails), type);
+
+        // constructors carry no member name
+        Assert.False(JintException.TryGetClrMemberName(ex, out _));
     }
 }
 

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -3132,8 +3132,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         var engine = new Engine(options => options.AllowClr());
         engine.SetValue("IntValueInput", TypeReference.CreateTypeReference(engine, typeof(IntValueInput)));
         var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("new IntValueInput().testFunc(NaN);").AsString());
-        Assert.StartsWith("No public methods with the specified arguments were found.", ex.Message);
-        Assert.Contains("IntValueInput", ex.Message);
+        // detailed resolution errors are off by default, so the terse message is used
+        Assert.Equal("No public methods with the specified arguments were found.", ex.Message);
 
         Assert.Equal(123, engine.Evaluate("new IntValueInput().testFunc(123);").AsNumber());
     }

--- a/Jint/JintException.cs
+++ b/Jint/JintException.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Jint.Native.Error;
 using Jint.Runtime;
 
 namespace Jint;
@@ -70,6 +71,40 @@ public abstract class JintException : Exception
         }
 
         callStack = null;
+        return false;
+    }
+
+    /// <summary>
+    /// If <paramref name="exception"/> was thrown because a CLR method or constructor call could not be
+    /// resolved (e.g. wrong number or types of arguments), returns the originating CLR <see cref="Type"/>.
+    /// This works regardless of <see cref="Jint.Options.InteropOptions.ExposeDetailedResolutionErrors"/>;
+    /// the type is host-only and never exposed to the running script.
+    /// </summary>
+    public static bool TryGetClrType(Exception? exception, [NotNullWhen(true)] out Type? clrType)
+    {
+        if (exception is JavaScriptException { Error: ErrorInstance { ClrResolutionType: { } type } })
+        {
+            clrType = type;
+            return true;
+        }
+
+        clrType = null;
+        return false;
+    }
+
+    /// <summary>
+    /// If <paramref name="exception"/> was thrown because a CLR method call could not be resolved,
+    /// returns the name of the member that was invoked. Constructors have no member name and return false.
+    /// </summary>
+    public static bool TryGetClrMemberName(Exception? exception, [NotNullWhen(true)] out string? memberName)
+    {
+        if (exception is JavaScriptException { Error: ErrorInstance { ClrResolutionMemberName: { } name } })
+        {
+            memberName = name;
+            return true;
+        }
+
+        memberName = null;
         return false;
     }
 }

--- a/Jint/Native/Error/ErrorInstance.cs
+++ b/Jint/Native/Error/ErrorInstance.cs
@@ -11,6 +11,21 @@ public class ErrorInstance : ObjectInstance
     }
 
     /// <summary>
+    /// When this error was produced by a failed CLR interop method or constructor resolution, the
+    /// originating CLR type. These are plain CLR fields (not JavaScript properties), so a running script
+    /// cannot observe them; the host reads them via <see cref="JintException.TryGetClrType"/>.
+    /// </summary>
+    internal Type? ClrResolutionType { get; private set; }
+
+    internal string? ClrResolutionMemberName { get; private set; }
+
+    internal void SetClrResolutionInfo(Type clrType, string? memberName)
+    {
+        ClrResolutionType = clrType;
+        ClrResolutionMemberName = memberName;
+    }
+
+    /// <summary>
     /// https://tc39.es/ecma262/#sec-installerrorcause
     /// </summary>
     internal void InstallErrorCause(JsValue options)

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -432,6 +432,19 @@ public class Options
         public bool ThrowOnUnresolvedMember { get; set; }
 
         /// <summary>
+        /// When <c>true</c>, the <see cref="Jint.Runtime.JavaScriptException"/> thrown when a CLR method or
+        /// constructor call cannot be resolved gets a detailed message naming the target CLR type, the provided
+        /// argument types, and the candidate signatures. When <c>false</c> (the default) a terse message is used
+        /// instead, so that untrusted scripts cannot enumerate the host's CLR surface through the error text.
+        /// <para>
+        /// This only controls the script-visible message. The originating CLR <see cref="System.Type"/> is always
+        /// attached to the exception regardless of this setting and can be read host-side via
+        /// <see cref="JintException.TryGetClrType"/> (it is not exposed to the running script).
+        /// </para>
+        /// </summary>
+        public bool ExposeDetailedResolutionErrors { get; set; }
+
+        /// <summary>
         /// Types of CLR members reported by <see cref="ObjectWrapper"/> when enumerating properties/serializing <see cref="ObjectWrapper.ToObject"/>.
         /// Supported values are: <see cref="MemberTypes.Field"/>, <see cref="MemberTypes.Property"/>, <see cref="MemberTypes.Method"/>.
         /// All other values are ignored.

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -189,7 +189,10 @@ internal sealed class MethodInfoFunction : Function
             return _fallbackFunctionInstance.Call(thisObject, jsArguments);
         }
 
-        Throw.TypeError(_engine.Realm, InteropErrorHelper.CreateNoMatchingMethodMessage(_targetType, _name, jsArguments, _methods));
+        var message = _engine.Options.Interop.ExposeDetailedResolutionErrors
+            ? InteropErrorHelper.CreateNoMatchingMethodMessage(_targetType, _name, jsArguments, _methods)
+            : "No public methods with the specified arguments were found.";
+        Throw.InteropResolutionError(_engine.Realm, message, _targetType, _name);
         return null;
     }
 

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -199,7 +199,10 @@ public sealed class TypeReference : Constructor, IObjectWrapper
 
             if (result is null)
             {
-                Throw.TypeError(realm, InteropErrorHelper.CreateNoMatchingConstructorMessage(referenceType, arguments, constructors));
+                var message = engine.Options.Interop.ExposeDetailedResolutionErrors
+                    ? InteropErrorHelper.CreateNoMatchingConstructorMessage(referenceType, arguments, constructors)
+                    : $"Could not resolve a constructor for type {referenceType} for given arguments";
+                Throw.InteropResolutionError(realm, message, referenceType, memberName: null);
             }
 
             result.SetPrototypeOf(state.TypeReference);

--- a/Jint/Runtime/Throw.cs
+++ b/Jint/Runtime/Throw.cs
@@ -83,6 +83,29 @@ internal static class Throw
         throw new JavaScriptException(realm.Intrinsics.TypeError, message).SetJavaScriptLocation(location);
     }
 
+    /// <summary>
+    /// Throws the TypeError used when an interop method or constructor call cannot be resolved.
+    /// The originating CLR <paramref name="clrType"/> (and optional <paramref name="memberName"/>) are
+    /// recorded on the error object so the host can read them via <see cref="JintException.TryGetClrType"/>
+    /// without parsing the message. They are CLR fields, not JavaScript properties, so the running script
+    /// cannot observe them; this is independent of <see cref="Options.InteropOptions.ExposeDetailedResolutionErrors"/>.
+    /// </summary>
+    [DoesNotReturn]
+    public static void InteropResolutionError(Realm realm, string message, Type clrType, string? memberName)
+    {
+        var location = realm.GlobalObject.Engine.GetLastSyntaxElement()?.Location ?? default;
+        var exception = new JavaScriptException(realm.Intrinsics.TypeError, message).SetJavaScriptLocation(location);
+
+        // The error value survives the interpreter's throw-completion reconstruction (the .NET exception
+        // instance does not), so record the CLR origin on the error object rather than on Exception.Data.
+        if (exception.Error is ErrorInstance errorInstance)
+        {
+            errorInstance.SetClrResolutionInfo(clrType, memberName);
+        }
+
+        throw exception;
+    }
+
     [DoesNotReturn]
     public static void RangeError(Realm realm, string? message = null)
     {


### PR DESCRIPTION
Follow-up to #2525 (discussion #2523).

### Two changes

**1. Gate the detailed message behind an opt-in flag (default off).**

The detail #2525 added — target CLR type, argument types, candidate signatures — is part of the thrown error's *message*, which a script can read (`try { ... } catch (e) { e.message }`). For engines running untrusted scripts that leaks the host's CLR surface. A new `options.Interop.ExposeDetailedResolutionErrors` (default **false**) controls it:

- **off (default):** the terse historical message — `"No public methods with the specified arguments were found."` / `"Could not resolve a constructor for type X for given arguments"`. This restores the exact pre-#2525 text.
- **on:** the rich #2525 message.

Since #2525 has not shipped in a release yet (latest is v4.9.3), this introduces no released-behavior change.

**2. Expose the originating CLR `Type` to the host without parsing the message** (the discussion's follow-up question).

```csharp
try { engine.Evaluate(script); }
catch (JavaScriptException ex) when (JintException.TryGetClrType(ex, out var type))
{
    logger.LogError("Interop call failed on {ClrType}", type);   // real System.Type
}
```

`JintException.TryGetClrType` / `TryGetClrMemberName` mirror the existing `TryGetJavaScriptLocation` helpers. The type is recorded on the error **object** (internal CLR fields on `ErrorInstance`, set in a new `Throw.InteropResolutionError`), not on the .NET `Exception.Data`: the error value survives the interpreter's throw→completion reconstruction whereas the .NET exception instance does not. Because the slot is a CLR field rather than a JS property, a running script cannot observe it, so the type is available host-side **regardless of the message flag** (and even survives a script-level `catch`/rethrow of the same error value).

### Tests
- `InteropTests.ErrorMessages.cs`: detailed-message tests now opt into the flag; added tests for the terse default (asserting no CLR detail leaks), and for `TryGetClrType`/`TryGetClrMemberName` returning the real type/member under the safe default, for both method and constructor failures.
- Restored the two `#2525`-touched assertions (`InteropTests`, `GenericMethodTests`) to the terse default.
- Full Jint.Tests (3129 net10.0 / 3067 net472) and Jint.Tests.PublicInterface (79/79) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)