### PR TITLE
Fix Proxy get trap being bypassed for properties named "revoke"

### DIFF
--- a/Jint.Tests/Runtime/ProxyTests.cs
+++ b/Jint.Tests/Runtime/ProxyTests.cs
@@ -24,6 +24,24 @@ public class ProxyTests
     }
 
     [Fact]
+    public void GetTrapIsCalledForPropertyNamedRevoke()
+    {
+        Assert.Equal("trapped", _engine.Evaluate("new Proxy({}, { get: () => 'trapped' }).revoke").AsString());
+    }
+
+    [Fact]
+    public void AccessingPropertyOnRevokedProxyThrowsTypeError()
+    {
+        _engine.Execute(@"
+            var revocable = Proxy.revocable({ foo: 1 }, { get: () => 'trapped' });
+            var proxy = revocable.proxy;
+            revocable.revoke();
+        ");
+        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("proxy.foo"));
+        AssertJsTypeError(_engine, ex, "Cannot perform 'foo' on a proxy that has been revoked");
+    }
+
+    [Fact]
     public void ProxyToStringUseTarget()
     {
         _engine.Execute(@"

--- a/Jint/Native/JsProxy.cs
+++ b/Jint/Native/JsProxy.cs
@@ -24,7 +24,6 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
     private static readonly JsString TrapOwnKeys = new JsString("ownKeys");
     private static readonly JsString TrapConstruct = new JsString("construct");
 
-    private static readonly JsString KeyFunctionRevoke = new JsString("revoke");
     private static readonly JsString KeyIsArray = new JsString("isArray");
 
     public JsProxy(
@@ -129,7 +128,7 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
         AssertTargetNotRevoked(property);
         var target = _target;
 
-        if (KeyFunctionRevoke.Equals(property) || !TryCallHandler(TrapGet, [target, TypeConverter.ToPropertyKey(property), receiver], out var result))
+        if (!TryCallHandler(TrapGet, [target, TypeConverter.ToPropertyKey(property), receiver], out var result))
         {
             return target.Get(property, receiver);
         }


### PR DESCRIPTION
`JsProxy.Get` special-cased any property named `revoke` to skip the get trap entirely:

```js
new Proxy({}, { get: () => 'trapped' }).revoke // Jint: undefined, spec/V8: 'trapped'
```

The bypass dates back to the original Proxy implementation (#681), where revocation was wired through dynamic property lookups. Today `Proxy.revocable` captures the proxy instance directly in the revoke closure, so the special case only remains as an observable spec violation ([Proxy [[Get]]](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver) has no such exception).

test262 has no coverage for a trapped property literally named `revoke` (verified), which is why this never surfaced. Cross-checked against node 24 / V8: trap is called, and revoked-proxy access errors match.

Tests: get trap fires for `revoke`; revocable round-trip and revoked-access TypeError still covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsHuKuE4UihKZp5HYapDHE