### PR TITLE
Evaluate sum-of-products assignments on raw doubles, boxing once

### DIFF
--- a/Jint.Tests/Runtime/SumOfProductsLaneTests.cs
+++ b/Jint.Tests/Runtime/SumOfProductsLaneTests.cs
@@ -1,0 +1,162 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the sum-of-products arithmetic lane (JintBinaryExpression.SumOfProductsLane): assignments
+/// whose right-hand side is a ± tree of products over numeric leaves compute on raw doubles and
+/// box once, and must match the generic tree evaluation.
+/// </summary>
+public class SumOfProductsLaneTests
+{
+    [Fact]
+    public void MatrixKernelMatchesManualComputation()
+    {
+        var engine = new Engine();
+        // the MMulti shape: 4 products over chained dense reads, computed-member store
+        var result = engine.Evaluate("""
+            (function () {
+                var m1 = [[1.5, 2, 3, 4], [5, 6, 7, 8]];
+                var m2 = [[0.5, 1], [2, 3], [4, 5], [6, 7]];
+                var m = [[], []];
+                for (var i = 0; i < 2; i++) {
+                    for (var j = 0; j < 2; j++) {
+                        m[i][j] = m1[i][0] * m2[0][j] + m1[i][1] * m2[1][j] + m1[i][2] * m2[2][j] + m1[i][3] * m2[3][j];
+                    }
+                }
+                return m.map(r => r.join(',')).join(';');
+            })()
+            """).AsString();
+
+        // row0: [1.5*0.5+2*2+3*4+4*6, 1.5*1+2*3+3*5+4*7] = [40.75, 50.5]
+        // row1: [5*0.5+6*2+7*4+8*6, 5*1+6*3+7*5+8*7] = [90.5, 114]
+        Assert.Equal("40.75,50.5;90.5,114", result);
+    }
+
+    [Fact]
+    public void MinusTermsAndConstantsAndScalarsWork()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var v = [2, 3, 4];
+                var cos = 0.5, sin = 0.25;
+                var out1 = [];
+                out1[0] = v[1] * cos - v[2] * sin;
+                out1[1] = v[1] * sin + v[2] * cos;
+                out1[2] = v[0] * 2 - v[1] * 3 + v[2] * 0.5;
+                return out1.join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal("0.5,2.75,-3", result); // 1.5-1=0.5; 0.75+2=2.75; 4-9+2=-3
+    }
+
+    [Fact]
+    public void SpecialValuesFlowThroughIeeeSemantics()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var a = [NaN, Infinity, -Infinity, 0, 5];
+                var r = [];
+                r[0] = a[0] * 2 + a[4] * 1;        // NaN
+                r[1] = a[1] * 2 + a[4] * 1;        // Infinity
+                r[2] = a[1] * 1 + a[2] * 1;        // Infinity + -Infinity = NaN
+                r[3] = a[3] * 1 + a[3] * 1;        // 0
+                return r.map(x => '' + x).join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal("NaN,Infinity,NaN,0", result);
+    }
+
+    [Fact]
+    public void IntegerLeavesStayExact()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var a = [3, 7, 11, 13];
+                var r = [];
+                r[0] = a[0] * a[1] + a[2] * a[3];             // 21 + 143 = 164
+                r[1] = a[3] * 1000000 + a[2] * 1000;          // 13011000
+                return r.join(',') + ':' + (r[0] === 164) + ':' + Number.isInteger(r[1]);
+            })()
+            """).AsString();
+
+        Assert.Equal("164,13011000:true:true", result);
+    }
+
+    [Fact]
+    public void NonNumericLeafDeclinesWithSingleEvaluation()
+    {
+        var engine = new Engine();
+        // the array element is a string: the lane's pure probe declines before any effect and the
+        // generic path performs the spec concatenation exactly once
+        var result = engine.Evaluate("""
+            (function () {
+                var a = [2, 'x'];
+                var r = [];
+                r[0] = a[0] * 3 + a[1] * 2;   // 6 + NaN ('x'*2) = NaN
+                r[1] = a[0] * 3 + a[0] * 2;   // 10
+                return r.map(x => '' + x).join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal("NaN,10", result);
+    }
+
+    [Fact]
+    public void GetterBaseDeclinesAndFiresExactlyOnce()
+    {
+        var engine = new Engine();
+        // a Proxy-backed "array" can't take the dense fast read: the lane must decline BEFORE
+        // touching it, so the generic evaluation's trap count stays exactly one per element read
+        var result = engine.Evaluate("""
+            (function () {
+                var reads = 0;
+                var target = [4, 5];
+                var p = new Proxy(target, { get(t, k, r) { if (k === '0' || k === '1') { reads++; } return Reflect.get(t, k, r); } });
+                var sink = [];
+                sink[0] = p[0] * 2 + p[1] * 3;   // 8 + 15 = 23
+                return sink[0] + ':' + reads;
+            })()
+            """).AsString();
+
+        Assert.Equal("23:2", result);
+    }
+
+    [Fact]
+    public void HoleyAndOutOfRangeReadsDecline()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var a = [1, , 3];       // hole at 1 → undefined → NaN through multiplication
+                var r = [];
+                r[0] = a[0] * 2 + a[1] * 3;
+                r[1] = a[0] * 2 + a[5] * 3;   // out of range → undefined
+                return r.map(x => '' + x).join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal("NaN,NaN", result);
+    }
+
+    [Fact]
+    public void NegativeZeroProductsFollowSpec()
+    {
+        var engine = new Engine();
+        // 0 * -1 is -0 per spec; summing two negative zeros keeps -0. The raw-double lane follows
+        // the spec exactly (Number::multiply is double multiplication).
+        var result = engine.Evaluate("""
+            (function () {
+                var a = [0, -1];
+                var r = [];
+                r[0] = a[0] * a[1] + a[0] * a[1];
+                return Object.is(r[0], -0) + ':' + Object.is(a[0] * a[1] + a[0] * 0, 0);
+            })()
+            """).AsString();
+
+        Assert.Equal("true:true", result);
+    }
+}

--- a/Jint/Runtime/Environments/DeclarativeEnvironment.cs
+++ b/Jint/Runtime/Environments/DeclarativeEnvironment.cs
@@ -123,6 +123,26 @@ internal class DeclarativeEnvironment : Environment
     }
 
     /// <summary>
+    /// Pure slot read returning the binding's value object for the arithmetic-lane leaves
+    /// (an unboxed number materializes with the standard write-back). Returns false for
+    /// out-of-range/stale indices and uninitialized (TDZ) bindings so the caller declines
+    /// to the generic path before any side effect.
+    /// </summary>
+    internal bool TryGetSlotValueForRead(int slotIndex, [NotNullWhen(true)] out JsValue? value)
+    {
+        var slots = _slots;
+        if (slots is null || (uint) slotIndex >= (uint) slots.Length)
+        {
+            value = null;
+            return false;
+        }
+
+        ref var binding = ref slots[slotIndex];
+        value = binding.HasReferenceValue ? binding.Value : MaterializeUnboxedOrNull(ref binding);
+        return value is not null;
+    }
+
+    /// <summary>
     /// Stores a raw number into a slot previously validated by <see cref="TryGetNumberSlot"/>
     /// without materializing a JsNumber.
     /// </summary>

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -612,6 +612,10 @@ internal sealed class JintAssignmentExpression : JintExpression
         // only routes this shape through EvaluateAndDiscard; every other assignment keeps its exact path.
         private readonly bool _structurallyNumeric;
 
+        // Sum-of-products right-hand sides (the 3d-cube matrix kernels) evaluate on raw doubles
+        // and box once instead of per binary node; see JintBinaryExpression.SumOfProductsLane.
+        private JintBinaryExpression.SumOfProductsLane? _rightSumOfProducts;
+
         public SimpleAssignmentExpression(AssignmentExpression expression) : base(expression)
         {
             _structurallyNumeric = IsNumericAssignmentShape(expression);
@@ -657,6 +661,7 @@ internal sealed class JintAssignmentExpression : JintExpression
             _right = Build(assignmentExpression.Right);
 
             TryEnableNumericFastPath(assignmentExpression);
+            _rightSumOfProducts = JintBinaryExpression.SumOfProductsLane.TryBuild(_right);
         }
 
         private void TryEnableNumericFastPath(AssignmentExpression assignmentExpression)
@@ -916,7 +921,10 @@ internal sealed class JintAssignmentExpression : JintExpression
 
             lref.AssertValid(engine.Realm);
 
-            var rval = _right.GetValue(context);
+            // sum-of-products right-hand sides compute on raw doubles and box once
+            var rval = _rightSumOfProducts is not null && _rightSumOfProducts.TryEvaluate(context, out var unboxedProductSum)
+                ? JsNumber.Create(unboxedProductSum)
+                : _right.GetValue(context);
 
             // If generator suspended or return requested during right-hand side evaluation, don't assign
             if (context.IsGeneratorAborted())

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -136,6 +136,253 @@ internal abstract class JintBinaryExpression : JintExpression
     }
 
     /// <summary>
+    /// Whole-tree lane for sum-of-products arithmetic over pure-readable numeric leaves —
+    /// `M1[i][0]*M2[0][j] + M1[i][1]*M2[1][j] + …`, the dromaeo-3d-cube MMulti/VMulti kernel shape,
+    /// which otherwise boxes a transient JsNumber per binary node. The whole tree is computed on
+    /// raw doubles (the spec arithmetic — integer-valued leaves produce identical results) and
+    /// boxed once by the consumer.
+    ///
+    /// Armed only for trees of two or more ± terms that are ALL products — a shape integer-heavy
+    /// workloads don't produce, so their dedicated per-op integer paths never see this probe.
+    /// Leaves are numeric constants, slot/global identifiers and dense computed reads with
+    /// identifier bases: every runtime read is pure, so a decline (any leaf missing the dense
+    /// fast path or not holding a Number) falls back to generic tree evaluation with no
+    /// observable double effects.
+    /// </summary>
+    internal sealed class SumOfProductsLane
+    {
+        private struct Leaf
+        {
+            public byte Kind;                                    // 0 constant, 1 identifier, 2 a[i], 3 a[i][j]
+            public double Constant;
+            public JintIdentifierExpression? Identifier;          // identifier leaf, or member base
+            public JintIdentifierExpression? Index1Identifier;    // first index (null => Constant1)
+            public JintIdentifierExpression? Index2Identifier;    // second index (null => Constant2)
+            public uint ConstantIndex1;
+            public uint ConstantIndex2;
+            public SlotLocationCache Cache;
+            public SlotLocationCache Index1Cache;
+            public SlotLocationCache Index2Cache;
+        }
+
+        private readonly Leaf[] _leaves;      // term k = leaves[2k] * leaves[2k+1]
+        private readonly bool[] _negated;     // sign per term (a right operand of Minus flips)
+
+        private SumOfProductsLane(Leaf[] leaves, bool[] negated)
+        {
+            _leaves = leaves;
+            _negated = negated;
+        }
+
+        internal static SumOfProductsLane? TryBuild(JintExpression expression)
+        {
+            var leaves = new List<Leaf>();
+            var negated = new List<bool>();
+            if (!CollectTerms(expression, leaves, negated) || negated.Count < 2)
+            {
+                return null;
+            }
+
+            return new SumOfProductsLane(leaves.ToArray(), negated.ToArray());
+        }
+
+        private static bool CollectTerms(JintExpression expression, List<Leaf> leaves, List<bool> negated)
+        {
+            // Only left-deep chains arm (the natural parse of `p1 + p2 - p3 …`), so the linear
+            // left-to-right fold reproduces the tree's association — and therefore its floating
+            // point rounding — exactly. A parenthesized right-nested sum stays on the generic path.
+            switch (expression)
+            {
+                case PlusBinaryExpression plus:
+                    return CollectTerms(plus._left, leaves, negated)
+                           && CollectProduct(plus._right, negate: false, leaves, negated);
+                case MinusBinaryExpression minus:
+                    return CollectTerms(minus._left, leaves, negated)
+                           && CollectProduct(minus._right, negate: true, leaves, negated);
+                case TimesBinaryExpression times:
+                    return CollectProduct(times, negate: false, leaves, negated);
+                default:
+                    return false;
+            }
+        }
+
+        private static bool CollectProduct(JintExpression expression, bool negate, List<Leaf> leaves, List<bool> negated)
+        {
+            if (expression is not TimesBinaryExpression times
+                || !TryClassifyLeaf(times._left, out var left)
+                || !TryClassifyLeaf(times._right, out var right))
+            {
+                return false;
+            }
+
+            leaves.Add(left);
+            leaves.Add(right);
+            negated.Add(negate);
+            return negated.Count <= 8;
+        }
+
+        private static bool TryClassifyLeaf(JintExpression expression, out Leaf leaf)
+        {
+            leaf = default;
+            switch (expression)
+            {
+                case JintConstantExpression { Value: JsNumber number }:
+                    leaf.Kind = 0;
+                    leaf.Constant = number._value;
+                    return true;
+
+                case JintIdentifierExpression identifier:
+                    leaf.Kind = 1;
+                    leaf.Identifier = identifier;
+                    return true;
+
+                case JintMemberExpression member when member.TryGetComputedIndexShape(out var objectExpression, out var indexIdentifier, out var constantIndex):
+                    if (objectExpression is JintIdentifierExpression identifierBase)
+                    {
+                        // a[i] / a[0]
+                        leaf.Kind = 2;
+                        leaf.Identifier = identifierBase;
+                        leaf.Index1Identifier = indexIdentifier;
+                        leaf.ConstantIndex1 = constantIndex;
+                        return true;
+                    }
+
+                    if (objectExpression is JintMemberExpression innerMember
+                        && innerMember.TryGetComputedIndexShape(out var innerObject, out var innerIndexIdentifier, out var innerConstantIndex)
+                        && innerObject is JintIdentifierExpression chainBase)
+                    {
+                        // m[i][j] / m[i][0] — the matrix-kernel leaf
+                        leaf.Kind = 3;
+                        leaf.Identifier = chainBase;
+                        leaf.Index1Identifier = innerIndexIdentifier;
+                        leaf.ConstantIndex1 = innerConstantIndex;
+                        leaf.Index2Identifier = indexIdentifier;
+                        leaf.ConstantIndex2 = constantIndex;
+                        return true;
+                    }
+
+                    return false;
+
+                default:
+                    return false;
+            }
+        }
+
+        public bool TryEvaluate(EvaluationContext context, out double result)
+        {
+            result = 0;
+
+            var engine = context.Engine;
+            if (context.OperatorOverloadingAllowed || engine.ExecutionContext.Suspendable is not null)
+            {
+                return false;
+            }
+
+            var env = engine.ExecutionContext.LexicalEnvironment;
+            var leaves = _leaves;
+            var negated = _negated;
+
+            // the first term seeds the accumulator (never negated in a left-deep chain) — seeding
+            // with +0 would inject a phantom term and lose a -0 sum's sign
+            if (!TryReadLeaf(ref leaves[0], engine, env, out var seedLeft)
+                || !TryReadLeaf(ref leaves[1], engine, env, out var seedRight))
+            {
+                return false;
+            }
+
+            result = seedLeft * seedRight;
+            for (var term = 1; term < negated.Length; term++)
+            {
+                if (!TryReadLeaf(ref leaves[2 * term], engine, env, out var left)
+                    || !TryReadLeaf(ref leaves[2 * term + 1], engine, env, out var right))
+                {
+                    result = 0;
+                    return false;
+                }
+
+                var product = left * right;
+                result = negated[term] ? result - product : result + product;
+            }
+
+            return true;
+        }
+
+        private static bool TryReadLeaf(ref Leaf leaf, Engine engine, Environments.Environment env, out double value)
+        {
+            switch (leaf.Kind)
+            {
+                case 0:
+                    value = leaf.Constant;
+                    return true;
+
+                case 1:
+                    if (leaf.Cache.TryResolve(engine, env, leaf.Identifier!.Identifier, out var identifierEnv, out var slotIndex)
+                        && identifierEnv.TryGetNumberSlotForRead(slotIndex, out value))
+                    {
+                        return true;
+                    }
+
+                    value = 0;
+                    return leaf.Identifier._cachedGlobalEnv is not null && TryReadGlobalNumber(leaf.Identifier, engine, env, out value);
+
+                default:
+                    value = 0;
+                    if (!leaf.Cache.TryResolve(engine, env, leaf.Identifier!.Identifier, out var baseEnv, out var baseSlot)
+                        || !baseEnv.TryGetSlotValueForRead(baseSlot, out var baseValue)
+                        || baseValue is not JsArray array
+                        || !array.CanUseFastAccess)
+                    {
+                        return false;
+                    }
+
+                    if (!TryReadIndex(leaf.Index1Identifier, ref leaf.Index1Cache, leaf.ConstantIndex1, engine, env, out var index)
+                        || !array.TryGetValueFast(index, out var element))
+                    {
+                        return false;
+                    }
+
+                    if (leaf.Kind == 3)
+                    {
+                        if (element is not JsArray innerArray
+                            || !innerArray.CanUseFastAccess
+                            || !TryReadIndex(leaf.Index2Identifier, ref leaf.Index2Cache, leaf.ConstantIndex2, engine, env, out var innerIndex)
+                            || !innerArray.TryGetValueFast(innerIndex, out element))
+                        {
+                            return false;
+                        }
+                    }
+
+                    if (element is JsNumber number)
+                    {
+                        value = number._value;
+                        return true;
+                    }
+
+                    return false;
+            }
+        }
+
+        private static bool TryReadIndex(JintIdentifierExpression? indexIdentifier, ref SlotLocationCache cache, uint constantIndex, Engine engine, Environments.Environment env, out uint index)
+        {
+            if (indexIdentifier is null)
+            {
+                index = constantIndex;
+                return true;
+            }
+
+            index = 0;
+            if (!cache.TryResolve(engine, env, indexIdentifier.Identifier, out var indexEnv, out var indexSlot)
+                || !indexEnv.TryGetNumberSlotForRead(indexSlot, out var indexNumber))
+            {
+                return false;
+            }
+
+            index = (uint) indexNumber;
+            return index == indexNumber;
+        }
+    }
+
+    /// <summary>
     /// Fused lane for the `identifier % numericConstant == numericConstant` test — the
     /// stopwatch.js if-chain shape. Reads the identifier through the same slot/global arms as
     /// <see cref="NumericConstantComparisonLane"/> and computes the whole test on raw doubles.

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Native.Array;
@@ -68,6 +69,43 @@ internal sealed class JintMemberExpression : JintExpression
         {
             _determinedProperty = determined;
         }
+    }
+
+    /// <summary>
+    /// Build-time probe for arithmetic-lane leaves: a computed read whose index is an identifier
+    /// or a numeric constant. The returned object expression lets the lane compose chains
+    /// (`m[i][j]` probes the outer member, then its inner member, down to an identifier base) —
+    /// shapes it can later read purely via slot-resolved dense access.
+    /// </summary>
+    internal bool TryGetComputedIndexShape(
+        [NotNullWhen(true)] out JintExpression? objectExpression,
+        out JintIdentifierExpression? indexIdentifier,
+        out uint constantIndex)
+    {
+        objectExpression = null;
+        indexIdentifier = null;
+        constantIndex = 0;
+
+        if (!_computedReadEligible)
+        {
+            return false;
+        }
+
+        if (_determinedProperty is JsNumber determinedNumber
+            && ArrayInstance.IsArrayIndex(determinedNumber, out constantIndex))
+        {
+            objectExpression = _objectExpression;
+            return true;
+        }
+
+        if (_propertyExpression is JintIdentifierExpression identifierIndex)
+        {
+            objectExpression = _objectExpression;
+            indexIdentifier = identifierIndex;
+            return true;
+        }
+
+        return false;
     }
 
     internal static JsValue InitializeDeterminedProperty(MemberExpression expression, bool cache)


### PR DESCRIPTION
### What

`M[i][j] = M1[i][0]*M2[0][j] + M1[i][1]*M2[1][j] + …` — the dromaeo-3d-cube MMulti/VMulti kernel
shape — boxed a transient `JsNumber` per binary node (~7 per matrix cell; 51% of the cube's
allocation in this campaign's Phase-0 census). Assignment right-hand sides that form a **left-deep
`±` chain of two or more products over pure-readable numeric leaves** now compute on raw doubles and
box a single result.

Leaves are numeric constants, slot/global identifiers, and one- or two-level dense computed reads
with identifier bases (`v[0]`, `m[i][j]`).

### Safety and semantics

- Every runtime leaf read is **pure** (slot/validated-global reads, `TryGetValueFast` dense probes),
  so a decline — leaf not dense, not a Number, TDZ — falls back to generic tree evaluation with no
  observable double effects. A Proxy-trap count test pins exactly-once evaluation on decline.
- Double arithmetic **is** the spec arithmetic (`Number::multiply`/`add`), so integer-valued leaves
  produce identical results; `0 * negative` correctly yields `−0` (Object.is-pinned).
- The accumulator seeds from the first term rather than `+0` — a phantom leading zero would turn a
  `(−0) + (−0)` sum into `+0` (a pin caught this during development) — and **only left-deep chains
  arm**, so the linear fold reproduces the tree's association, and therefore its floating-point
  rounding, exactly.
- Armed only for all-product chains (≥2 terms), a shape integer-heavy workloads don't produce —
  their dedicated per-op integer paths never see this probe (the constraint from the earlier
  unboxed-islands attempt).

### Results

A/B vs main (default job; base side via source checkout since the change was committed):

| measurement | before | after | |
|---|---|---|---|
| **dromaeo-3d-cube driver** (±0.7% class) | 30.83 ms/iter | 26.55 ms/iter | **−13.9%** |
| **cube allocation census** | 2.03 MB/iter | 1.31 MB/iter | **−35.5%** (JsNumber share 51% → 18%) |
| dromaeo-object-array driver (integer canary) | 40.42 ms/iter | 36.04 ms/iter | favorable/noise |
| ElementAccess Read / RMW / Append | 95.4 / 195.6 / 39.2 ms | 93.9 / 187.4 / 38.4 ms | −1.6 / −4.2 / −2.0% |
| ElementAccess Write / ChainedRead (untouched) | 96.7 / 134.7 ms | 101.4 / 138.9 ms | +3–5%, inside this family's documented swing; allocations byte-identical on every row |

### Gating

All-TFM build ✅ · Jint.Tests ×2 ✅ · PublicInterface ×2 ✅ · Test262 99,426/0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
