### PR TITLE
Default Interop.CacheRecentObjectWrappers to true for 4.14

### DIFF
--- a/Jint.Benchmark/InteropWrapperChurnBenchmark.cs
+++ b/Jint.Benchmark/InteropWrapperChurnBenchmark.cs
@@ -4,9 +4,10 @@ namespace Jint.Benchmark;
 
 /// <summary>
 /// Measures ObjectWrapper churn: a CLR member returning the SAME object reference repeatedly.
-/// With the default TrackObjectWrapperIdentity=false every crossing allocates a fresh
-/// ObjectWrapper; with the opt-in identity flag the ConditionalWeakTable returns the cached one.
-/// The two benchmarks bracket the design space for cheaper wrapper reuse.
+/// Since 4.14 the default engine keeps a small bounded cache of recently wrapped objects
+/// (CacheRecentObjectWrappers), so repeated crossings reuse the wrapper; the NoCache rows opt out
+/// to measure the fresh-wrapper-per-crossing path, and the identity-flag rows measure the
+/// ConditionalWeakTable variant. Together they bracket the design space for wrapper reuse.
 /// </summary>
 [MemoryDiagnoser]
 public class InteropWrapperChurnBenchmark
@@ -31,6 +32,7 @@ public class InteropWrapperChurnBenchmark
     }
 
     private Engine _engineDefault = null!;
+    private Engine _engineNoCache = null!;
     private Engine _engineIdentity = null!;
     private Engine _engineRecentCache = null!;
     private Engine _engineCopy = null!;
@@ -40,18 +42,26 @@ public class InteropWrapperChurnBenchmark
     {
         var holder = new Holder(new Payload { Value = 42 });
 
-        // the out-of-the-box engine: ArrayConversion defaults to LiveView since 4.14
+        // the out-of-the-box engine: since 4.14 ArrayConversion defaults to LiveView and
+        // CacheRecentObjectWrappers defaults to true (repeated crossings reuse the wrapper)
         _engineDefault = new Engine();
         _engineDefault.SetValue("h", holder);
         _engineDefault.Execute("h.Payload.Value");
 
+        // opt out of the recent-wrapper cache: every crossing builds a fresh wrapper
+        _engineNoCache = new Engine(cfg => cfg.Interop.CacheRecentObjectWrappers = false);
+        _engineNoCache.SetValue("h", holder);
+        _engineNoCache.Execute("h.Payload.Value");
+
         // the identity flags are most interesting on top of Copy, where they let the otherwise
         // per-read deep-copied JsArray snapshot be reused across crossings (pin Copy so the array
-        // traversal rows below measure exactly that; the object-churn rows are array-mode agnostic)
+        // traversal rows below measure exactly that; the object-churn rows are array-mode agnostic).
+        // The recent cache is disabled in the CWT lane so each row measures a single mechanism.
         _engineIdentity = new Engine(cfg =>
         {
             cfg.Interop.ArrayConversion = ArrayConversionMode.Copy;
             cfg.Interop.TrackObjectWrapperIdentity = true;
+            cfg.Interop.CacheRecentObjectWrappers = false;
         });
         _engineIdentity.SetValue("h", holder);
         _engineIdentity.Execute("h.Payload.Value");
@@ -65,7 +75,12 @@ public class InteropWrapperChurnBenchmark
         _engineRecentCache.Execute("h.Payload.Value");
 
         // the pre-4.14 default: every array crossing deep-copies into a fresh JsArray snapshot
-        _engineCopy = new Engine(cfg => cfg.Interop.ArrayConversion = ArrayConversionMode.Copy);
+        // (the cache opt-out keeps this row measuring the copy itself)
+        _engineCopy = new Engine(cfg =>
+        {
+            cfg.Interop.ArrayConversion = ArrayConversionMode.Copy;
+            cfg.Interop.CacheRecentObjectWrappers = false;
+        });
         _engineCopy.SetValue("h", holder);
         _engineCopy.Execute("h.Payload.Value");
     }
@@ -74,6 +89,12 @@ public class InteropWrapperChurnBenchmark
     public void SameObjectReturnedInLoop_DefaultFlag()
     {
         for (var i = 0; i < OperationsPerInvoke; i++) _engineDefault.Execute("h.Payload.Value");
+    }
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public void SameObjectReturnedInLoop_NoCache()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++) _engineNoCache.Execute("h.Payload.Value");
     }
 
     [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
@@ -98,6 +119,12 @@ public class InteropWrapperChurnBenchmark
     public void ArrayMemberTraversal_DefaultLiveView()
     {
         _engineDefault.Execute(_arrayTraversal);
+    }
+
+    [Benchmark]
+    public void ArrayMemberTraversal_LiveViewNoCache()
+    {
+        _engineNoCache.Execute(_arrayTraversal);
     }
 
     // The README-recommended pattern: hoist the collection into a local so the wrapper is created

--- a/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
+++ b/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
@@ -132,6 +132,21 @@ public class InteropExplicitTypeTests
         Assert.Equal(holder.IndexerI1[0].Name, _engine.Evaluate("holder.IndexerI1[0].Name"));
     }
 
+    [Fact]
+    public void RecentWrapperCacheKeepsExposedTypeViewsSeparate()
+    {
+        // the default recent-wrapper cache (see #2729) reuses wrappers by object identity; the same
+        // instance exposed under different CLR types must still resolve each view's own members
+        Assert.Equal("CI1", _engine.Evaluate("holder.ci1.Name").AsString());
+        Assert.Equal("CI1 as I1", _engine.Evaluate("holder.i1.Name").AsString());
+        Assert.Equal("Super", _engine.Evaluate("holder.super.Name").AsString());
+
+        // and in reverse order against the now-populated cache slots
+        Assert.Equal("Super", _engine.Evaluate("holder.super.Name").AsString());
+        Assert.Equal("CI1 as I1", _engine.Evaluate("holder.i1.Name").AsString());
+        Assert.Equal("CI1", _engine.Evaluate("holder.ci1.Name").AsString());
+    }
+
 
     [Fact]
     public void SuperClassFromField()

--- a/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
+++ b/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
@@ -10,8 +10,13 @@ public partial class InteropTests
     [Fact]
     public void ArrayConversionCreatesFreshCopyInCopyMode()
     {
-        // Copy is no longer the default (LiveView since 4.14), so select it explicitly to lock its snapshot contract
-        var engine = new Engine(options => options.Interop.ArrayConversion = ArrayConversionMode.Copy);
+        // Copy is no longer the default (LiveView since 4.14) and the recent-wrapper cache would
+        // reuse the first snapshot; opt out of both to lock the fresh-snapshot-per-crossing contract
+        var engine = new Engine(options =>
+        {
+            options.Interop.ArrayConversion = ArrayConversionMode.Copy;
+            options.Interop.CacheRecentObjectWrappers = false;
+        });
         engine.SetValue("host", new ArrayConversionHost());
 
         Assert.False(engine.Evaluate("host.Numbers === host.Numbers").AsBoolean());

--- a/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
+++ b/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
@@ -82,11 +82,18 @@ public partial class InteropTests
     [Fact]
     public void CopyModeArrayIsJsArraySnapshot()
     {
-        // opting back into Copy restores the pre-4.14 behavior: each crossing produces an independent JsArray snapshot
-        var engine = CreateCopyEngine();
+        // full pre-4.14 behavior needs Copy plus opting out of the recent-wrapper cache: each
+        // crossing then produces an independent JsArray snapshot
+        var engine = CreateCopyEngine(options => options.Interop.CacheRecentObjectWrappers = false);
         engine.SetValue("h", new ArrayHolder());
         Assert.True(engine.Evaluate("Array.isArray(h.Numbers)").AsBoolean());
         Assert.False(engine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
+
+        // with the default (cached) Copy engine the same snapshot is reused while cached
+        var cachedEngine = CreateCopyEngine();
+        cachedEngine.SetValue("h", new ArrayHolder());
+        Assert.True(cachedEngine.Evaluate("Array.isArray(h.Numbers)").AsBoolean());
+        Assert.True(cachedEngine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
     }
 
     [Fact]

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -348,9 +348,14 @@ public class Options
         /// alternative to <see cref="TrackObjectWrapperIdentity"/> that cannot grow memory unbounded;
         /// identity is only preserved for objects still present in the cache. Covers CLR arrays the same
         /// way <see cref="TrackObjectWrapperIdentity"/> does.
-        /// Defaults to false.
+        /// Defaults to true since 4.14: repeated crossings of a recently seen object return the same
+        /// wrapper instance, so script-attached state (freeze/defineProperty/expandos) stays stable and
+        /// the per-crossing wrapper allocation disappears. Note that under <see cref="ArrayConversionMode.Copy"/>
+        /// this also means repeated reads of the same CLR array reuse the first JsArray snapshot while it
+        /// stays cached (CLR-side mutations are not re-copied); set this to false for a fresh snapshot per
+        /// crossing (the pre-4.14 behavior).
         /// </summary>
-        public bool CacheRecentObjectWrappers { get; set; }
+        public bool CacheRecentObjectWrappers { get; set; } = true;
 
         /// <summary>
         /// How CLR arrays (<c>T[]</c>) are exposed to script code, defaults to <see cref="Jint.ArrayConversionMode.LiveView"/>

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -144,12 +144,15 @@ internal static class DefaultObjectConverter
             }
             else
             {
-                // check global cache, have we already wrapped the value?
-                if (engine._objectWrapperCache?.TryGetValue(value, out var cached) == true)
+                // check global cache, have we already wrapped the value? A cached wrapper is only
+                // valid for the same exposed CLR type — the same object may also cross as an
+                // explicit interface/superclass view, which resolves a different member set.
+                if (engine._objectWrapperCache?.TryGetValue(value, out var cached) == true
+                    && (cached is not ObjectWrapper cachedWrapper || cachedWrapper.ClrType == valueType))
                 {
                     result = cached;
                 }
-                else if (engine._recentObjectWrapperCache?.TryGet(value) is { } recentlyWrapped)
+                else if (engine._recentObjectWrapperCache?.TryGet(value, valueType) is { } recentlyWrapped)
                 {
                     result = recentlyWrapped;
                 }
@@ -170,6 +173,9 @@ internal static class DefaultObjectConverter
                         if (engine.Options.Interop.TrackObjectWrapperIdentity)
                         {
                             engine._objectWrapperCache ??= new ConditionalWeakTable<object, ObjectInstance>();
+                            // the table may hold a wrapper for a different exposed view of the same
+                            // object (the type-guarded lookup above missed it) — last view wins
+                            engine._objectWrapperCache.Remove(value);
                             engine._objectWrapperCache.Add(value, wrapped);
                         }
                         else if (engine.Options.Interop.CacheRecentObjectWrappers)
@@ -238,18 +244,21 @@ internal static class DefaultObjectConverter
 
     private static JsValue ConvertArray(Engine e, object v)
     {
-        // The identity caches (flag-gated, both default off) also cover arrays: repeated
-        // conversions of the same CLR array instance return the same result (JsArray snapshot under
-        // Copy, wrapper view under LiveView) instead of re-converting on every property read. With
-        // the flags off each conversion still produces a fresh copy/wrapper. All option checks must
-        // stay inside this method — _typeMappers is a static cross-engine memoization, so per-engine
-        // option state can never be baked into the memoized mapper.
-        if (e._objectWrapperCache?.TryGetValue(v, out var cached) == true)
+        // The identity caches (CacheRecentObjectWrappers default on since 4.14, the identity map
+        // opt-in) also cover arrays: repeated conversions of the same CLR array instance return the
+        // same result (JsArray snapshot under Copy, wrapper view under LiveView) instead of
+        // re-converting on every property read. With caching disabled each conversion still produces
+        // a fresh copy/wrapper. All option checks must stay inside this method — _typeMappers is a
+        // static cross-engine memoization, so per-engine option state can never be baked into the
+        // memoized mapper.
+        var arrayType = v.GetType();
+        if (e._objectWrapperCache?.TryGetValue(v, out var cached) == true
+            && (cached is not ObjectWrapper cachedWrapper || cachedWrapper.ClrType == arrayType))
         {
             return cached;
         }
 
-        if (e._recentObjectWrapperCache?.TryGet(v) is { } recentlyConverted)
+        if (e._recentObjectWrapperCache?.TryGet(v, arrayType) is { } recentlyConverted)
         {
             return recentlyConverted;
         }
@@ -339,14 +348,22 @@ internal sealed class RecentObjectWrapperCache
     private readonly ObjectInstance[] _wrappers = new ObjectInstance[Capacity];
     private int _next;
 
-    public ObjectInstance? TryGet(object target)
+    public ObjectInstance? TryGet(object target, Type clrType)
     {
         var targets = _targets;
         for (var i = 0; i < targets.Length; i++)
         {
             if (ReferenceEquals(targets[i], target))
             {
-                return _wrappers[i];
+                // the same object can cross under different exposed CLR types (explicit interface /
+                // superclass views resolve different members), so a wrapper is only reusable for the
+                // same exposed type. A mismatched slot is skipped rather than a terminal miss —
+                // wrappers for both views can coexist in the ring.
+                var wrapper = _wrappers[i];
+                if (wrapper is not ObjectWrapper objectWrapper || objectWrapper.ClrType == clrType)
+                {
+                    return wrapper;
+                }
             }
         }
 


### PR DESCRIPTION
Closes #2729.

With `LiveView` as the array default (#2728) and the wrapper-construction costs removed (#2730, #2731), the dominant remaining cost of a collection member being re-read from script was wrapper re-creation per crossing. This flips `Options.Interop.CacheRecentObjectWrappers` to `true`: a small bounded ring (8 entries, per engine, strong references — cannot grow unbounded) makes repeated crossings of the same object reuse its wrapper by default. `TrackObjectWrapperIdentity` remains the opt-in for full identity persistence; setting `CacheRecentObjectWrappers = false` restores fresh-wrapper-per-crossing.

**Latent cache bug fixed along the way** (it also affects the existing opt-in flags): both identity-cache lookups ignored the *exposed* CLR type, so an object crossing once as its concrete type and later as an explicit interface/superclass view (`holder.i1` vs `holder.ci1`) got the first wrapper back — resolving the wrong member set. Seven existing `InteropExplicitTypeTests` caught this the moment the cache was on by default. Cache hits now require the wrapper's `ClrType` to match the exposed type; the ring can hold both views of the same object, and the identity map replaces its entry when the view changes. A regression test exercises alternating views against the populated cache.

**Observable changes** (and their opt-outs):

* Wrapper *reference* identity is now stable for recently-crossed objects, so script-attached state (`Object.freeze`, `defineProperty`, expandos) survives crossings. (`===` was already true — wrapper equality compares targets.)
* Under explicit `ArrayConversionMode.Copy`, repeated reads of the same CLR array now reuse the first JsArray snapshot while cached — CLR-side mutations are not re-copied. Full pre-4.14 semantics = `Copy` + `CacheRecentObjectWrappers = false`; the option XML doc spells this out and the snapshot-contract tests migrated to the explicit opt-out, mirroring the #2728 test migration.

**Benchmarks** (same machine, adjacent same-base A/B vs main@fed894d43, default job)

`InteropWrapperChurnBenchmark`:

| Row | main | PR | delta |
|---|---|---|---|
| ArrayMemberTraversal_DefaultLiveView | 19.35 µs / 13,944 B | 15.27 µs / **344 B** | −21% / −97.5% |
| ArrayMemberTraversal_LiveViewNoCache (new opt-out lane) | — | 19.51 µs / 13,944 B | reproduces the old default |
| SameObjectReturnedInLoop_DefaultFlag | 2.58 µs / 2,336 B | 2.45 µs / 2,016 B | wrapper reused |
| ArrayHoistedTraversal / Copy lanes | | | flat / allocation-identical |

`EngineComparisonInteropBenchmark` (Jint lane):

| Row | main | PR | delta |
|---|---|---|---|
| interop-collection-traversal | 2,288 µs / 1,659 KB | **1,501 µs / 332 KB** | **−34% / −80%** |
| interop-method-calls / property-access / string-passing | | | allocation byte-identical, time within run-to-run wobble |

Cumulative on this row across the 4.14 interop work (#2728 → #2730/#2731 → this PR): 15.6 ms / 32.9 MB → 1.50 ms / 0.33 MB.

**Gates**: full Jint.Tests (net10.0 + net472), Jint.Tests.PublicInterface, Test262 99,431 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
