### PR TITLE
Harden LiveView array wrappers and interop wrapper caches for 4.14

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
+++ b/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
@@ -1,3 +1,5 @@
+using Jint.Runtime.Interop;
+
 namespace Jint.Tests.Runtime;
 
 public partial class InteropTests
@@ -57,5 +59,40 @@ public partial class InteropTests
         engine.SetValue("host", new ArrayConversionHost());
 
         Assert.True(engine.Evaluate("host.Numbers === host.Numbers").AsBoolean());
+    }
+
+    [Fact]
+    public void IdentityMapHandlesExposedTypeChangeForArrays()
+    {
+        // the identity map may hold a wrapper for a different exposed view of the same array;
+        // a type-guard miss must replace the entry (last view wins), not throw on Add
+        var engine = new Engine(options =>
+        {
+            options.Interop.TrackObjectWrapperIdentity = true;
+            options.Interop.WrapObjectHandler = static (e, target, type) =>
+                ObjectWrapper.Create(e, target, target is int[] ? typeof(System.Collections.IList) : type);
+        });
+
+        var array = new[] { 1, 2, 3 };
+        engine.SetValue("a", array);
+        Assert.Equal(1, engine.Evaluate("a[0]").AsNumber());
+
+        engine.Options.Interop.WrapObjectHandler = static (e, target, type) => ObjectWrapper.Create(e, target, type);
+        engine.SetValue("b", array);
+        Assert.Equal(1, engine.Evaluate("b[0]").AsNumber());
+    }
+
+    [Fact]
+    public void DisposeReleasesRecentWrapperCache()
+    {
+        // the recent-wrapper ring is on by default and strongly roots its targets;
+        // Dispose must release them even when the opt-in identity map was never created
+        var engine = new Engine();
+        engine.SetValue("host", new ArrayConversionHost());
+        engine.Evaluate("host.Numbers[0]");
+        Assert.NotNull(engine._recentObjectWrapperCache);
+
+        engine.Dispose();
+        Assert.Null(engine._recentObjectWrapperCache);
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
+++ b/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
@@ -65,9 +65,95 @@ public partial class InteropTests
         Assert.Equal(8, engine.Evaluate("intList[1]").AsNumber());
         Assert.True(engine.Evaluate("stringList[1] === null").AsBoolean());
 
-        // out-of-range keeps the general converter's result
-        Assert.True(engine.Evaluate("ints[99] === null").AsBoolean());
-        Assert.True(engine.Evaluate("intList[99] === null").AsBoolean());
+        // out-of-range and negative indices read like JS array holes
+        Assert.True(engine.Evaluate("ints[99] === undefined").AsBoolean());
+        Assert.True(engine.Evaluate("ints[-1] === undefined").AsBoolean());
+        Assert.True(engine.Evaluate("intList[99] === undefined").AsBoolean());
+    }
+
+    [Fact]
+    public void LiveViewHonorsNonArrayDeclaredType()
+    {
+        var engine = new Engine();
+        var host = new ReadOnlyDeclaredArrayHolder();
+        engine.SetValue("h", host);
+
+        // reads are live views over the underlying array
+        Assert.Equal(2, engine.Evaluate("h.Data[1]").AsNumber());
+        host.Mutate(1, 42);
+        Assert.Equal(42, engine.Evaluate("h.Data[1]").AsNumber());
+
+        // an array exposed under a read-only declared type must not produce a writable view
+        engine.Evaluate("h.Data[0] = 99;");
+        Assert.Equal(1, host.Raw[0]);
+        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("'use strict'; h.Data[0] = 99;"));
+        Assert.Contains("read only", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, host.Raw[0]);
+    }
+
+    private class ReadOnlyDeclaredArrayHolder
+    {
+        private readonly int[] _data = [1, 2, 3];
+        public IReadOnlyList<int> Data => _data;
+        public int[] Raw => _data;
+        public void Mutate(int index, int value) => _data[index] = value;
+    }
+
+    [Fact]
+    public void ArrayUnderNonArrayDeclaredTypeDoesNotPoisonTypeMapper()
+    {
+        // the static type-mapper memoization must not register the array lane under a non-array
+        // declared type: a later non-array value of the same declared type would hit an
+        // InvalidCastException — and poison every engine in the process
+        var engine = new Engine();
+        engine.SetValue("a", new EnumerableHolder { Data = [1] });
+        Assert.Equal(1, engine.Evaluate("a.Data[0]").AsNumber());
+
+        engine.SetValue("b", new EnumerableHolder { Data = new List<int> { 2 } });
+        Assert.Equal(2, engine.Evaluate("b.Data[0]").AsNumber());
+    }
+
+    private class EnumerableHolder
+    {
+        public IEnumerable<int> Data { get; set; }
+    }
+
+    [Fact]
+    public void InOperatorMatchesJsArraySemantics()
+    {
+        var engine = new Engine();
+        engine.SetValue("a", new[] { 1, 2, 3 });
+        engine.SetValue("l", new List<int> { 1, 2, 3 });
+
+        Assert.True(engine.Evaluate("0 in a").AsBoolean());
+        Assert.True(engine.Evaluate("2 in a").AsBoolean());
+        Assert.False(engine.Evaluate("3 in a").AsBoolean());
+        Assert.False(engine.Evaluate("-1 in a").AsBoolean());
+        Assert.False(engine.Evaluate("'-1' in a").AsBoolean());
+        Assert.False(engine.Evaluate("4000000000 in a").AsBoolean());
+        Assert.True(engine.Evaluate("'1' in a").AsBoolean());
+        Assert.False(engine.Evaluate("'08' in a").AsBoolean());
+
+        Assert.True(engine.Evaluate("0 in l").AsBoolean());
+        Assert.False(engine.Evaluate("3 in l").AsBoolean());
+        Assert.False(engine.Evaluate("-1 in l").AsBoolean());
+    }
+
+    [Fact]
+    public void KeyEnumerationYieldsIndexKeys()
+    {
+        var engine = new Engine();
+        engine.SetValue("a", new[] { 1, 2, 3 });
+        engine.SetValue("l", new List<string> { "x", "y" });
+
+        Assert.Equal("0,1,2", engine.Evaluate("Object.keys(a).join()").AsString());
+        Assert.Equal("0,1", engine.Evaluate("Object.keys(l).join()").AsString());
+        Assert.Equal("0,1,2", engine.Evaluate("var s=[];for(var k in a)s.push(k);s.join()").AsString());
+        Assert.Equal("1,2,3", engine.Evaluate("Object.values(a).join()").AsString());
+        Assert.Equal("""{"0":1,"1":2,"2":3}""", engine.Evaluate("JSON.stringify({...a})").AsString());
+
+        // members stay accessible even though they no longer enumerate
+        Assert.Equal(3, engine.Evaluate("a.length").AsNumber());
     }
 
     private static Engine CreateCopyEngine(Action<Options> additionalConfiguration = null)

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -2269,6 +2269,11 @@ public sealed partial class Engine : IDisposable
 
     public void Dispose()
     {
+        // the recent-wrapper ring (on by default since 4.14) strongly roots its targets and wrappers,
+        // so a disposed-but-still-referenced engine must release them
+        _recentObjectWrapperCache?.Clear();
+        _recentObjectWrapperCache = null;
+
         if (_objectWrapperCache is null)
         {
             return;

--- a/Jint/Native/Array/ArrayOperations.cs
+++ b/Jint/Native/Array/ArrayOperations.cs
@@ -640,7 +640,8 @@ internal abstract class ArrayOperations : IEnumerable<JsValue>
 
         private JsValue ReadValue(int index)
         {
-            return (uint) index < _target.Length ? JsValue.FromObject(_target.Engine, _target.GetAt(index)) : JsValue.Undefined;
+            // GetJsValueAt converts common primitive element types without boxing
+            return (uint) index < _target.Length ? _target.GetJsValueAt(index) : JsValue.Undefined;
         }
 
         public override bool HasProperty(ulong index) => index < (ulong) _target.Length;

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -335,9 +335,10 @@ public class Options
         /// <summary>
         /// Whether identity map is persisted for object wrappers in order to maintain object identity. This can cause
         /// memory usage to grow when targeting large set and freeing of memory can be delayed due to ConditionalWeakTable semantics.
-        /// Also covers CLR arrays: repeated conversions of the same array instance return the same JsArray snapshot
-        /// (script-side mutations persist across reads; CLR-side mutations after the first conversion are not re-copied)
-        /// instead of copying every element on every read.
+        /// Also covers CLR arrays: repeated conversions of the same array instance return the same result — the live
+        /// wrapper view under <see cref="ArrayConversionMode.LiveView"/> (the default), or the same JsArray snapshot
+        /// under <see cref="ArrayConversionMode.Copy"/> (script-side mutations persist across reads; CLR-side mutations
+        /// after the first conversion are not re-copied) — instead of re-converting on every read.
         /// Defaults to false.
         /// </summary>
         public bool TrackObjectWrapperIdentity { get; set; }
@@ -757,11 +758,19 @@ public enum ArrayConversionMode
     /// <see cref="System.Collections.Generic.List{T}"/> instances already behave: element reads and writes go
     /// straight to the array in both directions, and wrapper identity across repeated crossings follows the same
     /// caches as other wrapped objects (<see cref="Options.InteropOptions.TrackObjectWrapperIdentity"/> /
-    /// <see cref="Options.InteropOptions.CacheRecentObjectWrappers"/>). The view is array-like — iteration,
-    /// <c>Array.prototype</c> methods and JSON serialization as an array all work — but it is not a JavaScript
-    /// array: <c>Array.isArray</c> returns <c>false</c>, and because CLR arrays are fixed-size any attempt to
-    /// resize the view (growing writes, <c>push</c>/<c>pop</c>, <c>length</c> writes) throws a <c>TypeError</c>.
+    /// <see cref="Options.InteropOptions.CacheRecentObjectWrappers"/>). An array crossing under a non-array
+    /// declared type keeps honoring that contract (for example a member typed <c>IReadOnlyList&lt;T&gt;</c>
+    /// produces a read-only view).
+    /// <para>
+    /// The view is array-like — iteration, <c>Array.prototype</c> methods, index-key enumeration
+    /// (<c>Object.keys</c> / <c>for-in</c>), out-of-range reads yielding <c>undefined</c> and JSON
+    /// serialization as an array all work — but it is not a JavaScript array: <c>Array.isArray</c> returns
+    /// <c>false</c> (while <c>instanceof Array</c> is <c>true</c> through the attached prototype), and because
+    /// CLR arrays are fixed-size the view behaves like an integer-indexed exotic object: resizing attempts
+    /// (growing writes, <c>push</c>/<c>pop</c>, <c>length</c> writes) throw a <c>TypeError</c>, and like for
+    /// typed arrays, <c>shift</c>/<c>splice</c> may move elements before their length change throws.
     /// Multi-dimensional arrays are not supported by the view and behave as under <see cref="Copy"/>.
+    /// </para>
     /// </summary>
     LiveView,
 }

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -50,15 +50,34 @@ internal static class DefaultObjectConverter
         {
             if (value is Array a)
             {
-                // racy, we don't care, worst case we'll catch up later
-                Interlocked.CompareExchange(ref _typeMappers,
-                    new Dictionary<Type, Func<Engine, object, JsValue>>(typeMappers)
-                    {
-                        [valueType] = ConvertArray
-                    }, typeMappers);
+                if (valueType.IsArray)
+                {
+                    // memoization is only valid when the exposed type itself is an array type: every
+                    // future value crossing under it is an Array. A non-array exposed type (IEnumerable<T>,
+                    // IReadOnlyList<T>, ...) can later carry a List<T> or other non-array value, and
+                    // _typeMappers is a static cross-engine map — baking ConvertArray under such a type
+                    // would poison every engine in the process.
+                    // racy, we don't care, worst case we'll catch up later
+                    Interlocked.CompareExchange(ref _typeMappers,
+                        new Dictionary<Type, Func<Engine, object, JsValue>>(typeMappers)
+                        {
+                            [valueType] = ConvertArray
+                        }, typeMappers);
 
-                result = ConvertArray(engine, a);
-                return result is not null;
+                    result = ConvertArray(engine, a);
+                    return result is not null;
+                }
+
+                if (engine.Options.Interop.ArrayConversion == ArrayConversionMode.Copy)
+                {
+                    result = ConvertArray(engine, a);
+                    return result is not null;
+                }
+
+                // LiveView with a non-array exposed type: fall through to the wrapper lane below so the
+                // view honors the declared contract the same way other collections do — an array exposed
+                // as IReadOnlyList<T> must produce a read-only view, not a writable one keyed off the
+                // runtime type.
             }
 
             if (value is IConvertible convertible && TryConvertConvertible(engine, convertible, out result))
@@ -264,7 +283,7 @@ internal static class DefaultObjectConverter
         }
 
         if (e.Options.Interop.ArrayConversion == ArrayConversionMode.LiveView
-            && TryConvertArrayLiveView(e, v, out var liveView))
+            && TryConvertArrayLiveView(e, v, arrayType, out var liveView))
         {
             return liveView;
         }
@@ -283,6 +302,9 @@ internal static class DefaultObjectConverter
         if (e.Options.Interop.TrackObjectWrapperIdentity)
         {
             e._objectWrapperCache ??= new ConditionalWeakTable<object, ObjectInstance>();
+            // the table may hold a wrapper for a different exposed view of the same
+            // object (the type-guarded lookup above missed it) — last view wins
+            e._objectWrapperCache.Remove(v);
             e._objectWrapperCache.Add(v, result);
         }
         else if (e.Options.Interop.CacheRecentObjectWrappers)
@@ -301,9 +323,8 @@ internal static class DefaultObjectConverter
     /// plus the flag-gated identity caches — already consulted by the caller). Multi-rank (T[,]) and
     /// non-zero-based (T[*]) arrays return false so they keep the Copy-mode failure behavior.
     /// </summary>
-    private static bool TryConvertArrayLiveView(Engine e, object v, [NotNullWhen(true)] out JsValue? result)
+    private static bool TryConvertArrayLiveView(Engine e, object v, Type arrayType, [NotNullWhen(true)] out JsValue? result)
     {
-        var arrayType = v.GetType();
         if (arrayType.GetElementType() is not { } elementType
             || arrayType != elementType.MakeArrayType())
         {
@@ -322,6 +343,9 @@ internal static class DefaultObjectConverter
         if (e.Options.Interop.TrackObjectWrapperIdentity)
         {
             e._objectWrapperCache ??= new ConditionalWeakTable<object, ObjectInstance>();
+            // the table may hold a wrapper for a different exposed view of the same
+            // object (the type-guarded lookup above missed it) — last view wins
+            e._objectWrapperCache.Remove(v);
             e._objectWrapperCache.Add(v, wrapped);
         }
         else if (e.Options.Interop.CacheRecentObjectWrappers)
@@ -376,5 +400,12 @@ internal sealed class RecentObjectWrapperCache
         _targets[index] = target;
         _wrappers[index] = wrapper;
         _next = (index + 1) & (Capacity - 1);
+    }
+
+    public void Clear()
+    {
+        Array.Clear(_targets, 0, _targets.Length);
+        Array.Clear(_wrappers, 0, _wrappers.Length);
+        _next = 0;
     }
 }

--- a/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.Specialized.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using Jint.Extensions;
 using Jint.Native;
+using Jint.Native.Array;
 
 namespace Jint.Runtime.Interop;
 
@@ -37,13 +38,22 @@ internal sealed class ReadOnlyListWrapperFactory<[DynamicallyAccessedMembers(Dyn
 
 internal abstract class ArrayLikeWrapper : ObjectWrapper
 {
+    /// <summary>
+    /// Whether indexed element access can execute user CLR code (a custom IList/IReadOnlyList
+    /// implementation). Plain memory-backed targets (T[], List&lt;T&gt;) skip the host-boundary
+    /// constraint probe on the per-element hot path.
+    /// </summary>
+    private readonly bool _elementAccessMayRunHostCode;
+
     protected ArrayLikeWrapper(
         Engine engine,
         object obj,
         Type itemType,
-        Type? type = null) : base(engine, obj, type)
+        Type? type,
+        bool elementAccessMayRunHostCode) : base(engine, obj, type)
     {
         ItemType = itemType;
+        _elementAccessMayRunHostCode = elementAccessMayRunHostCode;
         if (engine.Options.Interop.AttachArrayPrototype)
         {
             Prototype = engine.Intrinsics.Array.PrototypeObject;
@@ -59,9 +69,19 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
     {
         if (property.IsInteger())
         {
-            var result = GetJsValueAt(property.AsInteger());
-            _engine.CheckAmortizedConstraintsAtHostBoundary();
-            return result;
+            var index = property.AsInteger();
+            if ((uint) index < (uint) Length)
+            {
+                var result = GetJsValueAt(index);
+                if (_elementAccessMayRunHostCode)
+                {
+                    _engine.CheckAmortizedConstraintsAtHostBoundary();
+                }
+                return result;
+            }
+
+            // out-of-range and negative indices read like JS array holes
+            return Undefined;
         }
 
         return base.Get(property, receiver);
@@ -69,16 +89,38 @@ internal abstract class ArrayLikeWrapper : ObjectWrapper
 
     public sealed override bool HasProperty(JsValue property)
     {
+        // dictionary-shaped targets (e.g. Newtonsoft's JObject: both IDictionary<string,_> and IList<_>)
+        // answer membership by key, not by index range
+        if (_typeDescriptor.IsDictionary)
+        {
+            return base.HasProperty(property);
+        }
+
         if (property.IsNumber())
         {
             var value = ((JsNumber) property)._value;
             if (TypeConverter.IsIntegralNumber(value))
             {
-                var index = (int) value;
-                if (Target is ICollection collection && index < collection.Count)
-                {
-                    return true;
-                }
+                // numeric membership of an array-like view is exactly the index range [0, Length);
+                // falling through would consult the reflected indexer, which reports presence for
+                // any parseable index (so e.g. "-1 in view" would be true). Compare as double so a
+                // negative or out-of-int-range index can never alias into range.
+                return value >= 0 && value < Length;
+            }
+        }
+        else if (property is JsString jsString)
+        {
+            var str = jsString.ToString();
+            var index = ArrayInstance.ParseArrayIndex(str);
+            if (index != uint.MaxValue)
+            {
+                return index < (uint) Length;
+            }
+            // an integer-shaped but non-canonical key ("-1", "08") is not a member of the view
+            // either, and must not fall through to the reflected indexer's presence-only answer
+            if (long.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+            {
+                return false;
             }
         }
 
@@ -338,7 +380,7 @@ internal sealed class ListWrapper : ArrayLikeWrapper
     private readonly IList? _list;
 
     internal ListWrapper(Engine engine, IList target, Type type)
-        : base(engine, target, typeof(object), type)
+        : base(engine, target, typeof(object), type, elementAccessMayRunHostCode: target is not (Array or ArrayList))
     {
         _list = target;
     }
@@ -375,7 +417,7 @@ internal class GenericListWrapper<[DynamicallyAccessedMembers(DynamicallyAccesse
     private readonly IList<T> _list;
 
     public GenericListWrapper(Engine engine, IList<T> target, Type? type)
-        : base(engine, target, typeof(T), type)
+        : base(engine, target, typeof(T), type, elementAccessMayRunHostCode: target is not (T[] or List<T>))
     {
         _list = target;
     }
@@ -400,8 +442,8 @@ internal class GenericListWrapper<[DynamicallyAccessedMembers(DynamicallyAccesse
             return TryConvertCommonItem(ref item) ?? FromObject(_engine, item);
         }
 
-        // preserve the out-of-range result of the boxing path (null → JS null)
-        return base.GetJsValueAt(index);
+        // defensive: callers bounds-check; out-of-range reads like a JS array hole
+        return Undefined;
     }
 
     protected override void DoSetAt(int index, object? value) => _list[index] = (T) value!;
@@ -429,7 +471,7 @@ internal sealed class ArrayWrapper<[DynamicallyAccessedMembers(DynamicallyAccess
     private readonly T[] _array;
 
     public ArrayWrapper(Engine engine, T[] target, Type? type)
-        : base(engine, target, typeof(T), type)
+        : base(engine, target, typeof(T), type, elementAccessMayRunHostCode: false)
     {
         _array = target;
     }
@@ -458,8 +500,8 @@ internal sealed class ArrayWrapper<[DynamicallyAccessedMembers(DynamicallyAccess
             return TryConvertCommonItem(ref item) ?? FromObject(_engine, item);
         }
 
-        // preserve the out-of-range result of the boxing path (null → JS null)
-        return base.GetJsValueAt(index);
+        // defensive: callers bounds-check; out-of-range reads like a JS array hole
+        return Undefined;
     }
 
     protected override void DoSetAt(int index, object? value)
@@ -495,7 +537,8 @@ internal sealed class ReadOnlyListWrapper<[DynamicallyAccessedMembers(Dynamicall
 {
     private readonly IReadOnlyList<T> _list;
 
-    public ReadOnlyListWrapper(Engine engine, IReadOnlyList<T> target, Type type) : base(engine, target, typeof(T), type)
+    public ReadOnlyListWrapper(Engine engine, IReadOnlyList<T> target, Type type)
+        : base(engine, target, typeof(T), type, elementAccessMayRunHostCode: target is not (T[] or List<T>))
     {
         _list = target;
     }
@@ -520,8 +563,8 @@ internal sealed class ReadOnlyListWrapper<[DynamicallyAccessedMembers(Dynamicall
             return TryConvertCommonItem(ref item) ?? FromObject(_engine, item);
         }
 
-        // preserve the out-of-range result of the boxing path (null → JS null)
-        return base.GetJsValueAt(index);
+        // defensive: callers bounds-check; out-of-range reads like a JS array hole
+        return Undefined;
     }
 
     protected override bool CanWrite => false;

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -586,6 +586,19 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                 }
             }
         }
+        else if (includeStrings && this is ArrayLikeWrapper arrayLike)
+        {
+            // array-like views enumerate like JS arrays: index keys, not reflected CLR member names —
+            // Object.keys / for-in / spread over a wrapped array or list must yield "0".."n-1"
+            // (members like Length or Count stay accessible, they just don't enumerate). Dictionary-shaped
+            // targets (e.g. Newtonsoft's JObject, which is both IDictionary<string,_> and IList<_>)
+            // are handled by the dictionary branches above.
+            var length = arrayLike.Length;
+            for (var i = 0; i < length; i++)
+            {
+                yield return JsString.Create(i);
+            }
+        }
         else if (includeStrings)
         {
             var interopOptions = _engine.Options.Interop;


### PR DESCRIPTION
Pre-release review hardening for the 4.14 default flips (`Interop.ArrayConversion = LiveView`, `Interop.CacheRecentObjectWrappers = true`). All issues below were verified with concrete repros before fixing.

## Correctness fixes

- **Read-only declared types produced writable live views.** `TryConvert` routed any runtime array through the LiveView lane keyed off `value.GetType()`, dropping the declared member type — so `IReadOnlyList<int>` backed by `int[]` came out as a writable `ArrayWrapper<int>` and `h.Data[0] = 42` silently mutated host state through a read-only API. Arrays crossing under a non-array declared type now flow through the regular wrapper lane and honor the declared contract (read-only view for `IReadOnlyList<T>`), the same way other collections already do. Copy mode keeps its snapshot behavior for such members.
- **Static type-mapper poisoning (pre-existing, crash).** The `_typeMappers` memoization registered `ConvertArray` under the *declared* type; with `IEnumerable<int>` first carrying `int[]` and later `List<int>`, the memoized mapper cast the list to `Array` → `InvalidCastException` — and since the map is static, one engine's conversion poisoned every engine in the process. Memoization now only happens when the declared type itself is an array type.
- **Identity-map `ArgumentException` on exposed-type change.** `ConvertArray`'s CWT inserts lacked the Remove-before-Add the general lane got with the type-guarded probe; a type-guard miss followed by `Add` threw. Last view wins now, matching the general lane.
- **`Engine.Dispose` leaked the recent-wrapper ring.** It early-returned when the opt-in identity map was never created — the common configuration since the cache default flip — leaving up to 8 host objects strongly rooted by a disposed engine.
- **`Object.keys` / `for-in` / spread on host arrays yielded reflected CLR member names** (`Length,LongLength,Rank,...`) instead of the `0,1,2` the 4.13 Copy default produced. Array-like wrappers now enumerate index keys like JS arrays; members stay accessible, they just don't enumerate. Dictionary-shaped hybrids (Newtonsoft `JObject` is both `IDictionary<string,_>` and `IList<_>`) keep dictionary key enumeration. Note this also applies to wrapped lists, which previously enumerated `Capacity,Count`.
- **`-1 in hostArray` was `true`.** The fall-through consulted the reflected indexer, which reports presence for any parseable index. Numeric membership of an array-like view is now exactly `[0, length)`, including string-form and non-canonical keys (`'-1'`, `'08'`).
- **Out-of-range reads returned `null` instead of `undefined`,** breaking `while (a[i] !== undefined)` idioms; they now read like JS array holes (matching `ArrayLikeOperations.Get`, which already did this).

## Perf

- `Array.prototype` methods (`map`/`join`/`filter`/`forEach`/`indexOf`) on array-like wrappers routed element reads through the boxing path (`GetAt` + `FromObject`), missing the #2731 boxing-free lane entirely; `ArrayLikeOperations.ReadValue` now uses `GetJsValueAt`.
- The per-element host-boundary constraint probe in the indexed `Get` lane is skipped for plain memory-backed targets (`T[]`, `List<T>`) where element access cannot execute user CLR code; custom `IList<T>`/`IReadOnlyList<T>` implementations keep the post-access probe.

## Docs

`ArrayConversionMode.LiveView` and `TrackObjectWrapperIdentity` XML docs updated: declared-type behavior, index-key enumeration, `undefined` for out-of-range reads, `instanceof Array` vs `Array.isArray`, and the typed-array-like partial-write behavior of `shift`/`splice` on fixed-size views.

Full suite green on net10.0 + net472 (Jint.Tests, PublicInterface, CommonScripts) and Test262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115tQFNyyQqc1HQGPLUgZND