### PR TITLE
Keep execution-context depth balanced under raw constraint exceptions

### DIFF
--- a/Jint.Tests/Runtime/ExecutionConstraintTests.cs
+++ b/Jint.Tests/Runtime/ExecutionConstraintTests.cs
@@ -972,6 +972,112 @@ myarr[0](0);
         Assert.Equal(1, probe.Accesses);
     }
 
+    [Fact]
+    public void ConstraintThrowInsideGeneratorResumeDoesNotPoisonHostBoundaryGate()
+    {
+        // a raw constraint exception thrown inside a resumed generator frame used to skip the
+        // execution-context pop, permanently satisfying the depth-keyed host-boundary gate: every
+        // later C#-side read of a wrapped object then re-observed the constraints while idle
+        using var cts = new CancellationTokenSource();
+        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
+        var probe = new HostBoundaryProbe();
+        engine.SetValue("probe", probe);
+        engine.SetValue("cancel", new Action(cts.Cancel));
+
+        engine.Execute("function* g() { cancel(); while (true) { } } var it = g();");
+        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("it.next();"));
+
+        // the token stays cancelled; only a leaked frame would make this idle read observe it
+        var wrapper = engine.GetValue("probe").AsObject();
+        Assert.Equal(42, wrapper.Get("value").AsNumber());
+    }
+
+    [Fact]
+    public void ConstraintThrowInsideAsyncResumeDoesNotPoisonHostBoundaryGate()
+    {
+        using var cts = new CancellationTokenSource();
+        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
+        var probe = new HostBoundaryProbe();
+        engine.SetValue("probe", probe);
+        engine.SetValue("cancel", new Action(cts.Cancel));
+
+        var gate = engine.Advanced.RegisterPromise();
+        engine.SetValue("gate", gate.Promise);
+        engine.Evaluate("(async () => { await gate; cancel(); })()");
+
+        Assert.Throws<ExecutionCanceledException>(() => gate.Resolve(JsValue.Undefined));
+
+        var wrapper = engine.GetValue("probe").AsObject();
+        Assert.Equal(42, wrapper.Get("value").AsNumber());
+    }
+
+    [Fact]
+    public void ConstraintThrowInsideAsyncGeneratorResumeDoesNotPoisonHostBoundaryGate()
+    {
+        using var cts = new CancellationTokenSource();
+        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
+        var probe = new HostBoundaryProbe();
+        engine.SetValue("probe", probe);
+        engine.SetValue("cancel", new Action(cts.Cancel));
+
+        engine.Execute("async function* ag() { cancel(); yield 1; } var it = ag();");
+        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("it.next();"));
+
+        var wrapper = engine.GetValue("probe").AsObject();
+        Assert.Equal(42, wrapper.Get("value").AsNumber());
+    }
+
+    [Fact]
+    public void ShadowRealmImportFailureDoesNotPoisonHostBoundaryGate()
+    {
+        // module resolution failures surface as ModuleResolutionException (not JavaScriptException);
+        // the ShadowRealm import lane must still pop the execution context it entered
+        using var cts = new CancellationTokenSource();
+        var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
+        var probe = new HostBoundaryProbe();
+        engine.SetValue("probe", probe);
+
+        engine.Execute("var sr = new ShadowRealm();");
+        Assert.ThrowsAny<Exception>(() => engine.Evaluate("sr.importValue('./does-not-exist.js', 'x')"));
+
+        cts.Cancel();
+        var wrapper = engine.GetValue("probe").AsObject();
+        Assert.Equal(42, wrapper.Get("value").AsNumber());
+    }
+
+    [Fact]
+    public void NestedEngineReentryDoesNotResetOuterConstraints()
+    {
+        // a host callback calling back into the engine re-enters ExecuteWithConstraints; the nested
+        // run must not re-arm the outer script's budget — "while (true) reenter();" would otherwise
+        // reset the statement counter (and timeout) on every iteration and run forever
+        var engine = new Engine(cfg => cfg.MaxStatements(5000));
+
+        var calls = 0;
+        engine.SetValue("reenter", new Action(() =>
+        {
+            if (++calls > 100_000)
+            {
+                throw new InvalidOperationException("outer budget was reset by nested evaluation");
+            }
+            engine.Evaluate("1;");
+        }));
+
+        Assert.Throws<StatementsCountOverflowException>(() => engine.Execute("while (true) { reenter(); }"));
+        Assert.True(calls < 5000);
+    }
+
+    [Fact]
+    public void SequentialTopLevelExecutionsStillResetConstraints()
+    {
+        // the nested-entry guard must not affect sequential top-level runs: each gets a fresh budget
+        var engine = new Engine(cfg => cfg.MaxStatements(100));
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.Equal(90, engine.Evaluate("var x = 0; for (var j = 0; j < 30; j++) { x += 3; } x;").AsNumber());
+        }
+    }
+
     private sealed class HostBoundaryProbe
     {
         public int Accesses;

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -889,6 +889,15 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     internal void CheckAmortizedConstraints()
     {
+        if (_debuggerEvaluating)
+        {
+            // a watch / conditional-breakpoint expression evaluated while paused past the timeout
+            // must not fail; the same exemption the host-boundary gate applies (see
+            // CheckAmortizedConstraintsAtHostBoundary), extended to the per-statement cadence so a
+            // longer debugger expression doesn't trip the countdown either
+            return;
+        }
+
         foreach (var constraint in _amortizedConstraints)
         {
             constraint.Check();
@@ -1248,7 +1257,17 @@ public sealed partial class Engine : IDisposable
 
     internal T ExecuteWithConstraints<T>(bool strict, Func<T> callback)
     {
-        ResetConstraints();
+        // A nested call — a host callback inside a running script calling back into the engine —
+        // must not re-arm the outer run's constraints: the outer budget (time/statements) keeps
+        // applying to everything the outer script triggers, otherwise `while (true) hostCallback()`
+        // where the callback re-enters the engine would reset the timeout on every iteration and
+        // run forever. Keyed on execution-context depth, the same signal the host-boundary
+        // constraint gate uses.
+        var isNested = _executionContexts.Count > 1;
+        if (!isNested)
+        {
+            ResetConstraints();
+        }
 
         var ownsContext = _activeEvaluationContext is null;
         _activeEvaluationContext ??= new EvaluationContext(this);
@@ -1266,7 +1285,10 @@ public sealed partial class Engine : IDisposable
             {
                 _activeEvaluationContext = null!;
             }
-            ResetConstraints();
+            if (!isNested)
+            {
+                ResetConstraints();
+            }
             _agent.ClearKeptObjects();
         }
     }

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
@@ -279,6 +279,14 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
                 final => SettleResumeRejection(final.Value, promiseCapability));
             return;
         }
+        catch
+        {
+            // a raw constraint exception (TimeoutException, ExecutionCanceledException) must not leak
+            // the entered frame: the execution-context depth gates the host-boundary constraint
+            // checks, and a leaked frame would satisfy the gate forever
+            _engine.LeaveExecutionContext();
+            throw;
+        }
 
         // Check if suspended at an await expression
         if (_awaitSuspended)

--- a/Jint/Native/Generator/GeneratorInstance.cs
+++ b/Jint/Native/Generator/GeneratorInstance.cs
@@ -240,8 +240,18 @@ internal sealed class GeneratorInstance : ObjectInstance, ISuspendable
         _generatorState = GeneratorState.Executing;
         _engine.EnterExecutionContext(genContext);
 
-        var result = _generatorBody.Execute(context);
-        _engine.LeaveExecutionContext();
+        Completion result;
+        try
+        {
+            result = _generatorBody.Execute(context);
+        }
+        finally
+        {
+            // a raw constraint exception (TimeoutException, ExecutionCanceledException) thrown inside
+            // the body must not skip the pop: the execution-context depth gates the host-boundary
+            // constraint checks, and a leaked frame would satisfy the gate forever
+            _engine.LeaveExecutionContext();
+        }
 
         // https://tc39.es/ecma262/#sec-generatorstart step 4.i-j
         // Dispose resources when generator body completes (not when yielding)

--- a/Jint/Native/ShadowRealm/ShadowRealm.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealm.cs
@@ -291,8 +291,17 @@ public sealed class ShadowRealm : ObjectInstance
         // 4. If runningContext is not already suspended, suspend runningContext.
 
         _engine.EnterExecutionContext(_executionContext);
-        _engine._host.LoadImportedModule(null, new ModuleRequest(specifierString, []), innerCapability);
-        _engine.LeaveExecutionContext();
+        try
+        {
+            _engine._host.LoadImportedModule(null, new ModuleRequest(specifierString, []), innerCapability);
+        }
+        finally
+        {
+            // module resolution failures throw ModuleResolutionException (not JavaScriptException);
+            // the entered frame must not leak — the execution-context depth gates the
+            // host-boundary constraint checks
+            _engine.LeaveExecutionContext();
+        }
 
         var onFulfilled = new StepsFunction(_engine, callerRealm, exportNameString);
         var promiseCapability = PromiseConstructor.NewPromiseCapability(_engine, _engine.Realm.Intrinsics.Promise);

--- a/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
@@ -262,6 +262,14 @@ internal sealed class JintAwaitExpression : JintExpression
                 final => SettleAsyncResumeCompletion(engine, asyncInstance, final));
             return;
         }
+        catch
+        {
+            // a raw constraint exception (TimeoutException, ExecutionCanceledException) must not leak
+            // the entered frame: the execution-context depth gates the host-boundary constraint
+            // checks, and a leaked frame would satisfy the gate forever
+            engine.LeaveExecutionContext();
+            throw;
+        }
 
         if (asyncInstance._state == AsyncFunctionState.SuspendedAwait)
         {

--- a/Jint/Runtime/Modules/SourceTextModule.cs
+++ b/Jint/Runtime/Modules/SourceTextModule.cs
@@ -452,6 +452,14 @@ internal class SourceTextModule : CyclicModule
                     }
                     return new Completion(CompletionType.Normal, JsValue.Undefined, null!);
                 }
+                catch
+                {
+                    // a raw constraint exception (TimeoutException, ExecutionCanceledException) must
+                    // not leak the entered frame: the execution-context depth gates the host-boundary
+                    // constraint checks, and a leaked frame would satisfy the gate forever
+                    _engine.LeaveExecutionContext();
+                    throw;
+                }
 
                 // Check if we suspended at an await
                 if (_tlaAsyncInstance._state == AsyncFunctionState.SuspendedAwait)


### PR DESCRIPTION
Pre-release review follow-up to the #2713–#2715 host-boundary constraint mechanism. The depth-keyed gate made execution-context push/pop balance a load-bearing invariant under **every** exception type, but several resume lanes only handled `JavaScriptException`:

- `GeneratorInstance.ResumeExecution` had no try/finally at all
- `AsyncFunctionResume`, `AsyncGeneratorInstance.ResumeExecution` and the top-level-await arm of `SourceTextModule.ExecuteModule` caught only `JavaScriptException`
- `ShadowRealm.ShadowRealmImportValue` leaked its frame when module resolution threw `ModuleResolutionException`

A raw constraint exception (`TimeoutException`, `ExecutionCanceledException`) unwinding one of these frames skipped the pop, leaving `_executionContexts.Count` elevated for the engine's lifetime — after which the depth gate was satisfied while the engine was idle, and every later C#-side read of a wrapped object re-observed the re-armed/cancelled constraints. Exactly the failure mode the gate exists to prevent; `HostSideAccessToWrappedObjectDoesNotObserveExpiredTimeoutAfterExecution` passed only because its script avoided generator/async frames. The leak shapes predate 4.14, but the depth gate is what made them observable.

Fixes: try/finally in the generator lane (pops are unconditional there), and a rebalancing catch-all (`Leave` + rethrow) in the async lanes whose pops are deferred into settle/dispose continuations — a blanket finally would double-pop there.

Two adjacent gaps from the same review:

- **Nested re-entry reset the outer budget.** `ExecuteWithConstraints` called `ResetConstraints()` unconditionally, so `while (true) hostCallbackThatCallsEvaluate()` re-armed the outer script's timeout/statement budget on every iteration and ran forever, contradicting the "detection latency bounded by one host call" guarantee. Nested entries (keyed on the same depth signal) now skip both resets; sequential top-level runs keep getting a fresh budget (covered by a new test plus the existing `ResetConstraints` test).
- **Debugger-evaluation exemption was incomplete.** The `_debuggerEvaluating` gate covered host-boundary checks but not the per-statement amortized countdown, so a ≥64-statement watch expression evaluated while paused past the timeout still threw. The exemption now covers the countdown too.

All new tests are deterministic (cancellation-token / statement-count based, no wall-clock). The generator/async/async-generator tests fail without the balance fixes (verified by reverting).

Full suite green on net10.0 + net472 (Jint.Tests, PublicInterface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115tQFNyyQqc1HQGPLUgZND