### PR TITLE
Build JSON.parse objects as hidden-class shapes; serialize shaped objects via slot walk

### DIFF
--- a/Jint.Tests/Runtime/JsonSerializerTests.cs
+++ b/Jint.Tests/Runtime/JsonSerializerTests.cs
@@ -159,4 +159,105 @@ public class JsonSerializerTests
         string actual = serializer.Serialize(new JsString(inputString)).ToString();
         Assert.Equal(expectedOutput, actual);
     }
+
+    [Fact]
+    public void ReplacerArrayOverParsedShapedRecordsUsesPropertyListOrder()
+    {
+        // A replacer array installs a PropertyList that dictates both the key set and their order,
+        // so shape-mode objects must take the generic path.
+        using var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var a = JSON.parse('[{"a":1,"b":2,"c":3},{"a":4,"b":5,"c":6}]');
+            JSON.stringify(a, ["b", "a"]) === '[{"b":2,"a":1},{"b":5,"a":4}]';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void ToJsonOnShapedObjectIsInvoked()
+    {
+        using var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var a = JSON.parse('[{"x":1,"y":2},{"x":3,"y":4}]');
+            a[0].toJSON = function (k) { return 'record-' + k; };
+            JSON.stringify(a) === '["record-0",{"x":3,"y":4}]';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void ToJsonMutatingShapedHolderMidSerializationFallsBackSafely()
+    {
+        // A member value's toJSON deopts the holder mid-serialization (delete converts it to
+        // dictionary mode); the remaining snapshotted keys must be read live like the generic path
+        // reads its snapshotted key list — the removed key serializes as absent.
+        using var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var o = JSON.parse('{"a":1,"b":2,"c":3}');
+            o.b = { toJSON: function () { delete o.c; o.a = 100; return 'B'; } };
+            JSON.stringify(o) === '{"a":1,"b":"B"}';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void ShapedAndDictionaryObjectsSerializeIdentically()
+    {
+        using var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var shaped = JSON.parse('{"a":1,"b":"x","c":[1,2],"d":{"e":null},"f":1.5,"g":true}');
+            var dict = JSON.parse('{"a":1,"b":"x","c":[1,2],"d":{"e":null},"f":1.5,"g":true}');
+            delete dict.g;              // deopts to dictionary mode
+            dict.g = true;              // re-added at the same (last) position
+            JSON.stringify(shaped) === JSON.stringify(dict)
+                && JSON.stringify(shaped, null, 2) === JSON.stringify(dict, null, 2)
+                && JSON.stringify(shaped) === '{"a":1,"b":"x","c":[1,2],"d":{"e":null},"f":1.5,"g":true}';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void UnserializableShapedMembersAreSkipped()
+    {
+        using var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var o = JSON.parse('{"a":1,"b":2}');
+            o.fn = function () {};      // stays shaped: post-parse adds transition the shape
+            o.u = undefined;
+            JSON.stringify(o) === '{"a":1,"b":2}';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void ShapedObjectWithDigitLeadingKeyFallsBackToSpecOrder()
+    {
+        // A digit-leading key added post-parse lives in the shape, but own-key order places integer
+        // indices first, which slot order cannot express — stringify must fall back and sort.
+        using var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var o = JSON.parse('{"b":1,"c":2}');
+            o['3'] = 3;
+            JSON.stringify(o) === '{"3":3,"b":1,"c":2}' && Object.keys(o).join() === '3,b,c';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void ReplacerFunctionAppliesToShapedObjects()
+    {
+        using var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var a = JSON.parse('[{"a":1,"b":2},{"a":3,"b":4}]');
+            JSON.stringify(a, function (k, v) { return k === 'b' ? undefined : v; }) === '[{"a":1},{"a":3}]';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
 }

--- a/Jint.Tests/Runtime/JsonTests.cs
+++ b/Jint.Tests/Runtime/JsonTests.cs
@@ -346,6 +346,260 @@ public class JsonTests
         Assert.Throws<JavaScriptException>(() => parser.Parse("[]"));
     }
 
+    [Fact]
+    public void ParsedProtoKeyBecomesOwnDataPropertyAndDoesNotPollutePrototype()
+    {
+        var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var o = JSON.parse('{"__proto__":{"a":1}}');
+            o.hasOwnProperty('__proto__')
+                && Object.getPrototypeOf(o) === Object.prototype
+                && o.__proto__.a === 1
+                && !('a' in {})
+                && Object.prototype.a === undefined;
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void ParsedProtoKeyBecomesOwnDataPropertyWithReviver()
+    {
+        var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var o = JSON.parse('{"__proto__":{"a":1}}', function (k, v) { return v; });
+            o.hasOwnProperty('__proto__')
+                && Object.getPrototypeOf(o) === Object.prototype
+                && o.__proto__.a === 1
+                && !('a' in {})
+                && Object.prototype.a === undefined;
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void DuplicateProtoKeysLastValueWins()
+    {
+        var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var o = JSON.parse('{"__proto__":1,"__proto__":2}');
+            var d = Object.getOwnPropertyDescriptor(o, '__proto__');
+            d.value === 2 && d.writable && d.enumerable && d.configurable
+                && Object.getPrototypeOf(o) === Object.prototype;
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void DuplicateKeysLastValueWinsAtFirstPosition()
+    {
+        var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var o = JSON.parse('{"a":1,"b":9,"a":2}');
+            o.a === 2
+                && JSON.stringify(Object.keys(o)) === '["a","b"]'
+                && JSON.stringify(o) === '{"a":2,"b":9}';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Theory]
+    [InlineData("""{"1":"y","b":"z"}""", """["1","b"]""")]
+    [InlineData("""{"b":"z","1":"y"}""", """["1","b"]""")]
+    [InlineData("""{"0":1}""", """["0"]""")]
+    [InlineData("""{"b":1,"1abc":2,"a":3}""", """["b","1abc","a"]""")]
+    public void IntegerLikeKeysEnumerateInSpecOrder(string json, string expectedKeys)
+    {
+        var engine = new Engine();
+        engine.SetValue("json", json);
+        var keys = engine.Evaluate("JSON.stringify(Object.keys(JSON.parse(json)))").AsString();
+
+        Assert.Equal(expectedKeys, keys);
+    }
+
+    [Fact]
+    public void CanParseObjectWithManyProperties()
+    {
+        // 100 properties trips the 64-own-property shape guard mid-build; the object finishes as a
+        // dictionary with insertion order intact and stays fully mutable.
+        var engine = new Engine();
+        var json = "{" + string.Join(",", Enumerable.Range(0, 100).Select(i => $"\"p{i}\":{i}")) + "}";
+        engine.SetValue("json", json);
+        var ok = engine.Evaluate("""
+            var o = JSON.parse(json);
+            var keys = Object.keys(o);
+            var ok = keys.length === 100;
+            for (var i = 0; i < 100; i++) {
+                ok = ok && keys[i] === ('p' + i) && o['p' + i] === i;
+            }
+            o.extra = 'x';
+            delete o.p0;
+            ok && o.extra === 'x' && !('p0' in o) && Object.keys(o).length === 100;
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void ReviverCanMutateAndDeleteParsedObjectProperties()
+    {
+        var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var o = JSON.parse('{"keep":1,"double":2,"drop":3}', function (k, v) {
+                if (k === 'drop') return undefined;
+                if (k === 'double') return v * 2;
+                return v;
+            });
+            o.keep === 1 && o.double === 4 && !('drop' in o)
+                && JSON.stringify(Object.keys(o)) === '["keep","double"]';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void ReviverWorksOverArrayOfRecords()
+    {
+        var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var a = JSON.parse('[{"id":1,"v":10},{"id":2,"v":20},{"id":3,"v":30}]', function (k, v) {
+                return typeof v === 'number' && k === 'v' ? v + 1 : v;
+            });
+            a.length === 3 && a[0].v === 11 && a[1].v === 21 && a[2].v === 31
+                && a[0].id === 1 && a[2].id === 3;
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void ReviverContextSourceIsProvidedForPrimitives()
+    {
+        var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var sources = {};
+            JSON.parse('{"a":1,"b":"x"}', function (k, v, context) {
+                if (context && typeof context.source === 'string') sources[k] = context.source;
+                return v;
+            });
+            sources.a === '1' && sources.b === '"x"';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void ParsedObjectSupportsPostParseMutation()
+    {
+        var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var o = JSON.parse('{"a":1,"b":2}');
+            var ok = !('x' in o);
+            o.x = 3;
+            ok = ok && o.x === 3 && ('x' in o);
+            delete o.b;
+            ok = ok && !('b' in o) && JSON.stringify(Object.keys(o)) === '["a","x"]';
+            Object.defineProperty(o, 'acc', { get: function () { return o.a + 10; }, configurable: true });
+            ok = ok && o.acc === 11;
+            Object.freeze(o);
+            o.a = 42;
+            ok && o.a === 1 && Object.isFrozen(o);
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void MutatingOneParsedRecordDoesNotAffectOthers()
+    {
+        var engine = new Engine();
+        var json = "[" + string.Join(",", Enumerable.Range(0, 100).Select(i => $"{{\"id\":{i},\"name\":\"n{i}\",\"flag\":true,\"score\":1.5}}")) + "]";
+        engine.SetValue("json", json);
+        var ok = engine.Evaluate("""
+            var a = JSON.parse(json);
+            a[42].name = 'changed';
+            a[42].id = -1;
+            var ok = a[42].name === 'changed' && a[42].id === -1;
+            for (var i = 0; i < 100; i++) {
+                if (i === 42) continue;
+                ok = ok && a[i].id === i && a[i].name === ('n' + i) && a[i].flag === true && a[i].score === 1.5;
+            }
+            ok;
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void ParseRemainsCorrectWhenShapeTransitionBudgetIsExhausted()
+    {
+        // >1024 distinct object layouts whose per-node fan-out stays below the megamorphic guard, so
+        // the parser's per-call transition budget runs out mid-document and later objects fall back to
+        // dictionary building. Only correctness (values and key order) is asserted.
+        var engine = new Engine();
+        var json = "[" + string.Join(",", Enumerable.Range(0, 1100).Select(i => $"{{\"a\":{i},\"b{i % 50}\":{i},\"c{i / 50}\":{i}}}")) + "]";
+        engine.SetValue("json", json);
+        var ok = engine.Evaluate("""
+            var a = JSON.parse(json);
+            var ok = a.length === 1100;
+            for (var i = 0; i < 1100; i++) {
+                var o = a[i];
+                var keys = Object.keys(o);
+                ok = ok && o.a === i
+                    && o['b' + (i % 50)] === i
+                    && o['c' + Math.floor(i / 50)] === i
+                    && keys.length === 3
+                    && keys[0] === 'a'
+                    && keys[1] === 'b' + (i % 50)
+                    && keys[2] === 'c' + Math.floor(i / 50);
+            }
+            ok;
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void ParsedRecordsFromSameDocumentShareShape()
+    {
+        var engine = new Engine();
+        var array = engine.Evaluate("""JSON.parse('[{"a":1,"b":2},{"a":3,"b":4}]')""").AsArray();
+        var first = Assert.IsType<JsObject>(array[0]);
+        var second = Assert.IsType<JsObject>(array[1]);
+
+        Assert.NotNull(first.ShapeOf);
+        Assert.Same(first.ShapeOf, second.ShapeOf);
+    }
+
+    [Fact]
+    public void ParsedRecordsRoundTripThroughStringify()
+    {
+        var engine = new Engine();
+        var ok = engine.Evaluate("""
+            JSON.stringify(JSON.parse('[{"a":1,"b":"x"},{"a":2,"b":"y"}]')) === '[{"a":1,"b":"x"},{"a":2,"b":"y"}]';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void CanParseNestedObjectsWithSharedAndDistinctLayouts()
+    {
+        var engine = new Engine();
+        var ok = engine.Evaluate("""
+            var o = JSON.parse('{"outer":{"inner":{"x":1,"y":2},"z":3},"w":{"x":4,"y":5}}');
+            o.outer.inner.x === 1 && o.outer.inner.y === 2 && o.outer.z === 3
+                && o.w.x === 4 && o.w.y === 5
+                && JSON.stringify(Object.keys(o)) === '["outer","w"]'
+                && JSON.stringify(Object.keys(o.outer)) === '["inner","z"]';
+            """).AsBoolean();
+
+        Assert.True(ok);
+    }
+
     private static string GenerateDeepNestedArray(int depth)
     {
         string arrayOpen = new string('[', depth);

--- a/Jint/Native/JsObject.cs
+++ b/Jint/Native/JsObject.cs
@@ -112,11 +112,20 @@ public sealed class JsObject : ObjectInstance
     /// guard trips (too many own properties, or this shape already has too many distinct child transitions),
     /// so the caller deopts to the dictionary representation. The key must be known-absent (callers check).
     /// </summary>
-    internal bool TryShapeAdd(in Key key, JsValue value)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryShapeAdd(in Key key, JsValue value) => TryShapeAdd(key, value, out _);
+
+    /// <summary>
+    /// Same as <see cref="TryShapeAdd(in Key, JsValue)"/>, additionally reporting whether the shape
+    /// transition was newly interned rather than reused (see <see cref="Shape.Add(in Key, out bool)"/>)
+    /// so callers can bound transition-tree growth.
+    /// </summary>
+    internal bool TryShapeAdd(in Key key, JsValue value, out bool created)
     {
         var shape = _shape!;
         if (shape.SlotCount >= Shape.MaxShapeProperties || shape.TransitionCount >= Shape.MaxFanout)
         {
+            created = false;
             return false;
         }
 
@@ -139,7 +148,7 @@ public sealed class JsObject : ObjectInstance
             _overflow[overflowIndex] = value;
         }
 
-        _shape = shape.Add(key);
+        _shape = shape.Add(key, out created);
         unchecked { _propertiesVersion++; }
         return true;
     }

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using Jint.Native.Object;
 using Jint.Pooling;
 using Jint.Runtime;
 
@@ -79,6 +80,21 @@ public sealed class JsonParser
     private string _source = null!;
     private readonly Token[] _tokenBuffer;
     private int _tokenBufferIndex;
+
+    // Hidden-class shaping of parsed objects (see Shape): members route through the shared
+    // per-prototype transition tree so an array of identically-laid-out records shares one interned
+    // Shape and each record costs a single allocation instead of a property dictionary plus
+    // per-property descriptors. _shapeBudget bounds how many NEW transition nodes one parse call may
+    // intern — reused transitions (the identical-records case) cost nothing — because the tree is
+    // pinned by its prototype for the prototype's lifetime, so an adversarial cold parse must not
+    // grow it without bound. Once exhausted, objects that have not yet started shaping build
+    // dictionaries for the rest of the call. The cached empty-root pair avoids a per-object
+    // ConditionalWeakTable lookup and is revalidated by prototype identity (mirrors
+    // ScriptFunction._ctorEmptyShape).
+    private const int ShapeTransitionBudget = 1024;
+    private int _shapeBudget;
+    private Shape? _cachedEmptyRoot;
+    private ObjectInstance? _cachedEmptyRootProto;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsDecimalDigit(char ch)
@@ -589,6 +605,8 @@ public sealed class JsonParser
         Expect(ref state, '{');
 
         var obj = new JsObject(_engine);
+        var shaped = false;
+        var first = true;
 
         var memberCount = 0;
         while (!Match('}'))
@@ -613,7 +631,7 @@ public sealed class JsonParser
 
             Expect(ref state, ':');
             var value = ParseJsonValue(ref state);
-            obj.FastSetDataProperty(name, value);
+            AddJsonMember(obj, name, value, ref shaped, ref first);
 
             if (!Match('}'))
             {
@@ -625,6 +643,77 @@ public sealed class JsonParser
         state.CurrentDepth--;
 
         return obj;
+    }
+
+    /// <summary>
+    /// Adds one parsed member to <paramref name="obj"/>, routing through the hidden-class machinery
+    /// (see <see cref="Shape"/>) so a run of identically-laid-out records — the dominant JSON payload —
+    /// shares one interned shape and each record is a single allocation instead of a property dictionary
+    /// plus per-property descriptors. <paramref name="shaped"/> and <paramref name="first"/> are the
+    /// caller's per-object locals (each recursive object activation carries its own). Anything a shape
+    /// cannot represent drops the object to dictionary mode, preserving the insertion order built so far.
+    /// A raw own-property store like today's dictionary path: the prototype chain is never consulted,
+    /// so an inherited setter (e.g. <c>__proto__</c>) is not invoked.
+    /// </summary>
+    private void AddJsonMember(JsObject obj, string name, JsValue value, ref bool shaped, ref bool first)
+    {
+        // Integer-like keys are pre-excluded from shapes (never build-then-deopt): own-key order puts
+        // integer indices first (https://tc39.es/ecma262/#sec-ordinaryownpropertykeys), which the
+        // slot (= insertion) order cannot express. Same conservative digit-leading classifier as the
+        // other shape guards.
+        var digitLeading = name.Length > 0 && char.IsDigit(name[0]);
+
+        if (first)
+        {
+            first = false;
+            // Start shaping lazily on the first member so `{}` stays a plain property-less JsObject.
+            if (_shapeBudget > 0 && !digitLeading && obj.Prototype is { } proto)
+            {
+                if (!ReferenceEquals(_cachedEmptyRootProto, proto))
+                {
+                    _cachedEmptyRoot = _engine.GetEmptyShape(proto);
+                    _cachedEmptyRootProto = proto;
+                }
+
+                obj.StartShapeBuilding(_cachedEmptyRoot!);
+                shaped = true;
+            }
+        }
+
+        if (shaped)
+        {
+            if (!digitLeading)
+            {
+                Key key = name;
+                if (obj.ShapeOf.TryGetSlot(key, out var slot))
+                {
+                    // Duplicate key: last value wins at the first occurrence's position, matching the
+                    // dictionary representation's replace-in-place.
+                    obj.SetSlot(slot, value);
+                    return;
+                }
+
+                if (obj.TryShapeAdd(key, value, out var created))
+                {
+                    if (created)
+                    {
+                        // Only newly interned transitions consume budget; an object mid-build may
+                        // finish shaped after the budget hits zero (overshoot bounded by
+                        // Shape.MaxShapeProperties).
+                        _shapeBudget--;
+                    }
+
+                    return;
+                }
+            }
+
+            // Integer-like key, or a megamorphic guard (own-property count / transition fan-out)
+            // refused the add: finish this object as a dictionary.
+            obj.ConvertToDictionaryMode();
+            shaped = false;
+        }
+
+        obj.FastSetDataProperty(name, value);
     }
 
     private static bool PropertyNameContainsInvalidCharacters(string propertyName)
@@ -680,6 +769,7 @@ public sealed class JsonParser
         _index = 0;
         _length = _source.Length;
         _lookahead = null!;
+        _shapeBudget = ShapeTransitionBudget;
 
         State state = new State();
 
@@ -705,6 +795,7 @@ public sealed class JsonParser
         _index = 0;
         _length = _source.Length;
         _lookahead = null!;
+        _shapeBudget = ShapeTransitionBudget;
 
         State state = new State();
 
@@ -825,6 +916,8 @@ public sealed class JsonParser
         Expect(ref state, '{');
 
         var obj = new JsObject(_engine);
+        var shaped = false;
+        var first = true;
 
         var memberCount = 0;
         while (!Match('}'))
@@ -849,7 +942,7 @@ public sealed class JsonParser
 
             Expect(ref state, ':');
             var valueResult = ParseJsonValueWithSourceInfo(ref state);
-            obj.FastSetDataProperty(name, valueResult.Value);
+            AddJsonMember(obj, name, valueResult.Value, ref shaped, ref first);
 
             if (valueResult.Node != null)
             {

--- a/Jint/Native/Json/JsonSerializer.cs
+++ b/Jint/Native/Json/JsonSerializer.cs
@@ -165,8 +165,16 @@ public sealed class JsonSerializer
     /// </summary>
     private SerializeResult SerializeJSONProperty(JsValue key, JsValue holder, ref ValueStringBuilder json)
     {
-        var value = ReadUnwrappedValue(key, holder);
+        return SerializeJSONValue(ReadUnwrappedValue(key, holder), ref json);
+    }
 
+    /// <summary>
+    /// The value-writing half of SerializeJSONProperty: serializes an already-read-and-unwrapped
+    /// value. Split out so the shaped fast path can feed slot-read values through the identical
+    /// pipeline.
+    /// </summary>
+    private SerializeResult SerializeJSONValue(JsValue value, ref ValueStringBuilder json)
+    {
         if (ReferenceEquals(value, JsValue.Null))
         {
             json.Append("null");
@@ -256,6 +264,16 @@ public sealed class JsonSerializer
             return value;
         }
 
+        return UnwrapValueSlow(key, holder, value);
+    }
+
+    /// <summary>
+    /// The observable part of the value read: toJSON lookup/call, replacer function call and wrapper
+    /// instance unwrapping. Split from <see cref="ReadUnwrappedValue"/> so the shaped fast path can
+    /// defer materializing the key (the toJSON/replacer argument) until a value actually needs it.
+    /// </summary>
+    private JsValue UnwrapValueSlow(JsValue key, JsValue holder, JsValue value)
+    {
         var isBigInt = value is BigIntInstance || value.IsBigInt();
         if (value.IsObject() || isBigInt)
         {
@@ -500,6 +518,16 @@ public sealed class JsonSerializer
     /// </summary>
     private void SerializeJSONObject(ObjectInstance value, ref ValueStringBuilder json)
     {
+        // Shape-mode fast arm, valid only when serializing ALL string-keyed own enumerable properties
+        // (no replacer-array PropertyList overriding the key set/order). May refuse — having written
+        // nothing — when slot order cannot express own-key order; the generic path below then handles it.
+        if (_propertyList is null
+            && (value._type & InternalTypes.ShapeMode) != InternalTypes.Empty
+            && TrySerializeShapedJSONObject(Unsafe.As<JsObject>(value), ref json))
+        {
+            return;
+        }
+
         var enumeration = _propertyList is null
             ? PropertyEnumeration.FromObjectInstance(value)
             : PropertyEnumeration.FromList(_propertyList);
@@ -577,6 +605,127 @@ public sealed class JsonSerializer
 
         _stack.Exit();
         _indent = stepback;
+    }
+
+    /// <summary>
+    /// Serializes a shape-mode plain object by walking its interned shape directly: keys come from
+    /// the shape in slot (= insertion) order and are written from <see cref="Key.Name"/> without
+    /// materializing per-key JsStrings or a key list, the enumerability probe is skipped (every shape
+    /// property is an enumerable CEW data property), and values are read straight from the slots.
+    /// Only key enumeration, own-property probing and the value read are replaced — the per-value
+    /// pipeline (toJSON, replacer function, wrapper unwrapping, the value switch) is shared with the
+    /// generic path. Returns <c>false</c>, before writing anything, when a digit-leading key is
+    /// present: own-key order then places integer indices first, which slot order cannot express, so
+    /// the caller falls back to the generic (sorting) path.
+    /// </summary>
+    private bool TrySerializeShapedJSONObject(JsObject value, ref ValueStringBuilder json)
+    {
+        var shape = value.ShapeOf;
+        var keys = shape.OrderedKeys;
+
+        for (var i = 0; i < keys.Length; i++)
+        {
+            var name = keys[i].Name;
+            if (name.Length > 0 && char.IsDigit(name[0]))
+            {
+                return false;
+            }
+        }
+
+        if (keys.Length == 0)
+        {
+            json.Append("{}");
+            return true;
+        }
+
+        _stack.Enter(value);
+        var stepback = _indent;
+        if (_gap.Length > 0)
+        {
+            _indent += _gap;
+        }
+
+        const char separator = ',';
+        var hasPrevious = false;
+        for (var i = 0; i < keys.Length; i++)
+        {
+            if (i > 0 && i % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
+            int position = json.Length;
+
+            if (hasPrevious)
+            {
+                json.Append(separator);
+            }
+            else
+            {
+                json.Append('{');
+            }
+
+            if (_gap.Length > 0)
+            {
+                json.Append('\n');
+                json.Append(_indent);
+            }
+
+            QuoteJSONString(keys[i].Name, ref json);
+            json.Append(':');
+            if (_gap.Length > 0)
+            {
+                json.Append(' ');
+            }
+
+            // A previous member's toJSON or the replacer function may have mutated this object
+            // (deopting it or transitioning its shape); the keys array is an immutable snapshot, so
+            // remaining members are then read through the generic Get — exactly how the generic path
+            // reads its snapshotted key list live. Slot reads are valid only while the object still
+            // has the captured shape.
+            JsValue member;
+            if (ReferenceEquals(value.ShapeOf, shape))
+            {
+                member = value.GetSlot(i);
+                if (member._type > InternalTypes.Integer || !_replacerFunction.IsUndefined())
+                {
+                    // the key is observable (toJSON/replacer argument); materialize it only now
+                    member = UnwrapValueSlow(new JsString(keys[i].Name), value, member);
+                }
+            }
+            else
+            {
+                member = ReadUnwrappedValue(new JsString(keys[i].Name), value);
+            }
+
+            if (SerializeJSONValue(member, ref json) == SerializeResult.Undefined)
+            {
+                json.Length = position;
+            }
+            else
+            {
+                hasPrevious = true;
+            }
+        }
+
+        if (!hasPrevious)
+        {
+            _stack.Exit();
+            _indent = stepback;
+            json.Append("{}");
+            return true;
+        }
+
+        if (_gap.Length > 0)
+        {
+            json.Append('\n');
+            json.Append(stepback);
+        }
+        json.Append('}');
+
+        _stack.Exit();
+        _indent = stepback;
+        return true;
     }
 
     private enum SerializeResult

--- a/Jint/Native/Object/Shape.cs
+++ b/Jint/Native/Object/Shape.cs
@@ -55,6 +55,11 @@ internal sealed class Shape
     // Lazily-built key -> slot index, only for wide shapes (SlotCount >= LinearScanLimit).
     private Dictionary<Key, int>? _index;
 
+    // Slot-ordered keys, memoized on first use (shapes are immutable, so the layout never changes)
+    // and shared by every object of this layout — e.g. the JSON serializer's shaped fast path reads
+    // property names from here without building a per-object key list.
+    private Key[]? _orderedKeys;
+
     /// <summary>Creates an empty root shape. There is one root per prototype, interned by the engine's
     /// empty-shape table, so all objects sharing a prototype build their layouts from the same tree.</summary>
     internal Shape()
@@ -148,6 +153,25 @@ internal sealed class Shape
         for (var shape = this; shape.Parent is not null; shape = shape.Parent)
         {
             dest[shape.SlotCount - 1] = shape.AddedKey;
+        }
+    }
+
+    /// <summary>
+    /// This shape's keys in slot (= insertion) order, computed once and shared by all objects of this
+    /// layout. Callers must treat the array as read-only.
+    /// </summary>
+    internal Key[] OrderedKeys
+    {
+        get
+        {
+            if (_orderedKeys is null)
+            {
+                var keys = new Key[SlotCount];
+                CollectKeys(keys);
+                _orderedKeys = keys;
+            }
+
+            return _orderedKeys;
         }
     }
 }

--- a/Jint/Native/Object/Shape.cs
+++ b/Jint/Native/Object/Shape.cs
@@ -75,13 +75,26 @@ internal sealed class Shape
     /// Returns the interned child shape that adds <paramref name="key"/> to this shape. Repeated calls
     /// with the same key return the same instance, so identical layouts share their whole chain.
     /// </summary>
-    internal Shape Add(in Key key)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal Shape Add(in Key key) => Add(key, out _);
+
+    /// <summary>
+    /// Same as <see cref="Add(in Key)"/>, additionally reporting whether a new transition node was
+    /// interned (<paramref name="created"/>) or an already-memoized child was reused. Callers that
+    /// bound transition-tree growth (JSON parsing) charge their budget only for newly created nodes.
+    /// </summary>
+    internal Shape Add(in Key key, out bool created)
     {
         var transitions = _transitions ??= new Dictionary<Key, Shape>();
         if (!transitions.TryGetValue(key, out var child))
         {
             child = new Shape(this, key);
             transitions[key] = child;
+            created = true;
+        }
+        else
+        {
+            created = false;
         }
 
         return child;


### PR DESCRIPTION
## Problem

`JSON.parse` builds every object in dictionary mode — ~11 allocations per 4-property object (JsObject + HybridDictionary + ListDictionary + per-property DictionaryNodes and PropertyDescriptors) with zero layout sharing across an array of identical records, the dominant JSON payload shape. On the new `json-parse` comparison workload (#2630) Jurassic currently beats Jint (284 vs 369 ms single-shot). Meanwhile object *literals* with the same layout cost 1 allocation via the hidden-class machinery.

## Approach

**Commit 1 — parser:** both JsonParser object loops (plain + reviver/source-info) route per-key adds through one helper that builds hidden-class shapes: lazy shape start on the first non-digit-leading key (`{}` parses byte-identically to today; root cached per prototype with identity revalidation), duplicate keys update the existing slot in place (last value wins at first-occurrence position), digit-leading keys are pre-excluded (never build-then-deopt — own-key order puts integer indices first, which slot order can't express), and the existing megamorphic guards convert oversized/fan-out layouts to the unchanged dictionary path mid-object with order preserved. A per-parse-call budget of **1,024 newly interned transitions** bounds transition-tree growth on adversarial cold parses (trees are pinned by their prototype); reused transitions — the identical-records case — cost nothing. Parsed records share interned Shape chains with identically-laid-out literals, so member-access inline caches hit across both.

**Commit 2 — serializer:** stringifying shaped objects initially *regressed* allocation (+27% — `GetOwnPropertyKeysFromShape` materializes Key[] + List + a JsString per key), so `SerializeJSONObject` gained a shape-mode arm: iterate the shape's memoized ordered keys (slot = insertion order), write names straight from `Key.Name` (no JsString), read values via slot access (shape props are always enumerable CEW data, so the enumerability probe is free). The per-value pipeline (toJSON, replacer-function, wrapper unwrap) is the same code as the generic path; a replacer **array** or any digit-leading key falls back to the generic path before writing anything; if a toJSON/replacer mutates the holder mid-serialization, a shape-identity check switches remaining keys to generic `Get` (mirroring the generic path's snapshot semantics).

## Benchmarks (default job, baseline = upstream/main `463157397`, back-to-back)

| JsonJsBenchmark | main | PR | Δ time | Δ alloc |
|---|---|---|---|---|
| ParseRecords (1,000×6-prop) | 701.35 µs / 1557.91 KB | 672.22 µs / 1073.56 KB | −4.2% | **−31.1%** |
| ParseConfig (depth-4 nested) | 111.59 µs / 298.07 KB | 104.02 µs / 167.55 KB | −6.8% | **−43.8%** |
| StringifyRecords | 637.86 µs / 547.77 KB | 441.20 µs / 250.89 KB | **−30.8%** | **−54.2%** |
| StringifyConfig | 90.38 µs / 125.16 KB | 52.63 µs / 50.53 KB | **−41.8%** | **−59.6%** |
| RoundTripRecords | 1,368.20 µs / 2101.76 KB | 1,116.57 µs / 1320.53 KB | **−18.4%** | **−37.2%** |
| ParseBigObject (100 props) | 10.33 µs / 23.57 KB | 11.42 µs / 23.52 KB | +10.6% | flat |

ParseBigObject is the deliberate guard-trip row: a >64-property object builds 64 shape slots, then converts to a dictionary and finishes — it pays both, disclosed as the trade for pathological width. Everything the machinery is meant for wins large.

## Verification

- Jint.Tests **3362/3362 (net10.0) + 3299/3299 (net472)**; JSON-focused filter 137/137 both TFMs (18 new parser pins + 7 new serializer pins: `__proto__` own-property/no-pollution incl. reviver + duplicate, duplicate keys + round-trip, integer-like ordering incl. `"1abc"`, 100-prop guard trip, reviver mutate/delete/`context.source`, post-parse add/delete/defineProperty/freeze, 100-record neighbor isolation, >1,024-layout budget exhaustion, internal shape-sharing assert, replacer-array fallback, toJSON over shaped records incl. holder mutation, shaped-vs-dictionary byte-identical output, digit-leading-key spec-order fallback).
- **Full Test262 (final commit): 99,426 passed / 0 failed**, wall-clock normal (no new timeouts — the diverse-object hazard gate).
- PublicInterface 82/82 both TFMs (run pre-machine-drift; the net472 `CanUseTimeProvider` wall-clock flake later appeared **on unmodified main too** — environmental).
- Alloc census: the HybridDictionary/ListDictionary/DictionaryNode/PropertyDescriptor rows that dominated `json-parse-records` collapse; remaining allocation is value strings/numbers + the array, identical on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
