### PR TITLE
Add opt-in ClrArrayConversion.LiveView interop mode for CLR arrays

### DIFF
--- a/Jint.Benchmark/InteropWrapperChurnBenchmark.cs
+++ b/Jint.Benchmark/InteropWrapperChurnBenchmark.cs
@@ -33,6 +33,7 @@ public class InteropWrapperChurnBenchmark
     private Engine _engineDefault = null!;
     private Engine _engineIdentity = null!;
     private Engine _engineRecentCache = null!;
+    private Engine _engineLiveView = null!;
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -50,6 +51,10 @@ public class InteropWrapperChurnBenchmark
         _engineRecentCache = new Engine(cfg => cfg.Interop.CacheRecentObjectWrappers = true);
         _engineRecentCache.SetValue("h", holder);
         _engineRecentCache.Execute("h.Payload.Value");
+
+        _engineLiveView = new Engine(cfg => cfg.Interop.ClrArrayConversion = ClrArrayConversion.LiveView);
+        _engineLiveView.SetValue("h", holder);
+        _engineLiveView.Execute("h.Payload.Value");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
@@ -91,5 +96,13 @@ public class InteropWrapperChurnBenchmark
     public void ArrayMemberTraversal_RecentCache()
     {
         _engineRecentCache.Execute(_arrayTraversal);
+    }
+
+    // LiveView: each h.Numbers read wraps the array in a live fixed-size view (no per-read deep copy);
+    // without an identity flag the wrapper itself is still allocated per crossing.
+    [Benchmark]
+    public void ArrayMemberTraversal_LiveView()
+    {
+        _engineLiveView.Execute(_arrayTraversal);
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
+++ b/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
@@ -1,0 +1,247 @@
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+public partial class InteropTests
+{
+    public sealed class ArrayHolder
+    {
+        public int[] Numbers { get; } = [10, 20, 30];
+    }
+
+    private static Engine CreateLiveViewEngine(Action<Options> additionalConfiguration = null)
+    {
+        return new Engine(options =>
+        {
+            options.Interop.ClrArrayConversion = ClrArrayConversion.LiveView;
+            additionalConfiguration?.Invoke(options);
+        });
+    }
+
+    [Fact]
+    public void ClrArrayConversionDefaultsToCopy()
+    {
+        Assert.Equal(ClrArrayConversion.Copy, new Options().Interop.ClrArrayConversion);
+
+        // Copy mode: each crossing produces an independent JsArray snapshot
+        var engine = new Engine();
+        engine.SetValue("h", new ArrayHolder());
+        Assert.True(engine.Evaluate("Array.isArray(h.Numbers)").AsBoolean());
+        Assert.False(engine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
+    }
+
+    [Fact]
+    public void CopyModeScriptWritesDoNotAffectClrArray()
+    {
+        var engine = new Engine();
+        var numbers = new[] { 1, 2, 3 };
+        engine.SetValue("arr", numbers);
+
+        engine.Execute("arr[1] = 42;");
+
+        Assert.Equal(2, numbers[1]);
+    }
+
+    [Fact]
+    public void LiveViewArrayMaintainsIdentity()
+    {
+        // wrapper equality is by wrapped target, so === holds even without any identity cache flag
+        var engine = CreateLiveViewEngine();
+        engine.SetValue("h", new ArrayHolder());
+        Assert.True(engine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
+
+        // with the identity map the same wrapper instance is also reused
+        var trackingEngine = CreateLiveViewEngine(options => options.Interop.TrackObjectWrapperIdentity = true);
+        trackingEngine.SetValue("h", new ArrayHolder());
+        Assert.True(trackingEngine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
+        Assert.Same(trackingEngine.Evaluate("h.Numbers"), trackingEngine.Evaluate("h.Numbers"));
+
+        var recentCacheEngine = CreateLiveViewEngine(options => options.Interop.CacheRecentObjectWrappers = true);
+        recentCacheEngine.SetValue("h", new ArrayHolder());
+        Assert.True(recentCacheEngine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
+        Assert.Same(recentCacheEngine.Evaluate("h.Numbers"), recentCacheEngine.Evaluate("h.Numbers"));
+    }
+
+    [Fact]
+    public void LiveViewArrayScriptWritesAreVisibleInClr()
+    {
+        var engine = CreateLiveViewEngine();
+        var numbers = new[] { 1, 2, 3 };
+        engine.SetValue("arr", numbers);
+
+        engine.Execute("arr[1] = 42;");
+
+        Assert.Equal(42, numbers[1]);
+    }
+
+    [Fact]
+    public void LiveViewArrayClrWritesAreVisibleInScript()
+    {
+        var engine = CreateLiveViewEngine();
+        var numbers = new[] { 1, 2, 3 };
+        engine.SetValue("arr", numbers);
+
+        Assert.Equal(3, engine.Evaluate("arr[2]").AsNumber());
+
+        numbers[2] = 99;
+
+        Assert.Equal(99, engine.Evaluate("arr[2]").AsNumber());
+    }
+
+    [Fact]
+    public void LiveViewArrayWriteConvertsToElementType()
+    {
+        var engine = CreateLiveViewEngine();
+        var strings = new[] { "a", "b" };
+        engine.SetValue("arr", strings);
+
+        engine.Execute("arr[0] = 'hello';");
+
+        Assert.Equal("hello", strings[0]);
+        Assert.Equal("b", strings[1]);
+    }
+
+    [Theory]
+    [InlineData("arr.push(4)")]
+    [InlineData("arr.pop()")]
+    [InlineData("arr.shift()")]
+    [InlineData("arr.unshift(0)")]
+    [InlineData("arr.splice(0, 1)")]
+    [InlineData("arr.length = 1")]
+    [InlineData("arr.length = 10")]
+    [InlineData("arr[3] = 4")]
+    [InlineData("arr[100] = 1")]
+    public void LiveViewArrayResizeAttemptsThrowTypeError(string operation)
+    {
+        var engine = CreateLiveViewEngine();
+        var numbers = new[] { 1, 2, 3 };
+        engine.SetValue("arr", numbers);
+
+        // a script-side catch proves the failure surfaces as a JS TypeError instead of
+        // a CLR exception (NotSupportedException etc.) bubbling past the script
+        var result = engine.Evaluate(
+            $"(function() {{ try {{ {operation}; return 'no-throw'; }} catch (e) {{ return e instanceof TypeError ? 'TypeError' : 'unexpected: ' + e; }} }})()");
+
+        Assert.Equal("TypeError", result.AsString());
+        Assert.Equal(3, engine.Evaluate("arr.length").AsNumber());
+    }
+
+    [Fact]
+    public void LiveViewArrayLengthWriteWithSameValueIsNoOp()
+    {
+        var engine = CreateLiveViewEngine();
+        engine.SetValue("arr", new[] { 1, 2, 3 });
+
+        engine.Execute("arr.length = 3;");
+
+        Assert.Equal(3, engine.Evaluate("arr.length").AsNumber());
+    }
+
+    [Fact]
+    public void LiveViewArrayIsNotJsArray()
+    {
+        var engine = CreateLiveViewEngine();
+        engine.SetValue("arr", new[] { 1, 2, 3 });
+
+        Assert.False(engine.Evaluate("Array.isArray(arr)").AsBoolean());
+        Assert.Equal("object", engine.Evaluate("typeof arr").AsString());
+    }
+
+    [Fact]
+    public void LiveViewArraySerializesAsJsonArray()
+    {
+        // JsonSerializer treats ObjectWrapper { IsArrayLike: true } as an array
+        var engine = CreateLiveViewEngine();
+        engine.SetValue("arr", new[] { 1, 2, 3 });
+        engine.SetValue("holder", new ArrayHolder());
+
+        Assert.Equal("[1,2,3]", engine.Evaluate("JSON.stringify(arr)").AsString());
+        Assert.Equal("""{"Numbers":[10,20,30]}""", engine.Evaluate("JSON.stringify(holder)").AsString());
+    }
+
+    [Fact]
+    public void LiveViewArraySupportsIteration()
+    {
+        var engine = CreateLiveViewEngine();
+        engine.SetValue("arr", new[] { 1, 2, 3 });
+
+        Assert.Equal("1,2,3,", engine.Evaluate("var s = ''; for (var x of arr) { s += x + ','; } s").AsString());
+        Assert.Equal("[1,2,3]", engine.Evaluate("JSON.stringify([...arr])").AsString());
+
+        // Array.prototype is attached by default, so array methods work against the live view
+        Assert.Equal("[2,4,6]", engine.Evaluate("JSON.stringify(arr.map(function (x) { return x * 2; }))").AsString());
+        Assert.Equal(1, engine.Evaluate("arr.indexOf(2)").AsNumber());
+    }
+
+    [Fact]
+    public void LiveViewArrayDeleteBehavesLikeIntegerIndexedExotic()
+    {
+        var engine = CreateLiveViewEngine();
+        var numbers = new[] { 1, 2, 3 };
+        engine.SetValue("arr", numbers);
+
+        // in-range elements cannot be removed from a fixed-size array: delete returns false
+        // and must not reset the slot to a default value
+        Assert.False(engine.Evaluate("delete arr[0]").AsBoolean());
+        Assert.Equal(1, numbers[0]);
+
+        // out-of-range delete is a JS no-op that reports success
+        Assert.True(engine.Evaluate("delete arr[100]").AsBoolean());
+
+        // strict mode surfaces the refusal as a TypeError
+        Assert.Equal("TypeError", engine.Evaluate(
+            "(function() { 'use strict'; try { delete arr[0]; return 'no-throw'; } catch (e) { return e instanceof TypeError ? 'TypeError' : 'unexpected: ' + e; } })()").AsString());
+    }
+
+    [Fact]
+    public void LiveViewArrayRespectsAllowWriteFalse()
+    {
+        var engine = CreateLiveViewEngine(options => options.Interop.AllowWrite = false);
+        var numbers = new[] { 1, 2, 3 };
+        engine.SetValue("arr", numbers);
+
+        engine.Execute("arr[1] = 42;");
+
+        Assert.Equal(2, numbers[1]);
+    }
+
+    [Fact]
+    public void LiveViewArrayRoundTripsOriginalReferenceToClr()
+    {
+        var engine = CreateLiveViewEngine();
+        var numbers = new[] { 1, 2, 3 };
+        int[] received = null;
+        engine.SetValue("arr", numbers);
+        engine.SetValue("receive", new Action<int[]>(a => received = a));
+
+        engine.Execute("receive(arr);");
+
+        Assert.Same(numbers, received);
+    }
+
+    [Fact]
+    public void MultiRankArraysKeepCopyModeFailureUnderBothModes()
+    {
+        // multi-dimensional arrays have never been convertible (Array.GetValue with a single
+        // flat index throws) and LiveView must not change that failure mode
+        var copyEngine = new Engine();
+        Assert.Throws<ArgumentException>(() => copyEngine.SetValue("md", new int[2, 2]));
+
+        var liveViewEngine = CreateLiveViewEngine();
+        Assert.Throws<ArgumentException>(() => liveViewEngine.SetValue("md", new int[2, 2]));
+    }
+
+    [Fact]
+    public void LiveViewDoesNotAffectListWrapping()
+    {
+        var engine = CreateLiveViewEngine();
+        var list = new List<int> { 1, 2, 3 };
+        engine.SetValue("list", list);
+
+        engine.Execute("list.push(4);");
+
+        Assert.Equal(4, list.Count);
+        Assert.Equal(4, list[3]);
+    }
+}

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -353,6 +353,15 @@ public class Options
         public bool CacheRecentObjectWrappers { get; set; }
 
         /// <summary>
+        /// How CLR arrays (<c>T[]</c>) are exposed to script code, defaults to <see cref="Jint.ClrArrayConversion.Copy"/>
+        /// which copies the array contents into a new JavaScript array on each conversion.
+        /// <see cref="Jint.ClrArrayConversion.LiveView"/> instead exposes single-rank arrays as live,
+        /// fixed-size wrapper views over the underlying array; see the enum members for the exact
+        /// semantic differences (write-through, identity, <c>Array.isArray</c>, resizing).
+        /// </summary>
+        public ClrArrayConversion ClrArrayConversion { get; set; } = ClrArrayConversion.Copy;
+
+        /// <summary>
         /// If no known type could be guessed, objects are by default wrapped as an
         /// ObjectInstance using class ObjectWrapper. This function can be used to
         /// change the behavior.
@@ -715,4 +724,32 @@ public enum ExperimentalFeature
     /// All coercion rules enabled.
     /// </summary>
     All = TaskInterop,
+}
+
+/// <summary>
+/// Strategy for exposing CLR arrays (<c>T[]</c>) to script code, see <see cref="Options.InteropOptions.ClrArrayConversion"/>.
+/// </summary>
+public enum ClrArrayConversion
+{
+    /// <summary>
+    /// Each conversion copies the array contents into a new JavaScript array (<c>Array.isArray</c> returns <c>true</c>).
+    /// Script-side mutations affect only the copy and CLR-side mutations after the conversion are not visible
+    /// through it. Each crossing produces a new independent snapshot unless
+    /// <see cref="Options.InteropOptions.TrackObjectWrapperIdentity"/> or
+    /// <see cref="Options.InteropOptions.CacheRecentObjectWrappers"/> reuses the earlier one.
+    /// </summary>
+    Copy,
+
+    /// <summary>
+    /// Single-rank arrays are exposed as live wrapper views over the underlying CLR array, the same way wrapped
+    /// <see cref="System.Collections.Generic.List{T}"/> instances already behave: element reads and writes go
+    /// straight to the array in both directions, and wrapper identity across repeated crossings follows the same
+    /// caches as other wrapped objects (<see cref="Options.InteropOptions.TrackObjectWrapperIdentity"/> /
+    /// <see cref="Options.InteropOptions.CacheRecentObjectWrappers"/>). The view is array-like — iteration,
+    /// <c>Array.prototype</c> methods and JSON serialization as an array all work — but it is not a JavaScript
+    /// array: <c>Array.isArray</c> returns <c>false</c>, and because CLR arrays are fixed-size any attempt to
+    /// resize the view (growing writes, <c>push</c>/<c>pop</c>, <c>length</c> writes) throws a <c>TypeError</c>.
+    /// Multi-dimensional arrays are not supported by the view and behave as under <see cref="Copy"/>.
+    /// </summary>
+    LiveView,
 }

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -239,11 +239,11 @@ internal static class DefaultObjectConverter
     private static JsValue ConvertArray(Engine e, object v)
     {
         // The identity caches (flag-gated, both default off) also cover arrays: repeated
-        // conversions of the same CLR array instance return the same JsArray snapshot instead of
-        // re-copying every element on every property read. With the flags off each conversion
-        // still produces a fresh, independent copy. The checks must stay inside this method —
-        // _typeMappers is a static cross-engine memoization, so per-engine option state can never
-        // be baked into the memoized mapper.
+        // conversions of the same CLR array instance return the same result (JsArray snapshot under
+        // Copy, wrapper view under LiveView) instead of re-converting on every property read. With
+        // the flags off each conversion still produces a fresh copy/wrapper. All option checks must
+        // stay inside this method — _typeMappers is a static cross-engine memoization, so per-engine
+        // option state can never be baked into the memoized mapper.
         if (e._objectWrapperCache?.TryGetValue(v, out var cached) == true)
         {
             return cached;
@@ -252,6 +252,12 @@ internal static class DefaultObjectConverter
         if (e._recentObjectWrapperCache?.TryGet(v) is { } recentlyConverted)
         {
             return recentlyConverted;
+        }
+
+        if (e.Options.Interop.ClrArrayConversion == ClrArrayConversion.LiveView
+            && TryConvertArrayLiveView(e, v, out var liveView))
+        {
+            return liveView;
         }
 
         var array = (Array) v;
@@ -277,6 +283,46 @@ internal static class DefaultObjectConverter
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// LiveView lane of <see cref="ConvertArray"/>: routes a single-rank zero-based array (T[])
+    /// through the same wrapper machinery as any other CLR object (<see cref="Options.InteropOptions.WrapObjectHandler"/>,
+    /// which by default builds an <see cref="ArrayWrapper{T}"/> via <see cref="ObjectWrapper.Create"/>,
+    /// plus the flag-gated identity caches — already consulted by the caller). Multi-rank (T[,]) and
+    /// non-zero-based (T[*]) arrays return false so they keep the Copy-mode failure behavior.
+    /// </summary>
+    private static bool TryConvertArrayLiveView(Engine e, object v, [NotNullWhen(true)] out JsValue? result)
+    {
+        var arrayType = v.GetType();
+        if (arrayType.GetElementType() is not { } elementType
+            || arrayType != elementType.MakeArrayType())
+        {
+            result = null;
+            return false;
+        }
+
+        var wrapped = e.Options.Interop.WrapObjectHandler.Invoke(e, v, arrayType);
+        if (wrapped is null)
+        {
+            // custom handler opted out, fall back to the Copy lane
+            result = null;
+            return false;
+        }
+
+        if (e.Options.Interop.TrackObjectWrapperIdentity)
+        {
+            e._objectWrapperCache ??= new ConditionalWeakTable<object, ObjectInstance>();
+            e._objectWrapperCache.Add(v, wrapped);
+        }
+        else if (e.Options.Interop.CacheRecentObjectWrappers)
+        {
+            e._recentObjectWrapperCache ??= new RecentObjectWrapperCache();
+            e._recentObjectWrapperCache.Add(v, wrapped);
+        }
+
+        result = wrapped;
+        return true;
     }
 }
 

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -68,6 +68,15 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
             var value = ((JsNumber) property)._value;
             if (TypeConverter.IsIntegralNumber(value))
             {
+                if (IsFixedSize)
+                {
+                    // elements of a fixed-size CLR array view cannot be removed (and resetting them to a
+                    // default value on delete would let Array.prototype.pop/shift/splice silently zero
+                    // slots before their length write throws). Mirror integer-indexed exotic object
+                    // semantics instead: false for an in-range index, true for anything out of range.
+                    return value < 0 || value >= Length;
+                }
+
                 var defaultValue = default(object);
                 if (typeof(JsValue).IsAssignableFrom(ItemType))
                 {
@@ -143,12 +152,39 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
             {
                 return false;
             }
+
+            // Fixed-size targets (CLR arrays) handle integral index writes here: in-range writes go
+            // straight to the backing store and anything else is a TypeError. The base.Set slow path
+            // below resolves the element writer through the reflection indexer, which for T[] finds
+            // the non-generic IList.Item (object-typed) indexer — element values would bypass item
+            // type coercion and out-of-range writes would leak CLR exceptions.
+            if (IsFixedSize && TypeConverter.IsIntegralNumber(numValue))
+            {
+                if (!CanWrite || !Extensible)
+                {
+                    return false;
+                }
+
+                if (numValue >= 0 && numValue < Length)
+                {
+                    SetAt((int) numValue, value);
+                    return true;
+                }
+
+                Throw.TypeError(_engine.Realm, "Cannot write outside the bounds of a fixed-size CLR array");
+            }
         }
 
         return base.Set(property, value, receiver);
     }
 
     protected virtual bool CanWrite => _engine.Options.Interop.AllowWrite;
+
+    /// <summary>
+    /// Whether the underlying collection cannot change its length (CLR arrays). Enables the direct
+    /// integral-index write lane in <see cref="Set"/>.
+    /// </summary>
+    protected virtual bool IsFixedSize => false;
 
     public void SetAt(int index, JsValue value)
     {
@@ -266,6 +302,67 @@ internal class GenericListWrapper<[DynamicallyAccessedMembers(DynamicallyAccesse
     }
 
     public override void RemoveAt(int index) => _list.RemoveAt(index);
+}
+
+/// <summary>
+/// Live view over a single-rank CLR array (<c>T[]</c>) used by <see cref="ClrArrayConversion.LiveView"/>.
+/// Element reads and writes go straight to the underlying array; because CLR arrays are fixed-size,
+/// every length-changing operation surfaces as a JavaScript <c>TypeError</c> instead of leaking a CLR
+/// <see cref="NotSupportedException"/> (which is what routing <c>T[]</c> through
+/// <see cref="GenericListWrapper{T}"/> would do via <c>IList&lt;T&gt;.Add</c>).
+/// </summary>
+internal sealed class ArrayWrapper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] T> : ArrayLikeWrapper
+{
+    private readonly T[] _array;
+
+    public ArrayWrapper(Engine engine, T[] target, Type? type)
+        : base(engine, target, typeof(T), type)
+    {
+        _array = target;
+    }
+
+    public override int Length => _array.Length;
+
+    protected override bool IsFixedSize => true;
+
+    public override object? GetAt(int index)
+    {
+        var array = _array;
+        if ((uint) index < (uint) array.Length)
+        {
+            return array[index];
+        }
+
+        return null;
+    }
+
+    protected override void DoSetAt(int index, object? value)
+    {
+        // defensive bounds guard: growth attempts are rejected by EnsureCapacity/Set before this
+        // method is reached, and the fixed-size Delete lane never calls it
+        var array = _array;
+        if ((uint) index < (uint) array.Length)
+        {
+            array[index] = (T) value!;
+        }
+    }
+
+    public override void AddDefault() => ThrowFixedSize();
+
+    public override void Add(JsValue value) => ThrowFixedSize();
+
+    public override void RemoveAt(int index) => ThrowFixedSize();
+
+    public override void EnsureCapacity(int capacity)
+    {
+        if (capacity > _array.Length)
+        {
+            ThrowFixedSize();
+        }
+    }
+
+    [DoesNotReturn]
+    private void ThrowFixedSize() => Throw.TypeError(_engine.Realm, "Cannot resize a fixed-size CLR array");
 }
 
 internal sealed class ReadOnlyListWrapper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] T> : ArrayLikeWrapper

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -148,6 +148,16 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 #pragma warning disable IL2070
 #pragma warning disable IL3050
 
+            // single-rank zero-based CLR arrays (T[]) get a fixed-size live wrapper; T[] implements
+            // IList<T> and would otherwise flow into GenericListWrapper<T> below, whose growth paths
+            // call IList<T>.Add and would leak NotSupportedException from the underlying array.
+            // The MakeArrayType equality intentionally excludes multi-rank (T[,]) and non-zero-based
+            // (T[*]) arrays, which keep their previous handling.
+            if (t.IsArray && t.GetElementType() is { } elementType && t == elementType.MakeArrayType())
+            {
+                return typeof(ArrayWrapper<>).MakeGenericType(elementType);
+            }
+
             // check for generic interfaces
             foreach (var i in t.GetInterfaces())
             {


### PR DESCRIPTION
Part of the V8-gap performance campaign (#1775 follow-up); completes the array-interop story started in #2716.

## Change

New `Options.Interop.ClrArrayConversion` enum: `Copy` (default — exact current behavior, locked by tests) and `LiveView`. Under `LiveView`, a single-rank `T[]` crossing into script becomes a live, fixed-size `ArrayWrapper<T>` view — aligned with how wrapped `List<T>` already behaves — instead of a per-read deep-copied `JsArray` snapshot:

- Index reads/writes go straight to the underlying CLR array (write-through both directions).
- Any length-changing operation (`push`, growth, length write) throws a JS `TypeError` — never a leaking CLR `NotSupportedException`.
- `Array.isArray` is `false` (matches the other wrappers; documented); `for..of`, spread and `Array.prototype` methods work via the attached array prototype; `JSON.stringify` still serializes as an array.
- Multi-rank (`T[,]`) and non-zero-based arrays keep their existing behavior in both modes.
- The flag-gated identity caches from #2716 apply naturally to the wrappers, and all option checks stay out of the static `_typeMappers` memoization.

## Numbers (default BDN job, `InteropWrapperChurnBenchmark.ArrayMemberTraversal`: 100 reads of an `int[100]` member per op)

| mode | Mean | Allocated |
|---|---:|---:|
| Copy (default) | 146.4 us | 333,944 B |
| **LiveView** | **59.4 us** | **83,544 B** |
| Copy + TrackObjectWrapperIdentity | 15.2 us | 344 B |
| Copy + CacheRecentObjectWrappers | 13.9 us | 344 B |

LiveView needs no identity flag for its 2.5× / −75% alloc win (live semantics, fresh wrapper per crossing); combined with an identity flag, array reads hit the wrapper cache like any other host object. Memory-probe verified: zero retained growth after full GC over 200k iterations.

## Gates

Rebased on current main (includes #2716–#2720): Jint.Tests 3689/3626 (net10/net472, includes 31 new LiveView tests), PublicInterface 114/114 both TFMs (API-approval snapshot updated for the new enum/property), Test262 99,431 passed / 0 failed. `InteropTests.NonWritableArrayElement_*` and `ShouldConvertArrayToArrayInstance` pass unchanged under default `Copy`.

A follow-up proposal issue for flipping the default to `LiveView` in the next major (aligning `T[]` with `List<T>` semantics) will be filed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)