### PR TITLE
Re-resolve slot locations when a shared handler tree changes function instance

### DIFF
--- a/Jint.Tests/Runtime/SlotLocationCacheTests.cs
+++ b/Jint.Tests/Runtime/SlotLocationCacheTests.cs
@@ -1,0 +1,90 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins SlotLocationCache behavior for handler trees shared across function instances
+/// (per-engine definition reuse): a node whose cached environment is unreachable from the
+/// current chain must re-resolve against it — declining forever would silently disable every
+/// slot-backed fast lane from the second re-evaluation of a prepared script onward.
+/// </summary>
+public class SlotLocationCacheTests
+{
+    [Fact]
+    public void RepeatedPreparedEvaluationsKeepProducingCorrectResults()
+    {
+        var engine = new Engine();
+        var prepared = Engine.PrepareScript("""
+            function f() {
+                var n = 0;
+                for (var i = 0; i < 1000; i++) { n += i; }
+                return n;
+            }
+            f();
+            """);
+
+        // the cached-definition handler tree serves a fresh function instance (fresh env) per
+        // evaluation; each must resolve slots against its own chain
+        for (var e = 0; e < 5; e++)
+        {
+            Assert.Equal(499500, engine.Evaluate(prepared).AsNumber());
+        }
+    }
+
+    [Fact]
+    public void AlternatingFunctionInstancesSharingOneTreeStayCorrect()
+    {
+        var engine = new Engine();
+        // two instances of the same nested declaration alternate calls: the shared tree's
+        // slot caches flip between the instances' environments and must stay correct
+        var result = engine.Evaluate("""
+            (function () {
+                function make(base) {
+                    function inner() {
+                        var acc = 0;
+                        for (var i = 0; i < 100; i++) { acc += base; }
+                        return acc;
+                    }
+                    return inner;
+                }
+                var a = make(1), b = make(1000);
+                var sum = 0;
+                for (var r = 0; r < 4; r++) { sum += a() + b(); }
+                return sum;
+            })()
+            """).AsNumber();
+
+        Assert.Equal(4 * (100 + 100_000), result);
+    }
+
+#if NET
+    [Fact]
+    public void SlotLanesSurviveRepeatedPreparedEvaluations()
+    {
+        var engine = new Engine();
+        var prepared = Engine.PrepareScript("""
+            function f() {
+                var n = 0;
+                for (var i = 0; i < 20000; i++) { n += 1; }
+                return n;
+            }
+            f();
+            """);
+
+        // evaluation 1 uses the first-build tree, 2 the freshly cached tree; from 3 on the
+        // cached tree runs under a different environment than the one that populated its
+        // slot caches — the lanes must re-resolve and stay unboxed instead of falling to
+        // the materializing generic path (which allocates a JsNumber per iteration here)
+        for (var e = 0; e < 3; e++)
+        {
+            engine.Evaluate(prepared);
+        }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        engine.Evaluate(prepared);
+        var perEvaluation = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(
+            perEvaluation < 150_000,
+            $"expected slot lanes to stay live across re-evaluations; allocated {perEvaluation} bytes in one evaluation");
+    }
+#endif
+}

--- a/Jint/Runtime/Environments/SlotLocationCache.cs
+++ b/Jint/Runtime/Environments/SlotLocationCache.cs
@@ -10,6 +10,10 @@ namespace Jint.Runtime.Environments;
 /// Validity reasoning: closure-captured environments cannot be pooled (escape detection
 /// prevents it), so a cached env reference is stable for the lifetime of the function
 /// instance that captured it, and slot indices are immutable for the lifetime of the env.
+/// Handler trees are shared across function INSTANCES though (per-engine definition reuse
+/// for re-evaluated scripts, class members and nested declarations), so a node outlives any
+/// one instance's environment: an unreachable cached env means the node moved to another
+/// instance and must re-resolve against the current chain, not decline.
 /// Slot layout is deterministic per AST node, so a node shared across engines via
 /// <c>Prepared&lt;Script&gt;</c> resolves to the same index everywhere; the engine-identity
 /// gate only avoids wasted walks against another engine's environments.
@@ -80,9 +84,13 @@ internal struct SlotLocationCache
                 search = search._outerEnv;
             }
 
-            slotEnv = null!;
-            slotIndex = -1;
-            return false;
+            // The cached location is not reachable from this chain. Handler trees are shared
+            // across function instances (per-engine definition reuse for re-evaluated scripts,
+            // class members, nested declarations), so the same node runs under a fresh
+            // environment per instance — re-resolve against the current chain exactly as a
+            // fresh node would (mirroring the cross-engine Prepared<Script> fall-through
+            // below) instead of declining forever. One bounded walk per instance switch;
+            // subsequent reads hit the re-populated cache.
         }
 
         if (_disabled)


### PR DESCRIPTION
#2613 shares one handler tree across the fresh function instances that a re-evaluated prepared script creates — but `SlotLocationCache` still assumed a node lives and dies with a single function instance. The cache stored the first instance's environment, and once that environment was no longer reachable from the current chain, `TryResolve` returned a **permanent miss**: it never fell through to re-resolution.

Net effect on main today: from the second re-evaluation of a prepared script onward (i.e. the second use of the #2613-cached tree), **every slot-backed fast lane in that script is silently dead** — unboxed loop counters, the comparison/equality lanes, fused modulo, sum-of-products — and every identifier read in a tight loop materializes a `JsNumber` through the generic path. The engine-reuse embedding scenario #2613 targeted is exactly the scenario that hits it.

How it surfaced: an A/B for a new lane showed its target row *allocation-unchanged* on both sides. A per-evaluation allocation probe with lane fire counters showed fires = 100k on evaluations 1–2, then 0 forever, with the allocation cliff at evaluation 3; decline-site counters pointed at the left slot resolve; the permanent-miss return in `TryResolve` was the mechanism.

## The fix

When the hit-walk exhausts without reaching the cached environment (and without meeting a shadowing binding or a with-object — those still decline this read), fall through to `ResolveAndPopulate` and re-cache against the current chain — exactly what the existing cross-engine `Prepared<Script>` path already does on an engine-identity mismatch. Cost: one bounded, pure walk per instance switch; subsequent reads hit the re-populated cache. The fall-through is also cheaper than the old behavior on the miss path itself, which re-walked and declined on *every* read.

## Benchmarks

`LoopDispatchBenchmarks` (one engine re-evaluating each prepared loop; every measured iteration past the first is a re-evaluation, so main's numbers are the degraded-lane floor):

| Method | main | fix | Δ time | main alloc | fix alloc |
|---|---:|---:|---:|---:|---:|
| EmptyLoop | 4.114 ms | 1.143 ms | **−72.2%** | 2.74 MB | 1.63 KB |
| VariableBoundLoop | 4.809 ms | 1.336 ms | **−72.2%** | 2.74 MB | 1.63 KB |
| CounterAdd | 7.796 ms | 2.058 ms | **−73.6%** | 5.48 MB | 1.63 KB |
| LocalCopy | 7.315 ms | 2.917 ms | **−60.1%** | 2.74 MB | 1.59 KB |
| StringAppend | 6.984 ms | 2.653 ms | **−62.0%** | 2.94 MB | 206.94 KB¹ |
| ComparisonOnly | 9.250 ms | 5.066 ms | **−45.2%** | 2.74 MB | 1.59 KB |
| StrictEqualTest | 8.392 ms | 4.156 ms | **−50.5%** | 2.74 MB | 1.59 KB |
| LooseEqualTest | 8.406 ms | 4.076 ms | **−51.5%** | 2.74 MB | 1.59 KB |
| ModuloEqualTest | 11.096 ms | 5.651 ms | **−49.1%** | 2.74 MB | 1.59 KB |

EmptyLoop returns to ~11 ns/iteration — the floor these lanes were built to deliver; on main every row was paying a JsNumber materialization per identifier read from the second evaluation on.

¹ StringAppend's remaining allocation is the rope builder for the 100k-char result string, not lane churn.

`PreparedAnomalyBenchmarks` guard (the #2613 gate):

| Method | main | fix | Δ time | Allocated |
|---|---:|---:|---:|---:|
| SourcePerOp | 13.93 ms | 13.74 ms | −1.4% | 45.25 KB (=) |
| PreparedShared | 13.77 ms | 14.08 ms | +2.3%² | 23.69 KB (=) |
| PreparedPerOp | 14.21 ms | 13.96 ms | −1.8% | 46.81 KB (=) |
| PreparedReusedEngine | 15.64 ms | 15.13 ms | −3.3% | 9.99 KB (=) |

² Within this row's run-to-run band; allocations byte-identical across all four rows.

## Tests

New `SlotLocationCacheTests`: correctness pins for repeated prepared evaluations and for two function instances alternating over one shared tree, plus an allocation pin (net10.0) that fails on main (626 KB/evaluation for a 20k-iteration counter loop) and passes with the fix.

Full gate: `Jint/Jint.csproj` all TFMs, Jint.Tests (net10.0 + net472), Jint.Tests.PublicInterface (net10.0 + net472), full Test262 (single failure = `Atomics/waitAsync/bigint/no-spurious-wakeup-no-operation.js`, the documented wall-clock flake family — 8/8 green re-run in isolation, 88 tests per run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BY8HoKam5H8vTPn1bMY2Hv
