### PR TITLE
Make Function.prototype.toString() source text retention opt-in (#2560)

### DIFF
--- a/Jint.Tests.Test262/Test262Test.cs
+++ b/Jint.Tests.Test262/Test262Test.cs
@@ -138,14 +138,19 @@ public abstract partial class Test262Test
             if (file.Type == ProgramType.Module)
             {
                 var specifier = "./" + Path.GetFileName(file.FileName);
-                engine.Modules.Add(specifier, builder => builder.AddSource(file.Program));
+                engine.Modules.Add(specifier, builder => builder
+                    .WithOptions(static options => options with { RetainFunctionSourceText = true })
+                    .AddSource(file.Program));
                 engine.Modules.Import(specifier);
             }
             else
             {
                 var script = Engine.PrepareScript(file.Program, source: file.FileName, options: new ScriptPreparationOptions
                 {
-                    ParsingOptions = ScriptParsingOptions.Default with { Tolerant = false, AllowReturnOutsideFunction = false },
+                    // Retain source text so Function.prototype.toString() conformance tests
+                    // (built-ins/Function/prototype/toString/*) validate the real-source output, which is
+                    // opt-in since the engine no longer retains source by default (issue #2560).
+                    ParsingOptions = ScriptParsingOptions.Default with { Tolerant = false, AllowReturnOutsideFunction = false, RetainFunctionSourceText = true },
                 });
 
                 engine.Execute(script);

--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -772,12 +772,12 @@ assertEqual(booleanCount, 1);
         (
         )=>0
         """)]
-    public void ToStringShouldProduceStandardsCompliantResultByDefault(string code, string expectedResult)
+    public void ToStringShouldProduceStandardsCompliantResultWhenSourceTextRetained(string code, string expectedResult)
     {
         code = Regex.Replace(code, @"\r\n?", "\n", RegexOptions.CultureInvariant); // normalize line endings to '\n'
         expectedResult = Regex.Replace(expectedResult, @"\r\n?", "\n", RegexOptions.CultureInvariant); // normalize line endings to '\n'
 
-        var returnValue = new Engine().Evaluate(code);
+        var returnValue = new Engine(options => options.RetainFunctionSourceText()).Evaluate(code);
 
         var actualResults = Assert.IsType<JsArray>(returnValue);
         Assert.Equal(2u, actualResults.Length);
@@ -787,5 +787,42 @@ assertEqual(booleanCount, 1);
 
         var actualResult2 = Assert.IsType<JsString>(actualResults[1]).ToString();
         Assert.Same(actualResult1, actualResult2);
+    }
+
+    [Fact]
+    public void ToStringReturnsNativeCodePlaceholderByDefault()
+    {
+        // By default the source text is not retained (to save memory), so toString() returns the
+        // native-code placeholder rather than the original source. See issue #2560.
+        var engine = new Engine();
+
+        Assert.Equal("function fn() { [native code] }", engine.Evaluate("function fn() { return 0; } fn.toString();").AsString());
+        Assert.Equal("function foo() { [native code] }", engine.Evaluate("var foo = function () {}; foo.toString();").AsString());
+        Assert.Equal("function () { [native code] }", engine.Evaluate("(() => 0).toString();").AsString());
+    }
+
+    [Fact]
+    public void ToStringReturnsSourceTextWhenRetainedViaParsingOptions()
+    {
+        // Opt in to source-text retention through parsing options (covers the prepared-script path too).
+        var engine = new Engine();
+        var parsingOptions = new ScriptParsingOptions { RetainFunctionSourceText = true };
+
+        Assert.Equal(
+            "function fn() { return 0; }",
+            engine.Evaluate("function fn() { return 0; } fn.toString();", parsingOptions).AsString());
+
+        var prepared = Engine.PrepareScript(
+            "function fn() { return 42; } fn.toString();",
+            options: new ScriptPreparationOptions { ParsingOptions = parsingOptions });
+        Assert.Equal("function fn() { return 42; }", new Engine().Evaluate(prepared).AsString());
+    }
+
+    [Fact]
+    public void PreparedScriptDoesNotRetainSourceTextByDefault()
+    {
+        // A prepared script must not retain its source by default: toString() falls back to native code.
+        var prepared = Engine.PrepareScript("function fn() { return 0; } fn.toString();");
+        Assert.Equal("function fn() { [native code] }", new Engine().Evaluate(prepared).AsString());
     }
 }

--- a/Jint.Tests/Runtime/GarbageCollectionTests.cs
+++ b/Jint.Tests/Runtime/GarbageCollectionTests.cs
@@ -1,4 +1,7 @@
-﻿namespace Jint.Tests.Runtime;
+using System.Text;
+using Acornima.Ast;
+
+namespace Jint.Tests.Runtime;
 
 // This needs to run without any parallelization because it uses
 // garbage collector metrics which cannot be isolated.
@@ -49,17 +52,75 @@ public class GarbageCollectionTests
                           ---
                           Acceptable  : {BytesToString(usedMemoryBytesBaseline + epsilon)}
                           """);
-        return;
+    }
 
-        static string BytesToString(long bytes)
-            => $"{(bytes / 1024.0 / 1024.0),6:0.0} MB";
+    [Fact]
+    public void PreparedScriptsDoNotRetainSourceTextByDefault()
+    {
+        // Regression test for #2560: by default a prepared script must not keep the full source text alive
+        // (it was retained per function node to back Function.prototype.toString()). With many large cached
+        // scripts this caused hundreds of MB of duplicated source strings. Holding N large scripts, the
+        // retaining variant must keep ~N * sourceSize more bytes alive than the non-retaining default.
+        //
+        // Each script is a tiny function wrapped around a large, unique comment: the source string is big
+        // (~commentChars * 2 bytes, UTF-16) while the AST is tiny, so the measured delta isolates the source.
 
-        static long CurrentlyUsedMemory()
+        const int count = 25;
+        const int commentChars = 400_000; // ~800 KB of source per script
+
+        var retained = MeasurePreparedHeap(count, commentChars, retainSourceText: true);
+        var notRetained = MeasurePreparedHeap(count, commentChars, retainSourceText: false);
+
+        // Theoretical savings ≈ count * commentChars * 2 (UTF-16). Assert at least half to absorb noise.
+        var minimumSavings = (long) count * commentChars; // bytes; conservative lower bound (< chars * 2)
+        var actualSavings = retained - notRetained;
+        Assert.True(
+            actualSavings > minimumSavings,
+            userMessage: $"""
+                          Disabling RetainFunctionSourceText did not free the expected source text.
+                          Retained     : {BytesToString(retained)}
+                          Not retained : {BytesToString(notRetained)}
+                          Savings      : {BytesToString(actualSavings)}
+                          Expected     : > {BytesToString(minimumSavings)}
+                          """);
+
+        static long MeasurePreparedHeap(int count, int commentChars, bool retainSourceText)
         {
-            // Just try to ensure that everything possible gets collected.
-            GC.Collect(2, GCCollectionMode.Forced, blocking: true);
-            var currentlyUsed = GC.GetTotalMemory(forceFullCollection: true);
-            return currentlyUsed;
+            var options = new ScriptPreparationOptions
+            {
+                ParsingOptions = new ScriptParsingOptions { RetainFunctionSourceText = retainSourceText },
+            };
+
+            var prepared = new List<Prepared<Script>>(count);
+            for (var i = 0; i < count; i++)
+            {
+                // The source string is built inline and never stored: only a retaining prepared script keeps
+                // it reachable. With retention off it becomes collectable once parsing completes.
+                prepared.Add(Engine.PrepareScript(BuildLargeScript(i, commentChars), options: options));
+            }
+
+            var used = CurrentlyUsedMemory();
+            GC.KeepAlive(prepared);
+            return used;
+        }
+
+        static string BuildLargeScript(int seed, int commentChars)
+        {
+            var sb = new StringBuilder(commentChars + 64);
+            sb.Append("function big").Append(seed).Append("() {\n  /* ").Append(seed).Append(' ');
+            sb.Append('x', commentChars); // unique-ish, large comment body kept only in the source text
+            sb.Append(" */\n  return 0;\n}\n");
+            return sb.ToString();
         }
     }
+
+    private static long CurrentlyUsedMemory()
+    {
+        // Just try to ensure that everything possible gets collected.
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        return GC.GetTotalMemory(forceFullCollection: true);
+    }
+
+    private static string BytesToString(long bytes)
+        => $"{(bytes / 1024.0 / 1024.0),6:0.0} MB";
 }

--- a/Jint/Engine.Ast.cs
+++ b/Jint/Engine.Ast.cs
@@ -70,11 +70,13 @@ public partial class Engine
     private sealed class AstAnalyzer
     {
         private readonly IPreparationOptions<IParsingOptions> _preparationOptions;
+        private readonly bool _retainSourceText;
         private readonly Dictionary<string, Environment.BindingName> _bindingNames = new(StringComparer.Ordinal);
 
         public AstAnalyzer(IPreparationOptions<IParsingOptions> preparationOptions)
         {
             _preparationOptions = preparationOptions;
+            _retainSourceText = preparationOptions.ParsingOptions.RetainFunctionSourceText;
         }
 
         public void NodeVisitor(Node node, in OnNodeContext ctx)
@@ -113,7 +115,7 @@ public partial class Engine
                 case NodeType.ArrowFunctionExpression:
                 case NodeType.FunctionDeclaration:
                 case NodeType.FunctionExpression:
-                    node.UserData = JintFunctionDefinition.BuildState((IFunction) node, ctx.Input);
+                    node.UserData = JintFunctionDefinition.BuildState((IFunction) node, _retainSourceText ? ctx.Input : null);
                     break;
 
                 case NodeType.Program:

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -182,7 +182,10 @@ public sealed partial class Engine : IDisposable
         CallStack = new JintCallStack(Options.Constraints.MaxRecursionDepth >= 0);
         _stackGuard = new StackGuard(this);
 
-        var defaultParserOptions = ScriptParsingOptions.Default.GetParserOptions(Options);
+        var scriptParsingDefaults = Options.RetainFunctionSourceText
+            ? ScriptParsingOptions.RetainingDefault
+            : ScriptParsingOptions.Default;
+        var defaultParserOptions = scriptParsingDefaults.GetParserOptions(Options);
         _defaultParser = new Parser(defaultParserOptions);
     }
 
@@ -229,7 +232,8 @@ public sealed partial class Engine : IDisposable
 
     public DebugHandler Debugger => _debugger ??= new DebugHandler(this, Options.Debugger.InitialStepMode);
 
-    internal ParserOptions DefaultModuleParserOptions => _defaultModuleParserOptions ??= ModuleParsingOptions.Default.GetParserOptions(Options);
+    internal ParserOptions DefaultModuleParserOptions => _defaultModuleParserOptions ??=
+        (Options.RetainFunctionSourceText ? ModuleParsingOptions.RetainingDefault : ModuleParsingOptions.Default).GetParserOptions(Options);
 
     internal ParserOptions GetActiveParserOptions()
     {

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -24,6 +24,17 @@ public static class OptionsExtensions
     }
 
     /// <summary>
+    /// Whether the engine's default parser retains function source text so that
+    /// <c>Function.prototype.toString()</c> returns the original source. Defaults to <see langword="false"/>
+    /// (returns a <c>function name() { [native code] }</c> placeholder and avoids keeping the source in memory).
+    /// </summary>
+    public static Options RetainFunctionSourceText(this Options options, bool retain = true)
+    {
+        options.RetainFunctionSourceText = retain;
+        return options;
+    }
+
+    /// <summary>
     /// Selects the handling for script <code>debugger</code> statements.
     /// </summary>
     /// <remarks>

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -79,6 +79,19 @@ public class Options
     public bool Strict { get; set; }
 
     /// <summary>
+    /// Whether the engine's default parser retains the full source text of parsed functions so that
+    /// <see cref="Native.Function.Function.ToString"><c>Function.prototype.toString()</c></see> can return
+    /// the original source. Defaults to <see langword="false"/>, in which case <c>toString()</c> returns a
+    /// <c>function name() { [native code] }</c> placeholder and the script source is not kept in memory.
+    /// </summary>
+    /// <remarks>
+    /// This only affects scripts/modules parsed by the engine itself (e.g. <see cref="Engine"/>'s <c>Execute(string)</c>).
+    /// When parsing via an explicit <see cref="ScriptParsingOptions"/>/<see cref="ModuleParsingOptions"/> or a
+    /// prepared script/module, the corresponding <see cref="IParsingOptions.RetainFunctionSourceText"/> setting applies.
+    /// </remarks>
+    public bool RetainFunctionSourceText { get; set; }
+
+    /// <summary>
     /// The culture the engine runs on, defaults to current culture.
     /// </summary>
     public CultureInfo Culture { get; set; } = _defaultCulture;

--- a/Jint/ParsingOptions.cs
+++ b/Jint/ParsingOptions.cs
@@ -34,6 +34,16 @@ public interface IParsingOptions
     /// Defaults to <see langword="false"/>.
     /// </summary>
     bool Tolerant { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether to retain the full source text of parsed functions so that
+    /// <see cref="Native.Function.Function.ToString"><c>Function.prototype.toString()</c></see>
+    /// can return the original source.
+    /// When <see langword="false"/> (the default), the source text is not kept and <c>toString()</c>
+    /// returns a <c>function name() { [native code] }</c> placeholder. This avoids retaining the entire
+    /// script source in memory, which can be significant for large and/or cached (prepared) scripts.
+    /// </summary>
+    bool RetainFunctionSourceText { get; init; }
 }
 
 public sealed record ScriptParsingOptions : IParsingOptions
@@ -43,10 +53,16 @@ public sealed record ScriptParsingOptions : IParsingOptions
         AllowReturnOutsideFunction = true,
         AllowTopLevelUsing = true,
         OnRegExp = Engine.DefaultConvertRegExpHandler,
-        OnNode = Engine.DefaultNodeHandler,
+        // OnNode (source-text retention) is applied conditionally in ApplyTo based on RetainFunctionSourceText.
     };
 
     public static readonly ScriptParsingOptions Default = new();
+
+    /// <summary>
+    /// A <see cref="Default"/> variant that retains function source text. Used by the engine when
+    /// <see cref="Options.RetainFunctionSourceText"/> is enabled to build its default parser.
+    /// </summary>
+    internal static readonly ScriptParsingOptions RetainingDefault = new() { RetainFunctionSourceText = true };
 
     /// <summary>
     /// Gets or sets whether to allow return statements at the top level.
@@ -63,6 +79,9 @@ public sealed record ScriptParsingOptions : IParsingOptions
     /// <inheritdoc/>
     public bool Tolerant { get; init; } = _defaultParserOptions.Tolerant;
 
+    /// <inheritdoc/>
+    public bool RetainFunctionSourceText { get; init; }
+
     /// <summary>
     /// Gets or sets the source location offset to apply when parsing.
     /// This allows mapping error locations back to the original source file
@@ -76,6 +95,7 @@ public sealed record ScriptParsingOptions : IParsingOptions
     {
         AllowReturnOutsideFunction = AllowReturnOutsideFunction,
         OnRegExp = GetOnRegExpHandler(fallbackCompileRegex, fallbackRegexTimeout),
+        OnNode = RetainFunctionSourceText ? Engine.DefaultNodeHandler : null,
         Tolerant = Tolerant,
     };
 
@@ -111,10 +131,16 @@ public sealed record class ModuleParsingOptions : IParsingOptions
     private static readonly ParserOptions _defaultParserOptions = Engine.BaseParserOptions with
     {
         OnRegExp = Engine.DefaultConvertRegExpHandler,
-        OnNode = Engine.DefaultNodeHandler,
+        // OnNode (source-text retention) is applied conditionally in ApplyTo based on RetainFunctionSourceText.
     };
 
     public static readonly ModuleParsingOptions Default = new();
+
+    /// <summary>
+    /// A <see cref="Default"/> variant that retains function source text. Used by the engine when
+    /// <see cref="Options.RetainFunctionSourceText"/> is enabled to build its default module parser.
+    /// </summary>
+    internal static readonly ModuleParsingOptions RetainingDefault = new() { RetainFunctionSourceText = true };
 
     /// <inheritdoc/>
     public bool? CompileRegex { get; init; }
@@ -125,9 +151,13 @@ public sealed record class ModuleParsingOptions : IParsingOptions
     /// <inheritdoc/>
     public bool Tolerant { get; init; } = _defaultParserOptions.Tolerant;
 
+    /// <inheritdoc/>
+    public bool RetainFunctionSourceText { get; init; }
+
     internal ParserOptions ApplyTo(ParserOptions baseOptions, bool fallbackCompileRegex, TimeSpan fallbackRegexTimeout) => baseOptions with
     {
         OnRegExp = GetOnRegExpHandler(fallbackCompileRegex, fallbackRegexTimeout),
+        OnNode = RetainFunctionSourceText ? Engine.DefaultNodeHandler : null,
         Tolerant = Tolerant,
     };
 

--- a/Jint/Test262Object.cs
+++ b/Jint/Test262Object.cs
@@ -35,7 +35,7 @@ internal static class Test262Object
 
                 var script = Engine.PrepareScript(args.At(0).AsString(), options: new ScriptPreparationOptions
                 {
-                    ParsingOptions = ScriptParsingOptions.Default with { Tolerant = false },
+                    ParsingOptions = ScriptParsingOptions.Default with { Tolerant = false, RetainFunctionSourceText = true },
                 });
 
                 return engine.Evaluate(script);


### PR DESCRIPTION
Fixes #2560.

## Problem

Since v4.9.0 (#2394), `Function.prototype.toString()` returns the real source text of user functions. To support this, **every parsed function node pins the entire source string** (`Node.UserData = ctx.Input`), released only lazily on the first `toString()` call. Applications that cache many large **prepared** scripts and never call `toString()` therefore retain the full source for the lifetime of the cache — the reporter observed **~250 MB of duplicated source strings** (the same ~500 KB string retained once per engine).

## Fix

Add an opt-in `RetainFunctionSourceText` option, **default `false`**:

- `IParsingOptions.RetainFunctionSourceText` on `ScriptParsingOptions` / `ModuleParsingOptions` — controls per-parse retention (prepared and non-prepared).
- `Options.RetainFunctionSourceText` (+ fluent `options.RetainFunctionSourceText()`) — engine-level toggle for the default parser, so bare `engine.Execute(string)` can opt in without passing parsing options.

When retention is disabled (the default), source text is not kept and `toString()` returns the pre-4.9 `function name() { [native code] }` placeholder. When enabled, real source is returned exactly as before.

```csharp
// lean by default now — no source retained:
new Engine().Evaluate("function f(){} f.toString()"); // "function f() { [native code] }"

// opt back in:
new Engine(o => o.RetainFunctionSourceText()).Evaluate("function f(){} f.toString()"); // real source
Engine.PrepareScript(code, options: new ScriptPreparationOptions {
    ParsingOptions = new ScriptParsingOptions { RetainFunctionSourceText = true } });
```

> **Behavior change:** this reverts the v4.9 default (real-source `toString()`) to opt-in, trading it for lower memory by default. The Test262 harness and the existing `toString` source tests opt in so conformance is unchanged.

## Verification

- **Jint.Tests:** 3147 passed / 0 failed (excluding the pre-existing, environment-sensitive `EngineLimitTests.ShouldAllowReasonableCallStackDepth`, which crashes on unmodified `main` here too).
- **Test262:** 99260 passed / 0 failed — the `built-ins/Function/prototype/toString/*` conformance tests stay green via the harness opt-in.
- **Retained memory** (`GarbageCollectionTests.PreparedScriptsDoNotRetainSourceTextByDefault`): holding 25 distinct ~800 KB cached prepared scripts retains **20.1 MB with retention on vs 1.8 MB off — ~18.3 MB / 91% freed**.

The secondary env-pooling suspect (#2413) is left for a separate, benchmarked PR; it is a bounded, self-healing-under-load retention, unlike the quantified source-string regression fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bf1LESD4X8dMNPwLKJCAh9