### PR TITLE
Built-in shapes: support per-realm instance properties; shape the Generator prototypes

### DIFF
--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -69,4 +69,17 @@ public class BuiltinShapeBenchmark
         engine.Evaluate(_initTemporalNow);
         return engine;
     }
+
+    // Forces the Generator + AsyncGenerator prototypes (3 functions + a constructor instance property each)
+    // to initialize — newly shape-backed here (via instance-property support), dictionary on main.
+    private static readonly Prepared<Script> _initGenerators = Engine.PrepareScript(
+        "(function*(){})().next; (async function*(){})().next;");
+
+    [Benchmark]
+    public Engine EngineInitGenerators()
+    {
+        var engine = new Engine();
+        engine.Evaluate(_initGenerators);
+        return engine;
+    }
 }

--- a/Jint.SourceGenerators/Diagnostics.cs
+++ b/Jint.SourceGenerators/Diagnostics.cs
@@ -111,7 +111,7 @@ internal static class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor UnsupportedShapeMember = new(
         id: "JINT022",
         title: "Built-in shape host has an unsupported member kind",
-        messageFormat: "Type '{0}' uses built-in shape storage (derives from BuiltinShapeObject) but declares an accessor / intrinsic reference / thrower / non-static or mutable property, which the shape path does not support; add [JsObject(UseShape = false)] or remove the member",
+        messageFormat: "Type '{0}' uses built-in shape storage (derives from BuiltinShapeObject) but declares an accessor / intrinsic reference / thrower, which the shape path does not support yet; add [JsObject(UseShape = false)] or remove the member",
         category: "Jint.SourceGenerators",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/Jint.SourceGenerators/Emitter.cs
+++ b/Jint.SourceGenerators/Emitter.cs
@@ -183,6 +183,16 @@ internal static class Emitter
             // Shape mode: install the shared layout + a per-realm lazily-filled descriptor array
             // (BuiltinShapeObject) instead of building a property dictionary.
             sb.AppendLine("        InitializeBuiltinShape();");
+            // Fill per-realm instance-property slots (value varies per realm; slot index = position in
+            // the sorted property list, since properties precede functions in the shape layout).
+            for (var i = 0; i < obj.Properties.Count; i++)
+            {
+                var prop = obj.Properties[i];
+                if (prop.IsStatic && prop.IsImmutable) continue;
+                sb.Append("        SetBuiltinInstanceDescriptor(").Append(i).Append(", ");
+                if (prop.IsStatic) sb.Append(obj.Name).Append('.');
+                sb.Append(prop.ClrName).Append(", ").Append(prop.FlagsExpression).AppendLine(");");
+            }
             sb.AppendLine("    }");
             EmitShapeMembers(sb, obj, dataProperties);
             return;
@@ -322,12 +332,6 @@ internal static class Emitter
     /// </summary>
     private static void EmitShapeMembers(StringBuilder sb, ObjectDefinition obj, List<FunctionDefinition> dataProperties)
     {
-        var constants = new List<PropertyDefinition>();
-        foreach (var prop in obj.Properties)
-        {
-            if (prop.IsStatic && prop.IsImmutable) constants.Add(prop);
-        }
-
         var dispatcher = "__" + obj.Name + "Function";
         var singleSlot = obj.Functions.Count == 1;
 
@@ -336,10 +340,19 @@ internal static class Emitter
         sb.AppendLine();
         sb.AppendLine("    private static global::Jint.Native.Object.BuiltinShape BuildBuiltinShape_Generated()");
         sb.AppendLine("    {");
-        sb.Append("        var builder = new global::Jint.Native.Object.BuiltinShape.Builder(").Append(constants.Count + dataProperties.Count).AppendLine(");");
-        foreach (var prop in constants)
+        sb.Append("        var builder = new global::Jint.Native.Object.BuiltinShape.Builder(").Append(obj.Properties.Count + dataProperties.Count).AppendLine(");");
+        // Properties first (matching the dictionary path's order): static-immutable constants share a
+        // process-wide descriptor; everything else is a per-realm instance slot filled in Initialize.
+        foreach (var prop in obj.Properties)
         {
-            sb.Append("        builder.Constant(__Key_").Append(SanitizeIdentifier(prop.JsName)).Append(", __").Append(obj.Name).Append("_Property_").Append(prop.ClrName).AppendLine(");");
+            if (prop.IsStatic && prop.IsImmutable)
+            {
+                sb.Append("        builder.Constant(__Key_").Append(SanitizeIdentifier(prop.JsName)).Append(", __").Append(obj.Name).Append("_Property_").Append(prop.ClrName).AppendLine(");");
+            }
+            else
+            {
+                sb.Append("        builder.Instance(__Key_").Append(SanitizeIdentifier(prop.JsName)).AppendLine(");");
+            }
         }
         foreach (var fn in dataProperties)
         {

--- a/Jint.SourceGenerators/Models.cs
+++ b/Jint.SourceGenerators/Models.cs
@@ -342,9 +342,9 @@ internal sealed record class ObjectDefinition(
                 typeSymbol.Name));
         }
 
-        // The shape path supports [JsFunction]s, static-immutable [JsProperty] constants, and symbols
-        // (incl. symbol-keyed functions). Accessors, intrinsic references, throwers and instance/mutable
-        // properties aren't representable — fail loudly rather than silently dropping them.
+        // The shape path supports [JsFunction]s, [JsProperty] constants & per-realm instance properties,
+        // and symbols (incl. symbol-keyed functions). Accessors, intrinsic references and throwers aren't
+        // representable yet — fail loudly rather than silently dropping them.
         if (useShape)
         {
             var hasUnsupported = intrinsicReferences.Count > 0 || throwerAccessors.Count > 0;
@@ -356,10 +356,6 @@ internal sealed record class ObjectDefinition(
                     hasUnsupported = true;
                     break;
                 }
-            }
-            foreach (var p in properties)
-            {
-                if (!p.IsStatic || !p.IsImmutable) { hasUnsupported = true; break; }
             }
             if (hasUnsupported)
             {

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorPrototype.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorPrototype.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.AsyncGenerator;
 /// https://tc39.es/ecma262/#sec-asyncgenerator-prototype-object
 /// </summary>
 [JsObject]
-internal sealed partial class AsyncGeneratorPrototype : ObjectInstance
+internal sealed partial class AsyncGeneratorPrototype : BuiltinShapeObject
 {
     private readonly Realm _realm;
 

--- a/Jint/Native/Generator/GeneratorPrototype.cs
+++ b/Jint/Native/Generator/GeneratorPrototype.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.Generator;
 /// https://tc39.es/ecma262/#sec-generator-objects
 /// </summary>
 [JsObject]
-internal sealed partial class GeneratorPrototype : ObjectInstance
+internal sealed partial class GeneratorPrototype : BuiltinShapeObject
 {
     private readonly Realm _realm;
 

--- a/Jint/Native/Object/BuiltinShape.cs
+++ b/Jint/Native/Object/BuiltinShape.cs
@@ -79,6 +79,21 @@ internal sealed class BuiltinShape
             _next++;
         }
 
+        /// <summary>
+        /// Reserves a slot for a per-realm instance property (a data property whose value varies per
+        /// realm, e.g. a prototype's <c>constructor</c> reference). The descriptor is filled at
+        /// initialization by the owner via <see cref="BuiltinShapeObject.SetBuiltinInstanceDescriptor"/>,
+        /// not lazily materialized — so its template slot stays null and it is never treated as a function.
+        /// </summary>
+        internal void Instance(in Key name)
+        {
+            _names[_next] = name;
+            _constTemplate[_next] = null;
+            _functionSlots[_next] = NotAFunction;
+            _index[name] = _next;
+            _next++;
+        }
+
         internal BuiltinShape Build() => new(_names, _constTemplate, _functionSlots, _functionFlags, _index);
     }
 }

--- a/Jint/Native/Object/BuiltinShapeObject.cs
+++ b/Jint/Native/Object/BuiltinShapeObject.cs
@@ -14,6 +14,13 @@ namespace Jint.Native.Object;
 /// dictionary path does (so test262's verifyProperty needs no deopt); adding or deleting an own property
 /// deopts to the ordinary dictionary, after which every path falls back to the unchanged base behavior.
 /// </para>
+/// <para>
+/// A shaped host's own string properties are exactly those in its <see cref="BuiltinShape"/>. It must
+/// therefore declare every own property through the generator surface — it must <b>not</b> add properties
+/// via the raw <c>SetProperty</c> primitive in <c>Initialize</c> (those land in <c>_properties</c>, which
+/// the shape lookup does not consult). A built-in that needs to (e.g. Intl, which registers constructor
+/// references from the realm intrinsics) is not shape-eligible and should not derive from this type.
+/// </para>
 /// </summary>
 internal abstract class BuiltinShapeObject : ObjectInstance
 {
@@ -35,6 +42,16 @@ internal abstract class BuiltinShapeObject : ObjectInstance
     private protected void InitializeBuiltinShape()
     {
         _builtinDescriptors = (PropertyDescriptor?[]) BuiltinShape.ConstTemplate.Clone();
+    }
+
+    /// <summary>
+    /// Fills a per-realm instance-property slot (reserved via <see cref="BuiltinShape.Builder.Instance"/>)
+    /// with its value for this realm. Call from the built-in's <c>Initialize</c>, after
+    /// <see cref="InitializeBuiltinShape"/>.
+    /// </summary>
+    private protected void SetBuiltinInstanceDescriptor(int slot, JsValue value, PropertyFlag flags)
+    {
+        _builtinDescriptors![slot] = new PropertyDescriptor(value, flags);
     }
 
     private PropertyDescriptor MaterializeSlot(int slot)


### PR DESCRIPTION
## Summary

Extend the built-in shape path to represent **per-realm instance properties** — a data property whose value varies per realm, e.g. a prototype's `constructor` reference — in addition to functions, static-immutable constants, and symbols. This is the most common single member kind that previously blocked shaping a built-in, and it's the foundation for shaping the larger prototype set.

## What changed

- `BuiltinShape.Builder.Instance` reserves a slot for a per-realm instance property; `BuiltinShapeObject.SetBuiltinInstanceDescriptor` fills it at initialization (never lazily materialized as a function).
- The generator emits an instance slot per non-static-immutable `[JsProperty]` plus a `SetBuiltinInstanceDescriptor` call in `CreateProperties_Generated` (slot index = the property's position in the layout). The `JINT022` diagnostic no longer rejects instance properties — only accessors / intrinsic references / throwers remain unsupported.
- **`Generator.prototype`** and **`AsyncGenerator.prototype`** (3 functions + a `constructor` instance property each) adopt shapes by simply deriving from `BuiltinShapeObject`.

### Scope notes (documented on `BuiltinShapeObject`)

- A shaped built-in's own string properties are exactly those in its shape, so it must declare them all through the generator surface and must **not** add properties via the raw `SetProperty` primitive in `Initialize`. **Intl** (which registers constructor references from the realm intrinsics that way) stays on the dictionary path.
- Prototypes that are `InternalTypes.PlainObject` (most — they derive from the `Prototype` base) still need member-read fast-path integration before they can be shaped. That's the next, separate change, which would unlock the big ones (Date.prototype = 46 functions, etc.).

## Benchmarks (`BuiltinShapeBenchmark`, default job, vs main)

`EngineOnly` control identical (13.69 KB).

| Benchmark | Allocation |
|---|---|
| `EngineInitMath` / `EngineInitTemporalNow` | unchanged (15.51 / 19.45 KB) |
| `EngineInitGenerators` | 20.06 → **19.44 KB (−3.1%)** |

## Conformance & tests

- Intl **6586/6586** (no regression — Intl deliberately stays dictionary-backed), Math 662, Generators 510.
- **Full Test262: 0 new failures** (the `annexB/RegExp-*-escape-BMP` timeout tests are pre-existing slow-eval flakes under concurrent load).
- `Jint.Tests` 3138/3076; `Jint.Tests.PublicInterface` 79/79; `Jint.Tests.SourceGenerators` 30/30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDS23QeSSNRkaUB2KL74U9
