### PR TITLE
Fix Map keys()/values() throwing InvalidOperationException on mutation

### DIFF
--- a/Jint.Tests/Runtime/MapTests.cs
+++ b/Jint.Tests/Runtime/MapTests.cs
@@ -27,6 +27,64 @@ public class MapTests
     }
 
     [Fact]
+    public void KeysIteratorToleratesDeletionDuringIteration()
+    {
+        const string Script = @"
+            var map = new Map([['a', 1], ['b', 2], ['c', 3]]);
+            var count = 0;
+            for (var key of map.keys()) { map.delete(key); count++; }
+            return count + '/' + map.size;";
+
+        Assert.Equal("3/0", new Engine().Evaluate(Script).AsString());
+    }
+
+    [Fact]
+    public void ValuesIteratorToleratesDeletionDuringIteration()
+    {
+        const string Script = @"
+            var map = new Map([['a', 1], ['b', 2], ['c', 3]]);
+            var keys = ['a', 'b', 'c'];
+            var count = 0;
+            for (var value of map.values()) { map.delete(keys[count]); count++; }
+            return count + '/' + map.size;";
+
+        Assert.Equal("3/0", new Engine().Evaluate(Script).AsString());
+    }
+
+    [Fact]
+    public void KeysIteratorSeesEntryAddedDuringIteration()
+    {
+        const string Script = @"
+            var map = new Map([['a', 1]]);
+            var seen = [];
+            for (var key of map.keys()) { seen.push(key); if (key === 'a') map.set('b', 2); }
+            return seen.join(',');";
+
+        Assert.Equal("a,b", new Engine().Evaluate(Script).AsString());
+    }
+
+    [Fact]
+    public void ValuesIteratorSkipsEntryDeletedAhead()
+    {
+        const string Script = @"
+            var map = new Map([['a', 1], ['b', 2], ['c', 3]]);
+            var seen = [];
+            for (var value of map.values()) { seen.push(value); if (value === 1) map.delete('b'); }
+            return seen.join(',');";
+
+        Assert.Equal("1,3", new Engine().Evaluate(Script).AsString());
+    }
+
+    [Fact]
+    public void KeysAndValuesIteratorsProduceExpectedSequence()
+    {
+        var engine = new Engine();
+        engine.Execute("var map = new Map([['a', 1], ['b', 2], ['c', 3]]);");
+        Assert.Equal("a,b,c", engine.Evaluate("[...map.keys()].join(',')").AsString());
+        Assert.Equal("1,2,3", engine.Evaluate("[...map.values()].join(',')").AsString());
+    }
+
+    [Fact]
     public void HasProperIteratorPrototypeChain()
     {
         const string Script = @"

--- a/Jint/Native/Map/MapIteratorPrototype.cs
+++ b/Jint/Native/Map/MapIteratorPrototype.cs
@@ -31,7 +31,7 @@ internal sealed partial class MapIteratorPrototype : IteratorPrototype
 
     internal IteratorInstance ConstructEntryIterator(JsMap map)
     {
-        var instance = new MapIterator(Engine, map)
+        var instance = new MapIterator(Engine, map, MapIteratorKind.KeyAndValue)
         {
             _prototype = this
         };
@@ -41,7 +41,7 @@ internal sealed partial class MapIteratorPrototype : IteratorPrototype
 
     internal IteratorInstance ConstructKeyIterator(JsMap map)
     {
-        var instance = new IteratorInstance.EnumerableIterator(Engine, map._map.Keys)
+        var instance = new MapIterator(Engine, map, MapIteratorKind.Key)
         {
             _prototype = this
         };
@@ -51,7 +51,7 @@ internal sealed partial class MapIteratorPrototype : IteratorPrototype
 
     internal IteratorInstance ConstructValueIterator(JsMap map)
     {
-        var instance = new IteratorInstance.EnumerableIterator(Engine, map._map.Values)
+        var instance = new MapIterator(Engine, map, MapIteratorKind.Value)
         {
             _prototype = this
         };
@@ -59,16 +59,25 @@ internal sealed partial class MapIteratorPrototype : IteratorPrototype
         return instance;
     }
 
+    private enum MapIteratorKind
+    {
+        Key,
+        Value,
+        KeyAndValue,
+    }
+
     private sealed class MapIterator : IteratorInstance
     {
         private readonly JintOrderedDictionary<JsValue, JsValue> _map;
+        private readonly MapIteratorKind _kind;
         private int _position;
         private JsValue? _lastKey;
         private bool _done;
 
-        public MapIterator(Engine engine, JsMap map) : base(engine)
+        public MapIterator(Engine engine, JsMap map, MapIteratorKind kind) : base(engine)
         {
             _map = map._map;
+            _kind = kind;
             _position = 0;
         }
 
@@ -107,10 +116,14 @@ internal sealed partial class MapIteratorPrototype : IteratorPrototype
             if (_position < _map.Count)
             {
                 var key = _map.GetKey(_position);
-                var value = _map[key];
                 _lastKey = key;
                 _position++;
-                nextItem = IteratorResult.CreateKeyValueIteratorPosition(_engine, key, value);
+                nextItem = _kind switch
+                {
+                    MapIteratorKind.Key => IteratorResult.CreateValueIteratorPosition(_engine, key),
+                    MapIteratorKind.Value => IteratorResult.CreateValueIteratorPosition(_engine, _map[key]),
+                    _ => IteratorResult.CreateKeyValueIteratorPosition(_engine, key, _map[key]),
+                };
                 return true;
             }
 


### PR DESCRIPTION
Iterating a Map's keys() or values() while mutating the map, which is spec-legal, throws a CLR exception that escapes to the host. Because it's a raw InvalidOperationException (not a JavaScriptException), script-level try/catch can't catch it and CatchClrExceptions() doesn't wrap it.

An example of a test that would fail 

```
const m = new Map([['a', 1], ['b', 2], ['c', 3]]);
for (const k of m.keys()) m.delete(k);
// System.InvalidOperationException: Collection was modified;
// enumeration operation may not execute.
```

## Summary

Adjusted the `MapIteratorPrototype` to reuse the already working `MapIterator` for the `keys()` and `values()`-iterations.

## Details

`MapIteratorPrototype` was updated with:
- An enum, `MapIteratorKind` specifying the three possible types of iteration.
- An additional private field on `MapIterator` (passed via additional constructor parameter).
- Method `TryIteratorStep` was modified so that the `MapIteratorKind` can be used to determine the kind of `IteratorResult` to return.

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark`

## Breaking change?

No.
