### PR TITLE
Shape-backed object literals inside generator/async frames when values cannot suspend

### DIFF
--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -35,6 +35,11 @@ internal sealed class JintObjectExpression : JintExpression
     // and don't require duplicate checking
     private readonly bool _canBuildFast;
 
+    // True when no property value contains a lexical yield/await (function boundaries excluded),
+    // so evaluating the values can never suspend this frame and the shape-backed build is safe
+    // even inside a generator/async function. Computed only when _canBuildFast.
+    private readonly bool _valuesCannotSuspend;
+
     private sealed class ObjectProperty
     {
         internal readonly string? _key;
@@ -137,6 +142,48 @@ internal sealed class JintObjectExpression : JintExpression
             }
             _fastKeys = keys;
             _fastKeysDistinct = AreKeysDistinct(keys);
+
+            _valuesCannotSuspend = true;
+            for (var i = 0; i < valueExpressions.Length; i++)
+            {
+                if (MaySuspendVisitor.MaySuspend(valueExpressions[i]))
+                {
+                    _valuesCannotSuspend = false;
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Detects whether evaluating a node could suspend the current generator/async frame: any
+    /// yield or await reachable without crossing into a nested function (whose suspensions belong
+    /// to its own frame). Class nodes are descended conservatively — their computed member keys
+    /// evaluate in the enclosing frame.
+    /// </summary>
+    private static class MaySuspendVisitor
+    {
+        public static bool MaySuspend(Node node)
+        {
+            if (node.Type is NodeType.YieldExpression or NodeType.AwaitExpression)
+            {
+                return true;
+            }
+
+            if (node.Type is NodeType.FunctionDeclaration or NodeType.FunctionExpression or NodeType.ArrowFunctionExpression)
+            {
+                return false;
+            }
+
+            foreach (var childNode in node.ChildNodes)
+            {
+                if (MaySuspend(childNode))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 
@@ -179,11 +226,12 @@ internal sealed class JintObjectExpression : JintExpression
         var engine = context.Engine;
         var suspendable = engine.ExecutionContext.Suspendable;
 
-        // Common case: not inside a generator/async frame (so no property value can suspend the build)
-        // and all keys distinct. Build (or reuse) a shared hidden-class shape and a flat slot array —
-        // no per-property PropertyDescriptor, no dictionary. Duplicate-keyed literals (e.g. { a:1, a:2 })
-        // and any literal evaluated inside a generator fall through to the general dictionary path below.
-        if (suspendable is null && _fastKeysDistinct)
+        // Common case: all keys distinct and either outside any generator/async frame or the property
+        // values provably cannot suspend (no lexical yield/await). Build (or reuse) a shared hidden-class
+        // shape and a flat slot array — no per-property PropertyDescriptor, no dictionary. Duplicate-keyed
+        // literals (e.g. { a:1, a:2 }) and literals whose values may suspend mid-build fall through to the
+        // general dictionary path below.
+        if (_fastKeysDistinct && (suspendable is null || _valuesCannotSuspend))
         {
             return BuildObjectFastShapeBacked(context, engine);
         }


### PR DESCRIPTION
# Shape-backed object literals inside generator/async frames when values cannot suspend

Follow-up to #2571/#2593: with the per-yield handler rebuild fixed, the dominant remaining allocation in generator bodies that build object literals is the **dictionary build path itself** — one `PropertyDescriptor` + a `PropertyDictionary` (plus its `ListDictionary` head) per constructed object.

That path exists because a literal evaluated inside a suspendable frame can suspend mid-build if a property value contains `yield`/`await`, and the shape-backed fast build (slot fill, no descriptors) has no resume support. But the exclusion was frame-based, not literal-based: `yield { a: i, b: i + 1 }` — a literal that can never suspend its own build — paid the dictionary path merely for being inside a generator.

## Change

At handler construction, prove per literal that no property value contains a lexical `yield`/`await`:

- descent stops at function boundaries (`function`/arrow) — suspensions there belong to the nested frame;
- class nodes are descended conservatively (computed member keys evaluate in the enclosing frame); in practice class-expression values already take the dictionary path via the existing function-definition exclusion;
- proof only computed for literals already eligible for the fast build (static distinct keys, no spread/accessors/function shorthand).

Proven-suspend-free literals then take the existing shape-backed build (`BuildObjectFastShapeBacked`) even when `ExecutionContext.Suspendable` is set. Literals whose values *do* contain `yield`/`await` keep the dictionary path and its suspend/resume machinery unchanged.

## Results

Census workload (generator yielding `{ a: i, b: i + 1, c: i + 2 }` 100k times, fresh engine per iter):

| | main | this PR |
|---|---|---|
| allocated/iter | 53.0 MB | **23.1 MB (−56%)** |
| `PropertyDescriptor` share | 18.3% | eliminated |
| `HybridDictionary`/`ListDictionary` share | 12.3% | eliminated |

Remaining allocations are user-visible: the literal objects themselves (45%), `IteratorResult` from explicit `.next()` calls (40%), boxed numbers (13%).

`GeneratorBenchmark` and `AsyncFunctionExitBenchmark` are neutral with byte-identical allocations (their bodies build no literals — the census script is the allocation authority for this pattern).

## Testing

- Full test262: **99,260 passed, 0 failed, 133 skipped** (yield-inside-literal suspension/resume is heavily covered there)
- `Jint.Tests` + `Jint.Tests.PublicInterface` green (net10.0 + net472)
- Smoke-verified: mid-build suspension (`{ first: 1, second: yield "mid", third: 3 }`) resumes with correct values and key order; nested deep `yield` keeps the outer literal on the resumable path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2U2y9voMQV9rvCkYeQbka
