### PR TITLE
Add unboxed operand lane for arithmetic binary operators

### DIFF
--- a/Jint.Tests/Runtime/NumberTests.cs
+++ b/Jint.Tests/Runtime/NumberTests.cs
@@ -250,11 +250,20 @@ public class NumberTests
                 r.push(Object.is(acc2, -0));
                 var acc3 = 0; acc3 *= 5;
                 r.push(Object.is(acc3, 0));
+                // discard-mode numeric-assignment shape (x = a * b as a statement, LHS already
+                // a number so the unboxed-slot store engages) and a first-assignment variant
+                // that exercises the value-producing binary lane instead
+                var prod = 1; prod = zero * negFive;
+                r.push(Object.is(prod, -0));
+                var prod2 = 1; prod2 = negFive * zero;
+                r.push(Object.is(prod2, -0));
+                var prod3; prod3 = zero * five;
+                r.push(Object.is(prod3, 0));
                 return r.join(',');
             })()
             """).AsString();
 
-        Assert.Equal("true,true,true,true,true,true,true,true,true,true,true", result);
+        Assert.Equal("true,true,true,true,true,true,true,true,true,true,true,true,true,true", result);
     }
 
     // The following tests guard the primitive-receiver method resolution that skips allocating a

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -633,14 +633,14 @@ internal sealed class JintAssignmentExpression : JintExpression
                 return false;
             }
 
-            // Multiplication is intentionally excluded: the boxed binary path computes 0 * negative as
-            // integers and yields +0, whereas raw-double multiplication yields the spec-correct -0, so a
-            // double-based fast path would change observable behaviour. Addition/subtraction/division/
-            // remainder produce identical results on both paths, keeping this a pure optimization.
+            // All five operators produce identical results on the raw-double and boxed paths:
+            // IEEE arithmetic is the spec algorithm, the boxed integer-multiply arm routes zero
+            // products through double math to preserve -0, and an unboxed slot stores -0 exactly.
             switch (binary.Operator)
             {
                 case Operator.Addition:
                 case Operator.Subtraction:
+                case Operator.Multiplication:
                 case Operator.Division:
                 case Operator.Remainder:
                     return IsIdentifierOrNumericLiteral(binary.Left) && IsIdentifierOrNumericLiteral(binary.Right);
@@ -681,6 +681,7 @@ internal sealed class JintAssignmentExpression : JintExpression
             {
                 case Operator.Addition:
                 case Operator.Subtraction:
+                case Operator.Multiplication:
                 case Operator.Division:
                 case Operator.Remainder:
                     break;
@@ -875,6 +876,11 @@ internal sealed class JintAssignmentExpression : JintExpression
                     break;
                 case Operator.Subtraction:
                     result = left - right;
+                    break;
+                case Operator.Multiplication:
+                    // IEEE 754 multiplication is Number::multiply, including -0 for zero products
+                    // of opposite signs; the unboxed slot stores -0 exactly
+                    result = left * right;
                     break;
                 case Operator.Division:
                     // IEEE 754 division matches the ECMAScript algorithm for all special cases

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -277,32 +277,26 @@ internal abstract class JintBinaryExpression : JintExpression
     /// to the Number:: op, which IEEE double arithmetic implements exactly (including the
     /// sign-of-zero rules), and JsNumber.Create normalizes integral results to the same
     /// Integer-typed instances the boxed arms produce, so downstream integer fast paths stay
-    /// armed. Unlike the comparison/bitwise lane structs this is a nullable class: Plus is the
-    /// most numerous binary node and often string-typed, so non-matching nodes pay one reference
-    /// field instead of an embedded pair of slot caches.
+    /// armed. Embedded directly as a struct in Minus/Times/Divide (almost always numeric —
+    /// same precedent as the comparison classes' embedded lane); Plus wraps it in
+    /// <see cref="BoxedNumericOperandLane"/> because string-concat Plus nodes are numerous and
+    /// should pay one reference field, not an embedded slot-cache pair, for a lane they never
+    /// arm. The embedded form matters on hit-heavy loops: a separate lane object costs an extra
+    /// dereference (cache line) per evaluation.
     /// </summary>
-    private protected sealed class NumericOperandLane
+    private protected struct NumericOperandLane
     {
-        private readonly JintIdentifierExpression? _leftIdentifier;   // null => _leftConstant
-        private readonly JintIdentifierExpression? _rightIdentifier;  // null => _rightConstant
-        private readonly double _leftConstant;
-        private readonly double _rightConstant;
+        private JintIdentifierExpression? _leftIdentifier;   // null => _leftConstant
+        private JintIdentifierExpression? _rightIdentifier;  // null => _rightConstant
+        private double _leftConstant;
+        private double _rightConstant;
+        private bool _armed;
         private SlotLocationCache _leftSlotCache;
         private SlotLocationCache _rightSlotCache;
 
-        private NumericOperandLane(
-            JintIdentifierExpression? leftIdentifier,
-            double leftConstant,
-            JintIdentifierExpression? rightIdentifier,
-            double rightConstant)
-        {
-            _leftIdentifier = leftIdentifier;
-            _leftConstant = leftConstant;
-            _rightIdentifier = rightIdentifier;
-            _rightConstant = rightConstant;
-        }
+        public readonly bool IsArmed => _armed;
 
-        public static NumericOperandLane? TryBuild(JintExpression left, JintExpression right)
+        public void Initialize(JintExpression left, JintExpression right)
         {
             var leftIdentifier = left as JintIdentifierExpression;
             var rightIdentifier = right as JintIdentifierExpression;
@@ -311,7 +305,7 @@ internal abstract class JintBinaryExpression : JintExpression
             // identifier keeps the lane off shapes other machinery owns
             if (leftIdentifier is null && rightIdentifier is null)
             {
-                return null;
+                return;
             }
 
             double leftConstant = 0;
@@ -319,7 +313,7 @@ internal abstract class JintBinaryExpression : JintExpression
             {
                 if (left is not JintConstantExpression { Value: JsNumber leftNumber })
                 {
-                    return null;
+                    return;
                 }
                 leftConstant = leftNumber._value;
             }
@@ -329,12 +323,16 @@ internal abstract class JintBinaryExpression : JintExpression
             {
                 if (right is not JintConstantExpression { Value: JsNumber rightNumber })
                 {
-                    return null;
+                    return;
                 }
                 rightConstant = rightNumber._value;
             }
 
-            return new NumericOperandLane(leftIdentifier, leftConstant, rightIdentifier, rightConstant);
+            _leftIdentifier = leftIdentifier;
+            _leftConstant = leftConstant;
+            _rightIdentifier = rightIdentifier;
+            _rightConstant = rightConstant;
+            _armed = true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -343,7 +341,7 @@ internal abstract class JintBinaryExpression : JintExpression
             left = _leftConstant;
             right = _rightConstant;
 
-            if (context.OperatorOverloadingAllowed)
+            if (!_armed || context.OperatorOverloadingAllowed)
             {
                 return false;
             }
@@ -381,6 +379,23 @@ internal abstract class JintBinaryExpression : JintExpression
             }
 
             return true;
+        }
+    }
+
+    /// <summary>
+    /// Heap-allocated <see cref="NumericOperandLane"/> for PlusBinaryExpression: allocated only
+    /// when the operand shape matches at build time, so the many string-concat Plus nodes carry
+    /// a single null reference field instead of the embedded lane struct.
+    /// </summary>
+    private protected sealed class BoxedNumericOperandLane
+    {
+        public NumericOperandLane Lane;
+
+        public static BoxedNumericOperandLane? TryBuild(JintExpression left, JintExpression right)
+        {
+            var lane = new NumericOperandLane();
+            lane.Initialize(left, right);
+            return lane.IsArmed ? new BoxedNumericOperandLane { Lane = lane } : null;
         }
     }
 
@@ -1317,16 +1332,16 @@ internal abstract class JintBinaryExpression : JintExpression
 
     private sealed class PlusBinaryExpression : JintBinaryExpression
     {
-        private readonly NumericOperandLane? _numericLane;
+        private readonly BoxedNumericOperandLane? _numericLane;
 
         public PlusBinaryExpression(NonLogicalBinaryExpression expression) : base(expression)
         {
-            _numericLane = NumericOperandLane.TryBuild(_left, _right);
+            _numericLane = BoxedNumericOperandLane.TryBuild(_left, _right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
-            if (_numericLane is not null && _numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            if (_numericLane is not null && _numericLane.Lane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
             {
                 return JsNumber.Create(unboxedLeft + unboxedRight);
             }
@@ -1459,16 +1474,16 @@ internal abstract class JintBinaryExpression : JintExpression
 
     private sealed class MinusBinaryExpression : JintBinaryExpression
     {
-        private readonly NumericOperandLane? _numericLane;
+        private NumericOperandLane _numericLane;
 
         public MinusBinaryExpression(NonLogicalBinaryExpression expression) : base(expression)
         {
-            _numericLane = NumericOperandLane.TryBuild(_left, _right);
+            _numericLane.Initialize(_left, _right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
-            if (_numericLane is not null && _numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            if (_numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
             {
                 return JsNumber.Create(unboxedLeft - unboxedRight);
             }
@@ -1514,16 +1529,16 @@ internal abstract class JintBinaryExpression : JintExpression
 
     private sealed class TimesBinaryExpression : JintBinaryExpression
     {
-        private readonly NumericOperandLane? _numericLane;
+        private NumericOperandLane _numericLane;
 
         public TimesBinaryExpression(NonLogicalBinaryExpression expression) : base(expression)
         {
-            _numericLane = NumericOperandLane.TryBuild(_left, _right);
+            _numericLane.Initialize(_left, _right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
-            if (_numericLane is not null && _numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            if (_numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
             {
                 // raw-double multiply is Number::multiply bit for bit, including -0 for zero
                 // products of opposite signs
@@ -1576,16 +1591,16 @@ internal abstract class JintBinaryExpression : JintExpression
 
     private sealed class DivideBinaryExpression : JintBinaryExpression
     {
-        private readonly NumericOperandLane? _numericLane;
+        private NumericOperandLane _numericLane;
 
         public DivideBinaryExpression(NonLogicalBinaryExpression expression) : base(expression)
         {
-            _numericLane = NumericOperandLane.TryBuild(_left, _right);
+            _numericLane.Initialize(_left, _right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
-            if (_numericLane is not null && _numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            if (_numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
             {
                 return JsNumber.Create(unboxedLeft / unboxedRight);
             }

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -269,6 +269,122 @@ internal abstract class JintBinaryExpression : JintExpression
     }
 
     /// <summary>
+    /// Unboxed operand lane for the arithmetic operators (+ - * /) over identifier and
+    /// numeric-constant leaf shapes (`a * b`, `x - 1`, `2 * x`). Both operands are read as raw
+    /// doubles through the slot/global caches — pure reads, so a decline (non-number binding,
+    /// TDZ, slot miss) falls into the generic path which replays left-then-right evaluation with
+    /// no observable double effect. For two runtime-proven Numbers the spec operator degenerates
+    /// to the Number:: op, which IEEE double arithmetic implements exactly (including the
+    /// sign-of-zero rules), and JsNumber.Create normalizes integral results to the same
+    /// Integer-typed instances the boxed arms produce, so downstream integer fast paths stay
+    /// armed. Unlike the comparison/bitwise lane structs this is a nullable class: Plus is the
+    /// most numerous binary node and often string-typed, so non-matching nodes pay one reference
+    /// field instead of an embedded pair of slot caches.
+    /// </summary>
+    private protected sealed class NumericOperandLane
+    {
+        private readonly JintIdentifierExpression? _leftIdentifier;   // null => _leftConstant
+        private readonly JintIdentifierExpression? _rightIdentifier;  // null => _rightConstant
+        private readonly double _leftConstant;
+        private readonly double _rightConstant;
+        private SlotLocationCache _leftSlotCache;
+        private SlotLocationCache _rightSlotCache;
+
+        private NumericOperandLane(
+            JintIdentifierExpression? leftIdentifier,
+            double leftConstant,
+            JintIdentifierExpression? rightIdentifier,
+            double rightConstant)
+        {
+            _leftIdentifier = leftIdentifier;
+            _leftConstant = leftConstant;
+            _rightIdentifier = rightIdentifier;
+            _rightConstant = rightConstant;
+        }
+
+        public static NumericOperandLane? TryBuild(JintExpression left, JintExpression right)
+        {
+            var leftIdentifier = left as JintIdentifierExpression;
+            var rightIdentifier = right as JintIdentifierExpression;
+
+            // constant-op-constant is folded before these nodes are built; requiring at least one
+            // identifier keeps the lane off shapes other machinery owns
+            if (leftIdentifier is null && rightIdentifier is null)
+            {
+                return null;
+            }
+
+            double leftConstant = 0;
+            if (leftIdentifier is null)
+            {
+                if (left is not JintConstantExpression { Value: JsNumber leftNumber })
+                {
+                    return null;
+                }
+                leftConstant = leftNumber._value;
+            }
+
+            double rightConstant = 0;
+            if (rightIdentifier is null)
+            {
+                if (right is not JintConstantExpression { Value: JsNumber rightNumber })
+                {
+                    return null;
+                }
+                rightConstant = rightNumber._value;
+            }
+
+            return new NumericOperandLane(leftIdentifier, leftConstant, rightIdentifier, rightConstant);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGetOperands(EvaluationContext context, out double left, out double right)
+        {
+            left = _leftConstant;
+            right = _rightConstant;
+
+            if (context.OperatorOverloadingAllowed)
+            {
+                return false;
+            }
+
+            var engine = context.Engine;
+            if (engine.ExecutionContext.Suspendable is not null)
+            {
+                // generator/async resume replays a saved left operand through the suspend
+                // protocol; live slot re-reads could observe a different value
+                return false;
+            }
+
+            var env = engine.ExecutionContext.LexicalEnvironment;
+
+            var leftIdentifier = _leftIdentifier;
+            if (leftIdentifier is not null
+                && (!_leftSlotCache.TryResolve(engine, env, leftIdentifier.Identifier, out var leftEnvironment, out var leftSlotIndex)
+                    || !leftEnvironment.TryGetNumberSlotForRead(leftSlotIndex, out left)))
+            {
+                if (leftIdentifier._cachedGlobalEnv is null || !TryReadGlobalNumber(leftIdentifier, engine, env, out left))
+                {
+                    return false;
+                }
+            }
+
+            var rightIdentifier = _rightIdentifier;
+            if (rightIdentifier is not null
+                && (!_rightSlotCache.TryResolve(engine, env, rightIdentifier.Identifier, out var rightEnvironment, out var rightSlotIndex)
+                    || !rightEnvironment.TryGetNumberSlotForRead(rightSlotIndex, out right)))
+            {
+                if (rightIdentifier._cachedGlobalEnv is null || !TryReadGlobalNumber(rightIdentifier, engine, env, out right))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    /// <summary>
     /// Whole-tree lane for sum-of-products arithmetic over pure-readable numeric leaves —
     /// `M1[i][0]*M2[0][j] + M1[i][1]*M2[1][j] + …`, the dromaeo-3d-cube MMulti/VMulti kernel shape,
     /// which otherwise boxes a transient JsNumber per binary node. The whole tree is computed on
@@ -1201,12 +1317,20 @@ internal abstract class JintBinaryExpression : JintExpression
 
     private sealed class PlusBinaryExpression : JintBinaryExpression
     {
+        private readonly NumericOperandLane? _numericLane;
+
         public PlusBinaryExpression(NonLogicalBinaryExpression expression) : base(expression)
         {
+            _numericLane = NumericOperandLane.TryBuild(_left, _right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
+            if (_numericLane is not null && _numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            {
+                return JsNumber.Create(unboxedLeft + unboxedRight);
+            }
+
             if (!TryEvaluateOperands(context, out var left, out var right))
             {
                 return JsValue.Undefined;
@@ -1335,12 +1459,20 @@ internal abstract class JintBinaryExpression : JintExpression
 
     private sealed class MinusBinaryExpression : JintBinaryExpression
     {
+        private readonly NumericOperandLane? _numericLane;
+
         public MinusBinaryExpression(NonLogicalBinaryExpression expression) : base(expression)
         {
+            _numericLane = NumericOperandLane.TryBuild(_left, _right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
+            if (_numericLane is not null && _numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            {
+                return JsNumber.Create(unboxedLeft - unboxedRight);
+            }
+
             if (!TryEvaluateOperands(context, out var left, out var right))
             {
                 return JsValue.Undefined;
@@ -1382,12 +1514,22 @@ internal abstract class JintBinaryExpression : JintExpression
 
     private sealed class TimesBinaryExpression : JintBinaryExpression
     {
+        private readonly NumericOperandLane? _numericLane;
+
         public TimesBinaryExpression(NonLogicalBinaryExpression expression) : base(expression)
         {
+            _numericLane = NumericOperandLane.TryBuild(_left, _right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
+            if (_numericLane is not null && _numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            {
+                // raw-double multiply is Number::multiply bit for bit, including -0 for zero
+                // products of opposite signs
+                return JsNumber.Create(unboxedLeft * unboxedRight);
+            }
+
             if (!TryEvaluateOperands(context, out var left, out var right))
             {
                 return JsValue.Undefined;
@@ -1434,12 +1576,20 @@ internal abstract class JintBinaryExpression : JintExpression
 
     private sealed class DivideBinaryExpression : JintBinaryExpression
     {
+        private readonly NumericOperandLane? _numericLane;
+
         public DivideBinaryExpression(NonLogicalBinaryExpression expression) : base(expression)
         {
+            _numericLane = NumericOperandLane.TryBuild(_left, _right);
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
+            if (_numericLane is not null && _numericLane.TryGetOperands(context, out var unboxedLeft, out var unboxedRight))
+            {
+                return JsNumber.Create(unboxedLeft / unboxedRight);
+            }
+
             if (!TryEvaluateOperands(context, out var left, out var right))
             {
                 return JsValue.Undefined;


### PR DESCRIPTION
## Summary

Comparison operators got an unboxed slot-operand lane in #2578 and bitwise operators have `BitwiseIdentifierLane`, but the arithmetic operators (`+ - * /`) still evaluate identifier operands through the full boxed read path — `JintIdentifierExpression.GetValue` → `MaterializeUnboxedOrNull`, re-materializing a `JsNumber` for every unboxed slot value written by the compound/assignment fast paths. ETW profiling shows Times/Plus as top drivers into the identifier-read lane (~11% inclusive on a SunSpider mix).

This adds `NumericOperandLane` for `id op id`, `id op numericConst` and `numericConst op id` leaf shapes: both operands are read as raw doubles through the established `SlotLocationCache` + `TryGetNumberSlotForRead` + validated-global-descriptor machinery, the op computes on raw doubles, and the result is boxed once by `JsNumber.Create`.

Three commits:

1. **The lane** — pure reads; a decline (non-number binding, TDZ, slot miss) falls to the generic path which replays left-then-right evaluation with no observable double effect, so string concat / `valueOf` / BigInt / TDZ ordering are untouched (the generic path still owns them). Suspendable frames decline (generator resume replays a saved left operand). Integer-typed results are preserved (`Create(double)` normalizes integral values to the same Integer-typed instances the boxed arms produce), so downstream integer fast paths stay armed.
2. **Re-admit `*` in the numeric assignment fast path** — the exclusion rationale predated #2620: the boxed integer-multiply arm used to produce `+0` for `0 * -5`; since #2620 routes zero products through double arithmetic, and an unboxed slot stores `-0` exactly, `x = a * b` can use the same slot lane as `+ - / %`. `IntegerMultiplicationPreservesNegativeZero` extended with the discard-mode shapes.
3. **Struct embedding** — the lane is an embedded struct in Minus/Times/Divide (same precedent as the comparison classes' embedded lane; a separate lane object costs an extra dereference per evaluation, measured at +8.7% on a hit-heavy loop). Plus wraps it in a heap-allocated `BoxedNumericOperandLane` built only when the shape matches, so the many string-concat Plus nodes carry a single null reference instead of an embedded slot-cache pair.

Depends on the `JsNumber.Create(double)` fmod fix (#2662) — the lane boxes results through `Create(double)`, which made the fmod-based integral detection a first-order cost.

## Benchmarks (default jobs, adjacent A/B vs #2662 branch)

| Benchmark | before | after | Δ |
|---|---:|---:|---:|
| FunctionLocalNumberLoop MixedArithmetic | 10.57 ms | 9.97 ms | **−5.7%** |
| SunSpider math-cordic | 116.06 ms | 108.96 ms | **−6.1%** |
| SunSpider math-spectral-norm | 54.22 ms | 52.19 ms | **−3.7%** |
| SunSpider math-partial-sums | 52.25 ms | 51.50 ms | −1.4% |
| SunSpider access-nbody | 76.61 ms | 77.34 ms | +1.0% (drift band) |
| PlainNumericAssign SumAssign / DivAssign / Mixed | 23.30 / 32.90 / 38.03 ms | 23.18 / 32.53 / 39.20 ms | neutral |
| StringBuilder One / Two / Three (`s + t` decline guard) | 2.12 / 2.70 / 3.20 µs | 2.17 / 2.69 / 3.19 µs | neutral |
| FunctionLocalNumberLoop AccumulatorWithCallArg | 22.51 ms ±0.61 | 23.10 ms ±1.05 | overlapping distributions (launchCount 5; row contains no armed node — bimodal layout noise, swings 21–24 ms across a day) |

## Gates

- Jint.Tests: 3537 (net10.0) + 3474 (net472) passed, 0 failed
- Jint.Tests.PublicInterface: 82 × 2 TFMs passed
- Jint.Tests.CommonScripts: 28 × 2 TFMs passed
- Test262: 99,429 passed, 0 failed
- Semantics smoke: −0 products (`Object.is`), `valueOf` called exactly once through the generic path, string concat, TDZ left-then-right ReferenceError ordering, integer-typing chains (`(a*b) % 5` stays on the integer remainder path) — verified cold and cache-armed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
