### PR TITLE
Raise fixed-slot function-environment cap from 16 to 24 bindings

### DIFF
--- a/Jint.Benchmark/ClosureCallBenchmarks.cs
+++ b/Jint.Benchmark/ClosureCallBenchmarks.cs
@@ -8,8 +8,9 @@ namespace Jint.Benchmark;
 /// EmptyClosureCall = 0-param/0-var closures where FunctionDeclarationInstantiation should be a no-op;
 /// CapturedVarReadWrite = closures reading/writing captured variables (environment-chain resolution);
 /// ParamLocalCall = guard for the existing fixed-slot fast-FDI path;
-/// ManyLocalCall = a function whose binding count (2 params + 18 vars) exceeds the 16 fixed-slot cap,
-/// so FunctionDeclarationInstantiation takes the dictionary-backed path (the DrawLine shape from 3d-cube).
+/// ManyLocalCall = a function with many locals (2 params + 18 vars = 20 bindings, the DrawLine shape from
+/// 3d-cube) that stresses per-call environment setup — exercises whichever FunctionDeclarationInstantiation
+/// path the fixed-slot cap routes that binding count to.
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
@@ -74,9 +75,9 @@ public class ClosureCallBenchmarks
             })();
             """, strict: true);
 
-        // 2 params + 18 var locals = 20 bindings, above the 16 fixed-slot cap, so each call builds a
-        // dictionary-backed environment. The body has no inner closures, so the environment is pooled
-        // and reused across calls (mirrors 3d-cube's DrawLine).
+        // 2 params + 18 var locals = 20 bindings. The body has no inner closures, so the environment is
+        // pooled and reused across calls (mirrors 3d-cube's DrawLine). Whether per-call setup uses the
+        // array-backed fixed-slot path or the dictionary path depends on the fixed-slot cap.
         _manyLocalCall = Engine.PrepareScript("""
             (function() {
                 function compute(a, b) {

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -16,6 +16,12 @@ namespace Jint.Runtime.Interpreter;
 /// </summary>
 internal sealed class JintFunctionDefinition
 {
+    // Upper bound on bindings that qualify for the array-backed fixed-slot fast path. Above this a
+    // function falls back to the dictionary-backed environment. Sized so the common "many locals"
+    // shape (e.g. 3d-cube's DrawLine: 2 params + 17 vars) stays on the slot fast path while keeping
+    // the linear SlotIndexOf scan (on cache misses) short.
+    private const int MaxFixedSlots = 24;
+
     private JintExpression? _bodyExpression;
     private JintStatementList? _bodyStatementList;
 
@@ -566,7 +572,7 @@ internal sealed class JintFunctionDefinition
             }
 
             var totalSlots = state.ParameterNames.Length + varsToInitialize.Count + lexicalBindingCount;
-            if (lexicalBindingCount >= 0 && totalSlots is > 0 and <= 16)
+            if (lexicalBindingCount >= 0 && totalSlots > 0 && totalSlots <= MaxFixedSlots)
             {
                 var slotNames = new Key[totalSlots];
                 state.ParameterNames.CopyTo(slotNames, 0);


### PR DESCRIPTION
## Summary

Functions whose binding count (params + vars + lexicals) is at most the fixed-slot cap use an **array-backed** environment and the fast `FunctionDeclarationInstantiation` path, with identifier reads/writes served by the cached slot index. Above the cap they fall back to a **dictionary-backed** environment (a hash lookup per uncached access).

The cap was **16**, which spilled common "many locals" functions onto the dictionary path. The canonical case is 3d-cube's `DrawLine` (2 params + 17 vars = 19 bindings). Raising the cap to **24** keeps these on the slot fast path.

24 (rather than 32) is chosen so the linear `SlotIndexOf` scan on a cache miss stays short; measurement showed 32 gives no further benefit over 24 for the target workloads.

## Benchmarks

Source-mode `CpuProfileDriver` A/B + BDN default job (baseline = cap 16, i.e. #2528):

| Workload | Before (cap 16) | After (cap 24) | Δ |
|---|---|---|---|
| 3d-cube (driver, ms/iter) | 15.83 | 13.82 | **−12.7%** |
| ClosureCallBenchmarks.ManyLocalCall (20 bindings) | 194.9 ms | ~153 ms | **−20%** (alloc unchanged) |
| linq-js (driver) | 3.35 | 3.39 | flat |
| stopwatch (driver) | ~171 ms | ~172 ms | flat |
| GlobalAccessBenchmarks | — | — | flat |
| cap=32 | — | no gain over 24 | — |

The flat stopwatch/linq-js/GlobalAccess rows confirm no regression on closure-heavy or global-access paths (the linear slot scan is amortized by the per-node slot-index cache on warm loops).

## Tests

Full Test262 (**99260 passed, 0 failed**, 133 skipped), `Jint.Tests`, and `Jint.Tests.CommonScripts` all pass on net10.0 and net472.

Builds on #2528 (now merged).