### PR TITLE
Make raw SetProperty before lazy initialization survive Initialize

### DIFF
--- a/Jint.Tests/Runtime/PropertyDescriptorTests.cs
+++ b/Jint.Tests/Runtime/PropertyDescriptorTests.cs
@@ -1,5 +1,6 @@
 using Jint.Native;
 using Jint.Native.Global;
+using Jint.Native.Symbol;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
@@ -111,6 +112,41 @@ public class PropertyDescriptorTests
         Assert.Equal(42, _engine.Evaluate("Math.custom").AsNumber());
         Assert.True(_engine.Evaluate("Object.getOwnPropertyNames(Math).includes('custom')").AsBoolean());
         Assert.Equal(4, _engine.Evaluate("Math.floor(4.7)").AsNumber());
+    }
+
+    [Fact]
+    public void FastSetPropertyBeforeLazyInitializationSurvivesOnDictionaryHost()
+    {
+        // a raw store before the host's first property access used to land in _properties and get
+        // wiped when the read-triggered Initialize() replaced the bag; RegExp is a dictionary-path host
+        var regExp = _engine.Evaluate("RegExp").AsObject();
+        regExp.FastSetProperty("custom", new PropertyDescriptor(42, PropertyFlag.ConfigurableEnumerableWritable));
+
+        Assert.Equal(42, _engine.Evaluate("RegExp.custom").AsNumber());
+        Assert.True(_engine.Evaluate("typeof RegExp.escape === 'function'").AsBoolean());
+    }
+
+    [Fact]
+    public void FastSetPropertyBeforeLazyInitializationSurvivesOnBuiltinShapedHost()
+    {
+        // the builtin-shape sibling of the dictionary-host case above
+        var math = _engine.Evaluate("Math").AsObject();
+        math.FastSetProperty("custom", new PropertyDescriptor(42, PropertyFlag.ConfigurableEnumerableWritable));
+
+        Assert.Equal(42, _engine.Evaluate("Math.custom").AsNumber());
+        Assert.True(_engine.Evaluate("Object.getOwnPropertyNames(Math).includes('custom')").AsBoolean());
+        Assert.Equal(4, _engine.Evaluate("Math.floor(4.7)").AsNumber());
+    }
+
+    [Fact]
+    public void SymbolSetPropertyBeforeLazyInitializationSurvives()
+    {
+        // symbol stores have the same pre-initialization hazard: Initialize() replaces _symbols
+        var math = _engine.Evaluate("Math").AsObject();
+        math.SetProperty(GlobalSymbolRegistry.Iterator, new PropertyDescriptor(42, PropertyFlag.ConfigurableEnumerableWritable));
+
+        Assert.Equal(42, _engine.Evaluate("Math[Symbol.iterator]").AsNumber());
+        Assert.Equal("Math", _engine.Evaluate("Math[Symbol.toStringTag]").AsString());
     }
 
     [Fact]

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -244,6 +244,10 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void SetProperty(Key property, PropertyDescriptor value)
     {
+        // A raw store must apply on top of the initialized state: on a lazily-initialized host the
+        // pending Initialize() would otherwise replace the property bag and silently drop this write.
+        EnsureInitialized();
+
         // Storing a raw descriptor is a dictionary-mode operation; deopt first if needed.
         if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
         {
@@ -284,6 +288,8 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         }
         else
         {
+            // same pre-initialization hazard as SetProperty(Key): Initialize() replaces _symbols
+            EnsureInitialized();
             _symbols ??= new SymbolDictionary();
             _symbols[(JsSymbol) propertyKey] = value;
         }


### PR DESCRIPTION
### What

Raw `SetProperty`/`FastSetProperty` calls made **before** a lazily-initialized host's first property
access no longer get silently dropped:

```csharp
var math = engine.Evaluate("Math").AsObject();          // host not yet initialized
math.FastSetProperty("custom", new PropertyDescriptor(42, PropertyFlag.ConfigurableEnumerableWritable));
engine.Evaluate("Math.custom");                          // was undefined → now 42
```

### Why

`SetProperty(Key)` writes straight into `_properties` without running `EnsureInitialized()`. The first
read then triggers `Initialize()`, whose generated `CreateProperties_Generated()` /
`CreateSymbols_Generated()` replaces the bag wholesale via `SetProperties`/`SetSymbols` — wiping the
earlier write. This was documented as a known pre-existing edge during #2591's review (where the
sibling shaped-host visibility gap was fixed); it affects dictionary-path hosts and builtin-shaped
hosts alike, and symbol writes the same way.

### How

`SetProperty(Key)` and the symbol arm of `SetPropertyUnlikely` now run `EnsureInitialized()` first, so
raw stores always apply **on top of the initialized state**: dictionary hosts append to the installed
bag, builtin-shaped hosts route through the existing #2591 hybrid side-dictionary arm, and hand-rolled
`SetProperty` tails inside `Initialize()` bodies are unaffected (the flag is already set there,
recursion-safe by design).

### Perf

`EnsureInitialized()` is a single predicted branch; the behavioral risk was something in engine/realm
construction hitting the new initialization path eagerly. EngineConstruction A/B (BenchmarkDotNet
default job, same window, stash-paired):

| | base | fix |
|---|---|---|
| BuildEngine | 556.3 ns / 6.63 KB | 555.6 ns / 6.63 KB |
| EvaluateSimple | 694.5 ns / 7.24 KB | 679.8 ns / 7.24 KB |

Allocation byte-identical on both rows; time within noise.

### Tests

- pre-init `FastSetProperty` on a dictionary-path host (`RegExp`) — write survives, generated
  `RegExp.escape` intact
- pre-init `FastSetProperty` on a builtin-shaped host (`Math`) — write survives shape initialization,
  enumeration sees it, `Math.floor` intact
- pre-init symbol store — write survives, generated `@@toStringTag` intact

### Gating

- `dotnet build Jint/Jint.csproj -c Release` (all TFMs): ✅
- `Jint.Tests` net10.0 + net472: ✅
- `Jint.Tests.PublicInterface` net10.0 + net472: ✅
- Full Test262: ✅ (99,260 passed / 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
