### PR TITLE
Resolve number/boolean/bigint primitive methods without allocating a wrapper

### DIFF
--- a/Jint.Tests/Runtime/NumberTests.cs
+++ b/Jint.Tests/Runtime/NumberTests.cs
@@ -256,4 +256,127 @@ public class NumberTests
 
         Assert.Equal("true,true,true,true,true,true,true,true,true,true,true", result);
     }
+
+    // The following tests guard the primitive-receiver method resolution that skips allocating a
+    // Number/Boolean/BigInt wrapper on `primitive.method()`. The wrapper was only ever a lookup
+    // vehicle (the this-value passed to the callee is the primitive, boxed at call time for sloppy
+    // functions), so removing it must not change any observable behavior.
+
+    [Fact]
+    public void PrimitiveNumberMethodsResolveWithoutWrapper()
+    {
+        var engine = new Engine();
+
+        Assert.Equal("3.14", engine.Evaluate("(3.14159).toFixed(2)").AsString());
+        Assert.Equal("3.14", engine.Evaluate("(3.14159).toPrecision(3)").AsString());
+        Assert.Equal("ff", engine.Evaluate("(255).toString(16)").AsString());
+        Assert.Equal("101", engine.Evaluate("(5).toString(2)").AsString());
+        Assert.Equal("10", engine.Evaluate("(10).toString()").AsString());
+        Assert.Equal(42d, engine.Evaluate("(42).valueOf()").AsNumber());
+        Assert.Equal("1.23e+3", engine.Evaluate("(1234).toExponential(2)").AsString());
+        Assert.Equal("-3", engine.Evaluate("(-2.5).toFixed(0)").AsString());
+
+        // computed-key and identifier-base (read-then-call) resolution paths
+        Assert.Equal("ff", engine.Evaluate("(255)['toString'](16)").AsString());
+        Assert.Equal("ff", engine.Evaluate("var n = 255; var f = n.toString; f.call(255, 16)").AsString());
+
+        // absent property resolves to undefined (not a throw)
+        Assert.Equal("undefined", engine.Evaluate("typeof (5).nope").AsString());
+    }
+
+    [Fact]
+    public void PatchedNumberPrototypeMethodSeesBoxedThisInSloppyMode()
+    {
+        var engine = new Engine();
+        engine.Execute("Number.prototype.typ = function () { return typeof this; };");
+
+        // Sloppy-mode user function boxes the primitive this-value, so it must observe an object.
+        Assert.Equal("object", engine.Evaluate("(5).typ()").AsString());
+        // and can still unwrap the underlying number
+        engine.Execute("Number.prototype.dbl = function () { return this.valueOf() * 2; };");
+        Assert.Equal(42d, engine.Evaluate("(21).dbl()").AsNumber());
+
+        // resolution stays live after the method is reassigned
+        engine.Execute("Number.prototype.typ = function () { return 'reassigned'; };");
+        Assert.Equal("reassigned", engine.Evaluate("(5).typ()").AsString());
+    }
+
+    [Fact]
+    public void PatchedNumberPrototypeMethodSeesPrimitiveThisInStrictMode()
+    {
+        var engine = new Engine();
+        engine.Execute("Number.prototype.styp = function () { 'use strict'; return typeof this; };");
+
+        // Strict-mode user function does not box the this-value, so it must observe the primitive.
+        Assert.Equal("number", engine.Evaluate("(5).styp()").AsString());
+        engine.Execute("Number.prototype.sinc = function () { 'use strict'; return this + 1; };");
+        Assert.Equal(42d, engine.Evaluate("(41).sinc()").AsNumber());
+    }
+
+    [Fact]
+    public void GetterOnNumberPrototypeReceivesCorrectReceiver()
+    {
+        var engine = new Engine();
+        engine.Execute("Object.defineProperty(Number.prototype, 'gs', { get: function () { return typeof this; }, configurable: true });");
+        engine.Execute("Object.defineProperty(Number.prototype, 'gt', { get: function () { 'use strict'; return typeof this; }, configurable: true });");
+
+        Assert.Equal("object", engine.Evaluate("(7).gs").AsString());
+        Assert.Equal("number", engine.Evaluate("(7).gt").AsString());
+    }
+
+    [Fact]
+    public void NumberMethodResolvesThroughObjectPrototype()
+    {
+        var engine = new Engine();
+        engine.Execute("Object.prototype.op = function () { return 'fromObjectProto'; };");
+
+        // property inherited from Object.prototype (past Number.prototype) still resolves
+        Assert.Equal("fromObjectProto", engine.Evaluate("(5).op()").AsString());
+        Assert.False(engine.Evaluate("(5).hasOwnProperty('x')").AsBoolean());
+    }
+
+    [Fact]
+    public void ProxyInNumberPrototypeChainReceivesPrimitiveReceiver()
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            var handler = { get: function (t, p, receiver) { return p === 'trapped' ? 'viaProxy:' + (typeof receiver) : Reflect.get(t, p, receiver); } };
+            Object.setPrototypeOf(Number.prototype, new Proxy({ base: 1 }, handler));
+            """);
+
+        // spec: GetValue passes the primitive base as the receiver to [[Get]], so a Proxy get trap
+        // on the prototype chain observes the primitive - identical to the boxed path.
+        Assert.Equal("viaProxy:number", engine.Evaluate("(5).trapped").AsString());
+        Assert.Equal(1d, engine.Evaluate("(5).base").AsNumber());
+    }
+
+    [Fact]
+    public void BooleanPrimitiveMethodsResolveWithoutWrapper()
+    {
+        var engine = new Engine();
+
+        Assert.Equal("true", engine.Evaluate("(true).toString()").AsString());
+        Assert.Equal("false", engine.Evaluate("(false).toString()").AsString());
+        Assert.True(engine.Evaluate("(true).valueOf()").AsBoolean());
+
+        engine.Execute("Boolean.prototype.typ = function () { return typeof this; };");
+        Assert.Equal("object", engine.Evaluate("(true).typ()").AsString());
+        engine.Execute("Boolean.prototype.styp = function () { 'use strict'; return typeof this; };");
+        Assert.Equal("boolean", engine.Evaluate("(true).styp()").AsString());
+    }
+
+    [Fact]
+    public void BigIntPrimitiveMethodsResolveWithoutWrapper()
+    {
+        var engine = new Engine();
+
+        Assert.Equal("ff", engine.Evaluate("(255n).toString(16)").AsString());
+        Assert.Equal("10", engine.Evaluate("(10n).valueOf().toString()").AsString());
+        Assert.Equal("12345678901234567890", engine.Evaluate("(12345678901234567890n).toString()").AsString());
+
+        engine.Execute("BigInt.prototype.typ = function () { return typeof this; };");
+        Assert.Equal("object", engine.Evaluate("(5n).typ()").AsString());
+        engine.Execute("BigInt.prototype.styp = function () { 'use strict'; return typeof this; };");
+        Assert.Equal("bigint", engine.Evaluate("(5n).styp()").AsString());
+    }
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -803,6 +803,16 @@ public sealed partial class Engine : IDisposable
                 return jsValue;
             }
 
+            // Number / Boolean / BigInt primitives box to a wrapper that owns no properties, so the member
+            // resolves entirely on the intrinsic prototype chain. Read straight from that prototype with the
+            // primitive as the receiver (reference.ThisValue) — identical to ToObject(base).Get(...) but with
+            // no wrapper allocated. Private references keep the boxing path so their "not declared" error and
+            // PrivateGet semantics are preserved.
+            if (o is null && !reference.IsPrivateReference)
+            {
+                o = Runtime.TypeConverter.PrimitiveLookupPrototypeOrNull(Realm, baseValue);
+            }
+
             if (o is null)
             {
                 o = Runtime.TypeConverter.ToObject(Realm, baseValue);

--- a/Jint/Native/JsValue.cs
+++ b/Jint/Native/JsValue.cs
@@ -298,7 +298,10 @@ public abstract partial class JsValue : IEquatable<JsValue>
     /// </summary>
     internal JsValue GetV(Realm realm, JsValue property)
     {
-        var o = TypeConverter.ToObject(realm, this);
+        // Number / Boolean / BigInt primitives resolve members on the intrinsic prototype without a
+        // wrapper (see PrimitiveLookupPrototypeOrNull); everything else (notably String, whose wrapper
+        // owns length and the indexed characters) still boxes via ToObject.
+        var o = TypeConverter.PrimitiveLookupPrototypeOrNull(realm, this) ?? TypeConverter.ToObject(realm, this);
         return o.Get(property, this);
     }
 

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -1042,6 +1042,32 @@ public static class TypeConverter
         }
     }
 
+    /// <summary>
+    /// For a Number, Boolean, or BigInt primitive, returns the intrinsic prototype object that a
+    /// wrapper produced by <see cref="ToObject"/> would delegate every property lookup to. These
+    /// wrapper types add no own properties (unlike a String wrapper, which owns <c>length</c> and the
+    /// indexed characters), so resolving a member against the intrinsic prototype with the primitive
+    /// itself as the receiver is observationally identical to boxing — same descriptor, same getter
+    /// receiver, same prototype-chain / Proxy traversal — but allocates no wrapper. Returns
+    /// <see langword="null"/> for every other value, leaving the caller to box via <see cref="ToObject"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static ObjectInstance? PrimitiveLookupPrototypeOrNull(Realm realm, JsValue value)
+    {
+        switch (value._type & ~InternalTypes.InternalFlags)
+        {
+            case InternalTypes.Number:
+            case InternalTypes.Integer:
+                return realm.Intrinsics.Number.PrototypeObject;
+            case InternalTypes.Boolean:
+                return realm.Intrinsics.Boolean.PrototypeObject;
+            case InternalTypes.BigInt:
+                return realm.Intrinsics.BigInt.PrototypeObject;
+            default:
+                return null;
+        }
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     internal static void CheckObjectCoercible(
         Engine engine,


### PR DESCRIPTION
## Problem

`n.toFixed(2)` and other method calls on a **number primitive** allocate a throwaway `NumberInstance` wrapper per call — the census on a `toFixed` loop showed `NumberInstance` at ~40% of allocated bytes. The wrapper is created by `Engine.GetValue`/`JsValue.GetV` purely to resolve the prototype method, then discarded; the `this`-value passed to the call is always the primitive. String primitives already dodge this (their fast path resolves against `String.prototype` without boxing); numbers, booleans and BigInts did not.

## Approach

New `TypeConverter.PrimitiveLookupPrototypeOrNull(realm, value)` returns the intrinsic `Number`/`Boolean`/`BigInt` prototype for those primitives (and `null` for everything else, so strings/symbols/objects keep their existing paths), wired into the two primitive member-read sites. These wrappers own **no** properties (unlike strings, which own `length` and indexed chars — the reason the string path needs a lowercase-name gate), so a lookup against the intrinsic prototype with the primitive as receiver is observationally identical to boxing for every key. Private references keep the `ToObject` path. `this`-observability is preserved by construction: the wrapper was never the `this`-value — boxing still happens in the callee (`OrdinaryCallBindThis`), so a sloppy user method sees `object` and a strict one sees `number`, exactly as before.

## Benchmarks (default job, baseline = upstream/main `4ccc2718e`, back-to-back)

| NumberParseBenchmark | main | PR | Δ time | Δ alloc |
|---|---|---|---|---|
| ToFixedLoop | 32.77 ms / 16.78 MB | 29.13 ms / 9.92 MB | **−11.1%** | **−40.9%** |
| ToStringRadix | 21.36 ms / 12.97 MB | 20.69 ms / 6.11 MB | −3.1% | **−52.9%** |
| ParseIntLoop / ParseFloatLoop / NumberCoerce | — | — | flat | byte-identical |

`parseInt`/`parseFloat`/`Number()` are flat — they're global functions / string coercion with no primitive receiver, so no wrapper was allocated to begin with. Guards: `ObjectAccessBenchmark` (object member read/write) byte-identical (60.42 / 30.22 MB both sides); `PropertyKeyInternBenchmarks` flat — object and string member reads are untouched.

## Verification

- 8 new `NumberTests` pins: primitive `toFixed`/`toPrecision`/`toString(radix)`/`valueOf`/`toExponential` (computed-key + identifier-read + absent-prop), patched-`Number.prototype`-method `this` in sloppy (`object`) and strict (`number`) mode, getter on `Number.prototype` receiver, resolve-through-`Object.prototype`, Proxy-in-prototype-chain receiver, and Boolean/BigInt primitive method equivalents.
- `NumberTests` 76/76 both TFMs; full Jint.Tests **3381/3381 (net10.0)**; PublicInterface 82/82 both TFMs (lazy-string gating intact); Jint.Tests.CommonScripts 28/28.
- **Full Test262: 99,426 passed / 0 failed** (the whole primitive-member-read surface + built-ins/Number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
