### PR TITLE
Cache the top-level statement list per engine for re-executed scripts

### DIFF
--- a/Jint.Tests/Runtime/ScriptStatementListReuseTests.cs
+++ b/Jint.Tests/Runtime/ScriptStatementListReuseTests.cs
@@ -1,0 +1,91 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the semantics of the per-engine top-level (Program) statement-list cache: re-evaluating the
+/// same prepared script on one engine reuses the top-level handler tree (and, through it, top-level
+/// function-expression definitions and their warm inline caches) while every closure, environment and
+/// per-run value stays strictly per evaluation. A first evaluation - the fresh-engine-per-op shape -
+/// builds the tree fresh and caches nothing, so those hosts stay byte-identical to the historical path;
+/// these tests exercise the RE-evaluation branch that the cache actually engages on.
+/// </summary>
+public class ScriptStatementListReuseTests
+{
+    // Each case is (source, expected string result). Re-evaluated many times on ONE engine: the result
+    // must be identical every time, matching a fresh engine — the reused top-level tree must not carry
+    // stale per-run state.
+    public static TheoryData<string, string> Cases() => new()
+    {
+        { "var x = 1 + 1 === 2; '' + x;", "true" },
+        { "var t = 0; for (var i = 0; i < 10; i++) { t += i; } '' + t;", "45" },
+        { "var s = 0; { let y = 3; const z = y * 2; s = y + z; } '' + s;", "9" },
+        { "var out = ''; for (var k of [1, 2, 3]) { out += k; } out;", "123" },
+        { "var o = { a: 1, b: 2 }; var ks = ''; for (var p in o) { ks += p; } ks;", "ab" },
+        { "var r; try { r = 1; throw 'e'; } catch (e) { r = 2; } finally { r += 10; } '' + r;", "12" },
+        { "'use strict'; var q = (function () { return 42; })(); '' + q;", "42" },
+        { "var m = [1, 2, 3].map(function (v) { return v * v; }).reduce(function (a, b) { return a + b; }, 0); '' + m;", "14" },
+        { "function g(n) { var r = 0; for (var i = 0; i < n; i++) { r += i; } return r; } '' + g(100);", "4950" },
+        { "var sw = ''; switch (2) { case 1: sw = 'one'; break; case 2: sw = 'two'; break; default: sw = 'd'; } sw;", "two" },
+    };
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void RepeatedEvaluationMatchesFreshEngine(string source, string expected)
+    {
+        var prepared = Engine.PrepareScript(source);
+
+        // Baseline: a first evaluation on a fresh engine (the uncached path).
+        Assert.Equal(expected, new Engine().Evaluate(prepared).ToString());
+
+        // Re-evaluations on a single engine must produce the identical value every time.
+        var engine = new Engine();
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.Equal(expected, engine.Evaluate(prepared).ToString());
+        }
+    }
+
+    [Fact]
+    public void ReusedTopLevelFunctionExpressionRecapturesCurrentState()
+    {
+        // A top-level function expression's interpreter definition is reused across evaluations once the
+        // top-level tree is cached, but each evaluation must still produce a closure over THIS run's
+        // freshly re-declared global state — not a stale binding from an earlier run.
+        var engine = new Engine();
+        var prepared = Engine.PrepareScript("""
+            var base = seed * 10;
+            var add = function (n) { return base + n; };
+            add(seed);
+            """);
+
+        engine.SetValue("seed", 1);
+        Assert.Equal(11, engine.Evaluate(prepared).AsNumber()); // base=10, add(1)=11
+
+        engine.SetValue("seed", 5);
+        Assert.Equal(55, engine.Evaluate(prepared).AsNumber()); // base=50, add(5)=55
+
+        engine.SetValue("seed", 9);
+        Assert.Equal(99, engine.Evaluate(prepared).AsNumber()); // base=90, add(9)=99
+    }
+
+    [Fact]
+    public void ReusedTopLevelIifeKeepsIndependentPerRunState()
+    {
+        // The dominant embedding shape (module-pattern library) is a single top-level IIFE. Caching the
+        // top-level list reuses the IIFE's body tree across runs; each run must still get fresh internal
+        // state (the counter starts at 0 every evaluation).
+        var engine = new Engine();
+        var prepared = Engine.PrepareScript("""
+            (function () {
+                var count = 0;
+                function bump() { count += 1; return count; }
+                bump(); bump(); bump();
+                return count;
+            })();
+            """);
+
+        for (var i = 0; i < 4; i++)
+        {
+            Assert.Equal(3, engine.Evaluate(prepared).AsNumber());
+        }
+    }
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -75,6 +75,38 @@ public sealed partial class Engine : IDisposable
     // above only engages on RE-evaluation (see GlobalDeclarationInstantiation).
     private readonly HashSet<Script> _evaluatedScripts = new();
 
+    // Per-engine cache of the top-level (Program) statement handler tree, keyed on the stable AST.
+    // Engine-owned for the same lifetime reasons as _functionDefinitions: the tree accumulates
+    // engine-affine per-node inline caches, so it must not be shared across engines via the AST.
+    // Lazily allocated and only populated on RE-evaluation, so fresh-engine-per-op hosts never
+    // touch it and stay byte-identical. See GetOrBuildScriptStatementList.
+    private Dictionary<Script, JintStatementList>? _scriptStatementLists;
+
+    private JintStatementList GetOrBuildScriptStatementList(Script script, bool reEvaluation)
+    {
+        if (!reEvaluation)
+        {
+            // First evaluation on this engine (fresh-engine-per-op hosts only ever hit this):
+            // build fresh and cache nothing, byte-identical to the historical path.
+            return new JintStatementList(null, script.Body);
+        }
+
+        var cache = _scriptStatementLists ??= new Dictionary<Script, JintStatementList>();
+        if (!cache.TryGetValue(script, out var list))
+        {
+            // backstop mirroring CacheFunctionDefinition: bound growth for hosts streaming endless
+            // distinct sources through one long-lived engine.
+            if (cache.Count >= 2048)
+            {
+                cache.Clear();
+            }
+
+            cache[script] = list = new JintStatementList(null, script.Body);
+        }
+
+        return list;
+    }
+
     internal JintFunctionDefinition GetOrCreateFunctionDefinition(FunctionDeclaration declaration)
     {
         if (!TryGetFunctionDefinition(declaration, out var definition))
@@ -558,9 +590,14 @@ public sealed partial class Engine : IDisposable
         try
         {
             var script = scriptRecord.EcmaScriptCode;
-            GlobalDeclarationInstantiation(script, globalEnv);
+            var reEvaluation = GlobalDeclarationInstantiation(script, globalEnv);
 
-            var list = new JintStatementList(null, script.Body);
+            // On re-evaluation reuse this engine's cached top-level handler tree (and its warm
+            // per-node inline caches) instead of rebuilding it; a first evaluation - the fresh-
+            // engine-per-run shape - takes plain construction so those hosts stay byte-identical.
+            // Engine-owned like the function-definition cache above (dies with the engine, so it
+            // never pins a dropped engine through the shared prepared AST).
+            var list = GetOrBuildScriptStatementList(script, reEvaluation);
 
             Completion result;
             try
@@ -1169,7 +1206,7 @@ public sealed partial class Engine : IDisposable
     /// <summary>
     /// https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
     /// </summary>
-    private void GlobalDeclarationInstantiation(
+    private bool GlobalDeclarationInstantiation(
         Script script,
         GlobalEnvironment env)
     {
@@ -1182,14 +1219,14 @@ public sealed partial class Engine : IDisposable
 
         var realm = Realm;
 
+        // The definition / statement-list caches pay only when the same script runs on this engine
+        // again (the cached-Prepared<Script> embedding pattern); a first evaluation - fresh-engine-
+        // per-run hosts never see a second one - takes plain construction so one-shot scripts stay
+        // byte-identical to the uncached path.
+        var reEvaluation = !_evaluatedScripts.Add(script);
+
         if (functionDeclarations != null)
         {
-            // The definition cache pays only when the same script runs on this engine again (the
-            // cached-Prepared<Script> embedding pattern); a first evaluation - fresh-engine-per-run
-            // hosts never see a second one - takes plain construction so one-shot scripts stay
-            // byte-identical to the uncached path.
-            var reEvaluation = !_evaluatedScripts.Add(script);
-
             for (var i = functionDeclarations.Count - 1; i >= 0; i--)
             {
                 var d = functionDeclarations[i];
@@ -1288,6 +1325,8 @@ public sealed partial class Engine : IDisposable
                 }
             }
         }
+
+        return reEvaluation;
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

The top-level `Program` statement list of a script was rebuilt (`new JintStatementList(...)`) on **every** `Engine.Execute` — even when the same `Prepared<Script>` is re-run on a reused engine, the recommended production pattern. At ~316 bytes per top-level statement that is pure waste on re-execution, and because a top-level function *expression* (e.g. a module-pattern IIFE) lives inside that list, rebuilding it also discarded the IIFE's already-warm body handler tree each run.

This came out of an investigation into a suspected per-operation function-body rebuild. That part is a genuine **NO-GO**: the only way to save the *fresh-engine* body rebuild is sharing the immutable handler tree across engines via the AST's `UserData`, but handlers embed per-engine mutable inline caches (`SlotLocationCache`, block/loop env caches), so cross-engine sharing either pins dropped engines (fails `SharedPreparedScriptDoesNotRetainEngines`) or moves the caches behind an indirection that kills the slot lanes — exactly the trap #2613/#2616 documents. This PR ships only the safe, adjacent win the investigation surfaced.

## Approach

Cache the top-level `JintStatementList` **per engine** in an engine-owned `Dictionary<Script, JintStatementList>`, keyed on the stable AST and **gated on `reEvaluation` exactly like the existing `_functionDefinitions` cache**. `GlobalDeclarationInstantiation` returns whether this is a re-evaluation; the first evaluation on any engine takes the historical `new JintStatementList` path and caches nothing.

Why it cannot regress the slot lanes (the mandatory check for anything touching handler-tree caching):
- **Fresh-engine byte-identical** — first evaluation is unchanged, so fresh-engine rows can't move.
- **Per-engine, not cross-engine** — the cache dies with the engine; no dropped-engine pinning.
- **Function-declaration body trees are untouched** (still `_functionDefinitions`) — the slot lanes live there, not in the top-level list.

## Benchmarks (default job, baseline = `ee6683b59`, back-to-back)

`PreparedAnomalyBenchmarks` — the reused-engine row is the target:

| Row | main | PR | Δ alloc |
|---|---|---|---|
| **PreparedReusedEngine** | 10.45 ms / 9.95 KB | 10.75 ms / **3.20 KB** | **−67.8%** |
| SourcePerOp (fresh) | 9.50 ms / 45.6 KB | 9.32 ms / 45.6 KB | byte-identical |
| PreparedShared (fresh) | 9.18 ms / 24.0 KB | 9.42 ms / 24.0 KB | byte-identical |
| PreparedPerOp (fresh) | 9.72 ms / 47.2 KB | 9.24 ms / 47.2 KB | byte-identical |

Per-op allocation probe on reused engines: **linq-js −46%, evaluation −59%, minimal −57%**, top-level var-decl (k=40) −81%.

**LoopDispatchBenchmarks — the slot-lane tripwire — held:** allocations went *down* (EmptyLoop / CounterAdd / equality rows 1.63 → 1.27 KB, the saved per-op top-level-list rebuild), rather than exploding to MB as a slot-lane regression would. Times are within the documented bimodal band (CounterAdd +5.6% and ModuloEqual −6.8% opposite-sign in the same run); the deterministic allocation floor is the gate and it improved.

## Verification

- New `ScriptStatementListReuseTests` (12): re-execution equivalence across var/blocks/let-const/for/for-of/for-in/switch/try-catch/IIFE/map-reduce, top-level function-expression re-capture, and IIFE per-run state independence.
- Full Jint.Tests **3496/3496 (net10.0) + 3433/3433 (net472)**; **Jint.Tests.CommonScripts 28/28**; PublicInterface 82/82 both TFMs (no public API change — additions are private).
- **Full Test262: 99,426 passed / 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
