### PR TITLE
Adopt the source shape when spreading a shaped object

### DIFF
--- a/Jint.Tests/Runtime/ObjectSpreadShapeTests.cs
+++ b/Jint.Tests/Runtime/ObjectSpreadShapeTests.cs
@@ -513,4 +513,165 @@ public class ObjectSpreadShapeTests
 
         Assert.Equal("""{"keys":["b","c","d"],"c":3,"d":4,"dWritable":false}""", result);
     }
+
+    // ---- Source-shape adoption fast path: `{ ...src }` where src is itself a shape-mode object ----
+
+    [Fact]
+    public void SpreadOfShapeSourceAdoptsSourceInternedShape()
+    {
+        var engine = new Engine();
+        engine.Execute("var src = { a: 1, b: 2, c: 3, d: 4 };");
+
+        var src = Assert.IsType<JsObject>(engine.Evaluate("src"));
+        var clone1 = Assert.IsType<JsObject>(engine.Evaluate("({ ...src })"));
+        var clone2 = Assert.IsType<JsObject>(engine.Evaluate("({ ...src })"));
+
+        // The clone reuses the source's exact interned leaf shape (same prototype + same key
+        // sequence + same attributes), so the member inline cache stays monomorphic across the
+        // source and every clone. Distinct objects, one shape.
+        Assert.NotSame(src, clone1);
+        Assert.NotSame(clone1, clone2);
+        Assert.True((clone1._type & InternalTypes.ShapeMode) != InternalTypes.Empty);
+        Assert.Same(src.ShapeOf, clone1.ShapeOf);
+        Assert.Same(clone1.ShapeOf, clone2.ShapeOf);
+
+        // `{ ...src, x }` extends the adopted shape by one interned transition — the same shape a
+        // streamed build would land on — so those clones also share a shape with each other.
+        var ext1 = Assert.IsType<JsObject>(engine.Evaluate("({ ...src, x: 1 })"));
+        var ext2 = Assert.IsType<JsObject>(engine.Evaluate("({ ...src, x: 2 })"));
+        Assert.Same(ext1.ShapeOf, ext2.ShapeOf);
+        Assert.NotSame(src.ShapeOf, ext1.ShapeOf);
+        Assert.Equal("a,b,c,d,x", engine.Evaluate("Object.keys({ ...src, x: 1 }).join()").AsString());
+    }
+
+    [Fact]
+    public void SpreadCloneHasIndependentSlotStorageInlineAndOverflow()
+    {
+        var engine = new Engine();
+        // Writing an own slot of the clone must never reach back into the source, for both in-object
+        // (a..d) and overflow (e, f) slots. Spread copies value references, so a nested object stays
+        // shared (shallow), but the top-level slots are separate storage.
+        var result = engine.Evaluate("""
+            (function () {
+                var src = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, nested: { v: 1 } };
+                var t = { ...src };
+                t.a = 99;   // inline slot
+                t.f = 88;   // overflow slot
+                t.nested.v = 42; // shallow: mutates the shared referent
+                return JSON.stringify({
+                    srcA: src.a, srcF: src.f, tA: t.a, tF: t.f,
+                    sharedNested: src.nested.v, sameNestedRef: src.nested === t.nested
+                });
+            })()
+            """).AsString();
+
+        Assert.Equal("""{"srcA":1,"srcF":6,"tA":99,"tF":88,"sharedNested":42,"sameNestedRef":true}""", result);
+    }
+
+    [Fact]
+    public void SpreadOfCustomPrototypeSourceDeclinesAndResultHasObjectPrototype()
+    {
+        var engine = new Engine();
+        // A source with a non-Object.prototype prototype must not have its shape adopted onto an
+        // Object.prototype target (interned shapes are rooted per prototype). The fast path declines
+        // and streams; only the source's own enumerable data property is copied and the result's
+        // prototype is Object.prototype.
+        var result = engine.Evaluate("""
+            (function () {
+                var proto = { inheritedKey: 'p' };
+                var src = Object.create(proto);
+                src.a = 1;
+                src.b = 2;
+                var o = { ...src };
+                return JSON.stringify({
+                    keys: Object.keys(o),
+                    hasInheritedOwn: Object.prototype.hasOwnProperty.call(o, 'inheritedKey'),
+                    protoIsObjectProto: Object.getPrototypeOf(o) === Object.prototype,
+                    a: o.a, b: o.b
+                });
+            })()
+            """).AsString();
+
+        Assert.Equal("""{"keys":["a","b"],"hasInheritedOwn":false,"protoIsObjectProto":true,"a":1,"b":2}""", result);
+    }
+
+    [Fact]
+    public void SpreadOfShapeSourceWithIntegerLikeKeyKeepsSpecOrderAndValues()
+    {
+        var engine = new Engine();
+        // A fast-built literal can be shape-mode while carrying a digit-leading key; own-key order then
+        // needs the numeric-first sort, produced on enumeration by the shape->dictionary deopt. Adopting
+        // such a shape is faithful because the same deopt applies to the source and the clone alike.
+        var result = engine.Evaluate("""
+            (function () {
+                var src = { a: 1, '0': 2, b: 3 };
+                var o = { ...src };
+                return JSON.stringify({ keys: Object.keys(o), zero: o['0'], a: o.a, b: o.b });
+            })()
+            """).AsString();
+
+        Assert.Equal("""{"keys":["0","a","b"],"zero":2,"a":1,"b":3}""", result);
+    }
+
+    [Fact]
+    public void SpreadOfSymbolCarryingShapeSourceDeclinesButCopiesSymbol()
+    {
+        var engine = new Engine();
+        // Symbols live outside the shape, so a source carrying an enumerable symbol declines the
+        // wholesale adopt and streams — the enumerable symbol is copied, a non-enumerable one skipped.
+        var result = engine.Evaluate("""
+            (function () {
+                var e = Symbol('e'), h = Symbol('h');
+                var src = { a: 1, b: 2 };
+                src[e] = 'enum';
+                Object.defineProperty(src, h, { value: 'hidden', enumerable: false });
+                var o = { ...src };
+                return JSON.stringify({
+                    keys: Object.keys(o),
+                    a: o.a, b: o.b,
+                    enumSym: o[e],
+                    hiddenSym: o[h] === undefined
+                });
+            })()
+            """).AsString();
+
+        Assert.Equal("""{"keys":["a","b"],"a":1,"b":2,"enumSym":"enum","hiddenSym":true}""", result);
+    }
+
+    [Fact]
+    public void SpreadNotFirstElementStreamsAndKeepsOrder()
+    {
+        var engine = new Engine();
+        // When the spread is not the first element the target already has slots, so the wholesale adopt
+        // is declined and the source keys stream in after the leading static key.
+        var result = engine.Evaluate("""
+            (function () {
+                var src = { b: 2, c: 3 };
+                var o = { a: 1, ...src, d: 4 };
+                return JSON.stringify({ keys: Object.keys(o), values: Object.values(o) });
+            })()
+            """).AsString();
+
+        Assert.Equal("""{"keys":["a","b","c","d"],"values":[1,2,3,4]}""", result);
+    }
+
+    [Fact]
+    public void SpreadTrailingKeyDoesNotLeakIntoAdoptedSource()
+    {
+        var engine = new Engine();
+        // The adopted clone must own its storage: adding a trailing key extends only the clone.
+        var result = engine.Evaluate("""
+            (function () {
+                var src = { a: 1, b: 2 };
+                var o = { ...src, c: 3 };
+                return JSON.stringify({
+                    cloneKeys: Object.keys(o),
+                    srcKeys: Object.keys(src),
+                    srcHasC: Object.prototype.hasOwnProperty.call(src, 'c')
+                });
+            })()
+            """).AsString();
+
+        Assert.Equal("""{"cloneKeys":["a","b","c"],"srcKeys":["a","b"],"srcHasC":false}""", result);
+    }
 }

--- a/Jint/Native/JsObject.cs
+++ b/Jint/Native/JsObject.cs
@@ -167,6 +167,66 @@ public sealed class JsObject : ObjectInstance
         return true;
     }
 
+    /// <summary>
+    /// Fast path for the object-spread copy idiom <c>{ ...src }</c>. When this target is a still-empty
+    /// shape-building object (the spread is the first element and nothing has been stored yet) and
+    /// <paramref name="source"/> is a shape-mode plain object that shares this object's prototype and
+    /// carries no symbol properties, the spread's result layout is <em>exactly</em> the source's: every
+    /// shape slot is an enumerable + writable + configurable data property — precisely the set
+    /// <see cref="ObjectInstance.CopyDataProperties"/> copies. So adopt the source's interned leaf
+    /// <see cref="Shape"/> and shallow-copy its slot values (value references, per spread semantics) in one
+    /// shot — O(slots) — instead of streaming O(keys) interned transitions through CreateDataProperty. The
+    /// <see cref="InternalTypes.ShapeBuilding"/> flag is left on so a trailing static key
+    /// (<c>{ ...src, x: 1 }</c>) still extends the adopted shape via <see cref="TryShapeAdd(in Key, JsValue)"/>.
+    /// Returns <c>false</c> — leaving this object untouched — when any precondition fails, so the caller
+    /// falls back to streaming.
+    /// </summary>
+    internal bool TryAdoptShapeFrom(JsObject source)
+    {
+        // Target (this) must be a fresh, empty shape-building object with no symbols yet. ShapeBuilding
+        // implies a non-null _shape, so the SlotCount read is safe once that flag is confirmed set.
+        if ((_type & InternalTypes.ShapeBuilding) == InternalTypes.Empty
+            || _shape!.SlotCount != 0
+            || _symbols is not null)
+        {
+            return false;
+        }
+
+        // Source must be a shape-mode plain object — which guarantees every own string property is an
+        // enumerable CEW data property (no getters, no non-enumerables), the exact set spread copies —
+        // carry no symbol properties (those live in _symbols, outside the shape; spread would copy the
+        // enumerable ones, so decline and let the caller stream them), and share this object's prototype.
+        // The interned shape is rooted per prototype (Engine.GetEmptyShape), so a shape whose root belongs
+        // to a different prototype must never be installed here.
+        if ((source._type & InternalTypes.ShapeMode) == InternalTypes.Empty
+            || source._symbols is not null
+            || !ReferenceEquals(source._prototype, _prototype))
+        {
+            return false;
+        }
+
+        var sourceShape = source._shape!;
+        _shape = sourceShape;
+
+        // In-object slots: one value-type copy brings over all InlineCapacity references at once. A layout
+        // smaller than InlineCapacity leaves the source's unused inline slots null, so the target's clear
+        // too; each object keeps its own storage, so a later write to a target slot never aliases back into
+        // the source.
+        _inline = source._inline;
+
+        var slotCount = sourceShape.SlotCount;
+        if (slotCount > InlineCapacity)
+        {
+            var overflowLength = slotCount - InlineCapacity;
+            var overflow = new JsValue[overflowLength];
+            System.Array.Copy(source._overflow!, overflow, overflowLength);
+            _overflow = overflow;
+        }
+
+        unchecked { _propertiesVersion++; }
+        return true;
+    }
+
     // The in-object slot block. On modern runtimes this is a single-field [InlineArray] so `_inline[i]`
     // lowers to a bounds-check-free field-offset access; on legacy TFMs it is an equivalent hand-rolled
     // fixed struct. InlineCapacity must equal the element count.

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -2101,6 +2101,20 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         ObjectInstance target,
         HashSet<JsValue>? excludedItems)
     {
+        // Fast path for the object-spread copy idiom `{ ...src }` (nothing excluded): when the target is a
+        // fresh shape-building object and the source (this) is a shape-mode plain object with the same
+        // prototype and no symbol properties, the target's resulting layout is exactly the source's. Adopt
+        // the interned shape and shallow-copy the slots — O(slots) — instead of streaming every key through
+        // CreateDataProperty. Object rest (`{ a, ...r }`) always passes a non-null excludedItems set, so it
+        // stays on the streaming path below where per-key exclusion is honored.
+        if (excludedItems is null
+            && target is JsObject targetJo
+            && this is JsObject sourceJo
+            && targetJo.TryAdoptShapeFrom(sourceJo))
+        {
+            return;
+        }
+
         var keys = GetOwnPropertyKeys();
         for (var i = 0; i < keys.Count; i++)
         {


### PR DESCRIPTION
## Problem

Object spread `{...src}` builds a shape-building target and streams every source key through `CopyDataProperties` → `CreateDataProperty` → `TryShapeAdd` — one interned transition plus a probe per key (#2635). That's already far cheaper than a dictionary, but `SpreadSmall` (`{...o}`, 4-property source) still cost **1.79× the allocation and ~1.5× the time** of the layout-equivalent shaped literal.

## Approach

When the source of a spread is itself a shape-mode object, the target's resulting layout is *exactly* the source's layout (a shaped object's own string properties are all enumerable CEW data). So instead of streaming keys, **adopt the source's interned leaf `Shape` and shallow-copy its slot values** — O(slots) ref-copy plus one shape install, replacing O(keys) transitions. Objects built from the same source layout then share the interned `Shape`, so the member inline cache hits across them too.

New `JsObject.TryAdoptShapeFrom(source)`, hooked at the top of `CopyDataProperties` (the spread choke point), fires only when all hold — otherwise it declines and the existing streaming path runs unchanged:

- target is a fresh empty shape-building `JsObject` (`SlotCount == 0`, `ShapeBuilding`, no symbols) — i.e. the spread is the first element;
- source is a shape-mode `JsObject` with no symbols;
- **prototypes match by reference** (interned shapes are rooted per-prototype via `Engine.GetEmptyShape`, so a shape rooted at a different prototype must never be adopted — the critical correctness gate);
- nothing is excluded (`excludedItems is null`, which cleanly scopes this to pure `{...src}` — object rest and function-parameter rest always pass a non-null exclusion set, so they stay on the streaming path).

`{...src, x: 1}` adopts then extends onto the same interned child shape; `{x: 1, ...src}` declines (a slot already exists); `{...a, ...b}` adopts `a` then streams `b`; symbol-carrying or dictionary-mode or custom-prototype sources decline and stream.

## Benchmarks (default job, baseline = `ee6683b59`, back-to-back)

| ObjectSpreadBenchmark | main | PR | Δ time | Δ alloc |
|---|---|---|---|---|
| LiteralClone (baseline row) | 11.50 ms / 10.68 MB | 11.02 ms / 10.68 MB | — | — |
| SpreadSmall `{...o}` | 17.36 ms / 19.08 MB (1.79×) | 6.27 ms / 10.68 MB (**1.00×**) | **−63.9%** | **−44.0%** |
| SpreadSmallOverride `{...o, d:i}` | 20.84 ms / 21.81 MB | 8.77 ms / 13.42 MB | **−57.9%** | **−38.5%** |
| SpreadTwoSources `{...a, ...b}` | 22.92 ms / 27.47 MB | 14.01 ms / 19.08 MB | **−38.9%** | **−30.5%** |
| SpreadLarge (24-prop) | 12.30 ms / 16.79 MB | 12.52 ms / 16.79 MB | flat | flat |

`SpreadSmall` now **allocates identically to the layout-equivalent literal** (ratio 1.79× → 1.00×) and runs *faster* than one (0.57× its time — it copies slots directly instead of evaluating four member reads). `SpreadLarge` is unchanged because its source is built by incremental `o[k]=v` assignment, which is dictionary-mode, not shaped — the fast path correctly declines. `PropertyAllocBenchmark` (literal/constructor construction) is byte-identical.

## Verification

- 7 new `ObjectSpreadShapeTests` pins (shape adoption + cross-instance sharing, inline + overflow independence, custom-prototype decline, integer-like-key source, symbol-source decline-but-copy, non-first-spread streaming, trailing-key isolation).
- `ObjectSpreadShapeTests` 31/31 both TFMs; full Jint.Tests **3491/3491 (net10.0) + 3428/3428 (net472)**; **Jint.Tests.CommonScripts 28/28** (babel-standalone gate); PublicInterface 82/82 (net472 `CanUseTimeProvider` is the documented pre-existing wall-clock flake).
- **Full Test262: 99,426 passed / 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
