### PR TITLE
Fix raw SetProperty on builtin-shaped hosts landing in an invisible dictionary

### DIFF
--- a/Jint.Tests/Runtime/PropertyDescriptorTests.cs
+++ b/Jint.Tests/Runtime/PropertyDescriptorTests.cs
@@ -99,6 +99,21 @@ public class PropertyDescriptorTests
     }
 
     [Fact]
+    public void FastSetPropertyIsVisibleOnBuiltinShapedHost()
+    {
+        // Math uses builtin-shape storage; a raw property store must deopt it to dictionary
+        // mode — without that, the write lands in a side dictionary the shape-mode read
+        // paths never consult and the property silently doesn't exist.
+        Assert.Equal(4, _engine.Evaluate("Math.floor(4.7)").AsNumber()); // initialize the shaped host
+        var math = _engine.Evaluate("Math").AsObject();
+        math.FastSetProperty("custom", new PropertyDescriptor(42, PropertyFlag.ConfigurableEnumerableWritable));
+
+        Assert.Equal(42, _engine.Evaluate("Math.custom").AsNumber());
+        Assert.True(_engine.Evaluate("Object.getOwnPropertyNames(Math).includes('custom')").AsBoolean());
+        Assert.Equal(4, _engine.Evaluate("Math.floor(4.7)").AsNumber());
+    }
+
+    [Fact]
     public void LazyPropertyDescriptor()
     {
         var pd = _engine.Evaluate("globalThis").AsObject().GetOwnProperty("decodeURI");

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -245,9 +245,15 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     internal void SetProperty(Key property, PropertyDescriptor value)
     {
         // Storing a raw descriptor is a dictionary-mode operation; deopt first if needed.
+        // Without the builtin-shape deopt, the write would land in a side dictionary that the
+        // shape-mode read paths never consult — the property would silently not exist.
         if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
         {
             ConvertToDictionaryMode();
+        }
+        else if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
+        {
+            DeoptBuiltinShape();
         }
         _properties ??= new PropertyDictionary();
         _properties[property] = value;


### PR DESCRIPTION
\`SetProperty(Key, ...)\` deopted hidden-class \ShapeMode\ objects before storing a raw descriptor, but not \BuiltinShapeMode\ hosts: the write created a side \_properties\ dictionary that the shape-mode read paths never consult, so the property silently did not exist. Reachable through the public \FastSetProperty\ API on any shaped built-in (\Math\, \JSON\, prototypes, ...) since the shapes migration.

Regression test included (raw store on shaped \Math\: value visible, enumerable via \getOwnPropertyNames\, existing shape members still functional after the deopt).

## Verification

- \Jint.Tests\ green (net10.0 + net472), \Jint.Tests.PublicInterface\ green
- Full test262: 99,260 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)