### PR TITLE
Precompute per-parameter interop binding flags

### DIFF
--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -29,6 +29,12 @@ internal sealed class MethodDescriptor
                 ParameterDefaultValuesCount++;
             }
         }
+
+        ParameterFlags = Parameters.Length == 0 ? [] : new InteropParameterFlags[Parameters.Length];
+        for (var i = 0; i < Parameters.Length; i++)
+        {
+            ParameterFlags[i] = ComputeParameterFlags(Parameters[i].ParameterType);
+        }
     }
 
     public MethodBase Method { get; }
@@ -36,6 +42,32 @@ internal sealed class MethodDescriptor
     public bool HasParams { get; }
     public int ParameterDefaultValuesCount { get; }
     public bool IsExtensionMethod { get; }
+
+    /// <summary>
+    /// Facts about each parameter type that argument binding consults on every call — computed
+    /// once so the per-call loop avoids reflection checks (and the boxing ToObject detour that
+    /// only generic-shaped parameters need). Valid for <see cref="Parameters"/> only; a resolved
+    /// generic method's parameters must be re-classified with <see cref="ComputeParameterFlags"/>.
+    /// </summary>
+    public InteropParameterFlags[] ParameterFlags { get; }
+
+    public static InteropParameterFlags ComputeParameterFlags(Type parameterType)
+    {
+        var flags = InteropParameterFlags.None;
+        if (typeof(JsValue).IsAssignableFrom(parameterType))
+        {
+            flags |= InteropParameterFlags.JsValueAssignable;
+        }
+        if (parameterType.IsGenericParameter || parameterType.IsGenericType)
+        {
+            flags |= InteropParameterFlags.GenericLike;
+        }
+        if (parameterType == typeof(JsValue[]))
+        {
+            flags |= InteropParameterFlags.JsValueArray;
+        }
+        return flags;
+    }
 
 #if NET8_0_OR_GREATER
     // lazily initialized fast invokers, benign race - last writer wins
@@ -282,6 +314,7 @@ internal sealed class MethodDescriptor
     {
         object?[] parameters = arguments.Length == 0 ? [] : new object?[arguments.Length];
         var methodParameters = Parameters;
+        var parameterFlags = ParameterFlags;
         var valueCoercionType = engine.Options.Interop.ValueCoercion;
 
         try
@@ -293,7 +326,7 @@ internal sealed class MethodDescriptor
                 var value = arguments[i];
                 object? converted;
 
-                if (typeof(JsValue).IsAssignableFrom(parameterType))
+                if ((parameterFlags[i] & InteropParameterFlags.JsValueAssignable) != InteropParameterFlags.None)
                 {
                     converted = value;
                 }
@@ -326,4 +359,22 @@ internal sealed class MethodDescriptor
             return null;
         }
     }
+}
+
+/// <summary>
+/// Per-parameter-type facts consulted by interop argument binding on every call.
+/// </summary>
+[Flags]
+internal enum InteropParameterFlags : byte
+{
+    None = 0,
+
+    /// <summary>The parameter accepts a JsValue directly, no conversion needed.</summary>
+    JsValueAssignable = 1,
+
+    /// <summary>Generic parameter or generic type — the only shapes the generic-binding probe can match.</summary>
+    GenericLike = 2,
+
+    /// <summary>The parameter is exactly JsValue[] (the params JsValue[] host signature).</summary>
+    JsValueArray = 4,
 }

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -248,10 +248,17 @@ internal sealed class MethodInfoFunction : Function
         var resolvedMethod = ResolveMethod(method.Method, methodParameters, arguments);
         // We only need to call GetParameters it if this ends up being a generic method (i.e. they will be different in that scenario)
         var isGenericDefinition = false;
+        var parameterFlags = method.ParameterFlags;
         if (resolvedMethod.IsGenericMethod)
         {
+            // the resolved parameters differ from the descriptor's, re-classify them
             methodParameters = resolvedMethod.GetParameters();
             isGenericDefinition = method.Method is MethodInfo { IsGenericMethodDefinition: true };
+            parameterFlags = new InteropParameterFlags[methodParameters.Length];
+            for (var i = 0; i < methodParameters.Length; i++)
+            {
+                parameterFlags[i] = MethodDescriptor.ComputeParameterFlags(methodParameters[i].ParameterType);
+            }
         }
 
         // NOTE: pooling this buffer via ArrayPool was measured slower than allocation (tiny
@@ -263,10 +270,11 @@ internal sealed class MethodInfoFunction : Function
         {
             var methodParameter = methodParameters[i];
             var parameterType = methodParameter.ParameterType;
+            var flags = parameterFlags[i];
             var argument = arguments.Length > i ? arguments[i] : null;
             object? argumentObject = null;
 
-            if (typeof(JsValue).IsAssignableFrom(parameterType))
+            if ((flags & InteropParameterFlags.JsValueAssignable) != InteropParameterFlags.None)
             {
                 parameters[i] = argument;
             }
@@ -275,13 +283,13 @@ internal sealed class MethodInfoFunction : Function
                 // optional
                 parameters[i] = System.Type.Missing;
             }
-            else if (IsGenericParameter(argumentObject = argument.ToObject(), parameterType)) // don't think we need the condition preface of (argument == null) because of earlier condition
+            else if ((flags & InteropParameterFlags.GenericLike) != InteropParameterFlags.None && IsGenericParameter(argumentObject = argument.ToObject(), parameterType))
             {
-                // ^ this is the best way I could think of to only eval argument.ToObject() when needed.
-                // But it's very cursed, I'm sorry.
+                // only generic-shaped parameter types can match the probe, so the boxing
+                // ToObject() detour is skipped entirely for plain parameter types
                 parameters[i] = argumentObject;
             }
-            else if (parameterType == typeof(JsValue[]) && argument.IsArray())
+            else if ((flags & InteropParameterFlags.JsValueArray) != InteropParameterFlags.None && argument.IsArray())
             {
                 // Handle specific case of F(params JsValue[])
                 var arrayInstance = argument.AsArray();
@@ -301,7 +309,7 @@ internal sealed class MethodInfoFunction : Function
             else
             {
                 if (!ReflectionExtensions.TryConvertViaTypeCoercion(parameterType, _engine.Options.Interop.ValueCoercion, argument, out parameters[i])
-                    && !converter.TryConvert(argumentObject, parameterType, CultureInfo.InvariantCulture, out parameters[i]))
+                    && !converter.TryConvert(argumentObject ?? argument.ToObject(), parameterType, CultureInfo.InvariantCulture, out parameters[i]))
                 {
                     // arguments don't match this method
                     return false;


### PR DESCRIPTION
Part of the V8-gap performance campaign (#1775 follow-up). Profiling `interop-method-calls` showed `MethodInfoFunction.TryCall` at 15.9% self — and most of it is constant-per-method work re-derived on every call.

## Change

Interop argument binding re-derived three per-parameter-type facts per argument per call: `typeof(JsValue).IsAssignableFrom(parameterType)`, the generic-shape test hidden inside `IsGenericParameter` (which forced a **boxing `argument.ToObject()` detour for every argument, including plain `int` parameters**), and the `JsValue[]` params-signature check.

`MethodDescriptor` now classifies each parameter once into `InteropParameterFlags`; `MethodInfoFunction.TryCall` and `MethodDescriptor.Call` branch on the cached flags. Resolved generic methods re-classify their own parameters (their `ParameterInfo`s differ from the descriptor's). The general conversion branch computes the boxed argument lazily now that the generic probe no longer produces it as a side effect. Conversion semantics are unchanged — the same conversions run in the same order; only constant-per-method reflection checks and the needless pre-boxing are gone.

## Numbers (default BDN job, same-base A/B)

| Row | base | change | delta |
|---|---:|---:|---:|
| SingleOverload_NoArg | 2.183 us | 1.960 us | **−10.2%** |
| SingleOverload_OneIntArg | 2.393 us / 2.89 KB | 2.346 us / 1.95 KB | −2.0% / **−33% alloc** |
| SingleOverload_OneDoubleArg | 2.593 us | 2.529 us | −2.5% |
| SingleOverload_OneStringArg | 2.617 us | 2.564 us | −2.0% |

Three rows (TwoArgs, Overloaded, Params) initially read +3–4% on single launches; a launchCount-5 verification on both sides shows them statistically tied (+0.2%, +0.3%, −2.1%) — layout bimodality, not regressions.

## Gates

Rebased on current main (includes #2716–#2718): Jint.Tests 3658/3595 (net10/net472), PublicInterface 114/114 both TFMs, Test262 99,431 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)