### PR TITLE
Add value-producing slot fast path for identifier ++/-- expressions

### DIFF
--- a/Jint.Benchmark/UpdateExpressionValueBenchmark.cs
+++ b/Jint.Benchmark/UpdateExpressionValueBenchmark.cs
@@ -1,0 +1,97 @@
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Value-producing update expressions on function-local (declarative-slot) counters: the
+/// increment/decrement result is consumed by the surrounding expression (<c>arr[i++]</c>,
+/// <c>acc += i++</c>, <c>while (n--)</c>, <c>++i</c>), so evaluation cannot take the discard-mode
+/// fast path and instead resolves the counter through the identifier slot cache. Complements
+/// <see cref="FunctionLocalNumberLoopBenchmark"/>, whose <c>i++</c> updates are all discarded.
+/// </summary>
+[MemoryDiagnoser]
+public class UpdateExpressionValueBenchmark
+{
+    private Engine _engine = null!;
+    private Prepared<Script> _postfixAccumulate;
+    private Prepared<Script> _prefixAccumulate;
+    private Prepared<Script> _arrayIndexPostInc;
+    private Prepared<Script> _whileCountdown;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        // postfix i++ consumed as a value every iteration (acc += i++)
+        _postfixAccumulate = Engine.PrepareScript("""
+            function f() {
+                var i = 0;
+                var acc = 0;
+                while (i < 100000) {
+                    acc += i++;
+                }
+                return acc;
+            }
+            f();
+            """);
+
+        // prefix ++i consumed as a value every iteration (acc += ++i)
+        _prefixAccumulate = Engine.PrepareScript("""
+            function f() {
+                var i = 0;
+                var acc = 0;
+                while (i < 100000) {
+                    acc += ++i;
+                }
+                return acc;
+            }
+            f();
+            """);
+
+        // sum += arr[i++]: the post-increment result indexes the array and advances the counter
+        _arrayIndexPostInc = Engine.PrepareScript("""
+            function f() {
+                var arr = new Array(100000);
+                for (var k = 0; k < 100000; k++) { arr[k] = k & 7; }
+                var sum = 0;
+                var i = 0;
+                while (i < 100000) {
+                    sum += arr[i++];
+                }
+                return sum;
+            }
+            f();
+            """);
+
+        // while (n--): the post-decrement value drives the loop condition
+        _whileCountdown = Engine.PrepareScript("""
+            function f() {
+                var n = 100000;
+                var count = 0;
+                while (n--) {
+                    count++;
+                }
+                return count;
+            }
+            f();
+            """);
+
+        _engine = new Engine();
+        _engine.Evaluate(_postfixAccumulate);
+        _engine.Evaluate(_prefixAccumulate);
+        _engine.Evaluate(_arrayIndexPostInc);
+        _engine.Evaluate(_whileCountdown);
+    }
+
+    [Benchmark]
+    public JsValue PostfixAccumulate() => _engine.Evaluate(_postfixAccumulate);
+
+    [Benchmark]
+    public JsValue PrefixAccumulate() => _engine.Evaluate(_prefixAccumulate);
+
+    [Benchmark]
+    public JsValue ArrayIndexPostInc() => _engine.Evaluate(_arrayIndexPostInc);
+
+    [Benchmark]
+    public JsValue WhileCountdown() => _engine.Evaluate(_whileCountdown);
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUpdateExpression.cs
@@ -95,6 +95,46 @@ internal sealed class JintUpdateExpression : JintExpression
         return true;
     }
 
+    /// <summary>
+    /// Value-producing twin of <see cref="TryUpdateUnboxed"/>: increments/decrements a slot-stored
+    /// number binding without an environment-chain walk or a second SetMutableBinding lookup, and
+    /// materializes the value the surrounding expression consumes — the OLD value for postfix
+    /// (<c>i++</c>), the NEW value for prefix (<c>++i</c>). Everything the fast path cannot prove
+    /// safe (operator overloading, generators/async, eval/arguments in strict mode, TDZ, const,
+    /// non-number values, global/object/dictionary environments) declines so the full materialized
+    /// path produces the exact errors and coercions.
+    /// </summary>
+    private bool TryUpdateIdentifierNumberSlot(EvaluationContext context, out JsValue? result)
+    {
+        var engine = context.Engine;
+        if (context.OperatorOverloadingAllowed
+            || engine.ExecutionContext.Suspendable is not null)
+        {
+            result = null;
+            return false;
+        }
+
+        if (_evalOrArguments && StrictModeScope.IsStrictModeCode)
+        {
+            // full path raises the proper SyntaxError
+            result = null;
+            return false;
+        }
+
+        if (!_slotCache.TryResolve(engine, engine.ExecutionContext.LexicalEnvironment, _leftIdentifier!.Identifier, out var environment, out var slotIndex)
+            || !environment.TryGetNumberSlot(slotIndex, out var value))
+        {
+            result = null;
+            return false;
+        }
+
+        var updated = value + _change;
+        environment.SetNumberSlot(slotIndex, updated);
+        // postfix (i++) yields the old value, prefix (++i) the new value; both are numbers here
+        result = JsNumber.Create(_prefix ? updated : value);
+        return true;
+    }
+
     private JsValue UpdateNonIdentifier(EvaluationContext context)
     {
         var engine = context.Engine;
@@ -163,6 +203,15 @@ internal sealed class JintUpdateExpression : JintExpression
     private JsValue? UpdateIdentifier(EvaluationContext context)
     {
         var engine = context.Engine;
+
+        // Local/block/function number-counter fast path (arr[i++], x = data[j++], while(n--)):
+        // resolve the slot location from the per-node cache and read/write the raw double, exactly
+        // as the discard-mode TryUpdateUnboxed does, but materialize the value the surrounding
+        // expression needs. Anything the fast path cannot prove safe declines to the paths below.
+        if (TryUpdateIdentifierNumberSlot(context, out var slotResult))
+        {
+            return slotResult;
+        }
 
         // Global-binding fast path: when this identifier resolves to a cached plain writable global
         // data property, read and write its descriptor value directly — no environment chain walk and


### PR DESCRIPTION
`JintUpdateExpression` had a slot-cache fast path (`TryUpdateUnboxed`) only for the **discard** case (`for(;;i++)`). When `i++`/`--i` is used **as a value** (`sum += arr[i++]`, `while (n--)`, `x = data[j++]`), it went through `UpdateIdentifier`, doing a full environment walk (`TryGetIdentifierEnvironmentWithBindingValue` + `SetMutableBinding`) every time for local/block/closure counters.

This adds a value-producing twin, `TryUpdateIdentifierNumberSlot`, mirroring the discard-path fast lane: resolve via the shared `_slotCache`, read/write the raw double via the number-slot accessors, and return the correct boxed value (old for postfix, new for prefix). It reuses the exact discard-path guards; correctness rests on `TryGetNumberSlot` declining for `const` (not mutable), TDZ (uninitialized), and non-number/BigInt slots — all of which fall through to the unchanged materialized path that raises the correct TypeError/ReferenceError or coerces. BigInt stays on the generic path.

### Benchmark (`UpdateExpressionValueBenchmark`, before → after)

| lane | time |
|---|---|
| `PostfixAccumulate` (`acc += i++`) | 3.15 ms → **2.49 ms** (−20.9%) |
| `PrefixAccumulate` (`acc += ++i`) | 3.05 ms → **2.54 ms** (−16.7%) |
| `WhileCountdown` (`while (n--)`) | 2.61 ms → **2.14 ms** (−17.8%) |
| `ArrayIndexPostInc` (`sum += arr[i++]`) | 13.15 ms → 13.81 ms (array/GC-dominated, within cross-run noise) |

### Correctness

Full Jint.Tests 0 failed; Test262 update 297, increment/decrement 586, expressions 21313, and full Test262 99,431/0 in integration. Postfix/prefix return values, `const`→TypeError, TDZ→ReferenceError, string/BigInt coercion, closures, and overflow-to-double all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM8rSnn8j66kDCTaP2exNK
