### PR TITLE
Preserve dictionary capacity across pooled function-environment reuse

### DIFF
--- a/Jint.Benchmark/ClosureCallBenchmarks.cs
+++ b/Jint.Benchmark/ClosureCallBenchmarks.cs
@@ -7,7 +7,9 @@ namespace Jint.Benchmark;
 /// Isolates the per-call cost of closure-style methods (the stopwatch.js shape):
 /// EmptyClosureCall = 0-param/0-var closures where FunctionDeclarationInstantiation should be a no-op;
 /// CapturedVarReadWrite = closures reading/writing captured variables (environment-chain resolution);
-/// ParamLocalCall = guard for the existing fixed-slot fast-FDI path.
+/// ParamLocalCall = guard for the existing fixed-slot fast-FDI path;
+/// ManyLocalCall = a function whose binding count (2 params + 18 vars) exceeds the 16 fixed-slot cap,
+/// so FunctionDeclarationInstantiation takes the dictionary-backed path (the DrawLine shape from 3d-cube).
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
@@ -17,6 +19,7 @@ public class ClosureCallBenchmarks
     private Prepared<Script> _emptyClosureCall;
     private Prepared<Script> _capturedVarReadWrite;
     private Prepared<Script> _paramLocalCall;
+    private Prepared<Script> _manyLocalCall;
 
     [GlobalSetup]
     public void Setup()
@@ -71,10 +74,45 @@ public class ClosureCallBenchmarks
             })();
             """, strict: true);
 
+        // 2 params + 18 var locals = 20 bindings, above the 16 fixed-slot cap, so each call builds a
+        // dictionary-backed environment. The body has no inner closures, so the environment is pooled
+        // and reused across calls (mirrors 3d-cube's DrawLine).
+        _manyLocalCall = Engine.PrepareScript("""
+            (function() {
+                function compute(a, b) {
+                    var v0 = a + b;
+                    var v1 = v0 + 1;
+                    var v2 = v1 + v0;
+                    var v3 = v2 - 1;
+                    var v4 = v3 + v1;
+                    var v5 = v4 + 2;
+                    var v6 = v5 + v2;
+                    var v7 = v6 - 3;
+                    var v8 = v7 + v3;
+                    var v9 = v8 + 4;
+                    var v10 = v9 + v4;
+                    var v11 = v10 - 5;
+                    var v12 = v11 + v5;
+                    var v13 = v12 + 6;
+                    var v14 = v13 + v6;
+                    var v15 = v14 - 7;
+                    var v16 = v15 + v7;
+                    var v17 = v16 + b;
+                    return v0 + v8 + v17;
+                }
+                var acc = 0;
+                for (var i = 0; i < 100000; i++) {
+                    acc = compute(acc, i) - acc;
+                }
+                return acc;
+            })();
+            """, strict: true);
+
         _engine = new Engine(static options => options.Strict());
         _engine.Evaluate(_emptyClosureCall);
         _engine.Evaluate(_capturedVarReadWrite);
         _engine.Evaluate(_paramLocalCall);
+        _engine.Evaluate(_manyLocalCall);
     }
 
     [Benchmark]
@@ -85,4 +123,7 @@ public class ClosureCallBenchmarks
 
     [Benchmark]
     public JsValue ParamLocalCall() => _engine.Evaluate(_paramLocalCall);
+
+    [Benchmark]
+    public JsValue ManyLocalCall() => _engine.Evaluate(_manyLocalCall);
 }

--- a/Jint/Collections/HybridDictionary.cs
+++ b/Jint/Collections/HybridDictionary.cs
@@ -227,6 +227,18 @@ internal sealed class HybridDictionary<TValue> : IEngineDictionary<Key, TValue>,
         _list?.Clear();
     }
 
+    /// <summary>
+    /// Clears all entries while keeping the backing dictionary's grown capacity, for pooled owners
+    /// (function environments) that refill with the same key count on every reuse. The cheap list
+    /// backing is cleared normally; only the dictionary's array growth is worth preserving.
+    /// See <see cref="StringDictionarySlim{TValue}.ClearPreservingCapacity"/>.
+    /// </summary>
+    public void ClearPreservingCapacity()
+    {
+        _dictionary?.ClearPreservingCapacity();
+        _list?.Clear();
+    }
+
     public bool ContainsKey(Key key)
     {
         ref var valueRefOrNullRef = ref GetValueRefOrNullRef(key);

--- a/Jint/Collections/StringDictionarySlim.cs
+++ b/Jint/Collections/StringDictionarySlim.cs
@@ -79,6 +79,27 @@ internal sealed class StringDictionarySlim<TValue> : DictionaryBase<TValue>, IRe
         _entries = InitialEntries;
     }
 
+    /// <summary>
+    /// Empties the dictionary but keeps the already-grown bucket and entry arrays, so a pooled owner
+    /// that immediately refills it with a similar key count avoids re-growing from the one-element dummy
+    /// arrays. Unlike <see cref="Clear"/> (which drops back to the shared dummies to release memory), this
+    /// trades a small retained footprint for zero reallocation on the next fill. Invalidates enumerators.
+    /// </summary>
+    public void ClearPreservingCapacity()
+    {
+        if (_count == 0)
+        {
+            // Never grew past the shared dummy arrays — nothing to keep, nothing to clear.
+            return;
+        }
+
+        // Bindings are only added (never removed) during a refill, so used entries are dense in [0, _count).
+        Array.Clear(_buckets, 0, _buckets.Length);
+        Array.Clear(_entries, 0, _count);
+        _count = 0;
+        _freeList = -1;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SetOrUpdateValue<TState>(Key key, Func<TValue, TState, TValue> updater, TState state)
     {

--- a/Jint/Runtime/Environments/FunctionEnvironment.cs
+++ b/Jint/Runtime/Environments/FunctionEnvironment.cs
@@ -56,7 +56,11 @@ internal sealed class FunctionEnvironment : DeclarativeEnvironment
         _thisBindingStatus = functionObject._functionDefinition?.Function.Type is NodeType.ArrowFunctionExpression
             ? ThisBindingStatus.Lexical
             : ThisBindingStatus.Uninitialized;
-        _dictionary?.Clear();
+        // Keep the dictionary's grown capacity: a pooled env is reused for the same State (same binding
+        // names), so the next call refills it with an identical key count. Dropping back to the dummy
+        // arrays would force the dictionary to re-grow on every call (see 3d-cube's DrawLine: 2 params
+        // + 17 vars rebuilt 100k+ times per run).
+        _dictionary?.ClearPreservingCapacity();
         ClearDisposeCapability();
     }
 


### PR DESCRIPTION
## Summary

Functions whose binding count exceeds the 16 fixed-slot cap instantiate a **dictionary-backed** environment instead of using fixed slots. When such a function's body creates no closures, its environment is **pooled and reused** across calls — but `FunctionEnvironment.Reset()` cleared the binding dictionary with `HybridDictionary.Clear()`, which drops `StringDictionarySlim` back to its one-element dummy arrays.

The consequence: every subsequent call **re-grew the dictionary from scratch** (the list→dictionary cutover plus repeated power-of-two resizes), allocating on every single invocation. The canonical case is 3d-cube's `DrawLine` (2 params + 17 vars = 19 bindings), which is called hundreds of thousands of times per run.

## Fix

Add a capacity-preserving clear (`ClearPreservingCapacity`) used **only** by the pooled-environment reset path. It empties the dictionary but keeps the already-grown bucket/entry arrays, so the next call refills an identically-sized dictionary with zero reallocation. The env pool is keyed on the function `State` (identical binding names on every reuse), so the refilled key count always matches the preserved capacity.

`HybridDictionary<Binding>.Clear()` is only reachable from this reset path, so the change is surgical — the general `Clear()` (which intentionally releases memory) is untouched and still used by `ObjectInstance.ClearProperties` etc.

## Benchmarks (BDN default job, net10.0)

New `ClosureCallBenchmarks.ManyLocalCall` (2 params + 18 vars, 100k calls — the dictionary-backed shape):

| Method | Allocated before | Allocated after | Time |
|---|---|---|---|
| ManyLocalCall | 337.05 MB | **6.7 MB (−98%)** | −7…15% |

Fixed-slot guard rows unchanged (mechanically a no-op there — `_dictionary` is null):

| Method | Before | After |
|---|---|---|
| EmptyClosureCall | 14.19 MB | 14.19 MB |
| CapturedVarReadWrite | 58.09 ms / 16.93 MB | 58.04 ms / 16.93 MB |
| ParamLocalCall | 99.54 ms / 23.19 MB | 99.10 ms / 23.19 MB |

3d-cube source driver (wall-clock A/B): **16.40 → 15.83 ms/iter (−3.5%)**.

## Tests

Full `Jint.Tests` (net10.0: 3131, net472: 3069) and `Jint.Tests.CommonScripts` (28×2) pass with 0 failures.