### PR TITLE
Keep builtin-shape deopt lazy: unmaterialized function slots stay deferred

### DIFF
--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -730,9 +730,14 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         return descriptor;
     }
 
-    // Fall back to the ordinary dictionary representation, materializing every slot so the object is
-    // byte-for-byte what a generated property dictionary would have produced. Called when a shaped host
-    // gains or loses an own string property (which the fixed layout cannot express).
+    // Fall back to the ordinary dictionary representation. Already-materialized slots keep their
+    // descriptor instance (inline caches and spec identity depend on it); unmaterialized function
+    // slots become lazy wrappers instead of forcing every dispatcher function into existence —
+    // for a host like the global object, an eager deopt (triggered by any top-level `var`) would
+    // otherwise instantiate dozens of functions nobody asked for. Unmaterialized accessors (rare)
+    // materialize eagerly since a data-descriptor wrapper cannot defer them; aliases share their
+    // target's entry so both names keep one function identity. Called when a shaped host gains or
+    // loses an own string property (which the fixed layout cannot express).
     private void DeoptBuiltinShape()
     {
         var shaped = Unsafe.As<IBuiltinShaped>(this);
@@ -742,11 +747,39 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             return;
         }
 
-        var names = shaped.BuiltinShape.Names;
+        var shape = shaped.BuiltinShape;
+        var names = shape.Names;
+
+        // First fill non-alias slots (reusing the per-realm array as scratch), then let aliases
+        // pick up their target's instance — whether it was already materialized or is now lazy.
+        for (var i = 0; i < names.Length; i++)
+        {
+            if (descriptors[i] is null && shape.Kinds[i] != BuiltinSlotKind.Alias)
+            {
+                descriptors[i] = shape.Kinds[i] == BuiltinSlotKind.Accessor
+                    ? MaterializeBuiltinSlot(shaped, i)
+                    : new LazyBuiltinSlotDescriptor(shaped, shape.FunctionSlots[i], shape.FunctionFlags[i]);
+            }
+        }
+
         var properties = new PropertyDictionary(names.Length, checkExistingKeys: false);
         for (var i = 0; i < names.Length; i++)
         {
-            properties[names[i]] = MaterializeBuiltinSlot(shaped, i);
+            var descriptor = descriptors[i];
+            if (descriptor is null)
+            {
+                // alias (possibly chained) — resolve to the ultimately shared instance
+                var target = i;
+                while (shape.Kinds[target] == BuiltinSlotKind.Alias)
+                {
+                    target = shape.FunctionSlots[target];
+                }
+
+                descriptor = descriptors[target]!;
+                descriptors[i] = descriptor;
+            }
+
+            properties[names[i]] = descriptor;
         }
 
         _type &= ~InternalTypes.BuiltinShapeMode;

--- a/Jint/Runtime/Descriptors/Specialized/LazyBuiltinSlotDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/LazyBuiltinSlotDescriptor.cs
@@ -1,0 +1,45 @@
+using System.Runtime.CompilerServices;
+using Jint.Native;
+using Jint.Native.Object;
+
+namespace Jint.Runtime.Descriptors.Specialized;
+
+/// <summary>
+/// Data descriptor for a built-in function slot that survives a shaped host's deopt to
+/// dictionary mode without forcing the dispatcher function into existence: the function
+/// materializes on first value read, exactly as it would have through
+/// <see cref="ObjectInstance"/>'s builtin-shape slot materialization. Shared between an
+/// alias slot and its target at deopt time so both names keep one function identity.
+/// </summary>
+internal sealed class LazyBuiltinSlotDescriptor : PropertyDescriptor
+{
+    private readonly IBuiltinShaped _shaped;
+    private readonly ushort _functionSlot;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal LazyBuiltinSlotDescriptor(IBuiltinShaped shaped, ushort functionSlot, PropertyFlag flags)
+        : base(null, flags | PropertyFlag.CustomJsValue)
+    {
+        _flags &= ~PropertyFlag.NonData;
+        _shaped = shaped;
+        _functionSlot = functionSlot;
+    }
+
+    protected internal override JsValue? CustomValue
+    {
+        get
+        {
+            var value = _value;
+            if (value is null)
+            {
+                _value = value = _shaped.MakeBuiltinFunction(_functionSlot);
+                // Once materialized this is semantically a plain data descriptor; clearing the
+                // flag lets value reads/writes skip the CustomValue indirection and admits the
+                // descriptor to the global-binding and member-write inline caches.
+                _flags &= ~PropertyFlag.CustomJsValue;
+            }
+            return value;
+        }
+        set => _value = value;
+    }
+}


### PR DESCRIPTION
`DeoptBuiltinShape` previously materialized **every** slot when a shaped built-in fell back to dictionary mode, forcing all of the host's dispatcher functions into existence the moment user code added or removed one own property — `Math.x = 1` instantiated all ~35 Math functions nobody asked for. For upcoming shaped hosts where deopt is routine (the global object deopts on any top-level `var`), an eager deopt would be strictly worse than the dictionary path it replaces, so this is a prerequisite for flipping `GlobalObject`/`FunctionPrototype` to shapes.

- Already-materialized slots keep their descriptor instance — inline caches and spec identity depend on it.
- Unmaterialized **function** slots become `LazyBuiltinSlotDescriptor` wrappers that create the dispatcher on first value read (mirroring `LazyPropertyDescriptor`, including clearing `CustomJsValue` once materialized).
- Unmaterialized **accessors** (rare) still materialize eagerly — a data-descriptor wrapper cannot defer them.
- **Aliases** share their target's instance — materialized or lazy, chains resolved — so pairs like `Set.prototype.keys === Set.prototype.values` keep one function identity across the deopt.
- Own-key order and dictionary contents are otherwise byte-identical to the previous deopt.

## Measurements

Deopt-triggering script (`Math.x = 1; JSON.x = 1; Reflect.x = 1` + calls, fresh engine per iteration): 43.7 -> 32.3 KB/iter (**-26%**), matching the dispatcher functions no longer force-created.

No-regression gates (BenchmarkDotNet default jobs, A/B vs main + A/B/A noise check): `BuiltinShapeBenchmark`, `EngineConstructionBenchmark`, `MinimalScriptBenchmark` — allocations byte-identical on every row, times within the suites'' observed run-to-run bands (the deopt path is not on any of their execution paths).

## Verification

- `Jint.Tests` green (net10.0 + net472), `Jint.Tests.PublicInterface` green
- Full test262: 99,260 passed, 0 failed
- Alias identity, delete-after-deopt, enumeration order and `getOwnPropertyNames` verified against a live engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)
