### PR TITLE
Add call-site constructor cache with zero-arg leaf fast path for new Date()

### DIFF
--- a/Jint.Tests/Runtime/NewExpressionCacheTests.cs
+++ b/Jint.Tests/Runtime/NewExpressionCacheTests.cs
@@ -1,0 +1,137 @@
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the semantics of the JintNewExpression call-site constructor cache: identity-validated,
+/// falls through on any miss, and the zero-arg leaf fast path (default-time-system Date) stays
+/// unobservable.
+/// </summary>
+public class NewExpressionCacheTests
+{
+    [Fact]
+    public void RepeatedNewDateUsesRealmPrototype()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var ok = 0;
+                var last = null;
+                for (var i = 0; i < 1000; i++) {
+                    var d = new Date();
+                    if (Object.getPrototypeOf(d) === Date.prototype && d !== last) ok++;
+                    last = d;
+                }
+                return ok;
+            })()
+            """).AsNumber();
+
+        Assert.Equal(1000, result);
+    }
+
+    [Fact]
+    public void ReassignedDateConstructorIsPickedUpAtWarmCallSite()
+    {
+        var engine = new Engine();
+        // warm the call site with the built-in Date, then swap the global binding: the cache
+        // must miss on identity and construct through the new function
+        var result = engine.Evaluate("""
+            (function () {
+                var seen = '';
+                function make() { return new Date(); }
+                for (var i = 0; i < 100; i++) make();
+                seen += (make() instanceof Date);
+                Date = function () { this.marker = 42; };
+                var d = make();
+                seen += ':' + d.marker;
+                return seen;
+            })()
+            """).AsString();
+
+        Assert.Equal("true:42", result);
+    }
+
+    [Fact]
+    public void SubclassedDateGetsSubclassPrototype()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                for (var i = 0; i < 100; i++) new Date();
+                class D extends Date { }
+                var d = new D();
+                return (Object.getPrototypeOf(d) === D.prototype) + ':' + (d instanceof Date);
+            })()
+            """).AsString();
+
+        Assert.Equal("true:true", result);
+    }
+
+    [Fact]
+    public void SharedPreparedScriptConstructsAgainstOwnRealm()
+    {
+        // one prepared script executed by two engines: the call-site cache must re-resolve per
+        // engine (identity miss) so each engine gets dates from its own realm intrinsics
+        var prepared = Engine.PrepareScript("""
+            var d = new Date();
+            Object.getPrototypeOf(d) === Date.prototype;
+            """);
+
+        var engine1 = new Engine();
+        var engine2 = new Engine();
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.True(engine1.Evaluate(prepared).AsBoolean());
+            Assert.True(engine2.Evaluate(prepared).AsBoolean());
+        }
+    }
+
+    [Fact]
+    public void CustomTimeSystemStillServesNewDate()
+    {
+        // a custom ITimeSystem disables the leaf fast path (exact-type gate); constructs run the
+        // generic path and observe the custom clock
+        var engine = new Engine(options => options.TimeSystem = new FixedTimeSystem());
+        var result = engine.Evaluate("""
+            (function () {
+                var ok = 0;
+                for (var i = 0; i < 100; i++) {
+                    if (new Date().getTime() === 123456789) ok++;
+                }
+                return ok;
+            })()
+            """).AsNumber();
+
+        Assert.Equal(100, result);
+    }
+
+    [Fact]
+    public void ThrowingCustomTimeSystemSurfacesExceptionPerConstruct()
+    {
+        var engine = new Engine(options => options.TimeSystem = new ThrowingTimeSystem());
+        var ex = Assert.Throws<InvalidOperationException>(() => engine.Evaluate("new Date()"));
+        Assert.Equal("clock is broken", ex.Message);
+    }
+
+    private sealed class FixedTimeSystem : ITimeSystem
+    {
+        public DateTimeOffset GetUtcNow() => DateTimeOffset.FromUnixTimeMilliseconds(123456789);
+        public TimeZoneInfo DefaultTimeZone => TimeZoneInfo.Utc;
+        public bool TryParse(string date, out long epochMilliseconds)
+        {
+            epochMilliseconds = 0;
+            return false;
+        }
+    }
+
+    private sealed class ThrowingTimeSystem : ITimeSystem
+    {
+        public DateTimeOffset GetUtcNow() => throw new InvalidOperationException("clock is broken");
+        public TimeZoneInfo DefaultTimeZone => TimeZoneInfo.Utc;
+        public bool TryParse(string date, out long epochMilliseconds)
+        {
+            epochMilliseconds = 0;
+            return false;
+        }
+    }
+}

--- a/Jint.Tests/Runtime/NewExpressionCacheTests.cs
+++ b/Jint.Tests/Runtime/NewExpressionCacheTests.cs
@@ -117,6 +117,7 @@ public class NewExpressionCacheTests
     {
         public DateTimeOffset GetUtcNow() => DateTimeOffset.FromUnixTimeMilliseconds(123456789);
         public TimeZoneInfo DefaultTimeZone => TimeZoneInfo.Utc;
+        public TimeSpan GetUtcOffset(long epochMilliseconds) => TimeSpan.Zero;
         public bool TryParse(string date, out long epochMilliseconds)
         {
             epochMilliseconds = 0;
@@ -128,6 +129,7 @@ public class NewExpressionCacheTests
     {
         public DateTimeOffset GetUtcNow() => throw new InvalidOperationException("clock is broken");
         public TimeZoneInfo DefaultTimeZone => TimeZoneInfo.Utc;
+        public TimeSpan GetUtcOffset(long epochMilliseconds) => TimeSpan.Zero;
         public bool TryParse(string date, out long epochMilliseconds)
         {
             epochMilliseconds = 0;

--- a/Jint/Native/Date/DateConstructor.cs
+++ b/Jint/Native/Date/DateConstructor.cs
@@ -17,6 +17,7 @@ internal sealed partial class DateConstructor : Constructor
     private static readonly long EpochTicks = Epoch.Ticks;
     private static readonly JsString _functionName = new JsString("Date");
     private readonly ITimeSystem _timeSystem;
+    private readonly bool _isZeroArgLeafConstructor;
 
     internal DateConstructor(
         Engine engine,
@@ -30,7 +31,14 @@ internal sealed partial class DateConstructor : Constructor
         _length = new PropertyDescriptor(7, PropertyFlag.Configurable);
         _prototypeDescriptor = new PropertyDescriptor(PrototypeObject, PropertyFlag.AllForbidden);
         _timeSystem = engine.Options.TimeSystem;
+
+        // Only the stock time system is proven side-effect- and throw-free; a derived or custom
+        // ITimeSystem could throw from GetUtcNow and would then miss its `new Date()` stack frame
+        // on the leaf construct path, so the exact type is required.
+        _isZeroArgLeafConstructor = _timeSystem.GetType() == typeof(DefaultTimeSystem);
     }
+
+    internal override bool IsZeroArgLeafConstructor => _isZeroArgLeafConstructor;
 
     internal DatePrototype PrototypeObject { get; }
 

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -86,6 +86,14 @@ public abstract partial class Function : ObjectInstance, ICallable
 
     internal override bool IsConstructor => this is IConstructor;
 
+    /// <summary>
+    /// True for built-in constructors whose zero-argument [[Construct]] with newTarget == this
+    /// runs no user-observable code and cannot raise a JavaScript error, allowing call sites to
+    /// skip the call-stack frame and constructor-resolution ceremony. Must stay false whenever a
+    /// user callback (e.g. a custom time system) could observe the call or throw through it.
+    /// </summary>
+    internal virtual bool IsZeroArgLeafConstructor => false;
+
     public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
     {
         if (_prototypeDescriptor != null)

--- a/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintNewExpression.cs
@@ -1,14 +1,29 @@
+using Jint.Native;
+using Jint.Native.Function;
+
 namespace Jint.Runtime.Interpreter.Expressions;
 
 internal sealed class JintNewExpression : JintExpression
 {
     private readonly ExpressionCache _arguments = new();
     private readonly JintExpression _calleeExpression;
+    private readonly bool _zeroArgs;
+
+    // Monomorphic call-site cache: the constructor object seen by the last evaluation.
+    // Identity pins the realm and the immutable per-instance IsConstructor /
+    // IsZeroArgLeafConstructor verdicts, so a hit skips the constructor type-test — and for
+    // zero-argument leaf built-ins (default-time-system Date) the whole Engine.Construct
+    // call-stack ceremony, which such constructors can neither observe nor throw through.
+    // A miss (callee reassigned, different engine sharing this prepared node) falls through
+    // to the generic path and re-caches — never a permanent decline.
+    private Function? _cachedConstructor;
+    private bool _cachedLeafZeroArg;
 
     public JintNewExpression(NewExpression expression) : base(expression)
     {
         _arguments.Initialize(expression.Arguments.AsSpan());
         _calleeExpression = Build(expression.Callee);
+        _zeroArgs = expression.Arguments.Count == 0;
     }
 
     protected override object EvaluateInternal(EvaluationContext context)
@@ -17,6 +32,18 @@ internal sealed class JintNewExpression : JintExpression
 
         // todo: optimize by defining a common abstract class or interface
         var jsValue = _calleeExpression.GetValue(context);
+
+        var isCachedConstructor = ReferenceEquals(jsValue, _cachedConstructor);
+        if (isCachedConstructor
+            && _cachedLeafZeroArg
+            && !engine._isDebugMode
+            && engine.ExecutionContext.Suspendable is null)
+        {
+            // Error objects cannot be produced, but a custom .NET-level failure would still
+            // resolve its script location from the last syntax element.
+            context.LastSyntaxElement = _expression;
+            return ((IConstructor) jsValue).Construct(Arguments.Empty, jsValue);
+        }
 
         if (context.IsSuspended())
         {
@@ -36,7 +63,7 @@ internal sealed class JintNewExpression : JintExpression
             return jsValue;
         }
 
-        if (!jsValue.IsConstructor)
+        if (!isCachedConstructor && !jsValue.IsConstructor)
         {
             Throw.TypeError(engine.Realm, $"{_calleeExpression.SourceText} is not a constructor");
         }
@@ -47,6 +74,12 @@ internal sealed class JintNewExpression : JintExpression
         if (rented)
         {
             engine._jsValueArrayPool.ReturnArray(arguments);
+        }
+
+        if (!isCachedConstructor && jsValue is Function function)
+        {
+            _cachedConstructor = function;
+            _cachedLeafZeroArg = _zeroArgs && function.IsZeroArgLeafConstructor && function is IConstructor;
         }
 
         return instance;


### PR DESCRIPTION
Every `new Date()` re-tested `IsConstructor` and entered the generic `Engine.Construct` — call-stack push/pop, recursion-depth compare — although the resolved constructor is already version-validated by the global identifier cache and its verdicts are immutable per instance. The stopwatch row pays this 171k times per op.

`JintNewExpression` now remembers the last constructor object it constructed through (monomorphic, `ReferenceEquals`-validated — identity pins the realm and the per-instance verdicts):

- An identity hit skips the `IsConstructor` type-test.
- When the cached constructor is additionally a **zero-argument leaf built-in** — a new `internal virtual Function.IsZeroArgLeafConstructor`, overridden by `DateConstructor` only when the engine runs the exact stock `DefaultTimeSystem` — the construct bypasses `Engine.Construct` entirely. Such a constructor runs no user-observable code and cannot raise a JavaScript error, so the call-stack frame is dead weight. Derived or custom time systems keep the frame (a throwing `GetUtcNow` would otherwise lose its `new Date()` stack entry), as do debug-mode engines and suspendable frames; `LastSyntaxElement` is still set so a .NET-level failure resolves its script location.
- A miss (callee reassigned, another engine sharing the prepared node) falls through to the generic path and re-caches — never a permanent decline (the #2616 pattern).

Scope is deliberately Date-first: the mechanism is general, but `Error` captures the stack (never leaf) and other built-ins aren't exercised by any row today.

Six pins in `NewExpressionCacheTests`: realm-prototype identity over a warmed call site, mid-script `Date` reassignment picked up at a warm site, subclass `newTarget` prototypes, two engines alternating over one shared prepared script, custom-`ITimeSystem` clocks served through the generic path, and a throwing custom time system surfacing its exception per construct.

## Benchmarks (before/after, same machine, sequential)

| Row | main | PR | Δ |
|---|---|---|---|
| DateConstruction NewDateNow (100k constructs/op) | 8.393 ms | 7.037 ms | **−16.2%** (84 → 70 ns/construct) |
| DateConstruction NewDateMillis (guard: 1-arg, non-leaf) | 13.570 ms | 12.967 ms | −4.4% |

Stopwatch rows moved within their single-launch mode bands in both directions (classic Execute −1.1%, classic ParsedScript +5.5%, modern flat; the mechanism's expected row share is only ~2%, inside the bands — the isolated driver row above is the evidence; row certification comes with the next EngineComparison refresh). PreparedAnomaly rows: times ±3..7% mixed-sign, allocations +10–20 B/op from the two new fields on `JintNewExpression` handler instances (fresh-engine-per-op hosts rebuild handlers each op) — disclosed, negligible.

Gates: Jint.Tests 3,295+3,232 pass (6 new pins), PublicInterface 82×2*, Test262 **99,426 pass / 0 fail** (exact baseline).

\* the net472 `TimeSystemTests.CanUseTimeProvider` wall-clock-tolerance test currently fails on this machine on unmodified main as well (verified 3/3, ~7 ms past its 100 ms window, post-sleep timer state) — environmental, not attributable to the change; the net10 arm and all other net472 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BY8HoKam5H8vTPn1bMY2Hv
