### PR TITLE
Shape hot constructors' instances (−22..36% Constructor allocation)

### DIFF
--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -17,6 +17,18 @@ public sealed class ScriptFunction : Function, IConstructor
     internal List<PrivateElement>? _privateMethods;
     internal List<ClassFieldDefinition>? _fields;
 
+    // Allocation-site feedback for shaping `new T()` instances. A constructor's first
+    // CtorShapePromoteThreshold instances build dictionaries (so a constructor called once or twice — the
+    // overwhelming norm, e.g. across the Test262 suite — never grows the shared per-prototype transition
+    // tree); once it proves "hot" it is promoted to shape mode so repeated `new T()` with a stable layout
+    // reuse one interned hidden class. _ctorEmptyShape caches the prototype's empty root to avoid a
+    // per-construct lookup (revalidated when .prototype is reassigned).
+    private const int CtorShapePromoteThreshold = 16;
+    private bool _ctorShaped;
+    private int _ctorSampleCount;
+    private Shape? _ctorEmptyShape;
+    private ObjectInstance? _ctorEmptyShapeProto;
+
     /// <summary>
     /// http://www.ecma-international.org/ecma-262/5.1/#sec-13.2
     /// </summary>
@@ -201,6 +213,26 @@ public sealed class ScriptFunction : Function, IConstructor
                     newTarget,
                     static intrinsics => intrinsics.Object.PrototypeObject,
                     static (Engine engine, Realm _, object? _) => new JsObject(engine));
+            }
+
+            // Once the constructor is hot, start each fresh `this` in shape-building mode so this.x= /
+            // class fields transition a shared interned hidden class instead of building a dictionary.
+            // Cold constructors (below the promote threshold) stay on the dictionary path.
+            if (thisArgument is JsObject thisObject && thisObject.Prototype is { } proto)
+            {
+                if (_ctorShaped)
+                {
+                    if (!ReferenceEquals(_ctorEmptyShapeProto, proto))
+                    {
+                        _ctorEmptyShape = _engine.GetEmptyShape(proto);
+                        _ctorEmptyShapeProto = proto;
+                    }
+                    thisObject.StartShapeBuilding(_ctorEmptyShape!);
+                }
+                else if (++_ctorSampleCount >= CtorShapePromoteThreshold)
+                {
+                    _ctorShaped = true;
+                }
             }
         }
 

--- a/Jint/Native/JsObject.cs
+++ b/Jint/Native/JsObject.cs
@@ -78,6 +78,52 @@ public sealed class JsObject : ObjectInstance
     internal void ClearShape()
     {
         _store = null;
-        _type &= ~InternalTypes.ShapeMode;
+        _type &= ~(InternalTypes.ShapeMode | InternalTypes.ShapeBuilding);
+    }
+
+    // store[0] is the shape; values start at [1], so a fresh builder has room for 3 properties before regrow.
+    private const int InitialBuildCapacity = 4;
+
+    /// <summary>
+    /// Starts incremental shape mode for a still-empty object (a constructor's <c>this</c>): installs the
+    /// prototype's empty root shape and a small growable store, so subsequent <c>this.x=</c> adds transition
+    /// the shape (interned, shared across <c>new T()</c> instances) instead of building a dictionary.
+    /// </summary>
+    internal void StartShapeBuilding(Shape emptyRoot)
+    {
+        var store = new object[InitialBuildCapacity];
+        store[0] = emptyRoot;
+        _store = store;
+        _type |= InternalTypes.ShapeMode | InternalTypes.ShapeBuilding;
+        unchecked { _propertiesVersion++; }
+    }
+
+    /// <summary>
+    /// Adds a brand-new configurable+enumerable+writable data property to a shape-mode object by
+    /// transitioning to the interned child shape and growing the store. Returns <c>false</c> — leaving the
+    /// object untouched — when a megamorphic guard trips (too many own properties, or this shape already
+    /// has too many distinct child transitions), so the caller deopts to the dictionary representation. The
+    /// key must be known-absent (callers check).
+    /// </summary>
+    internal bool TryShapeAdd(in Key key, JsValue value)
+    {
+        var store = _store!;
+        var shape = Unsafe.As<Shape>(store[0]);
+        if (shape.SlotCount >= Shape.MaxShapeProperties || shape.TransitionCount >= Shape.MaxFanout)
+        {
+            return false;
+        }
+
+        var valueIndex = shape.SlotCount + 1; // store[0] is the shape; the new value goes at SlotCount + 1
+        if (store.Length <= valueIndex)
+        {
+            System.Array.Resize(ref store, store.Length * 2);
+            _store = store;
+        }
+
+        store[valueIndex] = value;
+        store[0] = shape.Add(key);
+        unchecked { _propertiesVersion++; }
+        return true;
     }
 }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1627,10 +1627,15 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                     return true;
                 }
 
-                // Brand-new property added to an already-shaped object (e.g. an Object.assign / spread
-                // target, or assigning a new key to a literal). Object literals build their shape up front
-                // via JsObject.SetStore, so shape mode is never grown incrementally one property at a time;
-                // such adds fall back to the dictionary representation.
+                // Brand-new property: a hot constructor's `this` (ShapeBuilding) grows its shape via an
+                // interned transition shared across instances. Plain shaped objects (literals) lack the flag
+                // and fall through to deopt, since a one-off literal gaining a key is not a reused layout.
+                // The megamorphic guard inside TryShapeAdd also deopts object-as-hashmap usage.
+                if ((_type & InternalTypes.ShapeBuilding) != InternalTypes.Empty && jo.TryShapeAdd(key, v))
+                {
+                    return true;
+                }
+
                 ConvertToDictionaryMode();
                 SetOwnProperty(p, new PropertyDescriptor(v, PropertyFlag.ConfigurableEnumerableWritable));
                 return true;

--- a/Jint/Native/Object/Shape.cs
+++ b/Jint/Native/Object/Shape.cs
@@ -30,6 +30,13 @@ internal sealed class Shape
     // At or above it, a lazily-built key->slot index is used instead.
     private const int LinearScanLimit = 16;
 
+    // Megamorphic guards for incremental shape growth (constructor this.x= via TryShapeAdd). An object
+    // that grows past MaxShapeProperties, or a shape that sprouts more than MaxFanout distinct child
+    // transitions (the object-used-as-a-hashmap pattern), deopts to the dictionary representation so the
+    // shared per-prototype transition tree cannot grow without bound. Ordinary constructors never hit these.
+    internal const int MaxShapeProperties = 64;
+    internal const int MaxFanout = 64;
+
     /// <summary>Parent shape (one fewer property), or null for the empty root shape.</summary>
     internal readonly Shape? Parent;
 
@@ -38,6 +45,9 @@ internal sealed class Shape
 
     /// <summary>Number of own string properties (= slot count). The added property lives at slot <c>SlotCount - 1</c>.</summary>
     internal readonly int SlotCount;
+
+    /// <summary>Number of distinct add-property transitions out of this shape (fan-out).</summary>
+    internal int TransitionCount => _transitions?.Count ?? 0;
 
     // Add-property transitions: key -> child shape. Lazily allocated; this is what interns layouts.
     private Dictionary<Key, Shape>? _transitions;

--- a/Jint/Runtime/InternalTypes.cs
+++ b/Jint/Runtime/InternalTypes.cs
@@ -38,7 +38,11 @@ internal enum InternalTypes
     // dictionary mode. Lets the hot property paths discriminate shape vs dictionary storage with a single
     // flag test on the already-loaded _type instead of a `this is JsObject` type-check plus a field read.
     ShapeMode = 65536,
+    // a shape-mode JsObject that is still being built up incrementally (a hot constructor's `this`), so a
+    // brand-new property grows the shape via a transition. Plain shaped objects (object literals) lack this
+    // flag and deopt to a dictionary when they gain a key, since they aren't a reused allocation site.
+    ShapeBuilding = 131072,
 
     Primitive = Boolean | String | Number | Integer | BigInt | Symbol,
-    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode
+    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding
 }


### PR DESCRIPTION
## Summary

Extend the merged object-literal hidden classes (#2552) to **constructor instances** — `new T(){ this.a; this.b; this.c }`, the TreeNode / dromaeo-object-* pattern and the dominant object-creation shape in real JS. A hot constructor's `this` builds a shared hidden class instead of a per-object dictionary.

## Avoiding the diverse-object pitfall (allocation-site feedback)

Naively shaping every `this.x=` regresses *diverse one-off* objects (each unique layout spawns a `Shape` + transition with no reuse). This PR gates shaping on a constructor proving **hot**:

- A constructor's first **`CtorShapePromoteThreshold` (16)** instances build dictionaries, so a constructor called once or twice — the overwhelming norm — never grows the shared per-prototype transition tree.
- Once hot, it is promoted: `ScriptFunction.Construct` starts each fresh `this` in shape-building mode (`InternalTypes.ShapeBuilding`), so `this.x=` / class fields transition an **interned** hidden class shared across instances.
- A megamorphic guard (`Shape.MaxShapeProperties` / `MaxFanout`) deopts object-as-hashmap growth.
- Object **literals** keep their merged behavior (deopt on a brand-new key — a one-off literal isn't a reused allocation site); `Object.assign` / spread / `JSON.parse` targets stay on the dictionary (they never enter shape mode).

## Benchmarks (BenchmarkDotNet default job, vs merged main; allocation is deterministic)

### PropertyAllocBenchmark / ObjectAccessBenchmark

| Benchmark | Allocation | Gen0/1k | Time |
|---|---|---|---|
| **Constructor3** (`this.a=;this.b=;this.c=`) | 136.4 → **87.6 MB (−35.8%)** | 8500 → 5250 | 145.2 → 139.8 ms (−3.7%) |
| **Constructor1** (`this.value=`) | 85.2 → **66.8 MB (−21.5%)** | 5200 → 4167 | parity |
| Literal3 / Literal8 | unchanged (already shaped) | — | parity |
| UpdateObjectProperty / WriteObjectProperty | unchanged | — | parity |

### EngineComparison (`Jint_ParsedScript`, 19 scripts)

Allocation **flat to slightly better** — `dromaeo-3d-cube` −1.3% (its hot constructors now shape), everything else within ±1%. No regression.

## Conformance & tests

- **Test262: matches merged main run-for-run.** (A few slow annexB `RegExp-*-escape-BMP` eval-loop tests intermittently time out under heavy concurrent load on a busy machine — **identically with and without this change**, confirmed via a clean-main control run; on a fresh machine both are 0-fail.)
- `Jint.Tests`: **3138 (net10.0) / 3076 (net472)**, 0 failures.
- `Jint.Tests.PublicInterface`: **79/79** — no public API change (all additions internal).

## Design

- `ScriptFunction`: per-constructor feedback (`_ctorShaped`, `_ctorSampleCount`, threshold 16) + a cached prototype empty-shape root (avoids a per-construct lookup).
- `JsObject.StartShapeBuilding` (installs the empty root + a growable store, sets `ShapeMode | ShapeBuilding`); `JsObject.TryShapeAdd` (transition to the interned child + grow store + megamorphic caps).
- `ObjectInstance.CreateDataProperty`: a new key on a `ShapeBuilding` object transitions the shape; a plain shaped object (literal) deopts.
- `Shape.MaxShapeProperties` / `MaxFanout` / `TransitionCount` re-added for the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDS23QeSSNRkaUB2KL74U9
