### PR TITLE
Reduce per-call ceremony: thread FDI state, collapse suspendable probes

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1248,10 +1248,11 @@ public sealed partial class Engine : IDisposable
     internal JsArguments? FunctionDeclarationInstantiation(
         EvaluationContext context,
         Function function,
-        JsCallArguments argumentsList)
+        JsCallArguments argumentsList,
+        JintFunctionDefinition.State? state = null)
     {
-        var func = function._functionDefinition;
-        var configuration = func!.Initialize();
+        var func = function._functionDefinition!;
+        var configuration = state ?? func.Initialize();
 
         // Fastest path: nothing to instantiate at all (no parameters, vars, lexical declarations,
         // inner function declarations, arguments object or eval context).

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -322,11 +322,9 @@ public abstract partial class Function : ObjectInstance, ICallable
     /// https://tc39.es/ecma262/#sec-prepareforordinarycall
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal ref readonly ExecutionContext PrepareForOrdinaryCall(JsValue newTarget)
+    internal ref readonly ExecutionContext PrepareForOrdinaryCall(JsValue newTarget, JintFunctionDefinition.State state)
     {
-        var callerContext = _engine.ExecutionContext;
-
-        var localEnv = JintEnvironment.NewFunctionEnvironment(_engine, this, newTarget);
+        var localEnv = JintEnvironment.NewFunctionEnvironment(_engine, this, newTarget, state);
         var calleeRealm = _realm;
 
         var calleeContext = new ExecutionContext(

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -80,15 +80,15 @@ public sealed class ScriptFunction : Function, IConstructor
     /// </summary>
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
-        var strict = _functionDefinition!.Strict || _thisMode == FunctionThisMode.Strict;
+        var state = _functionDefinition!.Initialize();
+        var strict = _functionDefinition.Strict || _thisMode == FunctionThisMode.Strict;
         using (new StrictModeScope(strict, force: true))
         {
             FunctionEnvironment? funcEnv = null;
-            JintFunctionDefinition.State? state = null;
 
             try
             {
-                ref readonly var calleeContext = ref PrepareForOrdinaryCall(Undefined);
+                ref readonly var calleeContext = ref PrepareForOrdinaryCall(Undefined, state);
 
                 if (_isClassConstructor)
                 {
@@ -98,8 +98,7 @@ public sealed class ScriptFunction : Function, IConstructor
                 // Capture funcEnv for end-of-call pool return when bindings can't escape. Direct-recursive
                 // functions return their env to a small bounded pool (so each live frame reuses a distinct
                 // env); other non-escaping functions use the single-slot pool. Escaping envs are not pooled.
-                state = _functionDefinition.Initialize();
-                if (state is { EnvironmentMayEscape: false })
+                if (!state.EnvironmentMayEscape)
                 {
                     funcEnv = (FunctionEnvironment) calleeContext.LexicalEnvironment;
                 }
@@ -109,7 +108,7 @@ public sealed class ScriptFunction : Function, IConstructor
                 // actual call
                 var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
 
-                var result = _functionDefinition.EvaluateBody(context, this, arguments);
+                var result = _functionDefinition.EvaluateBody(context, this, arguments, state);
 
                 // For async functions/generators, DisposeResources is deferred to when
                 // the body truly completes (AsyncBlockStart/AsyncFunctionResume).
@@ -147,7 +146,7 @@ public sealed class ScriptFunction : Function, IConstructor
                     // Cache on this function instance (per-engine by construction, so a prepared script's
                     // shared State can't pin engines — see _envReuse). Single-threaded like the engine, so
                     // no Interlocked is needed on the instance side.
-                    if (state!.IsDirectRecursive)
+                    if (state.IsDirectRecursive)
                     {
                         // Return the env (with its fixed-slot array still attached) to the bounded
                         // recursive pool so another simultaneously live frame can reuse env + slots.
@@ -218,6 +217,7 @@ public sealed class ScriptFunction : Function, IConstructor
     /// </summary>
     ObjectInstance IConstructor.Construct(JsCallArguments arguments, JsValue newTarget)
     {
+        var state = _functionDefinition!.Initialize();
         var callerContext = _engine.ExecutionContext;
         var kind = _constructorKind;
 
@@ -264,7 +264,7 @@ public sealed class ScriptFunction : Function, IConstructor
             }
         }
 
-        ref readonly var calleeContext = ref PrepareForOrdinaryCall(newTarget);
+        ref readonly var calleeContext = ref PrepareForOrdinaryCall(newTarget, state);
         var constructorEnv = (FunctionEnvironment) calleeContext.LexicalEnvironment;
 
         var strict = _thisMode == FunctionThisMode.Strict;
@@ -280,7 +280,7 @@ public sealed class ScriptFunction : Function, IConstructor
 
                 var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
 
-                var result = _functionDefinition!.EvaluateBody(context, this, arguments);
+                var result = _functionDefinition.EvaluateBody(context, this, arguments, state);
                 result = constructorEnv.DisposeResources(result);
 
                 // The DebugHandler needs the current execution context before the return for stepping through the return point

--- a/Jint/Runtime/Environments/JintEnvironment.cs
+++ b/Jint/Runtime/Environments/JintEnvironment.cs
@@ -97,9 +97,8 @@ internal static class JintEnvironment
     /// <summary>
     /// https://tc39.es/ecma262/#sec-newfunctionenvironment
     /// </summary>
-    internal static FunctionEnvironment NewFunctionEnvironment(Engine engine, Function f, JsValue newTarget)
+    internal static FunctionEnvironment NewFunctionEnvironment(Engine engine, Function f, JsValue newTarget, Interpreter.JintFunctionDefinition.State state)
     {
-        var state = f._functionDefinition?.Initialize();
 
         // Direct-recursive functions use a small bounded pool so each simultaneously live frame rents a
         // distinct env (with its fixed-slot array attached) instead of allocating per call. The single

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -37,6 +37,11 @@ internal sealed class JintCallExpression : JintExpression
 
         var engine = context.Engine;
 
+        // The frame's suspendable is fixed for the duration of this evaluation (nested calls
+        // balance their context push/pop), so capture it once and probe the reference instead
+        // of re-reading the execution context after every sub-expression.
+        var suspendable = engine.ExecutionContext.Suspendable;
+
         object reference;
         Reference? referenceRecord;
         JsValue func;
@@ -55,7 +60,7 @@ internal sealed class JintCallExpression : JintExpression
             && !engine._customResolver)
         {
             fastFunc = member.GetCalleeForCall(context, out fastThis);
-            if (context.IsSuspended())
+            if (suspendable is not null && suspendable.IsSuspended)
             {
                 return fastFunc;
             }
@@ -77,7 +82,7 @@ internal sealed class JintCallExpression : JintExpression
             var calleeReference = _calleeExpression.Evaluate(context);
 
             // Check for generator suspension after evaluating callee
-            if (context.IsSuspended())
+            if (suspendable is not null && suspendable.IsSuspended)
             {
                 return calleeReference as JsValue ?? JsValue.Undefined;
             }
@@ -141,7 +146,7 @@ internal sealed class JintCallExpression : JintExpression
         var arguments = this._arguments.ArgumentListEvaluation(context, this, out var rented);
 
         // Check for generator suspension after argument evaluation
-        if (context.IsSuspended())
+        if (suspendable is not null && suspendable.IsSuspended)
         {
             // When suspended mid-arglist, ExpressionCache keeps the array alive
             // in suspend data and returns rented=false, so we don't release it here.

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -56,7 +56,7 @@ internal sealed class JintFunctionDefinition
     /// https://tc39.es/ecma262/#sec-ordinarycallevaluatebody
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining | (MethodImplOptions) 512)]
-    internal Completion EvaluateBody(EvaluationContext context, Function functionObject, JsCallArguments argumentsList)
+    internal Completion EvaluateBody(EvaluationContext context, Function functionObject, JsCallArguments argumentsList, State state)
     {
         Completion result;
         JsArguments? argumentsInstance = null;
@@ -73,7 +73,7 @@ internal sealed class JintFunctionDefinition
                 return EvaluateConciseBodyAsync(context, functionObject, argumentsList);
             }
 
-            argumentsInstance = context.Engine.FunctionDeclarationInstantiation(context, functionObject, argumentsList);
+            argumentsInstance = context.Engine.FunctionDeclarationInstantiation(context, functionObject, argumentsList, state);
             context.RunBeforeExecuteStatementChecks(Function.Body);
             var jsValue = _bodyExpression.GetValue(context).Clone();
             result = new Completion(CompletionType.Return, jsValue, Function.Body);
@@ -93,7 +93,7 @@ internal sealed class JintFunctionDefinition
             }
 
             // https://tc39.es/ecma262/#sec-runtime-semantics-evaluatefunctionbody
-            argumentsInstance = context.Engine.FunctionDeclarationInstantiation(context, functionObject, argumentsList);
+            argumentsInstance = context.Engine.FunctionDeclarationInstantiation(context, functionObject, argumentsList, state);
             _bodyStatementList ??= new JintStatementList(Function);
             result = _bodyStatementList.Execute(context);
         }

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -162,8 +162,10 @@ internal sealed class JintStatementList
                     c = new Completion(CompletionType.Return, pair.Value, pair.Statement._statement);
                 }
 
-                // Check for suspension (generator yield or async await)
-                if (context.IsSuspended())
+                // Check for suspension (generator yield or async await). The frame's suspendable
+                // reference is fixed for this call (captured above); only its state changes, so
+                // probing the captured reference avoids re-reading the execution context per statement.
+                if (suspendable is not null && suspendable.IsSuspended)
                 {
                     // Save position for resume - we'll re-execute this statement on resume
                     // The yield/await tracking handles knowing which suspension point to resume from
@@ -184,7 +186,7 @@ internal sealed class JintStatementList
 
                 if (c.Type != CompletionType.Normal)
                 {
-                    if (!context.IsSuspended())
+                    if (suspendable is null || !suspendable.IsSuspended)
                     {
                         var asyncFunction = context.Engine.ExecutionContext.AsyncFunction;
                         if (asyncFunction?._body != this)


### PR DESCRIPTION
Shaves fixed ceremony off every script-function call. Three independent, semantics-preserving mechanical changes:

1. **Thread `JintFunctionDefinition.State` through the call.** Every call resolved the definition state three times (`NewFunctionEnvironment`, `ScriptFunction.Call`, `FunctionDeclarationInstantiation`) — all cache hits on `node.UserData`, but each paying a cast and type test. The lookup is now hoisted to the top of `Call`/`Construct` and passed through `PrepareForOrdinaryCall`, `NewFunctionEnvironment`, `EvaluateBody` and FDI. Cold async/generator FDI callers keep the null default and resolve as before.
2. **Drop the unused `callerContext` struct copy** in `PrepareForOrdinaryCall` (an `ExecutionContext`-sized read nothing consumed).
3. **Collapse per-statement `context.IsSuspended()` probes** to a null check plus state read on the frame's captured suspendable reference in `JintStatementList` (two sites) and `JintCallExpression` (three sites). The reference is fixed for the duration of the frame (documented invariant at the capture site); only its state changes, and the state is still re-read per probe.

No behavioral change; allocations are byte-identical on every row below.

## Benchmarks (before/after, same machine, sequential runs)

Call-shape drivers — the targets:

| Row | main | PR | Δ |
|---|---|---|---|
| ClosureCall EmptyClosureCall | 33.81 ms | 32.33 ms | **−4.4%** |
| ClosureCall CapturedVarReadWrite | 45.63 ms | 41.27 ms | **−9.6%** |
| ClosureCall ParamLocalCall | 109.24 ms | 92.89 ms | **−15.0%** |
| ClosureCall ManyLocalCall | 149.70 ms | 136.57 ms | **−8.8%** |
| MethodCall MethodCallThis | 255.1 ms | 237.2 ms | **−7.0%** |
| MethodCall MethodCallCaptured | 256.3 ms | 248.0 ms | **−3.2%** |
| MethodCall UserPrototypeMethod | 276.9 ms | 245.9 ms | **−11.2%** |
| StopwatchBenchmark Execute (classic) | 144.4 ms | 131.8 ms | **−8.7%** |

Guards/canaries — expected flat:

| Row | main | PR | Δ |
|---|---|---|---|
| MethodCall FreeFunctionCall | 281.4 ms | 279.9 ms | −0.5% |
| MethodCall ArrayPushPop | 140.5 ms | 140.6 ms | +0.1% |
| FunctionInvocation Warm_Call / Apply / Bind / BindThenCall | 592 / 669 / 465 / 962 ns | 580 / 668 / 462 / 972 ns | flat |
| LoopDispatch EmptyLoop | 1.139 ms | 1.140 ms | +0.1% |
| PreparedAnomaly SourcePerOp / Shared / PerOp / ReusedEngine | 14.45 / 14.40 / 13.86 / 15.04 ms | 13.52 / 14.26 / 13.77 / 14.96 ms | −6..0% |
| Generators Small / Large / Interleaved | 971 / 2,338 / 1,034 µs | 1,045 / 2,409 / 986 µs | ±7% mixed, allocs identical |

Variance note: stopwatch `Execute_ParsedScript`/`Modern` rows and `SmallGenerators` moved within their per-process mode bands (wide StdDev, byte-identical allocations) — single-launch process mode-lock, not signal. Row-level stopwatch movement gets certified by the next full EngineComparison refresh; the call-shape drivers above are the per-PR evidence.

Gates: Jint.Tests 3,289+3,226 pass, PublicInterface 82×2 pass, Test262 **99,426 pass / 0 fail** (exact baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BY8HoKam5H8vTPn1bMY2Hv
