### PR TITLE
Construct new Date() from clock ticks without intermediate conversions

### DIFF
--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -14,6 +14,7 @@ namespace Jint.Native.Date;
 internal sealed partial class DateConstructor : Constructor
 {
     internal static readonly DateTime Epoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly long EpochTicks = Epoch.Ticks;
     private static readonly JsString _functionName = new JsString("Date");
     private readonly ITimeSystem _timeSystem;
 
@@ -106,20 +107,23 @@ internal sealed partial class DateConstructor : Constructor
         // fast path is building default, new Date()
         if (arguments.Length == 0 || newTarget.IsUndefined())
         {
-            var now = (_timeSystem.GetUtcNow().DateTime - Epoch).TotalMilliseconds;
+            // ticks-based epoch math: skips the DateTime/TimeSpan intermediates and the double
+            // division; integer division truncates toward zero exactly like TimeClip for
+            // positive values, and a ticks-derived current time is always inside the clip range
+            var nowMs = (_timeSystem.GetUtcNow().UtcTicks - EpochTicks) / TimeSpan.TicksPerMillisecond;
 
             // when newTarget is the built-in Date constructor, skip OrdinaryCreateFromConstructor
             // to avoid the GetPrototypeFromConstructor property lookup
             if (ReferenceEquals(newTarget, this))
             {
-                return new JsDate(_engine, now);
+                return JsDate.CreateForCurrentTime(_engine, nowMs);
             }
 
             return OrdinaryCreateFromConstructor(
                 newTarget,
                 static intrinsics => intrinsics.Date.PrototypeObject,
                 static (engine, _, dateValue) => new JsDate(engine, dateValue),
-                now);
+                (double) nowMs);
         }
 
         return ConstructUnlikely(arguments, newTarget);

--- a/Jint/Native/JsDate.cs
+++ b/Jint/Native/JsDate.cs
@@ -47,6 +47,19 @@ public sealed class JsDate : ObjectInstance
         _dateValue = dateValue.TimeClip();
     }
 
+    private JsDate(Engine engine, long dateValueMs, DateFlags flags) : base(engine, ObjectClass.Date, InternalTypes.Object | InternalTypes.PlainObject)
+    {
+        _prototype = engine.Realm.Intrinsics.Date.PrototypeObject;
+        _dateValueMs = dateValueMs;
+        _dateFlags = flags;
+    }
+
+    /// <summary>
+    /// The `new Date()` fast path: a millisecond value derived from clock ticks is always inside
+    /// the clip range, so the TimeClip validation and the double round-trip are unnecessary.
+    /// </summary>
+    internal static JsDate CreateForCurrentTime(Engine engine, long dateValueMs) => new(engine, dateValueMs, DateFlags.None);
+
     public DateTime ToDateTime()
     {
         if (_dateValue.Flags == DateFlags.DateTimeMinValue)


### PR DESCRIPTION
### What

The zero-argument `new Date()` path computed `(GetUtcNow().DateTime - Epoch).TotalMilliseconds` — a
`DateTimeOffset → DateTime → TimeSpan → double` chain — and then re-validated the value through
`TimeClip` inside the `JsDate` constructor. The milliseconds now come straight from ticks
(`(UtcTicks − EpochTicks) / TicksPerMillisecond`), and a clip-free internal constructor stores them
directly: integer division truncates toward zero exactly like `TimeClip` for positive values, and a
ticks-derived current time is always inside the clip range. The subclass path
(`OrdinaryCreateFromConstructor`) keeps the spec pipeline.

### Results

DateConstructionBenchmarks A/B (default job, adjacent runs):

| row | before | after | |
|---|---|---|---|
| **NewDateNow** | 9.060 ms | 8.048 ms | **−11.2%** (90.6 → 80.5 ns per `new Date()`) |
| NewDateMillis (guard, untouched path) | 11.66 ms | 11.81 ms | flat — launchCount-5 median; a single-launch +7.6% was a process mode |

Allocations byte-identical. Honest framing for stopwatch.js (which spends ~13% of its time in
`new Date()`, ~196k per op): the expected ~1% row gain sits inside the row's noise floor — the
±0.7% wall-clock driver read flat — so this is a micro-path win, not a row mover.

### Gating

All-TFM build ✅ · Jint.Tests ×2 ✅ · PublicInterface ×2 ✅ · Test262 99,426/0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
