### PR TITLE
Adaptively upgrade reused .NET regex adaptations to RegexOptions.Compiled

### DIFF
--- a/Jint.Tests/Runtime/ScriptModulePreparationTests.ScriptPreparation.cs
+++ b/Jint.Tests/Runtime/ScriptModulePreparationTests.ScriptPreparation.cs
@@ -25,7 +25,7 @@ public class ScriptModulePreparationTests
         // Regex is pre-compiled during preparation with Compiled flag
         var conversionOptions = init.ParseResult.AdditionalData as Engine.RegexConversionOptions;
         conversionOptions.Should().NotBeNull();
-        conversionOptions.Compiled.Should().BeTrue();
+        conversionOptions.Compilation.Should().Be(Jint.Native.RegExp.RegexCompilation.Compiled);
 
         // Prepared script executes correctly
         new Engine().Evaluate(script).AsNumber().Should().Be(1);

--- a/Jint/Engine.Defaults.cs
+++ b/Jint/Engine.Defaults.cs
@@ -1,4 +1,5 @@
 using Jint.Native.Function;
+using Jint.Native.RegExp;
 
 namespace Jint;
 
@@ -23,26 +24,33 @@ public partial class Engine
     internal static readonly TimeSpan DefaultRegexTimeout = TimeSpan.FromSeconds(10);
 
     /// <summary>
-    /// Cached OnRegExp handler for <see cref="DefaultRegexTimeout"/> (interpreted .NET Regex).
+    /// OnRegExp handler for <see cref="DefaultRegexTimeout"/> (interpreted .NET Regex).
     /// </summary>
     internal static OnRegExpHandler DefaultConvertRegExpHandler
-        => CreateRegExpHandler(compiled: false, DefaultRegexTimeout);
+        => CreateRegExpHandler(RegexCompilation.Interpreted, DefaultRegexTimeout);
 
     /// <summary>
-    /// Cached OnRegExp handler for <see cref="DefaultRegexTimeout"/> (compiled .NET Regex).
+    /// OnRegExp handler for <see cref="DefaultRegexTimeout"/> (eagerly compiled .NET Regex).
     /// </summary>
     internal static OnRegExpHandler DefaultCompileRegExpHandler
-        => CreateRegExpHandler(compiled: true, DefaultRegexTimeout);
+        => CreateRegExpHandler(RegexCompilation.Compiled, DefaultRegexTimeout);
+
+    /// <summary>
+    /// OnRegExp handler for <see cref="DefaultRegexTimeout"/> (interpreted .NET Regex, upgraded to
+    /// compiled on reuse; see <see cref="RegexCompilation.Adaptive"/>).
+    /// </summary>
+    internal static OnRegExpHandler DefaultAdaptiveRegExpHandler
+        => CreateRegExpHandler(RegexCompilation.Adaptive, DefaultRegexTimeout);
 
     /// <summary>
     /// Creates an OnRegExp handler with a caller-specified timeout.
     /// </summary>
-    internal static OnRegExpHandler CreateRegExpHandler(bool compiled, TimeSpan timeout)
-        => new RegexConversionOptions(compiled, timeout).HandleOnRegExp;
+    internal static OnRegExpHandler CreateRegExpHandler(RegexCompilation compilation, TimeSpan timeout)
+        => new RegexConversionOptions(compilation, timeout).HandleOnRegExp;
 
-    internal sealed class RegexConversionOptions(bool compiled, TimeSpan timeout)
+    internal sealed class RegexConversionOptions(RegexCompilation compilation, TimeSpan timeout)
     {
-        public bool Compiled { get; } = compiled;
+        public RegexCompilation Compilation { get; } = compilation;
         public TimeSpan Timeout { get; } = timeout;
 
         internal RegExpParseResult HandleOnRegExp(in RegExpParsingContext ctx)

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -473,8 +473,18 @@ public sealed partial class RegExpConstructor : Constructor
 
         if (!NeedCustomEngine(p, f))
         {
+            // Dynamic patterns are data-driven and may never repeat, so they are never compiled eagerly:
+            // Adaptive interprets a pattern on its first construction and upgrades to RegexOptions.Compiled
+            // only once the process-wide cache proves reuse, which amortizes the one-time compilation cost.
+            // An explicit CompileRegex = false on the active parsing options (honored via the conversion
+            // options instance the OnRegExp handler is bound to) opts out entirely. The timeout source is
+            // intentionally left unchanged so MatchTimeout semantics stay exactly as before.
+            var compilation = (parserOptions.OnRegExp?.Target as Engine.RegexConversionOptions)?.Compilation == RegexCompilation.Interpreted
+                ? RegexCompilation.Interpreted
+                : RegexCompilation.Adaptive;
+
 #pragma warning disable CS0618 // ParserOptions.RegexTimeout is obsolete but is the supported timeout source.
-            regExpParseResult = RegExpParseCache.GetOrAdapt(p, f, compiled: false, parserOptions.RegexTimeout);
+            regExpParseResult = RegExpParseCache.GetOrAdapt(p, f, compilation, parserOptions.RegexTimeout);
 #pragma warning restore CS0618
 
             if (regExpParseResult.Success)

--- a/Jint/Native/RegExp/RegExpParseCache.cs
+++ b/Jint/Native/RegExp/RegExpParseCache.cs
@@ -1,9 +1,39 @@
 using System.Collections.Concurrent;
+using System.Threading;
 
 namespace Jint.Native.RegExp;
 
 /// <summary>
-/// Process-wide bounded cache of compiled .NET <see cref="System.Text.RegularExpressions.Regex"/> adaptations
+/// How the .NET <see cref="System.Text.RegularExpressions.Regex"/> instances produced for JavaScript
+/// patterns are code-generated. The trade-off (measured on .NET 10): a compiled regex matches
+/// scan-heavy inputs roughly 2-16x faster than the built-in regex interpreter, but costs ~1.4 ms to
+/// construct and JIT versus ~3 us interpreted, so compilation only pays off for reused patterns.
+/// Under Native AOT the runtime silently ignores <see cref="System.Text.RegularExpressions.RegexOptions.Compiled"/>,
+/// making all three modes equivalent to <see cref="Interpreted"/> there.
+/// </summary>
+internal enum RegexCompilation : byte
+{
+    /// <summary>Always use the .NET regex interpreter (explicit <c>CompileRegex = false</c>).</summary>
+    Interpreted,
+
+    /// <summary>
+    /// Construct with <see cref="System.Text.RegularExpressions.RegexOptions.Compiled"/> eagerly
+    /// (explicit <c>CompileRegex = true</c> and the prepared script/module default, where reuse is declared).
+    /// </summary>
+    Compiled,
+
+    /// <summary>
+    /// Interpret a pattern on its first constructions and upgrade to
+    /// <see cref="System.Text.RegularExpressions.RegexOptions.Compiled"/> when the same pattern keeps
+    /// being constructed — at that point <see cref="RegExpParseCache"/> has proven reuse, so the one-time
+    /// compilation cost is amortized. One-shot patterns (cold-start scripts, data-driven
+    /// <c>new RegExp(...)</c> floods) never pay it.
+    /// </summary>
+    Adaptive,
+}
+
+/// <summary>
+/// Process-wide bounded cache of .NET <see cref="System.Text.RegularExpressions.Regex"/> adaptations
 /// (wrapped in Acornima's <c>RegExpParseResult</c>), keyed by the inputs that fully determine the result:
 /// pattern, flags, the compiled-codegen flag and the match timeout.
 /// <para>
@@ -14,9 +44,15 @@ namespace Jint.Native.RegExp;
 /// and thread-safe (match state lives on the JS RegExp instance / returned Match, not on the Regex).
 /// </para>
 /// <para>
+/// The cache also drives <see cref="RegexCompilation.Adaptive"/> tiering: the first construction of a
+/// pattern populates the interpreted lane, and once enough further constructions of the same pattern
+/// prove reuse it is upgraded to a compiled regex (dropping the interpreted entry).
+/// </para>
+/// <para>
 /// The cache is bounded: once it reaches <see cref="Capacity"/> distinct entries it is cleared and rebuilt,
 /// so a workload generating unboundedly many distinct patterns can never grow it without limit. Typical
-/// scripts use a small, stable set of patterns and fill it once.
+/// scripts use a small, stable set of patterns and fill it once. A clear also resets adaptive reuse
+/// tracking, which keeps distinct-pattern floods on the cheap interpreted path.
 /// </para>
 /// </summary>
 internal static class RegExpParseCache
@@ -25,9 +61,29 @@ internal static class RegExpParseCache
     // and self-healing when the working set shifts. Real scripts rarely approach this many distinct regexes.
     private const int Capacity = 256;
 
-    private static readonly ConcurrentDictionary<Key, RegExpParseResult> _cache = new();
+    // Number of adaptive re-constructions (hits on an interpreted entry) required before upgrading to a
+    // compiled regex, i.e. the upgrade happens on the (AdaptiveUpgradeThreshold + 1)th construction.
+    // Deliberately above the two sightings produced by running the same one-shot script twice (e.g.
+    // Test262's strict + sloppy dual runs of tests that eval tens of thousands of distinct literals,
+    // which would otherwise mass-upgrade under parallel lockstep); genuinely hot patterns sail past it.
+    private const int AdaptiveUpgradeThreshold = 2;
+
+    private static readonly ConcurrentDictionary<Key, Entry> _cache = new();
 
     private readonly record struct Key(string Pattern, string Flags, bool Compiled, long TimeoutTicks);
+
+    private sealed class Entry
+    {
+        public Entry(in RegExpParseResult result)
+        {
+            Result = result;
+        }
+
+        public readonly RegExpParseResult Result;
+
+        /// <summary>Number of adaptive re-constructions observed since the entry was created.</summary>
+        public int AdaptiveHits;
+    }
 
     /// <summary>
     /// Returns a cached adaptation for the given regex inputs, adapting (and caching on success) on a miss.
@@ -35,17 +91,57 @@ internal static class RegExpParseCache
     /// caller resolves per-realm. Callers must already have excluded custom-engine patterns
     /// (<see cref="RegExpConstructor.NeedCustomEngine"/>) before calling this.
     /// </summary>
-    public static RegExpParseResult GetOrAdapt(string pattern, string flags, bool compiled, TimeSpan timeout)
+    public static RegExpParseResult GetOrAdapt(string pattern, string flags, RegexCompilation compilation, TimeSpan timeout)
     {
-        var key = new Key(pattern, flags, compiled, timeout.Ticks);
-        if (_cache.TryGetValue(key, out var cached))
+        var compiledKey = new Key(pattern, flags, Compiled: true, timeout.Ticks);
+
+        if (compilation == RegexCompilation.Compiled)
         {
-            return cached;
+            return _cache.TryGetValue(compiledKey, out var cached) ? cached.Result : Adapt(compiledKey);
         }
 
+        var interpretedKey = compiledKey with { Compiled = false };
+
+        if (compilation == RegexCompilation.Interpreted)
+        {
+            return _cache.TryGetValue(interpretedKey, out var cached) ? cached.Result : Adapt(interpretedKey);
+        }
+
+        // RegexCompilation.Adaptive
+        if (_cache.TryGetValue(compiledKey, out var compiled))
+        {
+            return compiled.Result;
+        }
+
+        if (_cache.TryGetValue(interpretedKey, out var interpreted))
+        {
+            if (Interlocked.Increment(ref interpreted.AdaptiveHits) < AdaptiveUpgradeThreshold)
+            {
+                return interpreted.Result;
+            }
+
+            // Repeated construction of the same pattern: reuse is proven, so the one-time compilation cost
+            // is amortized from here on. Upgrade and drop the now-redundant interpreted entry.
+            var result = Adapt(compiledKey);
+            if (!result.Success)
+            {
+                // Shouldn't happen (the same pattern already adapted successfully), but never trade a
+                // working .NET adaptation for a custom-engine fallback.
+                return interpreted.Result;
+            }
+
+            _cache.TryRemove(interpretedKey, out _);
+            return result;
+        }
+
+        return Adapt(interpretedKey);
+    }
+
+    private static RegExpParseResult Adapt(in Key key)
+    {
 #pragma warning disable CS0618 // Tokenizer.AdaptRegExp is obsolete but is the supported adaptation entry point.
         var result = Tokenizer.AdaptRegExp(
-            pattern, flags, compiled, timeout, throwIfNotAdaptable: false,
+            key.Pattern, key.Flags, key.Compiled, TimeSpan.FromTicks(key.TimeoutTicks), throwIfNotAdaptable: false,
             Engine.BaseParserOptions.EcmaVersion, Engine.BaseParserOptions.ExperimentalESFeatures);
 #pragma warning restore CS0618
 
@@ -56,7 +152,7 @@ internal static class RegExpParseCache
                 _cache.Clear();
             }
 
-            _cache.TryAdd(key, result);
+            _cache.TryAdd(key, new Entry(result));
         }
 
         return result;

--- a/Jint/ParsingOptions.cs
+++ b/Jint/ParsingOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using Jint.Native.RegExp;
 
 namespace Jint;
 
@@ -8,12 +9,16 @@ public interface IParsingOptions
     /// Gets or sets whether to create compiled <see cref="Regex"/> instances when adapting regular expressions.
     /// When <see langword="true"/>, regex patterns are pre-compiled using <see cref="RegexOptions.Compiled"/>.
     /// When <see langword="false"/>, regex patterns are interpreted.
-    /// When <see langword="null"/>, regex patterns are interpreted in the case of non-prepared scripts and modules,
-    /// otherwise they are pre-compiled.
+    /// When <see langword="null"/>, regex patterns in prepared scripts and modules are pre-compiled, while
+    /// other regex patterns start out interpreted and are upgraded to <see cref="RegexOptions.Compiled"/>
+    /// when the same pattern keeps being constructed: successful adaptations are cached process-wide, which
+    /// both detects reuse and amortizes the one-time compilation cost, so one-shot patterns never pay it.
     /// Defaults to <see langword="null"/>.
     /// </summary>
     /// <remarks>
     /// Patterns that require the custom QuickJS engine are always interpreted regardless of this setting.
+    /// Under Native AOT the .NET runtime ignores <see cref="RegexOptions.Compiled"/> and such patterns
+    /// fall back to the built-in <see cref="Regex"/> interpreter.
     /// </remarks>
     bool? CompileRegex { get; init; }
 
@@ -52,7 +57,7 @@ public sealed record ScriptParsingOptions : IParsingOptions
     {
         AllowReturnOutsideFunction = true,
         AllowTopLevelUsing = true,
-        OnRegExp = Engine.DefaultConvertRegExpHandler,
+        OnRegExp = Engine.DefaultAdaptiveRegExpHandler,
         // OnNode (source-text retention) is applied conditionally in ApplyTo based on RetainFunctionSourceText.
     };
 
@@ -91,46 +96,52 @@ public sealed record ScriptParsingOptions : IParsingOptions
     /// </summary>
     public Position SourceOffset { get; init; }
 
-    internal ParserOptions ApplyTo(ParserOptions baseOptions, bool fallbackCompileRegex, TimeSpan fallbackRegexTimeout) => baseOptions with
+    internal ParserOptions ApplyTo(ParserOptions baseOptions, RegexCompilation fallbackRegexCompilation, TimeSpan fallbackRegexTimeout) => baseOptions with
     {
         AllowReturnOutsideFunction = AllowReturnOutsideFunction,
-        OnRegExp = GetOnRegExpHandler(fallbackCompileRegex, fallbackRegexTimeout),
+        OnRegExp = GetOnRegExpHandler(fallbackRegexCompilation, fallbackRegexTimeout),
         OnNode = RetainFunctionSourceText ? Engine.DefaultNodeHandler : null,
         Tolerant = Tolerant,
     };
 
-    private OnRegExpHandler? GetOnRegExpHandler(bool fallbackCompileRegex, TimeSpan fallbackRegexTimeout)
+    private OnRegExpHandler? GetOnRegExpHandler(RegexCompilation fallbackRegexCompilation, TimeSpan fallbackRegexTimeout)
     {
         // Explicit RegexTimeout takes priority, then engine's configured timeout
         var timeout = RegexTimeout ?? fallbackRegexTimeout;
 
-        if (CompileRegex ?? fallbackCompileRegex)
+        var compilation = CompileRegex switch
         {
-            return timeout == Engine.DefaultRegexTimeout
-                ? Engine.DefaultCompileRegExpHandler
-                : Engine.CreateRegExpHandler(compiled: true, timeout);
-        }
-        else
+            true => RegexCompilation.Compiled,
+            false => RegexCompilation.Interpreted,
+            null => fallbackRegexCompilation,
+        };
+
+        if (timeout != Engine.DefaultRegexTimeout)
         {
-            return timeout == Engine.DefaultRegexTimeout
-                ? Engine.DefaultConvertRegExpHandler
-                : Engine.CreateRegExpHandler(compiled: false, timeout);
+            return Engine.CreateRegExpHandler(compilation, timeout);
         }
+
+        return compilation switch
+        {
+            RegexCompilation.Compiled => Engine.DefaultCompileRegExpHandler,
+            RegexCompilation.Interpreted => Engine.DefaultConvertRegExpHandler,
+            _ => Engine.DefaultAdaptiveRegExpHandler,
+        };
     }
 
     internal ParserOptions GetParserOptions() => ReferenceEquals(this, Default)
         ? _defaultParserOptions
-        : ApplyTo(_defaultParserOptions, fallbackCompileRegex: false, Engine.DefaultRegexTimeout);
+        : ApplyTo(_defaultParserOptions, RegexCompilation.Adaptive, Engine.DefaultRegexTimeout);
 
     internal ParserOptions GetParserOptions(Options engineOptions)
-        => ApplyTo(_defaultParserOptions, fallbackCompileRegex: false, engineOptions.Constraints.RegexTimeout);
+        => ApplyTo(_defaultParserOptions, RegexCompilation.Adaptive, engineOptions.Constraints.RegexTimeout);
 }
 
 public sealed record class ModuleParsingOptions : IParsingOptions
 {
     private static readonly ParserOptions _defaultParserOptions = Engine.BaseParserOptions with
     {
-        OnRegExp = Engine.DefaultConvertRegExpHandler,
+        OnRegExp = Engine.DefaultAdaptiveRegExpHandler,
         // OnNode (source-text retention) is applied conditionally in ApplyTo based on RetainFunctionSourceText.
     };
 
@@ -154,36 +165,42 @@ public sealed record class ModuleParsingOptions : IParsingOptions
     /// <inheritdoc/>
     public bool RetainFunctionSourceText { get; init; }
 
-    internal ParserOptions ApplyTo(ParserOptions baseOptions, bool fallbackCompileRegex, TimeSpan fallbackRegexTimeout) => baseOptions with
+    internal ParserOptions ApplyTo(ParserOptions baseOptions, RegexCompilation fallbackRegexCompilation, TimeSpan fallbackRegexTimeout) => baseOptions with
     {
-        OnRegExp = GetOnRegExpHandler(fallbackCompileRegex, fallbackRegexTimeout),
+        OnRegExp = GetOnRegExpHandler(fallbackRegexCompilation, fallbackRegexTimeout),
         OnNode = RetainFunctionSourceText ? Engine.DefaultNodeHandler : null,
         Tolerant = Tolerant,
     };
 
-    private OnRegExpHandler? GetOnRegExpHandler(bool fallbackCompileRegex, TimeSpan fallbackRegexTimeout)
+    private OnRegExpHandler? GetOnRegExpHandler(RegexCompilation fallbackRegexCompilation, TimeSpan fallbackRegexTimeout)
     {
         // Explicit RegexTimeout takes priority, then engine's configured timeout
         var timeout = RegexTimeout ?? fallbackRegexTimeout;
 
-        if (CompileRegex ?? fallbackCompileRegex)
+        var compilation = CompileRegex switch
         {
-            return timeout == Engine.DefaultRegexTimeout
-                ? Engine.DefaultCompileRegExpHandler
-                : Engine.CreateRegExpHandler(compiled: true, timeout);
-        }
-        else
+            true => RegexCompilation.Compiled,
+            false => RegexCompilation.Interpreted,
+            null => fallbackRegexCompilation,
+        };
+
+        if (timeout != Engine.DefaultRegexTimeout)
         {
-            return timeout == Engine.DefaultRegexTimeout
-                ? Engine.DefaultConvertRegExpHandler
-                : Engine.CreateRegExpHandler(compiled: false, timeout);
+            return Engine.CreateRegExpHandler(compilation, timeout);
         }
+
+        return compilation switch
+        {
+            RegexCompilation.Compiled => Engine.DefaultCompileRegExpHandler,
+            RegexCompilation.Interpreted => Engine.DefaultConvertRegExpHandler,
+            _ => Engine.DefaultAdaptiveRegExpHandler,
+        };
     }
 
     internal ParserOptions GetParserOptions() => ReferenceEquals(this, Default)
         ? _defaultParserOptions
-        : ApplyTo(_defaultParserOptions, fallbackCompileRegex: false, Engine.DefaultRegexTimeout);
+        : ApplyTo(_defaultParserOptions, RegexCompilation.Adaptive, Engine.DefaultRegexTimeout);
 
     internal ParserOptions GetParserOptions(Options engineOptions)
-        => ApplyTo(_defaultParserOptions, fallbackCompileRegex: false, engineOptions.Constraints.RegexTimeout);
+        => ApplyTo(_defaultParserOptions, RegexCompilation.Adaptive, engineOptions.Constraints.RegexTimeout);
 }

--- a/Jint/PreparationOptions.cs
+++ b/Jint/PreparationOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Jint;
+﻿using Jint.Native.RegExp;
+
+namespace Jint;
 
 public interface IPreparationOptions<out TParsingOptions>
     where TParsingOptions : IParsingOptions
@@ -28,7 +30,7 @@ public sealed record class ScriptPreparationOptions : IPreparationOptions<Script
 
     internal ParserOptions GetParserOptions() => ReferenceEquals(this, Default)
         ? _defaultParserOptions
-        : ParsingOptions.ApplyTo(_defaultParserOptions, fallbackCompileRegex: true, Engine.DefaultRegexTimeout);
+        : ParsingOptions.ApplyTo(_defaultParserOptions, RegexCompilation.Compiled, Engine.DefaultRegexTimeout);
 }
 
 public sealed record class ModulePreparationOptions : IPreparationOptions<ModuleParsingOptions>
@@ -47,5 +49,5 @@ public sealed record class ModulePreparationOptions : IPreparationOptions<Module
 
     internal ParserOptions GetParserOptions() => ReferenceEquals(this, Default)
         ? _defaultParserOptions
-        : ParsingOptions.ApplyTo(_defaultParserOptions, fallbackCompileRegex: true, Engine.DefaultRegexTimeout);
+        : ParsingOptions.ApplyTo(_defaultParserOptions, RegexCompilation.Compiled, Engine.DefaultRegexTimeout);
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLiteralExpression.cs
@@ -87,7 +87,7 @@ internal sealed class JintLiteralExpression : JintExpression
                 // Process-wide cache: a fresh-parse (source-mode) literal recompiles the same Regex every
                 // run because the per-node UserData cache above only survives in a reused Prepared<Script>.
                 cachedParseResult = RegExpParseCache.GetOrAdapt(
-                    pattern, flags, conversionOptions.Compiled, conversionOptions.Timeout);
+                    pattern, flags, conversionOptions.Compilation, conversionOptions.Timeout);
 
                 if (cachedParseResult.Success)
                 {


### PR DESCRIPTION
## Summary

After PR #2682 routed most JS patterns to .NET Regex, they were still constructed without `RegexOptions.Compiled`, so matching ran on .NET's regex *interpreter* — ETW showed `RegexInterpreter.TryMatchAtCurrentPosition` at 1.5% on a mixed workload, and match-dominated scripts (regexp-dna) spent most of their time there.

Blanket `Compiled` is the wrong default: it pays ~1.4 ms of JIT per distinct pattern (measured ~450× the interpreted construction cost), which is catastrophic for construction-heavy/match-light code — 2,000 distinct one-shot patterns measured 3.1 s eager-compiled vs 31 ms interpreted (100×). The 256-entry pattern cache bounds *memory*, not per-miss compile cost.

So this adds an internal **adaptive tier** (no public API change): a tri-state `RegexCompilation { Interpreted, Compiled, Adaptive }`, with `CompileRegex = null` (the default for non-prepared scripts) now mapping to Adaptive. The first two constructions of a given (pattern, flags, timeout) key adapt interpreted; the **3rd construction proves reuse** and upgrades the cache entry to a compiled `Regex`. Explicit `CompileRegex = true/false` and the prepared-script eager-compile default are unchanged; dynamic `new RegExp(...)` is never eagerly compiled but now tiers and honors explicit opt-out. `MatchTimeout` sources are untouched (10 s literal / 5 s dynamic), and the custom-engine inline-deadline path (#2686) is unaffected. Under NativeAOT the runtime silently ignores `Compiled` (verified — no exception path; in-repo precedent from Temporal/Intl).

The threshold of 3 was load-bearing: at threshold 2 the Test262 S7.8.5 eval-flood tests (~65k distinct literals each, strict+sloppy) mass-upgraded and produced consistent 30 s timeouts; threshold 3 passes cleanly.

## Benchmarks (default jobs, adjacent A/B on latest main)

| Benchmark | main | PR | Δ |
|---|---:|---:|---:|
| SunSpider regexp-dna | 102.53 ms | 11.03 ms | **−89.2%** |
| RegExpSplit SplitWithCaptures | 3.291 ms | 2.539 ms | **−22.8%** |
| RegExpSplit Split | 1.989 ms | 1.573 ms | **−20.9%** |
| RegExpFreshEngine FreshEngineSource | 31.59 µs | 28.29 µs | **−10.4%** |
| RegExpExecLoop MatchAllIterate | 295.3 µs | 274.2 µs | −7.1% |
| SunSpider string-unpack-code | 44.60 ms | 41.90 ms | −6.1% |
| RegExpSplit SplitUnicode | 24.75 ms | 23.56 ms | −4.8% |
| SunSpider string-tagcloud | 41.08 ms | 40.74 ms | neutral |
| RegExpMatch MatchGlobal | 1.546 ms | 1.603 ms | +3.7% (match-light: compile cost not fully recouped) |

Match-heavy scripts reach compiled steady state from the 3rd execution; construction-flood pathology stays interpreted (2,000 distinct patterns ≈ interpreted cost, verified). Results bit-identical across tiers.

## Gates

- Jint.Tests: 3,597 (net10.0) + 3,534 (net472) passed, 0 failed
- Jint.Tests.PublicInterface: 114 × 2 TFMs passed
- Jint.Tests.CommonScripts: 28 × 2 TFMs passed (tagcloud/unpack-code/regexp-dna output-asserted)
- Test262: 99,429 passed, 0 failed (regexp-literal flood tests pass at threshold 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
