### PR TITLE
Shape statically-clean constructor instances from the third construction

### DIFF
--- a/Jint.Tests/Runtime/ConstructorShapeEligibilityTests.cs
+++ b/Jint.Tests/Runtime/ConstructorShapeEligibilityTests.cs
@@ -7,8 +7,9 @@ namespace Jint.Tests.Runtime;
 /// <summary>
 /// Pins static constructor-body shape eligibility (JintFunctionDefinition.ComputeCtorBodyShapeEligibility
 /// consumed by ScriptFunction's [[Construct]]): provably-clean constructors start hidden-class shape
-/// building from instance #1 instead of after the 16-instance sampling window, while everything else keeps
-/// the sampling behavior exactly — and correctness never depends on the verdict (deopt machinery unchanged).
+/// building from instance #2 (instance #1 stays dictionary-mode, so one-shot constructors intern no shape
+/// state) instead of after the 16-instance sampling window, while everything else keeps the sampling
+/// behavior exactly — and correctness never depends on the verdict (deopt machinery unchanged).
 /// </summary>
 public class ConstructorShapeEligibilityTests
 {
@@ -23,56 +24,63 @@ public class ConstructorShapeEligibilityTests
     }
 
     [Fact]
-    public void EligibleConstructorShapesFromFirstInstance()
+    public void EligibleConstructorShapesFromSecondInstance()
     {
         var engine = new Engine();
-        engine.Execute("function T() { this.a = 1; this.b = 2; } var t1 = new T(); var t2 = new T();");
+        engine.Execute("function T() { this.a = 1; this.b = 2; } var t1 = new T(); var t2 = new T(); var t3 = new T();");
 
         var t1 = GetObject(engine, "t1");
         var t2 = GetObject(engine, "t2");
+        var t3 = GetObject(engine, "t3");
 
-        Assert.True(IsShapeMode(t1));
+        // instance #1 stays a dictionary (a one-shot constructor interns no shape state at all);
+        // instances #2+ share one interned hidden class
+        Assert.False(IsShapeMode(t1));
         Assert.True(IsShapeMode(t2));
-        Assert.Same(ShapeOf(t1), ShapeOf(t2));
+        Assert.True(IsShapeMode(t3));
+        Assert.Same(ShapeOf(t2), ShapeOf(t3));
 
         Assert.Equal(1, engine.Evaluate("t1.a").AsNumber());
-        Assert.Equal(2, engine.Evaluate("t1.b").AsNumber());
+        Assert.Equal(2, engine.Evaluate("t2.b").AsNumber());
         Assert.Equal("a,b", engine.Evaluate("Object.keys(t1).join(',')").AsString());
-        Assert.True(engine.Evaluate("'a' in t1 && 'b' in t1 && !('c' in t1)").AsBoolean());
+        Assert.Equal("a,b", engine.Evaluate("Object.keys(t2).join(',')").AsString());
+        Assert.True(engine.Evaluate("'a' in t2 && 'b' in t2 && !('c' in t2)").AsBoolean());
     }
 
     [Fact]
     public void EarlierAssignmentsAreVisibleToLaterOnesWhileShaping()
     {
         var engine = new Engine();
-        engine.Execute("function T() { this.a = 1; this.b = this.a + 1; } var t = new T();");
+        engine.Execute("function T() { this.a = 1; this.b = this.a + 1; } var t1 = new T(); var t2 = new T();");
 
-        var t = GetObject(engine, "t");
-        Assert.True(IsShapeMode(t));
-        Assert.Equal(2, engine.Evaluate("t.b").AsNumber());
+        var t2 = GetObject(engine, "t2");
+        Assert.True(IsShapeMode(t2));
+        Assert.Equal(2, engine.Evaluate("t1.b").AsNumber());
+        Assert.Equal(2, engine.Evaluate("t2.b").AsNumber());
     }
 
     [Fact]
     public void ThisFreeCallsAndBareReturnAreEligible()
     {
         var engine = new Engine();
-        engine.Execute("function T() { this.abs = Math.abs(-5); this.t = Date.now(); return; } var t = new T();");
+        engine.Execute("function T() { this.abs = Math.abs(-5); this.t = Date.now(); return; } var t1 = new T(); var t2 = new T();");
 
-        var t = GetObject(engine, "t");
-        Assert.True(IsShapeMode(t));
-        Assert.Equal(5, engine.Evaluate("t.abs").AsNumber());
-        Assert.Equal("abs,t", engine.Evaluate("Object.keys(t).join(',')").AsString());
+        var t2 = GetObject(engine, "t2");
+        Assert.True(IsShapeMode(t2));
+        Assert.Equal(5, engine.Evaluate("t2.abs").AsNumber());
+        Assert.Equal("abs,t", engine.Evaluate("Object.keys(t2).join(',')").AsString());
     }
 
     [Fact]
     public void DirectivePrologueDoesNotBlockEligibility()
     {
         var engine = new Engine();
-        engine.Execute("function T() { 'use strict'; this.a = 1; } var t = new T();");
+        engine.Execute("function T() { 'use strict'; this.a = 1; } var t1 = new T(); var t2 = new T();");
 
-        var t = GetObject(engine, "t");
-        Assert.True(IsShapeMode(t));
-        Assert.Equal(1, engine.Evaluate("t.a").AsNumber());
+        var t2 = GetObject(engine, "t2");
+        Assert.True(IsShapeMode(t2));
+        Assert.Equal(1, engine.Evaluate("t1.a").AsNumber());
+        Assert.Equal(1, engine.Evaluate("t2.a").AsNumber());
     }
 
     [Fact]
@@ -85,59 +93,70 @@ public class ConstructorShapeEligibilityTests
                 this.a = 1;
                 this.get = function () { return self === this ? 'self' : 'other'; };
             }
-            var t = new T();
+            var t1 = new T();
+            var t2 = new T();
             """);
 
-        var t = GetObject(engine, "t");
-        Assert.True(IsShapeMode(t));
-        Assert.Equal("self", engine.Evaluate("t.get()").AsString());
+        var t2 = GetObject(engine, "t2");
+        Assert.True(IsShapeMode(t2));
+        Assert.Equal("self", engine.Evaluate("t1.get()").AsString());
+        Assert.Equal("self", engine.Evaluate("t2.get()").AsString());
     }
 
     [Fact]
-    public void IneligibleBodiesBehaveExactlyAsBeforeAndStayUnshapedAtFirstInstance()
+    public void IneligibleBodiesBehaveExactlyAsBeforeAndStayUnshaped()
     {
+        // Ineligible constructors keep the sampling window: with eligible ones now shaping from
+        // instance #2, asserting instance #2 is still dictionary-mode is what distinguishes them.
+
         // conditional assignment
         var engine = new Engine();
-        engine.Execute("function T(f) { if (f) { this.a = 1; } else { this.b = 2; } } var t = new T(true);");
+        engine.Execute("function T(f) { if (f) { this.a = 1; } else { this.b = 2; } } var t = new T(true); var t2 = new T(true);");
         var t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
+        Assert.False(IsShapeMode(GetObject(engine, "t2")));
         Assert.Equal(1, engine.Evaluate("t.a").AsNumber());
         Assert.False(engine.Evaluate("'b' in t").AsBoolean());
 
         // computed LHS
         engine = new Engine();
-        engine.Execute("function T(k) { this[k] = 42; } var t = new T('dyn');");
+        engine.Execute("function T(k) { this[k] = 42; } var t = new T('dyn'); var t2 = new T('dyn');");
         t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
+        Assert.False(IsShapeMode(GetObject(engine, "t2")));
         Assert.Equal(42, engine.Evaluate("t.dyn").AsNumber());
 
         // this-call in body
         engine = new Engine();
-        engine.Execute("function T() { this.init(); } T.prototype.init = function () { this.a = 1; }; var t = new T();");
+        engine.Execute("function T() { this.init(); } T.prototype.init = function () { this.a = 1; }; var t = new T(); var t2 = new T();");
         t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
+        Assert.False(IsShapeMode(GetObject(engine, "t2")));
         Assert.Equal(1, engine.Evaluate("t.a").AsNumber());
 
         // this escaping through a call in an assignment RHS; the escapee's write lands FIRST
         engine = new Engine();
-        engine.Execute("function ext(o) { o.dyn = 1; return 2; } function T() { this.a = ext(this); } var t = new T();");
+        engine.Execute("function ext(o) { o.dyn = 1; return 2; } function T() { this.a = ext(this); } var t = new T(); var t2 = new T();");
         t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
+        Assert.False(IsShapeMode(GetObject(engine, "t2")));
         Assert.Equal(2, engine.Evaluate("t.a").AsNumber());
         Assert.Equal("dyn,a", engine.Evaluate("Object.keys(t).join(',')").AsString());
 
         // this escaping through a call in a var initializer
         engine = new Engine();
-        engine.Execute("function grab(o) { o.dyn = 1; return 3; } function T() { var x = grab(this); this.a = x; } var t = new T();");
+        engine.Execute("function grab(o) { o.dyn = 1; return 3; } function T() { var x = grab(this); this.a = x; } var t = new T(); var t2 = new T();");
         t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
+        Assert.False(IsShapeMode(GetObject(engine, "t2")));
         Assert.Equal(3, engine.Evaluate("t.a").AsNumber());
 
         // this escaping through a parameter default (runs during construction)
         engine = new Engine();
-        engine.Execute("function capture(o) { o.k = 1; return 9; } function T(a = capture(this)) { this.x = a; } var t = new T();");
+        engine.Execute("function capture(o) { o.k = 1; return 9; } function T(a = capture(this)) { this.x = a; } var t = new T(); var t2 = new T();");
         t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
+        Assert.False(IsShapeMode(GetObject(engine, "t2")));
         Assert.Equal(9, engine.Evaluate("t.x").AsNumber());
         Assert.Equal(1, engine.Evaluate("t.k").AsNumber());
     }
@@ -160,37 +179,42 @@ public class ConstructorShapeEligibilityTests
     }
 
     [Fact]
-    public void ClassFieldOnlyInstanceShapesFromFirstInstance()
+    public void ClassFieldOnlyInstanceShapesFromSecondInstance()
     {
         var engine = new Engine();
-        engine.Execute("class A { x = 1 } var a1 = new A(); var a2 = new A();");
+        engine.Execute("class A { x = 1 } var a1 = new A(); var a2 = new A(); var a3 = new A();");
 
         var a1 = GetObject(engine, "a1");
         var a2 = GetObject(engine, "a2");
-        Assert.True(IsShapeMode(a1));
-        Assert.Same(ShapeOf(a1), ShapeOf(a2));
+        var a3 = GetObject(engine, "a3");
+        Assert.False(IsShapeMode(a1));
+        Assert.True(IsShapeMode(a2));
+        Assert.Same(ShapeOf(a2), ShapeOf(a3));
         Assert.Equal(1, engine.Evaluate("a1.x").AsNumber());
+        Assert.Equal(1, engine.Evaluate("a2.x").AsNumber());
     }
 
     [Fact]
     public void ClassFieldsRunBeforeConstructorBodyAssignments()
     {
         var engine = new Engine();
-        engine.Execute("class D { y = 1; constructor() { this.z = 2; } } var d = new D();");
+        engine.Execute("class D { y = 1; constructor() { this.z = 2; } } var d1 = new D(); var d2 = new D();");
 
-        var d = GetObject(engine, "d");
-        Assert.True(IsShapeMode(d));
-        Assert.Equal("y,z", engine.Evaluate("Object.keys(d).join(',')").AsString());
+        var d2 = GetObject(engine, "d2");
+        Assert.True(IsShapeMode(d2));
+        Assert.Equal("y,z", engine.Evaluate("Object.keys(d1).join(',')").AsString());
+        Assert.Equal("y,z", engine.Evaluate("Object.keys(d2).join(',')").AsString());
     }
 
     [Fact]
     public void IndexLikeComputedFieldNameFallsBackToSamplingWithCorrectOrder()
     {
         var engine = new Engine();
-        engine.Execute("class B { b = 2; ['0'] = 1 } var b1 = new B();");
+        engine.Execute("class B { b = 2; ['0'] = 1 } var b1 = new B(); var b2 = new B();");
 
         var b1 = GetObject(engine, "b1");
         Assert.False(IsShapeMode(b1));
+        Assert.False(IsShapeMode(GetObject(engine, "b2"))); // fields check rejects — sampling path, not #2 shaping
         // integer-index keys enumerate first regardless of insertion order
         Assert.Equal("0,b", engine.Evaluate("Object.keys(b1).join(',')").AsString());
         Assert.Equal(1, engine.Evaluate("b1[0]").AsNumber());
@@ -201,31 +225,38 @@ public class ConstructorShapeEligibilityTests
     public void PrivateFieldsDoNotBlockEligibility()
     {
         var engine = new Engine();
-        engine.Execute("class C { #p = 5; x = 1; getP() { return this.#p; } } var c = new C();");
+        engine.Execute("class C { #p = 5; x = 1; getP() { return this.#p; } } var c1 = new C(); var c2 = new C();");
 
-        var c = GetObject(engine, "c");
-        Assert.True(IsShapeMode(c));
-        Assert.Equal(1, engine.Evaluate("c.x").AsNumber());
-        Assert.Equal(5, engine.Evaluate("c.getP()").AsNumber());
-        Assert.Equal("x", engine.Evaluate("Object.keys(c).join(',')").AsString());
+        var c2 = GetObject(engine, "c2");
+        Assert.True(IsShapeMode(c2));
+        Assert.Equal(1, engine.Evaluate("c2.x").AsNumber());
+        Assert.Equal(5, engine.Evaluate("c1.getP()").AsNumber());
+        Assert.Equal(5, engine.Evaluate("c2.getP()").AsNumber());
+        Assert.Equal("x", engine.Evaluate("Object.keys(c2).join(',')").AsString());
     }
 
     [Fact]
-    public void DerivedConstructorOverEligibleBaseShapesFromFirstInstance()
+    public void DerivedConstructorOverEligibleBaseShapesFromSecondInstance()
     {
         var engine = new Engine();
         engine.Execute("""
             class A { constructor() { this.x = 1; } }
             class B extends A { constructor() { super(); this.y = 2; } }
-            var b = new B();
+            var b1 = new B();
+            var b2 = new B();
             """);
 
-        var b = GetObject(engine, "b");
-        Assert.True(IsShapeMode(b));
-        Assert.Equal(1, engine.Evaluate("b.x").AsNumber());
-        Assert.Equal(2, engine.Evaluate("b.y").AsNumber());
-        Assert.Equal("x,y", engine.Evaluate("Object.keys(b).join(',')").AsString());
-        Assert.True(engine.Evaluate("b instanceof B && b instanceof A").AsBoolean());
+        // eligibility lives on the allocating BASE constructor: B's first construction promotes A,
+        // B's second construction allocates a shaping `this`
+        var b1 = GetObject(engine, "b1");
+        var b2 = GetObject(engine, "b2");
+        Assert.False(IsShapeMode(b1));
+        Assert.True(IsShapeMode(b2));
+        Assert.Equal(1, engine.Evaluate("b2.x").AsNumber());
+        Assert.Equal(2, engine.Evaluate("b2.y").AsNumber());
+        Assert.Equal("x,y", engine.Evaluate("Object.keys(b1).join(',')").AsString());
+        Assert.Equal("x,y", engine.Evaluate("Object.keys(b2).join(',')").AsString());
+        Assert.True(engine.Evaluate("b2 instanceof B && b2 instanceof A").AsBoolean());
     }
 
     [Fact]
@@ -235,18 +266,20 @@ public class ConstructorShapeEligibilityTests
         engine.Execute("""
             function A() { this.x = 1; }
             function C() {}
-            var r = Reflect.construct(A, [], C);
-            var a = new A();
+            var a1 = new A();                    // #1: dictionary; promotes A
+            var r = Reflect.construct(A, [], C); // #2: shaped against C.prototype's root
+            var a2 = new A();                    // #3: shaped against A.prototype's root
             """);
 
         var r = GetObject(engine, "r");
-        var a = GetObject(engine, "a");
+        var a2 = GetObject(engine, "a2");
+        Assert.False(IsShapeMode(GetObject(engine, "a1")));
         Assert.True(IsShapeMode(r));
-        Assert.True(IsShapeMode(a));
+        Assert.True(IsShapeMode(a2));
         Assert.True(engine.Evaluate("Object.getPrototypeOf(r) === C.prototype").AsBoolean());
         Assert.Equal(1, engine.Evaluate("r.x").AsNumber());
         // different prototypes root different transition trees
-        Assert.NotSame(ShapeOf(r), ShapeOf(a));
+        Assert.NotSame(ShapeOf(r), ShapeOf(a2));
     }
 
     [Fact]
@@ -254,9 +287,9 @@ public class ConstructorShapeEligibilityTests
     {
         var assignments = string.Concat(Enumerable.Range(0, 70).Select(i => $"this.p{i} = {i};"));
         var engine = new Engine();
-        engine.Execute($"function T() {{ {assignments} }} var t = new T();");
+        engine.Execute($"function T() {{ {assignments} }} var t0 = new T(); var t = new T();");
 
-        // eligible, so instance #1 starts shaped — and deopts to dictionary at the 64-property guard
+        // eligible, so instance #2 starts shaped — and deopts to dictionary at the 64-property guard
         var t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
 
@@ -271,6 +304,7 @@ public class ConstructorShapeEligibilityTests
         var engine = new Engine();
         engine.Execute("""
             function T() { this.a = 1; }
+            var t0 = new T();
             var t1 = new T();
             T.prototype = { tag: 'p2' };
             var t2 = new T();
@@ -292,10 +326,10 @@ public class ConstructorShapeEligibilityTests
     }
 
     [Fact]
-    public void DeleteAndDefinePropertyOnShapedFirstInstanceDeoptCorrectly()
+    public void DeleteAndDefinePropertyOnShapedInstanceDeoptCorrectly()
     {
         var engine = new Engine();
-        engine.Execute("function T() { this.a = 1; this.b = 2; } var t = new T();");
+        engine.Execute("function T() { this.a = 1; this.b = 2; } var t0 = new T(); var t = new T();");
         Assert.True(IsShapeMode(GetObject(engine, "t")));
 
         engine.Execute("delete t.a;");

--- a/Jint.Tests/Runtime/ConstructorShapeEligibilityTests.cs
+++ b/Jint.Tests/Runtime/ConstructorShapeEligibilityTests.cs
@@ -7,9 +7,10 @@ namespace Jint.Tests.Runtime;
 /// <summary>
 /// Pins static constructor-body shape eligibility (JintFunctionDefinition.ComputeCtorBodyShapeEligibility
 /// consumed by ScriptFunction's [[Construct]]): provably-clean constructors start hidden-class shape
-/// building from instance #2 (instance #1 stays dictionary-mode, so one-shot constructors intern no shape
-/// state) instead of after the 16-instance sampling window, while everything else keeps the sampling
-/// behavior exactly — and correctness never depends on the verdict (deopt machinery unchanged).
+/// building from instance #3 (instances #1 and #2 stay dictionary-mode, so constructors of unrepeated
+/// layouts intern no shape state) instead of after the 16-instance sampling window, while everything else
+/// keeps the sampling behavior exactly — and correctness never depends on the verdict (deopt machinery
+/// unchanged).
 /// </summary>
 public class ConstructorShapeEligibilityTests
 {
@@ -24,63 +25,65 @@ public class ConstructorShapeEligibilityTests
     }
 
     [Fact]
-    public void EligibleConstructorShapesFromSecondInstance()
+    public void EligibleConstructorShapesFromThirdInstance()
     {
         var engine = new Engine();
-        engine.Execute("function T() { this.a = 1; this.b = 2; } var t1 = new T(); var t2 = new T(); var t3 = new T();");
+        engine.Execute("function T() { this.a = 1; this.b = 2; } var t1 = new T(); var t2 = new T(); var t3 = new T(); var t4 = new T();");
 
         var t1 = GetObject(engine, "t1");
         var t2 = GetObject(engine, "t2");
         var t3 = GetObject(engine, "t3");
+        var t4 = GetObject(engine, "t4");
 
-        // instance #1 stays a dictionary (a one-shot constructor interns no shape state at all);
-        // instances #2+ share one interned hidden class
+        // instances #1 and #2 stay dictionaries (the interned tree only pays off from ~3 instances,
+        // so unrepeated layouts intern no shape state at all); instances #3+ share one hidden class
         Assert.False(IsShapeMode(t1));
-        Assert.True(IsShapeMode(t2));
+        Assert.False(IsShapeMode(t2));
         Assert.True(IsShapeMode(t3));
-        Assert.Same(ShapeOf(t2), ShapeOf(t3));
+        Assert.True(IsShapeMode(t4));
+        Assert.Same(ShapeOf(t3), ShapeOf(t4));
 
         Assert.Equal(1, engine.Evaluate("t1.a").AsNumber());
-        Assert.Equal(2, engine.Evaluate("t2.b").AsNumber());
+        Assert.Equal(2, engine.Evaluate("t3.b").AsNumber());
         Assert.Equal("a,b", engine.Evaluate("Object.keys(t1).join(',')").AsString());
-        Assert.Equal("a,b", engine.Evaluate("Object.keys(t2).join(',')").AsString());
-        Assert.True(engine.Evaluate("'a' in t2 && 'b' in t2 && !('c' in t2)").AsBoolean());
+        Assert.Equal("a,b", engine.Evaluate("Object.keys(t3).join(',')").AsString());
+        Assert.True(engine.Evaluate("'a' in t3 && 'b' in t3 && !('c' in t3)").AsBoolean());
     }
 
     [Fact]
     public void EarlierAssignmentsAreVisibleToLaterOnesWhileShaping()
     {
         var engine = new Engine();
-        engine.Execute("function T() { this.a = 1; this.b = this.a + 1; } var t1 = new T(); var t2 = new T();");
+        engine.Execute("function T() { this.a = 1; this.b = this.a + 1; } var t1 = new T(); var t2 = new T(); var t3 = new T();");
 
-        var t2 = GetObject(engine, "t2");
-        Assert.True(IsShapeMode(t2));
+        var t3 = GetObject(engine, "t3");
+        Assert.True(IsShapeMode(t3));
         Assert.Equal(2, engine.Evaluate("t1.b").AsNumber());
-        Assert.Equal(2, engine.Evaluate("t2.b").AsNumber());
+        Assert.Equal(2, engine.Evaluate("t3.b").AsNumber());
     }
 
     [Fact]
     public void ThisFreeCallsAndBareReturnAreEligible()
     {
         var engine = new Engine();
-        engine.Execute("function T() { this.abs = Math.abs(-5); this.t = Date.now(); return; } var t1 = new T(); var t2 = new T();");
+        engine.Execute("function T() { this.abs = Math.abs(-5); this.t = Date.now(); return; } var t1 = new T(); var t2 = new T(); var t3 = new T();");
 
-        var t2 = GetObject(engine, "t2");
-        Assert.True(IsShapeMode(t2));
-        Assert.Equal(5, engine.Evaluate("t2.abs").AsNumber());
-        Assert.Equal("abs,t", engine.Evaluate("Object.keys(t2).join(',')").AsString());
+        var t3 = GetObject(engine, "t3");
+        Assert.True(IsShapeMode(t3));
+        Assert.Equal(5, engine.Evaluate("t3.abs").AsNumber());
+        Assert.Equal("abs,t", engine.Evaluate("Object.keys(t3).join(',')").AsString());
     }
 
     [Fact]
     public void DirectivePrologueDoesNotBlockEligibility()
     {
         var engine = new Engine();
-        engine.Execute("function T() { 'use strict'; this.a = 1; } var t1 = new T(); var t2 = new T();");
+        engine.Execute("function T() { 'use strict'; this.a = 1; } var t1 = new T(); var t2 = new T(); var t3 = new T();");
 
-        var t2 = GetObject(engine, "t2");
-        Assert.True(IsShapeMode(t2));
+        var t3 = GetObject(engine, "t3");
+        Assert.True(IsShapeMode(t3));
         Assert.Equal(1, engine.Evaluate("t1.a").AsNumber());
-        Assert.Equal(1, engine.Evaluate("t2.a").AsNumber());
+        Assert.Equal(1, engine.Evaluate("t3.a").AsNumber());
     }
 
     [Fact]
@@ -95,68 +98,69 @@ public class ConstructorShapeEligibilityTests
             }
             var t1 = new T();
             var t2 = new T();
+            var t3 = new T();
             """);
 
-        var t2 = GetObject(engine, "t2");
-        Assert.True(IsShapeMode(t2));
+        var t3 = GetObject(engine, "t3");
+        Assert.True(IsShapeMode(t3));
         Assert.Equal("self", engine.Evaluate("t1.get()").AsString());
-        Assert.Equal("self", engine.Evaluate("t2.get()").AsString());
+        Assert.Equal("self", engine.Evaluate("t3.get()").AsString());
     }
 
     [Fact]
     public void IneligibleBodiesBehaveExactlyAsBeforeAndStayUnshaped()
     {
         // Ineligible constructors keep the sampling window: with eligible ones now shaping from
-        // instance #2, asserting instance #2 is still dictionary-mode is what distinguishes them.
+        // instance #3, asserting instance #3 is still dictionary-mode is what distinguishes them.
 
         // conditional assignment
         var engine = new Engine();
-        engine.Execute("function T(f) { if (f) { this.a = 1; } else { this.b = 2; } } var t = new T(true); var t2 = new T(true);");
+        engine.Execute("function T(f) { if (f) { this.a = 1; } else { this.b = 2; } } var t = new T(true); var t2 = new T(true); var t3 = new T(true);");
         var t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
-        Assert.False(IsShapeMode(GetObject(engine, "t2")));
+        Assert.False(IsShapeMode(GetObject(engine, "t3")));
         Assert.Equal(1, engine.Evaluate("t.a").AsNumber());
         Assert.False(engine.Evaluate("'b' in t").AsBoolean());
 
         // computed LHS
         engine = new Engine();
-        engine.Execute("function T(k) { this[k] = 42; } var t = new T('dyn'); var t2 = new T('dyn');");
+        engine.Execute("function T(k) { this[k] = 42; } var t = new T('dyn'); var t2 = new T('dyn'); var t3 = new T('dyn');");
         t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
-        Assert.False(IsShapeMode(GetObject(engine, "t2")));
+        Assert.False(IsShapeMode(GetObject(engine, "t3")));
         Assert.Equal(42, engine.Evaluate("t.dyn").AsNumber());
 
         // this-call in body
         engine = new Engine();
-        engine.Execute("function T() { this.init(); } T.prototype.init = function () { this.a = 1; }; var t = new T(); var t2 = new T();");
+        engine.Execute("function T() { this.init(); } T.prototype.init = function () { this.a = 1; }; var t = new T(); var t2 = new T(); var t3 = new T();");
         t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
-        Assert.False(IsShapeMode(GetObject(engine, "t2")));
+        Assert.False(IsShapeMode(GetObject(engine, "t3")));
         Assert.Equal(1, engine.Evaluate("t.a").AsNumber());
 
         // this escaping through a call in an assignment RHS; the escapee's write lands FIRST
         engine = new Engine();
-        engine.Execute("function ext(o) { o.dyn = 1; return 2; } function T() { this.a = ext(this); } var t = new T(); var t2 = new T();");
+        engine.Execute("function ext(o) { o.dyn = 1; return 2; } function T() { this.a = ext(this); } var t = new T(); var t2 = new T(); var t3 = new T();");
         t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
-        Assert.False(IsShapeMode(GetObject(engine, "t2")));
+        Assert.False(IsShapeMode(GetObject(engine, "t3")));
         Assert.Equal(2, engine.Evaluate("t.a").AsNumber());
         Assert.Equal("dyn,a", engine.Evaluate("Object.keys(t).join(',')").AsString());
 
         // this escaping through a call in a var initializer
         engine = new Engine();
-        engine.Execute("function grab(o) { o.dyn = 1; return 3; } function T() { var x = grab(this); this.a = x; } var t = new T(); var t2 = new T();");
+        engine.Execute("function grab(o) { o.dyn = 1; return 3; } function T() { var x = grab(this); this.a = x; } var t = new T(); var t2 = new T(); var t3 = new T();");
         t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
-        Assert.False(IsShapeMode(GetObject(engine, "t2")));
+        Assert.False(IsShapeMode(GetObject(engine, "t3")));
         Assert.Equal(3, engine.Evaluate("t.a").AsNumber());
 
         // this escaping through a parameter default (runs during construction)
         engine = new Engine();
-        engine.Execute("function capture(o) { o.k = 1; return 9; } function T(a = capture(this)) { this.x = a; } var t = new T(); var t2 = new T();");
+        engine.Execute("function capture(o) { o.k = 1; return 9; } function T(a = capture(this)) { this.x = a; } var t = new T(); var t2 = new T(); var t3 = new T();");
         t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
-        Assert.False(IsShapeMode(GetObject(engine, "t2")));
+        Assert.False(IsShapeMode(GetObject(engine, "t3")));
         Assert.Equal(9, engine.Evaluate("t.x").AsNumber());
         Assert.Equal(1, engine.Evaluate("t.k").AsNumber());
     }
@@ -179,42 +183,44 @@ public class ConstructorShapeEligibilityTests
     }
 
     [Fact]
-    public void ClassFieldOnlyInstanceShapesFromSecondInstance()
+    public void ClassFieldOnlyInstanceShapesFromThirdInstance()
     {
         var engine = new Engine();
-        engine.Execute("class A { x = 1 } var a1 = new A(); var a2 = new A(); var a3 = new A();");
+        engine.Execute("class A { x = 1 } var a1 = new A(); var a2 = new A(); var a3 = new A(); var a4 = new A();");
 
         var a1 = GetObject(engine, "a1");
         var a2 = GetObject(engine, "a2");
         var a3 = GetObject(engine, "a3");
+        var a4 = GetObject(engine, "a4");
         Assert.False(IsShapeMode(a1));
-        Assert.True(IsShapeMode(a2));
-        Assert.Same(ShapeOf(a2), ShapeOf(a3));
+        Assert.False(IsShapeMode(a2));
+        Assert.True(IsShapeMode(a3));
+        Assert.Same(ShapeOf(a3), ShapeOf(a4));
         Assert.Equal(1, engine.Evaluate("a1.x").AsNumber());
-        Assert.Equal(1, engine.Evaluate("a2.x").AsNumber());
+        Assert.Equal(1, engine.Evaluate("a3.x").AsNumber());
     }
 
     [Fact]
     public void ClassFieldsRunBeforeConstructorBodyAssignments()
     {
         var engine = new Engine();
-        engine.Execute("class D { y = 1; constructor() { this.z = 2; } } var d1 = new D(); var d2 = new D();");
+        engine.Execute("class D { y = 1; constructor() { this.z = 2; } } var d1 = new D(); var d2 = new D(); var d3 = new D();");
 
-        var d2 = GetObject(engine, "d2");
-        Assert.True(IsShapeMode(d2));
+        var d3 = GetObject(engine, "d3");
+        Assert.True(IsShapeMode(d3));
         Assert.Equal("y,z", engine.Evaluate("Object.keys(d1).join(',')").AsString());
-        Assert.Equal("y,z", engine.Evaluate("Object.keys(d2).join(',')").AsString());
+        Assert.Equal("y,z", engine.Evaluate("Object.keys(d3).join(',')").AsString());
     }
 
     [Fact]
     public void IndexLikeComputedFieldNameFallsBackToSamplingWithCorrectOrder()
     {
         var engine = new Engine();
-        engine.Execute("class B { b = 2; ['0'] = 1 } var b1 = new B(); var b2 = new B();");
+        engine.Execute("class B { b = 2; ['0'] = 1 } var b1 = new B(); var b2 = new B(); var b3 = new B();");
 
         var b1 = GetObject(engine, "b1");
         Assert.False(IsShapeMode(b1));
-        Assert.False(IsShapeMode(GetObject(engine, "b2"))); // fields check rejects — sampling path, not #2 shaping
+        Assert.False(IsShapeMode(GetObject(engine, "b3"))); // fields check rejects — sampling path, not #3 shaping
         // integer-index keys enumerate first regardless of insertion order
         Assert.Equal("0,b", engine.Evaluate("Object.keys(b1).join(',')").AsString());
         Assert.Equal(1, engine.Evaluate("b1[0]").AsNumber());
@@ -225,18 +231,18 @@ public class ConstructorShapeEligibilityTests
     public void PrivateFieldsDoNotBlockEligibility()
     {
         var engine = new Engine();
-        engine.Execute("class C { #p = 5; x = 1; getP() { return this.#p; } } var c1 = new C(); var c2 = new C();");
+        engine.Execute("class C { #p = 5; x = 1; getP() { return this.#p; } } var c1 = new C(); var c2 = new C(); var c3 = new C();");
 
-        var c2 = GetObject(engine, "c2");
-        Assert.True(IsShapeMode(c2));
-        Assert.Equal(1, engine.Evaluate("c2.x").AsNumber());
+        var c3 = GetObject(engine, "c3");
+        Assert.True(IsShapeMode(c3));
+        Assert.Equal(1, engine.Evaluate("c3.x").AsNumber());
         Assert.Equal(5, engine.Evaluate("c1.getP()").AsNumber());
-        Assert.Equal(5, engine.Evaluate("c2.getP()").AsNumber());
-        Assert.Equal("x", engine.Evaluate("Object.keys(c2).join(',')").AsString());
+        Assert.Equal(5, engine.Evaluate("c3.getP()").AsNumber());
+        Assert.Equal("x", engine.Evaluate("Object.keys(c3).join(',')").AsString());
     }
 
     [Fact]
-    public void DerivedConstructorOverEligibleBaseShapesFromSecondInstance()
+    public void DerivedConstructorOverEligibleBaseShapesFromThirdInstance()
     {
         var engine = new Engine();
         engine.Execute("""
@@ -244,19 +250,22 @@ public class ConstructorShapeEligibilityTests
             class B extends A { constructor() { super(); this.y = 2; } }
             var b1 = new B();
             var b2 = new B();
+            var b3 = new B();
             """);
 
-        // eligibility lives on the allocating BASE constructor: B's first construction promotes A,
-        // B's second construction allocates a shaping `this`
+        // eligibility lives on the allocating BASE constructor: B's first two constructions promote A,
+        // B's third construction allocates a shaping `this`
         var b1 = GetObject(engine, "b1");
         var b2 = GetObject(engine, "b2");
+        var b3 = GetObject(engine, "b3");
         Assert.False(IsShapeMode(b1));
-        Assert.True(IsShapeMode(b2));
-        Assert.Equal(1, engine.Evaluate("b2.x").AsNumber());
-        Assert.Equal(2, engine.Evaluate("b2.y").AsNumber());
+        Assert.False(IsShapeMode(b2));
+        Assert.True(IsShapeMode(b3));
+        Assert.Equal(1, engine.Evaluate("b3.x").AsNumber());
+        Assert.Equal(2, engine.Evaluate("b3.y").AsNumber());
         Assert.Equal("x,y", engine.Evaluate("Object.keys(b1).join(',')").AsString());
-        Assert.Equal("x,y", engine.Evaluate("Object.keys(b2).join(',')").AsString());
-        Assert.True(engine.Evaluate("b2 instanceof B && b2 instanceof A").AsBoolean());
+        Assert.Equal("x,y", engine.Evaluate("Object.keys(b3).join(',')").AsString());
+        Assert.True(engine.Evaluate("b3 instanceof B && b3 instanceof A").AsBoolean());
     }
 
     [Fact]
@@ -266,20 +275,22 @@ public class ConstructorShapeEligibilityTests
         engine.Execute("""
             function A() { this.x = 1; }
             function C() {}
-            var a1 = new A();                    // #1: dictionary; promotes A
-            var r = Reflect.construct(A, [], C); // #2: shaped against C.prototype's root
-            var a2 = new A();                    // #3: shaped against A.prototype's root
+            var a1 = new A();                    // #1: dictionary
+            var a2 = new A();                    // #2: dictionary; promotes A
+            var r = Reflect.construct(A, [], C); // #3: shaped against C.prototype's root
+            var a3 = new A();                    // #4: shaped against A.prototype's root
             """);
 
         var r = GetObject(engine, "r");
-        var a2 = GetObject(engine, "a2");
+        var a3 = GetObject(engine, "a3");
         Assert.False(IsShapeMode(GetObject(engine, "a1")));
+        Assert.False(IsShapeMode(GetObject(engine, "a2")));
         Assert.True(IsShapeMode(r));
-        Assert.True(IsShapeMode(a2));
+        Assert.True(IsShapeMode(a3));
         Assert.True(engine.Evaluate("Object.getPrototypeOf(r) === C.prototype").AsBoolean());
         Assert.Equal(1, engine.Evaluate("r.x").AsNumber());
         // different prototypes root different transition trees
-        Assert.NotSame(ShapeOf(r), ShapeOf(a2));
+        Assert.NotSame(ShapeOf(r), ShapeOf(a3));
     }
 
     [Fact]
@@ -287,9 +298,9 @@ public class ConstructorShapeEligibilityTests
     {
         var assignments = string.Concat(Enumerable.Range(0, 70).Select(i => $"this.p{i} = {i};"));
         var engine = new Engine();
-        engine.Execute($"function T() {{ {assignments} }} var t0 = new T(); var t = new T();");
+        engine.Execute($"function T() {{ {assignments} }} var t0 = new T(); var t1 = new T(); var t = new T();");
 
-        // eligible, so instance #2 starts shaped — and deopts to dictionary at the 64-property guard
+        // eligible, so instance #3 starts shaped — and deopts to dictionary at the 64-property guard
         var t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
 
@@ -304,7 +315,8 @@ public class ConstructorShapeEligibilityTests
         var engine = new Engine();
         engine.Execute("""
             function T() { this.a = 1; }
-            var t0 = new T();
+            var t0a = new T();
+            var t0b = new T();
             var t1 = new T();
             T.prototype = { tag: 'p2' };
             var t2 = new T();
@@ -329,7 +341,7 @@ public class ConstructorShapeEligibilityTests
     public void DeleteAndDefinePropertyOnShapedInstanceDeoptCorrectly()
     {
         var engine = new Engine();
-        engine.Execute("function T() { this.a = 1; this.b = 2; } var t0 = new T(); var t = new T();");
+        engine.Execute("function T() { this.a = 1; this.b = 2; } var t0a = new T(); var t0b = new T(); var t = new T();");
         Assert.True(IsShapeMode(GetObject(engine, "t")));
 
         engine.Execute("delete t.a;");

--- a/Jint.Tests/Runtime/ConstructorShapeEligibilityTests.cs
+++ b/Jint.Tests/Runtime/ConstructorShapeEligibilityTests.cs
@@ -1,0 +1,317 @@
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins static constructor-body shape eligibility (JintFunctionDefinition.ComputeCtorBodyShapeEligibility
+/// consumed by ScriptFunction's [[Construct]]): provably-clean constructors start hidden-class shape
+/// building from instance #1 instead of after the 16-instance sampling window, while everything else keeps
+/// the sampling behavior exactly — and correctness never depends on the verdict (deopt machinery unchanged).
+/// </summary>
+public class ConstructorShapeEligibilityTests
+{
+    private static JsObject GetObject(Engine engine, string expression) => (JsObject) engine.Evaluate(expression);
+
+    private static bool IsShapeMode(JsObject o) => (o._type & InternalTypes.ShapeMode) != InternalTypes.Empty;
+
+    private static Shape ShapeOf(JsObject o)
+    {
+        Assert.True(IsShapeMode(o), "expected a shape-mode object");
+        return o.ShapeOf;
+    }
+
+    [Fact]
+    public void EligibleConstructorShapesFromFirstInstance()
+    {
+        var engine = new Engine();
+        engine.Execute("function T() { this.a = 1; this.b = 2; } var t1 = new T(); var t2 = new T();");
+
+        var t1 = GetObject(engine, "t1");
+        var t2 = GetObject(engine, "t2");
+
+        Assert.True(IsShapeMode(t1));
+        Assert.True(IsShapeMode(t2));
+        Assert.Same(ShapeOf(t1), ShapeOf(t2));
+
+        Assert.Equal(1, engine.Evaluate("t1.a").AsNumber());
+        Assert.Equal(2, engine.Evaluate("t1.b").AsNumber());
+        Assert.Equal("a,b", engine.Evaluate("Object.keys(t1).join(',')").AsString());
+        Assert.True(engine.Evaluate("'a' in t1 && 'b' in t1 && !('c' in t1)").AsBoolean());
+    }
+
+    [Fact]
+    public void EarlierAssignmentsAreVisibleToLaterOnesWhileShaping()
+    {
+        var engine = new Engine();
+        engine.Execute("function T() { this.a = 1; this.b = this.a + 1; } var t = new T();");
+
+        var t = GetObject(engine, "t");
+        Assert.True(IsShapeMode(t));
+        Assert.Equal(2, engine.Evaluate("t.b").AsNumber());
+    }
+
+    [Fact]
+    public void ThisFreeCallsAndBareReturnAreEligible()
+    {
+        var engine = new Engine();
+        engine.Execute("function T() { this.abs = Math.abs(-5); this.t = Date.now(); return; } var t = new T();");
+
+        var t = GetObject(engine, "t");
+        Assert.True(IsShapeMode(t));
+        Assert.Equal(5, engine.Evaluate("t.abs").AsNumber());
+        Assert.Equal("abs,t", engine.Evaluate("Object.keys(t).join(',')").AsString());
+    }
+
+    [Fact]
+    public void DirectivePrologueDoesNotBlockEligibility()
+    {
+        var engine = new Engine();
+        engine.Execute("function T() { 'use strict'; this.a = 1; } var t = new T();");
+
+        var t = GetObject(engine, "t");
+        Assert.True(IsShapeMode(t));
+        Assert.Equal(1, engine.Evaluate("t.a").AsNumber());
+    }
+
+    [Fact]
+    public void SelfAliasClosurePatternIsEligible()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            function T() {
+                var self = this;
+                this.a = 1;
+                this.get = function () { return self === this ? 'self' : 'other'; };
+            }
+            var t = new T();
+            """);
+
+        var t = GetObject(engine, "t");
+        Assert.True(IsShapeMode(t));
+        Assert.Equal("self", engine.Evaluate("t.get()").AsString());
+    }
+
+    [Fact]
+    public void IneligibleBodiesBehaveExactlyAsBeforeAndStayUnshapedAtFirstInstance()
+    {
+        // conditional assignment
+        var engine = new Engine();
+        engine.Execute("function T(f) { if (f) { this.a = 1; } else { this.b = 2; } } var t = new T(true);");
+        var t = GetObject(engine, "t");
+        Assert.False(IsShapeMode(t));
+        Assert.Equal(1, engine.Evaluate("t.a").AsNumber());
+        Assert.False(engine.Evaluate("'b' in t").AsBoolean());
+
+        // computed LHS
+        engine = new Engine();
+        engine.Execute("function T(k) { this[k] = 42; } var t = new T('dyn');");
+        t = GetObject(engine, "t");
+        Assert.False(IsShapeMode(t));
+        Assert.Equal(42, engine.Evaluate("t.dyn").AsNumber());
+
+        // this-call in body
+        engine = new Engine();
+        engine.Execute("function T() { this.init(); } T.prototype.init = function () { this.a = 1; }; var t = new T();");
+        t = GetObject(engine, "t");
+        Assert.False(IsShapeMode(t));
+        Assert.Equal(1, engine.Evaluate("t.a").AsNumber());
+
+        // this escaping through a call in an assignment RHS; the escapee's write lands FIRST
+        engine = new Engine();
+        engine.Execute("function ext(o) { o.dyn = 1; return 2; } function T() { this.a = ext(this); } var t = new T();");
+        t = GetObject(engine, "t");
+        Assert.False(IsShapeMode(t));
+        Assert.Equal(2, engine.Evaluate("t.a").AsNumber());
+        Assert.Equal("dyn,a", engine.Evaluate("Object.keys(t).join(',')").AsString());
+
+        // this escaping through a call in a var initializer
+        engine = new Engine();
+        engine.Execute("function grab(o) { o.dyn = 1; return 3; } function T() { var x = grab(this); this.a = x; } var t = new T();");
+        t = GetObject(engine, "t");
+        Assert.False(IsShapeMode(t));
+        Assert.Equal(3, engine.Evaluate("t.a").AsNumber());
+
+        // this escaping through a parameter default (runs during construction)
+        engine = new Engine();
+        engine.Execute("function capture(o) { o.k = 1; return 9; } function T(a = capture(this)) { this.x = a; } var t = new T();");
+        t = GetObject(engine, "t");
+        Assert.False(IsShapeMode(t));
+        Assert.Equal(9, engine.Evaluate("t.x").AsNumber());
+        Assert.Equal(1, engine.Evaluate("t.k").AsNumber());
+    }
+
+    [Fact]
+    public void IneligibleConstructorKeepsSamplingThresholdPacing()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            function T(k) { this[k] = 1; }
+            var arr = [];
+            for (var i = 0; i < 17; i++) { arr.push(new T('a')); }
+            """);
+
+        // instances 1..16 build dictionaries (the threshold-tripping 16th included); the 17th starts shaped
+        Assert.False(IsShapeMode(GetObject(engine, "arr[0]")));
+        Assert.False(IsShapeMode(GetObject(engine, "arr[15]")));
+        Assert.True(IsShapeMode(GetObject(engine, "arr[16]")));
+        Assert.True(engine.Evaluate("arr.every(function (x) { return x.a === 1; })").AsBoolean());
+    }
+
+    [Fact]
+    public void ClassFieldOnlyInstanceShapesFromFirstInstance()
+    {
+        var engine = new Engine();
+        engine.Execute("class A { x = 1 } var a1 = new A(); var a2 = new A();");
+
+        var a1 = GetObject(engine, "a1");
+        var a2 = GetObject(engine, "a2");
+        Assert.True(IsShapeMode(a1));
+        Assert.Same(ShapeOf(a1), ShapeOf(a2));
+        Assert.Equal(1, engine.Evaluate("a1.x").AsNumber());
+    }
+
+    [Fact]
+    public void ClassFieldsRunBeforeConstructorBodyAssignments()
+    {
+        var engine = new Engine();
+        engine.Execute("class D { y = 1; constructor() { this.z = 2; } } var d = new D();");
+
+        var d = GetObject(engine, "d");
+        Assert.True(IsShapeMode(d));
+        Assert.Equal("y,z", engine.Evaluate("Object.keys(d).join(',')").AsString());
+    }
+
+    [Fact]
+    public void IndexLikeComputedFieldNameFallsBackToSamplingWithCorrectOrder()
+    {
+        var engine = new Engine();
+        engine.Execute("class B { b = 2; ['0'] = 1 } var b1 = new B();");
+
+        var b1 = GetObject(engine, "b1");
+        Assert.False(IsShapeMode(b1));
+        // integer-index keys enumerate first regardless of insertion order
+        Assert.Equal("0,b", engine.Evaluate("Object.keys(b1).join(',')").AsString());
+        Assert.Equal(1, engine.Evaluate("b1[0]").AsNumber());
+        Assert.Equal(2, engine.Evaluate("b1.b").AsNumber());
+    }
+
+    [Fact]
+    public void PrivateFieldsDoNotBlockEligibility()
+    {
+        var engine = new Engine();
+        engine.Execute("class C { #p = 5; x = 1; getP() { return this.#p; } } var c = new C();");
+
+        var c = GetObject(engine, "c");
+        Assert.True(IsShapeMode(c));
+        Assert.Equal(1, engine.Evaluate("c.x").AsNumber());
+        Assert.Equal(5, engine.Evaluate("c.getP()").AsNumber());
+        Assert.Equal("x", engine.Evaluate("Object.keys(c).join(',')").AsString());
+    }
+
+    [Fact]
+    public void DerivedConstructorOverEligibleBaseShapesFromFirstInstance()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            class A { constructor() { this.x = 1; } }
+            class B extends A { constructor() { super(); this.y = 2; } }
+            var b = new B();
+            """);
+
+        var b = GetObject(engine, "b");
+        Assert.True(IsShapeMode(b));
+        Assert.Equal(1, engine.Evaluate("b.x").AsNumber());
+        Assert.Equal(2, engine.Evaluate("b.y").AsNumber());
+        Assert.Equal("x,y", engine.Evaluate("Object.keys(b).join(',')").AsString());
+        Assert.True(engine.Evaluate("b instanceof B && b instanceof A").AsBoolean());
+    }
+
+    [Fact]
+    public void ReflectConstructWithForeignNewTargetUsesForeignPrototype()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            function A() { this.x = 1; }
+            function C() {}
+            var r = Reflect.construct(A, [], C);
+            var a = new A();
+            """);
+
+        var r = GetObject(engine, "r");
+        var a = GetObject(engine, "a");
+        Assert.True(IsShapeMode(r));
+        Assert.True(IsShapeMode(a));
+        Assert.True(engine.Evaluate("Object.getPrototypeOf(r) === C.prototype").AsBoolean());
+        Assert.Equal(1, engine.Evaluate("r.x").AsNumber());
+        // different prototypes root different transition trees
+        Assert.NotSame(ShapeOf(r), ShapeOf(a));
+    }
+
+    [Fact]
+    public void MegamorphicGuardTripConvertsMidBuildKeepingAllPropertiesInOrder()
+    {
+        var assignments = string.Concat(Enumerable.Range(0, 70).Select(i => $"this.p{i} = {i};"));
+        var engine = new Engine();
+        engine.Execute($"function T() {{ {assignments} }} var t = new T();");
+
+        // eligible, so instance #1 starts shaped — and deopts to dictionary at the 64-property guard
+        var t = GetObject(engine, "t");
+        Assert.False(IsShapeMode(t));
+
+        var expectedKeys = string.Join(",", Enumerable.Range(0, 70).Select(i => $"p{i}"));
+        Assert.Equal(expectedKeys, engine.Evaluate("Object.keys(t).join(',')").AsString());
+        Assert.True(engine.Evaluate("(function () { for (var i = 0; i < 70; i++) { if (t['p' + i] !== i) return false; } return true; })()").AsBoolean());
+    }
+
+    [Fact]
+    public void PrototypeReassignmentBetweenConstructionsIsHonoured()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            function T() { this.a = 1; }
+            var t1 = new T();
+            T.prototype = { tag: 'p2' };
+            var t2 = new T();
+            var t3 = new T();
+            """);
+
+        var t1 = GetObject(engine, "t1");
+        var t2 = GetObject(engine, "t2");
+        var t3 = GetObject(engine, "t3");
+
+        Assert.True(IsShapeMode(t1));
+        Assert.True(IsShapeMode(t2));
+        Assert.NotSame(ShapeOf(t1), ShapeOf(t2)); // different prototype, different root
+        Assert.Same(ShapeOf(t2), ShapeOf(t3));
+
+        Assert.Equal(1, engine.Evaluate("t2.a").AsNumber());
+        Assert.Equal("p2", engine.Evaluate("t2.tag").AsString());
+        Assert.False(engine.Evaluate("'tag' in t1").AsBoolean());
+    }
+
+    [Fact]
+    public void DeleteAndDefinePropertyOnShapedFirstInstanceDeoptCorrectly()
+    {
+        var engine = new Engine();
+        engine.Execute("function T() { this.a = 1; this.b = 2; } var t = new T();");
+        Assert.True(IsShapeMode(GetObject(engine, "t")));
+
+        engine.Execute("delete t.a;");
+        var t = GetObject(engine, "t");
+        Assert.False(IsShapeMode(t));
+        Assert.False(engine.Evaluate("'a' in t").AsBoolean());
+        Assert.Equal(2, engine.Evaluate("t.b").AsNumber());
+        Assert.Equal("b", engine.Evaluate("Object.keys(t).join(',')").AsString());
+
+        engine.Execute("var u = new T(); Object.defineProperty(u, 'b', { enumerable: false });");
+        var u = GetObject(engine, "u");
+        Assert.False(IsShapeMode(u));
+        Assert.Equal(2, engine.Evaluate("u.b").AsNumber());
+        Assert.Equal("a", engine.Evaluate("Object.keys(u).join(',')").AsString());
+
+        engine.Execute("var v = new T(); Object.defineProperty(v, 'a', { get: function () { return 99; } });");
+        Assert.Equal(99, engine.Evaluate("v.a").AsNumber());
+    }
+}

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -33,6 +34,15 @@ public sealed class ScriptFunction : Function, IConstructor
     // per-construct lookup (revalidated when .prototype is reassigned).
     private const int CtorShapePromoteThreshold = 16;
     private bool _ctorShaped;
+
+    // Static eligibility verdict for this function instance: 0 = not yet analyzed, 1 = eligible
+    // (body statically clean AND every class field name shape-compatible), 2 = ineligible. Provably
+    // clean constructors skip the sampling window and shape from instance #1 — a short-lived engine
+    // constructing 1-15 instances of each type otherwise never promotes. Combines the AST-pure
+    // State.CtorBodyShapeEligibility with the per-function class-fields check; the combined verdict
+    // cannot live on the shared State because the shared empty-constructor AST serves classes with
+    // different fields.
+    private byte _ctorStaticEligibility;
     private int _ctorSampleCount;
     private Shape? _ctorEmptyShape;
     private ObjectInstance? _ctorEmptyShapeProto;
@@ -303,10 +313,11 @@ public sealed class ScriptFunction : Function, IConstructor
 
             // Once the constructor is hot, start each fresh `this` in shape-building mode so this.x= /
             // class fields transition a shared interned hidden class instead of building a dictionary.
-            // Cold constructors (below the promote threshold) stay on the dictionary path.
+            // Cold constructors (below the promote threshold) stay on the dictionary path — unless the
+            // body is statically provably clean, in which case shaping starts at instance #1.
             if (thisArgument is JsObject thisObject && thisObject.Prototype is { } proto)
             {
-                if (_ctorShaped)
+                if (_ctorShaped || CheckCtorShapeEligibility(state))
                 {
                     if (!ReferenceEquals(_ctorEmptyShapeProto, proto))
                     {
@@ -314,10 +325,6 @@ public sealed class ScriptFunction : Function, IConstructor
                         _ctorEmptyShapeProto = proto;
                     }
                     thisObject.StartShapeBuilding(_ctorEmptyShape!);
-                }
-                else if (++_ctorSampleCount >= CtorShapePromoteThreshold)
-                {
-                    _ctorShaped = true;
                 }
             }
         }
@@ -385,6 +392,88 @@ public sealed class ScriptFunction : Function, IConstructor
         }
 
         return (ObjectInstance) constructorEnv.GetThisBinding();
+    }
+
+    /// <summary>
+    /// Cold-path shaping decision for a not-yet-promoted constructor: statically clean bodies (see
+    /// <see cref="JintFunctionDefinition.ComputeCtorBodyShapeEligibility"/>) start shaping at instance #1,
+    /// everything else keeps the sampling threshold with its pre-existing pacing (the threshold-tripping
+    /// instance itself stays on the dictionary path; the next construct starts shaped). Returns whether
+    /// the CURRENT instance should start in shape-building mode. Contingency lever: should first-instance
+    /// shaping ever show one-shot-constructor regressions, eligible constructors can instead promote at
+    /// instance #2 by setting _ctorShaped without returning true on the first call.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool CheckCtorShapeEligibility(JintFunctionDefinition.State state)
+    {
+        var eligibility = _ctorStaticEligibility;
+        if (eligibility == 0)
+        {
+            _ctorStaticEligibility = eligibility = ComputeCtorStaticEligibility(state);
+        }
+
+        if (eligibility == 1)
+        {
+            _ctorShaped = true;
+            return true;
+        }
+
+        if (++_ctorSampleCount >= CtorShapePromoteThreshold)
+        {
+            _ctorShaped = true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Combines the shared AST-level body verdict (cached on the cross-engine State) with this function's
+    /// class-field names: every field must be a plain string key that cannot be an array index — a
+    /// digit-leading key would force the ordered-enumeration deopt on first keys read. Private names are
+    /// fine (PrivateFieldAdd bypasses property storage), while symbol names and decorator
+    /// extra-initializer runners (Name == Undefined; they invoke arbitrary callables against `this`)
+    /// reject. Field initializer bodies are deliberately not scanned: post-threshold hot constructors
+    /// already run them under shape building today, and TryShapeAdd's MaxFanout bounds any dynamism.
+    /// </summary>
+    private byte ComputeCtorStaticEligibility(JintFunctionDefinition.State state)
+    {
+        var bodyEligibility = state.CtorBodyShapeEligibility;
+        if (bodyEligibility == 0)
+        {
+            bodyEligibility = JintFunctionDefinition.ComputeCtorBodyShapeEligibility(_functionDefinition!.Function) ? (byte) 1 : (byte) 2;
+            state.CtorBodyShapeEligibility = bodyEligibility;
+        }
+
+        if (bodyEligibility != 1)
+        {
+            return 2;
+        }
+
+        var fields = _fields;
+        if (fields is not null)
+        {
+            for (var i = 0; i < fields.Count; i++)
+            {
+                var name = fields[i].Name;
+                if (name is PrivateName)
+                {
+                    continue;
+                }
+
+                if (name is not JsString jsString)
+                {
+                    return 2;
+                }
+
+                var stringName = jsString.ToString();
+                if (stringName.Length > 0 && char.IsDigit(stringName[0]))
+                {
+                    return 2;
+                }
+            }
+        }
+
+        return 1;
     }
 
     internal void MakeClassConstructor()

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -37,11 +37,12 @@ public sealed class ScriptFunction : Function, IConstructor
 
     // Static eligibility verdict for this function instance: 0 = not yet analyzed, 1 = eligible
     // (body statically clean AND every class field name shape-compatible), 2 = ineligible. Provably
-    // clean constructors skip the sampling window and shape from instance #1 — a short-lived engine
-    // constructing 1-15 instances of each type otherwise never promotes. Combines the AST-pure
-    // State.CtorBodyShapeEligibility with the per-function class-fields check; the combined verdict
-    // cannot live on the shared State because the shared empty-constructor AST serves classes with
-    // different fields.
+    // clean constructors skip the sampling window and shape from instance #2 — a short-lived engine
+    // constructing 2-15 instances of each type otherwise never promotes — while instance #1 stays on
+    // the dictionary path so a one-shot constructor interns no shape state at all. Combines the
+    // AST-pure State.CtorBodyShapeEligibility with the per-function class-fields check; the combined
+    // verdict cannot live on the shared State because the shared empty-constructor AST serves classes
+    // with different fields.
     private byte _ctorStaticEligibility;
     private int _ctorSampleCount;
     private Shape? _ctorEmptyShape;
@@ -314,7 +315,7 @@ public sealed class ScriptFunction : Function, IConstructor
             // Once the constructor is hot, start each fresh `this` in shape-building mode so this.x= /
             // class fields transition a shared interned hidden class instead of building a dictionary.
             // Cold constructors (below the promote threshold) stay on the dictionary path — unless the
-            // body is statically provably clean, in which case shaping starts at instance #1.
+            // body is statically provably clean, in which case shaping starts already at instance #2.
             if (thisArgument is JsObject thisObject && thisObject.Prototype is { } proto)
             {
                 if (_ctorShaped || CheckCtorShapeEligibility(state))
@@ -396,12 +397,16 @@ public sealed class ScriptFunction : Function, IConstructor
 
     /// <summary>
     /// Cold-path shaping decision for a not-yet-promoted constructor: statically clean bodies (see
-    /// <see cref="JintFunctionDefinition.ComputeCtorBodyShapeEligibility"/>) start shaping at instance #1,
-    /// everything else keeps the sampling threshold with its pre-existing pacing (the threshold-tripping
-    /// instance itself stays on the dictionary path; the next construct starts shaped). Returns whether
-    /// the CURRENT instance should start in shape-building mode. Contingency lever: should first-instance
-    /// shaping ever show one-shot-constructor regressions, eligible constructors can instead promote at
-    /// instance #2 by setting _ctorShaped without returning true on the first call.
+    /// <see cref="JintFunctionDefinition.ComputeCtorBodyShapeEligibility"/>) promote on their FIRST
+    /// construction but shape from instance #2 — the first instance stays on the dictionary path, so a
+    /// one-shot constructor (the overwhelming norm) never interns a transition tree, empty-shape root or
+    /// prototype CWT entry for a layout that is never reused. Measured on a 200-distinct-one-shot-ctor
+    /// guard, shaping at instance #1 regressed time/alloc ~20%, while the #2 start keeps 7/8 of the
+    /// shaping win on hot allocation sites; the documented alternative (shape from instance #1) is
+    /// `return true` from the eligible branch. Everything else keeps the sampling threshold with its
+    /// pre-existing pacing (the threshold-tripping instance itself stays on the dictionary path; the
+    /// next construct starts shaped). Returns whether the CURRENT instance should start in
+    /// shape-building mode.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     private bool CheckCtorShapeEligibility(JintFunctionDefinition.State state)
@@ -414,8 +419,9 @@ public sealed class ScriptFunction : Function, IConstructor
 
         if (eligibility == 1)
         {
+            // shape from the NEXT construction on
             _ctorShaped = true;
-            return true;
+            return false;
         }
 
         if (++_ctorSampleCount >= CtorShapePromoteThreshold)

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -37,12 +37,13 @@ public sealed class ScriptFunction : Function, IConstructor
 
     // Static eligibility verdict for this function instance: 0 = not yet analyzed, 1 = eligible
     // (body statically clean AND every class field name shape-compatible), 2 = ineligible. Provably
-    // clean constructors skip the sampling window and shape from instance #2 — a short-lived engine
-    // constructing 2-15 instances of each type otherwise never promotes — while instance #1 stays on
-    // the dictionary path so a one-shot constructor interns no shape state at all. Combines the
-    // AST-pure State.CtorBodyShapeEligibility with the per-function class-fields check; the combined
-    // verdict cannot live on the shared State because the shared empty-constructor AST serves classes
-    // with different fields.
+    // clean constructors skip the sampling window and shape from instance #3 — a short-lived engine
+    // constructing 3-15 instances of each type otherwise never promotes — while instances #1 and #2
+    // stay on the dictionary path: the shared per-prototype transition tree only pays off from about
+    // three instances of a layout, so constructors of unrepeated layouts intern no shape state at
+    // all. Combines the AST-pure State.CtorBodyShapeEligibility with the per-function class-fields
+    // check; the combined verdict cannot live on the shared State because the shared
+    // empty-constructor AST serves classes with different fields.
     private byte _ctorStaticEligibility;
     private int _ctorSampleCount;
     private Shape? _ctorEmptyShape;
@@ -315,7 +316,7 @@ public sealed class ScriptFunction : Function, IConstructor
             // Once the constructor is hot, start each fresh `this` in shape-building mode so this.x= /
             // class fields transition a shared interned hidden class instead of building a dictionary.
             // Cold constructors (below the promote threshold) stay on the dictionary path — unless the
-            // body is statically provably clean, in which case shaping starts already at instance #2.
+            // body is statically provably clean, in which case shaping starts already at instance #3.
             if (thisArgument is JsObject thisObject && thisObject.Prototype is { } proto)
             {
                 if (_ctorShaped || CheckCtorShapeEligibility(state))
@@ -397,16 +398,17 @@ public sealed class ScriptFunction : Function, IConstructor
 
     /// <summary>
     /// Cold-path shaping decision for a not-yet-promoted constructor: statically clean bodies (see
-    /// <see cref="JintFunctionDefinition.ComputeCtorBodyShapeEligibility"/>) promote on their FIRST
-    /// construction but shape from instance #2 — the first instance stays on the dictionary path, so a
-    /// one-shot constructor (the overwhelming norm) never interns a transition tree, empty-shape root or
-    /// prototype CWT entry for a layout that is never reused. Measured on a 200-distinct-one-shot-ctor
-    /// guard, shaping at instance #1 regressed time/alloc ~20%, while the #2 start keeps 7/8 of the
-    /// shaping win on hot allocation sites; the documented alternative (shape from instance #1) is
-    /// `return true` from the eligible branch. Everything else keeps the sampling threshold with its
-    /// pre-existing pacing (the threshold-tripping instance itself stays on the dictionary path; the
-    /// next construct starts shaped). Returns whether the CURRENT instance should start in
-    /// shape-building mode.
+    /// <see cref="JintFunctionDefinition.ComputeCtorBodyShapeEligibility"/>) promote after their SECOND
+    /// construction and shape from instance #3 — instances #1 and #2 stay on the dictionary path, so
+    /// constructors of layouts that never recur (the overwhelming norm) intern no transition tree,
+    /// empty-shape root or prototype CWT entry. Measured: shaping at instance #1 regressed a
+    /// 200-distinct-one-shot-ctor guard ~20% time/alloc; shaping at instance #2 still lost ~3% time /
+    /// ~440 B per eval on re-evaluated class declarations constructing exactly two instances — the
+    /// interned tree pays off at ≥3 instances of a layout. (Documented alternatives: shape from #1 =
+    /// `return true` from the eligible branch; from #2 = set _ctorShaped unconditionally there.)
+    /// Ineligible bodies keep the sampling threshold with its pre-existing pacing (the
+    /// threshold-tripping instance itself stays on the dictionary path; the next construct starts
+    /// shaped). Returns whether the CURRENT instance should start in shape-building mode.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     private bool CheckCtorShapeEligibility(JintFunctionDefinition.State state)
@@ -419,8 +421,11 @@ public sealed class ScriptFunction : Function, IConstructor
 
         if (eligibility == 1)
         {
-            // shape from the NEXT construction on
-            _ctorShaped = true;
+            // dictionaries for the first two instances; shape from the THIRD construction on
+            if (++_ctorSampleCount >= 2)
+            {
+                _ctorShaped = true;
+            }
             return false;
         }
 

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -770,9 +770,9 @@ internal sealed class JintFunctionDefinition
 
     /// <summary>
     /// Statically classifies a constructor body as safe to start hidden-class shape building from the
-    /// second instance on (see ScriptFunction's [[Construct]]; instance #1 stays dictionary-mode so
-    /// one-shot constructors intern no shape state) instead of after the sampling threshold.
-    /// Eligible bodies consist, at the top level, only of:
+    /// third instance on (see ScriptFunction's [[Construct]]; instances #1 and #2 stay dictionary-mode
+    /// so constructors of unrepeated layouts intern no shape state) instead of after the sampling
+    /// threshold. Eligible bodies consist, at the top level, only of:
     /// <list type="bullet">
     /// <item><c>this.identifier = value</c> assignments (plain <c>=</c>; non-computed, so index-like keys
     /// are excluded by grammar) whose RHS contains no call that can observe <c>this</c>;</item>

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -430,6 +430,15 @@ internal sealed class JintFunctionDefinition
         // references, and so can safely be shared across instances and engines.
         public bool IsDirectRecursive;
 
+        /// <summary>
+        /// Static constructor-body shape eligibility (see <see cref="ComputeCtorBodyShapeEligibility"/>):
+        /// 0 = not yet analyzed, 1 = eligible, 2 = ineligible. Computed lazily on first [[Construct]] —
+        /// never in BuildState, so never-constructed functions pay nothing. A pure function of the
+        /// immutable AST, so it is safe on this cross-engine shared State: racing recomputation is
+        /// idempotent and the byte write is atomic.
+        /// </summary>
+        public byte CtorBodyShapeEligibility;
+
         // Cleared fixed-slot Binding[] reused by the next call to any function instance sharing this State
         // (also across engines — e.g. freshly created instances when a prepared script is re-evaluated).
         // Interlocked is required: parallel test fixtures share cached States (see PR #2418 fallout).
@@ -757,6 +766,143 @@ internal sealed class JintFunctionDefinition
         state.SourceText = new SourceText(fullSourceText);
 
         return state;
+    }
+
+    /// <summary>
+    /// Statically classifies a constructor body as safe to start hidden-class shape building from the
+    /// very first instance (see ScriptFunction's [[Construct]]) instead of after the sampling threshold.
+    /// Eligible bodies consist, at the top level, only of:
+    /// <list type="bullet">
+    /// <item><c>this.identifier = value</c> assignments (plain <c>=</c>; non-computed, so index-like keys
+    /// are excluded by grammar) whose RHS contains no call that can observe <c>this</c>;</item>
+    /// <item><c>var</c>/<c>let</c>/<c>const</c> declarations, under the same no-this-escaping-call scan
+    /// (<c>var x = f(this)</c> is the same hazard as <c>this.x = f(this)</c>);</item>
+    /// <item>directives, empty statements and argument-less <c>return</c>s (in a base constructor
+    /// <c>return;</c> just yields <c>this</c>);</item>
+    /// </list>
+    /// and parameter defaults/patterns pass the same call scan (they evaluate during construction, after
+    /// <c>this</c> is bound). An EMPTY body is eligible — this covers class default constructors, whose
+    /// fields are vetted separately per function instance (the empty-constructor AST and hence this
+    /// verdict are shared across classes). A this-escaping call could add data-dependent keys mid-build,
+    /// polluting the shared per-prototype transition tree — the real hazard. Allowed: this-free calls
+    /// (<c>Date.now()</c>), <c>this.a</c> reads, literals, and function/arrow DEFINITIONS that capture
+    /// <c>this</c> (they cannot run during construction in an otherwise-eligible body). Anything else —
+    /// control flow, computed or non-this member targets, compound assignments — is ineligible and keeps
+    /// the sampling behavior. Purely a heuristic: TryShapeAdd's megamorphic guards and the dictionary
+    /// deopt remain the correctness authority either way.
+    /// </summary>
+    internal static bool ComputeCtorBodyShapeEligibility(IFunction function)
+    {
+        if (function.Body is not FunctionBody body)
+        {
+            // expression-bodied arrow — not constructible anyway
+            return false;
+        }
+
+        foreach (var parameter in function.Params.AsSpan())
+        {
+            if (!parameter.ChildNodes.IsEmpty() && ContainsThisEscapingCall(parameter))
+            {
+                return false;
+            }
+        }
+
+        foreach (var statement in body.Body.AsSpan())
+        {
+            switch (statement.Type)
+            {
+                case NodeType.EmptyStatement:
+                    continue;
+
+                case NodeType.ExpressionStatement:
+                    if (statement is Directive)
+                    {
+                        // directive prologue ("use strict") — an inert string literal
+                        continue;
+                    }
+
+                    if (((ExpressionStatement) statement).Expression is AssignmentExpression
+                        {
+                            Operator: Operator.Assignment,
+                            Left: MemberExpression { Object.Type: NodeType.ThisExpression, Computed: false, Property.Type: NodeType.Identifier },
+                        } assignment
+                        && !ContainsThisEscapingCall(assignment.Right))
+                    {
+                        continue;
+                    }
+
+                    return false;
+
+                case NodeType.VariableDeclaration:
+                    if (ContainsThisEscapingCall(statement))
+                    {
+                        return false;
+                    }
+                    continue;
+
+                case NodeType.ReturnStatement:
+                    if (((ReturnStatement) statement).Argument is not null)
+                    {
+                        // `return expr` could replace the instance or evaluate arbitrarily
+                        return false;
+                    }
+                    continue;
+
+                default:
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// True when the subtree contains a call-like node (call / new / tagged template) that could observe
+    /// <c>this</c> — i.e. carries a ThisExpression anywhere inside its own subtree. Function and arrow
+    /// definitions OUTSIDE such call subtrees are skipped: they merely capture <c>this</c> and cannot run
+    /// during construction in an otherwise-eligible body (any invocation route would itself be a rejected
+    /// call). Inside a call subtree nothing is skipped — <c>f(() =&gt; this)</c> hands the callee a live
+    /// capture it could invoke mid-construction. Aliases (<c>var self = this</c> passed to a later call)
+    /// are not tracked; a missed escape only risks bounded transition-tree churn, never correctness.
+    /// </summary>
+    private static bool ContainsThisEscapingCall(Node node)
+    {
+        var type = node.Type;
+        if (type is NodeType.CallExpression or NodeType.NewExpression or NodeType.TaggedTemplateExpression)
+        {
+            // A this-free call cannot leak `this`, and nothing nested inside it (including further
+            // calls) can contain one either — so this check is complete for the whole subtree.
+            return ContainsThis(node);
+        }
+
+        if (type is NodeType.FunctionExpression or NodeType.ArrowFunctionExpression or NodeType.FunctionDeclaration)
+        {
+            return false;
+        }
+
+        foreach (var childNode in node.ChildNodes)
+        {
+            if (!childNode.ChildNodes.IsEmpty() && ContainsThisEscapingCall(childNode))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsThis(Node node)
+    {
+        foreach (var childNode in node.ChildNodes)
+        {
+            if (childNode.Type == NodeType.ThisExpression
+                || (!childNode.ChildNodes.IsEmpty() && ContainsThis(childNode)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static void GetBoundNames(

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -770,7 +770,8 @@ internal sealed class JintFunctionDefinition
 
     /// <summary>
     /// Statically classifies a constructor body as safe to start hidden-class shape building from the
-    /// very first instance (see ScriptFunction's [[Construct]]) instead of after the sampling threshold.
+    /// second instance on (see ScriptFunction's [[Construct]]; instance #1 stays dictionary-mode so
+    /// one-shot constructors intern no shape state) instead of after the sampling threshold.
     /// Eligible bodies consist, at the top level, only of:
     /// <list type="bullet">
     /// <item><c>this.identifier = value</c> assignments (plain <c>=</c>; non-computed, so index-like keys


### PR DESCRIPTION
## Problem

Constructors build dictionary-mode instances until allocation-site sampling promotes them at the **16th** construction. Short-lived / per-request engines constructing a handful of instances of each type never promote and lose hidden-class shaping entirely — the `ColdConstructorBenchmark.FunctionCtor_x8` row (fresh engine, 8 instances) sits wholly inside that window.

## Approach

Static eligibility analysis, computed lazily on first `[[Construct]]` and cached AST-pure on the shared `JintFunctionDefinition.State`: a body consisting only of plain `this.identifier = value` assignments (plus variable declarations, directives, empty statements, argument-less returns; empty bodies eligible — covers class default ctors) where no call/new reachable during construction (assignment RHS, var initializers, parameter defaults) carries `this` in its subtree. Class field names are vetted per function (plain non-index string keys; private names fine). Eligible constructors skip most of the sampling window and **start shaping at instance #3**; ineligible ones keep the existing 16-threshold with identical pacing. Correctness never depends on the verdict — the megamorphic guards and dictionary deopt are unchanged.

Why instance #3 (the commit history tells the full story): promote-at-#1 regressed the diverse-ctor guard (`DistinctCtors200` +21% time / +19% alloc — 200 one-shot ctors interning transition trees with zero reuse); promote-at-#2 fixed that but regressed `ClassBenchmark.ReEvaluateClassDeclarations` (+2.8% alloc — its classes construct exactly twice per evaluation, and a tree interned for one shaped instance is a net loss). The transition tree pays for itself at ≥3 instances, so that's where eligible promotion sits; both alternatives are documented in code.

## Benchmarks (default job; ColdConstructor rows at `--launchCount 5`, medians quoted; baseline = upstream/main `463157397`)

| ColdConstructorBenchmark (fresh engine/op) | main (median) | PR (median) | Δ time | Δ alloc |
|---|---|---|---|---|
| EngineOnly (baseline row) | 543.6 ns | 541.6 ns | flat | byte-identical |
| FunctionCtor_x8 | 10,406.8 ns / 23.32 KB | 11,247.7 ns / 22.58 KB | +8.1% | **−3.2%** |
| FunctionCtor_x64 | 57,111.7 ns / 48.24 KB | 56,283.3 ns / 41.46 KB | −1.5% | **−14.1%** |
| FunctionCtor_x1000 | 817,414.3 ns / 363.15 KB | 805,496.6 ns / 356.37 KB | −1.5% | −1.9% |
| ClassCtor_x8 | 10,602.8 ns / 23.70 KB | 11,234.1 ns / 22.95 KB | +6.0% | **−3.2%** |
| DistinctCtors200 (diverse guard) | 339,317.2 ns / 957 KB | 346,583.7 ns / 957 KB | +2.1% | **byte-identical** |

Guards: `ClassBenchmark` all rows allocation byte-identical (incl. `ReEvaluateClassDeclarations` 635.79 MB both sides), times within noise; `PropertyAllocBenchmark` unchanged.

**Honest framing of the x8 time cost:** this row re-creates the engine *and prototype* every op, so instances 3–8 pay the one-time transition-tree interning amortized over just six instances (+~105 ns/instance); at x64 the same interning amortizes away and the row flips to a win (−14.1% alloc, time flat). Real embeddings that reuse engines intern each layout once for the prototype's lifetime — the fresh-per-op row is the worst case by construction. If the trade reads wrong, the eligible path is one line to revert to threshold-only.

## Verification

- 16 pins in `ConstructorShapeEligibilityTests` (instance #1/#2 not shaped, #3 shaped + Shape-reference sharing; incremental `this.b = this.a + 1` visibility; ineligible bodies byte-parity incl. computed/`this`-escaping shapes; class fields incl. computed-name-"0" fallback + private fields; derived + `Reflect.construct` foreign newTarget; 70-assignment guard trip mid-ctor; prototype reassignment; post-construction delete/defineProperty deopt) — 16/16 both TFMs; related+safety suites 882/882 both TFMs; full Jint.Tests 3353/3353 + 3290/3290; PublicInterface 82/82 both TFMs (pre-drift window).
- **Full Test262: 99,426 / 0 on the lever commit; final-commit run had 4 wall-clock timeouts in the known slowest family (`annexB` RegExp escape-BMP) after ~40 min of continuous benching — isolated rerun 124/124 in 6 s.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
