### PR TITLE
Cache array-like wrapper factories and materialize length lazily

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -1182,6 +1182,29 @@ public partial class InteropTests : IDisposable
     }
 
     [Fact]
+    public void LazilyMaterializedLengthPropertyBehavesLikeEagerOne()
+    {
+        _engine.SetValue("list", new List<string> { "a", "b" });
+        _engine.SetValue("array", new[] { 1, 2, 3 });
+
+        // plain reads (served by the ICollection fast path) and own-property reflection agree
+        Assert.Equal(2, _engine.Evaluate("list.length").AsNumber());
+        Assert.Equal(3, _engine.Evaluate("array.length").AsNumber());
+        Assert.True(_engine.Evaluate("'length' in list").AsBoolean());
+        Assert.True(_engine.Evaluate("list.hasOwnProperty('length')").AsBoolean());
+        Assert.True(_engine.Evaluate("array.hasOwnProperty('length')").AsBoolean());
+
+        // the accessor descriptor keeps its eager-era shape
+        Assert.Equal("function", _engine.Evaluate("typeof Object.getOwnPropertyDescriptor(list, 'length').get").AsString());
+        Assert.True(_engine.Evaluate("Object.getOwnPropertyDescriptor(list, 'length').configurable").AsBoolean());
+        Assert.True(_engine.Evaluate("Object.getOwnPropertyDescriptor(list, 'length').set === undefined").AsBoolean());
+
+        // deleting the forwarder removes the own property for good
+        Assert.True(_engine.Evaluate("delete list.length").AsBoolean());
+        Assert.False(_engine.Evaluate("list.hasOwnProperty('length')").AsBoolean());
+    }
+
+    [Fact]
     public void ForOfOverRevokedProxyOfClrListThrowsTypeError()
     {
         _engine.SetValue("list", new List<string> { "a", "b" });

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -6,6 +6,34 @@ using Jint.Native;
 
 namespace Jint.Runtime.Interop;
 
+/// <summary>
+/// Instantiated once per exposed CLR type (see ObjectWrapper's array-like resolution cache) so that
+/// per-wrapper creation is a plain virtual call and constructor invocation instead of
+/// <c>Activator.CreateInstance</c> with argument binding.
+/// </summary>
+internal abstract class ArrayLikeWrapperFactory
+{
+    public abstract ArrayLikeWrapper Create(Engine engine, object target, Type type);
+}
+
+internal sealed class ArrayWrapperFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] T> : ArrayLikeWrapperFactory
+{
+    public override ArrayLikeWrapper Create(Engine engine, object target, Type type)
+        => new ArrayWrapper<T>(engine, (T[]) target, type);
+}
+
+internal sealed class GenericListWrapperFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] T> : ArrayLikeWrapperFactory
+{
+    public override ArrayLikeWrapper Create(Engine engine, object target, Type type)
+        => new GenericListWrapper<T>(engine, (IList<T>) target, type);
+}
+
+internal sealed class ReadOnlyListWrapperFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields)] T> : ArrayLikeWrapperFactory
+{
+    public override ArrayLikeWrapper Create(Engine engine, object target, Type type)
+        => new ReadOnlyListWrapper<T>(engine, (IReadOnlyList<T>) target, type);
+}
+
 internal abstract class ArrayLikeWrapper : ObjectWrapper
 {
     protected ArrayLikeWrapper(

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -22,6 +22,7 @@ namespace Jint.Runtime.Interop;
 public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWrapper>
 {
     internal readonly TypeDescriptor _typeDescriptor;
+    private bool _lengthPropertyPending;
 
     internal ObjectWrapper(
         Engine engine,
@@ -39,10 +40,10 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 
         if (_typeDescriptor.LengthProperty is not null)
         {
-            // create a forwarder to produce length from Count or Length if one of them is present
-            var functionInstance = new ClrFunction(engine, "length", GetLength);
-            var descriptor = new GetSetPropertyDescriptor(functionInstance, Undefined, PropertyFlag.Configurable);
-            SetProperty(KnownKeys.Length, descriptor);
+            // the "length" forwarder (produced from Count or Length) is materialized lazily on first
+            // own-property consultation: plain length reads are served by the ICollection fast path in
+            // Get, so most wrappers never observe the descriptor itself
+            _lengthPropertyPending = true;
 
             if (_typeDescriptor.IsArrayLike && engine.Options.Interop.AttachArrayPrototype)
             {
@@ -132,7 +133,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         return new ObjectWrapper(engine, target, type);
     }
 
-    private static readonly ConcurrentDictionary<Type, Type?> _arrayLikeWrapperResolution = new();
+    private static readonly ConcurrentDictionary<Type, ArrayLikeWrapperFactory?> _arrayLikeWrapperResolution = new();
 
     private static bool TryBuildArrayLikeWrapper(
         Engine engine,
@@ -142,11 +143,16 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
     {
         result = null;
 
-        var arrayWrapperType = _arrayLikeWrapperResolution.GetOrAdd(type, static t =>
+        // resolved once per exposed type: reflection (interface scan + generic instantiation +
+        // Activator) runs only on the first sighting, every later wrapper creation is a single
+        // virtual call into the cached factory
+        var factory = _arrayLikeWrapperResolution.GetOrAdd(type, static t =>
         {
 #pragma warning disable IL2055
 #pragma warning disable IL2070
 #pragma warning disable IL3050
+
+            Type? factoryType = null;
 
             // single-rank zero-based CLR arrays (T[]) get a fixed-size live wrapper; T[] implements
             // IList<T> and would otherwise flow into GenericListWrapper<T> below, whose growth paths
@@ -155,52 +161,57 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             // (T[*]) arrays, which keep their previous handling.
             if (t.IsArray && t.GetElementType() is { } elementType && t == elementType.MakeArrayType())
             {
-                return typeof(ArrayWrapper<>).MakeGenericType(elementType);
+                factoryType = typeof(ArrayWrapperFactory<>).MakeGenericType(elementType);
             }
-
-            // check for generic interfaces
-            foreach (var i in t.GetInterfaces())
+            else
             {
-                if (!i.IsGenericType)
+                // check for generic interfaces
+                foreach (var i in t.GetInterfaces())
                 {
-                    continue;
-                }
+                    if (!i.IsGenericType)
+                    {
+                        continue;
+                    }
 
-                var arrayItemType = i.GenericTypeArguments[0];
+                    var arrayItemType = i.GenericTypeArguments[0];
 
-                if (i.GetGenericTypeDefinition() == typeof(IList<>))
-                {
-                    return typeof(GenericListWrapper<>).MakeGenericType(arrayItemType);
-                }
+                    if (i.GetGenericTypeDefinition() == typeof(IList<>))
+                    {
+                        factoryType = typeof(GenericListWrapperFactory<>).MakeGenericType(arrayItemType);
+                        break;
+                    }
 
-                if (i.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
-                {
-                    return typeof(ReadOnlyListWrapper<>).MakeGenericType(arrayItemType);
+                    if (i.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+                    {
+                        factoryType = typeof(ReadOnlyListWrapperFactory<>).MakeGenericType(arrayItemType);
+                        break;
+                    }
                 }
             }
 #pragma warning restore IL3050
 #pragma warning restore IL2070
 #pragma warning restore IL2055
 
-            return null;
-        });
+            if (factoryType is null)
+            {
+                return null;
+            }
 
-        if (arrayWrapperType is not null)
-        {
             // Activator.CreateInstance may fail in trimmed/AOT scenarios where the constructor
             // was removed by the linker - fall back to the non-generic ListWrapper in that case
             try
             {
-                result = (ArrayLikeWrapper) Activator.CreateInstance(arrayWrapperType, engine, target, type)!;
+                return (ArrayLikeWrapperFactory) Activator.CreateInstance(factoryType)!;
             }
             catch (MissingMethodException)
             {
-                // Constructor was trimmed, fall back to non-generic wrapper
-                if (target is IList list)
-                {
-                    result = new ListWrapper(engine, list, type);
-                }
+                return null;
             }
+        });
+
+        if (factory is not null)
+        {
+            result = factory.Create(engine, target, type);
         }
         else if (target is IList list)
         {
@@ -226,6 +237,10 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         if (property is JsString stringKey)
         {
             var member = stringKey.ToString();
+            if (_lengthPropertyPending && string.Equals(member, "length", StringComparison.Ordinal))
+            {
+                MaterializeLengthProperty();
+            }
             if (_properties is null || !_properties.ContainsKey(member))
             {
                 // can try utilize fast path
@@ -348,6 +363,13 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
 
     public override void RemoveOwnProperty(JsValue property)
     {
+        if (_lengthPropertyPending && CommonProperties.Length.Equals(property))
+        {
+            // an explicit removal of the not-yet-materialized forwarder must behave like removing the
+            // eagerly-created one did: the property is gone and does not come back
+            _lengthPropertyPending = false;
+        }
+
         if (_engine.Options.Interop.AllowWrite)
         {
             if (property is JsString jsString && _typeDescriptor.IsStringKeyedGenericDictionary)
@@ -628,6 +650,11 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             return x;
         }
 
+        if (_lengthPropertyPending && CommonProperties.Length.Equals(property))
+        {
+            return MaterializeLengthProperty();
+        }
+
         // if we have array-like or dictionary or expando, we can provide iterator
         if (property.IsSymbol())
         {
@@ -830,6 +857,16 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         return wrapper._typeDescriptor.IsDictionary
             ? new DictionaryIterator(wrapper._engine, wrapper)
             : new EnumerableIterator(wrapper._engine, (IEnumerable) wrapper.Target);
+    }
+
+    private GetSetPropertyDescriptor MaterializeLengthProperty()
+    {
+        _lengthPropertyPending = false;
+        // create a forwarder to produce length from Count or Length if one of them is present
+        var functionInstance = new ClrFunction(_engine, "length", GetLength);
+        var descriptor = new GetSetPropertyDescriptor(functionInstance, Undefined, PropertyFlag.Configurable);
+        SetProperty(KnownKeys.Length, descriptor);
+        return descriptor;
     }
 
     private static JsNumber GetLength(JsValue thisObject, JsCallArguments arguments)


### PR DESCRIPTION
With `ArrayConversion` defaulting to `LiveView` (#2728), the dominant cost of a CLR collection member read from script became wrapper construction itself (context in #2729). Profiling the `interop-collection-traversal` comparison row shows the conversion path at ~70% of the row, and inside it two avoidable blocks:

* `Activator.CreateInstance(arrayWrapperType, engine, target, type)` pays the full reflection binder (`DefaultBinder.BindToMethod` + `RuntimeConstructorInfo.Invoke` + argument marshaling) on **every** wrapper creation — over half the wrapper-build subtree.
* The `ObjectWrapper` constructor eagerly allocates the `length` forwarder (`ClrFunction` + `GetSetPropertyDescriptor` + the `_properties` store) that plain `length` reads never consult — they are served by the `ICollection` fast path in `Get`.

**Changes**

* The array-like resolution cache now stores a typed `ArrayLikeWrapperFactory` (one `Activator` call per exposed *type*, ever) and every wrapper creation is a virtual call + direct constructor. The trimming fallback behavior is unchanged: a trimmed constructor caches a `null` factory and falls back to the non-generic `ListWrapper` exactly as before.
* The `length` forwarder is materialized lazily on first own-property consultation (`GetOwnProperty`, the `Set` member gate, or an explicit removal). Descriptor shape, configurability, delete semantics and enumeration are unchanged — covered by a new test plus the existing extracted-getter tests.

**Benchmarks** (same machine, adjacent same-base A/B, default job)

`InteropWrapperChurnBenchmark`:

| Row | main | PR | delta |
|---|---|---|---|
| ArrayMemberTraversal_DefaultLiveView | 60.80 µs / 83,544 B | 23.28 µs / 16,344 B | **−62% / −80%** |
| ArrayMemberTraversal_CopyMode | 159.8 µs / 333,944 B | 157.3 µs / 333,944 B | flat |
| ArrayMemberTraversal_CopyIdentityFlag | 14.8 µs / 344 B | 15.0 µs / 344 B | flat |
| SameObjectReturnedInLoop_* | 2.5 µs / 2,336 B | 2.6 µs / 2,336 B | flat |

`EngineComparisonInteropBenchmark` (Jint lane):

| Row | main | PR | delta |
|---|---|---|---|
| interop-collection-traversal | 6.020 ms / 8,456 KB | 2.284 ms / 1,894 KB | **−62% / −78%** |
| interop-method-calls | 2.257 ms | 2.192 ms | flat |
| interop-string-passing | 1.061 ms | 0.996 ms | flat |
| interop-property-access | 1.829 ms (launchCount-5, σ=39 µs) | 1.821 ms (launchCount-5, σ=22 µs) | flat |

A single-launch run showed property-access +19% on this branch; a launchCount-5 A/B (both sides) adjudicated it as code-layout bimodality — the five-launch means are statistically identical. The collection-traversal delta was re-confirmed at launchCount-5 (6.044 → 2.302 ms).

**Gates**: full Jint.Tests (net10.0 + net472), Jint.Tests.PublicInterface, Test262 99,431 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
