### PR TITLE
Add benchmark coverage for common JS patterns missing from the suite

### DIFF
--- a/Jint.Benchmark/AllocTypeProbe.cs
+++ b/Jint.Benchmark/AllocTypeProbe.cs
@@ -10,12 +10,76 @@ namespace Jint.Benchmark;
 /// GC.GetAllocatedBytesForCurrentThread (MemoryProbe) can't say *which type*. Used to chase the
 /// per-call allocation floor seen in ClosureCallBenchmarks. Not a benchmark; temporary diagnostic.
 ///
-/// Usage: --profile-alloc-types [scriptName|empty-closure|captured-var] [iterations]
+/// Usage: --profile-alloc-types [scriptName|empty-closure|captured-var|campaignTarget] [iterations]
 /// With a Scripts/ name it runs that engine-comparison script (fresh engine/iter, like the BDN bench);
 /// "empty-closure"/"captured-var" run an inline isolated loop so the per-call floor is unmixed.
+/// Campaign targets (see <see cref="CampaignTargets"/>) run the exact GATE-row sources the coverage
+/// benchmark classes execute, in the same engine mode (reuse-engine warm vs fresh-engine per iter),
+/// so census output and BDN rows attribute the identical workload.
 /// </summary>
 internal static class AllocTypeProbe
 {
+    /// <summary>Census names → the coverage-suite GATE-row workloads (same static sources the benchmarks run).</summary>
+    private static readonly Dictionary<string, Func<Action>> CampaignTargets = new(StringComparer.Ordinal)
+    {
+        ["json-parse-records"] = static () => ReuseEngine(JsonJsBenchmark.ParseRecordsSource, static e => e.SetValue("recordsJson", JsonJsBenchmark.BuildRecordsJson())),
+        ["json-parse-config"] = static () => ReuseEngine(JsonJsBenchmark.ParseConfigSource, static e => e.SetValue("configJson", JsonJsBenchmark.BuildConfigJson())),
+        ["json-stringify-records"] = static () => ReuseEngine(
+            JsonJsBenchmark.StringifyRecordsSource,
+            static e =>
+            {
+                e.SetValue("recordsJson", JsonJsBenchmark.BuildRecordsJson());
+                e.SetValue("configJson", JsonJsBenchmark.BuildConfigJson());
+            },
+            JsonJsBenchmark.SetupSource),
+        ["object-spread-small"] = static () => ReuseEngine(ObjectSpreadBenchmark.SpreadSmallSource, setupSource: ObjectSpreadBenchmark.SetupSource),
+        ["object-assign-fresh"] = static () => ReuseEngine(ObjectSpreadBenchmark.AssignFreshTargetSource, setupSource: ObjectSpreadBenchmark.SetupSource),
+        ["rest-destructuring"] = static () => ReuseEngine(ObjectSpreadBenchmark.RestDestructuringSource, setupSource: ObjectSpreadBenchmark.SetupSource),
+        ["reduce-sum"] = static () => ReuseEngine(ArrayCallbackBenchmark.ReduceSumSource, setupSource: ArrayCallbackBenchmark.SetupSource),
+        ["map-filter-reduce"] = static () => ReuseEngine(ArrayCallbackBenchmark.MapFilterReduceChainSource, setupSource: ArrayCallbackBenchmark.SetupSource),
+        ["await-loop"] = static () => ReuseEngine(AsyncAwaitBenchmark.AwaitResolvedLoopSource),
+        ["then-chain"] = static () => ReuseEngine(AsyncAwaitBenchmark.ThenChain1000Source),
+        ["promise-all"] = static () => ReuseEngine(AsyncAwaitBenchmark.PromiseAll100Source),
+        ["try-nothrow"] = static () => ReuseEngine(ErrorHandlingBenchmark.TryNoThrowSource),
+        ["throw-catch"] = static () => ReuseEngine(ErrorHandlingBenchmark.ThrowCatchLoopSource),
+        ["error-stack"] = static () => ReuseEngine(ErrorHandlingBenchmark.ErrorStackAccessSource),
+        ["map-get-hit"] = static () => ReuseEngine(MapSetLookupBenchmark.MapGetHitSource, setupSource: MapSetLookupBenchmark.SetupSource),
+        ["memoize"] = static () => ReuseEngine(MapSetLookupBenchmark.MemoizePatternSource, setupSource: MapSetLookupBenchmark.SetupSource),
+        ["ctor-window-8"] = static () => FreshEngine(ColdConstructorBenchmark.FunctionCtorX8Source),
+        ["ctor-window-class-8"] = static () => FreshEngine(ColdConstructorBenchmark.ClassCtorX8Source),
+        ["ctor-distinct-200"] = static () => FreshEngine(ColdConstructorBenchmark.BuildDistinctCtorsSource()),
+        ["optional-chain-miss"] = static () => ReuseEngine(ModernOperatorsBenchmark.OptionalChainMissSource, setupSource: ModernOperatorsBenchmark.SetupSource),
+        ["nullish-coalesce"] = static () => ReuseEngine(ModernOperatorsBenchmark.NullishCoalesceSource, setupSource: ModernOperatorsBenchmark.SetupSource),
+        ["forin-hasown"] = static () => ReuseEngine(ForInGuardBenchmark.ForInHasOwnGuardSource, setupSource: ForInGuardBenchmark.SetupSource),
+        ["typeof-switch"] = static () => ReuseEngine(ForInGuardBenchmark.TypeofSwitchMixedSource, setupSource: ForInGuardBenchmark.SetupSource),
+        ["tagged-template"] = static () => ReuseEngine(TemplateLiteralBenchmark.TaggedTemplateSource),
+        ["template-many"] = static () => ReuseEngine(TemplateLiteralBenchmark.ManyInterpolationsSource),
+        ["parseint-loop"] = static () => ReuseEngine(NumberParseBenchmark.ParseIntLoopSource, setupSource: NumberParseBenchmark.SetupSource),
+        ["tofixed-loop"] = static () => ReuseEngine(NumberParseBenchmark.ToFixedLoopSource, setupSource: NumberParseBenchmark.SetupSource),
+        ["regexp-exec-loop"] = static () => ReuseEngine(RegExpExecLoopBenchmark.ExecWhileLoopSource, setupSource: RegExpExecLoopBenchmark.SetupSource),
+    };
+
+    /// <summary>One warm engine, row re-evaluated per iteration — the reuse-engine benchmark mode (non-strict, like the coverage classes).</summary>
+    private static Action ReuseEngine(string rowSource, Action<Engine>? seed = null, string? setupSource = null)
+    {
+        var engine = new Engine();
+        seed?.Invoke(engine);
+        if (setupSource is not null)
+        {
+            engine.Execute(setupSource);
+        }
+
+        var prepared = Engine.PrepareScript(rowSource);
+        return () => engine.Execute(prepared);
+    }
+
+    /// <summary>Fresh engine per iteration — the cold-start benchmark mode.</summary>
+    private static Action FreshEngine(string source)
+    {
+        var prepared = Engine.PrepareScript(source);
+        return () => new Engine().Execute(prepared);
+    }
+
     private const string DromaeoHelpers = """
         var startTest = function () { };
         var test = function (name, fn) { fn(); };
@@ -107,6 +171,10 @@ internal static class AllocTypeProbe
             var prepared = Engine.PrepareScript(src, strict: true);
             var engine = new Engine(static o => o.Strict());
             runOnce = () => engine.Execute(prepared);
+        }
+        else if (CampaignTargets.TryGetValue(target, out var factory))
+        {
+            runOnce = factory();
         }
         else
         {

--- a/Jint.Benchmark/ArrayCallbackBenchmark.cs
+++ b/Jint.Benchmark/ArrayCallbackBenchmark.cs
@@ -1,0 +1,93 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The callback-driven array pipeline: reduce/forEach/some/every and a map→filter→reduce chain
+/// over 100,000 LCG-mixed small integers (values vary enough that the branch predictor cannot
+/// memorize outcomes, yet stay inside the small-int cache so rows measure callback dispatch,
+/// not number boxing). One built-in call per op — the element count is the loop.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class ArrayCallbackBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _reduceSum;
+    private Prepared<Script> _reduceToObject;
+    private Prepared<Script> _forEachSum;
+    private Prepared<Script> _someMiss;
+    private Prepared<Script> _everyHit;
+    private Prepared<Script> _mapFilterReduceChain;
+
+    internal const string SetupSource = """
+        var data = [];
+        var data10k;
+        (function () {
+            var seed = 20260711;
+            for (var i = 0; i < 100000; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                data.push((seed >>> 4) & 1023);
+            }
+            data10k = data.slice(0, 10000);
+        })();
+        """;
+
+    internal const string ReduceSumSource = "data.reduce(function (a, x) { return a + x; }, 0);";
+    internal const string ForEachSumSource = "(function () { var s = 0; data.forEach(function (x) { s += x; }); return s; })();";
+    internal const string MapFilterReduceChainSource = """
+        data.map(function (x) { return x * 2; })
+            .filter(function (x) { return (x % 3) === 0; })
+            .reduce(function (a, x) { return a + x; }, 0);
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute(SetupSource);
+
+        _reduceSum = Engine.PrepareScript(ReduceSumSource);
+
+        // the dictionary-growth reduce shape: accumulator object gains keys as it goes
+        _reduceToObject = Engine.PrepareScript("""
+            data10k.reduce(function (a, x) { a['k' + (x & 63)] = x; return a; }, {});
+            """);
+
+        _forEachSum = Engine.PrepareScript(ForEachSumSource);
+
+        // full-scan miss: predicate never satisfied
+        _someMiss = Engine.PrepareScript("data.some(function (x) { return x < 0; });");
+
+        // full-scan hit: predicate always satisfied
+        _everyHit = Engine.PrepareScript("data.every(function (x) { return x >= 0; });");
+
+        _mapFilterReduceChain = Engine.PrepareScript(MapFilterReduceChainSource);
+
+        _engine.Evaluate(_reduceSum);
+        _engine.Evaluate(_reduceToObject);
+        _engine.Evaluate(_forEachSum);
+        _engine.Evaluate(_someMiss);
+        _engine.Evaluate(_everyHit);
+        _engine.Evaluate(_mapFilterReduceChain);
+    }
+
+    [Benchmark]
+    public JsValue ReduceSum() => _engine.Evaluate(_reduceSum);
+
+    [Benchmark]
+    public JsValue ReduceToObject() => _engine.Evaluate(_reduceToObject);
+
+    [Benchmark]
+    public JsValue ForEachSum() => _engine.Evaluate(_forEachSum);
+
+    [Benchmark]
+    public JsValue SomeMiss() => _engine.Evaluate(_someMiss);
+
+    [Benchmark]
+    public JsValue EveryHit() => _engine.Evaluate(_everyHit);
+
+    [Benchmark]
+    public JsValue MapFilterReduceChain() => _engine.Evaluate(_mapFilterReduceChain);
+}

--- a/Jint.Benchmark/AsyncAwaitBenchmark.cs
+++ b/Jint.Benchmark/AsyncAwaitBenchmark.cs
@@ -1,0 +1,124 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Resolved-promise await chains and microtask-heavy shapes — the dominant real-world async
+/// pattern. Top-level script evaluation drains the event loop until the continuation queue is
+/// empty (including continuations enqueued by continuations), so every row completes fully within
+/// one Evaluate; <see cref="AsyncFunctionExitBenchmark"/> keeps owning bare exit cost.
+/// <see cref="SyncCallLoop"/> is the baseline: the same call count without suspension, so
+/// per-await overhead = (AwaitResolvedLoop − SyncCallLoop) / 1000.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class AsyncAwaitBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _syncCallLoop;
+    private Prepared<Script> _awaitResolvedLoop;
+    private Prepared<Script> _awaitChainDepth50;
+    private Prepared<Script> _promiseAll100;
+    private Prepared<Script> _thenChain1000;
+    private Prepared<Script> _microtaskFanout;
+
+    internal const string AwaitResolvedLoopSource = """
+        async function f() {
+            var s = 0;
+            for (var i = 0; i < 1000; i++) { s += await Promise.resolve(1); }
+            return s;
+        }
+        f();
+        """;
+
+    internal const string ThenChain1000Source = """
+        (function () {
+            var p = Promise.resolve(0);
+            for (var i = 0; i < 1000; i++) { p = p.then(function (x) { return x + 1; }); }
+            return p;
+        })();
+        """;
+
+    internal const string PromiseAll100Source = """
+        (function () {
+            function run() {
+                var arr = [];
+                for (var i = 0; i < 100; i++) { arr.push(Promise.resolve(i)); }
+                return Promise.all(arr).then(function (r) { return r.length; });
+            }
+            var last;
+            for (var j = 0; j < 10; j++) { last = run(); }
+            return last;
+        })();
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+
+        // the sync floor for the same call count
+        _syncCallLoop = Engine.PrepareScript("""
+            function g(i) { return i + 1; }
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 1000; i++) { s = g(s); }
+                return s;
+            }
+            f();
+            """);
+
+        _awaitResolvedLoop = Engine.PrepareScript(AwaitResolvedLoopSource);
+
+        // 20 × a 50-deep await-recursion chain
+        _awaitChainDepth50 = Engine.PrepareScript("""
+            async function step(n) {
+                if (n === 0) { return 0; }
+                return (await step(n - 1)) + 1;
+            }
+            (function () {
+                var last;
+                for (var i = 0; i < 20; i++) { last = step(50); }
+                return last;
+            })();
+            """);
+
+        _promiseAll100 = Engine.PrepareScript(PromiseAll100Source);
+        _thenChain1000 = Engine.PrepareScript(ThenChain1000Source);
+
+        // 1,000 independent resolved promises, one .then each
+        _microtaskFanout = Engine.PrepareScript("""
+            (function () {
+                var last;
+                for (var i = 0; i < 1000; i++) { last = Promise.resolve(i).then(function (x) { return x + 1; }); }
+                return last;
+            })();
+            """);
+
+        _engine.Evaluate(_syncCallLoop);
+        _engine.Evaluate(_awaitResolvedLoop);
+        _engine.Evaluate(_awaitChainDepth50);
+        _engine.Evaluate(_promiseAll100);
+        _engine.Evaluate(_thenChain1000);
+        _engine.Evaluate(_microtaskFanout);
+    }
+
+    [Benchmark(Baseline = true)]
+    public JsValue SyncCallLoop() => _engine.Evaluate(_syncCallLoop);
+
+    [Benchmark]
+    public JsValue AwaitResolvedLoop() => _engine.Evaluate(_awaitResolvedLoop);
+
+    [Benchmark]
+    public JsValue AwaitChainDepth50() => _engine.Evaluate(_awaitChainDepth50);
+
+    [Benchmark]
+    public JsValue PromiseAll100() => _engine.Evaluate(_promiseAll100);
+
+    [Benchmark]
+    public JsValue ThenChain1000() => _engine.Evaluate(_thenChain1000);
+
+    [Benchmark]
+    public JsValue MicrotaskFanout() => _engine.Evaluate(_microtaskFanout);
+}

--- a/Jint.Benchmark/ColdConstructorBenchmark.cs
+++ b/Jint.Benchmark/ColdConstructorBenchmark.cs
@@ -1,0 +1,130 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The constructor allocation-site promote window on a FRESH engine per op — the short-lived /
+/// per-request embedding shape. Constructors currently build dictionary-mode instances until the
+/// 16th construction, so the x8 rows sit entirely inside that window while the x1000 rows show the
+/// promoted steady state; <see cref="EngineOnly"/> is the baseline so every row reads as a delta
+/// over bare engine construction. <see cref="DistinctCtors200"/> is the diverse-ctor guard: 200
+/// different one-shot constructors, the shape that must never regress when the window shrinks.
+/// </summary>
+[MemoryDiagnoser]
+public class ColdConstructorBenchmark
+{
+    private Prepared<Script> _functionCtorX8;
+    private Prepared<Script> _functionCtorX64;
+    private Prepared<Script> _functionCtorX1000;
+    private Prepared<Script> _classCtorX8;
+    private Prepared<Script> _classCtorX1000;
+    private Prepared<Script> _distinctCtors200;
+
+    internal const string FunctionCtorX8Source = """
+        function Rec(i) { this.a = i; this.b = i + 1; this.c = i + 2; this.d = i + 3; this.e = i + 4; this.f = i + 5; }
+        var arr = [];
+        for (var i = 0; i < 8; i++) { arr.push(new Rec(i)); }
+        arr.length;
+        """;
+
+    internal const string ClassCtorX8Source = """
+        class Rec {
+            constructor(i) { this.a = i; this.b = i + 1; this.c = i + 2; this.d = i + 3; this.e = i + 4; this.f = i + 5; }
+        }
+        var arr = [];
+        for (var i = 0; i < 8; i++) { arr.push(new Rec(i)); }
+        arr.length;
+        """;
+
+    /// <summary>200 distinct constructors, each constructed exactly once.</summary>
+    internal static string BuildDistinctCtorsSource()
+    {
+        var sb = new StringBuilder(32 * 1024);
+        sb.AppendLine("var arr = [];");
+        for (var i = 0; i < 200; i++)
+        {
+            sb.Append("function C").Append(i).Append("(v) { this.a = v; this.b = v + 1; this.c = v + 2; this.d = v + 3; }")
+                .Append(" arr.push(new C").Append(i).Append('(').Append(i).AppendLine("));");
+        }
+
+        sb.AppendLine("arr.length;");
+        return sb.ToString();
+    }
+
+    private static string BuildCtorLoopSource(string declaration, int count) => $$"""
+        {{declaration}}
+        var arr = [];
+        for (var i = 0; i < {{count}}; i++) { arr.push(new Rec(i)); }
+        arr.length;
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        const string FunctionDecl = "function Rec(i) { this.a = i; this.b = i + 1; this.c = i + 2; this.d = i + 3; this.e = i + 4; this.f = i + 5; }";
+        const string ClassDecl = """
+            class Rec {
+                constructor(i) { this.a = i; this.b = i + 1; this.c = i + 2; this.d = i + 3; this.e = i + 4; this.f = i + 5; }
+            }
+            """;
+
+        _functionCtorX8 = Engine.PrepareScript(FunctionCtorX8Source);
+        _functionCtorX64 = Engine.PrepareScript(BuildCtorLoopSource(FunctionDecl, 64));
+        _functionCtorX1000 = Engine.PrepareScript(BuildCtorLoopSource(FunctionDecl, 1000));
+        _classCtorX8 = Engine.PrepareScript(ClassCtorX8Source);
+        _classCtorX1000 = Engine.PrepareScript(BuildCtorLoopSource(ClassDecl, 1000));
+        _distinctCtors200 = Engine.PrepareScript(BuildDistinctCtorsSource());
+    }
+
+    [Benchmark(Baseline = true)]
+    public Engine EngineOnly() => new Engine();
+
+    [Benchmark]
+    public Engine FunctionCtor_x8()
+    {
+        var engine = new Engine();
+        engine.Execute(_functionCtorX8);
+        return engine;
+    }
+
+    [Benchmark]
+    public Engine FunctionCtor_x64()
+    {
+        var engine = new Engine();
+        engine.Execute(_functionCtorX64);
+        return engine;
+    }
+
+    [Benchmark]
+    public Engine FunctionCtor_x1000()
+    {
+        var engine = new Engine();
+        engine.Execute(_functionCtorX1000);
+        return engine;
+    }
+
+    [Benchmark]
+    public Engine ClassCtor_x8()
+    {
+        var engine = new Engine();
+        engine.Execute(_classCtorX8);
+        return engine;
+    }
+
+    [Benchmark]
+    public Engine ClassCtor_x1000()
+    {
+        var engine = new Engine();
+        engine.Execute(_classCtorX1000);
+        return engine;
+    }
+
+    [Benchmark]
+    public Engine DistinctCtors200()
+    {
+        var engine = new Engine();
+        engine.Execute(_distinctCtors200);
+        return engine;
+    }
+}

--- a/Jint.Benchmark/EngineComparisonBenchmark.cs
+++ b/Jint.Benchmark/EngineComparisonBenchmark.cs
@@ -28,6 +28,8 @@ public class EngineComparisonBenchmark
         { "array-stress", null },
         { "evaluation", null },
         { "evaluation-modern", null },
+        { "json-parse", null },
+        { "json-parse-modern", null },
         { "linq-js", null },
         { "minimal", null },
         { "stopwatch", null },

--- a/Jint.Benchmark/ErrorHandlingBenchmark.cs
+++ b/Jint.Benchmark/ErrorHandlingBenchmark.cs
@@ -1,0 +1,134 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Exception-path costs that validation/parse-style code pays constantly: try scaffolding without
+/// a throw (read against the LoopDispatch CounterAdd floor), throw+catch round-trips, Error
+/// construction with and without touching <c>.stack</c>, and unwinding through a deep call chain.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class ErrorHandlingBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _tryNoThrow;
+    private Prepared<Script> _throwCatchLoop;
+    private Prepared<Script> _throwCatchReuseError;
+    private Prepared<Script> _errorConstructOnly;
+    private Prepared<Script> _errorStackAccess;
+    private Prepared<Script> _deepStackThrow;
+
+    internal const string TryNoThrowSource = """
+        function f() {
+            var s = 0;
+            for (var i = 0; i < 100000; i++) {
+                try { s += 1; } catch (e) { }
+            }
+            return s;
+        }
+        f();
+        """;
+
+    internal const string ThrowCatchLoopSource = """
+        function f() {
+            var s = 0;
+            for (var i = 0; i < 10000; i++) {
+                try { throw new Error('x'); } catch (e) { s++; }
+            }
+            return s;
+        }
+        f();
+        """;
+
+    internal const string ErrorStackAccessSource = """
+        function f() {
+            var s = 0;
+            for (var i = 0; i < 10000; i++) {
+                var e = new Error('m');
+                s += e.stack.length;
+            }
+            return s;
+        }
+        f();
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute("var reusedError = new Error('r');");
+
+        _tryNoThrow = Engine.PrepareScript(TryNoThrowSource);
+        _throwCatchLoop = Engine.PrepareScript(ThrowCatchLoopSource);
+
+        // unwind cost isolated from Error construction
+        _throwCatchReuseError = Engine.PrepareScript("""
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 10000; i++) {
+                    try { throw reusedError; } catch (e) { s++; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        // construction only: no throw, no stack read
+        _errorConstructOnly = Engine.PrepareScript("""
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 10000; i++) {
+                    var e = new Error('m' + (i & 15));
+                    if (e) { s++; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _errorStackAccess = Engine.PrepareScript(ErrorStackAccessSource);
+
+        // throw from 50 frames down, catch at the top
+        _deepStackThrow = Engine.PrepareScript("""
+            function d(n) {
+                if (n === 0) { throw new Error('deep'); }
+                return d(n - 1);
+            }
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 2000; i++) {
+                    try { d(50); } catch (e) { s++; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _engine.Evaluate(_tryNoThrow);
+        _engine.Evaluate(_throwCatchLoop);
+        _engine.Evaluate(_throwCatchReuseError);
+        _engine.Evaluate(_errorConstructOnly);
+        _engine.Evaluate(_errorStackAccess);
+        _engine.Evaluate(_deepStackThrow);
+    }
+
+    [Benchmark]
+    public JsValue TryNoThrow() => _engine.Evaluate(_tryNoThrow);
+
+    [Benchmark]
+    public JsValue ThrowCatchLoop() => _engine.Evaluate(_throwCatchLoop);
+
+    [Benchmark]
+    public JsValue ThrowCatchReuseError() => _engine.Evaluate(_throwCatchReuseError);
+
+    [Benchmark]
+    public JsValue ErrorConstructOnly() => _engine.Evaluate(_errorConstructOnly);
+
+    [Benchmark]
+    public JsValue ErrorStackAccess() => _engine.Evaluate(_errorStackAccess);
+
+    [Benchmark]
+    public JsValue DeepStackThrow() => _engine.Evaluate(_deepStackThrow);
+}

--- a/Jint.Benchmark/ForInGuardBenchmark.cs
+++ b/Jint.Benchmark/ForInGuardBenchmark.cs
@@ -29,6 +29,7 @@ public class ForInGuardBenchmark
         var mixedVals = [];
         var instObjs = [];
         var inObjs = [];
+        var order = [];
         var str20k;
         class Base { constructor() { this.tag = 1; } }
         class Deriv extends Base { constructor() { super(); this.sub = 2; } }
@@ -45,6 +46,10 @@ public class ForInGuardBenchmark
                 else { mixedVals.push({ v: i }); }
                 instObjs.push(((seed >>> 6) & 1) === 0 ? new Deriv() : { tag: 0 });
                 inObjs.push(((seed >>> 7) & 1) === 0 ? { x: 1, y: 2 } : { y: 2 });
+            }
+            for (var i = 0; i < 8192; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                order.push((seed >>> 7) & 1023);
             }
             var chunk = 'abcdefghijklmnopqrst';
             var parts = [];
@@ -68,11 +73,9 @@ public class ForInGuardBenchmark
 
     internal const string TypeofSwitchMixedSource = """
         function f() {
-            var seed = 20260711;
             var s = 0;
             for (var i = 0; i < 100000; i++) {
-                seed = (seed * 1664525 + 1013904223) | 0;
-                var v = mixedVals[(seed >>> 4) & 1023];
+                var v = mixedVals[order[i & 8191]];
                 var t = typeof v;
                 if (t === 'number') { s += 1; }
                 else if (t === 'string') { s += 2; }
@@ -143,11 +146,9 @@ public class ForInGuardBenchmark
 
         _instanceofMixed = Engine.PrepareScript("""
             function f() {
-                var seed = 20260711;
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
-                    seed = (seed * 1664525 + 1013904223) | 0;
-                    if (instObjs[(seed >>> 4) & 1023] instanceof Base) { s++; }
+                    if (instObjs[order[i & 8191]] instanceof Base) { s++; }
                 }
                 return s;
             }
@@ -156,11 +157,9 @@ public class ForInGuardBenchmark
 
         _inOperatorMixed = Engine.PrepareScript("""
             function f() {
-                var seed = 20260711;
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
-                    seed = (seed * 1664525 + 1013904223) | 0;
-                    if ('x' in inObjs[(seed >>> 4) & 1023]) { s++; }
+                    if ('x' in inObjs[order[i & 8191]]) { s++; }
                 }
                 return s;
             }

--- a/Jint.Benchmark/ForInGuardBenchmark.cs
+++ b/Jint.Benchmark/ForInGuardBenchmark.cs
@@ -1,0 +1,203 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Object-iteration and type-guard idioms: for-in with and without the lint-mandated
+/// hasOwnProperty guard, prototype-chain filtering, for-of over a string, and typeof /
+/// instanceof / in dispatch over LCG-mixed inputs the branch predictor cannot memorize.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class ForInGuardBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _forInSmall;
+    private Prepared<Script> _forInWide;
+    private Prepared<Script> _forInHasOwnGuard;
+    private Prepared<Script> _forInProtoChain;
+    private Prepared<Script> _forOfString;
+    private Prepared<Script> _typeofSwitchMixed;
+    private Prepared<Script> _instanceofMixed;
+    private Prepared<Script> _inOperatorMixed;
+
+    internal const string SetupSource = """
+        var six = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 };
+        var wide = {};
+        var protoObj = Object.create({ pa: 1, pb: 2, pc: 3, pd: 4, pe: 5, pf: 6 });
+        var mixedVals = [];
+        var instObjs = [];
+        var inObjs = [];
+        var str20k;
+        class Base { constructor() { this.tag = 1; } }
+        class Deriv extends Base { constructor() { super(); this.sub = 2; } }
+        (function () {
+            var seed = 20260711;
+            for (var i = 0; i < 64; i++) { wide['w' + i] = i; }
+            protoObj.oa = 1; protoObj.ob = 2; protoObj.oc = 3; protoObj.od = 4; protoObj.oe = 5; protoObj.of = 6;
+            for (var i = 0; i < 1024; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                var pick = (seed >>> 4) & 3;
+                if (pick === 0) { mixedVals.push(seed & 255); }
+                else if (pick === 1) { mixedVals.push('s' + (seed & 15)); }
+                else if (pick === 2) { mixedVals.push(undefined); }
+                else { mixedVals.push({ v: i }); }
+                instObjs.push(((seed >>> 6) & 1) === 0 ? new Deriv() : { tag: 0 });
+                inObjs.push(((seed >>> 7) & 1) === 0 ? { x: 1, y: 2 } : { y: 2 });
+            }
+            var chunk = 'abcdefghijklmnopqrst';
+            var parts = [];
+            for (var i = 0; i < 1000; i++) { parts.push(chunk); }
+            str20k = parts.join('');
+        })();
+        """;
+
+    internal const string ForInHasOwnGuardSource = """
+        function f() {
+            var s = 0;
+            for (var i = 0; i < 20000; i++) {
+                for (var k in six) {
+                    if (six.hasOwnProperty(k)) { s++; }
+                }
+            }
+            return s;
+        }
+        f();
+        """;
+
+    internal const string TypeofSwitchMixedSource = """
+        function f() {
+            var seed = 20260711;
+            var s = 0;
+            for (var i = 0; i < 100000; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                var v = mixedVals[(seed >>> 4) & 1023];
+                var t = typeof v;
+                if (t === 'number') { s += 1; }
+                else if (t === 'string') { s += 2; }
+                else if (t === 'undefined') { s += 3; }
+                else { s += 4; }
+            }
+            return s;
+        }
+        f();
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute(SetupSource);
+
+        _forInSmall = Engine.PrepareScript("""
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 20000; i++) {
+                    for (var k in six) { s++; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _forInWide = Engine.PrepareScript("""
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 2000; i++) {
+                    for (var k in wide) { s++; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _forInHasOwnGuard = Engine.PrepareScript(ForInHasOwnGuardSource);
+
+        // 6 own + 6 enumerable inherited keys; the guard filters the inherited half
+        _forInProtoChain = Engine.PrepareScript("""
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 10000; i++) {
+                    for (var k in protoObj) {
+                        if (protoObj.hasOwnProperty(k)) { s++; }
+                    }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _forOfString = Engine.PrepareScript("""
+            function f() {
+                var n = 0;
+                for (var i = 0; i < 5; i++) {
+                    for (var ch of str20k) { n++; }
+                }
+                return n;
+            }
+            f();
+            """);
+
+        _typeofSwitchMixed = Engine.PrepareScript(TypeofSwitchMixedSource);
+
+        _instanceofMixed = Engine.PrepareScript("""
+            function f() {
+                var seed = 20260711;
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    seed = (seed * 1664525 + 1013904223) | 0;
+                    if (instObjs[(seed >>> 4) & 1023] instanceof Base) { s++; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _inOperatorMixed = Engine.PrepareScript("""
+            function f() {
+                var seed = 20260711;
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    seed = (seed * 1664525 + 1013904223) | 0;
+                    if ('x' in inObjs[(seed >>> 4) & 1023]) { s++; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _engine.Evaluate(_forInSmall);
+        _engine.Evaluate(_forInWide);
+        _engine.Evaluate(_forInHasOwnGuard);
+        _engine.Evaluate(_forInProtoChain);
+        _engine.Evaluate(_forOfString);
+        _engine.Evaluate(_typeofSwitchMixed);
+        _engine.Evaluate(_instanceofMixed);
+        _engine.Evaluate(_inOperatorMixed);
+    }
+
+    [Benchmark]
+    public JsValue ForInSmall() => _engine.Evaluate(_forInSmall);
+
+    [Benchmark]
+    public JsValue ForInWide() => _engine.Evaluate(_forInWide);
+
+    [Benchmark]
+    public JsValue ForInHasOwnGuard() => _engine.Evaluate(_forInHasOwnGuard);
+
+    [Benchmark]
+    public JsValue ForInProtoChain() => _engine.Evaluate(_forInProtoChain);
+
+    [Benchmark]
+    public JsValue ForOfString() => _engine.Evaluate(_forOfString);
+
+    [Benchmark]
+    public JsValue TypeofSwitchMixed() => _engine.Evaluate(_typeofSwitchMixed);
+
+    [Benchmark]
+    public JsValue InstanceofMixed() => _engine.Evaluate(_instanceofMixed);
+
+    [Benchmark]
+    public JsValue InOperatorMixed() => _engine.Evaluate(_inOperatorMixed);
+}

--- a/Jint.Benchmark/JsonJsBenchmark.cs
+++ b/Jint.Benchmark/JsonJsBenchmark.cs
@@ -1,0 +1,170 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Measures the JS-level <c>JSON.parse</c>/<c>JSON.stringify</c> API over the payload shapes real
+/// embeddings feed through scripts: a homogeneous array of records (the dominant API-payload shape)
+/// and a heterogeneous nested config object. Unlike <see cref="JsonBenchmark"/> (which drives the
+/// internal C# JsonParser/JsonSerializer over fixtures downloaded from the network), the payloads
+/// here are generated deterministically offline, so rows are stable gates. One parse or stringify
+/// per op — the Allocated column is the per-document allocation cost.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class JsonJsBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _parseRecords;
+    private Prepared<Script> _parseConfig;
+    private Prepared<Script> _parseBigObject;
+    private Prepared<Script> _stringifyRecords;
+    private Prepared<Script> _stringifyConfig;
+    private Prepared<Script> _roundTripRecords;
+
+    internal const string ParseRecordsSource = "JSON.parse(recordsJson);";
+    internal const string ParseConfigSource = "JSON.parse(configJson);";
+    internal const string ParseBigObjectSource = "JSON.parse(bigObjectJson);";
+    internal const string StringifyRecordsSource = "JSON.stringify(records);";
+    internal const string StringifyConfigSource = "JSON.stringify(config);";
+    internal const string RoundTripRecordsSource = "JSON.parse(JSON.stringify(records));";
+    internal const string SetupSource = "var records = JSON.parse(recordsJson); var config = JSON.parse(configJson);";
+
+    /// <summary>1,000 records × 6 mixed-type properties (~90 KB) — the array-of-identical-records shape.</summary>
+    internal static string BuildRecordsJson()
+    {
+        var random = new Random(42);
+        string[] tags = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"];
+        var sb = new StringBuilder(96 * 1024);
+        sb.Append('[');
+        for (var i = 0; i < 1_000; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(',');
+            }
+
+            sb.Append("{\"id\":").Append(i)
+                .Append(",\"name\":\"user").Append(random.Next(10_000))
+                .Append("\",\"active\":").Append(random.Next(2) == 0 ? "false" : "true")
+                .Append(",\"score\":").Append(random.Next(1_000)).Append('.').Append(random.Next(10))
+                .Append(",\"tags\":[\"").Append(tags[random.Next(tags.Length)]).Append("\",\"").Append(tags[random.Next(tags.Length)])
+                .Append("\"],\"ts\":").Append(1_700_000_000L + i)
+                .Append('}');
+        }
+
+        sb.Append(']');
+        return sb.ToString();
+    }
+
+    /// <summary>Nested config: depth 4, fan-out 4 (340 objects), leaves cycling string/number/bool/null.</summary>
+    internal static string BuildConfigJson()
+    {
+        var random = new Random(42);
+        var sb = new StringBuilder(16 * 1024);
+        AppendLevel(sb, random, depth: 4);
+        return sb.ToString();
+
+        static void AppendLevel(StringBuilder sb, Random random, int depth)
+        {
+            sb.Append('{');
+            for (var i = 0; i < 4; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(',');
+                }
+
+                sb.Append("\"node").Append((char) ('A' + i)).Append(depth).Append("\":");
+                if (depth > 0)
+                {
+                    AppendLevel(sb, random, depth - 1);
+                }
+                else
+                {
+                    switch (i % 4)
+                    {
+                        case 0:
+                            sb.Append("\"value").Append(random.Next(100)).Append('"');
+                            break;
+                        case 1:
+                            sb.Append(random.Next(100_000));
+                            break;
+                        case 2:
+                            sb.Append(random.Next(2) == 0 ? "false" : "true");
+                            break;
+                        default:
+                            sb.Append("null");
+                            break;
+                    }
+                }
+            }
+
+            sb.Append('}');
+        }
+    }
+
+    /// <summary>One object with 100 properties — trips the 64-property shape guard mid-build.</summary>
+    internal static string BuildBigObjectJson()
+    {
+        var random = new Random(42);
+        var sb = new StringBuilder(4 * 1024);
+        sb.Append('{');
+        for (var i = 0; i < 100; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(',');
+            }
+
+            sb.Append("\"prop").Append(i).Append("\":").Append(random.Next(1_000));
+        }
+
+        sb.Append('}');
+        return sb.ToString();
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.SetValue("recordsJson", BuildRecordsJson());
+        _engine.SetValue("configJson", BuildConfigJson());
+        _engine.SetValue("bigObjectJson", BuildBigObjectJson());
+        _engine.Execute(SetupSource);
+
+        _parseRecords = Engine.PrepareScript(ParseRecordsSource);
+        _parseConfig = Engine.PrepareScript(ParseConfigSource);
+        _parseBigObject = Engine.PrepareScript(ParseBigObjectSource);
+        _stringifyRecords = Engine.PrepareScript(StringifyRecordsSource);
+        _stringifyConfig = Engine.PrepareScript(StringifyConfigSource);
+        _roundTripRecords = Engine.PrepareScript(RoundTripRecordsSource);
+
+        _engine.Evaluate(_parseRecords);
+        _engine.Evaluate(_parseConfig);
+        _engine.Evaluate(_parseBigObject);
+        _engine.Evaluate(_stringifyRecords);
+        _engine.Evaluate(_stringifyConfig);
+        _engine.Evaluate(_roundTripRecords);
+    }
+
+    [Benchmark]
+    public JsValue ParseRecords() => _engine.Evaluate(_parseRecords);
+
+    [Benchmark]
+    public JsValue ParseConfig() => _engine.Evaluate(_parseConfig);
+
+    [Benchmark]
+    public JsValue ParseBigObject() => _engine.Evaluate(_parseBigObject);
+
+    [Benchmark]
+    public JsValue StringifyRecords() => _engine.Evaluate(_stringifyRecords);
+
+    [Benchmark]
+    public JsValue StringifyConfig() => _engine.Evaluate(_stringifyConfig);
+
+    [Benchmark]
+    public JsValue RoundTripRecords() => _engine.Evaluate(_roundTripRecords);
+}

--- a/Jint.Benchmark/MapSetLookupBenchmark.cs
+++ b/Jint.Benchmark/MapSetLookupBenchmark.cs
@@ -21,6 +21,8 @@ public class MapSetLookupBenchmark
     private Prepared<Script> _mapSetDeleteChurn;
     private Prepared<Script> _memoizePattern;
 
+    // Mixing is precomputed at setup into `order` (see ModernOperatorsBenchmark note): a
+    // per-iteration JS LCG boxes JsNumber transients that would dominate these lookup rows.
     internal const string SetupSource = """
         var m = new Map();
         var intSet = new Set();
@@ -28,6 +30,8 @@ public class MapSetLookupBenchmark
         var hitKeys = [];
         var mixedKeys = [];
         var memoKeys = [];
+        var probeInts = [];
+        var order = [];
         (function () {
             var seed = 20260711;
             for (var i = 0; i < 10000; i++) {
@@ -42,17 +46,20 @@ public class MapSetLookupBenchmark
             for (var i = 0; i < 2048; i++) {
                 seed = (seed * 1664525 + 1013904223) | 0;
                 memoKeys.push('memo' + ((seed >>> 4) % 2048));
+                probeInts.push((seed >>> 5) % 20000);
+            }
+            for (var i = 0; i < 8192; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                order.push((seed >>> 7) & 2047);
             }
         })();
         """;
 
     internal const string MapGetHitSource = """
         function f() {
-            var seed = 20260711;
             var s = 0;
             for (var i = 0; i < 100000; i++) {
-                seed = (seed * 1664525 + 1013904223) | 0;
-                s += m.get(hitKeys[(seed >>> 4) & 1023]);
+                s += m.get(hitKeys[order[i & 8191] & 1023]);
             }
             return s;
         }
@@ -61,11 +68,9 @@ public class MapSetLookupBenchmark
 
     internal const string MemoizePatternSource = """
         function f() {
-            var seed = 20260711;
             var s = 0;
             for (var i = 0; i < 100000; i++) {
-                seed = (seed * 1664525 + 1013904223) | 0;
-                var k = memoKeys[(seed >>> 4) & 2047];
+                var k = memoKeys[order[i & 8191]];
                 var v = cache.get(k);
                 if (v === undefined) { v = k.length * 2; cache.set(k, v); }
                 s += v;
@@ -86,11 +91,9 @@ public class MapSetLookupBenchmark
         // ~50% of probe keys are absent
         _mapGetMixed = Engine.PrepareScript("""
             function f() {
-                var seed = 20260711;
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
-                    seed = (seed * 1664525 + 1013904223) | 0;
-                    var v = m.get(mixedKeys[(seed >>> 4) & 1023]);
+                    var v = m.get(mixedKeys[order[i & 8191] & 1023]);
                     s += (v === undefined) ? 0 : v;
                 }
                 return s;
@@ -100,11 +103,9 @@ public class MapSetLookupBenchmark
 
         _mapHasMixed = Engine.PrepareScript("""
             function f() {
-                var seed = 20260711;
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
-                    seed = (seed * 1664525 + 1013904223) | 0;
-                    if (m.has(mixedKeys[(seed >>> 4) & 1023])) { s++; }
+                    if (m.has(mixedKeys[order[i & 8191] & 1023])) { s++; }
                 }
                 return s;
             }
@@ -114,11 +115,9 @@ public class MapSetLookupBenchmark
         // int keys: no key allocation at all
         _setHasMixed = Engine.PrepareScript("""
             function f() {
-                var seed = 20260711;
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
-                    seed = (seed * 1664525 + 1013904223) | 0;
-                    if (intSet.has((seed >>> 4) % 20000)) { s++; }
+                    if (intSet.has(probeInts[order[i & 8191]])) { s++; }
                 }
                 return s;
             }

--- a/Jint.Benchmark/MapSetLookupBenchmark.cs
+++ b/Jint.Benchmark/MapSetLookupBenchmark.cs
@@ -1,0 +1,168 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Map/Set read/has/delete hot loops — the memoization-cache and dedup shapes real code runs.
+/// Probe keys are prebuilt and selected with an inline LCG (50% absent on the Mixed rows) so rows
+/// measure the lookup path, not key construction, and the branch predictor cannot memorize hits.
+/// 100k operations per op inside a function frame.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class MapSetLookupBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _mapGetHit;
+    private Prepared<Script> _mapGetMixed;
+    private Prepared<Script> _mapHasMixed;
+    private Prepared<Script> _setHasMixed;
+    private Prepared<Script> _mapSetDeleteChurn;
+    private Prepared<Script> _memoizePattern;
+
+    internal const string SetupSource = """
+        var m = new Map();
+        var intSet = new Set();
+        var cache = new Map();
+        var hitKeys = [];
+        var mixedKeys = [];
+        var memoKeys = [];
+        (function () {
+            var seed = 20260711;
+            for (var i = 0; i < 10000; i++) {
+                m.set('k' + i, i);
+                intSet.add(i);
+            }
+            for (var i = 0; i < 1024; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                hitKeys.push('k' + ((seed >>> 4) % 10000));
+                mixedKeys.push('k' + ((seed >>> 5) % 20000));
+            }
+            for (var i = 0; i < 2048; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                memoKeys.push('memo' + ((seed >>> 4) % 2048));
+            }
+        })();
+        """;
+
+    internal const string MapGetHitSource = """
+        function f() {
+            var seed = 20260711;
+            var s = 0;
+            for (var i = 0; i < 100000; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                s += m.get(hitKeys[(seed >>> 4) & 1023]);
+            }
+            return s;
+        }
+        f();
+        """;
+
+    internal const string MemoizePatternSource = """
+        function f() {
+            var seed = 20260711;
+            var s = 0;
+            for (var i = 0; i < 100000; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                var k = memoKeys[(seed >>> 4) & 2047];
+                var v = cache.get(k);
+                if (v === undefined) { v = k.length * 2; cache.set(k, v); }
+                s += v;
+            }
+            return s;
+        }
+        f();
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute(SetupSource);
+
+        _mapGetHit = Engine.PrepareScript(MapGetHitSource);
+
+        // ~50% of probe keys are absent
+        _mapGetMixed = Engine.PrepareScript("""
+            function f() {
+                var seed = 20260711;
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    seed = (seed * 1664525 + 1013904223) | 0;
+                    var v = m.get(mixedKeys[(seed >>> 4) & 1023]);
+                    s += (v === undefined) ? 0 : v;
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _mapHasMixed = Engine.PrepareScript("""
+            function f() {
+                var seed = 20260711;
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    seed = (seed * 1664525 + 1013904223) | 0;
+                    if (m.has(mixedKeys[(seed >>> 4) & 1023])) { s++; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        // int keys: no key allocation at all
+        _setHasMixed = Engine.PrepareScript("""
+            function f() {
+                var seed = 20260711;
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    seed = (seed * 1664525 + 1013904223) | 0;
+                    if (intSet.has((seed >>> 4) % 20000)) { s++; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        // sliding window: add + delete keeping ~1k live entries
+        _mapSetDeleteChurn = Engine.PrepareScript("""
+            function f() {
+                var w = new Map();
+                for (var i = 0; i < 100000; i++) {
+                    w.set(i & 65535, i);
+                    if (i >= 1000) { w.delete((i - 1000) & 65535); }
+                }
+                return w.size;
+            }
+            f();
+            """);
+
+        _memoizePattern = Engine.PrepareScript(MemoizePatternSource);
+
+        _engine.Evaluate(_mapGetHit);
+        _engine.Evaluate(_mapGetMixed);
+        _engine.Evaluate(_mapHasMixed);
+        _engine.Evaluate(_setHasMixed);
+        _engine.Evaluate(_mapSetDeleteChurn);
+        _engine.Evaluate(_memoizePattern);
+    }
+
+    [Benchmark]
+    public JsValue MapGetHit() => _engine.Evaluate(_mapGetHit);
+
+    [Benchmark]
+    public JsValue MapGetMixed() => _engine.Evaluate(_mapGetMixed);
+
+    [Benchmark]
+    public JsValue MapHasMixed() => _engine.Evaluate(_mapHasMixed);
+
+    [Benchmark]
+    public JsValue SetHasMixed() => _engine.Evaluate(_setHasMixed);
+
+    [Benchmark]
+    public JsValue MapSetDeleteChurn() => _engine.Evaluate(_mapSetDeleteChurn);
+
+    [Benchmark]
+    public JsValue MemoizePattern() => _engine.Evaluate(_memoizePattern);
+}

--- a/Jint.Benchmark/ModernOperatorsBenchmark.cs
+++ b/Jint.Benchmark/ModernOperatorsBenchmark.cs
@@ -20,9 +20,16 @@ public class ModernOperatorsBenchmark
     private Prepared<Script> _nullishAssign;
     private Prepared<Script> _logicalOrAssign;
 
+    // Mixing is precomputed at setup into `order` (8,192 small-int indices) because a per-iteration
+    // JS LCG boxes JsNumber transients (~120 B/iter) that would dominate what these rows measure.
+    // All values stay inside the small-int cache and sub-selection reads stored array elements,
+    // so the rows themselves are allocation-free apart from the construct under test.
     internal const string SetupSource = """
         var objs = [];
         var vals = [];
+        var nullishInputs = [];
+        var zeroOnes = [];
+        var order = [];
         var present = { a: { b: { c: 1 } } };
         (function () {
             var seed = 20260711;
@@ -36,17 +43,22 @@ public class ModernOperatorsBenchmark
                 if (vpick < 2) { vals.push(i & 255); }
                 else if (vpick === 2) { vals.push(null); }
                 else { vals.push(undefined); }
+                var npick = (seed >>> 12) & 3;
+                nullishInputs.push(npick === 0 ? null : (npick === 1 ? undefined : (seed & 255)));
+                zeroOnes.push((seed >>> 16) & 1);
+            }
+            for (var i = 0; i < 8192; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                order.push((seed >>> 7) & 1023);
             }
         })();
         """;
 
     internal const string OptionalChainMissSource = """
         function f() {
-            var seed = 20260711;
             var s = 0;
             for (var i = 0; i < 100000; i++) {
-                seed = (seed * 1664525 + 1013904223) | 0;
-                var o = objs[(seed >>> 4) & 1023];
+                var o = objs[order[i & 8191]];
                 s += (o?.a?.b?.c || 0);
             }
             return s;
@@ -56,11 +68,9 @@ public class ModernOperatorsBenchmark
 
     internal const string NullishCoalesceSource = """
         function f() {
-            var seed = 20260711;
             var s = 0;
             for (var i = 0; i < 100000; i++) {
-                seed = (seed * 1664525 + 1013904223) | 0;
-                s += (vals[(seed >>> 6) & 1023] ?? 0);
+                s += (vals[order[i & 8191]] ?? 0);
             }
             return s;
         }
@@ -89,12 +99,9 @@ public class ModernOperatorsBenchmark
         // ??= on a local that is null/undefined/number in unpredictable rotation (~50% nullish)
         _nullishAssign = Engine.PrepareScript("""
             function f() {
-                var seed = 20260711;
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
-                    seed = (seed * 1664525 + 1013904223) | 0;
-                    var pick = seed & 3;
-                    var x = pick === 0 ? null : (pick === 1 ? undefined : (seed & 255));
+                    var x = nullishInputs[order[i & 8191]];
                     x ??= 7;
                     s += x;
                 }
@@ -106,11 +113,9 @@ public class ModernOperatorsBenchmark
         // ||= over a 50/50 truthy/falsy local
         _logicalOrAssign = Engine.PrepareScript("""
             function f() {
-                var seed = 20260711;
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
-                    seed = (seed * 1664525 + 1013904223) | 0;
-                    var x = (seed >>> 4) & 1;
+                    var x = zeroOnes[order[i & 8191]];
                     x ||= 7;
                     s += x;
                 }

--- a/Jint.Benchmark/ModernOperatorsBenchmark.cs
+++ b/Jint.Benchmark/ModernOperatorsBenchmark.cs
@@ -1,0 +1,143 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Optional chaining, nullish coalescing and logical assignment over inputs mixed with an inline
+/// LCG (~50% present / 50% short-circuiting) so the branch predictor cannot memorize the outcome —
+/// the modern null-guard idioms that pervade current JS but appear in no other benchmark.
+/// 100k iterations per op inside a function frame.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class ModernOperatorsBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _optionalChainHit;
+    private Prepared<Script> _optionalChainMiss;
+    private Prepared<Script> _nullishCoalesce;
+    private Prepared<Script> _nullishAssign;
+    private Prepared<Script> _logicalOrAssign;
+
+    internal const string SetupSource = """
+        var objs = [];
+        var vals = [];
+        var present = { a: { b: { c: 1 } } };
+        (function () {
+            var seed = 20260711;
+            for (var i = 0; i < 1024; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                var pick = (seed >>> 4) & 3;
+                if (pick < 2) { objs.push({ a: { b: { c: 1 } } }); }
+                else if (pick === 2) { objs.push({ a: null }); }
+                else { objs.push({}); }
+                var vpick = (seed >>> 8) & 3;
+                if (vpick < 2) { vals.push(i & 255); }
+                else if (vpick === 2) { vals.push(null); }
+                else { vals.push(undefined); }
+            }
+        })();
+        """;
+
+    internal const string OptionalChainMissSource = """
+        function f() {
+            var seed = 20260711;
+            var s = 0;
+            for (var i = 0; i < 100000; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                var o = objs[(seed >>> 4) & 1023];
+                s += (o?.a?.b?.c || 0);
+            }
+            return s;
+        }
+        f();
+        """;
+
+    internal const string NullishCoalesceSource = """
+        function f() {
+            var seed = 20260711;
+            var s = 0;
+            for (var i = 0; i < 100000; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                s += (vals[(seed >>> 6) & 1023] ?? 0);
+            }
+            return s;
+        }
+        f();
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute(SetupSource);
+
+        // all links present: the chain always completes
+        _optionalChainHit = Engine.PrepareScript("""
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 100000; i++) { s += present?.a?.b?.c; }
+                return s;
+            }
+            f();
+            """);
+
+        _optionalChainMiss = Engine.PrepareScript(OptionalChainMissSource);
+        _nullishCoalesce = Engine.PrepareScript(NullishCoalesceSource);
+
+        // ??= on a local that is null/undefined/number in unpredictable rotation (~50% nullish)
+        _nullishAssign = Engine.PrepareScript("""
+            function f() {
+                var seed = 20260711;
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    seed = (seed * 1664525 + 1013904223) | 0;
+                    var pick = seed & 3;
+                    var x = pick === 0 ? null : (pick === 1 ? undefined : (seed & 255));
+                    x ??= 7;
+                    s += x;
+                }
+                return s;
+            }
+            f();
+            """);
+
+        // ||= over a 50/50 truthy/falsy local
+        _logicalOrAssign = Engine.PrepareScript("""
+            function f() {
+                var seed = 20260711;
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    seed = (seed * 1664525 + 1013904223) | 0;
+                    var x = (seed >>> 4) & 1;
+                    x ||= 7;
+                    s += x;
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _engine.Evaluate(_optionalChainHit);
+        _engine.Evaluate(_optionalChainMiss);
+        _engine.Evaluate(_nullishCoalesce);
+        _engine.Evaluate(_nullishAssign);
+        _engine.Evaluate(_logicalOrAssign);
+    }
+
+    [Benchmark]
+    public JsValue OptionalChainHit() => _engine.Evaluate(_optionalChainHit);
+
+    [Benchmark]
+    public JsValue OptionalChainMiss() => _engine.Evaluate(_optionalChainMiss);
+
+    [Benchmark]
+    public JsValue NullishCoalesce() => _engine.Evaluate(_nullishCoalesce);
+
+    [Benchmark]
+    public JsValue NullishAssign() => _engine.Evaluate(_nullishAssign);
+
+    [Benchmark]
+    public JsValue LogicalOrAssign() => _engine.Evaluate(_logicalOrAssign);
+}

--- a/Jint.Benchmark/NumberParseBenchmark.cs
+++ b/Jint.Benchmark/NumberParseBenchmark.cs
@@ -19,10 +19,14 @@ public class NumberParseBenchmark
     private Prepared<Script> _toFixedLoop;
     private Prepared<Script> _toStringRadix;
 
+    // Mixing is precomputed at setup into `order` (see ModernOperatorsBenchmark note): a
+    // per-iteration JS LCG boxes JsNumber transients that would dominate these rows.
     internal const string SetupSource = """
         var intStrs = [];
         var fltStrs = [];
         var nums = [];
+        var radixNums = [];
+        var order = [];
         (function () {
             var seed = 20260711;
             for (var i = 0; i < 1024; i++) {
@@ -30,17 +34,20 @@ public class NumberParseBenchmark
                 intStrs.push('' + ((seed >>> 4) & 1048575));
                 fltStrs.push(((seed >>> 4) & 65535) + '.' + ((seed >>> 8) & 99));
                 nums.push(((seed >>> 4) & 65535) + ((seed >>> 8) & 99) / 100);
+                radixNums.push((seed >>> 8) & 1048575);
+            }
+            for (var i = 0; i < 8192; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                order.push((seed >>> 7) & 1023);
             }
         })();
         """;
 
     internal const string ParseIntLoopSource = """
         function f() {
-            var seed = 20260711;
             var s = 0;
             for (var i = 0; i < 100000; i++) {
-                seed = (seed * 1664525 + 1013904223) | 0;
-                s += parseInt(intStrs[(seed >>> 4) & 1023], 10);
+                s += parseInt(intStrs[order[i & 8191]], 10);
             }
             return s;
         }
@@ -49,11 +56,9 @@ public class NumberParseBenchmark
 
     internal const string ToFixedLoopSource = """
         function f() {
-            var seed = 20260711;
             var s = 0;
             for (var i = 0; i < 100000; i++) {
-                seed = (seed * 1664525 + 1013904223) | 0;
-                s += nums[(seed >>> 4) & 1023].toFixed(2).length;
+                s += nums[order[i & 8191]].toFixed(2).length;
             }
             return s;
         }
@@ -70,11 +75,9 @@ public class NumberParseBenchmark
 
         _parseFloatLoop = Engine.PrepareScript("""
             function f() {
-                var seed = 20260711;
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
-                    seed = (seed * 1664525 + 1013904223) | 0;
-                    s += parseFloat(fltStrs[(seed >>> 4) & 1023]);
+                    s += parseFloat(fltStrs[order[i & 8191]]);
                 }
                 return s;
             }
@@ -83,11 +86,9 @@ public class NumberParseBenchmark
 
         _numberCoerce = Engine.PrepareScript("""
             function f() {
-                var seed = 20260711;
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
-                    seed = (seed * 1664525 + 1013904223) | 0;
-                    s += Number(intStrs[(seed >>> 4) & 1023]);
+                    s += Number(intStrs[order[i & 8191]]);
                 }
                 return s;
             }
@@ -98,11 +99,9 @@ public class NumberParseBenchmark
 
         _toStringRadix = Engine.PrepareScript("""
             function f() {
-                var seed = 20260711;
                 var s = 0;
                 for (var i = 0; i < 100000; i++) {
-                    seed = (seed * 1664525 + 1013904223) | 0;
-                    s += (seed >>> 8).toString(16).length;
+                    s += radixNums[order[i & 8191]].toString(16).length;
                 }
                 return s;
             }

--- a/Jint.Benchmark/NumberParseBenchmark.cs
+++ b/Jint.Benchmark/NumberParseBenchmark.cs
@@ -1,0 +1,133 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Number parsing and formatting in loops — the CSV/JSON-ingestion and UI-formatting shapes:
+/// parseInt/parseFloat/Number() over prebuilt LCG-varied numeric strings, and
+/// toFixed/toString(radix) over varied doubles. 100k operations per op.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class NumberParseBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _parseIntLoop;
+    private Prepared<Script> _parseFloatLoop;
+    private Prepared<Script> _numberCoerce;
+    private Prepared<Script> _toFixedLoop;
+    private Prepared<Script> _toStringRadix;
+
+    internal const string SetupSource = """
+        var intStrs = [];
+        var fltStrs = [];
+        var nums = [];
+        (function () {
+            var seed = 20260711;
+            for (var i = 0; i < 1024; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                intStrs.push('' + ((seed >>> 4) & 1048575));
+                fltStrs.push(((seed >>> 4) & 65535) + '.' + ((seed >>> 8) & 99));
+                nums.push(((seed >>> 4) & 65535) + ((seed >>> 8) & 99) / 100);
+            }
+        })();
+        """;
+
+    internal const string ParseIntLoopSource = """
+        function f() {
+            var seed = 20260711;
+            var s = 0;
+            for (var i = 0; i < 100000; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                s += parseInt(intStrs[(seed >>> 4) & 1023], 10);
+            }
+            return s;
+        }
+        f();
+        """;
+
+    internal const string ToFixedLoopSource = """
+        function f() {
+            var seed = 20260711;
+            var s = 0;
+            for (var i = 0; i < 100000; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                s += nums[(seed >>> 4) & 1023].toFixed(2).length;
+            }
+            return s;
+        }
+        f();
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute(SetupSource);
+
+        _parseIntLoop = Engine.PrepareScript(ParseIntLoopSource);
+
+        _parseFloatLoop = Engine.PrepareScript("""
+            function f() {
+                var seed = 20260711;
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    seed = (seed * 1664525 + 1013904223) | 0;
+                    s += parseFloat(fltStrs[(seed >>> 4) & 1023]);
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _numberCoerce = Engine.PrepareScript("""
+            function f() {
+                var seed = 20260711;
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    seed = (seed * 1664525 + 1013904223) | 0;
+                    s += Number(intStrs[(seed >>> 4) & 1023]);
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _toFixedLoop = Engine.PrepareScript(ToFixedLoopSource);
+
+        _toStringRadix = Engine.PrepareScript("""
+            function f() {
+                var seed = 20260711;
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    seed = (seed * 1664525 + 1013904223) | 0;
+                    s += (seed >>> 8).toString(16).length;
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _engine.Evaluate(_parseIntLoop);
+        _engine.Evaluate(_parseFloatLoop);
+        _engine.Evaluate(_numberCoerce);
+        _engine.Evaluate(_toFixedLoop);
+        _engine.Evaluate(_toStringRadix);
+    }
+
+    [Benchmark]
+    public JsValue ParseIntLoop() => _engine.Evaluate(_parseIntLoop);
+
+    [Benchmark]
+    public JsValue ParseFloatLoop() => _engine.Evaluate(_parseFloatLoop);
+
+    [Benchmark]
+    public JsValue NumberCoerce() => _engine.Evaluate(_numberCoerce);
+
+    [Benchmark]
+    public JsValue ToFixedLoop() => _engine.Evaluate(_toFixedLoop);
+
+    [Benchmark]
+    public JsValue ToStringRadix() => _engine.Evaluate(_toStringRadix);
+}

--- a/Jint.Benchmark/ObjectSpreadBenchmark.cs
+++ b/Jint.Benchmark/ObjectSpreadBenchmark.cs
@@ -1,0 +1,139 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The immutable-update idioms: object spread, <c>Object.assign</c>, rest destructuring and
+/// <c>Object.fromEntries</c>, all copying from stable source objects in a hot loop.
+/// <see cref="LiteralClone"/> is the baseline — a plain shaped literal with the same four
+/// properties — so every other row reads as a multiple of the layout-equivalent literal cost.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class ObjectSpreadBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _literalClone;
+    private Prepared<Script> _spreadSmall;
+    private Prepared<Script> _spreadSmallOverride;
+    private Prepared<Script> _spreadLarge;
+    private Prepared<Script> _spreadTwoSources;
+    private Prepared<Script> _assignFreshTarget;
+    private Prepared<Script> _assignExistingTarget;
+    private Prepared<Script> _restDestructuring;
+    private Prepared<Script> _fromEntriesPairs;
+
+    internal const string SetupSource = """
+        var o = { a: 1, b: 2, c: 3, d: 4 };
+        var six = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 };
+        var half1 = { a: 1, b: 2 };
+        var half2 = { c: 3, d: 4 };
+        var acc = { a: 0, b: 0, c: 0, d: 0 };
+        var pairs = [['a', 1], ['b', 2], ['c', 3], ['d', 4]];
+        var wide = {};
+        (function () {
+            for (var i = 0; i < 24; i++) { wide['p' + (i < 10 ? '0' + i : i)] = i; }
+        })();
+        """;
+
+    internal const string SpreadSmallSource = """
+        function f() { var c; for (var i = 0; i < 100000; i++) { c = { ...o }; } return c.d; }
+        f();
+        """;
+
+    internal const string AssignFreshTargetSource = """
+        function f() { var c; for (var i = 0; i < 100000; i++) { c = Object.assign({}, o); } return c.d; }
+        f();
+        """;
+
+    internal const string RestDestructuringSource = """
+        function f() { var rest; for (var i = 0; i < 100000; i++) { var { a, ...r } = six; rest = r; } return rest.f; }
+        f();
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute(SetupSource);
+
+        // the layout-equivalent shaped literal: what a 4-prop copy costs when built as a literal
+        _literalClone = Engine.PrepareScript("""
+            function f() { var c; for (var i = 0; i < 100000; i++) { c = { a: o.a, b: o.b, c: o.c, d: o.d }; } return c.d; }
+            f();
+            """);
+
+        _spreadSmall = Engine.PrepareScript(SpreadSmallSource);
+
+        // spread + trailing static override — the {...defaults, x} config-merge shape
+        _spreadSmallOverride = Engine.PrepareScript("""
+            function f() { var c; for (var i = 0; i < 100000; i++) { c = { ...o, d: i }; } return c.d; }
+            f();
+            """);
+
+        // 24-prop source: beyond the 4-slot inline capacity and the 16-key linear-scan limit
+        _spreadLarge = Engine.PrepareScript("""
+            function f() { var c; for (var i = 0; i < 10000; i++) { c = { ...wide }; } return c.p23; }
+            f();
+            """);
+
+        // the two-source options-merge shape
+        _spreadTwoSources = Engine.PrepareScript("""
+            function f() { var c; for (var i = 0; i < 100000; i++) { c = { ...half1, ...half2 }; } return c.d; }
+            f();
+            """);
+
+        _assignFreshTarget = Engine.PrepareScript(AssignFreshTargetSource);
+
+        // assign onto a long-lived target: pure overwrite, no object creation
+        _assignExistingTarget = Engine.PrepareScript("""
+            function f() { for (var i = 0; i < 100000; i++) { Object.assign(acc, o); } return acc.d; }
+            f();
+            """);
+
+        _restDestructuring = Engine.PrepareScript(RestDestructuringSource);
+
+        _fromEntriesPairs = Engine.PrepareScript("""
+            function f() { var c; for (var i = 0; i < 10000; i++) { c = Object.fromEntries(pairs); } return c.d; }
+            f();
+            """);
+
+        _engine.Evaluate(_literalClone);
+        _engine.Evaluate(_spreadSmall);
+        _engine.Evaluate(_spreadSmallOverride);
+        _engine.Evaluate(_spreadLarge);
+        _engine.Evaluate(_spreadTwoSources);
+        _engine.Evaluate(_assignFreshTarget);
+        _engine.Evaluate(_assignExistingTarget);
+        _engine.Evaluate(_restDestructuring);
+        _engine.Evaluate(_fromEntriesPairs);
+    }
+
+    [Benchmark(Baseline = true)]
+    public JsValue LiteralClone() => _engine.Evaluate(_literalClone);
+
+    [Benchmark]
+    public JsValue SpreadSmall() => _engine.Evaluate(_spreadSmall);
+
+    [Benchmark]
+    public JsValue SpreadSmallOverride() => _engine.Evaluate(_spreadSmallOverride);
+
+    [Benchmark]
+    public JsValue SpreadLarge() => _engine.Evaluate(_spreadLarge);
+
+    [Benchmark]
+    public JsValue SpreadTwoSources() => _engine.Evaluate(_spreadTwoSources);
+
+    [Benchmark]
+    public JsValue AssignFreshTarget() => _engine.Evaluate(_assignFreshTarget);
+
+    [Benchmark]
+    public JsValue AssignExistingTarget() => _engine.Evaluate(_assignExistingTarget);
+
+    [Benchmark]
+    public JsValue RestDestructuring() => _engine.Evaluate(_restDestructuring);
+
+    [Benchmark]
+    public JsValue FromEntriesPairs() => _engine.Evaluate(_fromEntriesPairs);
+}

--- a/Jint.Benchmark/Program.cs
+++ b/Jint.Benchmark/Program.cs
@@ -1,5 +1,12 @@
-﻿using System.Reflection;
+using System.Reflection;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
+using Jint;
 using Jint.Benchmark;
 
 if (args.Length > 0 && args[0] == "--profile-memory")
@@ -20,6 +27,84 @@ if (args.Length > 0 && args[0] == "--profile-time")
 if (args.Length > 0 && args[0] == "--profile-alloc-types")
 {
     return AllocTypeProbe.Run(args);
+}
+
+if (args.Length > 0 && args[0] == "--smoke-comparison")
+{
+    // Runs one Scripts/<name>.js once per comparison engine and reports pass/fail + wall time.
+    // Validates that a new comparison script is compatible with every engine before it joins the table.
+    var name = args.Length > 1 ? args[1] : "json-parse";
+    var path = Path.Combine(AppContext.BaseDirectory, "Scripts", name + ".js");
+    if (!File.Exists(path))
+    {
+        Console.Error.WriteLine($"Script not found: {path}");
+        return 2;
+    }
+
+    var source = File.ReadAllText(path);
+    if (name.Contains("dromaeo", StringComparison.Ordinal))
+    {
+        source = """
+            var startTest = function () { };
+            var test = function (name, fn) { fn(); };
+            var endTest = function () { };
+            var prep = function (fn) { fn(); };
+            """ + Environment.NewLine + source;
+    }
+
+    var failures = 0;
+    RunSmoke("Jint", () => new Engine(static options => options.Strict()).Execute(source));
+    RunSmoke("Jurassic", () => new Jurassic.ScriptEngine { ForceStrictMode = true }.Execute(source));
+    RunSmoke("NiL.JS", () => new NiL.JS.Core.Context(strict: true).Eval(source));
+    RunSmoke("YantraJS", () =>
+    {
+        var engine = new YantraJS.Core.JSContext();
+        engine.Eval(source, null, engine);
+    });
+    return failures == 0 ? 0 : 1;
+
+    void RunSmoke(string engineName, Action run)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        try
+        {
+            run();
+            Console.WriteLine($"  {engineName,-10} OK    {sw.ElapsedMilliseconds,6} ms");
+        }
+        catch (Exception ex)
+        {
+            failures++;
+            Console.WriteLine($"  {engineName,-10} FAIL  {sw.ElapsedMilliseconds,6} ms  {ex.GetType().Name}: {ex.Message.Split('\n')[0]}");
+        }
+    }
+}
+
+if (args.Length > 0 && args[0] is "--disasm" or "--disasm-hw")
+{
+    // JIT-asm inspection per lane (ShortRun for turnaround). INSPECTION ONLY: never quote these
+    // numbers as benchmark gates — gating runs use the default job.
+    Console.WriteLine("== DISASSEMBLY INSPECTION MODE (ShortRun) — asm output only, numbers are NOT gate-quality ==");
+    var disasmConfig = ManualConfig.CreateEmpty()
+        .AddColumnProvider(DefaultColumnProviders.Instance)
+        .AddLogger(ConsoleLogger.Default)
+        .AddExporter(MarkdownExporter.GitHub)
+        .AddJob(Job.ShortRun)
+        .AddDiagnoser(new DisassemblyDiagnoser(new DisassemblyDiagnoserConfig(
+            maxDepth: 3,
+            printSource: true,
+            exportGithubMarkdown: true,
+            exportCombinedDisassemblyReport: true)));
+    if (args[0] == "--disasm-hw")
+    {
+        // ETW hardware counters need an elevated shell; optional by design.
+        disasmConfig = disasmConfig.AddHardwareCounters(HardwareCounter.BranchMispredictions, HardwareCounter.BranchInstructions);
+    }
+
+    BenchmarkSwitcher
+        .FromAssembly(typeof(ArrayBenchmark).GetTypeInfo().Assembly)
+        .Run(args.Skip(1).ToArray(), disasmConfig);
+
+    return 0;
 }
 
 BenchmarkSwitcher

--- a/Jint.Benchmark/RegExpExecLoopBenchmark.cs
+++ b/Jint.Benchmark/RegExpExecLoopBenchmark.cs
@@ -1,0 +1,114 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The tokenizer/scanner regex shapes missing from the match()-oriented suites: a global
+/// <c>exec()</c> while-loop, <c>matchAll</c> iteration, named-group access per match, and a
+/// sticky-flag scanner. Text is synthesized deterministically (~100 KB with embedded tokens);
+/// one full scan per op.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class RegExpExecLoopBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _execWhileLoop;
+    private Prepared<Script> _matchAllIterate;
+    private Prepared<Script> _namedGroupsAccess;
+    private Prepared<Script> _stickyExec;
+
+    internal const string SetupSource = """
+        var text;
+        var tokenText;
+        (function () {
+            var seed = 20260711;
+            var parts = [];
+            for (var i = 0; i < 4000; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                parts.push('word' + (seed & 1023) + ' ');
+                if ((seed & 7) === 0) { parts.push('id-' + (seed >>> 20) + ' '); }
+                if ((seed & 15) === 0) { parts.push('2026-07-' + (10 + (seed & 15)) + ' '); }
+            }
+            text = parts.join('');
+            var tokens = [];
+            for (var i = 0; i < 2500; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                tokens.push('tok' + (seed & 255) + ' ');
+            }
+            tokenText = tokens.join('');
+        })();
+        """;
+
+    internal const string ExecWhileLoopSource = """
+        function f() {
+            var re = /id-(\d+)/g;
+            var n = 0;
+            var m;
+            while ((m = re.exec(text)) !== null) { n += m[1].length; }
+            return n;
+        }
+        f();
+        """;
+
+    internal const string NamedGroupsAccessSource = """
+        function f() {
+            var re = /(?<y>\d{4})-(?<mo>\d{2})-(?<d>\d{2})/g;
+            var n = 0;
+            var m;
+            while ((m = re.exec(text)) !== null) { n += m.groups.y.length + m.groups.d.length; }
+            return n;
+        }
+        f();
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute(SetupSource);
+
+        _execWhileLoop = Engine.PrepareScript(ExecWhileLoopSource);
+
+        _matchAllIterate = Engine.PrepareScript("""
+            function f() {
+                var n = 0;
+                for (var m of text.matchAll(/id-(\d+)/g)) { n += m[1].length; }
+                return n;
+            }
+            f();
+            """);
+
+        _namedGroupsAccess = Engine.PrepareScript(NamedGroupsAccessSource);
+
+        // sticky scanner: every exec must match exactly at lastIndex
+        _stickyExec = Engine.PrepareScript("""
+            function f() {
+                var re = /\w+ /y;
+                var n = 0;
+                var m;
+                while ((m = re.exec(tokenText)) !== null) { n++; }
+                return n;
+            }
+            f();
+            """);
+
+        _engine.Evaluate(_execWhileLoop);
+        _engine.Evaluate(_matchAllIterate);
+        _engine.Evaluate(_namedGroupsAccess);
+        _engine.Evaluate(_stickyExec);
+    }
+
+    [Benchmark]
+    public JsValue ExecWhileLoop() => _engine.Evaluate(_execWhileLoop);
+
+    [Benchmark]
+    public JsValue MatchAllIterate() => _engine.Evaluate(_matchAllIterate);
+
+    [Benchmark]
+    public JsValue NamedGroupsAccess() => _engine.Evaluate(_namedGroupsAccess);
+
+    [Benchmark]
+    public JsValue StickyExec() => _engine.Evaluate(_stickyExec);
+}

--- a/Jint.Benchmark/Scripts/json-parse-modern.js
+++ b/Jint.Benchmark/Scripts/json-parse-modern.js
@@ -1,0 +1,33 @@
+let payload = (() => {
+    let seed = 20260711;
+    const next = () => { seed = (seed * 1664525 + 1013904223) | 0; return seed >>> 8; };
+    const tags = ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta', 'theta'];
+    const records = [];
+    for (let i = 0; i < 500; i++) {
+        records.push({
+            id: i,
+            name: `user${next() % 10000}`,
+            active: (next() & 1) === 1,
+            score: (next() % 10000) / 100,
+            tags: [tags[next() & 7], tags[next() & 7]],
+            ts: 1700000000 + i
+        });
+    }
+    return JSON.stringify(records);
+})();
+
+let checksum = 0;
+for (let iter = 0; iter < 32; iter++) {
+    const parsed = JSON.parse(payload);
+    let total = 0;
+    for (const r of parsed) {
+        total += r.id + r.score + (r.active ? 1 : 0) + r.tags.length + r.name.length;
+    }
+    checksum += total;
+    if ((iter & 7) === 7) {
+        payload = JSON.stringify(parsed);
+    }
+}
+if (!(checksum > 0)) {
+    throw new Error(`json-parse checksum mismatch: ${checksum}`);
+}

--- a/Jint.Benchmark/Scripts/json-parse.js
+++ b/Jint.Benchmark/Scripts/json-parse.js
@@ -1,0 +1,34 @@
+var payload = (function () {
+    var seed = 20260711;
+    function next() { seed = (seed * 1664525 + 1013904223) | 0; return seed >>> 8; }
+    var tags = ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta', 'theta'];
+    var records = [];
+    for (var i = 0; i < 500; i++) {
+        records.push({
+            id: i,
+            name: 'user' + (next() % 10000),
+            active: (next() & 1) === 1,
+            score: (next() % 10000) / 100,
+            tags: [tags[next() & 7], tags[next() & 7]],
+            ts: 1700000000 + i
+        });
+    }
+    return JSON.stringify(records);
+})();
+
+var checksum = 0;
+for (var iter = 0; iter < 32; iter++) {
+    var parsed = JSON.parse(payload);
+    var total = 0;
+    for (var i = 0; i < parsed.length; i++) {
+        var r = parsed[i];
+        total += r.id + r.score + (r.active ? 1 : 0) + r.tags.length + r.name.length;
+    }
+    checksum += total;
+    if ((iter & 7) === 7) {
+        payload = JSON.stringify(parsed);
+    }
+}
+if (!(checksum > 0)) {
+    throw new Error('json-parse checksum mismatch: ' + checksum);
+}

--- a/Jint.Benchmark/TemplateLiteralBenchmark.cs
+++ b/Jint.Benchmark/TemplateLiteralBenchmark.cs
@@ -1,0 +1,100 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Template-literal building beyond the trivial single-interpolation case: many slots, nesting,
+/// number-to-string interpolation, and tagged templates (whose spec-cached strings array should
+/// not be re-materialized per call). 100k evaluations per op inside a function frame.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class TemplateLiteralBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _manyInterpolations;
+    private Prepared<Script> _nestedTemplate;
+    private Prepared<Script> _numberInterpolation;
+    private Prepared<Script> _taggedTemplate;
+
+    internal const string ManyInterpolationsSource = """
+        function f() {
+            var a = 'aa', b = 'bb', c = 'cc', d = 'dd', e = 'ee', g = 'gg', h = 'hh';
+            var n = 0;
+            for (var i = 0; i < 100000; i++) {
+                var k = i & 15;
+                var r = `${a}-${b}-${c}-${d}-${e}-${g}-${h}-${k}`;
+                n += r.length;
+            }
+            return n;
+        }
+        f();
+        """;
+
+    internal const string TaggedTemplateSource = """
+        function tag(strings, a, b) { return strings.length + a + b; }
+        function f() {
+            var s = 0;
+            for (var i = 0; i < 100000; i++) {
+                s += tag`t ${i & 7} u ${i & 3} v`;
+            }
+            return s;
+        }
+        f();
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+
+        _manyInterpolations = Engine.PrepareScript(ManyInterpolationsSource);
+
+        // a template whose interpolated expression is itself a template
+        _nestedTemplate = Engine.PrepareScript("""
+            function f() {
+                var x = 'x';
+                var n = 0;
+                for (var i = 0; i < 100000; i++) {
+                    var r = `outer ${`inner ${x}${i & 7}`} tail`;
+                    n += r.length;
+                }
+                return n;
+            }
+            f();
+            """);
+
+        // number-to-string per iteration
+        _numberInterpolation = Engine.PrepareScript("""
+            function f() {
+                var n = 0;
+                for (var i = 0; i < 100000; i++) {
+                    var r = `v=${i}`;
+                    n += r.length;
+                }
+                return n;
+            }
+            f();
+            """);
+
+        _taggedTemplate = Engine.PrepareScript(TaggedTemplateSource);
+
+        _engine.Evaluate(_manyInterpolations);
+        _engine.Evaluate(_nestedTemplate);
+        _engine.Evaluate(_numberInterpolation);
+        _engine.Evaluate(_taggedTemplate);
+    }
+
+    [Benchmark]
+    public JsValue ManyInterpolations() => _engine.Evaluate(_manyInterpolations);
+
+    [Benchmark]
+    public JsValue NestedTemplate() => _engine.Evaluate(_nestedTemplate);
+
+    [Benchmark]
+    public JsValue NumberInterpolation() => _engine.Evaluate(_numberInterpolation);
+
+    [Benchmark]
+    public JsValue TaggedTemplate() => _engine.Evaluate(_taggedTemplate);
+}


### PR DESCRIPTION
## Problem

The engine-comparison table is in strong shape after the recent campaigns, but several patterns that dominate real-world JS have **no dedicated coverage** at all, so regressions there are invisible and improvements can't be gated: JS-level `JSON.parse`/`stringify` over object graphs, object spread / `Object.assign` / rest, `reduce`/`forEach`/`some`/`every` chains, optional chaining / nullish / logical assignment, resolved-`await` + microtask chains, `try`/`catch` + `Error` construction cost, Map/Set lookup loops, the cold constructor promote window, `for-in` + `hasOwnProperty` guards, `typeof`/`instanceof`/`in` dispatch, tagged templates, `parseInt`/`toFixed` loops, and `exec()`-style regex scanners.

This PR is **benchmark-project-only** (zero `Jint/` changes) and seeds an upcoming benchmark-gated performance campaign with its gate rows.

## What's included

**12 new benchmark classes** (house style: reuse-engine + prepared scripts, `[MemoryDiagnoser]`, function-wrapped hot loops; fresh-engine style where cold-start is the point):

| Class | Focus | Sample rows |
|---|---|---|
| `JsonJsBenchmark` | JS-level JSON API, offline deterministic payloads | ParseRecords (1,000×6-prop), ParseConfig (depth-4 nested), ParseBigObject (100 props), Stringify*, RoundTrip |
| `ObjectSpreadBenchmark` | immutable-update idioms vs a `LiteralClone` baseline | SpreadSmall, SpreadSmallOverride, AssignFreshTarget, RestDestructuring, FromEntriesPairs |
| `ArrayCallbackBenchmark` | callback pipelines over 100k LCG-mixed ints | ReduceSum, ForEachSum, SomeMiss/EveryHit, MapFilterReduceChain |
| `ModernOperatorsBenchmark` | `?.` / `??` / `??=` / `\|\|=` over ~50% short-circuiting inputs | OptionalChainHit/Miss, NullishCoalesce |
| `AsyncAwaitBenchmark` | resolved-await + microtask shapes vs a sync-call baseline | AwaitResolvedLoop, PromiseAll100, ThenChain1000, MicrotaskFanout |
| `ErrorHandlingBenchmark` | try scaffolding, throw/catch, Error + `.stack` | TryNoThrow, ThrowCatchLoop, ErrorStackAccess, DeepStackThrow |
| `MapSetLookupBenchmark` | cache/memoize shapes, 50/50 hit-miss probes | MapGetHit, MapHasMixed, MapSetDeleteChurn, MemoizePattern |
| `ColdConstructorBenchmark` | fresh engine per op; the ctor promote window | FunctionCtor_x8/x64/x1000, ClassCtor_x8/x1000, DistinctCtors200 |
| `ForInGuardBenchmark` | object iteration + type guards | ForInHasOwnGuard, ForInProtoChain, ForOfString, TypeofSwitchMixed |
| `TemplateLiteralBenchmark` | many-slot/nested/tagged templates | ManyInterpolations, TaggedTemplate |
| `NumberParseBenchmark` | parse/format loops | ParseIntLoop, ToFixedLoop, ToStringRadix |
| `RegExpExecLoopBenchmark` | tokenizer shapes | ExecWhileLoop, MatchAllIterate, NamedGroupsAccess, StickyExec |

Inputs are mixed with an inline LCG (`seed = (seed*1664525+1013904223)|0`) so the branch predictor can't memorize outcomes while runs stay fully deterministic — no network, no `Math.random`, no wall clock.

**`json-parse.js` + `json-parse-modern.js` join the engine-comparison suite** — the API-payload shape (parse array-of-records, touch fields, periodic re-stringify) that none of the 19 existing scripts exercises. Validated on all four engines with the new smoke mode:

```
$ dotnet run -c Release -- --smoke-comparison json-parse
  Jint       OK       369 ms
  Jurassic   OK       284 ms
  NiL.JS     OK       617 ms
  YantraJS   OK       301 ms
```

(`json-parse-modern` fails on Jurassic with a syntax error, exactly like every other `-modern` script — it reports NA in the table.) Note Jurassic currently **beats** Jint on this workload — JSON object materialization is a known dictionary-mode path and one of the campaign targets; this row makes that visible and gateable.

**Diagnostics** (benchmark project infrastructure):
- `AllocTypeProbe` gains 28 campaign census targets that execute the *identical* GATE-row sources the benchmark classes run (shared `internal static` sources), in the same engine mode (warm reuse vs fresh-per-iteration), so `--profile-alloc-types json-parse-records` attributes exactly what `JsonJsBenchmark.ParseRecords` measures.
- `--smoke-comparison <script>`: runs one comparison script once per engine and reports pass/fail + wall time — pre-flight for any future table addition.
- `--disasm` / `--disasm-hw`: `DisassemblyDiagnoser` (maxDepth 3, GitHub-markdown export, optional branch-misprediction hardware counters) behind a ShortRun config that is clearly bannered as **inspection-only** — gating numbers keep using the default job.

## Verification

- Release build clean (warnings-as-errors).
- BDN dry run across one row per class (GlobalSetup warm-evaluates *every* row script in-process): 14/14 cases, zero exceptions.
- Both json-parse scripts smoke-tested on all four engines (table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
