### PR TITLE
Update Test262 suite to f2d143564 and drop now-fixed exclusion

### DIFF
--- a/Jint.Tests.Test262/Test262Harness.settings.json
+++ b/Jint.Tests.Test262/Test262Harness.settings.json
@@ -1,5 +1,5 @@
 {
-  "SuiteGitSha": "d1d583db95a521218f3eb8341a887fd63eda8ff1",
+  "SuiteGitSha": "f2d1435644797268dca1f7988cad5a4e89ccd8d2",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Jint.Tests.Test262",
@@ -12,17 +12,6 @@
   "ExcludedDirectories": [
   ],
   "ExcludedFiles": [
-
-    // Upstream test262 bug (to be reported upstream). Added in test262 commit 6eec1ac9ee
-    // ("[await-dictionary] add remaining keyed Promise tests", #5074). The test calls
-    // verifyProperty(result, "fulfilled", { ..., configurable: true }) WITHOUT { restore: true };
-    // verifyProperty's configurable check does `delete result.fulfilled` and, absent the restore
-    // option, never puts it back. The test then dereferences result.fulfilled / result.rejected again
-    // (e.g. verifyProperty(result.fulfilled, "status", ...)), which now reads undefined and throws
-    // "Cannot convert undefined or null to object". This reproduces identically on V8/Node against a
-    // spec-correct null-prototype result object, so it is a test defect, not an engine bug. Jint builds
-    // the result object exactly per CreateKeyedPromiseCombinatorResultObject.
-    "built-ins/Promise/allSettledKeyed/result-property-descriptors.js",
 
     // === INTL402 EXCLUSIONS ===
     // The following tests require full CLDR locale data support which is not available in the default provider.


### PR DESCRIPTION
Bumps the pinned Test262 `SuiteGitSha` from `d1d583db9` to `f2d1435644797268dca1f7988cad5a4e89ccd8d2` (latest tc39/test262 `main`).

The only commit in this range is the upstream fix [_"[await-dictionary] Fix allSettledKeyed result test reusing deleted properties"_ (tc39/test262#5084)](https://github.com/tc39/test262/commit/f2d1435644797268dca1f7988cad5a4e89ccd8d2), which repairs `built-ins/Promise/allSettledKeyed/result-property-descriptors.js`.

That test was previously excluded here as a known upstream defect: `verifyProperty` deletes the property it checks during its `configurable` check without `{ restore: true }`, and the test then re-read the deleted `result.fulfilled` / `result.rejected` entries and threw. The upstream fix now captures those entries eagerly before the top-level `verifyProperty` calls run.

With the fix landed the test passes on Jint, so the exclusion entry and its explanatory comment are removed. Regenerated locally: all 88 `Promise_allSettledKeyed` cases (strict + sloppy) pass, including the newly-included test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)