### PR TITLE
Fix Proxy construct trap receiving Array-constructor-mangled arguments

### DIFF
--- a/Jint.Tests/Runtime/ProxyTests.cs
+++ b/Jint.Tests/Runtime/ProxyTests.cs
@@ -42,6 +42,24 @@ public class ProxyTests
     }
 
     [Fact]
+    public void ConstructTrapReceivesCreateArrayFromListArguments()
+    {
+        var result = _engine.Evaluate("""
+            var p = new Proxy(function () {}, { construct: (t, args) => ({ len: args.length, first: args[0] }) });
+            var r = new p(42);
+            r.len + ':' + r.first;
+            """).AsString();
+        Assert.Equal("1:42", result);
+    }
+
+    [Fact]
+    public void ConstructTrapAcceptsSingleFractionalArgument()
+    {
+        var result = _engine.Evaluate("new (new Proxy(function () {}, { construct: (t, args) => ({ v: args[0] }) }))(1.5).v");
+        Assert.Equal(1.5, result.AsNumber());
+    }
+
+    [Fact]
     public void ProxyToStringUseTarget()
     {
         _engine.Execute(@"

--- a/Jint/Native/JsProxy.cs
+++ b/Jint/Native/JsProxy.cs
@@ -85,7 +85,9 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
             Throw.TypeError(_engine.Realm, "Proxy target is not a constructor");
         }
 
-        var argArray = _engine.Realm.Intrinsics.Array.Construct(arguments, _engine.Realm.Intrinsics.Array);
+        // step 7: CreateArrayFromList(argumentsList) - must not use Array constructor semantics,
+        // a single numeric argument would create a hole-filled array of that length
+        var argArray = _engine.Realm.Intrinsics.Array.ConstructFast(arguments);
 
         if (!TryCallHandler(TrapConstruct, [_target, argArray, newTarget], out var result))
         {


### PR DESCRIPTION
`JsProxy.[[Construct]]` built the trap's `argumentsList` with `Array.Construct`, i.e. JS `Array(...)` constructor semantics. A single numeric argument therefore hit the `Array(length)` path:

```js
var p = new Proxy(function () {}, { construct: (t, args) => ({ len: args.length, first: args[0] }) });
new p(42)   // trap saw args.length === 42, args[0] === undefined; spec/V8: [42]
new p(1.5)  // threw RangeError: invalid array length; spec/V8: [1.5]
```

Per [spec step 7](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget) the list must be created with CreateArrayFromList — now uses `ConstructFast`, the same helper the `[[Call]]`/apply path already uses.

test262 misses this because `built-ins/Proxy/construct/call-parameters.js` constructs with two arguments. Cross-checked against node 24 / V8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsHuKuE4UihKZp5HYapDHE