### PR TITLE
Shape Number/%TypedArray% constructors and %TypedArray%.prototype; add [JsInstanceSlot]

### DIFF
--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -102,7 +102,8 @@ public class BuiltinShapeBenchmark
         + "Intl.DateTimeFormat.prototype.resolvedOptions; Intl.NumberFormat.prototype.resolvedOptions;"
         + "Array.prototype.map; Number.prototype.toFixed; Boolean.prototype.valueOf; Error.prototype.toString;"
         + "[].values().next; new Map().keys().next; new Set().values().next; ''[Symbol.iterator]().next;"
-        + "String.prototype.slice; Date.prototype.getTime; Set.prototype.union; RegExp.prototype.test;");
+        + "String.prototype.slice; Date.prototype.getTime; Set.prototype.union; RegExp.prototype.test;"
+        + "Uint8Array.prototype.join;");
 
     [Benchmark]
     public Engine EngineInitPrototypes()

--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -122,7 +122,8 @@ public class BuiltinShapeBenchmark
         + "Temporal.PlainTime.from; Temporal.PlainYearMonth.from; Temporal.PlainMonthDay.from; Temporal.ZonedDateTime.from;"
         + "Intl.NumberFormat.supportedLocalesOf; Intl.Collator.supportedLocalesOf; Intl.DateTimeFormat.supportedLocalesOf;"
         + "Intl.ListFormat.supportedLocalesOf; Intl.PluralRules.supportedLocalesOf; Intl.RelativeTimeFormat.supportedLocalesOf;"
-        + "Intl.Segmenter.supportedLocalesOf; Intl.DisplayNames.supportedLocalesOf; Intl.DurationFormat.supportedLocalesOf;");
+        + "Intl.Segmenter.supportedLocalesOf; Intl.DisplayNames.supportedLocalesOf; Intl.DurationFormat.supportedLocalesOf;"
+        + "Number.parseInt; Int8Array.from;");
 
     [Benchmark]
     public Engine EngineInitConstructors()

--- a/Jint.SourceGenerators/Attributes.cs
+++ b/Jint.SourceGenerators/Attributes.cs
@@ -217,5 +217,18 @@ internal static class Attributes
             public string Target { get; }
         }
 
+        // Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+        // properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+        // Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+        // can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+        // Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+        [global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+        [global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+        internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+        {
+            public JsInstanceSlotAttribute(string name) { Name = name; }
+            public string Name { get; }
+        }
+
         """;
 }

--- a/Jint.SourceGenerators/Emitter.cs
+++ b/Jint.SourceGenerators/Emitter.cs
@@ -131,6 +131,7 @@ internal static class Emitter
         foreach (var name in accessorsByName.Keys) yield return name;
         foreach (var thr in obj.ThrowerAccessors) yield return thr.JsName;
         foreach (var a in obj.Aliases) yield return a.Name;
+        foreach (var s in obj.InstanceSlots) yield return s;
     }
 
     /// <summary>
@@ -360,7 +361,7 @@ internal static class Emitter
         sb.AppendLine();
         sb.AppendLine("    private static global::Jint.Native.Object.BuiltinShape BuildBuiltinShape_Generated()");
         sb.AppendLine("    {");
-        sb.Append("        var builder = new global::Jint.Native.Object.BuiltinShape.Builder(").Append(obj.Properties.Count + dataProperties.Count + accessorsByName.Count + obj.Aliases.Count).AppendLine(");");
+        sb.Append("        var builder = new global::Jint.Native.Object.BuiltinShape.Builder(").Append(obj.Properties.Count + dataProperties.Count + accessorsByName.Count + obj.Aliases.Count + obj.InstanceSlots.Count).AppendLine(");");
         // Order matches the dictionary path: properties, then functions, then accessors (each sorted by JsName).
         // Static-immutable constants share a process-wide descriptor; other properties are per-realm instance slots.
         foreach (var prop in obj.Properties)
@@ -393,6 +394,11 @@ internal static class Emitter
         foreach (var alias in obj.Aliases)
         {
             sb.Append("        builder.Alias(__Key_").Append(SanitizeIdentifier(alias.Name)).Append(", __Key_").Append(SanitizeIdentifier(alias.Target)).AppendLine(");");
+        }
+        // Host-filled instance slots last (the host supplies the descriptor in Initialize via SetBuiltinSlotByName).
+        foreach (var slot in obj.InstanceSlots)
+        {
+            sb.Append("        builder.Instance(__Key_").Append(SanitizeIdentifier(slot)).AppendLine(");");
         }
         sb.AppendLine("        return builder.Build();");
         sb.AppendLine("    }");

--- a/Jint.SourceGenerators/Models.cs
+++ b/Jint.SourceGenerators/Models.cs
@@ -41,6 +41,7 @@ internal sealed record class ObjectDefinition(
     EquatableArray<ThrowerAccessorDefinition> ThrowerAccessors,
     EquatableArray<IntrinsicReferenceDefinition> IntrinsicReferences,
     EquatableArray<AliasDefinition> Aliases,
+    EquatableArray<string> InstanceSlots,
     EquatableArray<DiagnosticInfo> DiagnosticInfos)
 {
     public string HintName => string.IsNullOrEmpty(Namespace)
@@ -138,6 +139,7 @@ internal sealed record class ObjectDefinition(
         var throwerAccessors = new List<ThrowerAccessorDefinition>();
         var intrinsicReferences = new List<IntrinsicReferenceDefinition>();
         var aliases = new List<AliasDefinition>();
+        var instanceSlots = new List<string>();
         HashSet<string>? seenFunctionClrNames = null;
         HashSet<string>? seenThrowerNames = null;
         HashSet<string>? seenIntrinsicReferenceNames = null;
@@ -204,6 +206,16 @@ internal sealed record class ObjectDefinition(
             var aliasTarget = attr.ConstructorArguments[1].Value as string;
             if (string.IsNullOrWhiteSpace(aliasName) || string.IsNullOrWhiteSpace(aliasTarget)) continue;
             aliases.Add(new AliasDefinition(aliasName!, aliasTarget!));
+        }
+
+        // Class-level [JsInstanceSlot("name")] — a host-filled reserved slot (shape path only).
+        foreach (var attr in typeSymbol.GetAttributes())
+        {
+            if (attr.AttributeClass?.Name != "JsInstanceSlotAttribute") continue;
+            if (attr.ConstructorArguments.Length == 0) continue;
+            var slotName = attr.ConstructorArguments[0].Value as string;
+            if (string.IsNullOrWhiteSpace(slotName)) continue;
+            instanceSlots.Add(slotName!);
         }
 
         foreach (var member in typeSymbol.GetMembers())
@@ -397,6 +409,7 @@ internal sealed record class ObjectDefinition(
             ThrowerAccessors: throwerAccessors.ToEquatableArray(),
             IntrinsicReferences: intrinsicReferences.ToEquatableArray(),
             Aliases: aliases.ToEquatableArray(),
+            InstanceSlots: instanceSlots.ToEquatableArray(),
             DiagnosticInfos: diagnostics.ToEquatableArray());
     }
 

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterAndSetter#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorGetterOnly#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.AccessorWrongArity_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpan#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpan#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpanTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.CoercedRestSpanTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingAccessorFlags_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConflictingConversionAttrs_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ConversionTypeMismatch_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateIntrinsicReference_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateIntrinsicReference_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.DuplicateThrower_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.InstanceMethod#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntegerConversions#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReference#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReference#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReferenceWithoutRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.IntrinsicReferenceWithoutRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MinimalClass#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.MissingRealmField_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.NotPartial_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.OverloadCollision_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PassthroughArguments#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.PropertyConstants#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RestParameter#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.RichConversions#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolAccessorGetterOnly#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolFunctionMethod#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.SymbolMember#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToCallable#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThisObjectCastToObjectInstance#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ThrowerAccessor#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.ToNumberConversion#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
+++ b/Jint.Tests.SourceGenerators/Snapshots/ObjectGeneratorTests.UnsupportedReturnType_ProducesDiagnostic#JintAttributes.g.verified.cs
@@ -212,3 +212,16 @@ internal sealed class JsAliasAttribute : global::System.Attribute
     public string Name { get; }
     public string Target { get; }
 }
+
+// Class-level, repeats. Reserves a per-realm own-property slot (appended after all other own
+// properties, matching a hand-written SetProperty/AddDangerous tail) that the host fills in
+// Initialize via SetBuiltinSlotByName(name, descriptor) — for a computed/lazy value the generator
+// can't express, e.g. %TypedArray%.prototype.toString aliasing %Array.prototype.toString% lazily.
+// Shape hosts only (a non-shaped host just SetProperty()s the value in Initialize as before).
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true)]
+[global::System.Diagnostics.Conditional("JINT_SOURCE_GENERATORS")]
+internal sealed class JsInstanceSlotAttribute : global::System.Attribute
+{
+    public JsInstanceSlotAttribute(string name) { Name = name; }
+    public string Name { get; }
+}

--- a/Jint/Native/Number/NumberConstructor.cs
+++ b/Jint/Native/Number/NumberConstructor.cs
@@ -10,10 +10,19 @@ namespace Jint.Native.Number;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-number-constructor
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class NumberConstructor : Constructor
 {
     private static readonly JsString _functionName = new JsString("Number");
+
+    // Number.parseInt / parseFloat are the same functions as global parseInt / parseFloat (Jint's
+    // ClrFunction equality compares the underlying delegate). They wrap static delegates with no realm
+    // dependency, so they're per-realm instance slots created in the constructor (like RegExp exec).
+    [JsProperty(Name = "parseInt", Flags = PropertyFlag.Configurable | PropertyFlag.Writable)]
+    private readonly ClrFunction _parseInt;
+
+    [JsProperty(Name = "parseFloat", Flags = PropertyFlag.Configurable | PropertyFlag.Writable)]
+    private readonly ClrFunction _parseFloat;
 
     private const long MinSafeInteger = -9007199254740991;
     internal const long MaxSafeInteger = 9007199254740991;
@@ -38,19 +47,13 @@ internal sealed partial class NumberConstructor : Constructor
         PrototypeObject = new NumberPrototype(engine, realm, this, objectPrototype);
         _length = new PropertyDescriptor(JsNumber.PositiveOne, PropertyFlag.Configurable);
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
+        _parseInt = new ClrFunction(engine, "parseInt", GlobalObject.ParseInt, 0, PropertyFlag.Configurable);
+        _parseFloat = new ClrFunction(engine, "parseFloat", GlobalObject.ParseFloat, 0, PropertyFlag.Configurable);
     }
 
     protected override void Initialize()
     {
         CreateProperties_Generated();
-
-        // Per spec, Number.parseInt and Number.parseFloat are the same function objects as the global
-        // parseInt / parseFloat. Pre-source-gen Jint's behaviour relied on ClrFunction.Equals comparing
-        // the underlying delegate; the source generator's per-method dispatcher would break that
-        // identity, so register parseInt/parseFloat hand-rolled and let them keep the same delegate.
-        const PropertyFlag PropertyFlags = PropertyFlag.Configurable | PropertyFlag.Writable;
-        SetProperty("parseInt", new PropertyDescriptor(new ClrFunction(Engine, "parseInt", GlobalObject.ParseInt, 0, PropertyFlag.Configurable), PropertyFlags));
-        SetProperty("parseFloat", new PropertyDescriptor(new ClrFunction(Engine, "parseFloat", GlobalObject.ParseFloat, 0, PropertyFlag.Configurable), PropertyFlags));
     }
 
     [JsFunction(Length = 1)]

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -773,6 +773,17 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         Unsafe.As<IBuiltinShaped>(this).BuiltinDescriptors![slot] = new PropertyDescriptor(value, flags);
     }
 
+    // Fills a slot reserved by [JsInstanceSlot] with a host-computed descriptor (e.g. a lazy cross-realm
+    // alias). Call from a shaped host's Initialize, after CreateProperties_Generated.
+    private protected void SetBuiltinSlotByName(string name, PropertyDescriptor descriptor)
+    {
+        var shaped = Unsafe.As<IBuiltinShaped>(this);
+        if (shaped.BuiltinShape.Index.TryGetValue(name, out var slot))
+        {
+            shaped.BuiltinDescriptors![slot] = descriptor;
+        }
+    }
+
     protected internal virtual void SetOwnProperty(JsValue property, PropertyDescriptor desc)
     {
         EnsureInitialized();

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayConstructor.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayConstructor.cs
@@ -9,7 +9,7 @@ namespace Jint.Native.TypedArray;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%typedarray%-intrinsic-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class IntrinsicTypedArrayConstructor : Constructor
 {
     internal IntrinsicTypedArrayConstructor(

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -19,7 +19,10 @@ namespace Jint.Native.TypedArray;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-properties-of-the-%typedarrayprototype%-object
 /// </summary>
-[JsObject(ExtraCapacity = 1)]
+// toString is the same function as %Array.prototype.toString% (resolved lazily per realm) — reserved as a
+// host-filled instance slot since the generator can't express a cross-object alias.
+[JsInstanceSlot("toString")]
+[JsObject(UseShape = true)]
 internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 {
     private const int ConstraintCheckInterval = Engine.ConstraintCheckInterval;
@@ -42,11 +45,10 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         CreateProperties_Generated();
         CreateSymbols_Generated();
 
-        // Per spec (ECMA-262 23.2.3.32) the initial value of %TypedArray%.prototype.toString is the
-        // SAME function object as %Array.prototype.toString%. Hand-write this entry — the generator
-        // can't express "alias to another realm intrinsic" through [JsFunction]. AddDangerous skips
-        // SetOwnProperty's validation; ExtraCapacity=1 on [JsObject] presizes the dict.
-        _properties!.AddDangerous("toString", new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => prototype._realm.Intrinsics.Array.PrototypeObject.Get("toString"), PropertyFlags));
+        // Per spec (ECMA-262 23.2.3.32) the initial value of %TypedArray%.prototype.toString is the SAME
+        // function object as %Array.prototype.toString%. Fill the reserved [JsInstanceSlot] with the lazy
+        // descriptor (resolved on first read, so touching %TypedArray%.prototype doesn't force Array init).
+        SetBuiltinSlotByName("toString", new LazyPropertyDescriptor<IntrinsicTypedArrayPrototype>(this, static prototype => prototype._realm.Intrinsics.Array.PrototypeObject.Get("toString"), PropertyFlags));
 
         // Per spec, %TypedArray%.prototype[@@iterator] is the SAME function object as
         // %TypedArray%.prototype.values. Materialize the generated `values` slot and reuse it.


### PR DESCRIPTION
## Summary

Follow-up to #2580 — shapes three more built-in hosts, including the last big one, and adds a small reusable generator mechanism for host-computed properties.

- **NumberConstructor** — `Number.parseInt` / `parseFloat` are the same functions as global `parseInt` / `parseFloat` (Jint's `ClrFunction` equality compares the underlying delegate). They wrap static delegates with no realm dependency, so — like `RegExp.prototype.exec` in #2580 — they become per-realm `[JsProperty]` `ClrFunction` instance slots created in the constructor. Hand-written `SetProperty` tail + `ExtraCapacity` gone.
- **IntrinsicTypedArrayConstructor** (`%TypedArray%`) — clean (`from`/`of` + `@@species`); opts in directly.
- **New `[JsInstanceSlot("name")]`** — reserves a per-realm own-property slot (appended after all other own properties) that the host fills in `Initialize` via `SetBuiltinSlotByName(name, descriptor)`, for a computed/lazy value the generator can't express (specifically a cross-object alias).
- **IntrinsicTypedArrayPrototype** (`%TypedArray%.prototype`, 37 members: 10 accessors, ~20 methods, `@@iterator === values`) — its `toString` is the same function object as `%Array.prototype.toString%`, a lazy cross-object alias, now expressed via `[JsInstanceSlot]`. Resolution stays lazy, so touching `%TypedArray%.prototype` doesn't force `Array` init.

## Benchmarks

`Jint.Benchmark/BuiltinShapeBenchmark.cs`, default job. Each commit A/B'd against a byte-identical `EngineOnly` control (13.70 KB); per-realm `Initialize` allocation removed:

| Commit | Δ |
|---|---|
| NumberConstructor + `%TypedArray%` constructor | `EngineInitConstructors` 50.51 → 49.58 KB (**−0.93 KB**) |
| `[JsInstanceSlot]` + `%TypedArray%.prototype` | `EngineInitPrototypes` 84.83 → 81.14 KB (**−3.69 KB**) |

## Conformance

- **Full Test262: 0 new failures** on both commits (only the pre-existing `annexB RegExp-*-escape-BMP` concurrent-load timeout flakes).
- **Jint.Tests.SourceGenerators 30/30** (snapshot updated for the new attribute).

## Remaining (deliberately on the dictionary path)

The TypedArray *constructor* hierarchy (`Uint8ArrayConstructor` would re-implement `IBuiltinShaped` with only its own members, dropping the inherited `BYTES_PER_ELEMENT` from the abstract base's shape — needs generator support for inherited `[JsObject]` members), `RegExpConstructor` legacy statics, and the intrinsic-reference / thrower hosts (`GlobalObject`, Intl/Temporal instances, `FunctionPrototype`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Fq5mF1QEwh2qDMD8vVwt3
