### PR TITLE
Add decorator hook for CLR interop resolution errors

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
+++ b/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
 using Jint.Tests.Runtime.Domain;
@@ -133,6 +134,133 @@ public partial class InteropTests
 
         // constructors carry no member name
         Assert.False(JintException.TryGetClrMemberName(ex, out _));
+    }
+
+    [Fact]
+    public void ResolutionErrorDecoratorCanRewriteScriptVisibleMessage()
+    {
+        var engine = new Engine(options =>
+        {
+            options.Interop.ExposeDetailedResolutionErrors = true;
+            options.DecorateClrResolutionErrors(static (_, error, info) =>
+                error.Set("message", $"{info.Type.Name}.{info.MemberName}: no matching overload"));
+        });
+        engine.SetValue("speaker", new Speaker());
+
+        // a script-side try/catch sees the rewritten message, not the detailed one with the fully-qualified type
+        var scriptVisible = engine.Evaluate("try { speaker.Say('Hello', 'World'); } catch (e) { e.message }");
+        Assert.Equal("Speaker.Say: no matching overload", scriptVisible.AsString());
+
+        // and the host-side exception message matches
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+        Assert.Equal("Speaker.Say: no matching overload", ex.Message);
+    }
+
+    [Fact]
+    public void ResolutionErrorDecoratorCanAddErrorCodeProperty()
+    {
+        var engine = new Engine(options => options.DecorateClrResolutionErrors(
+            static (_, error, _) => error.Set("errorCode", "USR-001")));
+        engine.SetValue("speaker", new Speaker());
+
+        var errorCode = engine.Evaluate("try { speaker.Say('Hello', 'World'); } catch (e) { e.errorCode }");
+        Assert.Equal("USR-001", errorCode.AsString());
+
+        // without a decorator the property does not exist
+        var undecorated = new Engine();
+        undecorated.SetValue("speaker", new Speaker());
+        var missing = undecorated.Evaluate("try { speaker.Say('Hello', 'World'); } catch (e) { e.errorCode === undefined }");
+        Assert.True(missing.AsBoolean());
+    }
+
+    [Fact]
+    public void ResolutionErrorDecoratorReceivesStructuredInfoForMethods()
+    {
+        // detailed messages stay off: the decorator still receives the full structured information
+        ClrResolutionErrorInfo capturedInfo = null;
+        var engine = new Engine(options => options.Interop.ClrResolutionErrorDecorator = (_, _, info) => capturedInfo = info);
+        engine.SetValue("speaker", new Speaker());
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+
+        Assert.Equal("No public methods with the specified arguments were found.", ex.Message);
+
+        Assert.NotNull(capturedInfo);
+        Assert.Equal(typeof(Speaker), capturedInfo.Type);
+        Assert.Equal("Say", capturedInfo.MemberName);
+        Assert.False(capturedInfo.IsConstructor);
+        Assert.Equal(2, capturedInfo.Arguments.Count);
+        Assert.Equal("Hello", capturedInfo.Arguments[0].AsString());
+        Assert.Equal("World", capturedInfo.Arguments[1].AsString());
+        var candidate = Assert.Single(capturedInfo.Candidates);
+        Assert.Equal("Say", candidate.Name);
+        Assert.Equal("Say(String message)", Assert.Single(capturedInfo.CandidateSignatures));
+        Assert.Equal(
+            "No public methods with the specified arguments were found. Target: Jint.Tests.Runtime.Speaker.Say; provided arguments: (string, string); candidate signatures: Say(String message)",
+            capturedInfo.DetailedMessage);
+    }
+
+    [Fact]
+    public void ResolutionErrorDecoratorReceivesStructuredInfoForConstructors()
+    {
+        ClrResolutionErrorInfo capturedInfo = null;
+        var engine = new Engine(options => options.DecorateClrResolutionErrors((_, _, info) => capturedInfo = info));
+        engine.SetValue("CtorFails", TypeReference.CreateTypeReference<CtorFails>(engine));
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CtorFails(1, 2)"));
+
+        Assert.NotNull(capturedInfo);
+        Assert.Equal(typeof(CtorFails), capturedInfo.Type);
+        Assert.Null(capturedInfo.MemberName);
+        Assert.True(capturedInfo.IsConstructor);
+        Assert.Equal(2, capturedInfo.Arguments.Count);
+        var candidate = Assert.Single(capturedInfo.Candidates);
+        Assert.IsAssignableFrom<ConstructorInfo>(candidate);
+        Assert.Equal("CtorFails(String name)", Assert.Single(capturedInfo.CandidateSignatures));
+    }
+
+    [Fact]
+    public void ResolutionErrorDecoratorIsNotCalledOnSuccessfulResolution()
+    {
+        var called = false;
+        var engine = new Engine(options => options.DecorateClrResolutionErrors((_, _, _) => called = true));
+        engine.SetValue("speaker", new Speaker());
+
+        var result = engine.Evaluate("speaker.Say('Hello')");
+
+        Assert.Equal("Speaker says: Hello", result.AsString());
+        Assert.False(called);
+    }
+
+    [Fact]
+    public void ResolutionErrorDecoratorPreservesHostSideClrInfo()
+    {
+        var engine = new Engine(options => options.DecorateClrResolutionErrors(
+            static (_, error, _) => error.Set("message", "rewritten")));
+        engine.SetValue("speaker", new Speaker());
+
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+
+        Assert.Equal("rewritten", ex.Message);
+        Assert.True(JintException.TryGetClrType(ex, out var type));
+        Assert.Equal(typeof(Speaker), type);
+        Assert.True(JintException.TryGetClrMemberName(ex, out var member));
+        Assert.Equal("Say", member);
+    }
+
+    [Fact]
+    public void ResolutionErrorDecoratorArgumentsSurviveBeyondCallback()
+    {
+        ClrResolutionErrorInfo capturedInfo = null;
+        var engine = new Engine(options => options.DecorateClrResolutionErrors((_, _, info) => capturedInfo = info));
+        engine.SetValue("speaker", new Speaker());
+
+        Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+        // churn the engine's pooled/cached argument arrays; the captured copy must be unaffected
+        engine.Evaluate("for (var i = 0; i < 100; i++) { Math.max(i, i + 1, i + 2); }");
+
+        Assert.Equal("Hello", capturedInfo.Arguments[0].AsString());
+        Assert.Equal("World", capturedInfo.Arguments[1].AsString());
     }
 }
 

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -232,6 +232,20 @@ public static class OptionsExtensions
         return options;
     }
 
+    /// <summary>
+    /// Sets a decorator function that is called after the JavaScript error object for a failed CLR method
+    /// or constructor resolution is created, before it is thrown into the script. The decorator can overwrite
+    /// the script-visible message or add custom properties such as an error code.
+    /// </summary>
+    /// <param name="options">The engine options.</param>
+    /// <param name="decorator">A function that receives the engine, the created error object, and the structured resolution information.</param>
+    /// <returns>The options instance for fluent configuration.</returns>
+    public static Options DecorateClrResolutionErrors(this Options options, Options.ClrResolutionErrorDecoratorDelegate decorator)
+    {
+        options.Interop.ClrResolutionErrorDecorator = decorator;
+        return options;
+    }
+
     public static Options Constraint(this Options options, Constraint constraint)
     {
         if (constraint != null)

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -32,6 +32,8 @@ public class Options
 
     public delegate void ClrExceptionErrorDecoratorDelegate(Engine engine, ObjectInstance error, Exception exception);
 
+    public delegate void ClrResolutionErrorDecoratorDelegate(Engine engine, ObjectInstance error, ClrResolutionErrorInfo info);
+
     public delegate string? BuildCallStackDelegate(string shortDescription, SourceLocation location, string[]? arguments);
 
     public delegate string SerializeToJsonDelegate(object? target, string space, string? currentIndent);
@@ -381,6 +383,15 @@ public class Options
         public ClrExceptionErrorDecoratorDelegate? ClrExceptionErrorDecorator { get; set; }
 
         /// <summary>
+        /// Called after the JavaScript error object for a failed CLR method or constructor resolution has been
+        /// created, just before it is thrown into the script. The decorator may overwrite the script-visible
+        /// <c>message</c> and add custom properties (e.g. an error code). It receives the full structured
+        /// resolution information via <see cref="ClrResolutionErrorInfo"/> regardless of
+        /// <see cref="ExposeDetailedResolutionErrors"/>, which only selects the default message.
+        /// </summary>
+        public ClrResolutionErrorDecoratorDelegate? ClrResolutionErrorDecorator { get; set; }
+
+        /// <summary>
         /// Assemblies to allow scripts to call CLR types directly like <example>System.IO.File</example>.
         /// </summary>
         public List<Assembly> AllowedAssemblies { get; set; } = new();
@@ -452,7 +463,8 @@ public class Options
         /// <para>
         /// This only controls the script-visible message. The originating CLR <see cref="System.Type"/> is always
         /// attached to the exception regardless of this setting and can be read host-side via
-        /// <see cref="JintException.TryGetClrType"/> (it is not exposed to the running script).
+        /// <see cref="JintException.TryGetClrType"/> (it is not exposed to the running script). To customize
+        /// what the script sees (rewrite the message, attach an error code), use <see cref="ClrResolutionErrorDecorator"/>.
         /// </para>
         /// </summary>
         public bool ExposeDetailedResolutionErrors { get; set; }

--- a/Jint/Runtime/Interop/ClrResolutionErrorInfo.cs
+++ b/Jint/Runtime/Interop/ClrResolutionErrorInfo.cs
@@ -1,0 +1,80 @@
+using System.Reflection;
+using Jint.Native;
+
+namespace Jint.Runtime.Interop;
+
+/// <summary>
+/// Describes a failed CLR interop method or constructor resolution, passed to
+/// <see cref="Options.ClrResolutionErrorDecoratorDelegate"/>. Carries the full structured
+/// information regardless of <see cref="Options.InteropOptions.ExposeDetailedResolutionErrors"/>;
+/// the decorator runs host-side, so nothing here is visible to the running script unless the
+/// decorator writes it onto the error object.
+/// </summary>
+public sealed class ClrResolutionErrorInfo
+{
+    private readonly JsValue[] _arguments;
+    private readonly MethodDescriptor[] _candidates;
+
+    // lazily computed projections, benign race - last writer wins
+    private MethodBase[]? _candidateMembers;
+    private string[]? _candidateSignatures;
+    private string? _detailedMessage;
+
+    internal ClrResolutionErrorInfo(Type type, string? memberName, JsCallArguments arguments, MethodDescriptor[]? candidates)
+    {
+        Type = type;
+        MemberName = memberName;
+        // defensive element-wise copy: the incoming array can be a shared expression-cache array or
+        // rented from the engine's argument pool, both reused once the call site unwinds. The cached
+        // variant is also an Unsafe.As-reinterpreted array (see ExpressionCache.ArgumentListEvaluation)
+        // whose runtime type is not JsValue[], so Span/Array.Copy based copies would throw.
+        var copy = new JsValue[arguments.Length];
+        for (var i = 0; i < copy.Length; i++)
+        {
+            copy[i] = arguments[i];
+        }
+        _arguments = copy;
+        _candidates = candidates ?? [];
+    }
+
+    /// <summary>
+    /// The CLR type the failed call targeted.
+    /// </summary>
+    public Type Type { get; }
+
+    /// <summary>
+    /// The invoked member name, or <c>null</c> for constructor resolution failures.
+    /// </summary>
+    public string? MemberName { get; }
+
+    /// <summary>
+    /// Whether a constructor call failed to resolve (as opposed to a method call).
+    /// </summary>
+    public bool IsConstructor => MemberName is null;
+
+    /// <summary>
+    /// The JavaScript argument values the script supplied. The list is a copy and safe to retain.
+    /// </summary>
+    public IReadOnlyList<JsValue> Arguments => _arguments;
+
+    /// <summary>
+    /// The candidate CLR members that were considered but did not match the supplied arguments.
+    /// </summary>
+    public IReadOnlyList<MethodBase> Candidates => _candidateMembers ??= Array.ConvertAll(_candidates, static x => x.Method);
+
+    /// <summary>
+    /// Renderings of the candidate signatures, in the same format the detailed resolution error message uses,
+    /// e.g. <c>Say(String message)</c>.
+    /// </summary>
+    public IReadOnlyList<string> CandidateSignatures => _candidateSignatures ??= Array.ConvertAll(_candidates, static x => x.ToString());
+
+    /// <summary>
+    /// The detailed resolution error message naming the target type, the provided argument types and the
+    /// candidate signatures. Available even when
+    /// <see cref="Options.InteropOptions.ExposeDetailedResolutionErrors"/> is disabled - it is only handed
+    /// to the host-side decorator, which decides what the script gets to see.
+    /// </summary>
+    public string DetailedMessage => _detailedMessage ??= IsConstructor
+        ? InteropErrorHelper.CreateNoMatchingConstructorMessage(Type, _arguments, _candidates)
+        : InteropErrorHelper.CreateNoMatchingMethodMessage(Type, MemberName!, _arguments, _candidates);
+}

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -192,7 +192,7 @@ internal sealed class MethodInfoFunction : Function
         var message = _engine.Options.Interop.ExposeDetailedResolutionErrors
             ? InteropErrorHelper.CreateNoMatchingMethodMessage(_targetType, _name, jsArguments, _methods)
             : "No public methods with the specified arguments were found.";
-        Throw.InteropResolutionError(_engine.Realm, message, _targetType, _name);
+        Throw.InteropResolutionError(_engine.Realm, message, _targetType, _name, jsArguments, _methods);
         return null;
     }
 

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -202,7 +202,7 @@ public sealed class TypeReference : Constructor, IObjectWrapper
                 var message = engine.Options.Interop.ExposeDetailedResolutionErrors
                     ? InteropErrorHelper.CreateNoMatchingConstructorMessage(referenceType, arguments, constructors)
                     : $"Could not resolve a constructor for type {referenceType} for given arguments";
-                Throw.InteropResolutionError(realm, message, referenceType, memberName: null);
+                Throw.InteropResolutionError(realm, message, referenceType, memberName: null, arguments, constructors);
             }
 
             result.SetPrototypeOf(state.TypeReference);

--- a/Jint/Runtime/Throw.cs
+++ b/Jint/Runtime/Throw.cs
@@ -4,6 +4,7 @@ using System.Runtime.ExceptionServices;
 using Jint.Native;
 using Jint.Native.Error;
 using Jint.Runtime.CallStack;
+using Jint.Runtime.Interop;
 using Jint.Runtime.Modules;
 
 namespace Jint.Runtime;
@@ -89,21 +90,38 @@ internal static class Throw
     /// recorded on the error object so the host can read them via <see cref="JintException.TryGetClrType"/>
     /// without parsing the message. They are CLR fields, not JavaScript properties, so the running script
     /// cannot observe them; this is independent of <see cref="Options.InteropOptions.ExposeDetailedResolutionErrors"/>.
+    /// A configured <see cref="Options.InteropOptions.ClrResolutionErrorDecorator"/> runs against the error
+    /// object before the exception is created, so a rewritten <c>message</c> also becomes <see cref="Exception.Message"/>.
     /// </summary>
     [DoesNotReturn]
-    public static void InteropResolutionError(Realm realm, string message, Type clrType, string? memberName)
+    public static void InteropResolutionError(
+        Realm realm,
+        string message,
+        Type clrType,
+        string? memberName,
+        JsCallArguments arguments,
+        MethodDescriptor[]? candidates)
     {
-        var location = realm.GlobalObject.Engine.GetLastSyntaxElement()?.Location ?? default;
-        var exception = new JavaScriptException(realm.Intrinsics.TypeError, message).SetJavaScriptLocation(location);
+        var engine = realm.GlobalObject.Engine;
+        var location = engine.GetLastSyntaxElement()?.Location ?? default;
+
+        var error = realm.Intrinsics.TypeError.Construct(message);
 
         // The error value survives the interpreter's throw-completion reconstruction (the .NET exception
         // instance does not), so record the CLR origin on the error object rather than on Exception.Data.
-        if (exception.Error is ErrorInstance errorInstance)
+        if (error is ErrorInstance errorInstance)
         {
             errorInstance.SetClrResolutionInfo(clrType, memberName);
         }
 
-        throw exception;
+        var decorator = engine.Options.Interop.ClrResolutionErrorDecorator;
+        if (decorator is not null)
+        {
+            // the info object (and its argument copy) is only built when a decorator is configured - cold path
+            decorator(engine, error, new ClrResolutionErrorInfo(clrType, memberName, arguments, candidates));
+        }
+
+        throw new JavaScriptException(error).SetJavaScriptLocation(location);
     }
 
     [DoesNotReturn]


### PR DESCRIPTION
Follow-up to #2525/#2527, prompted by the latest feedback in discussion #2523: with `ExposeDetailedResolutionErrors` enabled, a script-side `try/catch` observes the raw detailed message — including the fully-qualified CLR type — through `e.message`, and there was no way to attach custom properties such as an error code to the error the script sees.

## Changes

- New `Options.Interop.ClrResolutionErrorDecorator` (+ fluent `DecorateClrResolutionErrors`), mirroring the existing `ClrExceptionErrorDecorator`: called after the TypeError for a failed CLR method/constructor resolution is created, just before it is thrown into the script. Since the `JavaScriptException` is created after decoration, a rewritten `message` also becomes the host-side `Exception.Message`.
- New public `ClrResolutionErrorInfo` passed to the decorator with the full structured failure information: target `Type`, `MemberName` (null for constructors), `IsConstructor`, the supplied JS `Arguments` (defensively copied — call-site arrays can be pooled or `Unsafe.As`-reinterpreted expression-cache arrays), `Candidates` (`MethodBase`), `CandidateSignatures` (same rendering as the detailed message), and the lazily-built `DetailedMessage`. The info is available regardless of `ExposeDetailedResolutionErrors` — it goes to the host-side callback only, same rationale as `JintException.TryGetClrType`; the flag keeps selecting only the *default* message.
- Behavior without a decorator is unchanged (message text, exception type, host-side CLR type slots, location).

## Example

```csharp
var engine = new Engine(options => options.DecorateClrResolutionErrors((engine, error, info) =>
{
    // script-visible message without the fully-qualified type
    error.Set("message", $"{info.Type.Name}.{info.MemberName}: no matching overload; candidates: {string.Join(", ", info.CandidateSignatures)}");
    error.Set("errorCode", "SCRIPT-1042");
}));
```

```js
try {
    users.create();
} catch (e) {
    e.message;   // "Users.create: no matching overload; candidates: create(String username, Object options = null)"
    e.errorCode; // "SCRIPT-1042"
}
```

## Tests

Seven new tests in `InteropTests.ErrorMessages.cs` covering message rewrite visible in script `try/catch` and `Exception.Message`, custom `errorCode` property, structured info for method and constructor failures (with the flag off), decorator not called on success, `TryGetClrType`/`TryGetClrMemberName` still working alongside the decorator, and captured argument copies staying valid after the call site unwinds. Full Jint.Tests and Jint.Tests.PublicInterface suites pass on net472/net8.0/net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)