### PR TITLE
Memoize slot-cache chain reachability for closure reads

### DIFF
--- a/Jint.Tests/Runtime/SlotLocationCacheTests.cs
+++ b/Jint.Tests/Runtime/SlotLocationCacheTests.cs
@@ -55,6 +55,187 @@ public class SlotLocationCacheTests
         Assert.Equal(4 * (100 + 100_000), result);
     }
 
+    [Fact]
+    public void AlternatingClosureInstancesReadingOuterBindingsStayCorrect()
+    {
+        var engine = new Engine();
+        // hops-1 closure reads through the chain memo: two closure instances of the same
+        // definition alternate at ONE callsite, so the shared node's pinned chain flips
+        // between the instances' environments on every call and must re-validate, not
+        // serve the other instance's binding
+        var result = engine.Evaluate("""
+            (function () {
+                function make(table) {
+                    return function () {
+                        var acc = '';
+                        for (var i = 0; i < 8; i++) { acc += table[i % table.length]; }
+                        return acc;
+                    };
+                }
+                var a = make(['A']), b = make(['B']);
+                var got = '';
+                for (var r = 0; r < 3; r++) { got += a() + '|' + b() + ';'; }
+                return got;
+            })()
+            """).AsString();
+
+        Assert.Equal("AAAAAAAA|BBBBBBBB;AAAAAAAA|BBBBBBBB;AAAAAAAA|BBBBBBBB;", result);
+    }
+
+    [Fact]
+    public void SloppyDirectEvalShadowingVarInvalidatesChainMemoMidLoop()
+    {
+        var engine = new Engine();
+        // sloppy direct eval injects `captured` into the enclosing FUNCTION env mid-loop:
+        // the pre-eval iterations pin a chain memo to the outer binding; post-injection the
+        // epoch bump must force the walk to see the new shadowing binding immediately
+        var result = engine.Evaluate("""
+            (function () {
+                var captured = 'outer';
+                function reader() {
+                    var seen = '';
+                    for (var i = 0; i < 6; i++) {
+                        seen += captured;
+                        if (i === 2) { eval("var captured = 'inner';"); }
+                        seen += ',';
+                    }
+                    return seen;
+                }
+                return reader() + '|' + captured;
+            })()
+            """).AsString();
+
+        // i=0..2 read the outer binding (the eval at i===2 runs AFTER the read); the
+        // injected var initializes to 'inner' and shadows from the i=3 read onward, and
+        // the outer binding must remain untouched
+        Assert.Equal("outer,outer,outer,inner,inner,inner,|outer", result);
+    }
+
+    [Fact]
+    public void SloppyDirectEvalHoistedVarShadowsFromInjectionOn()
+    {
+        var engine = new Engine();
+        // hoisting-only variant: `var captured;` without initializer still creates the
+        // shadowing binding (initialized to undefined by EvalDeclarationInstantiation),
+        // flipping subsequent memo-guarded reads from 'outer' to undefined
+        var result = engine.Evaluate("""
+            (function () {
+                var captured = 'outer';
+                function reader() {
+                    var seen = '';
+                    for (var i = 0; i < 4; i++) {
+                        seen += captured + ',';
+                        if (i === 1) { eval("var captured;"); }
+                    }
+                    return seen;
+                }
+                return reader();
+            })()
+            """).AsString();
+
+        Assert.Equal("outer,outer,undefined,undefined,", result);
+    }
+
+    [Fact]
+    public void WithBlockAroundClosureReadIsNeverSkipped()
+    {
+        var engine = new Engine();
+        // the same identifier node runs both under a with-ObjectEnvironment and without it:
+        // a chain pinned outside the with must never validate inside it (the with-object can
+        // shadow dynamically), and property addition mid-loop must be honored immediately
+        var result = engine.Evaluate("""
+            (function () {
+                var captured = 'free';
+                var obj = {};
+                function reader(useWith) {
+                    var seen = '';
+                    if (useWith) {
+                        with (obj) {
+                            for (var i = 0; i < 4; i++) {
+                                seen += captured + ',';
+                                if (i === 1) { obj.captured = 'shadowed'; }
+                            }
+                        }
+                    } else {
+                        for (var j = 0; j < 2; j++) { seen += captured + ','; }
+                    }
+                    return seen;
+                }
+                // warm the memo without the with-block, then run under it, then without again
+                return reader(false) + '|' + reader(true) + '|' + reader(false);
+            })()
+            """).AsString();
+
+        Assert.Equal("free,free,|free,free,shadowed,shadowed,|free,free,", result);
+    }
+
+    [Fact]
+    public void DeeplyNestedClosureChainsResolveCorrectly()
+    {
+        var engine = new Engine();
+        // reads at hop distances beyond MaxChainDepth must keep falling through to full
+        // resolution and stay correct; distances within the bound exercise the memo
+        var result = engine.Evaluate("""
+            (function () {
+                var deep = 'root';
+                function l1() {
+                    var a1 = 1;
+                    function l2() {
+                        var a2 = 2;
+                        function l3() {
+                            var a3 = 3;
+                            function l4() {
+                                var a4 = 4;
+                                function l5() {
+                                    var acc = '';
+                                    for (var i = 0; i < 3; i++) {
+                                        acc += deep + (a1 + a2 + a3 + a4);
+                                    }
+                                    return acc;
+                                }
+                                return l5();
+                            }
+                            return l4();
+                        }
+                        return l3();
+                    }
+                    return l2();
+                }
+                return l1() + '|' + l1();
+            })()
+            """).AsString();
+
+        Assert.Equal("root10root10root10|root10root10root10", result);
+    }
+
+    [Fact]
+    public void PooledLoopEnvironmentsReattachedAcrossEntriesKeepMemoValid()
+    {
+        var engine = new Engine();
+        // let-bound loop bodies get per-node pooled block environments re-attached across
+        // loop entries: the pinned chain's start link is the SAME instance on a fresh entry,
+        // so the memo re-validates against current outer pointers and must stay correct
+        // across function instance switches too
+        var result = engine.Evaluate("""
+            (function () {
+                function make(base) {
+                    return function () {
+                        var acc = 0;
+                        for (let i = 0; i < 50; i++) {
+                            const step = 1;
+                            acc += base + step;
+                        }
+                        return acc;
+                    };
+                }
+                var a = make(10), b = make(1000);
+                return a() + b() + a();
+            })()
+            """).AsNumber();
+
+        Assert.Equal(50 * 11 + 50 * 1001 + 50 * 11, result);
+    }
+
 #if NET
     [Fact]
     public void SlotLanesSurviveRepeatedPreparedEvaluations()

--- a/Jint/Runtime/Environments/SlotLocationCache.cs
+++ b/Jint/Runtime/Environments/SlotLocationCache.cs
@@ -3,6 +3,50 @@ using System.Runtime.CompilerServices;
 namespace Jint.Runtime.Environments;
 
 /// <summary>
+/// Immutable snapshot of a successful hops 1-3 slot-cache reachability walk: from
+/// <see cref="Start"/>, following exactly the pinned links, the cached slot environment was
+/// reached and none of the probed intermediates (<see cref="Start"/>, <see cref="Next1"/>,
+/// <see cref="Next2"/>) owned the name. While every link still matches by identity and
+/// <see cref="Engine._envBindingInjectionEpoch"/> is unchanged, the per-hop shadow probes are
+/// provably still false and the walk can be skipped entirely.
+/// </summary>
+/// <remarks>
+/// Validity reasoning, mirroring <c>JintIdentifierExpression.NestedChainMemo</c> (the global
+/// read cache's chain memo) with a declarative terminal instead of the global environment:
+/// a declarative environment's name set is a deterministic function of its defining AST
+/// node/definition — every reuse channel (per-function-instance env reuse, the recursive env
+/// pool, definition-level dynamic-function envs, per-node block/loop/catch env caches, the
+/// per-source eval env pool) re-initializes an instance with the identical name set. The only
+/// mutations that grow a PRE-EXISTING environment's name set (sloppy direct eval var/function
+/// hoisting, AnnexB block-function var-scope copies) bump the injection epoch; deletions only
+/// shrink it (a pinned "does not own the name" stays true), and an environment's class
+/// (ObjectEnvironment vs declarative) is immutable. Chain-LINK identity is required, not just
+/// the start: pooled environments are re-attached under different outers across entries, and
+/// validation follows the CURRENT <c>_outerEnv</c> pointers, so a re-attached or replaced link
+/// falls through to the walk. A memo is published as one immutable object through a single
+/// reference field so cross-engine shared handler trees observe consistent snapshots; a memo
+/// pinned by another engine always fails the start-identity check because environments are
+/// per-engine. The terminal is intentionally NOT pinned: the memo's claim is only about the
+/// probed intermediates, so it stays valid when the node re-resolves to a new slot env behind
+/// the same intermediates.
+/// </remarks>
+internal sealed class SlotChainMemo
+{
+    internal readonly Environment Start;
+    internal readonly Environment? Next1;
+    internal readonly Environment? Next2;
+    internal readonly int InjectionEpoch;
+
+    internal SlotChainMemo(Environment start, Environment? next1, Environment? next2, int injectionEpoch)
+    {
+        Start = start;
+        Next1 = next1;
+        Next2 = next2;
+        InjectionEpoch = injectionEpoch;
+    }
+}
+
+/// <summary>
 /// Per-AST-node cache of a binding's slot location (environment + slot index), shared by the
 /// identifier read fast path and the numeric read-modify-write discard fast paths.
 /// </summary>
@@ -23,7 +67,10 @@ namespace Jint.Runtime.Environments;
 /// eval can inject a shadowing var into an enclosing function environment — so the hit
 /// walk re-probes every intermediate declarative environment (pure) and refuses to skip
 /// over an <see cref="ObjectEnvironment"/> (a with-object can gain a shadowing property
-/// at any time, and probing it would be observable through proxy traps).
+/// at any time, and probing it would be observable through proxy traps). A successful walk
+/// is memoized as a <see cref="SlotChainMemo"/> so steady-state closure reads validate with
+/// a handful of reference compares instead of re-walking; the walk stays authoritative for
+/// every miss.
 /// Nodes whose binding can never be slot-stored (global/object/dictionary environments)
 /// disable themselves permanently so failed attempts don't re-walk the chain.
 /// </remarks>
@@ -35,6 +82,7 @@ internal struct SlotLocationCache
     private DeclarativeEnvironment? _cachedSlotEnv;
     private int _cachedSlotIndex;
     private bool _disabled;
+    private SlotChainMemo? _chainMemo;
 
     /// <summary>
     /// Resolves the slot location for <paramref name="name"/> against the current lexical
@@ -77,9 +125,10 @@ internal struct SlotLocationCache
 
     /// <summary>
     /// Out-of-line tail for everything that is not a hop-0 hit or a permanent decline: the
-    /// bounded hops 1-3 reachability walk, the decline check for nodes with a stale cached
-    /// env, and first-time population. Kept out of <see cref="TryResolve"/> so the
-    /// aggressively-inlined fast path stays small in every consuming lane.
+    /// bounded hops 1-3 reachability check (chain memo, then walk), the decline check for
+    /// nodes with a stale cached env, and first-time population. Kept out of
+    /// <see cref="TryResolve"/> so the aggressively-inlined fast path stays small in every
+    /// consuming lane.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     private bool TryResolveNonLocal(
@@ -92,7 +141,7 @@ internal struct SlotLocationCache
         var cached = _cachedSlotEnv;
         if (cached is not null
             && ReferenceEquals(cached._engine, engine)
-            && CanReachAtOuterHop(env, cached, name.Key))
+            && CanReachAtOuterHop(engine, env, cached, name.Key, ref _chainMemo))
         {
             slotEnv = cached;
             slotIndex = _cachedSlotIndex;
@@ -114,19 +163,57 @@ internal struct SlotLocationCache
             return false;
         }
 
-        return ResolveAndPopulate(env, name, out slotEnv, out slotIndex);
+        return ResolveAndPopulate(engine, env, name, out slotEnv, out slotIndex);
     }
 
     /// <summary>
-    /// Bounded hops 1-3 reachability walk for a slot-cache probe whose caller has already
+    /// Bounded hops 1-3 reachability check for a slot-cache probe whose caller has already
     /// rejected hop 0 (<paramref name="env"/> itself is not <paramref name="cached"/>).
     /// Because hop 0 failed, the current environment sits BETWEEN the reader and the cached
-    /// env and must be probed like any other intermediate before hopping outward.
+    /// env and must be probed like any other intermediate before hopping outward. A valid
+    /// <see cref="SlotChainMemo"/> answers with reference compares alone (see its remarks for
+    /// why identity + epoch freeze the probe results); everything else takes the walk, which
+    /// re-publishes the memo on success.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    internal static bool CanReachAtOuterHop(Environment env, DeclarativeEnvironment cached, Key key)
+    internal static bool CanReachAtOuterHop(Engine engine, Environment env, DeclarativeEnvironment cached, Key key, ref SlotChainMemo? memoSlot)
+    {
+        var memo = memoSlot;
+        if (memo is not null
+            && ReferenceEquals(env, memo.Start)
+            && engine._envBindingInjectionEpoch == memo.InjectionEpoch)
+        {
+            // Re-derive the chain from the CURRENT _outerEnv pointers against the pinned
+            // links: identity per link leaves no room for an inserted environment, and a
+            // pooled link re-attached under a different outer fails here and re-walks.
+            var next = env._outerEnv;
+            if (memo.Next1 is null
+                ? ReferenceEquals(next, cached)
+                : ReferenceEquals(next, memo.Next1)
+                  && (memo.Next2 is null
+                      ? ReferenceEquals(memo.Next1._outerEnv, cached)
+                      : ReferenceEquals(memo.Next1._outerEnv, memo.Next2)
+                        && ReferenceEquals(memo.Next2._outerEnv, cached)))
+            {
+                return true;
+            }
+        }
+
+        return WalkAndMemoize(engine, env, cached, key, ref memoSlot);
+    }
+
+    /// <summary>
+    /// The authoritative bounded walk: probes every intermediate declarative environment
+    /// (pure <see cref="DeclarativeEnvironment.HasBinding(Key)"/>) and refuses to cross an
+    /// <see cref="ObjectEnvironment"/>. On success the probed intermediates are published as
+    /// a <see cref="SlotChainMemo"/> so subsequent reads on the same chain skip the probes.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool WalkAndMemoize(Engine engine, Environment env, DeclarativeEnvironment cached, Key key, ref SlotChainMemo? memoSlot)
     {
         var search = env;
+        Environment? next1 = null;
+        Environment? next2 = null;
         for (var hops = 1; hops < MaxChainDepth; hops++)
         {
             if (search is ObjectEnvironment)
@@ -155,7 +242,17 @@ internal struct SlotLocationCache
 
             if (ReferenceEquals(search, cached))
             {
+                memoSlot = new SlotChainMemo(env, next1, next2, engine._envBindingInjectionEpoch);
                 return true;
+            }
+
+            if (hops == 1)
+            {
+                next1 = search;
+            }
+            else
+            {
+                next2 = search;
             }
         }
 
@@ -164,6 +261,7 @@ internal struct SlotLocationCache
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private bool ResolveAndPopulate(
+        Engine engine,
         Environment env,
         Environment.BindingName name,
         out DeclarativeEnvironment slotEnv,
@@ -178,6 +276,9 @@ internal struct SlotLocationCache
         // bindings are never slot-stored — reaching a non-declarative environment before the
         // binding means this node can never be safely slot-cached, without touching it.
         var record = env;
+        Environment? next1 = null;
+        Environment? next2 = null;
+        var depth = 0;
         while (record is not null)
         {
             if (record is not DeclarativeEnvironment declarativeEnvironment)
@@ -192,6 +293,13 @@ internal struct SlotLocationCache
                 {
                     _cachedSlotEnv = declarativeEnvironment;
                     _cachedSlotIndex = index;
+                    if ((uint) (depth - 1) < MaxChainDepth - 1)
+                    {
+                        // Found at hops 1-3: every traversed environment was declarative and
+                        // did not own the name — exactly the walk's success condition, so the
+                        // memo can be published without a second walk on the next read.
+                        _chainMemo = new SlotChainMemo(env, next1, next2, engine._envBindingInjectionEpoch);
+                    }
                     slotEnv = declarativeEnvironment;
                     slotIndex = index;
                     return true;
@@ -201,7 +309,17 @@ internal struct SlotLocationCache
                 break;
             }
 
+            if (depth == 1)
+            {
+                next1 = record;
+            }
+            else if (depth == 2)
+            {
+                next2 = record;
+            }
+
             record = record._outerEnv;
+            depth++;
         }
 
         // the binding for this node can never be slot-stored; stop attempting

--- a/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintIdentifierExpression.cs
@@ -23,6 +23,12 @@ internal sealed class JintIdentifierExpression : JintExpression
     private DeclarativeEnvironment? _cachedSlotEnv;
     private int _cachedSlotIndex = -1;
 
+    // Chain memo for the hops 1-3 slot reads (closure reads of outer bindings): pins the exact
+    // chain links a successful reachability walk probed, so steady-state loop reads validate
+    // with reference compares + the injection epoch instead of re-probing every intermediate.
+    // See SlotChainMemo for the soundness argument; the walk stays authoritative for misses.
+    private SlotChainMemo? _slotChainMemo;
+
     // Version-based inline cache for global bindings: when resolution (from any scope depth)
     // lands on a plain writable data property of the real GlobalObject, remember the
     // descriptor. Valid while the global object's own-property shape and the set of global
@@ -158,9 +164,11 @@ internal sealed class JintIdentifierExpression : JintExpression
         // cached resolving env IS the current lexical environment, so it gets a straight-line
         // identity check before any loop machinery and needs no shadow probes — no environment
         // sits between the reader and the binding. Reads at hops 1-3 (closure reads of outer
-        // bindings) take the out-of-line bounded walk, which re-probes every intermediate
-        // declarative environment and refuses to cross an ObjectEnvironment; see
-        // SlotLocationCache for why those probes are load-bearing.
+        // bindings) take the out-of-line bounded reachability check: a pinned chain memo
+        // answers with reference compares, everything else re-walks with per-intermediate
+        // shadow probes and refuses to cross an ObjectEnvironment; see SlotLocationCache and
+        // SlotChainMemo for why those probes (and the memo's identity + epoch guard) are
+        // load-bearing.
         // Engine-identity gate: a Prepared<Script> reused across multiple Engine instances
         // shares JintIdentifierExpression nodes, so the cached env may be from a previous
         // Engine and must not be dereferenced for slots. Gating up front also skips the walk —
@@ -170,7 +178,7 @@ internal sealed class JintIdentifierExpression : JintExpression
         if (cachedSlotEnv is not null && ReferenceEquals(cachedSlotEnv._engine, engine))
         {
             if (ReferenceEquals(env, cachedSlotEnv)
-                || SlotLocationCache.CanReachAtOuterHop(env, cachedSlotEnv, identifier.Key))
+                || SlotLocationCache.CanReachAtOuterHop(engine, env, cachedSlotEnv, identifier.Key, ref _slotChainMemo))
             {
                 var slots = cachedSlotEnv._slots;
                 var idx = _cachedSlotIndex;


### PR DESCRIPTION
Campaign-2 item (follow-up to #2716–#2723). Profiles show closure-variable reads re-validating their slot location on every access — `SlotLocationCache.CanReachAtOuterHop` 3.5% + `TryResolveNonLocal` 2.4% on `dromaeo-string-base64-modern`, driven from `JintIdentifierExpression.GetValue` (closure-captured lookup tables read in tight loops).

## Change

Plain per-node `(lastEnv, hop, slot)` caching guarded by environment identity alone is **unsound** — environment shapes are not immutable (sloppy direct `eval` injects vars into pre-existing function environments; AnnexB block-function semantics create var-scope bindings mid-execution). Instead this extends the guard pattern the codebase already ships for exactly this hazard in the global-read path (`NestedChainMemo` + `Engine._envBindingInjectionEpoch`):

- New immutable, single-reference-published `SlotChainMemo` pins the probed intermediate chain links by identity plus the injection epoch after a successful hop-1..3 walk. Steady-state closure reads validate with ~5 reference compares + 1 int compare instead of per-hop `HasBinding` probes.
- The walk stays authoritative for every miss and re-publishes; `with` insertion breaks link identity by construction; pooled/reused environments re-initialize with per-definition-deterministic name sets (every reuse channel audited); all dynamic injections bump the epoch (every `CreateMutableBinding` caller audited); deletions only shrink name sets, so a cached "not here" verdict stays valid.
- Cross-engine safety: memos publish as immutable single references (no torn reads on shared AST) and foreign-engine memos fail identity checks trivially since environments are per-engine.

## Numbers (launchCount-5, both sides, default job otherwise)

| Row | main | this PR | delta |
|---|---:|---:|---:|
| dromaeo-string-base64-modern (Jint_ParsedScript) | 22.48 ms | 21.08 ms | **−6.2%** |
| dromaeo-string-base64-modern (Jint) | 22.94 ms | 21.48 ms | **−6.4%** |
| dromaeo-object-string-modern | — | — | flat (few closure hops, expected) |

## Gates

Jint.Tests 3706/3643 (net10/net472) including 6 new soundness tests (alternating closure instances at one callsite, sloppy direct-eval shadowing mid-loop, `with` around closure reads with mid-loop injection, deep nesting past the memo depth, pooled loop environments re-attached across entries); PublicInterface 114/114; Test262 99,431 / 0 failed; CommonScripts 28/28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)