### PR TITLE
Replace flag-proven casts with Unsafe.As on hot arithmetic paths

### DIFF
--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -236,7 +237,8 @@ public static class JsValueExtensions
             ThrowWrongTypeException(value, "number");
         }
 
-        return ((JsNumber) value)._value;
+        Debug.Assert(value is JsNumber);
+        return Unsafe.As<JsNumber>(value)._value;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -1271,7 +1271,8 @@ internal abstract class JintBinaryExpression : JintExpression
             }
 
             var value = Compare(left, right);
-            return value._type != InternalTypes.Undefined && ((JsBoolean) value)._value;
+            // Compare only ever returns JsBoolean.True/False or undefined
+            return value._type != InternalTypes.Undefined && Unsafe.As<JsBoolean>(value)._value;
         }
     }
 
@@ -1326,7 +1327,8 @@ internal abstract class JintBinaryExpression : JintExpression
             }
 
             var value = Compare(right, left, false);
-            return value._type != InternalTypes.Undefined && ((JsBoolean) value)._value;
+            // Compare only ever returns JsBoolean.True/False or undefined
+            return value._type != InternalTypes.Undefined && Unsafe.As<JsBoolean>(value)._value;
         }
     }
 
@@ -1364,7 +1366,7 @@ internal abstract class JintBinaryExpression : JintExpression
 
             if (left._type == InternalTypes.Number && right._type == InternalTypes.Number)
             {
-                return JsNumber.Create(((JsNumber) left)._value + ((JsNumber) right)._value);
+                return JsNumber.Create(Unsafe.As<JsNumber>(left)._value + Unsafe.As<JsNumber>(right)._value);
             }
 
             var lprim = TypeConverter.ToPrimitive(left);
@@ -1506,7 +1508,7 @@ internal abstract class JintBinaryExpression : JintExpression
 
             if (left._type == InternalTypes.Number && right._type == InternalTypes.Number)
             {
-                return JsNumber.Create(((JsNumber) left)._value - ((JsNumber) right)._value);
+                return JsNumber.Create(Unsafe.As<JsNumber>(left)._value - Unsafe.As<JsNumber>(right)._value);
             }
 
             left = TypeConverter.ToNumeric(left);
@@ -1567,7 +1569,7 @@ internal abstract class JintBinaryExpression : JintExpression
             }
             else if (left._type == InternalTypes.Number && right._type == InternalTypes.Number)
             {
-                result = JsNumber.Create(((JsNumber) left)._value * ((JsNumber) right)._value);
+                result = JsNumber.Create(Unsafe.As<JsNumber>(left)._value * Unsafe.As<JsNumber>(right)._value);
             }
             else
             {
@@ -1618,7 +1620,7 @@ internal abstract class JintBinaryExpression : JintExpression
 
             if (left._type == InternalTypes.Number && right._type == InternalTypes.Number)
             {
-                return JsNumber.Create(((JsNumber) left)._value / ((JsNumber) right)._value);
+                return JsNumber.Create(Unsafe.As<JsNumber>(left)._value / Unsafe.As<JsNumber>(right)._value);
             }
 
             left = TypeConverter.ToNumeric(left);
@@ -1739,7 +1741,8 @@ internal abstract class JintBinaryExpression : JintExpression
             var right = _leftFirst ? rightValue : leftValue;
 
             var value = Compare(left, right, _leftFirst);
-            return value.IsUndefined() || ((JsBoolean) value)._value ? JsBoolean.False : JsBoolean.True;
+            // Compare only ever returns JsBoolean.True/False or undefined
+            return value.IsUndefined() || Unsafe.As<JsBoolean>(value)._value ? JsBoolean.False : JsBoolean.True;
         }
 
         public override bool GetBooleanValue(EvaluationContext context)
@@ -1764,7 +1767,8 @@ internal abstract class JintBinaryExpression : JintExpression
             var right = _leftFirst ? rightValue : leftValue;
 
             var value = Compare(left, right, _leftFirst);
-            return !value.IsUndefined() && !((JsBoolean) value)._value;
+            // Compare only ever returns JsBoolean.True/False or undefined
+            return !value.IsUndefined() && !Unsafe.As<JsBoolean>(value)._value;
         }
     }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using Jint.Native;
@@ -392,6 +393,9 @@ internal abstract class JintExpression
 
     private static JsValue CompareNumber(JsValue x, JsValue y, bool leftFirst)
     {
+        // only called from Compare which has proven both operands via IsNumber()
+        Debug.Assert(x is JsNumber && y is JsNumber);
+
         if (x.IsInteger() && y.IsInteger())
         {
             return x.AsInteger() < y.AsInteger() ? JsBoolean.True : JsBoolean.False;
@@ -400,13 +404,13 @@ internal abstract class JintExpression
         double nx, ny;
         if (leftFirst)
         {
-            nx = ((JsNumber) x)._value;
-            ny = ((JsNumber) y)._value;
+            nx = Unsafe.As<JsNumber>(x)._value;
+            ny = Unsafe.As<JsNumber>(y)._value;
         }
         else
         {
-            ny = ((JsNumber) y)._value;
-            nx = ((JsNumber) x)._value;
+            ny = Unsafe.As<JsNumber>(y)._value;
+            nx = Unsafe.As<JsNumber>(x)._value;
         }
 
         if (double.IsNaN(nx) || double.IsNaN(ny))

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 using Environment = Jint.Runtime.Environments.Environment;
 
@@ -297,7 +298,7 @@ internal sealed class JintUnaryExpression : JintExpression
         value = TypeConverter.ToNumeric(value);
         if (value.IsNumber())
         {
-            var n = ((JsNumber) value)._value;
+            var n = Unsafe.As<JsNumber>(value)._value;
             return double.IsNaN(n) ? JsNumber.DoubleNaN : JsNumber.Create(n * -1);
         }
 


### PR DESCRIPTION
## Summary

Idiom-consistency cleanup: the codebase's established pattern for flag-proven downcasts is `Unsafe.As<T>` after an `InternalTypes` test (~20 sites in ObjectInstance / JintMemberExpression), but the hot arithmetic paths still used plain `(T)` casts that emit `CastHelpers.ChkCastClass`. This applies the idiom to the sites where the dominating branch provably establishes the type:

- `(JsNumber)` pairs in the Plus/Minus/Times/Divide double lanes (`_type == InternalTypes.Number` on both operands)
- `(JsBoolean)` on `Compare(...)` results in the relational classes — the conversion is justified by a closed audit of Compare's return set (every path returns `JsBoolean.True/False` or `Undefined`; comment added at each site)
- `(JsNumber)` in `JintExpression.CompareNumber` (sole caller guards `IsNumber()` on both args; `Debug.Assert` precondition added) and `JintUnaryExpression.EvaluateMinus`
- `JsValueExtensions.AsNumber` — its own `IsNumber()` guard dominates the cast, so misuse still throws the same ArgumentException

**Deliberately skipped** (not provably safe):
- `Exponentiate`'s `(JsNumber)` casts — guarded only by `AreNonBigIntOperands`, which proves *not BigInt*; JsNumber-ness rests on an inter-procedural `ToNumeric` contract, not a same-variable check
- `JsValueExtensions.AsInteger` — 34 of 35 call sites are flag-proven, but the public `IConvertible.ToInt32` implementation (`JsValue.Convertible.cs`) calls it **unguarded**; today that's an `InvalidCastException`, with `Unsafe.As` it would be type confusion. Left unchanged.

## Impact

Benchmarks on the arithmetic set (stopwatch, math-cordic, string-fasta, crypto-md5) are **neutral** — within the ±2% machine drift band, as expected for a change whose entire budget was 0.7% of profile self time (much of which the recent lane work already bypassed). ETW confirms the mechanism: `ChkCastClass` self time 48.7 → 35.7 ms on the mixed SunSpider driver for identical work.

## Gates

- Jint.Tests: 3541 (net10.0) + 3478 (net472) passed, 0 failed
- Jint.Tests.PublicInterface: 82 × 2 TFMs passed
- Jint.Tests.CommonScripts: green both TFMs
- Test262: 99,429 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
