### PR TITLE
Shape TypedArray constructors; modernize element codecs with BinaryPrimitives

### DIFF
--- a/Jint.Benchmark/BuiltinShapeBenchmark.cs
+++ b/Jint.Benchmark/BuiltinShapeBenchmark.cs
@@ -124,7 +124,9 @@ public class BuiltinShapeBenchmark
         + "Intl.NumberFormat.supportedLocalesOf; Intl.Collator.supportedLocalesOf; Intl.DateTimeFormat.supportedLocalesOf;"
         + "Intl.ListFormat.supportedLocalesOf; Intl.PluralRules.supportedLocalesOf; Intl.RelativeTimeFormat.supportedLocalesOf;"
         + "Intl.Segmenter.supportedLocalesOf; Intl.DisplayNames.supportedLocalesOf; Intl.DurationFormat.supportedLocalesOf;"
-        + "Number.parseInt; Int8Array.from;");
+        + "Number.parseInt; Int8Array.from;"
+        + "Int8Array.BYTES_PER_ELEMENT; Uint16Array.BYTES_PER_ELEMENT; Int32Array.BYTES_PER_ELEMENT;"
+        + "Float32Array.BYTES_PER_ELEMENT; Float64Array.BYTES_PER_ELEMENT; Uint8Array.fromBase64;");
 
     [Benchmark]
     public Engine EngineInitConstructors()

--- a/Jint.Benchmark/TypedArrayElementBenchmark.cs
+++ b/Jint.Benchmark/TypedArrayElementBenchmark.cs
@@ -1,0 +1,64 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Exercises the <c>JsArrayBuffer</c> element read/write hot path (typed-array indexed set/get and
+/// DataView set/get) that routes through <c>SetValueInBuffer</c> / <c>RawBytesToNumeric</c>. The
+/// integer/bigint write path formerly allocated a scratch <c>byte[]</c> per element via
+/// <c>BitConverter.GetBytes</c>; the BinaryPrimitives rewrite writes straight into the buffer, so the
+/// Allocated column is the primary signal here.
+/// </summary>
+[MemoryDiagnoser]
+public class TypedArrayElementBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _intWriteRead;
+    private Prepared<Script> _floatWriteRead;
+    private Prepared<Script> _dataViewMixed;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute(@"
+var i16 = new Int16Array(1024), u16 = new Uint16Array(1024);
+var i32 = new Int32Array(1024), u32 = new Uint32Array(1024);
+var b64 = new BigInt64Array(1024);
+var f64 = new Float64Array(1024), f32 = new Float32Array(1024);
+var dv = new DataView(new ArrayBuffer(4096));");
+
+        // Integer typed-array element writes then reads — the allocation-sensitive path.
+        _intWriteRead = Engine.PrepareScript(@"
+var s = 0;
+for (var i = 0; i < 1024; i++) { i16[i] = i - 300; u16[i] = i; i32[i] = i * 40000; u32[i] = i * 40000; b64[i] = BigInt(i); }
+for (var i = 0; i < 1024; i++) { s += i16[i] + u16[i] + i32[i] + u32[i] + Number(b64[i]); }
+s;");
+
+        _floatWriteRead = Engine.PrepareScript(@"
+var s = 0;
+for (var i = 0; i < 1024; i++) { f64[i] = i * 1.5; f32[i] = i * 0.25; }
+for (var i = 0; i < 1024; i++) { s += f64[i] + f32[i]; }
+s;");
+
+        // DataView with explicit endianness (little and big), covering the reverse path.
+        _dataViewMixed = Engine.PrepareScript(@"
+var s = 0;
+for (var i = 0; i < 512; i++) {
+  dv.setInt16(0, i - 300, true); s += dv.getInt16(0, false);
+  dv.setInt32(0, i * 40000, false); s += dv.getInt32(0, true);
+  dv.setFloat64(0, i * 1.5, true); s += dv.getFloat64(0, false);
+  dv.setBigInt64(0, BigInt(i), false); s += Number(dv.getBigInt64(0, true));
+}
+s;");
+    }
+
+    [Benchmark]
+    public void IntWriteRead() => _engine.Evaluate(_intWriteRead);
+
+    [Benchmark]
+    public void FloatWriteRead() => _engine.Evaluate(_floatWriteRead);
+
+    [Benchmark]
+    public void DataViewMixed() => _engine.Evaluate(_dataViewMixed);
+}

--- a/Jint/Native/JsArrayBuffer.cs
+++ b/Jint/Native/JsArrayBuffer.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using Jint.Native.ArrayBuffer;
 using Jint.Native.Object;
 using Jint.Native.TypedArray;
@@ -10,7 +11,8 @@ namespace Jint.Native;
 /// </summary>
 public class JsArrayBuffer : ObjectInstance
 {
-    // so that we don't need to allocate while or reading setting values
+    // scratch space for byte-order-reversing a big-endian floating point element before decoding it,
+    // so the read path doesn't allocate (integer reads/writes go straight through BinaryPrimitives)
     private readonly byte[] _workBuffer = new byte[8];
 
     internal byte[]? _arrayBufferData;
@@ -113,104 +115,78 @@ public class JsArrayBuffer : ObjectInstance
     /// </summary>
     internal TypedArrayValue RawBytesToNumeric(TypedArrayElementType type, int byteIndex, bool isLittleEndian)
     {
-        if (type is TypedArrayElementType.Uint8 or TypedArrayElementType.Uint8C)
+        var block = _arrayBufferData!;
+
+        // Integer element types read straight from the buffer via BinaryPrimitives: no scratch buffer,
+        // no manual bit assembly, and endianness-correct regardless of the host's byte order.
+        switch (type)
         {
-            return new TypedArrayValue(Types.Number, _arrayBufferData![byteIndex], default);
+            case TypedArrayElementType.Uint8:
+            case TypedArrayElementType.Uint8C:
+                return new TypedArrayValue(Types.Number, block[byteIndex], default);
+            case TypedArrayElementType.Int8:
+                return (sbyte) block[byteIndex];
         }
 
-        var elementSize = type.GetElementSize();
-        var rawBytes = _arrayBufferData!;
-
-        // 8 byte values require a little more at the moment
-        var needsReverse = !isLittleEndian
-                           && elementSize > 1
-                           && type is TypedArrayElementType.Float16 or TypedArrayElementType.Float32 or TypedArrayElementType.Float64 or TypedArrayElementType.BigInt64 or TypedArrayElementType.BigUint64;
-
-        if (needsReverse)
+        var src = block.AsSpan(byteIndex);
+        switch (type)
         {
-            System.Array.Copy(rawBytes, byteIndex, _workBuffer, 0, elementSize);
+            case TypedArrayElementType.Int16:
+                return isLittleEndian ? BinaryPrimitives.ReadInt16LittleEndian(src) : BinaryPrimitives.ReadInt16BigEndian(src);
+            case TypedArrayElementType.Uint16:
+                return isLittleEndian ? BinaryPrimitives.ReadUInt16LittleEndian(src) : BinaryPrimitives.ReadUInt16BigEndian(src);
+            case TypedArrayElementType.Int32:
+                return isLittleEndian ? BinaryPrimitives.ReadInt32LittleEndian(src) : BinaryPrimitives.ReadInt32BigEndian(src);
+            case TypedArrayElementType.Uint32:
+                return isLittleEndian ? BinaryPrimitives.ReadUInt32LittleEndian(src) : BinaryPrimitives.ReadUInt32BigEndian(src);
+            case TypedArrayElementType.BigInt64:
+                return isLittleEndian ? BinaryPrimitives.ReadInt64LittleEndian(src) : BinaryPrimitives.ReadInt64BigEndian(src);
+            case TypedArrayElementType.BigUint64:
+                return isLittleEndian ? BinaryPrimitives.ReadUInt64LittleEndian(src) : BinaryPrimitives.ReadUInt64BigEndian(src);
+        }
+
+        // Floating point: BitConverter interprets in host-endian order, so reverse into the scratch
+        // buffer when the requested order differs. A NaN read canonicalizes to the NaN Number value.
+        var elementSize = type.GetElementSize();
+        var rawBytes = block;
+        if (!isLittleEndian && elementSize > 1)
+        {
+            System.Array.Copy(block, byteIndex, _workBuffer, 0, elementSize);
             byteIndex = 0;
             System.Array.Reverse(_workBuffer, 0, elementSize);
             rawBytes = _workBuffer;
         }
 
-        if (type == TypedArrayElementType.Float16)
+        switch (type)
         {
+            case TypedArrayElementType.Float16:
+                return ReadFloat16(rawBytes, byteIndex);
+            case TypedArrayElementType.Float32:
+                // A NaN read canonicalizes to the NaN Number value.
+                var single = BitConverter.ToSingle(rawBytes, byteIndex);
+                return float.IsNaN(single) ? double.NaN : single;
+            case TypedArrayElementType.Float64:
+                return BitConverter.ToDouble(rawBytes, byteIndex);
+            default:
+                Throw.ArgumentOutOfRangeException(nameof(type), type.ToString());
+                return default;
+        }
+    }
+
+    private static TypedArrayValue ReadFloat16(byte[] rawBytes, int byteIndex)
+    {
 #if SUPPORTS_HALF
-            // rawBytes concatenated and interpreted as a little-endian bit string encoding of an IEEE 754-2019 binary32 value.
-            var value = BitConverter.ToHalf(rawBytes, byteIndex);
-
-            // If value is an IEEE 754-2019 binary32 NaN value, return the NaN Number value.
-            if (Half.IsNaN(value))
-            {
-                return double.NaN;
-            }
-
-            return value;
+        // A NaN read canonicalizes to the NaN Number value.
+        var value = BitConverter.ToHalf(rawBytes, byteIndex);
+        if (Half.IsNaN(value))
+        {
+            return double.NaN;
+        }
+        return value;
 #else
-            Throw.NotImplementedException("Float16/Half type is not supported in this build");
-            return default;
+        Throw.NotImplementedException("Float16/Half type is not supported in this build");
+        return default;
 #endif
-
-        }
-
-        if (type == TypedArrayElementType.Float32)
-        {
-            // rawBytes concatenated and interpreted as a little-endian bit string encoding of an IEEE 754-2019 binary32 value.
-            var value = BitConverter.ToSingle(rawBytes, byteIndex);
-
-            // If value is an IEEE 754-2019 binary32 NaN value, return the NaN Number value.
-            if (float.IsNaN(value))
-            {
-                return double.NaN;
-            }
-
-            return value;
-        }
-
-        if (type == TypedArrayElementType.Float64)
-        {
-            // rawBytes concatenated and interpreted as a little-endian bit string encoding of an IEEE 754-2019 binary64 value.
-            var value = BitConverter.ToDouble(rawBytes, byteIndex);
-            return value;
-        }
-
-        if (type == TypedArrayElementType.BigUint64)
-        {
-            var value = BitConverter.ToUInt64(rawBytes, byteIndex);
-            return value;
-        }
-
-        if (type == TypedArrayElementType.BigInt64)
-        {
-            var value = BitConverter.ToInt64(rawBytes, byteIndex);
-            return value;
-        }
-
-        TypedArrayValue? arrayValue = type switch
-        {
-            TypedArrayElementType.Int8 => (sbyte) rawBytes[byteIndex],
-            TypedArrayElementType.Int16 => isLittleEndian
-                ? (short) (rawBytes[byteIndex] | (rawBytes[byteIndex + 1] << 8))
-                : (short) (rawBytes[byteIndex + 1] | (rawBytes[byteIndex] << 8)),
-            TypedArrayElementType.Uint16 => isLittleEndian
-                ? (ushort) (rawBytes[byteIndex] | (rawBytes[byteIndex + 1] << 8))
-                : (ushort) (rawBytes[byteIndex + 1] | (rawBytes[byteIndex] << 8)),
-            TypedArrayElementType.Int32 => isLittleEndian
-                ? rawBytes[byteIndex] | (rawBytes[byteIndex + 1] << 8) | (rawBytes[byteIndex + 2] << 16) | (rawBytes[byteIndex + 3] << 24)
-                : rawBytes[byteIndex + 3] | (rawBytes[byteIndex + 2] << 8) | (rawBytes[byteIndex + 1] << 16) | (rawBytes[byteIndex + 0] << 24),
-            TypedArrayElementType.Uint32 => isLittleEndian
-                ? (uint) (rawBytes[byteIndex] | (rawBytes[byteIndex + 1] << 8) | (rawBytes[byteIndex + 2] << 16) | (rawBytes[byteIndex + 3] << 24))
-                : (uint) (rawBytes[byteIndex + 3] | (rawBytes[byteIndex + 2] << 8) | (rawBytes[byteIndex + 1] << 16) | (rawBytes[byteIndex] << 24)),
-            _ => null
-        };
-
-        if (arrayValue is null)
-        {
-            Throw.ArgumentOutOfRangeException(nameof(type), type.ToString());
-        }
-
-        return arrayValue.Value;
     }
 
     /// <summary>
@@ -224,114 +200,118 @@ public class JsArrayBuffer : ObjectInstance
         ArrayBufferOrder order,
         bool? isLittleEndian = null)
     {
-        if (type is TypedArrayElementType.Uint8)
-        {
-            var doubleValue = value.DoubleValue;
-            var intValue = double.IsNaN(doubleValue) || doubleValue == 0 || double.IsInfinity(doubleValue)
-                ? 0
-                : (long) doubleValue;
+        var block = _arrayBufferData!;
+        // If isLittleEndian is not present, use the [[LittleEndian]] field of the surrounding agent's Agent Record.
+        var littleEndian = isLittleEndian ?? BitConverter.IsLittleEndian;
 
-            _arrayBufferData![byteIndex] = (byte) intValue;
-            return;
+        // Integer element types write straight into the buffer via BinaryPrimitives: no per-element
+        // byte[] allocation, no manual endian reversal. (short)/(ushort) and (int)/(uint) share the
+        // same bit pattern, so the signed overload serves the unsigned type too.
+        switch (type)
+        {
+            case TypedArrayElementType.Int8:
+                block[byteIndex] = (byte) (sbyte) DoubleToInt64(value.DoubleValue);
+                return;
+            case TypedArrayElementType.Uint8:
+                block[byteIndex] = (byte) DoubleToInt64(value.DoubleValue);
+                return;
+            case TypedArrayElementType.Uint8C:
+                block[byteIndex] = TypeConverter.ToUint8Clamp(value.DoubleValue);
+                return;
+            case TypedArrayElementType.Int16:
+            case TypedArrayElementType.Uint16:
+                {
+                    var v = (short) DoubleToInt64(value.DoubleValue);
+                    var dest = block.AsSpan(byteIndex);
+                    if (littleEndian)
+                    {
+                        BinaryPrimitives.WriteInt16LittleEndian(dest, v);
+                    }
+                    else
+                    {
+                        BinaryPrimitives.WriteInt16BigEndian(dest, v);
+                    }
+                    return;
+                }
+            case TypedArrayElementType.Int32:
+            case TypedArrayElementType.Uint32:
+                {
+                    var v = (int) DoubleToInt64(value.DoubleValue);
+                    var dest = block.AsSpan(byteIndex);
+                    if (littleEndian)
+                    {
+                        BinaryPrimitives.WriteInt32LittleEndian(dest, v);
+                    }
+                    else
+                    {
+                        BinaryPrimitives.WriteInt32BigEndian(dest, v);
+                    }
+                    return;
+                }
+            case TypedArrayElementType.BigInt64:
+                {
+                    var v = TypeConverter.ToBigInt64(value.BigInteger);
+                    var dest = block.AsSpan(byteIndex);
+                    if (littleEndian)
+                    {
+                        BinaryPrimitives.WriteInt64LittleEndian(dest, v);
+                    }
+                    else
+                    {
+                        BinaryPrimitives.WriteInt64BigEndian(dest, v);
+                    }
+                    return;
+                }
+            case TypedArrayElementType.BigUint64:
+                {
+                    var v = TypeConverter.ToBigUint64(value.BigInteger);
+                    var dest = block.AsSpan(byteIndex);
+                    if (littleEndian)
+                    {
+                        BinaryPrimitives.WriteUInt64LittleEndian(dest, v);
+                    }
+                    else
+                    {
+                        BinaryPrimitives.WriteUInt64BigEndian(dest, v);
+                    }
+                    return;
+                }
         }
 
-        var block = _arrayBufferData!;
-        // If isLittleEndian is not present, set isLittleEndian to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
-        var rawBytes = NumericToRawBytes(type, value, isLittleEndian ?? BitConverter.IsLittleEndian);
-        System.Array.Copy(rawBytes, 0, block, byteIndex, type.GetElementSize());
+        // Floating point: encode via BitConverter (NaN encoding is implementation-defined per spec) and
+        // copy into the buffer, reversing for big-endian order.
+        var rawBytes = FloatToRawBytes(type, value);
+        if (!littleEndian && rawBytes.Length > 1)
+        {
+            System.Array.Reverse(rawBytes);
+        }
+        System.Array.Copy(rawBytes, 0, block, byteIndex, rawBytes.Length);
     }
 
-    private byte[] NumericToRawBytes(TypedArrayElementType type, TypedArrayValue value, bool isLittleEndian)
+    // ℝ(value) truncated toward zero, with NaN, ±0 and ±∞ mapping to 0 — the integer conversion the
+    // spec's SetValueInBuffer applies before encoding an integer element type.
+    private static long DoubleToInt64(double doubleValue)
+        => double.IsNaN(doubleValue) || doubleValue == 0 || double.IsInfinity(doubleValue) ? 0 : (long) doubleValue;
+
+    private static byte[] FloatToRawBytes(TypedArrayElementType type, TypedArrayValue value)
     {
-        byte[] rawBytes;
-        if (type == TypedArrayElementType.Float16)
+        switch (type)
         {
+            case TypedArrayElementType.Float16:
 #if SUPPORTS_HALF
-            rawBytes = BitConverter.GetBytes((Half) value.DoubleValue);
+                return BitConverter.GetBytes((Half) value.DoubleValue);
 #else
-            Throw.NotImplementedException("Float16/Half type is not supported in this build");
-            return default!;
+                Throw.NotImplementedException("Float16/Half type is not supported in this build");
+                return default!;
 #endif
+            case TypedArrayElementType.Float32:
+                return BitConverter.GetBytes((float) value.DoubleValue);
+            case TypedArrayElementType.Float64:
+                return BitConverter.GetBytes(value.DoubleValue);
+            default:
+                Throw.ArgumentOutOfRangeException(nameof(type), type.ToString());
+                return null!;
         }
-        else if (type == TypedArrayElementType.Float32)
-        {
-            // Let rawBytes be a List whose elements are the 4 bytes that are the result of converting value to IEEE 754-2019 binary32 format using roundTiesToEven mode. If isLittleEndian is false, the bytes are arranged in big endian order. Otherwise, the bytes are arranged in little endian order. If value is NaN, rawBytes may be set to any implementation chosen IEEE 754-2019 binary32 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable NaN value.
-            rawBytes = BitConverter.GetBytes((float) value.DoubleValue);
-        }
-        else if (type == TypedArrayElementType.Float64)
-        {
-            // Let rawBytes be a List whose elements are the 8 bytes that are the IEEE 754-2019 binary64 format encoding of value. If isLittleEndian is false, the bytes are arranged in big endian order. Otherwise, the bytes are arranged in little endian order. If value is NaN, rawBytes may be set to any implementation chosen IEEE 754-2019 binary64 format Not-a-Number encoding. An implementation must always choose the same encoding for each implementation distinguishable NaN value.
-            rawBytes = BitConverter.GetBytes(value.DoubleValue);
-        }
-        else if (type == TypedArrayElementType.BigInt64)
-        {
-            rawBytes = BitConverter.GetBytes(TypeConverter.ToBigInt64(value.BigInteger));
-        }
-        else if (type == TypedArrayElementType.BigUint64)
-        {
-            rawBytes = BitConverter.GetBytes(TypeConverter.ToBigUint64(value.BigInteger));
-        }
-        else
-        {
-            // inlined conversion for faster speed instead of getting the method in spec
-            var doubleValue = value.DoubleValue;
-            var intValue = double.IsNaN(doubleValue) || doubleValue == 0 || double.IsInfinity(doubleValue)
-                ? 0
-                : (long) doubleValue;
-
-            rawBytes = _workBuffer;
-            switch (type)
-            {
-                case TypedArrayElementType.Int8:
-                    rawBytes[0] = (byte) (sbyte) intValue;
-                    break;
-                case TypedArrayElementType.Uint8:
-                    rawBytes[0] = (byte) intValue;
-                    break;
-                case TypedArrayElementType.Uint8C:
-                    rawBytes[0] = TypeConverter.ToUint8Clamp(value.DoubleValue);
-                    break;
-                case TypedArrayElementType.Int16:
-#if !NETSTANDARD2_1
-                    rawBytes = BitConverter.GetBytes((short) intValue);
-#else
-                    BitConverter.TryWriteBytes(rawBytes, (short) intValue);
-#endif
-                    break;
-                case TypedArrayElementType.Uint16:
-#if !NETSTANDARD2_1
-                    rawBytes = BitConverter.GetBytes((ushort) intValue);
-#else
-                    BitConverter.TryWriteBytes(rawBytes, (ushort) intValue);
-#endif
-                    break;
-                case TypedArrayElementType.Int32:
-#if !NETSTANDARD2_1
-                    rawBytes = BitConverter.GetBytes((uint) intValue);
-#else
-                    BitConverter.TryWriteBytes(rawBytes, (uint) intValue);
-#endif
-                    break;
-                case TypedArrayElementType.Uint32:
-#if !NETSTANDARD2_1
-                    rawBytes = BitConverter.GetBytes((uint) intValue);
-#else
-                    BitConverter.TryWriteBytes(rawBytes, (uint) intValue);
-#endif
-                    break;
-                default:
-                    Throw.ArgumentOutOfRangeException();
-                    return null;
-            }
-        }
-
-        var elementSize = type.GetElementSize();
-        if (!isLittleEndian && elementSize > 1)
-        {
-            System.Array.Reverse(rawBytes, 0, elementSize);
-        }
-
-        return rawBytes;
     }
 
     internal void Resize(uint newByteLength)

--- a/Jint/Native/TypedArray/TypedArrayConstructor.Uint8Array.cs
+++ b/Jint/Native/TypedArray/TypedArrayConstructor.Uint8Array.cs
@@ -8,7 +8,7 @@ using Jint.Runtime.Interop;
 
 namespace Jint.Native.TypedArray;
 
-[JsObject]
+[JsObject(UseShape = true)]
 public sealed partial class Uint8ArrayConstructor : TypedArrayConstructor
 {
     // Uint8 element size is fixed at 1; the base class also tracks BYTES_PER_ELEMENT but its

--- a/Jint/Native/TypedArray/TypedArrayConstructor.cs
+++ b/Jint/Native/TypedArray/TypedArrayConstructor.cs
@@ -12,7 +12,7 @@ namespace Jint.Native.TypedArray;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-typedarray-constructors
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 public abstract partial class TypedArrayConstructor : Constructor
 {
     private readonly TypedArrayElementType _arrayElementType;

--- a/Jint/Native/TypedArray/Uint8ArrayPrototype.cs
+++ b/Jint/Native/TypedArray/Uint8ArrayPrototype.cs
@@ -68,16 +68,11 @@ internal sealed partial class Uint8ArrayPrototype : Prototype
 
     private static void SetUint8ArrayBytes(JsTypedArray into, byte[] bytes)
     {
-        var offset = into._byteOffset;
-        var len = bytes.Length;
-        var index = 0;
-        while (index < len)
-        {
-            var b = bytes[index];
-            var byteIndexInBuffer = index + offset;
-            into._viewedArrayBuffer.SetValueInBuffer(byteIndexInBuffer, TypedArrayElementType.Uint8, b, isTypedArray: true, ArrayBufferOrder.Unordered);
-            index++;
-        }
+        // FromBase64/FromHex cap their output at the target's byte length, so the decoded bytes always
+        // fit within the typed array's view — copy them straight into the backing buffer. Uint8 needs
+        // no per-element conversion, so this is a single memcpy rather than N SetValueInBuffer calls.
+        var destination = into._viewedArrayBuffer._arrayBufferData!.AsSpan(into._byteOffset, bytes.Length);
+        bytes.AsSpan().CopyTo(destination);
     }
 
     [JsFunction]


### PR DESCRIPTION
## Summary

Follow-up to #2580 / #2581. Finishes the TypedArray corner of the built-in-shape rollout and, along the way, modernizes the TypedArray element codecs with current .NET idioms.

- **Shape the TypedArray constructor family.** The abstract `TypedArrayConstructor` and `Uint8ArrayConstructor` opt into `[JsObject(UseShape = true)]`. The 11 concrete per-type constructors (`Int8Array`, `Uint16Array`, …) declare no `[JsObject]` of their own, so they inherit the base shape and fill their per-type `BYTES_PER_ELEMENT` instance slot from it; `Uint8ArrayConstructor` re-declares `BYTES_PER_ELEMENT` locally (for its base64 statics) and so re-implements `IBuiltinShaped` with its own self-contained shape — the same derived-from-shaped interface re-implementation used by the iterator prototypes.

- **Modernize `JsArrayBuffer` element read/write with `BinaryPrimitives`.** `RawBytesToNumeric` / `SetValueInBuffer` hand-rolled the integer codecs — reads assembled values with per-byte bit-shifting, and writes allocated a scratch `byte[]` per element via `BitConverter.GetBytes` before an `Array.Copy`. Every integer and bigint element type now goes through `BinaryPrimitives.Read/Write{Int,UInt}{16,32,64}{Little,Big}Endian` straight on the buffer span: no per-element allocation, no manual bit assembly, and endianness-correct regardless of host byte order (the old GetBytes+conditional-reverse write was only correct on a little-endian host). The floating-point path is deliberately unchanged (same `BitConverter` round-trip, NaN canonicalization, and big-endian scratch reversal).

- **Bulk-copy decoded base64/hex bytes into `Uint8Array`.** `setFromBase64` / `setFromHex` wrote the decoder output into the backing buffer one byte at a time through `SetValueInBuffer`; since the target is Uint8 and the decoder caps output at the array's byte length, this is now a single `Span.CopyTo`.

## Benchmarks

Default BenchmarkDotNet job, each change A/B'd against its parent commit.

**Built-in shape init** (`BuiltinShapeBenchmark`, `EngineOnly` control byte-identical at 13.70 KB):

| Commit | Δ |
|---|---|
| TypedArray constructor family | `EngineInitConstructors` 54.71 → 53.66 KB (**−1.05 KB**) |

**Element read/write throughput** (new `TypedArrayElementBenchmark`, A/B/A to filter a thermal outlier on the neutral float row). Allocation is the exact, mechanism-backed signal:

| Method         | Time                       | Allocated                    |
|----------------|----------------------------|------------------------------|
| IntWriteRead   | 1,225 → 1,175 µs (−4%)     | 447.5 → 287.5 KB (**−35.8%**) |
| DataViewMixed  |   758 →   731 µs (−3.5%)   | 265.1 → 217.1 KB (**−18.1%**) |
| FloatWriteRead |   508 →   491 µs (noise)   | 203.8 → 203.8 KB (unchanged)  |

The integer/bigint write path no longer allocates a per-element scratch `byte[]`; the float path is byte-identical in allocation and within noise on time, as expected.

## Conformance

- **Full Test262: 99260 passed, 0 failed** (133 skipped).
- Jint.Tests 3210/0 (net10) · 3148/0 (net472); Jint.Tests.PublicInterface 82/0 (net10 + net472).
- REPL smoke tests: 35 cases across every element type, LE/BE round-trips, byte-order inspection, NaN canonicalization, −0 preservation, `Uint8ClampedArray` rounding and integer wrapping; plus `setFromHex`/`setFromBase64` with subarray offsets and partial/empty inputs — all matching prior behavior byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Fq5mF1QEwh2qDMD8vVwt3
