### PR TITLE
Make per-call nested function instantiation allocation-free

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1533,12 +1533,16 @@ public sealed partial class Engine : IDisposable
                         JsValue.Undefined, canBeDeleted: false, mutable: true, strict: false);
                 }
             }
-            else
+            else if (varsToInitialize.Count > 0)
             {
+                // Inlined bulk form of CreateMutableBindingAndInitialize (no slots, DisposeHint.Normal):
+                // pre-size once so a declaration-heavy body doesn't cut the list over to a dictionary
+                // insert by insert on every call (mirrors the lexical-declarations path below).
+                var dictionary = env._dictionary ??= new HybridDictionary<Binding>(varsToInitialize.Count, checkExistingKeys: true);
+                dictionary.EnsureCapacity(dictionary.Count + varsToInitialize.Count);
                 for (var i = 0; i < varsToInitialize.Count; i++)
                 {
-                    var pair = varsToInitialize[i];
-                    env.CreateMutableBindingAndInitialize(pair.Name, canBeDeleted: false, JsValue.Undefined, DisposeHint.Normal);
+                    dictionary[varsToInitialize[i].Name] = new Binding(JsValue.Undefined, canBeDeleted: false, mutable: true, strict: false);
                 }
             }
 

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1670,13 +1670,12 @@ public sealed partial class Engine : IDisposable
         if (configuration.FunctionsToInitialize != null)
         {
             var privateEnv = calleeContext.PrivateEnvironment;
-            var realm = Realm;
+            var intrinsicFunction = Realm.Intrinsics.Function;
             foreach (var f in configuration.FunctionsToInitialize)
             {
-                var jintFunctionDefinition = GetOrCreateFunctionDefinition(f);
-                var fn = jintFunctionDefinition.Name!;
-                var fo = realm.Intrinsics.Function.InstantiateFunctionObject(jintFunctionDefinition, lexEnv, privateEnv);
-                varEnv.SetMutableBinding(fn, fo, strict: false);
+                var jintFunctionDefinition = GetOrCreateFunctionDefinition(f.Declaration);
+                var fo = intrinsicFunction.InstantiateFunctionObject(jintFunctionDefinition, lexEnv, privateEnv);
+                varEnv.SetMutableBinding(f.Name, fo, strict: false);
             }
         }
 

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -162,6 +162,25 @@ public abstract partial class Function : ObjectInstance, ICallable
             yield return new KeyValuePair<JsValue, PropertyDescriptor>(CommonProperties.Name, GetOwnProperty(CommonProperties.Name));
         }
 
+        if (this is ScriptFunction scriptFunction)
+        {
+            var argumentsDescriptor = ReferenceEquals(scriptFunction._argumentsDescriptor, _pendingDescriptor)
+                ? scriptFunction.MaterializeArgumentsDescriptor()
+                : scriptFunction._argumentsDescriptor;
+            if (argumentsDescriptor is not null)
+            {
+                yield return new KeyValuePair<JsValue, PropertyDescriptor>(CommonProperties.Arguments, argumentsDescriptor);
+            }
+
+            var callerDescriptor = ReferenceEquals(scriptFunction._callerDescriptor, _pendingDescriptor)
+                ? scriptFunction.MaterializeCallerDescriptor()
+                : scriptFunction._callerDescriptor;
+            if (callerDescriptor is not null)
+            {
+                yield return new KeyValuePair<JsValue, PropertyDescriptor>(CommonProperties.Caller, callerDescriptor);
+            }
+        }
+
         foreach (var entry in base.GetOwnProperties())
         {
             yield return entry;
@@ -183,6 +202,19 @@ public abstract partial class Function : ObjectInstance, ICallable
         if (_prototypeDescriptor != null)
         {
             yield return CommonProperties.Prototype;
+        }
+
+        if (this is ScriptFunction scriptFunction)
+        {
+            if (scriptFunction._argumentsDescriptor is not null)
+            {
+                yield return CommonProperties.Arguments;
+            }
+
+            if (scriptFunction._callerDescriptor is not null)
+            {
+                yield return CommonProperties.Caller;
+            }
         }
     }
 
@@ -214,6 +246,22 @@ public abstract partial class Function : ObjectInstance, ICallable
                 nameDescriptor = MaterializeNameDescriptor();
             }
             return nameDescriptor ?? PropertyDescriptor.Undefined;
+        }
+
+        if (this is ScriptFunction scriptFunction)
+        {
+            if (scriptFunction._argumentsDescriptor is { } argumentsDescriptor && CommonProperties.Arguments.Equals(property))
+            {
+                return ReferenceEquals(argumentsDescriptor, _pendingDescriptor)
+                    ? scriptFunction.MaterializeArgumentsDescriptor()
+                    : argumentsDescriptor;
+            }
+            if (scriptFunction._callerDescriptor is { } callerDescriptor && CommonProperties.Caller.Equals(property))
+            {
+                return ReferenceEquals(callerDescriptor, _pendingDescriptor)
+                    ? scriptFunction.MaterializeCallerDescriptor()
+                    : callerDescriptor;
+            }
         }
 
         return base.GetOwnProperty(property);
@@ -252,6 +300,9 @@ public abstract partial class Function : ObjectInstance, ICallable
         {
             _nameDescriptor = desc;
         }
+        else if (this is ScriptFunction scriptFunction && scriptFunction.TrySetRestrictedOwnProperty(property, desc))
+        {
+        }
         else
         {
             base.SetOwnProperty(property, desc);
@@ -271,6 +322,17 @@ public abstract partial class Function : ObjectInstance, ICallable
         if (CommonProperties.Name.Equals(property))
         {
             _nameDescriptor = null;
+        }
+        if (this is ScriptFunction scriptFunction)
+        {
+            if (scriptFunction._argumentsDescriptor is not null && CommonProperties.Arguments.Equals(property))
+            {
+                scriptFunction._argumentsDescriptor = null;
+            }
+            if (scriptFunction._callerDescriptor is not null && CommonProperties.Caller.Equals(property))
+            {
+                scriptFunction._callerDescriptor = null;
+            }
         }
 
         base.RemoveOwnProperty(property);
@@ -377,9 +439,10 @@ public abstract partial class Function : ObjectInstance, ICallable
     internal void MakeMethod(ObjectInstance homeObject)
     {
         _homeObject = homeObject;
-        // Per ECMAScript spec, methods must not have own "arguments" or "caller" properties
-        RemoveOwnProperty(KnownKeys.Arguments.Name);
-        RemoveOwnProperty(KnownKeys.Caller.Name);
+        // Per ECMAScript spec, methods must not have own "arguments" or "caller" properties.
+        // Use the cached JsStrings so this allocates nothing.
+        RemoveOwnProperty(CommonProperties.Arguments);
+        RemoveOwnProperty(CommonProperties.Caller);
     }
 
     /// <summary>

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
 using Environment = Jint.Runtime.Environments.Environment;
@@ -19,6 +18,35 @@ public abstract partial class Function : ObjectInstance, ICallable
 
     protected internal PropertyDescriptor? _length;
     internal PropertyDescriptor? _nameDescriptor;
+
+    // Shared sentinel marking a script function's own name/length/prototype property as
+    // "exists, but its descriptor has not been materialized yet". Descriptors cannot be shared
+    // across function instances (DefineOwnProperty mutates them in place), so instead of
+    // allocating per instantiation — nested function declarations re-instantiate on every call
+    // of their enclosing function — the sentinel defers the allocation until the property is
+    // actually read. GetOwnProperty (which DefineOwnProperty and every other property protocol
+    // entry point consults first) swaps it for the real descriptor on first access; a null field
+    // still means "property absent/deleted". Never bumps _propertiesVersion: materialization is
+    // identity-stable and function receivers are outside the version-based inline caches anyway.
+    // The sentinel must never escape — its value accessors throw to make any leak loud.
+    private protected static readonly PropertyDescriptor _pendingDescriptor = new PendingPropertyDescriptor();
+
+    private sealed class PendingPropertyDescriptor : PropertyDescriptor
+    {
+        public PendingPropertyDescriptor() : base(PropertyFlag.CustomJsValue)
+        {
+        }
+
+        protected internal override JsValue? CustomValue
+        {
+            get
+            {
+                Throw.InvalidOperationException("a pending lazy property descriptor leaked without being materialized");
+                return null;
+            }
+            set => Throw.InvalidOperationException("a pending lazy property descriptor leaked without being materialized");
+        }
+    }
 
     internal Environment? _environment;
     internal readonly JintFunctionDefinition? _functionDefinition;
@@ -44,14 +72,16 @@ public abstract partial class Function : ObjectInstance, ICallable
         JintFunctionDefinition function,
         Environment env,
         FunctionThisMode thisMode)
-        : this(
-            engine,
-            realm,
-            !string.IsNullOrWhiteSpace(function.Name) ? new JsString(function.Name!) : null,
-            thisMode)
+        : this(engine, realm, name: null, thisMode)
     {
         _functionDefinition = function;
         _environment = env;
+        if (function.JsName is not null)
+        {
+            // The own "name" property exists from birth, but its descriptor is materialized
+            // lazily from the definition's cached JsName on first read (see _pendingDescriptor).
+            _nameDescriptor = _pendingDescriptor;
+        }
     }
 
     internal Function(
@@ -72,6 +102,24 @@ public abstract partial class Function : ObjectInstance, ICallable
 
     // for example RavenDB wants to inspect this
     public IFunction? FunctionDeclaration => _functionDefinition?.Function;
+
+    /// <summary>
+    /// True when the function already carries a non-empty own name, materialized or pending
+    /// (a pending descriptor stands for the definition's own name, which is never empty).
+    /// </summary>
+    internal bool HasNonEmptyOwnName
+    {
+        get
+        {
+            var nameDescriptor = _nameDescriptor;
+            if (nameDescriptor is null)
+            {
+                return false;
+            }
+            return ReferenceEquals(nameDescriptor, _pendingDescriptor)
+                   || !string.IsNullOrWhiteSpace(nameDescriptor._value?.ToString());
+        }
+    }
 
     internal override bool IsCallable => true;
 
@@ -96,13 +144,18 @@ public abstract partial class Function : ObjectInstance, ICallable
 
     public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
     {
-        if (_prototypeDescriptor != null)
+        var prototypeDescriptor = ReferenceEquals(_prototypeDescriptor, _pendingDescriptor)
+            ? MaterializePrototypeDescriptor()
+            : _prototypeDescriptor;
+        if (prototypeDescriptor != null)
         {
-            yield return new KeyValuePair<JsValue, PropertyDescriptor>(CommonProperties.Prototype, _prototypeDescriptor);
+            yield return new KeyValuePair<JsValue, PropertyDescriptor>(CommonProperties.Prototype, prototypeDescriptor);
         }
-        if (_length != null)
+
+        var length = ReferenceEquals(_length, _pendingDescriptor) ? MaterializeLengthDescriptor() : _length;
+        if (length != null)
         {
-            yield return new KeyValuePair<JsValue, PropertyDescriptor>(CommonProperties.Length, _length);
+            yield return new KeyValuePair<JsValue, PropertyDescriptor>(CommonProperties.Length, length);
         }
         if (_nameDescriptor != null)
         {
@@ -137,18 +190,52 @@ public abstract partial class Function : ObjectInstance, ICallable
     {
         if (CommonProperties.Prototype.Equals(property))
         {
-            return _prototypeDescriptor ?? PropertyDescriptor.Undefined;
+            var prototypeDescriptor = _prototypeDescriptor;
+            if (ReferenceEquals(prototypeDescriptor, _pendingDescriptor))
+            {
+                prototypeDescriptor = MaterializePrototypeDescriptor();
+            }
+            return prototypeDescriptor ?? PropertyDescriptor.Undefined;
         }
         if (CommonProperties.Length.Equals(property))
         {
-            return _length ?? PropertyDescriptor.Undefined;
+            var length = _length;
+            if (ReferenceEquals(length, _pendingDescriptor))
+            {
+                length = MaterializeLengthDescriptor();
+            }
+            return length ?? PropertyDescriptor.Undefined;
         }
         if (CommonProperties.Name.Equals(property))
         {
-            return _nameDescriptor ?? PropertyDescriptor.Undefined;
+            var nameDescriptor = _nameDescriptor;
+            if (ReferenceEquals(nameDescriptor, _pendingDescriptor))
+            {
+                nameDescriptor = MaterializeNameDescriptor();
+            }
+            return nameDescriptor ?? PropertyDescriptor.Undefined;
         }
 
         return base.GetOwnProperty(property);
+    }
+
+    private PropertyDescriptor MaterializeNameDescriptor()
+    {
+        return _nameDescriptor = new PropertyDescriptor(_functionDefinition!.JsName!, PropertyFlag.Configurable);
+    }
+
+    private PropertyDescriptor MaterializeLengthDescriptor()
+    {
+        return _length = new PropertyDescriptor(JsNumber.Create(_functionDefinition!.Initialize().Length), PropertyFlag.Configurable);
+    }
+
+    private protected PropertyDescriptor MaterializePrototypeDescriptor()
+    {
+        // Flags match the eager MakeConstructor path: writable, non-enumerable, non-configurable.
+        // The pending marker is only ever installed for writableProperty: true (the only caller shape).
+        return _prototypeDescriptor = new PropertyDescriptor(
+            CreateConstructorPrototype(),
+            PropertyFlag.Writable | PropertyFlag.WritableSet | PropertyFlag.EnumerableSet | PropertyFlag.ConfigurableSet);
     }
 
     protected internal override void SetOwnProperty(JsValue property, PropertyDescriptor desc)
@@ -194,7 +281,10 @@ public abstract partial class Function : ObjectInstance, ICallable
     /// </summary>
     internal void SetFunctionName(JsValue name, string? prefix = null, bool force = false)
     {
-        if (!force && _nameDescriptor != null && UnwrapJsValue(_nameDescriptor) != JsString.Empty)
+        var nameDescriptor = _nameDescriptor;
+        if (!force && nameDescriptor != null
+            // a pending descriptor stands for the definition's own (never empty) name
+            && (ReferenceEquals(nameDescriptor, _pendingDescriptor) || UnwrapJsValue(nameDescriptor) != JsString.Empty))
         {
             return;
         }
@@ -356,20 +446,21 @@ public abstract partial class Function : ObjectInstance, ICallable
     internal void MakeConstructor(bool writableProperty = true, ObjectInstance? prototype = null)
     {
         _constructorKind = ConstructorKind.Base;
-        if (prototype is null)
+        if (prototype is null && writableProperty)
         {
-            // Lazily create the .prototype object. Functions that are never used as a constructor and
-            // whose .prototype is never read (e.g. the hundreds of helper functions declared by
-            // linq-js) then skip the ObjectInstanceWithConstructor + its two descriptor allocations.
-            // The value is memoized on first access, so .prototype identity is stable. Flags match the
-            // eager descriptor below: writable=writableProperty, enumerable=false, configurable=false.
-            var flags = PropertyFlag.WritableSet | PropertyFlag.EnumerableSet | PropertyFlag.ConfigurableSet;
-            if (writableProperty)
-            {
-                flags |= PropertyFlag.Writable;
-            }
-
-            _prototypeDescriptor = new LazyPropertyDescriptor<Function>(this, static f => f.CreateConstructorPrototype(), flags);
+            // Lazily create both the .prototype descriptor and its object. Functions that are never
+            // used as a constructor and whose .prototype is never read (e.g. the hundreds of helper
+            // functions declared by linq-js, or nested declarations re-instantiated per call) then
+            // skip the descriptor + ObjectInstanceWithConstructor allocations entirely. GetOwnProperty
+            // materializes on first access (see _pendingDescriptor), so .prototype identity is stable.
+            _prototypeDescriptor = _pendingDescriptor;
+        }
+        else if (prototype is null)
+        {
+            // no caller today combines writableProperty: false with a lazily created prototype
+            _prototypeDescriptor = new PropertyDescriptor(
+                CreateConstructorPrototype(),
+                PropertyFlag.WritableSet | PropertyFlag.EnumerableSet | PropertyFlag.ConfigurableSet);
         }
         else
         {
@@ -415,7 +506,21 @@ public abstract partial class Function : ObjectInstance, ICallable
             }
         }
 
-        var nameValue = _nameDescriptor != null ? UnwrapJsValue(_nameDescriptor) : JsString.Empty;
+        var nameDescriptor = _nameDescriptor;
+        JsValue nameValue;
+        if (nameDescriptor is null)
+        {
+            nameValue = JsString.Empty;
+        }
+        else if (ReferenceEquals(nameDescriptor, _pendingDescriptor))
+        {
+            nameValue = _functionDefinition!.JsName!;
+        }
+        else
+        {
+            nameValue = UnwrapJsValue(nameDescriptor);
+        }
+
         var name = "";
         if (!nameValue.IsUndefined())
         {

--- a/Jint/Native/Function/FunctionConstructor.cs
+++ b/Jint/Native/Function/FunctionConstructor.cs
@@ -82,7 +82,11 @@ public sealed class FunctionConstructor : Constructor
             env,
             privateEnv);
 
-        F.SetFunctionName(functionDeclaration.Name ?? "default");
+        if (functionDeclaration.Name is null)
+        {
+            // anonymous export default declaration; named declarations already carry their name
+            F.SetFunctionName("default");
+        }
 
         return F;
     }
@@ -102,8 +106,12 @@ public sealed class FunctionConstructor : Constructor
             env,
             privateEnv);
 
-        var name = functionDeclaration.Name ?? "default";
-        F.SetFunctionName(name);
+        if (functionDeclaration.Name is null)
+        {
+            // anonymous export default declaration; named declarations already carry their name
+            F.SetFunctionName("default");
+        }
+
         F.MakeConstructor();
         return F;
     }
@@ -120,7 +128,6 @@ public sealed class FunctionConstructor : Constructor
             ? FunctionThisMode.Strict
             : FunctionThisMode.Global;
 
-        var name = functionDeclaration.Function.Id?.Name ?? "default";
         var F = OrdinaryFunctionCreate(
             _realm.Intrinsics.GeneratorFunction.PrototypeObject,
             functionDeclaration,
@@ -128,7 +135,11 @@ public sealed class FunctionConstructor : Constructor
             scope,
             privateScope);
 
-        F.SetFunctionName(name);
+        if (functionDeclaration.Name is null)
+        {
+            // anonymous export default declaration; named declarations already carry their name
+            F.SetFunctionName("default");
+        }
 
         var prototype = OrdinaryObjectCreate(_engine, _realm.Intrinsics.GeneratorFunction.PrototypeObject.PrototypeObject);
         F.DefinePropertyOrThrow(CommonProperties.Prototype, new PropertyDescriptor(prototype, PropertyFlag.Writable));
@@ -148,7 +159,6 @@ public sealed class FunctionConstructor : Constructor
             ? FunctionThisMode.Strict
             : FunctionThisMode.Global;
 
-        var name = functionDeclaration.Function.Id?.Name ?? "default";
         var F = OrdinaryFunctionCreate(
             _realm.Intrinsics.AsyncGeneratorFunction.PrototypeObject,
             functionDeclaration,
@@ -156,7 +166,11 @@ public sealed class FunctionConstructor : Constructor
             scope,
             privateScope);
 
-        F.SetFunctionName(name);
+        if (functionDeclaration.Name is null)
+        {
+            // anonymous export default declaration; named declarations already carry their name
+            F.SetFunctionName("default");
+        }
 
         var prototype = OrdinaryObjectCreate(_engine, _realm.Intrinsics.AsyncGeneratorFunction.PrototypeObject.PrototypeObject);
         F.DefinePropertyOrThrow(CommonProperties.Prototype, new PropertyDescriptor(prototype, PropertyFlag.Writable));

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -343,7 +343,7 @@ public sealed class ScriptFunction : Function, IConstructor
         if (kind == ConstructorKind.Base)
         {
             var currentPrototypeDescriptor = _prototypeDescriptor;
-            if (ReferenceEquals(currentPrototypeDescriptor, _pendingDescriptor))
+            if (ReferenceEquals(newTarget, this) && ReferenceEquals(currentPrototypeDescriptor, _pendingDescriptor))
             {
                 currentPrototypeDescriptor = MaterializePrototypeDescriptor();
             }

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -14,6 +14,17 @@ public sealed class ScriptFunction : Function, IConstructor
     internal bool _isClassConstructor;
     internal JsValue? _classFieldInitializerName;
 
+    // Own restricted "arguments"/"caller" properties of non-strict, non-arrow, non-generator,
+    // non-async functions. Dedicated fields (like Function's name/length/prototype) instead of
+    // dictionary entries, so a plain sloppy function's instantiation allocates neither the
+    // property dictionary nor the two descriptors: the fields start at the pending sentinel and
+    // materialize on first read. null means absent (strict functions, methods after MakeMethod,
+    // or deleted); a deleted-then-redefined property goes to the dictionary, which preserves the
+    // previous key order after resurrection. Enumeration order (length, name, prototype,
+    // arguments, caller) matches the old ctor-time dictionary inserts.
+    internal PropertyDescriptor? _argumentsDescriptor;
+    internal PropertyDescriptor? _callerDescriptor;
+
     // Reuse cache for this function's call environments, populated on a pool-eligible call's return.
     // Interpreted via State.IsDirectRecursive: a FunctionEnvironment (the next call reuses it directly)
     // for ordinary functions, or a RecursiveEnvPool for direct-recursive ones. Held per function instance
@@ -83,9 +94,44 @@ public sealed class ScriptFunction : Function, IConstructor
             && !function.Function.Generator
             && !function.Function.Async)
         {
-            SetProperty(KnownKeys.Arguments, new GetSetPropertyDescriptor.ThrowerPropertyDescriptor(engine, PropertyFlag.Configurable));
-            SetProperty(KnownKeys.Caller, new PropertyDescriptor(Undefined, PropertyFlag.Configurable));
+            _argumentsDescriptor = _pendingDescriptor;
+            _callerDescriptor = _pendingDescriptor;
         }
+    }
+
+    internal PropertyDescriptor MaterializeArgumentsDescriptor()
+    {
+        // Same deferred %ThrowTypeError% resolution as the old eager descriptor: the thrower is
+        // looked up from the engine's active realm on the first Get/Set access either way.
+        return _argumentsDescriptor = new GetSetPropertyDescriptor.ThrowerPropertyDescriptor(_engine, PropertyFlag.Configurable);
+    }
+
+    internal PropertyDescriptor MaterializeCallerDescriptor()
+    {
+        return _callerDescriptor = new PropertyDescriptor(Undefined, PropertyFlag.Configurable);
+    }
+
+    /// <summary>
+    /// Stores a replacement descriptor for a currently field-backed restricted property. Returns
+    /// false when the property is not field-backed (never was, or was deleted), in which case the
+    /// caller stores it in the property dictionary — putting a resurrected property at the end of
+    /// the key order exactly like the previous dictionary-backed representation did.
+    /// </summary>
+    internal bool TrySetRestrictedOwnProperty(JsValue property, PropertyDescriptor desc)
+    {
+        if (_argumentsDescriptor is not null && CommonProperties.Arguments.Equals(property))
+        {
+            _argumentsDescriptor = desc;
+            return true;
+        }
+
+        if (_callerDescriptor is not null && CommonProperties.Caller.Equals(property))
+        {
+            _callerDescriptor = desc;
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using Jint.Native.Object;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
-using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Environments;
 using Jint.Runtime.Interpreter;
 using Environment = Jint.Runtime.Environments.Environment;
@@ -75,7 +74,9 @@ public sealed class ScriptFunction : Function, IConstructor
         : base(engine, engine.Realm, function, env, thisMode)
     {
         _prototype = proto ?? _engine.Realm.Intrinsics.Function.PrototypeObject;
-        _length = new LazyPropertyDescriptor<JintFunctionDefinition>(function, static function => JsNumber.Create(function.Initialize().Length), PropertyFlag.Configurable);
+        // The own "length" property exists from birth; its descriptor is materialized lazily
+        // from the definition on first read (see Function._pendingDescriptor).
+        _length = _pendingDescriptor;
 
         if (!function.Strict
             && function.Function is not ArrowFunctionExpression
@@ -295,8 +296,14 @@ public sealed class ScriptFunction : Function, IConstructor
 
         if (kind == ConstructorKind.Base)
         {
+            var currentPrototypeDescriptor = _prototypeDescriptor;
+            if (ReferenceEquals(currentPrototypeDescriptor, _pendingDescriptor))
+            {
+                currentPrototypeDescriptor = MaterializePrototypeDescriptor();
+            }
+
             if (ReferenceEquals(newTarget, this)
-                && _prototypeDescriptor is { } prototypeDescriptor
+                && currentPrototypeDescriptor is { } prototypeDescriptor
                 && !prototypeDescriptor.IsAccessorDescriptor())
             {
                 var prototype = prototypeDescriptor.Value as ObjectInstance ?? _realm.Intrinsics.Object.PrototypeObject;

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -369,7 +369,7 @@ internal sealed class JintFunctionDefinition
         public bool ArgumentsObjectNeeded;
         public bool RequiresInputArgumentsOwnership;
         public List<Key>? VarNames;
-        public LinkedList<FunctionDeclaration>? FunctionsToInitialize;
+        public FunctionToInitialize[]? FunctionsToInitialize;
         public readonly HashSet<Key> FunctionNames = new();
         public DeclarationCache? LexicalDeclarations;
         public HashSet<Key>? ParameterBindings;
@@ -462,6 +462,14 @@ internal sealed class JintFunctionDefinition
         public SourceText SourceText;
 
         internal readonly record struct VariableValuePair(Key Name, JsValue? InitialValue);
+
+        /// <summary>
+        /// A function declaration hoisted by FunctionDeclarationInstantiation, with its binding
+        /// name pre-converted to a <see cref="Key"/> so the per-call FDI loop neither re-hashes
+        /// the name nor walks a linked list.
+        /// </summary>
+        [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+        internal readonly record struct FunctionToInitialize(FunctionDeclaration Declaration, Key Name);
     }
 
     internal static State BuildState(IFunction function, string? fullSourceText = null)
@@ -476,19 +484,27 @@ internal sealed class JintFunctionDefinition
         var lexicalNames = hoistingScope._lexicalNames;
         state.VarNames = hoistingScope._varNames;
 
-        LinkedList<FunctionDeclaration>? functionsToInitialize = null;
+        State.FunctionToInitialize[]? functionsToInitialize = null;
 
         if (functionDeclarations != null)
         {
-            functionsToInitialize = new LinkedList<FunctionDeclaration>();
+            // The last declaration of a name wins, others keep source order: walk backwards
+            // de-duplicating, then reverse the survivors.
+            var survivors = new List<State.FunctionToInitialize>(functionDeclarations.Count);
             for (var i = functionDeclarations.Count - 1; i >= 0; i--)
             {
                 var d = functionDeclarations[i];
-                var fn = d.Id!.Name;
+                Key fn = d.Id!.Name;
                 if (state.FunctionNames.Add(fn))
                 {
-                    functionsToInitialize.AddFirst(d);
+                    survivors.Add(new State.FunctionToInitialize(d, fn));
                 }
+            }
+
+            if (survivors.Count > 0)
+            {
+                survivors.Reverse();
+                functionsToInitialize = survivors.ToArray();
             }
         }
 

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -28,6 +28,11 @@ internal sealed class JintFunctionDefinition
     public readonly string? Name;
     public readonly IFunction Function;
 
+    // The function's own name as a JsValue, cached here so that every instantiation of this
+    // definition (nested function declarations re-instantiate on every call of their enclosing
+    // function) shares one immutable JsString instead of allocating a fresh one per instance.
+    public readonly JsString? JsName;
+
     // True for definitions created by the Function constructor (CreateDynamicFunction). Their
     // definition lives in the per-realm dynamic-function cache and every `new Function(...)`
     // produces a fresh ScriptFunction instance, which changes where call environments can be
@@ -42,6 +47,7 @@ internal sealed class JintFunctionDefinition
     {
         Function = function;
         Name = !string.IsNullOrEmpty(function.Id?.Name) ? function.Id!.Name : null;
+        JsName = Name is not null ? new JsString(Name) : null;
         SourceTextNode = sourceTextNode;
     }
 

--- a/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExportDefaultDeclaration.cs
@@ -78,8 +78,7 @@ internal sealed class JintExportDefaultDeclaration : JintStatement<ExportDefault
             return Completion.Empty();
         }
 
-        if (value is Function functionInstance
-            && string.IsNullOrWhiteSpace(functionInstance._nameDescriptor?._value?.ToString()))
+        if (value is Function functionInstance && !functionInstance.HasNonEmptyOwnName)
         {
             functionInstance.SetFunctionName("default");
         }


### PR DESCRIPTION
## Summary

Every call of a function whose body declares inner functions re-instantiates those functions (spec-required — each call's closures capture that call's environment). ETW profiling shows the instantiation chain (`FunctionDeclarationInstantiation` → `InstantiateFunctionObject` → `ScriptFunction..ctor`) at 4.6% of program time on closure-producing workloads. This makes each instantiation cheaper — instantiating a named sloppy nested function drops from ~7 side allocations (~250–300 B) to **zero** (only the `ScriptFunction` object itself remains, +16 B for two new lazy fields).

Five commits:

1. **Lazy name/length/prototype descriptors** — a shared pending-descriptor sentinel materializes the real `PropertyDescriptor` on first read (sharing actual descriptors across instances is provably unsafe: `ValidateAndApplyPropertyDescriptor` mutates them in place). The sentinel's value accessors throw so a leak fails loudly. The per-definition-constant function name `JsString` is cached on `JintFunctionDefinition`.
2. **Lazy sloppy-mode `arguments`/`caller` poison descriptors** — a plain sloppy function no longer creates any property dictionary at all; delete-then-redefine demotes to dictionary preserving key-resurrection order; initial key order unchanged; %ThrowTypeError% resolution stays deferred exactly as before.
3. **FDI hoisting-loop trims** — `FunctionsToInitialize` becomes a readonly record-struct array (was `LinkedList`) with the binding `Key` precomputed at BuildState; the intrinsic lookup is hoisted out of the loop; `SetFunctionName`'s per-call `JsString` allocation is skipped for named declarations.
4. **Pre-size the FDI var-binding dictionary** (mirrors the adjacent lexical-declarations pattern) instead of growing per insert.
5. **Materialize the pending prototype in `[[Construct]]` only when consulted.**

Functional verification beyond suites: 77 checks (descriptor shapes before/after calls via `getOwnPropertyDescriptor`, key order, delete/redefine/freeze, loop-closures, NFE recursion, generators/async, Proxy, bind, `with`, class) — output byte-identical to a pristine main build.

## Benchmarks (default jobs, adjacent A/B on latest main)

| Benchmark | main | PR | Δ |
|---|---:|---:|---:|
| FunctionDeclarationAlloc DeclareMany | 61.98 µs / 168.79 KB | 52.57 µs / 129.73 KB | **−15.2% time, −23.1% alloc** |
| FunctionDeclarationAlloc ConstructEach | 202.07 µs / 418.79 KB | 199.68 µs / 395.35 KB | −1.2% time, **−5.6% alloc** |
| ClosureCallBenchmarks (5 rows) | — | — | neutral (SloppyEmptyClosureCall settled by launchCount-5: 25.49 ±0.82 → 25.00 ±0.39 ms, allocations byte-identical) |
| SunSpider recursion rows (top-level functions — lane not exercised) | — | — | neutral |

## Gates

- Jint.Tests: 3,569 (net10.0) + 3,506 (net472) passed, 0 failed
- Jint.Tests.PublicInterface: green both TFMs (descriptor surface exercised)
- Jint.Tests.CommonScripts: green both TFMs
- Test262: 99,429 passed, 0 failed (run twice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
