### PR TITLE
Guard default RevocableProxy instances with a clear exception

### DIFF
--- a/Jint.Tests.PublicInterface/ClrProxyHandlerTests.cs
+++ b/Jint.Tests.PublicInterface/ClrProxyHandlerTests.cs
@@ -688,4 +688,13 @@ public class ClrProxyHandlerTests
         Assert.Throws<ArgumentNullException>(() => engine.Advanced.CreateRevocableProxy(null!, handler));
         Assert.Throws<ArgumentNullException>(() => engine.Advanced.CreateRevocableProxy(target, null!));
     }
+
+    [Fact]
+    public void DefaultRevocableProxyThrowsInvalidOperationException()
+    {
+        var uninitialized = default(RevocableProxy);
+
+        Assert.Throws<InvalidOperationException>(() => uninitialized.Proxy);
+        Assert.Throws<InvalidOperationException>(() => uninitialized.Revoke());
+    }
 }

--- a/Jint/Runtime/Interop/ProxyHandler.cs
+++ b/Jint/Runtime/Interop/ProxyHandler.cs
@@ -167,10 +167,26 @@ public readonly struct RevocableProxy
     /// <summary>
     /// The proxy object.
     /// </summary>
-    public ObjectInstance Proxy => _proxy;
+    /// <exception cref="InvalidOperationException">The instance was not created via <see cref="Engine.AdvancedOperations.CreateRevocableProxy"/>.</exception>
+    public ObjectInstance Proxy => _proxy ?? ThrowUninitialized();
 
     /// <summary>
     /// Revokes the proxy: subsequent trap operations throw a <c>TypeError</c>. Idempotent.
     /// </summary>
-    public void Revoke() => _proxy.Revoke();
+    /// <exception cref="InvalidOperationException">The instance was not created via <see cref="Engine.AdvancedOperations.CreateRevocableProxy"/>.</exception>
+    public void Revoke()
+    {
+        if (_proxy is null)
+        {
+            ThrowUninitialized();
+        }
+
+        _proxy.Revoke();
+    }
+
+    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+    private static JsProxy ThrowUninitialized()
+    {
+        throw new InvalidOperationException($"This {nameof(RevocableProxy)} has not been initialized; create instances via Engine.Advanced.CreateRevocableProxy.");
+    }
 }


### PR DESCRIPTION
Small follow-up to #2678: `default(RevocableProxy)` (an uninitialized struct someone stored in a field or default-constructed) threw `NullReferenceException` from both `Proxy` and `Revoke()`. Both now throw `InvalidOperationException` with a message pointing to `Engine.Advanced.CreateRevocableProxy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsHuKuE4UihKZp5HYapDHE