### PR TITLE
Extend the tight-loop lane to while and do-while statements

### DIFF
--- a/Jint.Benchmark/FunctionLocalNumberLoopBenchmark.cs
+++ b/Jint.Benchmark/FunctionLocalNumberLoopBenchmark.cs
@@ -17,6 +17,8 @@ public class FunctionLocalNumberLoopBenchmark
     private Prepared<Script> _largeIntCounter;
     private Prepared<Script> _accumulatorWithCallArg;
     private Prepared<Script> _mixedArithmetic;
+    private Prepared<Script> _whileAccumulator;
+    private Prepared<Script> _doWhileCounter;
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -77,11 +79,41 @@ public class FunctionLocalNumberLoopBenchmark
             f();
             """);
 
+        // the while/do-while twins of the for-loop accumulator: same tight-lane body shapes,
+        // different loop statements
+        _whileAccumulator = Engine.PrepareScript("""
+            function f() {
+                var s = 0.5;
+                var i = 0;
+                while (i < 100000) {
+                    s += 0.25;
+                    i++;
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _doWhileCounter = Engine.PrepareScript("""
+            function f() {
+                var n = 0;
+                var i = 0;
+                do {
+                    n += 1;
+                    i++;
+                } while (i < 100000);
+                return n;
+            }
+            f();
+            """);
+
         _engine = new Engine();
         _engine.Evaluate(_doubleAccumulator);
         _engine.Evaluate(_largeIntCounter);
         _engine.Evaluate(_accumulatorWithCallArg);
         _engine.Evaluate(_mixedArithmetic);
+        _engine.Evaluate(_whileAccumulator);
+        _engine.Evaluate(_doWhileCounter);
     }
 
     [Benchmark]
@@ -95,4 +127,10 @@ public class FunctionLocalNumberLoopBenchmark
 
     [Benchmark]
     public JsValue MixedArithmetic() => _engine.Evaluate(_mixedArithmetic);
+
+    [Benchmark]
+    public JsValue WhileAccumulator() => _engine.Evaluate(_whileAccumulator);
+
+    [Benchmark]
+    public JsValue DoWhileCounter() => _engine.Evaluate(_doWhileCounter);
 }

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -12,15 +12,53 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
     private readonly string? _labelSetName;
     private readonly JintExpression _test;
 
+    // Tight-lane state, mirroring JintWhileStatement (see there for the eligibility rationale).
+    private readonly bool _tightBodyEligible;
+    private readonly JintStatement? _tightSingleStatement;
+    private readonly JintStatementList? _tightBodyList;
+
     public JintDoWhileStatement(DoWhileStatement statement) : base(statement)
     {
         _body = new ProbablyBlockStatement(statement.Body);
         _test = JintExpression.Build(statement.Test);
         _labelSetName = statement.LabelSet?.Name;
+
+        if (JintForStatement.IsTightBodyShape(statement.Body))
+        {
+            if (_body.BlockStatement is { } bodyBlock)
+            {
+                if (bodyBlock.State.Declarations.Count == 0)
+                {
+                    _tightBodyEligible = true;
+                    // single-statement blocks live in SingleStatement, larger (and empty) ones in the list
+                    _tightSingleStatement = bodyBlock.SingleStatement;
+                    _tightBodyList = _tightSingleStatement is null ? bodyBlock.StatementList : null;
+                }
+            }
+            else
+            {
+                _tightBodyEligible = true;
+                if (_body.Statement is not JintEmptyStatement)
+                {
+                    // an EmptyStatement body leaves both references null (nothing to run per iteration)
+                    _tightSingleStatement = _body.Statement;
+                }
+            }
+        }
     }
 
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
+        // Same gate as the while/for tight lanes; see JintWhileStatement.ExecuteInternal.
+        if (_tightBodyEligible
+            && !context.CompletionValuesObservable
+            && !context.ShouldRunPerStatementChecks
+            && !context.DebugMode
+            && context.Engine.ExecutionContext.Suspendable is null)
+        {
+            return TightDoWhileBody(context);
+        }
+
         JsValue v = JsValue.Undefined;
         bool iterating;
         var suspensionNode = GetSuspensionNode(context.Engine.ExecutionContext.Suspendable);
@@ -84,5 +122,47 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
         } while (iterating);
 
         return new Completion(CompletionType.Normal, v, ((JintStatement) this)._statement);
+    }
+
+    /// <summary>
+    /// The bare per-iteration loop for structurally-Normal bodies — the do-while twin of
+    /// <see cref="JintWhileStatement"/>'s tight lane (body first, then test); see there for the
+    /// deferred-error and amortized-constraint reasoning.
+    /// </summary>
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private Completion TightDoWhileBody(EvaluationContext context)
+    {
+        var test = _test;
+        var single = _tightSingleStatement;
+        var list = _tightBodyList;
+        var engine = context.Engine;
+
+        do
+        {
+            context.RunAmortizedConstraintChecks();
+
+            if (single is not null)
+            {
+                single.ExecuteDiscarded(context);
+                if (engine._error is not null)
+                {
+                    return JintStatementList.HandleError(engine, single);
+                }
+            }
+            else if (list is not null)
+            {
+                for (var i = 0; i < list.Count; i++)
+                {
+                    var statement = list.GetStatement(i);
+                    statement.ExecuteDiscarded(context);
+                    if (engine._error is not null)
+                    {
+                        return JintStatementList.HandleError(engine, statement);
+                    }
+                }
+            }
+        } while (test.GetBooleanValue(context));
+
+        return new Completion(CompletionType.Normal, JsValue.Undefined, _statement);
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -165,9 +165,10 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
     /// expression statements, empty statements, var/let/const declarations, and if/else chains
     /// over such statements (including declaration-free brace blocks). Control flow that routes
     /// completions (break/continue/return/labels/loops/switch/try), other declarations, and
-    /// AnnexB function-declaration branches all disqualify the body.
+    /// AnnexB function-declaration branches all disqualify the body. Shared with the while and
+    /// do-while tight lanes, which apply the same predicate to their bodies.
     /// </summary>
-    private static bool IsTightBodyShape(Statement body)
+    internal static bool IsTightBodyShape(Statement body)
     {
         if (body is NestedBlockStatement block)
         {

--- a/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
@@ -12,15 +12,59 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
     private readonly ProbablyBlockStatement _body;
     private readonly JintExpression _test;
 
+    // Tight-lane state, mirroring JintForStatement: a structurally-Normal body executes via
+    // ExecuteDiscarded with no per-statement ceremony. While has no loop-env flattening
+    // machinery, so bodies with lexical declarations (which need a fresh block environment
+    // per iteration) stay on the generic path.
+    private readonly bool _tightBodyEligible;
+    private readonly JintStatement? _tightSingleStatement;
+    private readonly JintStatementList? _tightBodyList;
+
     public JintWhileStatement(WhileStatement statement) : base(statement)
     {
         _labelSetName = statement.LabelSet?.Name;
         _body = new ProbablyBlockStatement(statement.Body);
         _test = JintExpression.Build(statement.Test);
+
+        if (JintForStatement.IsTightBodyShape(statement.Body))
+        {
+            if (_body.BlockStatement is { } bodyBlock)
+            {
+                if (bodyBlock.State.Declarations.Count == 0)
+                {
+                    _tightBodyEligible = true;
+                    // single-statement blocks live in SingleStatement, larger (and empty) ones in the list
+                    _tightSingleStatement = bodyBlock.SingleStatement;
+                    _tightBodyList = _tightSingleStatement is null ? bodyBlock.StatementList : null;
+                }
+            }
+            else
+            {
+                _tightBodyEligible = true;
+                if (_body.Statement is not JintEmptyStatement)
+                {
+                    // an EmptyStatement body leaves both references null (nothing to run per iteration)
+                    _tightSingleStatement = _body.Statement;
+                }
+            }
+        }
     }
 
     protected override Completion ExecuteInternal(EvaluationContext context)
     {
+        // Same gate as JintForStatement.ForBodyEvaluation: with a structurally-Normal body,
+        // a non-suspendable frame, no per-statement (exact) constraint/debug checks and dead
+        // completion values, nothing per iteration remains observable but the test and the
+        // body expressions. Amortized constraints stay live through the shared countdown.
+        if (_tightBodyEligible
+            && !context.CompletionValuesObservable
+            && !context.ShouldRunPerStatementChecks
+            && !context.DebugMode
+            && context.Engine.ExecutionContext.Suspendable is null)
+        {
+            return TightWhileBody(context);
+        }
+
         var v = JsValue.Undefined;
         var suspensionNode = GetSuspensionNode(context.Engine.ExecutionContext.Suspendable);
         var skipTestOnce = suspensionNode is not null && IsNodeInsideRange(suspensionNode, _statement.Body.Range);
@@ -81,5 +125,50 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// The bare per-iteration loop for structurally-Normal bodies: test, discarded body
+    /// statements, deferred-error polls — nothing else. The loop's Normal completion value is
+    /// dead by the caller's gate, so Undefined stands in. Deferred errors surface as
+    /// Engine._error and convert per statement, exactly as JintStatementList would. Amortized
+    /// constraints are driven once per iteration through the context's shared countdown; exact
+    /// constraints and debug mode never reach this lane by the caller's gate.
+    /// </summary>
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private Completion TightWhileBody(EvaluationContext context)
+    {
+        var test = _test;
+        var single = _tightSingleStatement;
+        var list = _tightBodyList;
+        var engine = context.Engine;
+
+        while (test.GetBooleanValue(context))
+        {
+            context.RunAmortizedConstraintChecks();
+
+            if (single is not null)
+            {
+                single.ExecuteDiscarded(context);
+                if (engine._error is not null)
+                {
+                    return JintStatementList.HandleError(engine, single);
+                }
+            }
+            else if (list is not null)
+            {
+                for (var i = 0; i < list.Count; i++)
+                {
+                    var statement = list.GetStatement(i);
+                    statement.ExecuteDiscarded(context);
+                    if (engine._error is not null)
+                    {
+                        return JintStatementList.HandleError(engine, statement);
+                    }
+                }
+            }
+        }
+
+        return new Completion(CompletionType.Normal, JsValue.Undefined, _statement);
     }
 }


### PR DESCRIPTION
## Summary

`for`-loops with structurally-Normal bodies (expression statements, var/let/const, if/else chains — nothing that routes a break/continue/return/label) bypass per-iteration completion bookkeeping, suspension probes and per-statement ceremony via `JintForStatement.TightForBody`. `while` and `do-while` loops with the identical body shapes still paid all of it — a `Completion` struct and value-liveness check per iteration, two suspendable probes, and full `_body.Execute` dispatch.

This extends the same lane to `while` and `do-while`: the shared `IsTightBodyShape` predicate decides eligibility, and eligible bodies run through the same `ExecuteDiscarded` path — test, discarded body statements and a deferred-error poll per iteration, with amortized constraints (timeout/cancellation/memory) driven through the existing shared countdown. Bodies with lexical declarations stay on the generic path (while/do-while have no loop-env flattening machinery, so a `let` still needs its per-iteration block environment), as do observable-completion contexts (eval/global completion values), debug mode, exact constraints and suspendable (generator/async) frames.

## Benchmarks (default jobs, adjacent A/B on latest main)

New `FunctionLocalNumberLoopBenchmark` rows (the while/do-while twins of the existing for-loop accumulators; committed alongside):

| Benchmark | main | PR | Δ |
|---|---:|---:|---:|
| WhileAccumulator | 5.807 ms | 2.496 ms | **−57.0%** |
| DoWhileCounter | 6.298 ms | 2.299 ms | **−63.5%** |

Allocations unchanged (904 B both sides — the lane removes per-iteration `Completion` structs, which don't allocate).

SunSpider rows with while loops (crypto-md5/sha1, string-unpack-code, bitops-nsieve-bits, string-tagcloud) are **neutral** — their hot loops are for-loops or top-level while loops whose completion values are observable, so they don't hit the new lane; this PR targets function-local while/do-while, which the suite otherwise didn't cover.

## Semantics (12-case REPL verification, cold + cache-armed)

while/do-while sums, do-while runs body once when test false, break/continue/labeled-continue bodies stay generic and correct, `let` in body forces the generic path with correct closures, observable completion values (eval) force generic path, empty body with side-effectful test, exceptions propagate from tight bodies with correct loop state.

## Gates

- Jint.Tests: 3,597 (net10.0) + 3,534 (net472) passed, 0 failed
- Jint.Tests.PublicInterface: 114 × 2 TFMs passed
- Jint.Tests.CommonScripts: 28 × 2 TFMs passed
- Test262: 99,429 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
