### PR TITLE
Add write-side inline cache for property assignment (obj.prop = value)

### DIFF
--- a/Jint.Benchmark/ObjectAccessBenchmark.cs
+++ b/Jint.Benchmark/ObjectAccessBenchmark.cs
@@ -6,11 +6,19 @@ namespace Jint.Benchmark;
 public class ObjectAccessBenchmark
 {
     private readonly Prepared<Script> _script;
+    private readonly Prepared<Script> _writeOnlyScript;
 
     public ObjectAccessBenchmark()
     {
+        // Read-then-write of the same property: exercises both the member-read inline cache and the
+        // member-write inline cache on a stable object.
         const string Script = @"const summary = { res: 0 }; for (var i =0; i < 1_000_000; ++i){ summary.res = summary.res + 1; }";
         _script = Engine.PrepareScript(Script);
+
+        // Pure write of an existing property (the LHS node is never read), so the write-side inline cache
+        // can only warm up via write-miss population — then hit for the remaining iterations.
+        const string WriteOnlyScript = @"const summary = { res: 0 }; for (var i =0; i < 1_000_000; ++i){ summary.res = i; }";
+        _writeOnlyScript = Engine.PrepareScript(WriteOnlyScript);
     }
 
     [Benchmark]
@@ -18,5 +26,12 @@ public class ObjectAccessBenchmark
     {
         var engine = new Engine();
         engine.Evaluate(_script);
+    }
+
+    [Benchmark]
+    public void WriteObjectProperty()
+    {
+        var engine = new Engine();
+        engine.Evaluate(_writeOnlyScript);
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -563,8 +563,18 @@ internal sealed class JintAssignmentExpression : JintExpression
         // https://262.ecma-international.org/5.1/#sec-11.13.1
         private JsValue SetValue(EvaluationContext context)
         {
-            // slower version
             var engine = context.Engine;
+
+            // Write-side inline cache for `obj.prop = rhs` (mirrors JintMemberExpression.GetValue's read cache):
+            // resolves base+rhs once and stores straight into a live writable data descriptor, otherwise completes
+            // through PutValue. Only declines (returns false) before evaluating anything, so the slow path stays sound.
+            if (_left is JintMemberExpression memberLeft
+                && memberLeft.TryAssignFast(context, _right, out var fastResult))
+            {
+                return fastResult;
+            }
+
+            // slower version
             var lref = _left.Evaluate(context) as Reference;
             if (lref is null)
             {

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -435,4 +435,96 @@ internal sealed class JintMemberExpression : JintExpression
         thisObject = JsValue.Undefined;
         return JsValue.Undefined;
     }
+
+    /// <summary>
+    /// Write-side counterpart of <see cref="GetValue"/>'s inline cache for <c>obj.prop = rhs</c>. Reuses the
+    /// same version-gated own-property cache slots: when the receiver is a <see cref="InternalTypes.PlainObject"/>
+    /// whose shape is unchanged and the own property is a <em>live</em> writable, non-accessor, non-custom data
+    /// descriptor, the new value is written straight into the descriptor (no Reference rent, no property-key hash,
+    /// no dictionary lookup) — exactly the in-place store <see cref="ObjectInstance.Set(JsValue,JsValue,JsValue)"/>
+    /// performs, which by design does not bump <c>_propertiesVersion</c>.
+    /// <para>
+    /// The method returns <c>false</c> only from the eligibility gate, having evaluated nothing, so the caller's
+    /// unchanged slow path runs. Once the base and right-hand side have been evaluated (each exactly once, in spec
+    /// order) it always completes the assignment and returns <c>true</c>: either the in-place store, or — for an
+    /// absent / accessor / read-only / custom-value property, or a non-<see cref="ObjectInstance"/> base — a
+    /// fallback through <see cref="Engine.PutValue"/> rented from the already-resolved base+key (so a side-effecting
+    /// base or RHS is never evaluated twice and prototype-setter / CreateDataProperty / strict read-only semantics
+    /// are preserved).
+    /// </para>
+    /// </summary>
+    internal bool TryAssignFast(EvaluationContext context, JintExpression right, out JsValue result)
+    {
+        var engine = context.Engine;
+
+        // Same eligibility as GetValue's primary fast path, plus the computed-read path's Suspendable==null gate:
+        // a static string-named, non-optional, non-short-circuiting, non-super property write with no custom
+        // resolver, in a context where neither operand can suspend (so no generator/async bookkeeping is needed).
+        if (_propertyExpression is not null
+            || _determinedProperty is not JsString determinedProperty
+            || _memberExpression.Optional
+            || _objectExpressionCanShortCircuit
+            || engine._customResolver
+            || _objectExpression is JintSuperExpression
+            || engine.ExecutionContext.Suspendable is not null)
+        {
+            result = JsValue.Undefined;
+            return false;
+        }
+
+        // Evaluate base, then RHS — each exactly once, preserving base→key→rhs spec order. A null/undefined base
+        // is simply not a PlainObject and flows to the fallback, where PutValue→ToObject throws after the RHS.
+        var baseValue = _objectExpression.GetValue(context);
+        var rval = right.GetValue(context);
+
+        context.LastSyntaxElement = _expression;
+
+        if (baseValue is ObjectInstance baseObject
+            && (baseObject._type & InternalTypes.PlainObject) != InternalTypes.Empty)
+        {
+            PropertyDescriptor? descriptor;
+            if (ReferenceEquals(baseObject, _cachedReadObject)
+                && baseObject._propertiesVersion == _cachedReadVersion
+                && _cachedReadDescriptor is not null)
+            {
+                descriptor = _cachedReadDescriptor;
+            }
+            else
+            {
+                var ownDescriptor = baseObject.GetOwnProperty(determinedProperty);
+                if (ReferenceEquals(ownDescriptor, PropertyDescriptor.Undefined))
+                {
+                    // Absent own property: inherited-setter / CreateDataProperty semantics — handled by fallback.
+                    _cachedReadObject = null;
+                    _cachedReadDescriptor = null;
+                    descriptor = null;
+                }
+                else
+                {
+                    _cachedReadObject = baseObject;
+                    _cachedReadVersion = baseObject._propertiesVersion;
+                    _cachedReadDescriptor = ownDescriptor;
+                    descriptor = ownDescriptor;
+                }
+            }
+
+            // Re-read the flags live every store: Object.defineProperty flips Writable in place on the same
+            // descriptor without bumping the version, so the writability decision must never be cached. The mask
+            // must equal exactly Writable — i.e. writable, not an accessor (NonData), not custom-valued.
+            if (descriptor is not null
+                && (descriptor._flags & (PropertyFlag.NonData | PropertyFlag.CustomJsValue | PropertyFlag.Writable)) == PropertyFlag.Writable)
+            {
+                descriptor._value = rval;
+                result = rval;
+                return true;
+            }
+        }
+
+        // Fallback: complete via the normal pipeline from the already-resolved base + key (no re-evaluation).
+        var reference = engine._referencePool.Rent(baseValue, determinedProperty, StrictModeScope.IsStrictModeCode, thisValue: null);
+        engine.PutValue(reference, rval);
+        engine._referencePool.Return(reference);
+        result = rval;
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary

Reads of `obj.prop` already use a version-gated own-property **inline cache** in `JintMemberExpression.GetValue` that skips the dictionary lookup on repeat reads. Writes had no equivalent: every `obj.prop = value` rented a `Reference`, called `PutValue`, re-hashed the property key, and did a dictionary lookup before the in-place store.

This PR adds the write-side counterpart, `TryAssignFast`, hooked into `SimpleAssignmentExpression.SetValue`. It **reuses the same cache slots** (`_cachedReadObject` / `_cachedReadVersion` / `_cachedReadDescriptor`), so a `summary.res = summary.res + 1` site shares one cache between its read and its write. When the receiver is a `PlainObject` whose shape is unchanged and the own property is a *live* writable, non-accessor, non-custom data descriptor, the new value is written straight into the descriptor — no `Reference` rent, no key hash, no dictionary lookup — exactly the in-place store `ObjectInstance.Set` already performs (which by design does not bump `_propertiesVersion`).

## How it stays correct

- **The writability/data/custom flags are re-read live on every store** via `(_flags & (NonData | CustomJsValue | Writable)) == Writable`, never cached as a decision. This is required because `Object.defineProperty(obj, p, { writable: false })` flips the flag *in place* on the same descriptor object without bumping the version — only the live flag read catches it. Data↔accessor and get/set changes allocate a new descriptor via `SetOwnProperty`, which *does* bump the version → cache miss.
- The fast path **declines only at the eligibility gate, before evaluating anything** (gate: determined string-named property, non-optional, non-short-circuiting, no custom resolver, not `super`, and `Suspendable is null`). Once base and RHS are evaluated — each exactly once, in spec order — it always completes the assignment: either the in-place store, or a fallback through `PutValue` rented from the already-resolved base + key. So a side-effecting base or RHS is never evaluated twice, and absent / accessor / read-only / custom-value / non-`PlainObject` cases keep prototype-setter dispatch, `CreateDataProperty`, and the strict read-only `TypeError`.
- Scoped to `SimpleAssignmentExpression` only; compound (`+=`) / update (`++`) / discard paths are untouched.

## Benchmarks

BenchmarkDotNet `DefaultJob`, `net10.0`, AMD Ryzen 9 5950X, .NET 10.0.9. Baseline vs. this branch measured back-to-back in the same session (only the two interpreter files reverted for the baseline). `Literal3`/`Literal8` build via object literals — they don't touch the assignment path and serve as drift controls (here flat: +2.1% / −1.4%, opposite signs = noise, not drift).

| Method | Baseline | This PR | Δ time | Allocated |
| --- | ---: | ---: | ---: | ---: |
| `ObjectAccess.UpdateObjectProperty` (read+write loop) | 103.28 ms | 89.34 ms | **−13.5 %** | 60.43 MB (unchanged) |
| `ObjectAccess.WriteObjectProperty` (pure write, new) | 82.78 ms | 68.56 ms | **−17.2 %** | 30.22 MB (unchanged) |
| `PropertyAlloc.Constructor1` (`this.value = v`) | 89.75 ms | 79.40 ms | **−11.5 %** | 83.63 MB (unchanged) |
| `PropertyAlloc.Constructor3` (`this.a=a;this.b=b;this.c=c`) | 133.73 ms | 128.82 ms | −3.7 % | 134.88 MB (unchanged) |
| `PropertyAlloc.Literal3` *(control)* | 50.10 ms | 51.15 ms | +2.1 % | 95.21 MB (unchanged) |
| `PropertyAlloc.Literal8` *(control)* | 64.54 ms | 63.61 ms | −1.4 % | 159.92 MB (unchanged) |

- `UpdateObjectProperty` / `WriteObjectProperty`: steady-state writes lose the per-store `Reference` rent + `ToObject` + key hash + dictionary lookup. `WriteObjectProperty` (added here) is a *pure* write loop — its LHS node is never read — proving the write-miss population path warms the cache without any read.
- `Constructor1`/`Constructor3` (new-property writes, where the fast path falls back): no regression, and in fact faster, because `TryAssignFast`'s base resolution is leaner than the previous `Evaluate` → `Reference` → `PutValue` path even with the one extra `GetOwnProperty` miss-probe.
- Allocations are unchanged everywhere (the in-place store and the fallback are both allocation-free; the reported MB is the script's own `JsNumber` boxing).

## Testing

- `Jint.Tests` and `Jint.Tests.PublicInterface`: all green.
- `Jint.Tests.Test262`: baseline-equal (the only failures are 4 pre-existing `annexB/.../RegExp-*-escape-BMP` cases that hit the 30 s timeout — identical with and without this change).
- Targeted checks confirm: in-place updates, new-property creation, accessor setters still run, sloppy read-only no-op, strict read-only `TypeError`, `Object.defineProperty` flipping `writable` true→false in place is honored, inherited prototype setters, frozen objects, and array element / `length` writes (non-`PlainObject` fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
