### PR TITLE
Restructure identifier slot-cache hot paths as hop-0-first

### DIFF
--- a/Jint/Runtime/Environments/SlotLocationCache.cs
+++ b/Jint/Runtime/Environments/SlotLocationCache.cs
@@ -50,48 +50,62 @@ internal struct SlotLocationCache
         out DeclarativeEnvironment slotEnv,
         out int slotIndex)
     {
+        // Hop 0 first: the overwhelmingly common case is that the cached env IS the current
+        // lexical environment, so it gets a straight-line identity check before any loop
+        // machinery and needs no shadow probes — no environment sits between the reader and
+        // the binding. The engine-identity gate stays in front so a cached env from another
+        // engine (handler trees shared via Prepared<Script>) is never dereferenced for slots.
         var cached = _cachedSlotEnv;
-        if (cached is not null && ReferenceEquals(cached._engine, engine))
+        if (cached is not null && ReferenceEquals(cached._engine, engine) && ReferenceEquals(env, cached))
         {
-            var search = env;
-            for (var hops = 0; hops < MaxChainDepth && search is not null; hops++)
-            {
-                if (ReferenceEquals(search, cached))
-                {
-                    slotEnv = cached;
-                    slotIndex = _cachedSlotIndex;
-                    return true;
-                }
-
-                if (search is ObjectEnvironment)
-                {
-                    // a with-object between us and the cached slot may shadow the name dynamically
-                    break;
-                }
-
-                // An intermediate environment holding the name shadows the cached resolution.
-                // This happens when a node runs under a different chain than the one that
-                // populated the cache (an eval-cache-shared body under a block that declares
-                // the name, or a nested eval of the same source) or when a sloppy direct eval
-                // injected the name into an enclosing function environment. HasBinding on a
-                // declarative environment is pure, and the common case — the binding env
-                // itself, matched above before any probe — pays nothing.
-                if (search is DeclarativeEnvironment intermediate && intermediate.HasBinding(name.Key))
-                {
-                    break;
-                }
-
-                search = search._outerEnv;
-            }
-
-            // The cached location is not reachable from this chain. Handler trees are shared
-            // across function instances (per-engine definition reuse for re-evaluated scripts,
-            // class members, nested declarations), so the same node runs under a fresh
-            // environment per instance — re-resolve against the current chain exactly as a
-            // fresh node would (mirroring the cross-engine Prepared<Script> fall-through
-            // below) instead of declining forever. One bounded walk per instance switch;
-            // subsequent reads hit the re-populated cache.
+            slotEnv = cached;
+            slotIndex = _cachedSlotIndex;
+            return true;
         }
+
+        // Permanently declined nodes (binding can never be slot-stored) also answer inline:
+        // consuming lanes re-ask on every evaluation, so the miss must not pay a call.
+        if (cached is null && _disabled)
+        {
+            slotEnv = null!;
+            slotIndex = -1;
+            return false;
+        }
+
+        return TryResolveNonLocal(engine, env, name, out slotEnv, out slotIndex);
+    }
+
+    /// <summary>
+    /// Out-of-line tail for everything that is not a hop-0 hit or a permanent decline: the
+    /// bounded hops 1-3 reachability walk, the decline check for nodes with a stale cached
+    /// env, and first-time population. Kept out of <see cref="TryResolve"/> so the
+    /// aggressively-inlined fast path stays small in every consuming lane.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool TryResolveNonLocal(
+        Engine engine,
+        Environment env,
+        Environment.BindingName name,
+        out DeclarativeEnvironment slotEnv,
+        out int slotIndex)
+    {
+        var cached = _cachedSlotEnv;
+        if (cached is not null
+            && ReferenceEquals(cached._engine, engine)
+            && CanReachAtOuterHop(env, cached, name.Key))
+        {
+            slotEnv = cached;
+            slotIndex = _cachedSlotIndex;
+            return true;
+        }
+
+        // The cached location is not reachable from this chain. Handler trees are shared
+        // across function instances (per-engine definition reuse for re-evaluated scripts,
+        // class members, nested declarations), so the same node runs under a fresh
+        // environment per instance — re-resolve against the current chain exactly as a
+        // fresh node would (mirroring the cross-engine Prepared<Script> fall-through
+        // below) instead of declining forever. One bounded walk per instance switch;
+        // subsequent reads hit the re-populated cache.
 
         if (_disabled)
         {
@@ -101,6 +115,51 @@ internal struct SlotLocationCache
         }
 
         return ResolveAndPopulate(env, name, out slotEnv, out slotIndex);
+    }
+
+    /// <summary>
+    /// Bounded hops 1-3 reachability walk for a slot-cache probe whose caller has already
+    /// rejected hop 0 (<paramref name="env"/> itself is not <paramref name="cached"/>).
+    /// Because hop 0 failed, the current environment sits BETWEEN the reader and the cached
+    /// env and must be probed like any other intermediate before hopping outward.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal static bool CanReachAtOuterHop(Environment env, DeclarativeEnvironment cached, Key key)
+    {
+        var search = env;
+        for (var hops = 1; hops < MaxChainDepth; hops++)
+        {
+            if (search is ObjectEnvironment)
+            {
+                // a with-object between us and the cached slot may shadow the name dynamically
+                return false;
+            }
+
+            // An intermediate environment holding the name shadows the cached resolution.
+            // This happens when a node runs under a different chain than the one that
+            // populated the cache (an eval-cache-shared body under a block that declares
+            // the name, or a nested eval of the same source) or when a sloppy direct eval
+            // injected the name into an enclosing function environment. HasBinding on a
+            // declarative environment is pure, and the common case — a hop-0 hit on the
+            // binding env itself — never enters this walk at all.
+            if (search is DeclarativeEnvironment intermediate && intermediate.HasBinding(key))
+            {
+                return false;
+            }
+
+            search = search._outerEnv;
+            if (search is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(search, cached))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -154,56 +154,39 @@ internal sealed class JintIdentifierExpression : JintExpression
         var strict = StrictModeScope.IsStrictModeCode;
         JsValue? value;
 
-        // Slot-cache fast path: walk from the current env up the chain looking for the cached
-        // resolving env via ReferenceEquals; the common case matches at hop 0 without any
-        // probing. When found, read the slot value directly.
+        // Slot-cache fast path, hop 0 first: the overwhelmingly common case is that the
+        // cached resolving env IS the current lexical environment, so it gets a straight-line
+        // identity check before any loop machinery and needs no shadow probes — no environment
+        // sits between the reader and the binding. Reads at hops 1-3 (closure reads of outer
+        // bindings) take the out-of-line bounded walk, which re-probes every intermediate
+        // declarative environment and refuses to cross an ObjectEnvironment; see
+        // SlotLocationCache for why those probes are load-bearing.
         // Engine-identity gate: a Prepared<Script> reused across multiple Engine instances
         // shares JintIdentifierExpression nodes, so the cached env may be from a previous
-        // Engine. Skipping the walk when engines differ avoids 4 wasted hops per call —
+        // Engine and must not be dereferenced for slots. Gating up front also skips the walk —
         // significant on harnesses (DromaeoBenchmark, SunSpiderBenchmark) that create a
         // new Engine per iteration.
         var cachedSlotEnv = _cachedSlotEnv;
         if (cachedSlotEnv is not null && ReferenceEquals(cachedSlotEnv._engine, engine))
         {
-            var search = env;
-            for (var hops = 0; hops < MaxSlotCacheChainDepth && search is not null; hops++)
+            if (ReferenceEquals(env, cachedSlotEnv)
+                || SlotLocationCache.CanReachAtOuterHop(env, cachedSlotEnv, identifier.Key))
             {
-                if (ReferenceEquals(search, cachedSlotEnv))
+                var slots = cachedSlotEnv._slots;
+                var idx = _cachedSlotIndex;
+                if (slots is not null && (uint) idx < (uint) slots.Length)
                 {
-                    var slots = cachedSlotEnv._slots;
-                    var idx = _cachedSlotIndex;
-                    if (slots is not null && (uint) idx < (uint) slots.Length)
+                    ref var binding = ref slots[idx];
+                    value = binding.HasReferenceValue
+                        ? binding.Value
+                        : DeclarativeEnvironment.MaterializeUnboxedOrNull(ref binding);
+                    if (value is null)
                     {
-                        ref var binding = ref slots[idx];
-                        value = binding.HasReferenceValue
-                            ? binding.Value
-                            : DeclarativeEnvironment.MaterializeUnboxedOrNull(ref binding);
-                        if (value is null)
-                        {
-                            ThrowNotInitialized(engine);
-                        }
-                        return MaterializeIfArguments(value);
+                        ThrowNotInitialized(engine);
                     }
-                    break;
+                    return MaterializeIfArguments(value);
                 }
-
-                if (search is ObjectEnvironment)
-                {
-                    // a with-object between us and the cached slot may shadow the name
-                    // dynamically; only the full resolution can decide who owns the binding
-                    break;
-                }
-
-                // An intermediate environment holding the name shadows the cached resolution
-                // (an eval-cache-shared body under a shadowing block, a nested eval of the
-                // same source, or a sloppy direct eval injecting the name into an enclosing
-                // function environment). HasBinding on a declarative environment is pure.
-                if (search is DeclarativeEnvironment intermediate && intermediate.HasBinding(identifier.Key))
-                {
-                    break;
-                }
-
-                search = search._outerEnv;
+                // stale slot metadata for a reachable env — fall through to full resolution
             }
         }
 


### PR DESCRIPTION
## Summary

`JintIdentifierExpression.GetValue` is the hottest single frame on numeric workloads (~7.8% self time). Its slot-cache fast lane walked up to 4 environment hops inside a `for` loop — with counter setup and per-iteration shadowing probes — even though the overwhelmingly common case is hop 0, where the cached environment *is* the current lexical environment and no environment sits between the reader and the binding.

Restructure both the identifier lane and the shared `SlotLocationCache.TryResolve` (which is `AggressiveInlining` into every arithmetic/comparison/bitwise lane) so hop 0 is a straight-line `ReferenceEquals` check with **zero probes**, and the bounded multi-hop walk (hops 1–3) moves to a single shared `NoInlining` helper `CanReachAtOuterHop`. That helper preserves the load-bearing shadowing rules verbatim: it probes the now-intervening current env, refuses to cross `ObjectEnvironment`s, and `HasBinding`-probes every intermediate `DeclarativeEnvironment`. The engine-identity gate ordering is unchanged.

Behavior is bit-for-bit identical — pure control-flow restructuring. The win is twofold: hop 0 loses its loop preamble and becomes branch-predictable, and the ~50-instruction walk leaves `GetValue`'s body and every inlined `TryResolve` site (8 binary lanes, 4 assignment lanes, updates, `TryReadNumber`), shrinking inlined code size.

## Benchmarks (default jobs, adjacent A/B on latest main)

Tight function-local loops where the slot resolves at hop 0 every iteration:

| Benchmark | main | PR | Δ |
|---|---:|---:|---:|
| PlainNumericAssign SumAssign | 23.64 ms | 21.19 ms | **−10.4%** |
| FunctionLocalNumberLoop DoubleAccumulator | 2.252 ms | 2.047 ms | **−9.1%** |
| FunctionLocalNumberLoop LargeIntCounter | 2.212 ms | 2.034 ms | **−8.0%** |
| PlainNumericAssign Mixed | 38.27 ms | 35.19 ms | **−8.0%** |
| PlainNumericAssign DivAssign | 32.39 ms | 30.65 ms | **−5.4%** |
| FunctionLocalNumberLoop MixedArithmetic | 9.315 ms | 9.271 ms | neutral |
| FunctionLocalNumberLoop AccumulatorWithCallArg | 20.83 ms | 21.21 ms | neutral |

Neutral on call/multi-op-dominated rows (identifier reads aren't the bottleneck there) and on top-level SunSpider scripts (globals, not slots). Allocations unchanged.

## Gates

- Jint.Tests: 3,597 (net10.0) + 3,534 (net472) passed, 0 failed
- Jint.Tests.PublicInterface: 114 × 2 TFMs passed
- Jint.Tests.CommonScripts: 28 × 2 TFMs passed
- Test262: 99,429 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
