### PR TITLE
Keep the memory limit exact instead of amortizing it in tight loops

### DIFF
--- a/Jint/Engine.Constraints.cs
+++ b/Jint/Engine.Constraints.cs
@@ -10,14 +10,24 @@ public partial class Engine
     private readonly record struct ConstraintPartition(Constraint[] Exact, Constraint[] Amortized);
 
     /// <summary>
-    /// Splits the registered constraints by required check frequency. The built-in time,
-    /// cancellation and memory-limit constraints only observe external state (a timer, a token,
-    /// an allocation counter), so checking them every N statements is semantically equivalent to
+    /// Splits the registered constraints by required check frequency. The built-in time and
+    /// cancellation constraints only observe external state that a check reads without consuming
+    /// (a timer, a token), so checking them every N statements is semantically equivalent to
     /// checking per statement — only the detection latency is bounded instead of immediate (the
     /// same reasoning bulk built-ins apply via <see cref="ConstraintCheckInterval"/>). Everything
-    /// else stays exact: <see cref="MaxStatementsConstraint"/> counts statements, so its call
-    /// frequency IS its semantics, and user-derived constraints may depend on being called once
-    /// per statement — silently amortizing them would be a breaking behavior change.
+    /// else stays exact:
+    /// <list type="bullet">
+    /// <item><see cref="MaxStatementsConstraint"/> counts statements, so its call frequency IS its
+    /// semantics.</item>
+    /// <item><see cref="MemoryLimitConstraint"/> reads an allocation counter, but unlike a clock
+    /// that only advances, allocation between checks is irreversible and unbounded per statement
+    /// (a single iteration can allocate arbitrarily much, e.g. exponential string growth), so
+    /// amortizing it would let the process overshoot the configured cap — potentially to a real
+    /// OutOfMemoryException — before the next check. Keeping it exact preserves the memory bound
+    /// as a hard-ish guarantee for sandboxing untrusted code (matching pre-tight-lane behavior).</item>
+    /// <item>User-derived constraints may depend on being called once per statement — silently
+    /// amortizing them would be a breaking behavior change.</item>
+    /// </list>
     /// </summary>
     private static ConstraintPartition PartitionConstraints(Constraint[] constraints)
     {
@@ -30,8 +40,8 @@ public partial class Engine
         var amortized = new List<Constraint>(constraints.Length);
         foreach (var constraint in constraints)
         {
-            // All three types are sealed, so the checks cannot match a user-derived subclass.
-            if (constraint is TimeConstraint or CancellationConstraint or MemoryLimitConstraint)
+            // Both types are sealed, so the check cannot match a user-derived subclass.
+            if (constraint is TimeConstraint or CancellationConstraint)
             {
                 amortized.Add(constraint);
             }


### PR DESCRIPTION
### Problem

The tight-loop constraint amortization (#2672) checks the built-in `Time`, `Cancellation` **and** `MemoryLimit` constraints once every 64 statements. That reasoning is sound for a clock or a cancellation token — a check *reads* external state it does not consume, so bounded detection latency is equivalent to per-statement checking. But allocation is **irreversible and unbounded per statement**: a single iteration can allocate arbitrarily much (e.g. `s += s` doubling), so a function-body tight loop can overshoot the configured `LimitMemory` cap — up to a real `OutOfMemoryException` — before the next 64-statement check fires.

Because #2688 extended the tight lane to `while`/`do-while` and #2672 keeps it armed under constraints, an engine that relies on `LimitMemory` to sandbox untrusted code now enforces a much coarser bound than in 4.12.0, which had no while/do-while tight lane and checked memory every statement.

### Fix

Move `MemoryLimitConstraint` into the **exact** partition so memory-limited engines check it per statement again (as before the tight lane existed), preserving the limit as a hard-ish bound. `Time` and `Cancellation` stay amortized, so the common case — a timeout-only or unconstrained engine — keeps the tight-lane fast path completely unchanged. Only engines that register `LimitMemory` are affected, and they simply revert to pre-#2672 behavior.

### Testing

Full `Jint.Tests` green (3603/3540, net10/net472), including the existing `ShouldThrowMemoryLimitExceededInsideFunctionLocalTightLoop` / timeout tight-lane tests — the memory limit still fires, now per statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM8rSnn8j66kDCTaP2exNK
