### PR TITLE
Probe own-property existence/enumerability without materializing descriptors

### DIFF
--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -462,6 +462,50 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         return base.GetOwnProperty(property);
     }
 
+    /// <summary>
+    /// Element probe without the <see cref="TryGetDescriptor"/> materialization: enumerating a
+    /// dense array (for-in, Object.keys/values/entries, spread, assign) previously allocated one
+    /// CEW descriptor per touched index AND grew a permanent <c>_sparse</c> shadow dictionary
+    /// beside <c>_dense</c>. Presence and flags answer here allocation-free; a previously
+    /// materialized descriptor (if any) stays authoritative for its flags.
+    /// </summary>
+    internal override OwnPropertyProbe ProbeOwnProperty(JsValue property)
+    {
+        if (CommonProperties.Length.Equals(property))
+        {
+            // the length property is never enumerable
+            return HasLength ? OwnPropertyProbe.NonEnumerable : base.ProbeOwnProperty(property);
+        }
+
+        if (IsArrayIndex(property, out var index))
+        {
+            var temp = _dense;
+            if (temp is not null)
+            {
+                if (index < (uint) temp.Length && temp[index] is not null)
+                {
+                    if (_sparse is not null && _sparse.TryGetValue(index, out var materialized) && materialized is not null)
+                    {
+                        return materialized.Enumerable ? OwnPropertyProbe.Enumerable : OwnPropertyProbe.NonEnumerable;
+                    }
+
+                    return OwnPropertyProbe.Enumerable;
+                }
+
+                return OwnPropertyProbe.Missing;
+            }
+
+            if (_sparse is not null && _sparse.TryGetValue(index, out var descriptor) && descriptor is not null)
+            {
+                return descriptor.Enumerable ? OwnPropertyProbe.Enumerable : OwnPropertyProbe.NonEnumerable;
+            }
+
+            return OwnPropertyProbe.Missing;
+        }
+
+        return base.ProbeOwnProperty(property);
+    }
+
     internal JsValue Get(uint index)
     {
         if (!TryGetValue(index, out var value))

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -608,8 +608,7 @@ public sealed class JsonSerializer
             for (var i = 0; i < keys.Count; i++)
             {
                 var key = keys[i];
-                var desc = instance.GetOwnProperty(key);
-                if (desc == PropertyDescriptor.Undefined || !desc.Enumerable)
+                if (instance.ProbeOwnProperty(key) != OwnPropertyProbe.Enumerable)
                 {
                     keys.RemoveAt(i);
                     i--;

--- a/Jint/Native/Object/ObjectConstructor.cs
+++ b/Jint/Native/Object/ObjectConstructor.cs
@@ -54,8 +54,7 @@ public sealed partial class ObjectConstructor : Constructor
                 }
                 processed++;
 
-                var desc = from.GetOwnProperty(nextKey);
-                if (desc != PropertyDescriptor.Undefined && desc.Enumerable)
+                if (from.ProbeOwnProperty(nextKey) == OwnPropertyProbe.Enumerable)
                 {
                     var propValue = from.Get(nextKey);
                     to.Set(nextKey, propValue, throwOnError: true);
@@ -335,8 +334,7 @@ public sealed partial class ObjectConstructor : Constructor
         for (var i = 0; i < keys.Count; i++)
         {
             var nextKey = keys[i];
-            var propDesc = props.GetOwnProperty(nextKey);
-            if (propDesc == PropertyDescriptor.Undefined || !propDesc.Enumerable)
+            if (props.ProbeOwnProperty(nextKey) != OwnPropertyProbe.Enumerable)
             {
                 continue;
             }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -515,7 +515,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool HasOwnProperty(JsValue property)
     {
-        return !ReferenceEquals(GetOwnProperty(property), PropertyDescriptor.Undefined);
+        return ProbeOwnProperty(property) != OwnPropertyProbe.Missing;
     }
 
     public virtual void RemoveOwnProperty(JsValue property)
@@ -664,6 +664,33 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         }
 
         return descriptor ?? PropertyDescriptor.Undefined;
+    }
+
+    /// <summary>
+    /// Answers whether the named own property exists and is enumerable without materializing a
+    /// <see cref="PropertyDescriptor"/>. Shape-mode objects (sealed <see cref="JsObject"/>,
+    /// whose slots are always configurable/enumerable/writable — anything else deopts to
+    /// dictionary mode) answer straight from the shape; every other object — including exotics
+    /// like proxies (traps still fire), typed arrays and interop wrappers — routes through the
+    /// virtual <see cref="GetOwnProperty"/>. Read-only callers that don't need the descriptor's
+    /// value (existence checks, enumerability filters) should prefer this over GetOwnProperty.
+    /// </summary>
+    internal virtual OwnPropertyProbe ProbeOwnProperty(JsValue property)
+    {
+        if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty && property is JsString jsString)
+        {
+            return Unsafe.As<JsObject>(this).ShapeOf.TryGetSlot(jsString.ToString(), out _)
+                ? OwnPropertyProbe.Enumerable
+                : OwnPropertyProbe.Missing;
+        }
+
+        var desc = GetOwnProperty(property);
+        if (ReferenceEquals(desc, PropertyDescriptor.Undefined))
+        {
+            return OwnPropertyProbe.Missing;
+        }
+
+        return desc.Enumerable ? OwnPropertyProbe.Enumerable : OwnPropertyProbe.NonEnumerable;
     }
 
     // Built-in-shape storage helpers (InternalTypes.BuiltinShapeMode). Shared by every host that implements
@@ -1041,8 +1068,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     public virtual bool HasProperty(JsValue property)
     {
         var key = TypeConverter.ToPropertyKey(property);
-        var hasOwn = GetOwnProperty(key);
-        if (hasOwn != PropertyDescriptor.Undefined)
+        if (ProbeOwnProperty(key) != OwnPropertyProbe.Missing)
         {
             return true;
         }
@@ -1899,8 +1925,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             var key = keys[i];
             if (excludedItems == null || !excludedItems.Contains(key))
             {
-                var desc = GetOwnProperty(key);
-                if (desc.Enumerable)
+                if (ProbeOwnProperty(key) == OwnPropertyProbe.Enumerable)
                 {
                     var propValue = Get(key);
                     target.CreateDataProperty(key, propValue);
@@ -1942,8 +1967,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                 continue;
             }
 
-            var desc = GetOwnProperty(property);
-            if (desc != PropertyDescriptor.Undefined && desc.Enumerable)
+            if (ProbeOwnProperty(property) == OwnPropertyProbe.Enumerable)
             {
                 if (kind == EnumerableOwnPropertyNamesKind.Key)
                 {
@@ -2023,11 +2047,11 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         var visited = new HashSet<JsValue>();
         foreach (var key in GetOwnPropertyKeys(Types.String))
         {
-            var desc = GetOwnProperty(key);
-            if (desc != PropertyDescriptor.Undefined)
+            var probe = ProbeOwnProperty(key);
+            if (probe != OwnPropertyProbe.Missing)
             {
                 visited.Add(key);
-                if (desc.Enumerable)
+                if (probe == OwnPropertyProbe.Enumerable)
                 {
                     yield return key;
                 }

--- a/Jint/Native/Object/ObjectPrototype.cs
+++ b/Jint/Native/Object/ObjectPrototype.cs
@@ -186,12 +186,7 @@ public sealed partial class ObjectPrototype : Prototype
     {
         var p = TypeConverter.ToPropertyKey(v);
         var o = TypeConverter.ToObject(_realm, thisObject);
-        var desc = o.GetOwnProperty(p);
-        if (desc == PropertyDescriptor.Undefined)
-        {
-            return JsBoolean.False;
-        }
-        return desc.Enumerable;
+        return o.ProbeOwnProperty(p) == OwnPropertyProbe.Enumerable;
     }
 
     [JsFunction]
@@ -284,7 +279,6 @@ public sealed partial class ObjectPrototype : Prototype
     {
         var p = TypeConverter.ToPropertyKey(v);
         var o = TypeConverter.ToObject(_realm, thisObject);
-        var desc = o.GetOwnProperty(p);
-        return desc != PropertyDescriptor.Undefined;
+        return o.ProbeOwnProperty(p) != OwnPropertyProbe.Missing;
     }
 }

--- a/Jint/Native/Object/OwnPropertyProbe.cs
+++ b/Jint/Native/Object/OwnPropertyProbe.cs
@@ -1,0 +1,12 @@
+namespace Jint.Native.Object;
+
+/// <summary>
+/// Result of <see cref="ObjectInstance.ProbeOwnProperty"/>: the own property's existence and
+/// enumerability without materializing a <see cref="Runtime.Descriptors.PropertyDescriptor"/>.
+/// </summary>
+internal enum OwnPropertyProbe
+{
+    Missing,
+    NonEnumerable,
+    Enumerable,
+}


### PR DESCRIPTION
Read-only callers that only need "does this own property exist, and is it enumerable" previously went through `GetOwnProperty`, which has two allocation problems on hot enumeration paths:

- **shape-mode objects** allocate a fresh `SlotPropertyDescriptor` on every call (`hasOwnProperty`, `propertyIsEnumerable`, for-in, `Object.keys/values/entries`, spread, `Object.assign`, `JSON.stringify` all hit this per key — the handlebars `extend()` pattern conjures three of them per key per call);
- **dense arrays** allocate one CEW descriptor per touched index and grow a permanent `_sparse` shadow dictionary beside `_dense` (`TryGetDescriptor(createIfMissing: true)`), so merely enumerating a dense array bloats it for life.

This adds an internal tri-state probe and converts the read-only callers:

- `ObjectInstance.ProbeOwnProperty(JsValue)` returns `Missing`/`NonEnumerable`/`Enumerable`. The base implementation answers shape-mode objects straight from the shape (shape slots are always configurable/enumerable/writable — anything else deopts to dictionary mode); everything else routes through the virtual `GetOwnProperty`, so exotics keep exact semantics — proxy `getOwnPropertyDescriptor` traps still fire per key during for-in/`Object.keys`, typed arrays and interop wrappers are untouched.
- `ArrayInstance` overrides the probe to answer dense/sparse elements allocation-free with no `_sparse` materialization; a previously materialized `_sparse` descriptor (freeze/defineProperty flows) stays authoritative for its flags. `GetOwnProperty`/`TryGetDescriptor` remain byte-for-byte identical for every boundary that needs a real descriptor.
- Converted callers: `HasOwnProperty`, the own-property arm of `HasProperty`, for-in key enumeration (`GetKeys`), `EnumerableOwnProperties` (`Object.keys/values/entries`), `CopyDataProperties` (object spread / `Object.assign`), the `Object.defineProperties` props filter, `Object.prototype.hasOwnProperty` / `propertyIsEnumerable`, and the JSON serializer's key filter.

## Measurements

Allocation census (`--profile-alloc-types`, fresh engine per iteration — fresh arrays per round, so first-enumeration materialization is visible):

| workload | main | PR |
|---|---|---|
| `Object.keys`/`Object.assign` over fresh dense arrays | 80.96 MB/iter | 29.74 MB/iter (**−63%**; the `Dictionary<uint,PropertyDescriptor>` entry arrays disappear from the profile) |
| for-in over fresh dense arrays | 116.6 MB/iter | 78.2 MB/iter (**−33%**) |
| handlebars-style `extend()` over object literals | 111.8 MB/iter | 107.2 MB/iter (−4%, `SlotPropertyDescriptor` eliminated from the profile) |

BenchmarkDotNet default jobs (A/B vs main from separate worktrees; note these suites reuse arrays across iterations, so they mostly show the steady-state time win rather than the first-enumeration allocations):

| case | main | PR | delta |
|---|---|---|---|
| ArrayHoleyKeysBenchmark Gap=1 | 9.32 µs | 7.49 µs | **−19.6%** |
| ArrayHoleyKeysBenchmark Gap=100 / 1000 | 108.3 / 546.3 µs | 102.8 / 541.1 µs | −5.1% / −1.0% |
| JsonBenchmark Parse twitter / bestbuy | 2.56 ms / 240.1 ms | 2.48 ms / 236.9 ms | −3.2% / −1.4% |
| ObjectEnumerationBenchmark Entries / KeysFiltered | 394.0 / 187.5 µs | 383.3 / 184.6 µs | −2.7% / −1.5% |
| PreparedScriptBenchmark (prepared modes) | 40.2 / 41.3 ms | 39.9 / 39.7 ms | −0.6% / −3.9% |

No regressions; PreparedScript source mode (parse-dominated) moved within its error bars.

Considered and deferred: hoisting the loop-invariant transient descriptors in `SetIntegrityLevel` — needs a `ValidateAndApplyPropertyDescriptor` retention audit first, and freeze/seal is cold.

## Verification

- `Jint.Tests` green (net10.0 + net472), `Jint.Tests.PublicInterface` green
- Full test262: 99,260 passed, 0 failed (frozen/sealed array writes, Proxy `ownKeys`/`getOwnPropertyDescriptor` trap ordering, for-in semantics all covered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
