### PR TITLE
Built-in shapes default-on via base class (opt-out); shape Temporal.Now

### DIFF
--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -58,4 +58,15 @@ public class BuiltinShapeBenchmark
         engine.Evaluate(_initBuiltins);
         return engine;
     }
+
+    // Forces Temporal.Now (9 functions) to initialize — newly shape-backed here, dictionary on main.
+    private static readonly Prepared<Script> _initTemporalNow = Engine.PrepareScript("Temporal.Now.instant();");
+
+    [Benchmark]
+    public Engine EngineInitTemporalNow()
+    {
+        var engine = new Engine();
+        engine.Evaluate(_initTemporalNow);
+        return engine;
+    }
 }

--- a/Jint.SourceGenerators/Attributes.cs
+++ b/Jint.SourceGenerators/Attributes.cs
@@ -22,13 +22,15 @@ internal static class Attributes
             public int ExtraCapacity { get; set; }
 
             /// <summary>
-            /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-            /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-            /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-            /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-            /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+            /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+            /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+            /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+            /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+            /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+            /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+            /// BuiltinShapeObject.
             /// </summary>
-            public bool UseShape { get; set; }
+            public bool UseShape { get; set; } = true;
         }
 
         [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.SourceGenerators/Diagnostics.cs
+++ b/Jint.SourceGenerators/Diagnostics.cs
@@ -107,4 +107,12 @@ internal static class DiagnosticDescriptors
         category: "Jint.SourceGenerators",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UnsupportedShapeMember = new(
+        id: "JINT022",
+        title: "Built-in shape host has an unsupported member kind",
+        messageFormat: "Type '{0}' uses built-in shape storage (derives from BuiltinShapeObject) but declares an accessor / intrinsic reference / thrower / non-static or mutable property, which the shape path does not support; add [JsObject(UseShape = false)] or remove the member",
+        category: "Jint.SourceGenerators",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/Jint.SourceGenerators/Models.cs
+++ b/Jint.SourceGenerators/Models.cs
@@ -98,18 +98,31 @@ internal sealed record class ObjectDefinition(
             ? string.Empty
             : typeSymbol.ContainingNamespace.ToDisplayString();
 
-        // Read [JsObject(ExtraCapacity = N, UseShape = true)].
+        // Read [JsObject(ExtraCapacity = N, UseShape = ...)]. Shape storage is the default for any host
+        // that derives from BuiltinShapeObject (deriving from it is the opt-in); UseShape = false is the
+        // explicit opt-out. Hosts that don't derive from it always use the dictionary path regardless.
         var extraCapacity = 0;
-        var useShape = false;
+        var useShapeRequested = true;
         foreach (var attr in typeSymbol.GetAttributes())
         {
             if (attr.AttributeClass?.Name != "JsObjectAttribute") continue;
             foreach (var named in attr.NamedArguments)
             {
                 if (named.Key == "ExtraCapacity" && named.Value.Value is int v) extraCapacity = v;
-                else if (named.Key == "UseShape" && named.Value.Value is bool s) useShape = s;
+                else if (named.Key == "UseShape" && named.Value.Value is bool s) useShapeRequested = s;
             }
         }
+
+        var derivesFromBuiltinShapeObject = false;
+        for (var baseType = typeSymbol.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (baseType.Name == "BuiltinShapeObject")
+            {
+                derivesFromBuiltinShapeObject = true;
+                break;
+            }
+        }
+        var useShape = useShapeRequested && derivesFromBuiltinShapeObject;
 
         var functions = new List<FunctionDefinition>();
         var properties = new List<PropertyDefinition>();
@@ -327,6 +340,31 @@ internal sealed record class ObjectDefinition(
                 DiagnosticDescriptors.MissingRealmField,
                 location,
                 typeSymbol.Name));
+        }
+
+        // The shape path supports [JsFunction]s, static-immutable [JsProperty] constants, and symbols
+        // (incl. symbol-keyed functions). Accessors, intrinsic references, throwers and instance/mutable
+        // properties aren't representable — fail loudly rather than silently dropping them.
+        if (useShape)
+        {
+            var hasUnsupported = intrinsicReferences.Count > 0 || throwerAccessors.Count > 0;
+            foreach (var fn in functions)
+            {
+                if (fn.Registration is RegistrationKind.AccessorGet or RegistrationKind.AccessorSet
+                    or RegistrationKind.SymbolAccessorGet or RegistrationKind.SymbolAccessorSet)
+                {
+                    hasUnsupported = true;
+                    break;
+                }
+            }
+            foreach (var p in properties)
+            {
+                if (!p.IsStatic || !p.IsImmutable) { hasUnsupported = true; break; }
+            }
+            if (hasUnsupported)
+            {
+                diagnostics.Add(new DiagnosticInfo(DiagnosticDescriptors.UnsupportedShapeMember, location, typeSymbol.Name));
+            }
         }
 
         functions.Sort(static (a, b) => string.CompareOrdinal(a.JsName, b.JsName));

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpan#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpan#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpanTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpanTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateIntrinsicReference_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateIntrinsicReference_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReference#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReference#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReferenceWithoutRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReferenceWithoutRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -18,13 +18,15 @@ internal sealed class JsObjectAttribute : global::System.Attribute
     public int ExtraCapacity { get; set; }
 
     /// <summary>
-    /// Store this built-in's string-keyed own properties as a shared immutable BuiltinShape plus a
-    /// per-realm lazily-filled descriptor array instead of a per-realm property dictionary. The host
-    /// must derive from <c>BuiltinShapeObject</c>. Supported for hosts whose members are
-    /// [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s (namespace built-ins
-    /// such as Math/JSON/Reflect/Atomics). See BuiltinShapeObject.
+    /// Built-in shape storage (a shared immutable BuiltinShape plus a per-realm lazily-filled
+    /// descriptor array instead of a per-realm property dictionary) is used <b>by default</b> for any
+    /// host that derives from <c>BuiltinShapeObject</c> — deriving from it is the opt-in. Set this to
+    /// <c>false</c> to opt a derived host back out to the dictionary path. Hosts that do not derive
+    /// from <c>BuiltinShapeObject</c> always use the dictionary path regardless of this flag.
+    /// Supported members: [JsFunction]s, static-immutable [JsProperty] constants, and symbols. See
+    /// BuiltinShapeObject.
     /// </summary>
-    public bool UseShape { get; set; }
+    public bool UseShape { get; set; } = true;
 }
 
 [global::System.AttributeUsage(global::System.AttributeTargets.Method)]

--- a/Jint/Native/Atomics/AtomicsInstance.cs
+++ b/Jint/Native/Atomics/AtomicsInstance.cs
@@ -16,7 +16,7 @@ namespace Jint.Native.Atomics;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-atomics-object
 /// </summary>
-[JsObject(UseShape = true)]
+[JsObject]
 internal sealed partial class AtomicsInstance : BuiltinShapeObject
 {
     private readonly Realm _realm;

--- a/Jint/Native/Json/JsonInstance.cs
+++ b/Jint/Native/Json/JsonInstance.cs
@@ -4,7 +4,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Json;
 
-[JsObject(UseShape = true)]
+[JsObject]
 internal sealed partial class JsonInstance : BuiltinShapeObject
 {
     private readonly Realm _realm;

--- a/Jint/Native/Math/MathInstance.cs
+++ b/Jint/Native/Math/MathInstance.cs
@@ -6,7 +6,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Math;
 
-[JsObject(UseShape = true)]
+[JsObject]
 internal sealed partial class MathInstance : BuiltinShapeObject
 {
     private readonly Realm _realm;
@@ -31,7 +31,7 @@ internal sealed partial class MathInstance : BuiltinShapeObject
 
     protected override void Initialize()
     {
-        // CreateProperties_Generated installs the built-in shape (UseShape = true). See BuiltinShapeObject.
+        // CreateProperties_Generated installs the built-in shape (this derives from BuiltinShapeObject).
         CreateProperties_Generated();
         CreateSymbols_Generated();
     }

--- a/Jint/Native/Reflect/ReflectInstance.cs
+++ b/Jint/Native/Reflect/ReflectInstance.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Reflect;
 /// <summary>
 /// https://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect-object
 /// </summary>
-[JsObject(UseShape = true)]
+[JsObject]
 internal sealed partial class ReflectInstance : BuiltinShapeObject
 {
     private readonly Realm _realm;

--- a/Jint/Native/Temporal/Now/TemporalNow.cs
+++ b/Jint/Native/Temporal/Now/TemporalNow.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Temporal;
 /// https://tc39.es/proposal-temporal/#sec-temporal-now-object
 /// </summary>
 [JsObject]
-internal sealed partial class TemporalNow : ObjectInstance
+internal sealed partial class TemporalNow : BuiltinShapeObject
 {
     private readonly Realm _realm;
 


### PR DESCRIPTION
## Summary

Make built-in shape storage the **default** for any `[JsObject]` host that derives from `BuiltinShapeObject` — deriving from the base is now the opt-in, so a built-in adopts shapes with a **one-line base change** and no attribute flag. `UseShape = false` is the explicit opt-out; hosts that don't derive from `BuiltinShapeObject` keep the dictionary path regardless.

This was suggested on #2555: rather than an explicit `[JsObject(UseShape = true)]`, shapes are on by default and you opt *out*.

## What changed

- **Auto-detect**: the generator walks the base-type chain; a host deriving from `BuiltinShapeObject` uses the shape path by default. The `UseShape` attribute property now defaults to `true` and only means "opt this derived host back out" when set `false`.
- **New diagnostic `JINT022`**: a `BuiltinShapeObject`-derived host that declares an unsupported member (accessor / intrinsic reference / thrower / instance-or-mutable property) **fails the build** instead of silently dropping it.
- **Math, JSON, Reflect, Atomics** drop the now-redundant `UseShape = true` (auto-detected from the base).
- **`Temporal.Now`** (9 functions + `Symbol.toStringTag`, no properties) adopts shapes by simply deriving from `BuiltinShapeObject` — demonstrating the one-line adoption and adding a win.

## Benchmarks (`BuiltinShapeBenchmark`, default job, vs main)

`EngineOnly` control is **identical** (13.69 KB) on both.

| Benchmark | Allocation | Time |
|---|---|---|
| `EngineInitMath` / `EngineInitBuiltins` | 15.51 / 20.20 KB == 15.51 / 20.20 KB (**byte-identical** — the default change is neutral for the existing four) | neutral |
| `EngineInitTemporalNow` | 20.43 → **19.45 KB (−4.8%)** | 2.86 → 2.70 µs (−5.6%) |

## Conformance & tests

- Targeted Test262: **Math 662, JSON 502, Reflect 306, Atomics 779, Temporal.Now 138** — all 0 failures.
- **Full Test262: 0 new failures** (the `annexB/RegExp-*-escape-BMP` slow-eval timeout tests and the `Atomics.waitAsync` no-spurious-wakeup test are pre-existing timing flakes under concurrent load — they flake identically on `main` and pass in isolation).
- `Jint.Tests` 3138/3076; `Jint.Tests.PublicInterface` 79/79; `Jint.Tests.SourceGenerators` 30/30 (snapshots updated for the attribute default value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDS23QeSSNRkaUB2KL74U9
