### PR TITLE
CI: cross-OS Test262 suite cache + action/tool version bumps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,9 @@ Jint.Tests.Test262/** linguist-vendored
 *.verified.txt text eol=lf
 *.received.cs text eol=lf
 *.received.txt text eol=lf
+
+# The Test262 generated suite is cached across operating systems, keyed on a hash of this
+# settings file. It must therefore be byte-identical on every platform: a CRLF Windows checkout
+# would change the cache key (hashFiles) and the MSBuild regeneration gate, turning every
+# cross-OS cache restore into a full regeneration.
+Jint.Tests.Test262/Test262Harness.settings.json text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,13 +24,15 @@ jobs:
         dotnet-version: 10.0
 
     - name: Checkout source code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Cache Test262 generated suite
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: Jint.Tests.Test262/Generated
         key: test262-generated-${{ hashFiles('Jint.Tests.Test262/Test262Harness.settings.json') }}
+        # Seed a cross-OS cache so the PR workflow's Windows/macOS/ARM jobs can restore it too.
+        enableCrossOsArchive: true
 
     - name: Test
       run: dotnet test --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,13 +38,17 @@ jobs:
         dotnet-version: 10.0
 
     - name: Checkout source code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Cache Test262 generated suite
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: Jint.Tests.Test262/Generated
         key: test262-generated-${{ hashFiles('Jint.Tests.Test262/Test262Harness.settings.json') }}
+        # The generated suite is pure codegen (identical on every OS), so share one cache across
+        # platforms. Without this, only the Build workflow (Linux) ever seeds the cache and the
+        # Windows/macOS/ARM jobs regenerate the whole suite on every run.
+        enableCrossOsArchive: true
 
     - name: Test
       run: dotnet test --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"

--- a/Jint.Tests.Test262/.config/dotnet-tools.json
+++ b/Jint.Tests.Test262/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "test262harness.console": {
-      "version": "1.0.6",
+      "version": "1.1.0",
       "commands": [
         "test262"
       ]


### PR DESCRIPTION
A focused, structure-preserving subset of #2661 — **no sharding**, so the workflow keeps one job per OS (the `linux` / `linux - ARM` / `windows` / `macos` checks are unchanged and still report).

## Caching fix

The generated Test262 suite is pure codegen and byte-identical on every platform, but the cache is effectively OS-scoped and only the **Build** workflow (Linux) ever seeds it. So the PR workflow's **Windows / macOS / ARM** jobs never get a cache hit and regenerate the whole ~99.5k-case suite on every run.

Marking the cache `enableCrossOsArchive: true` (on both the Build seed and the PR restore) lets every OS restore the one Linux-seeded cache. The cache key and cache action version are otherwise unchanged.

The `.gitattributes` change is required for this: the cache key hashes `Test262Harness.settings.json`, which currently checks out **CRLF on Windows** (`* text=auto`), so without pinning it to LF the Windows key wouldn't match the Linux-seeded entry (and the MSBuild regeneration gate would also differ) — defeating the cross-OS restore.

> Note: on a PR that *changes* the settings file the four jobs cold-miss together and one wins the cache save (the others log a harmless "another job may be creating this cache"). That's cosmetic and infrequent; the common case (settings unchanged) is a warm hit with no generation. Fully removing even that cosmetic race needs a dedicated generate job, which is part of the sharding PR.

## Version bumps

- `test262harness.console` 1.0.6 → **1.1.0**
- `actions/checkout` v6 → **v7**
- `actions/cache` v5 → **v6**

🤖 Generated with [Claude Code](https://claude.com/claude-code)