### PR TITLE
Slot lane for plain assignment to local bindings

### DIFF
--- a/Jint.Tests/Runtime/PlainAssignmentTests.cs
+++ b/Jint.Tests/Runtime/PlainAssignmentTests.cs
@@ -1,0 +1,96 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Plain assignment to slot-stored bindings takes a fast lane; these pin its parity with the
+/// materialized AssignToIdentifier path: anonymous function/class naming, abrupt completions,
+/// const/TDZ error ordering, and targets rewritten during right-hand side evaluation.
+/// </summary>
+public class PlainAssignmentTests
+{
+    [Fact]
+    public void AnonymousFunctionAndClassGetAssignedName()
+    {
+        var engine = new Engine(static options => options.Strict());
+        var result = engine.Evaluate("""
+            function f() {
+                var g = function () {};
+                var C = class {};
+                var named = function realName() {};
+                var arrow = () => {};
+                return [g.name, C.name, named.name, arrow.name].join('|');
+            }
+            f();
+            """).AsString();
+
+        Assert.Equal("g|C|realName|arrow", result);
+    }
+
+    [Fact]
+    public void ValuePositionAndChainedAssignments()
+    {
+        var engine = new Engine(static options => options.Strict());
+        var result = engine.Evaluate("""
+            function f() {
+                var a = 1, b, c;
+                c = (b = a);
+                return '' + b + c;
+            }
+            f();
+            """).AsString();
+
+        Assert.Equal("11", result);
+    }
+
+    [Fact]
+    public void ThrowingRightHandSideDoesNotAssign()
+    {
+        var engine = new Engine(static options => options.Strict());
+        var result = engine.Evaluate("""
+            function f() {
+                var a = 'initial';
+                try { a = (function () { throw new Error('x'); })(); } catch (e) { }
+                return a;
+            }
+            f();
+            """).AsString();
+
+        Assert.Equal("initial", result);
+    }
+
+    [Fact]
+    public void RightHandSideRewritingTargetIsOverwritten()
+    {
+        var engine = new Engine(static options => options.Strict());
+        var result = engine.Evaluate("function f() { var b = 0; b = (b = 5, 9); return b; } f();").AsNumber();
+
+        Assert.Equal(9, result);
+    }
+
+    [Fact]
+    public void ConstTargetThrowsTypeErrorAfterEvaluatingRightHandSide()
+    {
+        var engine = new Engine(static options => options.Strict());
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("""
+            function f() {
+                const c = 1;
+                var order = [];
+                try { c = (order.push('rhs'), 2); } finally { globalThis.order = order.join(','); }
+            }
+            f();
+            """));
+        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.TypeError));
+        Assert.Equal("rhs", engine.Evaluate("globalThis.order").AsString());
+    }
+
+    [Fact]
+    public void AssignmentBeforeLetDeclarationThrowsReferenceError()
+    {
+        var engine = new Engine(static options => options.Strict());
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("function f() { { x = 1; let x; } } f();"));
+        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.ReferenceError));
+    }
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -716,9 +716,97 @@ internal sealed class JintAssignmentExpression : JintExpression
             object? completion = null;
             if (_leftIdentifier != null)
             {
+                // a populated global-binding cache means the target is a global — the slot lane
+                // can never apply, and AssignToIdentifier's cached-global arm is the fast path
+                if (_leftIdentifier._cachedGlobalEnv is null
+                    && !_evalOrArguments
+                    && !_leftIsCoverParenthesized
+                    && TryAssignSlot(context, out var slotResult))
+                {
+                    return slotResult;
+                }
+
                 completion = AssignToIdentifier(context, _leftIdentifier, _right, _evalOrArguments, !_leftIsCoverParenthesized);
             }
             return completion ?? SetValue(context);
+        }
+
+        /// <summary>
+        /// Plain assignment to a slot-stored binding (`b = a`, `x = f()` on locals): resolves the
+        /// target through the slot-location cache instead of the per-assignment environment walk,
+        /// mirroring <see cref="AssignToIdentifier"/>'s right-hand side semantics exactly
+        /// (anonymous function/class naming, abrupt and generator-abort completions). Const and
+        /// TDZ targets bail before any evaluation so the slow path produces the spec error
+        /// ordering; the target binding is re-validated after the right-hand side runs since it
+        /// may have been written (or in degenerate cases deleted) during evaluation.
+        /// </summary>
+        private bool TryAssignSlot(EvaluationContext context, out JsValue result)
+        {
+            result = null!;
+
+            var engine = context.Engine;
+            if (engine.ExecutionContext.Suspendable is not null)
+            {
+                return false;
+            }
+
+            if (!_lhsSlotCache.TryResolve(engine, engine.ExecutionContext.LexicalEnvironment, _leftIdentifier!.Identifier, out var environment, out var slotIndex))
+            {
+                return false;
+            }
+
+            var slots = environment._slots;
+            if (slots is null || (uint) slotIndex >= (uint) slots.Length)
+            {
+                return false;
+            }
+
+            {
+                ref var binding = ref slots[slotIndex];
+                if (!binding.Mutable || !binding.IsInitialized())
+                {
+                    return false;
+                }
+            }
+
+            JsValue completion;
+            var right = _right;
+            if (right is JintClassExpression classExpression && right._expression.IsAnonymousFunctionDefinition())
+            {
+                completion = classExpression.EvaluateWithName(context, _leftIdentifier.Identifier.Value.ToString());
+            }
+            else
+            {
+                completion = right.GetValue(context);
+            }
+
+            if (context.IsAbrupt() || context.IsGeneratorAborted())
+            {
+                result = completion;
+                return true;
+            }
+
+            var rval = completion.Clone();
+
+            if (right._expression.IsFunctionDefinition() && right is not JintClassExpression)
+            {
+                ((Function) rval).SetFunctionName(_leftIdentifier.Identifier.Value);
+            }
+
+            ref var bindingAfterRight = ref slots[slotIndex];
+            if (bindingAfterRight.Mutable && bindingAfterRight.IsInitialized())
+            {
+                slots[slotIndex] = bindingAfterRight.ChangeValue(rval);
+            }
+            else
+            {
+                // degenerate: the right-hand side changed the binding's state; the full store
+                // produces the exact semantics
+                environment.SetMutableBinding(_leftIdentifier.Identifier, rval, StrictModeScope.IsStrictModeCode);
+            }
+
+            result = rval;
+            return true;
         }
 
         internal override bool HasDiscardFastPath => _structurallyNumeric;


### PR DESCRIPTION
The loop-cost decomposition from #2574 left one shape on the slow path: **plain assignment to a local** (`b = a`, `x = f()`) always ran `AssignToIdentifier`'s uncached environment walk plus the by-name `SetMutableBinding` scan — costing more per iteration (+20 ns) than the compound lanes it sits next to. Only the `id = a op b` numeric shape had a fast path.

### What this does

`SimpleAssignmentExpression` gains a general slot lane: the target resolves once through the (shadow-aware) `SlotLocationCache`, the right-hand side evaluates with `AssignToIdentifier`'s exact semantics — anonymous function/class naming, abrupt and generator-abort completions, `completion.Clone()` — and the store goes straight to the slot, with the binding re-validated after the RHS runs (it may have been rewritten during evaluation). Const/TDZ targets bail before evaluating anything so the slow path produces the spec error ordering. Globals skip the lane on a single field test (`_cachedGlobalEnv is not null` means the cached-global arm is the fast path) — added after the first A/B round showed a +3% probe tax on `GlobalVarLoop`, now eliminated.

### Measurements (same-window stash A/B, BenchmarkDotNet default job)

| Benchmark | before | after | Δ |
|---|---:|---:|---|
| GlobalAccess LocalVarLoop | 52.23 ms | **44.68 ms** | **−14.5%** (StdDev ±0.3%) |
| GlobalAccess GlobalVarLoop / GlobalUpdateLoop | 44.70 / 90.74 ms | 44.66 / 90.83 ms | flat (probe tax removed) |
| LoopDispatch LocalCopy | 5.46 ms | 5.27 ms | −3.5% |
| EvalExecution EvalHot | 757.6 µs | 731.7 µs | −3.4% |
| stopwatch driver (canary) | 179.0 ms/iter | 176.3 ms/iter | within noise |

### Gates

* New `PlainAssignmentTests` (6) verified to pass identically on the code before and after the lane via stash cycles: anonymous fn/class naming (`g|C|realName|arrow`), chained/value positions, throwing RHS doesn't assign, RHS rewriting the target is overwritten, const TypeError ordering after RHS, TDZ ReferenceError.
* `Jint.Tests`, `PublicInterface`, `CommonScripts`, Test262 99,256 passed with the four known annexB `RegExp-*-escape-BMP` load-flakes timing out under full-suite parallelism only (all four pass in 6 s isolated on this change), all-TFM build.

Measurement note: an unrelated observation from these A/Bs — `EvalExecutionBenchmarks.NewFunctionHotReusedEngine` (repeated `new Function()` on one engine) reads ~960 µs on pre-#2568 main and ~1,470 µs on current main **on both sides of this A/B**, i.e. unrelated to this change; reported separately.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
