### PR TITLE
Add unboxed slot-number lane to equality operators

### DIFF
--- a/Jint.Benchmark/LoopDispatchBenchmarks.cs
+++ b/Jint.Benchmark/LoopDispatchBenchmarks.cs
@@ -20,6 +20,9 @@ public class LoopDispatchBenchmarks
     private Prepared<Script> _localCopy;
     private Prepared<Script> _stringAppend;
     private Prepared<Script> _comparisonOnly;
+    private Prepared<Script> _strictEqualTest;
+    private Prepared<Script> _looseEqualTest;
+    private Prepared<Script> _moduloEqualTest;
 
     [GlobalSetup]
     public void Setup()
@@ -60,6 +63,24 @@ public class LoopDispatchBenchmarks
             f();
             """);
 
+        // + one strict-equality test (=== over a slot and a constant)
+        _strictEqualTest = Engine.PrepareScript("""
+            function f() { var n = 0; for (var i = 0; i < 100000; i++) { if (i === 50000) { } } return n; }
+            f();
+            """);
+
+        // + one loose-equality test (== over a slot and a constant)
+        _looseEqualTest = Engine.PrepareScript("""
+            function f() { var n = 0; for (var i = 0; i < 100000; i++) { if (i == 50000) { } } return n; }
+            f();
+            """);
+
+        // + the stopwatch.js if-chain shape: modulo of a slot vs a constant, loosely compared
+        _moduloEqualTest = Engine.PrepareScript("""
+            function f() { var n = 0; for (var i = 0; i < 100000; i++) { if (i % 2 == 0) { } } return n; }
+            f();
+            """);
+
         _engine = new Engine();
         _engine.Evaluate(_emptyLoop);
         _engine.Evaluate(_variableBoundLoop);
@@ -67,6 +88,9 @@ public class LoopDispatchBenchmarks
         _engine.Evaluate(_localCopy);
         _engine.Evaluate(_stringAppend);
         _engine.Evaluate(_comparisonOnly);
+        _engine.Evaluate(_strictEqualTest);
+        _engine.Evaluate(_looseEqualTest);
+        _engine.Evaluate(_moduloEqualTest);
     }
 
     [Benchmark(Baseline = true)]
@@ -86,4 +110,13 @@ public class LoopDispatchBenchmarks
 
     [Benchmark]
     public JsValue ComparisonOnly() => _engine.Evaluate(_comparisonOnly);
+
+    [Benchmark]
+    public JsValue StrictEqualTest() => _engine.Evaluate(_strictEqualTest);
+
+    [Benchmark]
+    public JsValue LooseEqualTest() => _engine.Evaluate(_looseEqualTest);
+
+    [Benchmark]
+    public JsValue ModuloEqualTest() => _engine.Evaluate(_moduloEqualTest);
 }

--- a/Jint.Tests/Runtime/EqualityLaneTests.cs
+++ b/Jint.Tests/Runtime/EqualityLaneTests.cs
@@ -1,0 +1,80 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the semantics of the unboxed slot-number lane on ==/===/!=/!== (JintBinaryExpression):
+/// the lane engages for slot-stored numbers compared against numeric constants or other slots,
+/// and must reproduce the generic path exactly, declining for any non-number operand.
+/// </summary>
+public class EqualityLaneTests
+{
+    [Fact]
+    public void SlotNumberEqualityMatchesSpecForSpecialValues()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var nan = NaN, pz = 0, nz = -0, one = 1;
+                return [
+                    nan === nan, nan !== nan, nan == nan, nan != nan,
+                    pz === nz, pz == nz, pz !== nz,
+                    one === 1, one == 1, one !== 1, one != 1
+                ].join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal("false,true,false,true,true,true,false,true,true,false,false", result);
+    }
+
+    [Fact]
+    public void LaneDeclinesWhenSlotTypeChangesMidLoop()
+    {
+        var engine = new Engine();
+        // x starts as a number (lane engages), then becomes a string mid-loop; the
+        // per-evaluation slot probe must fall back to the coercing path
+        var result = engine.Evaluate("""
+            (function () {
+                var x = 1, hits = 0;
+                for (var i = 0; i < 4; i++) {
+                    if (x == 1) { hits++; }
+                    if (i === 1) { x = '1'; }
+                }
+                return hits;
+            })()
+            """).AsNumber();
+
+        Assert.Equal(4, result); // '1' == 1 keeps matching through loose coercion
+    }
+
+    [Fact]
+    public void BigIntAndMixedOperandsBailToGenericEquality()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var big = 1n, other = 1n, num = 1, str = '1', undef;
+                return [
+                    big === other, big !== other, big == num, big === num,
+                    str == num, str === num,
+                    undef == null, undef === null
+                ].join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal("true,false,true,false,true,false,true,false", result);
+    }
+
+    [Fact]
+    public void EqualityLaneWorksInValuePositions()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var a = 2, b = 2, c = 3;
+                var r1 = (a === b), r2 = (a !== c), r3 = (a == b), r4 = (a != c);
+                return r1 && r2 && r3 && r4;
+            })()
+            """).AsBoolean();
+
+        Assert.True(result);
+    }
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -35,7 +35,10 @@ internal abstract class JintBinaryExpression : JintExpression
     /// ping-ponging between its update (stores raw) and its loop test (would materialize).
     /// Slot reads are pure, so declining after a partial read has no observable effect.
     /// IEEE double comparisons reproduce the abstract relational operator for all four forms,
-    /// including NaN operands (spec result undefined, coerced to false).
+    /// including NaN operands (spec result undefined, coerced to false). For the equality
+    /// operators the operands are runtime-proven Numbers, so ==/===/!=/!== degenerate to the
+    /// numeric compare (IsLooselyEqual step 1 defers to IsStrictlyEqual for same-type operands):
+    /// IEEE == gives NaN == NaN false and +0 == -0 true, both spec-exact.
     /// </summary>
     private protected struct NumericConstantComparisonLane
     {
@@ -364,12 +367,20 @@ internal abstract class JintBinaryExpression : JintExpression
 
     private sealed class StrictlyEqualBinaryExpression : JintBinaryExpression
     {
+        private NumericConstantComparisonLane _numericLane;
+
         public StrictlyEqualBinaryExpression(NonLogicalBinaryExpression expression) : base(expression)
         {
+            _numericLane.Initialize(_left, _right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
+            if (_numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            {
+                return unboxedLeft == unboxedRight ? JsBoolean.True : JsBoolean.False;
+            }
+
             if (!TryEvaluateOperands(context, out var left, out var right))
             {
                 return JsValue.Undefined;
@@ -381,6 +392,11 @@ internal abstract class JintBinaryExpression : JintExpression
 
         public override bool GetBooleanValue(EvaluationContext context)
         {
+            if (_numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            {
+                return unboxedLeft == unboxedRight;
+            }
+
             if (!TryEvaluateOperands(context, out var left, out var right))
             {
                 return false;
@@ -392,12 +408,20 @@ internal abstract class JintBinaryExpression : JintExpression
 
     private sealed class StrictlyNotEqualBinaryExpression : JintBinaryExpression
     {
+        private NumericConstantComparisonLane _numericLane;
+
         public StrictlyNotEqualBinaryExpression(NonLogicalBinaryExpression expression) : base(expression)
         {
+            _numericLane.Initialize(_left, _right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
+            if (_numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            {
+                return unboxedLeft == unboxedRight ? JsBoolean.False : JsBoolean.True;
+            }
+
             if (!TryEvaluateOperands(context, out var left, out var right))
             {
                 return JsValue.Undefined;
@@ -408,6 +432,11 @@ internal abstract class JintBinaryExpression : JintExpression
 
         public override bool GetBooleanValue(EvaluationContext context)
         {
+            if (_numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            {
+                return unboxedLeft != unboxedRight;
+            }
+
             if (!TryEvaluateOperands(context, out var left, out var right))
             {
                 return false;
@@ -788,14 +817,21 @@ internal abstract class JintBinaryExpression : JintExpression
     private sealed class EqualBinaryExpression : JintBinaryExpression
     {
         private readonly bool _invert;
+        private NumericConstantComparisonLane _numericLane;
 
         public EqualBinaryExpression(NonLogicalBinaryExpression expression, bool invert = false) : base(expression)
         {
             _invert = invert;
+            _numericLane.Initialize(_left, _right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
+            if (_numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            {
+                return (unboxedLeft == unboxedRight) == !_invert ? JsBoolean.True : JsBoolean.False;
+            }
+
             if (!TryEvaluateOperands(context, out var left, out var right))
             {
                 return JsValue.Undefined;
@@ -817,6 +853,12 @@ internal abstract class JintBinaryExpression : JintExpression
 
         public override bool GetBooleanValue(EvaluationContext context)
         {
+            if (_numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            {
+                var equal = unboxedLeft == unboxedRight;
+                return _invert ? !equal : equal;
+            }
+
             if (!TryEvaluateOperands(context, out var left, out var right))
             {
                 return false;


### PR DESCRIPTION
### What

`===`, `!==`, `==` and `!=` now take the same per-node unboxed numeric lane the relational operators
gained in #2574/#2578: when both operands resolve to slot-stored numbers (or a numeric constant), the
comparison runs on raw doubles without materializing either side.

### Why

A loop test like `i === 50000` re-boxed the counter into a `JsNumber` on every iteration once it
exceeded the small-int cache — the equality operators were the only comparison family without the lane.

### Semantics

Both operands are runtime-proven Numbers (`TryGetNumberSlot` only succeeds for number-holding
bindings), so the IEEE compare is spec-exact for all four operators: `IsLooselyEqual` defers to
`IsStrictlyEqual` for same-type operands, `NaN == NaN` is false, `+0 == -0` is true. BigInt is
excluded by the JsNumber gates; any non-number operand declines to the generic coercing path before
any side effect.

### Results

LoopDispatchBenchmarks A/B (default job, adjacent runs; new rows added by this PR):

| row | base | lanes | |
|---|---|---|---|
| StrictEqualTest | 5.967 ms / 2,808 KB | 3.710 ms / 3.26 KB | −37.8% time, −99.9% alloc |
| LooseEqualTest | 5.523 ms / 2,808 KB | 3.777 ms / 3.27 KB | −31.6% time, −99.9% alloc |

Gen0 eliminated on both rows; untouched rows byte-identical allocation, time deltas sign-mixed and
resolved as window drift via an A/B/A on identical bits.

`ModuloEqualTest` (the stopwatch.js if-chain shape) is added as a baseline row but deliberately not
covered here — its left side is a modulo expression, not an identifier (see the follow-up PR).

### Tests

`EqualityLaneTests` pin NaN/signed-zero semantics, mid-loop type-change decline, BigInt/mixed-type
bail, and value positions.

### Gating

All-TFM build ✅ · Jint.Tests net10+net472 ✅ · PublicInterface ×2 ✅ · Test262 99,260/0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
