### PR TITLE
Remove the _privateElements field from ObjectInstance (relocate to a per-Engine weak table)

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -94,6 +94,11 @@ public sealed partial class Engine : IDisposable
     // cache for already wrapped CLR objects to keep object identity
     internal ConditionalWeakTable<object, ObjectInstance>? _objectWrapperCache;
 
+    // per-object private-element storage ([[PrivateElements]]). Kept off ObjectInstance in a weak table
+    // (keyed by the owning object) so the 8-byte reference doesn't bloat every object on the heap — only
+    // instances of JS classes that declare #private members ever allocate an entry here.
+    internal ConditionalWeakTable<ObjectInstance, Dictionary<PrivateName, PrivateElement>>? _privateElementStore;
+
     // bounded cache of most recently wrapped CLR objects, see Options.Interop.CacheRecentObjectWrappers
     internal RecentObjectWrapperCache? _recentObjectWrapperCache;
 

--- a/Jint/Native/Object/ObjectInstance.Private.cs
+++ b/Jint/Native/Object/ObjectInstance.Private.cs
@@ -6,7 +6,9 @@ namespace Jint.Native.Object;
 
 public partial class ObjectInstance
 {
-    private Dictionary<PrivateName, PrivateElement>? _privateElements;
+    // [[PrivateElements]] is stored off-object in Engine._privateElementStore (a weak table keyed by this
+    // object) so the reference doesn't cost 8 bytes on every ObjectInstance; only objects of classes that
+    // declare #private members ever allocate an entry. See Engine._privateElementStore.
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-initializeinstanceelements
@@ -51,8 +53,8 @@ public partial class ObjectInstance
             Throw.TypeError(_engine.Realm, "Already present");
         }
 
-        _privateElements ??= [];
-        _privateElements.Add(method.Key, method);
+        var store = _engine._privateElementStore ??= new();
+        store.GetOrCreateValue(this).Add(method.Key, method);
     }
 
     /// <summary>
@@ -74,8 +76,8 @@ public partial class ObjectInstance
             Throw.TypeError(_engine.Realm, "Already present");
         }
 
-        _privateElements ??= [];
-        _privateElements.Add(property, new PrivateElement { Key = property, Kind = PrivateElementKind.Field, Value = value });
+        var store = _engine._privateElementStore ??= new();
+        store.GetOrCreateValue(this).Add(property, new PrivateElement { Key = property, Kind = PrivateElementKind.Field, Value = value });
     }
 
     /// <summary>
@@ -141,7 +143,13 @@ public partial class ObjectInstance
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal PrivateElement? PrivateElementFind(PrivateName property)
     {
-        return _privateElements?.TryGetValue(property, out var pe) == true ? pe : null;
+        var store = _engine._privateElementStore;
+        if (store is not null && store.TryGetValue(this, out var elements))
+        {
+            return elements.TryGetValue(property, out var pe) ? pe : null;
+        }
+
+        return null;
     }
 }
 


### PR DESCRIPTION
## Summary

Every `ObjectInstance` carried a `Dictionary<PrivateName, PrivateElement>? _privateElements` reference (8 bytes) that is **null on all objects except instances of JS classes with `#private` members** — never a built-in, never on a hot allocation path.

This PR relocates that storage to a lazily-created **per-Engine `ConditionalWeakTable`** keyed by the owning object (sibling of the existing `_objectWrapperCache`), removing the reference from **every object on the heap**. Read paths stay non-creating (`TryGetValue`), so `#x in obj` brand checks and "private not declared" errors are unchanged; only the two `add` paths allocate an entry.

## Improvement vs `main`

| Metric | `main` | This PR | Δ |
|---|---:|---:|---:|
| `ObjectInstance` size (measured on `JsDate`) | 88 B | **80 B** | **−8 B** |
| every plain object / array / Date / … | — | −8 B each | whole heap shrinks |
| Full test262 | pass | **99,260 pass / 0 fail** | 0 regressions |
| Jint.Tests.PublicInterface | pass | pass | — |
| Build (all 5 TFMs) | — | 0 warn / 0 err | — |

Size measured deterministically via `GC.GetAllocatedBytesForCurrentThread()` delta over 1,000,000 allocations (88.00 → 80.00).

**Tradeoff:** `this.#x` private access becomes a weak-table lookup instead of an inlined field read. Private members are comparatively rare and never on a hot path (the `stopwatch` benchmark and full test262 show no regression).

### Combined with the companion PR #2535

Paired with #2535 (which shrinks `JsDate`'s date field by 8 B), the hot Date instance reaches its structural floor and the end-to-end `stopwatch` benchmark improves:

| Metric | `main` | Both PRs | Δ |
|---|---:|---:|---:|
| `JsDate` instance size | 88 B | **72 B** | **−18.2%** |
| `stopwatch` allocated / op (BenchmarkDotNet) | 26.5 MB | **23.88 MB** | **−9.9%** |
| `stopwatch` time | baseline | within noise (±3%, mixed sign) | no regression |
| Full test262 | pass | **99,260 pass / 0 fail** | 0 regressions |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
