### PR TITLE
Serve comparison-lane operands from the validated global-descriptor cache

### DIFF
--- a/Jint.Tests/Runtime/EqualityLaneTests.cs
+++ b/Jint.Tests/Runtime/EqualityLaneTests.cs
@@ -77,4 +77,63 @@ public class EqualityLaneTests
 
         Assert.True(result);
     }
+
+    [Fact]
+    public void GlobalNumberComparisonsMatchSpecThroughLane()
+    {
+        var engine = new Engine();
+        // top-level vars are global-object properties (never slots); the lane serves them
+        // through the validated global-descriptor cache. First iteration populates the cache
+        // via the slow path, later iterations must produce identical results through the lane.
+        var result = engine.Evaluate("""
+            var gx = 1, gnan = NaN, gz = -0;
+            var r = [];
+            for (var i = 0; i < 3; i++) {
+                r.push(gx === 1, gx == 1, gnan === gnan, gnan != gnan, gz === 0, gx < 2, gx > 2);
+            }
+            r.join(',');
+            """).AsString();
+
+        var iteration = "true,true,false,true,true,true,false";
+        Assert.Equal($"{iteration},{iteration},{iteration}", result);
+    }
+
+    [Fact]
+    public void GlobalLaneDeclinesWhenGlobalRedefinedAsAccessor()
+    {
+        var engine = new Engine();
+        // redefining the global to an accessor bumps the shape version; the lane must fall
+        // back to the generic path, which invokes the getter
+        var result = engine.Evaluate("""
+            globalThis.g = 1;
+            var hits = 0, reads = 0;
+            for (var i = 0; i < 4; i++) {
+                if (g == 1) { hits++; }
+                if (i === 1) {
+                    Object.defineProperty(globalThis, 'g', { get: function() { reads++; return 1; }, configurable: true });
+                }
+            }
+            hits + ':' + reads;
+            """).AsString();
+
+        Assert.Equal("4:2", result);
+    }
+
+    [Fact]
+    public void GlobalLaneDeclinesWhenValueTypeChangesInPlace()
+    {
+        var engine = new Engine();
+        // plain global writes mutate the descriptor value in place without a version bump;
+        // the lane re-checks the value type on every read
+        var result = engine.Evaluate("""
+            var g = 1, hits = 0;
+            for (var i = 0; i < 5; i++) {
+                if (g == 1) { hits++; }
+                if (i === 2) { g = 'x'; }
+            }
+            hits;
+            """).AsNumber();
+
+        Assert.Equal(3, result); // i = 0..2 while g is 1; 'x' == 1 is false afterwards
+    }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -90,7 +90,13 @@ internal abstract class JintBinaryExpression : JintExpression
             if (!_slotCache.TryResolve(engine, env, identifier.Identifier, out var environment, out var slotIndex)
                 || !environment.TryGetNumberSlot(slotIndex, out left))
             {
-                return false;
+                // top-level vars are global-object properties, never slots: fall back to the
+                // validated global-descriptor cache (the stopwatch-shape loop test). The null
+                // pre-check keeps the cost for plain slot misses to a single field test.
+                if (identifier._cachedGlobalEnv is null || !TryReadGlobalNumber(identifier, engine, env, out left))
+                {
+                    return false;
+                }
             }
 
             var rightIdentifier = _rightIdentifier;
@@ -99,8 +105,32 @@ internal abstract class JintBinaryExpression : JintExpression
                 return true;
             }
 
-            return _rightSlotCache.TryResolve(engine, env, rightIdentifier.Identifier, out var rightEnvironment, out var rightSlotIndex)
-                   && rightEnvironment.TryGetNumberSlot(rightSlotIndex, out right);
+            if (_rightSlotCache.TryResolve(engine, env, rightIdentifier.Identifier, out var rightEnvironment, out var rightSlotIndex)
+                && rightEnvironment.TryGetNumberSlot(rightSlotIndex, out right))
+            {
+                return true;
+            }
+
+            return rightIdentifier._cachedGlobalEnv is not null && TryReadGlobalNumber(rightIdentifier, engine, env, out right);
+        }
+
+        /// <summary>
+        /// Global-binding arm of the lane operand read: validated-cache probe plus a field read,
+        /// both pure — so a decline (or a left read followed by a right-side decline) has no
+        /// observable effect. The value type is re-checked on every read because in-place value
+        /// mutations bump no version. Out of line so lane misses don't grow the inlined probe.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static bool TryReadGlobalNumber(JintIdentifierExpression identifier, Engine engine, Environments.Environment env, out double value)
+        {
+            if (identifier.TryGetValidatedGlobalDescriptor(engine, env) is { _value: JsNumber number })
+            {
+                value = number._value;
+                return true;
+            }
+
+            value = 0;
+            return false;
         }
     }
 


### PR DESCRIPTION
(rebased onto latest main after #2602 merged)
### What

The numeric comparison lanes (relational since #2574/#2578, equality since the previous PR) could
only read slot-stored operands — so they never fired on top-level code: script-level `var`s are
global-object properties, not slots. That's the exact shape of stopwatch.js and every benchmark that
loops at script top level.

On a slot miss the lane now falls back to the identifier's validated global-descriptor cache
(engine identity + shape version + lexical version — populated by the regular GetValue slow path).

### Semantics

The probe is pure — cache validation plus a field read — so declines stay unobservable, and the value
type is re-checked on every read because in-place global writes bump no version (accessor
redefinition bumps the shape version and invalidates). The null pre-check keeps the cost for
non-global misses to one field test; the helper is out of line so lane misses don't grow the inlined
probe.

### Results

A/B vs the equality-lanes base (default job, adjacent runs):

- `GlobalAccessBenchmarks.GlobalUpdateLoop` 89.9 → 80.9 ms (**−10.1%**) — top-level loop counters'
  tests take the lane now
- stopwatch driver (±0.7% instrument) 175.7 → 171.5 ms/iter (−2.4%); StopwatchBenchmark classic
  prepared −1.0%, modern Execute −2.4%
- allocations byte-identical on every row; EmptyLoop/LocalVarLoop single-launch upticks resolved as
  process-mode noise via `--launchCount 5` (medians at or below base)

The bigger stopwatch win lands in the follow-up fused-modulo PR, which this unlocks.

### Tests

Global-binding lane semantics: NaN/signed zero through globals, accessor redefinition invalidating
via version bump, in-place value-type changes declining per read.

### Gating

All-TFM build ✅ · Jint.Tests ×2 ✅ · PublicInterface ×2 ✅ · Test262 99,260/0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
