### PR TITLE
Fuse strict-equality guards: x === undefined/null and typeof x === "literal"

### DIFF
--- a/Jint.Benchmark/GuardComparisonBenchmark.cs
+++ b/Jint.Benchmark/GuardComparisonBenchmark.cs
@@ -1,0 +1,132 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Guard-style strict comparisons over LCG-mixed inputs the branch predictor cannot memorize:
+/// `v === undefined`, `v === null`, `v == null` and `typeof v === '...'` — the idioms defensive
+/// library code (linq.js, lodash, handlebars) runs on nearly every call.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class GuardComparisonBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _isUndefinedGuard;
+    private Prepared<Script> _isNullGuard;
+    private Prepared<Script> _looseNullGuard;
+    private Prepared<Script> _typeofStringGuard;
+    private Prepared<Script> _typeofUndefinedGuard;
+
+    private const string SetupSource = """
+        var mixedVals = [];
+        var order = [];
+        (function () {
+            var seed = 20260713;
+            for (var i = 0; i < 1024; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                var pick = (seed >>> 4) & 3;
+                if (pick === 0) { mixedVals.push(seed & 255); }
+                else if (pick === 1) { mixedVals.push('s' + (seed & 15)); }
+                else if (pick === 2) { mixedVals.push(undefined); }
+                else { mixedVals.push(((seed >>> 6) & 1) === 0 ? null : { v: i }); }
+            }
+            for (var i = 0; i < 8192; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                order.push((seed >>> 7) & 1023);
+            }
+        })();
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute(SetupSource);
+
+        _isUndefinedGuard = Engine.PrepareScript("""
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    var v = mixedVals[order[i & 8191]];
+                    if (v === undefined) { s++; }
+                    if (v !== undefined) { s += 2; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _isNullGuard = Engine.PrepareScript("""
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    var v = mixedVals[order[i & 8191]];
+                    if (v === null) { s++; }
+                    if (v !== null) { s += 2; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _looseNullGuard = Engine.PrepareScript("""
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    var v = mixedVals[order[i & 8191]];
+                    if (v == null) { s++; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _typeofStringGuard = Engine.PrepareScript("""
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    var v = mixedVals[order[i & 8191]];
+                    if (typeof v === 'string') { s++; }
+                    if (typeof v !== 'number') { s += 2; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _typeofUndefinedGuard = Engine.PrepareScript("""
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    var v = mixedVals[order[i & 8191]];
+                    if (typeof v === 'undefined') { s++; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _engine.Evaluate(_isUndefinedGuard);
+        _engine.Evaluate(_isNullGuard);
+        _engine.Evaluate(_looseNullGuard);
+        _engine.Evaluate(_typeofStringGuard);
+        _engine.Evaluate(_typeofUndefinedGuard);
+    }
+
+    [Benchmark]
+    public JsValue IsUndefinedGuard() => _engine.Evaluate(_isUndefinedGuard);
+
+    [Benchmark]
+    public JsValue IsNullGuard() => _engine.Evaluate(_isNullGuard);
+
+    [Benchmark]
+    public JsValue LooseNullGuard() => _engine.Evaluate(_looseNullGuard);
+
+    [Benchmark]
+    public JsValue TypeofStringGuard() => _engine.Evaluate(_typeofStringGuard);
+
+    [Benchmark]
+    public JsValue TypeofUndefinedGuard() => _engine.Evaluate(_typeofUndefinedGuard);
+}

--- a/Jint.Tests/Runtime/GuardFusionTests.cs
+++ b/Jint.Tests/Runtime/GuardFusionTests.cs
@@ -1,0 +1,117 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the build-time fused guard comparisons (`x === undefined`, `x === null`,
+/// `typeof x === "literal"` and the !== forms) against the semantics of the generic
+/// strict-equality path they replace.
+/// </summary>
+public class GuardFusionTests
+{
+    [Fact]
+    public void UndefinedAndNullGuardsMatchGenericSemantics()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var u; var n = null; var s = 'x'; var zero = 0; var empty = '';
+            [
+                u === undefined, undefined === u, u !== undefined,
+                n === null, null === n, n !== null,
+                s === undefined, zero === null, empty === undefined,
+                n === undefined, u === null
+            ].join(',');
+            """).AsString();
+
+        Assert.Equal("true,true,false,true,true,false,false,false,false,false,false", result);
+    }
+
+    [Fact]
+    public void TypeofGuardsCoverEveryTypeofResult()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            [
+                typeof undefined === 'undefined',
+                typeof null === 'object',
+                typeof true === 'boolean',
+                typeof 1 === 'number',
+                typeof 1n === 'bigint',
+                typeof 'x' === 'string',
+                typeof Symbol() === 'symbol',
+                typeof (function () {}) === 'function',
+                typeof {} === 'object',
+                'string' === typeof 'x',
+                typeof 'x' !== 'number'
+            ].join(',');
+            """).AsString();
+
+        Assert.Equal("true,true,true,true,true,true,true,true,true,true,true", result);
+    }
+
+    [Fact]
+    public void TypeofUndeclaredIdentifierDoesNotThrow()
+    {
+        var engine = new Engine();
+        Assert.True(engine.Evaluate("typeof notDeclaredAnywhere === 'undefined'").AsBoolean());
+        Assert.False(engine.Evaluate("typeof notDeclaredAnywhere !== 'undefined'").AsBoolean());
+    }
+
+    [Fact]
+    public void ImpossibleTypeofLiteralStillEvaluatesOperandOnce()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var calls = 0;
+            function probe() { calls++; return 'x'; }
+            var matched = typeof probe() === 'bogus';
+            [matched, calls].join(',');
+            """).AsString();
+
+        Assert.Equal("false,1", result);
+    }
+
+    [Fact]
+    public void TypeofClrFunctionIsFunction()
+    {
+        var engine = new Engine();
+        engine.SetValue("clrCallback", new Func<int>(() => 42));
+        Assert.True(engine.Evaluate("typeof clrCallback === 'function'").AsBoolean());
+        Assert.False(engine.Evaluate("typeof clrCallback === 'object'").AsBoolean());
+    }
+
+    [Fact]
+    public void FusedGuardsWorkAcrossAwaitSuspension()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            async function f() {
+                var a = (await Promise.resolve(undefined)) === undefined;
+                var b = (await Promise.resolve(null)) === null;
+                var c = typeof (await Promise.resolve('s')) === 'string';
+                return [a, b, c].join(',');
+            }
+            f();
+            """).UnwrapIfPromise().AsString();
+
+        Assert.Equal("true,true,true", result);
+    }
+
+    [Fact]
+    public void GuardsDriveIfStatementBooleanFastPath()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var log = [];
+            var vals = [undefined, null, 'x', 5];
+            for (var i = 0; i < vals.length; i++) {
+                var v = vals[i];
+                if (v === undefined) { log.push('u'); }
+                else if (v === null) { log.push('n'); }
+                else if (typeof v === 'string') { log.push('s'); }
+                else { log.push('o'); }
+            }
+            log.join('');
+            """).AsString();
+
+        Assert.Equal("unso", result);
+    }
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -668,10 +668,10 @@ internal abstract class JintBinaryExpression : JintExpression
         switch (expression.Operator)
         {
             case Operator.StrictEquality:
-                result = new StrictlyEqualBinaryExpression(expression);
+                result = TryBuildFusedStrictEquality(expression, invert: false) ?? new StrictlyEqualBinaryExpression(expression);
                 break;
             case Operator.StrictInequality:
-                result = new StrictlyNotEqualBinaryExpression(expression);
+                result = TryBuildFusedStrictEquality(expression, invert: true) ?? new StrictlyNotEqualBinaryExpression(expression);
                 break;
             case Operator.LessThan:
                 result = new LessBinaryExpression(expression);
@@ -759,6 +759,70 @@ internal abstract class JintBinaryExpression : JintExpression
     }
 
     /// <summary>
+    /// Build-time fusion for the guard idioms `x === undefined`, `x === null` and
+    /// `typeof x === "literal"` (plus the !== forms): the constant side is known statically, so
+    /// the fused node evaluates only the interesting operand and answers with one type test or
+    /// one reference compare — no evaluation of the constant side and no generic strict-equality
+    /// dispatch. Returns null when the expression is not one of these shapes (including when both
+    /// sides are constants, which keeps the existing literal-vs-literal constant fold).
+    /// </summary>
+    private static JintBinaryExpression? TryBuildFusedStrictEquality(NonLogicalBinaryExpression expression, bool invert)
+    {
+        // typeof x === "literal" (either orientation)
+        if (expression.Left is NonUpdateUnaryExpression { Operator: Operator.TypeOf } && expression.Right is Literal { Value: string rightString })
+        {
+            return new TypeofStrictEqualityExpression(expression, typeofIsLeft: true, MapTypeofResultSingleton(rightString), invert);
+        }
+
+        if (expression.Right is NonUpdateUnaryExpression { Operator: Operator.TypeOf } && expression.Left is Literal { Value: string leftString })
+        {
+            return new TypeofStrictEqualityExpression(expression, typeofIsLeft: false, MapTypeofResultSingleton(leftString), invert);
+        }
+
+        // x === undefined / x === null (either orientation)
+        var leftSingleton = GetKnownSingletonType(expression.Left);
+        var rightSingleton = GetKnownSingletonType(expression.Right);
+        if (rightSingleton is not null && leftSingleton is null)
+        {
+            return new SingletonStrictEqualityExpression(expression, operandIsLeft: true, rightSingleton.Value, invert);
+        }
+
+        if (leftSingleton is not null && rightSingleton is null)
+        {
+            return new SingletonStrictEqualityExpression(expression, operandIsLeft: false, leftSingleton.Value, invert);
+        }
+
+        return null;
+    }
+
+    // The identifier `undefined` matches the same compile-time folding the identifier itself
+    // evaluates through (Environment.BindingName.CalculatedValue), so the fused semantics are
+    // exactly the unfused ones. `null` is a literal; ConvertToJsValue screens out the literals
+    // that don't convert statically (regex).
+    private static InternalTypes? GetKnownSingletonType(Expression expression) => expression switch
+    {
+        Identifier { Name: "undefined" } => InternalTypes.Undefined,
+        Literal literal when JintLiteralExpression.ConvertToJsValue(literal) is JsNull => InternalTypes.Null,
+        _ => null,
+    };
+
+    // typeof only ever returns these interned singletons (JintTypeOfExpression.GetTypeOfString and
+    // the unresolvable-reference shortcut), so a mapped literal compares by reference and an
+    // unmapped literal can never match — the operand still evaluates for its side effects.
+    private static JsString? MapTypeofResultSingleton(string literal) => literal switch
+    {
+        "undefined" => JsString.UndefinedString,
+        "object" => JsString.ObjectString,
+        "boolean" => JsString.BooleanString,
+        "number" => JsString.NumberString,
+        "bigint" => JsString.BigIntString,
+        "string" => JsString.StringString,
+        "symbol" => JsString.SymbolString,
+        "function" => JsString.FunctionString,
+        _ => null,
+    };
+
+    /// <summary>
     /// Detects left-recursive chains of '+' operations that include at least one string literal,
     /// and flattens them into a single StringConcatenationExpression to avoid intermediate allocations.
     /// </summary>
@@ -832,6 +896,91 @@ internal abstract class JintBinaryExpression : JintExpression
             {
                 Throw.RangeError(realm, "Maximum BigInt size exceeded");
             }
+        }
+    }
+
+    /// <summary>
+    /// Fused `x === undefined` / `x === null` (and the !== forms): only the interesting operand
+    /// evaluates, and the answer is a single internal-type test. Strict equality against these
+    /// singletons is exactly a type-identity check (IsHTMLDDA is only LOOSELY equal to them, so
+    /// no carve-out is needed on the strict path).
+    /// </summary>
+    private sealed class SingletonStrictEqualityExpression : JintBinaryExpression
+    {
+        private readonly JintExpression _operand;
+        private readonly InternalTypes _expectedType;
+        private readonly bool _invert;
+
+        public SingletonStrictEqualityExpression(NonLogicalBinaryExpression expression, bool operandIsLeft, InternalTypes expectedType, bool invert) : base(expression)
+        {
+            _operand = operandIsLeft ? _left : _right;
+            _expectedType = expectedType;
+            _invert = invert;
+        }
+
+        protected override object EvaluateInternal(EvaluationContext context)
+        {
+            var value = _operand.GetValue(context);
+            if (context.IsSuspended())
+            {
+                return JsValue.Undefined;
+            }
+
+            return (value._type == _expectedType) != _invert ? JsBoolean.True : JsBoolean.False;
+        }
+
+        public override bool GetBooleanValue(EvaluationContext context)
+        {
+            var value = _operand.GetValue(context);
+            if (context.IsSuspended())
+            {
+                return false;
+            }
+
+            return (value._type == _expectedType) != _invert;
+        }
+    }
+
+    /// <summary>
+    /// Fused `typeof x === "literal"` (and !==): the typeof side evaluates through the normal
+    /// JintTypeOfExpression — keeping the unresolvable-identifier shortcut and host-object
+    /// classification untouched — and since typeof only ever produces the interned JsString
+    /// singletons, the comparison is a reference test against the singleton the literal mapped
+    /// to at build time (null for a literal typeof can never produce).
+    /// </summary>
+    private sealed class TypeofStrictEqualityExpression : JintBinaryExpression
+    {
+        private readonly JintExpression _typeofExpression;
+        private readonly JsString? _expectedSingleton;
+        private readonly bool _invert;
+
+        public TypeofStrictEqualityExpression(NonLogicalBinaryExpression expression, bool typeofIsLeft, JsString? expectedSingleton, bool invert) : base(expression)
+        {
+            _typeofExpression = typeofIsLeft ? _left : _right;
+            _expectedSingleton = expectedSingleton;
+            _invert = invert;
+        }
+
+        protected override object EvaluateInternal(EvaluationContext context)
+        {
+            var actual = _typeofExpression.GetValue(context);
+            if (context.IsSuspended())
+            {
+                return JsValue.Undefined;
+            }
+
+            return ReferenceEquals(actual, _expectedSingleton) != _invert ? JsBoolean.True : JsBoolean.False;
+        }
+
+        public override bool GetBooleanValue(EvaluationContext context)
+        {
+            var actual = _typeofExpression.GetValue(context);
+            if (context.IsSuspended())
+            {
+                return false;
+            }
+
+            return ReferenceEquals(actual, _expectedSingleton) != _invert;
         }
     }
 


### PR DESCRIPTION
Third PR of the quickjs-ng learnings campaign (#2654 lanes, #2656 for-in array fast path). QuickJS dedicates opcodes (`is_undefined`, `is_null`, `typeof_is_undefined`, `typeof_is_function`) to these guard idioms, produced by its peephole pass; this is the AST-interpreter equivalent — a build-time specialized node.

## What

When one side of `===`/`!==` is statically known, the generic strict-equality node (evaluate both operands, generic dispatch) is replaced at build time:

* **`x === undefined` / `x === null`** (either orientation): evaluates only the interesting operand; the answer is a single internal-type test. The `undefined` form keys off the same compile-time folding the identifier itself already evaluates through (`BindingName.CalculatedValue`), so semantics match the unfused path exactly. Strict equality against these singletons is precisely a type-identity check (`document.all`-style IsHTMLDDA values are only *loosely* equal to them, so the strict path needs no carve-out).
* **`typeof x === "literal"`**: the typeof side still evaluates through `JintTypeOfExpression` — unresolvable identifiers and host-object classification untouched — and since typeof only ever produces the interned `JsString` singletons, the comparison is a **reference test** against the singleton the literal maps to at build time. An unmapped literal (`"bogus"`) can never match, but the operand still evaluates for its side effects.

Literal-vs-literal expressions keep the existing constant fold; loose equality (`== null`) is untouched.

## Numbers

New `GuardComparisonBenchmark` (LCG-mixed inputs the branch predictor cannot memorize), default job:

| Lane | Before | After | Δ |
|---|---:|---:|---:|
| IsUndefinedGuard | 13.54 ms | 10.36 ms | **−23.5%** |
| IsNullGuard | 12.42 ms | 10.29 ms | **−17.1%** |
| TypeofStringGuard | 17.06 ms | 14.24 ms | **−16.5%** |
| TypeofUndefinedGuard | 11.87 ms | 10.73 ms | **−9.6%** |
| TypeofSwitchMixed (existing lane) | 22.13 ms | 18.65 ms | **−15.7%** |
| LooseNullGuard (untouched path) | 10.13 ms | 10.26 ms | noise |

linq-js is within run-to-run noise (its `Execute` lane varies ±5% between identical binaries).

## Tests

New `GuardFusionTests` pin: both orientations, every typeof result string, undeclared-identifier typeof (no throw), impossible literals evaluating side effects exactly once, CLR interop callables classifying as `"function"`, fused guards across `await` suspension, and the if-statement boolean fast path.

Full gate green: Jint.Tests, PublicInterface, CommonScripts, and a clean 99,429-test Test262 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)