### PR TITLE
Store array length inline to avoid a per-array PropertyDescriptor

### DIFF
--- a/Jint.Benchmark/ArrayAllocBenchmark.cs
+++ b/Jint.Benchmark/ArrayAllocBenchmark.cs
@@ -1,0 +1,46 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Measures allocation of array creation, which previously paid one per-array <c>length</c>
+/// PropertyDescriptor. Fresh engine per invocation (mirrors ObjectAccessBenchmark) so each [Benchmark]
+/// reports the full allocation of building N arrays.
+/// </summary>
+[MemoryDiagnoser]
+public class ArrayAllocBenchmark
+{
+    private const int Iterations = 200_000;
+
+    private readonly Prepared<Script> _literalEmpty;
+    private readonly Prepared<Script> _newArray;
+    private readonly Prepared<Script> _literalSmall;
+    private readonly Prepared<Script> _pushLoop;
+
+    public ArrayAllocBenchmark()
+    {
+        _literalEmpty = Engine.PrepareScript(
+            $"var s=0; for (var i=0;i<{Iterations};++i){{ var a=[]; a.length=4; s+=a.length; }} s;");
+
+        _newArray = Engine.PrepareScript(
+            $"var s=0; for (var i=0;i<{Iterations};++i){{ var a=new Array(8); s+=a.length; }} s;");
+
+        _literalSmall = Engine.PrepareScript(
+            $"var s=0; for (var i=0;i<{Iterations};++i){{ var a=[i,i+1,i+2]; s+=a.length; }} s;");
+
+        _pushLoop = Engine.PrepareScript(
+            $"var s=0; for (var i=0;i<{Iterations};++i){{ var a=[]; a.push(i); a.push(i+1); s+=a.length; }} s;");
+    }
+
+    [Benchmark]
+    public void LiteralEmpty() => new Engine().Evaluate(_literalEmpty);
+
+    [Benchmark]
+    public void NewArray() => new Engine().Evaluate(_newArray);
+
+    [Benchmark]
+    public void LiteralSmall() => new Engine().Evaluate(_literalSmall);
+
+    [Benchmark]
+    public void PushLoop() => new Engine().Evaluate(_pushLoop);
+}

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -880,7 +880,7 @@ public sealed partial class ArrayConstructor : Constructor
                     break;
                 default:
                     instance = ArrayCreate(capacity, prototypeObject);
-                    instance._length!._value = JsNumber.PositiveZero;
+                    instance.SetLengthValue(JsNumber.PositiveZero);
                     instance.Push(arguments);
                     break;
             }
@@ -888,7 +888,7 @@ public sealed partial class ArrayConstructor : Constructor
         else
         {
             instance = ArrayCreate((ulong) arguments.Length, prototypeObject);
-            instance._length!._value = JsNumber.PositiveZero;
+            instance.SetLengthValue(JsNumber.PositiveZero);
             if (arguments.Length > 0)
             {
                 instance.Push(arguments);

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -11,7 +11,46 @@ namespace Jint.Native.Array;
 
 public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 {
-    internal PropertyDescriptor? _length;
+    // The "length" own property. To avoid a per-array PropertyDescriptor allocation in the common case,
+    // the value is stored inline in _lengthValue and a descriptor (_lengthDescriptor) is materialized and
+    // cached only when a caller needs the object: [[GetOwnProperty]], [[DefineOwnProperty]] (incl. making
+    // length non-writable), or reflection. Once _lengthDescriptor is non-null it is authoritative.
+    // Inline state is always the default (writable, non-enumerable, non-configurable) because the only ways
+    // to alter length's attributes go through DefineLength, which materializes first. Both fields null means
+    // length has been removed (only reachable internally; length is normally non-configurable).
+    private JsNumber? _lengthValue;
+    private protected PropertyDescriptor? _lengthDescriptor;
+
+    /// <summary>Current length value (PositiveZero if length was removed).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private JsNumber GetJsNumberLength()
+        => _lengthDescriptor is not null ? (JsNumber) _lengthDescriptor._value! : (_lengthValue ?? JsNumber.PositiveZero);
+
+    private bool HasLength => _lengthDescriptor is not null || _lengthValue is not null;
+
+    // Matches `_length is { Writable: true }`: present AND writable. Inline length is always writable
+    // (non-writable length only arises via DefineLength, which materializes the descriptor first).
+    private bool LengthIsWritable => _lengthDescriptor is not null ? _lengthDescriptor.Writable : _lengthValue is not null;
+
+    /// <summary>Materialize and cache the length descriptor for spec/reflection paths. Null only if removed.</summary>
+    private PropertyDescriptor? GetLengthDescriptor()
+        => _lengthDescriptor ??= _lengthValue is null ? null : new PropertyDescriptor(_lengthValue, PropertyFlag.OnlyWritable);
+
+    /// <summary>Update the length value (mutates the materialized descriptor when present, else inline).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void SetLengthValue(JsNumber value)
+    {
+        if (_lengthDescriptor is not null)
+        {
+            _lengthDescriptor.Value = value;
+        }
+        else
+        {
+            _lengthValue = value;
+        }
+    }
+
+    internal ulong GetLongLength() => (ulong) GetJsNumberLength()._value;
 
     private const int MaxDenseArrayLength = 10_000_000;
     internal const int MaxDenseArrayLengthInternal = MaxDenseArrayLength;
@@ -45,7 +84,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
             _sparse = new Dictionary<uint, PropertyDescriptor?>(1024);
         }
 
-        _length = new PropertyDescriptor(length, PropertyFlag.OnlyWritable);
+        _lengthValue = JsNumber.Create(length);
     }
 
     private protected ArrayInstance(Engine engine, JsValue[] items) : base(engine, type: InternalTypes.Object | InternalTypes.Array)
@@ -53,7 +92,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         InitializePrototypeAndValidateCapacity(engine, capacity: 0);
 
         _dense = items;
-        _length = new PropertyDescriptor(items.Length, PropertyFlag.OnlyWritable);
+        _lengthValue = JsNumber.Create(items.Length);
     }
 
     private void InitializePrototypeAndValidateCapacity(Engine engine, uint capacity)
@@ -147,7 +186,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
             Throw.RangeError(_engine.Realm);
         }
 
-        var oldLenDesc = _length;
+        var oldLenDesc = GetLengthDescriptor();
         var oldLen = (uint) TypeConverter.ToNumber(oldLenDesc!.Value);
 
         newLenDesc.Value = newLen;
@@ -268,7 +307,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
     private bool DefineOwnProperty(uint index, PropertyDescriptor desc)
     {
-        var oldLenDesc = _length;
+        var oldLenDesc = GetLengthDescriptor();
         var oldLen = (uint) TypeConverter.ToNumber(oldLenDesc!.Value);
 
         if (index >= oldLen && !oldLenDesc.Writable)
@@ -294,15 +333,12 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal override uint GetLength() => (uint) GetJsNumberLength()._value;
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private JsNumber GetJsNumberLength() => _length is null ? JsNumber.PositiveZero : (JsNumber) _length._value!;
-
     protected sealed override bool TryGetProperty(JsValue property, [NotNullWhen(true)] out PropertyDescriptor? descriptor)
     {
         if (CommonProperties.Length.Equals(property))
         {
-            descriptor = _length;
-            return _length != null;
+            descriptor = GetLengthDescriptor();
+            return descriptor != null;
         }
 
         return base.TryGetProperty(property, out descriptor);
@@ -336,7 +372,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
             }
         }
 
-        if (_length != null)
+        if (HasLength)
         {
             properties.Add(CommonProperties.Length);
         }
@@ -357,9 +393,9 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
             yield return new KeyValuePair<string, JsValue>(TypeConverter.ToString(index), value);
         }
 
-        if (includeLength && _length != null)
+        if (includeLength && HasLength)
         {
-            yield return new KeyValuePair<string, JsValue>(CommonProperties.Length._value, _length.Value);
+            yield return new KeyValuePair<string, JsValue>(CommonProperties.Length._value, GetJsNumberLength());
         }
     }
 
@@ -395,9 +431,9 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
             }
         }
 
-        if (_length != null)
+        if (GetLengthDescriptor() is { } lengthDescriptor)
         {
-            yield return new KeyValuePair<JsValue, PropertyDescriptor>(CommonProperties.Length, _length);
+            yield return new KeyValuePair<JsValue, PropertyDescriptor>(CommonProperties.Length, lengthDescriptor);
         }
 
         foreach (var entry in base.GetOwnProperties())
@@ -410,7 +446,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
     {
         if (CommonProperties.Length.Equals(property))
         {
-            return _length ?? PropertyDescriptor.Undefined;
+            return GetLengthDescriptor() ?? PropertyDescriptor.Undefined;
         }
 
         if (IsArrayIndex(property, out var index))
@@ -445,10 +481,9 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
         if (CommonProperties.Length.Equals(property))
         {
-            var length = _length?._value;
-            if (length is not null)
+            if (HasLength)
             {
-                return length;
+                return GetJsNumberLength();
             }
         }
 
@@ -467,14 +502,14 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
             }
 
             if (CommonProperties.Length.Equals(property)
-                && _length is { Writable: true }
+                && LengthIsWritable
                 && value is JsNumber jsNumber
                 && jsNumber.IsInteger()
                 && jsNumber._value <= MaxDenseArrayLength
                 && jsNumber._value >= GetLength())
             {
                 // we don't need explicit resize
-                _length.Value = jsNumber;
+                SetLengthValue(jsNumber);
                 return true;
             }
         }
@@ -526,7 +561,8 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         }
         else if (CommonProperties.Length.Equals(property))
         {
-            _length = desc;
+            _lengthDescriptor = desc;
+            _lengthValue = null;
         }
         else
         {
@@ -565,7 +601,8 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
         if (CommonProperties.Length.Equals(property))
         {
-            _length = null;
+            _lengthDescriptor = null;
+            _lengthValue = null;
         }
 
         base.RemoveOwnProperty(property);
@@ -630,9 +667,11 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void SetLength(JsNumber length)
     {
-        if (Extensible && _length!._flags == PropertyFlag.OnlyWritable)
+        // Fast path requires length present with the default (writable, non-enum, non-config) attributes —
+        // which is exactly the inline state, or a materialized descriptor still carrying OnlyWritable.
+        if (Extensible && (_lengthDescriptor is null ? _lengthValue is not null : _lengthDescriptor._flags == PropertyFlag.OnlyWritable))
         {
-            _length!.Value = length;
+            SetLengthValue(length);
         }
         else
         {
@@ -925,9 +964,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         // Lazy-backed arrays from `new Array(N)` start with _dense.Length=0 but _length=N;
         // a write to an index within N is not sparse intent, just realising the lazy capacity.
         // Compare against the larger of the physical backing length and the declared length.
-        var declaredLength = _length is { } lengthDesc && lengthDesc._value is JsNumber lengthNumber
-            ? (uint) lengthNumber._value
-            : 0u;
+        var declaredLength = (uint) GetJsNumberLength()._value;
         var denseHeadroom = System.Math.Max((uint) (dense?.Length ?? 0), declaredLength);
 
         var canUseDense = dense != null
@@ -1204,7 +1241,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         // check if we can set length fast without breaking ECMA specification
         if (n < uint.MaxValue && CanSetLength())
         {
-            _length!.Value = newLength;
+            SetLengthValue(JsNumber.Create(newLength));
         }
         else
         {
@@ -1251,7 +1288,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         // check if we can set length fast without breaking ECMA specification
         if (n < ArrayOperations.MaxArrayLength && CanSetLength())
         {
-            _length!.Value = n;
+            SetLengthValue(JsNumber.Create(n));
         }
         else
         {
@@ -1287,11 +1324,17 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
     private bool CanSetLength()
     {
-        if (!_length!.IsAccessorDescriptor())
+        var desc = _lengthDescriptor;
+        if (desc is null)
         {
-            return _length.Writable;
+            // inline length is always writable
+            return true;
         }
-        var set = _length.Set;
+        if (!desc.IsAccessorDescriptor())
+        {
+            return desc.Writable;
+        }
+        var set = desc.Set;
         return set is not null && !set.IsUndefined();
     }
 
@@ -1577,7 +1620,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
     public sealed override string ToString()
     {
         // debugger can make things hard when evaluates computed values
-        return "(" + (_length?._value!.AsNumber() ?? 0) + ")[]";
+        return "(" + GetJsNumberLength()._value + ")[]";
     }
 
     internal static void ThrowMaximumArraySizeReachedException(Engine engine, uint capacity)

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -262,10 +262,10 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
             => _target.GetSmallestIndex();
 
         public override uint GetLength()
-            => (uint) ((JsNumber) _target._length!._value!)._value;
+            => _target.GetLength();
 
         public override ulong GetLongLength()
-            => (ulong) ((JsNumber) _target._length!._value!)._value;
+            => _target.GetLongLength();
 
         public override void SetLength(ulong length)
             => _target.SetLength(length);

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -38,7 +38,9 @@ public sealed partial class ArrayPrototype : ArrayInstance
         ObjectPrototype objectPrototype) : base(engine, InternalTypes.Object)
     {
         _prototype = objectPrototype;
-        _length = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Writable);
+        // Array.prototype keeps an explicit length descriptor (preserves its exact PropertyFlag.Writable
+        // attributes; it's a one-time per-realm object so there is no allocation concern here).
+        _lengthDescriptor = new PropertyDescriptor(JsNumber.PositiveZero, PropertyFlag.Writable);
         _realm = realm;
         _constructor = arrayConstructor;
         _joinStack = new(engine);


### PR DESCRIPTION
## Problem

Every array allocates one `PropertyDescriptor` for its `length` own property (in the `ArrayInstance` constructors). This is the dominant descriptor cost of array-heavy code: e.g. of the ~27k `PropertyDescriptor`s allocated by the `dromaeo-object-array` benchmark, essentially all come from **array creation** (`[]`, `new Array(n)`, species-create), not element storage — the dense element path is already descriptor-free.

## Approach

`length` is always a data property (it is non-configurable, so it can never become an accessor) with only two states: writable (default) or non-writable. So the value is stored **inline** (`_lengthValue`) and a descriptor (`_lengthDescriptor`) is materialized and cached only when a caller needs the object — `[[GetOwnProperty]]`, `[[DefineOwnProperty]]` (including `ArraySetLength` and making `length` non-writable), or reflection. Once materialized the descriptor is authoritative.

Inline state always carries the default attributes, because the only ways to change `length`'s attributes go through `DefineLength`, which materializes the descriptor first. The hot paths — construction, `push`, `length=`, `GetLength` — read/write the inline value with **no descriptor allocation**. `Array.prototype` keeps an explicit descriptor (one-time per realm, preserves its exact attributes).

## Benchmarks

`ArrayAllocBenchmark` (added here), default job, net10.0, 200k arrays/op:

| Method | Allocated (before → after) | Time |
|---|---|---|
| `LiteralEmpty` (`[]; a.length=4`) | 37.77 → **33.20 MB** (−12.1%) | 38.4 → 39.7 ms |
| `NewArray` (`new Array(8)`) | 37.81 → **33.23 MB** (−12.1%) | 35.9 → 33.7 ms |
| `LiteralSmall` (`[i,i+1,i+2]`) | 58.48 → **53.91 MB** (−7.8%) | 42.4 → 41.0 ms |
| `PushLoop` (`[]; push×2`) | 54.17 → **49.59 MB** (−8.5%) | 72.3 → 70.1 ms |

Each array creation drops one 32 B `PropertyDescriptor`; time is neutral.

## Testing

test262 **0 failures** (99,260 passed) — including the full array suite; `Jint.Tests` 0 (net10.0 3131 / net472 3069); `Jint.Tests.PublicInterface` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)