### PR TITLE
Fuse x == null / x == undefined loose-equality guards

### DIFF
--- a/Jint.Benchmark/NullCheckBenchmark.cs
+++ b/Jint.Benchmark/NullCheckBenchmark.cs
@@ -1,0 +1,76 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The idiomatic "is null or undefined" test over an array — `if (arr[i] != null) sum++;` and the
+/// `== null` form — the shape the build-time loose-equality fusion targets. The array mixes
+/// null/undefined holes with numbers and objects so the branch is not memorizable, exercising the
+/// fused single type test against the generic evaluate-both-sides + IsLooselyEqual dispatch.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Error", "Gen0", "Gen1", "Gen2")]
+public class NullCheckBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _looseNotEqualNull;
+    private Prepared<Script> _looseEqualNull;
+
+    private const string SetupSource = """
+        var arr = [];
+        (function () {
+            var seed = 20260715;
+            for (var i = 0; i < 1024; i++) {
+                seed = (seed * 1664525 + 1013904223) | 0;
+                var pick = (seed >>> 4) & 3;
+                if (pick === 0) { arr.push(null); }
+                else if (pick === 1) { arr.push(undefined); }
+                else if (pick === 2) { arr.push(seed & 255); }
+                else { arr.push({ v: i }); }
+            }
+        })();
+        """;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _engine = new Engine();
+        _engine.Execute(SetupSource);
+
+        _looseNotEqualNull = Engine.PrepareScript("""
+            function f() {
+                var sum = 0;
+                for (var pass = 0; pass < 100; pass++) {
+                    for (var i = 0; i < arr.length; i++) {
+                        if (arr[i] != null) { sum++; }
+                    }
+                }
+                return sum;
+            }
+            f();
+            """);
+
+        _looseEqualNull = Engine.PrepareScript("""
+            function f() {
+                var sum = 0;
+                for (var pass = 0; pass < 100; pass++) {
+                    for (var i = 0; i < arr.length; i++) {
+                        if (arr[i] == null) { sum++; }
+                    }
+                }
+                return sum;
+            }
+            f();
+            """);
+
+        _engine.Evaluate(_looseNotEqualNull);
+        _engine.Evaluate(_looseEqualNull);
+    }
+
+    [Benchmark]
+    public JsValue LooseNotEqualNull() => _engine.Evaluate(_looseNotEqualNull);
+
+    [Benchmark]
+    public JsValue LooseEqualNull() => _engine.Evaluate(_looseEqualNull);
+}

--- a/Jint.Tests/Runtime/GuardFusionTests.cs
+++ b/Jint.Tests/Runtime/GuardFusionTests.cs
@@ -114,4 +114,139 @@ public class GuardFusionTests
 
         Assert.Equal("unso", result);
     }
+
+    [Fact]
+    public void LooseNullAndUndefinedGuardsMatchGenericSemantics()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var u; var n = null; var o = {}; var s = 'x'; var zero = 0; var empty = ''; var f = false; var nan = NaN;
+            [
+                // undefined / null are loosely equal to each other and to themselves (both orientations)
+                u == undefined, undefined == u, n == null, null == n,
+                u == null, null == u, n == undefined, undefined == n,
+                null == undefined, undefined == null,
+                // != negations
+                u != undefined, n != null, null != undefined, o != null,
+                // the classic false cases against null
+                zero == null, empty == null, f == null, nan == null, o == null, s == null,
+                // and against undefined
+                zero == undefined, empty == undefined, f == undefined, o == undefined,
+                // reversed operand order still declines for the non-nullish side
+                null == zero, undefined == empty, null == o
+            ].join(',');
+            """).AsString();
+
+        Assert.Equal(
+            "true,true,true,true," +
+            "true,true,true,true," +
+            "true,true," +
+            "false,false,false,true," +
+            "false,false,false,false,false,false," +
+            "false,false,false,false," +
+            "false,false,false",
+            result);
+    }
+
+    [Fact]
+    public void LooseGuardParityWithGenericPathAcrossOperandTypes()
+    {
+        // Cross-checks the fused `x == null`/`x == undefined` against a runtime-computed generic
+        // loose comparison (the ` == y` where y is a variable holding null/undefined is NOT fused,
+        // because the variable is not the `undefined` identifier / `null` literal).
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var nullVar = null, undefVar = undefined;
+            var samples = [undefined, null, 0, '', false, NaN, {}, [], 'x', 42];
+            var ok = true;
+            for (var i = 0; i < samples.length; i++) {
+                var v = samples[i];
+                if ((v == null) !== (v == nullVar)) ok = false;
+                if ((v == undefined) !== (v == undefVar)) ok = false;
+                if ((v != null) !== (v != nullVar)) ok = false;
+                if ((v != undefined) !== (v != undefVar)) ok = false;
+            }
+            ok;
+            """).AsBoolean();
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void LooseGuardEvaluatesOnlyInterestingOperandOnce()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var calls = 0;
+            function probe() { calls++; return undefined; }
+            var a = probe() == null;   // true, calls once
+            var b = null == probe();   // true, calls again
+            var c = probe() != null;   // false, calls again
+            [a, b, c, calls].join(',');
+            """).AsString();
+
+        Assert.Equal("true,true,false,3", result);
+    }
+
+    [Fact]
+    public void FusedLooseGuardsWorkAcrossAwaitSuspension()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            async function f() {
+                var a = (await Promise.resolve(undefined)) == null;
+                var b = (await Promise.resolve(null)) == undefined;
+                var c = (await Promise.resolve('s')) != null;
+                return [a, b, c].join(',');
+            }
+            f();
+            """).UnwrapIfPromise().AsString();
+
+        Assert.Equal("true,true,true", result);
+    }
+
+    [Fact]
+    public void LooseGuardsDriveIfStatementBooleanFastPath()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            var log = [];
+            var vals = [undefined, null, 'x', 5, {}];
+            for (var i = 0; i < vals.length; i++) {
+                var v = vals[i];
+                if (v == null) { log.push('n'); }              // matches both undefined and null
+                else if (typeof v === 'string') { log.push('s'); }
+                else { log.push('o'); }
+            }
+            log.join('');
+            """).AsString();
+
+        Assert.Equal("nnsoo", result);
+    }
+
+    [Fact]
+    public void LooseNullEqualityHonorsHtmlDdaAnnexB()
+    {
+        var engine = new Engine();
+        // an object with the [[IsHTMLDDA]] internal slot (the document.all shape)
+        var htmlDDA = new Jint.Native.IsHTMLDDA(engine);
+        engine.SetValue("htmlDDA", (Jint.Native.JsValue) htmlDDA);
+
+        // Annex B: loose equality with null/undefined is true (both orientations, both operators)
+        Assert.True(engine.Evaluate("htmlDDA == null").AsBoolean());
+        Assert.True(engine.Evaluate("null == htmlDDA").AsBoolean());
+        Assert.True(engine.Evaluate("htmlDDA == undefined").AsBoolean());
+        Assert.True(engine.Evaluate("undefined == htmlDDA").AsBoolean());
+        Assert.False(engine.Evaluate("htmlDDA != null").AsBoolean());
+        Assert.False(engine.Evaluate("htmlDDA != undefined").AsBoolean());
+
+        // strict equality must remain false — the strict fusion path is untouched
+        Assert.False(engine.Evaluate("htmlDDA === null").AsBoolean());
+        Assert.False(engine.Evaluate("htmlDDA === undefined").AsBoolean());
+        Assert.True(engine.Evaluate("htmlDDA !== null").AsBoolean());
+
+        // a plain object is never loosely equal to null/undefined
+        Assert.False(engine.Evaluate("({}) == null").AsBoolean());
+        Assert.False(engine.Evaluate("({}) == undefined").AsBoolean());
+    }
 }

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -827,10 +827,12 @@ internal abstract class JintBinaryExpression : JintExpression
                 result = new DivideBinaryExpression(expression);
                 break;
             case Operator.Equality:
-                result = new EqualBinaryExpression(expression);
+                result = TryBuildFusedLooseEquality(expression, invert: false);
+                result ??= new EqualBinaryExpression(expression);
                 break;
             case Operator.Inequality:
-                result = new EqualBinaryExpression(expression, invert: true);
+                result = TryBuildFusedLooseEquality(expression, invert: true);
+                result ??= new EqualBinaryExpression(expression, invert: true);
                 break;
             case Operator.GreaterThanOrEqual:
                 result = new CompareBinaryExpression(expression, leftFirst: true);
@@ -921,6 +923,34 @@ internal abstract class JintBinaryExpression : JintExpression
         if (leftSingleton is not null && rightSingleton is null)
         {
             return new SingletonStrictEqualityExpression(expression, operandIsLeft: false, leftSingleton.Value, invert);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Build-time fusion for the guard idioms `x == null` and `x == undefined` (plus the != forms):
+    /// the constant side is known statically, so the fused node evaluates only the interesting
+    /// operand and answers with one internal-type test — no evaluation of the constant side and no
+    /// generic loose-equality dispatch. Loose equality against null/undefined is true exactly when
+    /// the value is null, undefined, or has the [[IsHTMLDDA]] internal slot (Annex B), so the single
+    /// mask covers all three. Returns null when the expression is not one of these shapes, including
+    /// when BOTH sides are singletons (e.g. `null == undefined`) — that is left to the generic path,
+    /// mirroring <see cref="TryBuildFusedStrictEquality"/>, so cross-singleton semantics are preserved.
+    /// </summary>
+    private static SingletonLooseEqualityExpression? TryBuildFusedLooseEquality(NonLogicalBinaryExpression expression, bool invert)
+    {
+        var leftSingleton = GetKnownSingletonType(expression.Left);
+        var rightSingleton = GetKnownSingletonType(expression.Right);
+
+        if (rightSingleton is not null && leftSingleton is null)
+        {
+            return new SingletonLooseEqualityExpression(expression, operandIsLeft: true, invert);
+        }
+
+        if (leftSingleton is not null && rightSingleton is null)
+        {
+            return new SingletonLooseEqualityExpression(expression, operandIsLeft: false, invert);
         }
 
         return null;
@@ -1069,6 +1099,54 @@ internal abstract class JintBinaryExpression : JintExpression
             }
 
             return (value._type == _expectedType) != _invert;
+        }
+    }
+
+    /// <summary>
+    /// Fused `x == null` / `x == undefined` (and the != forms): only the interesting operand
+    /// evaluates, and the answer is a single internal-type test. Loose equality against null or
+    /// undefined is true exactly when the value is null, undefined, or carries the [[IsHTMLDDA]]
+    /// internal slot — Annex B makes `document.all == null` true — which is precisely the union of
+    /// those three type bits (see JsNull.IsLooselyEqual / JsUndefined.IsLooselyEqual).
+    /// The constant side is a `null` literal or the folded `undefined` identifier, both of which
+    /// have <c>ToObject()</c> == null, so operator overloading can never apply here; the fusion is
+    /// declined at build time when BOTH sides are singletons, preserving `null == undefined`.
+    /// </summary>
+    private sealed class SingletonLooseEqualityExpression : JintBinaryExpression
+    {
+        private const InternalTypes NullOrUndefinedOrHtmlDda = InternalTypes.Null | InternalTypes.Undefined | InternalTypes.IsHTMLDDA;
+
+        private readonly JintExpression _operand;
+        private readonly bool _invert;
+
+        public SingletonLooseEqualityExpression(NonLogicalBinaryExpression expression, bool operandIsLeft, bool invert) : base(expression)
+        {
+            _operand = operandIsLeft ? _left : _right;
+            _invert = invert;
+        }
+
+        protected override object EvaluateInternal(EvaluationContext context)
+        {
+            var value = _operand.GetValue(context);
+            if (context.IsSuspended())
+            {
+                return JsValue.Undefined;
+            }
+
+            var nullish = (value._type & NullOrUndefinedOrHtmlDda) != InternalTypes.Empty;
+            return nullish != _invert ? JsBoolean.True : JsBoolean.False;
+        }
+
+        public override bool GetBooleanValue(EvaluationContext context)
+        {
+            var value = _operand.GetValue(context);
+            if (context.IsSuspended())
+            {
+                return false;
+            }
+
+            var nullish = (value._type & NullOrUndefinedOrHtmlDda) != InternalTypes.Empty;
+            return nullish != _invert;
         }
     }
 


### PR DESCRIPTION
The idiomatic "is null or undefined" test `x == null` / `x != null` was not fused: `TryBuildFusedStrictEquality` handled only the strict forms, so the loose forms dispatched through the generic `IsLooselyEqual` evaluating both sides, even though the constant side is statically known and the whole test is one type check.

This adds a loose-equality fusion mirroring the existing strict one. When one side is the `null` literal or the `undefined` identifier (reusing `GetKnownSingletonType`, so shadowing behavior is identical to the strict fusion), the fused node evaluates only the other operand and answers `(value._type & (Null | Undefined | IsHTMLDDA)) != Empty` (negated for `!=`). The **`IsHTMLDDA` bit is included**, so Annex B holds: `document.all == null` is `true` while `=== null` is `false` (the strict path is untouched). When both sides are constants (e.g. `null == undefined`) it declines to the generic path, exactly as the strict fusion does.

### Benchmark (`NullCheckBenchmark`, before → after)

| lane | time |
|---|---|
| `LooseEqualNull` (`arr[i] == null`) | 9.94 ms → **7.77 ms** (−21.8%) |
| `LooseNotEqualNull` (`arr[i] != null`) | 8.37 ms → **7.96 ms** (−4.9%) |

### Correctness

Full Jint.Tests 0 failed; Test262 expressions 21313, equality 83, **annexB 1377** (the IsHTMLDDA/emulates-undefined tests), and full Test262 99,431/0 in integration. `null == undefined`→true, `0/""/false/NaN == null`→false, single-operand-evaluation (side-effect count 1), and a dedicated IsHTMLDDA test all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM8rSnn8j66kDCTaP2exNK
