### PR TITLE
Migrate remaining symbol-alias tails to [JsSymbolAlias]

### DIFF
--- a/Jint/Native/Disposable/AsyncDisposableStackPrototype.cs
+++ b/Jint/Native/Disposable/AsyncDisposableStackPrototype.cs
@@ -1,11 +1,13 @@
 using Jint.Native.Object;
 using Jint.Native.Promise;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Disposable;
 
+// Spec requires AsyncDisposableStack.prototype[@@asyncDispose] to be the same function object as
+// AsyncDisposableStack.prototype.disposeAsync; [JsSymbolAlias] shares the materialized function.
+[JsSymbolAlias("AsyncDispose", "disposeAsync")]
 [JsObject(UseShape = true)]
 internal sealed partial class AsyncDisposableStackPrototype : Prototype
 {
@@ -28,11 +30,6 @@ internal sealed partial class AsyncDisposableStackPrototype : Prototype
     {
         CreateProperties_Generated();
         CreateSymbols_Generated();
-
-        // Spec requires AsyncDisposableStack.prototype[@@asyncDispose] to be the same function object
-        // as AsyncDisposableStack.prototype.disposeAsync. Alias the descriptor here so the
-        // @@asyncDispose slot shares the same materialized function as `disposeAsync`.
-        SetProperty(GlobalSymbolRegistry.AsyncDispose, GetOwnProperty("disposeAsync"));
     }
 
     [JsFunction]

--- a/Jint/Native/Disposable/DisposableStackPrototype.cs
+++ b/Jint/Native/Disposable/DisposableStackPrototype.cs
@@ -1,10 +1,12 @@
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
 namespace Jint.Native.Disposable;
 
+// Spec requires DisposableStack.prototype[@@dispose] to be the same function object as
+// DisposableStack.prototype.dispose; [JsSymbolAlias] shares the materialized `dispose` function.
+[JsSymbolAlias("Dispose", "dispose")]
 [JsObject(UseShape = true)]
 internal sealed partial class DisposableStackPrototype : Prototype
 {
@@ -27,11 +29,6 @@ internal sealed partial class DisposableStackPrototype : Prototype
     {
         CreateProperties_Generated();
         CreateSymbols_Generated();
-
-        // Spec requires DisposableStack.prototype[@@dispose] to be the same function object as
-        // DisposableStack.prototype.dispose. Alias the descriptor here so the @@dispose slot shares
-        // the same materialized function as `dispose` rather than emitting a separate dispatcher.
-        SetProperty(GlobalSymbolRegistry.Dispose, GetOwnProperty("dispose"));
     }
 
     [JsFunction]

--- a/Jint/Native/Map/MapPrototype.cs
+++ b/Jint/Native/Map/MapPrototype.cs
@@ -1,7 +1,6 @@
 #pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of prototype methods return JsValue
 
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
@@ -10,6 +9,9 @@ namespace Jint.Native.Map;
 /// <summary>
 /// https://tc39.es/ecma262/#sec-map-objects
 /// </summary>
+// Spec requires Map.prototype[@@iterator] to be the same function object as Map.prototype.entries
+// (function identity, observable via ===); [JsSymbolAlias] shares the materialized `entries` function.
+[JsSymbolAlias("Iterator", "entries")]
 [JsObject(UseShape = true)]
 internal sealed partial class MapPrototype : Prototype
 {
@@ -32,11 +34,6 @@ internal sealed partial class MapPrototype : Prototype
     {
         CreateProperties_Generated();
         CreateSymbols_Generated();
-
-        // Spec requires Map.prototype[@@iterator] to be the same function object as Map.prototype.entries
-        // (function identity, observable via ===). Alias the descriptor here so the @@iterator slot
-        // shares the same materialized function as `entries` rather than emitting a separate dispatcher.
-        SetProperty(GlobalSymbolRegistry.Iterator, GetOwnProperty("entries"));
     }
 
     [JsAccessor("size")]

--- a/Jint/Native/Set/SetPrototype.cs
+++ b/Jint/Native/Set/SetPrototype.cs
@@ -1,7 +1,6 @@
 #pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of prototype methods return JsValue
 
 using Jint.Native.Object;
-using Jint.Native.Symbol;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 
@@ -10,9 +9,10 @@ namespace Jint.Native.Set;
 /// <summary>
 /// https://www.ecma-international.org/ecma-262/6.0/#sec-set-objects
 /// </summary>
-// Set.prototype.keys is the same function as `values` (spec identity); [JsAlias] expresses that through
-// the shape. Set.prototype[@@iterator] is aliased in Initialize (symbols are orthogonal to the shape).
+// Set.prototype.keys and Set.prototype[@@iterator] are the same function as `values` (spec identity);
+// [JsAlias] expresses the string alias through the shape, [JsSymbolAlias] the symbol-keyed alias.
 [JsAlias("keys", "values")]
+[JsSymbolAlias("Iterator", "values")]
 [JsObject(UseShape = true)]
 internal sealed partial class SetPrototype : Prototype
 {
@@ -35,10 +35,6 @@ internal sealed partial class SetPrototype : Prototype
     {
         CreateProperties_Generated();
         CreateSymbols_Generated();
-
-        // Set.prototype[@@iterator] is the same function as `values` (spec identity). Symbols are orthogonal
-        // to the string shape, so this stays hand-written; `keys` is handled by [JsAlias] on the class.
-        SetProperty(GlobalSymbolRegistry.Iterator, GetOwnProperty("values"));
     }
 
     [JsAccessor("size")]


### PR DESCRIPTION
## Problem

Four prototypes still hand-write their symbol-alias tails in `Initialize()` even though the source generator has expressed exactly this pattern via `[JsSymbolAlias]` since #2619 (ArrayPrototype / IntrinsicTypedArrayPrototype precedent):

- `SetPrototype`: `@@iterator` → `"values"`
- `MapPrototype`: `@@iterator` → `"entries"`
- `DisposableStackPrototype`: `@@dispose` → `"dispose"`
- `AsyncDisposableStackPrototype`: `@@asyncDispose` → `"disposeAsync"`

## Approach

Replace each hand-written `SetProperty(GlobalSymbolRegistry.X, GetOwnProperty("y"))` tail with a class-level `[JsSymbolAlias("X", "y")]`; each `Initialize()` shrinks to the two `*_Generated()` calls. Net −13 lines, no generator changes (snapshots byte-identical).

Semantics: function identity is preserved (`Set.prototype[Symbol.iterator] === Set.prototype.values` etc. all remain `true`); effective attributes are unchanged (`writable: true, enumerable: false, configurable: true` before and after — the only differing bit is the internal `EnumerableSet` marker, which is unobservable for stored own properties; verified through `FromPropertyDescriptor` and `ValidateAndApplyPropertyDescriptor`). One subtle improvement: the symbol key now has its own descriptor instance, so in-place attribute redefinition of one key can no longer leak to its alias twin (spec-correct independence). That costs one extra `PropertyDescriptor` per initialized prototype per realm (4 total when all four are touched) — the same trade the merged ArrayPrototype migration made.

## Verification

- Release build clean (warnings-as-errors).
- Source-generator snapshots: 36/36, zero `*.received.*` (generator untouched).
- Unit tests (Set/Map/Disposable filters): net10.0 190/190, net472 174/174.
- Jint.Tests.PublicInterface: net10.0 82/82, net472 82/82.
- **Full Test262: 99,426 passed / 0 failed** (baseline-identical).
- REPL identity probes: all four `===` identities true; `Set.prototype.keys === Set.prototype.values` still true; for-of over Set/Map correct; own-symbol order preserved (`@@toStringTag`, alias) on all four prototypes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
