### PR TITLE
Fix Proxy getPrototypeOf/setPrototypeOf traps with null prototypes

### DIFF
--- a/Jint.Tests/Runtime/ProxyTests.cs
+++ b/Jint.Tests/Runtime/ProxyTests.cs
@@ -457,6 +457,68 @@ public class ProxyTests
         """);
     }
 
+    // https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
+    [Fact]
+    public void ProxyHandlerGetPrototypeOfCanReturnNull()
+    {
+        Assert.True(_engine.Evaluate("Object.getPrototypeOf(new Proxy({}, { getPrototypeOf: () => null }))").IsNull());
+        Assert.True(_engine.Evaluate("Reflect.getPrototypeOf(new Proxy({}, { getPrototypeOf: () => null }))").IsNull());
+    }
+
+    [Fact]
+    public void ProxyHandlerGetPrototypeOfCanReturnNullForNonExtensibleTargetWithNullPrototype()
+    {
+        Assert.True(_engine.Evaluate("""
+            const t = Object.create(null);
+            Object.preventExtensions(t);
+            Object.getPrototypeOf(new Proxy(t, { getPrototypeOf: () => null }));
+        """).IsNull());
+    }
+
+    // https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v
+    [Fact]
+    public void ProxyHandlerSetPrototypeOfCanSetNullOnNonExtensibleTargetWithNullPrototype()
+    {
+        _engine.Execute("""
+            let t = Object.create(null);
+            Object.preventExtensions(t);
+        """);
+
+        Assert.True(_engine.Evaluate("let p1 = new Proxy(t, {}); Object.setPrototypeOf(p1, null) === p1").AsBoolean());
+        Assert.True(_engine.Evaluate("let p2 = new Proxy(t, { setPrototypeOf: () => true }); Object.setPrototypeOf(p2, null) === p2").AsBoolean());
+        Assert.True(_engine.Evaluate("Reflect.setPrototypeOf(new Proxy(t, {}), null)").AsBoolean());
+        Assert.True(_engine.Evaluate("Reflect.setPrototypeOf(new Proxy(t, { setPrototypeOf: () => true }), null)").AsBoolean());
+    }
+
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getPrototypeOf#invariants
+    // If the target object is not extensible, the prototype reported
+    // by the trap must be the same as the target object's prototype.
+    [Fact]
+    public void ProxyHandlerGetPrototypeOfInvariantsNonExtensibleTargetDifferentPrototype()
+    {
+        _engine.Execute("""
+            let t = {};
+            Object.preventExtensions(t);
+            let p = new Proxy(t, { getPrototypeOf: () => ({}) });
+        """);
+        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("Object.getPrototypeOf(p)"));
+        Assert.Same(TypeErrorPrototype(_engine), ex.Error.AsObject().Prototype);
+    }
+
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/setPrototypeOf#invariants
+    // If the target object is not extensible, the prototype cannot be changed.
+    [Fact]
+    public void ProxyHandlerSetPrototypeOfInvariantsNonExtensibleTargetDifferentPrototype()
+    {
+        _engine.Execute("""
+            let t = {};
+            Object.preventExtensions(t);
+            let p = new Proxy(t, { setPrototypeOf: () => true });
+        """);
+        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("Object.setPrototypeOf(p, null)"));
+        Assert.Same(TypeErrorPrototype(_engine), ex.Error.AsObject().Prototype);
+    }
+
     [Fact]
     public void ClrPropertySideEffect()
     {

--- a/Jint/Native/JsProxy.cs
+++ b/Jint/Native/JsProxy.cs
@@ -537,17 +537,19 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
             Throw.TypeError(_engine.Realm, "'getPrototypeOf' on proxy: trap returned neither object nor null");
         }
 
+        var proto = handlerProto.IsNull() ? null : (ObjectInstance) handlerProto;
+
         if (_target.Extensible)
         {
-            return (ObjectInstance) handlerProto;
+            return proto;
         }
 
-        if (!ReferenceEquals(handlerProto, _target.Prototype))
+        if (!ReferenceEquals(proto, _target.Prototype))
         {
             Throw.TypeError(_engine.Realm);
         }
 
-        return (ObjectInstance) handlerProto;
+        return proto;
     }
 
     /// <summary>
@@ -572,7 +574,9 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
             return true;
         }
 
-        if (!ReferenceEquals(value, _target.Prototype))
+        // callers have validated that value is either an object or null
+        var proto = value.IsNull() ? null : value as ObjectInstance;
+        if (!ReferenceEquals(proto, _target.Prototype))
         {
             Throw.TypeError(_engine.Realm);
         }


### PR DESCRIPTION
Two latent bugs in the prototype traps, both around JS `null` vs CLR `null`:

1. **Engine crash**: `JsProxy.GetPrototypeOf` cast the trap result straight to `ObjectInstance`, so a spec-legal null-returning trap crashed with `InvalidCastException` instead of returning `null`:
   ```js
   Object.getPrototypeOf(new Proxy({}, { getPrototypeOf: () => null })) // crash → now: null
   ```
2. **Spurious TypeError**: the non-extensible-target invariant compared the trap result (`JsNull`) against `_target.Prototype` (CLR `null`) with `ReferenceEquals`, so a null-prototype non-extensible target + null trap result wrongly threw; same pattern in `SetPrototypeOf` broke `Object.setPrototypeOf(proxy, null)` for non-extensible null-proto targets. Per spec the comparison is SameValue, which succeeds when both are null.

Fix: normalize the JS value to `ObjectInstance?` once after the object-or-null validation, then compare/return that. Trap fetch order, invariant semantics and messages unchanged.

test262 never exercises a null trap result in these paths (its getPrototypeOf suite only returns objects — verified file-by-file), hence latent. Expectations cross-checked against node 24 / V8. Negative validation: without the fix, the new tests reproduce the exact `InvalidCastException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsHuKuE4UihKZp5HYapDHE