### PR TITLE
Cover CLR arrays with the interop identity caches

### DIFF
--- a/Jint.Benchmark/CpuProfileDriver.cs
+++ b/Jint.Benchmark/CpuProfileDriver.cs
@@ -39,6 +39,9 @@ internal static class CpuProfileDriver
             src = DromaeoHelpers + Environment.NewLine + Environment.NewLine + src;
         }
 
+        // Interop scripts expect the same host binding as EngineComparisonInteropBenchmark.
+        var isInterop = scriptName.StartsWith("interop-", StringComparison.Ordinal);
+
         var prepared = Engine.PrepareScript(src, strict: true);
         var usePrepared = string.Equals(variant, "prepared", StringComparison.Ordinal);
 
@@ -61,6 +64,10 @@ internal static class CpuProfileDriver
         void RunOnce()
         {
             var engine = new Engine(static options => options.Strict());
+            if (isInterop)
+            {
+                engine.SetValue("host", new EngineComparisonInteropBenchmark.InteropHost());
+            }
             if (usePrepared)
             {
                 engine.Execute(prepared);

--- a/Jint.Benchmark/InteropWrapperChurnBenchmark.cs
+++ b/Jint.Benchmark/InteropWrapperChurnBenchmark.cs
@@ -21,6 +21,8 @@ public class InteropWrapperChurnBenchmark
         }
 
         public Payload Payload { get; }
+
+        public int[] Numbers { get; } = Enumerable.Range(0, 100).ToArray();
     }
 
     public sealed class Payload
@@ -66,5 +68,28 @@ public class InteropWrapperChurnBenchmark
     public void SameObjectReturnedInLoop_RecentCache()
     {
         for (var i = 0; i < OperationsPerInvoke; i++) _engineRecentCache.Execute("h.Payload.Value");
+    }
+
+    // A CLR array member read repeatedly inside the loop: with the flags off every h.Numbers read
+    // deep-copies the array into a fresh JsArray; with either identity flag the snapshot is reused.
+    private static readonly Prepared<Script> _arrayTraversal = Engine.PrepareScript(
+        "var s = 0; for (var i = 0; i < 100; i++) { s += h.Numbers[i]; }");
+
+    [Benchmark]
+    public void ArrayMemberTraversal_DefaultFlag()
+    {
+        _engineDefault.Execute(_arrayTraversal);
+    }
+
+    [Benchmark]
+    public void ArrayMemberTraversal_IdentityFlag()
+    {
+        _engineIdentity.Execute(_arrayTraversal);
+    }
+
+    [Benchmark]
+    public void ArrayMemberTraversal_RecentCache()
+    {
+        _engineRecentCache.Execute(_arrayTraversal);
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
+++ b/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
@@ -1,0 +1,47 @@
+namespace Jint.Tests.Runtime;
+
+public partial class InteropTests
+{
+    public class ArrayConversionHost
+    {
+        public int[] Numbers { get; } = [1, 2, 3];
+    }
+
+    [Fact]
+    public void ClrArrayConversionCreatesFreshCopyByDefault()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new ArrayConversionHost());
+
+        Assert.False(engine.Evaluate("host.Numbers === host.Numbers").AsBoolean());
+
+        // a script-side mutation of one snapshot is not visible in the next read
+        Assert.Equal(1, engine.Evaluate("var a = host.Numbers; a[0] = 42; host.Numbers[0]").AsNumber());
+    }
+
+    [Fact]
+    public void ClrArrayConversionReusesSnapshotWithTrackObjectWrapperIdentity()
+    {
+        var host = new ArrayConversionHost();
+        var engine = new Engine(options => options.Interop.TrackObjectWrapperIdentity = true);
+        engine.SetValue("host", host);
+
+        Assert.True(engine.Evaluate("host.Numbers === host.Numbers").AsBoolean());
+
+        // script-side mutations persist across reads (the identity contract)
+        Assert.Equal(42, engine.Evaluate("host.Numbers[0] = 42; host.Numbers[0]").AsNumber());
+
+        // CLR-side mutations after the first conversion are not re-copied (documented staleness)
+        host.Numbers[1] = 99;
+        Assert.Equal(2, engine.Evaluate("host.Numbers[1]").AsNumber());
+    }
+
+    [Fact]
+    public void ClrArrayConversionReusesSnapshotWithRecentObjectWrapperCache()
+    {
+        var engine = new Engine(options => options.Interop.CacheRecentObjectWrappers = true);
+        engine.SetValue("host", new ArrayConversionHost());
+
+        Assert.True(engine.Evaluate("host.Numbers === host.Numbers").AsBoolean());
+    }
+}

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -335,6 +335,9 @@ public class Options
         /// <summary>
         /// Whether identity map is persisted for object wrappers in order to maintain object identity. This can cause
         /// memory usage to grow when targeting large set and freeing of memory can be delayed due to ConditionalWeakTable semantics.
+        /// Also covers CLR arrays: repeated conversions of the same array instance return the same JsArray snapshot
+        /// (script-side mutations persist across reads; CLR-side mutations after the first conversion are not re-copied)
+        /// instead of copying every element on every read.
         /// Defaults to false.
         /// </summary>
         public bool TrackObjectWrapperIdentity { get; set; }
@@ -343,7 +346,8 @@ public class Options
         /// Whether a small bounded cache of most recently wrapped CLR objects is kept so that the same
         /// object crossing into script repeatedly reuses its wrapper (by reference identity). A lighter
         /// alternative to <see cref="TrackObjectWrapperIdentity"/> that cannot grow memory unbounded;
-        /// identity is only preserved for objects still present in the cache.
+        /// identity is only preserved for objects still present in the cache. Covers CLR arrays the same
+        /// way <see cref="TrackObjectWrapperIdentity"/> does.
         /// Defaults to false.
         /// </summary>
         public bool CacheRecentObjectWrappers { get; set; }

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -236,8 +236,24 @@ internal static class DefaultObjectConverter
         return result is not null;
     }
 
-    private static JsArray ConvertArray(Engine e, object v)
+    private static JsValue ConvertArray(Engine e, object v)
     {
+        // The identity caches (flag-gated, both default off) also cover arrays: repeated
+        // conversions of the same CLR array instance return the same JsArray snapshot instead of
+        // re-copying every element on every property read. With the flags off each conversion
+        // still produces a fresh, independent copy. The checks must stay inside this method —
+        // _typeMappers is a static cross-engine memoization, so per-engine option state can never
+        // be baked into the memoized mapper.
+        if (e._objectWrapperCache?.TryGetValue(v, out var cached) == true)
+        {
+            return cached;
+        }
+
+        if (e._recentObjectWrapperCache?.TryGet(v) is { } recentlyConverted)
+        {
+            return recentlyConverted;
+        }
+
         var array = (Array) v;
         var arrayLength = (uint) array.Length;
 
@@ -247,7 +263,20 @@ internal static class DefaultObjectConverter
             values[i] = JsValue.FromObject(e, array.GetValue(i));
         }
 
-        return new JsArray(e, values);
+        var result = new JsArray(e, values);
+
+        if (e.Options.Interop.TrackObjectWrapperIdentity)
+        {
+            e._objectWrapperCache ??= new ConditionalWeakTable<object, ObjectInstance>();
+            e._objectWrapperCache.Add(v, result);
+        }
+        else if (e.Options.Interop.CacheRecentObjectWrappers)
+        {
+            e._recentObjectWrapperCache ??= new RecentObjectWrapperCache();
+            e._recentObjectWrapperCache.Add(v, result);
+        }
+
+        return result;
     }
 }
 


### PR DESCRIPTION
First PR of the V8-gap performance campaign (follow-up to #1775, which surfaced this in the interop suite).

## Problem

Reading an array-valued host member (`host.numbers` where `numbers` is `int[]`) deep-copies the entire array into a fresh `JsValue[]` + `JsArray` on **every read**: the `Array` branch of `DefaultObjectConverter.TryConvert` returns before the identity caches are consulted, so `TrackObjectWrapperIdentity` / `CacheRecentObjectWrappers` never applied to arrays. On the `interop-collection-traversal` comparison row this is 19 ms / 32.9 MB for 10k reads of an `int[100]` — the one interop row where ClearScript currently beats Jint.

## Change

`ConvertArray` now consults and populates the same two identity caches. The checks live inside the method because `_typeMappers` is a static cross-engine memoization — per-engine option state must never be baked into the memoized mapper.

**Default behavior is unchanged** (both flags default to false; every read still yields a fresh, independent snapshot — locked in by a new test). With either flag enabled, the same CLR array instance returns the same `JsArray` snapshot: script-side mutations persist across reads, CLR-side mutations after first conversion are not re-copied — exactly the identity contract those flags already advertise for objects (doc comments extended).

## Numbers

`InteropWrapperChurnBenchmark.ArrayMemberTraversal` (new row: 100 reads of an `int[100]` member per op, default BDN job):

| flags | Mean | Allocated |
|---|---:|---:|
| off (default) | 146.7 us | 333,944 B |
| TrackObjectWrapperIdentity | 15.3 us | 344 B |
| CacheRecentObjectWrappers | 13.8 us | 344 B |

~10× faster, ~970× less allocation with either opt-in flag.

## Gates

- Jint.Tests 3648/3585 (net10/net472), PublicInterface 114/114, CommonScripts 28/28, Test262 99,431 — all green, 0 failures.
- New tests lock the flags-off default (`host.Numbers !== host.Numbers`, mutation isolation) and the flag-on identity/persistence/staleness semantics.

Also teaches `CpuProfileDriver` to bind the interop host for `interop-*` scripts so they can be CPU-profiled.

A follow-up PR will add an opt-in live-view path for CLR arrays (`ArrayWrapper<T>`, aligning `T[]` with the already-live `List<T>` semantics) — kept separate since it introduces new API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)