### PR TITLE
Reduce PropertyDescriptor allocations in hot paths

### DIFF
--- a/Jint.Benchmark/IterationBenchmark.cs
+++ b/Jint.Benchmark/IterationBenchmark.cs
@@ -1,0 +1,46 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Exercises the iterator-result hot path (for-of, spread, destructuring, Map/Set iteration). Each step of a
+/// native iterator builds an IteratorResult; the value/done are read via Get(). Used to measure the inline
+/// value/done storage that avoids two PropertyDescriptor allocations per step.
+/// </summary>
+[MemoryDiagnoser]
+public class IterationBenchmark
+{
+    private const int N = 100_000;
+
+    private readonly Prepared<Script> _forOfArray;
+    private readonly Prepared<Script> _spreadArray;
+    private readonly Prepared<Script> _mapIteration;
+    private readonly Prepared<Script> _destructuring;
+
+    public IterationBenchmark()
+    {
+        _forOfArray = Engine.PrepareScript(
+            $"var a=[]; for (var i=0;i<{N};++i) a.push(i); var s=0; for (const x of a) {{ s+=x; }} s;");
+
+        _spreadArray = Engine.PrepareScript(
+            $"var a=[]; for (var i=0;i<{N};++i) a.push(i); var s=0; for (var k=0;k<10;++k) {{ var b=[...a]; s+=b.length; }} s;");
+
+        _mapIteration = Engine.PrepareScript(
+            $"var m=new Map(); for (var i=0;i<{N};++i) m.set(i,i); var s=0; for (const [k,v] of m) {{ s+=v; }} s;");
+
+        _destructuring = Engine.PrepareScript(
+            $"var a=[]; for (var i=0;i<{N};++i) a.push(i); var s=0; for (var k=0;k<{N};++k) {{ var [x,y,z]=a; s+=x+y+z; }} s;");
+    }
+
+    [Benchmark]
+    public void ForOfArray() => new Engine().Evaluate(_forOfArray);
+
+    [Benchmark]
+    public void SpreadArray() => new Engine().Evaluate(_spreadArray);
+
+    [Benchmark]
+    public void MapIteration() => new Engine().Evaluate(_mapIteration);
+
+    [Benchmark]
+    public void Destructuring() => new Engine().Evaluate(_destructuring);
+}

--- a/Jint.Benchmark/PropertyAllocBenchmark.cs
+++ b/Jint.Benchmark/PropertyAllocBenchmark.cs
@@ -1,0 +1,51 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Increment 0 of VALUE_TYPED_DESCRIPTOR_SPIKE: measures the allocation footprint of the two hottest
+/// data-property-creating shapes in real JS:
+///   - constructor objects (this.a=a;this.b=b;this.c=c) — the access-binary-trees / TreeNode pattern that
+///     falsified the array-backed property bag (#2532),
+///   - object literals ({a:..,b:..,c:..}) — the BuildObjectFast path.
+/// Fresh engine per invocation (mirrors ObjectAccessBenchmark) so each [Benchmark] reports the full
+/// allocation of building N small objects. Compare the Allocated column against the PropertyDescriptor
+/// share reported by --profile-propdesc to decide GO/NO-GO.
+/// </summary>
+[MemoryDiagnoser]
+public class PropertyAllocBenchmark
+{
+    private const int Iterations = 200_000;
+
+    private readonly Prepared<Script> _constructor3;
+    private readonly Prepared<Script> _literal3;
+    private readonly Prepared<Script> _constructor1;
+    private readonly Prepared<Script> _literal8;
+
+    public PropertyAllocBenchmark()
+    {
+        _constructor3 = Engine.PrepareScript(
+            $"function T(a,b,c){{this.a=a;this.b=b;this.c=c;}} var s=0; for (var i=0;i<{Iterations};++i){{ var t=new T(i,i+1,i+2); s+=t.a; }} s;");
+
+        _literal3 = Engine.PrepareScript(
+            $"var s=0; for (var i=0;i<{Iterations};++i){{ var t={{a:i,b:i+1,c:i+2}}; s+=t.a; }} s;");
+
+        _constructor1 = Engine.PrepareScript(
+            $"function N(v){{this.value=v;}} var s=0; for (var i=0;i<{Iterations};++i){{ var n=new N(i); s+=n.value; }} s;");
+
+        _literal8 = Engine.PrepareScript(
+            $"var s=0; for (var i=0;i<{Iterations};++i){{ var t={{a:i,b:i,c:i,d:i,e:i,f:i,g:i,h:i}}; s+=t.a; }} s;");
+    }
+
+    [Benchmark]
+    public void Constructor3() => new Engine().Evaluate(_constructor3);
+
+    [Benchmark]
+    public void Literal3() => new Engine().Evaluate(_literal3);
+
+    [Benchmark]
+    public void Constructor1() => new Engine().Evaluate(_constructor1);
+
+    [Benchmark]
+    public void Literal8() => new Engine().Evaluate(_literal8);
+}

--- a/Jint/Native/Iterator/IteratorResult.cs
+++ b/Jint/Native/Iterator/IteratorResult.cs
@@ -9,15 +9,22 @@ namespace Jint.Native.Iterator;
 /// </summary>
 internal sealed class IteratorResult : ObjectInstance
 {
-    // Store as PropertyDescriptor fields for fast access while supporting delete
-    // Null means the property has been deleted
+    // value/done are stored inline so a per-step result object allocates NO PropertyDescriptor on the hot
+    // iteration path: for-of / spread / destructuring / generators read them via Get(), served straight from
+    // these fields, and the result object is then discarded. A heap PropertyDescriptor is materialized (and
+    // cached, so [[DefineOwnProperty]] mutations persist) only on the cold reflective paths
+    // (GetOwnProperty / GetOwnProperties), or stored directly when a script redefines the property via
+    // SetOwnProperty — in which case the descriptor takes precedence over the inline value. A null inline
+    // value together with a null descriptor means the property has been deleted.
+    private JsValue? _value;
+    private JsValue? _done;
     private PropertyDescriptor? _valueDesc;
     private PropertyDescriptor? _doneDesc;
 
     public IteratorResult(Engine engine, JsValue value, JsBoolean done) : base(engine)
     {
-        _valueDesc = new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable);
-        _doneDesc = new PropertyDescriptor(done, PropertyFlag.ConfigurableEnumerableWritable);
+        _value = value;
+        _done = done;
     }
 
     public static IteratorResult CreateValueIteratorPosition(Engine engine, JsValue? value = null, JsBoolean? done = null)
@@ -37,12 +44,20 @@ internal sealed class IteratorResult : ObjectInstance
     {
         if (CommonProperties.Value.Equals(property))
         {
-            return _valueDesc?.Value ?? base.Get(property, receiver);
+            if (_valueDesc is not null)
+            {
+                return _valueDesc.Value;
+            }
+            return _value ?? base.Get(property, receiver);
         }
 
         if (CommonProperties.Done.Equals(property))
         {
-            return _doneDesc?.Value ?? base.Get(property, receiver);
+            if (_doneDesc is not null)
+            {
+                return _doneDesc.Value;
+            }
+            return _done ?? base.Get(property, receiver);
         }
 
         return base.Get(property, receiver);
@@ -52,11 +67,21 @@ internal sealed class IteratorResult : ObjectInstance
     {
         if (CommonProperties.Value.Equals(property))
         {
+            // Materialize lazily and cache: callers (e.g. ValidateAndApplyPropertyDescriptor) mutate the
+            // returned descriptor in place and expect the change to land in storage.
+            if (_valueDesc is null && _value is not null)
+            {
+                _valueDesc = new PropertyDescriptor(_value, PropertyFlag.ConfigurableEnumerableWritable);
+            }
             return _valueDesc ?? base.GetOwnProperty(property);
         }
 
         if (CommonProperties.Done.Equals(property))
         {
+            if (_doneDesc is null && _done is not null)
+            {
+                _doneDesc = new PropertyDescriptor(_done, PropertyFlag.ConfigurableEnumerableWritable);
+            }
             return _doneDesc ?? base.GetOwnProperty(property);
         }
 
@@ -65,16 +90,31 @@ internal sealed class IteratorResult : ObjectInstance
 
     public override bool Set(JsValue property, JsValue value, JsValue receiver)
     {
-        if (CommonProperties.Value.Equals(property) && _valueDesc is not null)
+        if (CommonProperties.Value.Equals(property))
         {
-            _valueDesc.Value = value;
-            return true;
+            if (_valueDesc is not null)
+            {
+                _valueDesc.Value = value;
+                return true;
+            }
+            if (_value is not null)
+            {
+                _value = value;
+                return true;
+            }
         }
-
-        if (CommonProperties.Done.Equals(property) && _doneDesc is not null)
+        else if (CommonProperties.Done.Equals(property))
         {
-            _doneDesc.Value = value;
-            return true;
+            if (_doneDesc is not null)
+            {
+                _doneDesc.Value = value;
+                return true;
+            }
+            if (_done is not null)
+            {
+                _done = value;
+                return true;
+            }
         }
 
         return base.Set(property, value, receiver);
@@ -101,12 +141,14 @@ internal sealed class IteratorResult : ObjectInstance
     {
         if (CommonProperties.Value.Equals(property))
         {
+            _value = null;
             _valueDesc = null;
             return;
         }
 
         if (CommonProperties.Done.Equals(property))
         {
+            _done = null;
             _doneDesc = null;
             return;
         }
@@ -120,11 +162,11 @@ internal sealed class IteratorResult : ObjectInstance
 
         if ((types & Types.String) != Types.Empty)
         {
-            if (_valueDesc is not null)
+            if (_value is not null || _valueDesc is not null)
             {
                 keys.Add(CommonProperties.Value);
             }
-            if (_doneDesc is not null)
+            if (_done is not null || _doneDesc is not null)
             {
                 keys.Add(CommonProperties.Done);
             }
@@ -141,13 +183,15 @@ internal sealed class IteratorResult : ObjectInstance
 
     public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
     {
-        if (_valueDesc is not null)
+        if (_value is not null || _valueDesc is not null)
         {
+            _valueDesc ??= new PropertyDescriptor(_value!, PropertyFlag.ConfigurableEnumerableWritable);
             yield return new KeyValuePair<JsValue, PropertyDescriptor>(CommonProperties.Value, _valueDesc);
         }
 
-        if (_doneDesc is not null)
+        if (_done is not null || _doneDesc is not null)
         {
+            _doneDesc ??= new PropertyDescriptor(_done!, PropertyFlag.ConfigurableEnumerableWritable);
             yield return new KeyValuePair<JsValue, PropertyDescriptor>(CommonProperties.Done, _doneDesc);
         }
 

--- a/Jint/Native/JsObject.cs
+++ b/Jint/Native/JsObject.cs
@@ -10,5 +10,10 @@ public sealed class JsObject : ObjectInstance
 {
     public JsObject(Engine engine) : base(engine, type: InternalTypes.Object | InternalTypes.PlainObject)
     {
+        // A dynamically constructed object has no lazy intrinsic members to populate (Initialize() is the
+        // base no-op), so mark it initialized up front. This skips the per-object virtual Initialize() call
+        // that EnsureInitialized() would otherwise make on first property access, and lets value-creating
+        // fast paths (e.g. CreateDataProperty) run without that overhead.
+        _initialized = true;
     }
 }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -22,7 +22,7 @@ namespace Jint.Native.Object;
 [DebuggerTypeProxy(typeof(ObjectInstanceDebugView))]
 public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
 {
-    private bool _initialized;
+    private protected bool _initialized;
     private readonly ObjectClass _class;
 
     internal PropertyDictionary? _properties;
@@ -1385,6 +1385,39 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool CreateDataProperty(JsValue p, JsValue v)
     {
+        // Fast path for an ordinary, extensible object gaining a brand-new string-keyed data property.
+        // The generic DefineOwnProperty → ValidateAndApplyPropertyDescriptor route allocates a transient
+        // descriptor here and then a second, identical one to actually store (ValidateAndApply re-creates
+        // it), so an object filled via this.x= / spread / Object.assign pays two PropertyDescriptor
+        // allocations per property. When the receiver is a PlainObject (no exotic [[GetOwnProperty]]),
+        // extensible, and the key is absent, the result is simply "store one CEW data descriptor".
+        //
+        // Store through the virtual SetOwnProperty (exactly what ValidateAndApplyPropertyDescriptor uses)
+        // — NOT the raw SetProperty primitive — so side-effecting overrides still run. ObjectPrototype is
+        // itself a PlainObject and overrides SetOwnProperty to flip ObjectChangeFlags.ArrayIndex (which
+        // disables the array fast-access path); skipping it silently breaks inherited-index iteration in
+        // Array.prototype.concat/sort. No PlainObject overrides [[DefineOwnProperty]] without also
+        // overriding SetOwnProperty, so this routing is equivalent to the full path for every PlainObject.
+        //
+        // The `_initialized` gate keeps the absence check honest: a lazily-initialized PlainObject
+        // (intrinsic prototypes, GlobalObject, NumberPrototype) populates _properties in Initialize(), so
+        // before that runs a built-in key could be misread as absent and overwritten. Those objects are
+        // skipped here and handled by the generic path (whose GetOwnProperty runs EnsureInitialized).
+        // Ordinary user objects (JsObject) are born initialized, so they take this path with no per-object
+        // virtual Initialize() call.
+        if ((_type & InternalTypes.PlainObject) != InternalTypes.Empty
+            && _initialized
+            && Extensible
+            && p is JsString jsString)
+        {
+            Key key = jsString.ToString();
+            if (_properties is null || !_properties.TryGetValue(key, out _))
+            {
+                SetOwnProperty(p, new PropertyDescriptor(v, PropertyFlag.ConfigurableEnumerableWritable));
+                return true;
+            }
+        }
+
         return DefineOwnProperty(p, new PropertyDescriptor(v, PropertyFlag.ConfigurableEnumerableWritable));
     }
 

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -309,7 +309,7 @@ public class PropertyDescriptor
 
         if (hasWritable)
         {
-            desc.Writable = TypeConverter.ToBoolean(writable!.Value);
+            desc.Writable = writable!.Value;
             desc.WritableSet = true;
         }
 
@@ -333,10 +333,8 @@ public class PropertyDescriptor
             ((GetSetPropertyDescriptor) desc).SetSet(set!);
         }
 
-        if ((hasSet || hasGet) && (hasValue || hasWritable))
-        {
-            Throw.TypeError(realm, "Invalid property descriptor. Cannot both specify accessors and a value or writable attribute");
-        }
+        // NOTE: the accessor-vs-data conflict is already rejected above (before desc was built); the has*
+        // flags are immutable thereafter, so a second identical check here would be dead code.
 
         return desc;
     }


### PR DESCRIPTION
Cuts redundant `PropertyDescriptor` allocations on three hot paths. All changes route stores through the virtual `SetOwnProperty` / preserve the existing override semantics, and are gated on the full suite.

## 1. `CreateDataProperty` — single allocation for new data properties
`CreateDataProperty` minted a transient descriptor, then `ValidateAndApplyPropertyDescriptor` allocated a second identical one to store — so `this.x=` / spread / `Object.assign` paid **two** descriptors per property (object literals already paid one). A fast path now stores a single CEW descriptor directly when the receiver is an initialized, extensible `PlainObject` with the key absent.

Going through the virtual `SetOwnProperty` (not the raw `SetProperty`) preserves side-effecting overrides — `ObjectPrototype` is a `PlainObject` that flips `ObjectChangeFlags.ArrayIndex` there, which `Array.prototype.concat`/`sort` rely on for inherited-index iteration. The `_initialized` gate keeps the absence check correct for lazily-initialized intrinsics; `JsObject` is born initialized (its `Initialize()` is the base no-op) so user objects skip the per-object virtual call.

| `PropertyAllocBenchmark` | Time | Allocated |
|---|---|---|
| Constructor3 (`this.a=a;b;c`) | 154.3 → **139.6 ms** | 162.4 → **144.0 MB** (−11%) |
| Constructor1 (`this.value=v`) | 86.2 → 84 ms | 98.9 → **92.8 MB** (−6%) |
| Object literals | unchanged | unchanged |

SunSpider `access-binary-trees`: **−8.8%** total allocation (descriptors halved).

## 2. `IteratorResult` — inline value/done
Every native iterator step (for-of, spread, destructuring, generators, Map/Set) built an `IteratorResult` allocating **two** descriptors (value + done), though the hot path reads them via `Get()` and discards the object. Value/done are now stored inline; a descriptor is materialized (and cached, so `[[DefineOwnProperty]]` mutations persist) only on the cold reflective paths.

| `IterationBenchmark` | Allocated |
|---|---|
| ForOfArray (for-of, 100k) | 65.2 → **60.6 MB** (−7%); descriptors 200,006 → **4** |
| MapIteration | 98.3 → **93.7 MB** (−4.7%) |

## 3. `ToPropertyDescriptor` cleanup
Removed a second `ToBoolean()` on the already-boolean `writable` attribute and a duplicate, dead accessor-vs-data conflict check (kept the earlier one to preserve getter-callable error precedence).

## Testing
test262 **0 failures** (99,260 passed); `Jint.Tests` 0 (net10.0 3131 / net472 3069); `Jint.Tests.PublicInterface` 0.

## Deferred follow-ups (own PRs)
- **Inline the array `_length` descriptor** — the real source of `dromaeo-object-array`'s ~27k descriptors is the per-array `_length` `PropertyDescriptor` (not element descriptors; the dense element path is already descriptor-free). Worthwhile but it's a rewrite of the exotic `ArraySetLength` path, so it deserves a focused PR with full array-suite gating.
- No-descriptor enumeration path for exotic receivers (TypedArray/String/CLR) in `Object.keys/values/entries`, `for-in`, `assign`, `freeze`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)