### PR TITLE
Skip per-element IteratorResult allocation in value-kind array for-of

### DIFF
--- a/Jint.Benchmark/ForOfArrayBenchmark.cs
+++ b/Jint.Benchmark/ForOfArrayBenchmark.cs
@@ -1,0 +1,65 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Isolates the value-kind array for-of hot path. A dense (and a holey) array is built once in
+/// setup, then iterated with for-of in a tight repeated loop so the measured region is the
+/// per-element step rather than array construction. Gates the ArrayIterator/ArrayLikeIterator
+/// TryStepValue override that hands the element straight to the loop instead of allocating an
+/// IteratorResult object per element — watch the Allocated column.
+/// </summary>
+[MemoryDiagnoser]
+public class ForOfArrayBenchmark
+{
+    private const int ArraySize = 1000;
+    private const int Repeat = 1000;
+
+    private Engine _engine = null!;
+    private Prepared<Script> _forOfDense;
+    private Prepared<Script> _forOfHoley;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute($$"""
+            var denseArr = [];
+            for (var i = 0; i < {{ArraySize}}; i++) { denseArr[i] = i; }
+            var holeyArr = [];
+            for (var i = 0; i < {{ArraySize}}; i += 2) { holeyArr[i] = i; }
+            """);
+
+        _forOfDense = Engine.PrepareScript($$"""
+            function f() {
+                var s = 0;
+                for (var k = 0; k < {{Repeat}}; k++) {
+                    for (const x of denseArr) { s += x; }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _forOfHoley = Engine.PrepareScript($$"""
+            function f() {
+                var s = 0;
+                for (var k = 0; k < {{Repeat}}; k++) {
+                    for (const x of holeyArr) { if (x !== undefined) { s += x; } }
+                }
+                return s;
+            }
+            f();
+            """);
+
+        _engine.Evaluate(_forOfDense);
+        _engine.Evaluate(_forOfHoley);
+    }
+
+    [Benchmark]
+    public JsValue ForOfDenseArray() => _engine.Evaluate(_forOfDense);
+
+    [Benchmark]
+    public JsValue ForOfHoleyArray() => _engine.Evaluate(_forOfHoley);
+}

--- a/Jint/Native/Array/ArrayIteratorPrototype.cs
+++ b/Jint/Native/Array/ArrayIteratorPrototype.cs
@@ -89,6 +89,32 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
             nextItem = IteratorResult.CreateKeyValueIteratorPosition(_engine);
             return false;
         }
+
+        // for-of over a value-kind array iterator only needs the element, never the per-step
+        // IteratorResult object TryIteratorStep allocates. Mirror that method exactly (live length
+        // read each step, same done/closed transition, TryGetValue leaves holes as undefined) but
+        // hand the value back directly. Key/Entry kinds keep the wrapping path via base.
+        internal override bool TryStepValue([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out JsValue? value)
+        {
+            if (_kind == ArrayIteratorType.Value)
+            {
+                var len = _array.GetLength();
+                var position = _position;
+                if (!_closed && position < len)
+                {
+                    _array.TryGetValue(position, out var stepped);
+                    _position++;
+                    value = stepped;
+                    return true;
+                }
+
+                _closed = true;
+                value = null;
+                return false;
+            }
+
+            return base.TryStepValue(out value);
+        }
     }
 
     private sealed class ArrayLikeIterator : IteratorInstance
@@ -158,6 +184,32 @@ internal sealed partial class ArrayIteratorPrototype : IteratorPrototype
             _closed = true;
             nextItem = IteratorResult.CreateKeyValueIteratorPosition(_engine);
             return false;
+        }
+
+        // Value-kind for-of over a non-typed-array array-like only needs the element, so skip the
+        // per-step IteratorResult TryIteratorStep allocates. Mirrors the non-typed-array branch of
+        // that method exactly (live length each step, same done/closed transition, TryGetValue
+        // leaves holes as undefined). Typed arrays keep their detach/out-of-bounds guarded path,
+        // and Key/Entry kinds keep the wrapping path, both via base.
+        internal override bool TryStepValue([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out JsValue? value)
+        {
+            if (_kind == ArrayIteratorType.Value && _typedArray is null)
+            {
+                var len = _operations!.GetLength();
+                if (!_closed && _position < len)
+                {
+                    _operations!.TryGetValue(_position, out var stepped);
+                    _position++;
+                    value = stepped;
+                    return true;
+                }
+
+                _closed = true;
+                value = null;
+                return false;
+            }
+
+            return base.TryStepValue(out value);
         }
     }
 }


### PR DESCRIPTION
`for (const x of array)` drove `IteratorInstance.TryStepValue`'s default, which calls `TryIteratorStep` → allocates a fresh `IteratorResult` `ObjectInstance` **per element** and then reads its `.Value`. The for-in path already avoids this via a `TryStepValue` override on `ForInIterator`; the array value-iterator never got the equivalent.

This adds a `TryStepValue` override to **both** array iterators — `ArrayIterator` (the `JsArray` path that `for..of` over a dense array actually uses) and `ArrayLikeIterator` (non-typed-array array-likes) — gated to the **Value** kind. Each mirrors its own `TryIteratorStep` exactly (live `GetLength()` per step, identical done/closed transition, `TryGetValue` leaving holes as `undefined`) but returns the element directly. Key/Entry kinds and the typed-array (detach/OOB-guarded) path fall through to the base wrapping path; the manual `.next()` path is untouched.

### Benchmark (`ForOfArrayBenchmark`, before → after)

| lane | time | allocated |
|---|---|---|
| `ForOfDenseArray` | 62.3 ms → **50.8 ms** (−18.5%) | 92.0 MB → **0.35 MB** (−99.6%) |
| `ForOfHoleyArray` | 71.4 ms → **62.4 ms** (−12.5%) | 91.9 MB → **0.35 MB** (−99.6%) |

### Correctness

Full Jint.Tests 0 failed; Test262 `~Array` 11411 / iterator 1673 / for-of 1521, and full Test262 99,431/0 on an integration with the other perf changes. Holes stay `undefined` (not skipped, unlike for-in), live-length mutation, typed arrays, destructuring, spread, manual `.next()` all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM8rSnn8j66kDCTaP2exNK
