### PR TITLE
Serve arguments reads virtually; defer property materialization

### DIFF
--- a/Jint.Tests/Runtime/PrototypeMethodCacheTests.cs
+++ b/Jint.Tests/Runtime/PrototypeMethodCacheTests.cs
@@ -54,6 +54,7 @@ public class PrototypeMethodCacheTests
         var exoticGet = new[]
         {
             "Jint.Native.Iterator.IteratorResult",
+            "Jint.Native.JsArguments", // virtual read mode: [[Get]] answers from args/bindings without materializing properties
             "Jint.Native.JsProxy",
             "Jint.Native.JsTypedArray",
             "Jint.Runtime.Interop.ArrayLikeWrapper",

--- a/Jint/Native/JsArguments.cs
+++ b/Jint/Native/JsArguments.cs
@@ -21,13 +21,33 @@ public sealed class JsArguments : ObjectInstance
     private Key[] _names = null!;
     private JsValue[] _args = null!;
     private DeclarativeEnvironment _env = null!;
+    private Realm _realm = null!;
     private bool _canReturnToPool;
     private bool _hasRestParameter;
     private bool _materialized;
 
+    // Virtual read mode: while set, in-range index reads, length, @@iterator and (mapped) callee
+    // are answered from _args/_env/_func without materializing any property descriptors — the
+    // common `arguments[i]` / `arguments.length` / apply-forwarding patterns never build the
+    // length/callee/iterator descriptors, the parameter-map object or its ClrAccessDescriptors.
+    // Any operation that needs real properties routes through EnsureInitialized -> Initialize,
+    // which clears the flag, so every materializing path stays consistent.
+    private bool _virtualMode;
+
+    // Set when the owning call returned: the parameter map is detached, so mapped index reads
+    // switch from live bindings to the escaped snapshot (which write-syncs while mapped), and a
+    // later materialization must not rebuild the map — matching the long-standing behavior of
+    // nulling ParameterMap in FunctionWasCalled.
+    private bool _mapDetached;
+
     internal JsArguments(Engine engine)
         : base(engine, ObjectClass.Arguments)
     {
+        // Member reads must route through the virtual-mode [[Get]] instead of the
+        // GetOwnProperty-first protocol (which would materialize the property surface);
+        // arguments objects gain nothing from the member caches anyway — their identity
+        // churns per call, so a cached receiver never re-matches.
+        _type |= InternalTypes.ExoticGet;
     }
 
     internal void Prepare(
@@ -43,13 +63,39 @@ public sealed class JsArguments : ObjectInstance
         _env = env;
         _hasRestParameter = hasRestParameter;
         _canReturnToPool = true;
+        _virtualMode = true;
+        _mapDetached = false;
+
+        // Materialization can now be deferred past the owning call (even cross-realm queries),
+        // so pin the creating realm: %ThrowTypeError%, %Array.prototype.values% and the map's
+        // prototype are per-realm intrinsics.
+        _realm = _engine.Realm;
 
         ClearProperties();
     }
 
     protected override void Initialize()
     {
+        _virtualMode = false;
         _canReturnToPool = false;
+
+        // Materialization reconstructs properties that conceptually existed from the object's
+        // creation; a preventExtensions/freeze that happened while still virtual must not block
+        // them, so bypass the extensibility gate for the duration.
+        var wasExtensible = Extensible;
+        Extensible = true;
+        try
+        {
+            InitializeCore();
+        }
+        finally
+        {
+            Extensible = wasExtensible;
+        }
+    }
+
+    private void InitializeCore()
+    {
         var args = _args;
 
         DefinePropertyOrThrow(CommonProperties.Length, new PropertyDescriptor(_args.Length, PropertyFlag.NonEnumerable));
@@ -65,25 +111,31 @@ public sealed class JsArguments : ObjectInstance
                 CreateDataProperty(JsString.Create(i), val);
             }
 
-            DefinePropertyOrThrow(CommonProperties.Callee, new GetSetPropertyDescriptor.ThrowerPropertyDescriptor(_engine, PropertyFlag.None));
+            DefinePropertyOrThrow(CommonProperties.Callee, new GetSetPropertyDescriptor.ThrowerPropertyDescriptor(_realm, PropertyFlag.None));
         }
         else
         {
             ObjectInstance? map = null;
             if (args.Length > 0)
             {
-                var mappedNamed = _mappedNamed.Value!;
-                mappedNamed.Clear();
-
-                map = Engine.Realm.Intrinsics.Object.Construct(Arguments.Empty);
+                // index properties always materialize; the live-binding parameter map is only
+                // built while the owning call is still running (post-return the mapping is
+                // detached and the snapshot values are authoritative)
+                HashSet<Key>? mappedNamed = null;
+                if (!_mapDetached)
+                {
+                    mappedNamed = _mappedNamed.Value!;
+                    mappedNamed.Clear();
+                    map = _realm.Intrinsics.Object.Construct(Arguments.Empty);
+                }
 
                 for (uint i = 0; i < (uint) args.Length; i++)
                 {
                     SetOwnProperty(JsString.Create(i), new PropertyDescriptor(args[i], PropertyFlag.ConfigurableEnumerableWritable));
-                    if (i < _names.Length)
+                    if (map is not null && i < _names.Length)
                     {
                         var name = _names[i];
-                        if (mappedNamed.Add(name))
+                        if (mappedNamed!.Add(name))
                         {
                             map.SetOwnProperty(JsString.Create(i), new ClrAccessDescriptor(_env, Engine, name));
                         }
@@ -99,17 +151,106 @@ public sealed class JsArguments : ObjectInstance
 
         // Spec (10.4.4.6 step 19) requires arguments[@@iterator] to be %Array.prototype.values%
         // — the same function object, not a fresh wrapper.
-        var iteratorFunction = _engine.Realm.Intrinsics.Array.PrototypeObject.Get("values");
+        var iteratorFunction = _realm.Intrinsics.Array.PrototypeObject.Get("values");
         DefinePropertyOrThrow(GlobalSymbolRegistry.Iterator, new PropertyDescriptor(iteratorFunction, PropertyFlag.Writable | PropertyFlag.Configurable));
     }
 
-    internal ObjectInstance? ParameterMap { get; set; }
+    private ObjectInstance? _parameterMap;
+
+    internal ObjectInstance? ParameterMap
+    {
+        get
+        {
+            // internal consumers (and tests) expect the map to exist for a live mapped
+            // arguments object; materialize on demand when still in virtual mode
+            if (_virtualMode)
+            {
+                EnsureInitialized();
+            }
+
+            return _parameterMap;
+        }
+        set => _parameterMap = value;
+    }
 
     internal override bool IsArrayLike => true;
 
     internal override bool IsIntegerIndexedArray => true;
 
     public uint Length => (uint) _args.Length;
+
+    public override JsValue Get(JsValue property, JsValue receiver)
+    {
+        if (_virtualMode && ReferenceEquals(this, receiver))
+        {
+            if (Array.ArrayInstance.IsArrayIndex(property, out var index))
+            {
+                if (index < (uint) _args.Length)
+                {
+                    // the parameter map binds the FIRST index carrying each name (later duplicates
+                    // read the positional argument), mirroring Initialize's first-wins dedup;
+                    // once the call returned the map is detached and the snapshot is authoritative
+                    if (_func is not null && !_mapDetached && TryGetMappedName(index, out var mappedName))
+                    {
+                        return _env.GetBindingValue(mappedName, strict: false);
+                    }
+
+                    return _args[index];
+                }
+            }
+            else if (CommonProperties.Length.Equals(property))
+            {
+                return JsNumber.Create(_args.Length);
+            }
+            else if (CommonProperties.Callee.Equals(property) && _func is not null)
+            {
+                return _func;
+            }
+            else if (ReferenceEquals(property, GlobalSymbolRegistry.Iterator))
+            {
+                // spec identity: %Array.prototype.values%
+                return _realm.Intrinsics.Array.PrototypeObject.Get("values");
+            }
+        }
+
+        return base.Get(property, receiver);
+    }
+
+    private bool TryGetMappedName(uint index, out Key name)
+    {
+        var names = _names;
+        if (index >= (uint) names.Length)
+        {
+            name = default;
+            return false;
+        }
+
+        name = names[index];
+        for (var i = 0; i < index; i++)
+        {
+            if (names[i] == name)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // Before virtual read mode, an uninitialized arguments object was unreachable (any user
+    // access materialized it first); now the enumeration surfaces must initialize explicitly
+    // since they read the property bag directly.
+    public override List<JsValue> GetOwnPropertyKeys(Types types = Types.String | Types.Symbol)
+    {
+        EnsureInitialized();
+        return base.GetOwnPropertyKeys(types);
+    }
+
+    public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
+    {
+        EnsureInitialized();
+        return base.GetOwnProperties();
+    }
 
     public override PropertyDescriptor GetOwnProperty(JsValue property)
     {
@@ -139,6 +280,25 @@ public sealed class JsArguments : ObjectInstance
     /// for arrays
     public override bool Set(JsValue property, JsValue value, JsValue receiver)
     {
+        // Mapped-index writes go straight to the parameter binding (matching the
+        // ClrAccessDescriptor setter the map would install); anything else materializes.
+        if (_virtualMode && !_mapDetached && ReferenceEquals(this, receiver)
+            && _func is not null
+            && Array.ArrayInstance.IsArrayIndex(property, out var virtualIndex)
+            && virtualIndex < (uint) _args.Length
+            && TryGetMappedName(virtualIndex, out var virtualName))
+        {
+            _env.SetMutableBinding(virtualName, value, strict: true);
+            if (_materialized)
+            {
+                // keep the escaped snapshot in sync so a later materialization captures the
+                // written value (matching today's map-synced descriptor); pre-escape _args is
+                // the pooled caller array and must never be written
+                _args[virtualIndex] = value;
+            }
+            return true;
+        }
+
         EnsureInitialized();
 
         if (!CanPut(property))
@@ -251,8 +411,9 @@ public sealed class JsArguments : ObjectInstance
 
         _materialized = true;
 
-        EnsureInitialized();
-
+        // Snapshot the (pooled, caller-owned) argument values so reads stay valid after the
+        // call returns. Virtual mode keeps serving reads off the snapshot; the property
+        // descriptors materialize lazily only if something actually needs them.
         var args = _args;
         var copiedArgs = new JsValue[args.Length];
         System.Array.Copy(args, copiedArgs, args.Length);
@@ -263,6 +424,10 @@ public sealed class JsArguments : ObjectInstance
 
     internal void FunctionWasCalled()
     {
+        // Detach the mapping: post-call reads see the captured snapshot (write-synced while
+        // mapped), not live bindings, and a later materialization must not rebuild the map.
+        _mapDetached = true;
+
         // should no longer expose arguments which is special name
         ParameterMap = null;
 

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -85,7 +85,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     /// If true, own properties may be added to the
     /// object.
     /// </summary>
-    public virtual bool Extensible { get; private set; }
+    public virtual bool Extensible { get; internal set; }
 
     internal PropertyDictionary? Properties
     {

--- a/Jint/Runtime/Descriptors/GetSetPropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/GetSetPropertyDescriptor.cs
@@ -49,7 +49,8 @@ public sealed class GetSetPropertyDescriptor : PropertyDescriptor
 
     internal sealed class ThrowerPropertyDescriptor : PropertyDescriptor
     {
-        private readonly Engine _engine;
+        private readonly Engine? _engine;
+        private readonly Realm? _realm;
         private JsValue? _thrower;
 
         public ThrowerPropertyDescriptor(Engine engine, PropertyFlag flags)
@@ -59,8 +60,20 @@ public sealed class GetSetPropertyDescriptor : PropertyDescriptor
             _engine = engine;
         }
 
-        public override JsValue Get => _thrower ??= _engine.Realm.Intrinsics.ThrowTypeError;
-        public override JsValue Set => _thrower ??= _engine.Realm.Intrinsics.ThrowTypeError;
+        /// <summary>
+        /// Realm-pinned variant for descriptors whose creation is deferred past the point where
+        /// the active realm still matches the owning object's realm (e.g. lazily materialized
+        /// arguments objects queried cross-realm) — %ThrowTypeError% is a per-realm intrinsic.
+        /// </summary>
+        public ThrowerPropertyDescriptor(Realm realm, PropertyFlag flags)
+            : base(flags | PropertyFlag.CustomJsValue)
+        {
+            _flags |= PropertyFlag.NonData;
+            _realm = realm;
+        }
+
+        public override JsValue Get => _thrower ??= (_realm ?? _engine!.Realm).Intrinsics.ThrowTypeError;
+        public override JsValue Set => _thrower ??= (_realm ?? _engine!.Realm).Intrinsics.ThrowTypeError;
 
         protected internal override JsValue? CustomValue
         {

--- a/Jint/Runtime/Intrinsics.cs
+++ b/Jint/Runtime/Intrinsics.cs
@@ -332,11 +332,11 @@ public sealed partial class Intrinsics
         _uriError ??= new ErrorConstructor(_engine, _realm, Error, Error.PrototypeObject, _uriErrorFunctionName, static intrinsics => intrinsics.UriError.PrototypeObject);
 
     internal ThrowTypeError ThrowTypeError =>
-        _throwTypeError ??= new ThrowTypeError(_engine, _engine.Realm) { _prototype = _engine.Realm.Intrinsics.Function.PrototypeObject };
+        _throwTypeError ??= new ThrowTypeError(_engine, _realm) { _prototype = Function.PrototypeObject };
 
     internal AsyncDisposableStackConstructor AsyncDisposableStack =>
-        _asyncDisposableStack ??= new AsyncDisposableStackConstructor(_engine, _engine.Realm) { _prototype = _engine.Realm.Intrinsics.Function.PrototypeObject };
+        _asyncDisposableStack ??= new AsyncDisposableStackConstructor(_engine, _realm) { _prototype = Function.PrototypeObject };
 
     internal DisposableStackConstructor DisposableStack =>
-        _disposableStack ??= new DisposableStackConstructor(_engine, _engine.Realm) { _prototype = _engine.Realm.Intrinsics.Function.PrototypeObject };
+        _disposableStack ??= new DisposableStackConstructor(_engine, _realm) { _prototype = Function.PrototypeObject };
 }


### PR DESCRIPTION
The arguments exotic object materialized its full property surface on any touch: length + callee (+ thrower in strict) + `@@iterator` descriptors, one CEW descriptor per index, a symbol dictionary, and for mapped arguments a parameter-map object plus one `ClrAccessDescriptor` per named parameter — roughly 2N+4 allocations per call that touches `arguments`, dominating allocation profiles of `arguments`-using code (the census put descriptor/dictionary machinery at ~75% of such a workload).

`JsArguments` now starts in a **virtual read mode**: in-range index reads, `length`, `@@iterator` and (mapped) `callee` answer straight from the argument snapshot / parameter bindings / function reference; mapped index writes go directly to the parameter binding (matching the `ClrAccessDescriptor` setter) and keep the escaped snapshot in sync. Everything else — defineProperty, delete, keys enumeration, reflection, unmapped writes — routes through the existing lazy `Initialize`, which clears the virtual flag so all materializing paths stay consistent.

Key mechanics:

- `JsArguments` carries `InternalTypes.ExoticGet` so member reads route through the virtual `[[Get]]` instead of the member-expression GetOwnProperty-first protocol (which would materialize). Arguments objects gained nothing from the member caches anyway — their identity churns per call. Classified accordingly in the prototype-method-cache guard test.
- `Materialize()` (the identifier-read escape hook) still snapshots the pooled caller argument array and blocks pool return, but no longer forces property materialization.
- `FunctionWasCalled` detaches the map **virtually**: post-call mapped reads see the write-synced snapshot — byte-equivalent to the captured descriptors the eager path produced — and a later materialization skips map construction (index properties always materialize).
- `Initialize` reconstructs conceptually pre-existing properties, so it bypasses the extensibility gate (freeze/preventExtensions while virtual) and pins the creating realm for `%ThrowTypeError%`, `%Array.prototype.values%` and the map's prototype, since materialization can now run cross-realm.
- `GetOwnPropertyKeys`/`GetOwnProperties` initialize explicitly (an uninitialized arguments object used to be unreachable); `ParameterMap` materializes on access for internal consumers.

The first commit fixes a latent cross-realm bug this exposed: `Intrinsics.ThrowTypeError` (and the two DisposableStack constructors) were lazily constructed with `_engine.Realm` — the realm **active at first touch** — unlike every other lazy intrinsic, which uses the instance's own `_realm`. A cross-realm first touch permanently bound the wrong realm's `%ThrowTypeError%` (caught by `built-ins/ThrowTypeError/distinct-cross-realm.js` once materialization became deferrable).

## Measurements

Arguments-summing workload (strict, 5 args, 50k calls, fresh engine per iteration):

| metric | main | PR | delta |
|---|---|---|---|
| allocations | 73.7 MB/iter | 20.3 MB/iter | **−72%** |
| time (A/B/A/B) | 92.6 ms/iter | 65.1 ms/iter | **−30%** |

`PropertyDescriptor`, `DictionaryNode[PropertyDescriptor]`, symbol dictionaries, `GetSetPropertyDescriptor`/thrower descriptors all disappear from the allocation profile; what remains is the function-environment dictionary bindings (a separate concern) and the `JsArguments` instances themselves.

BenchmarkDotNet default jobs, A/B vs main from separate worktrees:

| case | main | PR | delta |
|---|---|---|---|
| PreparedScriptBenchmark prepared ×2 (handlebars — `arguments`-heavy) | 39.8/40.2 ms, 21.02 MB | 38.6/38.6 ms, 19.63 MB | **−3..−4% time, −6.6% alloc** |
| FunctionInvocationBenchmarks (Warm_Call/Apply/Bind/BindThenCall) | — | — | within error bars |
| ClosureCallBenchmarks | — | — | neutral (EmptyClosureCall single-run +8% resolved as PGO artifact: 3-launch A/B 37.40 ± 1.27 vs 37.44 ± 0.45) |

## Verification

- `Jint.Tests` green (net10.0 + net472), `Jint.Tests.PublicInterface` green (including the `ClrAccessDescriptor` internals-pinning test via the materializing `ParameterMap` accessor)
- Full test262: 99,260 passed, 0 failed — including the whole `language/arguments-object` directory (mapped aliasing both directions, delete-then-read, duplicate parameter names, strict callee poisoning), `Object.freeze/preventExtensions/isFrozen` over arguments, sloppy-arguments array-like consumption (`concat`/`from`/`every`/...), and cross-realm `%ThrowTypeError%` distinctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
