### PR TITLE
Prototype-method inline cache for `obj.method` resolved on the direct prototype

### DIFF
--- a/Jint.Benchmark/MethodCallBenchmark.cs
+++ b/Jint.Benchmark/MethodCallBenchmark.cs
@@ -51,10 +51,22 @@ public class MethodCallBenchmark
             s;
             """, strict: true);
 
+        _arrayPushPop = Engine.PrepareScript(
+            "var a = []; for (var i = 0; i < 1000000; i++) { a.push(i); a.pop(); } a.length;", strict: true);
+        _userProtoMethod = Engine.PrepareScript("""
+            function C() { this.v = 0; }
+            C.prototype.inc = function () { this.v = (this.v + 1) & 1023; return this.v; };
+            var c = new C(); var s = 0;
+            for (var i = 0; i < 1000000; i++) { s = (s + c.inc()) & 1023; }
+            s;
+            """, strict: true);
+
         _engine = new Engine(static options => options.Strict());
         _engine.Evaluate(_methodCallThis);
         _engine.Evaluate(_methodCallCaptured);
         _engine.Evaluate(_freeFunctionCall);
+        _engine.Evaluate(_arrayPushPop);
+        _engine.Evaluate(_userProtoMethod);
     }
 
     [Benchmark]
@@ -65,4 +77,15 @@ public class MethodCallBenchmark
 
     [Benchmark]
     public JsValue FreeFunctionCall() => _engine.Evaluate(_freeFunctionCall);
+
+    // Prototype-method calls — resolved on the receiver's prototype, the case the prototype-method inline
+    // cache targets (own-method calls above already hit the own-property cache). Prepared in Setup().
+    private Prepared<Script> _arrayPushPop;
+    private Prepared<Script> _userProtoMethod;
+
+    [Benchmark]
+    public JsValue ArrayPushPop() => _engine.Evaluate(_arrayPushPop);
+
+    [Benchmark]
+    public JsValue UserPrototypeMethod() => _engine.Evaluate(_userProtoMethod);
 }

--- a/Jint.Tests/Runtime/PrototypeMethodCacheTests.cs
+++ b/Jint.Tests/Runtime/PrototypeMethodCacheTests.cs
@@ -1,0 +1,169 @@
+using System.Reflection;
+using Jint.Native;
+using Jint.Native.Array;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Guards the prototype-method inline cache in <c>JintMemberExpression</c> (resolves <c>obj.method</c>
+/// when <c>method</c> lives on the receiver's direct prototype). The cache bypasses the receiver's
+/// <c>[[Get]]</c> on a hit, so it must stay consistent with ordinary lookup across the mutations that
+/// invalidate it.
+/// </summary>
+public class PrototypeMethodCacheTests
+{
+    /// <summary>
+    /// Tripwire: the cache short-circuits a receiver's <c>[[Get]]</c> on a hit, so it is only sound for
+    /// objects whose <c>[[Get]]</c> is <em>ordinary for string-keyed lookups that miss the own property</em>
+    /// — i.e. "no own property ⇒ walk the prototype". Every <see cref="ObjectInstance"/> subclass overriding
+    /// <c>Get(JsValue, JsValue)</c> must therefore be one of:
+    /// <list type="bullet">
+    /// <item>non-ordinary for named keys — must set <c>InternalTypes.ExoticGet</c> in its constructor so the
+    /// cache skips it as both receiver and prototype (Proxy traps, TypedArray canonical indices,
+    /// IteratorResult inline value/done, interop member resolution, module exports); or</item>
+    /// <item>non-ordinary only for keys it also reports from <c>GetOwnProperty</c> (array integer indices and
+    /// <c>length</c>) — safe <em>without</em> the flag, because the populate path defers to the full
+    /// <c>Get</c> whenever <c>GetOwnProperty</c> is non-undefined. <see cref="ArrayInstance"/> is the one
+    /// such case, and must stay unflagged so <c>arr.push</c> / <c>arr.pop</c> stay cacheable.</item>
+    /// </list>
+    /// When a new override appears this test fails, forcing the author to classify it rather than silently
+    /// regressing (or mis-caching) prototype-method reads.
+    /// </summary>
+    [Fact]
+    public void EveryGetOverrideIsClassifiedForThePrototypeMethodCache()
+    {
+        var assembly = typeof(Engine).Assembly;
+        var getParameters = new[] { typeof(JsValue), typeof(JsValue) };
+
+        var overriders = assembly.GetTypes()
+            .Where(t => typeof(ObjectInstance).IsAssignableFrom(t) && t != typeof(ObjectInstance))
+            .Where(t => t.GetMethod(
+                "Get",
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly,
+                binder: null,
+                getParameters,
+                modifiers: null) is not null)
+            .Select(t => t.FullName!)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        // Non-ordinary for named keys — each sets InternalTypes.ExoticGet in its constructor
+        // (ArrayLikeWrapper inherits it from the ObjectWrapper base constructor).
+        var exoticGet = new[]
+        {
+            "Jint.Native.Iterator.IteratorResult",
+            "Jint.Native.JsProxy",
+            "Jint.Native.JsTypedArray",
+            "Jint.Runtime.Interop.ArrayLikeWrapper",
+            "Jint.Runtime.Interop.NamespaceReference",
+            "Jint.Runtime.Interop.ObjectWrapper",
+            "Jint.Runtime.Modules.ModuleNamespace",
+        };
+
+        // Index/length-only exotic — ordinary for named keys, safe (and intentionally) unflagged.
+        var safeWithoutFlag = new[]
+        {
+            "Jint.Native.Array.ArrayInstance",
+        };
+
+        var expected = exoticGet.Concat(safeWithoutFlag).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+
+        Assert.Equal(expected, overriders);
+    }
+
+    [Fact]
+    public void ResolvesPrototypeMethodRepeatedly()
+    {
+        const string script = """
+            function C() { this.v = 0; }
+            C.prototype.inc = function () { return ++this.v; };
+            var c = new C(), last = 0;
+            for (var i = 0; i < 50; i++) { last = c.inc(); }
+            last;
+            """;
+        Assert.Equal(50, new Engine().Evaluate(script).AsNumber());
+    }
+
+    [Fact]
+    public void OwnPropertyAddedAfterCachingShadowsPrototype()
+    {
+        // First reads hit the prototype method and populate the cache; assigning an own property of the
+        // same name must shadow it on every subsequent read (the receiver version bump invalidates).
+        const string script = """
+            function C() {}
+            C.prototype.tag = function () { return 'proto'; };
+            var c = new C(), out = [];
+            for (var i = 0; i < 5; i++) {
+                if (i === 3) { c.tag = function () { return 'own'; }; }
+                out.push(c.tag());
+            }
+            out.join(',');
+            """;
+        Assert.Equal("proto,proto,proto,own,own", new Engine().Evaluate(script).AsString());
+    }
+
+    [Fact]
+    public void PrototypeMethodRedefinedAfterCachingIsReResolved()
+    {
+        const string script = """
+            function C() {}
+            C.prototype.tag = function () { return 'v1'; };
+            var c = new C(), out = [];
+            for (var i = 0; i < 4; i++) {
+                if (i === 2) { C.prototype.tag = function () { return 'v2'; }; }
+                out.push(c.tag());
+            }
+            out.join(',');
+            """;
+        Assert.Equal("v1,v1,v2,v2", new Engine().Evaluate(script).AsString());
+    }
+
+    [Fact]
+    public void PrototypeMethodDeletedAfterCachingFallsBack()
+    {
+        const string script = """
+            function C() {}
+            C.prototype.tag = function () { return 'v1'; };
+            var c = new C(), out = [];
+            for (var i = 0; i < 4; i++) {
+                if (i === 2) { delete C.prototype.tag; }
+                out.push(typeof c.tag === 'function' ? c.tag() : 'gone');
+            }
+            out.join(',');
+            """;
+        Assert.Equal("v1,v1,gone,gone", new Engine().Evaluate(script).AsString());
+    }
+
+    [Fact]
+    public void PrototypeReassignedAfterCachingIsHonoured()
+    {
+        const string script = """
+            var protoA = { tag: function () { return 'A'; } };
+            var protoB = { tag: function () { return 'B'; } };
+            var o = Object.create(protoA), out = [];
+            for (var i = 0; i < 4; i++) {
+                if (i === 2) { Object.setPrototypeOf(o, protoB); }
+                out.push(o.tag());
+            }
+            out.join(',');
+            """;
+        Assert.Equal("A,A,B,B", new Engine().Evaluate(script).AsString());
+    }
+
+    [Fact]
+    public void PrototypeGetterIsReInvokedEachRead()
+    {
+        // An accessor on the prototype must run its getter on every read, not be frozen as a value.
+        const string script = """
+            var n = 0;
+            var proto = {};
+            Object.defineProperty(proto, 'next', { get: function () { return ++n; } });
+            var o = Object.create(proto), out = [];
+            for (var i = 0; i < 4; i++) { out.push(o.next); }
+            out.join(',');
+            """;
+        Assert.Equal("1,2,3,4", new Engine().Evaluate(script).AsString());
+    }
+}

--- a/Jint/Native/Iterator/IteratorResult.cs
+++ b/Jint/Native/Iterator/IteratorResult.cs
@@ -23,6 +23,7 @@ internal sealed class IteratorResult : ObjectInstance
 
     public IteratorResult(Engine engine, JsValue value, JsBoolean done) : base(engine)
     {
+        _type |= InternalTypes.ExoticGet;
         _value = value;
         _done = done;
     }

--- a/Jint/Native/JsProxy.cs
+++ b/Jint/Native/JsProxy.cs
@@ -33,6 +33,7 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
         ObjectInstance handler)
         : base(engine, target.Class)
     {
+        _type |= InternalTypes.ExoticGet;
         _target = target;
         _handler = handler;
         IsCallable = target.IsCallable;

--- a/Jint/Native/JsTypedArray.cs
+++ b/Jint/Native/JsTypedArray.cs
@@ -27,6 +27,7 @@ public sealed class JsTypedArray : ObjectInstance
         TypedArrayElementType type,
         uint length) : base(engine)
     {
+        _type |= InternalTypes.ExoticGet;
         _intrinsics = intrinsics;
         _viewedArrayBuffer = new JsArrayBuffer(engine, []);
 

--- a/Jint/Runtime/InternalTypes.cs
+++ b/Jint/Runtime/InternalTypes.cs
@@ -42,7 +42,11 @@ internal enum InternalTypes
     // brand-new property grows the shape via a transition. Plain shaped objects (object literals) lack this
     // flag and deopt to a dictionary when they gain a key, since they aren't a reused allocation site.
     ShapeBuilding = 131072,
+    // the object overrides [[Get]] / [[GetOwnProperty]] with non-ordinary semantics (Proxy, TypedArray
+    // integer-index access, IteratorResult). The prototype-method inline cache skips such receivers and
+    // prototypes so it never bypasses their custom property resolution.
+    ExoticGet = 262144,
 
     Primitive = Boolean | String | Number | Integer | BigInt | Symbol,
-    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding
+    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet
 }

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -22,6 +22,9 @@ public class NamespaceReference : ObjectInstance, ICallable
 
     public NamespaceReference(Engine engine, string? path) : base(engine)
     {
+        // Member access resolves namespace/type segments, not ordinary property lookup, so the
+        // prototype-method inline cache must skip this receiver. See InternalTypes.ExoticGet.
+        _type |= InternalTypes.ExoticGet;
         _path = path;
     }
 

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -29,6 +29,10 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         Type? type = null)
         : base(engine)
     {
+        // Member access resolves against the wrapped CLR object, not ordinary own-property-then-prototype
+        // lookup, so the prototype-method inline cache must skip this receiver and any object whose
+        // prototype is a wrapper. See InternalTypes.ExoticGet.
+        _type |= InternalTypes.ExoticGet;
         Target = obj;
         ClrType = GetClrType(obj, type);
         _typeDescriptor = TypeDescriptor.Get(ClrType);

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -29,6 +29,19 @@ internal sealed class JintMemberExpression : JintExpression
     private Shape? _cachedShape;
     private int _cachedShapeSlot;
 
+    // Prototype-method inline cache: resolves `obj.method` where `method` lives on obj's direct prototype
+    // (e.g. arr.push, date.getTime, obj.protoMethod). The own-property caches above only handle own
+    // properties, so without this every such read/call re-walks the prototype chain and probes the
+    // prototype's dictionary. Validity: same receiver (so a per-site monomorphic hit), receiver own-shape
+    // unchanged (no own property added that would shadow), direct prototype unchanged (not re-pointed),
+    // and the holder's own-property shape unchanged (method not redefined/removed). Exotic receivers and
+    // prototypes (Proxy/TypedArray/IteratorResult) are excluded via InternalTypes.ExoticGet.
+    private ObjectInstance? _cachedProtoReceiver;
+    private uint _cachedProtoReceiverVersion;
+    private ObjectInstance? _cachedProtoHolder;
+    private uint _cachedProtoHolderVersion;
+    private PropertyDescriptor? _cachedProtoDescriptor;
+
     private static readonly JsValue _nullMarker = new JsString("NULL MARKER");
 
     public JintMemberExpression(MemberExpression expression) : base(expression)
@@ -256,7 +269,8 @@ internal sealed class JintMemberExpression : JintExpression
                         return shapeObj.GetSlot(slot);
                     }
 
-                    return baseObject.Get(determinedProperty, baseObject);
+                    // Slot miss ⇒ no own string property (any non-shapeable property would have deopted).
+                    return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: true);
                 }
 
                 if ((baseObject._type & InternalTypes.PlainObject) != InternalTypes.Empty)
@@ -280,11 +294,16 @@ internal sealed class JintMemberExpression : JintExpression
 
                         return ObjectInstance.UnwrapJsValue(ownDescriptor, baseObject);
                     }
+
+                    // GetOwnProperty already proved the own-property miss for this receiver.
+                    _cachedReadObject = null;
+                    _cachedReadDescriptor = null;
+                    return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: true);
                 }
 
                 _cachedReadObject = null;
                 _cachedReadDescriptor = null;
-                return baseObject.Get(determinedProperty, baseObject);
+                return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: false);
             }
 
             // JsString primitive: skip ToObject's StringInstance allocation for the hot `s.length`
@@ -453,7 +472,8 @@ internal sealed class JintMemberExpression : JintExpression
                     return shapeObj.GetSlot(slot);
                 }
 
-                return baseObject.Get(determinedProperty, baseObject);
+                // Slot miss ⇒ no own string property (any non-shapeable property would have deopted).
+                return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: true);
             }
 
             if ((baseObject._type & InternalTypes.PlainObject) != InternalTypes.Empty)
@@ -474,15 +494,76 @@ internal sealed class JintMemberExpression : JintExpression
                     return ObjectInstance.UnwrapJsValue(ownDescriptor, baseObject);
                 }
 
+                // GetOwnProperty already proved the own-property miss for this receiver.
                 _cachedReadObject = null;
                 _cachedReadDescriptor = null;
+                return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: true);
             }
 
-            return baseObject.Get(determinedProperty, baseObject);
+            return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: false);
         }
 
         thisObject = JsValue.Undefined;
         return JsValue.Undefined;
+    }
+
+    /// <summary>
+    /// Resolves a member read from <paramref name="baseObject"/> after the own-property fast paths have
+    /// missed: tries the prototype-method inline cache, then falls back to the full
+    /// <see cref="ObjectInstance.Get(JsValue, JsValue)"/> (deeper prototype chains, exotic objects, absent).
+    /// <paramref name="ownMissConfirmed"/> is <c>true</c> when the caller already proved the receiver has no
+    /// own property of this name (a shape slot miss or a <c>GetOwnProperty</c> that returned undefined), so
+    /// the populate path can skip re-probing it.
+    /// </summary>
+    private JsValue ReadAfterOwnMiss(ObjectInstance baseObject, JsString property, bool ownMissConfirmed)
+    {
+        var holder = _cachedProtoHolder;
+        if (holder is not null
+            && ReferenceEquals(baseObject, _cachedProtoReceiver)
+            && baseObject._propertiesVersion == _cachedProtoReceiverVersion
+            // GetPrototypeOf(), not the _prototype field: a subclass may shadow the field and override
+            // [[GetPrototypeOf]] (e.g. interop instances), and base Get walks via the same accessor. The
+            // receiver is pinned by identity, so this is a pure field read for ordinary objects and never
+            // the proxy trap (proxies carry ExoticGet and are never cached as the receiver).
+            && ReferenceEquals(baseObject.GetPrototypeOf(), holder)
+            && holder._propertiesVersion == _cachedProtoHolderVersion)
+        {
+            return ObjectInstance.UnwrapJsValue(_cachedProtoDescriptor!, baseObject);
+        }
+
+        return ReadAfterOwnMissUncached(baseObject, property, ownMissConfirmed);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private JsValue ReadAfterOwnMissUncached(ObjectInstance baseObject, JsString property, bool ownMissConfirmed)
+    {
+        // Only ordinary receivers with an ordinary direct prototype: a Proxy / TypedArray / IteratorResult
+        // has a custom [[Get]] / [[GetOwnProperty]] this cache must not bypass.
+        if ((baseObject._type & InternalTypes.ExoticGet) == InternalTypes.Empty)
+        {
+            var proto = baseObject.GetPrototypeOf();
+            if (proto is not null
+                && (proto._type & InternalTypes.ExoticGet) == InternalTypes.Empty
+                // No own property on the receiver (which would shadow the prototype's). The caller usually
+                // already established this (shape slot miss / GetOwnProperty undefined), so re-probe only
+                // when it didn't (a non-plain receiver reached here unchecked).
+                && (ownMissConfirmed || ReferenceEquals(baseObject.GetOwnProperty(property), PropertyDescriptor.Undefined)))
+            {
+                // ...and an own property on the *direct* prototype (deeper chains fall to the slow Get).
+                var descriptor = proto.GetOwnProperty(property);
+                if (!ReferenceEquals(descriptor, PropertyDescriptor.Undefined))
+                {
+                    _cachedProtoReceiver = baseObject;
+                    _cachedProtoReceiverVersion = baseObject._propertiesVersion;
+                    _cachedProtoHolder = proto;
+                    _cachedProtoHolderVersion = proto._propertiesVersion;
+                    _cachedProtoDescriptor = descriptor;
+                    return ObjectInstance.UnwrapJsValue(descriptor, baseObject);
+                }
+            }
+        }
+
+        return baseObject.Get(property, baseObject);
     }
 
     /// <summary>

--- a/Jint/Runtime/Modules/ModuleNamespace.cs
+++ b/Jint/Runtime/Modules/ModuleNamespace.cs
@@ -20,6 +20,9 @@ internal sealed class ModuleNamespace : ObjectInstance
 
     public ModuleNamespace(Engine engine, Module module, List<string> exports, bool deferred = false) : base(engine)
     {
+        // [[Get]] resolves module exports (and throws on symbol-like keys), not ordinary property lookup,
+        // so the prototype-method inline cache must skip this receiver. See InternalTypes.ExoticGet.
+        _type |= InternalTypes.ExoticGet;
         _module = module;
         _exports = new HashSet<string>(exports, StringComparer.Ordinal);
         _deferred = deferred;


### PR DESCRIPTION
Member reads and member-calls whose property lives on the receiver's *direct prototype* —
`arr.push(...)`, `date.getTime()`, `counter.inc()` where `inc` is on the prototype — had no inline
cache. Only *own* properties were cached, so every such access fell through the own-property fast
paths and re-walked the prototype chain: a dictionary miss-probe on the receiver, then a full
recursive `Get` on the prototype (its own fast-path check + dictionary hit-probe + descriptor unwrap).

Add a monomorphic prototype-method cache to `JintMemberExpression`, shared by the read and
member-call sites (a member node serves one role and reads one property name). On a hit it returns
the cached prototype descriptor's value directly. Validity is correct-by-construction:

  - same receiver instance (`ReferenceEquals`) — per-site monomorphic;
  - receiver own-shape unchanged (`_propertiesVersion`) — no own property added that would shadow;
  - direct prototype unchanged (`GetPrototypeOf()` `ReferenceEquals` the cached holder) — not re-pointed;
  - holder own-shape unchanged (`_propertiesVersion`) — method not redefined or deleted.

The prototype is derived through the virtual `GetPrototypeOf()` (exactly as `ObjectInstance.Get`
walks it), so objects that shadow the `_prototype` field and override `[[GetPrototypeOf]]` — e.g.
custom interop instances — resolve to the correct prototype.

The populate path no longer re-probes the receiver's own property: the read/member-call fast paths
already established the own-miss (a shape-slot miss, or a `GetOwnProperty` that returned undefined),
and thread that through as `ownMissConfirmed`, so a never-hitting (polymorphic-by-identity) site does
one own-property probe per call instead of two.

Receivers and prototypes with a non-ordinary `[[Get]]` for *named* keys must never be bypassed. Add
`InternalTypes.ExoticGet`, set in the constructors of the `ObjectInstance` subclasses whose `[[Get]]`
resolves named keys specially — `JsProxy`, `JsTypedArray`, `IteratorResult`, `ObjectWrapper`
(and its `ArrayLikeWrapper` subclass, which inherits the flag), `NamespaceReference`, `ModuleNamespace`
— and skip the cache when either the receiver or its direct prototype carries it. `ArrayInstance` also
overrides `Get`, but only for integer indices and `length` (both of which it reports from
`GetOwnProperty`, so the populate path defers to the full `Get` there); it is ordinary for named keys
and intentionally stays unflagged, which is what keeps `arr.push` / `arr.pop` cacheable.
`PrototypeMethodCacheTests` includes a reflection tripwire that fails if a new `Get` override appears
unclassified, plus behavioural tests for shadowing, redefinition, deletion, prototype reassignment,
and accessor re-invocation after the cache is warm.

Benchmarks (default jobs, same machine, baseline upstream/main d6e3da8c1, same thermal window):

MethodCallBenchmark — the dedicated, multi-iteration signal:
  | Method                              | Baseline | Branch   | Delta  |
  |-------------------------------------|----------|----------|--------|
  | ArrayPushPop   (arr.push/pop loop)  | 246.4 ms | 189.0 ms | -23.3% |
  | UserPrototypeMethod (c.inc on proto)| 343.0 ms | 294.8 ms | -14.1% |
  | MethodCallThis      (guard)         | 291.8 ms | 280.5 ms |  -3.9% |
  | MethodCallCaptured  (guard)         | 297.2 ms | 305.6 ms |  +2.8% |
  | FreeFunctionCall    (guard)         | 337.0 ms | 345.8 ms |  +2.6% |
  Guards exercise own-method / free-function paths the cache never reaches; they sit in the
  +/-3-4% run-to-run noise. Allocation is unchanged (this is a read-path speedup).

EngineComparison (Jint, prepared scripts; averaged over two same-window baseline/treatment pairings):
  consistent wins on array/object-heavy scripts — array-stress -12.3%, dromaeo-object-array-modern
  -9.7%. The remaining scripts fall within this machine's ~+/-3-4% process-to-process noise (their
  deltas sign-flip across repeated pairings); dromaeo-object-string, which a redundant own-property
  probe initially nudged ~+2%, is flat after the ownMissConfirmed change.

Test262: no new failures (Failed: 4 / Passed: 99256, identical to baseline d6e3da8c1; the 4 annexB
RegExp failures are pre-existing 65536-iteration eval + RegExp-compile loops that flaky-time-out
independent of this change). Jint.Tests (3145/0), Jint.Tests.PublicInterface, Jint.Tests.CommonScripts,
Jint.Tests.SourceGenerators all green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDS23QeSSNRkaUB2KL74U9
