### PR TITLE
Default Interop.ArrayConversion to LiveView for 4.14

### DIFF
--- a/Jint.Benchmark/InteropWrapperChurnBenchmark.cs
+++ b/Jint.Benchmark/InteropWrapperChurnBenchmark.cs
@@ -33,28 +33,41 @@ public class InteropWrapperChurnBenchmark
     private Engine _engineDefault = null!;
     private Engine _engineIdentity = null!;
     private Engine _engineRecentCache = null!;
-    private Engine _engineLiveView = null!;
+    private Engine _engineCopy = null!;
 
     [GlobalSetup]
     public void GlobalSetup()
     {
         var holder = new Holder(new Payload { Value = 42 });
 
+        // the out-of-the-box engine: ArrayConversion defaults to LiveView since 4.14
         _engineDefault = new Engine();
         _engineDefault.SetValue("h", holder);
         _engineDefault.Execute("h.Payload.Value");
 
-        _engineIdentity = new Engine(cfg => cfg.Interop.TrackObjectWrapperIdentity = true);
+        // the identity flags are most interesting on top of Copy, where they let the otherwise
+        // per-read deep-copied JsArray snapshot be reused across crossings (pin Copy so the array
+        // traversal rows below measure exactly that; the object-churn rows are array-mode agnostic)
+        _engineIdentity = new Engine(cfg =>
+        {
+            cfg.Interop.ArrayConversion = ArrayConversionMode.Copy;
+            cfg.Interop.TrackObjectWrapperIdentity = true;
+        });
         _engineIdentity.SetValue("h", holder);
         _engineIdentity.Execute("h.Payload.Value");
 
-        _engineRecentCache = new Engine(cfg => cfg.Interop.CacheRecentObjectWrappers = true);
+        _engineRecentCache = new Engine(cfg =>
+        {
+            cfg.Interop.ArrayConversion = ArrayConversionMode.Copy;
+            cfg.Interop.CacheRecentObjectWrappers = true;
+        });
         _engineRecentCache.SetValue("h", holder);
         _engineRecentCache.Execute("h.Payload.Value");
 
-        _engineLiveView = new Engine(cfg => cfg.Interop.ClrArrayConversion = ClrArrayConversion.LiveView);
-        _engineLiveView.SetValue("h", holder);
-        _engineLiveView.Execute("h.Payload.Value");
+        // the pre-4.14 default: every array crossing deep-copies into a fresh JsArray snapshot
+        _engineCopy = new Engine(cfg => cfg.Interop.ArrayConversion = ArrayConversionMode.Copy);
+        _engineCopy.SetValue("h", holder);
+        _engineCopy.Execute("h.Payload.Value");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
@@ -75,34 +88,33 @@ public class InteropWrapperChurnBenchmark
         for (var i = 0; i < OperationsPerInvoke; i++) _engineRecentCache.Execute("h.Payload.Value");
     }
 
-    // A CLR array member read repeatedly inside the loop: with the flags off every h.Numbers read
-    // deep-copies the array into a fresh JsArray; with either identity flag the snapshot is reused.
+    // A CLR array member read repeatedly inside the loop. Under the default (LiveView) each h.Numbers
+    // read wraps the array in a live fixed-size view without a per-read deep copy; the Copy-mode rows
+    // below deep-copy into a fresh JsArray unless an identity flag reuses the snapshot.
     private static readonly Prepared<Script> _arrayTraversal = Engine.PrepareScript(
         "var s = 0; for (var i = 0; i < 100; i++) { s += h.Numbers[i]; }");
 
     [Benchmark]
-    public void ArrayMemberTraversal_DefaultFlag()
+    public void ArrayMemberTraversal_DefaultLiveView()
     {
         _engineDefault.Execute(_arrayTraversal);
     }
 
     [Benchmark]
-    public void ArrayMemberTraversal_IdentityFlag()
+    public void ArrayMemberTraversal_CopyMode()
+    {
+        _engineCopy.Execute(_arrayTraversal);
+    }
+
+    [Benchmark]
+    public void ArrayMemberTraversal_CopyIdentityFlag()
     {
         _engineIdentity.Execute(_arrayTraversal);
     }
 
     [Benchmark]
-    public void ArrayMemberTraversal_RecentCache()
+    public void ArrayMemberTraversal_CopyRecentCache()
     {
         _engineRecentCache.Execute(_arrayTraversal);
-    }
-
-    // LiveView: each h.Numbers read wraps the array in a live fixed-size view (no per-read deep copy);
-    // without an identity flag the wrapper itself is still allocated per crossing.
-    [Benchmark]
-    public void ArrayMemberTraversal_LiveView()
-    {
-        _engineLiveView.Execute(_arrayTraversal);
     }
 }

--- a/Jint.Benchmark/README.md
+++ b/Jint.Benchmark/README.md
@@ -130,7 +130,7 @@ with same-base A/B gates: string-receiver method calls are cached per call site
 intermediate views (−99.3% on that pattern), interop argument binding lost its per-call
 reflection checks and boxing, ObjectWrapper members gained a per-callsite inline cache
 (`interop-property-access` −25%), and CLR arrays gained identity caching plus an opt-in
-`ClrArrayConversion.LiveView` mode (array traversal 2.5× faster, −75% allocation, without flags).
+`ArrayConversionMode.LiveView` mode (array traversal 2.5× faster, −75% allocation, without flags).
 
 A second campaign round (PRs [#2725](https://github.com/sebastienros/jint/pull/2725),
 [#2726](https://github.com/sebastienros/jint/pull/2726)) added bulk JSON string scanning plus an
@@ -185,7 +185,7 @@ What the numbers show:
   re-reads `host.numbers` inside the loop and the default `Copy` conversion re-copies the array
   per read. Two remedies ship today: hoist the collection into a local
   (`var numbers = host.numbers;` — drops Jint to ~1 ms, fastest in the field), or opt into
-  `Options.Interop.ClrArrayConversion = LiveView` for live, fixed-size array views (2.5× faster
+  `Options.Interop.ArrayConversion = LiveView` for live, fixed-size array views (2.5× faster
   and −75% allocation on this pattern with no other changes).
 
 | Method                | FileName                     | Mean        | StdDev    | Rank | Allocated   |

--- a/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
@@ -64,6 +64,10 @@ public class ExtensionMethodsTest
         var engine = new Engine(opts =>
         {
             opts.AddExtensionMethods(typeof(CustomStringExtensions));
+            // this exercises extension-method dispatch producing a CLR array (string[]) that the test
+            // reads back as a JS array; pin Copy so the result is a native JsArray (the LiveView default
+            // would expose it as a live wrapper that AsArray() does not accept)
+            opts.Interop.ArrayConversion = ArrayConversionMode.Copy;
         });
 
         //uses split function from StringPrototype
@@ -83,6 +87,9 @@ public class ExtensionMethodsTest
         var engine = new Engine(opts =>
         {
             opts.AddExtensionMethods(typeof(OverrideStringPrototypeExtensions));
+            // see PrototypeFunctionsShouldNotBeOverridden: the overriding split returns a CLR string[]
+            // that is read back as a JS array, so pin Copy for a native JsArray result
+            opts.Interop.ArrayConversion = ArrayConversionMode.Copy;
         });
 
         //uses the overridden split function from OverrideStringPrototypeExtensions
@@ -109,11 +116,12 @@ public class ExtensionMethodsTest
         Assert.Equal(JsValue.Undefined, propertyValue);
     }
 
-    private Engine GetLinqEngine()
+    private Engine GetLinqEngine(Action<Options> additionalConfiguration = null)
     {
         return new Engine(opts =>
         {
             opts.AddExtensionMethods(typeof(Enumerable));
+            additionalConfiguration?.Invoke(opts);
         });
     }
 
@@ -145,7 +153,12 @@ public class ExtensionMethodsTest
     [Fact]
     public void LinqExtensionMethodWithMultipleGenericParameters()
     {
-        var engine = GetLinqEngine();
+        // Pin Copy: '.ToArray()' returns a CLR string[], and under the LiveView default the resulting
+        // wrapper's target (string[] : IEnumerable<string>) makes the '.join()' call resolve to the CLR
+        // 'Enumerable.Join' extension method attached to the type rather than falling back to native
+        // 'Array.prototype.join'. Copy produces a native JsArray whose 'join' is the prototype method.
+        // (Under LiveView the equivalent works with Options.Interop.PreferJsPrototypeMethods = true.)
+        var engine = GetLinqEngine(opts => opts.Interop.ArrayConversion = ArrayConversionMode.Copy);
         var stringList = new List<string>() { "working", "linq" };
         engine.SetValue("stringList", stringList);
 
@@ -313,6 +326,9 @@ public class ExtensionMethodsTest
             options.AllowClr().AddExtensionMethods(typeof(Enumerable));
             // prevent ExpandoObject wrapping
             options.Interop.CreateClrObject = null;
+            // '.ToArray()' results are read back as JS arrays via AsArray(); pin Copy so they are native
+            // JsArrays rather than the LiveView default's live wrapper views
+            options.Interop.ArrayConversion = ArrayConversionMode.Copy;
         });
         engine.Execute("var a = [ 2, 4 ];");
 

--- a/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
+++ b/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
@@ -8,9 +8,10 @@ public partial class InteropTests
     }
 
     [Fact]
-    public void ClrArrayConversionCreatesFreshCopyByDefault()
+    public void ArrayConversionCreatesFreshCopyInCopyMode()
     {
-        var engine = new Engine();
+        // Copy is no longer the default (LiveView since 4.14), so select it explicitly to lock its snapshot contract
+        var engine = new Engine(options => options.Interop.ArrayConversion = ArrayConversionMode.Copy);
         engine.SetValue("host", new ArrayConversionHost());
 
         Assert.False(engine.Evaluate("host.Numbers === host.Numbers").AsBoolean());
@@ -20,10 +21,14 @@ public partial class InteropTests
     }
 
     [Fact]
-    public void ClrArrayConversionReusesSnapshotWithTrackObjectWrapperIdentity()
+    public void ArrayConversionReusesSnapshotWithTrackObjectWrapperIdentity()
     {
         var host = new ArrayConversionHost();
-        var engine = new Engine(options => options.Interop.TrackObjectWrapperIdentity = true);
+        var engine = new Engine(options =>
+        {
+            options.Interop.ArrayConversion = ArrayConversionMode.Copy;
+            options.Interop.TrackObjectWrapperIdentity = true;
+        });
         engine.SetValue("host", host);
 
         Assert.True(engine.Evaluate("host.Numbers === host.Numbers").AsBoolean());
@@ -37,9 +42,13 @@ public partial class InteropTests
     }
 
     [Fact]
-    public void ClrArrayConversionReusesSnapshotWithRecentObjectWrapperCache()
+    public void ArrayConversionReusesSnapshotWithRecentObjectWrapperCache()
     {
-        var engine = new Engine(options => options.Interop.CacheRecentObjectWrappers = true);
+        var engine = new Engine(options =>
+        {
+            options.Interop.ArrayConversion = ArrayConversionMode.Copy;
+            options.Interop.CacheRecentObjectWrappers = true;
+        });
         engine.SetValue("host", new ArrayConversionHost());
 
         Assert.True(engine.Evaluate("host.Numbers === host.Numbers").AsBoolean());

--- a/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
+++ b/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
@@ -14,18 +14,38 @@ public partial class InteropTests
     {
         return new Engine(options =>
         {
-            options.Interop.ClrArrayConversion = ClrArrayConversion.LiveView;
+            options.Interop.ArrayConversion = ArrayConversionMode.LiveView;
             additionalConfiguration?.Invoke(options);
         });
     }
 
     [Fact]
-    public void ClrArrayConversionDefaultsToCopy()
+    public void ArrayConversionDefaultsToLiveView()
     {
-        Assert.Equal(ClrArrayConversion.Copy, new Options().Interop.ClrArrayConversion);
+        Assert.Equal(ArrayConversionMode.LiveView, new Options().Interop.ArrayConversion);
 
-        // Copy mode: each crossing produces an independent JsArray snapshot
+        // LiveView mode (the default since 4.14): a CLR array crosses as a live wrapper view, not a
+        // native JS array snapshot, so it is not an Array and repeated crossings share wrapper identity
         var engine = new Engine();
+        engine.SetValue("h", new ArrayHolder());
+        Assert.False(engine.Evaluate("Array.isArray(h.Numbers)").AsBoolean());
+        Assert.True(engine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
+    }
+
+    private static Engine CreateCopyEngine(Action<Options> additionalConfiguration = null)
+    {
+        return new Engine(options =>
+        {
+            options.Interop.ArrayConversion = ArrayConversionMode.Copy;
+            additionalConfiguration?.Invoke(options);
+        });
+    }
+
+    [Fact]
+    public void CopyModeArrayIsJsArraySnapshot()
+    {
+        // opting back into Copy restores the pre-4.14 behavior: each crossing produces an independent JsArray snapshot
+        var engine = CreateCopyEngine();
         engine.SetValue("h", new ArrayHolder());
         Assert.True(engine.Evaluate("Array.isArray(h.Numbers)").AsBoolean());
         Assert.False(engine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
@@ -34,7 +54,7 @@ public partial class InteropTests
     [Fact]
     public void CopyModeScriptWritesDoNotAffectClrArray()
     {
-        var engine = new Engine();
+        var engine = CreateCopyEngine();
         var numbers = new[] { 1, 2, 3 };
         engine.SetValue("arr", numbers);
 

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -889,7 +889,13 @@ public partial class InteropTests : IDisposable
         // element descriptors are made non-writable and the array is made non-extensible, assigning to
         // an element must throw a TypeError in strict mode. Regression: it previously neither threw nor
         // assigned (the dense-write fast path bypassed the writability check).
-        var engine = new Engine(x => x.Strict());
+        // This scenario is about a copied JS array's per-element descriptors, so it pins Copy mode
+        // (the LiveView default exposes a live wrapper whose element writability is handled differently).
+        var engine = new Engine(x =>
+        {
+            x.Strict();
+            x.Interop.ArrayConversion = ArrayConversionMode.Copy;
+        });
 
         var context = new Dictionary<string, object>
         {
@@ -926,7 +932,8 @@ public partial class InteropTests : IDisposable
     {
         // Non-strict counterpart of https://github.com/sebastienros/jint/issues/2541:
         // the write to the non-writable element must be silently ignored, not applied.
-        var engine = new Engine();
+        // Pinned to Copy mode for the same reason as the strict-mode counterpart above.
+        var engine = new Engine(x => x.Interop.ArrayConversion = ArrayConversionMode.Copy);
 
         var context = new Dictionary<string, object>
         {

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -353,13 +353,14 @@ public class Options
         public bool CacheRecentObjectWrappers { get; set; }
 
         /// <summary>
-        /// How CLR arrays (<c>T[]</c>) are exposed to script code, defaults to <see cref="Jint.ClrArrayConversion.Copy"/>
-        /// which copies the array contents into a new JavaScript array on each conversion.
-        /// <see cref="Jint.ClrArrayConversion.LiveView"/> instead exposes single-rank arrays as live,
-        /// fixed-size wrapper views over the underlying array; see the enum members for the exact
-        /// semantic differences (write-through, identity, <c>Array.isArray</c>, resizing).
+        /// How CLR arrays (<c>T[]</c>) are exposed to script code, defaults to <see cref="Jint.ArrayConversionMode.LiveView"/>
+        /// (changed from <see cref="Jint.ArrayConversionMode.Copy"/> in 4.14), which exposes single-rank arrays as live,
+        /// fixed-size wrapper views over the underlying array — the same way wrapped <see cref="System.Collections.Generic.List{T}"/>
+        /// already behaves. <see cref="Jint.ArrayConversionMode.Copy"/> instead copies the array contents into a new
+        /// JavaScript array on each conversion; select it to preserve the pre-4.14 behavior. See the enum members for
+        /// the exact semantic differences (write-through, identity, <c>Array.isArray</c>, resizing).
         /// </summary>
-        public ClrArrayConversion ClrArrayConversion { get; set; } = ClrArrayConversion.Copy;
+        public ArrayConversionMode ArrayConversion { get; set; } = ArrayConversionMode.LiveView;
 
         /// <summary>
         /// If no known type could be guessed, objects are by default wrapped as an
@@ -733,9 +734,9 @@ public enum ExperimentalFeature
 }
 
 /// <summary>
-/// Strategy for exposing CLR arrays (<c>T[]</c>) to script code, see <see cref="Options.InteropOptions.ClrArrayConversion"/>.
+/// Strategy for exposing CLR arrays (<c>T[]</c>) to script code, see <see cref="Options.InteropOptions.ArrayConversion"/>.
 /// </summary>
-public enum ClrArrayConversion
+public enum ArrayConversionMode
 {
     /// <summary>
     /// Each conversion copies the array contents into a new JavaScript array (<c>Array.isArray</c> returns <c>true</c>).

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -254,7 +254,7 @@ internal static class DefaultObjectConverter
             return recentlyConverted;
         }
 
-        if (e.Options.Interop.ClrArrayConversion == ClrArrayConversion.LiveView
+        if (e.Options.Interop.ArrayConversion == ArrayConversionMode.LiveView
             && TryConvertArrayLiveView(e, v, out var liveView))
         {
             return liveView;

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -305,7 +305,7 @@ internal class GenericListWrapper<[DynamicallyAccessedMembers(DynamicallyAccesse
 }
 
 /// <summary>
-/// Live view over a single-rank CLR array (<c>T[]</c>) used by <see cref="ClrArrayConversion.LiveView"/>.
+/// Live view over a single-rank CLR array (<c>T[]</c>) used by <see cref="ArrayConversionMode.LiveView"/>.
 /// Element reads and writes go straight to the underlying array; because CLR arrays are fixed-size,
 /// every length-changing operation surfaces as a JavaScript <c>TypeError</c> instead of leaking a CLR
 /// <see cref="NotSupportedException"/> (which is what routing <c>T[]</c> through


### PR DESCRIPTION
Closes #2724. Follow-up to #2721 (which added the opt-in `LiveView` mode) and #2716 (array identity cache).

## Change

Flips the default of `Options.Interop.ArrayConversion` from `Copy` to **`LiveView`**. A single-rank CLR array (`T[]`) crossing host → script now becomes a live, fixed-size `ArrayWrapper<T>` view over the underlying array — the same way a wrapped `List<T>` (and every other host object) already behaves — instead of a per-read deep-copied `JsArray` snapshot. `Copy` remains fully supported for anyone who wants the pre-4.14 behavior:

```csharp
var engine = new Engine(options =>
    options.Interop.ArrayConversion = ArrayConversionMode.Copy);
```

This is a **behavioral breaking change**, intended for the 4.14 release with release notes (below).

> **Naming note:** #2721 introduced this option as `Interop.ClrArrayConversion` / enum `ClrArrayConversion`. Since that has not shipped in a release yet, this PR also renames it to `Interop.ArrayConversion` / enum `ArrayConversionMode` — dropping the redundant `Clr` under `Interop` and using the `Mode` suffix (an exclusive-choice enum, like `StepMode`, not a combinable `…Type` flags enum). `Jint.Tests.PublicInterface` stays 114/114 on both TFMs.

## Why

- Consistency: `T[]` now behaves like wrapped `List<T>`/`IList<T>` — reads and writes go straight to the underlying data in both directions.
- Performance: no per-read deep copy. ~2.5× faster and ~75% less allocation on array-member traversal (numbers below).
- Ecosystem alignment: NiL.JS, YantraJS and ClearScript all expose host arrays as live views.

## Breaking behavior (release notes)

When a `T[]` crosses into script under the new default:

| Aspect | Copy (old default) | LiveView (new default) |
|---|---|---|
| `Array.isArray(a)` | `true` | **`false`** (it is array-like, not a JS Array) |
| Script writes `a[i] = x` | affect only the JS copy | **write through to the CLR array** |
| `a.push()` / `a.pop()` / `a.length = n` / out-of-range write | grow/shrink the copy | **throw a JS `TypeError`** (arrays are fixed-size) |
| `a === a` (no identity flag) | `false` | `true` (wrapper equality is by target) |
| `delete a[i]` for in-range `i` | `true` | `false` |
| element writes | stored as-is on the copy | coerced to the CLR element type (or `TypeError`) |
| passing `a` back to CLR | a fresh `object[]` | the **same** underlying array instance |

Unchanged in both modes: `for..of`, spread, `Array.prototype` methods and `JSON.stringify(a)` all work; multi-rank (`T[,]`) and non-zero-based arrays keep their previous handling.

**One interaction to be aware of** — if you attach CLR extension methods whose names collide with `Array.prototype` methods (e.g. `AddExtensionMethods(typeof(Enumerable))` brings LINQ's `Join`, which maps to `join`), a LiveView wrapper resolves the CLR extension method first because its target type satisfies the extension's `this` constraint, so it no longer falls back to the native prototype method. Set `Options.Interop.PreferJsPrototypeMethods = true` (or use `Copy`) to keep the native `Array.prototype` method. A handful of extension-method tests were pinned to `Copy` for exactly this reason.

## Numbers (default BDN job, `InteropWrapperChurnBenchmark.ArrayMemberTraversal`: 100 reads of an `int[100]` member per op)

| Method | Mean | Allocated |
|---|---:|---:|
| **`Copy` (old default)** | 168.2 us | 333,944 B |
| **`LiveView` (new default)** | **58.1 us** | **83,544 B** |
| `Copy` + `TrackObjectWrapperIdentity` | 14.2 us | 344 B |
| `Copy` + `CacheRecentObjectWrappers` | 13.7 us | 344 B |

The new default is **~2.9× faster and allocates ~75% less** than the old default out of the box. Workloads that read the *same* array's every element many times can still go lower by opting into an identity flag (which caches the wrapper/snapshot); LiveView needs no flag for its win.

## Gates

- `Jint.Tests`: net10.0 3740/0, net472 3677/0 (includes the LiveView suite from #2721; four extension-method tests and the Copy-snapshot identity tests were pinned to `Copy`, which is what they actually exercise).
- `Jint.Tests.PublicInterface`: 114/114 net10.0 and net472 (API snapshot unchanged — this is a default-value change only).
- Test262 is unaffected: conformance tests never enable CLR interop or pass host arrays, so the interop default cannot influence them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
