### PR TITLE
Serve nested-scope global reads and writes from the global-binding cache

### DIFF
--- a/Jint/Runtime/Descriptors/Specialized/LazyPropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/LazyPropertyDescriptor.cs
@@ -19,7 +19,19 @@ internal sealed class LazyPropertyDescriptor<T> : PropertyDescriptor
 
     protected internal override JsValue? CustomValue
     {
-        get => _value ??= _resolver(_state);
+        get
+        {
+            var value = _value;
+            if (value is null)
+            {
+                _value = value = _resolver(_state);
+                // Once materialized this is semantically a plain data descriptor; clearing the
+                // flag lets value reads/writes skip the CustomValue indirection and admits the
+                // descriptor to the global-binding and member-write inline caches.
+                _flags &= ~PropertyFlag.CustomJsValue;
+            }
+            return value;
+        }
         set => _value = value;
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -962,8 +962,10 @@ internal sealed class JintAssignmentExpression : JintExpression
             // identifiers to a single field test; the rest stays out-of-line.
             if (left._cachedGlobalEnv is not null)
             {
+                // Writable is re-checked through the cached reference: defineProperty flips the
+                // flag in place without bumping the versions the validator checks.
                 var cachedGlobalDescriptor = left.TryGetValidatedGlobalDescriptor(engine, env);
-                if (cachedGlobalDescriptor is not null)
+                if (cachedGlobalDescriptor is not null && cachedGlobalDescriptor.Writable)
                 {
                     return AssignToCachedGlobalBinding(context, left, right, cachedGlobalDescriptor, hasEvalOrArguments, nameAnonymousFunction, strict);
                 }
@@ -1011,8 +1013,9 @@ internal sealed class JintAssignmentExpression : JintExpression
 
                 // Populate the global-binding cache from the write side too, so write-first
                 // patterns benefit from the next access on. Must run after the set: the set
-                // may have created the property (bumping the shape version).
-                if (ReferenceEquals(environmentRecord, env) && environmentRecord is GlobalEnvironment globalEnv)
+                // may have created the property (bumping the shape version). No hop
+                // restriction — the validator re-walks with shadow probes on every use.
+                if (environmentRecord is GlobalEnvironment globalEnv)
                 {
                     left.TryRememberGlobalBinding(globalEnv);
                 }

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -23,10 +23,11 @@ internal sealed class JintIdentifierExpression : JintExpression
     private DeclarativeEnvironment? _cachedSlotEnv;
     private int _cachedSlotIndex = -1;
 
-    // Version-based inline cache for global bindings: when top-level code (current lexical
-    // env IS the global env) resolves to a plain writable MutableBinding data property on the
-    // real GlobalObject, remember the descriptor. Valid while the global object's own-property
-    // shape and the set of global lexical declarations are unchanged — value writes mutate the
+    // Version-based inline cache for global bindings: when resolution (from any scope depth)
+    // lands on a plain writable data property of the real GlobalObject, remember the
+    // descriptor. Valid while the global object's own-property shape and the set of global
+    // lexical declarations are unchanged AND a bounded walk from the current env reaches the
+    // global env without an intermediate that could own the name — value writes mutate the
     // descriptor in place and bump neither version. Mirrors JintMemberExpression's read cache.
     internal GlobalEnvironment? _cachedGlobalEnv;
     private Runtime.Descriptors.PropertyDescriptor? _cachedGlobalDescriptor;
@@ -232,8 +233,10 @@ internal sealed class JintIdentifierExpression : JintExpression
                     _cachedSlotIndex = slotIndex;
                 }
             }
-            else if (ReferenceEquals(identifierEnvironment, env) && identifierEnvironment is GlobalEnvironment globalEnv)
+            else if (identifierEnvironment is GlobalEnvironment globalEnv)
             {
+                // No hop restriction: the validator re-walks with shadow probes on every read,
+                // so nested-scope reads of globals (loop bodies, closures) can use the cache.
                 TryRememberGlobalBinding(globalEnv);
             }
 
@@ -252,31 +255,77 @@ internal sealed class JintIdentifierExpression : JintExpression
     }
 
     /// <summary>
-    /// Validates the global-binding cache for the current environment: the current lexical env
-    /// must be the cached GlobalEnvironment itself (top-level code) and neither the global
-    /// object's own-property shape nor the global lexical declaration set may have changed.
-    /// Returns the cached plain writable data descriptor, or null on miss.
+    /// Validates the global-binding cache for the current environment: neither the global
+    /// object's own-property shape nor the global lexical declaration set may have changed,
+    /// and a bounded walk from the current lexical env must reach the cached GlobalEnvironment
+    /// without passing an environment that could own the name (mirrors the slot-cache walk:
+    /// with-objects and declarative envs holding the binding — e.g. sloppy direct eval injected
+    /// a var — bail to full resolution; the per-read probes are what make nested-scope use
+    /// safe). Returns the cached plain writable data descriptor, or null on miss.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     internal Runtime.Descriptors.PropertyDescriptor? TryGetValidatedGlobalDescriptor(Engine engine, Environment env)
     {
         var cachedGlobalEnv = _cachedGlobalEnv;
-        if (cachedGlobalEnv is not null
-            && ReferenceEquals(env, cachedGlobalEnv)
-            && ReferenceEquals(cachedGlobalEnv._engine, engine)
-            && cachedGlobalEnv._global._propertiesVersion == _cachedGlobalShapeVersion
-            && cachedGlobalEnv._lexicalMutations == _cachedGlobalLexicalVersion)
+        if (cachedGlobalEnv is null)
         {
-            return _cachedGlobalDescriptor;
+            return null;
+        }
+
+        // Hop 0 (top-level code) keeps the single identity compare up front — it is by far
+        // the most common case and must not pay for the nested-scope walk below.
+        if (ReferenceEquals(env, cachedGlobalEnv))
+        {
+            return ReferenceEquals(cachedGlobalEnv._engine, engine)
+                   && cachedGlobalEnv._global._propertiesVersion == _cachedGlobalShapeVersion
+                   && cachedGlobalEnv._lexicalMutations == _cachedGlobalLexicalVersion
+                ? _cachedGlobalDescriptor
+                : null;
+        }
+
+        if (!ReferenceEquals(cachedGlobalEnv._engine, engine)
+            || cachedGlobalEnv._global._propertiesVersion != _cachedGlobalShapeVersion
+            || cachedGlobalEnv._lexicalMutations != _cachedGlobalLexicalVersion)
+        {
+            return null;
+        }
+
+        var key = _identifier.Key;
+        var search = env;
+        for (var hops = 0; hops < MaxSlotCacheChainDepth; hops++)
+        {
+            if (search is ObjectEnvironment)
+            {
+                return null;
+            }
+
+            if (search is DeclarativeEnvironment intermediate && intermediate.HasBinding(key))
+            {
+                return null;
+            }
+
+            search = search._outerEnv;
+            if (search is null)
+            {
+                return null;
+            }
+
+            if (ReferenceEquals(search, cachedGlobalEnv))
+            {
+                return _cachedGlobalDescriptor;
+            }
         }
 
         return null;
     }
 
     /// <summary>
-    /// Caches the resolved global binding when it is a plain writable MutableBinding data
-    /// property on the real GlobalObject and no lexical declaration shadows it. Both reads
-    /// and writes may then operate on the descriptor directly while the versions hold.
+    /// Caches the resolved global binding when it is a plain writable data property on the
+    /// real GlobalObject (no CustomValue indirection — materialized lazy built-ins qualify,
+    /// live accessor-like descriptors never do) and no lexical declaration shadows it. Reads
+    /// may then use the descriptor directly while the versions hold; writers must re-check
+    /// <see cref="Runtime.Descriptors.PropertyDescriptor.Writable"/> through the cached
+    /// reference because defineProperty flips flags in place without bumping the versions.
     /// </summary>
     internal void TryRememberGlobalBinding(GlobalEnvironment globalEnv)
     {
@@ -287,10 +336,10 @@ internal sealed class JintIdentifierExpression : JintExpression
             return;
         }
 
-        if (globalObject._properties!.TryGetValue(identifier.Key, out var descriptor)
+        if (globalObject._properties?.TryGetValue(identifier.Key, out var descriptor) == true
             && descriptor.IsDataDescriptor()
             && descriptor.Writable
-            && (descriptor._flags & Runtime.Descriptors.PropertyFlag.MutableBinding) != Runtime.Descriptors.PropertyFlag.None)
+            && (descriptor._flags & Runtime.Descriptors.PropertyFlag.CustomJsValue) == Runtime.Descriptors.PropertyFlag.None)
         {
             _cachedGlobalEnv = globalEnv;
             _cachedGlobalDescriptor = descriptor;

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -272,8 +272,9 @@ internal sealed class JintIdentifierExpression : JintExpression
             return null;
         }
 
-        // Hop 0 (top-level code) keeps the single identity compare up front — it is by far
-        // the most common case and must not pay for the nested-scope walk below.
+        // Hop 0 (top-level code) keeps the single identity compare up front and this method
+        // compact — it is by far the most common case (var-heavy scripts validate here many
+        // times per loop iteration) and must not pay for the nested-scope walk's code size.
         if (ReferenceEquals(env, cachedGlobalEnv))
         {
             return ReferenceEquals(cachedGlobalEnv._engine, engine)
@@ -283,6 +284,12 @@ internal sealed class JintIdentifierExpression : JintExpression
                 : null;
         }
 
+        return TryGetValidatedGlobalDescriptorNested(engine, env, cachedGlobalEnv);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private Runtime.Descriptors.PropertyDescriptor? TryGetValidatedGlobalDescriptorNested(Engine engine, Environment env, GlobalEnvironment cachedGlobalEnv)
+    {
         if (!ReferenceEquals(cachedGlobalEnv._engine, engine)
             || cachedGlobalEnv._global._propertiesVersion != _cachedGlobalShapeVersion
             || cachedGlobalEnv._lexicalMutations != _cachedGlobalLexicalVersion)

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -172,7 +172,9 @@ internal sealed class JintUpdateExpression : JintExpression
         if (_leftIdentifier!._cachedGlobalEnv is not null && !context.OperatorOverloadingAllowed)
         {
             var descriptor = _leftIdentifier.TryGetValidatedGlobalDescriptor(engine, engine.ExecutionContext.LexicalEnvironment);
-            if (descriptor is not null && descriptor._value is { } current)
+            // Writable is re-checked through the cached reference: defineProperty flips the
+            // flag in place without bumping the versions the validator checks.
+            if (descriptor is not null && descriptor.Writable && descriptor._value is { } current)
             {
                 if (_evalOrArguments && StrictModeScope.IsStrictModeCode)
                 {


### PR DESCRIPTION
The identifier-level global-binding cache (descriptor + version validation) previously required the current lexical environment to *be* the global environment, so it only served top-level code. Reads of globals from loop bodies and closures — `sw`/`Date` in the stopwatch scripts, the helper functions and tables the dromaeo family calls constantly — walked the environment chain and repeated the global property lookup on every access.

Three changes let nested scopes use the cache safely:

1. **`TryGetValidatedGlobalDescriptor` accepts nested scopes** via a bounded walk that mirrors the existing slot-cache walk: any intermediate with-object, or declarative environment that has the binding (e.g. a sloppy direct `eval` injected a `var`), bails to full resolution — the per-read probes are the correctness pin. Hop 0 keeps its single identity compare up front in a compact method; the walk lives in a separate non-inlined method so var-heavy scripts that validate at hop 0 many times per loop iteration don't pay for its code size (an earlier single-method version cost classic stopwatch +3.5% purely through method growth).

2. **Cache population no longer requires hop-0 resolution** (read and write sides), and the admission gate becomes "plain writable data descriptor without CustomValue indirection" instead of requiring the `MutableBinding` flag. Writers now re-check `Writable` through the cached reference, since `defineProperty` flips flags in place without bumping the versions the validator checks.

3. **`LazyPropertyDescriptor` clears `CustomJsValue` once materialized** — from that point it is semantically a plain data descriptor (its getter returns `_value`, its setter writes `_value`), which admits materialized global built-ins (`Date` & co.) to this cache and to `JintMemberExpression`'s write cache.

## Benchmarks

BenchmarkDotNet default jobs, win-x64, .NET 10, A/B against main (with #2583) from separate worktrees; baseline run twice to establish per-suite noise bands.

| case | main | PR | delta |
|---|---|---|---|
| Stopwatch Execute (modern) | 179.3 / 182.0 ms | 170.2 ms | **−5.1..−6.5%** |
| Stopwatch Execute_ParsedScript (modern) | 178.9 / 177.5 ms | 173.4 ms | −2.3..−3.1% |
| Stopwatch Execute (classic) | 154.4 / 155.4 ms | 155.5 ms | neutral |
| Stopwatch Execute_ParsedScript (classic) | 153.1 / 154.0 ms | 150.6 ms | −2% |
| GlobalVarLoop / LocalVarLoop / GlobalUpdateLoop | 41.7-43.3 / 39.1-40.7 / 85.7-88.3 | 42.6 / 39.3 / 86.2 | inside baseline bands |
| DromaeoBenchmark (engine-reuse suite, 24 cases) | — | — | no regression; Cube modern-prepared −8% |

The engine-comparison README table measures a different shape — fresh engine per op, strict, source or prepared (`EngineComparisonBenchmark`). A/B with that shape (`--profile-cpu`, 20-50 iters, alternating binaries):

| script | main | PR | delta |
|---|---|---|---|
| dromaeo-string-base64 | 38.3 ms/iter | 32.5 ms/iter | **−15%** |
| dromaeo-3d-cube | 22.1 ms/iter | 20.0 ms/iter | **−10%** |
| dromaeo-object-string | 74.2 ms/iter | 70.7 ms/iter | −5% |

Allocations unchanged on every suite.

## Verification

- `Jint.Tests` green (net10.0 + net472), `Jint.Tests.PublicInterface` green
- Full test262: 99,260 passed, 0 failed (covers the sloppy-eval var-injection and `with` shadowing semantics the walk probes protect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
