### PR TITLE
Build the yield argument handler once, not per evaluation

### DIFF
--- a/Jint/Runtime/Interpreter/Expressions/JintYieldExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintYieldExpression.cs
@@ -10,8 +10,11 @@ namespace Jint.Runtime.Interpreter.Expressions;
 
 internal sealed class JintYieldExpression : JintExpression
 {
+    private readonly JintExpression? _argument;
+
     public JintYieldExpression(YieldExpression expression) : base(expression)
     {
+        _argument = expression.Argument is not null ? Build(expression.Argument) : null;
     }
 
     protected override object EvaluateInternal(EvaluationContext context)
@@ -171,9 +174,9 @@ internal sealed class JintYieldExpression : JintExpression
 
         // Normal yield: evaluate argument and yield the value
         JsValue value;
-        if (expression.Argument is not null)
+        if (_argument is not null)
         {
-            value = Build(expression.Argument).GetValue(context);
+            value = _argument.GetValue(context);
 
             // If the argument evaluation suspended the generator (nested yield), propagate
             // the suspension up without yielding again - the inner yield already suspended


### PR DESCRIPTION
\JintYieldExpression\ called \JintExpression.Build(expression.Argument)\ inside \EvaluateInternal\ — on **every yield evaluation**. \Build\ only returns a cached handler when the AST node's \UserData\ was pre-populated (prepared scripts), so for ordinary execution every \yield <expr>\ reconstructed the argument's whole handler subtree per iteration: for \yield { a: i, b: i + 1 }\ that is a \JintObjectExpression\ + \ObjectProperty[]\ + \ExpressionCache\ + identifier/binary handlers — every time the generator produced a value — and the handler lost all its per-node inline caches on each rebuild. The allocation census flagged this as ~51% of a generator-producing-literals workload (handler types should never appear in steady-state allocation profiles at all).

The argument handler is now built once in the constructor, like every other expression handler.

## Measurements

Generator yielding object literals (100k yields, fresh engine per iteration, A/B/A/B alternating binaries): **132.2 → 52.9 MB/iter (−60%), 98.4 → 67.9 ms/iter (−31%)**. All AST-handler types disappear from the allocation profile; what remains is the literal's dictionary-path descriptors and the user-visible generator result objects.

## Verification

- \Jint.Tests\ green (net10.0 + net472), \Jint.Tests.PublicInterface\ green
- Full test262: 99,260 passed, 0 failed (generator/async-generator suites cover yield, yield*, resume-with-throw/return and yields in loops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)