### PR TITLE
Enforce custom regex-engine timeout via an inline deadline instead of a thread-pool timer

### DIFF
--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CA1859 // Use concrete types when possible for improved performance -- most of prototype methods return JsValue
 
+using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -1255,26 +1256,29 @@ internal sealed partial class RegExpPrototype : Prototype
         ?? R.Engine.Options.Constraints.RegexTimeout;
 
     /// <summary>
-    /// Runs the custom regex engine with timeout enforcement. Throws <see cref="RegexMatchTimeoutException"/>
-    /// when the configured timeout elapses — mirrors how <see cref="Regex.Match(string,int)"/> uses
-    /// <see cref="Regex.MatchTimeout"/> on the .NET path.
+    /// Runs the custom regex engine under the configured timeout. The deadline is enforced by inline
+    /// elapsed-time checks inside <see cref="RegExpInterpreter"/> rather than a thread-pool
+    /// <see cref="CancellationTokenSource"/> timer, so the abort fires promptly
+    /// even when the pool is saturated — mirroring how <see cref="Regex.Match(string,int)"/> enforces
+    /// <see cref="Regex.MatchTimeout"/> on the .NET path. Throws <see cref="RegexMatchTimeoutException"/>
+    /// when the timeout elapses.
     /// </summary>
     private static RegExpMatchResult ExecuteWithTimeout(JsRegExp R, JintRegExpEngine engine, string s, int startIndex)
     {
         var timeout = GetCustomEngineTimeout(R);
-        if (timeout.TotalMilliseconds > 0 && timeout != Timeout.InfiniteTimeSpan)
+        if (timeout.TotalMilliseconds <= 0 || timeout == Timeout.InfiniteTimeSpan)
         {
-            using var cts = new CancellationTokenSource(timeout);
-            try
-            {
-                return engine.Execute(s, startIndex, cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                throw new RegexMatchTimeoutException(s, R.Source ?? "", timeout);
-            }
+            return engine.Execute(s, startIndex);
         }
-        return engine.Execute(s, startIndex);
+
+        try
+        {
+            return engine.Execute(s, startIndex, ComputeRegexDeadline(timeout));
+        }
+        catch (OperationCanceledException)
+        {
+            throw new RegexMatchTimeoutException(s, R.Source ?? "", timeout);
+        }
     }
 
     /// <summary>
@@ -1283,19 +1287,31 @@ internal sealed partial class RegExpPrototype : Prototype
     private static bool IsMatchWithTimeout(JsRegExp R, JintRegExpEngine engine, string s, int startIndex)
     {
         var timeout = GetCustomEngineTimeout(R);
-        if (timeout.TotalMilliseconds > 0 && timeout != Timeout.InfiniteTimeSpan)
+        if (timeout.TotalMilliseconds <= 0 || timeout == Timeout.InfiniteTimeSpan)
         {
-            using var cts = new CancellationTokenSource(timeout);
-            try
-            {
-                return engine.IsMatch(s, startIndex, cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                throw new RegexMatchTimeoutException(s, R.Source ?? "", timeout);
-            }
+            return engine.IsMatch(s, startIndex);
         }
-        return engine.IsMatch(s, startIndex);
+
+        try
+        {
+            return engine.IsMatch(s, startIndex, ComputeRegexDeadline(timeout));
+        }
+        catch (OperationCanceledException)
+        {
+            throw new RegexMatchTimeoutException(s, R.Source ?? "", timeout);
+        }
+    }
+
+    /// <summary>
+    /// Convert a positive, finite regex timeout into an absolute <see cref="Stopwatch.GetTimestamp"/>
+    /// deadline for the custom engine's inline interrupt checks. Saturates to <see cref="RegExpInterpreter.NoDeadline"/>
+    /// (never fires) instead of overflowing for extreme timeout values.
+    /// </summary>
+    private static long ComputeRegexDeadline(TimeSpan timeout)
+    {
+        var now = Stopwatch.GetTimestamp();
+        var ticks = timeout.TotalSeconds * Stopwatch.Frequency;
+        return ticks >= long.MaxValue - now ? RegExpInterpreter.NoDeadline : now + (long) ticks;
     }
 
     /// <summary>

--- a/Jint/Runtime/RegExp/JintRegExpEngine.cs
+++ b/Jint/Runtime/RegExp/JintRegExpEngine.cs
@@ -49,10 +49,14 @@ internal sealed class JintRegExpEngine
         return _groupNames[index];
     }
 
-    /// <summary>Execute the regex against the input string starting at the given index.</summary>
-    public RegExpMatchResult Execute(string input, int startIndex, CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Execute the regex against the input string starting at the given index. <paramref name="deadline"/>
+    /// is an absolute <see cref="System.Diagnostics.Stopwatch.GetTimestamp"/> value at/after which the
+    /// match is abandoned with an <see cref="OperationCanceledException"/> (<see cref="RegExpInterpreter.NoDeadline"/> = no timeout).
+    /// </summary>
+    public RegExpMatchResult Execute(string input, int startIndex, long deadline = NoDeadline)
     {
-        var captures = RegExpInterpreter.Execute(_bytecode, input, startIndex, _scanInfo, cancellationToken);
+        var captures = RegExpInterpreter.Execute(_bytecode, input, startIndex, _scanInfo, deadline);
         if (captures is null)
         {
             return RegExpMatchResult.NoMatch;
@@ -61,10 +65,10 @@ internal sealed class JintRegExpEngine
         return BuildResult(input, captures);
     }
 
-    /// <summary>Test if the regex matches the input string.</summary>
-    public bool IsMatch(string input, int startIndex = 0, CancellationToken cancellationToken = default)
+    /// <summary>Test if the regex matches the input string. See <see cref="Execute"/> for <paramref name="deadline"/>.</summary>
+    public bool IsMatch(string input, int startIndex = 0, long deadline = NoDeadline)
     {
-        return RegExpInterpreter.ExecuteIsMatch(_bytecode, input, startIndex, _scanInfo, cancellationToken);
+        return RegExpInterpreter.ExecuteIsMatch(_bytecode, input, startIndex, _scanInfo, deadline);
     }
 
     private RegExpMatchResult BuildResult(string input, int[] captures)

--- a/Jint/Runtime/RegExp/RegExpInterpreter.cs
+++ b/Jint/Runtime/RegExp/RegExpInterpreter.cs
@@ -25,11 +25,11 @@
 
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using Jint.Runtime.RegExp.Unicode;
 
 namespace Jint.Runtime.RegExp;
@@ -51,8 +51,14 @@ internal static class RegExpInterpreter
     /// <summary>Unset capture position sentinel (mirrors NULL in the C code).</summary>
     private const int Unset = -1;
 
-    /// <summary>Number of opcodes between cancellation checks.</summary>
+    /// <summary>Number of opcodes between timeout checks.</summary>
     private const int InterruptCounterInit = 10000;
+
+    /// <summary>
+    /// Sentinel deadline meaning "no timeout". <see cref="Stopwatch.GetTimestamp"/> never reaches
+    /// <see cref="long.MaxValue"/>, so <see cref="CheckDeadline"/> also short-circuits on it.
+    /// </summary>
+    internal const long NoDeadline = long.MaxValue;
 
     /// <summary>Initial backtracking stack capacity (in int elements).</summary>
     private const int InitialStackCapacity = 128;
@@ -89,7 +95,7 @@ internal static class RegExpInterpreter
         string input,
         int startIndex,
         in ScanLoopInfo scanInfo = default,
-        CancellationToken cancellationToken = default)
+        long deadline = NoDeadline)
     {
         var flags = GetFlags(bytecode);
         int captureCount = bytecode[RegExpHeader.OffsetCaptureCount];
@@ -123,7 +129,7 @@ internal static class RegExpInterpreter
 
         try
         {
-            int ret = ExecBacktrack(bc, input, capture, cindex, captureCount, isUnicode, scanInfo, cancellationToken);
+            int ret = ExecBacktrack(bc, input, capture, cindex, captureCount, isUnicode, scanInfo, deadline);
 
             int[]? result = null;
             if (ret == 1)
@@ -151,7 +157,7 @@ internal static class RegExpInterpreter
         string input,
         int startIndex,
         in ScanLoopInfo scanInfo = default,
-        CancellationToken cancellationToken = default)
+        long deadline = NoDeadline)
     {
         var flags = GetFlags(bytecode);
         int captureCount = bytecode[RegExpHeader.OffsetCaptureCount];
@@ -181,7 +187,7 @@ internal static class RegExpInterpreter
 
         try
         {
-            return ExecBacktrack(bc, input, capture, cindex, captureCount, isUnicode, scanInfo, cancellationToken) == 1;
+            return ExecBacktrack(bc, input, capture, cindex, captureCount, isUnicode, scanInfo, deadline) == 1;
         }
         finally
         {
@@ -897,7 +903,7 @@ internal static class RegExpInterpreter
     /// <summary>
     /// Execute the backtracking NFA interpreter.
     /// Returns 1 on match, 0 on no match.
-    /// Throws <see cref="OperationCanceledException"/> on timeout/cancellation.
+    /// Throws <see cref="OperationCanceledException"/> when the <paramref name="deadline"/> elapses.
     /// </summary>
     private static int ExecBacktrack(
         ReadOnlySpan<byte> bc,
@@ -907,7 +913,7 @@ internal static class RegExpInterpreter
         int captureCount,
         bool isUnicode,
         in ScanLoopInfo scanInfo,
-        CancellationToken cancellationToken)
+        long deadline)
     {
         int inputEnd = input.Length;
         int allocCount = capture.Length; // captures + registers
@@ -1121,7 +1127,7 @@ internal static class RegExpInterpreter
                         if (--interruptCounter <= 0)
                         {
                             interruptCounter = InterruptCounterInit;
-                            cancellationToken.ThrowIfCancellationRequested();
+                            CheckDeadline(deadline);
                         }
                         break;
                     }
@@ -1438,7 +1444,7 @@ internal static class RegExpInterpreter
                             if (--interruptCounter <= 0)
                             {
                                 interruptCounter = InterruptCounterInit;
-                                cancellationToken.ThrowIfCancellationRequested();
+                                CheckDeadline(deadline);
                             }
                         }
                         break;
@@ -1465,7 +1471,7 @@ internal static class RegExpInterpreter
                             if (--interruptCounter <= 0)
                             {
                                 interruptCounter = InterruptCounterInit;
-                                cancellationToken.ThrowIfCancellationRequested();
+                                CheckDeadline(deadline);
                             }
                         }
                         else
@@ -1617,7 +1623,7 @@ internal static class RegExpInterpreter
                                         if (--interruptCounter <= 0)
                                         {
                                             interruptCounter = InterruptCounterInit;
-                                            cancellationToken.ThrowIfCancellationRequested();
+                                            CheckDeadline(deadline);
                                         }
                                     }
                                 }
@@ -1645,7 +1651,7 @@ internal static class RegExpInterpreter
                                         if (--interruptCounter <= 0)
                                         {
                                             interruptCounter = InterruptCounterInit;
-                                            cancellationToken.ThrowIfCancellationRequested();
+                                            CheckDeadline(deadline);
                                         }
                                     }
                                 }
@@ -1778,12 +1784,33 @@ noMatch:
             if (--interruptCounter <= 0)
             {
                 interruptCounter = InterruptCounterInit;
-                cancellationToken.ThrowIfCancellationRequested();
+                CheckDeadline(deadline);
             }
         }
 
         } finally { ReturnStack(stackPooled); }
     }
+
+    /// <summary>
+    /// Enforce the match <paramref name="deadline"/> at an interrupt checkpoint. The deadline is an
+    /// absolute <see cref="Stopwatch.GetTimestamp"/> value checked inline on the interpreter's own
+    /// thread, rather than via a <see cref="System.Threading.CancellationTokenSource"/> timer whose
+    /// callback runs on the thread pool: under a saturated pool (e.g. parallel test runs) that
+    /// callback can be delayed for many seconds, deferring the abort far past the requested timeout.
+    /// The spinning interpreter thread is always scheduled, so an inline check aborts promptly
+    /// regardless of load — mirroring how .NET's <see cref="Regex"/> enforces <see cref="Regex.MatchTimeout"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void CheckDeadline(long deadline)
+    {
+        if (deadline != NoDeadline && Stopwatch.GetTimestamp() >= deadline)
+        {
+            ThrowRegexTimeout();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowRegexTimeout() => throw new OperationCanceledException();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowInvalidOpcode(RegExpOpcode opcode)


### PR DESCRIPTION
## Problem

The flaky test `RegExpTests.PreparedScriptHonorsRegexTimeoutForCustomEngine` intermittently fails on Windows CI ([example run](https://github.com/sebastienros/jint/actions/runs/29314972884/job/87026793560?pr=2683)):

```
Expected RegexMatchTimeoutException within 15s, took 17.5s
```

A 1s prepare-time regex timeout was observed to fire only after **17.5s**.

## Root cause

The custom (QuickJS-port) regex engine — used for patterns .NET `Regex` can't handle, like the catastrophic-backtracking `TestRegex` — enforced its match timeout with `new CancellationTokenSource(timeout)`. That source's timer callback runs on the **thread pool**. When the pool is saturated (parallel xUnit runs on a CI runner), the callback is starved and the token isn't cancelled until much later, so the interpreter keeps backtracking well past the requested timeout.

The delay is **unbounded** under load, so no test-side threshold can be made reliable while the timer approach stands — the fix has to be at the source.

I reproduced this directly under a flooded thread pool (net472):

| mechanism | observed abort latency for a 1s timeout |
|---|---|
| old: `CancellationTokenSource(1s)` timer | **25s+** (starved for the whole probe window) |
| new: inline `Stopwatch` deadline | **~1.3s** |

## Fix

Enforce the timeout with an inline monotonic deadline (`Stopwatch.GetTimestamp()`), checked at the interpreter's existing interrupt checkpoints (once per 10,000 opcodes) — exactly how .NET's own `Regex` enforces `MatchTimeout` (the code already claimed to "mirror" it). The interpreter thread is always scheduled while it spins, so the abort fires promptly regardless of pool pressure.

- `RegExpInterpreter` / `JintRegExpEngine`: thread a `long deadline` (absolute `Stopwatch.GetTimestamp()` value, `NoDeadline` = no timeout) instead of a `CancellationToken`; each checkpoint now calls `CheckDeadline(deadline)`.
- `RegExpPrototype.ExecuteWithTimeout` / `IsMatchWithTimeout`: compute the deadline from the configured timeout instead of allocating a `CancellationTokenSource` + timer per call. On expiry an `OperationCanceledException` is still mapped to the same rich `RegexMatchTimeoutException(input, source, timeout)`.

Bonus: removes a per-call `CancellationTokenSource` allocation + timer registration on the custom-engine path.

Internal-only change; no public API surface affected.

## Testing

- `Jint.Tests` full suite — net10.0 3597 / net472 3534, all green
- `Jint.Tests.PublicInterface` — 114/114 on both TFMs
- Test262 `~RegExp` subset — 3930/0
- Verified `TestRegex` still routes to the custom engine after #2682's routing rework (so this test genuinely exercises the fixed path)
- The starvation reproduction above (1.3s vs 25s+) confirms the root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)