### PR TITLE
Cut for-in allocation: memoized key strings, pooled loop-var reference and iterator

### DIFF
--- a/Jint.Tests/Runtime/ForInEnumerationTests.cs
+++ b/Jint.Tests/Runtime/ForInEnumerationTests.cs
@@ -1,0 +1,305 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins for-in enumeration semantics against the allocation-reduction work in the for-in lane:
+/// shape-level cached key strings, the pooled loop-variable Reference, and the per-statement pooled
+/// <c>ForInIterator</c>. Each behaviour below is a semantic invariant the optimizations must preserve —
+/// enumeration order, prototype-chain shadowing, delete/add-during-iteration, proxy trap counts, and
+/// (crucially for the pooled iterator) that two simultaneous enumerations of the same object never
+/// share live state.
+/// </summary>
+public class ForInEnumerationTests
+{
+    [Fact]
+    public void EnumeratesOwnKeysInInsertionOrder()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var six = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 };
+            var out = [];
+            for (var k in six) { out.push(k); }
+            out.join(',');
+            """).AsString();
+
+        Assert.Equal("a,b,c,d,e,f", result);
+    }
+
+    [Fact]
+    public void HasOwnPropertyGuardLoopCountsOnlyOwnKeys()
+    {
+        // The census idiom: the guard filters inherited keys, and the loop must produce the same count
+        // across repeated entries (each entry reuses the pooled iterator and the cached key strings).
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var six = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 };
+            var s = 0;
+            for (var i = 0; i < 100; i++) {
+                for (var k in six) { if (six.hasOwnProperty(k)) s++; }
+            }
+            s;
+            """).AsNumber();
+
+        Assert.Equal(600, result);
+    }
+
+    [Fact]
+    public void ShadowingOverTwoLevelChain()
+    {
+        // A key present (enumerable) on a shallower level suppresses the same key on a deeper level;
+        // deeper-only keys still appear, after the shallower keys.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var proto = { a: 1, x: 10 };
+            var child = Object.create(proto);
+            child.a = 2; // shadows proto.a
+            child.y = 20;
+            var out = [];
+            for (var k in child) { out.push(k + '=' + child[k]); }
+            out.join(',');
+            """).AsString();
+
+        Assert.Equal("a=2,y=20,x=10", result);
+    }
+
+    [Fact]
+    public void NonEnumerableShallowerKeyStillShadowsDeeperEnumerableKey()
+    {
+        // A present-but-non-enumerable own key on a shallower level must still shadow a deeper
+        // enumerable key of the same name (it never yields, but it does suppress).
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var proto = { a: 1 };
+            var child = Object.create(proto);
+            Object.defineProperty(child, 'a', { value: 2, enumerable: false });
+            var out = [];
+            for (var k in child) { out.push(k); }
+            out.join(',');
+            """).AsString();
+
+        Assert.Equal("", result);
+    }
+
+    [Fact]
+    public void DeleteDuringIterationSkipsNotYetVisitedKey()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var o = { a: 1, b: 2, c: 3 };
+            var out = [];
+            for (var k in o) { out.push(k); if (k === 'a') { delete o.c; } }
+            out.join(',');
+            """).AsString();
+
+        Assert.Equal("a,b", result);
+    }
+
+    [Fact]
+    public void AddDuringIterationDoesNotYieldNewKey()
+    {
+        // Spec permits either; this pins Jint's current behaviour (level keys are snapshotted at entry).
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var o = { a: 1 };
+            var out = [];
+            for (var k in o) { out.push(k); if (k === 'a') { o.z = 99; } }
+            out.join(',');
+            """).AsString();
+
+        Assert.Equal("a", result);
+    }
+
+    [Fact]
+    public void ReAddingADeletedKeyDuringIterationKeepsItInSnapshot()
+    {
+        // Deleting then re-adding a key that hasn't been visited yet: it was in the entry snapshot, so it
+        // is re-probed as present when its turn comes and still yields.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var o = { a: 1, b: 2 };
+            var out = [];
+            for (var k in o) { out.push(k); if (k === 'a') { delete o.b; o.b = 3; } }
+            out.join(',');
+            """).AsString();
+
+        Assert.Equal("a,b", result);
+    }
+
+    [Fact]
+    public void ProxyOwnKeysAndDescriptorTrapCountsUnchanged()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var calls = [];
+            var p = new Proxy({ a: 1, b: 2 }, {
+                ownKeys: function (t) { calls.push('ownKeys'); return Reflect.ownKeys(t); },
+                getOwnPropertyDescriptor: function (t, k) { calls.push('gopd:' + k); return Reflect.getOwnPropertyDescriptor(t, k); }
+            });
+            var out = [];
+            for (var k in p) { out.push(k); }
+            JSON.stringify([out, calls]);
+            """).AsString();
+
+        Assert.Equal("[[\"a\",\"b\"],[\"ownKeys\",\"gopd:a\",\"gopd:b\"]]", result);
+    }
+
+    [Fact]
+    public void TwoNestedForInOverSameObjectSimultaneously()
+    {
+        // Pooling must not share live iterator state: the inner loop runs a full enumeration on each
+        // outer step, and the outer must continue from where it left off.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var six = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 };
+            var pairs = [];
+            for (var k in six) { for (var j in six) { pairs.push(k + j); } }
+            [pairs.length, pairs[0], pairs[7], pairs[35]].join(',');
+            """).AsString();
+
+        // 6 * 6 = 36 pairs; pairs[0]=aa, pairs[7]=bb, pairs[35]=ff
+        Assert.Equal("36,aa,bb,ff", result);
+    }
+
+    [Fact]
+    public void RecursiveForInOfSameStatementKeepsOuterState()
+    {
+        // The same for-in statement re-entered recursively must allocate/keep independent state per level.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            function rec(o, depth) {
+                var out = [];
+                for (var k in o) { out.push(k); if (depth > 0) { out = out.concat(rec(o, depth - 1)); } }
+                return out;
+            }
+            rec({ p: 1, q: 2 }, 1).join(',');
+            """).AsString();
+
+        // p -> [p,q]; q -> [p,q]  =>  p,p,q,q,p,q
+        Assert.Equal("p,p,q,q,p,q", result);
+    }
+
+    [Fact]
+    public void InterleavedGeneratorsOverSameObjectDoNotShareState()
+    {
+        // Generators suspend across the for-in body; the iterator lives in suspend data and must never be
+        // pooled/shared. Two generator instances over the same object produce independent sequences.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var obj = { a: 1, b: 2, c: 3 };
+            function* keys(o) { for (var k in o) { yield k; } }
+            var g1 = keys(obj), g2 = keys(obj);
+            var seq = [];
+            seq.push(g1.next().value);
+            seq.push(g2.next().value);
+            seq.push(g1.next().value);
+            seq.push(g2.next().value);
+            seq.push(g1.next().value);
+            seq.push(g2.next().value);
+            seq.push(g1.next().done);
+            seq.join(',');
+            """).AsString();
+
+        // g1/g2 independently yield a,b,c; g1's 4th next() is done => the JS boolean true joins as "true".
+        Assert.Equal("a,a,b,b,c,c,true", result);
+    }
+
+    [Fact]
+    public void BreakThenReuseResetsPooledIterator()
+    {
+        // Breaking out early parks a partially-advanced iterator; the next entry must reset it.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var obj = { a: 1, b: 2, c: 3 };
+            var rounds = [];
+            for (var r = 0; r < 3; r++) {
+                var got = [];
+                for (var k in obj) { got.push(k); if (k === 'b') break; }
+                rounds.push(got.join(''));
+            }
+            rounds.join(',');
+            """).AsString();
+
+        Assert.Equal("ab,ab,ab", result);
+    }
+
+    [Fact]
+    public void ForInOverDictionaryModeObjectWithIntegerKeys()
+    {
+        // Integer-index-like keys enumerate first in ascending numeric order, then string keys in
+        // insertion order (the shape memo declines integer keys, so this routes through the dictionary
+        // path's numeric sort).
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var o = {};
+            for (var i = 0; i < 5; i++) { o['key' + i] = i; }
+            o['2'] = 1; o['10'] = 1; o['1'] = 1;
+            var out = [];
+            for (var k in o) { out.push(k); }
+            out.join(',');
+            """).AsString();
+
+        Assert.Equal("1,2,10,key0,key1,key2,key3,key4", result);
+    }
+
+    [Fact]
+    public void ForInOverArrayEnumeratesIndicesThenExtraProperties()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var arr = [10, 20, 30];
+            arr.foo = 'bar';
+            var out = [];
+            for (var k in arr) { out.push(k); }
+            out.join(',');
+            """).AsString();
+
+        Assert.Equal("0,1,2,foo", result);
+    }
+
+    [Fact]
+    public void ForInKeysAreStrings()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var six = { a: 1, b: 2, c: 3 };
+            var allStrings = true;
+            for (var k in six) { if (typeof k !== 'string') { allStrings = false; } }
+            allStrings;
+            """).AsBoolean();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void CachedKeyStringsEqualByValueAcrossEntries()
+    {
+        // The shape memo shares JsString instances across enumerations; value equality (and thus keyed
+        // lookups) must be unaffected.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var six = { a: 1, b: 2, c: 3 };
+            var first = [], second = [];
+            for (var k in six) { first.push(k); }
+            for (var k in six) { second.push(k); }
+            var ok = first.length === second.length;
+            for (var i = 0; i < first.length; i++) { if (first[i] !== second[i]) ok = false; }
+            ok;
+            """).AsBoolean();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ForInOverBuiltinPrototypeYieldsNoEnumerableKeys()
+    {
+        // The deeper for-in level is often a built-in (Object.prototype): all its members are
+        // non-enumerable, so a for-in over it directly yields nothing (exercises the builtin-shape memo).
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var out = [];
+            for (var k in Object.prototype) { out.push(k); }
+            out.length;
+            """).AsNumber();
+
+        Assert.Equal(0, result);
+    }
+}

--- a/Jint/Native/Iterator/IteratorInstance.cs
+++ b/Jint/Native/Iterator/IteratorInstance.cs
@@ -273,14 +273,14 @@ internal abstract class IteratorInstance : ObjectInstance
     internal sealed class ForInIterator : IteratorInstance
     {
         private ObjectInstance? _current;
-        private List<JsValue> _keys;
+        private IReadOnlyList<JsValue> _keys;
         private int _index;
         private bool _deeperLevel;
         private List<CompletedLevel>? _completedLevels;
         private HashSet<JsValue>? _visited;
 
         [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-        private readonly record struct CompletedLevel(ObjectInstance Owner, List<JsValue> Keys);
+        private readonly record struct CompletedLevel(ObjectInstance Owner, IReadOnlyList<JsValue> Keys);
 
         public ForInIterator(Engine engine, ObjectInstance target) : base(engine)
         {
@@ -288,8 +288,10 @@ internal abstract class IteratorInstance : ObjectInstance
             // matches the previous lazy enumerator's first step closely enough: no user code
             // can observe between head evaluation and the first step, so the ownKeys order
             // for proxies is preserved; GetPrototypeOf is deliberately NOT consulted here
-            // (a proxy trap must not fire before the first level is exhausted)
-            _keys = target.GetOwnPropertyKeys(Types.String);
+            // (a proxy trap must not fire before the first level is exhausted). Shape/builtin-shape
+            // objects hand back a shared, memoized key array (no per-entry List/JsString allocation);
+            // exotic objects (proxies) still route through the ownKeys-trapping GetOwnPropertyKeys.
+            _keys = target.GetForInStringKeys();
         }
 
         internal override bool TryStepValue([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out JsValue? value)
@@ -352,7 +354,7 @@ internal abstract class IteratorInstance : ObjectInstance
 
                 _deeperLevel = true;
                 _current = proto;
-                _keys = proto.GetOwnPropertyKeys(Types.String);
+                _keys = proto.GetForInStringKeys();
                 _index = 0;
             }
 
@@ -366,7 +368,7 @@ internal abstract class IteratorInstance : ObjectInstance
         /// current level, re-probing each key on its owning object. Prototype members are
         /// overwhelmingly non-enumerable, so most enumerations never get here.
         /// </summary>
-        private HashSet<JsValue> BuildVisited(ObjectInstance current, List<JsValue> currentKeys, int processedCount)
+        private HashSet<JsValue> BuildVisited(ObjectInstance current, IReadOnlyList<JsValue> currentKeys, int processedCount)
         {
             var set = new HashSet<JsValue>();
             if (_completedLevels is not null)
@@ -407,6 +409,44 @@ internal abstract class IteratorInstance : ObjectInstance
 
             nextItem = IteratorResult.CreateValueIteratorPosition(_engine, done: JsBoolean.True);
             return false;
+        }
+
+        /// <summary>
+        /// True when this iterator was created by <paramref name="engine"/>. A for-in handler is shared
+        /// across engines when a <c>Prepared&lt;Script&gt;</c> is reused, so a parked iterator must only be
+        /// reused by the engine that owns it.
+        /// </summary>
+        internal bool BelongsTo(Engine engine) => ReferenceEquals(_engine, engine);
+
+        /// <summary>
+        /// Re-arms a parked iterator to enumerate <paramref name="target"/>, reusing (clearing, not
+        /// reallocating) the retained level snapshots and shadow set so a pooled instance allocates nothing
+        /// per loop entry. Never called on an iterator that is mid-enumeration (the pool hands out at most
+        /// one live reference per statement — see JintForInForOfStatement).
+        /// </summary>
+        internal void ResetForReuse(ObjectInstance target)
+        {
+            _current = target;
+            _keys = target.GetForInStringKeys();
+            _index = 0;
+            _deeperLevel = false;
+            _completedLevels?.Clear();
+            _visited?.Clear();
+        }
+
+        /// <summary>
+        /// Drops references to the just-finished enumeration's object, keys, level snapshots and shadow set
+        /// before the iterator is parked, so a cached instance never roots them. The backing List/HashSet
+        /// storage is retained (cleared) for the next reuse.
+        /// </summary>
+        internal void ClearForPark()
+        {
+            _current = null;
+            _keys = System.Array.Empty<JsValue>();
+            _index = 0;
+            _deeperLevel = false;
+            _completedLevels?.Clear();
+            _visited?.Clear();
         }
     }
 

--- a/Jint/Native/Object/BuiltinShape.cs
+++ b/Jint/Native/Object/BuiltinShape.cs
@@ -55,7 +55,43 @@ internal sealed class BuiltinShape
     // name -> slot index.
     internal readonly StringDictionarySlim<int> Index;
 
+    // Slot-ordered names as shared, immutable JsString instances, memoized on first use. for-in over a
+    // built-in (e.g. an object's Object.prototype level) hands these out instead of recreating a JsString
+    // per name per enumeration. Built-in names are never integer-index-like, so no numeric-sort concern.
+    private JsValue[]? _namesAsJsStrings;
+
     internal int Count => Names.Length;
+
+    /// <summary>
+    /// This built-in's own property names as shared <see cref="JsString"/> instances in slot order,
+    /// memoized once per built-in type. Read-only; identity is unobservable to script.
+    /// </summary>
+    internal JsValue[] NamesAsJsStrings
+    {
+        get
+        {
+            if (_namesAsJsStrings is null)
+            {
+                var names = Names;
+                if (names.Length == 0)
+                {
+                    _namesAsJsStrings = System.Array.Empty<JsValue>();
+                }
+                else
+                {
+                    var arr = new JsValue[names.Length];
+                    for (var i = 0; i < names.Length; i++)
+                    {
+                        arr[i] = JsString.Create(names[i].Name);
+                    }
+
+                    _namesAsJsStrings = arr;
+                }
+            }
+
+            return _namesAsJsStrings;
+        }
+    }
 
     private BuiltinShape(Key[] names, BuiltinSlotKind[] kinds, PropertyDescriptor?[] constTemplate, ushort[] functionSlots, ushort[] setterSlots, PropertyFlag[] functionFlags, Func<ObjectInstance, PropertyDescriptor>?[]? factories, StringDictionarySlim<int> index)
     {

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -429,6 +429,43 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         return GetOwnPropertyKeysSorted(propertyKeys, returningStringKeys, returningSymbols);
     }
 
+    /// <summary>
+    /// Own string-keyed property names for for-in enumeration. Shape- and builtin-shape-mode objects hand
+    /// back a shared, memoized <see cref="JsValue"/>[] of <see cref="JsString"/> instances — no
+    /// per-enumeration List / JsString / scratch Key[] allocation; every other object (dictionaries, and
+    /// exotics like proxies whose ownKeys trap must still fire) builds the usual fresh list through the
+    /// virtual <see cref="GetOwnPropertyKeys"/>. The returned list MUST be treated as read-only: the shared
+    /// arrays back every object of that layout. for-in re-probes each candidate against the live object, so
+    /// a snapshot that is a shared immutable array is safe (deletes/adds are handled at step time).
+    /// </summary>
+    internal IReadOnlyList<JsValue> GetForInStringKeys()
+    {
+        EnsureInitialized();
+
+        if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
+        {
+            var shape = Unsafe.As<JsObject>(this).ShapeOf;
+            if (shape.TryGetOrderedKeyStrings(out var keyStrings))
+            {
+                return keyStrings;
+            }
+
+            // integer-index-like keys need numeric-sorted order → fall through to the dictionary path
+            // (GetOwnPropertyKeys deopts and sorts).
+        }
+        else if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty
+                 && _properties is null
+                 && ReferenceEquals(GetInitialOwnStringPropertyKeys(), System.Linq.Enumerable.Empty<JsValue>()))
+        {
+            // No function-derived length/name/prototype prefix and no hybrid dictionary additions, so the
+            // built-in's shared, ordered name list is exactly its own string keys — e.g. Object.prototype
+            // (the common deeper for-in level).
+            return Unsafe.As<IBuiltinShaped>(this).BuiltinShape.NamesAsJsStrings;
+        }
+
+        return GetOwnPropertyKeys(Types.String);
+    }
+
     private List<JsValue> GetOwnPropertyKeysFromShape(Shape shape, Types types)
     {
         var slotCount = shape.SlotCount;
@@ -444,25 +481,19 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
 
             if (slotCount > 0)
             {
-                var keys = new Key[slotCount];
-                shape.CollectKeys(keys);
-
                 // Spec ordering puts integer-index keys first (ascending) then string keys in insertion
-                // order. Shape slots are insertion order; if any key looks like an array index, deopt and
-                // reuse the dictionary path that already implements the numeric sort (rare for literals).
-                for (var i = 0; i < slotCount; i++)
+                // order. Shape slots are insertion order; if any key looks like an array index the memo
+                // declines, so we deopt and reuse the dictionary path's numeric sort (rare for literals).
+                // Otherwise reuse the shape's shared JsString instances — no per-enumeration JsString and
+                // no scratch Key[] allocation.
+                if (shape.TryGetOrderedKeyStrings(out var keyStrings))
                 {
-                    var name = keys[i].Name;
-                    if (name.Length > 0 && char.IsDigit(name[0]))
-                    {
-                        ConvertToDictionaryMode();
-                        return GetOwnPropertyKeys(types);
-                    }
+                    propertyKeys.AddRange(keyStrings);
                 }
-
-                for (var i = 0; i < slotCount; i++)
+                else
                 {
-                    propertyKeys.Add(new JsString(keys[i].Name));
+                    ConvertToDictionaryMode();
+                    return GetOwnPropertyKeys(types);
                 }
             }
         }
@@ -513,7 +544,9 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         return keys;
     }
 
-    internal virtual IEnumerable<JsValue> GetInitialOwnStringPropertyKeys() => [];
+    // Returns the shared Enumerable.Empty<JsValue>() sentinel (not a fresh []): callers detect "no
+    // function-derived length/name/prototype prefix" via ReferenceEquals against that same singleton.
+    internal virtual IEnumerable<JsValue> GetInitialOwnStringPropertyKeys() => System.Linq.Enumerable.Empty<JsValue>();
 
     protected virtual bool TryGetProperty(JsValue property, [NotNullWhen(true)] out PropertyDescriptor? descriptor)
     {
@@ -870,10 +903,8 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             {
                 keys.AddRange(initialOwnStringPropertyKeys);
             }
-            foreach (var name in names)
-            {
-                keys.Add(JsString.Create(name.Name));
-            }
+            // Reuse the built-in's shared JsString name instances instead of recreating them each call.
+            keys.AddRange(shaped.BuiltinShape.NamesAsJsStrings);
 
             // hybrid additions came after initialization; integer-like keys force a full deopt
             // before ever landing here, so shape-names-then-additions is the spec own-key order

--- a/Jint/Native/Object/Shape.cs
+++ b/Jint/Native/Object/Shape.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Jint.Native.Object;
@@ -59,6 +60,13 @@ internal sealed class Shape
     // and shared by every object of this layout — e.g. the JSON serializer's shaped fast path reads
     // property names from here without building a per-object key list.
     private Key[]? _orderedKeys;
+
+    // Slot-ordered keys as shared JsString instances, memoized alongside _orderedKeys. for-in and
+    // GetOwnPropertyKeys hand these out instead of allocating a fresh JsString per key per enumeration
+    // (the key strings are otherwise recreated on every step). Left null until first requested — and
+    // deliberately NOT built for a layout carrying an integer-index-like key, whose own-key order must
+    // be numerically sorted through the dictionary path.
+    private JsValue[]? _orderedKeyStrings;
 
     /// <summary>Creates an empty root shape. There is one root per prototype, interned by the engine's
     /// empty-shape table, so all objects sharing a prototype build their layouts from the same tree.</summary>
@@ -173,5 +181,49 @@ internal sealed class Shape
 
             return _orderedKeys;
         }
+    }
+
+    /// <summary>
+    /// This shape's own string keys as shared, immutable <see cref="JsString"/> instances in slot
+    /// (= insertion) order, memoized once per layout. Returns <c>false</c> — caching nothing — when any key
+    /// looks like an integer index (first char is a digit), because own-key order must then place integer
+    /// keys first in ascending numeric order, which only the dictionary path produces; the caller deopts.
+    /// Callers must treat the array as read-only. JsString identity is unobservable to script (<c>===</c>
+    /// is value-based), so sharing the same instances across every object of this layout is safe.
+    /// </summary>
+    internal bool TryGetOrderedKeyStrings([NotNullWhen(true)] out JsValue[]? strings)
+    {
+        strings = _orderedKeyStrings;
+        if (strings is not null)
+        {
+            return true;
+        }
+
+        var keys = OrderedKeys;
+        if (keys.Length == 0)
+        {
+            _orderedKeyStrings = strings = System.Array.Empty<JsValue>();
+            return true;
+        }
+
+        var arr = new JsValue[keys.Length];
+        for (var i = 0; i < keys.Length; i++)
+        {
+            var name = keys[i].Name;
+            if (name.Length > 0 && char.IsDigit(name[0]))
+            {
+                // integer-index-like key: order needs the numeric sort; leave the memo unbuilt.
+                strings = null;
+                return false;
+            }
+
+            // JsString.Create (not CachedCreate) — single-char names reuse the process-wide cache, longer
+            // names get one instance per shape; no global intern, so no unbounded memory pressure.
+            arr[i] = JsString.Create(name);
+        }
+
+        _orderedKeyStrings = arr;
+        strings = arr;
+        return true;
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -47,6 +47,14 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
     private readonly Binding[]? _iterationSlotTemplates;
     private DeclarativeEnvironment? _cachedIterationEnv;
 
+    // Per-statement pooled for-in key iterator (Enumerate kind only). Each loop entry otherwise allocates
+    // a fresh ForInIterator plus, on the first prototype-chain descent, a List<CompletedLevel>. Reused only
+    // in a non-suspendable frame (the loop then runs to completion, freeing the instance by the finally) and
+    // taken via Interlocked.Exchange, so a nested/recursive enumeration of the SAME statement finds the cache
+    // emptied and allocates its own — pooling never shares live enumeration state. Engine-identity checked,
+    // mirroring _cachedIterationEnv (a cached instance must never pin/serve a foreign engine, #2560).
+    private IteratorInstance.ForInIterator? _cachedForInIterator;
+
     public JintForInForOfStatement(ForInStatement statement) : base(statement)
     {
         _leftNode = statement.Left;
@@ -322,7 +330,26 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
             }
 
             var obj = TypeConverter.ToObject(engine.Realm, exprValue);
-            result = new IteratorInstance.ForInIterator(engine, obj);
+
+            // Reuse a parked iterator when not in a suspendable (generator/async) frame — the loop then
+            // runs start-to-finish, so the instance is free again by BodyEvaluation's finally. Interlocked
+            // take empties the cache, so a nested/recursive enumeration of the same statement allocates its
+            // own instance and never shares live state.
+            IteratorInstance.ForInIterator? pooled = null;
+            if (engine.ExecutionContext.Suspendable is null)
+            {
+                pooled = System.Threading.Interlocked.Exchange(ref _cachedForInIterator, null);
+            }
+
+            if (pooled is not null && pooled.BelongsTo(engine))
+            {
+                pooled.ResetForReuse(obj);
+                result = pooled;
+            }
+            else
+            {
+                result = new IteratorInstance.ForInIterator(engine, obj);
+            }
         }
         else if (_iterationKind == IterationKind.AsyncIterate)
         {
@@ -601,6 +628,13 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                             {
                                 engine.PutValue(reference, nextValue);
                             }
+
+                            // The lhs reference is rented fresh from the pool each iteration by
+                            // lhs.Evaluate(context) (identifier/member targets); neither
+                            // InitializeReferencedBinding nor PutValue returns it, so a var/assignment
+                            // for-in/of target leaked one Reference per key-step. Return it now — the
+                            // reference is not read again this iteration.
+                            engine._referencePool.Return(reference);
                         }
                     }
                     else
@@ -838,6 +872,18 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
                 reusableEnv._outerEnv = null;
                 ResetSlots(reusableEnv._slots!, _iterationSlotTemplates!);
                 System.Threading.Interlocked.Exchange(ref _cachedIterationEnv, reusableEnv);
+            }
+
+            // Park the for-in key iterator for the next entry. Gated on a non-suspendable frame (the loop
+            // ran to completion, so the instance is no longer referenced by suspend data or the body) and
+            // on engine identity. Cleared first so the cache never roots the finished enumeration's object.
+            if (iterationKind == IterationKind.Enumerate
+                && suspendable is null
+                && iteratorRecord is IteratorInstance.ForInIterator forInIterator
+                && forInIterator.BelongsTo(engine))
+            {
+                forInIterator.ClearForPark();
+                System.Threading.Interlocked.Exchange(ref _cachedForInIterator, forInIterator);
             }
 
             engine.UpdateLexicalEnvironment(oldEnv);


### PR DESCRIPTION
## Problem

`for (var k in obj)` allocates ~243 bytes per key-step. The census on a `for-in` + `hasOwnProperty` guard loop showed `JsString` at 37.4% (the enumerated key strings rebuilt every step), `Reference` at 19.0%, and `JsValue[]` + `List` + `ForInIterator` + `CompletedLevel[]` making up most of the rest — a fresh iterator and per-level bookkeeping on every loop entry. Object iteration is everywhere in real code and had no allocation coverage before this campaign.

## Approach

Three fixes, each independently reverting:

1. **Enumerated keys are memoized `JsString`s** on the immutable `Shape` (and `BuiltinShape`), so `GetOwnPropertyKeysFromShape` and the `for-in` iterator hand out shared instances instead of a scratch `Key[]` + a `new JsString` per key per step. (`JsString` equality is value-based, so the cross-level shadow set still dedups correctly across per-object memos.)
2. **The `for-in`/`for-of` `var`/member loop-variable Reference is returned to the pool.** It was rented per key-step by the target's `Evaluate()` and handed to `PutValue`/`InitializeReferencedBinding`, neither of which returned it — the exact rented-never-returned pattern the tagged-template fix (#2638) also hit. (The `hasOwnProperty` call itself already pools its reference and args via the fast-call path — the census "Reference 19%" was this loop variable, not the guard call.)
3. **One `ForInIterator` is pooled per statement** (Interlocked take, engine-identity checked, non-suspendable-gated, cleared at park — mirroring the `_cachedIterationEnv` precedent), killing the per-entry iterator + `CompletedLevel` list.

Enumeration order, prototype-chain shadowing, delete/add-during-iteration snapshot behavior, proxy `ownKeys` trap counts, and nested/interleaved enumerations over the same object are all preserved and pinned.

## Benchmarks (default job, baseline = upstream/main `4ccc2718e`, back-to-back)

| ForInGuardBenchmark | main | PR | Δ time | Δ alloc |
|---|---|---|---|---|
| ForInSmall | 16.514 ms / 29845.44 KB | 11.612 ms / 1.69 KB | **−29.7%** | **−99.99%** |
| ForInHasOwnGuard | 28.541 ms / 29845.49 KB | 23.525 ms / 1.74 KB | **−17.6%** | **−99.99%** |
| ForInWide (64-prop) | 11.440 ms / 12689.19 KB | 10.032 ms / 5220.44 KB | **−12.3%** | **−58.9%** |
| ForInProtoChain | 38.849 ms / 36173.62 KB | 32.296 ms / 3282.99 KB | **−16.9%** | **−90.9%** |
| ForOfString | 8.657 ms / 16408.99 KB | 8.455 ms / 11721.49 KB | −2.3% | **−28.6%** |
| TypeofSwitchMixed / InstanceofMixed / InOperatorMixed | — | — | flat | byte-identical |

Guard `IterationBenchmark` (for-of/spread/Map/destructuring): allocations byte-identical, times within noise.

## Verification

- 17 new `ForInEnumerationTests` pins incl. the two hardest: two simultaneous nested `for-in` over the same object and interleaved generators over the same object (both confirm pooling never shares live state), plus delete/add/re-add during iteration, proxy trap counts, shaped/dictionary/array objects, and cached-key value-equality.
- Full Jint.Tests **3390/3390 (net10.0) + 3327/3327 (net472)**; PublicInterface 82/82 both TFMs; Jint.Tests.CommonScripts 28/28.
- **Full Test262: 99,426 passed / 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
