### PR TITLE
Fix async function parameter binding after await resumption

### DIFF
--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -2890,6 +2890,148 @@ public class AsyncTests
         Assert.Equal("7", result.AsString());
     }
 
+    [Fact]
+    public async Task ShouldNotThrowWhenAsyncArrowWithDefaultParameterAwaitsHostTaskInsidePromiseAll()
+    {
+        // https://github.com/sebastienros/jint/issues/2564
+        var engine = new Engine(options =>
+        {
+            options.Strict();
+            options.Constraints.PromiseTimeout = TimeSpan.FromSeconds(30);
+        });
+
+        engine.SetValue("host", (Func<string, Task<string>>) (value => Task.FromResult(value)));
+
+        var result = await engine.EvaluateAsync("""
+            (async () => {
+                const f = async (meta = {}) => ({
+                    meta,
+                    value: await host('x')
+                });
+
+                return JSON.stringify(await Promise.all([
+                    f({ index: 1 })
+                ]));
+            })();
+            """);
+
+        Assert.Equal("""[{"meta":{"index":1},"value":"x"}]""", result.AsString());
+    }
+
+    [Fact]
+    public void ShouldNotThrowWhenAsyncArrowWithNullDefaultParameterAwaitsHostTask()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", (Func<string, Task<string>>) (value => Task.FromResult(value)));
+
+        var result = engine.Evaluate("""
+            (async () => {
+                const f = async (meta = null) => ({ meta, value: await host('x') });
+                return JSON.stringify(await f({ index: 1 }));
+            })()
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(5));
+
+        Assert.Equal("""{"meta":{"index":1},"value":"x"}""", result.AsString());
+    }
+
+    [Fact]
+    public void ShouldEvaluateDefaultParameterExpressionOnlyOnceAcrossAwaitResume()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", (Func<string, Task<string>>) (value => Task.FromResult(value)));
+
+        var result = engine.Evaluate("""
+            (async () => {
+                let count = 0;
+                const f = async (a = (count++, 'd')) => (await host('x'), a);
+                const r = await f();
+                return JSON.stringify([r, count]);
+            })()
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(5));
+
+        Assert.Equal("""["d",1]""", result.AsString());
+    }
+
+    [Fact]
+    public void ShouldPreserveParameterMutationAcrossAwaitResumeInConciseBody()
+    {
+        // With an all-literal argument list the arguments array is the expression cache's
+        // shared array: a resume-time re-instantiation would not crash but silently rebind
+        // the parameter back to its original argument value.
+        var engine = new Engine();
+        engine.SetValue("host", (Func<string, Task<string>>) (value => Task.FromResult(value)));
+
+        var result = engine.Evaluate("""
+            (async () => {
+                const f = async (a) => (await (a = 5, host('x')), a);
+                return await f(1);
+            })()
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(5, result.AsNumber());
+    }
+
+    [Fact]
+    public void ShouldResumeConciseBodyWithMultipleAwaitsAndExplicitArgument()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", (Func<string, Task<string>>) (value => Task.FromResult(value)));
+
+        var result = engine.Evaluate("""
+            (async () => {
+                const f = async (a = {}) => (await host('1')) + (await host('2')) + a.s;
+                return await f({ s: '!' });
+            })()
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(5));
+
+        Assert.Equal("12!", result.AsString());
+    }
+
+    [Fact]
+    public async Task ShouldEvaluateDefaultParameterDuringAsyncEventLoopDrain()
+    {
+        // A genuinely pending host Task makes the resume run inside EvaluateAsync's
+        // event-loop drain, where no ambient evaluation context is active. The default
+        // must be a non-literal expression to require one during parameter binding.
+        var engine = new Engine();
+        var tcs = new TaskCompletionSource<string>();
+        engine.SetValue("delayed", (Func<Task<string>>) (() => tcs.Task));
+
+        var evalTask = engine.EvaluateAsync("""
+            (async () => {
+                await delayed();
+                const g = (x = {}) => x;
+                return JSON.stringify(g());
+            })()
+            """);
+
+        tcs.SetResult("done");
+        var result = await evalTask;
+
+        Assert.Equal("{}", result.AsString());
+    }
+
+    [Fact]
+    public void ShouldEvaluateDefaultParameterDuringUnwrapIfPromiseDrain()
+    {
+        var engine = new Engine();
+        var tcs = new TaskCompletionSource<string>();
+        engine.SetValue("delayed", (Func<Task<string>>) (() => tcs.Task));
+
+        var promise = engine.Evaluate("""
+            (async () => {
+                await delayed();
+                const g = (x = {}) => x;
+                return JSON.stringify(g());
+            })()
+            """);
+
+        tcs.SetResult("done");
+        var result = promise.UnwrapIfPromise(TimeSpan.FromSeconds(5));
+
+        Assert.Equal("{}", result.AsString());
+    }
+
 #if !NETFRAMEWORK
     [Fact]
     public async Task EventLoopShouldSignalAllConcurrentWaiters()

--- a/Jint.Tests/Runtime/GeneratorTests.cs
+++ b/Jint.Tests/Runtime/GeneratorTests.cs
@@ -638,4 +638,110 @@ public class GeneratorTests
 
         Assert.Equal(1, result.AsNumber());
     }
+
+    [Fact]
+    public void InterleavedGeneratorsFromSameDeclarationKeepIndependentPositions()
+    {
+        // Each instance must track its own resume position: a shared statement list
+        // let one generator's completion reset another's, silently restarting it.
+        const string Script = """
+            function* gen() {
+                var log = [];
+                log.push('s');
+                yield 1;
+                log.push('m');
+                yield 2;
+                return log.join('');
+            }
+            var g1 = gen(), g2 = gen();
+            var out = [];
+            var steps = [g1, g2, g1, g2, g1, g2];
+            for (var i = 0; i < steps.length; i++) {
+                var r = steps[i].next();
+                out.push(r.value === undefined ? '-' : r.value, r.done);
+            }
+            return JSON.stringify(out);
+            """;
+
+        Assert.Equal("""[1,false,1,false,2,false,2,false,"sm",true,"sm",true]""", _engine.Evaluate(Script).AsString());
+    }
+
+    [Fact]
+    public void InterleavedGeneratorsKeepIndependentPositionsInsideNestedBlocks()
+    {
+        // Yields inside nested blocks exercise the nested statement lists' saved
+        // positions, which must also be per generator instance.
+        const string Script = """
+            function* gen(flag) {
+                var log = [];
+                if (flag) {
+                    log.push('a');
+                    yield 1;
+                    log.push('b');
+                    yield 2;
+                }
+                return log.join('');
+            }
+            var g1 = gen(true), g2 = gen(true);
+            var out = [];
+            var steps = [g1, g2, g1, g2, g1, g2];
+            for (var i = 0; i < steps.length; i++) {
+                var r = steps[i].next();
+                out.push(r.value === undefined ? '-' : r.value, r.done);
+            }
+            return JSON.stringify(out);
+            """;
+
+        Assert.Equal("""[1,false,1,false,2,false,2,false,"ab",true,"ab",true]""", _engine.Evaluate(Script).AsString());
+    }
+
+    [Fact]
+    public void InterleavedForOfOverGeneratorsFromSameDeclarationTerminates()
+    {
+        // With a shared statement list a second live instance restarted from the top
+        // after the first completed, making the iteration produce duplicate values.
+        const string Script = """
+            function* gen() {
+                yield 1;
+                yield 2;
+            }
+            var g1 = gen(), g2 = gen();
+            var out = [];
+            for (const v of g1) {
+                out.push(v);
+                out.push(g2.next().value);
+            }
+            out.push(g2.next().done);
+            return JSON.stringify(out);
+            """;
+
+        Assert.Equal("[1,1,2,2,true]", _engine.Evaluate(Script).AsString());
+    }
+
+    [Fact]
+    public void InterleavedAsyncGeneratorsFromSameDeclarationKeepIndependentPositions()
+    {
+        var result = _engine.Evaluate("""
+            (async () => {
+                async function* gen() {
+                    var log = [];
+                    log.push('s');
+                    yield 1;
+                    log.push('m');
+                    yield 2;
+                    return log.join('');
+                }
+                var g1 = gen(), g2 = gen();
+                var out = [];
+                var steps = [g1, g2, g1, g2, g1, g2];
+                for (var i = 0; i < steps.length; i++) {
+                    var r = await steps[i].next();
+                    out.push(r.value === undefined ? '-' : r.value, r.done);
+                }
+                return JSON.stringify(out);
+            })()
+            """).UnwrapIfPromise(TimeSpan.FromSeconds(5));
+
+        Assert.Equal("""[1,false,1,false,2,false,2,false,"sm",true,"sm",true]""", result.AsString());
+    }
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1193,6 +1193,7 @@ public sealed partial class Engine : IDisposable
     /// https://tc39.es/ecma262/#sec-functiondeclarationinstantiation
     /// </summary>
     internal JsArguments? FunctionDeclarationInstantiation(
+        EvaluationContext context,
         Function function,
         JsCallArguments argumentsList)
     {
@@ -1324,7 +1325,10 @@ public sealed partial class Engine : IDisposable
             // At this point, if hasParameterExpressions:
             // - VariableEnvironment = paramEnv (for eval vars during param init)
             // - LexicalEnvironment = paramEnv (for closures to capture)
-            env.AddFunctionParameters(_activeEvaluationContext!, func.Function, argumentsList);
+            // The caller's context is used instead of the ambient _activeEvaluationContext,
+            // which is null when a function is called from an event-loop drain (e.g. a promise
+            // reaction after awaiting a .NET Task via EvaluateAsync/UnwrapIfPromise).
+            env.AddFunctionParameters(context, func.Function, argumentsList);
         }
 
         // After parameter initialization, switch VariableEnvironment to varEnv for body vars

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -67,7 +67,7 @@ internal sealed class JintFunctionDefinition
                 return EvaluateConciseBodyAsync(context, functionObject, argumentsList);
             }
 
-            argumentsInstance = context.Engine.FunctionDeclarationInstantiation(functionObject, argumentsList);
+            argumentsInstance = context.Engine.FunctionDeclarationInstantiation(context, functionObject, argumentsList);
             context.RunBeforeExecuteStatementChecks(Function.Body);
             var jsValue = _bodyExpression.GetValue(context).Clone();
             result = new Completion(CompletionType.Return, jsValue, Function.Body);
@@ -87,7 +87,7 @@ internal sealed class JintFunctionDefinition
             }
 
             // https://tc39.es/ecma262/#sec-runtime-semantics-evaluatefunctionbody
-            argumentsInstance = context.Engine.FunctionDeclarationInstantiation(functionObject, argumentsList);
+            argumentsInstance = context.Engine.FunctionDeclarationInstantiation(context, functionObject, argumentsList);
             _bodyStatementList ??= new JintStatementList(Function);
             result = _bodyStatementList.Execute(context);
         }
@@ -105,13 +105,21 @@ internal sealed class JintFunctionDefinition
     {
         // local copies to prevent capturing the method parameters
         var function = functionObject;
-        var jsValues = argumentsList;
+        JsCallArguments? jsValues = argumentsList;
 
         var promiseCapability = PromiseConstructor.NewPromiseCapability(context.Engine, context.Engine.Realm.Intrinsics.Promise);
         // Expression bodies don't have a statement list (used only for resumption)
         AsyncFunctionStart(context, promiseCapability, body: null, context =>
         {
-            context.Engine.FunctionDeclarationInstantiation(function, jsValues);
+            // Instantiate only on the first, synchronous slice. The body delegate re-runs on every
+            // resume after an await, but by then the (possibly pooled) arguments array has been
+            // returned to its pool and the saved execution context already carries the environments
+            // and parameter bindings from this first run.
+            if (jsValues is not null)
+            {
+                context.Engine.FunctionDeclarationInstantiation(context, function, jsValues);
+                jsValues = null;
+            }
             context.RunBeforeExecuteStatementChecks(Function.Body);
             var jsValue = _bodyExpression!.GetValue(context).Clone();
 
@@ -142,7 +150,7 @@ internal sealed class JintFunctionDefinition
         var bodyStatementList = new JintStatementList(Function);
         AsyncFunctionStart(context, promiseCapability, bodyStatementList, context =>
         {
-            context.Engine.FunctionDeclarationInstantiation(function, arguments);
+            context.Engine.FunctionDeclarationInstantiation(context, function, arguments);
             return bodyStatementList.Execute(context);
         });
         return new Completion(CompletionType.Return, promiseCapability.PromiseInstance, Function.Body);
@@ -278,7 +286,7 @@ internal sealed class JintFunctionDefinition
         JsCallArguments argumentsList)
     {
         var engine = context.Engine;
-        engine.FunctionDeclarationInstantiation(functionObject, argumentsList);
+        engine.FunctionDeclarationInstantiation(context, functionObject, argumentsList);
         var G = engine.Realm.Intrinsics.Function.OrdinaryCreateFromConstructor(
             functionObject,
             static intrinsics => intrinsics.GeneratorFunction.PrototypeObject.PrototypeObject,
@@ -300,7 +308,7 @@ internal sealed class JintFunctionDefinition
         JsCallArguments argumentsList)
     {
         var engine = context.Engine;
-        engine.FunctionDeclarationInstantiation(functionObject, argumentsList);
+        engine.FunctionDeclarationInstantiation(context, functionObject, argumentsList);
         var G = engine.Realm.Intrinsics.Function.OrdinaryCreateFromConstructor(
             functionObject,
             static intrinsics => intrinsics.AsyncGeneratorFunction.PrototypeObject.PrototypeObject,

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -292,9 +292,10 @@ internal sealed class JintFunctionDefinition
             static intrinsics => intrinsics.GeneratorFunction.PrototypeObject.PrototypeObject,
             static (Engine engine, Realm _, object? _) => new GeneratorInstance(engine));
 
-        _bodyStatementList ??= new JintStatementList(Function);
-        _bodyStatementList.Reset();
-        G.GeneratorStart(_bodyStatementList);
+        // Each generator instance needs its own JintStatementList to track its own resume
+        // position — a shared cached list lets interleaved generators created from the same
+        // declaration corrupt each other's saved position (same rule as async function bodies).
+        G.GeneratorStart(new JintStatementList(Function));
 
         return new Completion(CompletionType.Return, G, Function.Body);
     }
@@ -314,9 +315,8 @@ internal sealed class JintFunctionDefinition
             static intrinsics => intrinsics.AsyncGeneratorFunction.PrototypeObject.PrototypeObject,
             static (Engine engine, Realm _, object? _) => new AsyncGeneratorInstance(engine));
 
-        _bodyStatementList ??= new JintStatementList(Function);
-        _bodyStatementList.Reset();
-        G.AsyncGeneratorStart(_bodyStatementList);
+        // See EvaluateGeneratorBody: resume position must be per generator instance.
+        G.AsyncGeneratorStart(new JintStatementList(Function));
 
         return new Completion(CompletionType.Return, G, Function.Body);
     }


### PR DESCRIPTION
Fixes #2564.

## Problem

`NullReferenceException` in `FunctionEnvironment.HandleAssignmentPatternOrExpression` when an async arrow with a concise (expression) body has a default parameter, receives an explicit argument, and awaits a host-provided .NET `Task`:

```js
const f = async (meta = {}) => ({ meta, value: await host('x') });
JSON.stringify(await Promise.all([f({ index: 1 })]));
```

(`Promise.all` is incidental — any pending await inside such a function reproduces.)

Analysis found two related defects behind the report, and review of the touched code surfaced a third, pre-existing bug in the same instantiation path.

### 1. Concise-body resume re-ran FunctionDeclarationInstantiation against a dead pooled array

Async functions replay their body on resume. For concise bodies, `EvaluateConciseBodyAsync` captures the caller's arguments array into the resumption closure and runs FDI inside it. The array is rented from `JsValueArrayPool`; when the function suspends at `await`, the call unwinds and `JintCallExpression` returns the array to the pool, which nulls its slots. On resume the closure re-ran FDI against that dead array:

- explicit argument + default parameter → `null` argument dereferenced → the reported NRE
- all-literal argument lists (expression cache's shared array) → **silent stale rebinding**: parameter mutations made before the await were reverted on resume
- zero-argument calls → default parameter expressions **re-ran their side effects** on every resume

Statement bodies were unaffected (their resume path executes the statement list directly and never re-runs FDI). The fix makes the concise-body path match: FDI now runs only on the first, synchronous slice — the saved execution context already carries the environments and parameter bindings, and async function environments are never pooled.

### 2. FDI read the null ambient evaluation context inside event-loop drains

`FunctionDeclarationInstantiation` passed the null-forgiven ambient `_activeEvaluationContext!` to `AddFunctionParameters`. That field is only set inside `Evaluate`/`Invoke`-style scopes; the event-loop drains used by `EvaluateAsync` and `UnwrapIfPromise` run promise reactions with it null. Any function with a non-literal parameter default (e.g. `(x = {}) => x`) called after awaiting a genuinely pending .NET Task crashed with an NRE while evaluating the default. The caller's `EvaluationContext` is now threaded through FDI instead of reading the ambient field (all call sites already have it in scope).

### 3. Generator instances shared one statement list (pre-existing, found by review)

The cached `_bodyStatementList` — including its mutable resume position — was shared by every live generator instance created from the same function definition, so one generator's completion or `Reset()` corrupted another's saved position:

```js
function* gen() { yield 1; yield 2; }
var g1 = gen(), g2 = gen();
// interleaved g1.next()/g2.next() produced duplicate values, re-ran body
// side effects, and could make for..of over a generator non-terminating
```

This reproduces on `main` and is independent of the async fixes, but lives on the same lines. Async function bodies already allocate a fresh `JintStatementList` per invocation for exactly this reason; sync and async generators now do the same.

## Tests

Eleven new regression tests, all red before their fix:

- `AsyncTests` (7): the issue's exact repro, the `= null` default variant, default side effects running exactly once across a resume, parameter mutation preserved across a resume, multiple awaits in one concise body, and the pending-task drain scenario via both `EvaluateAsync` and `UnwrapIfPromise`.
- `GeneratorTests` (4): interleaved sync generators (top-level and nested-block yields), interleaved `for..of` termination, interleaved async generators.

## Verification

- Jint.Tests: 3160 (net10.0) / 3098 (net472) passed, 0 failed
- Jint.Tests.PublicInterface: 79 + 79 passed
- Test262: 99260 passed, 0 failed (baseline parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)