### PR TITLE
Add unboxed operand lane for bitwise operators over identifiers

### DIFF
--- a/Jint.Benchmark/LoopDispatchBenchmarks.cs
+++ b/Jint.Benchmark/LoopDispatchBenchmarks.cs
@@ -25,6 +25,7 @@ public class LoopDispatchBenchmarks
     private Prepared<Script> _moduloEqualTest;
     private Prepared<Script> _ifChainLoop;
     private Prepared<Script> _varDeclBody;
+    private Prepared<Script> _xorAssignLoop;
     private Prepared<Script> _arrayLengthBound;
     private Prepared<Script> _stringLengthBound;
 
@@ -109,6 +110,13 @@ public class LoopDispatchBenchmarks
             f();
             """);
 
+        // + identifier ^ identifier over two slot numbers (the stopwatch `var z = x ^ y` shape;
+        // z stays inside the small-int cache so the measurement is operand handling, not boxing)
+        _xorAssignLoop = Engine.PrepareScript("""
+            function f() { var m = 3; var n = 0; for (var i = 0; i < 100000; i++) { var z = i ^ m; } return n; }
+            f();
+            """);
+
         // the member-bound loop test: `i < a.length` re-reads the live length every iteration
         // (6250 × 16 = 100k inner iterations)
         _arrayLengthBound = Engine.PrepareScript("""
@@ -135,6 +143,7 @@ public class LoopDispatchBenchmarks
         _engine.Evaluate(_moduloEqualTest);
         _engine.Evaluate(_ifChainLoop);
         _engine.Evaluate(_varDeclBody);
+        _engine.Evaluate(_xorAssignLoop);
         _engine.Evaluate(_arrayLengthBound);
         _engine.Evaluate(_stringLengthBound);
     }
@@ -171,6 +180,9 @@ public class LoopDispatchBenchmarks
 
     [Benchmark]
     public JsValue VarDeclBody() => _engine.Evaluate(_varDeclBody);
+
+    [Benchmark]
+    public JsValue XorAssignLoop() => _engine.Evaluate(_xorAssignLoop);
 
     [Benchmark]
     public JsValue ArrayLengthBound() => _engine.Evaluate(_arrayLengthBound);

--- a/Jint.Tests/Runtime/BitwiseLaneTests.cs
+++ b/Jint.Tests/Runtime/BitwiseLaneTests.cs
@@ -1,0 +1,173 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the semantics of the bitwise identifier-operand lane (BitwiseIdentifierLane): unboxed
+/// operand reads must be observably identical to the generic ToNumeric/ToInt32 path for every
+/// operator and every operand class, and every non-int32 shape must decline to the generic path.
+/// </summary>
+public class BitwiseLaneTests
+{
+    [Fact]
+    public void AllOperatorsMatchGenericSemanticsOverSlotNumbers()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var samples = [0, 1, 3, 5, 31, 32, 33, 1023, -1, -7, 2147483647, -2147483648];
+                var parts = [];
+                for (var i = 0; i < samples.length; i++) {
+                    for (var j = 0; j < samples.length; j++) {
+                        var x = samples[i];
+                        var y = samples[j];
+                        parts.push(x ^ y, x & y, x | y, x << y, x >> y, x >>> y);
+                    }
+                }
+                return parts.join(',');
+            })()
+            """).AsString();
+
+        // reference values computed with the generic path via Function-constructed code whose
+        // operands are member reads (never identifier-shaped, so the lane cannot arm there)
+        var engine2 = new Engine();
+        var expected = engine2.Evaluate("""
+            (function () {
+                var samples = [0, 1, 3, 5, 31, 32, 33, 1023, -1, -7, 2147483647, -2147483648];
+                var o = { x: 0, y: 0 };
+                var parts = [];
+                for (var i = 0; i < samples.length; i++) {
+                    for (var j = 0; j < samples.length; j++) {
+                        o.x = samples[i];
+                        o.y = samples[j];
+                        parts.push(o.x ^ o.y, o.x & o.y, o.x | o.y, o.x << o.y, o.x >> o.y, o.x >>> o.y);
+                    }
+                }
+                return parts.join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void NonInt32OperandsDeclineToGenericConversion()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var frac = 3.7;
+                var neg = -3.7;
+                var nan = NaN;
+                var inf = Infinity;
+                var ninf = -Infinity;
+                var big = 4294967298;   // 2^32 + 2 — beyond int32, ToInt32 wraps to 2
+                var mask = 5;
+                return [frac ^ mask, neg ^ mask, nan ^ mask, inf ^ mask, ninf ^ mask, big & -1,
+                        frac << 1, big >>> 0].join(',');
+            })()
+            """).AsString();
+
+        // ToInt32(3.7)=3, ToInt32(-3.7)=-3 (so -3^5 = 0xFFFFFFF8 = -8), ToInt32(NaN/±Inf)=0,
+        // ToInt32(2^32+2)=2, ToUint32(2^32+2)=2
+        Assert.Equal("6,-8,5,5,5,2,6,2", result);
+    }
+
+    [Fact]
+    public void NegativeZeroBehavesLikePositiveZero()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var nz = -0;
+                var x = 7;
+                return (nz ^ x) + ':' + (1 / (nz | 0));
+            })()
+            """).AsString();
+
+        // ToInt32(-0) = +0: xor gives 7, and (-0 | 0) is +0 so 1/(+0) = Infinity
+        Assert.Equal("7:Infinity", result);
+    }
+
+    [Fact]
+    public void BigIntOperandsKeepBigIntSemantics()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var a = 12345678901234567890n;
+                var b = 987654321n;
+                return (a ^ b).toString() + ':' + (a & b).toString();
+            })()
+            """).AsString();
+
+        // reference values verified independently with System.Numerics.BigInteger
+        Assert.Equal("12345678900808999523:706611344", result);
+
+        var mixEx = Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
+            engine.Evaluate("(function () { var a = 1n; var b = 2; return a ^ b; })()"));
+        Assert.Contains("BigInt", mixEx.Message);
+    }
+
+    [Fact]
+    public void ValueOfCoercionRunsExactlyOncePerEvaluation()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var calls = 0;
+                var box = { valueOf: function () { calls++; return 6; } };
+                var mask = 3;
+                var r = 0;
+                for (var i = 0; i < 5; i++) {
+                    r = box ^ mask;
+                }
+                return r + ':' + calls;
+            })()
+            """).AsString();
+
+        // the lane declines (binding holds an object, not a number); generic path calls valueOf
+        // once per evaluation — five iterations, five calls
+        Assert.Equal("5:5", result);
+    }
+
+    [Fact]
+    public void StringOperandsCoerceThroughGenericPath()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                var s = '12';
+                var x = 10;
+                return (x ^ s) + ':' + (s << 1);
+            })()
+            """).AsString();
+
+        Assert.Equal("6:24", result);
+    }
+
+    [Fact]
+    public void LetConstAndGlobalShapesAllCompute()
+    {
+        var engine = new Engine();
+        var viaLexical = engine.Evaluate("""
+            (function () {
+                let x = 12;
+                const m = 10;
+                let acc = 0;
+                for (let i = 0; i < 3; i++) {
+                    acc += x ^ m;
+                }
+                return acc;
+            })()
+            """).AsNumber();
+        Assert.Equal(18, viaLexical);
+
+        var viaGlobals = engine.Evaluate("""
+            gx = 12; gm = 10; gacc = 0;
+            for (var gi = 0; gi < 3; gi++) {
+                gacc += gx ^ gm;
+            }
+            gacc;
+            """).AsNumber();
+        Assert.Equal(18, viaGlobals);
+    }
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -179,6 +179,96 @@ internal abstract class JintBinaryExpression : JintExpression
     }
 
     /// <summary>
+    /// Unboxed operand lane for bitwise/shift operators over `identifier OP identifier` and
+    /// `identifier OP numericConstant` shapes (`x ^ y`, `z &amp; 3` — the stopwatch/masking loop
+    /// shapes). Both operands are read as raw doubles through the slot/global caches (pure reads,
+    /// so a decline re-evaluates generically with no observable double effect) and must be
+    /// int32-representable — exactly the values for which ToInt32(ToNumeric(v)) equals the plain
+    /// cast, so the integer op matches the generic path bit for bit. Fractional, NaN, infinite,
+    /// BigInt and non-number operands all decline to the generic path (which owns the valueOf
+    /// coercion, BigInt arms and error cases). The result is boxed once by the consumer.
+    /// </summary>
+    private protected struct BitwiseIdentifierLane
+    {
+        private JintIdentifierExpression? _identifier;
+        private JintIdentifierExpression? _rightIdentifier;   // null => use _constant
+        private double _constant;
+        private SlotLocationCache _slotCache;
+        private SlotLocationCache _rightSlotCache;
+
+        public void Initialize(JintExpression left, JintExpression right)
+        {
+            if (left is not JintIdentifierExpression identifier)
+            {
+                return;
+            }
+
+            switch (right)
+            {
+                case JintConstantExpression { Value: JsNumber number }:
+                    _identifier = identifier;
+                    _constant = number._value;
+                    break;
+                case JintIdentifierExpression rightIdentifier:
+                    _identifier = identifier;
+                    _rightIdentifier = rightIdentifier;
+                    break;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGetInt32Operands(EvaluationContext context, out int left, out int right)
+        {
+            left = 0;
+            right = 0;
+
+            var identifier = _identifier;
+            if (identifier is null || context.OperatorOverloadingAllowed)
+            {
+                return false;
+            }
+
+            var engine = context.Engine;
+            if (engine.ExecutionContext.Suspendable is not null)
+            {
+                return false;
+            }
+
+            double leftValue;
+            var env = engine.ExecutionContext.LexicalEnvironment;
+            if (!_slotCache.TryResolve(engine, env, identifier.Identifier, out var environment, out var slotIndex)
+                || !environment.TryGetNumberSlotForRead(slotIndex, out leftValue))
+            {
+                if (identifier._cachedGlobalEnv is null || !TryReadGlobalNumber(identifier, engine, env, out leftValue))
+                {
+                    return false;
+                }
+            }
+
+            double rightValue;
+            var rightIdentifier = _rightIdentifier;
+            if (rightIdentifier is null)
+            {
+                rightValue = _constant;
+            }
+            else if (!(_rightSlotCache.TryResolve(engine, env, rightIdentifier.Identifier, out var rightEnvironment, out var rightSlotIndex)
+                       && rightEnvironment.TryGetNumberSlotForRead(rightSlotIndex, out rightValue)))
+            {
+                if (rightIdentifier._cachedGlobalEnv is null || !TryReadGlobalNumber(rightIdentifier, engine, env, out rightValue))
+                {
+                    return false;
+                }
+            }
+
+            // int32-representable check: NaN/±Infinity/fractional values fail the round-trip
+            // equality and decline; -0 passes and converts to +0 exactly like ToInt32
+            left = (int) leftValue;
+            right = (int) rightValue;
+            return left == leftValue && right == rightValue;
+        }
+    }
+
+    /// <summary>
     /// Whole-tree lane for sum-of-products arithmetic over pure-readable numeric leaves —
     /// `M1[i][0]*M2[0][j] + M1[i][1]*M2[1][j] + …`, the dromaeo-3d-cube MMulti/VMulti kernel shape,
     /// which otherwise boxes a transient JsNumber per binary node. The whole tree is computed on
@@ -1596,14 +1686,24 @@ internal abstract class JintBinaryExpression : JintExpression
         }
 
         private readonly Operator _operator;
+        private BitwiseIdentifierLane _lane;
 
         public BitwiseBinaryExpression(NonLogicalBinaryExpression expression) : base(expression)
         {
             _operator = expression.Operator;
+            _lane.Initialize(_left, _right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
+            // `x ^ y` / `z & 3` over slot/global numbers: both operands read unboxed, the
+            // integer op boxed once. Declines (non-int32 values, non-number bindings, BigInt,
+            // suspendable frames) re-evaluate generically — the lane reads are pure.
+            if (_lane.TryGetInt32Operands(context, out var leftInt, out var rightInt))
+            {
+                return EvaluateIntegerBitwise(_operator, leftInt, rightInt);
+            }
+
             if (!TryEvaluateOperands(context, out var lval, out var rval))
             {
                 return JsValue.Undefined;
@@ -1623,6 +1723,42 @@ internal abstract class JintBinaryExpression : JintExpression
     }
 
     /// <summary>
+    /// The integer arm of <see cref="EvaluateBitwiseOperation"/>: operands already converted to
+    /// int32 (via integer-typed JsNumbers or the lane's int32-representability check, both of
+    /// which agree with ToInt32 exactly).
+    /// </summary>
+    internal static JsValue EvaluateIntegerBitwise(Operator op, int leftValue, int rightValue)
+    {
+        JsValue? result = null;
+        switch (op)
+        {
+            case Operator.BitwiseAnd:
+                result = JsNumber.Create(leftValue & rightValue);
+                break;
+            case Operator.BitwiseOr:
+                result = JsNumber.Create(leftValue | rightValue);
+                break;
+            case Operator.BitwiseXor:
+                result = JsNumber.Create(leftValue ^ rightValue);
+                break;
+            case Operator.LeftShift:
+                result = JsNumber.Create(leftValue << (int) ((uint) rightValue & 0x1F));
+                break;
+            case Operator.RightShift:
+                result = JsNumber.Create(leftValue >> (int) ((uint) rightValue & 0x1F));
+                break;
+            case Operator.UnsignedRightShift:
+                result = JsNumber.Create((uint) leftValue >> (int) ((uint) rightValue & 0x1F));
+                break;
+            default:
+                Throw.ArgumentOutOfRangeException(nameof(op), "unknown shift operator");
+                break;
+        }
+
+        return result!;
+    }
+
+    /// <summary>
     /// https://tc39.es/ecma262/#sec-numberbitwiseop (+ BigInt variants and shift operators).
     /// Operands must already be numeric (ToNumeric applied). Shared by the bitwise/shift
     /// binary operators and their compound assignment forms.
@@ -1636,36 +1772,7 @@ internal abstract class JintBinaryExpression : JintExpression
 
         if (AreIntegerOperands(left, right))
         {
-            int leftValue = left.AsInteger();
-            int rightValue = right.AsInteger();
-
-            JsValue? result = null;
-            switch (op)
-            {
-                case Operator.BitwiseAnd:
-                    result = JsNumber.Create(leftValue & rightValue);
-                    break;
-                case Operator.BitwiseOr:
-                    result = JsNumber.Create(leftValue | rightValue);
-                    break;
-                case Operator.BitwiseXor:
-                    result = JsNumber.Create(leftValue ^ rightValue);
-                    break;
-                case Operator.LeftShift:
-                    result = JsNumber.Create(leftValue << (int) ((uint) rightValue & 0x1F));
-                    break;
-                case Operator.RightShift:
-                    result = JsNumber.Create(leftValue >> (int) ((uint) rightValue & 0x1F));
-                    break;
-                case Operator.UnsignedRightShift:
-                    result = JsNumber.Create((uint) leftValue >> (int) ((uint) rightValue & 0x1F));
-                    break;
-                default:
-                    Throw.ArgumentOutOfRangeException(nameof(op), "unknown shift operator");
-                    break;
-            }
-
-            return result!;
+            return EvaluateIntegerBitwise(op, left.AsInteger(), right.AsInteger());
         }
 
         switch (op)


### PR DESCRIPTION
The stopwatch shape `var z = x ^ y` (and masking loops like `i & 1023`) evaluated both operands through the boxed `GetValue` path — suspendable probes, JsValue materialization of unboxed slot numbers, `ToNumeric` and integer re-extraction per operand — although the operands are plain slot/global numbers that the comparison lanes already read unboxed. The materialization is worse than ceremony when values leave the small-int cache: an unboxed counter (stored raw by `i++`) got a fresh `JsNumber` allocated on **every read**.

`BitwiseIdentifierLane` mirrors `NumericConstantComparisonLane`'s operand resolution for `identifier OP identifier` and `identifier OP numericConstant` shapes across all six bitwise/shift operators:

- Both operands are read as raw doubles through the slot/global caches (pure reads — a decline re-evaluates generically with no observable effect) and must round-trip through int32 exactly (`(int) d == d`), which is precisely the domain where `ToInt32(ToNumeric(v))` equals the plain cast; `-0` passes and converts to `+0` exactly like `ToInt32`.
- Fractional, NaN, infinite, out-of-int32, BigInt and non-number operands decline to the generic path, which keeps the `valueOf` coercion (pinned: called exactly once per evaluation), the BigInt arms and mixed-type errors.
- The integer op is shared with the generic path through an extracted `EvaluateIntegerBitwise`; the result boxes once (free for small-int-cache values).

Seven pins in `BitwiseLaneTests`: all six operators over a 12×12 sample grid compared against a member-read-shaped reference that can never arm the lane; ToInt32 truncation/wrapping shapes; `-0`; BigInt semantics and mixed-type errors; `valueOf` call counts; string coercion; let/const/global operand shapes. (Reference values for the negative/BigInt cases verified independently with `System.Numerics.BigInteger`.)

## Benchmarks (before/after, same machine, sequential)

Target rows — the allocation drop is deterministic (the lane stops re-materializing out-of-cache unboxed slot values per read):

| LoopDispatch row | main | PR | Δ time | Δ alloc |
|---|---|---|---|---|
| XorAssignLoop (new: `z = i ^ m`, two identifiers) | 7.011 ms / 5,612 KB | 4.871 ms / 2,807 KB | **−30.5%** | **−50%** |
| VarDeclBody (`z = i ^ 3`, identifier-constant) | 7.007 ms / 5,612 KB | 4.685 ms / 2,807 KB | **−33.1%** | **−50%** |
| IfChainLoop (contains one `i ^ 3`) | 25.68 ms / 7,342 KB | 24.17 ms / 4,537 KB | −5.9% | −38% |

Stopwatch rows:

| Row | main | PR | Δ |
|---|---|---|---|
| Execute / Execute_ParsedScript (modern — `x`,`y` are slots; kills the unboxed-store→boxed-read ping-pong) | 103.95 / 104.55 ms | 96.68 / 96.82 ms | **−7.0% / −7.4%** |
| Execute / Execute_ParsedScript (classic — `x`,`y` are globals, already boxed) | 100.60 / 99.96 ms | 99.54 / 98.45 ms | −1.1% / −1.5% |

Untouched canary rows moved within their documented single-launch mode bands in both directions (ComparisonOnly −21%, ModuloEqualTest +9.5%, CounterAdd/LocalCopy −5..7% — none contain a bitwise op, all with byte-identical allocations).

Gates: Jint.Tests 3,342×2-framework pass (7 new pins), PublicInterface 82 + 81* pass, Test262 **99,426 pass / 0 fail** (exact baseline).

\* the net472 `TimeSystemTests.CanUseTimeProvider` wall-clock-tolerance test still fails on this machine on unmodified main (post-sleep timer state, verified earlier today) — environmental; the net10 arm and all other net472 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BY8HoKam5H8vTPn1bMY2Hv
