### PR TITLE
Fix sticky+global [Symbol.match] .NET fast path returning wrong results

### DIFF
--- a/Jint.Tests/Runtime/RegExpTests.cs
+++ b/Jint.Tests/Runtime/RegExpTests.cs
@@ -35,6 +35,50 @@ public class RegExpTests
     }
 
     [Theory]
+    [InlineData("gy")]
+    [InlineData("guy")]
+    public void MatchStickyGlobalCollectsAllAdjacentMatches(string flags)
+    {
+        // without 'u' exercises the .NET sticky fast path, with 'u' the generic exec loop
+        var engine = new Engine();
+        var result = engine.Evaluate($"JSON.stringify(['aaa'.match(/a/{flags}), 'ababab'.match(/ab/{flags})])").AsString();
+
+        Assert.Equal("[[\"a\",\"a\",\"a\"],[\"ab\",\"ab\",\"ab\"]]", result);
+    }
+
+    [Theory]
+    [InlineData("gy")]
+    [InlineData("guy")]
+    public void MatchStickyGlobalStopsAtFirstGap(string flags)
+    {
+        // matches after the gap exist but are not adjacent, so sticky matching must not include them
+        var engine = new Engine();
+        var result = engine.Evaluate($"JSON.stringify(['aabaa'.match(/a/{flags}), 'baa'.match(/a/{flags})])").AsString();
+
+        Assert.Equal("[[\"a\",\"a\"],null]", result);
+    }
+
+    [Theory]
+    [InlineData("gy")]
+    [InlineData("guy")]
+    public void MatchStickyGlobalAdvancesOverEmptyMatches(string flags)
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate($"JSON.stringify('aab'.match(/a*/{flags}))").AsString();
+
+        Assert.Equal("[\"aa\",\"\",\"\"]", result);
+    }
+
+    [Fact]
+    public void MatchStickyGlobalResetsLastIndex()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("var r = /a/gy; r.lastIndex = 2; JSON.stringify(['aaa'.match(r), r.lastIndex])").AsString();
+
+        Assert.Equal("[[\"a\",\"a\",\"a\"],0]", result);
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData("u")]
     public void SplitCollectsSegmentsCapturesAndTail(string flags)

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -930,21 +930,28 @@ internal sealed partial class RegExpPrototype : Prototype
                     return Null;
                 }
 
-                a.SetIndexValue(0, match.Value, updateLength: false);
-                uint li = 0;
+                uint matchCount = 0;
                 while (true)
                 {
-                    if (li > 0 && li % ConstraintCheckInterval == 0)
+                    a.SetIndexValue(matchCount, match.Value, updateLength: false);
+                    matchCount++;
+
+                    if (matchCount % ConstraintCheckInterval == 0)
                     {
                         _engine.Constraints.Check();
                     }
 
+                    // sticky continuation: the next match must start exactly where the previous one
+                    // ended; an empty match advances by one (AdvanceStringIndex, never unicode here)
+                    var expectedIndex = match.Length == 0 ? match.Index + 1 : match.Index + match.Length;
                     match = match.NextMatch();
-                    if (!match.Success || match.Index != ++li)
+                    if (!match.Success || match.Index != expectedIndex)
+                    {
                         break;
-                    a.SetIndexValue(li, match.Value, updateLength: false);
+                    }
                 }
-                a.SetLength(li);
+
+                a.SetLength(matchCount);
                 return a;
             }
             else


### PR DESCRIPTION
### What

Fixes the sticky+global `[Symbol.match]` .NET fast path returning wrong results:

```js
"aaa".match(/a/gy)     // was ["a","a"]      → now ["a","a","a"]
"ababab".match(/ab/gy) // was ["ab"]         → now ["ab","ab","ab"]
"aab".match(/a*/gy)    // was ["aa"]         → now ["aa","",""]
```

### Why

The sticky branch in `RegExpPrototype.Match` compared `match.Index` (a **string position**) against
`++li` (a **match counter**), and called `SetLength(li)` after having written array index `li`:

- any match wider than one character made the position ≠ counter comparison break the loop after the
  first match, and
- even for single-character matches the final length truncated the last written element.

### How

The loop now tracks the expected continuation position — previous match end, or +1 for empty matches
(`AdvanceStringIndex`; this fast path is guarded `!fullUnicode`, so the advance is always one UTF-16
unit) — and sets the array length to the number of matches written. `lastIndex` semantics are already
covered by the `rx.Set(lastIndex, +0)` at the top of `Match` (final observable value matches the spec's
failing-exec reset).

### Tests

Test262 doesn't cover sticky+global `[Symbol.match]` through the .NET engine path, so this adds
regression tests (each shape runs against both the .NET fast path and the generic exec loop via the
`u` flag):

- adjacent single- and multi-char matches collected fully
- termination at the first non-adjacent position (later matches must not be included)
- empty-match advancement (`/a*/gy`)
- `lastIndex` reset to 0 after the call

### Gating

- `dotnet build Jint/Jint.csproj -c Release` (all TFMs): ✅
- `Jint.Tests` net10.0 + net472: ✅
- `Jint.Tests.PublicInterface` net10.0 + net472: ✅
- Full Test262: ✅ (99,260 passed / 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
