### PR TITLE
Built-in shapes for prototypes and constructors: composable storage, accessors, aliases

### DIFF
--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -91,7 +91,9 @@ public class BuiltinShapeBenchmark
         + "BigInt.prototype.toString; AggregateError.prototype.name; SuppressedError.prototype.constructor;"
         + "Uint8Array.prototype.setFromBase64; ShadowRealm.prototype.evaluate;"
         + "Object.getPrototypeOf(function*(){}).constructor; Object.getPrototypeOf(async function(){}).constructor;"
-        + "Object.getPrototypeOf(async function*(){}).constructor;");
+        + "Object.getPrototypeOf(async function*(){}).constructor;"
+        + "Map.prototype.has; Symbol.prototype.toString; ArrayBuffer.prototype.slice;"
+        + "DataView.prototype.getInt8; Iterator.prototype.toArray;");
 
     [Benchmark]
     public Engine EngineInitPrototypes()

--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -83,11 +83,15 @@ public class BuiltinShapeBenchmark
         return engine;
     }
 
-    // Forces the five function-only Prototype-derived prototypes shaped in wave 2 (Promise, WeakMap,
-    // WeakSet, WeakRef, FinalizationRegistry) to Initialize — dictionary on main, shape here. The delta
-    // vs EngineOnly is the aggregate per-realm storage overhead removed across them.
+    // Forces the function-only Prototype-derived prototypes shaped in this campaign to Initialize —
+    // dictionary on main, shape here. The delta vs EngineOnly is the aggregate per-realm storage overhead
+    // removed across them.
     private static readonly Prepared<Script> _initPrototypes = Engine.PrepareScript(
-        "Promise.prototype.then; WeakMap.prototype.has; WeakSet.prototype.has; WeakRef.prototype.deref; FinalizationRegistry.prototype.register;");
+        "Promise.prototype.then; WeakMap.prototype.has; WeakSet.prototype.has; WeakRef.prototype.deref; FinalizationRegistry.prototype.register;"
+        + "BigInt.prototype.toString; AggregateError.prototype.name; SuppressedError.prototype.constructor;"
+        + "Uint8Array.prototype.setFromBase64; ShadowRealm.prototype.evaluate;"
+        + "Object.getPrototypeOf(function*(){}).constructor; Object.getPrototypeOf(async function(){}).constructor;"
+        + "Object.getPrototypeOf(async function*(){}).constructor;");
 
     [Benchmark]
     public Engine EngineInitPrototypes()

--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -99,7 +99,9 @@ public class BuiltinShapeBenchmark
         + "Temporal.Instant.prototype.toString; Temporal.PlainTime.prototype.toString;"
         + "Temporal.PlainMonthDay.prototype.toString; Temporal.PlainYearMonth.prototype.toString;"
         + "Intl.Locale.prototype.toString; Intl.Collator.prototype.resolvedOptions;"
-        + "Intl.DateTimeFormat.prototype.resolvedOptions; Intl.NumberFormat.prototype.resolvedOptions;");
+        + "Intl.DateTimeFormat.prototype.resolvedOptions; Intl.NumberFormat.prototype.resolvedOptions;"
+        + "Array.prototype.map; Number.prototype.toFixed; Boolean.prototype.valueOf; Error.prototype.toString;"
+        + "[].values().next; new Map().keys().next; new Set().values().next; ''[Symbol.iterator]().next;");
 
     [Benchmark]
     public Engine EngineInitPrototypes()

--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -102,7 +102,7 @@ public class BuiltinShapeBenchmark
         + "Intl.DateTimeFormat.prototype.resolvedOptions; Intl.NumberFormat.prototype.resolvedOptions;"
         + "Array.prototype.map; Number.prototype.toFixed; Boolean.prototype.valueOf; Error.prototype.toString;"
         + "[].values().next; new Map().keys().next; new Set().values().next; ''[Symbol.iterator]().next;"
-        + "String.prototype.slice; Date.prototype.getTime; Set.prototype.union;");
+        + "String.prototype.slice; Date.prototype.getTime; Set.prototype.union; RegExp.prototype.test;");
 
     [Benchmark]
     public Engine EngineInitPrototypes()

--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -93,7 +93,13 @@ public class BuiltinShapeBenchmark
         + "Object.getPrototypeOf(function*(){}).constructor; Object.getPrototypeOf(async function(){}).constructor;"
         + "Object.getPrototypeOf(async function*(){}).constructor;"
         + "Map.prototype.has; Symbol.prototype.toString; ArrayBuffer.prototype.slice;"
-        + "DataView.prototype.getInt8; Iterator.prototype.toArray;");
+        + "DataView.prototype.getInt8; Iterator.prototype.toArray;"
+        + "Temporal.Duration.prototype.toString; Temporal.PlainDate.prototype.toString;"
+        + "Temporal.PlainDateTime.prototype.toString; Temporal.ZonedDateTime.prototype.toString;"
+        + "Temporal.Instant.prototype.toString; Temporal.PlainTime.prototype.toString;"
+        + "Temporal.PlainMonthDay.prototype.toString; Temporal.PlainYearMonth.prototype.toString;"
+        + "Intl.Locale.prototype.toString; Intl.Collator.prototype.resolvedOptions;"
+        + "Intl.DateTimeFormat.prototype.resolvedOptions; Intl.NumberFormat.prototype.resolvedOptions;");
 
     [Benchmark]
     public Engine EngineInitPrototypes()

--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -113,7 +113,13 @@ public class BuiltinShapeBenchmark
     // shape here. Constructors are Function-derived; the delta vs EngineOnly is the per-realm constructor
     // storage overhead removed.
     private static readonly Prepared<Script> _initConstructors = Engine.PrepareScript(
-        "Object.keys; Array.isArray; ArrayBuffer.isView; Map.groupBy; Set.prototype; Symbol.for; Promise.resolve;");
+        "Object.keys; Array.isArray; ArrayBuffer.isView; Map.groupBy; Set.prototype; Symbol.for; Promise.resolve;"
+        + "Date.now; BigInt.asIntN; String.fromCharCode; Proxy.revocable; Iterator.from;"
+        + "Temporal.PlainDate.from; Temporal.Duration.from; Temporal.Instant.from; Temporal.PlainDateTime.from;"
+        + "Temporal.PlainTime.from; Temporal.PlainYearMonth.from; Temporal.PlainMonthDay.from; Temporal.ZonedDateTime.from;"
+        + "Intl.NumberFormat.supportedLocalesOf; Intl.Collator.supportedLocalesOf; Intl.DateTimeFormat.supportedLocalesOf;"
+        + "Intl.ListFormat.supportedLocalesOf; Intl.PluralRules.supportedLocalesOf; Intl.RelativeTimeFormat.supportedLocalesOf;"
+        + "Intl.Segmenter.supportedLocalesOf; Intl.DisplayNames.supportedLocalesOf; Intl.DurationFormat.supportedLocalesOf;");
 
     [Benchmark]
     public Engine EngineInitConstructors()

--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -101,7 +101,8 @@ public class BuiltinShapeBenchmark
         + "Intl.Locale.prototype.toString; Intl.Collator.prototype.resolvedOptions;"
         + "Intl.DateTimeFormat.prototype.resolvedOptions; Intl.NumberFormat.prototype.resolvedOptions;"
         + "Array.prototype.map; Number.prototype.toFixed; Boolean.prototype.valueOf; Error.prototype.toString;"
-        + "[].values().next; new Map().keys().next; new Set().values().next; ''[Symbol.iterator]().next;");
+        + "[].values().next; new Map().keys().next; new Set().values().next; ''[Symbol.iterator]().next;"
+        + "String.prototype.slice; Date.prototype.getTime; Set.prototype.union;");
 
     [Benchmark]
     public Engine EngineInitPrototypes()

--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -82,4 +82,18 @@ public class BuiltinShapeBenchmark
         engine.Evaluate(_initGenerators);
         return engine;
     }
+
+    // Forces the five function-only Prototype-derived prototypes shaped in wave 2 (Promise, WeakMap,
+    // WeakSet, WeakRef, FinalizationRegistry) to Initialize — dictionary on main, shape here. The delta
+    // vs EngineOnly is the aggregate per-realm storage overhead removed across them.
+    private static readonly Prepared<Script> _initPrototypes = Engine.PrepareScript(
+        "Promise.prototype.then; WeakMap.prototype.has; WeakSet.prototype.has; WeakRef.prototype.deref; FinalizationRegistry.prototype.register;");
+
+    [Benchmark]
+    public Engine EngineInitPrototypes()
+    {
+        var engine = new Engine();
+        engine.Evaluate(_initPrototypes);
+        return engine;
+    }
 }

--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -108,4 +108,18 @@ public class BuiltinShapeBenchmark
         engine.Evaluate(_initPrototypes);
         return engine;
     }
+
+    // Forces the shaped constructors to Initialize (touch a static member on each) — dictionary on main,
+    // shape here. Constructors are Function-derived; the delta vs EngineOnly is the per-realm constructor
+    // storage overhead removed.
+    private static readonly Prepared<Script> _initConstructors = Engine.PrepareScript(
+        "Object.keys; Array.isArray; ArrayBuffer.isView; Map.groupBy; Set.prototype; Symbol.for; Promise.resolve;");
+
+    [Benchmark]
+    public Engine EngineInitConstructors()
+    {
+        var engine = new Engine();
+        engine.Evaluate(_initConstructors);
+        return engine;
+    }
 }

--- a/Jint.SourceGenerators/Attributes.cs
+++ b/Jint.SourceGenerators/Attributes.cs
@@ -195,5 +195,27 @@ internal static class Attributes
             public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
         }
 
+        // Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+        // generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+        // to the very same function object — the spec function-identity aliases, e.g.
+        //   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+        //   [JsAlias("trimLeft", "trimStart")]
+        //   [JsAlias("toGMTString", "toUTCString")]
+        // The alias appears after all other own properties in own-key order (matching the hand-written
+        // AddDangerous/SetProperty tail it replaces).
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+        [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+        internal sealed class JsAliasAttribute : global::System.Attribute
+        {
+            public JsAliasAttribute(string name, string target)
+            {
+                Name = name;
+                Target = target;
+            }
+
+            public string Name { get; }
+            public string Target { get; }
+        }
+
         """;
 }

--- a/Jint.SourceGenerators/Emitter.cs
+++ b/Jint.SourceGenerators/Emitter.cs
@@ -130,6 +130,7 @@ internal static class Emitter
         foreach (var ir in obj.IntrinsicReferences) yield return ir.JsName;
         foreach (var name in accessorsByName.Keys) yield return name;
         foreach (var thr in obj.ThrowerAccessors) yield return thr.JsName;
+        foreach (var a in obj.Aliases) yield return a.Name;
     }
 
     /// <summary>
@@ -177,7 +178,7 @@ internal static class Emitter
             }
         }
 
-        var totalEntries = dataProperties.Count + obj.Properties.Count + accessorsByName.Count + obj.ThrowerAccessors.Count + obj.IntrinsicReferences.Count;
+        var totalEntries = dataProperties.Count + obj.Properties.Count + accessorsByName.Count + obj.ThrowerAccessors.Count + obj.IntrinsicReferences.Count + obj.Aliases.Count;
 
         if (totalEntries > 0) EmitStaticKeyCache(sb, obj, dataProperties, accessorsByName);
 
@@ -326,6 +327,13 @@ internal static class Emitter
             }
         }
 
+        // Aliases: share the target member's descriptor (added last, matching own-key order).
+        foreach (var alias in obj.Aliases)
+        {
+            sb.Append("        properties.TryGetValue(__Key_").Append(SanitizeIdentifier(alias.Target)).Append(", out var __alias_").Append(SanitizeIdentifier(alias.Name)).AppendLine(");");
+            sb.Append("        properties.AddDangerous(__Key_").Append(SanitizeIdentifier(alias.Name)).Append(", __alias_").Append(SanitizeIdentifier(alias.Name)).AppendLine(");");
+        }
+
         sb.AppendLine("        SetProperties(properties);");
         sb.AppendLine("    }");
     }
@@ -352,7 +360,7 @@ internal static class Emitter
         sb.AppendLine();
         sb.AppendLine("    private static global::Jint.Native.Object.BuiltinShape BuildBuiltinShape_Generated()");
         sb.AppendLine("    {");
-        sb.Append("        var builder = new global::Jint.Native.Object.BuiltinShape.Builder(").Append(obj.Properties.Count + dataProperties.Count + accessorsByName.Count).AppendLine(");");
+        sb.Append("        var builder = new global::Jint.Native.Object.BuiltinShape.Builder(").Append(obj.Properties.Count + dataProperties.Count + accessorsByName.Count + obj.Aliases.Count).AppendLine(");");
         // Order matches the dictionary path: properties, then functions, then accessors (each sorted by JsName).
         // Static-immutable constants share a process-wide descriptor; other properties are per-realm instance slots.
         foreach (var prop in obj.Properties)
@@ -380,6 +388,11 @@ internal static class Emitter
             var (get, set, flags) = accessorsByName[name];
             sb.Append("        builder.Accessor(__Key_").Append(SanitizeIdentifier(name)).Append(", ")
               .Append(SlotExpr(get)).Append(", ").Append(SlotExpr(set)).Append(", ").Append(flags).AppendLine(");");
+        }
+        // Aliases last (matching own-key order); each shares its already-added target slot's descriptor.
+        foreach (var alias in obj.Aliases)
+        {
+            sb.Append("        builder.Alias(__Key_").Append(SanitizeIdentifier(alias.Name)).Append(", __Key_").Append(SanitizeIdentifier(alias.Target)).AppendLine(");");
         }
         sb.AppendLine("        return builder.Build();");
         sb.AppendLine("    }");

--- a/Jint.SourceGenerators/Emitter.cs
+++ b/Jint.SourceGenerators/Emitter.cs
@@ -26,7 +26,14 @@ internal static class Emitter
 
         sb.Append(obj.Accessibility).Append(" ");
         if (obj.IsSealed) sb.Append("sealed ");
-        sb.Append("partial class ").AppendLine(obj.Name);
+        sb.Append("partial class ").Append(obj.Name);
+        // A shaped host that does not derive from BuiltinShapeObject gets its IBuiltinShaped storage emitted
+        // here (see EmitShapeMembers); declare the interface on this partial so the field/impls satisfy it.
+        if (obj.UseShape && !obj.DerivesFromBuiltinShapeObject)
+        {
+            sb.Append(" : global::Jint.Native.Object.IBuiltinShaped");
+        }
+        sb.AppendLine();
         sb.AppendLine("{");
 
         EmitStaticPropertyDescriptors(sb, obj);
@@ -364,11 +371,31 @@ internal static class Emitter
         sb.AppendLine("        return builder.Build();");
         sb.AppendLine("    }");
         sb.AppendLine();
-        sb.AppendLine("    private protected override global::Jint.Native.Object.BuiltinShape BuiltinShape => __builtinShape;");
-        sb.AppendLine();
-        sb.Append("    private protected override global::Jint.Native.Function.Function MakeBuiltinFunction(global::System.UInt16 slot) => new ").Append(dispatcher).Append("(this");
-        if (!singleSlot) sb.Append(", (").Append(dispatcher).Append(".Slot) slot");
-        sb.AppendLine(");");
+
+        if (obj.DerivesFromBuiltinShapeObject)
+        {
+            // Storage (the per-realm descriptor array + IBuiltinShaped) comes from the BuiltinShapeObject base;
+            // just supply the two abstract hooks it declares.
+            sb.AppendLine("    private protected override global::Jint.Native.Object.BuiltinShape BuiltinShape => __builtinShape;");
+            sb.AppendLine();
+            sb.Append("    private protected override global::Jint.Native.Function.Function MakeBuiltinFunction(global::System.UInt16 slot) => new ").Append(dispatcher).Append("(this");
+            if (!singleSlot) sb.Append(", (").Append(dispatcher).Append(".Slot) slot");
+            sb.AppendLine(");");
+        }
+        else
+        {
+            // Non-BuiltinShapeObject host (prototype / constructor): emit the per-realm descriptor field and the
+            // IBuiltinShaped implementation here, so the shape store composes without a shared base class.
+            sb.AppendLine("    private global::Jint.Runtime.Descriptors.PropertyDescriptor?[]? __builtinDescriptors;");
+            sb.AppendLine();
+            sb.AppendLine("    global::Jint.Native.Object.BuiltinShape global::Jint.Native.Object.IBuiltinShaped.BuiltinShape => __builtinShape;");
+            sb.AppendLine();
+            sb.AppendLine("    global::Jint.Runtime.Descriptors.PropertyDescriptor?[]? global::Jint.Native.Object.IBuiltinShaped.BuiltinDescriptors { get => __builtinDescriptors; set => __builtinDescriptors = value; }");
+            sb.AppendLine();
+            sb.Append("    global::Jint.Native.Function.Function global::Jint.Native.Object.IBuiltinShaped.MakeBuiltinFunction(global::System.UInt16 slot) => new ").Append(dispatcher).Append("(this");
+            if (!singleSlot) sb.Append(", (").Append(dispatcher).Append(".Slot) slot");
+            sb.AppendLine(");");
+        }
     }
 
     private static void EmitDispatcher(StringBuilder sb, ObjectDefinition obj)

--- a/Jint.SourceGenerators/Emitter.cs
+++ b/Jint.SourceGenerators/Emitter.cs
@@ -201,7 +201,7 @@ internal static class Emitter
                 sb.Append(prop.ClrName).Append(", ").Append(prop.FlagsExpression).AppendLine(");");
             }
             sb.AppendLine("    }");
-            EmitShapeMembers(sb, obj, dataProperties);
+            EmitShapeMembers(sb, obj, dataProperties, accessorsByName);
             return;
         }
 
@@ -337,19 +337,24 @@ internal static class Emitter
     /// after the static Key / descriptor fields in this same generated file, so it runs after them.
     /// Supports [JsFunction]s, static-immutable [JsProperty] constants, and [JsSymbol]s.
     /// </summary>
-    private static void EmitShapeMembers(StringBuilder sb, ObjectDefinition obj, List<FunctionDefinition> dataProperties)
+    private static void EmitShapeMembers(StringBuilder sb, ObjectDefinition obj, List<FunctionDefinition> dataProperties, IReadOnlyDictionary<string, (FunctionDefinition? Get, FunctionDefinition? Set, string Flags)> accessorsByName)
     {
         var dispatcher = "__" + obj.Name + "Function";
         var singleSlot = obj.Functions.Count == 1;
+
+        // Slot expression for a getter/setter half: NotAFunction when absent, else the dispatcher slot id.
+        string SlotExpr(FunctionDefinition? fn) => fn is null
+            ? "global::Jint.Native.Object.BuiltinShape.NotAFunction"
+            : singleSlot ? "(global::System.UInt16) 0" : "(global::System.UInt16) " + dispatcher + ".Slot." + fn.ClrName;
 
         sb.AppendLine();
         sb.AppendLine("    private static readonly global::Jint.Native.Object.BuiltinShape __builtinShape = BuildBuiltinShape_Generated();");
         sb.AppendLine();
         sb.AppendLine("    private static global::Jint.Native.Object.BuiltinShape BuildBuiltinShape_Generated()");
         sb.AppendLine("    {");
-        sb.Append("        var builder = new global::Jint.Native.Object.BuiltinShape.Builder(").Append(obj.Properties.Count + dataProperties.Count).AppendLine(");");
-        // Properties first (matching the dictionary path's order): static-immutable constants share a
-        // process-wide descriptor; everything else is a per-realm instance slot filled in Initialize.
+        sb.Append("        var builder = new global::Jint.Native.Object.BuiltinShape.Builder(").Append(obj.Properties.Count + dataProperties.Count + accessorsByName.Count).AppendLine(");");
+        // Order matches the dictionary path: properties, then functions, then accessors (each sorted by JsName).
+        // Static-immutable constants share a process-wide descriptor; other properties are per-realm instance slots.
         foreach (var prop in obj.Properties)
         {
             if (prop.IsStatic && prop.IsImmutable)
@@ -367,6 +372,14 @@ internal static class Emitter
             if (singleSlot) sb.Append('0');
             else sb.Append(dispatcher).Append(".Slot.").Append(fn.ClrName);
             sb.Append(", ").Append(fn.FlagsExpression).AppendLine(");");
+        }
+        var accessorNames = new List<string>(accessorsByName.Keys);
+        accessorNames.Sort(StringComparer.Ordinal);
+        foreach (var name in accessorNames)
+        {
+            var (get, set, flags) = accessorsByName[name];
+            sb.Append("        builder.Accessor(__Key_").Append(SanitizeIdentifier(name)).Append(", ")
+              .Append(SlotExpr(get)).Append(", ").Append(SlotExpr(set)).Append(", ").Append(flags).AppendLine(");");
         }
         sb.AppendLine("        return builder.Build();");
         sb.AppendLine("    }");

--- a/Jint.SourceGenerators/Emitter.cs
+++ b/Jint.SourceGenerators/Emitter.cs
@@ -372,15 +372,26 @@ internal static class Emitter
         sb.AppendLine("    }");
         sb.AppendLine();
 
+        // A shaped host with no [JsFunction]s (only instance/constant properties + symbols) has no dispatcher
+        // and no function slots, so MakeBuiltinFunction is never invoked — emit a throwing body rather than
+        // reference a dispatcher type that isn't generated.
+        string makeBody;
+        if (obj.Functions.Count == 0)
+        {
+            makeBody = "=> throw new global::System.InvalidOperationException(\"" + obj.Name + " has no built-in function slots\")";
+        }
+        else
+        {
+            makeBody = "=> new " + dispatcher + "(this" + (singleSlot ? "" : ", (" + dispatcher + ".Slot) slot") + ")";
+        }
+
         if (obj.DerivesFromBuiltinShapeObject)
         {
             // Storage (the per-realm descriptor array + IBuiltinShaped) comes from the BuiltinShapeObject base;
             // just supply the two abstract hooks it declares.
             sb.AppendLine("    private protected override global::Jint.Native.Object.BuiltinShape BuiltinShape => __builtinShape;");
             sb.AppendLine();
-            sb.Append("    private protected override global::Jint.Native.Function.Function MakeBuiltinFunction(global::System.UInt16 slot) => new ").Append(dispatcher).Append("(this");
-            if (!singleSlot) sb.Append(", (").Append(dispatcher).Append(".Slot) slot");
-            sb.AppendLine(");");
+            sb.Append("    private protected override global::Jint.Native.Function.Function MakeBuiltinFunction(global::System.UInt16 slot) ").Append(makeBody).AppendLine(";");
         }
         else
         {
@@ -392,9 +403,7 @@ internal static class Emitter
             sb.AppendLine();
             sb.AppendLine("    global::Jint.Runtime.Descriptors.PropertyDescriptor?[]? global::Jint.Native.Object.IBuiltinShaped.BuiltinDescriptors { get => __builtinDescriptors; set => __builtinDescriptors = value; }");
             sb.AppendLine();
-            sb.Append("    global::Jint.Native.Function.Function global::Jint.Native.Object.IBuiltinShaped.MakeBuiltinFunction(global::System.UInt16 slot) => new ").Append(dispatcher).Append("(this");
-            if (!singleSlot) sb.Append(", (").Append(dispatcher).Append(".Slot) slot");
-            sb.AppendLine(");");
+            sb.Append("    global::Jint.Native.Function.Function global::Jint.Native.Object.IBuiltinShaped.MakeBuiltinFunction(global::System.UInt16 slot) ").Append(makeBody).AppendLine(";");
         }
     }
 

--- a/Jint.SourceGenerators/Models.cs
+++ b/Jint.SourceGenerators/Models.cs
@@ -354,17 +354,11 @@ internal sealed record class ObjectDefinition(
         // representable yet — fail loudly rather than silently dropping them.
         if (useShape)
         {
-            var hasUnsupported = intrinsicReferences.Count > 0 || throwerAccessors.Count > 0;
-            foreach (var fn in functions)
-            {
-                if (fn.Registration is RegistrationKind.AccessorGet or RegistrationKind.AccessorSet
-                    or RegistrationKind.SymbolAccessorGet or RegistrationKind.SymbolAccessorSet)
-                {
-                    hasUnsupported = true;
-                    break;
-                }
-            }
-            if (hasUnsupported)
+            // The shape path supports [JsFunction]s, static-immutable constants + per-realm instance
+            // properties, symbols, string [JsAccessor]s (a GetSetPropertyDescriptor slot), and symbol
+            // accessors (which register in the symbol dictionary, orthogonal to the string shape).
+            // Intrinsic references and thrower accessors are not representable yet — fail loudly.
+            if (intrinsicReferences.Count > 0 || throwerAccessors.Count > 0)
             {
                 diagnostics.Add(new DiagnosticInfo(DiagnosticDescriptors.UnsupportedShapeMember, location, typeSymbol.Name));
             }

--- a/Jint.SourceGenerators/Models.cs
+++ b/Jint.SourceGenerators/Models.cs
@@ -40,6 +40,7 @@ internal sealed record class ObjectDefinition(
     EquatableArray<SymbolDefinition> Symbols,
     EquatableArray<ThrowerAccessorDefinition> ThrowerAccessors,
     EquatableArray<IntrinsicReferenceDefinition> IntrinsicReferences,
+    EquatableArray<AliasDefinition> Aliases,
     EquatableArray<DiagnosticInfo> DiagnosticInfos)
 {
     public string HintName => string.IsNullOrEmpty(Namespace)
@@ -136,6 +137,7 @@ internal sealed record class ObjectDefinition(
         var symbols = new List<SymbolDefinition>();
         var throwerAccessors = new List<ThrowerAccessorDefinition>();
         var intrinsicReferences = new List<IntrinsicReferenceDefinition>();
+        var aliases = new List<AliasDefinition>();
         HashSet<string>? seenFunctionClrNames = null;
         HashSet<string>? seenThrowerNames = null;
         HashSet<string>? seenIntrinsicReferenceNames = null;
@@ -191,6 +193,17 @@ internal sealed record class ObjectDefinition(
                 JsName: jsName!,
                 IntrinsicMember: intrinsicMember!,
                 FlagsExpression: FlagExpression.From(refFlagsExplicit, "Configurable")));
+        }
+
+        // Class-level [JsAlias("name", "target")] — a string property that shares another member's descriptor.
+        foreach (var attr in typeSymbol.GetAttributes())
+        {
+            if (attr.AttributeClass?.Name != "JsAliasAttribute") continue;
+            if (attr.ConstructorArguments.Length < 2) continue;
+            var aliasName = attr.ConstructorArguments[0].Value as string;
+            var aliasTarget = attr.ConstructorArguments[1].Value as string;
+            if (string.IsNullOrWhiteSpace(aliasName) || string.IsNullOrWhiteSpace(aliasTarget)) continue;
+            aliases.Add(new AliasDefinition(aliasName!, aliasTarget!));
         }
 
         foreach (var member in typeSymbol.GetMembers())
@@ -383,6 +396,7 @@ internal sealed record class ObjectDefinition(
             Symbols: symbols.ToEquatableArray(),
             ThrowerAccessors: throwerAccessors.ToEquatableArray(),
             IntrinsicReferences: intrinsicReferences.ToEquatableArray(),
+            Aliases: aliases.ToEquatableArray(),
             DiagnosticInfos: diagnostics.ToEquatableArray());
     }
 
@@ -491,6 +505,8 @@ internal enum RegistrationKind
 internal sealed record class ThrowerAccessorDefinition(string JsName, string FlagsExpression);
 
 internal sealed record class IntrinsicReferenceDefinition(string JsName, string IntrinsicMember, string FlagsExpression);
+
+internal sealed record class AliasDefinition(string Name, string Target);
 
 internal sealed record class FunctionDefinition(
     string ClrName,

--- a/Jint.SourceGenerators/Models.cs
+++ b/Jint.SourceGenerators/Models.cs
@@ -34,6 +34,7 @@ internal sealed record class ObjectDefinition(
     bool IsSealed,
     int ExtraCapacity,
     bool UseShape,
+    bool DerivesFromBuiltinShapeObject,
     EquatableArray<FunctionDefinition> Functions,
     EquatableArray<PropertyDefinition> Properties,
     EquatableArray<SymbolDefinition> Symbols,
@@ -103,13 +104,14 @@ internal sealed record class ObjectDefinition(
         // explicit opt-out. Hosts that don't derive from it always use the dictionary path regardless.
         var extraCapacity = 0;
         var useShapeRequested = true;
+        var useShapeExplicitlySet = false;
         foreach (var attr in typeSymbol.GetAttributes())
         {
             if (attr.AttributeClass?.Name != "JsObjectAttribute") continue;
             foreach (var named in attr.NamedArguments)
             {
                 if (named.Key == "ExtraCapacity" && named.Value.Value is int v) extraCapacity = v;
-                else if (named.Key == "UseShape" && named.Value.Value is bool s) useShapeRequested = s;
+                else if (named.Key == "UseShape" && named.Value.Value is bool s) { useShapeRequested = s; useShapeExplicitlySet = true; }
             }
         }
 
@@ -122,7 +124,12 @@ internal sealed record class ObjectDefinition(
                 break;
             }
         }
-        var useShape = useShapeRequested && derivesFromBuiltinShapeObject;
+        // Two opt-ins: deriving from BuiltinShapeObject enables shapes by default (UseShape = false opts out);
+        // a host on any other base (a prototype / constructor) opts in with an explicit [JsObject(UseShape = true)],
+        // in which case the generator emits the IBuiltinShaped storage glue onto the host itself.
+        var useShape = derivesFromBuiltinShapeObject
+            ? useShapeRequested
+            : (useShapeExplicitlySet && useShapeRequested);
 
         var functions = new List<FunctionDefinition>();
         var properties = new List<PropertyDefinition>();
@@ -376,6 +383,7 @@ internal sealed record class ObjectDefinition(
             IsSealed: typeSymbol.IsSealed,
             ExtraCapacity: extraCapacity,
             UseShape: useShape,
+            DerivesFromBuiltinShapeObject: derivesFromBuiltinShapeObject,
             Functions: functions.ToEquatableArray(),
             Properties: properties.ToEquatableArray(),
             Symbols: symbols.ToEquatableArray(),

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpan#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpan#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpanTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpanTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateIntrinsicReference_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateIntrinsicReference_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReference#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReference#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReferenceWithoutRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReferenceWithoutRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -190,3 +190,25 @@ internal sealed class JsSymbolAccessorAttribute : global::System.Attribute
     public AccessorKind Kind { get; }
     public global::Jint.Runtime.Descriptors.PropertyFlag Flags { get; set; } = global::Jint.Runtime.Descriptors.PropertyFlag.Configurable;
 }
+
+// Class-level, repeats. Registers a string own property <Name> that shares the descriptor of another
+// generated [JsFunction] member <Target> (which must exist on the same host), so the two names resolve
+// to the very same function object — the spec function-identity aliases, e.g.
+//   [JsAlias("keys", "values")]       // Set.prototype.keys === values
+//   [JsAlias("trimLeft", "trimStart")]
+//   [JsAlias("toGMTString", "toUTCString")]
+// The alias appears after all other own properties in own-key order (matching the hand-written
+// AddDangerous/SetProperty tail it replaces).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsAliasAttribute : global::System.Attribute
+{
+    public JsAliasAttribute(string name, string target)
+    {
+        Name = name;
+        Target = target;
+    }
+
+    public string Name { get; }
+    public string Target { get; }
+}

--- a/Jint/Native/AggregateError/AggregateErrorPrototype.cs
+++ b/Jint/Native/AggregateError/AggregateErrorPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.AggregateError;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-prototype-objects
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class AggregateErrorPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -14,7 +14,7 @@ using Jint.Runtime.Interop;
 
 namespace Jint.Native.Array;
 
-[JsObject]
+[JsObject(UseShape = true)]
 public sealed partial class ArrayConstructor : Constructor
 {
     private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;

--- a/Jint/Native/Array/ArrayIteratorPrototype.cs
+++ b/Jint/Native/Array/ArrayIteratorPrototype.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.Array;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
 {
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString ArrayIteratorToStringTag = new("Array Iterator");

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -18,7 +18,7 @@ namespace Jint.Native.Array;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-array-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 public sealed partial class ArrayPrototype : ArrayInstance
 {
     private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;

--- a/Jint/Native/ArrayBuffer/ArrayBufferConstructor.cs
+++ b/Jint/Native/ArrayBuffer/ArrayBufferConstructor.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.ArrayBuffer;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 public sealed partial class ArrayBufferConstructor : Constructor
 {
     private static readonly JsString _functionName = new("ArrayBuffer");

--- a/Jint/Native/ArrayBuffer/ArrayBufferPrototype.cs
+++ b/Jint/Native/ArrayBuffer/ArrayBufferPrototype.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.ArrayBuffer;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class ArrayBufferPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/AsyncFunction/AsyncFunctionPrototype.cs
+++ b/Jint/Native/AsyncFunction/AsyncFunctionPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.AsyncFunction;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-async-function-prototype-properties
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class AsyncFunctionPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorFunctionPrototype.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorFunctionPrototype.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.AsyncGenerator;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction-prototype
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class AsyncGeneratorFunctionPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.Configurable)]

--- a/Jint/Native/BigInt/BigIntConstructor.cs
+++ b/Jint/Native/BigInt/BigIntConstructor.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.BigInt;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-bigint-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class BigIntConstructor : Constructor
 {
     private static readonly JsString _functionName = new("BigInt");

--- a/Jint/Native/BigInt/BigIntPrototype.cs
+++ b/Jint/Native/BigInt/BigIntPrototype.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.BigInt;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-bigint-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class BigIntPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Boolean/BooleanPrototype.cs
+++ b/Jint/Native/Boolean/BooleanPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.Boolean;
 /// <summary>
 ///     http://www.ecma-international.org/ecma-262/5.1/#sec-15.6.4
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class BooleanPrototype : BooleanInstance
 {
     private readonly Realm _realm;

--- a/Jint/Native/DataView/DataViewPrototype.cs
+++ b/Jint/Native/DataView/DataViewPrototype.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.DataView;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-dataview-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class DataViewPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Date;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-date-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class DateConstructor : Constructor
 {
     internal static readonly DateTime Epoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);

--- a/Jint/Native/Date/DatePrototype.cs
+++ b/Jint/Native/Date/DatePrototype.cs
@@ -16,7 +16,10 @@ namespace Jint.Native.Date;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-date-prototype-object
 /// </summary>
-[JsObject(ExtraCapacity = 1)]
+// Annex B 7.1.2: Date.prototype.toGMTString is the same function as toUTCString — [JsAlias] expresses
+// that through the shape.
+[JsAlias("toGMTString", "toUTCString")]
+[JsObject(UseShape = true)]
 internal sealed partial class DatePrototype : Prototype
 {
     // ES6 section 20.3.1.1 Time Values and Time Range
@@ -45,12 +48,6 @@ internal sealed partial class DatePrototype : Prototype
     {
         CreateProperties_Generated();
         CreateSymbols_Generated();
-        // Annex B 7.1.2: Date.prototype.toGMTString must be the same function reference as toUTCString.
-        // Aliasing the same descriptor instance — the lazy resolver fires once and both keys see the
-        // same Function object. AddDangerous skips SetOwnProperty's validation; ExtraCapacity=1 on
-        // [JsObject] presizes the dict so this add doesn't trigger a resize.
-        _properties!.TryGetValue("toUTCString", out var utcDesc);
-        _properties.AddDangerous("toGMTString", utcDesc);
     }
 
     /// <summary>

--- a/Jint/Native/Disposable/AsyncDisposableStackPrototype.cs
+++ b/Jint/Native/Disposable/AsyncDisposableStackPrototype.cs
@@ -6,7 +6,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Disposable;
 
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class AsyncDisposableStackPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Disposable/DisposableStackPrototype.cs
+++ b/Jint/Native/Disposable/DisposableStackPrototype.cs
@@ -5,7 +5,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Disposable;
 
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class DisposableStackPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Error/ErrorConstructor.cs
+++ b/Jint/Native/Error/ErrorConstructor.cs
@@ -4,7 +4,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Error;
 
-[JsObject]
+[JsObject(UseShape = true)]
 public sealed partial class ErrorConstructor : Constructor
 {
     private readonly Func<Intrinsics, ObjectInstance> _intrinsicDefaultProto;

--- a/Jint/Native/Error/ErrorPrototype.cs
+++ b/Jint/Native/Error/ErrorPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.Error;
 /// <summary>
 /// http://www.ecma-international.org/ecma-262/5.1/#sec-15.11.4
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class ErrorPrototype : ErrorInstance
 {
     [JsProperty(Name = "name", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/FinalizationRegistry/FinalizationRegistryPrototype.cs
+++ b/Jint/Native/FinalizationRegistry/FinalizationRegistryPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.FinalizationRegistry;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class FinalizationRegistryPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Generator/GeneratorFunctionPrototype.cs
+++ b/Jint/Native/Generator/GeneratorFunctionPrototype.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.Generator;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class GeneratorFunctionPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.Configurable)]

--- a/Jint/Native/Intl/CollatorConstructor.cs
+++ b/Jint/Native/Intl/CollatorConstructor.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-the-intl-collator-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class CollatorConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Collator");
@@ -385,18 +385,14 @@ internal sealed partial class CollatorConstructor : Constructor
     {
         var options = sensitivity switch
         {
-            "base" =>
-                // Ignore case and accents
-                CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace,
-            "accent" =>
-                // Ignore case but consider accents
-                CompareOptions.IgnoreCase,
-            "case" =>
-                // Consider case but ignore accents
-                CompareOptions.IgnoreNonSpace,
-            "variant" =>
-                // Consider both case and accents
-                CompareOptions.None,
+            // Ignore case and accents
+            "base" => CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace,
+            // Ignore case but consider accents
+            "accent" => CompareOptions.IgnoreCase,
+            // Consider case but ignore accents
+            "case" => CompareOptions.IgnoreNonSpace,
+            // Consider both case and accents
+            "variant" => CompareOptions.None,
             _ => CompareOptions.None,
         };
 

--- a/Jint/Native/Intl/CollatorPrototype.cs
+++ b/Jint/Native/Intl/CollatorPrototype.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-the-intl-collator-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class CollatorPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -23,7 +23,7 @@ internal enum DateTimeDefaults { Date, Time, YearMonth, MonthDay, ZonedDateTime,
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class DateTimeFormatConstructor : Constructor
 {
     private static readonly JsString _functionName = new("DateTimeFormat");

--- a/Jint/Native/Intl/DateTimeFormatPrototype.cs
+++ b/Jint/Native/Intl/DateTimeFormatPrototype.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-datetimeformat-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class DateTimeFormatPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Intl/DisplayNamesConstructor.cs
+++ b/Jint/Native/Intl/DisplayNamesConstructor.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-displaynames-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class DisplayNamesConstructor : Constructor
 {
     private static readonly JsString _functionName = new("DisplayNames");

--- a/Jint/Native/Intl/DisplayNamesPrototype.cs
+++ b/Jint/Native/Intl/DisplayNamesPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-displaynames-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class DisplayNamesPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Intl/DurationFormatConstructor.cs
+++ b/Jint/Native/Intl/DurationFormatConstructor.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/proposal-intl-duration-format/
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class DurationFormatConstructor : Constructor
 {
     private static readonly JsString _functionName = new("DurationFormat");

--- a/Jint/Native/Intl/DurationFormatPrototype.cs
+++ b/Jint/Native/Intl/DurationFormatPrototype.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/proposal-intl-duration-format/
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class DurationFormatPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Intl/IntlInstance.cs
+++ b/Jint/Native/Intl/IntlInstance.cs
@@ -8,10 +8,20 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#intl-object
 /// </summary>
-// ExtraCapacity = 10 covers the post-Initialize SetProperty calls below for the 10 sub-namespace
-// constructor refs (Collator/DateTimeFormat/.../Segmenter), which can't be expressed via [JsProperty]
-// because they read from _realm.Intrinsics.X (not generator-friendly).
-[JsObject(ExtraCapacity = 10)]
+// The 10 sub-namespace constructor references (Collator/DateTimeFormat/.../Segmenter) are lazy
+// realm-intrinsic references, emitted by the generator exactly like globalThis's constructor
+// properties (see GlobalObject.Properties.cs): each resolves _realm.Intrinsics.X on first read.
+[JsIntrinsicReference("Collator")]
+[JsIntrinsicReference("DateTimeFormat")]
+[JsIntrinsicReference("DisplayNames")]
+[JsIntrinsicReference("DurationFormat")]
+[JsIntrinsicReference("ListFormat")]
+[JsIntrinsicReference("Locale")]
+[JsIntrinsicReference("NumberFormat")]
+[JsIntrinsicReference("PluralRules")]
+[JsIntrinsicReference("RelativeTimeFormat")]
+[JsIntrinsicReference("Segmenter")]
+[JsObject]
 internal sealed partial class IntlInstance : ObjectInstance
 {
     private readonly Realm _realm;
@@ -36,20 +46,6 @@ internal sealed partial class IntlInstance : ObjectInstance
     {
         CreateProperties_Generated();
         CreateSymbols_Generated();
-
-        // Constructor references aren't generator-friendly (they pull from _realm.Intrinsics);
-        // register them after generated properties to avoid a separate generator feature.
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        SetProperty("Collator", new PropertyDescriptor(_realm.Intrinsics.Collator, PropertyFlags));
-        SetProperty("DateTimeFormat", new PropertyDescriptor(_realm.Intrinsics.DateTimeFormat, PropertyFlags));
-        SetProperty("DisplayNames", new PropertyDescriptor(_realm.Intrinsics.DisplayNames, PropertyFlags));
-        SetProperty("DurationFormat", new PropertyDescriptor(_realm.Intrinsics.DurationFormat, PropertyFlags));
-        SetProperty("ListFormat", new PropertyDescriptor(_realm.Intrinsics.ListFormat, PropertyFlags));
-        SetProperty("Locale", new PropertyDescriptor(_realm.Intrinsics.Locale, PropertyFlags));
-        SetProperty("NumberFormat", new PropertyDescriptor(_realm.Intrinsics.NumberFormat, PropertyFlags));
-        SetProperty("PluralRules", new PropertyDescriptor(_realm.Intrinsics.PluralRules, PropertyFlags));
-        SetProperty("RelativeTimeFormat", new PropertyDescriptor(_realm.Intrinsics.RelativeTimeFormat, PropertyFlags));
-        SetProperty("Segmenter", new PropertyDescriptor(_realm.Intrinsics.Segmenter, PropertyFlags));
     }
 
     /// <summary>

--- a/Jint/Native/Intl/ListFormatConstructor.cs
+++ b/Jint/Native/Intl/ListFormatConstructor.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-listformat-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class ListFormatConstructor : Constructor
 {
     private static readonly JsString _functionName = new("ListFormat");

--- a/Jint/Native/Intl/ListFormatPrototype.cs
+++ b/Jint/Native/Intl/ListFormatPrototype.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-listformat-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class ListFormatPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Intl/LocalePrototype.cs
+++ b/Jint/Native/Intl/LocalePrototype.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-locale-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class LocalePrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Intl/NumberFormatConstructor.cs
+++ b/Jint/Native/Intl/NumberFormatConstructor.cs
@@ -12,7 +12,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-numberformat-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class NumberFormatConstructor : Constructor
 {
     private static readonly JsString _functionName = new("NumberFormat");

--- a/Jint/Native/Intl/NumberFormatPrototype.cs
+++ b/Jint/Native/Intl/NumberFormatPrototype.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-numberformat-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class NumberFormatPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Intl/PluralRulesConstructor.cs
+++ b/Jint/Native/Intl/PluralRulesConstructor.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-pluralrules-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PluralRulesConstructor : Constructor
 {
     private static readonly JsString _functionName = new("PluralRules");

--- a/Jint/Native/Intl/PluralRulesPrototype.cs
+++ b/Jint/Native/Intl/PluralRulesPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-pluralrules-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PluralRulesPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/RelativeTimeFormatConstructor.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-relativetimeformat-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class RelativeTimeFormatConstructor : Constructor
 {
     private static readonly JsString _functionName = new("RelativeTimeFormat");

--- a/Jint/Native/Intl/RelativeTimeFormatPrototype.cs
+++ b/Jint/Native/Intl/RelativeTimeFormatPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-relativetimeformat-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class RelativeTimeFormatPrototype : Prototype
 {
     private static readonly string[] ValidUnits = ["second", "seconds", "minute", "minutes", "hour", "hours", "day", "days", "week", "weeks", "month", "months", "quarter", "quarters", "year", "years"];

--- a/Jint/Native/Intl/SegmenterConstructor.cs
+++ b/Jint/Native/Intl/SegmenterConstructor.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-intl-segmenter-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class SegmenterConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Segmenter");

--- a/Jint/Native/Intl/SegmenterPrototype.cs
+++ b/Jint/Native/Intl/SegmenterPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.Intl;
 /// <summary>
 /// https://tc39.es/ecma402/#sec-properties-of-intl-segmenter-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class SegmenterPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Iterator/AsyncIteratorConstructor.cs
+++ b/Jint/Native/Iterator/AsyncIteratorConstructor.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.Iterator;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-asynciterator-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class AsyncIteratorConstructor : Constructor
 {
     private static readonly JsString _functionName = new("AsyncIterator");
@@ -135,7 +135,7 @@ internal sealed class WrapForValidAsyncIterator : ObjectInstance
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%wrapforvalidasynciteratorprototype%-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class WrapForValidAsyncIteratorPrototype : Prototype
 {
     internal WrapForValidAsyncIteratorPrototype(

--- a/Jint/Native/Iterator/AsyncIteratorHelperPrototype.cs
+++ b/Jint/Native/Iterator/AsyncIteratorHelperPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.Iterator;
 /// https://tc39.es/ecma262/#sec-%asynciteratorhelperprototype%-object
 /// The %AsyncIteratorHelperPrototype% object is the prototype of async iterator helper objects.
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class AsyncIteratorHelperPrototype : Prototype
 {
     internal AsyncIteratorHelperPrototype(

--- a/Jint/Native/Iterator/AsyncIteratorPrototype.cs
+++ b/Jint/Native/Iterator/AsyncIteratorPrototype.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Iterator;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-asynciteratorprototype
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class AsyncIteratorPrototype : Prototype
 {
     private static readonly JsString AsyncIteratorToStringTag = new("AsyncIterator");

--- a/Jint/Native/Iterator/IteratorConstructor.cs
+++ b/Jint/Native/Iterator/IteratorConstructor.cs
@@ -6,7 +6,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Iterator;
 
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class IteratorConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Iterator");

--- a/Jint/Native/Iterator/IteratorHelperPrototype.cs
+++ b/Jint/Native/Iterator/IteratorHelperPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.Iterator;
 /// https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-object
 /// The %IteratorHelperPrototype% object is the prototype of iterator helper objects.
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class IteratorHelperPrototype : Prototype
 {
     private readonly IteratorPrototype _iteratorPrototype;

--- a/Jint/Native/Iterator/IteratorPrototype.cs
+++ b/Jint/Native/Iterator/IteratorPrototype.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.Iterator;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%iteratorprototype%-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal partial class IteratorPrototype : Prototype
 {
     internal IteratorPrototype(

--- a/Jint/Native/Iterator/WrapForValidIteratorPrototype.cs
+++ b/Jint/Native/Iterator/WrapForValidIteratorPrototype.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.Iterator;
 /// https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%-object
 /// The %WrapForValidIteratorPrototype% object is the prototype of wrapped iterator objects from Iterator.from.
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class WrapForValidIteratorPrototype : Prototype
 {
     internal WrapForValidIteratorPrototype(

--- a/Jint/Native/Map/MapConstructor.cs
+++ b/Jint/Native/Map/MapConstructor.cs
@@ -8,7 +8,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Map;
 
-[JsObject]
+[JsObject(UseShape = true)]
 public sealed partial class MapConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Map");

--- a/Jint/Native/Map/MapIteratorPrototype.cs
+++ b/Jint/Native/Map/MapIteratorPrototype.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.Map;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%mapiteratorprototype%-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class MapIteratorPrototype : IteratorPrototype
 {
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString MapIteratorToStringTag = new("Map Iterator");

--- a/Jint/Native/Map/MapPrototype.cs
+++ b/Jint/Native/Map/MapPrototype.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Map;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-map-objects
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class MapPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Number/NumberPrototype.cs
+++ b/Jint/Native/Number/NumberPrototype.cs
@@ -13,7 +13,7 @@ namespace Jint.Native.Number;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-number-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class NumberPrototype : NumberInstance
 {
     private const int SmallDtoaLength = FastDtoa.KFastDtoaMaximalLength + 8;

--- a/Jint/Native/Object/BuiltinShape.cs
+++ b/Jint/Native/Object/BuiltinShape.cs
@@ -82,7 +82,7 @@ internal sealed class BuiltinShape
         /// <summary>
         /// Reserves a slot for a per-realm instance property (a data property whose value varies per
         /// realm, e.g. a prototype's <c>constructor</c> reference). The descriptor is filled at
-        /// initialization by the owner via <see cref="BuiltinShapeObject.SetBuiltinInstanceDescriptor"/>,
+        /// initialization by the owner via <see cref="ObjectInstance.SetBuiltinInstanceDescriptor"/>,
         /// not lazily materialized — so its template slot stays null and it is never treated as a function.
         /// </summary>
         internal void Instance(in Key name)

--- a/Jint/Native/Object/BuiltinShape.cs
+++ b/Jint/Native/Object/BuiltinShape.cs
@@ -15,6 +15,9 @@ internal enum BuiltinSlotKind : byte
     // Lazily-materialized accessor; FunctionSlots holds the getter dispatcher slot (or NotAFunction) and
     // SetterSlots the setter dispatcher slot (or NotAFunction).
     Accessor,
+    // Shares another slot's materialized descriptor (spec function-identity aliases, e.g.
+    // Set.prototype.keys === Set.prototype.values). FunctionSlots holds the target slot index.
+    Alias,
 }
 
 /// <summary>
@@ -136,6 +139,22 @@ internal sealed class BuiltinShape
             _kinds[_next] = BuiltinSlotKind.Instance;
             _constTemplate[_next] = null;
             _functionSlots[_next] = NotAFunction;
+            _setterSlots[_next] = NotAFunction;
+            _index[name] = _next;
+            _next++;
+        }
+
+        /// <summary>
+        /// Reserves an alias slot that shares the descriptor of an earlier slot named <paramref name="target"/>
+        /// (which must already be added), so the two names resolve to the same materialized function/accessor
+        /// — the spec function-identity aliases like <c>Set.prototype.keys === Set.prototype.values</c>.
+        /// </summary>
+        internal void Alias(in Key name, in Key target)
+        {
+            _names[_next] = name;
+            _kinds[_next] = BuiltinSlotKind.Alias;
+            _constTemplate[_next] = null;
+            _functionSlots[_next] = (ushort) _index[target]; // target slot index
             _setterSlots[_next] = NotAFunction;
             _index[name] = _next;
             _next++;

--- a/Jint/Native/Object/BuiltinShape.cs
+++ b/Jint/Native/Object/BuiltinShape.cs
@@ -3,12 +3,26 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Object;
 
+/// <summary>How a <see cref="BuiltinShape"/> slot's descriptor is produced.</summary>
+internal enum BuiltinSlotKind : byte
+{
+    // Value is the process-shared descriptor already present in ConstTemplate.
+    Constant,
+    // Per-realm data property (e.g. a prototype's `constructor`); descriptor filled by SetBuiltinInstanceDescriptor.
+    Instance,
+    // Lazily-materialized function; FunctionSlots holds the dispatcher slot id.
+    Function,
+    // Lazily-materialized accessor; FunctionSlots holds the getter dispatcher slot (or NotAFunction) and
+    // SetterSlots the setter dispatcher slot (or NotAFunction).
+    Accessor,
+}
+
 /// <summary>
 /// Immutable, process-shared description of a built-in object's string-keyed own-property layout
 /// (names, attributes, and how each slot is produced), built once per built-in type. Paired with a
-/// per-realm value array on <see cref="BuiltinShapeObject"/>, it replaces the per-realm dictionary of
-/// descriptors a built-in would otherwise allocate in <c>Initialize</c>. Symbols are orthogonal and stay
-/// in the object's symbol dictionary.
+/// per-realm value array on a host that implements <see cref="IBuiltinShaped"/>, it replaces the per-realm
+/// dictionary of descriptors a built-in would otherwise allocate in <c>Initialize</c>. Symbols are
+/// orthogonal and stay in the object's symbol dictionary.
 /// </summary>
 internal sealed class BuiltinShape
 {
@@ -16,36 +30,44 @@ internal sealed class BuiltinShape
 
     // Property names in own-property (insertion) order.
     internal readonly Key[] Names;
-    // Per slot: the process-shared descriptor for an immutable constant, or null for a function slot
-    // (filled lazily per realm). Cloned into each instance as the starting per-realm descriptor array.
+    // Per slot: how the slot's descriptor is produced.
+    internal readonly BuiltinSlotKind[] Kinds;
+    // Per slot: the process-shared descriptor for an immutable constant, or null for a lazily-filled slot
+    // (function / accessor / instance). Cloned into each instance as the starting per-realm descriptor array.
     internal readonly PropertyDescriptor?[] ConstTemplate;
-    // Per slot: the dispatcher slot id to materialize for a function, or NotAFunction for a constant.
+    // Per slot: the dispatcher slot id to materialize for a function / accessor getter, or NotAFunction.
     internal readonly ushort[] FunctionSlots;
-    // Per slot: the attributes for a function slot (unused for constants — those carry their own flags).
+    // Per slot: the setter dispatcher slot id for an Accessor slot, or NotAFunction (also for non-accessors).
+    internal readonly ushort[] SetterSlots;
+    // Per slot: the attributes for a function / accessor slot (unused for constants — those carry their own flags).
     internal readonly PropertyFlag[] FunctionFlags;
     // name -> slot index.
     internal readonly StringDictionarySlim<int> Index;
 
     internal int Count => Names.Length;
 
-    private BuiltinShape(Key[] names, PropertyDescriptor?[] constTemplate, ushort[] functionSlots, PropertyFlag[] functionFlags, StringDictionarySlim<int> index)
+    private BuiltinShape(Key[] names, BuiltinSlotKind[] kinds, PropertyDescriptor?[] constTemplate, ushort[] functionSlots, ushort[] setterSlots, PropertyFlag[] functionFlags, StringDictionarySlim<int> index)
     {
         Names = names;
+        Kinds = kinds;
         ConstTemplate = constTemplate;
         FunctionSlots = functionSlots;
+        SetterSlots = setterSlots;
         FunctionFlags = functionFlags;
         Index = index;
     }
 
     /// <summary>
-    /// Accumulates a built-in's entries (constants first, then functions, matching the order a generated
-    /// property dictionary would use) and produces the shared <see cref="BuiltinShape"/>.
+    /// Accumulates a built-in's entries (constants/instances first, then functions, then accessors — matching
+    /// the order a generated property dictionary would use) and produces the shared <see cref="BuiltinShape"/>.
     /// </summary>
     internal sealed class Builder
     {
         private readonly Key[] _names;
+        private readonly BuiltinSlotKind[] _kinds;
         private readonly PropertyDescriptor?[] _constTemplate;
         private readonly ushort[] _functionSlots;
+        private readonly ushort[] _setterSlots;
         private readonly PropertyFlag[] _functionFlags;
         private readonly StringDictionarySlim<int> _index;
         private int _next;
@@ -53,8 +75,10 @@ internal sealed class BuiltinShape
         internal Builder(int capacity)
         {
             _names = new Key[capacity];
+            _kinds = new BuiltinSlotKind[capacity];
             _constTemplate = new PropertyDescriptor?[capacity];
             _functionSlots = new ushort[capacity];
+            _setterSlots = new ushort[capacity];
             _functionFlags = new PropertyFlag[capacity];
             _index = new StringDictionarySlim<int>(capacity);
             _next = 0;
@@ -63,8 +87,10 @@ internal sealed class BuiltinShape
         internal void Constant(in Key name, PropertyDescriptor descriptor)
         {
             _names[_next] = name;
+            _kinds[_next] = BuiltinSlotKind.Constant;
             _constTemplate[_next] = descriptor;
             _functionSlots[_next] = NotAFunction;
+            _setterSlots[_next] = NotAFunction;
             _index[name] = _next;
             _next++;
         }
@@ -72,8 +98,27 @@ internal sealed class BuiltinShape
         internal void Function(in Key name, ushort slot, PropertyFlag flags)
         {
             _names[_next] = name;
+            _kinds[_next] = BuiltinSlotKind.Function;
             _constTemplate[_next] = null;
             _functionSlots[_next] = slot;
+            _setterSlots[_next] = NotAFunction;
+            _functionFlags[_next] = flags;
+            _index[name] = _next;
+            _next++;
+        }
+
+        /// <summary>
+        /// Reserves a slot for a lazily-materialized accessor. <paramref name="getterSlot"/> /
+        /// <paramref name="setterSlot"/> are dispatcher slot ids, or <see cref="NotAFunction"/> for the
+        /// absent half. The <see cref="GetSetPropertyDescriptor"/> is created on first access.
+        /// </summary>
+        internal void Accessor(in Key name, ushort getterSlot, ushort setterSlot, PropertyFlag flags)
+        {
+            _names[_next] = name;
+            _kinds[_next] = BuiltinSlotKind.Accessor;
+            _constTemplate[_next] = null;
+            _functionSlots[_next] = getterSlot;
+            _setterSlots[_next] = setterSlot;
             _functionFlags[_next] = flags;
             _index[name] = _next;
             _next++;
@@ -88,12 +133,14 @@ internal sealed class BuiltinShape
         internal void Instance(in Key name)
         {
             _names[_next] = name;
+            _kinds[_next] = BuiltinSlotKind.Instance;
             _constTemplate[_next] = null;
             _functionSlots[_next] = NotAFunction;
+            _setterSlots[_next] = NotAFunction;
             _index[name] = _next;
             _next++;
         }
 
-        internal BuiltinShape Build() => new(_names, _constTemplate, _functionSlots, _functionFlags, _index);
+        internal BuiltinShape Build() => new(_names, _kinds, _constTemplate, _functionSlots, _setterSlots, _functionFlags, _index);
     }
 }

--- a/Jint/Native/Object/BuiltinShapeObject.cs
+++ b/Jint/Native/Object/BuiltinShapeObject.cs
@@ -4,11 +4,17 @@ using Jint.Runtime.Descriptors;
 namespace Jint.Native.Object;
 
 /// <summary>
-/// Base for built-in objects (Math, JSON, Reflect, ...) that store their string-keyed own properties as
-/// a shared immutable <see cref="BuiltinShape"/> plus a per-realm, lazily-filled descriptor array,
-/// instead of building a per-realm dictionary of descriptors in <c>Initialize</c>. Immutable constants
+/// Convenience base for built-in objects (Math, JSON, Reflect, ...) that store their string-keyed own
+/// properties as a shared immutable <see cref="BuiltinShape"/> plus a per-realm, lazily-filled descriptor
+/// array, instead of building a per-realm dictionary of descriptors in <c>Initialize</c>. Immutable constants
 /// reuse process-shared descriptors; function descriptors are created on first access (their dispatcher
 /// <see cref="Function"/> was already lazy, so nothing is materialized eagerly that wasn't already).
+/// <para>
+/// The behavior lives on <see cref="ObjectInstance"/>, gated by <see cref="InternalTypes.BuiltinShapeMode"/>
+/// and reached through <see cref="IBuiltinShaped"/>; this base just supplies the per-realm descriptor field
+/// and the two abstract hooks. Hosts that cannot derive from it (prototypes, constructors) get an equivalent
+/// field + <see cref="IBuiltinShaped"/> implementation emitted by the source generator instead.
+/// </para>
 /// <para>
 /// Redefining an existing property's attributes mutates the per-realm descriptor in place exactly as the
 /// dictionary path does (so test262's verifyProperty needs no deopt); adding or deleting an own property
@@ -22,7 +28,7 @@ namespace Jint.Native.Object;
 /// references from the realm intrinsics) is not shape-eligible and should not derive from this type.
 /// </para>
 /// </summary>
-internal abstract class BuiltinShapeObject : ObjectInstance
+internal abstract class BuiltinShapeObject : ObjectInstance, IBuiltinShaped
 {
     // Lazily-filled descriptors, parallel to BuiltinShape.Names: constants point at the shared static
     // descriptors, functions are null until first accessed. Null == deopted to the base _properties.
@@ -38,10 +44,21 @@ internal abstract class BuiltinShapeObject : ObjectInstance
     /// <summary>Creates the dispatcher function for a function slot (e.g. <c>new __XxxFunction(this, (Slot) slot)</c>).</summary>
     private protected abstract Jint.Native.Function.Function MakeBuiltinFunction(ushort slot);
 
+    BuiltinShape IBuiltinShaped.BuiltinShape => BuiltinShape;
+
+    PropertyDescriptor?[]? IBuiltinShaped.BuiltinDescriptors
+    {
+        get => _builtinDescriptors;
+        set => _builtinDescriptors = value;
+    }
+
+    Jint.Native.Function.Function IBuiltinShaped.MakeBuiltinFunction(ushort slot) => MakeBuiltinFunction(slot);
+
     /// <summary>Call from the built-in's <c>Initialize</c> (before any symbol setup).</summary>
     private protected void InitializeBuiltinShape()
     {
         _builtinDescriptors = (PropertyDescriptor?[]) BuiltinShape.ConstTemplate.Clone();
+        _type |= InternalTypes.BuiltinShapeMode;
     }
 
     /// <summary>
@@ -52,135 +69,5 @@ internal abstract class BuiltinShapeObject : ObjectInstance
     private protected void SetBuiltinInstanceDescriptor(int slot, JsValue value, PropertyFlag flags)
     {
         _builtinDescriptors![slot] = new PropertyDescriptor(value, flags);
-    }
-
-    private PropertyDescriptor MaterializeSlot(int slot)
-    {
-        var descriptors = _builtinDescriptors!;
-        var descriptor = descriptors[slot];
-        if (descriptor is null)
-        {
-            var shape = BuiltinShape;
-            descriptor = new PropertyDescriptor(MakeBuiltinFunction(shape.FunctionSlots[slot]), shape.FunctionFlags[slot]);
-            descriptors[slot] = descriptor;
-        }
-        return descriptor;
-    }
-
-    public override PropertyDescriptor GetOwnProperty(JsValue property)
-    {
-        EnsureInitialized();
-        if (_builtinDescriptors is not null && property is JsString jsString)
-        {
-            if (BuiltinShape.Index.TryGetValue(jsString.ToString(), out var slot))
-            {
-                return MaterializeSlot(slot);
-            }
-            return PropertyDescriptor.Undefined;
-        }
-        // Symbol key, or already deopted: the base reads _symbols / _properties.
-        return base.GetOwnProperty(property);
-    }
-
-    protected internal override void SetOwnProperty(JsValue property, PropertyDescriptor desc)
-    {
-        EnsureInitialized();
-        if (_builtinDescriptors is not null && property is JsString jsString)
-        {
-            if (BuiltinShape.Index.TryGetValue(jsString.ToString(), out var slot))
-            {
-                // Redefine an existing own property (e.g. data -> accessor) in place; no deopt needed.
-                _builtinDescriptors[slot] = desc;
-                unchecked { _propertiesVersion++; }
-                return;
-            }
-            // Adding a brand-new own string property can't be expressed in the fixed layout.
-            DeoptToDictionary();
-        }
-        base.SetOwnProperty(property, desc);
-    }
-
-    public override bool Delete(JsValue property)
-    {
-        EnsureInitialized();
-        if (_builtinDescriptors is not null && property is JsString jsString && BuiltinShape.Index.ContainsKey(jsString.ToString()))
-        {
-            DeoptToDictionary();
-        }
-        return base.Delete(property);
-    }
-
-    public override List<JsValue> GetOwnPropertyKeys(Types types = Types.String | Types.Symbol)
-    {
-        EnsureInitialized();
-        if (_builtinDescriptors is null)
-        {
-            return base.GetOwnPropertyKeys(types);
-        }
-
-        var names = BuiltinShape.Names;
-        var keys = new List<JsValue>(names.Length + (_symbols?.Count ?? 0));
-        if ((types & Types.String) != Types.Empty)
-        {
-            foreach (var name in names)
-            {
-                keys.Add(JsString.Create(name.Name));
-            }
-        }
-        if ((types & Types.Symbol) != Types.Empty && _symbols is not null)
-        {
-            foreach (var pair in _symbols)
-            {
-                keys.Add(pair.Key);
-            }
-        }
-        return keys;
-    }
-
-    public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
-    {
-        EnsureInitialized();
-        if (_builtinDescriptors is null)
-        {
-            foreach (var pair in base.GetOwnProperties())
-            {
-                yield return pair;
-            }
-            yield break;
-        }
-
-        var names = BuiltinShape.Names;
-        for (var i = 0; i < names.Length; i++)
-        {
-            yield return new KeyValuePair<JsValue, PropertyDescriptor>(JsString.Create(names[i].Name), MaterializeSlot(i));
-        }
-        if (_symbols is not null)
-        {
-            foreach (var pair in _symbols)
-            {
-                yield return new KeyValuePair<JsValue, PropertyDescriptor>(pair.Key, pair.Value);
-            }
-        }
-    }
-
-    // Fall back to the ordinary dictionary representation, materializing every slot so the object is
-    // byte-for-byte what a generated property dictionary would have produced.
-    private void DeoptToDictionary()
-    {
-        var descriptors = _builtinDescriptors;
-        if (descriptors is null)
-        {
-            return;
-        }
-
-        var names = BuiltinShape.Names;
-        var properties = new PropertyDictionary(names.Length, checkExistingKeys: false);
-        for (var i = 0; i < names.Length; i++)
-        {
-            properties[names[i]] = MaterializeSlot(i);
-        }
-
-        _builtinDescriptors = null;
-        SetProperties(properties); // sets _properties, bumps version (symbols stay in _symbols)
     }
 }

--- a/Jint/Native/Object/BuiltinShapeObject.cs
+++ b/Jint/Native/Object/BuiltinShapeObject.cs
@@ -53,21 +53,4 @@ internal abstract class BuiltinShapeObject : ObjectInstance, IBuiltinShaped
     }
 
     Jint.Native.Function.Function IBuiltinShaped.MakeBuiltinFunction(ushort slot) => MakeBuiltinFunction(slot);
-
-    /// <summary>Call from the built-in's <c>Initialize</c> (before any symbol setup).</summary>
-    private protected void InitializeBuiltinShape()
-    {
-        _builtinDescriptors = (PropertyDescriptor?[]) BuiltinShape.ConstTemplate.Clone();
-        _type |= InternalTypes.BuiltinShapeMode;
-    }
-
-    /// <summary>
-    /// Fills a per-realm instance-property slot (reserved via <see cref="BuiltinShape.Builder.Instance"/>)
-    /// with its value for this realm. Call from the built-in's <c>Initialize</c>, after
-    /// <see cref="InitializeBuiltinShape"/>.
-    /// </summary>
-    private protected void SetBuiltinInstanceDescriptor(int slot, JsValue value, PropertyFlag flags)
-    {
-        _builtinDescriptors![slot] = new PropertyDescriptor(value, flags);
-    }
 }

--- a/Jint/Native/Object/IBuiltinShaped.cs
+++ b/Jint/Native/Object/IBuiltinShaped.cs
@@ -1,0 +1,33 @@
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Native.Object;
+
+/// <summary>
+/// Per-host storage surface for a built-in whose string-keyed own properties are a shared, immutable
+/// <see cref="BuiltinShape"/> plus a per-realm, lazily-filled descriptor array (rather than a per-realm
+/// property dictionary). The host carries <see cref="Jint.Runtime.InternalTypes.BuiltinShapeMode"/>;
+/// <see cref="ObjectInstance"/>'s property virtuals (GetOwnProperty / SetOwnProperty / RemoveOwnProperty /
+/// GetOwnProperties / GetOwnPropertyKeys) dispatch to the shared shape logic when that flag is set.
+/// <para>
+/// This interface exposes only the per-host <b>storage</b> — no behavior — so the mechanism composes
+/// across host base classes (<see cref="Jint.Native.Prototype"/>, <c>Constructor</c>/<c>Function</c>,
+/// instance types like <c>ArrayInstance</c>) that cannot all share a single <see cref="BuiltinShapeObject"/>
+/// base under single inheritance. <see cref="BuiltinShapeObject"/> implements it with a field; the source
+/// generator emits an equivalent field + implementation onto any other shaped host.
+/// </para>
+/// </summary>
+internal interface IBuiltinShaped
+{
+    /// <summary>The process-shared layout for this built-in type (typically a <c>static readonly</c> field).</summary>
+    BuiltinShape BuiltinShape { get; }
+
+    /// <summary>
+    /// The per-realm descriptor array (parallel to <see cref="BuiltinShape.Names"/>): constants point at the
+    /// shared static descriptors, functions/accessors are null until first materialized. <c>null</c> once the
+    /// host has deopted to the ordinary <c>_properties</c> dictionary.
+    /// </summary>
+    PropertyDescriptor?[]? BuiltinDescriptors { get; set; }
+
+    /// <summary>Creates the dispatcher function for a function slot (e.g. <c>new __XxxFunction(this, (Slot) slot)</c>).</summary>
+    Jint.Native.Function.Function MakeBuiltinFunction(ushort slot);
+}

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -4,7 +4,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Object;
 
-[JsObject]
+[JsObject(UseShape = true)]
 public sealed partial class ObjectConstructor : Constructor
 {
     private static readonly JsString _name = new JsString("Object");

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -544,7 +544,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
 
     public override JsValue Get(JsValue property, JsValue receiver)
     {
-        if ((_type & InternalTypes.PlainObject) != InternalTypes.Empty && ReferenceEquals(this, receiver) && property.IsString())
+        if ((_type & (InternalTypes.PlainObject | InternalTypes.BuiltinShapeMode)) == InternalTypes.PlainObject && _initialized && ReferenceEquals(this, receiver) && property.IsString())
         {
             EnsureInitialized();
             if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
@@ -739,6 +739,23 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         return keys;
     }
 
+    // Install the shared layout + a per-realm descriptor array cloned from the shape's constant template,
+    // and flip on BuiltinShapeMode. Called from a shaped host's generated CreateProperties_Generated (works
+    // for both BuiltinShapeObject-derived hosts and generator-emitted IBuiltinShaped prototypes/constructors).
+    private protected void InitializeBuiltinShape()
+    {
+        var shaped = Unsafe.As<IBuiltinShaped>(this);
+        shaped.BuiltinDescriptors = (PropertyDescriptor?[]) shaped.BuiltinShape.ConstTemplate.Clone();
+        _type |= InternalTypes.BuiltinShapeMode;
+    }
+
+    // Fill a per-realm instance-property slot (reserved via BuiltinShape.Builder.Instance) with its value
+    // for this realm. Called from generated CreateProperties_Generated after InitializeBuiltinShape.
+    private protected void SetBuiltinInstanceDescriptor(int slot, JsValue value, PropertyFlag flags)
+    {
+        Unsafe.As<IBuiltinShaped>(this).BuiltinDescriptors![slot] = new PropertyDescriptor(value, flags);
+    }
+
     protected internal virtual void SetOwnProperty(JsValue property, PropertyDescriptor desc)
     {
         EnsureInitialized();
@@ -801,7 +818,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Set(JsValue property, JsValue value)
     {
-        if ((_type & InternalTypes.PlainObject) != InternalTypes.Empty && property is JsString jsString)
+        if ((_type & (InternalTypes.PlainObject | InternalTypes.BuiltinShapeMode)) == InternalTypes.PlainObject && _initialized && property is JsString jsString)
         {
             if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
             {
@@ -832,7 +849,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     /// </summary>
     public override bool Set(JsValue property, JsValue value, JsValue receiver)
     {
-        if ((_type & InternalTypes.PlainObject) != InternalTypes.Empty && ReferenceEquals(this, receiver) && property.IsString())
+        if ((_type & (InternalTypes.PlainObject | InternalTypes.BuiltinShapeMode)) == InternalTypes.PlainObject && _initialized && ReferenceEquals(this, receiver) && property.IsString())
         {
             var key = (Key) property.ToString();
             if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
@@ -1727,7 +1744,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         // skipped here and handled by the generic path (whose GetOwnProperty runs EnsureInitialized).
         // Ordinary user objects (JsObject) are born initialized, so they take this path with no per-object
         // virtual Initialize() call.
-        if ((_type & InternalTypes.PlainObject) != InternalTypes.Empty
+        if ((_type & (InternalTypes.PlainObject | InternalTypes.BuiltinShapeMode)) == InternalTypes.PlainObject
             && _initialized
             && Extensible
             && p is JsString jsString)

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -680,7 +680,18 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         if (descriptor is null)
         {
             var shape = shaped.BuiltinShape;
-            descriptor = new PropertyDescriptor(shaped.MakeBuiltinFunction(shape.FunctionSlots[slot]), shape.FunctionFlags[slot]);
+            if (shape.Kinds[slot] == BuiltinSlotKind.Accessor)
+            {
+                var getterSlot = shape.FunctionSlots[slot];
+                var setterSlot = shape.SetterSlots[slot];
+                var getter = getterSlot == BuiltinShape.NotAFunction ? null : shaped.MakeBuiltinFunction(getterSlot);
+                var setter = setterSlot == BuiltinShape.NotAFunction ? null : shaped.MakeBuiltinFunction(setterSlot);
+                descriptor = new GetSetPropertyDescriptor(getter, setter, shape.FunctionFlags[slot]);
+            }
+            else
+            {
+                descriptor = new PropertyDescriptor(shaped.MakeBuiltinFunction(shape.FunctionSlots[slot]), shape.FunctionFlags[slot]);
+            }
             descriptors[slot] = descriptor;
         }
         return descriptor;

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -304,6 +304,15 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                 }
             }
         }
+        else if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
+        {
+            var shaped = Unsafe.As<IBuiltinShaped>(this);
+            var names = shaped.BuiltinShape.Names;
+            for (var i = 0; i < names.Length; i++)
+            {
+                yield return new KeyValuePair<JsValue, PropertyDescriptor>(JsString.Create(names[i].Name), MaterializeBuiltinSlot(shaped, i));
+            }
+        }
         else if (_properties != null)
         {
             foreach (var pair in _properties)
@@ -328,6 +337,11 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
         {
             return GetOwnPropertyKeysFromShape(Unsafe.As<JsObject>(this).ShapeOf, types);
+        }
+
+        if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
+        {
+            return GetBuiltinShapeOwnPropertyKeys(types);
         }
 
         var returningSymbols = (types & Types.Symbol) != Types.Empty && _symbols?.Count > 0;
@@ -511,10 +525,14 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         var key = TypeConverter.ToPropertyKey(property);
         if (!key.IsSymbol())
         {
-            // Removing a string property can't be expressed as a shape transition; deopt first.
+            // Removing a string property can't be expressed as a shape / built-in-shape layout; deopt first.
             if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
             {
                 ConvertToDictionaryMode();
+            }
+            else if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
+            {
+                DeoptBuiltinShape();
             }
             _properties?.Remove(TypeConverter.ToString(key));
             unchecked { _propertiesVersion++; }
@@ -615,13 +633,25 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         if (!key.IsSymbol())
         {
             var name = TypeConverter.ToString(key);
-            if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
+            if ((_type & (InternalTypes.ShapeMode | InternalTypes.BuiltinShapeMode)) != InternalTypes.Empty)
             {
-                var jo = Unsafe.As<JsObject>(this);
-                if (jo.ShapeOf.TryGetSlot(name, out var slot))
+                if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
                 {
-                    return new SlotPropertyDescriptor(jo, slot);
+                    var jo = Unsafe.As<JsObject>(this);
+                    if (jo.ShapeOf.TryGetSlot(name, out var slot))
+                    {
+                        return new SlotPropertyDescriptor(jo, slot);
+                    }
                 }
+                else
+                {
+                    var shaped = Unsafe.As<IBuiltinShaped>(this);
+                    if (shaped.BuiltinShape.Index.TryGetValue(name, out var slot))
+                    {
+                        return MaterializeBuiltinSlot(shaped, slot);
+                    }
+                }
+                // string key absent from the shape ⇒ no own property (descriptor stays null → Undefined)
             }
             else
             {
@@ -636,9 +666,95 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         return descriptor ?? PropertyDescriptor.Undefined;
     }
 
+    // Built-in-shape storage helpers (InternalTypes.BuiltinShapeMode). Shared by every host that implements
+    // IBuiltinShaped — BuiltinShapeObject-derived namespaces today, generator-emitted prototypes/constructors
+    // later — so the storage is composable across base classes that cannot share a single base. See BuiltinShape.
+
+    // Materialize a shaped slot's descriptor. Constants point at the shared static descriptor; functions are
+    // created on first access and stored so their identity is stable (the inline caches rely on this — a
+    // materialize must never bump _propertiesVersion).
+    private static PropertyDescriptor MaterializeBuiltinSlot(IBuiltinShaped shaped, int slot)
+    {
+        var descriptors = shaped.BuiltinDescriptors!;
+        var descriptor = descriptors[slot];
+        if (descriptor is null)
+        {
+            var shape = shaped.BuiltinShape;
+            descriptor = new PropertyDescriptor(shaped.MakeBuiltinFunction(shape.FunctionSlots[slot]), shape.FunctionFlags[slot]);
+            descriptors[slot] = descriptor;
+        }
+        return descriptor;
+    }
+
+    // Fall back to the ordinary dictionary representation, materializing every slot so the object is
+    // byte-for-byte what a generated property dictionary would have produced. Called when a shaped host
+    // gains or loses an own string property (which the fixed layout cannot express).
+    private void DeoptBuiltinShape()
+    {
+        var shaped = Unsafe.As<IBuiltinShaped>(this);
+        var descriptors = shaped.BuiltinDescriptors;
+        if (descriptors is null)
+        {
+            return;
+        }
+
+        var names = shaped.BuiltinShape.Names;
+        var properties = new PropertyDictionary(names.Length, checkExistingKeys: false);
+        for (var i = 0; i < names.Length; i++)
+        {
+            properties[names[i]] = MaterializeBuiltinSlot(shaped, i);
+        }
+
+        _type &= ~InternalTypes.BuiltinShapeMode;
+        shaped.BuiltinDescriptors = null;
+        SetProperties(properties); // sets _properties, bumps version (symbols stay in _symbols)
+    }
+
+    private List<JsValue> GetBuiltinShapeOwnPropertyKeys(Types types)
+    {
+        var shaped = Unsafe.As<IBuiltinShaped>(this);
+        var names = shaped.BuiltinShape.Names;
+        var keys = new List<JsValue>(names.Length + (_symbols?.Count ?? 0));
+        if ((types & Types.String) != Types.Empty)
+        {
+            // Function-derived hosts surface length/name/prototype ahead of their shape members (matching the
+            // dictionary path); ordinary hosts return Enumerable.Empty here.
+            var initialOwnStringPropertyKeys = GetInitialOwnStringPropertyKeys();
+            if (!ReferenceEquals(initialOwnStringPropertyKeys, System.Linq.Enumerable.Empty<JsValue>()))
+            {
+                keys.AddRange(initialOwnStringPropertyKeys);
+            }
+            foreach (var name in names)
+            {
+                keys.Add(JsString.Create(name.Name));
+            }
+        }
+        if ((types & Types.Symbol) != Types.Empty && _symbols is not null)
+        {
+            foreach (var pair in _symbols)
+            {
+                keys.Add(pair.Key);
+            }
+        }
+        return keys;
+    }
+
     protected internal virtual void SetOwnProperty(JsValue property, PropertyDescriptor desc)
     {
         EnsureInitialized();
+        if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty && property is JsString jsString)
+        {
+            var shaped = Unsafe.As<IBuiltinShaped>(this);
+            if (shaped.BuiltinShape.Index.TryGetValue(jsString.ToString(), out var slot))
+            {
+                // Redefine an existing own property (e.g. data -> accessor) in place; no deopt needed.
+                shaped.BuiltinDescriptors![slot] = desc;
+                unchecked { _propertiesVersion++; }
+                return;
+            }
+            // Adding a brand-new own string property can't be expressed in the fixed layout.
+            DeoptBuiltinShape();
+        }
         SetProperty(property, desc);
     }
 

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -688,6 +688,12 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                 var setter = setterSlot == BuiltinShape.NotAFunction ? null : shaped.MakeBuiltinFunction(setterSlot);
                 descriptor = new GetSetPropertyDescriptor(getter, setter, shape.FunctionFlags[slot]);
             }
+            else if (shape.Kinds[slot] == BuiltinSlotKind.Alias)
+            {
+                // Share the target slot's descriptor so the two names resolve to the same function object
+                // (spec identity, e.g. Set.prototype.keys === Set.prototype.values).
+                descriptor = MaterializeBuiltinSlot(shaped, shape.FunctionSlots[slot]);
+            }
             else
             {
                 descriptor = new PropertyDescriptor(shaped.MakeBuiltinFunction(shape.FunctionSlots[slot]), shape.FunctionFlags[slot]);

--- a/Jint/Native/Object/ObjectPrototype.cs
+++ b/Jint/Native/Object/ObjectPrototype.cs
@@ -7,7 +7,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Object;
 
-[JsObject]
+[JsObject(UseShape = true)]
 public sealed partial class ObjectPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.Configurable | PropertyFlag.Writable)]

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -14,7 +14,7 @@ internal sealed record PromiseCapability(
     JsValue ResolveObj,
     JsValue RejectObj);
 
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PromiseConstructor : Constructor
 {
     private static readonly JsString _functionName = new JsString("Promise");

--- a/Jint/Native/Promise/PromisePrototype.cs
+++ b/Jint/Native/Promise/PromisePrototype.cs
@@ -5,7 +5,7 @@ using Jint.Runtime.Interop;
 
 namespace Jint.Native.Promise;
 
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PromisePrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Proxy/ProxyConstructor.cs
+++ b/Jint/Native/Proxy/ProxyConstructor.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Proxy;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-proxy-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class ProxyConstructor : Constructor
 {
     private static readonly JsString _name = new JsString("Proxy");

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -15,7 +15,7 @@ using Jint.Runtime.RegExp;
 
 namespace Jint.Native.RegExp;
 
-[JsObject(ExtraCapacity = 1)]
+[JsObject(UseShape = true)]
 internal sealed partial class RegExpPrototype : Prototype
 {
     private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;
@@ -38,6 +38,13 @@ internal sealed partial class RegExpPrototype : Prototype
     [JsProperty(Name = "constructor", Flags = PropertyFlag.Configurable | PropertyFlag.Writable)]
     private readonly RegExpConstructor _constructor;
 
+    // exec is a per-realm instance slot (not a [JsFunction]): HasDefaultExec compares the current exec
+    // value's underlying delegate against _defaultExec to detect user replacement, so it must be a
+    // ClrFunction wrapping _defaultExec with a stable per-realm identity — which the shape's instance slot
+    // provides (a generated dispatcher would be a different Function subtype and break the check).
+    [JsProperty(Name = "exec", Flags = PropertyFlag.Configurable | PropertyFlag.Writable)]
+    private readonly ClrFunction _execFunction;
+
     private readonly JsCallDelegate _defaultExec;
 
     internal RegExpPrototype(
@@ -47,6 +54,7 @@ internal sealed partial class RegExpPrototype : Prototype
         ObjectPrototype objectPrototype) : base(engine, realm)
     {
         _defaultExec = Exec;
+        _execFunction = new ClrFunction(engine, "exec", _defaultExec, 1, PropertyFlag.Configurable);
         _constructor = constructor;
         _prototype = objectPrototype;
     }
@@ -55,13 +63,6 @@ internal sealed partial class RegExpPrototype : Prototype
     {
         CreateProperties_Generated();
         CreateSymbols_Generated();
-
-        // exec stays manually registered: HasDefaultRegExpExec compares by reference against the
-        // ClrFunction wrapping _defaultExec to detect "user replaced exec on the prototype". The
-        // generator's lazy descriptor would create a different Function instance each realm, breaking
-        // that identity check until first access. AddDangerous skips SetOwnProperty's validation;
-        // ExtraCapacity=1 on [JsObject] presizes the dict so this add doesn't trigger a resize.
-        _properties!.AddDangerous("exec", new PropertyDescriptor(new ClrFunction(Engine, "exec", _defaultExec, 1, PropertyFlag.Configurable), PropertyFlag.Configurable | PropertyFlag.Writable));
     }
 
     // Spec: each prototype getter, when called on RegExp.prototype itself (not a JsRegExp instance),

--- a/Jint/Native/RegExp/RegExpStringIteratorPrototype.cs
+++ b/Jint/Native/RegExp/RegExpStringIteratorPrototype.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.RegExp;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class RegExpStringIteratorPrototype : IteratorPrototype
 {
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString RegExpStringIteratorToStringTag = new("RegExp String Iterator");

--- a/Jint/Native/Set/SetConstructor.cs
+++ b/Jint/Native/Set/SetConstructor.cs
@@ -5,7 +5,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Set;
 
-[JsObject]
+[JsObject(UseShape = true)]
 public sealed partial class SetConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Set");

--- a/Jint/Native/Set/SetIteratorPrototype.cs
+++ b/Jint/Native/Set/SetIteratorPrototype.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.Set;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%setiteratorprototype%-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class SetIteratorPrototype : IteratorPrototype
 {
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString SetIteratorToStringTag = new("Set Iterator");

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -10,6 +10,8 @@ namespace Jint.Native.Set;
 /// <summary>
 /// https://www.ecma-international.org/ecma-262/6.0/#sec-set-objects
 /// </summary>
+// Not shape-eligible: Initialize aliases the string property `keys` to the `values` function via
+// SetProperty (spec requires Set.prototype.keys === values), which the fixed shape layout can't express.
 [JsObject]
 internal sealed partial class SetPrototype : Prototype
 {

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -10,9 +10,10 @@ namespace Jint.Native.Set;
 /// <summary>
 /// https://www.ecma-international.org/ecma-262/6.0/#sec-set-objects
 /// </summary>
-// Not shape-eligible: Initialize aliases the string property `keys` to the `values` function via
-// SetProperty (spec requires Set.prototype.keys === values), which the fixed shape layout can't express.
-[JsObject]
+// Set.prototype.keys is the same function as `values` (spec identity); [JsAlias] expresses that through
+// the shape. Set.prototype[@@iterator] is aliased in Initialize (symbols are orthogonal to the shape).
+[JsAlias("keys", "values")]
+[JsObject(UseShape = true)]
 internal sealed partial class SetPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]
@@ -35,12 +36,9 @@ internal sealed partial class SetPrototype : Prototype
         CreateProperties_Generated();
         CreateSymbols_Generated();
 
-        // Spec requires Set.prototype.keys, Set.prototype.values, and Set.prototype[@@iterator] to all be
-        // the same function object (function identity, observable via ===). Alias the descriptors here
-        // so they share the same materialized function as `values` rather than emitting separate dispatchers.
-        var valuesDesc = GetOwnProperty("values");
-        SetProperty("keys", valuesDesc);
-        SetProperty(GlobalSymbolRegistry.Iterator, valuesDesc);
+        // Set.prototype[@@iterator] is the same function as `values` (spec identity). Symbols are orthogonal
+        // to the string shape, so this stays hand-written; `keys` is handled by [JsAlias] on the class.
+        SetProperty(GlobalSymbolRegistry.Iterator, GetOwnProperty("values"));
     }
 
     [JsAccessor("size")]

--- a/Jint/Native/ShadowRealm/ShadowRealmPrototype.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealmPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.ShadowRealm;
 /// <summary>
 /// https://tc39.es/proposal-shadowrealm/#sec-properties-of-the-shadowrealm-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class ShadowRealmPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/SharedArrayBuffer/SharedArrayBufferConstructor.cs
+++ b/Jint/Native/SharedArrayBuffer/SharedArrayBufferConstructor.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.SharedArrayBuffer;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-sharedarraybuffer-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class SharedArrayBufferConstructor : Constructor
 {
     private static readonly JsString _functionName = new("SharedArrayBuffer");

--- a/Jint/Native/SharedArrayBuffer/SharedArrayBufferPrototype.cs
+++ b/Jint/Native/SharedArrayBuffer/SharedArrayBufferPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.SharedArrayBuffer;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-sharedarraybuffer-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class SharedArrayBufferPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/String/StringConstructor.cs
+++ b/Jint/Native/String/StringConstructor.cs
@@ -13,7 +13,7 @@ namespace Jint.Native.String;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-string-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class StringConstructor : Constructor
 {
     private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;

--- a/Jint/Native/String/StringIteratorPrototype.cs
+++ b/Jint/Native/String/StringIteratorPrototype.cs
@@ -8,7 +8,7 @@ namespace Jint.Native.String;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%stringiteratorprototype%-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class StringIteratorPrototype : IteratorPrototype
 {
     [JsSymbol("ToStringTag", Flags = PropertyFlag.Configurable)] private static readonly JsString StringIteratorToStringTag = new("String Iterator");

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -19,7 +19,11 @@ namespace Jint.Native.String;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-string-prototype-object
 /// </summary>
-[JsObject(ExtraCapacity = 2)]
+// B.2.3: trimLeft/trimRight are aliases for trimStart/trimEnd (same function object) — [JsAlias]
+// expresses that through the shape.
+[JsAlias("trimLeft", "trimStart")]
+[JsAlias("trimRight", "trimEnd")]
+[JsObject(UseShape = true)]
 internal sealed partial class StringPrototype : StringInstance
 {
     private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;
@@ -50,15 +54,6 @@ internal sealed partial class StringPrototype : StringInstance
         const PropertyFlag propertyFlags = lengthFlags | PropertyFlag.Writable;
 
         CreateProperties_Generated();
-
-        // B.2.3: trimLeft/trimRight are aliases for trimStart/trimEnd. Aliasing the same descriptor
-        // instance shares the same lazy-resolved Function reference. AddDangerous skips
-        // duplicate-key probing and SetOwnProperty's validation pipeline; ExtraCapacity=2 on
-        // [JsObject] presizes the dict so these adds don't trigger a resize.
-        _properties!.TryGetValue("trimStart", out var trimStartDescriptor);
-        _properties.TryGetValue("trimEnd", out var trimEndDescriptor);
-        _properties.AddDangerous("trimLeft", trimStartDescriptor);
-        _properties.AddDangerous("trimRight", trimEndDescriptor);
 
         // [Symbol.iterator] kept hand-written: needs to capture _originalIteratorFunction for
         // the HasOriginalIterator fast-path detection used by string iteration consumers.

--- a/Jint/Native/SuppressedError/SuppressedErrorPrototype.cs
+++ b/Jint/Native/SuppressedError/SuppressedErrorPrototype.cs
@@ -4,7 +4,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.SuppressedError;
 
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class SuppressedErrorPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Symbol/SymbolConstructor.cs
+++ b/Jint/Native/Symbol/SymbolConstructor.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.Symbol;
 /// 19.4
 /// http://www.ecma-international.org/ecma-262/6.0/index.html#sec-symbol-objects
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class SymbolConstructor : Constructor
 {
     private static readonly JsString _functionName = new JsString("Symbol");

--- a/Jint/Native/Symbol/SymbolPrototype.cs
+++ b/Jint/Native/Symbol/SymbolPrototype.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.Symbol;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-symbol-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class SymbolPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Temporal/Duration/DurationConstructor.cs
+++ b/Jint/Native/Temporal/Duration/DurationConstructor.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.duration
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class DurationConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Duration");

--- a/Jint/Native/Temporal/Duration/DurationPrototype.cs
+++ b/Jint/Native/Temporal/Duration/DurationPrototype.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-duration-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class DurationPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Temporal/Instant/InstantConstructor.cs
+++ b/Jint/Native/Temporal/Instant/InstantConstructor.cs
@@ -11,7 +11,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.instant
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class InstantConstructor : Constructor
 {
     private static readonly JsString _functionName = new("Instant");

--- a/Jint/Native/Temporal/Instant/InstantPrototype.cs
+++ b/Jint/Native/Temporal/Instant/InstantPrototype.cs
@@ -12,7 +12,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-instant-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class InstantPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Temporal/PlainDate/PlainDateConstructor.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDateConstructor.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.plaindate
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PlainDateConstructor : Constructor
 {
     private static readonly JsString _functionName = new("PlainDate");

--- a/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
+++ b/Jint/Native/Temporal/PlainDate/PlainDatePrototype.cs
@@ -12,7 +12,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaindate-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PlainDatePrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimeConstructor.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PlainDateTimeConstructor : Constructor
 {
     private static readonly JsString _functionName = new("PlainDateTime");

--- a/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainDateTime/PlainDateTimePrototype.cs
@@ -12,7 +12,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaindatetime-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PlainDateTimePrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayConstructor.cs
+++ b/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayConstructor.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PlainMonthDayConstructor : Constructor
 {
     private static readonly JsString _functionName = new("PlainMonthDay");

--- a/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
+++ b/Jint/Native/Temporal/PlainMonthDay/PlainMonthDayPrototype.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plainmonthday-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PlainMonthDayPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Temporal/PlainTime/PlainTimeConstructor.cs
+++ b/Jint/Native/Temporal/PlainTime/PlainTimeConstructor.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.plaintime
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PlainTimeConstructor : Constructor
 {
     private static readonly JsString _functionName = new("PlainTime");

--- a/Jint/Native/Temporal/PlainTime/PlainTimePrototype.cs
+++ b/Jint/Native/Temporal/PlainTime/PlainTimePrototype.cs
@@ -12,7 +12,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaintime-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PlainTimePrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthConstructor.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PlainYearMonthConstructor : Constructor
 {
     private static readonly JsString _functionName = new("PlainYearMonth");

--- a/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
+++ b/Jint/Native/Temporal/PlainYearMonth/PlainYearMonthPrototype.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plainyearmonth-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class PlainYearMonthPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/Temporal/TemporalInstance.cs
+++ b/Jint/Native/Temporal/TemporalInstance.cs
@@ -8,9 +8,19 @@ namespace Jint.Native.Temporal;
 /// The Temporal namespace object.
 /// https://tc39.es/proposal-temporal/#sec-temporal-objects
 /// </summary>
-// ExtraCapacity = 9 covers the post-Initialize SetProperty calls below for Duration/Instant/PlainDate/
-// PlainDateTime/PlainMonthDay/PlainTime/PlainYearMonth/ZonedDateTime/Now (cross-realm references).
-[JsObject(ExtraCapacity = 9)]
+// The 9 sub-namespace references (Duration/Instant/.../ZonedDateTime/Now) are lazy realm-intrinsic
+// references, emitted by the generator like globalThis's constructor properties (see
+// GlobalObject.Properties.cs). IntrinsicMember maps each JS name to its Temporal*-prefixed intrinsic.
+[JsIntrinsicReference("Duration", IntrinsicMember = "TemporalDuration")]
+[JsIntrinsicReference("Instant", IntrinsicMember = "TemporalInstant")]
+[JsIntrinsicReference("Now", IntrinsicMember = "TemporalNow")]
+[JsIntrinsicReference("PlainDate", IntrinsicMember = "TemporalPlainDate")]
+[JsIntrinsicReference("PlainDateTime", IntrinsicMember = "TemporalPlainDateTime")]
+[JsIntrinsicReference("PlainMonthDay", IntrinsicMember = "TemporalPlainMonthDay")]
+[JsIntrinsicReference("PlainTime", IntrinsicMember = "TemporalPlainTime")]
+[JsIntrinsicReference("PlainYearMonth", IntrinsicMember = "TemporalPlainYearMonth")]
+[JsIntrinsicReference("ZonedDateTime", IntrinsicMember = "TemporalZonedDateTime")]
+[JsObject]
 internal sealed partial class TemporalInstance : ObjectInstance
 {
     private readonly Realm _realm;
@@ -30,18 +40,5 @@ internal sealed partial class TemporalInstance : ObjectInstance
     {
         CreateProperties_Generated();
         CreateSymbols_Generated();
-
-        // Constructor references aren't generator-friendly (they pull from _realm.Intrinsics);
-        // wire them after generated symbols.
-        const PropertyFlag PropertyFlags = PropertyFlag.Writable | PropertyFlag.Configurable;
-        SetProperty("Duration", new PropertyDescriptor(_realm.Intrinsics.TemporalDuration, PropertyFlags));
-        SetProperty("Instant", new PropertyDescriptor(_realm.Intrinsics.TemporalInstant, PropertyFlags));
-        SetProperty("PlainDate", new PropertyDescriptor(_realm.Intrinsics.TemporalPlainDate, PropertyFlags));
-        SetProperty("PlainDateTime", new PropertyDescriptor(_realm.Intrinsics.TemporalPlainDateTime, PropertyFlags));
-        SetProperty("PlainMonthDay", new PropertyDescriptor(_realm.Intrinsics.TemporalPlainMonthDay, PropertyFlags));
-        SetProperty("PlainTime", new PropertyDescriptor(_realm.Intrinsics.TemporalPlainTime, PropertyFlags));
-        SetProperty("PlainYearMonth", new PropertyDescriptor(_realm.Intrinsics.TemporalPlainYearMonth, PropertyFlags));
-        SetProperty("ZonedDateTime", new PropertyDescriptor(_realm.Intrinsics.TemporalZonedDateTime, PropertyFlags));
-        SetProperty("Now", new PropertyDescriptor(_realm.Intrinsics.TemporalNow, PropertyFlags));
     }
 }

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimeConstructor.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class ZonedDateTimeConstructor : Constructor
 {
     private static readonly JsString _functionName = new("ZonedDateTime");

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.Temporal;
 /// <summary>
 /// https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-zoneddatetime-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class ZonedDateTimePrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/TypedArray/TypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/TypedArrayPrototype.cs
@@ -6,7 +6,7 @@ namespace Jint.Native.TypedArray;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-typedarray-prototype-objects
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class TypedArrayPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/TypedArray/Uint8ArrayPrototype.cs
+++ b/Jint/Native/TypedArray/Uint8ArrayPrototype.cs
@@ -7,7 +7,7 @@ using Jint.Runtime.Interop;
 
 namespace Jint.Native.TypedArray;
 
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class Uint8ArrayPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/WeakMap/WeakMapPrototype.cs
+++ b/Jint/Native/WeakMap/WeakMapPrototype.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.WeakMap;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-weakmap-objects
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class WeakMapPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/WeakRef/WeakRefPrototype.cs
+++ b/Jint/Native/WeakRef/WeakRefPrototype.cs
@@ -7,7 +7,7 @@ namespace Jint.Native.WeakRef;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-prototype-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class WeakRefPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Native/WeakSet/WeakSetPrototype.cs
+++ b/Jint/Native/WeakSet/WeakSetPrototype.cs
@@ -10,7 +10,7 @@ namespace Jint.Native.WeakSet;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-weakset-objects
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class WeakSetPrototype : Prototype
 {
     [JsProperty(Name = "constructor", Flags = PropertyFlag.NonEnumerable)]

--- a/Jint/Runtime/InternalTypes.cs
+++ b/Jint/Runtime/InternalTypes.cs
@@ -46,7 +46,12 @@ internal enum InternalTypes
     // integer-index access, IteratorResult). The prototype-method inline cache skips such receivers and
     // prototypes so it never bypasses their custom property resolution.
     ExoticGet = 262144,
+    // a built-in whose string-keyed own properties live in a shared BuiltinShape + a per-realm descriptor
+    // array reached via IBuiltinShaped, not _properties. Set when the shape is installed, cleared on deopt
+    // to dictionary mode. Mutually exclusive with ShapeMode; lets ObjectInstance's property virtuals
+    // discriminate built-in-shape vs dictionary storage with a single flag test on the already-loaded _type.
+    BuiltinShapeMode = 524288,
 
     Primitive = Boolean | String | Number | Integer | BigInt | Symbol,
-    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet
+    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -273,7 +273,7 @@ internal sealed class JintMemberExpression : JintExpression
                     return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: true);
                 }
 
-                if ((baseObject._type & InternalTypes.PlainObject) != InternalTypes.Empty)
+                if ((baseObject._type & (InternalTypes.PlainObject | InternalTypes.BuiltinShapeMode)) != InternalTypes.Empty)
                 {
                     // Version-based inline cache: as long as the same object is read and its own-property
                     // shape (descriptor add/replace/remove) hasn't changed since we cached, the previously
@@ -476,7 +476,7 @@ internal sealed class JintMemberExpression : JintExpression
                 return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: true);
             }
 
-            if ((baseObject._type & InternalTypes.PlainObject) != InternalTypes.Empty)
+            if ((baseObject._type & (InternalTypes.PlainObject | InternalTypes.BuiltinShapeMode)) != InternalTypes.Empty)
             {
                 if (ReferenceEquals(baseObject, _cachedReadObject)
                     && baseObject._propertiesVersion == _cachedReadVersion
@@ -640,7 +640,7 @@ internal sealed class JintMemberExpression : JintExpression
                     return true;
                 }
             }
-            else if ((baseObject._type & InternalTypes.PlainObject) != InternalTypes.Empty)
+            else if ((baseObject._type & (InternalTypes.PlainObject | InternalTypes.BuiltinShapeMode)) != InternalTypes.Empty)
             {
                 PropertyDescriptor? descriptor;
                 if (ReferenceEquals(baseObject, _cachedReadObject)


### PR DESCRIPTION
## Summary

Extends the built-in **hidden-class shape** storage (a process-shared `BuiltinShape` layout + a per-realm lazily-filled descriptor array, from the last release) from the 7 `BuiltinShapeObject` namespaces to **~96 built-in hosts across every base class** — all `Prototype`-derived hosts (function-only, accessor-bearing, instance-typed, iterators, and the root `Object.prototype`) and `Function`-derived constructors. Each shaped host stops allocating a per-realm `PropertyDictionary` of lazy descriptors in `Initialize`.

The single blocker was C# single inheritance: prototypes derive from `Prototype`/instance types, constructors from `Constructor : Function`, so none could also derive from `BuiltinShapeObject`. This PR makes the shape storage **composable** so any `[JsObject]` host opts in with a one-liner, and it removes the hand-written registration tails (Intl/Temporal intrinsic refs, `keys`/`trimLeft`/`toGMTString`/`exec` aliases) — the "coherent, full-blown generator usage" goal.

## How it works

- **Composable storage** — `InternalTypes.BuiltinShapeMode` flag + an `IBuiltinShaped` storage interface + logic on `ObjectInstance` (dispatched from the property virtuals via `Unsafe.As<IBuiltinShaped>`, mirroring how `ShapeMode` is already handled). The per-realm descriptor field is **generator-emitted onto each host**, so the million-population bases (`ObjectInstance`, `Function`, `ArrayInstance`, …) pay nothing.
- **Dual-mode generator** — a host that doesn't derive from `BuiltinShapeObject` opts in with `[JsObject(UseShape = true)]`; the generator emits the field + `IBuiltinShaped` glue onto it.
- **Slot kinds** — `Constant` / `Instance` / `Function` / `Accessor` (`GetSetPropertyDescriptor`, materialized lazily — leaner than the dictionary path's eager `LazyGetSetPropertyDescriptor`) / `Alias` (new `[JsAlias("name","target")]` for spec function-identity aliases like `Set.prototype.keys === values`).
- **Member-read fast-path integration** — the `ObjectInstance` `_properties` fast paths are gated `(_type & (PlainObject | BuiltinShapeMode)) == PlainObject`, and the `JintMemberExpression` receiver inline-cache gate broadened to `PlainObject | BuiltinShapeMode`, so shaped prototypes/constructors keep the version-gated descriptor cache. Redefine mutates the slot in place; add/delete deopts to a dictionary — byte-for-byte the pre-shape representation.

Two bugs the verification caught and fixed: a lazy-init fast-path bug (`typeof WeakMap.prototype.get` → `undefined` on first read, fixed with an `_initialized` gate) and the string-alias hazard (a naive shaping of `SetPrototype` dropped `keys` and broke 74 tests — the reason for `[JsAlias]`).

## Benchmarks

`Jint.Benchmark/BuiltinShapeBenchmark.cs`, default job. **Every commit was A/B'd against an `EngineOnly` control that stayed byte-identical at 13.70 KB** (no regression to bare-engine construction, and ordinary-object get/set/create allocation is byte-identical throughout). Per-realm `Initialize` allocation removed, per commit:

| Commit | Hosts | Δ (per-realm init) |
|---|---|---|
| Intl/Temporal → `[JsIntrinsicReference]` | Intl/Temporal namespaces | cold-start **−9…17%** (eager→lazy) |
| Composable storage foundation | (7 existing, refactor) | byte-identical |
| Fast-path + 5 function-only prototypes | Promise, Weak×3, FinalizationRegistry | −1.60 KB |
| 18 more function-only prototypes | BigInt, errors, TypedArray, iterator helpers, … | −1.94 KB |
| Accessor support + 6 accessor prototypes | Symbol, Map, ArrayBuffer, DataView, … | −5.74 KB |
| Object + Temporal + Intl prototypes | root `Object.prototype`, 8× Temporal, Intl | **−24.69 KB** |
| Constructors (Function-derived) | Object, Array, Map, Set, Symbol, Promise, ArrayBuffer | **−4.95 KB (−39.3% of ctor storage, −10.7% time)** |
| 25 more constructors | Date, Error, BigInt, String, Proxy, Intl, Temporal | −4.72 KB |
| Iterators + instance-typed prototypes | Array, Number, Boolean, Error, 5× iterators | −5.71 KB |
| `[JsAlias]` → Set, String, Date | (largest, always-used prototypes) | **−10.62 KB** |
| RegExpPrototype (`exec` → instance slot) | RegExp | −1.35 KB |

Summing the batches, the shaped surface eliminates **~61 KB of per-realm property-dictionary allocation** (~51 KB prototypes + ~10 KB constructors) when the full built-in surface is exercised, plus the Intl/Temporal cold-start improvements. Final absolute figures (all-shaped): `EngineInitPrototypes` 79.09 KB and `EngineInitConstructors` 46.54 KB vs the 13.70 KB control.

## Conformance

- **Full Test262: 0 new failures** across every phase (only the pre-existing `annexB RegExp-*-escape-BMP` and `Atomics.waitAsync` concurrent-load timeout flakes, which flake identically on `main` and pass in isolation).
- **Jint.Tests 3210/0** (net10) + 3148/0 (net472); **Jint.Tests.PublicInterface 82/0** (no public API change); **Jint.Tests.SourceGenerators 30/30** (snapshots updated for the new attributes).

## Notes / left on the dictionary path (intentional)

Cross-object aliases (`%TypedArray%.prototype.toString` === `Array.prototype.toString`; `Number.parseInt` === global `parseInt`), the TypedArray constructor hierarchy, and the intrinsic-reference / thrower-accessor hosts (`GlobalObject`, Intl/Temporal instances, `FunctionPrototype`). Extending `[JsAlias]` to cross-host would unblock the two alias cases; a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Fq5mF1QEwh2qDMD8vVwt3
