### PR TITLE
Add InternalTypes.Function flag to skip is-Function and env-cast checks on hot paths

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -977,7 +977,7 @@ public sealed partial class Engine : IDisposable
             return o.Get(property, reference.ThisValue);
         }
 
-        var record = (Environment) baseValue;
+        var record = Environment.FromReferenceBase(baseValue);
         var bindingValue = record.GetBindingValue(reference.ReferencedName.ToString(), reference.Strict);
 
         if (returnReferenceToPool)
@@ -1075,7 +1075,7 @@ public sealed partial class Engine : IDisposable
         }
         else
         {
-            ((Environment) reference.Base).SetMutableBinding(Runtime.TypeConverter.ToString(property), value, reference.Strict);
+            Environment.FromReferenceBase(reference.Base).SetMutableBinding(Runtime.TypeConverter.ToString(property), value, reference.Strict);
         }
     }
 
@@ -2102,7 +2102,7 @@ public sealed partial class Engine : IDisposable
         JsValue newTarget,
         JintExpression? expression)
     {
-        if (constructor is Function functionInstance)
+        if (constructor.AsFunctionInstanceOrNull() is { } functionInstance)
         {
             return Construct(functionInstance, arguments, newTarget, expression);
         }

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -549,17 +549,43 @@ public static class JsValueExtensions
         return null;
     }
 
+    /// <summary>
+    /// True when the value is a <see cref="Function"/> (any JS function object). A single flag test on
+    /// the already-loaded type instead of an <c>is Function</c> class-hierarchy check; see
+    /// <see cref="InternalTypes.Function"/>.
+    /// </summary>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsFunctionInstance(this JsValue value)
+    {
+        return (value._type & InternalTypes.Function) != InternalTypes.Empty;
+    }
+
+    /// <summary>
+    /// Returns the value as a <see cref="Function"/> when it is one, otherwise <c>null</c> — the
+    /// flag-based equivalent of <c>value as Function</c>, avoiding the covariant class-cast check on the
+    /// per-call dispatch path. The flag proves the type, so <see cref="Unsafe.As{T}"/> is safe.
+    /// </summary>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Function? AsFunctionInstanceOrNull(this JsValue value)
+    {
+        return (value._type & InternalTypes.Function) != InternalTypes.Empty
+            ? Unsafe.As<Function>(value)
+            : null;
+    }
+
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Function AsFunctionInstance(this JsValue value)
     {
-        if (value is not Function instance)
+        if (!value.IsFunctionInstance())
         {
             ThrowWrongTypeException(value, "FunctionInstance");
             return null!;
         }
 
-        return instance;
+        return Unsafe.As<Function>(value);
     }
 
     [Pure]

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -91,6 +91,9 @@ public abstract partial class Function : ObjectInstance, ICallable
         FunctionThisMode thisMode = FunctionThisMode.Global)
         : base(engine, ObjectClass.Function)
     {
+        // The single writer of InternalTypes.Function: every function object (script/CLR/bound and
+        // built-in constructors) chains through this ctor, and no non-Function value reaches it.
+        _type |= InternalTypes.Function;
         if (name is not null)
         {
             _nameDescriptor = new PropertyDescriptor(name, PropertyFlag.Configurable);

--- a/Jint/Runtime/Environments/Environment.cs
+++ b/Jint/Runtime/Environments/Environment.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Jint.Native;
 using Jint.Native.Disposable;
 
@@ -18,6 +19,22 @@ internal abstract class Environment : JsValue
     protected Environment(Engine engine) : base(InternalTypes.ObjectEnvironmentRecord)
     {
         _engine = engine;
+    }
+
+    /// <summary>
+    /// The base of a non-property (environment) reference is always an environment record. The
+    /// <see cref="InternalTypes.ObjectEnvironmentRecord"/> flag — single-sourced in this ctor — is its
+    /// discriminator, so <see cref="Unsafe.As{T}"/> skips the covariant class-cast check on the hot
+    /// reference-resolution path; a violated invariant still surfaces as today's InvalidCastException
+    /// through the checked fallback.
+    /// </summary>
+    [System.Diagnostics.Contracts.Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Environment FromReferenceBase(JsValue baseValue)
+    {
+        return (baseValue._type & InternalTypes.ObjectEnvironmentRecord) != InternalTypes.Empty
+            ? Unsafe.As<Environment>(baseValue)
+            : (Environment) baseValue;
     }
 
     /// <summary>

--- a/Jint/Runtime/InternalTypes.cs
+++ b/Jint/Runtime/InternalTypes.cs
@@ -51,7 +51,13 @@ internal enum InternalTypes
     // to dictionary mode. Mutually exclusive with ShapeMode; lets ObjectInstance's property virtuals
     // discriminate built-in-shape vs dictionary storage with a single flag test on the already-loaded _type.
     BuiltinShapeMode = 524288,
+    // the object is a Function (base of every JS function object: script/CLR/bound functions and built-in
+    // constructors). Set once in the Function base ctor — a single writer, and never on a non-Function
+    // ICallable such as a callable Proxy (which derives from ObjectInstance directly). Lets the per-call
+    // dispatch discriminate a Function from other callables with a flag test on the already-loaded _type
+    // instead of an `is Function` class-hierarchy check (CastHelpers.IsInstanceOfClass).
+    Function = 1048576,
 
     Primitive = Boolean | String | Number | Integer | BigInt | Symbol,
-    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode
+    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode | Function
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -128,7 +128,7 @@ internal sealed class JintCallExpression : JintExpression
                     }
                     else
                     {
-                        var refEnv = (Environment) baseValue;
+                        var refEnv = Environment.FromReferenceBase(baseValue);
                         thisObject = refEnv.WithBaseObject();
                     }
                 }
@@ -177,7 +177,7 @@ internal sealed class JintCallExpression : JintExpression
         // ensure logic is in sync between Call, Construct and JintCallExpression!
 
         JsValue result;
-        if (callable is Function functionInstance)
+        if (func.AsFunctionInstanceOrNull() is { } functionInstance)
         {
             var callStack = engine.CallStack;
             var recursionDepth = callStack.Push(functionInstance, _calleeExpression, engine.ExecutionContext);

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -267,7 +267,7 @@ internal sealed class JintUnaryExpression : JintExpression
                     Throw.SyntaxError(engine.Realm);
                 }
 
-                var bindings = (Environment) r.Base;
+                var bindings = Environment.FromReferenceBase(r.Base);
                 engine._referencePool.Return(r);
 
                 return bindings.DeleteBinding(r.ReferencedName.ToString()) ? JsBoolean.True : JsBoolean.False;

--- a/Jint/Runtime/Reference.cs
+++ b/Jint/Runtime/Reference.cs
@@ -108,7 +108,7 @@ public sealed class Reference
 
     internal void InitializeReferencedBinding(JsValue value, DisposeHint hint)
     {
-        ((Environment) _base).InitializeBinding(TypeConverter.ToString(_referencedName), value, hint);
+        Environment.FromReferenceBase(_base).InitializeBinding(TypeConverter.ToString(_referencedName), value, hint);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary

Two class-hierarchy casts run on hot call/reference paths and show up in ETW as `CastHelpers`:

- **`callable is Function`** in per-call dispatch (`JintCallExpression`, `Engine.Construct`) — an `IsInstanceOfClass` on every call, distinguishing a JS function from other callables (a callable Proxy).
- **`(Environment) reference.Base`** in environment-reference resolution (`Engine.GetValue`/`PutValue`, `JintCallExpression`, delete, binding init) — a `ChkCastClass` on every global/env variable access.

Both are now flag tests. `InternalTypes.Function` is added (free bit, 2^20) and set **once** in the `Function` base constructor — the single writer every function object (script/CLR/bound functions, built-in constructors) chains through. A callable `Proxy` derives from `ObjectInstance`, not `Function`, so it correctly never gets the flag and still dispatches through the `ICallable` path (verified).

Two shared helpers replace the casts with `flag test + Unsafe.As`:
- `JsValue.AsFunctionInstanceOrNull()` — the flag-based equivalent of `value as Function`, used at the call/construct dispatch sites (and the existing throwing `AsFunctionInstance` now shares the same fast test).
- `Environment.FromReferenceBase(JsValue)` — keyed on the `ObjectEnvironmentRecord` flag (single-sourced in the `Environment` ctor), keeping the checked cast as the mismatch fallback so any invariant violation still throws today's `InvalidCastException`.

Behavior is unchanged — the flags are proven single-writer, so `Unsafe.As` is safe. The two `Engine` call sites typed as `ICallable` (cold C#-invoke entry points, not the interpreter per-call path) are deliberately left as-is: converting them would need an interface→JsValue cast, defeating the purpose.

## Benchmarks

~2% on a call/reference-dispatch-heavy loop (interleaved wall clock, branch 3.20/3.14 s vs baseline 3.24 s — both branch runs below baseline); neutral on non-call-dominated workloads. The change targets the per-call `is Function` and per-reference `(Environment)` casts specifically; SunSpider scripts and micro-loops that don't churn calls/references are unaffected.

(Absolute BDN numbers are omitted: this machine is thermally drifting ±40% run-to-run after extended benchmarking, which swamps a ~2% effect. The interleaved wall-clock A/B/A is the reliable read; the mechanism — removing the per-call/per-reference class-casts — is the justification, in the spirit of #2673.)

## Gates

- Jint.Tests: 3,597 (net10.0) + 3,534 (net472) passed, 0 failed
- Jint.Tests.PublicInterface: 114 × 2 TFMs passed
- Jint.Tests.CommonScripts: 28 × 2 TFMs passed
- Test262: 99,429 passed, 0 failed
- Semantics smoke: normal/method/arrow/bound calls, `new` construction, callable-Proxy and apply-trap dispatch (Function-flag discrimination), `instanceof Function`, recursion, built-in constructor dispatch, `with`/env-reference assignment and delete — all correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
