### PR TITLE
Extend prepared-script engine-retention test to newer env cache shapes

### DIFF
--- a/Jint.Tests/Runtime/GarbageCollectionTests.cs
+++ b/Jint.Tests/Runtime/GarbageCollectionTests.cs
@@ -123,15 +123,22 @@ public class GarbageCollectionTests
         // per engine) rather than on state shared through the AST, so once an engine is dropped its cached
         // environments — and the engine/realm they reference — become collectable even while the prepared
         // script stays cached. The script covers every cache shape: an ordinary function (single-slot env
-        // cache), a direct-recursive one (bounded RecursiveEnvPool), a let/const block (block env cache)
-        // and a for-let loop (loop env cache).
+        // cache), a direct-recursive one (bounded RecursiveEnvPool), a let/const block (block env cache),
+        // a for-let loop (loop env cache), for-of/for-in with let head (per-iteration env cache on the
+        // JintForInForOfStatement handler) and a Function-constructor function (definition-level env parked
+        // on the realm-cached dynamic State, which must die with the realm).
 
         var prepared = Engine.PrepareScript("""
             function f(x) { var y = x + 1; return y; }
             function fib(n) { return n < 2 ? n : fib(n - 1) + fib(n - 2); }
             function b(x) { { let y = x + 1; const z = y * 2; f(y + z); } }
             function l(x) { var sum = 0; for (let i = 0; i < 3; i++) { sum += i; } return sum; }
+            function fo(arr) { var sum = 0; for (let v of arr) { sum += v; } return sum; }
+            function fi(obj) { var keys = ''; for (let k in obj) { keys += k; } return keys; }
+            var dyn = new Function('a', 'return a + 1');
             f(1); f(2); fib(8); b(1); b(2); l(1); l(2);
+            fo([1, 2, 3]); fo([4, 5]); fi({ a: 1, b: 2 }); fi({ c: 3 });
+            dyn(1); dyn(2);
             """);
 
         const int count = 20;


### PR DESCRIPTION
Follow-up to the analysis of #2587.

## Analysis summary

Walking every object a prepared script can retain after engine disposal (everything parked on AST `UserData` at prepare/build time) confirms the v4.11.0 snapshot in #2587 is fully by design — nothing engine-owned survives:

| Retained type | What it is | Why it is safe |
|---|---|---|
| `JintConstantExpression` + `JsString`/`JsNumber` | constant-folding results for literals and foldable unary/binary expressions | immutable, realm-free primitives |
| `JintFunctionDefinition.State` | per-function FDI metadata (parameter/slot layout, hoisting); grew 56→92 B for the fixed-slot call fast paths | the only environment field (`_dynamicCachedEnv`) is gated to Function-constructor definitions living in the per-realm cache, never on prepared ASTs; `_cachedSlots` is cleared before parking |
| `JintBlockStatement.BlockState` | block declaration cache (wraps the former `DeclarationCache`, 16→28 B) | documented invariant: never holds environments — env caches live on per-engine handler instances |
| `Environment.BindingName` | Key + canonical `JsString` per identifier name | `CalculatedValue` is readonly and only ever the `Undefined` singleton |
| `CachedHoistingScope`, `ConstantStatement` | hoisting cache / stateless return-literal handler | no engine state |

The net retained size actually dropped vs v4.4.0 (127.8 → 120.7 MB) because identifiers now park a single deduplicated `BindingName` per name instead of one `JintIdentifierExpression` handler per node (was ~8 MB in the v4.4.0 snapshot).

## Change

`GarbageCollectionTests.SharedPreparedScriptDoesNotRetainEngines` locks the invariant that a shared prepared script must not pin engines, but it predates two environment-cache shapes added since it was written:

- the for-of/for-in per-iteration environment cache on the `JintForInForOfStatement` handler (#2586)
- the Function-constructor definition-level environment parked on the realm-cached dynamic `State` (#2579)

This extends the test script to exercise both, so a future refactor moving either cache onto shared AST state fails the test. Verified green on net10.0 and net472.

No product code changes; #2587 needs no fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)