### PR TITLE
Let branchy constructors with static this-stores shape from instance three

### DIFF
--- a/Jint.Tests/Runtime/ConstructorShapeEligibilityTests.cs
+++ b/Jint.Tests/Runtime/ConstructorShapeEligibilityTests.cs
@@ -108,24 +108,48 @@ public class ConstructorShapeEligibilityTests
     }
 
     [Fact]
+    public void ConditionalThisAssignmentsAreEligible()
+    {
+        // The sunspider-3d-raytrace Triangle pattern: branches assigning the same key set.
+        // Eligibility only decides how early shaping starts, so branchy-but-static bodies
+        // shape from instance #3 like straight-line ones.
+        var engine = new Engine();
+        engine.Execute("function T(f) { if (f) this.axis = 0; else this.axis = 2; this.n = 1; } var t1 = new T(true); var t2 = new T(false); var t3 = new T(true); var t4 = new T(false);");
+        Assert.False(IsShapeMode(GetObject(engine, "t1")));
+        Assert.True(IsShapeMode(GetObject(engine, "t3")));
+        Assert.True(IsShapeMode(GetObject(engine, "t4")));
+        Assert.Same(ShapeOf(GetObject(engine, "t3")), ShapeOf(GetObject(engine, "t4")));
+        Assert.Equal(0, engine.Evaluate("t3.axis").AsNumber());
+        Assert.Equal(2, engine.Evaluate("t4.axis").AsNumber());
+        Assert.Equal("axis,n", engine.Evaluate("Object.keys(t3).join(',')").AsString());
+
+        // divergent key sets per branch: both layouts stay correct, shapes differ per path
+        engine = new Engine();
+        engine.Execute("function T(f) { if (f) { this.a = 1; } else { this.b = 2; } } var t1 = new T(true); var t2 = new T(true); var t3 = new T(true); var t4 = new T(false);");
+        Assert.True(IsShapeMode(GetObject(engine, "t3")));
+        Assert.True(IsShapeMode(GetObject(engine, "t4")));
+        Assert.Equal(1, engine.Evaluate("t3.a").AsNumber());
+        Assert.False(engine.Evaluate("'b' in t3").AsBoolean());
+        Assert.Equal(2, engine.Evaluate("t4.b").AsNumber());
+        Assert.False(engine.Evaluate("'a' in t4").AsBoolean());
+
+        // a this-escaping call in the if TEST still rejects eligibility
+        engine = new Engine();
+        engine.Execute("function ext(o) { o.dyn = 1; return true; } function T() { if (ext(this)) this.a = 1; } var t1 = new T(); var t2 = new T(); var t3 = new T();");
+        Assert.False(IsShapeMode(GetObject(engine, "t3")));
+        Assert.Equal("dyn,a", engine.Evaluate("Object.keys(t3).join(',')").AsString());
+    }
+
+    [Fact]
     public void IneligibleBodiesBehaveExactlyAsBeforeAndStayUnshaped()
     {
         // Ineligible constructors keep the sampling window: with eligible ones now shaping from
         // instance #3, asserting instance #3 is still dictionary-mode is what distinguishes them.
 
-        // conditional assignment
-        var engine = new Engine();
-        engine.Execute("function T(f) { if (f) { this.a = 1; } else { this.b = 2; } } var t = new T(true); var t2 = new T(true); var t3 = new T(true);");
-        var t = GetObject(engine, "t");
-        Assert.False(IsShapeMode(t));
-        Assert.False(IsShapeMode(GetObject(engine, "t3")));
-        Assert.Equal(1, engine.Evaluate("t.a").AsNumber());
-        Assert.False(engine.Evaluate("'b' in t").AsBoolean());
-
         // computed LHS
-        engine = new Engine();
+        var engine = new Engine();
         engine.Execute("function T(k) { this[k] = 42; } var t = new T('dyn'); var t2 = new T('dyn'); var t3 = new T('dyn');");
-        t = GetObject(engine, "t");
+        var t = GetObject(engine, "t");
         Assert.False(IsShapeMode(t));
         Assert.False(IsShapeMode(GetObject(engine, "t3")));
         Assert.Equal(42, engine.Evaluate("t.dyn").AsNumber());

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -810,51 +810,76 @@ internal sealed class JintFunctionDefinition
 
         foreach (var statement in body.Body.AsSpan())
         {
-            switch (statement.Type)
+            if (!IsShapeEligibleCtorStatement(statement))
             {
-                case NodeType.EmptyStatement:
-                    continue;
-
-                case NodeType.ExpressionStatement:
-                    if (statement is Directive)
-                    {
-                        // directive prologue ("use strict") — an inert string literal
-                        continue;
-                    }
-
-                    if (((ExpressionStatement) statement).Expression is AssignmentExpression
-                        {
-                            Operator: Operator.Assignment,
-                            Left: MemberExpression { Object.Type: NodeType.ThisExpression, Computed: false, Property.Type: NodeType.Identifier },
-                        } assignment
-                        && !ContainsThisEscapingCall(assignment.Right))
-                    {
-                        continue;
-                    }
-
-                    return false;
-
-                case NodeType.VariableDeclaration:
-                    if (ContainsThisEscapingCall(statement))
-                    {
-                        return false;
-                    }
-                    continue;
-
-                case NodeType.ReturnStatement:
-                    if (((ReturnStatement) statement).Argument is not null)
-                    {
-                        // `return expr` could replace the instance or evaluate arbitrarily
-                        return false;
-                    }
-                    continue;
-
-                default:
-                    return false;
+                return false;
             }
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// The statement forms an eligible constructor body may contain: static-key `this.x = rhs`
+    /// stores, local declarations and bare returns (each without a this-escaping call), and —
+    /// because eligibility only decides how early shaping starts, never correctness — if/else and
+    /// blocks over those same forms. Branchy constructors like sunspider-3d-raytrace's Triangle
+    /// (`if (...) this.axis = 0; else this.axis = 2;`) assign the same key set on every path in
+    /// practice, and a path-divergent layout merely splits the interned transition tree, which
+    /// TryShapeAdd's fanout guard already bounds.
+    /// </summary>
+    private static bool IsShapeEligibleCtorStatement(Statement statement)
+    {
+        switch (statement.Type)
+        {
+            case NodeType.EmptyStatement:
+                return true;
+
+            case NodeType.ExpressionStatement:
+                if (statement is Directive)
+                {
+                    // directive prologue ("use strict") — an inert string literal
+                    return true;
+                }
+
+                if (((ExpressionStatement) statement).Expression is AssignmentExpression
+                    {
+                        Operator: Operator.Assignment,
+                        Left: MemberExpression { Object.Type: NodeType.ThisExpression, Computed: false, Property.Type: NodeType.Identifier },
+                    } assignment
+                    && !ContainsThisEscapingCall(assignment.Right))
+                {
+                    return true;
+                }
+
+                return false;
+
+            case NodeType.VariableDeclaration:
+                return !ContainsThisEscapingCall(statement);
+
+            case NodeType.ReturnStatement:
+                // `return expr` could replace the instance or evaluate arbitrarily
+                return ((ReturnStatement) statement).Argument is null;
+
+            case NodeType.IfStatement:
+                var ifStatement = (IfStatement) statement;
+                return !ContainsThisEscapingCall(ifStatement.Test)
+                    && IsShapeEligibleCtorStatement(ifStatement.Consequent)
+                    && (ifStatement.Alternate is null || IsShapeEligibleCtorStatement(ifStatement.Alternate));
+
+            case NodeType.BlockStatement:
+                foreach (var inner in ((BlockStatement) statement).Body.AsSpan())
+                {
+                    if (!IsShapeEligibleCtorStatement(inner))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+
+            default:
+                return false;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

`ComputeCtorBodyShapeEligibility` rejected any constructor body containing an if/else or block statement, so branchy-but-static constructors — like sunspider-3d-raytrace's `Triangle`, whose branches just pick a value for the same `this.axis` key — waited out the 16-instance sampling window before hidden-class shaping. Instances built before promotion stay dictionary-mode forever; on the raytrace driver, per-pixel reads against those instances show as `ObjectInstance.GetOwnProperty` at 4.9% self time.

Recurse the eligibility check through if/else (test guarded against this-escaping calls) and blocks over the same allowed statement forms, so such constructors shape from instance #3. Eligibility only decides how early shaping starts, never correctness: a path-divergent key set merely splits the interned transition tree, which the shape fanout guard already bounds.

## Impact (honest framing)

Mechanism-proven, wall-clock-neutral at raytrace's instance scale: ETW on a raytrace driver shows `GetOwnProperty` (207 ms, 4.9% self) **eliminated** from the profile, but shape-building costs for the newly-shaped instances offset most of the read savings at ~dozens of instances — interleaved wall clock 5.39 → 5.36 s and the SunSpider row is within noise (77.7 → 79.2 ms, day-drift band). The change pays off in read-heavy/long-lived-instance code and removes the dictionary-probe class of work; it is low-risk and gate-clean, so submitted with neutral benchmark expectations.

New `ConditionalThisAssignmentsAreEligible` test: same-key branches (the Triangle pattern, shaped from #3, shared shape across paths), divergent-key branches (both layouts correct, per-path shapes), and a this-escaping call in the if test still rejecting eligibility.

## Gates

- Jint.Tests: 3,570 (net10.0) + 3,507 (net472) passed, 0 failed
- Jint.Tests.PublicInterface / CommonScripts: green both TFMs
- Test262: 99,421/8 under 4-way parallel suite contention (known S7.8.5 regexp-literal 30 s timeout flakes; all 476 pass isolated in 10 s) — 0 real failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
