### PR TITLE
Cache resolved ObjectWrapper members per member-expression node

### DIFF
--- a/Jint.Tests/Runtime/InteropWrapperMemberCacheTests.cs
+++ b/Jint.Tests/Runtime/InteropWrapperMemberCacheTests.cs
@@ -1,0 +1,299 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the ObjectWrapper member inline cache (the wrapper lane in JintMemberExpression): cached
+/// descriptors must stay live (CLR getters/setters run on every use), any property define/redefine
+/// on the wrapper must invalidate, distinct wrapper instances must not cross-contaminate one call
+/// site, dictionary-backed wrappers must stay dynamic, and read-only CLR property write semantics
+/// must stay byte-identical in strict and sloppy mode.
+/// </summary>
+public class InteropWrapperMemberCacheTests
+{
+    public class CountingHost
+    {
+        private int _value;
+
+        public int Reads;
+        public List<int> WrittenValues { get; } = new();
+
+        public int value
+        {
+            get
+            {
+                Reads++;
+                return _value;
+            }
+            set
+            {
+                WrittenValues.Add(value);
+                _value = value;
+            }
+        }
+
+        public void SetBackingField(int newValue) => _value = newValue;
+
+        public int add(int a, int b) => a + b;
+    }
+
+    public class ReadOnlyHost
+    {
+        public int Fixed => 42;
+    }
+
+    [Fact]
+    public void PropertyReadsAndWritesInLoopStayLive()
+    {
+        var host = new CountingHost();
+        var engine = new Engine().SetValue("host", host);
+
+        var sum = engine.Evaluate("""
+            var sum = 0;
+            for (var i = 0; i < 10; i++) {
+                host.value = i;
+                sum += host.value;
+            }
+            sum;
+            """).AsNumber();
+
+        Assert.Equal(45, sum);
+        // every JS-side read must have invoked the CLR getter (the cache holds the descriptor, never the value)
+        Assert.Equal(10, host.Reads);
+        // every JS-side write must have reached the CLR setter
+        Assert.Equal(Enumerable.Range(0, 10), host.WrittenValues);
+    }
+
+    [Fact]
+    public void ClrSideMutationsBetweenIterationsAreVisible()
+    {
+        var host = new CountingHost();
+        var engine = new Engine()
+            .SetValue("host", host)
+            .SetValue("mutate", new Action<int>(host.SetBackingField));
+
+        var result = engine.Evaluate("""
+            var r = [];
+            for (var i = 0; i < 5; i++) {
+                r.push(host.value);
+                mutate((i + 1) * 100);
+            }
+            r.join(',');
+            """).AsString();
+
+        Assert.Equal("0,100,200,300,400", result);
+        Assert.Equal(5, host.Reads);
+    }
+
+    [Fact]
+    public void DefinePropertyOnWrapperMidLoopInvalidatesReadCache()
+    {
+        var engine = new Engine().SetValue("host", new CountingHost());
+
+        var result = engine.Evaluate("""
+            Object.defineProperty(host, 'extra', { value: 'first', writable: true, configurable: true });
+            var r = [];
+            for (var i = 0; i < 6; i++) {
+                if (i === 3) {
+                    Object.defineProperty(host, 'extra', { get: function () { return 'redefined'; }, configurable: true });
+                }
+                r.push(host.extra);
+            }
+            r.join(',');
+            """).AsString();
+
+        Assert.Equal("first,first,first,redefined,redefined,redefined", result);
+    }
+
+    [Fact]
+    public void DefinePropertyOnWrapperMidLoopInvalidatesMethodCallCache()
+    {
+        var engine = new Engine().SetValue("host", new CountingHost());
+
+        var result = engine.Evaluate("""
+            var r = [];
+            for (var i = 0; i < 6; i++) {
+                if (i === 3) {
+                    Object.defineProperty(host, 'add', { value: function (a, b) { return a * b; } });
+                }
+                r.push(host.add(2, 3));
+            }
+            r.join(',');
+            """).AsString();
+
+        Assert.Equal("5,5,5,6,6,6", result);
+    }
+
+    [Fact]
+    public void AlternatingWrapperInstancesAtOneCallSiteDoNotCrossContaminate()
+    {
+        var first = new CountingHost();
+        var second = new CountingHost();
+        first.SetBackingField(1);
+        second.SetBackingField(2);
+
+        var engine = new Engine()
+            .SetValue("first", first)
+            .SetValue("second", second);
+
+        var result = engine.Evaluate("""
+            function read(h) { return h.value; }
+            function write(h, v) { h.value = v; }
+            var r = [];
+            for (var i = 0; i < 6; i++) {
+                var h = i % 2 === 0 ? first : second;
+                r.push(read(h));
+                write(h, read(h) + 10);
+            }
+            r.join(',');
+            """).AsString();
+
+        Assert.Equal("1,2,11,12,21,22", result);
+        Assert.Equal(31, first.value);
+        Assert.Equal(32, second.value);
+    }
+
+    [Fact]
+    public void AlternatingWrapperAndPlainObjectAtOneCallSiteKeepsCorrectValues()
+    {
+        var host = new CountingHost();
+        host.SetBackingField(7);
+        var engine = new Engine().SetValue("host", host);
+
+        var result = engine.Evaluate("""
+            function read(o) { return o.value; }
+            var plain = { value: 'p' };
+            var r = [];
+            for (var i = 0; i < 6; i++) {
+                r.push(read(i % 2 === 0 ? host : plain));
+            }
+            r.join(',');
+            """).AsString();
+
+        Assert.Equal("7,p,7,p,7,p", result);
+    }
+
+    [Fact]
+    public void DictionaryBackedWrapperMembersStayDynamic()
+    {
+        var dictionary = new Dictionary<string, object>();
+        var engine = new Engine()
+            .SetValue("dict", dictionary)
+            .SetValue("clrSet", new Action(() => dictionary["key"] = "clr"))
+            .SetValue("clrRemove", new Action(() => dictionary.Remove("key")));
+
+        var result = engine.Evaluate("""
+            var r = [];
+            for (var i = 0; i < 5; i++) {
+                dict.key = i;
+                r.push(dict.key);
+            }
+            clrSet();
+            r.push(dict.key);
+            clrRemove();
+            r.push(dict.key === undefined ? 'gone' : dict.key);
+            r.join(',');
+            """).AsString();
+
+        Assert.Equal("0,1,2,3,4,clr,gone", result);
+        Assert.False(dictionary.ContainsKey("key"));
+    }
+
+    [Fact]
+    public void ReadOnlyClrPropertyWriteIsIgnoredInSloppyMode()
+    {
+        var engine = new Engine().SetValue("host", new ReadOnlyHost());
+
+        var result = engine.Evaluate("""
+            var r = [];
+            for (var i = 0; i < 5; i++) {
+                r.push(host.fixed);
+                host.fixed = i;
+            }
+            r.push(host.fixed);
+            r.join(',');
+            """).AsString();
+
+        Assert.Equal("42,42,42,42,42,42", result);
+    }
+
+    [Fact]
+    public void ReadOnlyClrPropertyWriteThrowsTypeErrorInStrictMode()
+    {
+        var engine = new Engine().SetValue("host", new ReadOnlyHost());
+
+        var result = engine.Evaluate("""
+            var r = [];
+            // reads populate the wrapper member cache before the write attempts
+            r.push(host.fixed);
+            r.push(host.fixed);
+            var attempt = function () { 'use strict'; host.fixed = 99; };
+            for (var i = 0; i < 3; i++) {
+                try {
+                    attempt();
+                    r.push('no-throw');
+                } catch (e) {
+                    r.push(e instanceof TypeError);
+                }
+            }
+            r.push(host.fixed);
+            r.join(',');
+            """).AsString();
+
+        Assert.Equal("42,42,true,true,true,42", result);
+    }
+
+    [Fact]
+    public void FastLaneAgreesWithForcedSlowLaneAcrossMutations()
+    {
+        var host = new CountingHost();
+        var engine = new Engine()
+            .SetValue("host", host)
+            .SetValue("mutate", new Action<int>(host.SetBackingField));
+
+        var result = engine.Evaluate("""
+            // fast: literal-name lane (cacheable); slow: computed non-literal name forces the Reference path
+            function fast() { return host.value; }
+            function slow() { var k = 'val'; return host[k + 'ue']; }
+            var r = [];
+            for (var i = 0; i < 5; i++) {
+                host.value = i * 3;
+                r.push(fast() === slow());
+                mutate(i * 3 + 1);
+                r.push(fast() === slow());
+            }
+            r.join(',');
+            """).AsString();
+
+        Assert.Equal(string.Join(",", Enumerable.Repeat("true", 10)), result);
+    }
+
+    [Fact]
+    public void CustomMemberAccessorMembersAreNotCached()
+    {
+        var calls = 0;
+        var engine = new Engine(options =>
+        {
+            options.Interop.MemberAccessor = (e, target, member) =>
+            {
+                if (member == "dynamicMember")
+                {
+                    calls++;
+                    return calls;
+                }
+
+                return null;
+            };
+        }).SetValue("host", new CountingHost());
+
+        var result = engine.Evaluate("""
+            var r = [];
+            for (var i = 0; i < 3; i++) {
+                r.push(host.dynamicMember);
+            }
+            r.join(',');
+            """).AsString();
+
+        // the custom accessor must be consulted on every read
+        Assert.Equal("1,2,3", result);
+        Assert.Equal(3, calls);
+    }
+}

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -367,9 +367,15 @@ public class Options
         public BuildCallStackDelegate? BuildCallStackHandler { get; set; }
 
         /// <summary>
+        /// Named default so the interop member inline cache (see JintMemberExpression's wrapper lane) can
+        /// detect by reference when a custom accessor has been configured and stay out of the way.
+        /// </summary>
+        internal static readonly MemberAccessorDelegate _defaultMemberAccessor = static (engine, target, member) => null;
+
+        /// <summary>
         ///
         /// </summary>
-        public MemberAccessorDelegate MemberAccessor { get; set; } = static (engine, target, member) => null;
+        public MemberAccessorDelegate MemberAccessor { get; set; } = _defaultMemberAccessor;
 
         /// <summary>
         /// Exceptions that thrown from CLR code are converted to JavaScript errors and

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -734,6 +734,50 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         return descriptor;
     }
 
+    /// <summary>
+    /// Per-AST-node inline-cache support (see the wrapper member lane in
+    /// <see cref="Runtime.Interpreter.Expressions.JintMemberExpression"/>): returns the already-stored own
+    /// descriptor a member read/write would consult, when — and only when — caching it per call site is
+    /// sound. The result is exactly what <see cref="Get"/> / <see cref="Set"/> resolve through
+    /// <c>TryGetProperty</c> once <see cref="GetOwnProperty(JsValue)"/> has stored the member (a live
+    /// <see cref="Descriptors.Specialized.ReflectionDescriptor"/> for CLR properties/fields, so every use
+    /// still flows through the CLR accessors), making a receiver-identity + <c>_propertiesVersion</c>
+    /// guard sufficient: any define/redefine/delete on the wrapper bumps the version and invalidates.
+    /// </summary>
+    /// <remarks>
+    /// Bails with <c>null</c> when:
+    /// <list type="bullet">
+    /// <item>the receiver is a subclass (e.g. <see cref="ArrayLikeWrapper"/> overrides Get/Set with its own semantics),</item>
+    /// <item>the target is a dictionary (member values are dynamic; descriptors are created fresh per access),</item>
+    /// <item>a custom <see cref="Options.InteropOptions.MemberAccessor"/> is configured (stay conservative),</item>
+    /// <item>the name is <c>length</c> on an <see cref="ICollection"/> target (<see cref="Get"/> serves the live count ahead of any stored descriptor),</item>
+    /// <item>the member has not been resolved-and-stored yet — the caller's slow path performs the store (bumping the version) so a later populate succeeds.</item>
+    /// </list>
+    /// </remarks>
+    internal PropertyDescriptor? TryGetInlineCacheableDescriptor(JsString property)
+    {
+        if (GetType() != typeof(ObjectWrapper)
+            || _typeDescriptor.IsDictionary
+            || _properties is null
+            || !ReferenceEquals(_engine.Options.Interop.MemberAccessor, Options.InteropOptions._defaultMemberAccessor))
+        {
+            return null;
+        }
+
+        if (Target is ICollection && CommonProperties.Length.Equals(property))
+        {
+            return null;
+        }
+
+        if (!_properties.TryGetValue(property.ToString(), out var descriptor)
+            || ReferenceEquals(descriptor, PropertyDescriptor.Undefined))
+        {
+            return null;
+        }
+
+        return descriptor;
+    }
+
     // need to be public for advanced cases like RavenDB yielding properties from CLR objects
     public static PropertyDescriptor GetPropertyDescriptor(Engine engine, object target, MemberInfo member)
     {

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -5,6 +5,7 @@ using Jint.Native.Array;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Environments;
+using Jint.Runtime.Interop;
 
 namespace Jint.Runtime.Interpreter.Expressions;
 
@@ -54,6 +55,22 @@ internal sealed class JintMemberExpression : JintExpression
     private uint _cachedStringProtoHolderVersion;
     private PropertyDescriptor? _cachedStringProtoDescriptor;
     private readonly bool _stringReceiverCallEligible;
+
+    // ObjectWrapper member cache: interop receivers carry InternalTypes.ExoticGet (members resolve against
+    // the wrapped CLR object), so none of the caches above apply and every host.value read/write walks
+    // ObjectWrapper.Get/Set → GetOwnProperty → dictionary probe → reflection accessor. But once
+    // ObjectWrapper.GetOwnProperty has resolved a member it stores the descriptor in the wrapper's own
+    // _properties and every subsequent Get/Set consults that stored instance first — so receiver identity +
+    // _propertiesVersion prove the stored descriptor is still exactly what the wrapper would hand back, and
+    // reads/writes can go straight through it. The cached descriptor stays live: a CLR property's
+    // ReflectionDescriptor re-invokes the CLR getter/setter on every use, so host-side value changes remain
+    // visible and JS-side writes reach the CLR setter. Any define/redefine/delete on the wrapper bumps the
+    // version and re-resolves. Population is gated by ObjectWrapper.TryGetInlineCacheableDescriptor (exact
+    // ObjectWrapper type only, no dictionary targets, no ICollection `length`, no custom member accessor);
+    // _cachedWrapperDescriptor is non-null whenever _cachedWrapper is.
+    private ObjectWrapper? _cachedWrapper;
+    private uint _cachedWrapperVersion;
+    private PropertyDescriptor? _cachedWrapperDescriptor;
 
     private static readonly JsValue _nullMarker = new JsString("NULL MARKER");
 
@@ -411,7 +428,7 @@ internal sealed class JintMemberExpression : JintExpression
 
                 _cachedReadObject = null;
                 _cachedReadDescriptor = null;
-                return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: false);
+                return ReadFromNonPlainReceiver(baseObject, determinedProperty);
             }
 
             // JsString primitive: skip ToObject's StringInstance allocation for the hot `s.length`
@@ -612,7 +629,7 @@ internal sealed class JintMemberExpression : JintExpression
                 return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: true);
             }
 
-            return ReadAfterOwnMiss(baseObject, determinedProperty, ownMissConfirmed: false);
+            return ReadFromNonPlainReceiver(baseObject, determinedProperty);
         }
 
         if (_stringReceiverCallEligible && baseValue is JsString jsString)
@@ -650,6 +667,38 @@ internal sealed class JintMemberExpression : JintExpression
 
         thisObject = JsValue.Undefined;
         return JsValue.Undefined;
+    }
+
+    /// <summary>
+    /// Read completion for receivers outside the shape / plain-object lanes. An <see cref="ObjectWrapper"/>
+    /// receiver first consults the wrapper member cache: on a hit (same wrapper instance, unchanged
+    /// <c>_propertiesVersion</c>) the stored descriptor is still exactly what <c>ObjectWrapper.Get</c>'s
+    /// own-property probe would return, so it unwraps directly — for a CLR property that re-invokes the CLR
+    /// getter through the live <c>ReflectionDescriptor</c>, identical to the full path. Everything else —
+    /// and any wrapper bail — funnels into <see cref="ReadAfterOwnMiss"/>, whose full <c>Get</c> resolves
+    /// and stores the wrapper member so the next populate attempt succeeds.
+    /// </summary>
+    private JsValue ReadFromNonPlainReceiver(ObjectInstance baseObject, JsString property)
+    {
+        if (ReferenceEquals(baseObject, _cachedWrapper)
+            && baseObject._propertiesVersion == _cachedWrapperVersion)
+        {
+            return ObjectInstance.UnwrapJsValue(_cachedWrapperDescriptor!, baseObject);
+        }
+
+        if (baseObject is ObjectWrapper wrapper)
+        {
+            var descriptor = wrapper.TryGetInlineCacheableDescriptor(property);
+            if (descriptor is not null)
+            {
+                _cachedWrapper = wrapper;
+                _cachedWrapperVersion = wrapper._propertiesVersion;
+                _cachedWrapperDescriptor = descriptor;
+                return ObjectInstance.UnwrapJsValue(descriptor, wrapper);
+            }
+        }
+
+        return ReadAfterOwnMiss(baseObject, property, ownMissConfirmed: false);
     }
 
     /// <summary>
@@ -822,6 +871,58 @@ internal sealed class JintMemberExpression : JintExpression
                     descriptor._value = rval;
                     result = rval;
                     return true;
+                }
+            }
+            else
+            {
+                // ObjectWrapper member lane: a stored member means ObjectWrapper.Set would route through
+                // SetSlow (ContainsKey ⇒ CanPut + `ownDesc.Value = value`), and the receiver-identity +
+                // _propertiesVersion guard proves the cached descriptor is that stored instance. Mirror
+                // SetSlow exactly: CanPut's own-descriptor branch with live flag/accessor reads
+                // (defineProperty can mutate the same instance without a version bump), then store through
+                // the descriptor — a ReflectionDescriptor forwards to the CLR setter, keeping conversion
+                // and exception semantics. Non-writable members (e.g. read-only CLR properties, whose
+                // ReflectionDescriptor exposes no setter when not writable or interop writes are disabled)
+                // fall through to the PutValue fallback so strict/sloppy failure behavior stays identical.
+                // Population only consumes descriptors a read has already stored; it never resolves members
+                // itself, so unstored writes keep ObjectWrapper.Set's accessor fast path untouched.
+                PropertyDescriptor? descriptor;
+                if (ReferenceEquals(baseObject, _cachedWrapper)
+                    && baseObject._propertiesVersion == _cachedWrapperVersion)
+                {
+                    descriptor = _cachedWrapperDescriptor;
+                }
+                else if (baseObject is ObjectWrapper wrapper
+                    && (descriptor = wrapper.TryGetInlineCacheableDescriptor(determinedProperty)) is not null)
+                {
+                    _cachedWrapper = wrapper;
+                    _cachedWrapperVersion = wrapper._propertiesVersion;
+                    _cachedWrapperDescriptor = descriptor;
+                }
+                else
+                {
+                    descriptor = null;
+                }
+
+                if (descriptor is not null)
+                {
+                    bool canPut;
+                    if (descriptor.IsAccessorDescriptor())
+                    {
+                        var set = descriptor.Set;
+                        canPut = set is not null && !set.IsUndefined();
+                    }
+                    else
+                    {
+                        canPut = descriptor.Writable;
+                    }
+
+                    if (canPut)
+                    {
+                        descriptor.Value = rval;
+                        result = rval;
+                        return true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Part of the V8-gap performance campaign (#1775 follow-up); the last profile-ranked interop item. `ObjectWrapper` receivers carry `InternalTypes.ExoticGet`, so every `host.value` read/write bypassed all AST inline caches and walked `ObjectWrapper.Get/Set → GetOwnProperty → dictionary probe → reflection accessor` — ~20% of the `interop-property-access` comparison row.

## Change

Per-AST-node monomorphic cache in `JintMemberExpression` (read lane, call lane via `GetCalleeForCall`, and the plain-assign write lane), guarded by **wrapper reference identity + `_propertiesVersion`** — the same stamp mechanism #2717 uses for prototypes, which `ObjectWrapper`'s own member store already bumps on define/redefine/delete.

The soundness invariant: `ObjectWrapper.GetOwnProperty` stores each resolved member in the wrapper's `_properties`, and `Get`/`SetSlow` consult that stored instance first — so same wrapper + unchanged version means the cached descriptor is exactly what the full path would resolve. The cached `ReflectionDescriptor` is live (re-invokes the CLR getter/setter per use), so host-side value changes stay visible and writes keep CLR conversion/exception semantics. Notably, a naive "never cache accessors" rule would have excluded the entire target case: CLR property descriptors are `NonData|CustomJsValue` — the stored-instance identity guard is what makes caching them sound.

Population is deliberately conservative — it only consumes descriptors a prior resolution already stored, and bails permanently for: subclassed wrappers (`ArrayLikeWrapper` family), dictionary-backed targets, custom `Options.Interop.MemberAccessor` (reference-compared against a named internal default), and `length` on `ICollection` targets (served live ahead of any stored descriptor). Write-only members are never populated from the write path — doing so would route `ObjectWrapper.Set` past its `Extensible` check, an observable behavior change; the read stores the descriptor and the write cache consumes it from the next iteration.

## Numbers (default BDN job, same-base A/B vs current main)

| Row | main | this PR | delta |
|---|---:|---:|---:|
| interop-property-access (Jint) | 2.303 ms | 1.723 ms | **−25.2%** |
| interop-method-calls (Jint) | 2.230 ms | 2.167 ms | −2.8% |

## Gates

Jint.Tests 3676/3613 (net10/net472, includes 11 new tests with CLR getter/setter invocation counting as cache-liveness proof), PublicInterface 114/114 both TFMs, Test262 99,431 passed / 0 failed. Tests cover mid-loop `defineProperty` invalidation (data→accessor), two wrapper instances alternating at one callsite, dictionary-backed members staying dynamic, readonly CLR property writes in strict (TypeError) and sloppy (silent) through the cache-hit→fallback path, and custom MemberAccessor consultation on every read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)