### PR TITLE
Intern object property keys within a single JSON parse

### DIFF
--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using Jint.Extensions;
 using Jint.Native.Object;
 using Jint.Pooling;
 using Jint.Runtime;
@@ -95,6 +96,21 @@ public sealed class JsonParser
     private int _shapeBudget;
     private Shape? _cachedEmptyRoot;
     private ObjectInstance? _cachedEmptyRootProto;
+
+    // Property keys repeat across every record of a homogeneous array (the dominant JSON.parse payload):
+    // an array of 500 identically-shaped records re-scans the same "id"/"name"/... key hundreds of times.
+    // Interning object keys within a single parse lets those records share one key string (and its
+    // JsString) instead of re-allocating both per record. Only property KEYS are interned, never string
+    // values, and the table is bounded — keys must be at most MaxInternedKeyLength chars and at most
+    // MaxInternedKeys distinct keys are cached — so a hostile payload with millions of distinct/long keys
+    // cannot grow it without bound. The table is per-parser-instance and reset per parse (no cross-parse
+    // or global state). _expectKey is set immediately before the Lex that scans a key token (right after
+    // '{' or ',' inside an object) and consumed by the very next scan, so only keys route through interning.
+    private const int MaxInternedKeyLength = 64;
+    private const int MaxInternedKeys = 64;
+    private InternedKeyEntry[]? _internedKeys;
+    private int _internedKeyCount;
+    private bool _expectKey;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsDecimalDigit(char ch)
@@ -349,7 +365,7 @@ public sealed class JsonParser
         return null!;
     }
 
-    private Token ScanStringLiteral(ref State state)
+    private Token ScanStringLiteral(ref State state, bool isPropertyKey)
     {
         char quote = _source[_index];
         int start = _index;
@@ -431,12 +447,61 @@ public sealed class JsonParser
             ThrowError(_index, Messages.UnexpectedEOS);
         }
 
+        if (isPropertyKey)
+        {
+            // Intern object keys straight off the scanned span so repeated keys reuse one string/JsString
+            // and skip the span->string allocation entirely on a cache hit (the common homogeneous-record case).
+            var interned = InternPropertyKey(sb.AsSpan());
+            return CreateToken(Tokens.String, interned.Name, '\"', interned.Value, new TextRange(start, _index));
+        }
+
         var value = sb.ToString();
         return CreateToken(Tokens.String, value, '\"', new JsString(value), new TextRange(start, _index));
     }
 
+    /// <summary>
+    /// Interns a just-scanned property-key span for the lifetime of the current parse: identical keys across
+    /// records return the same <see cref="string"/> and <see cref="JsString"/> instances, and on a cache hit
+    /// no new string is materialized at all. Bounded by <see cref="MaxInternedKeyLength"/> and
+    /// <see cref="MaxInternedKeys"/> so adversarial payloads cannot grow the table without bound; keys outside
+    /// the bounds are materialized fresh (current behavior) without being cached.
+    /// </summary>
+    private InternedKey InternPropertyKey(ReadOnlySpan<char> span)
+    {
+        var hash = Hash.GetFNVHashCode(span);
+
+        var entries = _internedKeys;
+        if (entries is not null)
+        {
+            var count = _internedKeyCount;
+            for (var i = 0; i < count; i++)
+            {
+                ref var entry = ref entries[i];
+                if (entry.Hash == hash && span.SequenceEqual(entry.Name.AsSpan()))
+                {
+                    return new InternedKey(entry.Name, entry.Value);
+                }
+            }
+        }
+
+        var name = span.ToString();
+        var value = new JsString(name);
+
+        if (span.Length <= MaxInternedKeyLength && _internedKeyCount < MaxInternedKeys)
+        {
+            entries ??= _internedKeys = new InternedKeyEntry[MaxInternedKeys];
+            entries[_internedKeyCount++] = new InternedKeyEntry(hash, name, value);
+        }
+
+        return new InternedKey(name, value);
+    }
+
     private Token Advance(ref State state)
     {
+        // Consumed by exactly this scan: set immediately before the Lex that reads a key token.
+        var isPropertyKey = _expectKey;
+        _expectKey = false;
+
         char ch = ReadToNextSignificantCharacter();
 
         if (ch == char.MinValue)
@@ -448,7 +513,7 @@ public sealed class JsonParser
         // Single quote (#39) are not allowed in JSON.
         if (ch == '"')
         {
-            return ScanStringLiteral(ref state);
+            return ScanStringLiteral(ref state, isPropertyKey);
         }
 
         if (ch == '-') // Negative Number
@@ -602,6 +667,8 @@ public sealed class JsonParser
             ThrowDepthLimitReached(_lookahead);
         }
 
+        // The token right after '{' is the first key (or '}'): route it through key interning.
+        _expectKey = true;
         Expect(ref state, '{');
 
         var obj = new JsObject(_engine);
@@ -635,6 +702,8 @@ public sealed class JsonParser
 
             if (!Match('}'))
             {
+                // The token right after ',' is the next key.
+                _expectKey = true;
                 Expect(ref state, ',');
             }
         }
@@ -770,6 +839,8 @@ public sealed class JsonParser
         _length = _source.Length;
         _lookahead = null!;
         _shapeBudget = ShapeTransitionBudget;
+        _internedKeyCount = 0;
+        _expectKey = false;
 
         State state = new State();
 
@@ -796,6 +867,8 @@ public sealed class JsonParser
         _length = _source.Length;
         _lookahead = null!;
         _shapeBudget = ShapeTransitionBudget;
+        _internedKeyCount = 0;
+        _expectKey = false;
 
         State state = new State();
 
@@ -913,6 +986,8 @@ public sealed class JsonParser
         var startPos = _lookahead.Range.Start;
         var entries = new Dictionary<string, JsonParseNode>(StringComparer.Ordinal);
 
+        // The token right after '{' is the first key (or '}'): route it through key interning.
+        _expectKey = true;
         Expect(ref state, '{');
 
         var obj = new JsObject(_engine);
@@ -951,6 +1026,8 @@ public sealed class JsonParser
 
             if (!Match('}'))
             {
+                // The token right after ',' is the next key.
+                _expectKey = true;
                 Expect(ref state, ',');
             }
         }
@@ -1010,6 +1087,14 @@ public sealed class JsonParser
         public int Start { get; }
         public int End { get; }
     }
+
+    /// <summary>An interned property key: the deduplicated name and its (also deduplicated) <see cref="JsString"/>.</summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct InternedKey(string Name, JsString Value);
+
+    /// <summary>One entry in the per-parse key-intern table; <see cref="Hash"/> is the FNV hash of <see cref="Name"/>.</summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct InternedKeyEntry(int Hash, string Name, JsString Value);
 
     static class Messages
     {

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -101,15 +101,16 @@ public sealed class JsonParser
     // an array of 500 identically-shaped records re-scans the same "id"/"name"/... key hundreds of times.
     // Interning object keys within a single parse lets those records share one key string (and its
     // JsString) instead of re-allocating both per record. Only property KEYS are interned, never string
-    // values, and the table is bounded — keys must be at most MaxInternedKeyLength chars and at most
-    // MaxInternedKeys distinct keys are cached — so a hostile payload with millions of distinct/long keys
-    // cannot grow it without bound. The table is per-parser-instance and reset per parse (no cross-parse
-    // or global state). _expectKey is set immediately before the Lex that scans a key token (right after
-    // '{' or ',' inside an object) and consumed by the very next scan, so only keys route through interning.
+    // values. The table is direct-mapped (slot = hash & mask, replace on collision): both hit and miss
+    // cost a single compare, so key-diverse payloads (whose keys mostly miss) pay no probe tax, hot keys
+    // of homogeneous payloads statistically keep their slots, and a hostile payload with millions of
+    // distinct/long keys cannot grow the fixed-size table. The table is per-parser-instance and reset per
+    // parse (no cross-parse or global state). _expectKey is set immediately before the Lex that scans a
+    // key token (right after '{' or ',' inside an object) and consumed by the very next scan, so only
+    // keys route through interning.
     private const int MaxInternedKeyLength = 64;
-    private const int MaxInternedKeys = 64;
+    private const int InternedKeySlots = 256; // power of two, indexed by hash & (InternedKeySlots - 1)
     private InternedKeyEntry[]? _internedKeys;
-    private int _internedKeyCount;
     private bool _expectKey;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -462,37 +463,29 @@ public sealed class JsonParser
     /// <summary>
     /// Interns a just-scanned property-key span for the lifetime of the current parse: identical keys across
     /// records return the same <see cref="string"/> and <see cref="JsString"/> instances, and on a cache hit
-    /// no new string is materialized at all. Bounded by <see cref="MaxInternedKeyLength"/> and
-    /// <see cref="MaxInternedKeys"/> so adversarial payloads cannot grow the table without bound; keys outside
-    /// the bounds are materialized fresh (current behavior) without being cached.
+    /// no new string is materialized at all. The table is direct-mapped with replace-on-collision, so hits
+    /// and misses both cost one compare; keys longer than <see cref="MaxInternedKeyLength"/> are materialized
+    /// fresh (current behavior) without touching the table.
     /// </summary>
     private InternedKey InternPropertyKey(ReadOnlySpan<char> span)
     {
-        var hash = Hash.GetFNVHashCode(span);
-
-        var entries = _internedKeys;
-        if (entries is not null)
+        if (span.Length > MaxInternedKeyLength)
         {
-            var count = _internedKeyCount;
-            for (var i = 0; i < count; i++)
-            {
-                ref var entry = ref entries[i];
-                if (entry.Hash == hash && span.SequenceEqual(entry.Name.AsSpan()))
-                {
-                    return new InternedKey(entry.Name, entry.Value);
-                }
-            }
+            var longName = span.ToString();
+            return new InternedKey(longName, new JsString(longName));
+        }
+
+        var hash = Hash.GetFNVHashCode(span);
+        var entries = _internedKeys ??= new InternedKeyEntry[InternedKeySlots];
+        ref var entry = ref entries[hash & (InternedKeySlots - 1)];
+        if (entry.Hash == hash && entry.Name is not null && span.SequenceEqual(entry.Name.AsSpan()))
+        {
+            return new InternedKey(entry.Name, entry.Value);
         }
 
         var name = span.ToString();
         var value = new JsString(name);
-
-        if (span.Length <= MaxInternedKeyLength && _internedKeyCount < MaxInternedKeys)
-        {
-            entries ??= _internedKeys = new InternedKeyEntry[MaxInternedKeys];
-            entries[_internedKeyCount++] = new InternedKeyEntry(hash, name, value);
-        }
-
+        entry = new InternedKeyEntry(hash, name, value);
         return new InternedKey(name, value);
     }
 
@@ -839,7 +832,10 @@ public sealed class JsonParser
         _length = _source.Length;
         _lookahead = null!;
         _shapeBudget = ShapeTransitionBudget;
-        _internedKeyCount = 0;
+        if (_internedKeys is not null)
+        {
+            System.Array.Clear(_internedKeys, 0, _internedKeys.Length);
+        }
         _expectKey = false;
 
         State state = new State();
@@ -867,7 +863,10 @@ public sealed class JsonParser
         _length = _source.Length;
         _lookahead = null!;
         _shapeBudget = ShapeTransitionBudget;
-        _internedKeyCount = 0;
+        if (_internedKeys is not null)
+        {
+            System.Array.Clear(_internedKeys, 0, _internedKeys.Length);
+        }
         _expectKey = false;
 
         State state = new State();


### PR DESCRIPTION
Part of the V8-gap performance campaign (#1775 follow-up). Profiling `json-parse-modern` (500 homogeneous records × 32 parses) showed `JsonParser.ScanStringLiteral` at 7.8% self — the same six property-name strings re-scanned and re-allocated 3,000 times per parse.

## Change

`JsonParser` interns object **property-key** strings within a single parse, at the scan seam: a `_expectKey` signal (set right before the `Lex` that reads a key token) routes only keys through a direct-mapped 256-slot intern table (slot = FNV hash & mask, replace on collision — one compare for hit and miss alike). On a hit no string and no `JsString` are materialized at all. Value strings are untouched; keys > 64 chars bypass the table; the table is per-parser and cleared per parse, so hostile payloads cannot grow it.

The direct-mapped layout matters: an earlier linear-probe variant taxed key-diverse payloads (+8% on twitter.json). 256 slots fit real-world key populations, so hot keys keep their slots instead of thrashing.

## Numbers (default BDN job, same-base A/B vs main)

| Benchmark | main | this PR | delta |
|---|---:|---:|---:|
| JsonBenchmark.Parse bestbuy_dataset | 164.1 ms / 85.5 MB | 127.6 ms / 58.5 MB | **−22% / −32% alloc** |
| JsonBenchmark.Parse twitter | 2.316 ms / 2.26 MB | 2.316 ms / 1.43 MB | **flat / −37% alloc** |
| json-parse-modern row (Jint_ParsedScript) | 18.44 ms / 20.9 MB | 17.62 ms / 15.0 MB | **−4.4% / −28% alloc** |

## Gates

Jint.Tests 3654/3591 (net10/net472), Test262 99,431 passed / 0 failed (re-run after each variant). Functional checks include duplicate keys (last wins), escaped-character keys, over-bound keys, and 100+-distinct-key objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)