### PR TITLE
Capture Proxy [[Construct]] at creation per ProxyCreate

### DIFF
--- a/Jint.Tests/Runtime/ProxyTests.cs
+++ b/Jint.Tests/Runtime/ProxyTests.cs
@@ -205,6 +205,43 @@ public class ProxyTests
         Assert.True(_engine.Evaluate(Script).AsBoolean());
     }
 
+    // https://tc39.es/ecma262/#sec-proxycreate
+    // A proxy only has [[Construct]] if its target is a constructor at creation time;
+    // a handler "construct" trap cannot confer constructability.
+    [Fact]
+    public void ProxyWithNonConstructorTargetIsNotConstructor()
+    {
+        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("new (new Proxy(() => {}, { construct: () => ({}) }))()"));
+        Assert.Same(TypeErrorPrototype(_engine), ex.Error.AsObject().Prototype);
+    }
+
+    [Fact]
+    public void ProxyWithConstructorTargetUsesConstructTrap()
+    {
+        var result = _engine.Evaluate("new (new Proxy(function(){}, { construct: () => ({ x: 1 }) }))().x");
+        Assert.Equal(1, result.AsInteger());
+    }
+
+    [Fact]
+    public void ReflectConstructRequiresConstructorNewTarget()
+    {
+        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("Reflect.construct(function(){ return; }, [], new Proxy(() => {}, { construct: () => ({}) }))"));
+        Assert.Same(TypeErrorPrototype(_engine), ex.Error.AsObject().Prototype);
+    }
+
+    [Fact]
+    public void RevokedConstructorProxyKeepsTypeofFunctionButConstructThrowsRevokedError()
+    {
+        _engine.Execute("var r = Proxy.revocable(function(){}, {}); r.revoke();");
+
+        // typeof relies on the [[Call]] slot captured at creation, revocation does not remove it
+        Assert.Equal("function", _engine.Evaluate("typeof r.proxy").AsString());
+
+        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("new r.proxy()"));
+        Assert.Same(TypeErrorPrototype(_engine), ex.Error.AsObject().Prototype);
+        Assert.Contains("revoked", ex.Message);
+    }
+
     [Fact]
     public void ProxyHandlerGetDataPropertyShouldNotUseReferenceEquals()
     {

--- a/Jint/Native/JsProxy.cs
+++ b/Jint/Native/JsProxy.cs
@@ -10,6 +10,13 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
     internal ObjectInstance _target;
     internal ObjectInstance? _handler;
 
+    // https://tc39.es/ecma262/#sec-proxycreate
+    // A proxy has [[Construct]] iff its target is a constructor at creation time;
+    // a handler "construct" trap cannot confer constructability. Captured here so
+    // IsConstructor probes are side-effect free (no handler getter invocation) and
+    // remain correct after revocation nulls the target.
+    private readonly bool _isConstructor;
+
     private static readonly JsString TrapApply = new JsString("apply");
     private static readonly JsString TrapGet = new JsString("get");
     private static readonly JsString TrapSet = new JsString("set");
@@ -36,6 +43,7 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
         _target = target;
         _handler = handler;
         IsCallable = target.IsCallable;
+        _isConstructor = target.IsConstructor;
     }
 
     /// <summary>
@@ -43,9 +51,11 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
     /// </summary>
     JsValue ICallable.Call(JsValue thisObject, params JsCallArguments arguments)
     {
-        if (_target is not ICallable)
+        AssertNotRevoked(TrapApply);
+
+        if (!IsCallable)
         {
-            Throw.TypeError(_engine.Realm, "(intermediate value) is not a function");
+            Throw.TypeError(_engine.Realm, "Proxy target is not a function");
         }
 
         var jsValues = new[] { _target, thisObject, _engine.Realm.Intrinsics.Array.ConstructFast(arguments) };
@@ -68,9 +78,11 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
     /// </summary>
     ObjectInstance IConstructor.Construct(JsCallArguments arguments, JsValue newTarget)
     {
-        if (_target is not ICallable)
+        AssertNotRevoked(TrapConstruct);
+
+        if (!_isConstructor)
         {
-            Throw.TypeError(_engine.Realm, "(intermediate value) is not a constructor");
+            Throw.TypeError(_engine.Realm, "Proxy target is not a constructor");
         }
 
         var argArray = _engine.Realm.Intrinsics.Array.Construct(arguments, _engine.Realm.Intrinsics.Array);
@@ -102,23 +114,7 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
 
     public override object ToObject() => _target.ToObject();
 
-    internal override bool IsConstructor
-    {
-        get
-        {
-            if (_target is not null && _target.IsConstructor)
-            {
-                return true;
-            }
-
-            if (_handler is not null && _handler.TryGetValue(TrapConstruct, out var handlerFunction) && handlerFunction is IConstructor)
-            {
-                return true;
-            }
-
-            return false;
-        }
-    }
+    internal override bool IsConstructor => _isConstructor;
 
     /// <summary>
     /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver


### PR DESCRIPTION
Per [ProxyCreate](https://tc39.es/ecma262/#sec-proxycreate), a proxy has [[Construct]] iff its **target** is a constructor at creation time — a handler `construct` trap cannot confer constructability. `JsProxy.IsConstructor` additionally probed the handler for a `construct` property, so:

```js
new (new Proxy(() => {}, { construct: () => ({}) }))() // Jint: trap ran, spec/V8: TypeError
```

The probe (`handler.TryGetValue("construct")`) could also fire user getters as a side effect of mere `IsConstructor` checks (e.g. `Reflect.construct` newTarget validation).

Changes:
- `_isConstructor` captured once in the constructor from `target.IsConstructor` (mirrors how `IsCallable` is already captured); the property returns the field.
- `[[Construct]]`/`[[Call]]` now check revocation **first**, so calling/constructing a revoked proxy throws the correct `Cannot perform 'construct'/'apply' on a proxy that has been revoked` (character-identical to V8) instead of `"(intermediate value) is not a constructor/function"`; the defensive not-a-constructor/function guards remain (JsProxy always implements the call interfaces, so callers' casts pass even for non-callable targets) with real messages.
- `typeof` on revoked proxies is unaffected (`IsCallable` stays a captured value, per spec: revocation does not remove the slots).

Cross-checked against node 24 / V8 on all new tests. Observable behavior change (construct-trap-on-non-constructor now correctly throws) — worth a release-note line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsHuKuE4UihKZp5HYapDHE