### PR TITLE
Reuse a fixed-slot per-iteration environment in for-of/for-in

### DIFF
--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -36,6 +36,17 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
     private readonly JintExpression? _forInVarInitializer;
     private readonly string? _forInVarName;
 
+    // Per-iteration environment reuse: for-of/for-in create a fresh binding per iteration with
+    // no copy step, so when nothing in the body (or a destructuring default) captures the
+    // environment, one fixed-slot environment reset per iteration is unobservable — and its
+    // stable identity keeps per-node slot caches in the body hot. The pooled instance lives on
+    // this handler (per statement list); the Interlocked + engine-identity discipline mirrors
+    // JintForStatement._cachedLoopEnv (a cached env must never pin a foreign engine, #2560).
+    private readonly bool _canReuseIterationEnv;
+    private readonly Key[]? _iterationSlotNames;
+    private readonly Binding[]? _iterationSlotTemplates;
+    private DeclarativeEnvironment? _cachedIterationEnv;
+
     public JintForInForOfStatement(ForInStatement statement) : base(statement)
     {
         _leftNode = statement.Left;
@@ -53,6 +64,8 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
             _forInVarInitializer = JintExpression.Build(varDecl.Declarations[0].Init!);
             _forInVarName = id.Name;
         }
+
+        InitializeIterationEnvReuse(out _canReuseIterationEnv, out _iterationSlotNames, out _iterationSlotTemplates);
     }
 
     public JintForInForOfStatement(ForOfStatement statement) : base(statement)
@@ -64,6 +77,55 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
         InitializeLhs(out _lhsKind, out _disposeHint, out _tdzNames, out _destructuring, out _assignmentPattern, out _expr);
         _body = new ProbablyBlockStatement(_forBody);
         _right = JintExpression.Build(_rightExpression);
+
+        InitializeIterationEnvReuse(out _canReuseIterationEnv, out _iterationSlotNames, out _iterationSlotTemplates);
+    }
+
+    private void InitializeIterationEnvReuse(out bool canReuse, out Key[]? slotNames, out Binding[]? slotTemplates)
+    {
+        canReuse = false;
+        slotNames = null;
+        slotTemplates = null;
+
+        // Only plain let/const heads qualify (using/await-using register per-iteration dispose
+        // resources on the environment), with 1-16 bindings, and nothing in the body — or in a
+        // destructuring pattern's default-value expressions — may capture or escape the
+        // per-iteration environment (closures, direct eval).
+        if (_lhsKind != LhsKind.LexicalBinding
+            || _disposeHint != DisposeHint.Normal
+            || _tdzNames is null
+            || _tdzNames.Count is 0 or > 16)
+        {
+            return;
+        }
+
+        if (JintFunctionDefinition.EnvironmentEscapeAstVisitor.IsCapturing(_forBody)
+            || JintFunctionDefinition.EnvironmentEscapeAstVisitor.MayEscape(_forBody))
+        {
+            return;
+        }
+
+        if (_destructuring
+            && (JintFunctionDefinition.EnvironmentEscapeAstVisitor.IsCapturing(_leftNode)
+                || JintFunctionDefinition.EnvironmentEscapeAstVisitor.MayEscape(_leftNode)))
+        {
+            return;
+        }
+
+        var kind = ((VariableDeclaration) _leftNode).Kind;
+        var names = new Key[_tdzNames.Count];
+        var templates = new Binding[_tdzNames.Count];
+        for (var i = 0; i < _tdzNames.Count; i++)
+        {
+            names[i] = _tdzNames[i];
+            templates[i] = kind == VariableDeclarationKind.Const
+                ? new Binding(null!, canBeDeleted: false, mutable: false, strict: true)
+                : new Binding(null!, canBeDeleted: false, mutable: true, strict: false);
+        }
+
+        slotNames = names;
+        slotTemplates = templates;
+        canReuse = true;
     }
 
     private void InitializeLhs(
@@ -214,17 +276,19 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
     {
         var engine = context.Engine;
         var oldEnv = engine.ExecutionContext.LexicalEnvironment;
-        var tdz = JintEnvironment.NewDeclarativeEnvironment(engine, oldEnv);
+
+        // Spec only requires the TDZ environment when there are TDZ names to protect (lexical
+        // heads); var/assignment forms evaluate the right-hand side in the current environment.
         if (_tdzNames != null)
         {
-            var TDZEnvRec = tdz;
+            var tdz = JintEnvironment.NewDeclarativeEnvironment(engine, oldEnv);
             foreach (var name in _tdzNames)
             {
-                TDZEnvRec.CreateMutableBinding(name);
+                tdz.CreateMutableBinding(name);
             }
-        }
 
-        engine.UpdateLexicalEnvironment(tdz);
+            engine.UpdateLexicalEnvironment(tdz);
+        }
 
         // AnnexB B.3.6: evaluate for-in initializer before the right-hand expression
         if (_forInVarInitializer is not null)
@@ -235,7 +299,10 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
         }
 
         var exprValue = _right.GetValue(context);
-        engine.UpdateLexicalEnvironment(oldEnv);
+        if (_tdzNames != null)
+        {
+            engine.UpdateLexicalEnvironment(oldEnv);
+        }
 
         // Check if execution suspended during the right-hand-side evaluation (e.g., await in array)
         if (context.IsSuspended())
@@ -295,6 +362,26 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
         {
             oldEnv = suspendData.OuterEnv;
             engine.UpdateLexicalEnvironment(oldEnv);
+        }
+
+        // Reusable fixed-slot iteration environment: gated on a non-suspendable context so a
+        // pooled env never round-trips through suspend/resume save-and-restore. ResetSlots at
+        // each iteration start re-establishes TDZ; the stable identity keeps body slot caches hot.
+        DeclarativeEnvironment? reusableEnv = null;
+        if (_canReuseIterationEnv && suspendable is null)
+        {
+            var cachedEnv = System.Threading.Interlocked.Exchange(ref _cachedIterationEnv, null);
+            if (cachedEnv is not null && ReferenceEquals(cachedEnv._engine, engine))
+            {
+                cachedEnv._outerEnv = oldEnv;
+                reusableEnv = cachedEnv;
+            }
+            else
+            {
+                reusableEnv = JintEnvironment.NewDeclarativeEnvironment(engine, oldEnv);
+                reusableEnv._slotNames = _iterationSlotNames;
+                reusableEnv._slots = (Binding[]) _iterationSlotTemplates!.Clone();
+            }
         }
 
         // Restore accumulated value if resuming
@@ -454,6 +541,15 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                             lhsRef = lhs!.Evaluate(context);
                         }
                     }
+                    else if (reusableEnv is not null)
+                    {
+                        // Fresh per-iteration binding via slot reset (spec has no copy step for
+                        // for-in/of, so reuse is unobservable without captures). The single
+                        // identifier binding initializes straight into its slot below.
+                        ResetSlots(reusableEnv._slots!, _iterationSlotTemplates!);
+                        iterationEnv = reusableEnv;
+                        engine.UpdateLexicalEnvironment(iterationEnv);
+                    }
                     else
                     {
                         iterationEnv = JintEnvironment.NewDeclarativeEnvironment(engine, oldEnv);
@@ -478,7 +574,12 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
 
                     if (!destructuring)
                     {
-                        if (context.IsAbrupt())
+                        if (reusableEnv is not null)
+                        {
+                            // single bound name -> slot 0; ChangeValue preserves the const/let flags
+                            iterationEnv!.InitializeSlotBinding(0, nextValue);
+                        }
+                        else if (context.IsAbrupt())
                         {
                             close = true;
                             status = context.Completion;
@@ -726,7 +827,40 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     }
                 }
             }
+
+            // Park the reusable iteration environment for the next loop entry; reset at park
+            // time so the cached env doesn't root the completed loop's values or scope chain.
+            // Reuse is gated on non-suspendable contexts, so the loop cannot exit suspended.
+            if (reusableEnv is not null)
+            {
+                reusableEnv._outerEnv = null;
+                ResetSlots(reusableEnv._slots!, _iterationSlotTemplates!);
+                System.Threading.Interlocked.Exchange(ref _cachedIterationEnv, reusableEnv);
+            }
+
             engine.UpdateLexicalEnvironment(oldEnv);
+        }
+    }
+
+    /// <summary>
+    /// Reset the slots of a reused iteration environment to the pre-computed templates (every
+    /// binding back to uninitialized/TDZ). Hand-rolled small-array fast path: for-of/for-in
+    /// heads hold 1-2 bindings.
+    /// </summary>
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    private static void ResetSlots(Binding[] slots, Binding[] templates)
+    {
+        var len = slots.Length;
+        if (len == templates.Length && len <= 4)
+        {
+            for (var i = 0; i < len; i++)
+            {
+                slots[i] = templates[i];
+            }
+        }
+        else
+        {
+            templates.AsSpan().CopyTo(slots);
         }
     }
 


### PR DESCRIPTION
`for (const x of arr)` / `for (const k in obj)` previously paid per **iteration**: a fresh `DeclarativeEnvironment`, a `List<Key>` + `Key[]` from `GetBoundNames` inside `BindingInstantiation`, dictionary-backed bindings (`HybridDictionary` + nodes — the fresh environment has no slot layout), and a pooled-`Reference` round-trip through `ResolveBinding` + `InitializeReferencedBinding`.

The spec creates a fresh binding per iteration with **no copy step** (unlike `for (let ...)`), so when nothing can observe environment identity the loop now reuses one fixed-slot environment:

- **Eligibility (static, computed once per handler)**: lexical head (`let`/`const`, 1–16 bound names), and `EnvironmentEscapeAstVisitor` proves nothing in the body — or in a destructuring pattern's default-value expressions — captures or escapes (closures, direct eval). `using`/`await using` heads stay on the existing path (they register per-iteration dispose resources).
- **Per iteration**: `ResetSlots` re-establishes TDZ from the templates, the single identifier binding initializes straight into its slot, destructuring initializes into slots by name via the existing `ProcessPatterns` path. The environment's stable identity also keeps the body's per-node slot caches hot.
- **Pooling across loop entries** on the handler instance with the `Interlocked` + engine-identity discipline of `JintForStatement._cachedLoopEnv`; parked (and reset) in the `finally` so the cached env never roots the completed loop's values.
- **Suspendable contexts (generators/async) are excluded** — a pooled environment must never round-trip through suspend/resume — and keep the existing per-iteration path unchanged.
- Rider: `HeadEvaluation` no longer allocates its TDZ environment when there are no TDZ names (var/assignment forms).

## Measurements

BenchmarkDotNet default jobs, A/B vs main (with #2585) from separate worktrees:

| case | main | PR | delta |
|---|---|---|---|
| IterationBenchmark.ForOfArray | 38.77 ms / 59.83 MB | 29.98 ms / 22.44 MB | **−22.7% time / −62.5% alloc** |
| IterationBenchmark.MapIteration | 50.98 ms / 89.87 MB | 42.16 ms / 50.96 MB | **−17.3% / −43.3%** |
| IterationBenchmark.SpreadArray | 32.94 ms | 33.08 ms | flat (no lexical head) |
| IterationBenchmark.Destructuring | 46.38 ms | 46.88 ms | within noise, alloc identical |
| DromaeoBenchmark.ObjectArray (4 cases) | — | — | flat to slightly better |

Allocation census (fresh engine per iteration, `for (const x of arr)` over 1000 elements × 300 loops): 148.9 → 36.8 MB/iter (**−75%**), 52.9 → 35.2 ms/iter (**−33%**). The environment types (`DeclarativeEnvironment`, `Key[]`, `DictionaryNode[Binding]`, `HybridDictionary`, `Reference`) disappear from the profile entirely; what remains is iterator-protocol `IteratorResult` steps — a separate follow-up.

## Verification

- `Jint.Tests` green (net10.0 + net472), `Jint.Tests.PublicInterface` green
- Full test262: 99,260 passed, 0 failed — run twice (pre- and post-rebase onto #2585), covering for-of/for-in closures-in-body, destructuring with defaults, generators/async iteration, `using` heads, and labeled break/continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
