### PR TITLE
Return the tag reference to the pool; fix tagged-template this-binding

### DIFF
--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -113,6 +113,70 @@ bar += 'bar';
     }
 
     [Fact]
+    public void TaggedTemplateCachesTemplateObjectPerCallSite()
+    {
+        var engine = new Engine();
+
+        // https://tc39.es/ecma262/#sec-gettemplateobject : the same call site must pass
+        // the identical (frozen) strings array on every invocation; raw preserves escapes.
+        var result = engine.Evaluate("""
+            var seen = [];
+            function tag(strings, v) { seen.push(strings); return strings[0] + v + strings[1]; }
+            function run(v) { return tag`a ${v}\n`; }
+            var r1 = run(1);
+            var r2 = run(2);
+            JSON.stringify({
+                r1: r1,
+                r2: r2,
+                sameIdentity: seen[0] === seen[1],
+                frozen: Object.isFrozen(seen[0]) && Object.isFrozen(seen[0].raw),
+                cooked: seen[0][1] === '\n',
+                raw: seen[0].raw[1] === '\\n',
+                distinctSites: (function () { tag`x${0}`; tag`x${0}`; return seen[seen.length - 2] !== seen[seen.length - 1]; })()
+            });
+            """).AsString();
+
+        Assert.Equal(
+            """{"r1":"a 1\n","r2":"a 2\n","sameIdentity":true,"frozen":true,"cooked":true,"raw":true,"distinctSites":true}""",
+            result);
+    }
+
+    [Fact]
+    public void TaggedTemplateMemberTagPreservesThisBinding()
+    {
+        var engine = new Engine();
+
+        // https://tc39.es/ecma262/#sec-evaluatecall : a member-expression tag is called with its receiver as `this`
+        Assert.Equal("x 6 y", engine.Evaluate("""
+            var obj = { mul: 3, tag: function (strings, v) { return strings[0] + (v * this.mul) + strings[1]; } };
+            obj.tag`x ${2} y`;
+            """).AsString());
+
+        // computed member tag
+        Assert.Equal("x 12 y", engine.Evaluate("obj['tag']`x ${4} y`;").AsString());
+
+        // super property tag: GetThisValue returns the reference's [[ThisValue]] (the instance), not the home object
+        Assert.Equal("b:q1", engine.Evaluate("""
+            class A { tag(strings, v) { return this.name + ':' + strings[0] + v; } }
+            class B extends A { constructor() { super(); this.name = 'b'; } m() { return super.tag`q${1}`; } }
+            new B().m();
+            """).AsString());
+
+        // `with`-scoped tag: this is the with-statement binding object (WithBaseObject)
+        Assert.True(engine.Evaluate("""
+            var box = { tag: function (strings) { return this === box; } };
+            var wr; with (box) { wr = tag`x`; }
+            wr;
+            """).AsBoolean());
+
+        // plain identifier tag in sloppy mode: this is undefined, coerced to globalThis by the call
+        Assert.True(engine.Evaluate("""
+            function gt() { return this === globalThis; }
+            gt`x`;
+            """).AsBoolean());
+    }
+
+    [Fact]
     public void ShouldCompareWithLocale()
     {
         var engine = new Engine();

--- a/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintTaggedTemplateExpression.cs
@@ -1,6 +1,7 @@
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
+using Environment = Jint.Runtime.Environments.Environment;
 
 namespace Jint.Runtime.Interpreter.Expressions;
 
@@ -38,7 +39,7 @@ internal sealed class JintTaggedTemplateExpression : JintExpression
         }
         else
         {
-            var identifier = _tagIdentifier.Evaluate(context);
+            var tagValue = _tagIdentifier.Evaluate(context);
             if (context.IsSuspended())
             {
                 // _tagIdentifier (e.g. a member expression) suspended; that expression
@@ -46,16 +47,34 @@ internal sealed class JintTaggedTemplateExpression : JintExpression
                 return JsValue.Undefined;
             }
 
-            var taggerCandidate = engine.GetValue(identifier) as ICallable;
+            var taggerCandidate = engine.GetValue(tagValue) as ICallable;
             if (taggerCandidate is null)
             {
                 Throw.TypeError(engine.Realm, "Argument must be callable");
             }
             tagger = taggerCandidate;
 
-            thisObject = identifier is Reference reference && reference.IsPropertyReference
-                ? reference.Base
-                : JsValue.Undefined;
+            // https://tc39.es/ecma262/#sec-evaluatecall steps 1-2: property references call with
+            // GetThisValue (the receiver, or [[ThisValue]] for super tags), environment references
+            // with WithBaseObject (the binding object inside `with`, undefined otherwise).
+            if (tagValue is Reference reference)
+            {
+                if (reference.IsPropertyReference)
+                {
+                    thisObject = reference.ThisValue;
+                }
+                else
+                {
+                    thisObject = reference.Base is Environment refEnv ? refEnv.WithBaseObject() : JsValue.Undefined;
+                }
+
+                // the reference is fully consumed; return it so each tagged call doesn't leak one pooled instance
+                engine._referencePool.Return(reference);
+            }
+            else
+            {
+                thisObject = JsValue.Undefined;
+            }
 
             args = engine._jsValueArrayPool.RentArray(expressions.Length + 1);
             args[0] = GetTemplateObject(context);


### PR DESCRIPTION
## Problem

Every tagged-template invocation leaks one pooled `Reference`: `JintTaggedTemplateExpression` evaluates its tag expression (which rents a `Reference` from the pool) and reads the this-binding off it, but never returns it — `JintCallExpression` has the matching `_referencePool.Return(...)`, the tagged path didn't. With the pool holding only 10 instances, every call past warm-up allocates a fresh Reference: ~48 B/call, and 99.2% of the new `TemplateLiteralBenchmark.TaggedTemplate` row's allocation.

## Fix

Return the reference to the pool once the tagger and this-binding are extracted (before the interpolation loop, so the mid-interpolation suspension path can't leak either). While touching those exact lines, the this-binding now matches spec EvaluateCall the way `JintCallExpression` already does — which fixed two latent bugs confirmed on unmodified main:

- `super.tag`…`` ` bound the home-object prototype instead of the instance `this` (now uses `ThisValue`);
- `with (obj) { tag`…` }` bound `globalThis` instead of the with-object (now uses `WithBaseObject()`, guarded so custom-resolver sentinels keep their old behavior).

Template-object caching (per-site strings-array identity) is untouched and now pinned. Optional-chained tags are a parse-time SyntaxError, so no interplay.

## Benchmarks (default job, baseline = upstream/main `4ccc2718e`, back-to-back)

| TemplateLiteralBenchmark | main | PR | Δ time | Δ alloc |
|---|---|---|---|---|
| TaggedTemplate (100k calls) | 28.34 ms / 4.58 MB | 24.33 ms / **2.52 KB** | **−14.2%** | **−99.9%** |
| ManyInterpolations (guard) | 25.02 ms / 9.92 MB | 24.44 ms / 9.92 MB | −2.3% | byte-identical |
| NestedTemplate (guard) | 19.82 ms / 16.02 MB | 20.55 ms / 16.02 MB | +3.7% | byte-identical |
| NumberInterpolation (guard) | 13.29 ms / 12.62 MB | 12.36 ms (median) / 12.62 MB | noise | byte-identical |

Guards never execute the changed code; their time deltas are mixed-sign within the documented noise band with byte-identical allocations. A per-call probe confirms 48.03 → 0.03 B/call over 100k tagged calls.

## Verification

- 2 new facts in StringTests: per-site template-object identity across calls (+ distinct across sites, frozen, cooked-vs-raw) and this-binding coverage (member tag, computed-member tag, `super` instance-this, `with`-object this, sloppy-global coercion).
- Template/tagged filters 9/9 both TFMs; sanity sweep (String/Async/Generator/Destructuring/Eval) 1022+1064; full Jint.Tests **3375/3375 + 3312/3312**; PublicInterface 82/82 both TFMs.
- **Full Test262: 99,426 passed / 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
