### PR TITLE
In-object properties: small shaped objects store slots inline (one allocation, not two)

### DIFF
--- a/Jint.Benchmark/PropertyAllocBenchmark.cs
+++ b/Jint.Benchmark/PropertyAllocBenchmark.cs
@@ -21,6 +21,8 @@ public class PropertyAllocBenchmark
     private readonly Prepared<Script> _literal3;
     private readonly Prepared<Script> _constructor1;
     private readonly Prepared<Script> _literal8;
+    private readonly Prepared<Script> _constructor3Cached;
+    private readonly Prepared<Script> _literal2Cached;
 
     public PropertyAllocBenchmark()
     {
@@ -35,6 +37,16 @@ public class PropertyAllocBenchmark
 
         _literal8 = Engine.PrepareScript(
             $"var s=0; for (var i=0;i<{Iterations};++i){{ var t={{a:i,b:i,c:i,d:i,e:i,f:i,g:i,h:i}}; s+=t.a; }} s;");
+
+        // Cached-value variants: field values stay in the small-integer cache (m = i & 1023), so JsNumber
+        // boxing of the stored values does not dilute the signal — the Allocated delta isolates the
+        // per-object construction cost (object + slot storage), which in-object properties cuts to a single
+        // allocation for objects within the in-object capacity.
+        _constructor3Cached = Engine.PrepareScript(
+            $"function T(a,b,c){{this.a=a;this.b=b;this.c=c;}} var s=0; for (var i=0;i<{Iterations};++i){{ var m=i&1023; var t=new T(m,m,m); s=(s+t.a)&1023; }} s;");
+
+        _literal2Cached = Engine.PrepareScript(
+            $"var s=0; for (var i=0;i<{Iterations};++i){{ var m=i&1023; var t={{a:m,b:m}}; s=(s+t.a)&1023; }} s;");
     }
 
     [Benchmark]
@@ -48,4 +60,10 @@ public class PropertyAllocBenchmark
 
     [Benchmark]
     public void Literal8() => new Engine().Evaluate(_literal8);
+
+    [Benchmark]
+    public void Constructor3Cached() => new Engine().Evaluate(_constructor3Cached);
+
+    [Benchmark]
+    public void Literal2Cached() => new Engine().Evaluate(_literal2Cached);
 }

--- a/Jint/Native/JsObject.cs
+++ b/Jint/Native/JsObject.cs
@@ -1,7 +1,4 @@
 using System.Runtime.CompilerServices;
-#if NET6_0_OR_GREATER
-using System.Runtime.InteropServices;
-#endif
 using Jint.Native.Object;
 using Jint.Runtime;
 
@@ -13,14 +10,18 @@ namespace Jint.Native;
 public sealed class JsObject : ObjectInstance
 {
     // Hidden-class shape storage lives here (not on base ObjectInstance) so only plain objects — the
-    // population that benefits from shapes — carry this reference; JsDate/JsArray/TypedArray/wrappers/
-    // built-ins keep their (smaller) size. A single array holds the shared Shape at index [0] and the
-    // per-instance slot values at [1..], so an unshaped JsObject pays only one extra reference (+8 B)
-    // rather than two, and a shaped object is allocation-neutral vs. separate shape+slots fields (the
-    // object saves a field, the array grows one element). Null = dictionary mode (mutually exclusive
-    // with the base _properties for string keys). Reached only via `this is JsObject` / the ShapeMode
-    // type flag.
-    private object[]? _store;
+    // population that benefits from shapes — carry these fields; JsDate/JsArray/TypedArray/wrappers/
+    // built-ins keep their (smaller) size. In-object properties: a small shaped object keeps its shape
+    // reference and its first InlineCapacity slot values in-object (no separate array), so it allocates a
+    // SINGLE object; only an object whose layout exceeds InlineCapacity spills the surplus into _overflow.
+    // Null _shape = dictionary mode (mutually exclusive with the base _properties for string keys).
+    // Reached only via `this is JsObject` / the ShapeMode type flag.
+    private Shape? _shape;
+    private InlineSlots _inline;
+    private JsValue[]? _overflow;
+
+    // Slots [0, InlineCapacity) live in-object; the rest (rare) in _overflow[slot - InlineCapacity].
+    private const int InlineCapacity = 4;
 
     public JsObject(Engine engine) : base(engine, type: InternalTypes.Object | InternalTypes.PlainObject)
     {
@@ -31,99 +32,149 @@ public sealed class JsObject : ObjectInstance
         _initialized = true;
     }
 
-    /// <summary>The hidden-class shape (stored at <c>_store[0]</c>). Only valid when in shape mode.</summary>
+    /// <summary>The hidden-class shape. Only valid when in shape mode.</summary>
     internal Shape ShapeOf
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Unsafe.As<Shape>(_store![0]);
+        get => _shape!;
     }
 
     /// <summary>
-    /// Installs the combined shape+slots store (shape at [0], slot values at [1..]) and flips on shape
-    /// mode. The store is built by the caller so a shape-mode object allocates exactly one array.
+    /// Installs <paramref name="shape"/> and prepares slot storage — allocating the overflow array only
+    /// when the layout exceeds the in-object capacity — then flips on shape mode. The caller fills the
+    /// slots via <see cref="SetSlot"/>, so a small object allocates no slot array at all.
     /// </summary>
-    internal void SetStore(object[] store)
+    internal void InitShape(Shape shape)
     {
-        _store = store;
+        _shape = shape;
+        var slotCount = shape.SlotCount;
+        if (slotCount > InlineCapacity)
+        {
+            _overflow = new JsValue[slotCount - InlineCapacity];
+        }
         _type |= InternalTypes.ShapeMode;
         unchecked { _propertiesVersion++; }
     }
 
     // Slot accessors used by the hot shape paths. The slot is always proven in range by the caller (it
-    // comes from this object's Shape, and the store is sized to exactly Shape.SlotCount + 1), so the
-    // bounds check is redundant and elided via GetArrayDataReference on runtimes that expose it. Values
-    // live at [slot + 1] (index 0 is the shape). Only ever called when ShapeMode is set (=> _store != null).
+    // comes from this object's Shape). Slots below InlineCapacity are read straight from the in-object
+    // fields (no array indirection); the rest from the overflow array.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal JsValue GetSlot(int slot)
     {
-#if NET6_0_OR_GREATER
-        return Unsafe.As<JsValue>(Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(_store!), slot + 1));
-#else
-        return Unsafe.As<JsValue>(_store![slot + 1]);
-#endif
+        if (slot < InlineCapacity)
+        {
+            return _inline[slot]!;
+        }
+        return _overflow![slot - InlineCapacity];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void SetSlot(int slot, JsValue value)
     {
-#if NET6_0_OR_GREATER
-        Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(_store!), slot + 1) = value;
-#else
-        _store![slot + 1] = value;
-#endif
+        if (slot < InlineCapacity)
+        {
+            _inline[slot] = value;
+        }
+        else
+        {
+            _overflow![slot - InlineCapacity] = value;
+        }
     }
 
-    /// <summary>Drops shape mode back to dictionary mode's starting state (clears the store and the
-    /// <see cref="InternalTypes.ShapeMode"/> flag). Callers must populate <c>_properties</c>.</summary>
+    /// <summary>Drops shape mode back to dictionary mode's starting state (clears the shape and slot
+    /// storage and the <see cref="InternalTypes.ShapeMode"/> flag). Callers must populate <c>_properties</c>.</summary>
     internal void ClearShape()
     {
-        _store = null;
+        _shape = null;
+        _overflow = null;
+        _inline = default; // release in-object slot references so they don't outlive shape mode
         _type &= ~(InternalTypes.ShapeMode | InternalTypes.ShapeBuilding);
     }
 
-    // store[0] is the shape; values start at [1], so a fresh builder has room for 3 properties before regrow.
-    private const int InitialBuildCapacity = 4;
-
     /// <summary>
     /// Starts incremental shape mode for a still-empty object (a constructor's <c>this</c>): installs the
-    /// prototype's empty root shape and a small growable store, so subsequent <c>this.x=</c> adds transition
-    /// the shape (interned, shared across <c>new T()</c> instances) instead of building a dictionary.
+    /// prototype's empty root shape with no slot storage, so subsequent <c>this.x=</c> adds transition the
+    /// shape (interned, shared across <c>new T()</c> instances) and fill an in-object slot — a constructor
+    /// whose instance stays within InlineCapacity properties allocates no slot array.
     /// </summary>
     internal void StartShapeBuilding(Shape emptyRoot)
     {
-        var store = new object[InitialBuildCapacity];
-        store[0] = emptyRoot;
-        _store = store;
+        _shape = emptyRoot;
         _type |= InternalTypes.ShapeMode | InternalTypes.ShapeBuilding;
         unchecked { _propertiesVersion++; }
     }
 
     /// <summary>
     /// Adds a brand-new configurable+enumerable+writable data property to a shape-mode object by
-    /// transitioning to the interned child shape and growing the store. Returns <c>false</c> — leaving the
-    /// object untouched — when a megamorphic guard trips (too many own properties, or this shape already
-    /// has too many distinct child transitions), so the caller deopts to the dictionary representation. The
-    /// key must be known-absent (callers check).
+    /// transitioning to the interned child shape and storing the value in the next slot (in-object, or
+    /// growing the overflow array). Returns <c>false</c> — leaving the object untouched — when a megamorphic
+    /// guard trips (too many own properties, or this shape already has too many distinct child transitions),
+    /// so the caller deopts to the dictionary representation. The key must be known-absent (callers check).
     /// </summary>
     internal bool TryShapeAdd(in Key key, JsValue value)
     {
-        var store = _store!;
-        var shape = Unsafe.As<Shape>(store[0]);
+        var shape = _shape!;
         if (shape.SlotCount >= Shape.MaxShapeProperties || shape.TransitionCount >= Shape.MaxFanout)
         {
             return false;
         }
 
-        var valueIndex = shape.SlotCount + 1; // store[0] is the shape; the new value goes at SlotCount + 1
-        if (store.Length <= valueIndex)
+        var slot = shape.SlotCount; // the new value occupies slot index == current SlotCount
+        if (slot < InlineCapacity)
         {
-            System.Array.Resize(ref store, store.Length * 2);
-            _store = store;
+            _inline[slot] = value;
+        }
+        else
+        {
+            var overflowIndex = slot - InlineCapacity;
+            if (_overflow is null)
+            {
+                _overflow = new JsValue[4];
+            }
+            else if (overflowIndex >= _overflow.Length)
+            {
+                System.Array.Resize(ref _overflow, _overflow.Length * 2);
+            }
+            _overflow[overflowIndex] = value;
         }
 
-        store[valueIndex] = value;
-        store[0] = shape.Add(key);
+        _shape = shape.Add(key);
         unchecked { _propertiesVersion++; }
         return true;
     }
+
+    // The in-object slot block. On modern runtimes this is a single-field [InlineArray] so `_inline[i]`
+    // lowers to a bounds-check-free field-offset access; on legacy TFMs it is an equivalent hand-rolled
+    // fixed struct. InlineCapacity must equal the element count.
+#if NET8_0_OR_GREATER
+    [System.Runtime.CompilerServices.InlineArray(InlineCapacity)]
+    private struct InlineSlots
+    {
+        private JsValue? _slot0;
+    }
+#else
+    private struct InlineSlots
+    {
+        private JsValue? _slot0;
+        private JsValue? _slot1;
+        private JsValue? _slot2;
+        private JsValue? _slot3;
+
+        public JsValue? this[int index]
+        {
+            get => index switch { 0 => _slot0, 1 => _slot1, 2 => _slot2, _ => _slot3 };
+            set
+            {
+                switch (index)
+                {
+                    case 0: _slot0 = value; break;
+                    case 1: _slot1 = value; break;
+                    case 2: _slot2 = value; break;
+                    default: _slot3 = value; break;
+                }
+            }
+        }
+    }
+#endif
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -255,16 +255,15 @@ internal sealed class JintObjectExpression : JintExpression
             _cachedShapeProto = proto;
         }
 
-        // Single combined store: shape at [0], slot values at [1..] (matches JsObject's layout).
-        var store = new object[keys.Length + 1];
-        store[0] = shape;
+        // In-object properties: install the shape, then fill slots directly. A layout within the in-object
+        // capacity allocates no slot array — the object itself is the only allocation.
+        var obj = new JsObject(engine);
+        obj.InitShape(shape);
         for (var i = 0; i < keys.Length; i++)
         {
-            store[i + 1] = _valueExpressions.GetValue(context, i);
+            obj.SetSlot(i, _valueExpressions.GetValue(context, i));
         }
 
-        var obj = new JsObject(engine);
-        obj.SetStore(store);
         return obj;
     }
 


### PR DESCRIPTION
## Summary

A shape-mode `JsObject` kept its hidden-class shape and slot values in a single combined `object[]` store (`[shape, v0, v1, …]`), so constructing one allocated **two** objects: the `JsObject` and the store array.

This makes the slot values *in-object*. `JsObject` now holds the shape reference and the first `InlineCapacity` (4) slot values in fields — via an `[InlineArray]` block on modern runtimes, hand-rolled fixed fields on legacy TFMs — spilling only the surplus of larger layouts into an overflow array.

As a result:

- A constructor or object literal whose instance fits the in-object capacity — the overwhelming majority of real objects (points, pairs, nodes, small records) — now allocates a **single object**.
- `StartShapeBuilding` (a constructor's `this`) allocates **no slot storage at all** until `this.x=` fills a slot.
- Reads drop the pointer-chase: a slot below the inline capacity is a field-offset access, not a load of the store array followed by an index.

All access goes through the existing `ShapeOf` / `GetSlot` / `SetSlot` seam, so the change is contained to `JsObject` plus the literal builder (which fills slots directly instead of building an array). Objects larger than the in-object capacity keep an overflow array and are allocation-neutral; dictionary-mode objects are functionally unaffected and pay only the wider inline-slot fields.

## Benchmarks

Default jobs, same machine, baseline `#2558` (`3c42a267b`).

### Construction — `PropertyAlloc`

Cached-value variants (`m = i & 1023`) isolate the per-object construction cost from `JsNumber` boxing:

| Benchmark | Baseline | Branch | Δ time | Δ alloc |
| --- | --- | --- | --- | --- |
| `Constructor3Cached` | 133.2 ms / 69.9 MB | 122.9 ms / 66.9 MB | **−7.7%** | −4.4% (Gen0 −5.9%) |
| `Literal2Cached` | 38.5 ms / 28.7 MB | 38.0 ms / 27.2 MB | −1.3% | −5.3% |
| `Constructor1` (boxing-mixed) | 69.9 MB | 66.9 MB | −4.6% | −4.6% |
| `Literal3` (boxing-mixed) | 50.2 MB | 47.0 MB | −3.2% | −6.4% |

### Access — `ObjectAccess` (2-run average)

| Benchmark | Δ time | Cause |
| --- | --- | --- |
| `UpdateObjectProperty` (read + write) | **−1.7%** | inline read skips the array pointer-chase |
| `WriteObjectProperty` (pure write) | +2.2% | the inline/overflow branch in `SetSlot` |

### Real-world — `EngineComparison` (`Jint_ParsedScript`, 19 scripts)

Allocation-**neutral** (−0.4% … +0.5%) and **time-flat** — neither the write cost nor the wider footprint shows up outside the microbenchmarks.

## Tradeoffs

The win is **construction throughput** (one fewer allocation per small object → faster construction and less GC) plus a read speed-up. The costs are a ~2% slow-down on a *pure*-write microbenchmark (offset by the read speed-up in any read+write pattern) and a wider per-`JsObject` footprint.

The byte savings are modest (~−16 B/object net) because the inline fields grow the `JsObject` itself, offsetting most of the eliminated array — C# can't do V8-style variable-size in-object allocation, so the fixed 4-slot reservation is the practical equivalent. That footprint cost lands almost entirely on **dictionary-mode** objects (the minority); **shape-mode** objects (the majority) stay size-neutral while dropping an allocation. `InlineCapacity` is a single tunable constant.

## Testing

- **Test262:** 0 failures / 99 260 passed (unchanged from baseline).
- `Jint.Tests`, `Jint.Tests.PublicInterface`, `Jint.Tests.CommonScripts`, `Jint.Tests.SourceGenerators` — all green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDS23QeSSNRkaUB2KL74U9
