### PR TITLE
Skip the prototype walk for array hole reads when the chain is provably clean

### DIFF
--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -25,6 +25,53 @@ public class ArrayTests
     }
 
     [Fact]
+    public void HoleReadFindsInheritedIndexOnArrayPrototype()
+    {
+        // The pristine-prototypes shortcut must disengage the moment Array.prototype (or
+        // Object.prototype) gains an index property: hole reads and `in` then walk the chain.
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var a = [1, , 3];
+            var before = [a[1], 1 in a, a[10], 10 in a];
+            Array.prototype[1] = 'ap';
+            Object.prototype[10] = 'op';
+            var after = [a[1], 1 in a, a[10], 10 in a];
+            JSON.stringify([before, after]);
+            """).AsString();
+
+        Assert.Equal("[[null,false,null,false],[\"ap\",true,\"op\",true]]", result);
+    }
+
+    [Fact]
+    public void HoleReadHonorsIndexGetterOnArrayItself()
+    {
+        // an exotic own descriptor clears the fast-access invariant on the instance
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var a = [1, 2, 3];
+            Object.defineProperty(a, '5', { get: function () { return 'got'; } });
+            [a[5], 5 in a, a[7] === undefined].join(',');
+            """).AsString();
+
+        Assert.Equal("got,true,true", result);
+    }
+
+    [Fact]
+    public void HoleReadWalksCustomPrototypeChain()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var proto = { 1: 'inherited' };
+            var a = [0];
+            a.length = 3;
+            Object.setPrototypeOf(a, proto);
+            [a[1], 1 in a, a[2] === undefined, 2 in a].join(',');
+            """).AsString();
+
+        Assert.Equal("inherited,true,true,false", result);
+    }
+
+    [Fact]
     public void FilterSubclassUsesSpecies()
     {
         var result = _engine.Evaluate("""

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -606,6 +606,15 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
     {
         if (!TryGetValue(index, out var value))
         {
+            // Reading a hole walks the prototype chain, but when nothing relevant has changed
+            // (no exotic descriptors here, prototypes pristine — the same invariant the write
+            // fast path trusts) the walk provably yields undefined: skip it and the per-hole
+            // JsString the probe would allocate.
+            if (CanUseFastAccess)
+            {
+                return Undefined;
+            }
+
             value = Prototype?.Get(JsString.Create(index)) ?? Undefined;
         }
 
@@ -614,9 +623,18 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
     public sealed override JsValue Get(JsValue property, JsValue receiver)
     {
-        if (IsSafeSelfTarget(receiver) && IsArrayIndex(property, out var index) && TryGetValue(index, out var value))
+        if (IsSafeSelfTarget(receiver) && IsArrayIndex(property, out var index))
         {
-            return value;
+            if (TryGetValue(index, out var value))
+            {
+                return value;
+            }
+
+            // hole/out-of-range read with pristine prototypes: see Get(uint)
+            if (CanUseFastAccess)
+            {
+                return Undefined;
+            }
         }
 
         if (CommonProperties.Length.Equals(property))
@@ -662,9 +680,19 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
     public sealed override bool HasProperty(JsValue property)
     {
-        if (IsArrayIndex(property, out var index) && GetValue(index, unwrapFromNonDataDescriptor: false) is not null)
+        if (IsArrayIndex(property, out var index))
         {
-            return true;
+            if (GetValue(index, unwrapFromNonDataDescriptor: false) is not null)
+            {
+                return true;
+            }
+
+            // absent index with pristine prototypes: the chain walk provably finds nothing
+            // (same invariant as Get; exotic own descriptors clear CanUseFastAccess)
+            if (CanUseFastAccess)
+            {
+                return false;
+            }
         }
 
         return base.HasProperty(property);


### PR DESCRIPTION
Fourth PR of the quickjs-ng learnings campaign (#2654 lanes, #2656 for-in array fast path, #2658 guard fusion). QuickJS guards its entire array element fast path — including hole semantics — with a single `std_array_prototype` invariant flag; Jint already tracks the equivalent invariant (`CanUseFastAccess`: no exotic own descriptors, prototype identity intact, no index properties placed on `Array.prototype`/`Object.prototype`) and trusts it on the **write** side. This PR extends that trust to the read side.

## What

Reading a hole (or any absent index) fell off the dense fast path into a full prototype-chain probe that allocates a `JsString` per index — a loop summing a 75%-holey array allocated **7 MB per op**, and `in` over the same array the same. Now `Get(uint)`, the indexed `Get(JsValue)` miss and `HasProperty` return `undefined`/`false` directly when `CanUseFastAccess` holds.

Every escape hatch falls through to the unchanged walk, and each is pinned by a new test:

* an index **getter on the array itself** sets `NonDefaultDataDescriptorUsage` (via `TrackChanges`),
* placing an **index property on `Array.prototype` or `Object.prototype`** sets `ObjectChangeFlags.ArrayIndex` on the prototype,
* **subclass instances and custom prototypes** fail the prototype-identity check.

## Numbers

`ArrayHoleTraversalBenchmark` (default job):

| Lane | Before | After | Δ |
|---|---:|---:|---|
| SumHoley | 21.03 ms / 7,015.7 KB | 14.50 ms / **1.32 KB** | **−31% time, −99.98% alloc** |
| InOperatorHoley | 16.70 ms / 7,015.7 KB | 8.45 ms / **1.32 KB** | **−49% time, −99.98% alloc** |
| SumDense | 10.44 ms | 9.97–11.01 ms | within noise (this lane bounces ±5% between identical binaries) |
| Join / IndexOf lanes | | | unchanged (already dense-aware) |

## Gate

Full gate green: Jint.Tests (incl. three new escape-hatch tests), PublicInterface, CommonScripts, and a clean 99,429-test Test262 run — which includes the `Array.prototype` index-shadowing suites this change must respect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)