### PR TITLE
Add tests for using modules from script code run via Evaluate

### DIFF
--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -122,6 +122,50 @@ public class ModuleTests
     }
 
     [Fact]
+    public void CanDynamicallyImportFromScriptCode()
+    {
+        // https://github.com/sebastienros/jint/discussions/1472
+        // Static import/export declarations only exist in modules, but the dynamic import()
+        // expression is valid inside classic scripts run via Evaluate/Execute. It should
+        // resolve modules registered via Modules.Add without requiring EnableModules or
+        // a source location for the script.
+        _engine.Modules.Add("imported-module", "export function add(a, b) { return a + b; }");
+
+        _engine.Evaluate("import('imported-module').then(ns => { globalThis.result = ns.add(1, 2); });");
+
+        Assert.Equal(3, _engine.Evaluate("globalThis.result").AsInteger());
+    }
+
+    [Fact]
+    public void CanAwaitDynamicImportFromScriptCode()
+    {
+        _engine.Modules.Add("imported-module", "export const value = 'exported value';");
+
+        _engine.Evaluate(@"
+            (async () => {
+                const ns = await import('imported-module');
+                globalThis.result = ns.value;
+            })();
+        ");
+        _engine.Advanced.ProcessTasks();
+
+        Assert.Equal("exported value", _engine.Evaluate("globalThis.result").AsString());
+    }
+
+    [Fact]
+    public void CanExposeModuleNamespaceToScriptCode()
+    {
+        // Importing from .NET and exposing the namespace object as a global lets
+        // script code run via Evaluate use module exports without being a module.
+        _engine.Modules.Add("imported-module", "export function add(a, b) { return a + b; }");
+
+        var ns = _engine.Modules.Import("imported-module");
+        _engine.SetValue("lib", ns);
+
+        Assert.Equal(3, _engine.Evaluate("lib.add(1, 2)").AsInteger());
+    }
+
+    [Fact]
     public void NestedEvaluateFromModuleExecutionDoesNotClobberCompletionValue()
     {
         // Regression test for https://github.com/sebastienros/jint/issues/2492


### PR DESCRIPTION
## Summary

Adds test coverage for the patterns that answer [discussion #1472](https://github.com/sebastienros/jint/discussions/1472) ("Cannot use import/export statements outside a module" — how to use modules from code run via `Evaluate`):

- `CanDynamicallyImportFromScriptCode` — dynamic `import()` inside a classic script resolves modules registered via `Modules.Add`, without `EnableModules` or a script source location. This path had no coverage; existing script-side dynamic import tests all use custom module loaders with explicit `source:` parameters.
- `CanAwaitDynamicImportFromScriptCode` — same via `await import()` in an async IIFE.
- `CanExposeModuleNamespaceToScriptCode` — importing a module from .NET and exposing its namespace object as a global for `Evaluate`-based code.

No production code changes.

## Test plan

- [x] `dotnet test --configuration Release Jint.Tests --filter "FullyQualifiedName~Jint.Tests.Runtime.ModuleTests"` — 57 passed (net10.0 and net472)

🤖 Generated with [Claude Code](https://claude.com/claude-code)