### PR TITLE
Flip Intl, Temporal and %AsyncFromSyncIteratorPrototype% to builtin shapes

### DIFF
--- a/Jint/Native/Intl/IntlInstance.cs
+++ b/Jint/Native/Intl/IntlInstance.cs
@@ -21,7 +21,7 @@ namespace Jint.Native.Intl;
 [JsIntrinsicReference("PluralRules")]
 [JsIntrinsicReference("RelativeTimeFormat")]
 [JsIntrinsicReference("Segmenter")]
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class IntlInstance : ObjectInstance
 {
     private readonly Realm _realm;

--- a/Jint/Native/Iterator/AsyncFromSyncIterator.cs
+++ b/Jint/Native/Iterator/AsyncFromSyncIterator.cs
@@ -26,7 +26,7 @@ internal sealed class AsyncFromSyncIterator : ObjectInstance
 /// <summary>
 /// https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%-object
 /// </summary>
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class AsyncFromSyncIteratorPrototype : ObjectInstance
 {
     private readonly Realm _realm;

--- a/Jint/Native/Temporal/TemporalInstance.cs
+++ b/Jint/Native/Temporal/TemporalInstance.cs
@@ -20,7 +20,7 @@ namespace Jint.Native.Temporal;
 [JsIntrinsicReference("PlainTime", IntrinsicMember = "TemporalPlainTime")]
 [JsIntrinsicReference("PlainYearMonth", IntrinsicMember = "TemporalPlainYearMonth")]
 [JsIntrinsicReference("ZonedDateTime", IntrinsicMember = "TemporalZonedDateTime")]
-[JsObject]
+[JsObject(UseShape = true)]
 internal sealed partial class TemporalInstance : ObjectInstance
 {
     private readonly Realm _realm;

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -687,7 +687,7 @@ public enum ExperimentalFeature
     /// <summary>
     /// Generator support
     /// </summary>
-    [Obsolete("This flag is no longer necessary as generators are fully supported.")]
+    [Obsolete("This flag is no longer necessary as generators are fully supported.", error: true)]
     Generators = 1,
 
     /// <summary>


### PR DESCRIPTION
# Flip Intl, Temporal and %AsyncFromSyncIteratorPrototype% to builtin shapes

Completes the host sweep for the builtin-shape system: after #2590 made intrinsic references and throwers expressible as Factory slots, three generator-emitted hosts were still on the dictionary path for no remaining reason:

- **`Intl`** — 10 lazy intrinsic references (Collator … Segmenter) + `getCanonicalLocales`/`supportedValuesOf` + `@@toStringTag`
- **`Temporal`** — 9 lazy intrinsic references + `@@toStringTag`
- **`%AsyncFromSyncIteratorPrototype%`** — `next`/`return`/`throw`

Each now gets `[JsObject(UseShape = true)]`: process-shared layout, per-realm descriptor array, no per-realm `PropertyDictionary`.

## Results (BenchmarkDotNet default jobs)

`IntlColdStartBenchmark` (fresh engine per op): **−1.07…−1.08 KB allocated per row (−4.3%)** across all five benchmarks, time neutral. `EngineConstructionBenchmark` byte-identical — these hosts are lazily initialized, so engine construction never touches them.

## Audited and skipped

- **`RegExpConstructor`**: its Initialize hand-rolls 21 Annex B legacy accessors (`$1`–`$9`, `` $` ``, `$&`, …) via raw `SetProperty`; a flip would need an instance slot per accessor. Low value for the churn — left on the dictionary path with this note.
- **`JsSegments`**: per-call instance (returned by `Intl.Segmenter.prototype.segment`), not a per-realm singleton, and no representative workload traffic.
- `Math`/`JSON`/`Reflect`/`Atomics`/`GeneratorPrototype`/`AsyncGeneratorPrototype`/`TemporalNow` already use `BuiltinShapeObject` storage — nothing to do.

## Rider

`ExperimentalFeature.Generators` `[Obsolete]` escalated to `error: true` — the flag has been a no-op since generators became fully supported; escalation stages its removal for the next major. No in-repo consumers; `Jint.Tests.PublicInterface` green after the change.

## Testing

- Full test262: **99,260 passed, 0 failed, 133 skipped**
- `Jint.Tests`, `Jint.Tests.PublicInterface`, `Jint.Tests.SourceGenerators` green
- Smoke: `Object.getOwnPropertyNames(Intl)`/`(Temporal)` key order identical to the dictionary path; formatters construct and format; `@@toStringTag` intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2U2y9voMQV9rvCkYeQbka
