### PR TITLE
Observe cancellation during the top-level-await event-loop drain

### DIFF
--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -981,6 +981,75 @@ public class AsyncTests
         Assert.Throws<JavaScriptException>(() => engine.Modules.Import("main"));
     }
 
+    [Fact]
+    public void ShouldObserveCancellationDuringTopLevelAwaitOfNeverCompletingTaskInModule()
+    {
+        // Robustness gap in the #2663 drain: when an embedder registers a cancellation-based
+        // constraint (options.CancellationToken) and cancels it while a module's top-level await is
+        // hanging on a never-completing .NET Task, the otherwise-idle event-loop drain must observe
+        // the cancellation and break out PROMPTLY - throwing ExecutionCanceledException, the same way
+        // per-statement execution surfaces cancellation - instead of blocking until PromiseTimeout.
+        using var cts = new CancellationTokenSource();
+        Engine engine = new(options =>
+        {
+            options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
+            // Deliberately huge so that a wait that lasts anywhere near it proves cancellation was NOT observed.
+            options.Constraints.PromiseTimeout = GenerousPromiseTimeout;
+            options.CancellationToken(cts.Token);
+        });
+
+        // A Task that never completes: the awaited promise stays pending forever unless cancellation breaks in.
+        var neverCompletes = new TaskCompletionSource<int>();
+        engine.SetValue("hang", new Func<Task<int>>(() => neverCompletes.Task));
+
+        engine.Modules.Add("main", """
+            const x = await hang();
+            export const answer = x;
+            """);
+
+        // Cancel shortly after Import starts blocking on the drain (fires on a ThreadPool thread).
+        cts.CancelAfter(TimeSpan.FromMilliseconds(200));
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        Assert.Throws<ExecutionCanceledException>(() => engine.Modules.Import("main"));
+        sw.Stop();
+
+        // Prompt: nowhere near the multi-minute PromiseTimeout. A generous ceiling keeps this stable under CI load.
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(10), $"Cancellation was not observed promptly: took {sw.Elapsed}.");
+
+        neverCompletes.TrySetCanceled();
+    }
+
+    [Fact]
+    public void ShouldTimeOutTopLevelAwaitOfNeverCompletingTaskInModuleWithoutCancellation()
+    {
+        // Invariant: with NO cancellation registered, a genuinely never-settling top-level await must
+        // still be BOUNDED by PromiseTimeout (not hang), surfacing as an error out of Modules.Import.
+        Engine engine = new(options =>
+        {
+            options.ExperimentalFeatures = ExperimentalFeature.TaskInterop;
+            options.Constraints.PromiseTimeout = TimeSpan.FromMilliseconds(500);
+        });
+
+        var neverCompletes = new TaskCompletionSource<int>();
+        engine.SetValue("hang", new Func<Task<int>>(() => neverCompletes.Task));
+
+        engine.Modules.Add("main", """
+            const x = await hang();
+            export const answer = x;
+            """);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        // The drain gives up at PromiseTimeout with the promise still pending, so evaluation reports a
+        // non-fulfilled promise rather than hanging.
+        Assert.Throws<InvalidOperationException>(() => engine.Modules.Import("main"));
+        sw.Stop();
+
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(30), $"Never-settling await was not bounded: took {sw.Elapsed}.");
+
+        neverCompletes.TrySetCanceled();
+    }
+
 #if !NETFRAMEWORK
 
     [Fact]

--- a/Jint/Constraints/CancellationConstraint.cs
+++ b/Jint/Constraints/CancellationConstraint.cs
@@ -12,6 +12,13 @@ public sealed class CancellationConstraint : Constraint
         _cancellationToken = cancellationToken;
     }
 
+    /// <summary>
+    /// The token this constraint observes. Exposed so that blocking waits outside the
+    /// per-statement check loop (e.g. the module top-level-await event-loop drain) can
+    /// observe the same cancellation.
+    /// </summary>
+    internal CancellationToken Token => _cancellationToken;
+
     public override void Check()
     {
         if (_cancellationToken.IsCancellationRequested)

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Jint.Collections;
+using Jint.Constraints;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Native.Generator;
@@ -769,7 +770,11 @@ public sealed partial class Engine : IDisposable
     /// A tight spin loop gives up in microseconds and never observes a Task that only completes
     /// milliseconds later on a ThreadPool thread (issue #2663). This mirrors the polling in
     /// <see cref="JsValueExtensions.UnwrapIfPromise(Native.JsValue, TimeSpan)"/>. A non-positive
-    /// <paramref name="timeout"/> means wait indefinitely.
+    /// <paramref name="timeout"/> means wait indefinitely. A registered
+    /// <see cref="Constraints.CancellationConstraint"/> is observed during the idle waits so that a
+    /// cancelled engine breaks out promptly (throwing <see cref="ExecutionCanceledException"/>, the
+    /// same way per-statement execution surfaces cancellation) instead of blocking up to the full
+    /// timeout while awaiting a never-settling Task.
     /// </remarks>
     internal void DrainEventLoopUntilSettled(JsPromise promise, TimeSpan timeout)
     {
@@ -778,6 +783,13 @@ public sealed partial class Engine : IDisposable
         // nesting (e.g. a re-entrant UnwrapIfPromise already waiting).
         var previousWaitingThreadId = _eventLoop._waitingThreadId;
         _eventLoop._waitingThreadId = System.Environment.CurrentManagedThreadId;
+
+        // Observe a registered CancellationConstraint during the otherwise-idle waits. No statements
+        // run while we block on the completion event, so the per-statement constraint checks never
+        // fire; without this, cancelling the engine while a top-level await hangs on a never-settling
+        // Task would go unnoticed until PromiseTimeout. Defaults to CancellationToken.None when no
+        // such constraint is registered, which leaves the wait behavior unchanged.
+        var cancellationToken = Constraints.Find<CancellationConstraint>()?.Token ?? default;
 
         try
         {
@@ -795,6 +807,7 @@ public sealed partial class Engine : IDisposable
                     break;
                 }
 
+                var waitInterval = pollInterval;
                 if (hasTimeout)
                 {
                     var remaining = deadline - DateTime.UtcNow;
@@ -803,11 +816,22 @@ public sealed partial class Engine : IDisposable
                         break;
                     }
 
-                    completedEvent.Wait(remaining < pollInterval ? remaining : pollInterval);
+                    if (remaining < waitInterval)
+                    {
+                        waitInterval = remaining;
+                    }
                 }
-                else
+
+                try
                 {
-                    completedEvent.Wait(pollInterval);
+                    completedEvent.Wait(waitInterval, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    // The registered CancellationConstraint's token was cancelled during the idle wait.
+                    // Surface it exactly as per-statement execution does (CancellationConstraint.Check),
+                    // rather than swallowing it and letting the drain fall through to a silent timeout.
+                    Throw.ExecutionCanceledException();
                 }
             }
         }


### PR DESCRIPTION
### Problem

`Engine.DrainEventLoopUntilSettled` (added for top-level `await` of a .NET `Task`, #2665) polls `completedEvent.Wait(pollInterval)` bounded by `PromiseTimeout` (default 10s), but took no cancellation token. If an embedder registers `options.CancellationToken(ct)` and cancels while a module import is awaiting a never-completing `Task`, the cancellation was **not** observed during the idle wait — the import blocked up to the full `PromiseTimeout` instead of returning promptly. Bounded, but unresponsive.

### Fix

Resolve the registered token once via `Constraints.Find<CancellationConstraint>()?.Token` (defaults to `CancellationToken.None` when no such constraint exists, so behavior is unchanged for engines without cancellation), pass it into `completedEvent.Wait(interval, token)`, and translate the resulting `OperationCanceledException` into `ExecutionCanceledException` — exactly how `CancellationConstraint.Check()` surfaces cancellation during per-statement execution (not swallowed into a silent timeout). The `PromiseTimeout` bound, poll interval, and `_waitingThreadId` save/restore are preserved.

### Verification

Two new tests: a cancelled never-completing module TLA now throws `ExecutionCanceledException` in **314ms** (vs a 2-minute `PromiseTimeout`), and the no-cancellation path still times out bounded (no hang). Green: full Jint.Tests 3599, `~Async` 185 (incl. the #2665 delayed/faulted-Task tests), Test262 top-level-await 257 + module/import 2581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM8rSnn8j66kDCTaP2exNK
