### PR TITLE
Compose &&/|| and ! through unboxed GetBooleanValue in boolean contexts

### DIFF
--- a/Jint.Benchmark/GuardComparisonBenchmark.cs
+++ b/Jint.Benchmark/GuardComparisonBenchmark.cs
@@ -18,6 +18,7 @@ public class GuardComparisonBenchmark
     private Prepared<Script> _looseNullGuard;
     private Prepared<Script> _typeofStringGuard;
     private Prepared<Script> _typeofUndefinedGuard;
+    private Prepared<Script> _logicalGuard;
 
     private const string SetupSource = """
         var mixedVals = [];
@@ -108,11 +109,30 @@ public class GuardComparisonBenchmark
             f();
             """);
 
+        // Composed guards: `&&`/`||`/`!` over comparisons in a boolean `if` context. Each
+        // comparison feeds the enclosing logical operator's unboxed GetBooleanValue, so the whole
+        // condition stays off the JsBoolean-materialization path.
+        _logicalGuard = Engine.PrepareScript("""
+            function f() {
+                var s = 0;
+                for (var i = 0; i < 100000; i++) {
+                    var v = mixedVals[order[i & 8191]];
+                    if (v !== undefined && v !== null) { s++; }
+                    if (v === undefined || v === null) { s += 2; }
+                    if (typeof v === 'string' || typeof v === 'number') { s += 3; }
+                    if (!(v === null)) { s += 4; }
+                }
+                return s;
+            }
+            f();
+            """);
+
         _engine.Evaluate(_isUndefinedGuard);
         _engine.Evaluate(_isNullGuard);
         _engine.Evaluate(_looseNullGuard);
         _engine.Evaluate(_typeofStringGuard);
         _engine.Evaluate(_typeofUndefinedGuard);
+        _engine.Evaluate(_logicalGuard);
     }
 
     [Benchmark]
@@ -129,4 +149,7 @@ public class GuardComparisonBenchmark
 
     [Benchmark]
     public JsValue TypeofUndefinedGuard() => _engine.Evaluate(_typeofUndefinedGuard);
+
+    [Benchmark]
+    public JsValue LogicalGuard() => _engine.Evaluate(_logicalGuard);
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintLogicalAndExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLogicalAndExpression.cs
@@ -59,4 +59,22 @@ internal sealed class JintLogicalAndExpression : JintExpression
         suspendable?.Data.Clear(this);
         return right;
     }
+
+    public override bool GetBooleanValue(EvaluationContext context)
+    {
+        // In a plain synchronous frame nothing can suspend or resume mid-expression, so both
+        // operands take the unboxed boolean path (comparison lanes return raw bools) instead of
+        // materializing a JsValue only to feed TypeConverter.ToBoolean. C# && preserves the
+        // JS short-circuit: the right operand is skipped when the left is falsy. Operator
+        // overloading, generator/async suspension and the engine-less fast-eval context all fall
+        // back to the materializing base path (ToBoolean(GetValue)), whose EvaluateInternal keeps
+        // the left operand's side effects from re-running across a suspend/resume.
+        var suspendable = context.Engine?.ExecutionContext.Suspendable;
+        if (suspendable is null && context.Engine is not null && !context.OperatorOverloadingAllowed)
+        {
+            return _left.GetBooleanValue(context) && _right.GetBooleanValue(context);
+        }
+
+        return base.GetBooleanValue(context);
+    }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintLogicalOrExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintLogicalOrExpression.cs
@@ -59,4 +59,22 @@ internal sealed class JintLogicalOrExpression : JintExpression
         suspendable?.Data.Clear(this);
         return right;
     }
+
+    public override bool GetBooleanValue(EvaluationContext context)
+    {
+        // In a plain synchronous frame nothing can suspend or resume mid-expression, so both
+        // operands take the unboxed boolean path (comparison lanes return raw bools) instead of
+        // materializing a JsValue only to feed TypeConverter.ToBoolean. C# || preserves the
+        // JS short-circuit: the right operand is skipped when the left is truthy. Operator
+        // overloading, generator/async suspension and the engine-less fast-eval context all fall
+        // back to the materializing base path (ToBoolean(GetValue)), whose EvaluateInternal keeps
+        // the left operand's side effects from re-running across a suspend/resume.
+        var suspendable = context.Engine?.ExecutionContext.Suspendable;
+        if (suspendable is null && context.Engine is not null && !context.OperatorOverloadingAllowed)
+        {
+            return _left.GetBooleanValue(context) || _right.GetBooleanValue(context);
+        }
+
+        return base.GetBooleanValue(context);
+    }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -139,6 +139,26 @@ internal sealed class JintUnaryExpression : JintExpression
         return EvaluateJsValue(context);
     }
 
+    public override bool GetBooleanValue(EvaluationContext context)
+    {
+        // `!x` in a boolean context (if/while/ternary/nested !) is exactly !ToBoolean(x), so the
+        // argument can take the unboxed boolean path instead of materializing a JsBoolean only to
+        // unbox it again. Gated identically to the logical expressions: operator overloading
+        // (op_LogicalNot), generator/async suspension and the engine-less fast-eval context fall
+        // back to the materializing base path. The single operand carries no left-operand state,
+        // so no suspend bookkeeping is needed on this fast path (it never runs while suspendable).
+        if (_operator == Operator.LogicalNot)
+        {
+            var suspendable = context.Engine?.ExecutionContext.Suspendable;
+            if (suspendable is null && context.Engine is not null && !context.OperatorOverloadingAllowed)
+            {
+                return !_argument.GetBooleanValue(context);
+            }
+        }
+
+        return base.GetBooleanValue(context);
+    }
+
     private JsValue EvaluateJsValue(EvaluationContext context)
     {
         var engine = context.Engine;


### PR DESCRIPTION
`JintLogicalAndExpression` / `JintLogicalOrExpression` did not override `GetBooleanValue`, so in boolean contexts — `if (a && b)`, `while (x || y)`, ternary conditions, `!(a && b)` — the base ran `ToBoolean(GetValue(...))`, fully materializing and boxing the operand values only to unbox them, throwing away the children's already-unboxed comparison lanes.

This adds `GetBooleanValue` overrides that compose the children's `GetBooleanValue` via the short-circuit boolean identity, plus a `LogicalNot` fast path in `JintUnaryExpression`. Following `JintConditionalExpression`'s precedent, the unboxed path is gated on `suspendable is null && engine is not null && !OperatorOverloadingAllowed`; all suspendable (generator/async), operator-overloading and engine-less cases fall back to the identical pre-change `ToBoolean(GetValue())` path (these classes had no override before, so that fallback is byte-for-byte the old behavior). This preserves the generator suspend/resume bookkeeping — a naive override would re-fire the left operand's side effect on resume.

### Benchmark (`GuardComparisonBenchmark.LogicalGuard`, before → after)

`LogicalGuard` (`if (v !== undefined && v !== null)` etc.): **24.16 ms → 20.15 ms (−16.6%)**, allocation unchanged.

### Correctness

Full Jint.Tests 0 failed; Test262 logical/conditional/unary 616, control-flow + generators + async 8455, expressions 21313, and full Test262 99,431/0 in integration. Short-circuit side-effect counts, generator/async suspension (left fires exactly once), operator overloading, and truthiness all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM8rSnn8j66kDCTaP2exNK
