### PR TITLE
GlobalObject joins the builtin-shape system via hybrid shape+overflow storage

### DIFF
--- a/Jint.Tests/Runtime/PropertyDescriptorTests.cs
+++ b/Jint.Tests/Runtime/PropertyDescriptorTests.cs
@@ -101,9 +101,9 @@ public class PropertyDescriptorTests
     [Fact]
     public void FastSetPropertyIsVisibleOnBuiltinShapedHost()
     {
-        // Math uses builtin-shape storage; a raw property store must deopt it to dictionary
-        // mode — without that, the write lands in a side dictionary the shape-mode read
-        // paths never consult and the property silently doesn't exist.
+        // Math uses builtin-shape storage; a raw property store of a non-shape name joins the
+        // hybrid side dictionary, which every read/enumeration surface must consult — without
+        // that, the property silently doesn't exist.
         Assert.Equal(4, _engine.Evaluate("Math.floor(4.7)").AsNumber()); // initialize the shaped host
         var math = _engine.Evaluate("Math").AsObject();
         math.FastSetProperty("custom", new PropertyDescriptor(42, PropertyFlag.ConfigurableEnumerableWritable));
@@ -116,13 +116,33 @@ public class PropertyDescriptorTests
     [Fact]
     public void LazyPropertyDescriptor()
     {
+        // the shaped global materializes a targeted slot on demand (other slots stay untouched)
         var pd = _engine.Evaluate("globalThis").AsObject().GetOwnProperty("decodeURI");
         if (checkType)
         {
-            Assert.IsType<LazyPropertyDescriptor<GlobalObject>>(pd);
+            Assert.IsType<PropertyDescriptor>(pd);
         }
         Assert.Equal(false, pd.IsAccessorDescriptor());
         Assert.Equal(true, pd.IsDataDescriptor());
+
+        // parseInt is a host-filled instance slot carrying a LazyPropertyDescriptor
+        var lazy = _engine.Evaluate("globalThis").AsObject().GetOwnProperty("parseInt");
+        if (checkType)
+        {
+            Assert.IsType<LazyPropertyDescriptor<GlobalObject>>(lazy);
+        }
+        Assert.Equal(true, lazy.IsDataDescriptor());
+
+        // deleting a shape name deopts the global; untouched function slots must survive
+        // as lazy wrappers instead of eagerly instantiating every built-in dispatcher
+        _engine.Evaluate("delete globalThis.escape");
+        var afterDeopt = _engine.Evaluate("globalThis").AsObject().GetOwnProperty("encodeURI");
+        if (checkType)
+        {
+            Assert.IsType<LazyBuiltinSlotDescriptor>(afterDeopt);
+        }
+        Assert.Equal(true, afterDeopt.IsDataDescriptor());
+        Assert.Equal("test", _engine.Evaluate("encodeURI('test')").AsString());
     }
 
     [Fact]

--- a/Jint/Native/Global/GlobalObject.Properties.cs
+++ b/Jint/Native/Global/GlobalObject.Properties.cs
@@ -68,6 +68,9 @@ namespace Jint.Native.Global;
 [JsIntrinsicReference("WeakRef")]
 [JsIntrinsicReference("WeakSet")]
 [JsIntrinsicReference("eval", IntrinsicMember = "Eval")]
+[JsInstanceSlot("parseInt")]
+[JsInstanceSlot("parseFloat")]
+[JsInstanceSlot("globalThis")]
 public partial class GlobalObject
 {
     [JsProperty(Name = "NaN", Flags = PropertyFlag.AllForbidden)]
@@ -86,11 +89,7 @@ public partial class GlobalObject
 
         CreateProperties_Generated();
 
-        // After CreateProperties_Generated, _properties is the HybridDictionary wrapper around the
-        // generator-built StringDictionarySlim. AddDangerous skips both duplicate-key lookup and
-        // SetOwnProperty's validation path. These 3 entries are new keys (not overwriting), so the
-        // direct path is correct. [JsObject(ExtraCapacity = 3)] presizes the underlying slim dict
-        // so the adds don't trigger a resize.
+        // The three entries that can't be expressed declaratively fill reserved [JsInstanceSlot]s.
         // parseInt / parseFloat are kept hand-rolled because spec requires
         // Number.parseInt === parseInt (and Number.parseFloat === parseFloat). Pre-source-gen Jint
         // satisfied that via ClrFunction.Equals comparing the underlying delegate; both globalThis
@@ -99,8 +98,8 @@ public partial class GlobalObject
         // break the strict-equality test. NumberConstructor.cs:50 documents the reciprocal half.
         // globalThis is a self-reference (the GlobalObject instance itself), which can't be
         // expressed as a static [JsProperty] field or as an intrinsic.
-        _properties!.AddDangerous("parseInt", new LazyPropertyDescriptor<GlobalObject>(this, static global => new ClrFunction(global._engine, "parseInt", ParseInt, 2, LengthFlags), PropertyFlags));
-        _properties.AddDangerous("parseFloat", new LazyPropertyDescriptor<GlobalObject>(this, static global => new ClrFunction(global._engine, "parseFloat", ParseFloat, 1, LengthFlags), PropertyFlags));
-        _properties.AddDangerous("globalThis", new PropertyDescriptor(this, PropertyFlags));
+        SetBuiltinSlotByName("parseInt", new LazyPropertyDescriptor<GlobalObject>(this, static global => new ClrFunction(global._engine, "parseInt", ParseInt, 2, LengthFlags), PropertyFlags));
+        SetBuiltinSlotByName("parseFloat", new LazyPropertyDescriptor<GlobalObject>(this, static global => new ClrFunction(global._engine, "parseFloat", ParseFloat, 1, LengthFlags), PropertyFlags));
+        SetBuiltinSlotByName("globalThis", new PropertyDescriptor(this, PropertyFlags));
     }
 }

--- a/Jint/Native/Global/GlobalObject.cs
+++ b/Jint/Native/Global/GlobalObject.cs
@@ -10,10 +10,7 @@ using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Global;
 
-// ExtraCapacity = 3 presizes the generator-emitted HybridDictionary for the 3 entries that
-// can't be expressed declaratively (parseInt, parseFloat, globalThis — see Initialize). Without
-// this hint the dictionary is sized for 68 and resizes when those 3 are added post-init.
-[JsObject(ExtraCapacity = 3)]
+[JsObject(UseShape = true)]
 public sealed partial class GlobalObject : ObjectInstance
 {
     private readonly Realm _realm;
@@ -731,14 +728,46 @@ uriError:
             return true;
         }
 
+        // the validate/apply protocol stores through the property dictionary
+        EnsureDictionaryProperties();
         return ValidateAndApplyPropertyDescriptor(this, new JsString(property), true, desc, current);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal PropertyDescriptor GetOwnProperty(Key property)
     {
-        Properties!.TryGetValue(property, out var descriptor);
-        return descriptor ?? PropertyDescriptor.Undefined;
+        if (_properties is not null)
+        {
+            _properties.TryGetValue(property, out var descriptor);
+            if (descriptor is not null || (_type & InternalTypes.BuiltinShapeMode) == InternalTypes.Empty)
+            {
+                return descriptor ?? PropertyDescriptor.Undefined;
+            }
+            // hybrid: side dictionary miss on a still-shaped global falls through to the shape
+        }
+
+        return GetOwnPropertyFromShape(property);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private PropertyDescriptor GetOwnPropertyFromShape(Key property)
+    {
+        // builtin-shape mode (no dictionary until something deopts the global): misses cost an
+        // index probe, hits materialize the slot's descriptor once with stable identity.
+        EnsureInitialized();
+        var shaped = (IBuiltinShaped) this;
+        if (shaped.BuiltinDescriptors is not null && shaped.BuiltinShape.Index.TryGetValue(property.Name, out var slot))
+        {
+            return MaterializeBuiltinSlot(shaped, slot);
+        }
+
+        // EnsureInitialized may have deopted or filled the dictionary meanwhile
+        if (_properties is not null && _properties.TryGetValue(property, out var descriptor))
+        {
+            return descriptor ?? PropertyDescriptor.Undefined;
+        }
+
+        return PropertyDescriptor.Undefined;
     }
 
     internal bool SetFromMutableBinding(Key property, JsValue value, bool strict)
@@ -746,13 +775,31 @@ uriError:
         // here we are called only from global environment record context
         // we can take some shortcuts to be faster
 
-        if (!_properties!.TryGetValue(property, out var existingDescriptor))
+        PropertyDescriptor? existingDescriptor = null;
+        _properties?.TryGetValue(property, out existingDescriptor);
+        if (existingDescriptor is null && (_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
+        {
+            existingDescriptor = GetOwnPropertyFromShape(property);
+            if (existingDescriptor == PropertyDescriptor.Undefined)
+            {
+                existingDescriptor = null;
+            }
+        }
+
+        if (existingDescriptor is null)
         {
             if (strict)
             {
                 Throw.ReferenceNameError(_realm, property.Name);
             }
-            _properties[property] = new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable | PropertyFlag.MutableBinding);
+            var fresh = new PropertyDescriptor(value, PropertyFlag.ConfigurableEnumerableWritable | PropertyFlag.MutableBinding);
+            // binding names are identifiers, so a still-shaped global takes the hybrid side dictionary
+            if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty && TryHybridAddToShapedHost(property, fresh))
+            {
+                return true;
+            }
+            _properties ??= new PropertyDictionary();
+            _properties[property] = fresh;
             unchecked { _propertiesVersion++; }
             return true;
         }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -245,14 +245,27 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     internal void SetProperty(Key property, PropertyDescriptor value)
     {
         // Storing a raw descriptor is a dictionary-mode operation; deopt first if needed.
-        // Without the builtin-shape deopt, the write would land in a side dictionary that the
-        // shape-mode read paths never consult — the property would silently not exist.
         if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
         {
             ConvertToDictionaryMode();
         }
         else if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
         {
+            var shaped = Unsafe.As<IBuiltinShaped>(this);
+            if (shaped.BuiltinShape.Index.TryGetValue(property.Name, out var slot))
+            {
+                // raw replace of an existing shape slot happens in place
+                shaped.BuiltinDescriptors![slot] = value;
+                unchecked { _propertiesVersion++; }
+                return;
+            }
+
+            if (TryHybridAddToShapedHost(property, value))
+            {
+                return;
+            }
+
+            // integer-like key: the fixed layout can't express the required own-key order
             DeoptBuiltinShape();
         }
         _properties ??= new PropertyDictionary();
@@ -266,13 +279,8 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         var propertyKey = TypeConverter.ToPropertyKey(property);
         if (!property.IsSymbol())
         {
-            if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
-            {
-                ConvertToDictionaryMode();
-            }
-            _properties ??= new PropertyDictionary();
-            _properties[TypeConverter.ToString(propertyKey)] = value;
-            unchecked { _propertiesVersion++; }
+            // route through the Key overload so shape/builtin-shape modes are handled
+            SetProperty(TypeConverter.ToString(propertyKey), value);
         }
         else
         {
@@ -317,6 +325,15 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             for (var i = 0; i < names.Length; i++)
             {
                 yield return new KeyValuePair<JsValue, PropertyDescriptor>(JsString.Create(names[i].Name), MaterializeBuiltinSlot(shaped, i));
+            }
+
+            // hybrid additions (added after every shape name, preserving insertion order)
+            if (_properties != null)
+            {
+                foreach (var pair in _properties)
+                {
+                    yield return new KeyValuePair<JsValue, PropertyDescriptor>(new JsString(pair.Key), pair.Value);
+                }
             }
         }
         else if (_properties != null)
@@ -531,16 +548,21 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         var key = TypeConverter.ToPropertyKey(property);
         if (!key.IsSymbol())
         {
-            // Removing a string property can't be expressed as a shape / built-in-shape layout; deopt first.
+            var name = TypeConverter.ToString(key);
+
+            // Removing a string property can't be expressed as a shape / built-in-shape layout;
+            // deopt first — except a hybrid addition on a shaped host, which lives in the side
+            // dictionary and removes directly.
             if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
             {
                 ConvertToDictionaryMode();
             }
-            else if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
+            else if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty
+                     && Unsafe.As<IBuiltinShaped>(this).BuiltinShape.Index.TryGetValue(name, out _))
             {
                 DeoptBuiltinShape();
             }
-            _properties?.Remove(TypeConverter.ToString(key));
+            _properties?.Remove(name);
             unchecked { _propertiesVersion++; }
             return;
         }
@@ -656,8 +678,11 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                     {
                         return MaterializeBuiltinSlot(shaped, slot);
                     }
+
+                    // hybrid addition on a shaped host (side dictionary holds post-init adds)
+                    _properties?.TryGetValue(name, out descriptor);
                 }
-                // string key absent from the shape ⇒ no own property (descriptor stays null → Undefined)
+                // string key absent from the shape (and hybrid additions) ⇒ no own property
             }
             else
             {
@@ -706,7 +731,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     // Materialize a shaped slot's descriptor. Constants point at the shared static descriptor; functions are
     // created on first access and stored so their identity is stable (the inline caches rely on this — a
     // materialize must never bump _propertiesVersion).
-    private static PropertyDescriptor MaterializeBuiltinSlot(IBuiltinShaped shaped, int slot)
+    private protected static PropertyDescriptor MaterializeBuiltinSlot(IBuiltinShaped shaped, int slot)
     {
         var descriptors = shaped.BuiltinDescriptors!;
         var descriptor = descriptors[slot];
@@ -738,6 +763,19 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             descriptors[slot] = descriptor;
         }
         return descriptor;
+    }
+
+    /// <summary>
+    /// Guarantees the ordinary dictionary representation for callers that add own properties
+    /// through the raw property bag (e.g. the global var-binding protocol); no-op unless the
+    /// host is currently in builtin-shape mode.
+    /// </summary>
+    internal void EnsureDictionaryProperties()
+    {
+        if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
+        {
+            DeoptBuiltinShape();
+        }
     }
 
     // Fall back to the ordinary dictionary representation. Already-materialized slots keep their
@@ -777,7 +815,8 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             }
         }
 
-        var properties = new PropertyDictionary(names.Length, checkExistingKeys: false);
+        var additions = _properties; // hybrid side-dictionary entries added after the shape names
+        var properties = new PropertyDictionary(names.Length + (additions?.Count ?? 0), checkExistingKeys: false);
         for (var i = 0; i < names.Length; i++)
         {
             var descriptor = descriptors[i];
@@ -797,6 +836,15 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             properties[names[i]] = descriptor;
         }
 
+        if (additions is not null)
+        {
+            // preserve insertion order: every addition came after initialization
+            foreach (var pair in additions)
+            {
+                properties[pair.Key] = pair.Value;
+            }
+        }
+
         _type &= ~InternalTypes.BuiltinShapeMode;
         shaped.BuiltinDescriptors = null;
         SetProperties(properties); // sets _properties, bumps version (symbols stay in _symbols)
@@ -806,7 +854,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     {
         var shaped = Unsafe.As<IBuiltinShaped>(this);
         var names = shaped.BuiltinShape.Names;
-        var keys = new List<JsValue>(names.Length + (_symbols?.Count ?? 0));
+        var keys = new List<JsValue>(names.Length + (_properties?.Count ?? 0) + (_symbols?.Count ?? 0));
         if ((types & Types.String) != Types.Empty)
         {
             // Function-derived hosts surface length/name/prototype ahead of their shape members (matching the
@@ -819,6 +867,16 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             foreach (var name in names)
             {
                 keys.Add(JsString.Create(name.Name));
+            }
+
+            // hybrid additions came after initialization; integer-like keys force a full deopt
+            // before ever landing here, so shape-names-then-additions is the spec own-key order
+            if (_properties is not null)
+            {
+                foreach (var pair in _properties)
+                {
+                    keys.Add(JsString.Create(pair.Key.Name));
+                }
             }
         }
         if ((types & Types.Symbol) != Types.Empty && _symbols is not null)
@@ -872,10 +930,37 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                 unchecked { _propertiesVersion++; }
                 return;
             }
-            // Adding a brand-new own string property can't be expressed in the fixed layout.
+
+            // A brand-new own string property joins the hybrid side dictionary (the shape keeps
+            // serving its slots); only integer-like keys force the full dictionary fallback.
+            if (TryHybridAddToShapedHost(jsString.ToString(), desc))
+            {
+                return;
+            }
+
             DeoptBuiltinShape();
         }
         SetProperty(property, desc);
+    }
+
+    /// <summary>
+    /// Adds a post-initialization own property to a builtin-shaped host's side dictionary,
+    /// keeping the shape alive for its slots — the caller has verified the name is not a shape
+    /// slot. Integer-like keys must sort before string keys in own-key order, which the
+    /// shape-then-additions enumeration cannot express, so they refuse and the caller deopts.
+    /// </summary>
+    internal bool TryHybridAddToShapedHost(Key name, PropertyDescriptor value)
+    {
+        var s = name.Name;
+        if (s.Length > 0 && char.IsDigit(s[0]))
+        {
+            return false;
+        }
+
+        _properties ??= new PropertyDictionary();
+        _properties[name] = value;
+        unchecked { _propertiesVersion++; }
+        return true;
     }
 
     public bool TryGetValue(JsValue property, out JsValue value)

--- a/Jint/Runtime/Environments/GlobalEnvironment.cs
+++ b/Jint/Runtime/Environments/GlobalEnvironment.cs
@@ -83,12 +83,25 @@ internal sealed class GlobalEnvironment : Environment
         // we unwrap by name
         value = default;
 
-        // normal case is to find
-        if (_global._properties!._dictionary.TryGetValue(name.Key, out var property)
+        // normal case is to find: script-created globals live in the (hybrid) dictionary,
+        // shape slots serve the built-ins until something deopts the global
+        if (_global._properties is not null
+            && _global._properties.TryGetValue(name.Key, out var property)
+            && property is not null
             && property != PropertyDescriptor.Undefined)
         {
             value = ObjectInstance.UnwrapJsValue(property, _global);
             return true;
+        }
+
+        if ((_global._type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
+        {
+            var shaped = _global.GetOwnProperty(name.Value);
+            if (shaped != PropertyDescriptor.Undefined)
+            {
+                value = ObjectInstance.UnwrapJsValue(shaped, _global);
+                return true;
+            }
         }
 
         if (_global._prototype is not null)
@@ -158,9 +171,14 @@ internal sealed class GlobalEnvironment : Environment
         {
             _declarativeRecord.InitializeBinding(name, value, hint);
         }
+        else if (_global._properties?.TryGetValue(name, out var descriptor) == true)
+        {
+            descriptor.Value = value;
+        }
         else
         {
-            _global._properties![name].Value = value;
+            // builtin-shape mode; the binding's property exists as a shape slot (e.g. var Array)
+            _global.GetOwnProperty(name.Name).Value = value;
         }
     }
 
@@ -230,13 +248,11 @@ internal sealed class GlobalEnvironment : Environment
         }
 
         // see ObjectEnvironmentRecord.GetBindingValue
-        var desc = PropertyDescriptor.Undefined;
+        PropertyDescriptor desc;
         if (_globalObject is not null)
         {
-            if (_globalObject._properties?.TryGetValue(name, out desc) == false)
-            {
-                desc = PropertyDescriptor.Undefined;
-            }
+            // hybrid-aware: dictionary first, then shape slots
+            desc = _globalObject.GetOwnProperty(name);
         }
         else
         {
@@ -280,13 +296,10 @@ internal sealed class GlobalEnvironment : Environment
 
     internal bool HasRestrictedGlobalProperty(Key name)
     {
-        if (_globalObject is not null)
-        {
-            return _globalObject._properties?.TryGetValue(name, out var desc) == true
-                   && !desc.Configurable;
-        }
+        var existingProp = _globalObject is not null
+            ? _globalObject.GetOwnProperty(name) // hybrid-aware: dictionary first, then shape slots
+            : _global.GetOwnProperty(name.Name);
 
-        var existingProp = _global.GetOwnProperty(name.Name);
         if (existingProp == PropertyDescriptor.Undefined)
         {
             return false;
@@ -297,7 +310,13 @@ internal sealed class GlobalEnvironment : Environment
 
     public bool CanDeclareGlobalVar(Key name)
     {
-        if (_global._properties!.ContainsKey(name))
+        if (_global._properties?.ContainsKey(name) == true)
+        {
+            return true;
+        }
+
+        if ((_global._type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty
+            && HasShapedGlobalOwnProperty(name))
         {
             return true;
         }
@@ -305,10 +324,25 @@ internal sealed class GlobalEnvironment : Environment
         return _global.Extensible;
     }
 
+    private bool HasShapedGlobalOwnProperty(Key name)
+    {
+        return _globalObject is not null
+            ? _globalObject.HasProperty(name)
+            : _global.HasOwnProperty(name.Name);
+    }
+
     public bool CanDeclareGlobalFunction(Key name)
     {
-        if (!_global._properties!.TryGetValue(name, out var existingProp)
-            || existingProp == PropertyDescriptor.Undefined)
+        PropertyDescriptor? existingProp = null;
+        _global._properties?.TryGetValue(name, out existingProp);
+
+        if ((existingProp is null || existingProp == PropertyDescriptor.Undefined)
+            && (_global._type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
+        {
+            existingProp = _global.GetOwnProperty(name.Name);
+        }
+
+        if (existingProp is null || existingProp == PropertyDescriptor.Undefined)
         {
             return _global.Extensible;
         }
@@ -333,9 +367,7 @@ internal sealed class GlobalEnvironment : Environment
             return;
         }
 
-        _global._properties!.TryAdd(name, new PropertyDescriptor(Undefined, canBeDeleted
-            ? PropertyFlag.ConfigurableEnumerableWritable | PropertyFlag.MutableBinding
-            : PropertyFlag.NonConfigurable | PropertyFlag.MutableBinding));
+        CreateGlobalVarBindingCore(name, canBeDeleted);
     }
 
     internal void CreateGlobalVarBindings(List<Key> names, bool canBeDeleted)
@@ -347,12 +379,36 @@ internal sealed class GlobalEnvironment : Environment
 
         for (var i = 0; i < names.Count; i++)
         {
-            var name = names[i];
-
-            _global._properties!.TryAdd(name, new PropertyDescriptor(Undefined, canBeDeleted
-                ? PropertyFlag.ConfigurableEnumerableWritable | PropertyFlag.MutableBinding
-                : PropertyFlag.NonConfigurable | PropertyFlag.MutableBinding));
+            CreateGlobalVarBindingCore(names[i], canBeDeleted);
         }
+    }
+
+    private void CreateGlobalVarBindingCore(Key name, bool canBeDeleted)
+    {
+        // add-if-absent: a shape slot (e.g. `var Array`) already satisfies the binding, and a
+        // fresh script-created global joins the hybrid side dictionary without deopting the
+        // shape (var names are identifiers, never integer-like)
+        if ((_global._type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
+        {
+            if (_global._properties?.ContainsKey(name) == true || HasShapedGlobalOwnProperty(name))
+            {
+                return;
+            }
+
+            if (_global.TryHybridAddToShapedHost(name, new PropertyDescriptor(Undefined, canBeDeleted
+                    ? PropertyFlag.ConfigurableEnumerableWritable | PropertyFlag.MutableBinding
+                    : PropertyFlag.NonConfigurable | PropertyFlag.MutableBinding)))
+            {
+                return;
+            }
+
+            _global.EnsureDictionaryProperties();
+        }
+
+        _global._properties ??= new PropertyDictionary();
+        _global._properties.TryAdd(name, new PropertyDescriptor(Undefined, canBeDeleted
+            ? PropertyFlag.ConfigurableEnumerableWritable | PropertyFlag.MutableBinding
+            : PropertyFlag.NonConfigurable | PropertyFlag.MutableBinding));
     }
 
     /// <summary>
@@ -379,7 +435,10 @@ internal sealed class GlobalEnvironment : Environment
 
     internal override bool HasBindings()
     {
-        return _declarativeRecord.HasBindings() || _globalObject?._properties?.Count > 0 || _global._properties?.Count > 0;
+        return _declarativeRecord.HasBindings()
+               || _globalObject?._properties?.Count > 0
+               || _global._properties?.Count > 0
+               || (_global._type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty;
     }
 
     internal override string[] GetAllBindingNames()

--- a/Jint/Runtime/Environments/ObjectEnvironment.cs
+++ b/Jint/Runtime/Environments/ObjectEnvironment.cs
@@ -163,7 +163,7 @@ internal sealed class ObjectEnvironment : Environment
 
     internal override JsValue WithBaseObject() => _withEnvironment ? _bindingObject : Undefined;
 
-    internal override bool HasBindings() => _bindingObject._properties?.Count > 0 || (_bindingObject._type & InternalTypes.ShapeMode) != InternalTypes.Empty;
+    internal override bool HasBindings() => _bindingObject._properties?.Count > 0 || (_bindingObject._type & (InternalTypes.ShapeMode | InternalTypes.BuiltinShapeMode)) != InternalTypes.Empty;
 
     internal override string[] GetAllBindingNames()
     {

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -343,7 +343,21 @@ internal sealed class JintIdentifierExpression : JintExpression
             return;
         }
 
-        if (globalObject._properties?.TryGetValue(identifier.Key, out var descriptor) == true
+        Runtime.Descriptors.PropertyDescriptor? descriptor = null;
+        globalObject._properties?.TryGetValue(identifier.Key, out descriptor);
+        if (descriptor is null && (globalObject._type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
+        {
+            // built-ins on a shaped global live in shape slots; materialization is stable
+            // (same stored instance every read) and never bumps the version, while any slot
+            // redefine/deopt does bump it — so the cached reference validates correctly
+            var shaped = globalObject.GetOwnProperty(identifier.Key);
+            if (shaped != Runtime.Descriptors.PropertyDescriptor.Undefined)
+            {
+                descriptor = shaped;
+            }
+        }
+
+        if (descriptor is not null
             && descriptor.IsDataDescriptor()
             && descriptor.Writable
             && (descriptor._flags & Runtime.Descriptors.PropertyFlag.CustomJsValue) == Runtime.Descriptors.PropertyFlag.None)


### PR DESCRIPTION
# Hybrid shape+overflow storage for builtin-shaped hosts; GlobalObject joins the shape system

Finishes the built-in shapes rollout (#2580, #2581, #2582) by flipping its largest remaining dictionary host — `GlobalObject`, 71 entries built per realm — and introduces the mechanism that makes the flip viable: a **hybrid mode** where a builtin-shaped host can gain new own properties in a side dictionary while the shape keeps serving its slots.

## Why hybrid

A shaped global without hybrid storage deopts on the first top-level `var` (every script-created global adds an own property the fixed layout can't express). Paying shape initialization *and* an immediate deopt-rebuild made evaluate-style workloads sharply worse in an earlier attempt at this flip (`Evaluate("1")` +72%), which is why it was parked. With hybrid mode the shape survives script-created globals, so both the construction win and the evaluate win land:

## Results (BenchmarkDotNet default jobs, .NET 10)

| Benchmark | main | this PR | time | alloc |
|---|---|---|---|---|
| EngineConstruction `BuildEngine` | 1.275 µs / 13.71 KB | 0.515 µs / 6.63 KB | **−60%** | **−52%** |
| EngineConstruction `EvaluateSimple` | 1.399 µs / 14.33 KB | 0.683 µs / 7.24 KB | **−51%** | **−49%** |
| MinimalScript `Execute` | 2.692 µs / 17.33 KB | 1.944 µs / 10.36 KB | **−28%** | **−40%** |
| MinimalScript `Execute_ParsedScript` | 1.666 µs / 15.41 KB | 0.909 µs / 8.45 KB | **−45%** | **−45%** |

No-regression gates:

- `GlobalAccessBenchmarks`: GlobalVarLoop/GlobalUpdateLoop neutral in A/B and reversed-order B/A; LocalVarLoop neutral at `--launchCount 5` (single-launch deltas were PGO mode-locking — both sides alternate ~38.5/~41.5 ms launch modes).
- `StopwatchBenchmark`: classic neutral-or-better; modern prepared +1.1% at `--launchCount 3`, within the noise of sibling rows that flip sign between runs.
- **SunSpider, full 26-file suite**: all rows within the suite's usual ±4% run-to-run band with mixed signs (mean ≈ 0); `date-format-xparb` −7.8% (it extends `Date.prototype`, which now stays shaped). The one outlier, `controlflow-recursive` +11% in the single-launch pair, disappears at `--launchCount 5`: baseline 67.86 ms vs this PR 67.72 ms with fully overlapping launch distributions (the original baseline reading of 64.5 ms is not reproduced by any of its own five launches).

## Semantics

For a host in builtin-shape mode:

- **Add a new own string property** (script global via `var`/assignment, `Engine.SetValue`, prototype extension like `Date.prototype.format = ...`): joins the hybrid side dictionary; shape stays live. Own-key order remains correct because every addition post-dates every shape name (shape names, then dictionary, then symbols).
- **Integer-like keys** must sort *before* string keys in own-key order, which shape-then-additions cannot express ⇒ full deopt (unchanged).
- **Delete / redefine of a shape name** ⇒ full deopt (unchanged), which since #2588 preserves laziness via `LazyBuiltinSlotDescriptor`.
- **Write to a shape name** (`parseInt = 5`, `Object.defineProperty` on an existing slot): in-place slot replace + version bump, no deopt.

Every read/enumeration surface consults dictionary-then-shape: `GetOwnProperty`, `GetOwnProperties`, own-key enumeration, `ProbeOwnProperty`, the member-expression inline caches (validated by `_propertiesVersion`, which hybrid additions bump), and the global-environment binding protocol (`TryGetBinding` / `GetBindingValue` / `CanDeclareGlobalVar` / `CreateGlobalVarBinding` / `SetFromMutableBinding`). The global identifier-binding cache now also learns shape-slot descriptors — materialization is identity-stable and never bumps the version, while any slot redefine/deopt does, so the existing validation scheme covers them.

`GlobalObject`'s three non-declarative entries (`parseInt`/`parseFloat` — spec identity with `Number.parseInt`/`parseFloat` — and the `globalThis` self-reference) fill reserved `[JsInstanceSlot]`s with the same lazy descriptors as before.

Also fixes a latent hole on the same path: `SetPropertyUnlikely` (non-`JsString` keys) wrote straight to the raw dictionary, bypassing shape handling; it now routes through the mode-aware `SetProperty(Key)`.

## Testing

- `Jint.Tests`, `Jint.Tests.PublicInterface` green (net10.0 + net472)
- **Full test262: 99,260 passed, 0 failed, 133 skipped** — global property attributes, own-key ordering and `var`/function/lexical global-binding semantics are heavily covered there
- REPL smoke: script globals visible through `globalThis`, key order (shape names before additions), `var Array` resolving to the slot in place, non-configurable `var` surviving `delete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2U2y9voMQV9rvCkYeQbka
