### PR TITLE
Bump Verify.NUnit to 31.24.0 and force LF line endings for snapshot files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,11 @@ Jint.Tests/** linguist-vendored
 Jint.Tests.Ecma/** linguist-vendored
 Jint.Tests.CommonScripts/** linguist-vendored
 Jint.Tests.Test262/** linguist-vendored
+
+# Verify snapshot files must use LF line endings on all platforms.
+# Verify (31.21.0+) rejects carriage returns in verified files, which otherwise
+# break on Windows checkouts where autocrlf converts LF to CRLF.
+*.verified.cs text eol=lf
+*.verified.txt text eol=lf
+*.received.cs text eol=lf
+*.received.txt text eol=lf

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" PrivateAssets="all" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageVersion Include="Verify.NUnit" Version="31.20.0" />
+    <PackageVersion Include="Verify.NUnit" Version="31.24.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />


### PR DESCRIPTION
Supersedes #2644, which fails Windows CI.

## Problem

Verify 31.21.0+ ([#1762](https://github.com/VerifyTests/Verify/pull/1762)) **rejects carriage returns in verified files instead of normalizing** them. On the Windows CI runner (`core.autocrlf=true`), the snapshot files under `Jint.Tests.SourceGenerators/Snapshots` are checked out with CRLF line endings, so the source generator tests fail with:

```
System.Exception : Verified file must use \n line endings, but it contains a \r (carriage return).
```

Linux/macOS pass because their checkouts keep LF. The files are stored LF in git — only the Windows checkout conversion (`* text=auto`) introduces the CRLF.

## Fix

- Bump `Verify.NUnit` 31.20.0 → 31.24.0 (the dependency update from #2644).
- Add `.gitattributes` rules forcing `eol=lf` for `*.verified.*` / `*.received.*` snapshot files so they stay LF on every platform's checkout, regardless of `core.autocrlf`.

## Verification

`dotnet test --configuration Release Jint.Tests.SourceGenerators` → **39/39 pass** after re-checking out the snapshots with the new attribute (confirmed the working-tree files convert from CRLF to LF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)