### PR TITLE
Reuse class member definitions across class re-evaluations

### DIFF
--- a/Jint.Benchmark/ClassBenchmark.cs
+++ b/Jint.Benchmark/ClassBenchmark.cs
@@ -51,4 +51,38 @@ public class ClassBenchmark
             _engine.Evaluate(script);
         }
     }
+
+    [Benchmark]
+    public void ReEvaluateClassDeclarations()
+    {
+        // the dom.js / class-factory shape: one engine re-evaluates the same prepared script that
+        // declares classes; member definitions come from the per-engine cache while class
+        // identities, prototypes, private state and static-block effects stay per-evaluation
+        var script = Engine.PrepareScript("""
+            (function () {
+                class Node {
+                    #tag = 'node';
+                    static VERSION = 1;
+                    static { this.registry = []; }
+                    constructor(name) { this.name = name; this.children = []; }
+                    appendChild(child) { this.children.push(child); return child; }
+                    get childCount() { return this.children.length; }
+                    set alias(value) { this.name = value; }
+                    describe() { return this.#tag + ':' + this.name; }
+                    static create(name) { return new Node(name); }
+                }
+                class Element extends Node {
+                    describe() { return 'element:' + super.describe(); }
+                }
+                const e = new Element('div');
+                e.appendChild(Node.create('span'));
+                e.alias = 'main';
+                return e.describe() + '/' + e.childCount + '/' + Element.VERSION;
+            })();
+            """);
+        for (var i = 0; i < 40_000; ++i)
+        {
+            _engine.Evaluate(script);
+        }
+    }
 }

--- a/Jint.Tests/Runtime/ClassReEvaluationTests.cs
+++ b/Jint.Tests/Runtime/ClassReEvaluationTests.cs
@@ -1,0 +1,80 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the semantics of the per-engine function-definition cache applied to class evaluation:
+/// re-evaluating the same class AST (factory functions, re-run prepared scripts) reuses the
+/// members' interpreter definitions, while closures, home objects, environments and private
+/// state stay strictly per evaluation.
+/// </summary>
+public class ClassReEvaluationTests
+{
+    [Fact]
+    public void ClassFactoriesProduceIndependentClasses()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                function make(tag) {
+                    return class {
+                        static origin = tag;
+                        #secret = tag + '!';
+                        constructor() { this.made = tag; }
+                        get secret() { return this.#secret; }
+                        describe() { return tag + ':' + this.made; }
+                        static { this.stamped = tag.toUpperCase(); }
+                    };
+                }
+                const A = make('a'), B = make('b');
+                const a = new A(), b = new B();
+                return [
+                    A !== B, A.prototype !== B.prototype,
+                    A.prototype.describe !== B.prototype.describe,
+                    a.describe(), b.describe(),
+                    a.secret, b.secret,
+                    A.origin, B.origin, A.stamped, B.stamped,
+                    a instanceof A, a instanceof B
+                ].join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal("true,true,true,a:a,b:b,a!,b!,a,b,A,B,true,false", result);
+    }
+
+    [Fact]
+    public void SuperAndHomeObjectStayPerEvaluation()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                function make(base) {
+                    return class extends base { hello() { return 'sub-' + super.hello(); } };
+                }
+                class B1 { hello() { return 'one'; } }
+                class B2 { hello() { return 'two'; } }
+                const S1 = make(B1), S2 = make(B2);
+                return new S1().hello() + '|' + new S2().hello();
+            })()
+            """).AsString();
+
+        Assert.Equal("sub-one|sub-two", result);
+    }
+
+    [Fact]
+    public void RepeatedPreparedScriptEvaluationStaysCorrect()
+    {
+        var engine = new Engine();
+        // top-level `class` is a lexical declaration and correctly throws on re-declaration, so the
+        // re-evaluation pattern wraps it — the class AST (and its cached member definitions) still
+        // repeats across evaluations
+        var prepared = Engine.PrepareScript("""
+            (function () {
+                class Point { #x; constructor(x) { this.#x = x; } get x() { return this.#x; } double() { return this.x * 2; } }
+                return new Point(21).double();
+            })();
+            """);
+
+        Assert.Equal(42, engine.Evaluate(prepared).AsNumber());
+        Assert.Equal(42, engine.Evaluate(prepared).AsNumber());
+        Assert.Equal(42, engine.Evaluate(prepared).AsNumber());
+    }
+}

--- a/Jint/AstExtensions.cs
+++ b/Jint/AstExtensions.cs
@@ -329,7 +329,14 @@ public static class AstExtensions
             Throw.SyntaxError(engine.Realm);
         }
 
-        var definition = new JintFunctionDefinition(function, sourceTextNode);
+        // re-evaluating the same class (factory functions, re-run prepared scripts) reuses the
+        // method's interpreter definition and its warm body handler tree; the closure, home object
+        // and environments stay per-evaluation
+        if (!engine.TryGetFunctionDefinition((Node) function, out var definition))
+        {
+            engine.CacheFunctionDefinition((Node) function, definition = new JintFunctionDefinition(function, sourceTextNode));
+        }
+
         var closure = intrinsics.Function.OrdinaryFunctionCreate(prototype, definition, definition.ThisMode, env, privateEnv);
         closure.MakeMethod(obj);
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -54,10 +54,11 @@ public sealed partial class Engine : IDisposable
     internal EvaluationContext? _activeEvaluationContext;
     internal ErrorDispatchInfo? _error;
 
-    // Per-engine cache of function declarations' interpreter definitions, keyed on the AST node.
-    // The definition owns the lazily-built body handler tree — and through it every per-node inline
-    // cache — so reusing it across evaluations and calls keeps a prepared script's functions warm
-    // instead of rebuilding the subtree each time declaration instantiation runs.
+    // Per-engine cache of interpreter function definitions — hoisted declarations, class methods,
+    // class field initializers and static blocks — keyed on the stable AST node. The definition
+    // owns the lazily-built body handler tree — and through it every per-node inline cache — so
+    // reusing it across evaluations and calls keeps a prepared script's functions warm instead of
+    // rebuilding the subtree each time declaration instantiation or class evaluation runs.
     //
     // Lifetime notes. Engine-owned rather than shared via the AST's UserData State because handler
     // trees accumulate engine-affine cache entries, and sharing them across engines retains dead
@@ -68,7 +69,7 @@ public sealed partial class Engine : IDisposable
     // failure the weak table was meant to avoid. The strong form instead retains definitions for
     // scripts this engine evaluated until the engine dies, mirroring Realm._templateMap's existing
     // behavior.
-    private readonly Dictionary<FunctionDeclaration, JintFunctionDefinition> _hoistedFunctionDefinitions = new();
+    private readonly Dictionary<Node, JintFunctionDefinition> _functionDefinitions = new();
 
     // Scripts this engine has run global declaration instantiation for, so the definition cache
     // above only engages on RE-evaluation (see GlobalDeclarationInstantiation).
@@ -76,20 +77,28 @@ public sealed partial class Engine : IDisposable
 
     internal JintFunctionDefinition GetOrCreateFunctionDefinition(FunctionDeclaration declaration)
     {
-        if (!_hoistedFunctionDefinitions.TryGetValue(declaration, out var definition))
+        if (!TryGetFunctionDefinition(declaration, out var definition))
         {
-            // backstop for hosts streaming endless distinct sources (unique eval/script texts)
-            // through one engine: reset rather than grow without bound - steady-state reuse of a
-            // sane number of scripts never reaches this
-            if (_hoistedFunctionDefinitions.Count >= 2048)
-            {
-                _hoistedFunctionDefinitions.Clear();
-            }
-
-            _hoistedFunctionDefinitions[declaration] = definition = new JintFunctionDefinition(declaration);
+            CacheFunctionDefinition(declaration, definition = new JintFunctionDefinition(declaration));
         }
 
         return definition;
+    }
+
+    internal bool TryGetFunctionDefinition(Node key, [NotNullWhen(true)] out JintFunctionDefinition? definition)
+        => _functionDefinitions.TryGetValue(key, out definition);
+
+    internal void CacheFunctionDefinition(Node key, JintFunctionDefinition definition)
+    {
+        // backstop for hosts streaming endless distinct sources (unique eval/script texts)
+        // through one engine: reset rather than grow without bound - steady-state reuse of a
+        // sane number of scripts never reaches this
+        if (_functionDefinitions.Count >= 2048)
+        {
+            _functionDefinitions.Clear();
+        }
+
+        _functionDefinitions[key] = definition;
     }
 
     private readonly EventLoop _eventLoop = new();

--- a/Jint/Native/Function/ClassDefinition.cs
+++ b/Jint/Native/Function/ClassDefinition.cs
@@ -613,7 +613,11 @@ internal sealed class ClassDefinition
                 var env = engine.ExecutionContext.LexicalEnvironment;
                 var privEnv = engine.ExecutionContext.PrivateEnvironment;
 
-                var definition = new JintFunctionDefinition(new ClassFieldFunction(accessorProperty.Value));
+                if (!engine.TryGetFunctionDefinition(accessorProperty.Value, out var definition))
+                {
+                    engine.CacheFunctionDefinition(accessorProperty.Value, definition = new JintFunctionDefinition(new ClassFieldFunction(accessorProperty.Value)));
+                }
+
                 initializer = intrinsics.Function.OrdinaryFunctionCreate(intrinsics.Function.PrototypeObject, definition, FunctionThisMode.Global, env, privEnv);
                 initializer.MakeMethod(target);
                 initializer._classFieldInitializerName = name;
@@ -658,7 +662,11 @@ internal sealed class ClassDefinition
                 var env = engine.ExecutionContext.LexicalEnvironment;
                 var privEnv = engine.ExecutionContext.PrivateEnvironment;
 
-                var definition = new JintFunctionDefinition(new ClassFieldFunction(accessorProperty.Value));
+                if (!engine.TryGetFunctionDefinition(accessorProperty.Value, out var definition))
+                {
+                    engine.CacheFunctionDefinition(accessorProperty.Value, definition = new JintFunctionDefinition(new ClassFieldFunction(accessorProperty.Value)));
+                }
+
                 initializer = intrinsics.Function.OrdinaryFunctionCreate(intrinsics.Function.PrototypeObject, definition, FunctionThisMode.Global, env, privEnv);
                 initializer.MakeMethod(target);
                 initializer._classFieldInitializerName = name;
@@ -689,7 +697,11 @@ internal sealed class ClassDefinition
             var env = engine.ExecutionContext.LexicalEnvironment;
             var privateEnv = engine.ExecutionContext.PrivateEnvironment;
 
-            var definition = new JintFunctionDefinition(new ClassFieldFunction(fieldDefinition.Value));
+            if (!engine.TryGetFunctionDefinition(fieldDefinition.Value, out var definition))
+            {
+                engine.CacheFunctionDefinition(fieldDefinition.Value, definition = new JintFunctionDefinition(new ClassFieldFunction(fieldDefinition.Value)));
+            }
+
             initializer = intrinsics.Function.OrdinaryFunctionCreate(intrinsics.Function.PrototypeObject, definition, FunctionThisMode.Global, env, privateEnv);
 
             initializer.MakeMethod(homeObject);
@@ -729,7 +741,10 @@ internal sealed class ClassDefinition
     {
         var intrinsics = engine.Realm.Intrinsics;
 
-        var definition = new JintFunctionDefinition(new ClassStaticBlockFunction(o));
+        if (!engine.TryGetFunctionDefinition(o, out var definition))
+        {
+            engine.CacheFunctionDefinition(o, definition = new JintFunctionDefinition(new ClassStaticBlockFunction(o)));
+        }
 
         var lex = engine.ExecutionContext.LexicalEnvironment;
         var privateEnv = engine.ExecutionContext.PrivateEnvironment;
@@ -799,7 +814,11 @@ internal sealed class ClassDefinition
             return DefineMethodProperty(obj, methodDef.Key, methodDef.Closure, enumerable);
         }
 
-        var definition = new JintFunctionDefinition(function, sourceTextNode: method);
+        if (!engine.TryGetFunctionDefinition((Node) function, out var definition))
+        {
+            engine.CacheFunctionDefinition((Node) function, definition = new JintFunctionDefinition(function, sourceTextNode: method));
+        }
+
         var intrinsics = engine.Realm.Intrinsics;
 
         var value = method.TryGetKey(engine);


### PR DESCRIPTION
Follow-up to #2613, extending the per-engine function-definition cache from hoisted declarations to class evaluation. Real-world motivation: the dom.js / SimpleCrawler pattern from #2569, where a factory function (or a re-run prepared script) evaluates the same `class` declaration over and over — every evaluation rebuilt a fresh `JintFunctionDefinition` (and, lazily, a fresh body handler tree plus all its inline caches) for every method, accessor, field initializer and static block.

## What changed

The #2613 cache widens from `Dictionary<FunctionDeclaration, ...>` to `Dictionary<Node, ...>` behind two new internal accessors (`TryGetFunctionDefinition` / `CacheFunctionDefinition`, same 2048-entry backstop), and class evaluation now reuses cached definitions at all per-member sites:

- `ClassDefinition.MethodDefinitionEvaluation` — methods and accessors
- class field initializers and auto-accessor backing initializers
- static initialization blocks
- `AstExtensions.DefineMethod` — object-literal and class method definition

Per-evaluation semantics are untouched: every evaluation still produces fresh `ScriptFunction` closures, fresh class identity, fresh prototypes, per-evaluation private state and re-run static blocks — only the immutable interpreter definition (and its warm handler tree) is shared, the same object each *call* of one class's method already shared.

## Benchmarks

New `ClassBenchmark.ReEvaluateClassDeclarations` row (one engine re-evaluating a prepared script declaring a 2-class hierarchy with methods, accessors, private field, static property and static block, 40k evaluations per op) — A/B against main in one window, base side = engine sources from main with the same benchmark row:

| Method | main | PR | Δ time | main alloc | PR alloc | Δ alloc |
|---|---:|---:|---:|---:|---:|---:|
| ReEvaluateClassDeclarations | 524.5 ms | 404.7 ms | **−22.8%** | 967.07 MB | 641.05 MB | **−33.7%** |
| ConstructSimple | 157.5 ms | 157.4 ms | −0.1% | 366.15 MB | 366.15 MB | = |
| ConstructDeepInheritance | 154.6 ms | 154.5 ms | −0.1% | 278.88 MB | 278.88 MB | = |
| GetSet | 190.4 ms | 152.8 ms | −19.7%¹ | 556.89 MB | 556.89 MB | = |

¹ GetSet doesn't touch class evaluation and its allocation is byte-identical — the time swing is code layout/iteration noise on an `InvocationCount=1` row, not a claimed win.

`PreparedAnomalyBenchmarks` guard (the #2613 gate — the hoisted-declaration path shares the touched cache):

| Method | main | PR | Δ time | Allocated |
|---|---:|---:|---:|---:|
| SourcePerOp | 13.90 ms | 13.79 ms | −0.8% | 45.24 KB (=) |
| PreparedShared | 14.12 ms | 13.89 ms | −1.6% | 23.68 KB (=) |
| PreparedPerOp | 14.11 ms | 13.87 ms | −1.7% | 46.8 KB (=) |
| PreparedReusedEngine | 16.55 ms | 15.57 ms | −5.9% | 9.99 KB (=) |

All guard allocations byte-identical; times flat-to-slightly-better.

## Tests

New `ClassReEvaluationTests` pin the per-evaluation semantics (independent class identities/prototypes/private fields/static-block effects across evaluations of one AST, super/home-object correctness, repeated prepared-script evaluation).

Full gate green: `Jint/Jint.csproj` all TFMs, Jint.Tests (net10.0: 3266, net472: 3204), Jint.Tests.PublicInterface (82×2), full Test262 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BY8HoKam5H8vTPn1bMY2Hv
