### PR TITLE
Upgrade dependencies, fix MA0074 build errors, and group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot version updates.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Dependencies are split into logical groups so each weekly PR is cohesive and
+# easy to review/revert, instead of one large PR bumping everything at once.
+# A dependency is placed in the FIRST group whose patterns it matches, so the
+# groups below are ordered most-specific first, with the broad "microsoft"
+# catch-all last. Packages that match no group get their own individual PR.
 
 version: 2
 updates:
@@ -9,8 +13,45 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
     groups:
-       # Grouped version updates configuration
-       all-dependencies:
-          patterns:
-            - "*"
+      # Roslyn analyzers and source generators (build-time only).
+      analyzers:
+        patterns:
+          - "Meziantou.Analyzer"
+          - "Microsoft.CodeAnalysis.*"
+          - "PolySharp"
+      # Test frameworks, runners, adapters and assertion/helper libraries.
+      testing:
+        patterns:
+          - "xunit*"
+          - "NUnit*"
+          - "Microsoft.NET.Test.Sdk"
+          - "Microsoft.Extensions.TimeProvider.Testing"
+          - "AwesomeAssertions"
+          - "Verify.*"
+          - "GitHubActionsTestLogger"
+          - "Test262Harness"
+          - "MongoDB.Bson.signed"
+          - "Flurl.Http.Signed"
+          - "SharpZipLib"
+      # Benchmarking tooling.
+      benchmark:
+        patterns:
+          - "BenchmarkDotNet*"
+      # Alternative JS engines used only for comparison benchmarks/tests.
+      js-engine-comparisons:
+        patterns:
+          - "Jurassic"
+          - "NiL.JS"
+          - "YantraJS.Core"
+      # The Acornima parser packages, which are versioned in lockstep.
+      acornima:
+        patterns:
+          - "Acornima*"
+      # Remaining Microsoft / System runtime packages
+      # (e.g. Microsoft.Extensions.DependencyInjection, System.Text.Json).
+      microsoft:
+        patterns:
+          - "Microsoft.*"
+          - "System.*"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,20 +7,20 @@
     <PackageVersion Include="Acornima" Version="1.6.2" />
     <PackageVersion Include="Acornima.Extras" Version="1.6.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="BenchmarkDotNet.TestAdapter" Version="0.13.12" />
+    <PackageVersion Include="BenchmarkDotNet.TestAdapter" Version="0.15.8" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Flurl.Http.Signed" Version="4.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
-    <PackageVersion Include="ICU4N" Version="60.1.0-alpha.439" />
+    <PackageVersion Include="ICU4N" Version="60.1.0-alpha.440" />
     <PackageVersion Include="Jurassic" Version="3.2.9" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.101" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.109" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageVersion Include="Verify.NUnit" Version="31.19.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Verify.NUnit" Version="31.20.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="MongoDB.Bson.signed" Version="2.19.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NiL.JS" Version="2.6.1722" />
@@ -29,13 +29,13 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="SourceMaps" Version="0.3.0" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.45.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
     <PackageVersion Include="Test262Harness" Version="1.0.6" />
     <PackageVersion Include="xunit.v3.mtp-off" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
-    <PackageVersion Include="YantraJS.Core" Version="1.2.405" />
-    <PackageVersion Include="Zio" Version="0.22.2" />
+    <PackageVersion Include="YantraJS.Core" Version="1.2.406" />
+    <PackageVersion Include="Zio" Version="0.24.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="PolySharp" Version="1.16.0" />

--- a/Jint/Native/Intl/DisplayNamesPrototype.cs
+++ b/Jint/Native/Intl/DisplayNamesPrototype.cs
@@ -118,7 +118,7 @@ internal sealed partial class DisplayNamesPrototype : Prototype
         }
 
         // Check for empty subtags (consecutive hyphens)
-        if (code.Contains("--"))
+        if (code.Contains("--", StringComparison.Ordinal))
         {
             return false;
         }

--- a/Jint/Native/Intl/JsNumberFormat.cs
+++ b/Jint/Native/Intl/JsNumberFormat.cs
@@ -358,7 +358,7 @@ internal sealed class JsNumberFormat : ObjectInstance
             compactFormatted = compactValue.ToString("F" + compactDecimalPlaces, NumberFormatInfo);
             // Trim trailing zeros after decimal
             var decSep = NumberFormatInfo.NumberDecimalSeparator;
-            if (compactFormatted.Contains(decSep))
+            if (compactFormatted.Contains(decSep, StringComparison.Ordinal))
             {
                 compactFormatted = compactFormatted.TrimEnd('0');
                 if (compactFormatted.EndsWith(decSep, StringComparison.Ordinal))
@@ -452,7 +452,7 @@ internal sealed class JsNumberFormat : ObjectInstance
                 formatted = rounded.ToString("F" + decimalPlaces, NumberFormatInfo);
                 // Trim trailing zeros
                 var decSep = NumberFormatInfo.NumberDecimalSeparator;
-                if (formatted.Contains(decSep))
+                if (formatted.Contains(decSep, StringComparison.Ordinal))
                 {
                     formatted = formatted.TrimEnd('0');
                     if (formatted.EndsWith(decSep, StringComparison.Ordinal))
@@ -474,7 +474,7 @@ internal sealed class JsNumberFormat : ObjectInstance
 
         // Trim trailing zeros but keep at least required precision
         var sep = NumberFormatInfo.NumberDecimalSeparator;
-        if (smallFormatted.Contains(sep))
+        if (smallFormatted.Contains(sep, StringComparison.Ordinal))
         {
             smallFormatted = smallFormatted.TrimEnd('0');
             if (smallFormatted.EndsWith(sep, StringComparison.Ordinal))

--- a/Jint/Native/Intl/LocaleConstructor.cs
+++ b/Jint/Native/Intl/LocaleConstructor.cs
@@ -431,7 +431,7 @@ internal sealed class LocaleConstructor : Constructor
         }
 
         // Check for double dashes
-        if (stringValue.Contains("--"))
+        if (stringValue.Contains("--", StringComparison.Ordinal))
         {
             Throw.RangeError(_realm, $"Invalid variants option: {stringValue}");
         }


### PR DESCRIPTION
## Why

[#2544](https://github.com/sebastienros/jint/pull/2544) (the weekly Dependabot bump) fails to build on every platform. The root cause is the **Meziantou.Analyzer `3.0.101` → `3.0.109`** bump, which promotes **MA0074** (*use a `Contains` overload that takes a `StringComparison`*). Because warnings are treated as errors, five existing `string.Contains(string)` calls in the Intl code break the build:

- `Jint/Native/Intl/JsNumberFormat.cs` (3 sites)
- `Jint/Native/Intl/LocaleConstructor.cs`
- `Jint/Native/Intl/DisplayNamesPrototype.cs`

## What

**Fix the build (MA0074)** — add `StringComparison.Ordinal` to the five flagged calls. This is behaviour-identical: `string.Contains(string)` already performs an ordinal comparison, and `Ordinal` matches the adjacent `EndsWith(..., StringComparison.Ordinal)` calls in the same methods.

**Upgrade all packages to their latest stable versions** (so we don't have to update again right away; prereleases/betas were intentionally skipped):

| Package | From | To |
| --- | --- | --- |
| ICU4N | 60.1.0-alpha.439 | 60.1.0-alpha.440 |
| Meziantou.Analyzer | 3.0.101 | 3.0.109 |
| Microsoft.Extensions.DependencyInjection | 10.0.8 | 10.0.9 |
| Microsoft.Extensions.TimeProvider.Testing | 10.6.0 | 10.7.0 |
| Verify.NUnit | 31.19.0 | 31.20.0 |
| YantraJS.Core | 1.2.405 | 1.2.406 |
| BenchmarkDotNet.TestAdapter | 0.13.12 | 0.15.8 |
| Microsoft.NET.Test.Sdk | 18.6.0 | 18.7.0 |
| System.Text.Json | 10.0.8 | 10.0.9 |
| Spectre.Console.Cli | 0.45.0 | 0.55.0 |
| Zio | 0.22.2 | 0.24.0 |

The first six rows are the bumps originally proposed by #2544; the rest bring the remaining packages current. Packages with only prerelease updates available (M.E.DI 11.0-preview, Newtonsoft.Json 13.0.5-beta1, System.Text.Json 11.0-preview, xunit 4.0-pre, Spectre 1.0-alpha) were left on their latest stable.

**Improve Dependabot grouping** — replace the single catch-all `all-dependencies` group with logical, purpose-based groups so each weekly PR is cohesive and easy to review/revert instead of one large mixed bump:

- `analyzers` — Meziantou.Analyzer, Microsoft.CodeAnalysis.\*, PolySharp
- `testing` — xunit, NUnit, test SDK, assertion/helper libraries, Verify, Test262Harness, etc.
- `benchmark` — BenchmarkDotNet\*
- `js-engine-comparisons` — Jurassic, NiL.JS, YantraJS.Core
- `acornima` — the lockstep parser packages
- `microsoft` — remaining `Microsoft.*` / `System.*` runtime packages

Groups are ordered most-specific first since Dependabot assigns each dependency to the first matching group.

## Testing

- `dotnet build --configuration Release` — succeeds, 0 warnings / 0 errors
- `Jint.Tests` — 3131 passed (net10.0), 3069 passed (net472), 0 failed
- `Jint.Tests.CommonScripts` — 28 passed on both TFMs
- `Jint.Tests.PublicInterface` — all green except `CanUseTimeProvider` on net472, which is a pre-existing timing-sensitive test (a 100 ms window around the real system clock on cold-start JIT) that fails identically on unmodified `main`; none of the bumped packages are on its code path.

This PR supersedes #2544.

🤖 Generated with [Claude Code](https://claude.com/claude-code)