### PR TITLE
Share compiled statement lists across generator and async invocations

### DIFF
--- a/Jint.Benchmark/GeneratorBenchmark.cs
+++ b/Jint.Benchmark/GeneratorBenchmark.cs
@@ -1,0 +1,89 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Measures generator instantiation and iteration cost. Generator bodies share their
+/// compiled statement handler tree across instances (resume positions live on the
+/// instance), so creating many short-lived generators from the same declaration must
+/// not pay a per-instantiation handler tree rebuild. The large-body case is the worst
+/// case for such rebuilds; the interleaved case pins cross-instance state isolation.
+/// </summary>
+[MemoryDiagnoser]
+public class GeneratorBenchmark
+{
+    private Prepared<Script> _smallGenerators;
+    private Prepared<Script> _largeBodyGenerators;
+    private Prepared<Script> _interleavedGenerators;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _smallGenerators = Engine.PrepareScript("""
+            function* g(n) { yield n; yield n + 1; }
+            let sum = 0;
+            for (let i = 0; i < 1000; i++) {
+                for (const v of g(i)) sum += v;
+            }
+            sum;
+            """);
+
+        _largeBodyGenerators = Engine.PrepareScript("""
+            function* g(n) {
+                let a0 = n + 0; let a1 = n + 1; let a2 = n + 2; let a3 = n + 3; let a4 = n + 4;
+                let a5 = n + 5; let a6 = n + 6; let a7 = n + 7; let a8 = n + 8; let a9 = n + 9;
+                if (a0 >= 0) {
+                    a1 += a0; a2 += a1; a3 += a2; a4 += a3;
+                    if (a4 >= 0) {
+                        a5 += a4; a6 += a5; a7 += a6;
+                    }
+                }
+                yield a7;
+                for (let j = 0; j < 3; j++) {
+                    a8 += j;
+                    yield a8;
+                }
+                switch (n % 2) {
+                    case 0:
+                        a9 += 1;
+                        break;
+                    default:
+                        a9 += 2;
+                        break;
+                }
+                yield a9;
+                return a0 + a9;
+            }
+            let sum = 0;
+            for (let i = 0; i < 500; i++) {
+                for (const v of g(i)) sum += v;
+            }
+            sum;
+            """);
+
+        _interleavedGenerators = Engine.PrepareScript("""
+            function* g(n) {
+                yield n;
+                { yield n + 1; }
+                yield n + 2;
+            }
+            let sum = 0;
+            for (let i = 0; i < 500; i++) {
+                const g1 = g(i), g2 = g(i + 1);
+                sum += g1.next().value + g2.next().value;
+                sum += g1.next().value + g2.next().value;
+                sum += g1.next().value + g2.next().value;
+            }
+            sum;
+            """);
+    }
+
+    [Benchmark]
+    public void SmallGenerators_1000() => new Engine().Execute(_smallGenerators);
+
+    [Benchmark]
+    public void LargeBodyGenerators_500() => new Engine().Execute(_largeBodyGenerators);
+
+    [Benchmark]
+    public void InterleavedGenerators_500() => new Engine().Execute(_interleavedGenerators);
+}

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -146,8 +146,9 @@ internal sealed class JintFunctionDefinition
         var arguments = argumentsList;
 
         var promiseCapability = PromiseConstructor.NewPromiseCapability(context.Engine, context.Engine.Realm.Intrinsics.Promise);
-        // Each async function invocation needs its own JintStatementList to track its own position
-        var bodyStatementList = new JintStatementList(Function);
+        // The statement list is immutable and shareable across invocations: each invocation's
+        // resume position lives on its AsyncFunctionInstance (SuspendDataDictionary).
+        var bodyStatementList = _bodyStatementList ??= new JintStatementList(Function);
         AsyncFunctionStart(context, promiseCapability, bodyStatementList, context =>
         {
             context.Engine.FunctionDeclarationInstantiation(context, function, arguments);

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -292,10 +292,10 @@ internal sealed class JintFunctionDefinition
             static intrinsics => intrinsics.GeneratorFunction.PrototypeObject.PrototypeObject,
             static (Engine engine, Realm _, object? _) => new GeneratorInstance(engine));
 
-        // Each generator instance needs its own JintStatementList to track its own resume
-        // position — a shared cached list lets interleaved generators created from the same
-        // declaration corrupt each other's saved position (same rule as async function bodies).
-        G.GeneratorStart(new JintStatementList(Function));
+        // The statement list is immutable and shareable across generator instances:
+        // each instance's resume position lives on the instance itself (SuspendDataDictionary).
+        _bodyStatementList ??= new JintStatementList(Function);
+        G.GeneratorStart(_bodyStatementList);
 
         return new Completion(CompletionType.Return, G, Function.Body);
     }
@@ -315,8 +315,9 @@ internal sealed class JintFunctionDefinition
             static intrinsics => intrinsics.AsyncGeneratorFunction.PrototypeObject.PrototypeObject,
             static (Engine engine, Realm _, object? _) => new AsyncGeneratorInstance(engine));
 
-        // See EvaluateGeneratorBody: resume position must be per generator instance.
-        G.AsyncGeneratorStart(new JintStatementList(Function));
+        // See EvaluateGeneratorBody: the shared list is safe, positions are per instance.
+        _bodyStatementList ??= new JintStatementList(Function);
+        G.AsyncGeneratorStart(_bodyStatementList);
 
         return new Completion(CompletionType.Return, G, Function.Body);
     }

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -26,8 +26,11 @@ internal sealed class JintStatementList
     private readonly Statement? _statement;
     private readonly CompletionValueObservability _observability;
 
+    // This class must stay immutable after construction: instances are cached on shared
+    // interpreter handlers (function definitions, blocks, switch cases) and executed by
+    // multiple live generator / async function instances concurrently. Per-execution
+    // resume positions live on the suspendable (SuspendDataDictionary), not here.
     private readonly Pair[] _jintStatements;
-    private uint _index;
 
     public JintStatementList(IFunction function) : this((FunctionBody) function.Body)
     {
@@ -89,9 +92,14 @@ internal sealed class JintStatementList
             context.CompletionValuesObservable = _observability == CompletionValueObservability.Observable;
         }
 
+        // The resume position is stored per suspendable instance: this list is shared by
+        // every live generator / async function created from the same declaration, and the
+        // frame's suspendable is fixed for the duration of this call.
+        var suspendable = context.Engine.ExecutionContext.Suspendable;
+
         // The value of a StatementList is the value of the last value-producing item in the StatementList
         var lastValue = JsEmpty.Instance;
-        var i = _index;
+        var i = suspendable is not null ? suspendable.Data.GetStatementListPosition(this) : 0;
         var temp = _jintStatements!;
         try
         {
@@ -114,22 +122,21 @@ internal sealed class JintStatementList
                 }
 
                 // Check for suspension (generator yield or async await)
-                var suspendable = context.Engine.ExecutionContext.Suspendable;
                 if (context.IsSuspended())
                 {
                     // Save position for resume - we'll re-execute this statement on resume
                     // The yield/await tracking handles knowing which suspension point to resume from
-                    _index = i;
+                    suspendable!.Data.SetStatementListPosition(this, i);
                     // Use the suspended value, as the statement's completion value
                     // might be different (e.g., variable declarations return Empty, not the yielded value)
-                    var suspendedValue = suspendable?.SuspendedValue ?? c.Value;
+                    var suspendedValue = suspendable.SuspendedValue ?? c.Value;
                     return new Completion(CompletionType.Return, suspendedValue, pair.Statement._statement);
                 }
 
                 // Check for return request (from generator.return() call)
                 if (suspendable?.ReturnRequested == true)
                 {
-                    Reset();
+                    suspendable.Data.ClearStatementListPosition(this);
                     var returnValue = suspendable.SuspendedValue ?? c.Value;
                     return new Completion(CompletionType.Return, returnValue, pair.Statement._statement);
                 }
@@ -141,7 +148,7 @@ internal sealed class JintStatementList
                         var asyncFunction = context.Engine.ExecutionContext.AsyncFunction;
                         if (asyncFunction?._body != this)
                         {
-                            Reset();
+                            suspendable?.Data.ClearStatementListPosition(this);
                         }
                     }
 
@@ -155,20 +162,20 @@ internal sealed class JintStatementList
                 }
             }
 
-            // Reset index after normal loop completion for potential re-execution
+            // Clear the saved position after normal loop completion for potential re-execution
             // (e.g., this block is a for-of body that will execute again on next iteration)
-            // But don't reset for async function/module bodies - if pending promise reactions
+            // But don't clear for async function/module bodies - if pending promise reactions
             // call AsyncFunctionResume after completion, we shouldn't re-execute from start.
             // Async bodies should complete exactly once.
             var currentAsyncFn = context.Engine.ExecutionContext.AsyncFunction;
             if (currentAsyncFn?._body != this)
             {
-                _index = 0;
+                suspendable?.Data.ClearStatementListPosition(this);
             }
         }
         catch (Exception ex)
         {
-            Reset();
+            suspendable?.Data.ClearStatementListPosition(this);
 
             if (ex is JintException)
             {
@@ -324,12 +331,5 @@ internal sealed class JintStatementList
         }
 
         dictionary.CheckExistingKeys = true;
-    }
-
-    public bool Completed => _index == _jintStatements?.Length;
-
-    public void Reset()
-    {
-        _index = 0;
     }
 }

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -342,22 +342,51 @@ internal sealed class SuspendDataDictionary
     /// blocks, switch cases), so their resume position must live on the suspendable —
     /// two live generators from the same declaration would otherwise corrupt each other.
     /// </summary>
-    private Dictionary<object, uint>? _statementListPositions;
+    /// Most suspendables only ever track one list (the function body), so a single
+    /// inline slot fronts the dictionary; a key never moves between slot and dictionary.
+    private object? _positionKey;
+    private uint _position;
+    private Dictionary<object, uint>? _morePositions;
 
     public uint GetStatementListPosition(object key)
     {
-        return _statementListPositions?.TryGetValue(key, out var index) == true ? index : 0;
+        if (ReferenceEquals(_positionKey, key))
+        {
+            return _position;
+        }
+
+        return _morePositions?.TryGetValue(key, out var index) == true ? index : 0;
     }
 
     public void SetStatementListPosition(object key, uint index)
     {
-        _statementListPositions ??= [];
-        _statementListPositions[key] = index;
+        if (ReferenceEquals(_positionKey, key))
+        {
+            _position = index;
+            return;
+        }
+
+        if (_positionKey is null && _morePositions?.ContainsKey(key) != true)
+        {
+            _positionKey = key;
+            _position = index;
+            return;
+        }
+
+        _morePositions ??= [];
+        _morePositions[key] = index;
     }
 
     public void ClearStatementListPosition(object key)
     {
-        _statementListPositions?.Remove(key);
+        if (ReferenceEquals(_positionKey, key))
+        {
+            _positionKey = null;
+            _position = 0;
+            return;
+        }
+
+        _morePositions?.Remove(key);
     }
 
     /// <summary>

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -337,6 +337,30 @@ internal sealed class SuspendDataDictionary
     private Dictionary<object, SuspendData>? _suspendData;
 
     /// <summary>
+    /// Saved resume positions of statement lists, keyed by the JintStatementList instance.
+    /// Statement lists are cached on shared interpreter handlers (function definitions,
+    /// blocks, switch cases), so their resume position must live on the suspendable —
+    /// two live generators from the same declaration would otherwise corrupt each other.
+    /// </summary>
+    private Dictionary<object, uint>? _statementListPositions;
+
+    public uint GetStatementListPosition(object key)
+    {
+        return _statementListPositions?.TryGetValue(key, out var index) == true ? index : 0;
+    }
+
+    public void SetStatementListPosition(object key, uint index)
+    {
+        _statementListPositions ??= [];
+        _statementListPositions[key] = index;
+    }
+
+    public void ClearStatementListPosition(object key)
+    {
+        _statementListPositions?.Remove(key);
+    }
+
+    /// <summary>
     /// Gets or creates suspend data of the specified type (for constructs without iterators).
     /// </summary>
     public T GetOrCreate<T>(object key, IteratorInstance? iteratorInstance = null) where T : SuspendData, new()


### PR DESCRIPTION
Follow-up to #2567. That fix gave each generator instance its own `JintStatementList` to stop live instances from corrupting each other's resume position — at the cost of rebuilding the whole compiled statement handler tree on every generator instantiation (a price async statement bodies had also been paying per invocation since their introduction).

## Change

`JintStatementList` is now immutable after construction: the mutable resume position (`_index`) moves into the suspendable instance's `SuspendDataDictionary`, keyed by the list — completing the pattern already used for every other piece of suspension state (loop iterators, destructuring, block environments). With positions per instance, the cached list is safe to share, so:

- sync and async generator bodies reuse the cached statement list again (`_bodyStatementList ??=`),
- async function statement bodies stop allocating a fresh list (and handler tree) per call.

Most suspendables only ever track one list (the function body), so a one-entry inline slot fronts the position dictionary; nested-list suspensions fall back to the dictionary. A key never moves between slot and dictionary, so lookups cannot observe stale entries. The sync execution path only gains one frame-suspendable read per list execution — it was already read per statement for the suspension checks.

## Benchmarks

BenchmarkDotNet default job, .NET 10, A/B against `main` (059f17421) from separate worktrees, idle machine. `GeneratorBenchmark` is added in this PR (small bodies, a large body with nested blocks/loops/switch, and interleaved instances).

| Benchmark | main | PR | Δ time | Δ alloc |
|---|---:|---:|---:|---:|
| SmallGenerators_1000 | 1,310.0 us / 2,640 KB | 1,247.4 us / 2,417 KB | **−4.8%** | **−8.5%** |
| LargeBodyGenerators_500 | 3,725.6 us / 7,813 KB | 2,711.7 us / 3,010 KB | **−27.2%** | **−61.5%** |
| InterleavedGenerators_500 | 1,166.3 us / 1,752 KB | 1,150.9 us / 1,382 KB | −1.3% | **−21.1%** |
| PlainAsyncFunctionExit_1000 | 556.3 us / 2,033 KB | 461.9 us / 1,802 KB | **−17.0%** | **−11.4%** |
| AsyncFunctionWithSyncUsing_1000 | 961.4 us / 2,818 KB | 768.1 us / 2,263 KB | **−20.1%** | **−19.7%** |
| PlainAsyncGeneratorExit_500 | 1,453.1 us / 4,955 KB | 1,349.2 us / 4,843 KB | **−7.1%** | −2.3% |

Sync neutrality probes (StopwatchBenchmark ×4, RecursionBenchmark Fib/Tak/DeepSum): allocations byte-identical to main on all seven; time deltas ranged −4.9%..+6.4% with inconsistent signs across closely related methods (e.g. Stopwatch Execute +5.3% while Execute_ParsedScript −2.8%), i.e. run-to-run noise rather than a systematic shift.

## Verification

- Jint.Tests: 3160 (net10.0) / 3098 (net472) passed, 0 failed — including the #2567 interleaved-generator regression tests (top-level, nested-block, for..of termination, async generators)
- Jint.Tests.PublicInterface: 79 + 79 passed
- Test262: 99260 passed, 0 failed (baseline parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)