### PR TITLE
Add process-wide cache of compiled regex adaptations

### DIFF
--- a/Jint.Benchmark/RegExpFreshEngineBenchmark.cs
+++ b/Jint.Benchmark/RegExpFreshEngineBenchmark.cs
@@ -1,0 +1,63 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates the cost of compiling regex literals (and dynamic <c>new RegExp</c>) when a fresh Engine runs the
+/// same script from source on every iteration — the common "one Engine per request/sandbox" shape. Without a
+/// process-wide compiled-Regex cache each iteration re-adapts every pattern to a .NET Regex; with one, only the
+/// first iteration pays. Matching work is kept minimal so the measurement reflects compilation, not execution.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class RegExpFreshEngineBenchmark
+{
+    private const string Script = """
+        var patterns = [
+            /foo\d+bar/g,
+            /[a-z]+@[a-z0-9.]+\.[a-z]{2,}/i,
+            /^\s*(\w+)\s*=\s*(.+)$/m,
+            /\b\d{4}-\d{2}-\d{2}\b/,
+            /(https?):\/\/([^\/\s]+)(\/[^\s]*)?/i,
+            /<([a-z][a-z0-9]*)\b[^>]*>(.*?)<\/\1>/is,
+            /[À-ſ]+/u,
+            /(?:abc|def|ghi)+\d*/g,
+            /\$\{([^}]+)\}/g,
+            /^(?!.*\bnot\b).*$/m,
+            /[A-Z][a-z]+(?:\s[A-Z][a-z]+)*/,
+            /\d+(?:\.\d+)?(?:e[+-]?\d+)?/i
+        ];
+        var dyn = new RegExp("a" + "b+c", "g");
+        var hits = 0;
+        for (var i = 0; i < patterns.length; i++) {
+            if (patterns[i].test("sample-123-text")) hits++;
+        }
+        if (dyn.test("abbbc")) hits++;
+        hits;
+        """;
+
+    private Prepared<Script> _prepared;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _prepared = Engine.PrepareScript(Script, strict: true);
+    }
+
+    // Fresh Engine + fresh parse each call: every regex literal is re-adapted unless a shared cache holds it.
+    [Benchmark]
+    public void FreshEngineSource()
+    {
+        var engine = new Engine(static options => options.Strict());
+        engine.Execute(Script);
+    }
+
+    // Fresh Engine but prepared script: the per-AST-node cache already survives, so this isolates the
+    // remaining per-Engine cost and acts as a no-regression guard for the cached path.
+    [Benchmark]
+    public void FreshEnginePrepared()
+    {
+        var engine = new Engine(static options => options.Strict());
+        engine.Execute(_prepared);
+    }
+}

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -473,10 +473,9 @@ public sealed partial class RegExpConstructor : Constructor
 
         if (!NeedCustomEngine(p, f))
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            regExpParseResult = Tokenizer.AdaptRegExp(p, f, compiled: false, parserOptions.RegexTimeout, throwIfNotAdaptable: false,
-#pragma warning restore CS0618 // Type or member is obsolete
-                Engine.BaseParserOptions.EcmaVersion, Engine.BaseParserOptions.ExperimentalESFeatures);
+#pragma warning disable CS0618 // ParserOptions.RegexTimeout is obsolete but is the supported timeout source.
+            regExpParseResult = RegExpParseCache.GetOrAdapt(p, f, compiled: false, parserOptions.RegexTimeout);
+#pragma warning restore CS0618
 
             if (regExpParseResult.Success)
             {

--- a/Jint/Native/RegExp/RegExpParseCache.cs
+++ b/Jint/Native/RegExp/RegExpParseCache.cs
@@ -1,0 +1,64 @@
+using System.Collections.Concurrent;
+
+namespace Jint.Native.RegExp;
+
+/// <summary>
+/// Process-wide bounded cache of compiled .NET <see cref="System.Text.RegularExpressions.Regex"/> adaptations
+/// (wrapped in Acornima's <c>RegExpParseResult</c>), keyed by the inputs that fully determine the result:
+/// pattern, flags, the compiled-codegen flag and the match timeout.
+/// <para>
+/// Regex literals already cache their adaptation on the AST node, but that cache only helps a reused
+/// <c>Prepared&lt;Script&gt;</c>; running a script from source (fresh parse, fresh Engine) re-adapts the same
+/// literal every time, and dynamic <c>new RegExp(...)</c> has no per-node cache at all. A shared cache closes
+/// that gap because a successful adaptation is a pure function of the key and the produced Regex is immutable
+/// and thread-safe (match state lives on the JS RegExp instance / returned Match, not on the Regex).
+/// </para>
+/// <para>
+/// The cache is bounded: once it reaches <see cref="Capacity"/> distinct entries it is cleared and rebuilt,
+/// so a workload generating unboundedly many distinct patterns can never grow it without limit. Typical
+/// scripts use a small, stable set of patterns and fill it once.
+/// </para>
+/// </summary>
+internal static class RegExpParseCache
+{
+    // Bounded to cap retained compiled automata. Cleared (not LRU-evicted) on overflow: cheap, thread-safe,
+    // and self-healing when the working set shifts. Real scripts rarely approach this many distinct regexes.
+    private const int Capacity = 256;
+
+    private static readonly ConcurrentDictionary<Key, RegExpParseResult> _cache = new();
+
+    private readonly record struct Key(string Pattern, string Flags, bool Compiled, long TimeoutTicks);
+
+    /// <summary>
+    /// Returns a cached adaptation for the given regex inputs, adapting (and caching on success) on a miss.
+    /// Only successful adaptations are cached; a failure means the pattern needs the custom engine, which the
+    /// caller resolves per-realm. Callers must already have excluded custom-engine patterns
+    /// (<see cref="RegExpConstructor.NeedCustomEngine"/>) before calling this.
+    /// </summary>
+    public static RegExpParseResult GetOrAdapt(string pattern, string flags, bool compiled, TimeSpan timeout)
+    {
+        var key = new Key(pattern, flags, compiled, timeout.Ticks);
+        if (_cache.TryGetValue(key, out var cached))
+        {
+            return cached;
+        }
+
+#pragma warning disable CS0618 // Tokenizer.AdaptRegExp is obsolete but is the supported adaptation entry point.
+        var result = Tokenizer.AdaptRegExp(
+            pattern, flags, compiled, timeout, throwIfNotAdaptable: false,
+            Engine.BaseParserOptions.EcmaVersion, Engine.BaseParserOptions.ExperimentalESFeatures);
+#pragma warning restore CS0618
+
+        if (result.Success)
+        {
+            if (_cache.Count >= Capacity)
+            {
+                _cache.Clear();
+            }
+
+            _cache.TryAdd(key, result);
+        }
+
+        return result;
+    }
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -84,11 +84,10 @@ internal sealed class JintLiteralExpression : JintExpression
 
             if (!RegExpConstructor.NeedCustomEngine(pattern, flags))
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                cachedParseResult = Tokenizer.AdaptRegExp(
-#pragma warning restore CS0618 // Type or member is obsolete
-                    pattern, flags, conversionOptions.Compiled, conversionOptions.Timeout, throwIfNotAdaptable: false,
-                    Engine.BaseParserOptions.EcmaVersion, Engine.BaseParserOptions.ExperimentalESFeatures);
+                // Process-wide cache: a fresh-parse (source-mode) literal recompiles the same Regex every
+                // run because the per-node UserData cache above only survives in a reused Prepared<Script>.
+                cachedParseResult = RegExpParseCache.GetOrAdapt(
+                    pattern, flags, conversionOptions.Compiled, conversionOptions.Timeout);
 
                 if (cachedParseResult.Success)
                 {


### PR DESCRIPTION
## Summary

Adapting a JS regex (pattern + flags) to a .NET `Regex` is a pure function of the **pattern, flags, compiled-codegen flag and match timeout**, and the produced `Regex` is immutable and thread-safe (match state lives on the JS RegExp instance / returned `Match`, not on the `Regex`).

Regex literals already cache their adaptation on the AST node — but that only survives a reused `Prepared<Script>`. Running a script **from source** (a fresh parse on a fresh `Engine`, the common "one Engine per request/sandbox" shape) re-adapts every literal each time, and dynamic `new RegExp(...)` has no per-node cache at all.

This routes both adaptation sites (the regex-literal evaluator and `RegExpConstructor`'s runtime initializer) through a **process-wide bounded cache** keyed by `(pattern, flags, compiled, timeout)`.

- **Bounded:** 256 entries, cleared on overflow, so a workload generating unboundedly many distinct patterns can't grow it without limit. Typical scripts use a small, stable set and fill it once.
- **Custom-engine path untouched:** patterns that need Jint's custom regex engine are excluded up front (`NeedCustomEngine`), so only the .NET-`Regex` adaptation is cached.
- **Correctness:** a cached `RegExpParseResult` is identical to a freshly-adapted one for the same key; the result depends only on the key plus process-static parser constants (`EcmaVersion`, `ExperimentalESFeatures`).

## Benchmarks

New `RegExpFreshEngineBenchmark` (fresh `Engine` per op, source mode, compilation-bound):

| Method | Before | After | Δ |
|---|---|---|---|
| FreshEngineSource | 216.1 us / 227 KB | **59.4 us / 141 KB** | **−72.5% time, −38% alloc** |
| FreshEnginePrepared | 11.7 us | 10.0 us | flat (already served by the per-node cache) |

The matching-dominated `dromaeo-object-regexp` source row improves modestly (~5%) — that workload spends almost all its time matching large strings, which the cache doesn't touch. `RegExpCustomEngineBenchmark` is unchanged.

## Tests

`Jint.Tests` and `Jint.Tests.CommonScripts` pass on net10.0 and net472. Full Test262 shows **no RegExp regressions** (99259 passing). The lone failing test is a flaky timing-sensitive `Atomics.waitAsync` case — it fails a *different* test on each run (`no-spurious-wakeup-on-sub` then `no-spurious-wakeup-on-exchange`), which a real regression would not.