### PR TITLE
Skip covariant store checks when populating exact JsValue arrays

### DIFF
--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -259,8 +259,6 @@ internal sealed partial class RegExpPrototype : Prototype
                 string Evaluator(Match match)
                 {
                     var actualGroupCount = GetActualRegexGroupCount(rei, match);
-                    var replacerArgs = new List<JsValue>(actualGroupCount + 2);
-                    replacerArgs.Add(match.Value);
 
                     ObjectInstance? groups = null;
                     // Pre-initialize groups with unique names in order
@@ -277,10 +275,16 @@ internal sealed partial class RegExpPrototype : Prototype
                         }
                     }
 
+                    // matched + captures + position + string + optional groups object; the array is freshly
+                    // allocated and exactly JsValue[], so writes can skip the covariant store type check.
+                    var replacerArgs = new JsValue[actualGroupCount + 2 + (groups is not null ? 1 : 0)];
+                    var argIndex = 0;
+                    Arguments.WriteNoTypeCheck(replacerArgs, argIndex++, match.Value);
+
                     for (var i = 1; i < actualGroupCount; i++)
                     {
                         var capture = match.Groups[i];
-                        replacerArgs.Add(capture.Success ? capture.Value : Undefined);
+                        Arguments.WriteNoTypeCheck(replacerArgs, argIndex++, capture.Success ? capture.Value : Undefined);
 
                         var groupName = GetRegexGroupName(rei, i);
                         if (!string.IsNullOrWhiteSpace(groupName) && capture.Success)
@@ -289,11 +293,11 @@ internal sealed partial class RegExpPrototype : Prototype
                         }
                     }
 
-                    replacerArgs.Add(match.Index);
-                    replacerArgs.Add(s);
+                    Arguments.WriteNoTypeCheck(replacerArgs, argIndex++, match.Index);
+                    Arguments.WriteNoTypeCheck(replacerArgs, argIndex++, s);
                     if (groups is not null)
                     {
-                        replacerArgs.Add(groups);
+                        Arguments.WriteNoTypeCheck(replacerArgs, argIndex, groups);
                     }
 
                     return CallFunctionalReplace(replaceValue, replacerArgs);
@@ -374,18 +378,22 @@ internal sealed partial class RegExpPrototype : Prototype
             string replacement;
             if (functionalReplace)
             {
-                var replacerArgs = new List<JsValue>();
-                replacerArgs.Add(matched);
+                // matched + captures + position + string + optional named captures; the array is freshly
+                // allocated and exactly JsValue[], so writes can skip the covariant store type check.
+                var hasNamedCaptures = !namedCaptures.IsUndefined();
+                var replacerArgs = new JsValue[captures.Count + 3 + (hasNamedCaptures ? 1 : 0)];
+                var argIndex = 0;
+                Arguments.WriteNoTypeCheck(replacerArgs, argIndex++, matched);
                 foreach (var capture in captures)
                 {
-                    replacerArgs.Add(capture);
+                    Arguments.WriteNoTypeCheck(replacerArgs, argIndex++, capture);
                 }
 
-                replacerArgs.Add(position);
-                replacerArgs.Add(s);
-                if (!namedCaptures.IsUndefined())
+                Arguments.WriteNoTypeCheck(replacerArgs, argIndex++, position);
+                Arguments.WriteNoTypeCheck(replacerArgs, argIndex++, s);
+                if (hasNamedCaptures)
                 {
-                    replacerArgs.Add(namedCaptures);
+                    Arguments.WriteNoTypeCheck(replacerArgs, argIndex, namedCaptures);
                 }
 
                 replacement = CallFunctionalReplace(replaceValue, replacerArgs);
@@ -422,9 +430,9 @@ internal sealed partial class RegExpPrototype : Prototype
 #pragma warning restore CA1845
     }
 
-    private static string CallFunctionalReplace(JsValue replacer, List<JsValue> replacerArgs)
+    private static string CallFunctionalReplace(JsValue replacer, JsCallArguments replacerArgs)
     {
-        var result = ((ICallable) replacer).Call(Undefined, replacerArgs.ToArray());
+        var result = ((ICallable) replacer).Call(Undefined, replacerArgs);
         return TypeConverter.ToString(result);
     }
 

--- a/Jint/Runtime/Arguments.cs
+++ b/Jint/Runtime/Arguments.cs
@@ -1,4 +1,8 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
+#if NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
 using Jint.Native;
 
 namespace Jint.Runtime;
@@ -29,6 +33,36 @@ public static class Arguments
     public static JsValue At(this JsValue[] args, int index)
     {
         return At(args, index, JsValue.Undefined);
+    }
+
+    /// <summary>
+    /// Writes <paramref name="value"/> to <paramref name="array"/> without the covariant array store
+    /// type check (stelemref). Because <see cref="JsValue"/> is not sealed, a plain <c>array[index] = value</c>
+    /// must verify at runtime that the array's actual element type accepts the value; that check is pure
+    /// overhead when the array is known to be exactly <see cref="JsValue"/>[]. Bounds are checked explicitly.
+    /// </summary>
+    /// <remarks>
+    /// Callers MUST guarantee that <paramref name="array"/> is exactly of type <see cref="JsValue"/>[] —
+    /// freshly allocated via <c>new JsValue[n]</c> or rented from <see cref="Jint.Pooling.JsValueArrayPool"/>
+    /// (whose factories only ever create such arrays). Writing through this helper into an array whose
+    /// element type is a subtype of <see cref="JsValue"/> would break array type safety. In particular,
+    /// never use it on caller-supplied <see cref="JsCallArguments"/> whose provenance is unknown.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void WriteNoTypeCheck(JsValue[] array, int index, JsValue value)
+    {
+        Debug.Assert(array.GetType() == typeof(JsValue[]), "array must be exactly JsValue[]");
+
+        if ((uint) index >= (uint) array.Length)
+        {
+            Throw.ArgumentOutOfRangeException(nameof(index), "Index was outside the bounds of the array.");
+        }
+
+#if NET8_0_OR_GREATER
+        Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index) = value;
+#else
+        array[index] = value;
+#endif
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Runtime/Interpreter/Expressions/ExpressionCache.cs
+++ b/Jint/Runtime/Interpreter/Expressions/ExpressionCache.cs
@@ -113,13 +113,18 @@ internal sealed class ExpressionCache
         return arguments;
     }
 
+    /// <summary>
+    /// Evaluates argument expressions into <paramref name="targetArray"/>, which callers must have
+    /// allocated via <c>new JsValue[n]</c> or rented from the engine's <see cref="Pooling.JsValueArrayPool"/>
+    /// so that it is exactly <see cref="JsValue"/>[] (see <see cref="Arguments.WriteNoTypeCheck"/>).
+    /// </summary>
     internal int BuildArguments(EvaluationContext context, JsValue[] targetArray, int startIndex = 0)
     {
         var expressions = _expressions;
         int i = startIndex;
         for (; (uint) i < (uint) expressions.Length; i++)
         {
-            targetArray[i] = GetValue(context, expressions[i])!;
+            Arguments.WriteNoTypeCheck(targetArray, i, GetValue(context, expressions[i])!);
 
             // Check for generator suspension after each expression evaluation
             // This is needed because yield expressions return normally instead of throwing


### PR DESCRIPTION
## Summary

`JsValue` is not sealed, so every `array[i] = value` store into a `JsValue[]` pays a runtime covariant-store check (`CastHelpers.StelemRef_Helper`) — ETW-measured at ~1.4% of program time on call-heavy workloads, 62% of it from call-argument population.

Adds `Arguments.WriteNoTypeCheck` — explicit bounds check plus a ref write via `MemoryMarshal.GetArrayDataReference` on net8+ (plain store on older TFMs), with a `Debug.Assert` and a documented exactness precondition — and uses it where the array is provably exactly `JsValue[]`: the interpreter's argument-building loop (`ExpressionCache.BuildArguments`, arrays freshly allocated or rented from `JsValueArrayPool`, whose factories only create exact arrays — verified) and `RegExp.Replace`'s functional-replace paths, which also drop a `List<JsValue>` + `ToArray()` double allocation per match in favor of exact-sized arrays.

Orthogonal to argument pooling/lifetime (which stays on `JsValueArrayPool` with return-after-call semantics) — this changes only the store instruction.

## Benchmarks (default jobs, adjacent A/B on latest main)

| Benchmark | main | PR | Δ |
|---|---:|---:|---:|
| Recursion DeepSum | 225.27 ms | 211.78 ms | **−6.0%** |
| SunSpider controlflow-recursive | 65.48 ms | 61.92 ms | **−5.4%** |
| SunSpider access-binary-trees | 49.96 ms | 47.56 ms | **−4.8%** |
| Recursion Fib | 487.74 ms | 469.83 ms | **−3.7%** |
| Recursion Tak | 14.33 ms | 13.84 ms | −3.4% |
| SunSpider 3d-raytrace | 77.72 ms | 77.61 ms | neutral |

## Gates

- Jint.Tests: 3,569 (net10.0) + 3,506 (net472) passed, 0 failed
- Jint.Tests.PublicInterface / CommonScripts: green both TFMs
- Test262: 99,421/8 under 4-way parallel suite contention (the 8 = known S7.8.5 regexp-literal 30 s timeout flakes); all 476 regexp-literal tests pass in 10 s when re-run isolated — 0 real failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
