### PR TITLE
Shard Test262 across parallel CI runners + fix cross-OS suite cache

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,9 @@ Jint.Tests.Test262/** linguist-vendored
 *.verified.txt text eol=lf
 *.received.cs text eol=lf
 *.received.txt text eol=lf
+
+# The Test262 generated suite is cached across operating systems, keyed on a hash of this
+# settings file. It must therefore be byte-identical on every platform: a CRLF Windows checkout
+# would change both the cache key (hashFiles) and the MSBuild regeneration gate, turning every
+# cross-OS cache restore into a full regeneration.
+Jint.Tests.Test262/Test262Harness.settings.json text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,16 @@ on:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  # Number of shards the Test262 suite is split into. Keep in sync with the `shard` matrix lists below.
+  TEST262_SHARD_COUNT: 4
 
 jobs:
-  build:
+
+  # Everything except Test262: fast, run once.
+  unit:
 
     runs-on: ubuntu-latest
+
     steps:
 
     - name: Setup NET
@@ -24,16 +29,110 @@ jobs:
         dotnet-version: 10.0
 
     - name: Checkout source code
-      uses: actions/checkout@v6
-
-    - name: Cache Test262 generated suite
-      uses: actions/cache@v5
-      with:
-        path: Jint.Tests.Test262/Generated
-        key: test262-generated-${{ hashFiles('Jint.Tests.Test262/Test262Harness.settings.json') }}
+      uses: actions/checkout@v7
 
     - name: Test
-      run: dotnet test --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"
+      shell: bash
+      run: |
+        set -e
+        for proj in \
+          Jint.Tests/Jint.Tests.csproj \
+          Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj \
+          Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj \
+          Jint.Tests.SourceGenerators/Jint.Tests.SourceGenerators.csproj; do
+          echo "::group::$proj"
+          dotnet test "$proj" --configuration Release \
+            --logger "console;verbosity=quiet" \
+            --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"
+          echo "::endgroup::"
+        done
+
+  # Generate each Test262 shard once and publish it to a cross-OS cache. Because default-branch
+  # caches are visible to pull requests, this seeds the shards that PR jobs restore.
+  generate-test262:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Setup NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0
+
+    - name: Checkout source code
+      uses: actions/checkout@v7
+
+    - name: Cache Test262 generated shard
+      id: cache
+      uses: actions/cache@v6
+      with:
+        path: Jint.Tests.Test262/Generated
+        key: test262-generated-${{ hashFiles('Jint.Tests.Test262/Test262Harness.settings.json') }}-shard${{ matrix.shard }}-of-${{ env.TEST262_SHARD_COUNT }}
+        enableCrossOsArchive: true
+
+    - name: Generate shard
+      if: steps.cache.outputs.cache-hit != 'true'
+      env:
+        TEST262_SHARD_INDEX: ${{ matrix.shard }}
+      run: dotnet build Jint.Tests.Test262/Jint.Tests.Test262.csproj --configuration Release -t:GenerateTestSuite
+
+  # Validate Test262 on Linux, sharded.
+  test262:
+
+    needs: generate-test262
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+
+    runs-on: ubuntu-latest
+
+    env:
+      TEST262_SHARD_INDEX: ${{ matrix.shard }}
+
+    steps:
+
+    - name: Setup NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0
+
+    - name: Checkout source code
+      uses: actions/checkout@v7
+
+    - name: Restore Test262 generated shard
+      uses: actions/cache@v6
+      with:
+        path: Jint.Tests.Test262/Generated
+        key: test262-generated-${{ hashFiles('Jint.Tests.Test262/Test262Harness.settings.json') }}-shard${{ matrix.shard }}-of-${{ env.TEST262_SHARD_COUNT }}
+        enableCrossOsArchive: true
+
+    - name: Test
+      run: dotnet test Jint.Tests.Test262/Jint.Tests.Test262.csproj --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"
+
+  # Pack and publish the preview package once, after the suites pass.
+  publish:
+
+    needs: [ unit, test262 ]
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Setup NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0
+
+    - name: Checkout source code
+      uses: actions/checkout@v7
 
     - name: Pack with dotnet
       run: dotnet pack Jint/Jint.csproj --output artifacts --configuration Release -p:VersionSuffix=preview-$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=True

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,9 +15,10 @@ concurrency:
 
 jobs:
 
-  test:
+  # Everything except Test262: fast (< 1 min), so run the whole set once per OS.
+  unit:
 
-    name: ${{ matrix.os.name }}
+    name: unit - ${{ matrix.os.name }}
 
     strategy:
       fail-fast: false
@@ -38,14 +39,137 @@ jobs:
         dotnet-version: 10.0
 
     - name: Checkout source code
-      uses: actions/checkout@v6
-
-    - name: Cache Test262 generated suite
-      uses: actions/cache@v5
-      with:
-        path: Jint.Tests.Test262/Generated
-        key: test262-generated-${{ hashFiles('Jint.Tests.Test262/Test262Harness.settings.json') }}
+      uses: actions/checkout@v7
 
     - name: Test
-      run: dotnet test --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"
+      shell: bash
+      run: |
+        set -e
+        for proj in \
+          Jint.Tests/Jint.Tests.csproj \
+          Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj \
+          Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj \
+          Jint.Tests.SourceGenerators/Jint.Tests.SourceGenerators.csproj; do
+          echo "::group::$proj"
+          dotnet test "$proj" --configuration Release \
+            --logger "console;verbosity=quiet" \
+            --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"
+          echo "::endgroup::"
+        done
 
+  # Generate each Test262 shard once (codegen is OS-independent) and publish it to a cross-OS
+  # cache. Keyed per shard, so the previous same-key race between OS jobs is gone. These shards
+  # feed the sharded linux/windows test jobs below.
+  generate-test262:
+
+    name: generate test262 (shard ${{ matrix.shard }})
+
+    env:
+      TEST262_SHARD_COUNT: 4
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Setup NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0
+
+    - name: Checkout source code
+      uses: actions/checkout@v7
+
+    - name: Cache Test262 generated shard
+      id: cache
+      uses: actions/cache@v6
+      with:
+        path: Jint.Tests.Test262/Generated
+        key: test262-generated-${{ hashFiles('Jint.Tests.Test262/Test262Harness.settings.json') }}-shard${{ matrix.shard }}-of-${{ env.TEST262_SHARD_COUNT }}
+        enableCrossOsArchive: true
+
+    - name: Generate shard
+      if: steps.cache.outputs.cache-hit != 'true'
+      env:
+        TEST262_SHARD_INDEX: ${{ matrix.shard }}
+      run: dotnet build Jint.Tests.Test262/Jint.Tests.Test262.csproj --configuration Release -t:GenerateTestSuite
+
+  # x64 linux and windows are the slow runners: shard Test262 4 ways across them. Each job restores
+  # its shard from the cross-OS cache, then compiles and runs only its ~1/4 slice of the suite.
+  test262-sharded:
+
+    name: test262 - ${{ matrix.os.name }} (shard ${{ matrix.shard }})
+
+    needs: generate-test262
+
+    env:
+      TEST262_SHARD_COUNT: 4
+      TEST262_SHARD_INDEX: ${{ matrix.shard }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - { name: 'linux', image: 'ubuntu-latest' }
+          - { name: 'windows', image: 'windows-latest' }
+        shard: [0, 1, 2, 3]
+
+    runs-on: ${{ matrix.os.image }}
+
+    steps:
+
+    - name: Setup NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0
+
+    - name: Checkout source code
+      uses: actions/checkout@v7
+
+    - name: Restore Test262 generated shard
+      uses: actions/cache@v6
+      with:
+        path: Jint.Tests.Test262/Generated
+        key: test262-generated-${{ hashFiles('Jint.Tests.Test262/Test262Harness.settings.json') }}-shard${{ matrix.shard }}-of-${{ env.TEST262_SHARD_COUNT }}
+        enableCrossOsArchive: true
+
+    - name: Test
+      run: dotnet test Jint.Tests.Test262/Jint.Tests.Test262.csproj --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"
+
+  # macOS and ARM runners are scarcer (and already fast per-core), so run the full suite unsharded
+  # there — one runner each. The generated suite is cached per-OS (no cross-OS sharing needed).
+  test262-full:
+
+    name: test262 - ${{ matrix.os.name }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - { name: 'linux - ARM', image: 'ubuntu-24.04-arm' }
+          - { name: 'macos', image: 'macos-latest' }
+
+    runs-on: ${{ matrix.os.image }}
+
+    steps:
+
+    - name: Setup NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0
+
+    - name: Checkout source code
+      uses: actions/checkout@v7
+
+    - name: Cache Test262 generated suite
+      uses: actions/cache@v6
+      with:
+        path: Jint.Tests.Test262/Generated
+        key: test262-generated-${{ hashFiles('Jint.Tests.Test262/Test262Harness.settings.json') }}-full
+
+    - name: Test
+      run: dotnet test Jint.Tests.Test262/Jint.Tests.Test262.csproj --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"

--- a/Jint.Tests.Test262/.config/dotnet-tools.json
+++ b/Jint.Tests.Test262/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "test262harness.console": {
-      "version": "1.0.6",
+      "version": "1.1.0",
       "commands": [
         "test262"
       ]

--- a/Jint.Tests.Test262/Jint.Tests.Test262.csproj
+++ b/Jint.Tests.Test262/Jint.Tests.Test262.csproj
@@ -45,12 +45,30 @@
       <_SettingsFilePath>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), $(SettingsFile)))</_SettingsFilePath>
       <_GeneratedDirPath>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), $(GeneratedTestSuiteDir)))</_GeneratedDirPath>
     </PropertyGroup>
-    
+
+    <!--
+      Optional suite sharding. A CI matrix sets TEST262_SHARD_COUNT / TEST262_SHARD_INDEX (surfaced as
+      MSBuild properties) so each job only generates, compiles and runs its deterministic slice of the
+      suite. Defaults to a single shard = the full suite, so local builds are unaffected.
+    -->
+    <PropertyGroup>
+      <Test262ShardCount Condition="'$(Test262ShardCount)' == ''">$(TEST262_SHARD_COUNT)</Test262ShardCount>
+      <Test262ShardCount Condition="'$(Test262ShardCount)' == ''">1</Test262ShardCount>
+      <Test262ShardIndex Condition="'$(Test262ShardIndex)' == ''">$(TEST262_SHARD_INDEX)</Test262ShardIndex>
+      <Test262ShardIndex Condition="'$(Test262ShardIndex)' == ''">0</Test262ShardIndex>
+      <_Test262ShardArgs Condition="$(Test262ShardCount) &gt; 1">--shard-count $(Test262ShardCount) --shard-index $(Test262ShardIndex)</_Test262ShardArgs>
+    </PropertyGroup>
+
     <!-- Compute current settings file hash -->
     <GetFileHash Files="$(_SettingsFilePath)" Algorithm="SHA256">
       <Output TaskParameter="Hash" PropertyName="_CurrentSettingsHash" />
     </GetFileHash>
-    
+
+    <!-- Fold the shard identity into the hash so switching shards in place forces a regeneration -->
+    <PropertyGroup>
+      <_CurrentSettingsHash>$(_CurrentSettingsHash)-shard$(Test262ShardIndex)-of-$(Test262ShardCount)</_CurrentSettingsHash>
+    </PropertyGroup>
+
     <!-- Read stored hash if it exists -->
     <ReadLinesFromFile File="$(_SettingsHashFilePath)" Condition="Exists('$(_SettingsHashFilePath)')">
       <Output TaskParameter="Lines" PropertyName="_StoredSettingsHash" />
@@ -71,7 +89,7 @@
     
     <!-- Run generation if needed -->
     <Exec Command="dotnet tool restore" Condition="'$(_NeedsRegeneration)' == 'true'" />
-    <Exec Command="dotnet test262 generate" Condition="'$(_NeedsRegeneration)' == 'true'" />
+    <Exec Command="dotnet test262 generate $(_Test262ShardArgs)" Condition="'$(_NeedsRegeneration)' == 'true'" />
     
     <!-- Store the new hash after successful generation -->
     <WriteLinesToFile File="$(_SettingsHashFilePath)" Lines="$(_CurrentSettingsHash)" Overwrite="true" Condition="'$(_NeedsRegeneration)' == 'true'" />


### PR DESCRIPTION
> **Draft — blocked on** [lahma/test262-harness-dotnet#161](https://github.com/lahma/test262-harness-dotnet/pull/161) shipping as `test262harness.console` **1.1.0** (this PR bumps the pinned tool to it). CI here will fail until that version is on NuGet.

## Why

Test262 execution is **~55-60% of every CI job** (349s on linux, 380s on windows), and free GitHub runners are capped at **4 vCPU** — which NUnit already saturates (`NumberOfTestWorkers` defaults to `ProcessorCount`). An A/B sweep on a real 4-vCPU runner confirmed raising the worker count does **not** help:

| workers | 4 | 6 | 8 | 12 | 16 |
|---|---|---|---|---|---|
| Test262 wall | 5m51s | 5m48s | 5m53s | 5m54s | 6m02s |

Flat through 12 (inside the noise band of `workers=4`), worse at 16 — textbook CPU-bound saturation. So the only lever for wall-clock is **horizontal sharding across runners**, which is free for public repos.

## What

- **Sharding** (`Jint.Tests.Test262.csproj`): `TEST262_SHARD_COUNT` / `TEST262_SHARD_INDEX` make the project generate, compile and run only its deterministic slice. Defaults to the full suite, so local builds are unchanged. Shard assignment lives in the harness (stable FNV-1a hash → disjoint shards whose union is the full 99,566-case suite, verified).
- **`pr.yml`**: 4-way shard on the slow x64 **linux/windows** runners; **macOS/ARM** run the full suite unsharded (one runner each — they're scarcer and already fast per-core); a fast **`unit`** job runs everything except Test262 once per OS.
- **Cache fix**: a `generate-test262` job produces each shard once into a **per-shard, cross-OS** cache. This removes the previous 4-way same-key race (*"another job may be creating this cache"*) and the redundant per-OS regeneration.
- **`.gitattributes`**: forces `Test262Harness.settings.json` to `eol=lf` — required so the cross-OS cache key (`hashFiles`) and the MSBuild regeneration gate are byte-identical (it currently checks out CRLF on Windows).
- Bump `actions/checkout` → v7, `actions/cache` → v6.

## Expected payoff

Per-shard Test262 exec ~349s → **~87s**; a run drops from ~10-12 min to roughly **~4-5 min** on the sharded runners (macOS/ARM stay ~7 min by design), and the cache is effective on warm runs instead of racing.

## Validation

The harness feature and the csproj plumbing were validated locally (4 shards summing exactly to 99,566; `TEST262_SHARD_INDEX=1` generated the correct 24,592-case slice with the shard folded into the regen hash). The workflow behavior itself should get one real Actions run once 1.1.0 is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)