### PR TITLE
Gate host-boundary constraint checks on active evaluation and harden coverage

### DIFF
--- a/Jint.Tests/Runtime/ExecutionConstraintTests.cs
+++ b/Jint.Tests/Runtime/ExecutionConstraintTests.cs
@@ -658,134 +658,95 @@ myarr[0](0);
         Assert.Throws<ScriptPreparationException>(() => new Engine().Execute(sb.ToString()));
     }
 
+    // https://github.com/sebastienros/jint/discussions/2707
+    // With only amortized constraints registered (here: a cancellation token), the
+    // statement-count amortization must not defer cancellation across host calls that can each
+    // take arbitrarily long; the host-call boundary re-check bounds detection latency to a
+    // single call. Cancelling from inside the 3rd host call makes the assertion deterministic:
+    // the check at that call's return must abort the loop before a 4th call starts (without the
+    // boundary check the loop would continue until the 64-statement countdown fires, i.e.
+    // dozens of calls later).
+    private static void AssertCancelledDuringThirdHostCall(Func<CancellationTokenSource, Engine, Func<int>> setup, string script)
+    {
+        using var cts = new CancellationTokenSource();
+        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
+        var hostCallCount = setup(cts, engine);
+
+        Assert.Throws<ExecutionCanceledException>(() => engine.Execute(script));
+        Assert.Equal(3, hostCallCount());
+    }
+
     [Fact]
     public void CancellationIsObservedBetweenSlowHostDelegateCalls()
     {
-        // https://github.com/sebastienros/jint/discussions/2707
-        // With only amortized constraints registered (here: a cancellation token), the
-        // statement-count amortization must not defer cancellation across host calls that can
-        // each take arbitrarily long; the host-call boundary re-check bounds detection latency
-        // to a single call. Cancelling from inside the 3rd call makes the assertion
-        // deterministic: the check at that call's return must abort the loop before a 4th call
-        // starts (without the boundary check the loop would continue until the 64-statement
-        // countdown fires, i.e. dozens of calls later).
-        using var cts = new CancellationTokenSource();
-        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
-
-        var calls = 0;
-        engine.SetValue("work", new Action(() =>
+        AssertCancelledDuringThirdHostCall((cts, engine) =>
         {
-            if (++calls == 3)
-            {
-                cts.Cancel();
-            }
-        }));
-
-        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("for (var i = 0; i < 40; i++) { work(); }"));
-        Assert.Equal(3, calls);
+            var calls = 0;
+            engine.SetValue("work", new Action(() => { if (++calls == 3) { cts.Cancel(); } }));
+            return () => calls;
+        }, "for (var i = 0; i < 40; i++) { work(); }");
     }
 
     [Fact]
     public void CancellationIsObservedBetweenSlowHostDelegateCallsInFunctionLocalTightLoop()
     {
-        // Same as above, with the function-local expression-body loop shape that arms the
-        // interpreter's tight for-body lane.
-        using var cts = new CancellationTokenSource();
-        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
-
-        var calls = 0;
-        engine.SetValue("work", new Action(() =>
+        // the function-local expression-body loop shape arms the interpreter's tight for-body lane
+        AssertCancelledDuringThirdHostCall((cts, engine) =>
         {
-            if (++calls == 3)
-            {
-                cts.Cancel();
-            }
-        }));
-
-        Assert.Throws<ExecutionCanceledException>(
-            () => engine.Execute("function f() { for (var i = 0; i < 40; i++) { work(); } } f();"));
-        Assert.Equal(3, calls);
+            var calls = 0;
+            engine.SetValue("work", new Action(() => { if (++calls == 3) { cts.Cancel(); } }));
+            return () => calls;
+        }, "function f() { for (var i = 0; i < 40; i++) { work(); } } f();");
     }
 
     [Fact]
     public void CancellationIsObservedBetweenSlowClrMethodCalls()
     {
-        using var cts = new CancellationTokenSource();
-        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
-
-        var probe = new HostBoundaryProbe();
-        probe.OnAccess = () =>
+        AssertCancelledDuringThirdHostCall((cts, engine) =>
         {
-            if (probe.Accesses == 3)
-            {
-                cts.Cancel();
-            }
-        };
-        engine.SetValue("probe", probe);
-
-        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("for (var i = 0; i < 40; i++) { probe.method(); }"));
-        Assert.Equal(3, probe.Accesses);
+            var probe = new HostBoundaryProbe();
+            probe.OnAccess = () => { if (probe.Accesses == 3) { cts.Cancel(); } };
+            engine.SetValue("probe", probe);
+            return () => probe.Accesses;
+        }, "for (var i = 0; i < 40; i++) { probe.method(); }");
     }
 
     [Fact]
     public void CancellationIsObservedBetweenSlowClrPropertyReads()
     {
-        using var cts = new CancellationTokenSource();
-        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
-
-        var probe = new HostBoundaryProbe();
-        probe.OnAccess = () =>
+        AssertCancelledDuringThirdHostCall((cts, engine) =>
         {
-            if (probe.Accesses == 3)
-            {
-                cts.Cancel();
-            }
-        };
-        engine.SetValue("probe", probe);
-
-        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("for (var i = 0; i < 40; i++) { var x = probe.value; }"));
-        Assert.Equal(3, probe.Accesses);
+            var probe = new HostBoundaryProbe();
+            probe.OnAccess = () => { if (probe.Accesses == 3) { cts.Cancel(); } };
+            engine.SetValue("probe", probe);
+            return () => probe.Accesses;
+        }, "for (var i = 0; i < 40; i++) { var x = probe.value; }");
     }
 
     [Fact]
     public void CancellationIsObservedBetweenSlowClrPropertyWrites()
     {
-        using var cts = new CancellationTokenSource();
-        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
-
-        var probe = new HostBoundaryProbe();
-        probe.OnAccess = () =>
+        AssertCancelledDuringThirdHostCall((cts, engine) =>
         {
-            if (probe.Accesses == 3)
-            {
-                cts.Cancel();
-            }
-        };
-        engine.SetValue("probe", probe);
-
-        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("for (var i = 0; i < 40; i++) { probe.value = i; }"));
-        Assert.Equal(3, probe.Accesses);
+            var probe = new HostBoundaryProbe();
+            probe.OnAccess = () => { if (probe.Accesses == 3) { cts.Cancel(); } };
+            engine.SetValue("probe", probe);
+            return () => probe.Accesses;
+        }, "for (var i = 0; i < 40; i++) { probe.value = i; }");
     }
 
     [Fact]
     public void CancellationIsObservedBetweenSlowClrConstructorCalls()
     {
-        using var cts = new CancellationTokenSource();
-        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
-
-        CtorProbe.Constructions = 0;
-        CtorProbe.OnConstruct = () =>
-        {
-            if (CtorProbe.Constructions == 3)
-            {
-                cts.Cancel();
-            }
-        };
         try
         {
-            engine.SetValue("Probe", Jint.Runtime.Interop.TypeReference.CreateTypeReference<CtorProbe>(engine));
-            Assert.Throws<ExecutionCanceledException>(() => engine.Execute("for (var i = 0; i < 40; i++) { new Probe(); }"));
-            Assert.Equal(3, CtorProbe.Constructions);
+            AssertCancelledDuringThirdHostCall((cts, engine) =>
+            {
+                CtorProbe.Constructions = 0;
+                CtorProbe.OnConstruct = () => { if (CtorProbe.Constructions == 3) { cts.Cancel(); } };
+                engine.SetValue("Probe", Jint.Runtime.Interop.TypeReference.CreateTypeReference<CtorProbe>(engine));
+                return () => CtorProbe.Constructions;
+            }, "for (var i = 0; i < 40; i++) { new Probe(); }");
         }
         finally
         {
@@ -794,24 +755,95 @@ myarr[0](0);
     }
 
     [Fact]
-    public void TimeoutIsObservedBetweenSlowHostDelegateCalls()
+    public void CancellationIsObservedBetweenSlowDictionaryReads()
     {
-        // The discussion's original shape: a timeout much shorter than the loop's host-call
-        // time. Without the host-boundary re-check the countdown would only fire after ~64
-        // statements (dozens of slow calls); with it the in-flight call's return observes the
-        // expired budget. Only one-sided bounds are asserted to stay robust against CI timer
-        // scheduling jitter.
-        var engine = new Engine(cfg => cfg.TimeoutInterval(TimeSpan.FromMilliseconds(100)));
+        // wrapped IDictionary<string, T> reads bypass ReflectionAccessor and route through
+        // TypeDescriptor.TryGetDictionaryValue; that lane must observe the boundary too
+        AssertCancelledDuringThirdHostCall((cts, engine) =>
+        {
+            var dictionary = new SlowDictionary { { "someKey", 42 } };
+            dictionary.OnAccess = () => { if (dictionary.Accesses == 3) { cts.Cancel(); } };
+            engine.SetValue("cfg", dictionary);
+            return () => dictionary.Accesses;
+        }, "for (var i = 0; i < 40; i++) { var v = cfg.someKey; }");
+    }
+
+    [Fact]
+    public void CancellationIsObservedBetweenSlowEnumerableIterations()
+    {
+        // for-of over a wrapped IEnumerable drives the user's IEnumerator.MoveNext directly
+        AssertCancelledDuringThirdHostCall((cts, engine) =>
+        {
+            var enumerable = new SlowEnumerable();
+            enumerable.OnMoveNext = () => { if (enumerable.MoveNextCalls == 3) { cts.Cancel(); } };
+            engine.SetValue("items", enumerable);
+            return () => enumerable.MoveNextCalls;
+        }, "for (const x of items) { }");
+    }
+
+    [Fact]
+    public void CancellationDuringLoneHostCallIsObservedAtItsReturn()
+    {
+        // isolates the post-invoke check: no further host call or 64-statement countdown
+        // follows, so only the check at the first call's own return can observe the cancellation
+        using var cts = new CancellationTokenSource();
+        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
 
         var calls = 0;
-        engine.SetValue("sleep", new Action(() =>
-        {
-            calls++;
-            Thread.Sleep(200);
-        }));
+        engine.SetValue("work", new Action(() => { calls++; cts.Cancel(); }));
 
-        Assert.Throws<TimeoutException>(() => engine.Execute("for (var i = 0; i < 40; i++) { sleep(); }"));
-        Assert.True(calls <= 10, $"expected the timeout to interrupt the loop within a few host calls, but {calls} calls ran");
+        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("work(); work();"));
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void HostSideAccessToWrappedObjectDoesNotObserveCancellationAfterExecution()
+    {
+        // constraint state is only meaningful inside an Execute/Invoke window; cancelling the
+        // token during normal teardown must not make later C#-side reads of wrapped objects throw
+        using var cts = new CancellationTokenSource();
+        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
+        var probe = new HostBoundaryProbe();
+        engine.SetValue("probe", probe);
+        engine.Execute("probe.value;");
+
+        cts.Cancel();
+
+        var wrapper = engine.GetValue("probe").AsObject();
+        Assert.Equal(42, wrapper.Get("value").AsNumber());
+    }
+
+    [Fact]
+    public void HostSideAccessToWrappedObjectDoesNotObserveExpiredTimeoutAfterExecution()
+    {
+        // the time constraint's CTS is re-armed at the end of every run and keeps counting while
+        // the engine is idle; an expired timer must not make later C#-side reads throw
+        var engine = new Engine(cfg => cfg.TimeoutInterval(TimeSpan.FromMilliseconds(50)));
+        var probe = new HostBoundaryProbe();
+        engine.SetValue("probe", probe);
+        engine.Execute("probe.value;");
+
+        Thread.Sleep(200);
+
+        var wrapper = engine.GetValue("probe").AsObject();
+        Assert.Equal(42, wrapper.Get("value").AsNumber());
+    }
+
+    [Fact]
+    public void DebugModeEngineDoesNotRunHostBoundaryChecks()
+    {
+        // in debug mode the boundary checks are disabled so that watch/conditional-breakpoint
+        // evaluation cannot deterministically trip an expired constraint on interop access;
+        // few enough statements run here that the amortized countdown cannot fire either, so
+        // the loop must complete all its host calls despite the mid-loop cancellation
+        using var cts = new CancellationTokenSource();
+        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token).DebugMode());
+
+        var calls = 0;
+        engine.SetValue("work", new Action(() => { if (++calls == 3) { cts.Cancel(); } }));
+
+        engine.Execute("for (var i = 0; i < 5; i++) { work(); }");
+        Assert.Equal(5, calls);
     }
 
     private sealed class HostBoundaryProbe
@@ -851,6 +883,85 @@ myarr[0](0);
         {
             Constructions++;
             OnConstruct();
+        }
+    }
+
+    private sealed class SlowDictionary : IDictionary<string, object>
+    {
+        private readonly Dictionary<string, object> _inner = new();
+
+        public int Accesses;
+        public Action OnAccess = static () => { };
+
+        public object this[string key]
+        {
+            get
+            {
+                Accesses++;
+                OnAccess();
+                return _inner[key];
+            }
+            set
+            {
+                Accesses++;
+                OnAccess();
+                _inner[key] = value;
+            }
+        }
+
+        public bool TryGetValue(string key, out object value)
+        {
+            Accesses++;
+            OnAccess();
+            return _inner.TryGetValue(key, out value);
+        }
+
+        public ICollection<string> Keys => _inner.Keys;
+        public ICollection<object> Values => _inner.Values;
+        public int Count => _inner.Count;
+        public bool IsReadOnly => false;
+
+        public void Add(string key, object value) => _inner.Add(key, value);
+        public bool ContainsKey(string key) => _inner.ContainsKey(key);
+        public bool Remove(string key) => _inner.Remove(key);
+        public void Add(KeyValuePair<string, object> item) => _inner.Add(item.Key, item.Value);
+        public void Clear() => _inner.Clear();
+        public bool Contains(KeyValuePair<string, object> item) => _inner.ContainsKey(item.Key);
+        public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex) => ((IDictionary<string, object>) _inner).CopyTo(array, arrayIndex);
+        public bool Remove(KeyValuePair<string, object> item) => _inner.Remove(item.Key);
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => _inner.GetEnumerator();
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _inner.GetEnumerator();
+    }
+
+    private sealed class SlowEnumerable : System.Collections.IEnumerable
+    {
+        public int MoveNextCalls;
+        public Action OnMoveNext = static () => { };
+
+        public System.Collections.IEnumerator GetEnumerator() => new Enumerator(this);
+
+        private sealed class Enumerator : System.Collections.IEnumerator
+        {
+            private readonly SlowEnumerable _owner;
+            private int _index;
+
+            public Enumerator(SlowEnumerable owner)
+            {
+                _owner = owner;
+            }
+
+            public object Current => _index;
+
+            public bool MoveNext()
+            {
+                _owner.MoveNextCalls++;
+                _owner.OnMoveNext();
+                return _index++ < 40;
+            }
+
+            public void Reset()
+            {
+            }
         }
     }
 

--- a/Jint/Engine.Constraints.cs
+++ b/Jint/Engine.Constraints.cs
@@ -28,12 +28,8 @@ public partial class Engine
     /// <item>User-derived constraints may depend on being called once per statement — silently
     /// amortizing them would be a breaking behavior change.</item>
     /// </list>
-    /// The statement-count cadence is a wall-clock proxy only while statements stay cheap, so
-    /// interop call sites that hand control to user CLR code (delegates, reflected members,
-    /// constructors) re-check via <see cref="CheckAmortizedConstraintsAtHostBoundary"/> — a loop
-    /// of slow host calls must not stretch the detection window (a call can take arbitrarily
-    /// long, and only <see cref="Runtime.Interpreter.EvaluationContext.AmortizedConstraintCheckInterval"/>
-    /// statements' worth of them would otherwise elapse unchecked).
+    /// Interop call sites additionally re-check on return from user CLR code — see
+    /// <see cref="CheckAmortizedConstraintsAtHostBoundary"/> for that mechanism's rationale.
     /// </summary>
     private static ConstraintPartition PartitionConstraints(Constraint[] constraints)
     {

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -892,19 +892,41 @@ public sealed partial class Engine : IDisposable
     }
 
     /// <summary>
-    /// Re-checks the amortized constraints at an interpreter/host-code boundary. The per-statement
-    /// amortization bounds timeout/cancellation detection latency in statement count, which tracks
-    /// wall-clock time only while statements stay cheap; a single call into user CLR code can take
-    /// arbitrarily long, so interop call sites check on entry (no new host work starts once the
-    /// budget has expired) and again after the host code returns (time that passed inside the call
-    /// is observed immediately), keeping detection latency bounded by one host call instead of
-    /// <see cref="EvaluationContext.AmortizedConstraintCheckInterval"/> of them. Intentionally not
-    /// wired into built-in <see cref="ClrFunction"/> dispatch: that would reintroduce the per-call
-    /// check cost on hot built-ins, and long-running built-ins already bound their own latency via
-    /// <see cref="ConstraintCheckInterval"/> self-checks.
+    /// Re-checks the amortized constraints when control returns from user CLR code to the
+    /// interpreter. The per-statement amortization bounds timeout/cancellation detection latency
+    /// in statement count, which tracks wall-clock time only while statements stay cheap; a single
+    /// host call can take arbitrarily long, so interop call sites re-check after the host code
+    /// returns, keeping detection latency bounded by one host call instead of
+    /// <see cref="EvaluationContext.AmortizedConstraintCheckInterval"/> statements' worth of them.
+    /// The boundaries of the mechanism are deliberate:
+    /// <list type="bullet">
+    /// <item>Only after the host call returns, never on entry — an entry check would block host
+    /// cleanup calls (e.g. a release-the-lock delegate inside a JS finally block) once
+    /// cancellation is pending, skipping cleanup that ran before this mechanism existed.</item>
+    /// <item>Only while script evaluation is active — constraint state is only meaningful inside
+    /// an Execute/Invoke window: <see cref="Constraints.TimeConstraint"/>'s timer is re-armed at
+    /// the end of every run and keeps counting, and a cancellation token may be cancelled during
+    /// normal teardown, so host-initiated access to wrapped objects from C# after execution must
+    /// not observe either.</item>
+    /// <item>Not in debug mode — a debugger paused longer than the timeout would otherwise
+    /// deterministically fail every interop read in watch/conditional-breakpoint evaluation;
+    /// debug-mode engines keep the pre-existing amortized-countdown-only behavior.</item>
+    /// <item>Not wired into built-in <see cref="ClrFunction"/> dispatch (would reintroduce the
+    /// per-call cost on hot built-ins that the amortization removed; long-running built-ins bound
+    /// their own latency via <see cref="ConstraintCheckInterval"/> self-checks), nor into
+    /// operator-overload resolution (whose catch-all would launder constraint exceptions into
+    /// TargetInvocationException), nor into user-supplied converter/factory callbacks —
+    /// embedder-authored code hosting long operations can observe the CancellationToken itself.</item>
+    /// </list>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void CheckAmortizedConstraintsAtHostBoundary() => CheckAmortizedConstraints();
+    internal void CheckAmortizedConstraintsAtHostBoundary()
+    {
+        if (_activeEvaluationContext is not null && !_isDebugMode)
+        {
+            CheckAmortizedConstraints();
+        }
+    }
 
     internal JsValue GetValue(object value)
     {

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -41,8 +41,6 @@ internal sealed class DelegateWrapper : Function
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
-        Engine.CheckAmortizedConstraintsAtHostBoundary();
-
         var parameterInfos = _d.Method.GetParameters();
 
 #if NETFRAMEWORK
@@ -136,12 +134,13 @@ internal sealed class DelegateWrapper : Function
         try
         {
             var result = _d.DynamicInvoke(parameters);
+            // an awaitable result must reach promise conversion before a constraint can throw,
+            // so that the in-flight Task gets a continuation attached and is never left unobserved
+            var returnValue = IsAwaitable(result)
+                ? ConvertAwaitableToPromise(Engine, result!)
+                : FromObject(Engine, result);
             Engine.CheckAmortizedConstraintsAtHostBoundary();
-            if (!IsAwaitable(result))
-            {
-                return FromObject(Engine, result);
-            }
-            return ConvertAwaitableToPromise(Engine, result!);
+            return returnValue;
         }
         catch (TargetInvocationException exception)
         {

--- a/Jint/Runtime/Interop/GetterFunction.cs
+++ b/Jint/Runtime/Interop/GetterFunction.cs
@@ -19,9 +19,6 @@ internal sealed class GetterFunction : Function
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
-        _engine.CheckAmortizedConstraintsAtHostBoundary();
-        var result = _getter(thisObject);
-        _engine.CheckAmortizedConstraintsAtHostBoundary();
-        return result;
+        return _getter(thisObject);
     }
 }

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -280,8 +280,6 @@ internal sealed class MethodDescriptor
 
     public JsValue Call(Engine engine, object? instance, JsCallArguments arguments)
     {
-        engine.CheckAmortizedConstraintsAtHostBoundary();
-
         object?[] parameters = arguments.Length == 0 ? [] : new object?[arguments.Length];
         var methodParameters = Parameters;
         var valueCoercionType = engine.Options.Interop.ValueCoercion;
@@ -320,7 +318,6 @@ internal sealed class MethodDescriptor
             }
 
             var retVal = Invoke(instance, parameters);
-            engine.CheckAmortizedConstraintsAtHostBoundary();
             return JsValue.FromObject(engine, retVal);
         }
         catch (TargetInvocationException exception)

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -155,8 +155,6 @@ internal sealed class MethodInfoFunction : Function
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments jsArguments)
     {
-        _engine.CheckAmortizedConstraintsAtHostBoundary();
-
         var converter = Engine.TypeConverter;
         var thisObj = thisObject.ToObject() ?? _target;
         var state = new MethodResolverState(_engine, thisObject, jsArguments);

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -297,7 +297,9 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                 return false;
             }
 
-            return _typeDescriptor.TrySetDictionaryValue(Target, clrKey!, clrValue);
+            var written = _typeDescriptor.TrySetDictionaryValue(Target, clrKey!, clrValue);
+            _engine.CheckAmortizedConstraintsAtHostBoundary();
+            return written;
         }
 
         return SetSlow(property, value);
@@ -434,17 +436,21 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             }
             else
             {
-                if (_typeDescriptor.IsStringKeyedGenericDictionary
-                    && _typeDescriptor.TryGetDictionaryValue(Target, property.ToString(), out var value))
+                if (_typeDescriptor.IsStringKeyedGenericDictionary)
                 {
-                    // Check stored properties first - frozen/sealed objects have descriptors in _properties
-                    // that must be respected to return the same (frozen) instance
-                    if (TryGetProperty(property, out var stored))
+                    var found = _typeDescriptor.TryGetDictionaryValue(Target, property.ToString(), out var value);
+                    _engine.CheckAmortizedConstraintsAtHostBoundary();
+                    if (found)
                     {
-                        return UnwrapJsValue(stored, receiver);
-                    }
+                        // Check stored properties first - frozen/sealed objects have descriptors in _properties
+                        // that must be respected to return the same (frozen) instance
+                        if (TryGetProperty(property, out var stored))
+                        {
+                            return UnwrapJsValue(stored, receiver);
+                        }
 
-                    return FromObject(_engine, value);
+                        return FromObject(_engine, value);
+                    }
                 }
             }
         }
@@ -456,9 +462,9 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         {
             // Prototype chain is intentionally skipped on miss: non-string non-symbol keys can't
             // resolve to Object.prototype members (which are all string/symbol-keyed).
-            return _typeDescriptor.TryGetDictionaryValue(Target, clrKey!, out var raw)
-                ? FromObject(_engine, raw)
-                : Undefined;
+            var found = _typeDescriptor.TryGetDictionaryValue(Target, clrKey!, out var raw);
+            _engine.CheckAmortizedConstraintsAtHostBoundary();
+            return found ? FromObject(_engine, raw) : Undefined;
         }
 
         // slow path requires us to create a property descriptor that might get cached or not
@@ -622,15 +628,19 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         if (!property.IsString() && _typeDescriptor.IsNonStringKeyedGenericDictionary)
         {
             // non-string-keyed CLR generic dictionary — resolve via underlying CLR key, not string
-            if (TryConvertJsValueToDictionaryKey(property, _typeDescriptor.GenericDictionaryKeyType!, out var clrKey)
-                && _typeDescriptor.TryGetDictionaryValue(Target, clrKey!, out var raw))
+            if (TryConvertJsValueToDictionaryKey(property, _typeDescriptor.GenericDictionaryKeyType!, out var clrKey))
             {
-                var flags = PropertyFlag.Enumerable;
-                if (_engine.Options.Interop.AllowWrite)
+                var found = _typeDescriptor.TryGetDictionaryValue(Target, clrKey!, out var raw);
+                _engine.CheckAmortizedConstraintsAtHostBoundary();
+                if (found)
                 {
-                    flags |= PropertyFlag.Configurable;
+                    var flags = PropertyFlag.Enumerable;
+                    if (_engine.Options.Interop.AllowWrite)
+                    {
+                        flags |= PropertyFlag.Configurable;
+                    }
+                    return new PropertyDescriptor(FromObject(_engine, raw), flags);
                 }
-                return new PropertyDescriptor(FromObject(_engine, raw), flags);
             }
             return PropertyDescriptor.Undefined;
         }
@@ -643,7 +653,9 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         var isDictionary = _typeDescriptor.IsStringKeyedGenericDictionary;
         if (isDictionary)
         {
-            if (_typeDescriptor.TryGetDictionaryValue(Target, member, out var value))
+            var found = _typeDescriptor.TryGetDictionaryValue(Target, member, out var value);
+            _engine.CheckAmortizedConstraintsAtHostBoundary();
+            if (found)
             {
                 var flags = PropertyFlag.Enumerable;
                 if (_engine.Options.Interop.AllowWrite)
@@ -667,6 +679,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         }
 
         var result = Engine.Options.Interop.MemberAccessor(Engine, Target, member);
+        Engine.CheckAmortizedConstraintsAtHostBoundary();
         if (result is not null)
         {
             return new PropertyDescriptor(result, PropertyFlag.OnlyEnumerable);
@@ -831,7 +844,9 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 
         public override bool TryIteratorStep(out ObjectInstance nextItem)
         {
-            if (_enumerator.MoveNext())
+            var hasNext = _enumerator.MoveNext();
+            _engine.CheckAmortizedConstraintsAtHostBoundary();
+            if (hasNext)
             {
                 var key = _enumerator.Current;
                 var value = _target.Get(key);
@@ -862,7 +877,9 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 
         public override bool TryIteratorStep(out ObjectInstance nextItem)
         {
-            if (_enumerator.MoveNext())
+            var hasNext = _enumerator.MoveNext();
+            _engine.CheckAmortizedConstraintsAtHostBoundary();
+            if (hasNext)
             {
                 var value = _enumerator.Current;
                 nextItem = IteratorResult.CreateValueIteratorPosition(_engine, FromObject(_engine, value));

--- a/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
@@ -46,8 +46,6 @@ internal abstract class ReflectionAccessor
             return constantValue;
         }
 
-        engine.CheckAmortizedConstraintsAtHostBoundary();
-
         // first check indexer so we don't confuse inherited properties etc
         var value = TryReadFromIndexer(target, memberName);
 
@@ -90,8 +88,6 @@ internal abstract class ReflectionAccessor
 
     public void SetValue(Engine engine, object target, string memberName, JsValue value)
     {
-        engine.CheckAmortizedConstraintsAtHostBoundary();
-
         object? converted;
         if (_memberType == typeof(JsValue))
         {

--- a/Jint/Runtime/Interop/SetterFunction.cs
+++ b/Jint/Runtime/Interop/SetterFunction.cs
@@ -19,9 +19,7 @@ internal sealed class SetterFunction : Function
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
-        _engine.CheckAmortizedConstraintsAtHostBoundary();
         _setter(thisObject, arguments[0]);
-        _engine.CheckAmortizedConstraintsAtHostBoundary();
 
         return Null;
     }

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -205,6 +205,10 @@ public sealed class TypeReference : Constructor, IObjectWrapper
                 Throw.InteropResolutionError(realm, message, referenceType, memberName: null, arguments, constructors);
             }
 
+            // all three creation branches above (user factory, Activator, reflected constructor)
+            // ran user CLR code
+            engine.CheckAmortizedConstraintsAtHostBoundary();
+
             result.SetPrototypeOf(state.TypeReference);
 
             return result;

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -13,11 +13,8 @@ internal sealed class EvaluationContext
     /// Engine.Constraints.cs for the partition rationale). Small enough that timeout /
     /// cancellation / memory-limit detection latency stays far below anything observable at
     /// the granularity those constraints operate on, large enough that the per-statement cost
-    /// collapses to a countdown decrement and branch. The statement-count bound tracks
-    /// wall-clock time only while statements stay cheap; statements that transfer control to
-    /// user CLR code re-check at the transition instead (see
-    /// <see cref="Engine.CheckAmortizedConstraintsAtHostBoundary"/>), since a single host call
-    /// can consume unbounded wall-clock time.
+    /// collapses to a countdown decrement and branch. Statements that call user CLR code
+    /// re-check on return instead — see <see cref="Engine.CheckAmortizedConstraintsAtHostBoundary"/>.
     /// </summary>
     internal const int AmortizedConstraintCheckInterval = 64;
 


### PR DESCRIPTION
## Summary

Follow-up hardening for #2713 (merged before this review pass landed on the branch). An adversarial multi-agent review of the boundary-check mechanism confirmed several edge-case regressions and coverage gaps in the merged version; this PR fixes them.

## Regressions fixed

- **Host-initiated interop access observed constraint state outside script execution** (A/B-verified against the pre-#2713 behavior). The time constraint's CTS is re-armed at the end of every run and keeps counting while the engine is idle, and `CancellationConstraint` state survives execution — so after #2713, reading a wrapped object's members from plain C# after execution could throw `TimeoutException`/`ExecutionCanceledException` with no script running. The boundary check is now gated on an active evaluation context.
- **Entry checks blocked host cleanup calls**: with cancellation pending, a CLR delegate invoked inside a JS `finally` block (release-a-lock pattern) threw before the delegate body ran, skipping cleanup that executed pre-#2713. Checks now run only after the host call returns — the post-return check alone preserves the ≤ 1-host-call detection bound.
- **Debugger watch evaluation**: an engine paused at a breakpoint longer than its `TimeoutInterval` would deterministically fail every interop read in watch/conditional-breakpoint expressions. Debug-mode engines now keep the pre-existing amortized-countdown-only behavior.
- **Unobserved `Task`**: the check between `DynamicInvoke` and promise conversion could discard a still-running `Task` returned by an async host delegate, surfacing its eventual fault as `TaskScheduler.UnobservedTaskException`. Awaitable results now reach `ConvertAwaitableToPromise` (attaching the continuation) before the check.
- **Constraint-exception laundering**: the checks inside `MethodDescriptor.Call` sat inside operator-overload resolution's catch-all, which rethrows as `TargetInvocationException` — embedder sandbox handlers catching `ExecutionCanceledException`/`TimeoutException` would miss. The constructor-lane check moved to `TypeReference.Construct`, where it now also covers the `Options.Interop.CreateTypeReferenceObject` factory and `Activator` value-type branches.

## Coverage extended

The #2707 deferred-detection gap also existed in lanes #2713 did not instrument; now covered:

- Dictionary-shaped interop (`TryGetDictionaryValue`/`TrySetDictionaryValue` on wrapped `IDictionary<,>` — e.g. a service-backed dictionary with slow lookups)
- Wrapped-`IEnumerable` iteration (`MoveNext` in for-of)
- The `Options.Interop.MemberAccessor` callback

Also removed the redundant `GetterFunction`/`SetterFunction` checks (both consumers either re-check inside `ReflectionAccessor` or run no host code).

Still intentionally uninstrumented: built-in `ClrFunction` dispatch (per-call cost on hot built-ins; built-ins self-check via `Engine.ConstraintCheckInterval`), operator-overload resolution, and user-supplied converter/factory callbacks.

## Tests

- The CTS-timer-dependent timeout test from #2713 (flaky under thread-pool starvation, cf. the PR #2686 investigation) is replaced by a deterministic lone-host-call test that isolates the post-invoke check.
- New regression guards: host-side C# reads must not throw after post-execution cancellation or idle-engine budget expiry; debug-mode engines complete short host-call loops despite mid-loop cancellation.
- New deterministic lane tests for dictionary reads and for-of iteration (cancel inside the 3rd host call, exactly 3 calls asserted).
- Shared scaffolding extracted for the cancellation tests.

Full `Jint.Tests`, `Jint.Tests.PublicInterface`, `Jint.Tests.CommonScripts` and Test262 suites pass on net10.0 and net472. `InteropLambdaBenchmark.ForLoop` A/B (including the newly covered Dictionary lane) shows no regression — all rows within variance, allocations byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
