### PR TITLE
Allocation-free for-in key enumeration

### DIFF
--- a/Jint/Native/Iterator/IteratorInstance.cs
+++ b/Jint/Native/Iterator/IteratorInstance.cs
@@ -22,6 +22,24 @@ internal abstract class IteratorInstance : ObjectInstance
     public abstract bool TryIteratorStep(out ObjectInstance nextItem);
 
     /// <summary>
+    /// Steps the iterator and hands back the value directly, letting concrete iterators skip
+    /// the per-step IteratorResult object when nothing user-visible needs it (for-in keys).
+    /// The default wraps <see cref="TryIteratorStep"/> with exactly the read the for-in/of
+    /// loop used to perform, so behavior is unchanged for every other iterator.
+    /// </summary>
+    internal virtual bool TryStepValue([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out JsValue? value)
+    {
+        if (!TryIteratorStep(out var result))
+        {
+            value = null;
+            return false;
+        }
+
+        value = result.Get(CommonProperties.Value);
+        return true;
+    }
+
+    /// <summary>
     /// https://tc39.es/ecma262/#sec-iteratornext
     /// IteratorNext with an optional value argument, using the cached [[NextMethod]].
     /// </summary>
@@ -238,6 +256,157 @@ internal abstract class IteratorInstance : ObjectInstance
 
             nextItem = CreateIterResultObject(match, false);
             return true;
+        }
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-enumerate-object-properties
+    /// for-in key enumerator: walks own string keys level by level up the prototype chain,
+    /// probing presence and enumerability per key at step time (a key deleted before its turn
+    /// is skipped). Keys seen as present on shallower levels are tracked in a plain list; the
+    /// hash set that shadow-filters deeper levels materializes only when a deeper level
+    /// actually produces a present key — enumerating an object whose prototypes contribute
+    /// nothing (the common case: every Object.prototype / Array.prototype member is
+    /// non-enumerable... but present, so they still probe) allocates no per-step result
+    /// objects and no nested per-level iterator machinery.
+    /// </summary>
+    internal sealed class ForInIterator : IteratorInstance
+    {
+        private ObjectInstance? _current;
+        private List<JsValue> _keys;
+        private int _index;
+        private bool _deeperLevel;
+        private List<CompletedLevel>? _completedLevels;
+        private HashSet<JsValue>? _visited;
+
+        [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+        private readonly record struct CompletedLevel(ObjectInstance Owner, List<JsValue> Keys);
+
+        public ForInIterator(Engine engine, ObjectInstance target) : base(engine)
+        {
+            _current = target;
+            // matches the previous lazy enumerator's first step closely enough: no user code
+            // can observe between head evaluation and the first step, so the ownKeys order
+            // for proxies is preserved; GetPrototypeOf is deliberately NOT consulted here
+            // (a proxy trap must not fire before the first level is exhausted)
+            _keys = target.GetOwnPropertyKeys(Types.String);
+        }
+
+        internal override bool TryStepValue([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out JsValue? value)
+        {
+            while (_current is not null)
+            {
+                var current = _current;
+                var keys = _keys;
+                while (_index < keys.Count)
+                {
+                    var key = keys[_index++];
+                    var probe = current.ProbeOwnProperty(key);
+                    if (probe == OwnPropertyProbe.Missing)
+                    {
+                        // deleted before its turn — not visited, does not shadow
+                        continue;
+                    }
+
+                    if (_deeperLevel)
+                    {
+                        if (_visited is null)
+                        {
+                            if (probe != OwnPropertyProbe.Enumerable)
+                            {
+                                // present but non-enumerable: never yields, and its shadowing
+                                // of still-deeper levels is reconstructed from the retained
+                                // level snapshots if a set is ever needed
+                                continue;
+                            }
+
+                            _visited = BuildVisited(current, keys, _index - 1);
+                        }
+
+                        if (!_visited.Add(key))
+                        {
+                            continue; // shadowed by a shallower level
+                        }
+                    }
+
+                    if (probe == OwnPropertyProbe.Enumerable)
+                    {
+                        value = key;
+                        return true;
+                    }
+                }
+
+                var proto = current.GetPrototypeOf();
+                if (proto is null)
+                {
+                    _current = null;
+                    break;
+                }
+
+                if (_visited is null)
+                {
+                    // retain the exhausted level's snapshot (a list reference, no copy) so a
+                    // later set build can reconstruct what it shadowed
+                    (_completedLevels ??= []).Add(new CompletedLevel(current, keys));
+                }
+
+                _deeperLevel = true;
+                _current = proto;
+                _keys = proto.GetOwnPropertyKeys(Types.String);
+                _index = 0;
+            }
+
+            value = null;
+            return false;
+        }
+
+        /// <summary>
+        /// First enumerable candidate on a deeper level: build the shadow set from every
+        /// shallower level's retained snapshot plus the already-processed prefix of the
+        /// current level, re-probing each key on its owning object. Prototype members are
+        /// overwhelmingly non-enumerable, so most enumerations never get here.
+        /// </summary>
+        private HashSet<JsValue> BuildVisited(ObjectInstance current, List<JsValue> currentKeys, int processedCount)
+        {
+            var set = new HashSet<JsValue>();
+            if (_completedLevels is not null)
+            {
+                foreach (var level in _completedLevels)
+                {
+                    var levelKeys = level.Keys;
+                    for (var i = 0; i < levelKeys.Count; i++)
+                    {
+                        if (level.Owner.ProbeOwnProperty(levelKeys[i]) != OwnPropertyProbe.Missing)
+                        {
+                            set.Add(levelKeys[i]);
+                        }
+                    }
+                }
+
+                _completedLevels = null;
+            }
+
+            for (var i = 0; i < processedCount; i++)
+            {
+                if (current.ProbeOwnProperty(currentKeys[i]) != OwnPropertyProbe.Missing)
+                {
+                    set.Add(currentKeys[i]);
+                }
+            }
+
+            return set;
+        }
+
+        public override bool TryIteratorStep(out ObjectInstance nextItem)
+        {
+            if (TryStepValue(out var value))
+            {
+                nextItem = IteratorResult.CreateValueIteratorPosition(_engine, value);
+                return true;
+            }
+
+            nextItem = IteratorResult.CreateValueIteratorPosition(_engine, done: JsBoolean.True);
+            return false;
         }
     }
 

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -2090,36 +2090,6 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
 
     public override int GetHashCode() => RuntimeHelpers.GetHashCode(this);
 
-    internal IEnumerable<JsValue> GetKeys()
-    {
-        var visited = new HashSet<JsValue>();
-        foreach (var key in GetOwnPropertyKeys(Types.String))
-        {
-            var probe = ProbeOwnProperty(key);
-            if (probe != OwnPropertyProbe.Missing)
-            {
-                visited.Add(key);
-                if (probe == OwnPropertyProbe.Enumerable)
-                {
-                    yield return key;
-                }
-            }
-        }
-
-        if (Prototype is null)
-        {
-            yield break;
-        }
-
-        foreach (var protoKey in Prototype.GetKeys())
-        {
-            if (!visited.Contains(protoKey))
-            {
-                yield return protoKey;
-            }
-        }
-    }
-
     public override string ToString()
     {
         return TypeConverter.ToString(this);

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -322,7 +322,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
             }
 
             var obj = TypeConverter.ToObject(engine.Realm, exprValue);
-            result = new IteratorInstance.EnumerableIterator(engine, obj.GetKeys());
+            result = new IteratorInstance.ForInIterator(engine, obj);
         }
         else if (_iterationKind == IterationKind.AsyncIterate)
         {
@@ -428,11 +428,9 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                     asyncResumeData.CurrentValue = null;
                     resuming = false;
                 }
-                else
+                else if (iteratorKind == IteratorKind.Async)
                 {
                     ObjectInstance nextResult;
-
-                    if (iteratorKind == IteratorKind.Async)
                     {
                         // For async iteration, we need to await the Promise from next()
                         // Note: We need direct access to async instances for state manipulation in SuspendForAsyncIteration
@@ -508,19 +506,23 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                             }
                         }
                     }
-                    else
-                    {
-                        // Sync iteration - use existing TryIteratorStep
-                        if (!iteratorRecord.TryIteratorStep(out nextResult))
-                        {
-                            close = true;
-                            // Clean up suspend data on normal completion
-                            suspendable?.Data.Clear(this);
-                            return new Completion(CompletionType.Normal, v, _statement!);
-                        }
-                    }
 
                     nextValue = nextResult.Get(CommonProperties.Value);
+                }
+                else
+                {
+                    // Sync iteration; TryStepValue skips the per-step IteratorResult for
+                    // iterators that can (for-in keys) and is the same TryIteratorStep +
+                    // Get(value) sequence for everything else.
+                    if (!iteratorRecord.TryStepValue(out var steppedValue))
+                    {
+                        close = true;
+                        // Clean up suspend data on normal completion
+                        suspendable?.Data.Clear(this);
+                        return new Completion(CompletionType.Normal, v, _statement!);
+                    }
+
+                    nextValue = steppedValue;
                 }
 
                 close = true;


### PR DESCRIPTION
for-in previously allocated per **loop**: an unconditional `HashSet` visited-set (plus its entry/bucket arrays), nested per-prototype-level C# iterator state machines (`ObjectInstance.GetKeys` recursion — one state machine and set per level), and an `EnumerableIterator` wrapper; and per **step**: an `IteratorResult` object. The allocation census put this machinery at 40-55% of enumeration-heavy workloads.

A dedicated `IteratorInstance.ForInIterator` now walks own string keys level by level, probing presence/enumerability per key at step time through the allocation-free `ProbeOwnProperty` (#2585) — deleted-before-visit keys stay skipped, per-level key snapshots keep proxy `ownKeys`/`getOwnPropertyDescriptor` trap ordering. The shadow set for deeper levels materializes only when a deeper level actually produces a present **and enumerable** key: exhausted level snapshots are retained as list references and re-probed once to build the set on demand. Prototype members are overwhelmingly non-enumerable, so common enumerations (plain objects, arrays, handlebars-style `extend`) allocate no set at all.

The step protocol gains `IteratorInstance.TryStepValue`, which skips the per-step `IteratorResult` for iterators that can and is byte-for-byte the old `TryIteratorStep` + `Get(value)` sequence for every other iterator; the for-in/for-of sync loop consumes it. `ObjectInstance.GetKeys` (sole consumer: the for-in head) is removed.

## Measurements

Fresh-engine probes (A/B/A/B, alternating binaries):

| workload | main | PR | delta |
|---|---|---|---|
| for-in over 1000-element arrays (fresh array per round) | 78.2 MB/iter, 68.5 ms | 28.5 MB/iter, 58.9 ms | **-64% alloc, -14% time** |
| handlebars-style extend() (for-in + hasOwnProperty per key) | 107.2 MB/iter, 105.9 ms | 58.2 MB/iter, 89.0 ms | **-46% alloc, -16% time** |

`IteratorResult`, `HashSet` entries/buckets and the `<GetKeys>` state machines disappear from the allocation profiles; what remains is member-read `Reference` traffic and the key snapshots themselves.

BenchmarkDotNet default jobs (A/B vs main from separate worktrees): PreparedScriptBenchmark prepared modes **-1.3/-1.8% time, -2.2% alloc**; ObjectEnumerationBenchmark and DromaeoBenchmark.ObjectArray flat (they use `Object.keys`, not for-in); PreparedScript source mode within its observed run-to-run band with allocations down.

## Verification

- `Jint.Tests` green (net10.0 + net472), `Jint.Tests.PublicInterface` green
- Full test262: 99,260 passed, 0 failed — for-in order, shadowing by non-enumerable shallower keys, delete-during-enumeration, proxy trap order all covered
- Live-engine checks: proto-chain order, non-enumerable shadowing across levels, delete-during-enumeration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
