### PR TITLE
Run expression-only for-loop bodies through a tight per-iteration cycle

### DIFF
--- a/Jint.Tests/Runtime/TightLoopTests.cs
+++ b/Jint.Tests/Runtime/TightLoopTests.cs
@@ -1,0 +1,87 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the semantics of the for-statement tight loop (JintForStatement.TightForBody): it engages
+/// for expression-statements-only bodies in frames where completion values are dead, and must be
+/// indistinguishable from the generic path.
+/// </summary>
+public class TightLoopTests
+{
+    [Fact]
+    public void FunctionLocalLoopComputesThroughTightPath()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var s = '';
+                for (var i = 0; i < 5; i++) { s += i; }
+                var total = 0;
+                for (var j = 0; j < 100; j++) total += j;
+                for (var k = 0; k < 3; k++) { }
+                for (var m = 0; m < 3; ) { m += 1; }
+                return s + ':' + total + ':' + k + ':' + m;
+            })()
+            """).AsString();
+
+        Assert.Equal("01234:4950:3:3", result);
+    }
+
+    [Fact]
+    public void ScriptTopLevelLoopKeepsCompletionValue()
+    {
+        var engine = new Engine();
+        // at script top level completion values are observable: the for statement's value is the
+        // last body statement's value, so the tight loop must not engage and eat it
+        var result = engine.Evaluate("var s = ''; for (var i = 0; i < 3; i++) { s += i; }").AsString();
+
+        Assert.Equal("012", result);
+    }
+
+    [Fact]
+    public void ThrowInsideTightLoopPropagatesWithState()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var i = 0;
+                try {
+                    for (i = 0; i < 10; i++) { mustNotExist(); }
+                } catch (e) {
+                    return (e instanceof ReferenceError) + ':' + i;
+                }
+                return 'no-throw';
+            })()
+            """).AsString();
+
+        Assert.Equal("true:0", result);
+    }
+
+    [Fact]
+    public void LetLoopWithReusableEnvironmentStaysCorrect()
+    {
+        var engine = new Engine();
+        // let-header loops with a non-capturing body reuse the iteration environment and remain
+        // tight-loop eligible; capturing bodies are excluded by the reuse analysis
+        var result = engine.Evaluate("""
+            (function () {
+                let total = 0;
+                for (let i = 0; i < 4; i++) { total += i * 10; }
+                const fns = [];
+                for (let j = 0; j < 3; j++) { fns.push(() => j); }
+                return total + ':' + fns.map(f => f()).join('');
+            })()
+            """).AsString();
+
+        Assert.Equal("60:012", result);
+    }
+
+    [Fact]
+    public void ConstraintConfiguredEngineStillEnforcesInsideLoops()
+    {
+        var engine = new Engine(options => options.MaxStatements(50));
+        // constraint-configured contexts must keep per-statement accounting (tight loop is
+        // gated off), so a runaway loop still trips MaxStatements
+        Assert.Throws<Jint.Runtime.StatementsCountOverflowException>(() =>
+            engine.Evaluate("(function () { var x = 0; for (var i = 0; i < 100000; i++) { x += 1; } })()"));
+    }
+}

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -29,6 +29,12 @@ internal sealed class EvaluationContext
     public bool DebugMode => Engine._isDebugMode;
 
     /// <summary>
+    /// Frozen per context (constraints or debug mode at creation); statement fast paths that
+    /// skip <see cref="RunBeforeExecuteStatementChecks"/> entirely must be gated on this.
+    /// </summary>
+    internal bool ShouldRunBeforeExecuteStatementChecks => _shouldRunBeforeExecuteStatementChecks;
+
+    /// <summary>
     /// Returns true if the generator is suspended (yielded) or a return was requested.
     /// This is the combined check that should be used after evaluating sub-expressions.
     /// </summary>

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -32,6 +32,10 @@ internal sealed class JintStatementList
     // resume positions live on the suspendable (SuspendDataDictionary), not here.
     private readonly Pair[] _jintStatements;
 
+    // exposed so enclosing loop fast paths can iterate the exact handler instances of this list
+    internal int Count => _jintStatements.Length;
+    internal JintStatement GetStatement(int index) => _jintStatements[index].Statement;
+
     public JintStatementList(IFunction function) : this((FunctionBody) function.Body)
     {
     }

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -16,6 +16,10 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
     private readonly JintStatement? _singleStatement;
     private readonly BlockState _blockState;
 
+    // exposed so enclosing loop fast paths can reuse the exact handler instances of this block
+    internal JintStatement? SingleStatement => _singleStatement;
+    internal JintStatementList? StatementList => _statementList;
+
     // Reuse cache for this block's fixed-slot environment. Held on the handler instance — which is built
     // per statement list, i.e. per engine — rather than on the shared BlockState: BlockState lives on the
     // AST node's UserData and is shared by every engine running a prepared script, and an environment roots

--- a/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
@@ -39,4 +39,22 @@ internal sealed class JintExpressionStatement : JintStatement<ExpressionStatemen
         _expression.EvaluateAndDiscard(context);
         return new Completion(context.Completion, JsValue.Undefined, _statement);
     }
+
+    /// <summary>
+    /// Tight-loop entry: evaluates the expression for side effects only, skipping the
+    /// per-statement ceremony (PrepareFor, constraint checks, Completion construction).
+    /// Callers guarantee a non-suspendable frame, no constraint/debug checks and dead
+    /// completion values; expression evaluation still tracks the current node for errors.
+    /// </summary>
+    internal void ExecuteDiscarded(EvaluationContext context)
+    {
+        if (_expressionCanDiscard)
+        {
+            _expression.EvaluateAndDiscard(context);
+        }
+        else
+        {
+            _expression.GetValue(context);
+        }
+    }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -21,6 +21,15 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
     private readonly ProbablyBlockStatement _body;
     private readonly List<Key>? _boundNames;
 
+    // Tight loop: an expression-statements-only body (single statement, empty statement or a
+    // brace block of them) cannot break/continue/label/declare, so when the frame additionally
+    // cannot suspend, debug or observe completion values, the per-iteration bookkeeping is dead.
+    // The references reuse the body's own handler instances — building duplicates here would
+    // allocate a fresh subtree every time this handler is constructed.
+    private readonly bool _tightBodyEligible;
+    private readonly JintExpressionStatement? _tightSingleStatement;
+    private readonly JintStatementList? _tightBodyList;
+
     private readonly bool _shouldCreatePerIterationEnvironment;
     private readonly bool _canReuseIterationEnvironment;
 
@@ -90,6 +99,50 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
             // so the discard path matches today's semantics exactly
             _incrementCanDiscard = _increment.HasDiscardFastPath;
         }
+
+        if (_test is not null && IsTightBodyShape(statement.Body))
+        {
+            _tightBodyEligible = true;
+            if (_body.BlockStatement is { } bodyBlock)
+            {
+                // single-statement blocks live in SingleStatement, larger (and empty) ones in the list
+                _tightSingleStatement = bodyBlock.SingleStatement as JintExpressionStatement;
+                _tightBodyList = _tightSingleStatement is null ? bodyBlock.StatementList : null;
+            }
+            else
+            {
+                // an EmptyStatement body leaves both references null
+                _tightSingleStatement = _body.Statement as JintExpressionStatement;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A tight-loop body is an expression statement, an empty statement, or a brace block
+    /// containing only expression statements. Any other statement type — declarations, control
+    /// flow, labels, debugger — disqualifies the body.
+    /// </summary>
+    private static bool IsTightBodyShape(Statement body)
+    {
+        if (body is ExpressionStatement or EmptyStatement)
+        {
+            return true;
+        }
+
+        if (body is not NestedBlockStatement block)
+        {
+            return false;
+        }
+
+        foreach (var statement in block.Body)
+        {
+            if (statement is not ExpressionStatement)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     protected override Completion ExecuteInternal(EvaluationContext context)
@@ -313,6 +366,22 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
     {
         var v = initialValue;
 
+        // Tight loop: with an expression-statements-only body, a non-suspendable frame, no
+        // constraint/debug checks, dead completion values and no fresh per-iteration environment,
+        // nothing per iteration remains observable but test, body expressions and update.
+        // The DebugMode probe is live (same coarseness as the debugHandler hoisting below).
+        if (_tightBodyEligible
+            && !skipTestOnce
+            && !resumeUpdateOnce
+            && !context.CompletionValuesObservable
+            && !context.ShouldRunBeforeExecuteStatementChecks
+            && !context.DebugMode
+            && (!_shouldCreatePerIterationEnvironment || _canReuseIterationEnvironment)
+            && context.Engine.ExecutionContext.Suspendable is null)
+        {
+            return TightForBody(context);
+        }
+
         if (!resumeUpdateOnce && _shouldCreatePerIterationEnvironment && !_canReuseIterationEnvironment)
         {
             CreatePerIterationEnvironment(context);
@@ -412,6 +481,60 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// The bare test → body-expressions → update cycle. Exceptions propagate to the enclosing
+    /// statement list exactly as on the generic path (ForBodyEvaluation catches nothing); the
+    /// loop's Normal completion value is dead by the caller's gate, so Undefined stands in.
+    /// Deferred errors surface as Engine._error instead of a .NET throw; the statement list
+    /// converts them per statement, and so must the tight loop.
+    /// </summary>
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private Completion TightForBody(EvaluationContext context)
+    {
+        var test = _test!;
+        var increment = _increment;
+        var single = _tightSingleStatement;
+        var list = _tightBodyList;
+
+        while (test.GetBooleanValue(context))
+        {
+            if (single is not null)
+            {
+                single.ExecuteDiscarded(context);
+                if (context.Engine._error is not null)
+                {
+                    return JintStatementList.HandleError(context.Engine, single);
+                }
+            }
+            else if (list is not null)
+            {
+                for (var i = 0; i < list.Count; i++)
+                {
+                    var statement = (JintExpressionStatement) list.GetStatement(i);
+                    statement.ExecuteDiscarded(context);
+                    if (context.Engine._error is not null)
+                    {
+                        return JintStatementList.HandleError(context.Engine, statement);
+                    }
+                }
+            }
+
+            if (increment is not null)
+            {
+                if (_incrementCanDiscard)
+                {
+                    increment.EvaluateAndDiscard(context);
+                }
+                else
+                {
+                    increment.Evaluate(context);
+                }
+            }
+        }
+
+        return new Completion(CompletionType.Normal, JsValue.Undefined, ((JintStatement) this)._statement);
     }
 
     private void SaveAccumulatedValue(EvaluationContext context, JsValue value)

--- a/Jint/Runtime/Interpreter/Statements/ProbablyBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/ProbablyBlockStatement.cs
@@ -13,6 +13,9 @@ internal readonly struct ProbablyBlockStatement
     private readonly JintStatement? _statement = null;
     private readonly JintBlockStatement? _blockStatement = null;
 
+    internal JintStatement? Statement => _statement;
+    internal JintBlockStatement? BlockStatement => _blockStatement;
+
     public ProbablyBlockStatement(Statement statement)
     {
         if (statement is NestedBlockStatement blockStatement)


### PR DESCRIPTION
### What

A `for` statement whose body contains only expression statements cannot `break`, `continue`, carry
labels or declare bindings — so when the frame additionally cannot suspend (no generator/async), is
not being debugged, has no per-statement constraint checks and its completion values are dead
(function bodies), the per-iteration bookkeeping in `ForBodyEvaluation` is unobservable: suspension
probes, `Completion` struct churn, per-statement `PrepareFor`/`RunBeforeExecuteStatementChecks` and
accumulated-value tracking. Such loops now run a bare test → body-expressions → update cycle.

### Correctness notes

- deferred errors (`Engine._error`) are converted per body statement via
  `JintStatementList.HandleError`, exactly like the statement list does; .NET exceptions propagate
  to the enclosing list unchanged
- the tight path **references the body's own handler instances**
  (`JintBlockStatement.SingleStatement`/`StatementList`) instead of building duplicates: the
  enclosing function's handler subtree is constructed per evaluation, so ctor-time `Build()` calls
  would allocate a fresh subtree per op (measured +264 B/op with duplicates, byte-parity after)
- constraint-configured engines (MaxStatements etc.) keep the generic path via the frozen
  `ShouldRunBeforeExecuteStatementChecks` gate — pinned by a test

### Results

LoopDispatchBenchmarks A/B (default job, adjacent runs):

| row | before | after | |
|---|---|---|---|
| EmptyLoop | 3.037 ms | 1.046 ms | **−65.6%** |
| VariableBoundLoop | 3.374 ms | 1.248 ms | −63.0% |
| CounterAdd | 3.889 ms | 1.933 ms | −50.3% |
| LocalCopy | 4.592 ms | 2.805 ms | −38.9% |
| StringAppend | 4.486 ms | 2.601 ms | −42.0% |
| ComparisonOnly (if-statement body, stays generic) | 4.960 ms | 4.917 ms | flat |

The function-local loop floor drops from ~30 to ~10 ns/iteration. Allocations flat (+10–20 B/op =
three new handler fields, constructed per op like the rest of the function-body subtree).
`EvalHotReusedEngine` +1.5–3%: observable frames (eval/script top level) still take the generic
path; the follow-up dead-completion-value PR moves them onto the tight path and is gated against
exactly that row.

### Tests

Function-local computation through the tight path, script top-level completion values staying intact
(the tight path must not engage there), throw propagation with loop state, let-loop
reusable-environment interaction, MaxStatements enforcement.

### Gating

All-TFM build ✅ · Jint.Tests ×2 ✅ · PublicInterface ×2 ✅ · Test262 99,260/0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
