### PR TITLE
Mark dead completion values at script/eval top level

### DIFF
--- a/Jint.Tests/Runtime/TightLoopTests.cs
+++ b/Jint.Tests/Runtime/TightLoopTests.cs
@@ -76,6 +76,41 @@ public class TightLoopTests
     }
 
     [Fact]
+    public void DeadMarkedTopLevelLoopRunsTightWithTrailingValue()
+    {
+        var engine = new Engine();
+        // the trailing expression statement makes the for's completion value dead at script top
+        // level, unlocking the tight path there; the script value comes from the trailing read
+        var result = engine.Evaluate("var s = ''; for (var i = 0; i < 3; i++) { s += i; } s;").AsString();
+        Assert.Equal("012", result);
+
+        var evalResult = engine.Evaluate("eval(\"var t = 0; for (var i = 0; i < 5; i++) { t += i; } t;\")").AsNumber();
+        Assert.Equal(10, evalResult);
+    }
+
+    [Fact]
+    public void LabeledBreakOutOfBlockKeepsEarlierCompletionValue()
+    {
+        var engine = new Engine();
+        // the block's list is an Inherit list: the labeled break (an Empty-valued abrupt
+        // completion) jumps over the trailing 'b', so dead-value marking must NOT apply there —
+        // UpdateEmpty surfaces the loop's accumulated 'v' as the script value
+        var result = engine.Evaluate("foo: { for (var i = 0; ; i++) { 'v'; break foo; } 'b'; }").AsString();
+        Assert.Equal("v", result);
+    }
+
+    [Fact]
+    public void ConditionalTrailingStatementProducesSpecCompletion()
+    {
+        var engine = new Engine();
+        // an untaken if completes with undefined (UpdateEmpty(stmt, undefined) per spec), which
+        // overwrites the loop's value regardless of dead-marking; pins that the conservative
+        // analysis (which does not count if statements as always-valued) changes nothing here
+        var result = engine.Evaluate("for (var i = 0; i < 1; i++) { 'v'; } if (false) 'b';");
+        Assert.True(result.IsUndefined());
+    }
+
+    [Fact]
     public void ConstraintConfiguredEngineStillEnforcesInsideLoops()
     {
         var engine = new Engine(options => options.MaxStatements(50));

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -21,7 +21,7 @@ internal enum CompletionValueObservability : byte
 
 internal sealed class JintStatementList
 {
-    private readonly record struct Pair(JintStatement Statement, JsValue? Value);
+    private readonly record struct Pair(JintStatement Statement, JsValue? Value, bool NormalValueDead);
 
     private readonly Statement? _statement;
     private readonly CompletionValueObservability _observability;
@@ -67,8 +67,32 @@ internal sealed class JintStatementList
             // FastResolve pre-evaluates literal return values.
             // Debug mode check moved to Execute loop to preserve stepping behavior.
             var value = JintStatement.FastResolve(esprimaStatement);
-            jintStatements[i] = new Pair(stmt, value);
+            jintStatements[i] = new Pair(stmt, value, NormalValueDead: false);
         }
+
+        // Dead completion-value analysis, top-level (Observable) lists only: a statement's Normal
+        // completion value can never become the list value when a LATER sibling always produces one
+        // (an expression statement), because nothing at script/eval/module top level can jump over
+        // later siblings — break/continue cannot target past them and throw abandons the value
+        // entirely. NOT sound for nested (Inherit) lists: a labeled break out of a block skips the
+        // block's remaining statements, so an earlier value may still surface through UpdateEmpty.
+        if (_observability == CompletionValueObservability.Observable)
+        {
+            var laterAlwaysValued = false;
+            for (var i = jintStatements.Length - 1; i >= 0; i--)
+            {
+                if (laterAlwaysValued)
+                {
+                    jintStatements[i] = jintStatements[i] with { NormalValueDead = true };
+                }
+
+                if (statements[i] is ExpressionStatement)
+                {
+                    laterAlwaysValued = true;
+                }
+            }
+        }
+
         _jintStatements = jintStatements;
     }
 
@@ -113,7 +137,20 @@ internal sealed class JintStatementList
 
                 if (pair.Value is null || context.DebugMode)
                 {
-                    c = pair.Statement.Execute(context);
+                    if (pair.NormalValueDead && context.CompletionValuesObservable)
+                    {
+                        // a later sibling always overwrites this statement's Normal value, so it may
+                        // run with elision on (unlocking the loop/statement fast paths); the flag was
+                        // just set true for this Observable list, restore it for the next statement
+                        context.CompletionValuesObservable = false;
+                        c = pair.Statement.Execute(context);
+                        context.CompletionValuesObservable = true;
+                    }
+                    else
+                    {
+                        c = pair.Statement.Execute(context);
+                    }
+
                     if (context.Engine._error is not null)
                     {
                         c = HandleError(context.Engine, pair.Statement);


### PR DESCRIPTION
> Rebased onto latest main after #2605 merged.

### What

A top-level statement's Normal completion value can never become the script/eval result when a
**later sibling always produces one** (an expression statement): nothing at top level can jump over
later siblings — `break`/`continue` cannot target past them, and `throw` abandons the value
entirely. Such statements now execute with completion-value elision on, which lets the for-statement
tight loop (#2605) engage at **script/eval top level** — the dromaeo-core-eval payload shape (a
string-append loop followed by `ret = str;`).

### Soundness

The analysis applies **only to Observable (top-level) lists, never to nested Inherit lists**: a
labeled break out of a block skips the block's remaining statements while carrying an Empty value,
so an earlier statement's value can still surface through `UpdateEmpty` — a test pins that exact
shape. Only expression statements count as always-valued (untaken `if`s complete with `undefined`
and would also qualify per `UpdateEmpty(stmt, undefined)`, but the conservative set covers the
target shapes).

### Results

EvalExecutionBenchmarks A/B (default job, adjacent runs):

| row | before | after | |
|---|---|---|---|
| **EvalHotReusedEngine** | 732.7 µs | 422.7 µs | **−42.3%** |
| **EvalFreshEngine** | 718.0 µs | 498.4 µs | **−30.6%** |
| NewFunctionHotReusedEngine (guard) | 415.9 µs | 416.9 µs | flat |
| PlainFunctionLoopReference (guard) | 413.8 µs | 420.6 µs | +1.6% |
| ParseOnlyTmp (guard) | 38.7 µs | 39.8 µs | flat |

dromaeo-core-eval driver: 11.12 → 10.06 ms/iter (−9.5%). Allocations byte-identical on every row.

Eval bodies now hit the same per-iteration floor as function bodies, closing the historic ~13%
eval-vs-function execution gap. Composed onto the dromaeo-core-eval row (2 parses + eval-exec +
newFunction-exec): ≈ **−20% on the row**, to be confirmed at the next EngineComparison refresh.

### Tests

Dead-marked top-level loop running tight with a trailing value read (script and eval), the
labeled-break-out-of-block shape that must NOT be dead-marked, and the spec `undefined` completion
of untaken trailing `if`s.

### Gating

All-TFM build ✅ · Jint.Tests ×2 ✅ · PublicInterface ×2 ✅ · Test262 99,260/0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
