### PR TITLE
Preserve -0 in integer multiplication fast paths

### DIFF
--- a/Jint.Tests/Runtime/NumberTests.cs
+++ b/Jint.Tests/Runtime/NumberTests.cs
@@ -221,4 +221,39 @@ public class NumberTests
         var tdzUpdate = Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("(function() { { y++; let y; } })()"));
         Assert.Equal("ReferenceError", tdzUpdate.Error.AsObject().Get("constructor").AsObject().Get("name").AsString());
     }
+
+    [Fact]
+    public void IntegerMultiplicationPreservesNegativeZero()
+    {
+        var engine = new Engine();
+        // Number::multiply: a zero product takes a negative sign when the operand signs differ.
+        // The integer fast paths (binary * and compound *=) cannot represent -0 and must route
+        // zero products through double arithmetic; test every operand shape the lanes serve.
+        var result = engine.Evaluate("""
+            (function () {
+                var zero = 0, negFive = -5, five = 5;
+                var r = [];
+                r.push(Object.is(zero * negFive, -0));
+                r.push(Object.is(negFive * zero, -0));
+                r.push(Object.is(zero * five, 0));
+                r.push(Object.is(zero * zero, 0));
+                r.push(Object.is(0 * -5, -0));
+                var arr = [0, -5];
+                r.push(Object.is(arr[0] * arr[1], -0));
+                var o = { a: 0, b: -5 };
+                r.push(Object.is(o.a * o.b, -0));
+                function f(x, y) { return x * y; }
+                r.push(Object.is(f(0, -5), -0));
+                var acc = 0; acc *= -5;
+                r.push(Object.is(acc, -0));
+                var acc2 = -5; acc2 *= 0;
+                r.push(Object.is(acc2, -0));
+                var acc3 = 0; acc3 *= 5;
+                r.push(Object.is(acc3, 0));
+                return r.join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal("true,true,true,true,true,true,true,true,true,true,true", result);
+    }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -281,7 +281,12 @@ internal sealed class JintAssignmentExpression : JintExpression
                 {
                     if (AreIntegerOperands(originalLeftValue, rval))
                     {
-                        return JsNumber.Create((long) originalLeftValue.AsInteger() * rval.AsInteger());
+                        var product = (long) originalLeftValue.AsInteger() * rval.AsInteger();
+                        // Number::multiply gives -0 for zero products of opposite signs (0 * -5),
+                        // which integer math cannot represent — route through double arithmetic
+                        return product != 0
+                            ? JsNumber.Create(product)
+                            : JsNumber.Create((double) originalLeftValue.AsInteger() * rval.AsInteger());
                     }
 
                     var leftNumeric = TypeConverter.ToNumeric(originalLeftValue);

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -1162,7 +1162,12 @@ internal abstract class JintBinaryExpression : JintExpression
             }
             else if (AreIntegerOperands(left, right))
             {
-                result = JsNumber.Create((long) left.AsInteger() * right.AsInteger());
+                var product = (long) left.AsInteger() * right.AsInteger();
+                // Number::multiply gives -0 for zero products of opposite signs (0 * -5), which
+                // integer math cannot represent — route zero products through double arithmetic
+                result = product != 0
+                    ? JsNumber.Create(product)
+                    : JsNumber.Create((double) left.AsInteger() * right.AsInteger());
             }
             else if (left._type == InternalTypes.Number && right._type == InternalTypes.Number)
             {


### PR DESCRIPTION
Spec bug in the integer-operand fast paths of multiplication: `Number::multiply` gives a **negative-signed zero** when a zero product's operand signs differ — `Object.is(0 * -5, -0)` must be `true` — but both binary `*` (`TimesBinaryExpression`) and compound `*=` (`ComputeCompound`) computed integer products in `long` arithmetic, where the sign of zero cannot be represented, and returned `+0`:

```js
var zero = 0, negFive = -5;
Object.is(zero * negFive, -0);   // main: false — spec/V8: true
var acc = 0; acc *= -5;
Object.is(acc, -0);              // main: false — spec/V8: true
```

Literal forms (`0 * -5` with both operands literal) were unaffected because constant folding already runs on doubles — which is why Test262's multiplication suites (literal-shaped) never caught it; any *runtime* integer operands (slots, array elements, properties, call results) hit the bug.

## The fix

Compute the `long` product first; a nonzero product keeps the exact integer path unchanged, a zero product re-derives the result via double multiplication to pick up the sign rule. Zero products are rare in numeric loops, so the extra branch sits on a cold edge.

Audit of the other `AreIntegerOperands` fast paths: `Remainder` and `DivideInteger` already handle their `-0` cases explicitly; integer addition/subtraction cannot produce `-0` (integer-typed operands can't hold `-0`, and `x + (−x)` / `x − x` are `+0` per spec); bitwise ops are ToInt32-domain. Only the two multiplication sites were affected.

## Benchmarks

The integer multiply path is hot in numeric workloads — guard A/B (stash-pair, one window):

`DromaeoBenchmark` Cube (multiply-heavy) at `--launchCount 5` (the single-launch run showed a +12.9% swing on one Cube row alongside a −15% swing on another — the classic code-layout signature for these `InvocationCount=1` rows, so the decision runs on multi-launch medians):

| Row | main (median) | PR (median) | Δ | Allocated |
|---|---:|---:|---:|---:|
| Cube classic, source | 8.739 ms | 8.456 ms | −3.2% | 1.59 MB (=) |
| Cube classic, prepared | 6.945 ms | 6.996 ms | +0.7% | 1.31 MB (=) |
| Cube modern, source | 7.799 ms | 7.966 ms | +2.1% | 1.59 MB (=) |
| Cube modern, prepared | 7.190 ms | 7.104 ms | −1.2% | 1.3 MB (=) |

ObjectArray (integer-arithmetic-heavy, single launch): all four variants within ±3% both directions, allocations byte-identical. Mixed signs inside the documented noise band on every row — the zero-product branch is perf-neutral, as expected for a predicted-not-taken edge.

## Tests

New `NumberTests.IntegerMultiplicationPreservesNegativeZero` pins 11 shapes: slot × slot both orders, positive/zero controls, literal form, array elements, object properties, function returns, and compound `*=` in three sign combinations.

Full gate: `Jint/Jint.csproj` all TFMs, Jint.Tests (net10.0 + net472), Jint.Tests.PublicInterface (net10.0 + net472), full Test262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BY8HoKam5H8vTPn1bMY2Hv
