### PR TITLE
Remove unused StringBuilder FNV-hash overload; simplify RefStack.Clear

### DIFF
--- a/Jint/Collections/RefStack.cs
+++ b/Jint/Collections/RefStack.cs
@@ -146,14 +146,9 @@ internal sealed class RefStack<T> : IEnumerable<T> where T : struct
     {
         if (_size > 0)
         {
-#if NETFRAMEWORK || NETSTANDARD2_0
-            for (var i = 0; i < _size; i++)
-            {
-                _array[i] = default;
-            }
-#else
-            Array.Fill(_array, default, 0, _size);
-#endif
+            // Array.Clear zeroes the elements (== default(T) for the struct T) and is a JIT intrinsic on
+            // every target framework, so it beats both the manual loop (old targets) and Array.Fill(default).
+            Array.Clear(_array, 0, _size);
             _size = 0;
         }
     }

--- a/Jint/Extensions/Hash.cs
+++ b/Jint/Extensions/Hash.cs
@@ -43,35 +43,6 @@ internal static class Hash
     internal static int GetFNVHashCode(string text) => CombineFNVHash(FnvOffsetBias, text);
 
     /// <summary>
-    /// Compute the hashcode of a string using FNV-1a
-    /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
-    /// </summary>
-    /// <param name="text">The input string</param>
-    /// <returns>The FNV-1a hash code of <paramref name="text"/></returns>
-    internal static int GetFNVHashCode(System.Text.StringBuilder text)
-    {
-        int hashCode = FnvOffsetBias;
-
-#if NETCOREAPP3_1_OR_GREATER
-        foreach (var chunk in text.GetChunks())
-        {
-            hashCode = CombineFNVHash(hashCode, chunk.Span);
-        }
-#else
-        // StringBuilder.GetChunks is not available in this target framework. Since there is no other direct access
-        // to the underlying storage spans of StringBuilder, we fall back to using slower per-character operations.
-        int end = text.Length;
-
-        for (int i = 0; i < end; i++)
-        {
-            hashCode = unchecked((hashCode ^ text[i]) * FnvPrime);
-        }
-#endif
-
-        return hashCode;
-    }
-
-    /// <summary>
     /// Combine a string with an existing FNV-1a hash code
     /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
     /// </summary>


### PR DESCRIPTION
## Cleanup (no behaviour change)

Two small hygiene changes in the internal collection helpers:

- **Remove the unused `Hash.GetFNVHashCode(System.Text.StringBuilder)` overload.** It has no callers anywhere in the codebase — only the `string` overload is used (via `Key`). Dead code.
- **Simplify `RefStack<T>.Clear()`** to `Array.Clear(_array, 0, _size)`. It previously used a manual zeroing loop on net462/netstandard2.0 and `Array.Fill(_array, default, …)` elsewhere; `Array.Clear` is a JIT intrinsic available on every target framework and lets the `#if` go away.

This is a cleanup PR with **no performance claim** (so no benchmark is attached). It came out of a broader data-structure performance pass; the substantive, benchmarked changes will land as separate PRs.

## Verification

Clean build across all five TFMs (net462, netstandard2.0, netstandard2.1, net8.0, net10.0) — 0 warnings (warnings-as-errors is on). `Jint.Tests` green on net10.0 and net472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
