### PR TITLE
Allocate no function objects for engine-internal promise reactions and resolving functions

### DIFF
--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -1,5 +1,6 @@
 using Jint.Native;
 using Jint.Native.Object;
+using Jint.Native.Promise;
 using Jint.Runtime;
 
 // obsolete GetCompletionValue
@@ -714,5 +715,237 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
 
         var result = await unwrapTask;
         Assert.Equal(99, result.AsInteger());
+    }
+
+    // ========================================================================
+    // Internal-continuation reaction allocation cut — spec-observability pins.
+    // These guard the engine-internal await/reaction fast paths against
+    // regressing microtask ordering, unhandled-rejection tracking, thenable
+    // adoption, species subclassing, and resolving-function observability.
+    // ========================================================================
+
+    [Fact]
+    public void AwaitAndThenInterleaveInSpecMicrotaskOrder()
+    {
+        // Classic resolved-await vs then interleaving. `await` costs one microtask tick,
+        // so the two async steps interleave with the three .then steps in a fixed pattern.
+        var engine = new Engine();
+        engine.Evaluate("var log = [];");
+
+        engine.Execute("""
+            async function a() {
+                log.push('a1');
+                await Promise.resolve();
+                log.push('a2');
+                await Promise.resolve();
+                log.push('a3');
+            }
+            Promise.resolve()
+                .then(function () { log.push('t1'); })
+                .then(function () { log.push('t2'); })
+                .then(function () { log.push('t3'); });
+            a();
+        """);
+
+        var log = engine.GetValue("log").AsArray();
+        string[] expected = ["a1", "t1", "a2", "t2", "a3", "t3"];
+        Assert.Equal(expected, log.Select(x => x.AsString()).ToArray());
+    }
+
+    [Fact]
+    public void AwaitOfPrimitiveStillCostsExactlyOneTick()
+    {
+        // The primitive-await fast path must not skip the microtask: `await 1` interleaves
+        // with a competing then-chain exactly like `await Promise.resolve(1)` would.
+        var engine = new Engine();
+        engine.Evaluate("var log = [];");
+
+        engine.Execute("""
+            async function a() {
+                log.push('a1');
+                await 1;
+                log.push('a2');
+                await 2;
+                log.push('a3');
+            }
+            Promise.resolve()
+                .then(function () { log.push('t1'); })
+                .then(function () { log.push('t2'); })
+                .then(function () { log.push('t3'); });
+            a();
+        """);
+
+        var log = engine.GetValue("log").AsArray();
+        string[] expected = ["a1", "t1", "a2", "t2", "a3", "t3"];
+        Assert.Equal(expected, log.Select(x => x.AsString()).ToArray());
+    }
+
+    [Fact]
+    public void AwaitedRejectionCaughtInsideAsyncFunctionIsTrackedThenHandled()
+    {
+        var engine = new Engine();
+        var operations = new List<PromiseRejectionOperation>();
+        engine.Advanced.PromiseRejectionTracker += (_, args) => operations.Add(args.Operation);
+
+        engine.Evaluate("var caught = '';");
+        engine.Execute("""
+            (async function () {
+                try {
+                    await Promise.reject('boom');
+                } catch (e) {
+                    caught = e;
+                }
+            })();
+        """);
+        engine.Advanced.ProcessTasks();
+
+        Assert.Equal("boom", engine.GetValue("caught").AsString());
+        // Promise.reject creates an already-rejected promise (fires Reject), and the await's
+        // internal continuation attaches a handler via PerformPromiseThen (fires Handle).
+        // The internal-continuation path must keep firing BOTH tracker operations, exactly
+        // like an explicit .catch() would — the rejection is ultimately handled.
+        Assert.Equal([PromiseRejectionOperation.Reject, PromiseRejectionOperation.Handle], operations);
+    }
+
+    [Fact]
+    public void UncaughtAwaitedRejectionRejectsTheAsyncFunctionsPromise()
+    {
+        var engine = new Engine();
+
+        var result = engine.Evaluate("""
+            (async function () {
+                await Promise.reject('propagated');
+            })();
+        """);
+
+        var ex = Assert.Throws<PromiseRejectedException>(() => result.UnwrapIfPromise());
+        Assert.Equal("propagated", ex.RejectedValue.AsString());
+    }
+
+    [Fact]
+    public void AwaitAdoptsThenableViaResolve()
+    {
+        // Awaiting a non-promise thenable must run PromiseResolve (read .then, adopt it),
+        // which the fast path preserves for object values.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (async function () {
+                return await { then: function (resolve) { resolve(42); } };
+            })();
+        """);
+
+        Assert.Equal(42, result.UnwrapIfPromise().AsInteger());
+    }
+
+    [Fact]
+    public void ThenGetterThrowIsCaughtAsRejectionOfAwait()
+    {
+        // The .then read during PromiseResolve can throw (a getter); that must reject,
+        // and the await must observe it as a throw.
+        var engine = new Engine();
+        engine.Evaluate("var caught = '';");
+        engine.Execute("""
+            (async function () {
+                try {
+                    await { get then() { throw 'getter-boom'; } };
+                } catch (e) {
+                    caught = e;
+                }
+            })();
+        """);
+        engine.Advanced.ProcessTasks();
+
+        Assert.Equal("getter-boom", engine.GetValue("caught").AsString());
+    }
+
+    [Fact]
+    public void ThenOnSubclassUsesSpeciesConstructorForResultCapability()
+    {
+        // Promise.prototype.then goes through SpeciesConstructor; a subclass must NOT hit the
+        // intrinsic fast path — the result capability must be an instance of the subclass.
+        var engine = new Engine();
+        engine.Evaluate("var subIsMy = false; var subVal = 0;");
+        engine.Execute("""
+            class MyPromise extends Promise {}
+            var sub = MyPromise.resolve(7).then(function (x) { return x + 1; });
+            subIsMy = sub instanceof MyPromise;
+            sub.then(function (v) { subVal = v; });
+        """);
+        engine.Advanced.ProcessTasks();
+
+        Assert.True(engine.GetValue("subIsMy").AsBoolean());
+        Assert.Equal(8, engine.GetValue("subVal").AsInteger());
+    }
+
+    [Fact]
+    public void ExecutorResolveFunctionsAreCallableIdempotentAndObservable()
+    {
+        // `new Promise(executor)` must still hand the executor real resolving functions
+        // with name "" / length 1, and resolve/reject share one [[AlreadyResolved]].
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var meta;
+            var p = new Promise(function (resolve, reject) {
+                meta = typeof resolve + '/' + resolve.length + '/' + JSON.stringify(resolve.name)
+                     + '/' + (typeof reject) + '/' + (resolve === reject);
+                resolve(11);
+                resolve(22); // idempotent - ignored
+                reject(33);  // idempotent - ignored
+            });
+            p.then(function (v) { meta = meta + '/' + v; });
+            meta;
+        """);
+        // meta captured before the .then microtask runs
+        Assert.Equal("function/1/\"\"/function/false", result.AsString());
+
+        var settled = engine.GetValue("p");
+        Assert.Equal(11, settled.UnwrapIfPromise().AsInteger());
+    }
+
+    [Fact]
+    public void WithResolversExposesCallableIdempotentResolvingFunctions()
+    {
+        // Promise.withResolvers goes through NewPromiseCapability on the intrinsic (fast path);
+        // the escaping resolve/reject must still be real, stable, idempotent functions.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var wr = Promise.withResolvers();
+            var meta = typeof wr.resolve + '/' + wr.resolve.length + '/' + JSON.stringify(wr.resolve.name)
+                     + '/' + (wr.resolve === wr.resolve);
+            wr.resolve('first');
+            wr.resolve('second'); // idempotent
+            wr.reject('nope');    // idempotent
+            meta;
+        """);
+        Assert.Equal("function/1/\"\"/true", result.AsString());
+
+        Assert.Equal("first", engine.GetValue("wr").AsObject().Get("promise").UnwrapIfPromise().AsString());
+    }
+
+    [Fact]
+    public void PromiseAllMixesResolvedPromisesAndPlainValues()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            Promise.all([Promise.resolve(1), 2, Promise.resolve(3)]).then(function (r) { return r.join('-'); });
+        """);
+
+        Assert.Equal("1-2-3", result.UnwrapIfPromise().AsString());
+    }
+
+    [Fact]
+    public void LongAwaitLoopAccumulatesCorrectly()
+    {
+        // Exercises the resolved-promise await fast path at volume (the AwaitResolvedLoop shape).
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (async function () {
+                var s = 0;
+                for (var i = 0; i < 1000; i++) { s += await Promise.resolve(1); }
+                return s;
+            })();
+        """);
+
+        Assert.Equal(1000, result.UnwrapIfPromise().AsInteger());
     }
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -684,6 +684,15 @@ public sealed partial class Engine : IDisposable
     }
 
     /// <summary>
+    /// Enqueues a promise reaction job without allocating a closure: the (reaction, argument)
+    /// pair is the job's state. See <see cref="EventLoopJob"/>.
+    /// </summary>
+    internal void AddToEventLoop(PromiseReaction reaction, JsValue value)
+    {
+        _eventLoop.Enqueue(new EventLoopJob(reaction, value));
+    }
+
+    /// <summary>
     /// Called by the host when a promise rejection is tracked/untracked.
     /// Raises the <see cref="AdvancedOperations.PromiseRejectionTracker"/> event.
     /// </summary>
@@ -699,7 +708,7 @@ public sealed partial class Engine : IDisposable
 
     internal void RunAvailableContinuations()
     {
-        _eventLoop.RunAvailableContinuations();
+        _eventLoop.RunAvailableContinuations(this);
     }
 
     internal void RunBeforeExecuteStatementChecks(StatementOrExpression? statement)

--- a/Jint/Native/Array/ArrayConstructor.cs
+++ b/Jint/Native/Array/ArrayConstructor.cs
@@ -179,17 +179,17 @@ public sealed partial class ArrayConstructor : Constructor
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(Undefined, e.Error);
+            promiseCapability.Reject(e.Error);
         }
         catch (TypeErrorException e)
         {
             var error = _realm.Intrinsics.TypeError.Construct(e.Message);
-            promiseCapability.Reject.Call(Undefined, error);
+            promiseCapability.Reject(error);
         }
         catch (RangeErrorException e)
         {
             var error = _realm.Intrinsics.RangeError.Construct(e.Message);
-            promiseCapability.Reject.Call(Undefined, error);
+            promiseCapability.Reject(error);
         }
     }
 
@@ -308,7 +308,7 @@ public sealed partial class ArrayConstructor : Constructor
             var nextMethod = iterator.Get(CommonProperties.Next);
             if (nextMethod is not ICallable nextCallable)
             {
-                promiseCapability.Reject.Call(Undefined, _realm.Intrinsics.TypeError.Construct("Iterator next is not a function"));
+                promiseCapability.Reject(_realm.Intrinsics.TypeError.Construct("Iterator next is not a function"));
                 return;
             }
 
@@ -323,7 +323,7 @@ public sealed partial class ArrayConstructor : Constructor
                 var iterResult = args.At(0);
                 if (iterResult is not ObjectInstance iterResultObj)
                 {
-                    promiseCapability.Reject.Call(Undefined, _realm.Intrinsics.TypeError.Construct("Iterator result is not an object"));
+                    promiseCapability.Reject(_realm.Intrinsics.TypeError.Construct("Iterator result is not an object"));
                     return Undefined;
                 }
 
@@ -335,11 +335,11 @@ public sealed partial class ArrayConstructor : Constructor
                     try
                     {
                         target.SetLength(capturedK);
-                        promiseCapability.Resolve.Call(Undefined, target.Target);
+                        promiseCapability.Resolve(target.Target);
                     }
                     catch (JavaScriptException e)
                     {
-                        promiseCapability.Reject.Call(Undefined, e.Error);
+                        promiseCapability.Reject(e.Error);
                     }
                     return Undefined;
                 }
@@ -354,7 +354,7 @@ public sealed partial class ArrayConstructor : Constructor
 
             var onRejected = new ClrFunction(_engine, "", (_, args) =>
             {
-                promiseCapability.Reject.Call(Undefined, [args.At(0)]);
+                promiseCapability.Reject(args.At(0));
                 return Undefined;
             }, 1, PropertyFlag.Configurable);
 
@@ -362,7 +362,7 @@ public sealed partial class ArrayConstructor : Constructor
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(Undefined, e.Error);
+            promiseCapability.Reject(e.Error);
         }
     }
 
@@ -391,7 +391,7 @@ public sealed partial class ArrayConstructor : Constructor
             var onRejected = new ClrFunction(_engine, "", (_, args) =>
             {
                 AsyncIteratorClose(_engine, iterator);
-                promiseCapability.Reject.Call(Undefined, [args.At(0)]);
+                promiseCapability.Reject(args.At(0));
                 return Undefined;
             }, 1, PropertyFlag.Configurable);
 
@@ -427,7 +427,7 @@ public sealed partial class ArrayConstructor : Constructor
                 catch (JavaScriptException e)
                 {
                     if (iterator is not null) AsyncIteratorClose(_engine, iterator);
-                    promiseCapability.Reject.Call(Undefined, e.Error);
+                    promiseCapability.Reject(e.Error);
                     return;
                 }
 
@@ -445,7 +445,7 @@ public sealed partial class ArrayConstructor : Constructor
                     catch (JavaScriptException e2)
                     {
                         if (capturedIterator is not null) AsyncIteratorClose(_engine, capturedIterator);
-                        promiseCapability.Reject.Call(Undefined, e2.Error);
+                        promiseCapability.Reject(e2.Error);
                         return Undefined;
                     }
                     _engine.AddToEventLoop(continueLoop);
@@ -455,7 +455,7 @@ public sealed partial class ArrayConstructor : Constructor
                 var onRejected = new ClrFunction(_engine, "", (_, args) =>
                 {
                     if (capturedIterator is not null) AsyncIteratorClose(_engine, capturedIterator);
-                    promiseCapability.Reject.Call(Undefined, [args.At(0)]);
+                    promiseCapability.Reject(args.At(0));
                     return Undefined;
                 }, 1, PropertyFlag.Configurable);
 
@@ -470,7 +470,7 @@ public sealed partial class ArrayConstructor : Constructor
                 catch (JavaScriptException e)
                 {
                     if (iterator is not null) AsyncIteratorClose(_engine, iterator);
-                    promiseCapability.Reject.Call(Undefined, e.Error);
+                    promiseCapability.Reject(e.Error);
                     return;
                 }
                 _engine.AddToEventLoop(continueLoop);
@@ -479,7 +479,7 @@ public sealed partial class ArrayConstructor : Constructor
         catch (JavaScriptException e)
         {
             if (iterator is not null) AsyncIteratorClose(_engine, iterator);
-            promiseCapability.Reject.Call(Undefined, e.Error);
+            promiseCapability.Reject(e.Error);
         }
     }
 
@@ -526,17 +526,17 @@ public sealed partial class ArrayConstructor : Constructor
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(Undefined, e.Error);
+            promiseCapability.Reject(e.Error);
         }
         catch (TypeErrorException e)
         {
             var error = _realm.Intrinsics.TypeError.Construct(e.Message);
-            promiseCapability.Reject.Call(Undefined, error);
+            promiseCapability.Reject(error);
         }
         catch (RangeErrorException e)
         {
             var error = _realm.Intrinsics.RangeError.Construct(e.Message);
-            promiseCapability.Reject.Call(Undefined, error);
+            promiseCapability.Reject(error);
         }
     }
 
@@ -555,11 +555,11 @@ public sealed partial class ArrayConstructor : Constructor
             try
             {
                 target.SetLength(len);
-                promiseCapability.Resolve.Call(Undefined, target.Target);
+                promiseCapability.Resolve(target.Target);
             }
             catch (JavaScriptException e)
             {
-                promiseCapability.Reject.Call(Undefined, e.Error);
+                promiseCapability.Reject(e.Error);
             }
             return;
         }
@@ -583,7 +583,7 @@ public sealed partial class ArrayConstructor : Constructor
 
             var onRejected = new ClrFunction(_engine, "", (_, args) =>
             {
-                promiseCapability.Reject.Call(Undefined, [args.At(0)]);
+                promiseCapability.Reject(args.At(0));
                 return Undefined;
             }, 1, PropertyFlag.Configurable);
 
@@ -591,7 +591,7 @@ public sealed partial class ArrayConstructor : Constructor
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(Undefined, e.Error);
+            promiseCapability.Reject(e.Error);
         }
     }
 
@@ -627,7 +627,7 @@ public sealed partial class ArrayConstructor : Constructor
 
                 var onRejected = new ClrFunction(_engine, "", (_, args) =>
                 {
-                    promiseCapability.Reject.Call(Undefined, [args.At(0)]);
+                    promiseCapability.Reject(args.At(0));
                     return Undefined;
                 }, 1, PropertyFlag.Configurable);
 
@@ -642,7 +642,7 @@ public sealed partial class ArrayConstructor : Constructor
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(Undefined, e.Error);
+            promiseCapability.Reject(e.Error);
         }
     }
 

--- a/Jint/Native/AsyncFunction/AsyncFunctionInstance.cs
+++ b/Jint/Native/AsyncFunction/AsyncFunctionInstance.cs
@@ -2,6 +2,7 @@ using Jint.Native.Promise;
 using Jint.Runtime;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
+using Jint.Runtime.Interpreter.Expressions;
 
 namespace Jint.Native.AsyncFunction;
 
@@ -9,7 +10,7 @@ namespace Jint.Native.AsyncFunction;
 /// Tracks the execution state of an async function, enabling suspension at await points
 /// and resumption when the awaited promise settles.
 /// </summary>
-internal sealed class AsyncFunctionInstance : ISuspendable
+internal sealed class AsyncFunctionInstance : ISuspendable, IPromiseContinuation
 {
     internal AsyncFunctionState _state;
 
@@ -98,6 +99,17 @@ internal sealed class AsyncFunctionInstance : ISuspendable
     /// Used to properly resume execution in finally blocks.
     /// </summary>
     object? ISuspendable.CurrentFinallyStatement { get; set; }
+
+    /// <summary>
+    /// Await continuation (https://tc39.es/ecma262/#await steps 3-9): the promise reaction job
+    /// resumes this instance directly — no JS-callable handler pair is materialized per await.
+    /// </summary>
+    void IPromiseContinuation.Invoke(Engine engine, JsValue value, ReactionType type)
+    {
+        _resumeValue = value;
+        _resumeWithThrow = type == ReactionType.Reject;
+        JintAwaitExpression.AsyncFunctionResume(engine, this);
+    }
 }
 
 /// <summary>

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
@@ -370,7 +370,7 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
     internal void AsyncGeneratorResolve(JsValue value, bool done, PromiseCapability promiseCapability)
     {
         var iterResult = IteratorResult.CreateValueIteratorPosition(_engine, value, done ? JsBoolean.True : JsBoolean.False);
-        promiseCapability.Resolve.Call(Undefined, new[] { iterResult });
+        promiseCapability.Resolve(iterResult);
     }
 
     /// <summary>
@@ -379,7 +379,7 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
     /// </summary>
     internal static void AsyncGeneratorReject(JsValue exception, PromiseCapability promiseCapability)
     {
-        promiseCapability.Reject.Call(JsValue.Undefined, new[] { exception });
+        promiseCapability.Reject(exception);
     }
 
     /// <summary>
@@ -388,7 +388,7 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
     private JsPromise CreateResolvedPromise(JsValue value)
     {
         var capability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
-        capability.Resolve.Call(JsValue.Undefined, new[] { value });
+        capability.Resolve(value);
         return (JsPromise) capability.PromiseInstance;
     }
 

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorPrototype.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorPrototype.cs
@@ -98,7 +98,7 @@ internal sealed partial class AsyncGeneratorPrototype : BuiltinShapeObject
     {
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _realm.Intrinsics.Promise);
         var error = _realm.Intrinsics.TypeError.Construct(message);
-        promiseCapability.Reject.Call(Undefined, new[] { error });
+        promiseCapability.Reject(error);
         return promiseCapability.PromiseInstance;
     }
 }

--- a/Jint/Native/Atomics/AtomicsInstance.cs
+++ b/Jint/Native/Atomics/AtomicsInstance.cs
@@ -205,7 +205,7 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
                 // Queue microtask to resolve the promise
                 _engine.AddToEventLoop(() =>
                 {
-                    _promiseCapability.Resolve.Call(JsValue.Undefined, [new JsString(result)]);
+                    _promiseCapability.Resolve(new JsString(result));
                 });
             }
         }
@@ -681,7 +681,7 @@ internal sealed partial class AtomicsInstance : BuiltinShapeObject
             // No buffer data - resolve immediately with "timed-out"
             _engine.AddToEventLoop(() =>
             {
-                promiseCapability.Resolve.Call(JsValue.Undefined, [new JsString("timed-out")]);
+                promiseCapability.Resolve(new JsString("timed-out"));
             });
         }
 

--- a/Jint/Native/Disposable/AsyncDisposableStackPrototype.cs
+++ b/Jint/Native/Disposable/AsyncDisposableStackPrototype.cs
@@ -59,7 +59,7 @@ internal sealed partial class AsyncDisposableStackPrototype : Prototype
             if (!stack.TryMarkDisposed())
             {
                 // Already disposed — resolve with undefined.
-                capability.Resolve.Call(Undefined, Undefined);
+                capability.Resolve(Undefined);
                 return capability.PromiseInstance;
             }
 
@@ -74,17 +74,17 @@ internal sealed partial class AsyncDisposableStackPrototype : Prototype
                 {
                     if (final.Type == CompletionType.Throw)
                     {
-                        capability.Reject.Call(Undefined, final.Value);
+                        capability.Reject(final.Value);
                     }
                     else
                     {
-                        capability.Resolve.Call(Undefined, Undefined);
+                        capability.Resolve(Undefined);
                     }
                 });
         }
         catch (JavaScriptException e)
         {
-            capability.Reject.Call(Undefined, e.Error);
+            capability.Reject(e.Error);
         }
         return capability.PromiseInstance;
     }

--- a/Jint/Native/Iterator/AsyncFromSyncIterator.cs
+++ b/Jint/Native/Iterator/AsyncFromSyncIterator.cs
@@ -58,7 +58,7 @@ internal sealed partial class AsyncFromSyncIteratorPrototype : ObjectInstance
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(Undefined, [e.Error]);
+            promiseCapability.Reject(e.Error);
             return promiseCapability.PromiseInstance;
         }
 
@@ -83,7 +83,7 @@ internal sealed partial class AsyncFromSyncIteratorPrototype : ObjectInstance
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(Undefined, [e.Error]);
+            promiseCapability.Reject(e.Error);
             return promiseCapability.PromiseInstance;
         }
 
@@ -91,7 +91,7 @@ internal sealed partial class AsyncFromSyncIteratorPrototype : ObjectInstance
         {
             // If return is undefined, create a done iterator result
             var iterResult = IteratorResult.CreateValueIteratorPosition(_engine, value, done: JsBoolean.True);
-            promiseCapability.Resolve.Call(Undefined, new[] { iterResult });
+            promiseCapability.Resolve(iterResult);
             return promiseCapability.PromiseInstance;
         }
 
@@ -103,14 +103,14 @@ internal sealed partial class AsyncFromSyncIteratorPrototype : ObjectInstance
             {
                 // Per spec step 10: reject promise instead of throwing synchronously
                 var typeError = _realm.Intrinsics.TypeError.Construct("Iterator result is not an object");
-                promiseCapability.Reject.Call(Undefined, [typeError]);
+                promiseCapability.Reject(typeError);
                 return promiseCapability.PromiseInstance;
             }
             result = oi;
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(Undefined, [e.Error]);
+            promiseCapability.Reject(e.Error);
             return promiseCapability.PromiseInstance;
         }
 
@@ -135,7 +135,7 @@ internal sealed partial class AsyncFromSyncIteratorPrototype : ObjectInstance
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(Undefined, [e.Error]);
+            promiseCapability.Reject(e.Error);
             return promiseCapability.PromiseInstance;
         }
 
@@ -149,12 +149,12 @@ internal sealed partial class AsyncFromSyncIteratorPrototype : ObjectInstance
             catch (JavaScriptException closeError)
             {
                 // IfAbruptRejectPromise: if close throws, reject with that error
-                promiseCapability.Reject.Call(Undefined, [closeError.Error]);
+                promiseCapability.Reject(closeError.Error);
                 return promiseCapability.PromiseInstance;
             }
 
             var typeError = _realm.Intrinsics.TypeError.Construct("The iterator does not provide a throw method");
-            promiseCapability.Reject.Call(Undefined, [typeError]);
+            promiseCapability.Reject(typeError);
             return promiseCapability.PromiseInstance;
         }
 
@@ -166,14 +166,14 @@ internal sealed partial class AsyncFromSyncIteratorPrototype : ObjectInstance
             {
                 // Per spec step 10: reject promise instead of throwing synchronously
                 var typeError = _realm.Intrinsics.TypeError.Construct("Iterator result is not an object");
-                promiseCapability.Reject.Call(Undefined, [typeError]);
+                promiseCapability.Reject(typeError);
                 return promiseCapability.PromiseInstance;
             }
             result = oi;
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(Undefined, [e.Error]);
+            promiseCapability.Reject(e.Error);
             return promiseCapability.PromiseInstance;
         }
 
@@ -202,7 +202,7 @@ internal sealed partial class AsyncFromSyncIteratorPrototype : ObjectInstance
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(Undefined, [e.Error]);
+            promiseCapability.Reject(e.Error);
             return promiseCapability.PromiseInstance;
         }
 
@@ -228,7 +228,7 @@ internal sealed partial class AsyncFromSyncIteratorPrototype : ObjectInstance
                 }
             }
             // 7. IfAbruptRejectPromise(valueWrapper, promiseCapability).
-            promiseCapability.Reject.Call(Undefined, [e.Error]);
+            promiseCapability.Reject(e.Error);
             return promiseCapability.PromiseInstance;
         }
 

--- a/Jint/Native/Iterator/AsyncIteratorConstructor.cs
+++ b/Jint/Native/Iterator/AsyncIteratorConstructor.cs
@@ -194,7 +194,7 @@ internal sealed partial class WrapForValidAsyncIteratorPrototype : Prototype
         }
         catch (JavaScriptException ex)
         {
-            promiseCapability.Reject.Call(Undefined, new[] { ex.Error });
+            promiseCapability.Reject(ex.Error);
         }
 
         return promiseCapability.PromiseInstance;
@@ -223,7 +223,7 @@ internal sealed partial class WrapForValidAsyncIteratorPrototype : Prototype
             {
                 // Return a resolved promise with {value: undefined, done: true}
                 var doneResult = IteratorResult.CreateValueIteratorPosition(_engine, Undefined, JsBoolean.True);
-                promiseCapability.Resolve.Call(Undefined, new JsValue[] { doneResult });
+                promiseCapability.Resolve(doneResult);
             }
             else
             {
@@ -247,7 +247,7 @@ internal sealed partial class WrapForValidAsyncIteratorPrototype : Prototype
         }
         catch (JavaScriptException ex)
         {
-            promiseCapability.Reject.Call(Undefined, new[] { ex.Error });
+            promiseCapability.Reject(ex.Error);
         }
 
         return promiseCapability.PromiseInstance;

--- a/Jint/Native/Iterator/AsyncIteratorHelper.cs
+++ b/Jint/Native/Iterator/AsyncIteratorHelper.cs
@@ -59,7 +59,7 @@ internal abstract class AsyncIteratorHelper : ObjectInstance
                 Exhausted = true;
                 try { Iterated.Close(CompletionType.Throw); } catch { /* ignore */ }
             }
-            promiseCapability.Reject.Call(Undefined, new[] { ex.Error });
+            promiseCapability.Reject(ex.Error);
         }
 
         return promiseCapability.PromiseInstance;
@@ -88,13 +88,13 @@ internal abstract class AsyncIteratorHelper : ObjectInstance
 
                     var onFulfilled = new ClrFunction(_engine, "", (_, _) =>
                     {
-                        promiseCapability.Resolve.Call(Undefined, new JsValue[] { CreateIteratorResult(Undefined, done: true) });
+                        promiseCapability.Resolve(CreateIteratorResult(Undefined, done: true));
                         return Undefined;
                     }, 1, PropertyFlag.Configurable);
 
                     var onRejected = new ClrFunction(_engine, "", (_, args) =>
                     {
-                        promiseCapability.Reject.Call(Undefined, new[] { args.At(0) });
+                        promiseCapability.Reject(args.At(0));
                         return Undefined;
                     }, 1, PropertyFlag.Configurable);
 
@@ -104,13 +104,13 @@ internal abstract class AsyncIteratorHelper : ObjectInstance
             }
             catch (JavaScriptException ex)
             {
-                promiseCapability.Reject.Call(Undefined, new[] { ex.Error });
+                promiseCapability.Reject(ex.Error);
                 return promiseCapability.PromiseInstance;
             }
         }
 
         var doneResult = CreateIteratorResult(Undefined, done: true);
-        promiseCapability.Resolve.Call(Undefined, new JsValue[] { doneResult });
+        promiseCapability.Resolve(doneResult);
         return promiseCapability.PromiseInstance;
     }
 
@@ -147,7 +147,7 @@ internal abstract class AsyncIteratorHelper : ObjectInstance
     {
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
         var result = CreateIteratorResult(value, done);
-        promiseCapability.Resolve.Call(Undefined, new JsValue[] { result });
+        promiseCapability.Resolve(result);
         return promiseCapability.PromiseInstance;
     }
 
@@ -158,7 +158,7 @@ internal abstract class AsyncIteratorHelper : ObjectInstance
     protected void ResolveYield(PromiseCapability promiseCapability, JsValue value)
     {
         State = GeneratorState.SuspendedYield;
-        promiseCapability.Resolve.Call(Undefined, new JsValue[] { CreateIteratorResult(value, done: false) });
+        promiseCapability.Resolve(CreateIteratorResult(value, done: false));
     }
 
     /// <summary>
@@ -169,7 +169,7 @@ internal abstract class AsyncIteratorHelper : ObjectInstance
     {
         State = GeneratorState.Completed;
         Exhausted = true;
-        promiseCapability.Resolve.Call(Undefined, new JsValue[] { CreateIteratorResult(Undefined, done: true) });
+        promiseCapability.Resolve(CreateIteratorResult(Undefined, done: true));
     }
 
     /// <summary>
@@ -180,7 +180,7 @@ internal abstract class AsyncIteratorHelper : ObjectInstance
         State = GeneratorState.Completed;
         Exhausted = true;
         try { Iterated.Close(CompletionType.Throw); } catch { /* ignore */ }
-        promiseCapability.Reject.Call(Undefined, new[] { error });
+        promiseCapability.Reject(error);
     }
 }
 
@@ -388,7 +388,7 @@ internal sealed class AsyncTakeIterator : AsyncIteratorHelper
             State = GeneratorState.Completed;
             Exhausted = true;
             try { Iterated.Close(CompletionType.Normal); } catch { /* ignore */ }
-            promiseCapability.Resolve.Call(Undefined, new JsValue[] { CreateIteratorResult(Undefined, done: true) });
+            promiseCapability.Resolve(CreateIteratorResult(Undefined, done: true));
             return;
         }
 
@@ -550,13 +550,13 @@ internal sealed class AsyncFlatMapIterator : AsyncIteratorHelper
 
                     var onFulfilled = new ClrFunction(_engine, "", (_, _) =>
                     {
-                        promiseCapability.Resolve.Call(Undefined, new JsValue[] { CreateIteratorResult(Undefined, done: true) });
+                        promiseCapability.Resolve(CreateIteratorResult(Undefined, done: true));
                         return Undefined;
                     }, 1, PropertyFlag.Configurable);
 
                     var onRejected = new ClrFunction(_engine, "", (_, args) =>
                     {
-                        promiseCapability.Reject.Call(Undefined, new[] { args.At(0) });
+                        promiseCapability.Reject(args.At(0));
                         return Undefined;
                     }, 1, PropertyFlag.Configurable);
 
@@ -567,11 +567,11 @@ internal sealed class AsyncFlatMapIterator : AsyncIteratorHelper
         }
         catch (JavaScriptException ex)
         {
-            promiseCapability.Reject.Call(Undefined, new[] { ex.Error });
+            promiseCapability.Reject(ex.Error);
             return promiseCapability.PromiseInstance;
         }
 
-        promiseCapability.Resolve.Call(Undefined, new JsValue[] { CreateIteratorResult(Undefined, done: true) });
+        promiseCapability.Resolve(CreateIteratorResult(Undefined, done: true));
         return promiseCapability.PromiseInstance;
     }
 

--- a/Jint/Native/Iterator/AsyncIteratorPrototype.cs
+++ b/Jint/Native/Iterator/AsyncIteratorPrototype.cs
@@ -207,7 +207,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         }
         catch (JavaScriptException ex)
         {
-            promiseCapability.Reject.Call(Undefined, new[] { ex.Error });
+            promiseCapability.Reject(ex.Error);
             return null;
         }
     }
@@ -239,7 +239,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
                 var iterResult = args.At(0);
                 if (iterResult is not ObjectInstance iterResultObj)
                 {
-                    promiseCapability.Reject.Call(Undefined, new JsValue[] { _engine.Realm.Intrinsics.TypeError.Construct("Iterator result is not an object") });
+                    promiseCapability.Reject(_engine.Realm.Intrinsics.TypeError.Construct("Iterator result is not an object"));
                     return Undefined;
                 }
 
@@ -256,14 +256,14 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
             }
             catch (JavaScriptException ex)
             {
-                promiseCapability.Reject.Call(Undefined, new[] { ex.Error });
+                promiseCapability.Reject(ex.Error);
                 return Undefined;
             }
         }, 1, PropertyFlag.Configurable);
 
         var onRejected = new ClrFunction(_engine, "", (_, args) =>
         {
-            promiseCapability.Reject.Call(Undefined, new[] { args.At(0) });
+            promiseCapability.Reject(args.At(0));
             return Undefined;
         }, 1, PropertyFlag.Configurable);
 
@@ -291,7 +291,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         var onRejected = new ClrFunction(_engine, "", (_, innerArgs) =>
         {
             try { iterated.Close(CompletionType.Throw); } catch { /* ignore */ }
-            promiseCapability.Reject.Call(Undefined, new[] { innerArgs.At(0) });
+            promiseCapability.Reject(innerArgs.At(0));
             return Undefined;
         }, 1, PropertyFlag.Configurable);
 
@@ -322,13 +322,13 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         }
         catch (JavaScriptException ex)
         {
-            promiseCapability.Reject.Call(Undefined, ex.Error);
+            promiseCapability.Reject(ex.Error);
             return promiseCapability.PromiseInstance;
         }
 
         if (returnMethod is null)
         {
-            promiseCapability.Resolve.Call(Undefined, Undefined);
+            promiseCapability.Resolve(Undefined);
         }
         else
         {
@@ -340,7 +340,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
             }
             catch (JavaScriptException ex)
             {
-                promiseCapability.Reject.Call(Undefined, ex.Error);
+                promiseCapability.Reject(ex.Error);
                 return promiseCapability.PromiseInstance;
             }
 
@@ -351,7 +351,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
             }
             catch (JavaScriptException ex)
             {
-                promiseCapability.Reject.Call(Undefined, ex.Error);
+                promiseCapability.Reject(ex.Error);
                 return promiseCapability.PromiseInstance;
             }
 
@@ -430,11 +430,11 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
             {
                 if (!capturedHasAccumulator)
                 {
-                    cap.Reject.Call(Undefined, new JsValue[] { _engine.Realm.Intrinsics.TypeError.Construct("Reduce of empty iterator with no initial value") });
+                    cap.Reject(_engine.Realm.Intrinsics.TypeError.Construct("Reduce of empty iterator with no initial value"));
                 }
                 else
                 {
-                    cap.Resolve.Call(Undefined, new[] { capturedAccumulator });
+                    cap.Resolve(capturedAccumulator);
                 }
             },
             onValue: (value, idx, cap) =>
@@ -453,7 +453,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
                 catch (JavaScriptException ex)
                 {
                     try { iterated.Close(CompletionType.Throw); } catch { /* ignore */ }
-                    cap.Reject.Call(Undefined, new[] { ex.Error });
+                    cap.Reject(ex.Error);
                     return;
                 }
 
@@ -491,7 +491,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
             onDone: (_, cap) =>
             {
                 var array = new JsArray(_engine, items.ToArray());
-                cap.Resolve.Call(Undefined, new JsValue[] { array });
+                cap.Resolve(array);
             },
             onValue: (value, _, _) =>
             {
@@ -508,7 +508,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
 
         AsyncConsumeLoop(iterated, procedure, promiseCapability,
-            onDone: cap => cap.Resolve.Call(Undefined, Undefined),
+            onDone: cap => cap.Resolve(Undefined),
             shouldStop: null);
 
         return promiseCapability.PromiseInstance;
@@ -522,12 +522,12 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
 
         AsyncConsumeLoop(iterated, predicate, promiseCapability,
-            onDone: cap => cap.Resolve.Call(Undefined, new JsValue[] { JsBoolean.False }),
+            onDone: cap => cap.Resolve(JsBoolean.False),
             shouldStop: (resolved, value, cap) =>
             {
                 if (!TypeConverter.ToBoolean(resolved)) return false;
                 try { iterated.Close(CompletionType.Normal); } catch { /* ignore */ }
-                cap.Resolve.Call(Undefined, new JsValue[] { JsBoolean.True });
+                cap.Resolve(JsBoolean.True);
                 return true;
             });
 
@@ -542,12 +542,12 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
 
         AsyncConsumeLoop(iterated, predicate, promiseCapability,
-            onDone: cap => cap.Resolve.Call(Undefined, new JsValue[] { JsBoolean.True }),
+            onDone: cap => cap.Resolve(JsBoolean.True),
             shouldStop: (resolved, value, cap) =>
             {
                 if (TypeConverter.ToBoolean(resolved)) return false;
                 try { iterated.Close(CompletionType.Normal); } catch { /* ignore */ }
-                cap.Resolve.Call(Undefined, new JsValue[] { JsBoolean.False });
+                cap.Resolve(JsBoolean.False);
                 return true;
             });
 
@@ -562,12 +562,12 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);
 
         AsyncConsumeLoop(iterated, predicate, promiseCapability,
-            onDone: cap => cap.Resolve.Call(Undefined, Undefined),
+            onDone: cap => cap.Resolve(Undefined),
             shouldStop: (resolved, value, cap) =>
             {
                 if (!TypeConverter.ToBoolean(resolved)) return false;
                 try { iterated.Close(CompletionType.Normal); } catch { /* ignore */ }
-                cap.Resolve.Call(Undefined, new[] { value });
+                cap.Resolve(value);
                 return true;
             });
 
@@ -599,7 +599,7 @@ internal sealed partial class AsyncIteratorPrototype : Prototype
                 catch (JavaScriptException ex)
                 {
                     try { iterated.Close(CompletionType.Throw); } catch { /* ignore */ }
-                    cap.Reject.Call(Undefined, new[] { ex.Error });
+                    cap.Reject(ex.Error);
                     return;
                 }
 

--- a/Jint/Native/JsPromise.cs
+++ b/Jint/Native/JsPromise.cs
@@ -53,8 +53,10 @@ internal sealed class JsPromise : ObjectInstance
     /// </summary>
     internal bool PromiseIsHandled { get; set; }
 
-    internal List<PromiseReaction> PromiseRejectReactions = new();
-    internal List<PromiseReaction> PromiseFulfillReactions = new();
+    // Allocated lazily on the first PerformPromiseThen against a pending promise;
+    // nulled again on settle (a settled promise never accumulates reactions).
+    internal List<PromiseReaction>? PromiseRejectReactions;
+    internal List<PromiseReaction>? PromiseFulfillReactions;
 
     internal JsPromise(Engine engine) : base(engine)
     {
@@ -144,6 +146,12 @@ internal sealed class JsPromise : ObjectInstance
         return RejectPromise(reason);
     }
 
+    /// <summary>
+    /// Reject entry point for <see cref="Promise.PromiseCapability"/>'s intrinsic fast mode;
+    /// the [[AlreadyResolved]] guard lives on the capability.
+    /// </summary>
+    internal JsValue Reject(JsValue reason) => RejectPromise(reason);
+
 
     // https://tc39.es/ecma262/#sec-rejectpromise
     // 1. Assert: The value of promise.[[PromiseState]] is pending.
@@ -164,8 +172,8 @@ internal sealed class JsPromise : ObjectInstance
         Settle(PromiseState.Rejected, reason);
 
         var reactions = PromiseRejectReactions;
-        PromiseRejectReactions = new List<PromiseReaction>();
-        PromiseFulfillReactions.Clear();
+        PromiseRejectReactions = null;
+        PromiseFulfillReactions = null;
         _completedEvent?.Set();
 
         // 7. If promise.[[PromiseIsHandled]] is false, perform HostPromiseRejectionTracker(promise, "reject").
@@ -187,8 +195,8 @@ internal sealed class JsPromise : ObjectInstance
 
         Settle(PromiseState.Fulfilled, result);
         var reactions = PromiseFulfillReactions;
-        PromiseFulfillReactions = new List<PromiseReaction>();
-        PromiseRejectReactions.Clear();
+        PromiseFulfillReactions = null;
+        PromiseRejectReactions = null;
         _completedEvent?.Set();
 
         return PromiseOperations.TriggerPromiseReactions(_engine, reactions, result);

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -2034,11 +2034,11 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                         try
                         {
                             method.Call(this);
-                            promiseCapability.Resolve.Call(Undefined, Undefined);
+                            promiseCapability.Resolve(Undefined);
                         }
                         catch (JavaScriptException e)
                         {
-                            promiseCapability.Reject.Call(Undefined, e.Error);
+                            promiseCapability.Reject(e.Error);
                         }
                         return promiseCapability.PromiseInstance;
                     };

--- a/Jint/Native/Promise/PromiseCapability.cs
+++ b/Jint/Native/Promise/PromiseCapability.cs
@@ -1,0 +1,130 @@
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.Native.Promise;
+
+/// <summary>
+/// https://tc39.es/ecma262/#sec-promisecapability-records
+/// </summary>
+/// <remarks>
+/// Operates in one of two modes:
+/// <para>
+/// Intrinsic fast mode (<see cref="_promise"/> is not null): the capability was created by
+/// <see cref="PromiseConstructor.NewPromiseCapability"/> for a realm's %Promise% intrinsic.
+/// The spec's GetCapabilitiesExecutor dance is unobservable there (the executor and both
+/// resolving functions are engine-created and handed only to engine code), so the promise is
+/// created directly and <see cref="Resolve"/>/<see cref="Reject"/> settle it without
+/// materializing JS-callable resolving functions. The function objects are created lazily by
+/// <see cref="ResolveObj"/>/<see cref="RejectObj"/> only when they must escape to user code
+/// (e.g. Promise.withResolvers or a combinator invoking a user-visible then).
+/// </para>
+/// <para>
+/// Spec mode: for any other constructor the executor dance ran and the captured resolve/reject
+/// callables are invoked, exactly as before.
+/// </para>
+/// </remarks>
+internal sealed class PromiseCapability
+{
+    private readonly Engine _engine;
+    internal readonly JsValue PromiseInstance;
+
+    // Intrinsic fast mode: settle the promise directly, guarded by [[AlreadyResolved]].
+    private readonly JsPromise? _promise;
+    private bool _alreadyResolved;
+
+    // Spec mode: the resolve/reject functions captured from the executor.
+    private readonly ICallable? _resolve;
+    private readonly ICallable? _reject;
+
+    private JsValue? _resolveObj;
+    private JsValue? _rejectObj;
+
+    internal PromiseCapability(Engine engine, JsPromise promise)
+    {
+        _engine = engine;
+        _promise = promise;
+        PromiseInstance = promise;
+    }
+
+    internal PromiseCapability(
+        Engine engine,
+        JsValue promiseInstance,
+        ICallable resolve,
+        ICallable reject,
+        JsValue resolveObj,
+        JsValue rejectObj)
+    {
+        _engine = engine;
+        PromiseInstance = promiseInstance;
+        _resolve = resolve;
+        _reject = reject;
+        _resolveObj = resolveObj;
+        _rejectObj = rejectObj;
+    }
+
+    /// <summary>
+    /// The JS-visible resolve function object, materialized on demand in intrinsic fast mode.
+    /// </summary>
+    internal JsValue ResolveObj => _resolveObj ??= CreateResolvingFunction(rejecting: false);
+
+    /// <summary>
+    /// The JS-visible reject function object, materialized on demand in intrinsic fast mode.
+    /// </summary>
+    internal JsValue RejectObj => _rejectObj ??= CreateResolvingFunction(rejecting: true);
+
+    private ClrFunction CreateResolvingFunction(bool rejecting)
+    {
+        // Matches CreateResolvingFunctions: an anonymous built-in with length 1 sharing this
+        // capability's [[AlreadyResolved]] state (Resolve/Reject below carry the guard).
+        return rejecting
+            ? new ClrFunction(_engine, "", (_, args) =>
+            {
+                Reject(args.At(0));
+                return JsValue.Undefined;
+            }, 1, PropertyFlag.Configurable)
+            : new ClrFunction(_engine, "", (_, args) =>
+            {
+                Resolve(args.At(0));
+                return JsValue.Undefined;
+            }, 1, PropertyFlag.Configurable);
+    }
+
+    /// <summary>
+    /// Call(promiseCapability.[[Resolve]], undefined, « value »).
+    /// </summary>
+    internal void Resolve(JsValue value)
+    {
+        if (_promise is not null)
+        {
+            if (!_alreadyResolved)
+            {
+                _alreadyResolved = true;
+                _promise.Resolve(value);
+            }
+
+            return;
+        }
+
+        _resolve!.Call(JsValue.Undefined, value);
+    }
+
+    /// <summary>
+    /// Call(promiseCapability.[[Reject]], undefined, « reason »).
+    /// </summary>
+    internal void Reject(JsValue reason)
+    {
+        if (_promise is not null)
+        {
+            if (!_alreadyResolved)
+            {
+                _alreadyResolved = true;
+                _promise.Reject(reason);
+            }
+
+            return;
+        }
+
+        _reject!.Call(JsValue.Undefined, reason);
+    }
+}

--- a/Jint/Native/Promise/PromiseConstructor.cs
+++ b/Jint/Native/Promise/PromiseConstructor.cs
@@ -7,13 +7,6 @@ using Jint.Runtime.Interop;
 
 namespace Jint.Native.Promise;
 
-internal sealed record PromiseCapability(
-    JsValue PromiseInstance,
-    ICallable Resolve,
-    ICallable Reject,
-    JsValue ResolveObj,
-    JsValue RejectObj);
-
 [JsObject(UseShape = true)]
 internal sealed partial class PromiseConstructor : Constructor
 {
@@ -137,7 +130,7 @@ internal sealed partial class PromiseConstructor : Constructor
 
         var capability = NewPromiseCapability(_engine, thisObject);
 
-        capability.Resolve.Call(Undefined, x);
+        capability.Resolve(x);
 
         return capability.PromiseInstance;
     }
@@ -162,7 +155,7 @@ internal sealed partial class PromiseConstructor : Constructor
 
         var capability = NewPromiseCapability(_engine, thisObject);
 
-        capability.Reject.Call(Undefined, r);
+        capability.Reject(r);
 
         return capability.PromiseInstance;
     }
@@ -184,11 +177,11 @@ internal sealed partial class PromiseConstructor : Constructor
         try
         {
             var status = callbackfn.Call(Undefined, arguments.AsSpan().Slice(1).ToArray());
-            promiseCapability.Resolve.Call(Undefined, status);
+            promiseCapability.Resolve(status);
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(Undefined, e.Error);
+            promiseCapability.Reject(e.Error);
         }
 
         return promiseCapability.PromiseInstance;
@@ -212,7 +205,7 @@ internal sealed partial class PromiseConstructor : Constructor
         }
         catch (JavaScriptException e)
         {
-            capability.Reject.Call(Undefined, e.Error);
+            capability.Reject(e.Error);
             return capability.PromiseInstance;
         }
 
@@ -228,7 +221,7 @@ internal sealed partial class PromiseConstructor : Constructor
         }
         catch (JavaScriptException e)
         {
-            capability.Reject.Call(Undefined, e.Error);
+            capability.Reject(e.Error);
         }
 
         return capability.PromiseInstance;
@@ -252,7 +245,7 @@ internal sealed partial class PromiseConstructor : Constructor
         }
         catch (JavaScriptException e)
         {
-            capability.Reject.Call(Undefined, e.Error);
+            capability.Reject(e.Error);
             return capability.PromiseInstance;
         }
 
@@ -268,7 +261,7 @@ internal sealed partial class PromiseConstructor : Constructor
         }
         catch (JavaScriptException e)
         {
-            capability.Reject.Call(Undefined, e.Error);
+            capability.Reject(e.Error);
         }
 
         return capability.PromiseInstance;
@@ -320,7 +313,7 @@ internal sealed partial class PromiseConstructor : Constructor
                         if (remainingElementsCount == 0)
                         {
                             var resultObj = CreateKeyedPromiseCombinatorResultObject(keys, values);
-                            resultCapability.Resolve.Call(Undefined, resultObj);
+                            resultCapability.Resolve(resultObj);
                         }
                     }
                     return Undefined;
@@ -339,7 +332,7 @@ internal sealed partial class PromiseConstructor : Constructor
                         if (remainingElementsCount == 0)
                         {
                             var resultObj = CreateKeyedPromiseCombinatorResultObject(keys, values);
-                            resultCapability.Resolve.Call(Undefined, resultObj);
+                            resultCapability.Resolve(resultObj);
                         }
                     }
                     return Undefined;
@@ -371,7 +364,7 @@ internal sealed partial class PromiseConstructor : Constructor
                         if (remainingElementsCount == 0)
                         {
                             var resultObj = CreateKeyedPromiseCombinatorResultObject(keys, values);
-                            resultCapability.Resolve.Call(Undefined, resultObj);
+                            resultCapability.Resolve(resultObj);
                         }
                     }
                     return Undefined;
@@ -399,7 +392,7 @@ internal sealed partial class PromiseConstructor : Constructor
         if (remainingElementsCount == 0)
         {
             var resultObj = CreateKeyedPromiseCombinatorResultObject(keys, values);
-            resultCapability.Resolve.Call(Undefined, resultObj);
+            resultCapability.Resolve(resultObj);
         }
     }
 
@@ -425,7 +418,6 @@ internal sealed partial class PromiseConstructor : Constructor
 
         //2. Let promiseCapability be ? NewPromiseCapability(C).
         capability = NewPromiseCapability(_engine, thisObject);
-        var reject = capability.Reject;
 
         //3. Let promiseResolve be GetPromiseResolve(C).
         // 4. IfAbruptRejectPromise(promiseResolve, promiseCapability).
@@ -435,7 +427,7 @@ internal sealed partial class PromiseConstructor : Constructor
         }
         catch (JavaScriptException e)
         {
-            reject.Call(Undefined, e.Error);
+            capability.Reject(e.Error);
             promiseResolve = null!;
             iterator = null!;
             return false;
@@ -458,7 +450,7 @@ internal sealed partial class PromiseConstructor : Constructor
         }
         catch (JavaScriptException e)
         {
-            reject.Call(Undefined, e.Error);
+            capability.Reject(e.Error);
             iterator = null!;
             return false;
         }
@@ -485,7 +477,7 @@ internal sealed partial class PromiseConstructor : Constructor
             if (results.TrueForAll(static x => x is not null) && doneIterating)
             {
                 var array = _realm.Intrinsics.Array.ConstructFast(results);
-                capability.Resolve.Call(Undefined, array);
+                capability.Resolve(array);
             }
         }
 
@@ -512,7 +504,7 @@ internal sealed partial class PromiseConstructor : Constructor
                 }
                 catch (JavaScriptException e)
                 {
-                    capability.Reject.Call(Undefined, e.Error);
+                    capability.Reject(e.Error);
                     return capability.PromiseInstance;
                 }
 
@@ -561,7 +553,7 @@ internal sealed partial class PromiseConstructor : Constructor
             {
                 // ignore any errors from closing the iterator
             }
-            capability.Reject.Call(Undefined, e.Error);
+            capability.Reject(e.Error);
             return capability.PromiseInstance;
         }
 
@@ -587,7 +579,7 @@ internal sealed partial class PromiseConstructor : Constructor
             if (results.TrueForAll(static x => x is not null) && doneIterating)
             {
                 var array = _realm.Intrinsics.Array.ConstructFast(results);
-                capability.Resolve.Call(Undefined, array);
+                capability.Resolve(array);
             }
         }
 
@@ -614,7 +606,7 @@ internal sealed partial class PromiseConstructor : Constructor
                 }
                 catch (JavaScriptException e)
                 {
-                    capability.Reject.Call(Undefined, e.Error);
+                    capability.Reject(e.Error);
                     return capability.PromiseInstance;
                 }
 
@@ -685,7 +677,7 @@ internal sealed partial class PromiseConstructor : Constructor
             {
                 // ignore any errors from closing the iterator
             }
-            capability.Reject.Call(Undefined, e.Error);
+            capability.Reject(e.Error);
             return capability.PromiseInstance;
         }
 
@@ -715,7 +707,7 @@ internal sealed partial class PromiseConstructor : Constructor
             {
                 var array = _realm.Intrinsics.Array.ConstructFast(errors);
 
-                capability.Reject.Call(Undefined, Construct(_realm.Intrinsics.AggregateError, [array]));
+                capability.Reject(Construct(_realm.Intrinsics.AggregateError, [array]));
             }
         }
 
@@ -796,7 +788,7 @@ internal sealed partial class PromiseConstructor : Constructor
                     // ignore any errors from closing the iterator
                 }
             }
-            capability.Reject.Call(Undefined, e.Error);
+            capability.Reject(e.Error);
             return capability.PromiseInstance;
         }
 
@@ -828,7 +820,7 @@ internal sealed partial class PromiseConstructor : Constructor
                 }
                 catch (JavaScriptException e)
                 {
-                    capability.Reject.Call(Undefined, e.Error);
+                    capability.Reject(e.Error);
                     return capability.PromiseInstance;
                 }
 
@@ -845,7 +837,7 @@ internal sealed partial class PromiseConstructor : Constructor
                     return capability.PromiseInstance;
                 }
 
-                thenFunc.Call(nextPromise, (JsValue) capability.Resolve, capability.RejectObj);
+                thenFunc.Call(nextPromise, capability.ResolveObj, capability.RejectObj);
             } while (true);
         }
         catch (JavaScriptException e)
@@ -858,7 +850,7 @@ internal sealed partial class PromiseConstructor : Constructor
             {
                 // ignore any errors from closing the iterator
             }
-            capability.Reject.Call(Undefined, e.Error);
+            capability.Reject(e.Error);
             return capability.PromiseInstance;
         }
 
@@ -912,6 +904,21 @@ internal sealed partial class PromiseConstructor : Constructor
     // 12. Return promiseCapability.
     internal static PromiseCapability NewPromiseCapability(Engine engine, JsValue c)
     {
+        // Fast path for a realm's %Promise% intrinsic: its [[Construct]] is exactly the
+        // built-in algorithm (an ordinary promise using c's own Promise.prototype, the executor
+        // invoked synchronously with fresh resolving functions), and both the executor and the
+        // resolving functions are engine-created — user code cannot observe any part of the
+        // GetCapabilitiesExecutor dance. Create the promise directly and let the capability
+        // settle it without materializing any function objects.
+        if (c is PromiseConstructor promiseConstructor)
+        {
+            var promise = new JsPromise(engine)
+            {
+                _prototype = promiseConstructor.PrototypeObject,
+            };
+            return new PromiseCapability(engine, promise);
+        }
+
         var ctor = AssertConstructor(engine, c);
 
         JsValue? resolveArg = null;
@@ -962,10 +969,11 @@ internal sealed partial class PromiseConstructor : Constructor
         }
 
         return new PromiseCapability(
-            PromiseInstance: instance,
-            Resolve: resolve,
-            Reject: reject,
-            RejectObj: rejectArg,
-            ResolveObj: resolveArg);
+            engine,
+            promiseInstance: instance,
+            resolve: resolve,
+            reject: reject,
+            resolveObj: resolveArg,
+            rejectObj: rejectArg);
     }
 }

--- a/Jint/Native/Promise/PromiseOperations.cs
+++ b/Jint/Native/Promise/PromiseOperations.cs
@@ -27,45 +27,59 @@ internal static class PromiseOperations
     //      j. Else,
     //          i. Let status be Call(promiseCapability.[[Resolve]], undefined, « handlerResult.[[Value]] »).
     //      k. Return Completion(status).
-    private static Action NewPromiseReactionJob(PromiseReaction reaction, JsValue value)
+    //
+    // The job's state is carried by the queued (reaction, argument) pair itself instead of a
+    // captured closure — see EventLoopJob.
+    internal static void RunReactionJob(Engine engine, PromiseReaction reaction, JsValue value)
     {
-        return () =>
+        var promiseCapability = reaction.Capability;
+
+        if (reaction.Continuation is { } continuation)
         {
-            var promiseCapability = reaction.Capability;
-
-            if (reaction.Handler is ICallable handler)
+            // Engine-internal handler (e.g. an await continuation): invoked directly, no JS
+            // function object involved. These reactions never carry a capability, so mirror
+            // the JS-handler path below: a JavaScriptException that escapes has no reject
+            // target and is dropped.
+            try
             {
-                try
-                {
-                    var result = handler.Call(JsValue.Undefined, value);
-                    // If promiseCapability is undefined, just return (spec step g)
-                    promiseCapability?.Resolve.Call(JsValue.Undefined, result);
-                }
-                catch (JavaScriptException e)
-                {
-                    // If promiseCapability is undefined, this is an assertion failure per spec
-                    // but we need to handle it gracefully
-                    promiseCapability?.Reject.Call(JsValue.Undefined, e.Error);
-                }
+                continuation.Invoke(engine, value, reaction.Type);
             }
-            else
+            catch (JavaScriptException)
             {
-                // If no handler, capability must be defined per spec
-                switch (reaction.Type)
-                {
-                    case ReactionType.Fulfill:
-                        promiseCapability?.Resolve.Call(JsValue.Undefined, value);
-                        break;
-
-                    case ReactionType.Reject:
-                        promiseCapability?.Reject.Call(JsValue.Undefined, value);
-                        break;
-
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(reaction), "Unknown reaction type");
-                }
             }
-        };
+        }
+        else if (reaction.Handler is ICallable handler)
+        {
+            try
+            {
+                var result = handler.Call(JsValue.Undefined, value);
+                // If promiseCapability is undefined, just return (spec step g)
+                promiseCapability?.Resolve(result);
+            }
+            catch (JavaScriptException e)
+            {
+                // If promiseCapability is undefined, this is an assertion failure per spec
+                // but we need to handle it gracefully
+                promiseCapability?.Reject(e.Error);
+            }
+        }
+        else
+        {
+            // If no handler, capability must be defined per spec
+            switch (reaction.Type)
+            {
+                case ReactionType.Fulfill:
+                    promiseCapability?.Resolve(value);
+                    break;
+
+                case ReactionType.Reject:
+                    promiseCapability?.Reject(value);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(reaction), "Unknown reaction type");
+            }
+        }
     }
 
     // https://tc39.es/ecma262/#sec-newpromiseresolvethenablejob
@@ -105,11 +119,14 @@ internal static class PromiseOperations
     // a. Let job be NewPromiseReactionJob(reaction, argument).
     // b. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
     // 2. Return undefined.
-    internal static JsValue TriggerPromiseReactions(Engine engine, List<PromiseReaction> reactions, JsValue result)
+    internal static JsValue TriggerPromiseReactions(Engine engine, List<PromiseReaction>? reactions, JsValue result)
     {
-        foreach (var reaction in reactions)
+        if (reactions is not null)
         {
-            engine.AddToEventLoop(NewPromiseReactionJob(reaction, result));
+            foreach (var reaction in reactions)
+            {
+                engine.AddToEventLoop(reaction, result);
+            }
         }
 
         return JsValue.Undefined;
@@ -121,25 +138,23 @@ internal static class PromiseOperations
         JsPromise promise,
         JsValue onFulfilled,
         JsValue onRejected,
-        PromiseCapability resultCapability)
+        PromiseCapability? resultCapability)
     {
         var wasAlreadyHandled = promise.PromiseIsHandled;
-        var fulfilReaction = new PromiseReaction(ReactionType.Fulfill, resultCapability, onFulfilled);
-        var rejectReaction = new PromiseReaction(ReactionType.Reject, resultCapability, onRejected);
 
         switch (promise.State)
         {
             case PromiseState.Pending:
-                promise.PromiseFulfillReactions.Add(fulfilReaction);
-                promise.PromiseRejectReactions.Add(rejectReaction);
+                (promise.PromiseFulfillReactions ??= new List<PromiseReaction>()).Add(new PromiseReaction(ReactionType.Fulfill, resultCapability, onFulfilled));
+                (promise.PromiseRejectReactions ??= new List<PromiseReaction>()).Add(new PromiseReaction(ReactionType.Reject, resultCapability, onRejected));
                 break;
 
             case PromiseState.Fulfilled:
-                engine.AddToEventLoop(NewPromiseReactionJob(fulfilReaction, promise.Value));
+                engine.AddToEventLoop(new PromiseReaction(ReactionType.Fulfill, resultCapability, onFulfilled), promise.Value);
 
                 break;
             case PromiseState.Rejected:
-                engine.AddToEventLoop(NewPromiseReactionJob(rejectReaction, promise.Value));
+                engine.AddToEventLoop(new PromiseReaction(ReactionType.Reject, resultCapability, onRejected), promise.Value);
 
                 break;
             default:
@@ -168,5 +183,45 @@ internal static class PromiseOperations
         }
 
         return resultCapability.PromiseInstance;
+    }
+
+    /// <summary>
+    /// PerformPromiseThen for engine-internal continuations (the Await abstract operation's
+    /// steps 3-10): both reactions carry <paramref name="continuation"/> in place of the spec's
+    /// onFulfilled/onRejected closures — those closures are unobservable from user code, so no
+    /// JS function objects are materialized — and there is no result capability.
+    /// https://tc39.es/ecma262/#await
+    /// </summary>
+    internal static void PerformPromiseThen(Engine engine, JsPromise promise, IPromiseContinuation continuation)
+    {
+        var wasAlreadyHandled = promise.PromiseIsHandled;
+
+        switch (promise.State)
+        {
+            case PromiseState.Pending:
+                (promise.PromiseFulfillReactions ??= new List<PromiseReaction>()).Add(new PromiseReaction(ReactionType.Fulfill, Capability: null, Handler: null, continuation));
+                (promise.PromiseRejectReactions ??= new List<PromiseReaction>()).Add(new PromiseReaction(ReactionType.Reject, Capability: null, Handler: null, continuation));
+                break;
+
+            case PromiseState.Fulfilled:
+                engine.AddToEventLoop(new PromiseReaction(ReactionType.Fulfill, Capability: null, Handler: null, continuation), promise.Value);
+                break;
+
+            case PromiseState.Rejected:
+                engine.AddToEventLoop(new PromiseReaction(ReactionType.Reject, Capability: null, Handler: null, continuation), promise.Value);
+                break;
+
+            default:
+                Throw.ArgumentOutOfRangeException();
+                break;
+        }
+
+        // 12. Set promise.[[PromiseIsHandled]] to true.
+        promise.PromiseIsHandled = true;
+
+        if (promise.State == PromiseState.Rejected && !wasAlreadyHandled)
+        {
+            engine._host.HostPromiseRejectionTracker(promise, PromiseRejectionOperation.Handle);
+        }
     }
 }

--- a/Jint/Native/Promise/PromiseTypes.cs
+++ b/Jint/Native/Promise/PromiseTypes.cs
@@ -15,9 +15,22 @@ internal enum ReactionType
 
 internal sealed record PromiseReaction(
     ReactionType Type,
-    PromiseCapability Capability,
-    JsValue Handler
+    PromiseCapability? Capability,
+    JsValue? Handler,
+    IPromiseContinuation? Continuation = null
 );
+
+/// <summary>
+/// An engine-internal reaction target invoked directly by the promise reaction job in place of
+/// a JS-callable handler. Used where the spec's handler closure can never be observed from user
+/// code (await continuations and similar engine bookkeeping), so no JS function object, delegate
+/// or name/length descriptors need to be materialized per reaction. Reactions carrying a
+/// continuation never have a result capability.
+/// </summary>
+internal interface IPromiseContinuation
+{
+    void Invoke(Engine engine, JsValue value, ReactionType type);
+}
 
 internal sealed record ResolvingFunctions(
     Function.Function Resolve,

--- a/Jint/Runtime/EventLoop.cs
+++ b/Jint/Runtime/EventLoop.cs
@@ -1,11 +1,48 @@
 using System.Collections.Concurrent;
 using System.Threading;
+using Jint.Native;
+using Jint.Native.Promise;
 
 namespace Jint.Runtime;
 
+/// <summary>
+/// A single queued event-loop entry: either an opaque <see cref="Action"/> continuation or a
+/// promise reaction job carried as its (reaction, argument) pair so that enqueueing a reaction
+/// does not allocate a closure per job.
+/// </summary>
+internal readonly struct EventLoopJob
+{
+    private readonly object _state;
+    private readonly JsValue? _argument;
+
+    public EventLoopJob(Action continuation)
+    {
+        _state = continuation;
+        _argument = null;
+    }
+
+    public EventLoopJob(PromiseReaction reaction, JsValue argument)
+    {
+        _state = reaction;
+        _argument = argument;
+    }
+
+    public void Run(Engine engine)
+    {
+        if (_state is PromiseReaction reaction)
+        {
+            PromiseOperations.RunReactionJob(engine, reaction, _argument!);
+        }
+        else
+        {
+            ((Action) _state)();
+        }
+    }
+}
+
 internal sealed record EventLoop
 {
-    private readonly ConcurrentQueue<Action> _events = new();
+    private readonly ConcurrentQueue<EventLoopJob> _events = new();
 
     /// <summary>
     /// Tracks whether we are currently processing the event loop.
@@ -25,7 +62,7 @@ internal sealed record EventLoop
 
     /// <summary>
     /// Async wake signals registered by callers of <see cref="WaitForEventAsync"/>.
-    /// Each call appends its own TCS so that <see cref="Enqueue"/> can wake every
+    /// Each call appends its own TCS so that <see cref="Enqueue(in EventLoopJob)"/> can wake every
     /// outstanding waiter — supporting concurrent awaiters on a single engine
     /// (e.g. a caller that <c>await</c>s two engine-internal promises in parallel
     /// via <c>Task.WhenAll</c>). Replaces an earlier single-field design that
@@ -37,9 +74,11 @@ internal sealed record EventLoop
 
     public bool IsEmpty => _events.IsEmpty;
 
-    public void Enqueue(Action continuation)
+    public void Enqueue(Action continuation) => Enqueue(new EventLoopJob(continuation));
+
+    public void Enqueue(in EventLoopJob job)
     {
-        _events.Enqueue(continuation);
+        _events.Enqueue(job);
 
         // Wake every registered async waiter. Each one re-checks its own promise
         // state on resume, so spurious wakes loop harmlessly back to WaitForEventAsync.
@@ -67,7 +106,7 @@ internal sealed record EventLoop
     /// Used by the async API path (EvaluateAsync/ExecuteAsync/InvokeAsync) to avoid
     /// blocking a thread during IO-bound operations. During the wait, zero threads
     /// are consumed. Multiple concurrent waiters are supported — each registers its
-    /// own TCS and is signaled on every <see cref="Enqueue"/>.
+    /// own TCS and is signaled on every <see cref="Enqueue(in EventLoopJob)"/>.
     /// </summary>
     /// <param name="cancellationToken">Token to observe for cancellation.</param>
     /// <returns>A task that completes when events are available or cancellation is requested.</returns>
@@ -106,7 +145,7 @@ internal sealed record EventLoop
         return tcs.Task;
     }
 
-    public void RunAvailableContinuations()
+    public void RunAvailableContinuations(Engine engine)
     {
         // If there's a waiting thread (e.g., in UnwrapIfPromise), only that thread
         // should execute continuations. This prevents background threads (from Task
@@ -127,10 +166,10 @@ internal sealed record EventLoop
 
         try
         {
-            while (_events.TryDequeue(out var nextContinuation))
+            while (_events.TryDequeue(out var job))
             {
-                // note that continuation can enqueue new events
-                nextContinuation();
+                // note that a job can enqueue new events
+                job.Run(engine);
             }
         }
         finally

--- a/Jint/Runtime/Host.cs
+++ b/Jint/Runtime/Host.cs
@@ -160,7 +160,7 @@ public class Host
                 if (moduleRequest.Phase == ModuleImportPhase.Source)
                 {
                     var error = Engine.Realm.Intrinsics.SyntaxError.Construct("Source phase import is not supported for JavaScript modules");
-                    payload.Reject.Call(JsValue.Undefined, error);
+                    payload.Reject(error);
                     return JsValue.Undefined;
                 }
 
@@ -192,7 +192,7 @@ public class Host
                 {
                     // Non-cyclic module - shouldn't happen but handle gracefully
                     var ns = Module.GetModuleNamespace(moduleRecord);
-                    payload.Resolve.Call(JsValue.Undefined, ns);
+                    payload.Resolve(ns);
                     return JsValue.Undefined;
                 }
 
@@ -200,11 +200,11 @@ public class Host
                 {
                     // Sync completion - resolve immediately with namespace
                     var ns = Module.GetModuleNamespace(moduleRecord);
-                    payload.Resolve.Call(JsValue.Undefined, ns);
+                    payload.Resolve(ns);
                 }
                 else if (evaluatePromise.State == PromiseState.Rejected)
                 {
-                    payload.Reject.Call(JsValue.Undefined, evaluatePromise.Value);
+                    payload.Reject(evaluatePromise.Value);
                 }
                 else
                 {
@@ -212,13 +212,13 @@ public class Host
                     var onEvalFulfilled = new ClrFunction(Engine, "", (_, evalArgs) =>
                     {
                         var ns = Module.GetModuleNamespace(moduleRecord);
-                        payload.Resolve.Call(JsValue.Undefined, ns);
+                        payload.Resolve(ns);
                         return JsValue.Undefined;
                     }, 0, PropertyFlag.Configurable);
 
                     var onEvalRejected = new ClrFunction(Engine, "", (_, evalArgs) =>
                     {
-                        payload.Reject.Call(JsValue.Undefined, evalArgs.At(0));
+                        payload.Reject(evalArgs.At(0));
                         return JsValue.Undefined;
                     }, 1, PropertyFlag.Configurable);
 
@@ -228,7 +228,7 @@ public class Host
             }
             catch (JavaScriptException ex)
             {
-                payload.Reject.Call(JsValue.Undefined, ex.Error);
+                payload.Reject(ex.Error);
             }
             return JsValue.Undefined;
         }, 0, PropertyFlag.Configurable);
@@ -236,7 +236,7 @@ public class Host
         var onRejected = new ClrFunction(Engine, "", (thisObj, args) =>
         {
             var error = args.At(0);
-            payload.Reject.Call(JsValue.Undefined, error);
+            payload.Reject(error);
             return JsValue.Undefined;
         }, 1, PropertyFlag.Configurable);
 
@@ -259,7 +259,7 @@ public class Host
         if (asyncDeps.Count == 0)
         {
             // No async deps - resolve immediately with deferred namespace.
-            payload.Resolve.Call(JsValue.Undefined, Module.GetModuleNamespace(moduleRecord, ModuleImportPhase.Defer));
+            payload.Resolve(Module.GetModuleNamespace(moduleRecord, ModuleImportPhase.Defer));
             return;
         }
 
@@ -290,13 +290,13 @@ public class Host
         // Promise.all semantics: reject on first rejection, otherwise wait for all to fulfill.
         if (firstRejected is not null)
         {
-            payload.Reject.Call(JsValue.Undefined, firstRejected.Value);
+            payload.Reject(firstRejected.Value);
             return;
         }
 
         if (pending == 0)
         {
-            payload.Resolve.Call(JsValue.Undefined, Module.GetModuleNamespace(moduleRecord, ModuleImportPhase.Defer));
+            payload.Resolve(Module.GetModuleNamespace(moduleRecord, ModuleImportPhase.Defer));
             return;
         }
 
@@ -317,7 +317,7 @@ public class Host
             if (--remaining == 0)
             {
                 settled = true;
-                payload.Resolve.Call(JsValue.Undefined, Module.GetModuleNamespace(deferredModule, ModuleImportPhase.Defer));
+                payload.Resolve(Module.GetModuleNamespace(deferredModule, ModuleImportPhase.Defer));
             }
             return JsValue.Undefined;
         }, 0, PropertyFlag.Configurable);
@@ -330,7 +330,7 @@ public class Host
             }
 
             settled = true;
-            payload.Reject.Call(JsValue.Undefined, depArgs.At(0));
+            payload.Reject(depArgs.At(0));
             return JsValue.Undefined;
         }, 1, PropertyFlag.Configurable);
 

--- a/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
@@ -2,9 +2,8 @@ using Jint.Native;
 using Jint.Native.AsyncFunction;
 using Jint.Native.AsyncGenerator;
 using Jint.Native.Disposable;
+using Jint.Native.Object;
 using Jint.Native.Promise;
-using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 
 namespace Jint.Runtime.Interpreter.Expressions;
 
@@ -86,13 +85,16 @@ internal sealed class JintAwaitExpression : JintExpression
             return value;
         }
 
-        // Wrap in promise if not already a promise
-        JsPromise promise;
+        // Wrap in a promise if not already a promise. Primitives can never be thenables, so
+        // their wrapper — which would fulfill immediately and only ever feed the single
+        // reaction job — is skipped entirely; Suspend* enqueues that job directly (promise
+        // stays null). The spec's microtask count is preserved: exactly one tick either way.
+        JsPromise? promise = null;
         if (value is JsPromise p)
         {
             promise = p;
         }
-        else
+        else if (value is ObjectInstance)
         {
             promise = new JsPromise(engine)
             {
@@ -104,13 +106,13 @@ internal sealed class JintAwaitExpression : JintExpression
         // === Async generator: suspend for await ===
         if (asyncGenerator is not null)
         {
-            return SuspendForAwaitInAsyncGenerator(context, asyncGenerator, promise);
+            return SuspendForAwaitInAsyncGenerator(context, asyncGenerator, promise, value);
         }
 
         // === Async function: suspend for await ===
         if (asyncInstance is not null)
         {
-            return SuspendForAwait(context, asyncInstance, promise);
+            return SuspendForAwait(context, asyncInstance, promise, value);
         }
 
         // Fallback for non-async contexts - use blocking behavior
@@ -126,14 +128,15 @@ internal sealed class JintAwaitExpression : JintExpression
     }
 
     /// <summary>
-    /// Suspends the async generator at an await expression, creating promise handlers
-    /// that will resume execution when the awaited promise settles.
+    /// Suspends the async generator at an await expression, wiring an engine-internal
+    /// continuation that resumes execution when the awaited promise settles.
     /// Follows the same pattern as SuspendForAsyncIteration in JintForInForOfStatement.
     /// </summary>
     private JsValue SuspendForAwaitInAsyncGenerator(
         EvaluationContext context,
         AsyncGeneratorInstance asyncGenerator,
-        JsPromise promise)
+        JsPromise? promise,
+        JsValue value)
     {
         var engine = context.Engine;
 
@@ -145,37 +148,46 @@ internal sealed class JintAwaitExpression : JintExpression
 
         // Capture the current promise capability. The request was already dequeued by
         // AsyncGeneratorResumeNext(), so we must continue THIS request's execution on resume.
-        var currentCapability = asyncGenerator._currentPromiseCapability!;
+        // Resume directly in the reaction job (like async functions), not via an extra
+        // AddToEventLoop hop, so await consumes exactly 1 microtask tick for correct interleaving.
+        var continuation = new AsyncGeneratorAwaitContinuation(asyncGenerator, asyncGenerator._currentPromiseCapability!);
 
-        // Resume directly in the reaction handler (like async functions), not via AddToEventLoop.
-        // This ensures await consumes exactly 1 microtask tick for correct interleaving.
-        var onFulfilled = new ClrFunction(engine, "", (_, args) =>
+        if (promise is null)
         {
-            var resolvedValue = args.At(0);
-            asyncGenerator._nextValue = resolvedValue;
-            asyncGenerator._resumeWithThrow = false;
-            asyncGenerator._awaitSuspended = false;
-            asyncGenerator.AsyncGeneratorContinueForAwait(currentCapability);
-            return JsValue.Undefined;
-        }, 1, PropertyFlag.Configurable);
-
-        var onRejected = new ClrFunction(engine, "", (_, args) =>
+            // Awaited a non-thenable primitive: the wrapper promise would fulfill immediately
+            // and PerformPromiseThen would enqueue exactly this one reaction job.
+            engine.AddToEventLoop(new PromiseReaction(ReactionType.Fulfill, Capability: null, Handler: null, continuation), value);
+        }
+        else
         {
-            var rejectedValue = args.At(0);
-            asyncGenerator._nextValue = rejectedValue;
-            asyncGenerator._resumeWithThrow = true;
-            asyncGenerator._awaitSuspended = false;
-            asyncGenerator.AsyncGeneratorContinueForAwait(currentCapability);
-            return JsValue.Undefined;
-        }, 1, PropertyFlag.Configurable);
-
-        PromiseOperations.PerformPromiseThen(engine, promise, onFulfilled, onRejected, null!);
+            PromiseOperations.PerformPromiseThen(engine, promise, continuation);
+        }
 
         // Return undefined - the body will unwind because IsSuspended is now true
         return JsValue.Undefined;
     }
 
-    private JsValue SuspendForAwait(EvaluationContext context, AsyncFunctionInstance asyncInstance, JsPromise promise)
+    private sealed class AsyncGeneratorAwaitContinuation : IPromiseContinuation
+    {
+        private readonly AsyncGeneratorInstance _asyncGenerator;
+        private readonly PromiseCapability _capability;
+
+        public AsyncGeneratorAwaitContinuation(AsyncGeneratorInstance asyncGenerator, PromiseCapability capability)
+        {
+            _asyncGenerator = asyncGenerator;
+            _capability = capability;
+        }
+
+        public void Invoke(Engine engine, JsValue value, ReactionType type)
+        {
+            _asyncGenerator._nextValue = value;
+            _asyncGenerator._resumeWithThrow = type == ReactionType.Reject;
+            _asyncGenerator._awaitSuspended = false;
+            _asyncGenerator.AsyncGeneratorContinueForAwait(_capability);
+        }
+    }
+
+    private JsValue SuspendForAwait(EvaluationContext context, AsyncFunctionInstance asyncInstance, JsPromise? promise, JsValue value)
     {
         var engine = context.Engine;
 
@@ -183,25 +195,18 @@ internal sealed class JintAwaitExpression : JintExpression
         asyncInstance._state = AsyncFunctionState.SuspendedAwait;
         asyncInstance._savedContext = engine.ExecutionContext;
 
-        var onFulfilled = new ClrFunction(engine, "", (_, args) =>
+        // The async instance itself is the reaction's continuation — no JS-callable handler
+        // pair, no closure, no per-await function objects.
+        if (promise is null)
         {
-            var resolvedValue = args.At(0);
-            asyncInstance._resumeValue = resolvedValue;
-            asyncInstance._resumeWithThrow = false;
-            AsyncFunctionResume(engine, asyncInstance);
-            return JsValue.Undefined;
-        }, 1, PropertyFlag.Configurable);
-
-        var onRejected = new ClrFunction(engine, "", (_, args) =>
+            // Awaited a non-thenable primitive: the wrapper promise would fulfill immediately
+            // and PerformPromiseThen would enqueue exactly this one reaction job.
+            engine.AddToEventLoop(new PromiseReaction(ReactionType.Fulfill, Capability: null, Handler: null, asyncInstance), value);
+        }
+        else
         {
-            var rejectedValue = args.At(0);
-            asyncInstance._resumeValue = rejectedValue;
-            asyncInstance._resumeWithThrow = true;
-            AsyncFunctionResume(engine, asyncInstance);
-            return JsValue.Undefined;
-        }, 1, PropertyFlag.Configurable);
-
-        PromiseOperations.PerformPromiseThen(engine, promise, onFulfilled, onRejected, null!);
+            PromiseOperations.PerformPromiseThen(engine, promise, asyncInstance);
+        }
 
         return JsValue.Undefined;
     }
@@ -247,7 +252,7 @@ internal sealed class JintAwaitExpression : JintExpression
             {
                 engine.LeaveExecutionContext();
                 asyncInstance._state = AsyncFunctionState.Completed;
-                asyncInstance._capability.Reject.Call(JsValue.Undefined, e.Error);
+                asyncInstance._capability.Reject(e.Error);
                 return;
             }
             DisposeResourcesHelper.DisposeAndThen(
@@ -281,15 +286,15 @@ internal sealed class JintAwaitExpression : JintExpression
 
         if (final.Type == CompletionType.Throw)
         {
-            asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
+            asyncInstance._capability.Reject(final.Value);
         }
         else if (final.Type == CompletionType.Return)
         {
-            asyncInstance._capability.Resolve.Call(JsValue.Undefined, final.Value);
+            asyncInstance._capability.Resolve(final.Value);
         }
         else
         {
-            asyncInstance._capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
+            asyncInstance._capability.Resolve(JsValue.Undefined);
         }
     }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintImportExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintImportExpression.cs
@@ -95,7 +95,7 @@ internal sealed class JintImportExpression : JintExpression
         }
         catch (JavaScriptException e)
         {
-            promiseCapability.Reject.Call(JsValue.Undefined, e.Error);
+            promiseCapability.Reject(e.Error);
         }
 
         return promiseCapability.PromiseInstance;

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -239,7 +239,7 @@ internal sealed class JintFunctionDefinition
             if (!env.HasDisposeResources)
             {
                 asyncInstance._state = AsyncFunctionState.Completed;
-                asyncInstance._capability.Reject.Call(JsValue.Undefined, e.Error);
+                asyncInstance._capability.Reject(e.Error);
                 return;
             }
             DisposeResourcesHelper.DisposeAndThen(
@@ -249,7 +249,7 @@ internal sealed class JintFunctionDefinition
                 final =>
                 {
                     asyncInstance._state = AsyncFunctionState.Completed;
-                    asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
+                    asyncInstance._capability.Reject(final.Value);
                 });
             return;
         }
@@ -280,19 +280,19 @@ internal sealed class JintFunctionDefinition
 
         if (final.Type == CompletionType.Throw)
         {
-            asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
+            asyncInstance._capability.Reject(final.Value);
         }
         else if (final.Type == CompletionType.Normal)
         {
-            asyncInstance._capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
+            asyncInstance._capability.Resolve(JsValue.Undefined);
         }
         else if (final.Type == CompletionType.Return)
         {
-            asyncInstance._capability.Resolve.Call(JsValue.Undefined, final.Value);
+            asyncInstance._capability.Resolve(final.Value);
         }
         else
         {
-            asyncInstance._capability.Reject.Call(JsValue.Undefined, final.Value);
+            asyncInstance._capability.Reject(final.Value);
         }
     }
 

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -912,35 +912,10 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
             asyncInstance._state = AsyncFunctionState.SuspendedAwait;
             asyncInstance._savedContext = engine.ExecutionContext;
 
-            // Create resume handlers - resume directly inside the reaction job (no extra AddToEventLoop hop)
-            var onFulfilled = new ClrFunction(engine, "", (_, args) =>
-            {
-                var resolvedValue = args.At(0);
-
-                // Store the resolved iterator result for resume
-                var resumeSuspendData = asyncInstance.Data.GetOrCreate<ForAwaitSuspendData>(this);
-                resumeSuspendData.ResolvedIteratorResult = resolvedValue as ObjectInstance;
-
-                asyncInstance._resumeValue = JsValue.Undefined;
-                asyncInstance._resumeWithThrow = false;
-                JintAwaitExpression.AsyncFunctionResume(engine, asyncInstance);
-
-                return JsValue.Undefined;
-            }, 1, PropertyFlag.Configurable);
-
-            var onRejected = new ClrFunction(engine, "", (_, args) =>
-            {
-                var rejectedValue = args.At(0);
-
-                asyncInstance._resumeValue = rejectedValue;
-                asyncInstance._resumeWithThrow = true;
-                JintAwaitExpression.AsyncFunctionResume(engine, asyncInstance);
-
-                return JsValue.Undefined;
-            }, 1, PropertyFlag.Configurable);
-
-            // Per spec Await step 3: PerformPromiseThen(promise, onFulfilled, onRejected) with no resultCapability
-            PromiseOperations.PerformPromiseThen(engine, promise, onFulfilled, onRejected, null!);
+            // Per spec Await step 3: PerformPromiseThen(promise, onFulfilled, onRejected) with no
+            // resultCapability. The continuation resumes directly inside the reaction job (no
+            // extra AddToEventLoop hop) and needs no JS-callable handler pair.
+            PromiseOperations.PerformPromiseThen(engine, promise, new ForAwaitFunctionContinuation(this, asyncInstance));
 
             // Return with completion that signals suspension
             return new Completion(CompletionType.Normal, JsValue.Undefined, _statement!);
@@ -952,53 +927,20 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
             suspendData.Iterator = iterator;
             suspendData.AccumulatedValue = accumulatedValue;
 
+            // Mark that we're waiting for the iterator result
+            asyncGenerator._asyncGeneratorState = Native.AsyncGenerator.AsyncGeneratorState.SuspendedYield;
+
             // Capture the current promise capability before suspending —
             // the request was already dequeued by AsyncGeneratorResumeNext() before
             // reaching here, so the queue is now empty. On resume we must continue
             // THIS request's execution, not start a new one via AsyncGeneratorResumeNext().
-            var currentCapability = asyncGenerator._currentPromiseCapability!;
-
-            // Mark that we're waiting for the iterator result
-            asyncGenerator._asyncGeneratorState = Native.AsyncGenerator.AsyncGeneratorState.SuspendedYield;
-
-            // Create resume handlers. Use AddToEventLoop (like the async-function path) so
-            // the actual resumption happens in a distinct event-loop turn, matching spec
+            // The continuation re-enqueues via AddToEventLoop (like the async-function path)
+            // so the actual resumption happens in a distinct event-loop turn, matching spec
             // microtask ordering.
-            var onFulfilled = new ClrFunction(engine, "", (_, args) =>
-            {
-                var resolvedValue = args.At(0);
-
-                engine.AddToEventLoop(() =>
-                {
-                    // Store the resolved iterator result so the for-await-of loop can use it
-                    var resumeSuspendData = asyncGenerator.Data.GetOrCreate<ForAwaitSuspendData>(this);
-                    resumeSuspendData.ResolvedIteratorResult = resolvedValue as ObjectInstance;
-
-                    // Resume the current request's execution (queue is empty – cannot use AsyncGeneratorResumeNext)
-                    asyncGenerator.AsyncGeneratorContinueForAwait(currentCapability);
-                });
-
-                return JsValue.Undefined;
-            }, 1, PropertyFlag.Configurable);
-
-            var onRejected = new ClrFunction(engine, "", (_, args) =>
-            {
-                var rejectedValue = args.At(0);
-
-                engine.AddToEventLoop(() =>
-                {
-                    // Store the rejection so ExecuteInternal can propagate it as a throw
-                    var resumeSuspendData = asyncGenerator.Data.GetOrCreate<ForAwaitSuspendData>(this);
-                    resumeSuspendData.RejectedValue = rejectedValue;
-
-                    // Resume the current request's execution so the throw can be handled
-                    asyncGenerator.AsyncGeneratorContinueForAwait(currentCapability);
-                });
-
-                return JsValue.Undefined;
-            }, 1, PropertyFlag.Configurable);
-
-            PromiseOperations.PerformPromiseThen(engine, promise, onFulfilled, onRejected, null!);
+            PromiseOperations.PerformPromiseThen(
+                engine,
+                promise,
+                new ForAwaitGeneratorContinuation(this, asyncGenerator, asyncGenerator._currentPromiseCapability!));
 
             // Return with completion that signals suspension
             return new Completion(CompletionType.Normal, JsValue.Undefined, _statement!);
@@ -1019,6 +961,85 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 Throw.JavaScriptException(engine, e.RejectedValue, _statement!.Location);
                 return default;
             }
+        }
+    }
+
+    /// <summary>
+    /// Await continuation for a for-await-of running inside an async function: stores the
+    /// resolved iterator result and resumes directly inside the reaction job.
+    /// </summary>
+    private sealed class ForAwaitFunctionContinuation : IPromiseContinuation
+    {
+        private readonly JintForInForOfStatement _statement;
+        private readonly AsyncFunctionInstance _asyncInstance;
+
+        public ForAwaitFunctionContinuation(JintForInForOfStatement statement, AsyncFunctionInstance asyncInstance)
+        {
+            _statement = statement;
+            _asyncInstance = asyncInstance;
+        }
+
+        public void Invoke(Engine engine, JsValue value, ReactionType type)
+        {
+            if (type == ReactionType.Fulfill)
+            {
+                // Store the resolved iterator result for resume
+                var resumeSuspendData = _asyncInstance.Data.GetOrCreate<ForAwaitSuspendData>(_statement);
+                resumeSuspendData.ResolvedIteratorResult = value as ObjectInstance;
+
+                _asyncInstance._resumeValue = JsValue.Undefined;
+                _asyncInstance._resumeWithThrow = false;
+            }
+            else
+            {
+                _asyncInstance._resumeValue = value;
+                _asyncInstance._resumeWithThrow = true;
+            }
+
+            JintAwaitExpression.AsyncFunctionResume(engine, _asyncInstance);
+        }
+    }
+
+    /// <summary>
+    /// Await continuation for a for-await-of running inside an async generator: hands the
+    /// settled value to the suspend data and resumes the current request in a distinct
+    /// event-loop turn (see the enqueueing comment at the PerformPromiseThen call site).
+    /// </summary>
+    private sealed class ForAwaitGeneratorContinuation : IPromiseContinuation
+    {
+        private readonly JintForInForOfStatement _statement;
+        private readonly Native.AsyncGenerator.AsyncGeneratorInstance _asyncGenerator;
+        private readonly PromiseCapability _capability;
+
+        public ForAwaitGeneratorContinuation(
+            JintForInForOfStatement statement,
+            Native.AsyncGenerator.AsyncGeneratorInstance asyncGenerator,
+            PromiseCapability capability)
+        {
+            _statement = statement;
+            _asyncGenerator = asyncGenerator;
+            _capability = capability;
+        }
+
+        public void Invoke(Engine engine, JsValue value, ReactionType type)
+        {
+            engine.AddToEventLoop(() =>
+            {
+                var resumeSuspendData = _asyncGenerator.Data.GetOrCreate<ForAwaitSuspendData>(_statement);
+                if (type == ReactionType.Fulfill)
+                {
+                    // Store the resolved iterator result so the for-await-of loop can use it
+                    resumeSuspendData.ResolvedIteratorResult = value as ObjectInstance;
+                }
+                else
+                {
+                    // Store the rejection so ExecuteInternal can propagate it as a throw
+                    resumeSuspendData.RejectedValue = value;
+                }
+
+                // Resume the current request's execution (queue is empty – cannot use AsyncGeneratorResumeNext)
+                _asyncGenerator.AsyncGeneratorContinueForAwait(_capability);
+            });
         }
     }
 
@@ -1199,23 +1220,8 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
         asyncFn._state = AsyncFunctionState.SuspendedAwait;
         asyncFn._savedContext = engine.ExecutionContext;
 
-        var onFulfilled = new ClrFunction(engine, "", (_, args) =>
-        {
-            asyncFn._resumeValue = args.At(0);
-            asyncFn._resumeWithThrow = false;
-            JintAwaitExpression.AsyncFunctionResume(engine, asyncFn);
-            return JsValue.Undefined;
-        }, 1, PropertyFlag.Configurable);
-
-        var onRejected = new ClrFunction(engine, "", (_, args) =>
-        {
-            asyncFn._resumeValue = args.At(0);
-            asyncFn._resumeWithThrow = true;
-            JintAwaitExpression.AsyncFunctionResume(engine, asyncFn);
-            return JsValue.Undefined;
-        }, 1, PropertyFlag.Configurable);
-
-        PromiseOperations.PerformPromiseThen(engine, promise, onFulfilled, onRejected, null!);
+        // The async instance is its own await continuation (same as a plain await).
+        PromiseOperations.PerformPromiseThen(engine, promise, asyncFn);
     }
 
     private void SaveDisposeSuspendState(

--- a/Jint/Runtime/Modules/CyclicModule.cs
+++ b/Jint/Runtime/Modules/CyclicModule.cs
@@ -141,7 +141,7 @@ public abstract class CyclicModule : Module
             }
 
             _abnormalCompletionLocation = result.Location;
-            capability.Reject.Call(Undefined, result.Value);
+            capability.Reject(result.Value);
         }
         else
         {
@@ -162,7 +162,7 @@ public abstract class CyclicModule : Module
                     Throw.InvalidOperationException("Error while evaluating module: Module is in an invalid state");
                 }
 
-                capability.Resolve.Call(Undefined, Array.Empty<JsValue>());
+                capability.Resolve(JsValue.Undefined);
             }
 
             if (stack.Count > 0)
@@ -522,7 +522,7 @@ public abstract class CyclicModule : Module
                 Throw.InvalidOperationException("Error while evaluating module: Module is in an invalid state");
             }
 
-            module._topLevelCapability.Resolve.Call(Undefined, Array.Empty<JsValue>());
+            module._topLevelCapability.Resolve(JsValue.Undefined);
         }
 
         var execList = new List<CyclicModule>();
@@ -558,7 +558,7 @@ public abstract class CyclicModule : Module
                             Throw.InvalidOperationException("Error while evaluating module: Module is in an invalid state");
                         }
 
-                        m._topLevelCapability.Resolve.Call(Undefined, Array.Empty<JsValue>());
+                        m._topLevelCapability.Resolve(JsValue.Undefined);
                     }
                 }
             }
@@ -597,7 +597,7 @@ public abstract class CyclicModule : Module
                 Throw.InvalidOperationException("Error while evaluating module: Module is in an invalid state");
             }
 
-            module._topLevelCapability.Reject.Call(Undefined, error);
+            module._topLevelCapability.Reject(error);
         }
 
         var asyncParentModules = module._asyncParentModules;

--- a/Jint/Runtime/Modules/SourceTextModule.cs
+++ b/Jint/Runtime/Modules/SourceTextModule.cs
@@ -440,7 +440,7 @@ internal class SourceTextModule : CyclicModule
                     var cap = capability!;
                     if (!env.HasDisposeResources)
                     {
-                        cap.Reject.Call(JsValue.Undefined, e.Error);
+                        cap.Reject(e.Error);
                     }
                     else
                     {
@@ -448,7 +448,7 @@ internal class SourceTextModule : CyclicModule
                             _engine,
                             env,
                             new Completion(CompletionType.Throw, e.Error, null!),
-                            final => cap.Reject.Call(JsValue.Undefined, final.Value));
+                            final => cap.Reject(final.Value));
                     }
                     return new Completion(CompletionType.Normal, JsValue.Undefined, null!);
                 }
@@ -491,15 +491,15 @@ internal class SourceTextModule : CyclicModule
     {
         if (final.Type == CompletionType.Normal)
         {
-            capability.Resolve.Call(JsValue.Undefined, JsValue.Undefined);
+            capability.Resolve(JsValue.Undefined);
         }
         else if (final.Type == CompletionType.Throw)
         {
-            capability.Reject.Call(JsValue.Undefined, final.Value);
+            capability.Reject(final.Value);
         }
         else
         {
-            capability.Resolve.Call(JsValue.Undefined, final.Value);
+            capability.Resolve(final.Value);
         }
     }
 }

--- a/Jint/Runtime/Modules/SyntheticModule.cs
+++ b/Jint/Runtime/Modules/SyntheticModule.cs
@@ -58,7 +58,7 @@ internal sealed class SyntheticModule : Module
         _engine.LeaveExecutionContext();
 
         var pc = PromiseConstructor.NewPromiseCapability(_engine, _realm.Intrinsics.Promise);
-        pc.Resolve.Call(Undefined, Array.Empty<JsValue>());
+        pc.Resolve(JsValue.Undefined);
         return pc.PromiseInstance;
     }
 


### PR DESCRIPTION
## Problem

Every resolved-`await` and `.then()` allocates ~2 KB of engine-internal scaffolding that never escapes to JS: the census on a 1000-iteration await loop showed `ClrFunction` at 36.9% and `Func<JsValue,JsValue[],JsValue>` at 13.5% of allocated bytes — the `onFulfilled`/`onRejected` reaction handlers and the per-promise resolving-function pair, each with their own name/length descriptors. Async is a first-class workload with no allocation-focused coverage before this campaign.

## Approach

Internal-continuation reactions: when a promise reaction's handler is engine-internal — the await continuation, combinator bookkeeping — `PromiseReaction` carries an `IPromiseContinuation` and the reaction job invokes it directly, allocating no JS-callable function object, no delegate, no descriptors. `AsyncFunctionInstance` **is** its own await continuation. User `.then(f)` keeps real function objects. `PromiseCapability` gains an intrinsic fast mode that settles a `%Promise%`-created promise via a shared `[[AlreadyResolved]]` guard with zero resolving-function objects; those materialize only when they can escape (executor, `withResolvers`, combinator arguments). `await` of a primitive skips the wrapper promise while preserving the one-microtask tick. Enqueue uses a struct `EventLoopJob` (no per-job closure).

Every spec-observable behavior is unchanged and gated strictly on `c is PromiseConstructor` (subclasses/species take the untouched executor path): microtask ordering, `HostPromiseRejectionTracker` (both the reject and handle calls), thenable adoption, resolving-function observability (name `""`, length 1, identity, idempotency), async-generator vs for-await-of tick counts.

## Benchmarks (default job, baseline = upstream/main `4ccc2718e`, back-to-back)

| AsyncAwaitBenchmark | main | PR | Δ time | Δ alloc |
|---|---|---|---|---|
| SyncCallLoop (baseline) | 196.5 µs / 2.46 KB | 191.5 µs / 2.46 KB | flat | byte-identical |
| AwaitResolvedLoop (1000 awaits) | 678.3 µs / 2120.74 KB | 412.6 µs / 291.51 KB | **−39.2%** | **−86.3%** (2120→291 B/await) |
| AwaitChainDepth50 | 1,015.3 µs / 3035.16 KB | 606.7 µs / 1292.66 KB | **−40.2%** | **−57.4%** |
| PromiseAll100 | 815.6 µs / 3384.84 KB | 433.9 µs / 1084.69 KB | **−46.8%** | **−68.0%** |
| ThenChain1000 | 632.9 µs / 2286.33 KB | 444.8 µs / 1191.39 KB | **−29.7%** | **−47.9%** |
| MicrotaskFanout | 990.4 µs / 3464.89 KB | 543.4 µs / 1183.64 KB | **−45.1%** | **−65.8%** |

The `AsyncFunctionExitBenchmark` guard (exit cost, owned by that suite) also improves since exit routes through the same reaction machinery: `PlainAsyncFunctionExit_1000` 451.5→313.8 µs (−30.5%) / 1.76 MB→722.57 KB (−59.9%), `PlainAsyncGeneratorExit_500` 1286.5→731.2 µs (−43.2%). Census confirmation: `ClrFunction` (was 36.9%) and `Func<…>` (was 13.5%) drop out of the top allocated types entirely.

## Verification

- 11 new `PromiseTests` pins (await/then interleaving incl. primitive-await, tracked-then-handled awaited rejection, uncaught propagation, thenable adoption, then-getter throw, species subclass on `.then`, executor + `withResolvers` idempotent/observable, `Promise.all` mixed values, 1000-await loop).
- Full Jint.Tests **3384/3384 (net10.0) + 3321/3321 (net472)**; PublicInterface 82/82 both TFMs; Jint.Tests.CommonScripts 28/28.
- **Full Test262: 99,426 passed / 0 failed** (the entire language/async + built-ins/Promise + module + for-await surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
