### PR TITLE
Deduplicate implicitly implemented interface methods in member resolution

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
+++ b/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
@@ -25,6 +25,20 @@ public partial class InteropTests
     }
 
     [Fact]
+    public void FailedMethodResolutionDoesNotDuplicateImplicitlyImplementedInterfaceMethods()
+    {
+        var engine = DetailedErrorsEngine();
+        engine.SetValue("holder", new GreeterHolder(new Greeter()));
+
+        // Greeter.Greet is collected both from the class and from IGreeter, it must be reported once
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("holder.Greeter.Greet()"));
+
+        Assert.Equal(
+            "No public methods with the specified arguments were found. Target: Jint.Tests.Runtime.Greeter.Greet; provided arguments: (); candidate signatures: Greet(String name)",
+            ex.Message);
+    }
+
+    [Fact]
     public void FailedMethodResolutionDescribesArgumentKinds()
     {
         var engine = DetailedErrorsEngine();
@@ -285,4 +299,27 @@ public class CtorFails
     public CtorFails(string name)
     {
     }
+}
+
+public interface IGreeter
+{
+    string Greet(string name);
+}
+
+public class Greeter : IGreeter
+{
+    public string Greet(string name) => $"Hello, {name}";
+}
+
+public class GreeterHolder
+{
+    private readonly IGreeter _greeter;
+
+    public GreeterHolder(IGreeter greeter)
+    {
+        _greeter = greeter;
+    }
+
+    // object-typed on purpose: the wrapper resolves members against the runtime type
+    public object Greeter => _greeter;
 }

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -189,7 +189,8 @@ public sealed class TypeResolver
 
                     foreach (var name in typeResolverMemberNameCreator(imethod))
                     {
-                        if (typeResolverMemberNameComparer.Equals(name, memberName))
+                        if (typeResolverMemberNameComparer.Equals(name, memberName)
+                            && !ContainsMethodWithSameSignature(explicitMethods, imethod))
                         {
                             explicitMethods ??= new List<MethodInfo>();
                             explicitMethods.Add(imethod);
@@ -274,6 +275,106 @@ public sealed class TypeResolver
         }
 
         return ConstantValueAccessor.NullAccessor;
+    }
+
+    private static bool ContainsMethodWithSameSignature(List<MethodInfo>? methods, MethodInfo method)
+    {
+        if (methods is null)
+        {
+            return false;
+        }
+
+        foreach (var existing in methods)
+        {
+            if (HasSameSignature(existing, method))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasSameSignature(MethodInfo a, MethodInfo b)
+    {
+        if (!string.Equals(a.Name, b.Name, StringComparison.Ordinal)
+            || a.IsGenericMethodDefinition != b.IsGenericMethodDefinition)
+        {
+            return false;
+        }
+
+        if (a.IsGenericMethodDefinition && a.GetGenericArguments().Length != b.GetGenericArguments().Length)
+        {
+            return false;
+        }
+
+        var parametersA = a.GetParameters();
+        var parametersB = b.GetParameters();
+        if (parametersA.Length != parametersB.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < parametersA.Length; i++)
+        {
+            if (!TypesMatch(parametersA[i].ParameterType, parametersB[i].ParameterType))
+            {
+                return false;
+            }
+        }
+
+        return TypesMatch(a.ReturnType, b.ReturnType);
+    }
+
+    /// <summary>
+    /// Structural type equality that treats positionally identical generic method parameters as equal,
+    /// the same method seen through both a class and an interface has distinct generic parameter instances.
+    /// </summary>
+    private static bool TypesMatch(Type a, Type b)
+    {
+        if (a == b)
+        {
+            return true;
+        }
+
+        if (a.IsGenericParameter || b.IsGenericParameter)
+        {
+            return a.IsGenericParameter
+                && b.IsGenericParameter
+                && a.DeclaringMethod is not null
+                && b.DeclaringMethod is not null
+                && a.GenericParameterPosition == b.GenericParameterPosition;
+        }
+
+        if (a.HasElementType || b.HasElementType)
+        {
+            return a.HasElementType
+                && b.HasElementType
+                && a.IsArray == b.IsArray
+                && a.IsByRef == b.IsByRef
+                && a.IsPointer == b.IsPointer
+                && (!a.IsArray || a.GetArrayRank() == b.GetArrayRank())
+                && TypesMatch(a.GetElementType()!, b.GetElementType()!);
+        }
+
+        if (a.IsConstructedGenericType
+            && b.IsConstructedGenericType
+            && a.GetGenericTypeDefinition() == b.GetGenericTypeDefinition())
+        {
+            var argumentsA = a.GenericTypeArguments;
+            var argumentsB = b.GenericTypeArguments;
+            for (var i = 0; i < argumentsA.Length; i++)
+            {
+                if (!TypesMatch(argumentsA[i], argumentsB[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     private static int CalculateIndexerScore(ParameterInfo parameter, bool isInteger)
@@ -389,7 +490,7 @@ public sealed class TypeResolver
 
         // if no properties were found then look for a method
         List<MethodInfo>? methods = null;
-        void AddMethod(MethodInfo m)
+        void AddMethod(MethodInfo m, bool skipIfSignatureAlreadyPresent = false)
         {
             if (!Filter(engine, type, m))
             {
@@ -400,8 +501,16 @@ public sealed class TypeResolver
             {
                 if (memberNameComparer.Equals(name, memberName))
                 {
+                    // an implicitly implemented interface method is also reported through the class,
+                    // only add a secondary slot when it brings a new signature
+                    if (skipIfSignatureAlreadyPresent && ContainsMethodWithSameSignature(methods, m))
+                    {
+                        return;
+                    }
+
                     methods ??= new List<MethodInfo>();
                     methods.Add(m);
+                    return;
                 }
             }
         }
@@ -415,7 +524,7 @@ public sealed class TypeResolver
         {
             foreach (var m in iface.GetMethods())
             {
-                AddMethod(m);
+                AddMethod(m, skipIfSignatureAlreadyPresent: true);
             }
         }
 
@@ -433,7 +542,7 @@ public sealed class TypeResolver
         {
             foreach (var m in typeof(object).GetMethods(bindingFlags ?? engine.Options.Interop.ObjectWrapperReportedMethodBindingFlags))
             {
-                AddMethod(m);
+                AddMethod(m, skipIfSignatureAlreadyPresent: true);
             }
         }
 


### PR DESCRIPTION
Fixes the duplicated candidate signatures reported in https://github.com/sebastienros/jint/discussions/2523#discussioncomment-17640145.

## Problem

When a member is resolved against a concrete type, `TypeResolver.TryFindMemberAccessor` collects candidate methods both from the type itself and from every implemented interface. An implicitly implemented interface method is present in both sets, so it was added twice. With `ExposeDetailedResolutionErrors` enabled a failed call then reported the same signature twice:

```
No public methods with the specified arguments were found. Target: MyIntefaceImpl.MyMethod; provided arguments: (); candidate signatures: MyMethod(String a), MyMethod(String a)
```

The duplicate also meant redundant work during overload resolution since both entries bind to the same implementation.

## Fix

Interface-sourced (and, for interface targets, `object`-sourced) methods are now skipped when an earlier candidate already has the same signature. Because class methods are collected first, the class implementation wins, matching C# semantics for a call on the concrete type. The signature comparison is structural:

- generic methods match across their distinct generic parameter instances (`T` of the class method vs `T` of the interface method), including through constructed generics, by-ref and array types
- genuinely different methods are kept, e.g. an interface method hiding `Object.GetHashCode()` with a different return type, or `Equals()` overloading `Equals(object)` - the existing `InteropExplicitTypeTests` covering those scenarios still pass

The same dedupe is applied to the explicit interface implementation path, where identical redeclared signatures from multiple interfaces could previously also be reported twice.

## Testing

Added a regression test mirroring the discussion repro (interface implementation exposed through an `object`-typed property). Full `Jint.Tests` and `Jint.Tests.PublicInterface` suites pass on net10.0 and net472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)