### PR TITLE
Slim allocations in Proxy ownKeys trap validation

### DIFF
--- a/Jint/Native/JsProxy.cs
+++ b/Jint/Native/JsProxy.cs
@@ -186,38 +186,50 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
 
     private List<JsValue> ValidateOwnKeysTrapResult(ObjectInstance target, JsValue result)
     {
-        var trapResult = new List<JsValue>(FunctionPrototype.CreateListFromArrayLike(_engine.Realm, result, Types.String | Types.Symbol));
+        var keys = FunctionPrototype.CreateListFromArrayLike(_engine.Realm, result, Types.String | Types.Symbol);
 
-        if (trapResult.Count != new HashSet<JsValue>(trapResult).Count)
+        // one set serves both duplicate detection and the spec's uncheckedResultKeys below
+        var uncheckedResultKeys = new HashSet<JsValue>();
+        var trapResult = new List<JsValue>(keys.Length);
+        foreach (var key in keys)
         {
-            Throw.TypeError(_engine.Realm);
+            if (!uncheckedResultKeys.Add(key))
+            {
+                Throw.TypeError(_engine.Realm);
+            }
+            trapResult.Add(key);
         }
 
         var extensibleTarget = target.Extensible;
         var targetKeys = target.GetOwnPropertyKeys();
-        var targetConfigurableKeys = new List<JsValue>();
-        var targetNonconfigurableKeys = new List<JsValue>();
+        List<JsValue>? targetConfigurableKeys = null;
+        List<JsValue>? targetNonconfigurableKeys = null;
 
+        // every target key must be probed with [[GetOwnProperty]] before any invariant throw,
+        // the probe is observable when the target is itself exotic
         foreach (var property in targetKeys)
         {
             var desc = target.GetOwnProperty(property);
             if (desc != PropertyDescriptor.Undefined && !desc.Configurable)
             {
-                targetNonconfigurableKeys.Add(property);
+                (targetNonconfigurableKeys ??= new List<JsValue>()).Add(property);
             }
-            else
+            else if (!extensibleTarget)
             {
-                targetConfigurableKeys.Add(property);
+                // the configurable partition is only consulted when the target is non-extensible
+                (targetConfigurableKeys ??= new List<JsValue>()).Add(property);
             }
         }
 
-        var uncheckedResultKeys = new HashSet<JsValue>(trapResult);
-        for (var i = 0; i < targetNonconfigurableKeys.Count; i++)
+        if (targetNonconfigurableKeys is not null)
         {
-            var key = targetNonconfigurableKeys[i];
-            if (!uncheckedResultKeys.Remove(key))
+            for (var i = 0; i < targetNonconfigurableKeys.Count; i++)
             {
-                Throw.TypeError(_engine.Realm);
+                var key = targetNonconfigurableKeys[i];
+                if (!uncheckedResultKeys.Remove(key))
+                {
+                    Throw.TypeError(_engine.Realm);
+                }
             }
         }
 
@@ -226,12 +238,15 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
             return trapResult;
         }
 
-        for (var i = 0; i < targetConfigurableKeys.Count; i++)
+        if (targetConfigurableKeys is not null)
         {
-            var key = targetConfigurableKeys[i];
-            if (!uncheckedResultKeys.Remove(key))
+            for (var i = 0; i < targetConfigurableKeys.Count; i++)
             {
-                Throw.TypeError(_engine.Realm);
+                var key = targetConfigurableKeys[i];
+                if (!uncheckedResultKeys.Remove(key))
+                {
+                    Throw.TypeError(_engine.Realm);
+                }
             }
         }
 


### PR DESCRIPTION
Follow-up to #2674/#2675. The trapped `ownKeys` validation allocated five collections per call: a `List` copy of the trap result, a throwaway `HashSet` just for duplicate detection, two eagerly-built partition `List`s, and the spec's `uncheckedResultKeys` `HashSet`.

Now:
- one pass builds the result `List` with exact capacity while a single `HashSet` detects duplicates (`!Add`) — and that same set then serves as the spec's `uncheckedResultKeys`;
- the partition lists are lazy: the configurable partition only exists for non-extensible targets (the only case that consults it), the non-configurable one only when such keys exist.

The per-key `[[GetOwnProperty]]` probe loop still visits every target key before any invariant throw — observable when the target is itself exotic (guarded by test262 `internals-call-order` tests).

**ProxyBenchmark** `OwnKeysTrap`: allocated **26.93 MB → 23.96 MB (−11%)**, time flat-to-slightly-better (median −7%, layout-noisy lane, verified with `--launchCount 5`). `OwnKeysForward` untouched.

Verification: full Jint.Tests, PublicInterface, test262 `~Proxy` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsHuKuE4UihKZp5HYapDHE