### PR TITLE
Avoid per-call closure allocation in EvaluateBody

### DIFF
--- a/Jint.Benchmark/AllocTypeProbe.cs
+++ b/Jint.Benchmark/AllocTypeProbe.cs
@@ -1,0 +1,213 @@
+#nullable enable
+using System.Diagnostics.Tracing;
+using System.Globalization;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Attributes managed allocations by CLR type using the runtime's GCAllocationTick events
+/// (sampled ~every 100 KB per type), to find what allocates on a hot path when code reading and
+/// GC.GetAllocatedBytesForCurrentThread (MemoryProbe) can't say *which type*. Used to chase the
+/// per-call allocation floor seen in ClosureCallBenchmarks. Not a benchmark; temporary diagnostic.
+///
+/// Usage: --profile-alloc-types [scriptName|empty-closure|captured-var] [iterations]
+/// With a Scripts/ name it runs that engine-comparison script (fresh engine/iter, like the BDN bench);
+/// "empty-closure"/"captured-var" run an inline isolated loop so the per-call floor is unmixed.
+/// </summary>
+internal static class AllocTypeProbe
+{
+    private const string DromaeoHelpers = """
+        var startTest = function () { };
+        var test = function (name, fn) { fn(); };
+        var endTest = function () { };
+        var prep = function (fn) { fn(); };
+        """;
+
+    private sealed class AllocListener : EventListener
+    {
+        public readonly Dictionary<string, (long Bytes, long Count)> ByType = new(StringComparer.Ordinal);
+        private volatile bool _enabled;
+
+        public bool Enabled
+        {
+            get => _enabled;
+            set => _enabled = value;
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == "Microsoft-Windows-DotNETRuntime")
+            {
+                // keyword 0x1 = GC; Verbose so GCAllocationTick fires.
+                EnableEvents(eventSource, EventLevel.Verbose, (EventKeywords) 0x1);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs e)
+        {
+            if (!_enabled || e.EventName is not ("GCAllocationTick_V4" or "GCAllocationTick_V3" or "GCAllocationTick_V2"))
+            {
+                return;
+            }
+
+            string? typeName = null;
+            long amount = 0;
+            var names = e.PayloadNames;
+            for (var i = 0; names is not null && i < names.Count; i++)
+            {
+                switch (names[i])
+                {
+                    case "TypeName":
+                        typeName = e.Payload![i] as string;
+                        break;
+                    case "AllocationAmount64":
+                        amount = Convert.ToInt64(e.Payload![i], CultureInfo.InvariantCulture);
+                        break;
+                    case "AllocationAmount" when amount == 0:
+                        amount = Convert.ToInt64(e.Payload![i], CultureInfo.InvariantCulture);
+                        break;
+                }
+            }
+
+            if (typeName is null)
+            {
+                return;
+            }
+
+            ByType.TryGetValue(typeName, out var cur);
+            ByType[typeName] = (cur.Bytes + amount, cur.Count + 1);
+        }
+    }
+
+    public static int Run(string[] args)
+    {
+        var target = args.Length > 1 ? args[1] : "empty-closure";
+        var iterations = args.Length > 2 ? int.Parse(args[2], CultureInfo.InvariantCulture) : 40;
+
+        Action runOnce;
+        if (target is "empty-closure" or "captured-var")
+        {
+            var body = target == "empty-closure"
+                ? "b.nop(); b.nop(); b.nop();"
+                : "b.enable(); b.toggle(); b.bump();";
+            var src = $$"""
+                (function() {
+                    function Box() {
+                        var on = false; var count = 0;
+                        this.nop = function () { };
+                        this.enable = function () { on = true; };
+                        this.toggle = function () { on = !on; };
+                        this.bump = function () { count = count + 1; return on; };
+                    }
+                    var b = new Box();
+                    for (var i = 0; i < 100000; i++) { {{body}} }
+                    return b;
+                })();
+                """;
+            var prepared = Engine.PrepareScript(src, strict: true);
+            var engine = new Engine(static o => o.Strict());
+            runOnce = () => engine.Execute(prepared);
+        }
+        else
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "Scripts", target + ".js");
+            if (!File.Exists(path))
+            {
+                Console.Error.WriteLine($"Script not found: {path}");
+                return 2;
+            }
+            var src = File.ReadAllText(path);
+            if (target.Contains("dromaeo", StringComparison.Ordinal))
+            {
+                src = DromaeoHelpers + Environment.NewLine + Environment.NewLine + src;
+            }
+            var prepared = Engine.PrepareScript(src, strict: true);
+            runOnce = () =>
+            {
+                var engine = new Engine(static o => o.Strict());
+                engine.Execute(prepared);
+            };
+        }
+
+        using var listener = new AllocListener();
+
+        // Warm up (JIT, statics) with the listener disabled so startup allocation is excluded.
+        for (var i = 0; i < 3; i++)
+        {
+            runOnce();
+        }
+
+        listener.Enabled = true;
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < iterations; i++)
+        {
+            runOnce();
+        }
+        var after = GC.GetAllocatedBytesForCurrentThread();
+        listener.Enabled = false;
+
+        // Resolve compiler-generated short names (e.g. "<>c__DisplayClass12_0") to their full
+        // declaring type so we can locate the source method. The runtime's GCAllocationTick reports
+        // only the nested simple name; multiple declaring types can share it.
+        var jintAssembly = typeof(Engine).Assembly;
+        var allTypes = jintAssembly.GetTypes();
+        var fullNames = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var t in allTypes)
+        {
+            if (t.Name.Contains("c__DisplayClass", StringComparison.Ordinal) || t.Name.Contains("<>c", StringComparison.Ordinal))
+            {
+                if (!fullNames.TryGetValue(t.Name, out var list))
+                {
+                    fullNames[t.Name] = list = new List<string>();
+                }
+                list.Add(t.FullName ?? t.Name);
+            }
+        }
+
+        var sampled = listener.ByType.Values.Sum(v => v.Bytes);
+        Console.WriteLine($"# alloc-types: target={target}, iterations={iterations}");
+        Console.WriteLine($"# end-to-end thread allocations: {Format(after - before)} total, {Format((after - before) / iterations)}/iter");
+        Console.WriteLine($"# GCAllocationTick sampled total: {Format(sampled)} (sampled ~100KB/type; ranking, not exact)");
+        Console.WriteLine();
+        Console.WriteLine("  |  sampled bytes |    % |  ticks | type");
+        Console.WriteLine("  |---------------:|-----:|-------:|-----");
+        foreach (var (type, v) in listener.ByType.OrderByDescending(kv => kv.Value.Bytes))
+        {
+            var pct = sampled > 0 ? 100.0 * v.Bytes / sampled : 0;
+            Console.WriteLine($"  | {Format(v.Bytes),14} | {pct,4:F1} | {v.Count,6} | {type}");
+        }
+        Console.WriteLine();
+
+        Console.WriteLine("# compiler-generated type name resolution (Jint assembly):");
+        foreach (var (type, _) in listener.ByType.OrderByDescending(kv => kv.Value.Bytes))
+        {
+            if (fullNames.TryGetValue(type, out var matches))
+            {
+                Console.WriteLine($"  {type} =>");
+                foreach (var fn in matches)
+                {
+                    var t = allTypes.FirstOrDefault(x => x.FullName == fn);
+                    var fields = t is null
+                        ? ""
+                        : string.Join(", ", t.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).Select(f => $"{f.FieldType.Name} {f.Name}"));
+                    Console.WriteLine($"      {fn}  {{ {fields} }}");
+                }
+            }
+        }
+        Console.WriteLine();
+        return 0;
+    }
+
+    private static string Format(long bytes)
+    {
+        if (bytes < 1024)
+        {
+            return bytes.ToString("N0", CultureInfo.InvariantCulture) + " B";
+        }
+        if (bytes < 1024L * 1024)
+        {
+            return (bytes / 1024.0).ToString("N1", CultureInfo.InvariantCulture) + " KB";
+        }
+        return (bytes / 1024.0 / 1024.0).ToString("N2", CultureInfo.InvariantCulture) + " MB";
+    }
+}

--- a/Jint.Benchmark/Program.cs
+++ b/Jint.Benchmark/Program.cs
@@ -12,6 +12,11 @@ if (args.Length > 0 && args[0] == "--profile-cpu")
     return CpuProfileDriver.Run(args);
 }
 
+if (args.Length > 0 && args[0] == "--profile-alloc-types")
+{
+    return AllocTypeProbe.Run(args);
+}
+
 BenchmarkSwitcher
     .FromAssembly(typeof(ArrayBenchmark).GetTypeInfo().Assembly)
     .Run(args);

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -58,37 +58,19 @@ internal sealed class JintFunctionDefinition
         {
             // https://tc39.es/ecma262/#sec-runtime-semantics-evaluateconcisebody
             _bodyExpression ??= JintExpression.Build((Expression) Function.Body);
+
+            // The async path captures locals into a closure; keeping it in a separate non-inlined
+            // method ensures the C# compiler does not allocate that display class on the hot sync
+            // call path (every function call goes through EvaluateBody).
             if (Function.Async)
             {
-                // local copies to prevent capturing closure created on top of method
-                var function = functionObject;
-                var jsValues = argumentsList;
-
-                var promiseCapability = PromiseConstructor.NewPromiseCapability(context.Engine, context.Engine.Realm.Intrinsics.Promise);
-                // Expression bodies don't have a statement list (used only for resumption)
-                AsyncFunctionStart(context, promiseCapability, body: null, context =>
-                {
-                    context.Engine.FunctionDeclarationInstantiation(function, jsValues);
-                    context.RunBeforeExecuteStatementChecks(Function.Body);
-                    var jsValue = _bodyExpression.GetValue(context).Clone();
-
-                    // Check for async suspension - if suspended, return early to allow resumption
-                    if (context.IsSuspended())
-                    {
-                        return new Completion(CompletionType.Normal, jsValue, _bodyExpression._expression);
-                    }
-
-                    return new Completion(CompletionType.Return, jsValue, _bodyExpression._expression);
-                });
-                result = new Completion(CompletionType.Return, promiseCapability.PromiseInstance, Function.Body);
+                return EvaluateConciseBodyAsync(context, functionObject, argumentsList);
             }
-            else
-            {
-                argumentsInstance = context.Engine.FunctionDeclarationInstantiation(functionObject, argumentsList);
-                context.RunBeforeExecuteStatementChecks(Function.Body);
-                var jsValue = _bodyExpression.GetValue(context).Clone();
-                result = new Completion(CompletionType.Return, jsValue, Function.Body);
-            }
+
+            argumentsInstance = context.Engine.FunctionDeclarationInstantiation(functionObject, argumentsList);
+            context.RunBeforeExecuteStatementChecks(Function.Body);
+            var jsValue = _bodyExpression.GetValue(context).Clone();
+            result = new Completion(CompletionType.Return, jsValue, Function.Body);
         }
         else if (Function.Generator)
         {
@@ -98,33 +80,72 @@ internal sealed class JintFunctionDefinition
         }
         else
         {
+            // See note above: extracted so the closure's display class is not allocated per sync call.
             if (Function.Async)
             {
-                // local copies to prevent capturing closure created on top of method
-                var function = functionObject;
-                var arguments = argumentsList;
+                return EvaluateFunctionBodyAsync(context, functionObject, argumentsList);
+            }
 
-                var promiseCapability = PromiseConstructor.NewPromiseCapability(context.Engine, context.Engine.Realm.Intrinsics.Promise);
-                // Each async function invocation needs its own JintStatementList to track its own position
-                var bodyStatementList = new JintStatementList(Function);
-                AsyncFunctionStart(context, promiseCapability, bodyStatementList, context =>
-                {
-                    context.Engine.FunctionDeclarationInstantiation(function, arguments);
-                    return bodyStatementList.Execute(context);
-                });
-                result = new Completion(CompletionType.Return, promiseCapability.PromiseInstance, Function.Body);
-            }
-            else
-            {
-                // https://tc39.es/ecma262/#sec-runtime-semantics-evaluatefunctionbody
-                argumentsInstance = context.Engine.FunctionDeclarationInstantiation(functionObject, argumentsList);
-                _bodyStatementList ??= new JintStatementList(Function);
-                result = _bodyStatementList.Execute(context);
-            }
+            // https://tc39.es/ecma262/#sec-runtime-semantics-evaluatefunctionbody
+            argumentsInstance = context.Engine.FunctionDeclarationInstantiation(functionObject, argumentsList);
+            _bodyStatementList ??= new JintStatementList(Function);
+            result = _bodyStatementList.Execute(context);
         }
 
         argumentsInstance?.FunctionWasCalled();
         return result;
+    }
+
+    /// <summary>
+    /// Async concise-body (arrow expression body) evaluation. Kept out of <see cref="EvaluateBody"/>
+    /// so the captured-locals closure's display class is not allocated on the hot sync call path.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private Completion EvaluateConciseBodyAsync(EvaluationContext context, Function functionObject, JsCallArguments argumentsList)
+    {
+        // local copies to prevent capturing the method parameters
+        var function = functionObject;
+        var jsValues = argumentsList;
+
+        var promiseCapability = PromiseConstructor.NewPromiseCapability(context.Engine, context.Engine.Realm.Intrinsics.Promise);
+        // Expression bodies don't have a statement list (used only for resumption)
+        AsyncFunctionStart(context, promiseCapability, body: null, context =>
+        {
+            context.Engine.FunctionDeclarationInstantiation(function, jsValues);
+            context.RunBeforeExecuteStatementChecks(Function.Body);
+            var jsValue = _bodyExpression!.GetValue(context).Clone();
+
+            // Check for async suspension - if suspended, return early to allow resumption
+            if (context.IsSuspended())
+            {
+                return new Completion(CompletionType.Normal, jsValue, _bodyExpression._expression);
+            }
+
+            return new Completion(CompletionType.Return, jsValue, _bodyExpression._expression);
+        });
+        return new Completion(CompletionType.Return, promiseCapability.PromiseInstance, Function.Body);
+    }
+
+    /// <summary>
+    /// Async function-body evaluation. Kept out of <see cref="EvaluateBody"/> so the captured-locals
+    /// closure's display class is not allocated on the hot sync call path.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private Completion EvaluateFunctionBodyAsync(EvaluationContext context, Function functionObject, JsCallArguments argumentsList)
+    {
+        // local copies to prevent capturing the method parameters
+        var function = functionObject;
+        var arguments = argumentsList;
+
+        var promiseCapability = PromiseConstructor.NewPromiseCapability(context.Engine, context.Engine.Realm.Intrinsics.Promise);
+        // Each async function invocation needs its own JintStatementList to track its own position
+        var bodyStatementList = new JintStatementList(Function);
+        AsyncFunctionStart(context, promiseCapability, bodyStatementList, context =>
+        {
+            context.Engine.FunctionDeclarationInstantiation(function, arguments);
+            return bodyStatementList.Execute(context);
+        });
+        return new Completion(CompletionType.Return, promiseCapability.PromiseInstance, Function.Body);
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

`JintFunctionDefinition.EvaluateBody` runs on **every** JS function call. Its two `async` branches capture locals into C#-compiler-generated closures (display classes). Because those lambdas lived in the same method as the hot **synchronous** path, the compiler allocated a display class on every call — even for plain sync functions that never enter the async branch. (The existing "local copies to prevent capturing closure" comment did not actually prevent the allocation.)

Allocation-by-type profiling (`GCAllocationTick`) attributed this single type as:
- **80%** of allocation in a tight empty-closure call loop
- **67%** in a captured-var call loop
- **~45%** of the `stopwatch` engine-comparison script's allocation

## Fix

Extract both async branches into `[MethodImpl(MethodImplOptions.NoInlining)]` helpers (`EvaluateConciseBodyAsync`, `EvaluateFunctionBodyAsync`) so the hot sync `EvaluateBody` contains no captured lambda and allocates nothing extra per call.

Pure method extraction — behavior preserving. The async branches don't use `argumentsInstance`, so returning the `Completion` directly from the helpers keeps the trailing `argumentsInstance?.FunctionWasCalled()` no-op intact.

## Results (.NET 10.0.9, default BenchmarkDotNet jobs)

`ClosureCallBenchmarks`:

| Benchmark | Time | Allocated |
|---|---|---|
| EmptyClosureCall | 38.9 → 39.0 ms (flat) | 14.87 → 2.74 MB (**−81.6%**) |
| CapturedVarReadWrite | 62.6 → 60.3 ms (−3.8%) | 17.75 → 5.49 MB (**−69.1%**) |
| ParamLocalCall | 115.3 → 102.8 ms (−10.9%) | 24.31 → 11.74 MB (**−51.7%**) |
| ManyLocalCall | 162.1 → 150.1 ms (−7.4%) | 6.70 → 2.88 MB (**−57.0%**) |

EngineComparison `stopwatch` (the call-dominated script): **−6.2% time / −45.5% alloc** (170→160 ms, 27.2→14.8 MB/op); `stopwatch-modern` −7…10% / −45.6%. Its remaining allocation is now almost entirely the mandatory `new Date()` result objects.

The eliminated allocation is short-lived gen0, so single-threaded wall-clock gains are modest; the larger value is reduced GC pressure (memory-limited hosts, concurrent/server workloads). The fix benefits every call-heavy script.

## Tooling

Adds `AllocTypeProbe` (`--profile-alloc-types`), a `GCAllocationTick`-based allocation-by-type diagnostic (alongside the existing `MemoryProbe` / `CpuProfileDriver`), used to pin down the allocating type.

## Validation

All green on net10.0 and net472: async/generator/promise tests, full `Jint.Tests` (3131/3069), `Jint.Tests.CommonScripts` (28/28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)