### PR TITLE
Trim per-iteration block ceremony; slot lane for lexical declaration initialization

### DIFF
--- a/Jint/Runtime/Environments/DeclarativeEnvironment.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironment.cs
@@ -225,6 +225,19 @@ internal class DeclarativeEnvironment : Environment
         _dictionary.CreateImmutableBinding(name, strict);
     }
 
+    /// <summary>
+    /// Slot-lane variant of <see cref="InitializeBinding"/> for lexical declarations whose slot
+    /// index was already resolved against this environment's slot layout by the caller. Only
+    /// valid for let/const targets (DisposeHint.Normal); mirrors the slot arm of
+    /// <see cref="InitializeBinding"/> exactly.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void InitializeSlotBinding(int index, JsValue value)
+    {
+        ref var binding = ref _slots![index];
+        binding = binding.ChangeValue(value);
+    }
+
     internal sealed override void InitializeBinding(Key name, JsValue value, DisposeHint hint)
     {
         if (_slots is not null)

--- a/Jint/Runtime/ExecutionContextStack.cs
+++ b/Jint/Runtime/ExecutionContextStack.cs
@@ -21,7 +21,9 @@ internal sealed class ExecutionContextStack
         var array = _stack._array;
         var size = _stack._size;
         ref var executionContext = ref array[size - 1];
-        executionContext = executionContext.UpdateLexicalEnvironment(newEnv);
+        // In-place single-field write instead of rebuilding the whole 10-field struct; the
+        // instance lives in a mutable array slot, so casting away the field's readonly is safe.
+        Unsafe.AsRef(in executionContext.LexicalEnvironment) = newEnv;
     }
 
     public void ReplaceTopVariableEnvironment(Environment newEnv)
@@ -29,7 +31,7 @@ internal sealed class ExecutionContextStack
         var array = _stack._array;
         var size = _stack._size;
         ref var executionContext = ref array[size - 1];
-        executionContext = executionContext.UpdateVariableEnvironment(newEnv);
+        Unsafe.AsRef(in executionContext.VariableEnvironment) = newEnv;
     }
 
     public void ReplaceTopPrivateEnvironment(PrivateEnvironment? newEnv)

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -140,6 +140,25 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
                     data.OuterEnvironment = oldEnv;
                 }
             }
+            else if (!blockEnv.HasDisposeResources)
+            {
+                // Nothing was registered for dispose (no using/await-using declaration ran), so the
+                // dispose state machine is a no-op — finalize inline instead of round-tripping a
+                // DisposeStepResult through CompleteDispose. Mirrors its finalize arm exactly.
+                suspendable?.Data.Clear(this);
+                if (oldEnv is not null)
+                {
+                    engine.UpdateLexicalEnvironment(oldEnv);
+
+                    if (blockEnv._slots is not null)
+                    {
+                        blockEnv._outerEnv = null;
+                        ResetSlots(blockEnv._slots, _blockState.SlotTemplates!);
+                        _cachedEnv = blockEnv;
+                    }
+                }
+                return blockValue;
+            }
             else
             {
                 return CompleteDispose(

--- a/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
@@ -133,34 +133,12 @@ internal sealed class JintVariableDeclaration : JintStatement<VariableDeclaratio
                     }
                 }
 
-                var lhs = (Reference) declaration.Left.Evaluate(context);
-                var value = JsValue.Undefined;
-                if (declaration.Init != null)
+                // Slow arm kept out-of-line so this method stays compact for the var path.
+                var completion = InitializeLexicalBindingSlow(context, engine, declaration);
+                if (completion is not null)
                 {
-                    if (declaration.Init is JintClassExpression classExpr && declaration.Init._expression.IsAnonymousFunctionDefinition())
-                    {
-                        value = classExpr.EvaluateWithName(context, lhs.ReferencedName.ToString()).Clone();
-                    }
-                    else
-                    {
-                        value = declaration.Init.GetValue(context).Clone();
-                    }
-
-                    // Check for generator suspension after evaluating initializer
-                    if (context.IsSuspended())
-                    {
-                        engine._referencePool.Return(lhs);
-                        return new Completion(CompletionType.Normal, value, _statement);
-                    }
-
-                    if (declaration.Init._expression.IsFunctionDefinition() && declaration.Init is not JintClassExpression)
-                    {
-                        ((Function) value).SetFunctionName(lhs.ReferencedName);
-                    }
+                    return completion.Value;
                 }
-
-                lhs.InitializeReferencedBinding(value, _statement.Kind.GetDisposeHint());
-                engine._referencePool.Return(lhs);
             }
             else if (declaration.Init != null)
             {
@@ -231,5 +209,44 @@ internal sealed class JintVariableDeclaration : JintStatement<VariableDeclaratio
         }
 
         return Completion.Empty();
+    }
+
+    /// <summary>
+    /// Initializes a lexical (let/const/using) identifier binding through the Reference-based
+    /// path (targets the slot lane can't serve). Returns a completion only when the initializer
+    /// suspended (generator/async); null means the binding was initialized and the caller
+    /// continues with the next declarator.
+    /// </summary>
+    private Completion? InitializeLexicalBindingSlow(EvaluationContext context, Engine engine, ResolvedDeclaration declaration)
+    {
+        var lhs = (Reference) declaration.Left!.Evaluate(context);
+        var value = JsValue.Undefined;
+        if (declaration.Init != null)
+        {
+            if (declaration.Init is JintClassExpression classExpr && declaration.Init._expression.IsAnonymousFunctionDefinition())
+            {
+                value = classExpr.EvaluateWithName(context, lhs.ReferencedName.ToString()).Clone();
+            }
+            else
+            {
+                value = declaration.Init.GetValue(context).Clone();
+            }
+
+            // Check for generator suspension after evaluating initializer
+            if (context.IsSuspended())
+            {
+                engine._referencePool.Return(lhs);
+                return new Completion(CompletionType.Normal, value, _statement);
+            }
+
+            if (declaration.Init._expression.IsFunctionDefinition() && declaration.Init is not JintClassExpression)
+            {
+                ((Function) value).SetFunctionName(lhs.ReferencedName);
+            }
+        }
+
+        lhs.InitializeReferencedBinding(value, _statement.Kind.GetDisposeHint());
+        engine._referencePool.Return(lhs);
+        return null;
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
@@ -1,5 +1,6 @@
 using Jint.Native;
 using Jint.Native.Function;
+using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter.Expressions;
 
 namespace Jint.Runtime.Interpreter.Statements;
@@ -15,6 +16,27 @@ internal sealed class JintVariableDeclaration : JintStatement<VariableDeclaratio
         internal JintExpression? Init;
         internal JintIdentifierExpression? LeftIdentifierExpression;
         internal bool EvalOrArguments;
+        internal bool CanUseSlotLane;
+        internal SlotLane? Lane;
+    }
+
+    /// <summary>
+    /// Monomorphic cache mapping a slotted environment's layout (by <see cref="Key"/>-array
+    /// identity, stable across engines for shared prepared scripts) to the declared name's slot
+    /// index, so repeated lexical initialization skips the Reference rent/return and name scan.
+    /// A single reference field keeps publication atomic on shared handler trees; Index -1
+    /// records "no slot in this layout" so misses don't rescan.
+    /// </summary>
+    private sealed class SlotLane
+    {
+        internal readonly Key[] SlotNames;
+        internal readonly int Index;
+
+        internal SlotLane(Key[] slotNames, int index)
+        {
+            SlotNames = slotNames;
+            Index = index;
+        }
     }
 
     public JintVariableDeclaration(VariableDeclaration statement) : base(statement)
@@ -43,13 +65,24 @@ internal sealed class JintVariableDeclaration : JintStatement<VariableDeclaratio
             }
 
             var leftIdentifier = left as JintIdentifierExpression;
+
+            // let/const identifier targets whose initializer needs no naming side channel
+            // (function definitions and class expressions call SetFunctionName/EvaluateWithName
+            // with the reference's name) can initialize straight into a resolved slot.
+            var canUseSlotLane = statement.Kind is VariableDeclarationKind.Let or VariableDeclarationKind.Const
+                && leftIdentifier is not null
+                && leftIdentifier.HasEvalOrArguments == false
+                && (declaration.Init is null
+                    || (declaration.Init is not ClassExpression && !declaration.Init.IsFunctionDefinition()));
+
             _declarations[i] = new ResolvedDeclaration
             {
                 Left = left,
                 LeftPattern = pattern,
                 LeftIdentifierExpression = leftIdentifier,
                 EvalOrArguments = leftIdentifier?.HasEvalOrArguments == true,
-                Init = init
+                Init = init,
+                CanUseSlotLane = canUseSlotLane,
             };
         }
     }
@@ -61,6 +94,45 @@ internal sealed class JintVariableDeclaration : JintStatement<VariableDeclaratio
         {
             if (_statement.Kind != VariableDeclarationKind.Var && declaration.Left != null)
             {
+                // Slot lane: the declaration's own binding lives in the current environment by
+                // construction (blocks/loops instantiate their env before executing statements),
+                // so when that env stores bindings in slots we can initialize the slot directly
+                // and skip the Reference rent/evaluate/return round-trip and the name scan.
+                if (declaration.CanUseSlotLane
+                    && engine.ExecutionContext.LexicalEnvironment is DeclarativeEnvironment denv
+                    && denv._slotNames is not null)
+                {
+                    var lane = declaration.Lane;
+                    if (lane is null || !ReferenceEquals(lane.SlotNames, denv._slotNames))
+                    {
+                        declaration.Lane = lane = new SlotLane(
+                            denv._slotNames,
+                            denv.FindSlotIndex(declaration.LeftIdentifierExpression!.Identifier.Key));
+                    }
+
+                    if (lane.Index >= 0)
+                    {
+                        JsValue laneValue;
+                        if (declaration.Init is null)
+                        {
+                            laneValue = JsValue.Undefined;
+                        }
+                        else
+                        {
+                            laneValue = declaration.Init.GetValue(context).Clone();
+
+                            // Check for generator suspension after evaluating initializer
+                            if (context.IsSuspended())
+                            {
+                                return new Completion(CompletionType.Normal, laneValue, _statement);
+                            }
+                        }
+
+                        denv.InitializeSlotBinding(lane.Index, laneValue);
+                        continue;
+                    }
+                }
+
                 var lhs = (Reference) declaration.Left.Evaluate(context);
                 var value = JsValue.Undefined;
                 if (declaration.Init != null)


### PR DESCRIPTION
Modern `let`/`const` loop bodies pay a large per-iteration tax that `var`-based code doesn't: in the engine-comparison table, `stopwatch-modern` runs ~55 ms/iter slower than classic `stopwatch` on identical logic. Probe attribution (A/B script variants via `CpuProfileDriver`) decomposed that gap into block-environment ceremony (~42%), lexical const-init overhead (~20%), let-loop header residual (~22%), and nested global reads (~13%). This PR removes the first two components with three targeted changes:

1. **`JintBlockStatement.ExecuteBlock`**: when the block environment registered no dispose resources (no `using`/`await using` declaration ran), finalize inline — restore the outer environment and park the reusable env — instead of round-tripping a `DisposeStepResult` through `CompleteDispose`. `BeginDispose` on an empty capability is a pure `Done(c)`, so semantics are unchanged.

2. **`ExecutionContextStack.ReplaceTopLexicalEnvironment` / `ReplaceTopVariableEnvironment`**: write the single field in place (`Unsafe.AsRef`) instead of constructing and copying back the whole 10-field `ExecutionContext` struct. The instance lives in a mutable array slot, so casting away the field's `readonly` is safe; every block entry/exit and function-call env switch benefits.

3. **`JintVariableDeclaration`**: a slot lane for `let`/`const` identifier declarations. The declaration's own binding lives in the current environment by construction (blocks/loops instantiate their environment before executing statements), so when that environment stores bindings in fixed slots the initializer value is written straight into the resolved slot. The slot index is cached per slot-layout identity (`Key[]` identity is stable across engines for shared prepared scripts; publication is a single reference write, so shared handler trees stay race-free). This skips the pooled `Reference` rent/evaluate/return round-trip and the `SlotIndexOf` scan. Excluded statically and left on the existing path: `var`, `using`/`await using`, destructuring targets, `eval`/`arguments` names, and function-definition/class-expression initializers (those need the reference's name for `SetFunctionName`/`EvaluateWithName`). The Reference-based arm moved to a non-inlined method so the var-declaration path stays compact (an earlier inline version cost `var`-only workloads ~6% through pure code-size effects).

## Benchmarks

BenchmarkDotNet default jobs, win-x64, .NET 10, A/B against upstream/main from separate worktrees (each run from its own CWD).

**StopwatchBenchmark** (the target):

| case | main | PR | delta |
|---|---|---|---|
| Execute (modern) | 215.3 ms | 176.2 ms | **−18.2%** |
| Execute_ParsedScript (modern) | 210.2 ms | 172.7 ms | **−17.8%** |
| Execute (classic) | 157.5 ms | 156.7 ms | −0.5% |
| Execute_ParsedScript (classic) | 156.4 ms | 154.6 ms | −1.2% |

**GeneratorBenchmark** (block-heavy bodies benefit):

| case | main | PR | delta |
|---|---|---|---|
| SmallGenerators_1000 | 1.306 ms | 1.156 ms | **−11.5%** |
| LargeBodyGenerators_500 | 2.853 ms | 2.627 ms | **−7.9%** |
| InterleavedGenerators_500 | 1.137 ms | 1.097 ms | −3.5% |

**No-regression gates**: ClosureCallBenchmarks (EmptyClosureCall −8.2%, CapturedVarReadWrite +1.3%, ManyLocalCall −1.5%; ParamLocalCall statistically identical across 5-launch runs: 104.2 ± 5.7 → 103.2 ± 4.1 ms), FunctionLocalNumberLoopBenchmark (−1.2%/−2.8%/+1.1%/+1.4%), DromaeoBenchmark Cube modern −4..−12%, Cube classic within its observed run-to-run band. Dromaeo CoreEval turned out to be bimodal on identical bits (baseline itself swung 2.9 → 9.6 ms between runs) and cannot gate either way.

Allocations unchanged on every suite.

## Verification

- `Jint.Tests` green (net10.0 + net472), `Jint.Tests.PublicInterface` green
- Full test262: 99,260 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
