### PR TITLE
Pool Proxy trap argument arrays

### DIFF
--- a/Jint/Native/JsProxy.cs
+++ b/Jint/Native/JsProxy.cs
@@ -669,24 +669,54 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
         return callable;
     }
 
+    // trap argument arrays are rented and returned after the call completes, following the
+    // interpreter call-site pattern (no finally: an exception lets the array fall to the GC,
+    // and JsArguments.Materialize protects arrays captured by the callee)
+
     private JsValue CallTrap(ICallable trap, JsValue arg0)
     {
-        return trap.Call(_handler!, [arg0]);
+        var pool = _engine._jsValueArrayPool;
+        var args = pool.RentArray(1);
+        args[0] = arg0;
+        var result = trap.Call(_handler!, args);
+        pool.ReturnArray(args);
+        return result;
     }
 
     private JsValue CallTrap(ICallable trap, JsValue arg0, JsValue arg1)
     {
-        return trap.Call(_handler!, [arg0, arg1]);
+        var pool = _engine._jsValueArrayPool;
+        var args = pool.RentArray(2);
+        args[0] = arg0;
+        args[1] = arg1;
+        var result = trap.Call(_handler!, args);
+        pool.ReturnArray(args);
+        return result;
     }
 
     private JsValue CallTrap(ICallable trap, JsValue arg0, JsValue arg1, JsValue arg2)
     {
-        return trap.Call(_handler!, [arg0, arg1, arg2]);
+        var pool = _engine._jsValueArrayPool;
+        var args = pool.RentArray(3);
+        args[0] = arg0;
+        args[1] = arg1;
+        args[2] = arg2;
+        var result = trap.Call(_handler!, args);
+        pool.ReturnArray(args);
+        return result;
     }
 
     private JsValue CallTrap(ICallable trap, JsValue arg0, JsValue arg1, JsValue arg2, JsValue arg3)
     {
-        return trap.Call(_handler!, [arg0, arg1, arg2, arg3]);
+        var pool = _engine._jsValueArrayPool;
+        var args = pool.RentArray(4);
+        args[0] = arg0;
+        args[1] = arg1;
+        args[2] = arg2;
+        args[3] = arg3;
+        var result = trap.Call(_handler!, args);
+        pool.ReturnArray(args);
+        return result;
     }
 
     private void AssertNotRevoked(JsValue key)

--- a/Jint/Pooling/JsValueArrayPool.cs
+++ b/Jint/Pooling/JsValueArrayPool.cs
@@ -12,12 +12,14 @@ internal sealed class JsValueArrayPool
     private readonly ObjectPool<JsValue[]> _poolArray1;
     private readonly ObjectPool<JsValue[]> _poolArray2;
     private readonly ObjectPool<JsValue[]> _poolArray3;
+    private readonly ObjectPool<JsValue[]> _poolArray4;
 
     public JsValueArrayPool()
     {
         _poolArray1 = new ObjectPool<JsValue[]>(Factory1, PoolSize);
         _poolArray2 = new ObjectPool<JsValue[]>(Factory2, PoolSize);
         _poolArray3 = new ObjectPool<JsValue[]>(Factory3, PoolSize);
+        _poolArray4 = new ObjectPool<JsValue[]>(Factory4, PoolSize);
     }
 
     private static JsValue[] Factory1()
@@ -33,6 +35,11 @@ internal sealed class JsValueArrayPool
     private static JsValue[] Factory3()
     {
         return new JsValue[3];
+    }
+
+    private static JsValue[] Factory4()
+    {
+        return new JsValue[4];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -53,6 +60,10 @@ internal sealed class JsValueArrayPool
         if (size == 3)
         {
             return _poolArray3.Allocate();
+        }
+        if (size == 4)
+        {
+            return _poolArray4.Allocate();
         }
 
         return new JsValue[size];
@@ -82,6 +93,14 @@ internal sealed class JsValueArrayPool
             array[1] = null!;
             array[2] = null!;
             _poolArray3.Free(array);
+        }
+        else if (array.Length == 4)
+        {
+            array[0] = null!;
+            array[1] = null!;
+            array[2] = null!;
+            array[3] = null!;
+            _poolArray4.Free(array);
         }
     }
 }


### PR DESCRIPTION
Follow-up to #2674. `CallTrap` now rents the trap argument array from `JsValueArrayPool` and returns it after the call — the same rent/call/return contract as the interpreter call sites (`JintCallExpression`), with `JsArguments.Materialize` protecting arrays captured by the callee.

The `set` trap takes four arguments (target, key, value, receiver), so the pool gains a **size-4 bucket**. Bonus: the two existing `RentArray(4)`/`ReturnArray` sites in `IntrinsicTypedArrayPrototype` (`sort` comparers etc.) start actually pooling — until now size-4 rents always allocated and returns were silent no-ops.

**ProxyBenchmark**, control vs change on the same base commit (time flat within run noise; allocation is the win):

| Lane | Allocated |
|---|---:|
| TrapGet | **4,689 KB → 1.3 KB** |
| TrapHas | **3,908 KB → 1.3 KB** |
| TrapSet | 8,275 KB → 2,806 KB (−66%) |
| ApplyTrap | 25,143 KB → 20,455 KB (−19%) |
| ConstructTrap | 3,048 KB → 2,579 KB (−15%) |
| Forward lanes | unchanged (untouched by this PR) |

Verification: full test262 suite green (99,429 passed / 0 failed), full Jint.Tests + PublicInterface green, ProxyTests 43/43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsHuKuE4UihKZp5HYapDHE