### PR TITLE
Materialize arguments escaping a short-circuiting logical compound assignment

### DIFF
--- a/Jint.Tests/Runtime/ArgumentsCacheBehaviorTests.cs
+++ b/Jint.Tests/Runtime/ArgumentsCacheBehaviorTests.cs
@@ -60,6 +60,62 @@ public class ArgumentsCacheBehaviorTests
             "(function(){ function f(a){ var s=arguments; delete arguments[0]; a=9; return arguments.hasOwnProperty('0')+':'+arguments[0]; } return f(1); })()").AsString());
     }
 
+    [Theory]
+    [InlineData("??=")]
+    [InlineData("||=")]
+    public void LogicalCompoundAssignmentToArgumentsDoesNotEscapePooledObject(string op)
+    {
+        // Regression: `arguments ??= x` / `arguments ||= x` short-circuits on the (always truthy,
+        // never nullish) arguments object and yields it as the expression result WITHOUT reading it
+        // through the identifier path that normally materializes it. When that raw result escapes the
+        // call, a later call reuses the pooled backing array and corrupts the escaped object.
+        var engine = new Engine();
+
+        // escapes as the direct return value (no identifier re-read to trigger materialization)
+        var directReturn = $@"
+            (function() {{
+                function f() {{ return (arguments {op} 0); }}
+                var e = f(11, 22);
+                function o() {{ return arguments.length; }}
+                o(1, 2, 3, 4, 5, 6);        // reuses the pooled array
+                return e[0] + ',' + e[1] + ',' + e.length;
+            }})()";
+        Assert.Equal("11,22,2", engine.Evaluate(directReturn).AsString());
+
+        // escapes via a property store (never re-read as an identifier)
+        var propertyStore = $@"
+            (function() {{
+                var holder = {{}};
+                function f() {{ holder.y = (arguments {op} 0); }}
+                f(11, 22);
+                function o() {{ return arguments.length; }}
+                o(1, 2, 3, 4, 5, 6);
+                var y = holder.y;
+                return y[0] + ',' + y[1] + ',' + y.length;
+            }})()";
+        Assert.Equal("11,22,2", engine.Evaluate(propertyStore).AsString());
+    }
+
+    [Fact]
+    public void LogicalAndCompoundAssignmentToArgumentsReassignsAndReturnsRhs()
+    {
+        // `arguments &&= x` never short-circuits (arguments is always truthy): it reassigns the
+        // binding to x and yields x. The pooled arguments object never escapes as the result.
+        var engine = new Engine();
+        Assert.Equal(99, engine.Evaluate(
+            "(function(){ function f(){ var y = (arguments &&= 99); return y; } return f(11, 22); })()").AsNumber());
+    }
+
+    [Fact]
+    public void CompoundAssignmentToNonArgumentsBindingIsUnaffected()
+    {
+        // The materialize guard must only fire for JsArguments; ordinary compound assignment
+        // (including the logical/nullish forms) keeps its exact behavior.
+        var engine = new Engine();
+        Assert.Equal("7,4,5,8", engine.Evaluate(
+            "(function(){ var x; x ??= 7; var a = 3; a += 1; var b = 0; b ||= 5; var c = 1; c &&= 8; return x+','+a+','+b+','+c; })()").AsString());
+    }
+
     [Fact]
     public void ArgsForGeneratorsAreNotReusedFromCache()
     {

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -139,7 +139,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         {
                             engine._referencePool.Return(lref);
                             suspendable?.Data.Clear(this);
-                            return originalLeftValue;
+                            return MaterializeIfArguments(originalLeftValue);
                         }
 
                         var rval = NamedEvaluation(context, _right);
@@ -159,7 +159,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         {
                             engine._referencePool.Return(lref);
                             suspendable?.Data.Clear(this);
-                            return originalLeftValue;
+                            return MaterializeIfArguments(originalLeftValue);
                         }
 
                         var rval = NamedEvaluation(context, _right);
@@ -179,7 +179,7 @@ internal sealed class JintAssignmentExpression : JintExpression
                         {
                             engine._referencePool.Return(lref);
                             suspendable?.Data.Clear(this);
-                            return originalLeftValue;
+                            return MaterializeIfArguments(originalLeftValue);
                         }
 
                         var rval = NamedEvaluation(context, _right);
@@ -217,6 +217,24 @@ internal sealed class JintAssignmentExpression : JintExpression
         engine._referencePool.Return(lref);
         suspendable?.Data.Clear(this);
         return newLeftValue!;
+    }
+
+    /// <summary>
+    /// A logical/nullish compound assignment (<c>??=</c>/<c>||=</c>/<c>&amp;&amp;=</c>) can short-circuit and
+    /// yield the current left-hand binding value as the expression result without ever reading it through
+    /// the identifier read path. When that value is the pooled <see cref="JsArguments"/> object it must opt
+    /// out of the pool before it escapes — otherwise a later call reuses its backing array and corrupts the
+    /// escaped object. Mirrors <c>JintIdentifierExpression.GetValue</c>'s materialize-on-read; the guard keeps
+    /// the common non-arguments assignment untouched.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static JsValue MaterializeIfArguments(JsValue value)
+    {
+        if (value is JsArguments argumentsInstance)
+        {
+            argumentsInstance.Materialize();
+        }
+        return value;
     }
 
     /// <summary>


### PR DESCRIPTION
### Problem

The `arguments` object is backed by a pooled array; it stays valid past the call only if `Materialize()` is invoked (which snapshots the array and opts it out of the pool). `JsValue.Clone()` is a no-op for `JsArguments`, and normal identifier reads materialize via `JintIdentifierExpression.GetValue`. But a logical/nullish compound assignment (`??=` / `||=` / `&&=`) reads its LHS **raw** (via `TryGetIdentifierEnvironmentWithBindingValue`, no materialize) and, when it short-circuits, returns that raw value as the expression result. So `return (arguments ??= 0)` yields the pooled object un-materialized; a later call reuses the backing array and corrupts it:

```js
function f() { return (arguments ??= 0); }
var e = f(11, 22);
function o() { return arguments.length; }
o(1, 2, 3, 4, 5, 6);        // reuses the pool
// e[0],e[1],e.length  →  before: 1,2,6 (corrupted)   after: 11,22,2
```

### Fix

Wrap the three short-circuit `return originalLeftValue;` sites in `JintAssignmentExpression` with a guarded `MaterializeIfArguments` (mirrors `JintIdentifierExpression`'s materialize-on-read; only acts when the value is a `JsArguments`, so the common non-arguments assignment is untouched). `??=`/`||=` short-circuit on the always-truthy/never-nullish arguments object and were the escape; `&&=` never short-circuits on it (returns the RHS) but is guarded for completeness. Values whose RHS is `arguments` (`x = arguments`, `x ??= arguments`) already materialize via the identifier read path.

### Verification

Before/after repro: 4 escape cases (direct return + property store, for `??=` and `||=`) corrupted on baseline, correct after. Invariants preserved (mapped/strict arguments, `&&=`→RHS, non-arguments compound assignment, reassignment). New regression tests in `ArgumentsCacheBehaviorTests`. Green: full Jint.Tests 3601/3538, Test262 `~arguments` 1255 / `~logical-assignment` 142 / `~compound-assignment` 789.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM8rSnn8j66kDCTaP2exNK
