### PR TITLE
Decline the compiled-invoker fast lane for custom type converters and foreign receivers

### DIFF
--- a/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
+++ b/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
@@ -200,4 +200,59 @@ public class InteropCompiledInvokerTests
             return false;
         }
     }
+
+    [Fact]
+    public void CustomTypeConverterStillIntercepts()
+    {
+        // a user-installed ITypeConverter participates in some exact-type argument conversions on
+        // the slow path (e.g. bool); the fast lane must decline so it keeps being consulted
+        var engine = new Engine(options => options.SetTypeConverter(e => new BoolVetoingTypeConverter(e)));
+        engine.SetValue("host", new Host());
+
+        var ex = Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("host.And(true, true)"));
+        Assert.Contains("No public methods", ex.Message);
+
+        // conversions the veto does not touch keep working
+        Assert.Equal(5, engine.Evaluate("host.AddInt(2, 3)").AsNumber());
+    }
+
+    private sealed class BoolVetoingTypeConverter : Jint.Runtime.Interop.DefaultTypeConverter
+    {
+        public BoolVetoingTypeConverter(Engine engine) : base(engine)
+        {
+        }
+
+        public override bool TryConvert(object? value, Type type, IFormatProvider formatProvider, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? converted)
+        {
+            if (type == typeof(bool))
+            {
+                converted = null;
+                return false;
+            }
+
+            return base.TryConvert(value, type, formatProvider, out converted);
+        }
+    }
+
+    [Fact]
+    public void WrongTypedThisSurfacesReflectionPathException()
+    {
+        // an extracted method invoked with a foreign receiver must decline the fast lane so the
+        // host observes the same TargetException the reflection path always produced (not the
+        // compiled cast's InvalidCastException) — ExceptionHandler predicates key on the type
+        var engine = new Engine(options => options.Interop.ExceptionHandler = _ => false);
+        engine.SetValue("host", new Host());
+        engine.SetValue("other", new OtherHost());
+
+        var ex = Assert.ThrowsAny<Exception>(() => engine.Evaluate("var f = host.TimesTwo; f.call(other, 21)"));
+        Assert.IsAssignableFrom<System.Reflection.TargetException>(ex);
+
+        // a correctly-typed extracted call still uses the fast lane and works
+        Assert.Equal(42, engine.Evaluate("var g = host.TimesTwo; g.call(host, 21)").AsNumber());
+    }
+
+    public sealed class OtherHost
+    {
+        public int Unrelated => 1;
+    }
 }

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -173,8 +173,15 @@ internal sealed class MethodInfoFunction : Function
 #if NET8_0_OR_GREATER
                 // exact-type fast lane: a compiled delegate binds and invokes without the object?[]
                 // parameter array, argument boxes, boxed return, and return-mapper lookup. Skipped
-                // when custom object converters are registered because those must see return values.
-                if (_engine._objectConverters is null && method.GetCompiledInvoker() is { } compiledInvoker)
+                // when custom object converters are registered because those must see return values,
+                // and when a custom ITypeConverter is installed because the slow path consults it for
+                // some exact-type conversions (e.g. bool) that the compiled lane performs directly.
+                // A wrong-typed receiver (extracted method invoked via .call on a foreign this) also
+                // declines so the reflection path surfaces the same TargetException it always did.
+                if (_engine._objectConverters is null
+                    && _engine.TypeConverter.GetType() == typeof(DefaultTypeConverter)
+                    && method.GetCompiledInvoker() is { } compiledInvoker
+                    && (method.Method.IsStatic || method.Method.DeclaringType?.IsInstanceOfType(thisObj) == true))
                 {
                     JsValue compiledResult = null!;
                     bool handled;


### PR DESCRIPTION
Pre-release review follow-up to #2733. Two behavior-parity gaps in the exact-type compiled fast lane, both verified with repros against 4.13 behavior:

1. **Custom `ITypeConverter` bypass.** The gate checked `_objectConverters` but not the engine's user-replaceable `TypeConverter`. The reflection path consults it for some exact-type argument conversions (a `bool` argument under default value coercion flows through `converter.TryConvert`), so a converter installed via `SetTypeConverter` that vetoes/transforms those conversions was silently skipped and calls succeeded that previously failed (or were transformed). The lane now requires the exact `DefaultTypeConverter` type — `TryConvert` is virtual, so an `is` check would not do.
2. **Foreign-receiver exception drift.** `var f = host.method; f.call(other)` surfaced `InvalidCastException` from the compiled receiver cast instead of the reflection path's `TargetException`. Host `catch` clauses and `Interop.ExceptionHandler` predicates key on the exception type. The lane now declines when the receiver is not an instance of the declaring type (one `isinst` per call), letting the slow path surface the original exception shape.

Both new tests fail without the gate changes (verified by reverting). Full suite green on net10.0 + net472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115tQFNyyQqc1HQGPLUgZND