### PR TITLE
Harden ObjectWrapper iterator helpers against foreign and revoked receivers

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -1127,6 +1127,86 @@ public partial class InteropTests : IDisposable
     }
 
     [Fact]
+    public void ShouldForOfOnProxiedList()
+    {
+        _engine.SetValue("list", new List<string> { "a", "b" });
+
+        var result = _engine.Evaluate("var l = ''; for (var x of new Proxy(list, {})) l += x; return l;").AsString();
+        Assert.Equal("ab", result);
+
+        // nested proxies unwrap all the way down to the wrapper
+        result = _engine.Evaluate("var l = ''; for (var x of new Proxy(new Proxy(list, {}), {})) l += x; return l;").AsString();
+        Assert.Equal("ab", result);
+    }
+
+    [Fact]
+    public void ExtractedClrIteratorCalledWithForeignObjectThisThrowsTypeError()
+    {
+        _engine.SetValue("list", new List<string> { "a", "b" });
+
+        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("var f = list[Symbol.iterator]; f.call({});"));
+        Assert.Equal("Method '[Symbol.iterator]' called on incompatible receiver", ex.Message);
+
+        // the error is a proper TypeError catchable from script
+        var result = _engine.Evaluate("var f = list[Symbol.iterator]; try { f.call({}); 'no error' } catch (e) { e instanceof TypeError }");
+        Assert.True(result.AsBoolean());
+    }
+
+    [Fact]
+    public void ExtractedClrIteratorCalledWithPrimitiveThisThrowsTypeError()
+    {
+        _engine.SetValue("list", new List<string> { "a", "b" });
+
+        // primitive receiver has no engine attached, error is materialized as TypeError by the interpreter
+        var result = _engine.Evaluate("var f = list[Symbol.iterator]; try { f.call('x'); 'no error' } catch (e) { e instanceof TypeError }");
+        Assert.True(result.AsBoolean());
+    }
+
+    [Fact]
+    public void ExtractedClrLengthGetterCalledWithForeignThisThrowsTypeError()
+    {
+        _engine.SetValue("list", new List<string> { "a", "b" });
+
+        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("Object.getOwnPropertyDescriptor(list, 'length').get.call({});"));
+        Assert.Equal("Method 'length' called on incompatible receiver", ex.Message);
+
+        var result = _engine.Evaluate("var g = Object.getOwnPropertyDescriptor(list, 'length').get; try { g.call('x'); 'no error' } catch (e) { e instanceof TypeError }");
+        Assert.True(result.AsBoolean());
+    }
+
+    [Fact]
+    public void ForOfOverRevokedProxyOfClrListThrowsTypeError()
+    {
+        _engine.SetValue("list", new List<string> { "a", "b" });
+
+        // the proxy's own [[Get]] rejects the revoked proxy before the iterator helper runs,
+        // actual message: "Cannot perform 'get' on a proxy that has been revoked" (matches V8/node)
+        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("""
+            var r = Proxy.revocable(list, {});
+            r.revoke();
+            for (var x of r.proxy) {}
+        """));
+        Assert.Same(_engine.Realm.Intrinsics.TypeError.PrototypeObject, ex.Error.AsObject().Prototype);
+    }
+
+    [Fact]
+    public void ExtractedClrIteratorCalledOnRevokedProxyThrowsTypeError()
+    {
+        _engine.SetValue("list", new List<string> { "a", "b" });
+
+        // extract while alive, revoke, then re-invoke with the revoked proxy as receiver;
+        // this bypasses the proxy [[Get]] guard and exercises the iterator helper directly
+        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("""
+            var r = Proxy.revocable(list, {});
+            var f = r.proxy[Symbol.iterator];
+            r.revoke();
+            f.call(r.proxy);
+        """));
+        Assert.Equal("Cannot perform '[Symbol.iterator]' on a proxy that has been revoked", ex.Message);
+        Assert.Same(_engine.Realm.Intrinsics.TypeError.PrototypeObject, ex.Error.AsObject().Prototype);
+    }
+
+    [Fact]
     public void CanAccessAnonymousObject()
     {
         var p = new

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -744,10 +744,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 
     private static JsValue Iterator(JsValue thisObject, JsCallArguments arguments)
     {
-        if (thisObject is JsProxy proxy)
-            return Iterator(proxy._target, arguments);
-
-        var wrapper = (ObjectWrapper) thisObject;
+        var wrapper = UnwrapReceiver(thisObject, "[Symbol.iterator]");
 
         return wrapper._typeDescriptor.IsDictionary
             ? new DictionaryIterator(wrapper._engine, wrapper)
@@ -756,11 +753,43 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 
     private static JsNumber GetLength(JsValue thisObject, JsCallArguments arguments)
     {
-        if (thisObject is JsProxy proxy)
-            return GetLength(proxy._target, arguments);
-
-        var wrapper = (ObjectWrapper) thisObject;
+        var wrapper = UnwrapReceiver(thisObject, "length");
         return JsNumber.Create((int) (wrapper._typeDescriptor.LengthProperty?.GetValue(wrapper.Target) ?? 0));
+    }
+
+    /// <summary>
+    /// Resolves the <see cref="ObjectWrapper"/> receiver for the host helper functions above (the
+    /// Symbol.iterator implementation and the length getter). Script code can extract these functions
+    /// and re-target them (e.g. <c>f.call({})</c>) or invoke them through a (possibly revoked) Proxy,
+    /// so a foreign or revoked receiver must surface as a JavaScript TypeError instead of a CLR crash.
+    /// </summary>
+    private static ObjectWrapper UnwrapReceiver(JsValue thisObject, string functionName)
+    {
+        var current = thisObject;
+        while (current is JsProxy proxy)
+        {
+            if (proxy.IsRevoked)
+            {
+                Throw.TypeError(proxy.Engine.Realm, $"Cannot perform '{functionName}' on a proxy that has been revoked");
+            }
+
+            current = proxy._target;
+        }
+
+        if (current is ObjectWrapper wrapper)
+        {
+            return wrapper;
+        }
+
+        var message = $"Method '{functionName}' called on incompatible receiver";
+        if (current is ObjectInstance objectInstance)
+        {
+            Throw.TypeError(objectInstance.Engine.Realm, message);
+        }
+
+        // primitive receiver, no engine reachable - converted to a JS TypeError by the interpreter
+        Throw.TypeErrorNoEngine(message);
+        return null!;
     }
 
     internal override ulong GetSmallestIndex(ulong length)


### PR DESCRIPTION
Two engine-crash modes in the `ObjectWrapper` interop helpers, both reachable from script:

1. **Foreign `this`** — the `Symbol.iterator` ClrFunction and the `length` getter are script-extractable (`Object.getOwnPropertyDescriptor(clrList, 'length').get.call({})`), and both hard-cast `(ObjectWrapper) thisObject` → uncaught `InvalidCastException`.
2. **Revoked proxy** — the proxy-unwrap recursion passed the revoked proxy's null target straight into the cast (null passes reference casts) → `NullReferenceException` on first member access.

Both helpers now share an `UnwrapReceiver` that unwraps nested proxy chains iteratively, throws `TypeError: Cannot perform '[Symbol.iterator]' on a proxy that has been revoked` for revoked proxies (V8 wording), and `TypeError: Method '…' called on incompatible receiver` for foreign receivers — including primitive `this`, where no engine is reachable and the deferred-realm TypeError path is used (verified catchable and `instanceof TypeError` from script).

`for...of` directly over a revoked proxy still throws from the proxy's own `[[Get]]` guard first, matching node — covered by test. Regression tests confirm iteration over single and nested proxies wrapping CLR lists still works.

6 new tests; full Jint.Tests, PublicInterface, and test262 `~Proxy` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsHuKuE4UihKZp5HYapDHE