### PR TITLE
4.12.0 release prep: correctness fixes from pre-release review + benchmark refresh

### DIFF
--- a/Jint.Benchmark/README.md
+++ b/Jint.Benchmark/README.md
@@ -4,22 +4,22 @@ This project benchmarks Jint against the other managed JavaScript engines for .N
 ([Jurassic](https://github.com/paiden/Jurassic), [NiL.JS](https://github.com/nilproject/NiL.JS) and
 [YantraJS](https://github.com/yantrajs/yantra)) across a set of representative scripts.
 
-## At a glance (current main, post-4.11.0)
+## At a glance (4.12.0)
 
 Using Jint's recommended production path (a cached prepared script) and comparing against the
 **closest competitor** on each script:
 
 * **Fastest engine on 17 of the 21 scripts** — leading the object, string, base64, regex and JSON
-  scripts by **1.05×–4.9×** over the next-fastest engine, starting tiny scripts up **3×–6×** faster
-  (`minimal` executes in **under a microsecond**), and leading `dromaeo-core-eval`. The new
-  `json-parse` row is a Jint win outright: **2.3× faster than Jurassic and 1.4× faster than the
-  YantraJS JIT** while allocating the least of any engine.
-* **Fastest interpreter on every script.** On the remaining four rows only the IL-compiling engine
-  is ahead: `dromaeo-3d-cube` runs **1.18×** ahead of the next interpreter and `stopwatch` /
-  `stopwatch-modern` — long the closest-fought interpreter rows — lead the nearest interpreter by
-  **~1.33× / ~1.6×**.
+  scripts by **1.05×–5.4×** over the next-fastest engine, starting tiny scripts up **3×–6×** faster
+  (`minimal` executes in **under a microsecond**), and leading `dromaeo-core-eval`. The
+  `json-parse` row is a Jint win outright: **the fastest of any engine**, ahead of the closest
+  competitor while allocating the least in the field.
+* **Fastest interpreter on every script.** On the remaining four rows only the engine that compiles
+  JavaScript to IL is ahead: `dromaeo-3d-cube` runs **1.21×** ahead of the next interpreter and
+  `stopwatch` / `stopwatch-modern` — long the closest-fought interpreter rows — lead the nearest
+  interpreter by **~1.4× / ~1.6×**.
 * **By far the lowest memory use.** Typically **2×–63×** less allocation than the closest competitor
-  — and up to **470×** less than the highest in the field — which means much lighter GC pressure in
+  — and up to **471×** less than the highest in the field — which means much lighter GC pressure in
   real applications.
 
 ## Running the benchmarks
@@ -42,15 +42,15 @@ Notes:
 
 ## How to read the table
 
-* All engines are run in **global strict mode** — YantraJS is strict-only, and strict mode improves
-  performance across the board.
+* All engines are run in **global strict mode** — one competitor is strict-only, and strict mode
+  improves performance across the board.
 * `Jint` re-parses the script source on every operation; `Jint_ParsedScript` reuses a cached
   `Prepared<Script>` produced once by `Engine.PrepareScript`. The gap between the two is pure
   parsing cost — **in production you should cache the prepared script**, which is what
   `Jint_ParsedScript` represents.
 * The `*-modern` scripts are ES2015+ rewrites (`const`, arrow functions, …) of the classic ES5
-  scripts. **Jurassic reports `NA` on every `-modern` row** because it predates ES2015 and cannot
-  parse that syntax.
+  scripts. The one ES5-era engine in the field reports `NA` on every `-modern` row because it
+  predates ES2015 and cannot parse that syntax.
 * `Mean` is time per operation (lower is better); `Allocated` is managed memory per operation
   (lower is better). `Rank` groups results that are statistically tied.
 
@@ -59,27 +59,26 @@ Notes:
 Numbers use Jint's recommended production path (`Jint_ParsedScript`, a cached prepared script) and
 compare against the closest competitor on each script.
 
-* **Tiny-script latency.** `minimal` runs in **0.94 µs** and `evaluation` / `evaluation-modern` in
-  ~4.2–4.3 µs — **3× and 6× faster than the closest competitor**.
-* **Cached scripts avoid re-parsing.** `linq-js` drops from 1,180 µs (re-parsed every run) to
-  **59 µs** when the prepared script is reused — ~20× — which is also **5.6× faster than the
+* **Tiny-script latency.** `minimal` runs in **0.95 µs** and `evaluation` / `evaluation-modern` in
+  ~4.2–4.4 µs — **3× and 6× faster than the closest competitor**.
+* **Cached scripts avoid re-parsing.** `linq-js` drops from 1,193 µs (re-parsed every run) to
+  **58 µs** when the prepared script is reused — ~20× — which is also **5.5× faster than the
   next-fastest engine**. Cache your `Prepared<Script>` in production.
 * **eval-heavy code.** `dromaeo-core-eval` runs in **0.97 ms — 1.26× faster than the closest
-  competitor** (the modern variant is 1.56× faster); eval bodies execute on the same per-iteration
+  competitor** (the modern variant is 1.46× faster); eval bodies execute on the same per-iteration
   fast paths as regular function bodies.
 * **Object, string, base64 and regex workloads.** Jint is the fastest engine on
-  `dromaeo-object-array` (**2.1×**), `dromaeo-object-string` (**3.0×**), `dromaeo-object-regexp`
-  (**4.9×**) and `dromaeo-string-base64` (**1.05×**, allocating **12× less** than the next
+  `dromaeo-object-array` (**2.1×**), `dromaeo-object-string` (**3.3×**), `dromaeo-object-regexp`
+  (**5.4×**) and `dromaeo-string-base64` (**1.05×**, allocating **12× less** than the next
   engine).
-* **JSON parsing** (`json-parse` / `json-parse-modern`): **20.3 ms / 18.2 ms — the fastest of any
-  engine**, 2.3× ahead of Jurassic and **1.4× ahead of the YantraJS JIT**, while allocating the
-  least in the field (21 MB vs 44–76 MB, 2.1×–3.6× less). Parsed objects build a shared hidden
-  class, so an array of like-shaped records is one allocation per record instead of a property
-  dictionary each.
-* **Call- and closure-heavy loops** (`stopwatch` / `stopwatch-modern`): **~100 ms and 91 ms — the
-  fastest interpreter, ~1.33× / ~1.6× ahead of the nearest interpreter** (previously the
-  closest-fought rows in the table), while allocating **7.9×–26×** less than any competitor.
-* **Heavy floating-point math among interpreters.** `dromaeo-3d-cube` runs in **5.08 ms — 1.18×
+* **JSON parsing** (`json-parse` / `json-parse-modern`): **20.1 ms / 17.8 ms — the fastest of any
+  engine**, ahead of the closest competitor while allocating the least in the field (21 MB vs
+  44–76 MB, 2.1×–3.6× less). Parsed objects build a shared hidden class, so an array of like-shaped
+  records is one allocation per record instead of a property dictionary each.
+* **Call- and closure-heavy loops** (`stopwatch` / `stopwatch-modern`): **~95 ms and 90 ms — the
+  fastest interpreter, ~1.4× / ~1.6× ahead of the nearest interpreter** (previously the
+  closest-fought rows in the table), while allocating **7.9×–18×** less than any competitor.
+* **Heavy floating-point math among interpreters.** `dromaeo-3d-cube` runs in **5.11 ms — 1.21×
   ahead of every other interpreter** — while allocating the least of any engine on that script
   (1.4 MB vs 4.9–10.7 MB).
 * **Allocations are one to two orders of magnitude lower than the field,** which means far less GC
@@ -88,7 +87,7 @@ compare against the closest competitor on each script.
   | Benchmark | Jint | Closest competitor | Highest in field |
   |--- |---: |---: |---: |
   | `dromaeo-object-string` | **21 MB** | 1,355 MB (63×) | 1,653 MB (77×) |
-  | `dromaeo-string-base64` | **1.6 MB** | 20 MB (12×) | 764 MB (472×) |
+  | `dromaeo-string-base64` | **1.6 MB** | 20 MB (12×) | 764 MB (471×) |
   | `dromaeo-object-array` | **8.9 MB** | 18 MB (2.0×) | 215 MB (24×) |
   | `stopwatch` | **12 MB** | 95 MB (7.9×) | 216 MB (18×) |
   | `json-parse` | **21 MB** | 44 MB (2.1×) | 76 MB (3.6×) |
@@ -98,26 +97,28 @@ compare against the closest competitor on each script.
 Only the engine that compiles JavaScript to IL remains ahead, and only on tight numeric/call loops
 where compiled code runs close to native speed — the structural interpreter-vs-compiler gap:
 
-* **Heavy floating-point / matrix math** (`dromaeo-3d-cube`): 5.08 ms vs the IL compiler's 2.47 ms
-  (2.1×). Every interpreter is behind Jint on this script.
+* **Heavy floating-point / matrix math** (`dromaeo-3d-cube`): 5.11 ms vs the IL compiler's 2.56 ms
+  (2.0×). Every interpreter is behind Jint on this script.
 * **Call- and closure-heavy loops with frequent `new Date()`** (`stopwatch` / `stopwatch-modern`):
-  ~100 ms / 91 ms vs the IL compiler's 57 ms / 60 ms (1.77× / 1.53×) — while allocating 18× less
-  than it. These rows are bimodal on this machine (the re-parsing `Jint` row reads 95.6 ms,
-  slightly ahead of the cached `Jint_ParsedScript` row); either way Jint is the fastest interpreter.
+  ~95 ms / 90 ms vs the IL compiler's 56 ms / 59 ms (1.69× / 1.51×) — while allocating 18× less
+  than it. Either way Jint is the fastest interpreter on both rows.
 
-## What's new since the previous refresh
+## What's new in 4.12.0
 
-Measured against the previous refresh ([#2629](https://github.com/sebastienros/jint/pull/2629)) —
-competitor versions are unchanged, and their rows were used as a thermal canary to confirm the
-window is comparable (times within ±3%).
+Measured against the 4.11.0 release; competitor versions are unchanged.
 
 * **New `json-parse` / `json-parse-modern` rows, and Jint leads them.** `JSON.parse` now builds
   parsed objects as shared hidden classes
   ([#2634](https://github.com/sebastienros/jint/pull/2634)) — an array of like-shaped records costs
   one allocation per record instead of a property dictionary plus per-property descriptors, so the
   win shows even on a freshly constructed engine. Jint parses the array-of-records workload in
-  **20.3 ms / 21 MB — 2.3× faster than Jurassic and 1.4× faster than the YantraJS JIT**, allocating
-  2.1×–3.6× less than either.
+  **20.1 ms / 21 MB — the fastest of any engine**, ahead of the closest competitor and allocating
+  2.1×–3.6× less than the field.
+* **Tighter call and loop dispatch.** A dispatch campaign
+  ([#2622](https://github.com/sebastienros/jint/pull/2622)–[#2628](https://github.com/sebastienros/jint/pull/2628))
+  trimmed per-call ceremony, added unboxed operand lanes for comparisons and bitwise operators, and
+  cached zero-argument constructors, which is most visible on the call- and closure-heavy
+  `stopwatch` / `stopwatch-modern` rows and keeps Jint the fastest interpreter there.
 * **A coverage campaign added benchmarks for common patterns the table did not exercise**
   ([#2630](https://github.com/sebastienros/jint/pull/2630)) — `reduce`/`forEach`, object
   spread/`Object.assign`, optional chaining, async/await + microtasks, `try`/`catch` + `Error`,
@@ -135,20 +136,15 @@ window is comparable (times within ±3%).
   hidden class from its third instance instead of after the sixteenth
   ([#2636](https://github.com/sebastienros/jint/pull/2636)), helping short-lived / per-request
   engines that never reached the old promote threshold.
-* The remaining table rows are within noise of the previous refresh, as expected — the object,
-  string, base64, regex, eval, `stopwatch` and `3d-cube` rows were already at the levels the
-  preceding dispatch campaign ([#2622](https://github.com/sebastienros/jint/pull/2622)–[#2629](https://github.com/sebastienros/jint/pull/2629))
-  established, and this campaign targeted patterns that engine-reuse — not fresh construction —
-  makes visible.
 
 ## Engine versions
 
-* Jint main (post-4.11.0)
+* Jint 4.12.0
 * Jurassic 3.2.9
 * NiL.JS 2.6.1722
 * YantraJS.Core 1.2.406
 
-Last updated 2026-07-11.
+Last updated 2026-07-12.
 
 ```
 
@@ -162,128 +158,128 @@ AMD Ryzen 9 5950X 3.40GHz, 1 CPU, 32 logical and 16 physical cores
 ```
 | Method            | FileName                     | Mean             | StdDev           | Median           | Rank | Allocated     |
 |------------------ |----------------------------- |-----------------:|-----------------:|-----------------:|-----:|--------------:|
-| Jint_ParsedScript | array-stress                 |   2,367,685.0 ns |     10,328.31 ns |   2,372,176.2 ns |    1 |    1059.78 KB |
-| Jint              | array-stress                 |   2,422,946.1 ns |     98,947.68 ns |   2,367,493.8 ns |    1 |    1088.51 KB |
-| YantraJS          | array-stress                 |   2,927,969.9 ns |     18,930.99 ns |   2,928,348.8 ns |    2 |   17123.82 KB |
-| NilJS             | array-stress                 |   4,906,359.4 ns |     30,002.30 ns |   4,899,641.8 ns |    3 |    4521.19 KB |
-| Jurassic          | array-stress                 |   8,969,059.3 ns |     65,019.25 ns |   8,953,382.8 ns |    4 |   11644.88 KB |
+| Jint_ParsedScript | array-stress                 |   2,377,261.6 ns |     22,074.11 ns |   2,375,025.2 ns |    1 |     1059.9 KB |
+| Jint              | array-stress                 |   2,432,410.2 ns |     11,736.49 ns |   2,437,587.5 ns |    1 |    1088.63 KB |
+| YantraJS          | array-stress                 |   2,962,473.3 ns |     24,026.83 ns |   2,964,086.7 ns |    2 |   17123.82 KB |
+| NilJS             | array-stress                 |   4,935,863.9 ns |     26,287.35 ns |   4,928,714.1 ns |    3 |    4521.19 KB |
+| Jurassic          | array-stress                 |   9,084,724.3 ns |     31,059.94 ns |   9,077,957.8 ns |    4 |   11644.87 KB |
 |                   |                              |                  |                  |                  |      |               |
-| YantraJS          | dromaeo-3d-cube              |   2,553,403.9 ns |     17,766.99 ns |   2,551,056.6 ns |    1 |    7596.01 KB |
-| Jint_ParsedScript | dromaeo-3d-cube              |   5,094,186.2 ns |     27,322.71 ns |   5,093,593.0 ns |    2 |     1418.6 KB |
-| Jint              | dromaeo-3d-cube              |   5,530,627.0 ns |     33,060.97 ns |   5,534,997.3 ns |    3 |    1722.58 KB |
-| NilJS             | dromaeo-3d-cube              |   6,283,147.2 ns |     32,810.05 ns |   6,276,694.5 ns |    4 |    4903.32 KB |
-| Jurassic          | dromaeo-3d-cube              |  54,991,977.9 ns |    163,238.29 ns |  54,943,145.0 ns |    5 |   10654.72 KB |
+| YantraJS          | dromaeo-3d-cube              |   2,561,766.0 ns |     27,070.22 ns |   2,553,780.9 ns |    1 |    7596.01 KB |
+| Jint_ParsedScript | dromaeo-3d-cube              |   5,107,575.2 ns |     27,901.62 ns |   5,104,432.4 ns |    2 |    1418.61 KB |
+| Jint              | dromaeo-3d-cube              |   5,604,767.0 ns |     28,874.45 ns |   5,596,511.7 ns |    3 |    1722.59 KB |
+| NilJS             | dromaeo-3d-cube              |   6,160,956.3 ns |     26,192.56 ns |   6,150,566.4 ns |    4 |    4903.32 KB |
+| Jurassic          | dromaeo-3d-cube              |  55,830,544.3 ns |    207,702.36 ns |  55,850,430.0 ns |    5 |   10654.72 KB |
 |                   |                              |                  |                  |                  |      |               |
 | Jurassic          | dromaeo-3d-cube-modern       |               NA |               NA |               NA |    ? |            NA |
-| YantraJS          | dromaeo-3d-cube-modern       |   2,521,332.4 ns |     17,063.91 ns |   2,520,745.3 ns |    1 |    7514.24 KB |
-| Jint_ParsedScript | dromaeo-3d-cube-modern       |   5,069,655.6 ns |     23,720.98 ns |   5,067,628.9 ns |    2 |    1344.25 KB |
-| Jint              | dromaeo-3d-cube-modern       |   5,478,349.9 ns |     11,192.32 ns |   5,481,219.1 ns |    3 |    1648.04 KB |
-| NilJS             | dromaeo-3d-cube-modern       |   7,139,304.2 ns |     41,613.63 ns |   7,120,471.1 ns |    4 |    5977.95 KB |
+| YantraJS          | dromaeo-3d-cube-modern       |   2,547,685.1 ns |     17,772.11 ns |   2,556,654.3 ns |    1 |    7514.24 KB |
+| Jint_ParsedScript | dromaeo-3d-cube-modern       |   5,147,509.7 ns |     16,493.69 ns |   5,145,196.9 ns |    2 |    1344.26 KB |
+| Jint              | dromaeo-3d-cube-modern       |   5,542,344.7 ns |     28,215.38 ns |   5,547,254.7 ns |    3 |    1648.05 KB |
+| NilJS             | dromaeo-3d-cube-modern       |   7,085,778.3 ns |     31,631.74 ns |   7,085,266.8 ns |    4 |    5977.95 KB |
 |                   |                              |                  |                  |                  |      |               |
-| Jint_ParsedScript | dromaeo-core-eval            |     965,808.8 ns |      4,187.16 ns |     965,885.3 ns |    1 |     340.53 KB |
-| Jint              | dromaeo-core-eval            |   1,001,650.2 ns |      7,337.67 ns |   1,000,871.3 ns |    2 |     360.98 KB |
-| NilJS             | dromaeo-core-eval            |   1,235,228.2 ns |     10,886.31 ns |   1,232,450.8 ns |    3 |     1577.1 KB |
-| YantraJS          | dromaeo-core-eval            |   4,917,499.9 ns |     74,359.00 ns |   4,920,242.2 ns |    4 |   35784.73 KB |
-| Jurassic          | dromaeo-core-eval            |  16,815,663.3 ns |    104,998.16 ns |  16,800,131.2 ns |    5 |    2876.04 KB |
+| Jint_ParsedScript | dromaeo-core-eval            |     970,521.1 ns |      4,197.76 ns |     970,979.5 ns |    1 |     340.65 KB |
+| Jint              | dromaeo-core-eval            |     978,891.5 ns |      7,385.88 ns |     977,063.5 ns |    1 |      361.1 KB |
+| NilJS             | dromaeo-core-eval            |   1,222,849.4 ns |      8,278.98 ns |   1,220,361.3 ns |    2 |     1577.1 KB |
+| YantraJS          | dromaeo-core-eval            |   5,085,778.9 ns |     42,106.17 ns |   5,081,568.4 ns |    3 |   35784.73 KB |
+| Jurassic          | dromaeo-core-eval            |  16,799,198.8 ns |     66,670.63 ns |  16,781,481.2 ns |    4 |    2876.11 KB |
 |                   |                              |                  |                  |                  |      |               |
 | Jurassic          | dromaeo-core-eval-modern     |               NA |               NA |               NA |    ? |            NA |
-| Jint_ParsedScript | dromaeo-core-eval-modern     |     950,410.8 ns |      4,717.88 ns |     948,553.9 ns |    1 |     340.34 KB |
-| Jint              | dromaeo-core-eval-modern     |     992,673.4 ns |      4,046.04 ns |     993,194.8 ns |    2 |     360.05 KB |
-| NilJS             | dromaeo-core-eval-modern     |   1,417,470.1 ns |      8,424.90 ns |   1,418,806.2 ns |    3 |    1575.94 KB |
-| YantraJS          | dromaeo-core-eval-modern     |   4,948,015.0 ns |     43,124.99 ns |   4,939,085.5 ns |    4 |   35784.84 KB |
+| Jint_ParsedScript | dromaeo-core-eval-modern     |     955,586.4 ns |      6,260.46 ns |     954,861.7 ns |    1 |     340.45 KB |
+| Jint              | dromaeo-core-eval-modern     |     996,669.7 ns |      4,605.74 ns |     996,358.3 ns |    2 |     360.17 KB |
+| NilJS             | dromaeo-core-eval-modern     |   1,397,301.0 ns |      5,253.50 ns |   1,397,674.2 ns |    3 |    1575.94 KB |
+| YantraJS          | dromaeo-core-eval-modern     |   4,782,230.0 ns |     52,091.30 ns |   4,778,414.1 ns |    4 |   35784.84 KB |
 |                   |                              |                  |                  |                  |      |               |
-| Jint              | dromaeo-object-array         |  11,766,127.6 ns |     79,271.25 ns |  11,794,828.1 ns |    1 |     9164.5 KB |
-| Jint_ParsedScript | dromaeo-object-array         |  12,021,449.7 ns |     85,975.11 ns |  12,037,174.2 ns |    1 |    9116.09 KB |
-| YantraJS          | dromaeo-object-array         |  24,923,264.1 ns |     57,647.19 ns |  24,916,221.9 ns |    2 |  220011.02 KB |
-| Jurassic          | dromaeo-object-array         |  36,133,644.6 ns |  1,114,946.95 ns |  35,901,553.6 ns |    3 |   25809.29 KB |
-| NilJS             | dromaeo-object-array         |  52,301,016.7 ns |    142,264.68 ns |  52,285,350.0 ns |    4 |   17862.17 KB |
+| Jint              | dromaeo-object-array         |  11,734,070.8 ns |     24,769.73 ns |  11,732,057.8 ns |    1 |    9164.62 KB |
+| Jint_ParsedScript | dromaeo-object-array         |  11,848,101.5 ns |    148,691.21 ns |  11,769,998.4 ns |    1 |    9116.21 KB |
+| YantraJS          | dromaeo-object-array         |  24,885,871.9 ns |    122,500.69 ns |  24,850,543.8 ns |    2 |  220011.02 KB |
+| Jurassic          | dromaeo-object-array         |  36,852,412.6 ns |    414,307.34 ns |  37,006,846.2 ns |    3 |   25808.85 KB |
+| NilJS             | dromaeo-object-array         |  51,968,596.4 ns |    278,679.88 ns |  51,948,890.0 ns |    4 |   17862.17 KB |
 |                   |                              |                  |                  |                  |      |               |
 | Jurassic          | dromaeo-object-array-modern  |               NA |               NA |               NA |    ? |            NA |
-| Jint_ParsedScript | dromaeo-object-array-modern  |  15,272,670.0 ns |     55,547.33 ns |  15,277,971.1 ns |    1 |    9117.65 KB |
-| Jint              | dromaeo-object-array-modern  |  15,556,543.5 ns |     91,077.89 ns |  15,521,724.2 ns |    1 |    9165.04 KB |
-| YantraJS          | dromaeo-object-array-modern  |  25,039,326.6 ns |    369,632.66 ns |  25,078,678.1 ns |    2 |  223803.33 KB |
-| NilJS             | dromaeo-object-array-modern  |  53,326,535.3 ns |    238,138.22 ns |  53,280,880.0 ns |    3 |   17863.19 KB |
+| Jint_ParsedScript | dromaeo-object-array-modern  |  14,636,747.8 ns |    107,715.09 ns |  14,675,878.1 ns |    1 |    9117.77 KB |
+| Jint              | dromaeo-object-array-modern  |  15,032,690.4 ns |    121,041.45 ns |  15,042,318.8 ns |    1 |    9165.16 KB |
+| YantraJS          | dromaeo-object-array-modern  |  24,666,946.7 ns |    553,079.34 ns |  24,919,767.2 ns |    2 |  223803.33 KB |
+| NilJS             | dromaeo-object-array-modern  |  51,456,789.3 ns |    221,398.90 ns |  51,420,225.0 ns |    3 |   17863.19 KB |
 |                   |                              |                  |                  |                  |      |               |
-| Jint_ParsedScript | dromaeo-object-regexp        | 107,283,743.1 ns |  4,074,046.75 ns | 107,433,520.0 ns |    1 |  156672.11 KB |
-| Jint              | dromaeo-object-regexp        | 119,247,442.2 ns |  6,490,391.49 ns | 116,886,250.0 ns |    2 |  155188.01 KB |
-| NilJS             | dromaeo-object-regexp        | 525,172,194.4 ns | 10,541,455.24 ns | 523,316,450.0 ns |    3 |  765635.07 KB |
-| Jurassic          | dromaeo-object-regexp        | 675,056,796.2 ns | 17,789,127.00 ns | 677,059,600.0 ns |    4 |  825213.33 KB |
-| YantraJS          | dromaeo-object-regexp        | 712,107,600.0 ns |  6,597,436.50 ns | 715,644,100.0 ns |    5 |  823988.74 KB |
+| Jint_ParsedScript | dromaeo-object-regexp        |  99,397,424.1 ns |  5,187,878.46 ns |  99,105,900.0 ns |    1 |  159484.19 KB |
+| Jint              | dromaeo-object-regexp        | 121,920,600.0 ns |  4,517,573.70 ns | 122,353,133.3 ns |    2 |  154780.48 KB |
+| NilJS             | dromaeo-object-regexp        | 533,917,041.2 ns | 10,914,303.67 ns | 532,245,400.0 ns |    3 |   767448.2 KB |
+| Jurassic          | dromaeo-object-regexp        | 688,122,775.0 ns | 17,668,388.65 ns | 691,421,000.0 ns |    4 |  831751.28 KB |
+| YantraJS          | dromaeo-object-regexp        | 719,093,020.0 ns |  4,256,641.94 ns | 719,911,400.0 ns |    4 |   825423.4 KB |
 |                   |                              |                  |                  |                  |      |               |
 | Jurassic          | dromaeo-object-regexp-modern |               NA |               NA |               NA |    ? |            NA |
-| Jint_ParsedScript | dromaeo-object-regexp-modern | 103,746,144.5 ns |  3,157,827.93 ns | 103,207,460.0 ns |    1 |  155630.77 KB |
-| Jint              | dromaeo-object-regexp-modern | 122,124,285.9 ns |  4,638,530.53 ns | 123,167,766.7 ns |    2 |  157474.95 KB |
-| NilJS             | dromaeo-object-regexp-modern | 533,831,813.3 ns |  8,360,126.65 ns | 531,678,700.0 ns |    3 |  767177.59 KB |
-| YantraJS          | dromaeo-object-regexp-modern | 709,789,385.7 ns | 10,539,573.08 ns | 714,021,200.0 ns |    4 |  825336.03 KB |
+| Jint_ParsedScript | dromaeo-object-regexp-modern |  95,252,668.4 ns |  3,322,069.84 ns |  94,795,100.0 ns |    1 |   153586.8 KB |
+| Jint              | dromaeo-object-regexp-modern | 115,301,910.2 ns |  5,080,328.67 ns | 113,304,400.0 ns |    2 |  154275.57 KB |
+| NilJS             | dromaeo-object-regexp-modern | 530,882,869.2 ns |  5,331,822.71 ns | 531,923,900.0 ns |    3 |  765558.98 KB |
+| YantraJS          | dromaeo-object-regexp-modern | 714,553,964.3 ns |  7,419,506.80 ns | 717,243,050.0 ns |    4 |  828657.69 KB |
 |                   |                              |                  |                  |                  |      |               |
-| Jint_ParsedScript | dromaeo-object-string        |  44,249,779.8 ns |    548,172.07 ns |  44,042,541.7 ns |    1 |   21542.13 KB |
-| Jint              | dromaeo-object-string        |  44,282,187.2 ns |  1,108,168.55 ns |  43,971,000.0 ns |    1 |   21649.53 KB |
-| NilJS             | dromaeo-object-string        | 132,881,186.4 ns |  3,142,258.10 ns | 132,345,550.0 ns |    2 | 1355040.14 KB |
-| YantraJS          | dromaeo-object-string        | 156,668,485.5 ns |  3,936,479.85 ns | 156,774,966.7 ns |    3 | 1653002.42 KB |
-| Jurassic          | dromaeo-object-string        | 208,366,033.3 ns |  6,489,728.48 ns | 209,774,400.0 ns |    4 | 1430487.87 KB |
+| Jint_ParsedScript | dromaeo-object-string        |  44,850,624.5 ns |    632,186.43 ns |  45,144,718.2 ns |    1 |   21585.85 KB |
+| Jint              | dromaeo-object-string        |  46,304,197.0 ns |    821,304.67 ns |  46,624,054.5 ns |    1 |   21680.99 KB |
+| NilJS             | dromaeo-object-string        | 149,830,460.0 ns |  3,878,608.64 ns | 148,667,000.0 ns |    2 | 1354908.97 KB |
+| YantraJS          | dromaeo-object-string        | 179,837,241.7 ns |  4,487,951.27 ns | 180,884,100.0 ns |    3 | 1653065.13 KB |
+| Jurassic          | dromaeo-object-string        | 232,088,525.0 ns |  6,363,256.78 ns | 230,991,300.0 ns |    4 | 1430425.69 KB |
 |                   |                              |                  |                  |                  |      |               |
 | Jurassic          | dromaeo-object-string-modern |               NA |               NA |               NA |    ? |            NA |
-| Jint              | dromaeo-object-string-modern |  56,202,203.0 ns |  1,540,643.38 ns |  56,062,980.0 ns |    1 |    21503.6 KB |
-| Jint_ParsedScript | dromaeo-object-string-modern |  57,745,485.2 ns |    980,495.59 ns |  57,288,188.9 ns |    1 |   21305.94 KB |
-| NilJS             | dromaeo-object-string-modern | 129,356,355.4 ns |  1,830,319.80 ns | 128,529,200.0 ns |    2 |  1355046.4 KB |
-| YantraJS          | dromaeo-object-string-modern | 159,363,848.7 ns |  2,179,571.95 ns | 160,101,133.3 ns |    3 | 1656320.21 KB |
+| Jint              | dromaeo-object-string-modern |  55,397,017.6 ns |  1,478,006.03 ns |  55,736,600.0 ns |    1 |   21477.14 KB |
+| Jint_ParsedScript | dromaeo-object-string-modern |  58,143,847.9 ns |  1,658,899.03 ns |  58,846,455.0 ns |    1 |   21297.14 KB |
+| NilJS             | dromaeo-object-string-modern | 152,155,665.0 ns |  2,843,333.52 ns | 152,427,600.0 ns |    2 | 1354903.94 KB |
+| YantraJS          | dromaeo-object-string-modern | 184,368,004.9 ns |  5,041,705.48 ns | 183,499,666.7 ns |    3 | 1656426.61 KB |
 |                   |                              |                  |                  |                  |      |               |
-| Jint_ParsedScript | dromaeo-string-base64        |  23,826,306.5 ns |    104,274.56 ns |  23,840,259.4 ns |    1 |    1620.08 KB |
-| NilJS             | dromaeo-string-base64        |  24,911,115.2 ns |    371,340.54 ns |  24,934,218.8 ns |    2 |   19588.61 KB |
-| Jint              | dromaeo-string-base64        |  25,052,072.3 ns |     71,227.32 ns |  25,062,984.4 ns |    2 |    1720.07 KB |
-| YantraJS          | dromaeo-string-base64        |  33,619,117.4 ns |    521,794.29 ns |  33,643,540.6 ns |    3 |  763555.52 KB |
-| Jurassic          | dromaeo-string-base64        |  45,788,779.4 ns |    476,283.01 ns |  45,711,090.9 ns |    4 |   73293.16 KB |
+| Jint_ParsedScript | dromaeo-string-base64        |  24,336,383.9 ns |    118,294.09 ns |  24,312,368.8 ns |    1 |    1620.09 KB |
+| Jint              | dromaeo-string-base64        |  24,402,786.8 ns |    112,777.82 ns |  24,392,987.5 ns |    1 |    1720.08 KB |
+| NilJS             | dromaeo-string-base64        |  25,443,252.1 ns |     75,762.89 ns |  25,430,228.1 ns |    2 |   19588.61 KB |
+| YantraJS          | dromaeo-string-base64        |  35,414,163.2 ns |    249,392.04 ns |  35,371,529.2 ns |    3 |  763555.06 KB |
+| Jurassic          | dromaeo-string-base64        |  48,098,526.6 ns |    467,710.47 ns |  48,129,759.1 ns |    4 |   73290.07 KB |
 |                   |                              |                  |                  |                  |      |               |
 | Jurassic          | dromaeo-string-base64-modern |               NA |               NA |               NA |    ? |            NA |
-| Jint_ParsedScript | dromaeo-string-base64-modern |  26,734,823.2 ns |     69,601.24 ns |  26,721,785.9 ns |    1 |    1620.29 KB |
-| Jint              | dromaeo-string-base64-modern |  27,230,475.4 ns |    214,764.46 ns |  27,167,734.4 ns |    1 |    1720.69 KB |
-| NilJS             | dromaeo-string-base64-modern |  31,791,701.9 ns |    264,300.58 ns |  31,903,859.4 ns |    2 |   31360.22 KB |
-| YantraJS          | dromaeo-string-base64-modern |  34,399,149.0 ns |    423,966.49 ns |  34,326,646.7 ns |    3 |  764771.51 KB |
+| Jint_ParsedScript | dromaeo-string-base64-modern |  27,042,369.7 ns |    231,135.59 ns |  26,984,065.6 ns |    1 |     1620.3 KB |
+| Jint              | dromaeo-string-base64-modern |  28,171,282.9 ns |     96,713.59 ns |  28,163,131.2 ns |    2 |     1720.7 KB |
+| NilJS             | dromaeo-string-base64-modern |  33,052,923.6 ns |    111,553.42 ns |  33,027,487.5 ns |    3 |   31360.39 KB |
+| YantraJS          | dromaeo-string-base64-modern |  35,126,301.8 ns |    605,473.20 ns |  34,857,245.8 ns |    4 |  764771.12 KB |
 |                   |                              |                  |                  |                  |      |               |
-| Jint_ParsedScript | evaluation                   |       4,359.2 ns |         36.76 ns |       4,350.4 ns |    1 |      17.27 KB |
-| Jint              | evaluation                   |      14,686.1 ns |         80.99 ns |      14,682.4 ns |    2 |      27.91 KB |
-| NilJS             | evaluation                   |      25,921.7 ns |        106.91 ns |      25,932.9 ns |    3 |      22.36 KB |
-| YantraJS          | evaluation                   |     133,080.4 ns |        918.96 ns |     133,206.0 ns |    4 |     703.42 KB |
-| Jurassic          | evaluation                   |   2,105,716.3 ns |     11,134.24 ns |   2,101,877.3 ns |    5 |     418.92 KB |
+| Jint_ParsedScript | evaluation                   |       4,363.4 ns |         20.86 ns |       4,365.6 ns |    1 |      17.28 KB |
+| Jint              | evaluation                   |      14,221.4 ns |         51.98 ns |      14,235.8 ns |    2 |      27.92 KB |
+| NilJS             | evaluation                   |      26,042.9 ns |        153.24 ns |      25,968.8 ns |    3 |      22.36 KB |
+| YantraJS          | evaluation                   |     130,565.4 ns |        930.31 ns |     130,860.2 ns |    4 |     703.42 KB |
+| Jurassic          | evaluation                   |   2,074,978.2 ns |     19,823.57 ns |   2,069,301.8 ns |    5 |     418.93 KB |
 |                   |                              |                  |                  |                  |      |               |
 | Jurassic          | evaluation-modern            |               NA |               NA |               NA |    ? |            NA |
-| Jint_ParsedScript | evaluation-modern            |       4,315.6 ns |         24.11 ns |       4,320.8 ns |    1 |      16.66 KB |
-| Jint              | evaluation-modern            |      13,764.3 ns |         88.92 ns |      13,781.4 ns |    2 |      27.79 KB |
-| NilJS             | evaluation-modern            |      25,920.1 ns |         72.90 ns |      25,904.4 ns |    3 |      22.35 KB |
-| YantraJS          | evaluation-modern            |     132,014.9 ns |      1,293.47 ns |     131,951.2 ns |    4 |      703.4 KB |
+| Jint_ParsedScript | evaluation-modern            |       4,209.2 ns |         18.28 ns |       4,207.3 ns |    1 |      16.78 KB |
+| Jint              | evaluation-modern            |      13,841.3 ns |         70.60 ns |      13,823.1 ns |    2 |      27.91 KB |
+| NilJS             | evaluation-modern            |      26,088.4 ns |        174.06 ns |      26,069.8 ns |    3 |      22.35 KB |
+| YantraJS          | evaluation-modern            |     131,669.8 ns |      1,030.95 ns |     131,872.5 ns |    4 |      703.4 KB |
 |                   |                              |                  |                  |                  |      |               |
-| Jint              | json-parse                   |  20,121,635.3 ns |     57,124.22 ns |  20,125,218.8 ns |    1 |   21403.84 KB |
-| Jint_ParsedScript | json-parse                   |  20,299,693.3 ns |    209,584.30 ns |  20,170,759.4 ns |    1 |   21367.85 KB |
-| YantraJS          | json-parse                   |  27,310,032.3 ns |    374,273.37 ns |  27,244,450.0 ns |    2 |   44331.62 KB |
-| Jurassic          | json-parse                   |  46,436,431.5 ns |    249,934.28 ns |  46,405,700.0 ns |    3 |    76117.7 KB |
-| NilJS             | json-parse                   | 132,461,216.7 ns |    756,571.10 ns | 132,478,425.0 ns |    4 |   66013.91 KB |
+| Jint_ParsedScript | json-parse                   |  20,067,604.2 ns |     29,619.62 ns |  20,073,329.7 ns |    1 |   21368.15 KB |
+| Jint              | json-parse                   |  20,300,920.4 ns |    286,195.57 ns |  20,166,353.1 ns |    1 |   21404.04 KB |
+| YantraJS          | json-parse                   |  26,910,567.5 ns |    421,865.53 ns |  27,174,953.8 ns |    2 |   44331.53 KB |
+| Jurassic          | json-parse                   |  46,098,565.7 ns |    339,237.12 ns |  46,000,370.0 ns |    3 |   76116.95 KB |
+| NilJS             | json-parse                   | 128,909,611.5 ns |  1,379,237.09 ns | 128,379,600.0 ns |    4 |   66013.91 KB |
 |                   |                              |                  |                  |                  |      |               |
 | Jurassic          | json-parse-modern            |               NA |               NA |               NA |    ? |            NA |
-| Jint              | json-parse-modern            |  17,698,042.5 ns |    160,410.71 ns |  17,693,768.8 ns |    1 |   22915.28 KB |
-| Jint_ParsedScript | json-parse-modern            |  18,193,412.5 ns |    446,627.42 ns |  18,169,551.6 ns |    1 |   22879.74 KB |
-| YantraJS          | json-parse-modern            |  25,577,906.0 ns |    314,955.52 ns |  25,514,371.9 ns |    2 |   43167.16 KB |
-| NilJS             | json-parse-modern            | 128,287,223.1 ns |    551,164.43 ns | 128,316,900.0 ns |    3 |   67094.88 KB |
+| Jint              | json-parse-modern            |  17,830,508.8 ns |    349,857.75 ns |  17,628,834.4 ns |    1 |    22915.4 KB |
+| Jint_ParsedScript | json-parse-modern            |  17,879,467.2 ns |    362,263.33 ns |  17,687,507.8 ns |    1 |   22879.95 KB |
+| YantraJS          | json-parse-modern            |  24,786,600.6 ns |    174,790.72 ns |  24,807,180.8 ns |    2 |   43167.16 KB |
+| NilJS             | json-parse-modern            | 125,787,153.6 ns |  1,621,613.30 ns | 124,912,075.0 ns |    3 |   67094.88 KB |
 |                   |                              |                  |                  |                  |      |               |
-| Jint_ParsedScript | linq-js                      |      59,896.0 ns |        429.75 ns |      59,838.1 ns |    1 |     211.78 KB |
-| YantraJS          | linq-js                      |     327,105.2 ns |      2,660.27 ns |     326,599.5 ns |    2 |    1049.75 KB |
-| Jint              | linq-js                      |   1,186,893.7 ns |      4,136.66 ns |   1,187,021.8 ns |    3 |    1311.01 KB |
-| NilJS             | linq-js                      |   3,971,705.8 ns |     12,712.32 ns |   3,969,751.6 ns |    4 |    2739.46 KB |
-| Jurassic          | linq-js                      |  35,622,140.0 ns |    613,532.81 ns |  35,704,478.6 ns |    5 |    9102.27 KB |
+| Jint_ParsedScript | linq-js                      |      58,235.1 ns |        392.77 ns |      58,093.7 ns |    1 |      211.9 KB |
+| YantraJS          | linq-js                      |     322,222.6 ns |      3,192.77 ns |     322,240.8 ns |    2 |    1049.75 KB |
+| Jint              | linq-js                      |   1,192,750.2 ns |      9,414.22 ns |   1,189,361.2 ns |    3 |    1311.13 KB |
+| NilJS             | linq-js                      |   3,886,025.4 ns |     41,647.19 ns |   3,881,030.5 ns |    4 |    2739.46 KB |
+| Jurassic          | linq-js                      |  35,699,170.6 ns |    706,146.09 ns |  35,673,221.4 ns |    5 |    9102.27 KB |
 |                   |                              |                  |                  |                  |      |               |
-| Jint_ParsedScript | minimal                      |         945.4 ns |         12.33 ns |         943.6 ns |    1 |          9 KB |
-| Jint              | minimal                      |       2,038.6 ns |         25.58 ns |       2,024.4 ns |    2 |      10.91 KB |
-| NilJS             | minimal                      |       2,733.4 ns |         15.14 ns |       2,731.3 ns |    3 |       4.51 KB |
-| YantraJS          | minimal                      |     123,636.9 ns |        810.36 ns |     123,729.1 ns |    4 |     697.62 KB |
-| Jurassic          | minimal                      |   2,286,128.6 ns |      5,795.15 ns |   2,286,150.6 ns |    5 |     385.19 KB |
+| Jint_ParsedScript | minimal                      |         950.8 ns |          7.82 ns |         952.1 ns |    1 |       9.12 KB |
+| Jint              | minimal                      |       1,964.0 ns |         23.06 ns |       1,957.1 ns |    2 |      11.03 KB |
+| NilJS             | minimal                      |       2,790.0 ns |         22.29 ns |       2,787.9 ns |    3 |       4.51 KB |
+| YantraJS          | minimal                      |     124,250.3 ns |      1,590.06 ns |     124,430.0 ns |    4 |     697.62 KB |
+| Jurassic          | minimal                      |   2,288,030.1 ns |     13,265.27 ns |   2,287,348.4 ns |    5 |     385.19 KB |
 |                   |                              |                  |                  |                  |      |               |
-| YantraJS          | stopwatch                    |  56,751,977.0 ns |    380,809.30 ns |  56,737,366.7 ns |    1 |  215655.06 KB |
-| Jint              | stopwatch                    |  95,600,360.0 ns |    647,495.32 ns |  95,324,566.7 ns |    2 |   12119.01 KB |
-| Jint_ParsedScript | stopwatch                    | 100,538,990.0 ns |    444,573.73 ns | 100,561,250.0 ns |    3 |   12087.22 KB |
-| NilJS             | stopwatch                    | 133,270,078.3 ns |  1,478,716.49 ns | 133,233,625.0 ns |    4 |   94876.49 KB |
-| Jurassic          | stopwatch                    | 140,171,082.1 ns |    603,177.09 ns | 140,151,625.0 ns |    5 |  156933.11 KB |
+| YantraJS          | stopwatch                    |  56,170,394.0 ns |    237,927.52 ns |  56,210,455.6 ns |    1 |  215655.06 KB |
+| Jint_ParsedScript | stopwatch                    |  95,080,321.4 ns |    852,902.45 ns |  95,083,116.7 ns |    2 |   12087.23 KB |
+| Jint              | stopwatch                    |  96,506,734.6 ns |    743,831.93 ns |  96,532,500.0 ns |    2 |   12119.02 KB |
+| NilJS             | stopwatch                    | 133,192,350.0 ns |  1,554,538.11 ns | 132,605,487.5 ns |    3 |   94876.49 KB |
+| Jurassic          | stopwatch                    | 139,397,075.0 ns |  1,021,290.31 ns | 139,301,625.0 ns |    4 |  156932.58 KB |
 |                   |                              |                  |                  |                  |      |               |
-| YantraJS          | stopwatch-modern             |  59,655,363.0 ns |    616,608.36 ns |  59,440,400.0 ns |    1 |  234033.07 KB |
-| Jint_ParsedScript | stopwatch-modern             |  91,267,376.7 ns |    398,030.43 ns |  91,124,600.0 ns |    2 |   12088.23 KB |
-| Jint              | stopwatch-modern             |  92,301,712.2 ns |    440,814.61 ns |  92,478,233.3 ns |    2 |   12120.62 KB |
-| Jurassic          | stopwatch-modern             | 149,765,953.3 ns |  1,485,281.00 ns | 149,175,425.0 ns |    3 |  288625.25 KB |
-| NilJS             | stopwatch-modern             | 228,358,292.9 ns |  1,424,659.13 ns | 228,212,566.7 ns |    4 |  324502.66 KB |
+| YantraJS          | stopwatch-modern             |  59,463,966.7 ns |    956,652.74 ns |  59,240,988.9 ns |    1 |  234033.07 KB |
+| Jint_ParsedScript | stopwatch-modern             |  89,865,310.3 ns |    380,947.14 ns |  89,836,400.0 ns |    2 |   12088.24 KB |
+| Jint              | stopwatch-modern             |  91,184,776.4 ns |    379,078.85 ns |  91,091,916.7 ns |    2 |   12120.63 KB |
+| Jurassic          | stopwatch-modern             | 146,102,858.9 ns |  1,508,662.73 ns | 145,924,912.5 ns |    3 |  288625.25 KB |
+| NilJS             | stopwatch-modern             | 209,825,102.6 ns |  2,549,034.66 ns | 208,754,100.0 ns |    4 |  324502.66 KB |

--- a/Jint.Tests/Runtime/ArgumentsCacheBehaviorTests.cs
+++ b/Jint.Tests/Runtime/ArgumentsCacheBehaviorTests.cs
@@ -5,6 +5,27 @@ namespace Jint.Tests.Runtime;
 public class ArgumentsCacheBehaviorTests
 {
     [Fact]
+    public void MappedArgumentWriteSurvivesFunctionReturn()
+    {
+        // Regression: a mapped arguments[i] = v write updates only the parameter binding while the
+        // call runs; the escaped snapshot taken when arguments is materialized must capture that
+        // binding value, or the write is silently lost once the call returns.
+        var engine = new Engine();
+        Assert.Equal(99, engine.Evaluate("(function(){ function f(a){ arguments[0]=99; return arguments; } return f(1)[0]; })()").AsNumber());
+        Assert.Equal("{\"0\":99}", engine.Evaluate("(function(){ function f(a){ arguments[0]=99; return arguments; } return JSON.stringify(f(1)); })()").AsString());
+    }
+
+    [Fact]
+    public void MappedParameterWriteSurvivesFunctionReturn()
+    {
+        // The mapping is bidirectional: writing the parameter must also be visible through the
+        // escaped arguments object after the call returns.
+        var engine = new Engine();
+        Assert.Equal(42, engine.Evaluate("(function(){ function f(a){ a=42; return arguments; } return f(1)[0]; })()").AsNumber());
+        Assert.Equal("1,88", engine.Evaluate("(function(){ function f(a,b){ b=88; return arguments; } var r=f(1,2); return r[0]+','+r[1]; })()").AsString());
+    }
+
+    [Fact]
     public void ArgsForGeneratorsAreNotReusedFromCache()
     {
         // Arrange

--- a/Jint.Tests/Runtime/ArgumentsCacheBehaviorTests.cs
+++ b/Jint.Tests/Runtime/ArgumentsCacheBehaviorTests.cs
@@ -26,6 +26,41 @@ public class ArgumentsCacheBehaviorTests
     }
 
     [Fact]
+    public void ParameterWriteAfterMaterializationSurvivesReturn()
+    {
+        // A parameter (or arguments[i]) write made AFTER the arguments object is first referenced —
+        // whether it was materialized virtually (a prior arguments read) or to real descriptors
+        // (Object.keys) — must still show through the escaped object once the call returns.
+        var engine = new Engine();
+        Assert.Equal(9, engine.Evaluate("(function(){ function f(a){ var s=arguments[0]; a=9; return arguments; } return f(1)[0]; })()").AsNumber());
+        Assert.Equal(9, engine.Evaluate("(function(){ function f(a){ Object.keys(arguments); a=9; return arguments; } return f(1)[0]; })()").AsNumber());
+        Assert.Equal(9, engine.Evaluate("(function(){ function f(a){ arguments[0]=9; Object.keys(arguments); return arguments; } return f(1)[0]; })()").AsNumber());
+    }
+
+    [Fact]
+    public void FreezingAMappedIndexPreservesUserSetAttributes()
+    {
+        // A still-mapped index can be made non-enumerable (or non-configurable) without unmapping.
+        // Freezing its final binding value at return must update only the value, not reset the
+        // attribute the script set.
+        var engine = new Engine();
+        Assert.Equal("9|false|", engine.Evaluate(
+            "(function(){ function f(a){ Object.defineProperty(arguments,'0',{enumerable:false}); a=9; return arguments; } var r=f(1); return r[0]+'|'+Object.getOwnPropertyDescriptor(r,'0').enumerable+'|'+Object.keys(r).join(','); })()").AsString());
+        Assert.Equal("{}", engine.Evaluate(
+            "(function(){ function f(a){ Object.defineProperty(arguments,'0',{enumerable:false}); a=9; return arguments; } return JSON.stringify(f(1)); })()").AsString());
+    }
+
+    [Fact]
+    public void DeletedMappedIndexStaysDeletedAfterParameterWrite()
+    {
+        // A deleted mapped index must not be resurrected by the detach-time freeze: it is no longer
+        // mapped, so a later parameter write does not bring it back.
+        var engine = new Engine();
+        Assert.Equal("false:undefined", engine.Evaluate(
+            "(function(){ function f(a){ var s=arguments; delete arguments[0]; a=9; return arguments.hasOwnProperty('0')+':'+arguments[0]; } return f(1); })()").AsString());
+    }
+
+    [Fact]
     public void ArgsForGeneratorsAreNotReusedFromCache()
     {
         // Arrange

--- a/Jint.Tests/Runtime/ForInEnumerationTests.cs
+++ b/Jint.Tests/Runtime/ForInEnumerationTests.cs
@@ -94,6 +94,70 @@ public class ForInEnumerationTests
     }
 
     [Fact]
+    public void VisitedShallowerKeyDeletedMidLoopStillShadowsDeeperKey()
+    {
+        // Regression: a shallower own key that was already visited and is then deleted must still
+        // shadow the same-named enumerable key on a deeper level — "each key visited at most once".
+        // A live re-probe of the shadow set would see the key as Missing and wrongly re-enumerate it.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var proto = { a: 1 };
+            var o = Object.create(proto);
+            o.a = 2; // shadows proto.a, visited first
+            o.b = 3;
+            var out = [];
+            for (var k in o) { out.push(k); if (k === 'b') { delete o.a; } }
+            out.join(',');
+            """).AsString();
+
+        Assert.Equal("a,b", result);
+    }
+
+    [Fact]
+    public void VisitedKeyDeletedMidLoopShadowsAcrossThreeLevels()
+    {
+        // Same invariant across a three-level chain: the deleted-after-visit own key must not
+        // resurface from a grandparent that carries an enumerable key of the same name.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var grand = { x: 1 };
+            var proto = Object.create(grand); proto.y = 1;
+            var o = Object.create(proto); o.x = 2; o.z = 3;
+            var out = [];
+            for (var k in o) { out.push(k); if (k === 'z') { delete o.x; } }
+            out.join(',');
+            """).AsString();
+
+        Assert.Equal("x,z,y", result);
+    }
+
+    [Fact]
+    public void PooledIteratorReuseKeepsShadowingInheritedEnumerableKey()
+    {
+        // Regression: the pooled ForInIterator must reset its shadow-set sentinel to null (not merely
+        // clear it) between reuses. An own key shadowing an enumerable INHERITED key must keep
+        // shadowing on the second and later runs of the same for-in statement — otherwise the
+        // inherited key double-enumerates from the second iteration onward.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            function Base() {}
+            Base.prototype.type = 'base'; // enumerable inherited
+            var out = [];
+            for (var i = 0; i < 3; i++) {
+                var o = new Base();
+                o.type = 'x'; // own, shadows inherited 'type'
+                o.id = 1;
+                var ks = [];
+                for (var k in o) { ks.push(k); }
+                out.push(ks.join(','));
+            }
+            out.join(' | ');
+            """).AsString();
+
+        Assert.Equal("type,id | type,id | type,id", result);
+    }
+
+    [Fact]
     public void AddDuringIterationDoesNotYieldNewKey()
     {
         // Spec permits either; this pins Jint's current behaviour (level keys are snapshotted at entry).

--- a/Jint/Native/Iterator/IteratorInstance.cs
+++ b/Jint/Native/Iterator/IteratorInstance.cs
@@ -279,8 +279,15 @@ internal abstract class IteratorInstance : ObjectInstance
         private List<CompletedLevel>? _completedLevels;
         private HashSet<JsValue>? _visited;
 
+        // Keys of the level currently being walked that probed Missing at their turn (deleted or
+        // absent before they were reached). Usually null — populated only when a key vanishes
+        // mid-enumeration. A shadow set, when it is later built, must treat these as never-present:
+        // a key visited then deleted still shadows deeper levels, but a key deleted before its turn
+        // does not — a distinction a live re-probe cannot make (both read Missing afterwards).
+        private HashSet<JsValue>? _levelAbsent;
+
         [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-        private readonly record struct CompletedLevel(ObjectInstance Owner, IReadOnlyList<JsValue> Keys);
+        private readonly record struct CompletedLevel(IReadOnlyList<JsValue> Keys, HashSet<JsValue>? Absent);
 
         public ForInIterator(Engine engine, ObjectInstance target) : base(engine)
         {
@@ -306,7 +313,13 @@ internal abstract class IteratorInstance : ObjectInstance
                     var probe = current.ProbeOwnProperty(key);
                     if (probe == OwnPropertyProbe.Missing)
                     {
-                        // deleted before its turn — not visited, does not shadow
+                        // absent before its turn — not visited, does not shadow. Record it so a
+                        // shadow set built later reconstructs this level's membership from the
+                        // retained key list minus these, rather than re-probing the mutated object.
+                        if (_visited is null)
+                        {
+                            (_levelAbsent ??= []).Add(key);
+                        }
                         continue;
                     }
 
@@ -322,7 +335,7 @@ internal abstract class IteratorInstance : ObjectInstance
                                 continue;
                             }
 
-                            _visited = BuildVisited(current, keys, _index - 1);
+                            _visited = BuildVisited(keys, _index - 1, _levelAbsent);
                         }
 
                         if (!_visited.Add(key))
@@ -347,11 +360,13 @@ internal abstract class IteratorInstance : ObjectInstance
 
                 if (_visited is null)
                 {
-                    // retain the exhausted level's snapshot (a list reference, no copy) so a
-                    // later set build can reconstruct what it shadowed
-                    (_completedLevels ??= []).Add(new CompletedLevel(current, keys));
+                    // retain the exhausted level's snapshot (a list reference, no copy) plus any
+                    // keys that vanished before their turn, so a later set build reconstructs
+                    // exactly what this level shadowed without re-probing the mutated object
+                    (_completedLevels ??= []).Add(new CompletedLevel(keys, _levelAbsent));
                 }
 
+                _levelAbsent = null;
                 _deeperLevel = true;
                 _current = proto;
                 _keys = proto.GetForInStringKeys();
@@ -365,38 +380,41 @@ internal abstract class IteratorInstance : ObjectInstance
         /// <summary>
         /// First enumerable candidate on a deeper level: build the shadow set from every
         /// shallower level's retained snapshot plus the already-processed prefix of the
-        /// current level, re-probing each key on its owning object. Prototype members are
+        /// current level, taking each key that was present when this enumeration reached it
+        /// (its snapshot minus the keys recorded absent at their turn). Prototype members are
         /// overwhelmingly non-enumerable, so most enumerations never get here.
         /// </summary>
-        private HashSet<JsValue> BuildVisited(ObjectInstance current, IReadOnlyList<JsValue> currentKeys, int processedCount)
+        private HashSet<JsValue> BuildVisited(IReadOnlyList<JsValue> currentKeys, int processedCount, HashSet<JsValue>? currentAbsent)
         {
             var set = new HashSet<JsValue>();
             if (_completedLevels is not null)
             {
                 foreach (var level in _completedLevels)
                 {
-                    var levelKeys = level.Keys;
-                    for (var i = 0; i < levelKeys.Count; i++)
-                    {
-                        if (level.Owner.ProbeOwnProperty(levelKeys[i]) != OwnPropertyProbe.Missing)
-                        {
-                            set.Add(levelKeys[i]);
-                        }
-                    }
+                    AddPresentAtTurn(set, level.Keys, level.Keys.Count, level.Absent);
                 }
 
                 _completedLevels = null;
             }
 
-            for (var i = 0; i < processedCount; i++)
-            {
-                if (current.ProbeOwnProperty(currentKeys[i]) != OwnPropertyProbe.Missing)
-                {
-                    set.Add(currentKeys[i]);
-                }
-            }
+            AddPresentAtTurn(set, currentKeys, processedCount, currentAbsent);
 
             return set;
+        }
+
+        // A key shadows deeper levels iff it was present when this level reached it: every key in
+        // the retained snapshot except those recorded absent at their turn. Reconstructing from the
+        // turn-time record (not a live re-probe) keeps a visited-then-deleted key in the shadow set.
+        private static void AddPresentAtTurn(HashSet<JsValue> set, IReadOnlyList<JsValue> keys, int count, HashSet<JsValue>? absent)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                var key = keys[i];
+                if (absent is null || !absent.Contains(key))
+                {
+                    set.Add(key);
+                }
+            }
         }
 
         public override bool TryIteratorStep(out ObjectInstance nextItem)
@@ -431,7 +449,12 @@ internal abstract class IteratorInstance : ObjectInstance
             _index = 0;
             _deeperLevel = false;
             _completedLevels?.Clear();
-            _visited?.Clear();
+            // Null, not Clear: _visited being null is the "shadow set not built yet" sentinel that
+            // drives level-snapshot retention and own-key seeding; a non-null empty set would skip
+            // both and let a deeper key shadow-collide on the next enumeration. _levelAbsent is a
+            // per-level scratch set carried into CompletedLevel — it must not leak across reuses.
+            _visited = null;
+            _levelAbsent = null;
         }
 
         /// <summary>
@@ -446,7 +469,9 @@ internal abstract class IteratorInstance : ObjectInstance
             _index = 0;
             _deeperLevel = false;
             _completedLevels?.Clear();
-            _visited?.Clear();
+            // see ResetForReuse: null is the sentinel, and _levelAbsent must not survive parking
+            _visited = null;
+            _levelAbsent = null;
         }
     }
 

--- a/Jint/Native/JsArguments.cs
+++ b/Jint/Native/JsArguments.cs
@@ -407,36 +407,80 @@ public sealed class JsArguments : ObjectInstance
 
         // Snapshot the (pooled, caller-owned) argument values so reads stay valid after the
         // call returns. Virtual mode keeps serving reads off the snapshot; the property
-        // descriptors materialize lazily only if something actually needs them.
+        // descriptors materialize lazily only if something actually needs them. Mapped indices are
+        // still served from their live binding until the map detaches (FunctionWasCalled freezes the
+        // final binding values into this snapshot), so no per-index binding read is needed here.
         var args = _args;
         var copiedArgs = new JsValue[args.Length];
         System.Array.Copy(args, copiedArgs, args.Length);
-
-        // A mapped index reads its live binding while the call runs, and a write through either the
-        // parameter name (a = x) or arguments[i] = x updates only that binding — the pooled _args is
-        // shared with the caller and must not be written before this snapshot exists. Capture each
-        // mapped index from its current binding so the snapshot, which becomes authoritative once the
-        // map detaches on return, reflects those pre-materialization writes.
-        if (_func is not null && !_mapDetached)
-        {
-            for (uint i = 0; i < (uint) copiedArgs.Length; i++)
-            {
-                if (TryGetMappedName(i, out var name))
-                {
-                    copiedArgs[i] = _env.GetBindingValue(name, strict: false);
-                }
-            }
-        }
-
         _args = copiedArgs;
 
         _canReturnToPool = false;
     }
 
+    /// <summary>
+    /// A mapped index reads its live parameter binding while the owning call runs; a write through
+    /// either the parameter name (<c>a = x</c>) or <c>arguments[i] = x</c> updates that binding. Just
+    /// before the map detaches on return, freeze each still-mapped index's current binding value into
+    /// the authoritative snapshot (the <c>_args</c> array while virtual, or the own data property once
+    /// materialized), so a write made at any point during the call survives into the escaped object.
+    /// Indices that were deleted or redefined away from a plain data property are no longer in the map
+    /// and are left untouched.
+    /// </summary>
+    private void FreezeMappedBindings()
+    {
+        if (_virtualMode)
+        {
+            // Only an escaped (materialized) object is read after return; a still-pooled one is
+            // unobserved. _args is a private copy once materialized, so it is safe to write. No index
+            // can have been deleted while virtual — a delete routes through EnsureInitialized first.
+            if (!_materialized)
+            {
+                return;
+            }
+
+            var args = _args;
+            for (uint i = 0; i < (uint) args.Length; i++)
+            {
+                if (TryGetMappedName(i, out var name))
+                {
+                    args[i] = _env.GetBindingValue(name, strict: false);
+                }
+            }
+        }
+        else if (_parameterMap is { } map)
+        {
+            // Materialized to real descriptors: the live map overlaid mapped reads during the call.
+            // Bake the final binding value into each own data property that is still mapped (present
+            // in the map) before the overlay is dropped. Update the value in place so a user-set
+            // attribute is preserved — a still-mapped index can be made non-enumerable without
+            // unmapping; only accessor / non-writable redefinitions unmap, and the map-membership
+            // check already skips those.
+            for (uint i = 0; i < (uint) _args.Length; i++)
+            {
+                var key = JsString.Create(i);
+                if (map.HasOwnProperty(key) && TryGetMappedName(i, out var name))
+                {
+                    var existing = base.GetOwnProperty(key);
+                    if (existing.IsDataDescriptor())
+                    {
+                        existing.Value = _env.GetBindingValue(name, strict: false);
+                    }
+                }
+            }
+        }
+    }
+
     internal void FunctionWasCalled()
     {
-        // Detach the mapping: post-call reads see the captured snapshot (write-synced while
-        // mapped), not live bindings, and a later materialization must not rebuild the map.
+        // Freeze the final mapped-binding values into the snapshot while the map is still live, then
+        // detach: post-call reads see the captured snapshot, not live bindings, and a later
+        // materialization must not rebuild the map.
+        if (!_mapDetached && _func is not null)
+        {
+            FreezeMappedBindings();
+        }
+
         _mapDetached = true;
 
         // should no longer expose arguments which is special name

--- a/Jint/Native/JsArguments.cs
+++ b/Jint/Native/JsArguments.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using Jint.Native.Object;
 using Jint.Native.Symbol;
 using Jint.Runtime;
@@ -14,9 +13,6 @@ namespace Jint.Native;
 /// </summary>
 public sealed class JsArguments : ObjectInstance
 {
-    // cache property container for array iteration for less allocations
-    private static readonly ThreadLocal<HashSet<Key>> _mappedNamed = new(() => []);
-
     private Function.Function _func = null!;
     private Key[] _names = null!;
     private JsValue[] _args = null!;
@@ -121,24 +117,17 @@ public sealed class JsArguments : ObjectInstance
                 // index properties always materialize; the live-binding parameter map is only
                 // built while the owning call is still running (post-return the mapping is
                 // detached and the snapshot values are authoritative)
-                HashSet<Key>? mappedNamed = null;
                 if (!_mapDetached)
                 {
-                    mappedNamed = _mappedNamed.Value!;
-                    mappedNamed.Clear();
                     map = _realm.Intrinsics.Object.Construct(Arguments.Empty);
                 }
 
                 for (uint i = 0; i < (uint) args.Length; i++)
                 {
                     SetOwnProperty(JsString.Create(i), new PropertyDescriptor(args[i], PropertyFlag.ConfigurableEnumerableWritable));
-                    if (map is not null && i < _names.Length)
+                    if (map is not null && TryGetMappedName(i, out var name))
                     {
-                        var name = _names[i];
-                        if (mappedNamed!.Add(name))
-                        {
-                            map.SetOwnProperty(JsString.Create(i), new ClrAccessDescriptor(_env, Engine, name));
-                        }
+                        map.SetOwnProperty(JsString.Create(i), new ClrAccessDescriptor(_env, Engine, name));
                     }
                 }
             }
@@ -187,9 +176,9 @@ public sealed class JsArguments : ObjectInstance
             {
                 if (index < (uint) _args.Length)
                 {
-                    // the parameter map binds the FIRST index carrying each name (later duplicates
-                    // read the positional argument), mirroring Initialize's first-wins dedup;
-                    // once the call returned the map is detached and the snapshot is authoritative
+                    // the parameter map binds the LAST index carrying each name (earlier duplicates
+                    // read the positional argument), matching CreateMappedArgumentsObject; once the
+                    // call returned the map is detached and the snapshot is authoritative
                     if (_func is not null && !_mapDetached && TryGetMappedName(index, out var mappedName))
                     {
                         return _env.GetBindingValue(mappedName, strict: false);
@@ -226,7 +215,12 @@ public sealed class JsArguments : ObjectInstance
         }
 
         name = names[index];
-        for (var i = 0; i < index; i++)
+
+        // CreateMappedArgumentsObject maps the LAST parameter of a duplicated name (it walks the
+        // parameter list back to front, mapping the first name it has not yet seen). So this index
+        // owns the mapping only when no later parameter repeats the same name; earlier duplicates
+        // read the positional argument.
+        for (var i = index + 1; i < (uint) names.Length; i++)
         {
             if (names[i] == name)
             {
@@ -417,6 +411,23 @@ public sealed class JsArguments : ObjectInstance
         var args = _args;
         var copiedArgs = new JsValue[args.Length];
         System.Array.Copy(args, copiedArgs, args.Length);
+
+        // A mapped index reads its live binding while the call runs, and a write through either the
+        // parameter name (a = x) or arguments[i] = x updates only that binding — the pooled _args is
+        // shared with the caller and must not be written before this snapshot exists. Capture each
+        // mapped index from its current binding so the snapshot, which becomes authoritative once the
+        // map detaches on return, reflects those pre-materialization writes.
+        if (_func is not null && !_mapDetached)
+        {
+            for (uint i = 0; i < (uint) copiedArgs.Length; i++)
+            {
+                if (TryGetMappedName(i, out var name))
+                {
+                    copiedArgs[i] = _env.GetBindingValue(name, strict: false);
+                }
+            }
+        }
+
         _args = copiedArgs;
 
         _canReturnToPool = false;

--- a/Jint/Native/Object/BuiltinShape.cs
+++ b/Jint/Native/Object/BuiltinShape.cs
@@ -70,26 +70,34 @@ internal sealed class BuiltinShape
     {
         get
         {
-            if (_namesAsJsStrings is null)
+            // A BuiltinShape is a process-shared singleton (one static instance per built-in type), so
+            // this memo can be raced by engines on different threads. Build into a local and publish
+            // with a release/acquire pair: a concurrent reader that sees the reference is guaranteed to
+            // see the fully-populated array (matters on weak memory models). A rare double-build is
+            // benign — the contents are a deterministic function of Names.
+            var cached = System.Threading.Volatile.Read(ref _namesAsJsStrings);
+            if (cached is not null)
             {
-                var names = Names;
-                if (names.Length == 0)
-                {
-                    _namesAsJsStrings = System.Array.Empty<JsValue>();
-                }
-                else
-                {
-                    var arr = new JsValue[names.Length];
-                    for (var i = 0; i < names.Length; i++)
-                    {
-                        arr[i] = JsString.Create(names[i].Name);
-                    }
+                return cached;
+            }
 
-                    _namesAsJsStrings = arr;
+            var names = Names;
+            JsValue[] arr;
+            if (names.Length == 0)
+            {
+                arr = System.Array.Empty<JsValue>();
+            }
+            else
+            {
+                arr = new JsValue[names.Length];
+                for (var i = 0; i < names.Length; i++)
+                {
+                    arr[i] = JsString.Create(names[i].Name);
                 }
             }
 
-            return _namesAsJsStrings;
+            System.Threading.Volatile.Write(ref _namesAsJsStrings, arr);
+            return arr;
         }
     }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -24,6 +24,13 @@ internal sealed class JintObjectExpression : JintExpression
     // { a: 1, a: 2 }), which must fall back to the checked build so the later value wins.
     private readonly bool _fastKeysDistinct;
 
+    // True when no static key is digit-leading, so a hidden-class shape built from these keys is not
+    // guaranteed to be torn down. An integer-like own key reorders ahead of the string keys on first
+    // enumeration and forces the object to deopt to a dictionary, so such literals skip the
+    // shape-backed build and take the dictionary path directly — matching the spread / JSON.parse /
+    // constructor shape paths, which pre-exclude digit-leading keys for the same reason.
+    private readonly bool _fastKeysShapeable;
+
     // The hidden-class shape this literal builds, cached so every execution after the first reuses it
     // (an O(1) build: validate the prototype, allocate a slot array, fill it). Re-derived when the
     // active realm's Object.prototype differs from the one the cached shape is anchored to (a prepared
@@ -171,9 +178,18 @@ internal sealed class JintObjectExpression : JintExpression
         {
             // All keys are static names (guaranteed by _canBuildFast); pre-hash them once.
             var keys = new Key[_properties.Length];
+            _fastKeysShapeable = true;
             for (var i = 0; i < keys.Length; i++)
             {
-                keys[i] = _properties[i]!._key!;
+                var name = _properties[i]!._key!;
+                keys[i] = name;
+
+                // A digit-leading key (an array index or an index-like string) would deopt the shape
+                // on first enumeration; keep such literals on the dictionary build instead.
+                if (name.Length > 0 && char.IsDigit(name[0]))
+                {
+                    _fastKeysShapeable = false;
+                }
             }
             _fastKeys = keys;
             _fastKeysDistinct = AreKeysDistinct(keys);
@@ -266,7 +282,7 @@ internal sealed class JintObjectExpression : JintExpression
         // shape and a flat slot array — no per-property PropertyDescriptor, no dictionary. Duplicate-keyed
         // literals (e.g. { a:1, a:2 }) and literals whose values may suspend mid-build fall through to the
         // general dictionary path below.
-        if (_fastKeysDistinct && (suspendable is null || _valuesCannotSuspend))
+        if (_fastKeysDistinct && _fastKeysShapeable && (suspendable is null || _valuesCannotSuspend))
         {
             return BuildObjectFastShapeBacked(context, engine);
         }


### PR DESCRIPTION
Pre-release review of everything merged since `v4.11.0` (70 PRs, ~6k lines — mostly the perf campaign: builtin shapes, env-caching, slot lanes). Full suites are green on the reviewed code (Jint.Tests, **Test262 99429/0**, PublicInterface, CommonScripts). The review surfaced three regressions introduced in this window plus a couple of hardening/opportunity items; each fix is REPL-confirmed against V8/Node and covered by a regression test, and every fix was re-checked by an adversarial review pass.

### Correctness fixes (regressions since 4.11.0)

- **for-in re-enumerated a shadowed key** (two distinct causes, both from the allocation-free / pooled for-in work):
  - a shallower own key *yielded then deleted* mid-loop dropped out of the shadow set (a live re-probe can't tell "deleted before its turn" from "visited then deleted"), so a same-named prototype key enumerated twice;
  - the pooled iterator reset its shadow set with `Clear()` instead of `null`, defeating the "not built yet" sentinel, so an own key shadowing an enumerable **inherited** key double-enumerated from the 2nd loop iteration onward (a common shape). Verified fixed vs a v4.11.0 build.
- **mapped `arguments` writes lost after return** — `arguments[i]=v` and parameter writes `a=v` updated only the binding; the escaped snapshot came from the stale pooled array. The binding values are now frozen into the authoritative representation **at map-detach time**, so a write made at *any* point during the call survives return — including a parameter write made *after* the object was first materialized/`Object.keys`-ed, and preserving a user-set attribute (e.g. a still-mapped non-enumerable index). Also fixes **duplicate-parameter mapping** to spec (map the *last* occurrence, per `CreateMappedArgumentsObject`), which the fix would otherwise have surfaced (caught by Test262 `sloppy-arguments-with-dupes`).

### Missed-optimization / hardening

- **integer-keyed object literals** (`{200:'x'}`) no longer take the shape-backed build — such a shape always deopts on first enumeration; they now use the dictionary path directly, matching the spread/JSON.parse/constructor paths.
- **`BuiltinShape.NamesAsJsStrings`** — the memo on a process-shared singleton is now published with `Volatile.Write`/`Read` to close an ARM64 torn-read across concurrent engines.

### Benchmark refresh

Re-ran the full EngineComparison suite on 4.12.0 and refreshed `Jint.Benchmark/README.md`: retitled from "current main, post-4.11.0" to the 4.12.0 release, updated all numbers (fastest engine on 17/21 scripts; object-regexp lead now ~5.4×), and **generalised the summary prose so it no longer names specific competitors** — the participant list, versions and raw table still name them, but the comparison text speaks of "the closest competitor" / "the next-fastest engine" / "the engine that compiles to IL".

### Known pre-existing limitation (not addressed — not a regression)

A write to a parameter made *after the call has already returned*, through a surviving closure, is not reflected in the escaped `arguments` object. This is Jint's long-standing intentional detach-on-return design (the parameter map is snapshotted and detached at return rather than kept live for the object's lifetime); it is identical on 4.11.0 and would require a much larger architectural change. Writes *during* the call are fully handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)