### PR TITLE
Memoize nested-scope global reads behind chain identity and an injection epoch

### DIFF
--- a/Jint.Benchmark/GlobalAccessBenchmarks.cs
+++ b/Jint.Benchmark/GlobalAccessBenchmarks.cs
@@ -16,6 +16,8 @@ public class GlobalAccessBenchmarks
     private Prepared<Script> _globalVarLoop;
     private Prepared<Script> _localVarLoop;
     private Prepared<Script> _globalUpdateLoop;
+    private Prepared<Script> _nestedGlobalReadLoop;
+    private Prepared<Script> _nestedGlobalWriteLoop;
 
     [GlobalSetup]
     public void Setup()
@@ -55,11 +57,45 @@ public class GlobalAccessBenchmarks
             gx + gy;
             """, strict: true);
 
+        // Global reads from a NESTED lexical scope (let-header loop + const body): the validator
+        // cannot take the hop-0 identity arm and re-walks the chain with shadow probes per read —
+        // the stopwatch-modern shape where the most-referenced binding (`sw`) is a global reached
+        // from two levels of loop scope.
+        _nestedGlobalReadLoop = Engine.PrepareScript("""
+            gobj = { n: 0 };
+            gsum = 0;
+            (function () {
+                var t = 0;
+                for (let r = 0; r < 20; r++) {
+                    for (let i = 0; i < 10000; i++) {
+                        const a = gobj;
+                        const b = gobj;
+                        t = (t + (a === b ? 1 : 0)) & 1023;
+                    }
+                }
+                return t;
+            })();
+            """, strict: true);
+
+        _nestedGlobalWriteLoop = Engine.PrepareScript("""
+            gval = 0;
+            (function () {
+                for (let r = 0; r < 20; r++) {
+                    for (let i = 0; i < 10000; i++) {
+                        gval = i & 1023;
+                    }
+                }
+                return gval;
+            })();
+            """, strict: true);
+
         _engine = new Engine(static options => options.Strict());
-        _engine.Execute("var gx = 0; var gy = 0; var gz = 0;");
+        _engine.Execute("var gx = 0; var gy = 0; var gz = 0; var gobj = null; var gsum = 0; var gval = 0;");
         _engine.Evaluate(_globalVarLoop);
         _engine.Evaluate(_localVarLoop);
         _engine.Evaluate(_globalUpdateLoop);
+        _engine.Evaluate(_nestedGlobalReadLoop);
+        _engine.Evaluate(_nestedGlobalWriteLoop);
     }
 
     [Benchmark]
@@ -70,4 +106,10 @@ public class GlobalAccessBenchmarks
 
     [Benchmark]
     public JsValue GlobalUpdateLoop() => _engine.Evaluate(_globalUpdateLoop);
+
+    [Benchmark]
+    public JsValue NestedGlobalReadLoop() => _engine.Evaluate(_nestedGlobalReadLoop);
+
+    [Benchmark]
+    public JsValue NestedGlobalWriteLoop() => _engine.Evaluate(_nestedGlobalWriteLoop);
 }

--- a/Jint.Tests/Runtime/NestedGlobalMemoTests.cs
+++ b/Jint.Tests/Runtime/NestedGlobalMemoTests.cs
@@ -1,0 +1,187 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the semantics of the nested-scope global-read chain memo in JintIdentifierExpression:
+/// a pinned identity-stable chain must still observe every legal way a binding can appear
+/// between the reading scope and the global environment.
+/// </summary>
+public class NestedGlobalMemoTests
+{
+    [Fact]
+    public void SloppyEvalInjectionIntoPinnedChainIsObserved()
+    {
+        var engine = new Engine();
+        // The chain [pooled loop env] -> [run's reused fn env] -> [host's fn env] -> global stays
+        // identity-stable across the two run() calls, so only the injection epoch can reveal the
+        // eval-hoisted `g` in host's var env. Without it the second run() would keep reading the
+        // global through the memo.
+        var result = engine.Evaluate("""
+            var g = 1;
+            function host() {
+                var out = '';
+                function run() {
+                    for (let i = 0; i < 3; i++) { out += typeof g + ';'; }
+                }
+                run();
+                eval("var g = 'injected';");
+                run();
+                return out;
+            }
+            host();
+            """).AsString();
+
+        Assert.Equal("number;number;number;string;string;string;", result);
+    }
+
+    [Fact]
+    public void SloppyEvalInjectionRedirectsNestedWrites()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var gw = 0;
+            function hostw() {
+                function run(v) {
+                    for (let i = 0; i < 1; i++) { gw = v; }
+                }
+                run(1);
+                eval("var gw = 'local';");
+                run(2);
+                return gw + ':' + globalThis.gw;
+            }
+            hostw();
+            """).AsString();
+
+        // after injection the write must land on host's binding; the global keeps run(1)'s value
+        Assert.Equal("2:1", result);
+    }
+
+    [Fact]
+    public void AnnexBBlockFunctionShadowIsObserved()
+    {
+        var engine = new Engine();
+        // sloppy block-level function: the var binding pre-exists from function entry (AnnexB),
+        // so reads before the block see undefined and after it the function
+        var result = engine.Evaluate("""
+            var out2 = '';
+            function host3() {
+                function run() {
+                    for (let i = 0; i < 2; i++) { out2 += typeof hoisted + ';'; }
+                }
+                run();
+                { function hoisted() {} }
+                run();
+                return out2;
+            }
+            host3();
+            """).AsString();
+
+        Assert.Equal("undefined;undefined;function;function;", result);
+    }
+
+    [Fact]
+    public void WithEnvironmentBlocksTheMemo()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var w = 'global';
+            function f() {
+                var out = '';
+                for (let i = 0; i < 2; i++) { out += w + ';'; }
+                with ({ w: 'with' }) {
+                    for (let i = 0; i < 2; i++) { out += w + ';'; }
+                }
+                for (let i = 0; i < 2; i++) { out += w + ';'; }
+                return out;
+            }
+            f();
+            """).AsString();
+
+        Assert.Equal("global;global;with;with;global;global;", result);
+    }
+
+    [Fact]
+    public void SharedPreparedScriptResolvesPerEngine()
+    {
+        var prepared = Engine.PrepareScript("""
+            (function () {
+                var t = '';
+                for (let i = 0; i < 3; i++) { t += gv; }
+                return t;
+            })();
+            """);
+
+        var engine1 = new Engine();
+        engine1.Execute("var gv = 'a';");
+        var engine2 = new Engine();
+        engine2.Execute("var gv = 'b';");
+
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal("aaa", engine1.Evaluate(prepared).AsString());
+            Assert.Equal("bbb", engine2.Evaluate(prepared).AsString());
+        }
+    }
+
+    [Fact]
+    public void GlobalLexicalShadowAfterMemoizationIsObserved()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            globalThis.gp = 'prop';
+            function r() {
+                var t = '';
+                for (let i = 0; i < 2; i++) { t += gp; }
+                return t;
+            }
+            """);
+
+        Assert.Equal("propprop", engine.Evaluate("r();").AsString());
+
+        // a global let now shadows the plain global property; _lexicalMutations invalidates
+        engine.Execute("let gp = 'lexical';");
+        Assert.Equal("lexicallexical", engine.Evaluate("r();").AsString());
+    }
+
+    [Fact]
+    public void DeletedGlobalThrowsAfterMemoization()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            globalThis.gd = 'here';
+            function r() {
+                var t = '';
+                for (let i = 0; i < 2; i++) { t += gd; }
+                return t;
+            }
+            """);
+
+        Assert.Equal("herehere", engine.Evaluate("r();").AsString());
+
+        engine.Execute("delete globalThis.gd;");
+        var ex = Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("r();"));
+        Assert.Contains("gd is not defined", ex.Message);
+    }
+
+    [Fact]
+    public void PooledLoopEnvReattachmentKeepsCorrectChain()
+    {
+        var engine = new Engine();
+        // the same pooled loop env instance is re-attached under different function activations;
+        // the memo's chain-link identity must miss (or match correctly) — values stay per-call
+        var result = engine.Evaluate("""
+            var acc = '';
+            function makeReader(tag) {
+                return function reader() {
+                    for (let i = 0; i < 2; i++) { acc += tag + ':' + gshared + ';'; }
+                };
+            }
+            var gshared = 'X';
+            var r1 = makeReader('a');
+            var r2 = makeReader('b');
+            r1(); r2(); r1();
+            acc;
+            """).AsString();
+
+        Assert.Equal("a:X;a:X;b:X;b:X;a:X;a:X;", result);
+    }
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -254,6 +254,13 @@ public sealed partial class Engine : IDisposable
 
     internal Node? _lastSyntaxElement;
 
+    // Bumped when a binding is injected into a PRE-EXISTING environment mid-execution (sloppy
+    // direct eval var/function hoisting, AnnexB block-function var-scope copies). Nested-scope
+    // global-read memos pin environment chains by identity and re-validate against this — chain
+    // identity alone cannot see a name added to a pinned env. Creates into fresh environments
+    // never bump: a fresh environment cannot appear in a previously pinned chain.
+    internal int _envBindingInjectionEpoch;
+
     internal Realm Realm => _realmInConstruction ?? ExecutionContext.Realm;
 
     /// <summary>
@@ -1521,6 +1528,13 @@ public sealed partial class Engine : IDisposable
         var varEnvRec = varEnv;
 
         var realm = Realm;
+
+        if (!strict)
+        {
+            // Sloppy direct eval hoists vars/functions into the CALLER's pre-existing variable
+            // environment — the one mutation that invalidates pinned nested-global chain memos.
+            _envBindingInjectionEpoch++;
+        }
 
         if (!strict && hoistingScope._variablesDeclarations != null)
         {

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -33,9 +33,40 @@ internal sealed class JintIdentifierExpression : JintExpression
     private Runtime.Descriptors.PropertyDescriptor? _cachedGlobalDescriptor;
     private uint _cachedGlobalShapeVersion;
     private int _cachedGlobalLexicalVersion;
+    private NestedChainMemo? _nestedChainMemo;
 
     // Bounded walk: chain depth is typically 1-3 in real code; deeper chains fall through.
     private const int MaxSlotCacheChainDepth = 4;
+
+    /// <summary>
+    /// Memo of a successful nested-scope global walk: from the pinned start environment,
+    /// following the pinned intermediate links, the walk reached the cached GlobalEnvironment
+    /// with no intermediate owning the name. Chain-LINK identity is required, not just the
+    /// start: pooled loop environments are re-attached under different outers across entries,
+    /// so the same start instance can sit on a different chain. Post-creation binding injection
+    /// into a pinned intermediate (sloppy direct eval hoisting, AnnexB function copies) is the
+    /// one mutation identity cannot see — covered by <see cref="Engine._envBindingInjectionEpoch"/>.
+    /// Instances are immutable and published through a single reference field so cross-engine
+    /// shared handler trees observe consistent snapshots; a mismatch falls through to the walk
+    /// and re-publishes (never a permanent decline).
+    /// </summary>
+    private sealed class NestedChainMemo
+    {
+        internal readonly Environment Start;
+        internal readonly Environment? Next1;
+        internal readonly Environment? Next2;
+        internal readonly Environment? Next3;
+        internal readonly int InjectionEpoch;
+
+        internal NestedChainMemo(Environment start, Environment? next1, Environment? next2, Environment? next3, int injectionEpoch)
+        {
+            Start = start;
+            Next1 = next1;
+            Next2 = next2;
+            Next3 = next3;
+            InjectionEpoch = injectionEpoch;
+        }
+    }
 
     public JintIdentifierExpression(Identifier expression) : base(expression)
     {
@@ -297,8 +328,34 @@ internal sealed class JintIdentifierExpression : JintExpression
             return null;
         }
 
+        // Chain-shape memo: when the exact pinned chain (every link by identity) still connects
+        // the current env to the global env and no binding has been injected into a pre-existing
+        // environment since (epoch), the per-hop shadow probes of the walk below are provably
+        // still false — the name sets of pinned envs are otherwise immutable.
+        var memo = _nestedChainMemo;
+        if (memo is not null
+            && ReferenceEquals(env, memo.Start)
+            && engine._envBindingInjectionEpoch == memo.InjectionEpoch)
+        {
+            var next = env._outerEnv;
+            if (memo.Next1 is null
+                ? ReferenceEquals(next, cachedGlobalEnv)
+                : ReferenceEquals(next, memo.Next1)
+                  && (memo.Next2 is null
+                      ? ReferenceEquals(memo.Next1._outerEnv, cachedGlobalEnv)
+                      : ReferenceEquals(memo.Next1._outerEnv, memo.Next2)
+                        && (memo.Next3 is null
+                            ? ReferenceEquals(memo.Next2._outerEnv, cachedGlobalEnv)
+                            : ReferenceEquals(memo.Next2._outerEnv, memo.Next3)
+                              && ReferenceEquals(memo.Next3._outerEnv, cachedGlobalEnv))))
+            {
+                return _cachedGlobalDescriptor;
+            }
+        }
+
         var key = _identifier.Key;
         var search = env;
+        Environment? next1 = null, next2 = null, next3 = null;
         for (var hops = 0; hops < MaxSlotCacheChainDepth; hops++)
         {
             if (search is ObjectEnvironment)
@@ -319,7 +376,21 @@ internal sealed class JintIdentifierExpression : JintExpression
 
             if (ReferenceEquals(search, cachedGlobalEnv))
             {
+                _nestedChainMemo = new NestedChainMemo(env, next1, next2, next3, engine._envBindingInjectionEpoch);
                 return _cachedGlobalDescriptor;
+            }
+
+            if (hops == 0)
+            {
+                next1 = search;
+            }
+            else if (hops == 1)
+            {
+                next2 = search;
+            }
+            else
+            {
+                next3 = search;
             }
         }
 

--- a/Jint/Runtime/Interpreter/JintStatementList.cs
+++ b/Jint/Runtime/Interpreter/JintStatementList.cs
@@ -364,6 +364,9 @@ internal sealed class JintStatementList
 
                         if (shouldCopy)
                         {
+                            // this may CREATE a binding in the pre-existing var env (sloppy
+                            // set-on-missing) — invalidate pinned nested-global chain memos
+                            engine._envBindingInjectionEpoch++;
                             varEnv.SetMutableBinding(fn, fo, strict: false);
                         }
                     }

--- a/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
@@ -117,6 +117,9 @@ internal sealed class JintIfStatement : JintStatement<IfStatement>
 
             if (shouldCopy)
             {
+                // this may CREATE a binding in the pre-existing var env (sloppy set-on-missing)
+                // — invalidate pinned nested-global chain memos
+                engine._envBindingInjectionEpoch++;
                 varEnv.SetMutableBinding(fn, fo, strict: false);
             }
         }


### PR DESCRIPTION
Global reads from nested lexical scopes (loop bodies, closures) validate through `TryGetValidatedGlobalDescriptorNested`, which re-walks up to four environments with per-hop shadow probes on **every read**. This is the dominant cost difference between the stopwatch-modern and classic variants: modern's most-referenced binding (`sw`) is a global reached from two levels of loop scope, ~3 reads × 391k iterations per op, each paying two `HasBinding` name scans that classic's hop-0 identity arm never sees.

The walk's outcome is now memoized per identifier node (`NestedChainMemo`, immutable, published through a single reference field — safe on cross-engine shared handler trees):

- **Pinned chain, link by link.** The start environment and every intermediate link are held by identity, and a repeat read from the identical chain revalidates with reference compares instead of scans. Chain-**link** identity (not just the start) is required because pooled loop environments are re-attached under different outers across entries — a changed link misses and re-walks.
- **Injection epoch.** The one mutation identity cannot see — a binding *added* to a pre-existing pinned environment — is covered by a new `Engine._envBindingInjectionEpoch`, bumped only at the sites that can do that: sloppy direct-eval instantiation and the AnnexB block-function var-scope copies. Creates into fresh environments never bump (a fresh environment cannot appear in a previously pinned chain). Binding *removal* cannot create shadowing, so it needs no bump.
- The existing global shape/lexical version checks run before the memo and cover all global-side mutations (let/const shadowing, redefine, delete); `with` environments bail out of the walk as before, so a memo never pins through one. A miss falls through to the walk and re-publishes — never a permanent decline (the #2616 pattern). Reads, writes and the unboxed numeric lanes are all served through the shared validator.

Eight pins in `NestedGlobalMemoTests`, including the load-bearing one: an identity-stable chain (pooled loop env → reused function env → host env → global) where a mid-activation `eval("var g = …")` injects into the host's env between two calls — only the epoch can reveal it. Others: injection redirecting nested *writes*, AnnexB block-function shadowing, `with` blocking, two engines alternating over one shared prepared script, global `let` shadow and `delete globalThis.x` after memoization, pooled-env re-attachment across function instances.

## Benchmarks (before/after, same machine, sequential)

Target rows (new `GlobalAccessBenchmarks` rows — global access from a nested `let`/`const` scope, the stopwatch-modern shape):

| Row | main | PR | Δ |
|---|---|---|---|
| NestedGlobalReadLoop (400k nested reads/op) | 40.25 ms | 36.43 ms | **−9.5%** |
| NestedGlobalWriteLoop (200k nested writes/op) | 11.01 ms | 10.09 ms | **−8.4%** |
| Stopwatch Execute_ParsedScript (modern) | 148.0 ms | 141.2 ms | **−4.6%** |

Guards — expected flat, and are:

| Row | main | PR | Δ |
|---|---|---|---|
| GlobalVarLoop / GlobalUpdateLoop (hop-0 arm, untouched) | 35.87 / 44.44 ms | 34.78 / 44.33 ms | −3.0% / −0.2% |
| Stopwatch classic Execute / ParsedScript | 136.3 / 136.4 ms | 138.8 / 136.5 ms | +1.8% / +0.1% |
| Stopwatch modern Execute | 148.2 ms | 147.2 ms | −0.7% |
| ForBenchmark ReenteredInnerLetLoop (pooled-env reuse guard) | 48.07 ms | 48.83 ms | +1.6% |
| ForVar / ForLet / ForOf rows | — | — | ±1..4% mixed |
| PreparedAnomaly | 13.62..15.92 ms | 13.69..15.09 ms | ±4% mixed |

Allocations: +0.26 KB/op on fresh-engine-per-op hosts (PreparedAnomaly 45.29 → 45.55 KB) — the memo objects themselves, re-established per engine; steady-state hosts re-use the published memo.

Gates: Jint.Tests 3,297+3,234 pass (8 new pins), PublicInterface 82×2*, Test262 **99,426 pass / 0 fail** (exact baseline).

\* the net472 `TimeSystemTests.CanUseTimeProvider` wall-clock-tolerance test currently fails on this machine on unmodified main as well (verified 3/3, ~7 ms past its 100 ms window, post-sleep timer state) — environmental, not attributable to the change; the net10 arm and all other net472 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BY8HoKam5H8vTPn1bMY2Hv
