### PR TITLE
Route member-expression identifier-object reads through identifier caches

### DIFF
--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -19,6 +19,7 @@ internal sealed class JintMemberExpression : JintExpression
     private readonly JsValue? _determinedProperty;
     private readonly bool _objectExpressionCanShortCircuit;
     private readonly bool _computedReadEligible;
+    private readonly bool _objectReadKeepsRawEnvironmentWalk;
     private ObjectInstance? _cachedReadObject;
     private PropertyDescriptor? _cachedReadDescriptor;
     private uint _cachedReadVersion;
@@ -50,6 +51,7 @@ internal sealed class JintMemberExpression : JintExpression
         _memberExpression = (MemberExpression) _expression;
         _objectExpression = Build(_memberExpression.Object);
         _objectExpressionCanShortCircuit = CanShortCircuit(_memberExpression.Object);
+        _objectReadKeepsRawEnvironmentWalk = _objectExpression is JintIdentifierExpression { HasEvalOrArguments: true };
 
         // Computed reads like a[i] / a[i][j] / a[0] (but not super[i] or optional a?.[i]) can take a
         // dense-array fast path in GetValue that resolves base+index without a Reference rent.
@@ -186,15 +188,27 @@ internal sealed class JintMemberExpression : JintExpression
         {
             if (_objectExpression is JintIdentifierExpression identifierExpression)
             {
-                var identifier = identifierExpression.Identifier;
-                baseReferenceName = identifier.Key.Name;
-                var env = engine.ExecutionContext.LexicalEnvironment;
-                JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(
-                    env,
-                    identifier,
-                    strict,
-                    out _,
-                    out baseValue);
+                baseReferenceName = identifierExpression.Identifier.Key.Name;
+                if (_objectReadKeepsRawEnvironmentWalk)
+                {
+                    // `arguments[i]` / `eval.x`: GetValue would run MaterializeIfArguments and
+                    // permanently opt the frame's JsArguments out of pooling; the raw walk
+                    // returns the live object and mapped-index reads stay on the parameter map.
+                    var env = engine.ExecutionContext.LexicalEnvironment;
+                    JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue(
+                        env,
+                        identifierExpression.Identifier,
+                        strict,
+                        out _,
+                        out baseValue);
+                }
+                else
+                {
+                    // Route through the identifier node's slot/global caches instead of walking
+                    // the environment chain on every evaluation; unresolvable and TDZ bases
+                    // throw the same ReferenceError the generic fallback would produce.
+                    baseValue = identifierExpression.GetValue(context);
+                }
             }
             else if (_objectExpression is JintThisExpression thisExpression)
             {


### PR DESCRIPTION
## Summary

`JintMemberExpression.EvaluateInternal` resolves an identifier base (`a` in `a[i] = v`, `a[i] += x`, `a[i]++`, `obj[m]()`, `delete obj.prop`) by calling `JintEnvironment.TryGetIdentifierEnvironmentWithBindingValue` directly — a full environment-chain walk with virtual `TryGetBinding` probes on **every evaluation**. That call predates the slot/global/nested-chain caches that `JintIdentifierExpression.GetValue` has since grown; the read paths (`GetValue`, `GetCalleeForCall`, `TryAssignFast`) were upgraded to those caches long ago, this branch never was.

This PR routes the identifier-object read through `identifierExpression.GetValue(context)` so it hits the identifier node's own caches (hop-0 slot reads, validated global descriptors), with one carve-out: `arguments` / `eval` bases keep the raw walk, because `GetValue` runs `MaterializeIfArguments`, which would permanently opt the frame's `JsArguments` out of pooling for `arguments[i]` readers and detach mapped-index reads from the parameter map. Aliases (`var a = arguments`) already materialize at assignment time, so the carve-out only needs to cover the direct name.

Found via ETW sampling (ultra @ 8190 Hz) of a steady-state SunSpider mix, where the raw walk accounted for a large share of `TryGetIdentifierEnvironmentWithBindingValue`'s 3.3% self time and `EvaluateInternal`'s 2.6%.

## Semantics notes

- Unresolvable bases throw the identical `ReferenceError` through the identical `engine.GetValue(unresolvable reference)` path.
- TDZ bases now throw "X has not been initialized" instead of "Cannot access 'X' before initialization" — this **aligns** `EvaluateInternal` with the message the member *read* path (`GetValue`) already throws for the same code; no test asserts the old message on this path.
- `with`/ObjectEnvironment and eval-injected bindings behave identically: the identifier caches refuse to cross `ObjectEnvironment`s and HasBinding-probe hopped intermediate envs, falling back to the same full walk.
- Suspend machinery untouched — identifier reads never suspend.

## Benchmarks (default jobs, back-to-back A/B on same machine)

| Benchmark | main | PR | Δ |
|---|---:|---:|---:|
| ElementAccess Write | 90.51 ms | 83.10 ms | **−8.2%** |
| ElementAccess ReadModifyWrite | 155.62 ms | 143.97 ms | **−7.5%** |
| ElementAccess AppendWrite | 39.32 ms | 34.71 ms | **−11.7%** |
| ElementAccess ChainedRead | 137.01 ms | 130.16 ms | −5.0% |
| ElementAccess Read | 101.31 ms | 98.66 ms | −2.6% |
| SunSpider bitops-nsieve-bits | 89.73 ms | 82.13 ms | **−8.5%** |
| SunSpider access-fannkuch | 219.55 ms | 206.38 ms | −6.0% |
| SunSpider 3d-cube | 39.59 ms | 37.49 ms | −5.3% |
| SunSpider crypto-md5 | 57.44 ms | 54.38 ms | −5.3% |
| SunSpider crypto-aes | 57.85 ms | 55.92 ms | −3.3% |
| SunSpider string-fasta | 76.74 ms | 74.43 ms | −3.0% |
| Uncacheable guard (interop member reads) | 51.38 / 47.30 ms | 51.22 / 45.77 ms | neutral |

Allocations unchanged on every row.

ETW re-profile of a function-wrapped SunSpider mix (fixed work, 45 iterations): total 15,687 → 13,617 ms (**−13.2%**); `JintMemberExpression.EvaluateInternal` self 401 → 267 ms (−34%). The function-wrapped shape (identifier bases in slots — typical of real code in functions) benefits more than the global-scope BDN scripts.

## Gates

- Jint.Tests: 3537 (net10.0) + 3474 (net472) passed, 0 failed
- Jint.Tests.PublicInterface: 82 × 2 TFMs passed
- Jint.Tests.CommonScripts: 28 × 2 TFMs passed
- Test262: 99,429 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
