### PR TITLE
Shrink JsDate instances by 8 bytes via decomposed date storage

### DIFF
--- a/Jint/Native/JsDate.cs
+++ b/Jint/Native/JsDate.cs
@@ -12,7 +12,22 @@ public sealed class JsDate : ObjectInstance
     // Minimum allowed value to prevent DateTime overflow
     internal static readonly long Min = (long) -(DateConstructor.Epoch - DateTime.MinValue).TotalMilliseconds;
 
-    internal DatePresentation _dateValue;
+    // The clipped time value is decomposed into a long + a DateFlags byte rather than stored as the
+    // 16-byte DatePresentation struct: the flag byte rides in the object's existing field padding, so
+    // every JsDate instance is 8 bytes smaller on the hot `new Date()` allocation path. DatePresentation
+    // remains the transient computation/return type, reconstructed on access below.
+    private long _dateValueMs;
+    private DateFlags _dateFlags;
+
+    internal DatePresentation _dateValue
+    {
+        get => new(_dateValueMs, _dateFlags);
+        set
+        {
+            _dateValueMs = value.Value;
+            _dateFlags = value.Flags;
+        }
+    }
 
     public JsDate(Engine engine, DateTimeOffset value) : this(engine, value.UtcDateTime)
     {


### PR DESCRIPTION
## Summary

`new Date()` must return a fresh, identity-bearing object on every call (spec-mandated), so these objects can't be pooled or cached — the only lever on their cost is **per-object size**. They dominate the remaining allocation in the `stopwatch` benchmark.

`JsDate` stored its clipped time value as a **16-byte `DatePresentation`** struct (`long` value + 1-byte `DateFlags` + 7 bytes of padding). This PR decomposes that field into a `long` + a `DateFlags` byte exposed via an internal property of the **same** `DatePresentation` type, so the flag byte rides in the object's **existing field padding**. Every `JsDate` is **8 bytes smaller**, and all ~18 call sites compile unchanged.

`DatePresentation` stays the transient computation/return type, so the `DateTimeMinValue`/`MaxValue` flags that `ToDateTime()` relies on (and `DateTests` asserts) are preserved.

## Improvement vs `main`

| Metric | `main` | This PR | Δ |
|---|---:|---:|---:|
| `JsDate` instance size (x64) | 88 B | **80 B** | **−8 B (−9.1%)** |
| Date conformance (test262) | pass | pass | 0 regressions |
| Jint.Tests Date suite | pass | pass | — |
| Build (all 5 TFMs) | — | 0 warn / 0 err | — |

Size measured deterministically via `GC.GetAllocatedBytesForCurrentThread()` delta over 1,000,000 `new JsDate(...)` allocations — clean integers (88.00 → 80.00), no estimation.

### Combined with the companion PR #2536

Paired with #2536 (which removes another 8 B from **every** object), the hot Date instance shrinks further and the end-to-end `stopwatch` benchmark improves:

| Metric | `main` | Both PRs | Δ |
|---|---:|---:|---:|
| `JsDate` instance size | 88 B | **72 B** | **−18.2%** |
| `stopwatch` allocated / op (BenchmarkDotNet) | 26.5 MB | **23.88 MB** | **−9.9%** |
| `stopwatch` time | baseline | within noise (±3%, mixed sign) | no regression |
| Full test262 | pass | **99,260 pass / 0 fail** | 0 regressions |

Time was verified with a thermally-matched A/B (re-running the baseline warm) to rule out the drift that makes a naïve sequential comparison look like a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
