### PR TITLE
Update Test262 suite to d1d583db

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -1,5 +1,5 @@
 {
-  "SuiteGitSha": "250f204f23a9249ff204be2baec29600faae7b75",
+  "SuiteGitSha": "d1d583db95a521218f3eb8341a887fd63eda8ff1",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Jint.Tests.Test262",

--- a/Jint/Runtime/Modules/CyclicModule.cs
+++ b/Jint/Runtime/Modules/CyclicModule.cs
@@ -140,7 +140,15 @@ public abstract class CyclicModule : Module
                 m._evalError = result;
             }
 
-            _abnormalCompletionLocation = result.Location;
+            // A completion recorded by AsyncModuleExecutionRejected carries only the thrown value and has
+            // no associated AST node (source is default). Re-evaluating an errored top-level-await cycle
+            // root - e.g. a dynamic import of a fulfilled member of an already-errored cycle - returns that
+            // recorded [[EvaluationError]] here, so only capture a location when the completion has one.
+            if (result._source is not null)
+            {
+                _abnormalCompletionLocation = result.Location;
+            }
+
             capability.Reject(result.Value);
         }
         else


### PR DESCRIPTION
Updates the pinned Test262 suite to [`d1d583db`](https://github.com/tc39/test262/commit/d1d583db95a521218f3eb8341a887fd63eda8ff1) — the current tip of `tc39/test262` `main`, from the previous `250f204f`.

The delta is two new module test files:

- `language/import/import-defer/deferred-namespace-object/json-module.js` (import-defer + JSON modules) — **passes** unchanged.
- `language/expressions/dynamic-import/import-fulfilled-member-of-errored-cycle.js` (dynamic import of a fulfilled member of an errored TLA cycle) — **exposed a genuine engine bug**, fixed here.

## The fix

Dynamically importing a fulfilled member of an already-errored top-level-await cycle threw a `NullReferenceException` instead of rejecting with the recorded `[[EvaluationError]]`.

When `CyclicModule.Evaluate` re-evaluates the errored cycle root, `InnerModuleEvaluation` returns the completion previously recorded by `AsyncModuleExecutionRejected`. That completion carries only the thrown value and has **no** associated AST node (`default` source), so capturing `result.Location` for `_abnormalCompletionLocation` dereferenced a null source:

```
System.NullReferenceException
   at Jint.Runtime.Completion.get_Location()
   at Jint.Runtime.Modules.CyclicModule.Evaluate()
```

The location is only needed to enrich the error surfaced on the synchronous evaluation path; on the async/`import()` path the rejection propagates the original error value regardless. The fix guards the location capture on the completion actually having a source, so the import now rejects with the same error object the cycle originally failed with (as the test asserts: `errorFromC === errorFromMain`).

## Testing

Full Test262 run at the new SHA: **0 failed, 99429 passed, 137 skipped**. `Jint.Tests` module suite green on net10.0 and net472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)