### PR TITLE
Fix for-in missing inherited enumerable index properties placed on Array.prototype

### DIFF
--- a/Jint.Tests/Runtime/ForInEnumerationTests.cs
+++ b/Jint.Tests/Runtime/ForInEnumerationTests.cs
@@ -320,6 +320,27 @@ public class ForInEnumerationTests
     }
 
     [Fact]
+    public void ForInOverArrayIncludesInheritedEnumerableArrayPrototypeIndex()
+    {
+        // Regression: Array.prototype is itself array-backed, so script-placed elements on it live in
+        // its dense store — the builtin-shape shared name list does not include them. The for-in key
+        // shortcut must not hand out that list once Array.prototype carries own index keys: the
+        // inherited enumerable '5' must be enumerated after the own indices, and the own '1' must
+        // shadow the inherited '1'.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            Array.prototype[5] = 'inherited';
+            Array.prototype[1] = 'shadowed';
+            var arr = [10, 20];
+            var out = [];
+            for (var k in arr) { out.push(k); }
+            out.join(',');
+            """).AsString();
+
+        Assert.Equal("0,1,5", result);
+    }
+
+    [Fact]
     public void ForInKeysAreStrings()
     {
         var engine = new Engine();

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -506,6 +506,33 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         return base.ProbeOwnProperty(property);
     }
 
+    /// <summary>
+    /// True when any own index-keyed element exists: a present dense element or a materialized
+    /// per-index descriptor. O(1) for the pristine case that matters (Array.prototype's empty
+    /// backing store) — the dense scan only runs over slots the object actually allocated.
+    /// </summary>
+    internal bool HasAnyOwnIndex()
+    {
+        if (_sparse is { Count: > 0 })
+        {
+            return true;
+        }
+
+        var dense = _dense;
+        if (dense is not null)
+        {
+            foreach (var element in dense)
+            {
+                if (element is not null)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     internal JsValue Get(uint index)
     {
         if (!TryGetValue(index, out var value))

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -455,11 +455,13 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         }
         else if ((_type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty
                  && _properties is null
+                 && (this is not Array.ArrayInstance arrayInstance || !arrayInstance.HasAnyOwnIndex())
                  && ReferenceEquals(GetInitialOwnStringPropertyKeys(), System.Linq.Enumerable.Empty<JsValue>()))
         {
-            // No function-derived length/name/prototype prefix and no hybrid dictionary additions, so the
-            // built-in's shared, ordered name list is exactly its own string keys — e.g. Object.prototype
-            // (the common deeper for-in level).
+            // No function-derived length/name/prototype prefix, no hybrid dictionary additions, and no
+            // exotic index storage (Array.prototype is array-backed: script CAN place elements on it,
+            // which the shared name list would miss), so the built-in's shared, ordered name list is
+            // exactly its own string keys — e.g. Object.prototype (the common deeper for-in level).
             return Unsafe.As<IBuiltinShaped>(this).BuiltinShape.NamesAsJsStrings;
         }
 


### PR DESCRIPTION
## Bug

```js
Array.prototype[5] = "inherited";
for (var k in [10, 20]) print(k);
// actual:   0, 1
// expected: 0, 1, 5
```

`Array.prototype` is itself array-backed, so script-placed elements live in its dense element store. The for-in key-collection shortcut for builtin-shaped hosts (`GetForInStringKeys`) handed out the shared builtin *name* list, which only covers shape slots — own index keys on the prototype were invisible to enumeration. Verified against pristine `main`.

## Fix

The shortcut steps aside when an array-backed host carries any own index-keyed element (new `ArrayInstance.HasAnyOwnIndex()`: a present dense element or a materialized per-index descriptor); the fallback path collects indices and builtin names correctly. For pristine prototypes — the overwhelmingly common case — the added cost is one type test plus a scan of an empty backing store, and the shared-name-list shortcut still applies.

Found by a new enumeration test written while working on the for-in array fast path (follow-up PR); regression test included.

## Gate

Jint.Tests, PublicInterface, CommonScripts all green; Test262 full run green except the four known load-dependent `annexB RegExp *-escape-BMP` slow tests, which pass in 5s when run in isolation (they time out at 30s only under full-suite CPU starvation — flake hardening for those is coming separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)