### PR TITLE
Fix spurious TDZ when a for-header reads a name the loop body shadows

### DIFF
--- a/Jint.Tests/Runtime/LoopBodyFlatteningTests.cs
+++ b/Jint.Tests/Runtime/LoopBodyFlatteningTests.cs
@@ -143,6 +143,89 @@ public class LoopBodyFlatteningTests
     }
 
     [Fact]
+    public void HeaderInitReferencingOuterNameShadowedByBodyReadsOuter()
+    {
+        var engine = new Engine();
+        // the header init reads `r`; the body block declares its own `r`. The names do not overlap
+        // the header's declared name (`l`), so the old NamesOverlap gate let flattening fold the
+        // body's `r` slot into the loop env — where the init's `r` then resolved to the
+        // still-uninitialized slot and threw a spurious TDZ. The init's `r` is an OUTER reference.
+        var result = engine.Evaluate("""
+            (function () {
+                let r = 5, o = 8, seen = [];
+                for (let l = r; l < o; l++) {
+                    let r = l * 10;
+                    seen.push(r);
+                }
+                return seen.join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal("50,60,70", result);
+    }
+
+    [Fact]
+    public void HeaderTestReferencingOuterNameShadowedByBodyReadsOuter()
+    {
+        var engine = new Engine();
+        // same shape, but the outer name is read from the loop test rather than the init
+        var result = engine.Evaluate("""
+            (function () {
+                let r = 3, seen = [];
+                for (let l = 0; l < r; l++) {
+                    let r = l * 10;
+                    seen.push(r);
+                }
+                return seen.join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal("0,10,20", result);
+    }
+
+    [Fact]
+    public void HeaderUpdateReferencingOuterNameShadowedByBodyReadsOuter()
+    {
+        var engine = new Engine();
+        // the update reads outer `step`; the body shadows `step`
+        var result = engine.Evaluate("""
+            (function () {
+                let step = 2, seen = [];
+                for (let l = 0; l < 6; l += step) {
+                    let step = l * 10;
+                    seen.push(step);
+                }
+                return seen.join(',');
+            })()
+            """).AsString();
+
+        Assert.Equal("0,20,40", result);
+    }
+
+    [Fact]
+    public void TurbopackChunkShapeResolvesModuleFactory()
+    {
+        var engine = new Engine();
+        // reduced from a Turbopack runtime chunk: a header `for (let l = r; ...)` over a body that
+        // block-scopes `r` and `o` while the header reads the outer `r`/`o` — the exact shape that
+        // aborted the Next.js bootstrap with "r has not been initialized"
+        var result = engine.Evaluate("""
+            (function () {
+                let e = [0, 0, 'fa', 'fb'];
+                let t = new Map();
+                let r = 2, o = 4, n;
+                for (let l = r; l < o; l++) {
+                    let r = e[l], o = t.get(r);
+                    if (o) { n = o; break; }
+                }
+                return 'ok:' + (n === undefined);
+            })()
+            """).AsString();
+
+        Assert.Equal("ok:true", result);
+    }
+
+    [Fact]
     public void UsingDeclarationsKeepBlockDisposeSemantics()
     {
         var engine = new Engine();

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -123,7 +123,8 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
             if (bodyState.SlotNames is { } bodyNames
                 && _boundNames!.Count + bodyNames.Length <= 16
                 && !HasUsingDeclarations(bodyState)
-                && !NamesOverlap(_loopSlotNames!, bodyNames))
+                && !NamesOverlap(_loopSlotNames!, bodyNames)
+                && !HeaderReferencesAnyBodyName(statement, bodyNames))
             {
                 var headerCount = _loopSlotNames!.Length;
                 var combinedNames = new Key[headerCount + bodyNames.Length];
@@ -458,6 +459,50 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
                 {
                     return true;
                 }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether the loop header (init, test, or update) contains an identifier matching a body-block
+    /// lexical name. Flattening folds the body's let/const slots into the loop environment, so such a
+    /// name resolves there — but the header scope excludes the body block's declarations, so the
+    /// reference targets an <b>outer</b> binding the body shadows. Folding it in resolves the header
+    /// reference against the still-uninitialized body slot, a spurious TDZ ("x has not been
+    /// initialized"). Over-approximates in the safe direction (a matching property name or a
+    /// nested-scope declaration only forgoes the optimization), mirroring
+    /// <c>EnvironmentEscapeAstVisitor.ClosureReferencesAny</c>.
+    /// </summary>
+    private static bool HeaderReferencesAnyBodyName(ForStatement statement, Key[] bodyNames)
+    {
+        return (statement.Init is not null && ReferencesAnyName(statement.Init, bodyNames))
+            || (statement.Test is not null && ReferencesAnyName(statement.Test, bodyNames))
+            || (statement.Update is not null && ReferencesAnyName(statement.Update, bodyNames));
+    }
+
+    private static bool ReferencesAnyName(Node node, Key[] names)
+    {
+        if (node.Type == NodeType.Identifier)
+        {
+            var name = ((Identifier) node).Name;
+            foreach (var candidate in names)
+            {
+                if (string.Equals(candidate.Name, name, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        foreach (var childNode in node.ChildNodes)
+        {
+            if (ReferencesAnyName(childNode, names))
+            {
+                return true;
             }
         }
 


### PR DESCRIPTION
## Summary
Fix spurious TDZ when a for-header reads a name the loop body shadows

## Details
Loop-body lexical flattening (#2610) folds an eligible body block's `let`/`const`
bindings into the pooled loop environment. The eligibility gate (`NamesOverlap`)
only checked body names against the header's *declared* names — it missed the case
where a body name shadows an *outer* binding that a header expression references:

```js
for (let l = r; l < o; l++) { let r = e[l], o = t.get(r); ... }
```

Here `r`/`o` in the header resolve to outer bindings, but flattening folded the
body's `r`/`o` slots into the loop env, so the header read them while still
uninitialized → `ReferenceError: r has not been initialized`. V8/SpiderMonkey/JSC
run it fine. This is the exact shape in Turbopack's module-factory runtime, so it
aborted rendering of Turbopack/Next.js bundles. The bug fires from the test and
update positions too, not just init.

Fix: add `HeaderReferencesAnyBodyName`, declining to flatten when any body slot
name appears as an identifier in the init/test/update. It over-approximates in the
safe direction (a matching property name or nested-scope declaration only forgoes
the optimization), mirroring `EnvironmentEscapeAstVisitor.ClosureReferencesAny`.
The scan runs once at statement construction, so there is no per-iteration cost,
and flattening still applies to loops whose headers reference no shadowed name.

Regression introduced in 4.12.0 (#2610); worked in 4.11.0.

## Linked issue

Fixes #2708

## Test plan

- [x] Added or updated unit tests in `Jint.Tests` (`LoopBodyFlatteningTests`: init/test/update header refs + a reduced Turbopack module-factory shape)
- [x] Ran `dotnet test --configuration Release` locally (3629 net10.0 / 3566 net472, 0 failures)
- [x] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions (99431 pass, 0 fail, 135 skip)
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop` — n/a
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark` — n/a (narrows an existing optimization; construction-time guard only)

## Breaking change?

No.
