### PR TITLE
Skip per-iteration TDZ re-init for loop bodies proven init-before-use

### DIFF
--- a/Jint.Tests/Runtime/TdzResetSkipTests.cs
+++ b/Jint.Tests/Runtime/TdzResetSkipTests.cs
@@ -1,0 +1,338 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the semantics of the flattened for-loop body TDZ reset skip: when the body block's
+/// conservative scan (BlockState.AllBodySlotsInitBeforeUse) proves every slot binding is
+/// initialized by its declaration before any reference to it can evaluate, the per-iteration
+/// re-TDZ of the body slot range is skipped in both the generic and tight flattened arms.
+/// Shapes the scan rejects — any identifier occurrence of a slot name textually before its
+/// declaring statement, including inside its own initializer — must keep the per-iteration
+/// reset and throw ReferenceError on every iteration, not just the first.
+/// </summary>
+public class TdzResetSkipTests
+{
+    [Fact]
+    public void EligibleConstBodyComputesCorrectValuesAcrossIterations()
+    {
+        var engine = new Engine();
+        // same body twice through the tight arm (expression/declaration statements only) and once
+        // through the generic arm (the never-taken break disqualifies the tight shape but not
+        // flattening); repeated calls also pin that loop entry re-establishes the full TDZ
+        var result = engine.Evaluate("""
+            (function () {
+                function tightShape() {
+                    var acc = [];
+                    for (let i = 0; i < 3; i++) {
+                        const z = i * 2;
+                        acc.push(z);
+                    }
+                    return acc.join(',');
+                }
+                function genericShape() {
+                    var acc = [];
+                    for (let i = 0; i < 3; i++) {
+                        const z = i * 2;
+                        acc.push(z);
+                        if (i > 100) break;
+                    }
+                    return acc.join(',');
+                }
+                return tightShape() + '|' + tightShape() + '|' + genericShape();
+            })()
+            """).AsString();
+
+        Assert.Equal("0,2,4|0,2,4|0,2,4", result);
+    }
+
+    [Fact]
+    public void ChainedConstDeclarationsComputeCorrectly()
+    {
+        var engine = new Engine();
+        // the stopwatch-modern shape: several const slots per iteration, each initializer only
+        // referencing already-declared names — scan accepts, tight arm runs without any re-TDZ
+        var result = engine.Evaluate("""
+            (function () {
+                let acc = 0;
+                for (let i = 0; i < 50; i++) {
+                    const x = i | 0;
+                    const y = i * 3;
+                    const z = x ^ y;
+                    acc = (acc + z) | 0;
+                }
+                return acc;
+            })()
+            """).AsNumber();
+
+        var expected = 0;
+        for (var i = 0; i < 50; i++)
+        {
+            expected = expected + (i ^ (i * 3));
+        }
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ReadBeforeDeclarationThrowsOnEveryIteration()
+    {
+        var engine = new Engine();
+        // the scan rejects this shape (z referenced textually before its declaration), so the
+        // per-iteration reset must still run: the read throws on all three iterations — a wrongly
+        // applied skip would leave iteration 1's value in the slot and only throw once
+        var result = engine.Evaluate("""
+            (function () {
+                let threw = 0;
+                for (let i = 0; i < 3; i++) {
+                    try { z; } catch (e) { if (e instanceof ReferenceError) threw++; }
+                    const z = i;
+                }
+                return threw;
+            })()
+            """).AsNumber();
+
+        Assert.Equal(3, result);
+    }
+
+    [Fact]
+    public void WriteBeforeDeclarationStillThrowsOnLaterIterations()
+    {
+        var engine = new Engine();
+        // assignment is a reference too: iteration 1's write lands in the TDZ re-established by
+        // the retained reset (tight arm), never on iteration 0's stale initialized binding
+        var result = engine.Evaluate("""
+            (function () {
+                try {
+                    for (let i = 0; i < 3; i++) {
+                        if (i === 1) { z = 5; }
+                        let z = i;
+                    }
+                } catch (e) {
+                    return e instanceof ReferenceError ? 'tdz-write' : 'other';
+                }
+                return 'no-throw';
+            })()
+            """).AsString();
+
+        Assert.Equal("tdz-write", result);
+    }
+
+    [Fact]
+    public void ContinueOverInitializationKeepsCorrectValues()
+    {
+        var engine = new Engine();
+        // continue skips the declaration for odd iterations, leaving a stale value in the slot;
+        // it is unobservable because every read is lexically after the declaration re-initializes
+        var result = engine.Evaluate("""
+            (function () {
+                let sum = 0, visits = 0;
+                for (let i = 0; i < 4; i++) {
+                    visits++;
+                    if (i & 1) continue;
+                    const z = i;
+                    sum += z;
+                }
+                return sum + ':' + visits;
+            })()
+            """).AsString();
+
+        Assert.Equal("2:4", result);
+    }
+
+    [Fact]
+    public void ClosureCapturingBodyLetKeepsPerIterationSemantics()
+    {
+        var engine = new Engine();
+        // a capturing body is never slot-eligible, so flattening (and the skip) cannot engage;
+        // the per-iteration block environments must keep giving each closure its own binding
+        var result = engine.Evaluate("""
+            (function () {
+                const fns = [];
+                for (let i = 0; i < 3; i++) {
+                    let v = i * 10;
+                    fns.push(function () { return v; });
+                }
+                return fns.map(function (f) { return f(); }).join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal("0,10,20", result);
+    }
+
+    [Fact]
+    public void ReenteredInnerLetLoopWithConstBodyStaysCorrect()
+    {
+        var engine = new Engine();
+        // the ForBenchmark.ReenteredInnerLetLoop shape with a body lexical: every inner() entry
+        // reuses the pooled environment, whose entry reset must keep covering the first iteration
+        var result = engine.Evaluate("""
+            (function () {
+                function inner() {
+                    var s = 0;
+                    for (let j = 0; j < 4; j++) {
+                        const d = j * j;
+                        s += d;
+                    }
+                    return s;
+                }
+                var total = 0;
+                for (var k = 0; k < 5; k++) { total += inner(); }
+                return total;
+            })()
+            """).AsNumber();
+
+        Assert.Equal(70, result);
+    }
+
+    [Fact]
+    public void SelfReferencingInitializerCountsAsBeforeUse()
+    {
+        var engine = new Engine();
+        // let x = x reads x while it is still uninitialized: ReferenceError on entry and again on
+        // a fresh entry (the loop environment is pooled across entries)
+        var immediate = engine.Evaluate("""
+            (function () {
+                var hits = [];
+                function run() {
+                    try {
+                        for (let i = 0; i < 3; i++) { let x = x; }
+                    } catch (e) {
+                        hits.push(e instanceof ReferenceError);
+                    }
+                }
+                run(); run();
+                return hits.join(',');
+            })()
+            """).AsString();
+        Assert.Equal("true,true", immediate);
+
+        // conditional self-reference: iteration 0 initializes z without reading it, iteration 1's
+        // initializer reads z. The scan must treat the initializer as running before its own name
+        // is declared (reject), keeping the reset so the read throws instead of seeing 1
+        var conditional = engine.Evaluate("""
+            (function () {
+                try {
+                    for (let i = 0; i < 3; i++) { const z = i === 0 ? 1 : z; }
+                } catch (e) {
+                    return e instanceof ReferenceError ? 'tdz' : 'other';
+                }
+                return 'no-throw';
+            })()
+            """).AsString();
+        Assert.Equal("tdz", conditional);
+    }
+
+    [Fact]
+    public void HeaderAndOuterShadowingStayCorrect()
+    {
+        var engine = new Engine();
+        // header names are not body slots: reading the header binding in a slot initializer is
+        // always after-use and stays eligible
+        var header = engine.Evaluate("""
+            (function () {
+                var acc = [];
+                for (let z = 0; z < 2; z++) {
+                    const z2 = z * 3;
+                    acc.push(z2);
+                }
+                return acc.join(',');
+            })()
+            """).AsString();
+        Assert.Equal("0,3", header);
+
+        // body slot shadowing an outer binding: body reads see the freshly initialized inner
+        // binding every iteration and the outer binding stays untouched
+        var shadow = engine.Evaluate("""
+            (function () {
+                let z = 'outer';
+                var acc = [];
+                for (let i = 0; i < 2; i++) {
+                    const z = 'inner' + i;
+                    acc.push(z);
+                }
+                acc.push(z);
+                return acc.join(',');
+            })()
+            """).AsString();
+        Assert.Equal("inner0,inner1,outer", shadow);
+
+        // shadow read before the declaration, conditionally so iteration 0 completes: the body's
+        // own binding covers the whole block in TDZ, so iteration 1 must throw — never fall back
+        // to the outer binding or (scan rejects, reset retained) see iteration 0's stale value
+        var beforeDeclaration = engine.Evaluate("""
+            (function () {
+                let q = 'outer';
+                var seen = 'none';
+                try {
+                    for (let i = 0; i < 2; i++) {
+                        if (i === 1) { seen = q; }
+                        const q = 'inner' + i;
+                    }
+                } catch (e) {
+                    return (e instanceof ReferenceError) + ':' + seen;
+                }
+                return 'no-throw:' + seen;
+            })()
+            """).AsString();
+        Assert.Equal("true:none", beforeDeclaration);
+    }
+
+    [Fact]
+    public void MultiDeclaratorStatementsScanPerDeclarator()
+    {
+        var engine = new Engine();
+        // within one statement, later declarators may reference earlier ones (accepted, skip active)
+        var forward = engine.Evaluate("""
+            (function () {
+                var acc = [];
+                for (let i = 0; i < 2; i++) {
+                    const a = i + 1, b = a * 10;
+                    acc.push(a + ':' + b);
+                }
+                return acc.join('|');
+            })()
+            """).AsString();
+        Assert.Equal("1:10|2:20", forward);
+
+        // ...but an earlier declarator referencing a later one is before-use: the scan rejects,
+        // the reset stays, and iteration 1's read throws instead of seeing iteration 0's value
+        var backward = engine.Evaluate("""
+            (function () {
+                try {
+                    for (let i = 0; i < 2; i++) {
+                        let a = i === 0 ? 0 : b, b = i;
+                    }
+                } catch (e) {
+                    return e instanceof ReferenceError ? 'tdz' : 'other';
+                }
+                return 'no-throw';
+            })()
+            """).AsString();
+        Assert.Equal("tdz", backward);
+    }
+
+    [Fact]
+    public void MultiSlotEligibleBodyReinitializesEverySlot()
+    {
+        var engine = new Engine();
+        // initializer-less let re-initializes to undefined each iteration (i === 0 sets u, later
+        // iterations must observe undefined again, not the stale value); a nested block shadowing
+        // a declared slot name after its declaration does not affect eligibility
+        var result = engine.Evaluate("""
+            (function () {
+                var acc = [];
+                for (let i = 0; i < 3; i++) {
+                    const a = i;
+                    let b = a * 2;
+                    b = b + 1;
+                    let u;
+                    if (i === 0) u = 'set';
+                    { let a = 99; b += a - 99; }
+                    acc.push(a + ':' + b + ':' + u);
+                }
+                return acc.join('|');
+            })()
+            """).AsString();
+
+        Assert.Equal("0:1:set|1:3:undefined|2:5:undefined", result);
+    }
+}

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -445,6 +445,14 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
         public readonly Key[]? SlotNames;
         public readonly Binding[]? SlotTemplates;
 
+        // True when a conservative in-order scan proves every slot binding's declaring statement
+        // executes before any reference to its name can evaluate. Re-establishing the slots' TDZ
+        // between repeated executions of the block against the same environment (enclosing-loop
+        // body flattening) is then unobservable — every reachable read/write hits a binding its
+        // own execution just initialized — so the per-iteration reset can be skipped. Meaningful
+        // only when SlotNames is non-null; false never affects semantics, it just keeps the reset.
+        public readonly bool AllBodySlotsInitBeforeUse;
+
         public BlockState(DeclarationCache declarationCache, BlockStatement blockStatement)
         {
             DeclarationCache = declarationCache;
@@ -484,8 +492,102 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
                     }
                     SlotNames = slotNames;
                     SlotTemplates = slotTemplates;
+                    AllBodySlotsInitBeforeUse = ComputeAllSlotsInitializedBeforeUse(blockStatement, slotNames);
                 }
             }
+        }
+
+        /// <summary>
+        /// Conservative scan over the block's top-level statements in source order, tracking which
+        /// slot names have completed their declaring declarator. Any identifier occurrence of a
+        /// not-yet-declared slot name rejects: identifiers are over-approximated as references
+        /// (property keys, labels etc. count too), which can only cost the optimization, never
+        /// correctness. A declarator's initializer is scanned before its own name is marked, so
+        /// `let x = x` counts as before-use; destructuring declarators reject outright (computed
+        /// keys and defaults evaluate while the pattern's own names are still uninitialized).
+        /// Slot eligibility has already excluded closures, direct eval and `with`, so a runtime
+        /// reference to a slot binding always appears as an Identifier node in this subtree.
+        /// </summary>
+        private static bool ComputeAllSlotsInitializedBeforeUse(BlockStatement blockStatement, Key[] slotNames)
+        {
+            var declaredMask = 0; // bit i set => slotNames[i] initialized; eligibility caps slots at 16
+            ref readonly var statements = ref blockStatement.Body;
+            foreach (var statement in statements.AsSpan())
+            {
+                if (statement is VariableDeclaration { Kind: not VariableDeclarationKind.Var } declaration)
+                {
+                    for (var i = 0; i < declaration.Declarations.Count; i++)
+                    {
+                        var declarator = declaration.Declarations[i];
+                        if (declarator.Id is not Identifier identifier)
+                        {
+                            return false;
+                        }
+
+                        if (declarator.Init is { } init && ReferencesUndeclaredSlot(init, slotNames, declaredMask))
+                        {
+                            return false;
+                        }
+
+                        // mark only after the initializer scan: the name is in TDZ while its own initializer runs
+                        var index = FindSlotName(slotNames, identifier.Name);
+                        if (index >= 0)
+                        {
+                            declaredMask |= 1 << index;
+                        }
+                    }
+                }
+                else if (ReferencesUndeclaredSlot(statement, slotNames, declaredMask))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool ReferencesUndeclaredSlot(Node node, Key[] slotNames, int declaredMask)
+        {
+            if (node.Type == NodeType.Identifier)
+            {
+                return IsUndeclaredSlotName(((Identifier) node).Name, slotNames, declaredMask);
+            }
+
+            foreach (var child in node.ChildNodes)
+            {
+                if (ReferencesUndeclaredSlot(child, slotNames, declaredMask))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsUndeclaredSlotName(string name, Key[] slotNames, int declaredMask)
+        {
+            for (var i = 0; i < slotNames.Length; i++)
+            {
+                if ((declaredMask & (1 << i)) == 0 && string.Equals(slotNames[i].Name, name, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static int FindSlotName(Key[] slotNames, string name)
+        {
+            for (var i = 0; i < slotNames.Length; i++)
+            {
+                if (string.Equals(slotNames[i].Name, name, StringComparison.Ordinal))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -39,8 +39,11 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
     // contain no using declarations and don't shadow the loop header's names, they fold into the
     // pooled loop environment. The body then runs against that environment directly, eliding the
     // block-env attach/swap/park ceremony per iteration; the body's slot range is re-TDZ'd before
-    // each iteration instead.
+    // each iteration instead — unless the block's conservative scan proved every slot initializes
+    // before any reference can evaluate, in which case the previous iteration's leftover values
+    // are unobservable and the per-iteration reset is skipped (loop entry still TDZ's all slots).
     private readonly bool _bodyFlattened;
+    private readonly bool _flattenedBodySlotsInitBeforeUse;
     private readonly int _flattenedHeaderSlotCount;
     private readonly JintBlockStatement? _flattenedBodyBlock;
 
@@ -134,6 +137,7 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                 _loopSlotTemplates = combinedTemplates;
                 _flattenedHeaderSlotCount = headerCount;
                 _flattenedBodyBlock = flattenCandidate;
+                _flattenedBodySlotsInitBeforeUse = bodyState.AllBodySlotsInitBeforeUse;
                 _bodyFlattened = true;
             }
         }
@@ -416,6 +420,10 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
     /// <summary>
     /// Re-establishes the TDZ of the flattened body's slot range before an iteration; the header
     /// range is left untouched (a reused iteration environment keeps its header bindings).
+    /// Skipped entirely when <see cref="JintBlockStatement.BlockState.AllBodySlotsInitBeforeUse"/>
+    /// holds for the body: no reference can evaluate before its slot's declaration re-initializes
+    /// it, so the previous iteration's values are dead and loop entry's full reset covers the
+    /// first iteration.
     /// </summary>
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     private static void ResetBodySlotRange(Binding[] slots, Binding[] templates, int headerCount)
@@ -559,8 +567,14 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                     // the pooled loop environment carries the body's slots: re-establish their TDZ
                     // and run the block contents in place. Under a debugger the normal block path
                     // runs instead — its fresh env shadows the (uninitialized) flattened slots.
-                    var env = (DeclarativeEnvironment) context.Engine.ExecutionContext.LexicalEnvironment;
-                    ResetBodySlotRange(env._slots!, _loopSlotTemplates!, _flattenedHeaderSlotCount);
+                    // When the block scan proved every slot initializes before any use, the
+                    // re-TDZ is unobservable (loop entry already reset the whole slot array for
+                    // the first iteration) and is skipped.
+                    if (!_flattenedBodySlotsInitBeforeUse)
+                    {
+                        var env = (DeclarativeEnvironment) context.Engine.ExecutionContext.LexicalEnvironment;
+                        ResetBodySlotRange(env._slots!, _loopSlotTemplates!, _flattenedHeaderSlotCount);
+                    }
                     result = _flattenedBodyBlock!.ExecuteFlattenedContents(context);
                 }
                 else
@@ -640,7 +654,8 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
     /// Deferred errors surface as Engine._error instead of a .NET throw; the statement list
     /// converts them per statement, and so must the tight loop. Under flattening the pooled
     /// loop environment carries the body's slots: their TDZ is re-established per iteration
-    /// before the body statements run, mirroring the generic flattened arm.
+    /// before the body statements run, mirroring the generic flattened arm — skipped when the
+    /// block scan proved every slot initializes before any use (leftovers are unobservable).
     /// </summary>
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
     private Completion TightForBody(EvaluationContext context, bool flattenActive)
@@ -650,10 +665,11 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         var single = _tightSingleStatement;
         var list = _tightBodyList;
         var engine = context.Engine;
+        var resetBodySlotsPerIteration = flattenActive && !_flattenedBodySlotsInitBeforeUse;
 
         while (test.GetBooleanValue(context))
         {
-            if (flattenActive)
+            if (resetBodySlotsPerIteration)
             {
                 var env = (DeclarativeEnvironment) engine.ExecutionContext.LexicalEnvironment;
                 ResetBodySlotRange(env._slots!, _loopSlotTemplates!, _flattenedHeaderSlotCount);


### PR DESCRIPTION
## Problem

Loops whose bodies declare lexical slots re-TDZ every body slot on **every iteration** (`ResetBodySlotRange` in the flattened arm, per-iteration env reset in the tight arm) even when the body provably initializes each slot before any use — which is the overwhelmingly common shape (`for (...) { const z = f(i); ... }`). The reset is pure ceremony there: no read can observe the TDZ hole it re-arms.

## Approach

A conservative static scan, computed once per block alongside the existing slot layout (`BlockState.AllBodySlotsInitBeforeUse`): walk the block's top-level statements in order, tracking which slot names have had their declaring statement seen; any identifier occurrence of a not-yet-declared slot name rejects the block. A declarator's initializer is scanned **before** its name is marked (`let x = x` counts as before-use), destructuring declarators reject outright, multi-declarator statements are processed per-declarator (`const a = 1, b = a` accepts; backward references reject). Soundness of the identifier over-approximation rests on the existing `SlotNames` eligibility, which already excludes closures, direct `eval`, and `with`.

When the flag holds, the per-iteration re-TDZ is skipped in both for-statement arms (generic flattened + tight); **first-entry initialization is untouched** (loop entry still resets the full slot array), so re-entry semantics and first-iteration TDZ are exactly as before. `for-of`/`for-in` per-iteration machinery is different plumbing and deliberately out of scope.

## Benchmarks (default job, baseline = upstream/main `463157397`, back-to-back same thermal window)

Gate rows (lexical loop bodies):

| Row | main | PR | Δ time | Allocated |
|---|---|---|---|---|
| ForBenchmark.ReenteredInnerLetLoop | 52.53 ms | 47.76 ms | **−9.1%** | byte-identical |
| ForBenchmark.ForLet | 82.20 µs | 77.16 µs | **−6.1%** | byte-identical |
| StopwatchBenchmark Execute (modern) | 96.09 ms | 92.82 ms | **−3.4%** | byte-identical |
| StopwatchBenchmark Prepared (modern) | 94.09 ms | 90.62 ms | **−3.7%** | byte-identical |

Guards: full `LoopDispatchBenchmarks` (var-only bodies — the gate never fires) flat within ±1–3% with byte-identical allocations on every row; `ForVar`/`ForOfLet`/`ForOfConst` flat; classic stopwatch −2.3%/+0.1% (few lexical loop bodies). Allocations are unchanged everywhere by construction — this is a pure ceremony skip.

## Tests

11 new pins in `TdzResetSkipTests` + 5 pre-existing TDZ pins all green (16/16 both TFMs), `For` filter 286/286 (net10.0) / 279/279 (net472). Key pins: a rejected shape (read-before-decl) throws on **every** iteration, not just the first; a conditional self-reference (`const z = i === 0 ? 1 : z`) throws on iteration 1 instead of seeing the stale value — the observable difference between skipping and resetting; continue-over-init; closure-capture bodies; header/outer shadowing; initializer-less `let` re-init-to-undefined.

- Full Test262: **99,426 passed / 0 failed**.
- Jint.Tests: 3348/3348 (net10.0), 3285/3285 (net472).
- PublicInterface: net10.0 82/82; net472 has the known `TimeSystemTests.CanUseTimeProvider` wall-clock failure which **also fails on unmodified upstream/main on this machine** (isolated control run) — environmental, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
