### PR TITLE
Add a compiled-invoker fast lane for single-candidate interop method calls

### DIFF
--- a/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
+++ b/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
@@ -1,0 +1,203 @@
+#nullable enable
+using Jint.Native;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Exercises the exact-type compiled-invoker fast lane for single-candidate interop method calls
+/// (see <c>CompiledMethodInvoker</c>) together with the fallback path it declines to for anything
+/// that is not an exact-type hit. Every fallback assertion is written against the behavior that
+/// predates the fast lane so a regression is caught.
+/// </summary>
+public class InteropCompiledInvokerTests
+{
+    public sealed class Host
+    {
+        public bool VoidCalled { get; private set; }
+
+        public int AddInt(int a, int b) => a + b;
+        public long AddLong(long a, long b) => a + b;
+        public double AddDouble(double a, double b) => a + b;
+        public bool And(bool a, bool b) => a && b;
+        public string Concat(string a, string b) => a + b;
+        public JsValue Echo(JsValue value) => value;
+        public int TimesTwo(int x) => x * 2;
+
+        public void DoVoid() => VoidCalled = true;
+
+        public int Throws() => throw new InvalidOperationException("boom from host");
+
+        public static int StaticAdd(int a, int b) => a + b;
+
+        // overloaded -> not a single candidate, never uses the fast lane
+        public int Over(int x) => x + 1;
+        public string Over(string x) => x + "!";
+
+        // params -> ineligible for the fast lane
+        public int SumParams(params int[] values)
+        {
+            var sum = 0;
+            foreach (var v in values)
+            {
+                sum += v;
+            }
+            return sum;
+        }
+
+        // optional argument -> ineligible for the fast lane
+        public int WithOptional(int a, int b = 10) => a + b;
+    }
+
+    private static Engine CreateEngine()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new Host());
+        return engine;
+    }
+
+    [Fact]
+    public void FastLane_IntArgsAndReturn()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(5, engine.Evaluate("host.AddInt(2, 3)").AsNumber());
+        // negative and zero still exact-type integers
+        Assert.Equal(-1, engine.Evaluate("host.AddInt(-4, 3)").AsNumber());
+    }
+
+    [Fact]
+    public void FastLane_LongArgsAndReturn()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(7, engine.Evaluate("host.AddLong(3, 4)").AsNumber());
+    }
+
+    [Fact]
+    public void FastLane_DoubleArgsAndReturn()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(3.75, engine.Evaluate("host.AddDouble(1.5, 2.25)").AsNumber());
+        // integral JS numbers bind to a double parameter as well
+        Assert.Equal(5.0, engine.Evaluate("host.AddDouble(2, 3)").AsNumber());
+    }
+
+    [Fact]
+    public void FastLane_BoolArgsAndReturn()
+    {
+        var engine = CreateEngine();
+        Assert.True(engine.Evaluate("host.And(true, true)").AsBoolean());
+        Assert.False(engine.Evaluate("host.And(true, false)").AsBoolean());
+    }
+
+    [Fact]
+    public void FastLane_StringArgsAndReturn()
+    {
+        var engine = CreateEngine();
+        Assert.Equal("ab", engine.Evaluate("host.Concat('a', 'b')").AsString());
+    }
+
+    [Fact]
+    public void FastLane_JsValuePassthrough()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(42, engine.Evaluate("host.Echo(42)").AsNumber());
+        Assert.Equal("x", engine.Evaluate("host.Echo('x')").AsString());
+        Assert.True(engine.Evaluate("host.Echo(true)").AsBoolean());
+    }
+
+    [Fact]
+    public void FastLane_StaticMethod()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(9, engine.Evaluate("host.StaticAdd(4, 5)").AsNumber());
+    }
+
+    [Fact]
+    public void FastLane_VoidReturnsNull()
+    {
+        var engine = CreateEngine();
+        var host = new Host();
+        engine.SetValue("host", host);
+
+        var result = engine.Evaluate("host.DoVoid()");
+        // CLR void is exposed to JS as null (not undefined) - preserved by the fast lane
+        Assert.True(result.IsNull());
+        Assert.True(host.VoidCalled);
+    }
+
+    [Fact]
+    public void HostExceptionSurfacesAsSameClrException()
+    {
+        var engine = CreateEngine();
+        var ex = Assert.Throws<InvalidOperationException>(() => engine.Evaluate("host.Throws()"));
+        Assert.Equal("boom from host", ex.Message);
+    }
+
+    [Fact]
+    public void Fallback_FractionalNumberToIntParam()
+    {
+        var engine = CreateEngine();
+        // fractional numbers are not exact-type integers: the fast lane declines and the fallback
+        // converter rounds (banker's rounding, 2.5 -> 2), so 2 * 2 == 4. This locks in the behavior
+        // that predates the fast lane.
+        Assert.Equal(4, engine.Evaluate("host.TimesTwo(2.5)").AsNumber());
+    }
+
+    [Fact]
+    public void Fallback_StringToIntParam()
+    {
+        var engine = CreateEngine();
+        // a non-number argument to an int parameter is not an exact-type hit; the fallback coerces
+        // the string "5" to 5, so 5 * 2 == 10.
+        Assert.Equal(10, engine.Evaluate("host.TimesTwo('5')").AsNumber());
+    }
+
+    [Fact]
+    public void Fallback_OverloadedMethod()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(6, engine.Evaluate("host.Over(5)").AsNumber());
+        Assert.Equal("hi!", engine.Evaluate("host.Over('hi')").AsString());
+    }
+
+    [Fact]
+    public void Fallback_ParamsMethod()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(6, engine.Evaluate("host.SumParams(1, 2, 3)").AsNumber());
+    }
+
+    [Fact]
+    public void Fallback_OptionalArgMethod()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(15, engine.Evaluate("host.WithOptional(5)").AsNumber());
+        Assert.Equal(9, engine.Evaluate("host.WithOptional(5, 4)").AsNumber());
+    }
+
+    [Fact]
+    public void CustomObjectConverterStillSeesReturnValue()
+    {
+        // when a custom object converter is registered the fast lane is bypassed so the converter
+        // observes primitive return values exactly as before
+        var engine = new Engine(options => options.Interop.ObjectConverters.Add(new PlusOneIntConverter()));
+        engine.SetValue("host", new Host());
+
+        // AddInt returns 5, the converter turns any int into int+1 => 6
+        Assert.Equal(6, engine.Evaluate("host.AddInt(2, 3)").AsNumber());
+    }
+
+    private sealed class PlusOneIntConverter : Jint.Runtime.Interop.IObjectConverter
+    {
+        public bool TryConvert(Engine engine, object value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out JsValue? result)
+        {
+            if (value is int i)
+            {
+                result = JsNumber.Create(i + 1);
+                return true;
+            }
+
+            result = JsValue.Undefined;
+            return false;
+        }
+    }
+}

--- a/Jint/Runtime/Interop/CompiledMethodInvoker.cs
+++ b/Jint/Runtime/Interop/CompiledMethodInvoker.cs
@@ -1,0 +1,341 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+using Jint.Native;
+using Expression = System.Linq.Expressions.Expression;
+using ConditionalExpression = System.Linq.Expressions.ConditionalExpression;
+
+// The delegate is compiled with System.Linq.Expressions; every member it references is public
+// (JsValue implicit operators, JsValueExtensions accessors, JsValue.Null) so the generated
+// dynamic method needs no reflection-visibility relaxation. IL2075/IL3050 cover the reflection +
+// dynamic-code use, which is gated behind RuntimeFeature.IsDynamicCodeCompiled at the call site.
+#pragma warning disable IL2075
+#pragma warning disable IL3050
+
+namespace Jint.Runtime.Interop;
+
+/// <summary>
+/// Builds a strongly-typed delegate that binds JavaScript arguments to a CLR method and invokes it
+/// directly, for the dominant interop shape where every parameter is an exact-type primitive
+/// (<see cref="int"/>, <see cref="long"/>, <see cref="double"/>, <see cref="bool"/>,
+/// <see cref="string"/>) or a pass-through <see cref="JsValue"/>. This removes, per call, the
+/// <c>object?[]</c> parameter array, the argument boxes, the boxed return value, and the
+/// return-mapper dictionary lookup that the reflection path pays.
+/// <para>
+/// The delegate only handles exact-type hits (the hot case). Any argument that is not the exact
+/// expected JavaScript type — including a fractional number bound to an integer parameter, or a
+/// number outside the target integer range — makes it return <see langword="false"/> so the caller
+/// falls back to the full <c>TryCall</c> machinery, preserving today's conversion behavior
+/// bit-for-bit. Exceptions thrown by the target method propagate as-is; the caller normalizes them
+/// exactly like the reflection path does.
+/// </para>
+/// </summary>
+internal static class CompiledMethodInvoker
+{
+    /// <summary>
+    /// Invokes the bound method. Returns <see langword="true"/> and sets <paramref name="result"/>
+    /// when every argument was an exact-type match; returns <see langword="false"/> (declining) when
+    /// any argument requires the fallback conversion path.
+    /// </summary>
+    internal delegate bool Invoker(object? target, JsCallArguments arguments, out JsValue result);
+
+    private static readonly MethodInfo _asNumber = typeof(JsValueExtensions).GetMethod(nameof(JsValueExtensions.AsNumber), [typeof(JsValue)])!;
+    private static readonly MethodInfo _asBoolean = typeof(JsValueExtensions).GetMethod(nameof(JsValueExtensions.AsBoolean), [typeof(JsValue)])!;
+    private static readonly MethodInfo _objectToString = typeof(object).GetMethod(nameof(ToString), Type.EmptyTypes)!;
+    private static readonly MethodInfo _doubleIsNaN = typeof(double).GetMethod(nameof(double.IsNaN), [typeof(double)])!;
+    private static readonly MethodInfo _doubleIsInfinity = typeof(double).GetMethod(nameof(double.IsInfinity), [typeof(double)])!;
+
+    // (double) long.MaxValue rounds up to 2^63 which overflows long, the bound must be exclusive -
+    // this mirrors InteropHelper.TryConvertNumberFast exactly.
+    private const double LongMaxValueExclusiveUpperBound = 9223372036854775808d;
+
+    internal static bool TryBuild(MethodDescriptor descriptor, [NotNullWhen(true)] out Invoker? invoker)
+    {
+        invoker = null;
+
+        // Only plain (non-generic, non-params, no optional args, non-extension) MethodInfo call
+        // sites are eligible; anything else keeps the reflection path.
+        if (descriptor.Method is not MethodInfo method
+            || descriptor.HasParams
+            || descriptor.ParameterDefaultValuesCount != 0
+            || descriptor.IsGenericMethod
+            || descriptor.IsExtensionMethod
+            || !method.IsPublic)
+        {
+            return false;
+        }
+
+        var declaringType = method.DeclaringType;
+        if (declaringType is null || !declaringType.IsVisible)
+        {
+            // the compiled expression can only bind a call to a publicly visible declaring type
+            return false;
+        }
+
+        // Open-instance delegates over value-type receivers need a by-ref first parameter, which
+        // this simple Func/Action binding does not model - leave structs to the reflection path.
+        if (!method.IsStatic && declaringType.IsValueType)
+        {
+            return false;
+        }
+
+        var returnType = method.ReturnType;
+        if (!IsSupportedReturnType(returnType))
+        {
+            return false;
+        }
+
+        var parameters = descriptor.Parameters;
+        foreach (var parameter in parameters)
+        {
+            if (!IsSupportedParameterType(parameter.ParameterType))
+            {
+                return false;
+            }
+        }
+
+        // The method is invoked through an open delegate (built once, embedded as a constant) rather
+        // than a direct Expression.Call. A direct call lets the JIT inline a small host method into
+        // the compiled lambda, which erases the host method's frame from a thrown exception's stack
+        // trace - the reflection MethodInvoker path never inlines, so bubbling CLR exceptions would
+        // no longer look identical. The delegate invoke keeps that frame while staying allocation
+        // free and fully typed (no argument/return boxing).
+        if (!TryCreateInvocationDelegate(method, declaringType, parameters, returnType, out var invocationDelegate, out var delegateType))
+        {
+            return false;
+        }
+
+        var targetParam = Expression.Parameter(typeof(object), "target");
+        var argsParam = Expression.Parameter(typeof(JsCallArguments), "arguments");
+        var resultParam = Expression.Parameter(typeof(JsValue).MakeByRefType(), "result");
+        var returnLabel = Expression.Label(typeof(bool), "return");
+
+        var locals = new List<ParameterExpression>();
+        var body = new List<Expression>();
+
+        // result is an out parameter: seed it so the decline paths satisfy definite assignment.
+        // The caller ignores it whenever we return false.
+        body.Add(Expression.Assign(resultParam, Expression.Constant(JsValue.Undefined, typeof(JsValue))));
+
+        var boundCount = method.IsStatic ? parameters.Length : parameters.Length + 1;
+        var invokeArguments = new Expression[boundCount];
+        var offset = 0;
+        if (!method.IsStatic)
+        {
+            invokeArguments[0] = Expression.Convert(targetParam, declaringType);
+            offset = 1;
+        }
+
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            invokeArguments[offset + i] = BuildArgumentBinding(i, parameters[i].ParameterType, argsParam, returnLabel, locals, body);
+        }
+
+        var call = Expression.Invoke(Expression.Constant(invocationDelegate, delegateType), invokeArguments);
+
+        body.Add(BuildResultAssignment(resultParam, call, returnType));
+        body.Add(Expression.Return(returnLabel, Expression.Constant(true)));
+        body.Add(Expression.Label(returnLabel, Expression.Constant(false)));
+
+        var lambda = Expression.Lambda<Invoker>(Expression.Block(typeof(bool), locals, body), targetParam, argsParam, resultParam);
+        invoker = lambda.Compile();
+        return true;
+    }
+
+    /// <summary>
+    /// Builds the open <see cref="Func{T}"/>/<see cref="Action"/> delegate that invokes the method:
+    /// an instance method's receiver is the delegate's first parameter. Declines when the signature
+    /// exceeds the available Func/Action arities or the delegate cannot be bound.
+    /// </summary>
+    private static bool TryCreateInvocationDelegate(
+        MethodInfo method,
+        Type declaringType,
+        ParameterInfo[] parameters,
+        Type returnType,
+        [NotNullWhen(true)] out Delegate? invocationDelegate,
+        [NotNullWhen(true)] out Type? delegateType)
+    {
+        invocationDelegate = null;
+        delegateType = null;
+
+        var isVoid = returnType == typeof(void);
+        var instanceSlot = method.IsStatic ? 0 : 1;
+        var typeArgs = new Type[instanceSlot + parameters.Length + (isVoid ? 0 : 1)];
+
+        var index = 0;
+        if (!method.IsStatic)
+        {
+            typeArgs[index++] = declaringType;
+        }
+
+        foreach (var parameter in parameters)
+        {
+            typeArgs[index++] = parameter.ParameterType;
+        }
+
+        if (isVoid)
+        {
+            if (!Expression.TryGetActionType(typeArgs, out delegateType))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            typeArgs[index] = returnType;
+            if (!Expression.TryGetFuncType(typeArgs, out delegateType))
+            {
+                return false;
+            }
+        }
+
+        try
+        {
+            invocationDelegate = method.CreateDelegate(delegateType);
+        }
+        catch (Exception)
+        {
+            // an accessibility/binding quirk the eligibility checks did not anticipate
+            invocationDelegate = null;
+            delegateType = null;
+            return false;
+        }
+
+        return true;
+    }
+
+    // Exactly JsValue is a safe pass-through: every argument already is a JsValue. More specific
+    // JsValue subtypes are left to the fallback so a wrong subtype keeps today's behavior instead of
+    // an InvalidCastException.
+    private static bool IsSupportedParameterType(Type type)
+    {
+        return type == typeof(int)
+               || type == typeof(long)
+               || type == typeof(double)
+               || type == typeof(bool)
+               || type == typeof(string)
+               || type == typeof(JsValue);
+    }
+
+    // JsValue or any subtype flows straight back (matching FromObjectWithType); a null result is
+    // mapped to JsValue.Null in BuildResultAssignment.
+    private static bool IsSupportedReturnType(Type type)
+    {
+        return type == typeof(void)
+               || type == typeof(int)
+               || type == typeof(long)
+               || type == typeof(double)
+               || type == typeof(bool)
+               || type == typeof(string)
+               || typeof(JsValue).IsAssignableFrom(type);
+    }
+
+    /// <summary>
+    /// Emits the type test + typed read for one argument, returning an expression of the parameter
+    /// type. A non-exact match jumps to <paramref name="returnLabel"/> with <see langword="false"/>.
+    /// </summary>
+    private static Expression BuildArgumentBinding(
+        int index,
+        Type parameterType,
+        ParameterExpression argsParam,
+        LabelTarget returnLabel,
+        List<ParameterExpression> locals,
+        List<Expression> body)
+    {
+        var arg = Expression.Variable(typeof(JsValue), "a" + index);
+        locals.Add(arg);
+        body.Add(Expression.Assign(arg, Expression.ArrayIndex(argsParam, Expression.Constant(index))));
+
+        if (parameterType == typeof(JsValue))
+        {
+            return arg;
+        }
+
+        if (parameterType == typeof(string))
+        {
+            // accept only JsString; ToString() returns the underlying string without a copy
+            body.Add(DeclineIfNotType(arg, typeof(JsString), returnLabel));
+            return Expression.Call(arg, _objectToString);
+        }
+
+        if (parameterType == typeof(bool))
+        {
+            body.Add(DeclineIfNotType(arg, typeof(JsBoolean), returnLabel));
+            return Expression.Call(_asBoolean, arg);
+        }
+
+        // int / long / double
+        body.Add(DeclineIfNotType(arg, typeof(JsNumber), returnLabel));
+
+        var value = Expression.Variable(typeof(double), "d" + index);
+        locals.Add(value);
+        body.Add(Expression.Assign(value, Expression.Call(_asNumber, arg)));
+
+        if (parameterType == typeof(double))
+        {
+            return value;
+        }
+
+        // Replicate InteropHelper.TryConvertNumberFast exactly: only convert integral values within
+        // the target range, otherwise decline so the fallback reproduces today's behavior.
+        var isNaN = Expression.Call(_doubleIsNaN, value);
+        var isInfinity = Expression.Call(_doubleIsInfinity, value);
+        var notIntegral = Expression.NotEqual(Expression.Modulo(value, Expression.Constant(1d)), Expression.Constant(0d));
+
+        Expression belowRange;
+        Expression aboveRange;
+        if (parameterType == typeof(int))
+        {
+            belowRange = Expression.LessThan(value, Expression.Constant((double) int.MinValue));
+            aboveRange = Expression.GreaterThan(value, Expression.Constant((double) int.MaxValue));
+        }
+        else
+        {
+            belowRange = Expression.LessThan(value, Expression.Constant((double) long.MinValue));
+            aboveRange = Expression.GreaterThanOrEqual(value, Expression.Constant(LongMaxValueExclusiveUpperBound));
+        }
+
+        var decline = Expression.OrElse(
+            Expression.OrElse(Expression.OrElse(isNaN, isInfinity), notIntegral),
+            Expression.OrElse(belowRange, aboveRange));
+
+        body.Add(Expression.IfThen(decline, Expression.Return(returnLabel, Expression.Constant(false))));
+
+        return Expression.Convert(value, parameterType);
+    }
+
+    private static ConditionalExpression DeclineIfNotType(Expression arg, Type jsType, LabelTarget returnLabel)
+    {
+        return Expression.IfThen(
+            Expression.Not(Expression.TypeIs(arg, jsType)),
+            Expression.Return(returnLabel, Expression.Constant(false)));
+    }
+
+    private static Expression BuildResultAssignment(ParameterExpression resultParam, Expression call, Type returnType)
+    {
+        var nullConstant = Expression.Constant(JsValue.Null, typeof(JsValue));
+
+        if (returnType == typeof(void))
+        {
+            // CLR void is exposed to JS as null (matching FromObjectWithType(engine, null, ...))
+            return Expression.Block(call, Expression.Assign(resultParam, nullConstant));
+        }
+
+        if (returnType == typeof(int)
+            || returnType == typeof(long)
+            || returnType == typeof(double)
+            || returnType == typeof(bool)
+            || returnType == typeof(string))
+        {
+            // the public JsValue implicit operators produce the exact same JsValue as
+            // DefaultObjectConverter (and handle string null -> JsValue.Null internally)
+            var op = typeof(JsValue).GetMethod("op_Implicit", [returnType])!;
+            return Expression.Assign(resultParam, Expression.Call(op, call));
+        }
+
+        // JsValue or a subtype: flow straight back, coalescing a null result to JsValue.Null
+        return Expression.Assign(resultParam, Expression.Coalesce(Expression.Convert(call, typeof(JsValue)), nullConstant));
+    }
+}
+#endif

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -15,6 +15,9 @@ internal sealed class MethodDescriptor
         Method = method;
         Parameters = method.GetParameters();
         IsExtensionMethod = method.IsDefined(typeof(ExtensionAttribute), true);
+        // MethodBase.IsGenericMethod ends up in RuntimeMethodHandle::HasMethodInstantiation, a
+        // non-trivial reflection call; cache it so the per-call binding path never pays for it.
+        IsGenericMethod = method.IsGenericMethod;
 
         foreach (var parameter in Parameters)
         {
@@ -42,6 +45,12 @@ internal sealed class MethodDescriptor
     public bool HasParams { get; }
     public int ParameterDefaultValuesCount { get; }
     public bool IsExtensionMethod { get; }
+
+    /// <summary>
+    /// Cached <see cref="MethodBase.IsGenericMethod"/> — the reflection property is a per-call
+    /// hotspot in argument binding, so it is computed once in the constructor.
+    /// </summary>
+    public bool IsGenericMethod { get; }
 
     /// <summary>
     /// Facts about each parameter type that argument binding consults on every call — computed
@@ -73,6 +82,45 @@ internal sealed class MethodDescriptor
     // lazily initialized fast invokers, benign race - last writer wins
     private MethodInvoker? _methodInvoker;
     private ConstructorInvoker? _constructorInvoker;
+
+    // lazily built strongly-typed invoker for the exact-type numeric/string/bool fast lane,
+    // benign race - last writer wins. Once _compiledInvokerUnavailable is set the method is
+    // permanently ineligible (or the runtime cannot JIT the lambda) and we never retry.
+    private CompiledMethodInvoker.Invoker? _compiledInvoker;
+    private bool _compiledInvokerUnavailable;
+
+    /// <summary>
+    /// Returns a compiled delegate that binds and invokes this method without the per-call
+    /// <c>object?[]</c> parameter array, argument boxing, boxed return, and return-mapper lookup —
+    /// or <see langword="null"/> when the method is ineligible or the runtime cannot compile the
+    /// delegate to native code. Only usable for single-candidate call sites.
+    /// </summary>
+    internal CompiledMethodInvoker.Invoker? GetCompiledInvoker()
+    {
+        if (_compiledInvoker is { } invoker)
+        {
+            return invoker;
+        }
+
+        if (_compiledInvokerUnavailable)
+        {
+            return null;
+        }
+
+        // Build the delegate ONLY when the runtime will JIT it to native code. Under AOT and under
+        // an interpreted-only Expression.Compile (e.g. Mono interpreter) IsDynamicCodeCompiled is
+        // false, and an interpreted lambda is slower than the cached MethodInvoker reflection path,
+        // so we decline and keep that path.
+        if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeCompiled
+            || !CompiledMethodInvoker.TryBuild(this, out var built))
+        {
+            _compiledInvokerUnavailable = true;
+            return null;
+        }
+
+        _compiledInvoker = built;
+        return built;
+    }
 #endif
 
     /// <summary>
@@ -170,12 +218,12 @@ internal sealed class MethodDescriptor
         static int CreateComparison(MethodDescriptor d1, MethodDescriptor d2)
         {
             // if its a generic method, put it on the end
-            if (d1.Method.IsGenericMethod && !d2.Method.IsGenericMethod)
+            if (d1.IsGenericMethod && !d2.IsGenericMethod)
             {
                 return 1;
             }
 
-            if (d2.Method.IsGenericMethod && !d1.Method.IsGenericMethod)
+            if (d2.IsGenericMethod && !d1.IsGenericMethod)
             {
                 return -1;
             }

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -109,9 +109,10 @@ internal sealed class MethodInfoFunction : Function
         }
     }
 
-    private static MethodBase ResolveMethod(MethodBase method, ParameterInfo[] methodParameters, JsCallArguments arguments)
+    private static MethodBase ResolveMethod(MethodDescriptor descriptor, ParameterInfo[] methodParameters, JsCallArguments arguments)
     {
-        if (!method.IsGenericMethod)
+        var method = descriptor.Method;
+        if (!descriptor.IsGenericMethod)
         {
             return method;
         }
@@ -167,10 +168,42 @@ internal sealed class MethodInfoFunction : Function
             var arguments = ArgumentProvider(method, state);
             if (arguments.Length <= parameterInfos.Length
                 && arguments.Length >= parameterInfos.Length - method.ParameterDefaultValuesCount
-                && CanBindNullArguments(parameterInfos, arguments)
-                && TryCall(method, arguments, thisObj, converter, out var fastResult))
+                && CanBindNullArguments(parameterInfos, arguments))
             {
-                return fastResult;
+#if NET8_0_OR_GREATER
+                // exact-type fast lane: a compiled delegate binds and invokes without the object?[]
+                // parameter array, argument boxes, boxed return, and return-mapper lookup. Skipped
+                // when custom object converters are registered because those must see return values.
+                if (_engine._objectConverters is null && method.GetCompiledInvoker() is { } compiledInvoker)
+                {
+                    JsValue compiledResult = null!;
+                    bool handled;
+                    try
+                    {
+                        handled = compiledInvoker(thisObj, arguments, out compiledResult);
+                    }
+                    catch (Exception exception)
+                    {
+                        // the target method threw; surface it exactly like the reflection path, which
+                        // normalizes non-TargetInvocationException throws to TargetInvocationException
+                        _engine.CheckAmortizedConstraintsAtHostBoundary();
+                        var normalized = exception as TargetInvocationException ?? new TargetInvocationException(exception);
+                        Throw.MeaningfulException(_engine, normalized);
+                        throw; // unreachable, MeaningfulException does not return
+                    }
+
+                    if (handled)
+                    {
+                        _engine.CheckAmortizedConstraintsAtHostBoundary();
+                        return compiledResult;
+                    }
+                    // declined (non-exact argument) - fall through to the full binding path
+                }
+#endif
+                if (TryCall(method, arguments, thisObj, converter, out var fastResult))
+                {
+                    return fastResult;
+                }
             }
         }
         else
@@ -245,11 +278,13 @@ internal sealed class MethodInfoFunction : Function
         callResult = null;
 
         var methodParameters = method.Parameters;
-        var resolvedMethod = ResolveMethod(method.Method, methodParameters, arguments);
+        var resolvedMethod = ResolveMethod(method, methodParameters, arguments);
         // We only need to call GetParameters it if this ends up being a generic method (i.e. they will be different in that scenario)
         var isGenericDefinition = false;
         var parameterFlags = method.ParameterFlags;
-        if (resolvedMethod.IsGenericMethod)
+        // when the descriptor is not generic, resolvedMethod is the (non-generic) descriptor method,
+        // so the cached flag lets us skip the resolvedMethod.IsGenericMethod reflection call
+        if (method.IsGenericMethod)
         {
             // the resolved parameters differ from the descriptor's, re-classify them
             methodParameters = resolvedMethod.GetParameters();


### PR DESCRIPTION
For the dominant interop shape — a single-candidate method whose parameters are exact-type primitives — the binding path still pays four allocations per call (`object?[]` parameter array, per-argument boxes, boxed return) plus the `MethodInvoker` indirection and the return-mapper dictionary lookup. #2719 removed the reflection re-derivation; this PR removes the rest for the hot case.

**Changes**

* `MethodDescriptor` caches `IsGenericMethod` (the reflection property resolves through `RuntimeMethodHandle::HasMethodInstantiation` — ~1% of the interop-method-calls row on its own) and uses it in binding and overload ordering. This part benefits every target including AOT.
* net8+: a lazily compiled, strongly-typed invoker delegate per eligible `MethodDescriptor` (same benign-race lazy-field idiom as `_methodInvoker`). Eligibility is conservative: single candidate, public non-generic instance/static method on a visible reference type, no params/optional arguments, parameters in {int, long, double, bool, string, JsValue}, return in {void, int, long, double, bool, string, JsValue-assignable}. The delegate handles exact-type argument hits only; anything else (fractional number to int, out-of-range, wrong JS type, custom object converters registered) declines and falls back to the existing `TryCall` machinery, so conversion behavior is preserved bit-for-bit — the int/long guards replicate `TryConvertNumberFast` exactly, including the exclusive 2^63 upper bound.
* The compiled lane is runtime-gated on `RuntimeFeature.IsDynamicCodeCompiled`: under AOT (or interpreted `Expression.Compile`) an interpreted lambda would be slower than the cached `MethodInvoker`, so those targets keep the current path unchanged.
* The target method is invoked through a cached open delegate rather than a direct `Expression.Call`: a direct call lets the JIT inline small host methods into the lambda, which erases the host method's frame from thrown exceptions' stack traces (caught by the existing error tests). The delegate invoke keeps frames identical to the reflection path while staying allocation-free. Exception normalization (`TargetInvocationException`) and the host-boundary constraint checks sit at the same points as the reflection path.

**Benchmarks** (same machine, adjacent same-base A/B, default job)

`InteropMethodDispatchBenchmark`:

| Row | main | PR | delta |
|---|---|---|---|
| SingleOverload_OneIntArg | 2.740 µs / 2.01 KB | 2.496 µs / 1.93 KB | −8.9% |
| SingleOverload_TwoArgs_IntString | 3.083 µs | 2.742 µs | −11.1% |
| SingleOverload_OneDoubleArg / OneStringArg | 2.76 µs / 2.75 µs | 2.60 µs / 2.58 µs | −6% |
| Overloaded_MixedArgs | 8.835 µs | 8.836 µs | flat (ineligible, fallback intact) |
| ParamsMethod_Spread | 3.405 µs | 3.432 µs | flat |

`EngineComparisonInteropBenchmark` (Jint lane):

| Row | main | PR | delta |
|---|---|---|---|
| interop-method-calls | 2.257 ms / 1,424.5 KB | 2.049 ms / 347.0 KB | **−9.2% / −75.6%** |
| interop-string-passing | 1.061 ms / 384.3 KB | 0.860 ms / 316.9 KB | **−18.9% / −17.5%** |
| interop-property-access / collection-traversal | | | flat (allocation byte-identical) |

**Gates**: full Jint.Tests on net10.0 (fast lane active) and net472 (lane compiled out — proves fallback identity), Jint.Tests.PublicInterface both TFMs, Test262 99,431 passed / 0 failed. 15 new targeted tests cover fast-lane hits per type, fallback cases (overloads, params, optional args, coercions), host exceptions, and void returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
