### PR TITLE
Align JSON.parse with the JSON grammar for numbers, line separators and keys

### DIFF
--- a/Jint.Tests/Runtime/JsonTests.cs
+++ b/Jint.Tests/Runtime/JsonTests.cs
@@ -657,17 +657,60 @@ public class JsonTests
     }
 
     [Fact]
-    public void BulkScanPreservesUnicodeLineSeparatorTermination()
+    public void UnicodeLineSeparatorsAreValidInsideStrings()
     {
-        // U+2028 / U+2029 terminate the string scan with the quote still open, which the original
-        // char-by-char scanner reported as UnexpectedEOS just past the separator. Lock that in.
+        // the JSON grammar permits any code point except '"', '\' and control characters (< 0x20)
+        // raw inside a string, including the Unicode line separators U+2028 / U+2029 (which V8
+        // accepts too); they historically terminated the scan with an UnexpectedEOS error
         var parser = new JsonParser(new Engine());
 
-        var ex = Assert.ThrowsAny<JavaScriptException>(() => parser.Parse("\"ab\u2028cd\""));
-        Assert.Equal("Unexpected end of JSON input at position 4", ex.Message);
+        Assert.Equal("ab\u2028cd", parser.Parse("\"ab\u2028cd\"").AsString());
+        Assert.Equal("ab\u2029cd", parser.Parse("\"ab\u2029cd\"").AsString());
+    }
 
-        var ex2 = Assert.ThrowsAny<JavaScriptException>(() => parser.Parse("\"ab\u2029cd\""));
-        Assert.Equal("Unexpected end of JSON input at position 4", ex2.Message);
+    [Fact]
+    public void EscapedControlCharactersAreValidInPropertyKeys()
+    {
+        // any string is a valid member key; escaped control characters were rejected in keys
+        // while being accepted in values
+        var parser = new JsonParser(new Engine());
+
+        Assert.Equal(1, parser.Parse("{\"\\u0001\":1}").AsObject().Get("\u0001").AsNumber());
+        Assert.Equal(2, parser.Parse("{\"a\\u0000b\":2}").AsObject().Get("a\u0000b").AsNumber());
+
+        // raw (unescaped) control characters keep being rejected, in keys and values alike
+        Assert.ThrowsAny<JavaScriptException>(() => parser.Parse("{\"\u0001\":1}"));
+    }
+
+    [Theory]
+    [InlineData("-09")]
+    [InlineData("-00")]
+    [InlineData("-01.5")]
+    [InlineData("1.")]
+    [InlineData("1.e3")]
+    [InlineData("-2.")]
+    public void InvalidNumberFormsAreRejected(string json)
+    {
+        // int = zero / (digit1-9 *DIGIT) - also after a sign; frac = decimal-point 1*DIGIT
+        var parser = new JsonParser(new Engine());
+        Assert.ThrowsAny<JavaScriptException>(() => parser.Parse(json));
+    }
+
+    [Theory]
+    [InlineData("-0", -0.0)]
+    [InlineData("0", 0.0)]
+    [InlineData("-0.5", -0.5)]
+    [InlineData("10.25", 10.25)]
+    [InlineData("-0e2", -0.0)]
+    public void ValidNumberFormsKeepParsing(string json, double expected)
+    {
+        var parser = new JsonParser(new Engine());
+        var value = parser.Parse(json).AsNumber();
+        Assert.Equal(expected, value);
+#if !NETFRAMEWORK
+        // .NET Framework's double.Parse loses the sign of negative zero (fixed in .NET Core 3.0)
+        Assert.Equal(double.IsNegativeInfinity(1 / expected), double.IsNegativeInfinity(1 / value));
+#endif
     }
 
     private const NumberStyles JsonNumberStyles =

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -261,7 +261,9 @@ public sealed class JsonParser
 
             // Hex number starts with '0x'.
             // Octal number starts with '0'.
-            if (sb.Length == 1 && firstCharacter == '0')
+            // This runs right after the first digit was appended (a possible sign does not matter),
+            // so the leading-zero rule also rejects '-09' per the JSON grammar (int = zero / digit1-9 *DIGIT).
+            if (firstCharacter == '0')
             {
                 canBeInteger = false;
                 // decimal number starts with '0' such as '09' is illegal.
@@ -283,6 +285,12 @@ public sealed class JsonParser
             canBeInteger = false;
             sb.Append(ch);
             _index++;
+
+            // the JSON grammar requires at least one digit after the decimal point ('1.' is illegal)
+            if (!IsDecimalDigit(_source.CharCodeAt(_index)))
+            {
+                ThrowError(_index, Messages.UnexpectedToken, _source.CharCodeAt(_index));
+            }
 
             while (IsDecimalDigit((ch = _source.CharCodeAt(_index))))
             {
@@ -501,29 +509,28 @@ public sealed class JsonParser
     }
 
 #if NET8_0_OR_GREATER
-    // Characters that terminate a bulk string-content run: the closing quote, the escape backslash,
-    // every control character (< 0x20, which JSON forbids unescaped) and the two Unicode line
-    // separators the original char-by-char scanner treated as terminators. IndexOfAny over this set
-    // finds the first such character exactly where the per-char loop would have stopped.
+    // Characters that terminate a bulk string-content run: the closing quote, the escape backslash and
+    // every control character (< 0x20, which JSON forbids unescaped). Any other code point \u2014 including
+    // the Unicode line separators U+2028/U+2029, which the JSON grammar permits raw inside strings \u2014
+    // is ordinary content. IndexOfAny over this set finds the first such character exactly where a
+    // per-char loop would have stopped.
     private static readonly SearchValues<char> JsonStringStopChars = CreateStringStopChars();
 
     private static SearchValues<char> CreateStringStopChars()
     {
-        Span<char> stops = stackalloc char[36];
+        Span<char> stops = stackalloc char[34];
         for (var i = 0; i < 32; i++)
         {
             stops[i] = (char) i;
         }
         stops[32] = '"';
         stops[33] = '\\';
-        stops[34] = '\u2028';
-        stops[35] = '\u2029';
         return SearchValues.Create(stops);
     }
 #else
     // Portable fallback: the vectorized IndexOfAny locates the next quote/backslash, then we make sure
-    // no control character (< 0x20) or line separator (U+2028/U+2029) appears earlier, so the returned
-    // index matches the NET8 SearchValues path (and the original per-char scanner).
+    // no control character (< 0x20) appears earlier, so the returned index matches the NET8
+    // SearchValues path.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int IndexOfStringStop(ReadOnlySpan<char> span)
     {
@@ -531,8 +538,7 @@ public sealed class JsonParser
         var limit = qb < 0 ? span.Length : qb;
         for (var i = 0; i < limit; i++)
         {
-            var c = span[i];
-            if (c < ' ' || c == '\u2028' || c == '\u2029')
+            if (span[i] < ' ')
             {
                 return i;
             }
@@ -554,10 +560,10 @@ public sealed class JsonParser
         var scanned = 0;
         while (_index < length)
         {
-            // Bulk fast path: copy the run of ordinary characters up to the next quote, backslash,
-            // control character (< 0x20) or Unicode line separator in one shot. The search lands on
-            // exactly the character the original per-char loop would have stopped at, so escapes and
-            // every error position are preserved byte-for-byte.
+            // Bulk fast path: copy the run of ordinary characters up to the next quote, backslash or
+            // control character (< 0x20) in one shot. The search lands on exactly the character a
+            // per-char loop would have stopped at, so escapes and every error position are preserved
+            // byte-for-byte.
             var remaining = source.AsSpan(_index, length - _index);
 #if NET8_0_OR_GREATER
             var stop = remaining.IndexOfAny(JsonStringStopChars);
@@ -636,12 +642,6 @@ public sealed class JsonParser
                         ThrowError(_index - 1, Messages.UnexpectedToken, ch);
                         break;
                 }
-            }
-            else
-            {
-                // Unicode line separator (U+2028 / U+2029): the original char-by-char scanner breaks
-                // here with the quote still open, which surfaces as UnexpectedEOS at _index below.
-                break;
             }
         }
 
@@ -928,10 +928,6 @@ public sealed class JsonParser
 
             var nameToken = Lex(ref state);
             var name = nameToken.Text!; // String tokens (keys) always carry non-null Text
-            if (PropertyNameContainsInvalidCharacters(name))
-            {
-                ThrowError(nameToken, Messages.InvalidCharacter);
-            }
 
             Expect(ref state, ':');
             var value = ParseJsonValue(ref state);
@@ -1020,19 +1016,6 @@ public sealed class JsonParser
         }
 
         obj.FastSetDataProperty(name, value);
-    }
-
-    private static bool PropertyNameContainsInvalidCharacters(string propertyName)
-    {
-        const char max = (char) 31;
-        foreach (var c in propertyName)
-        {
-            if (c != '\t' && c != '\n' && c != '\r' && c != '\b' && c != '\f' && c <= max)
-            {
-                return true;
-            }
-        }
-        return false;
     }
 
     /// <summary>
@@ -1261,10 +1244,6 @@ public sealed class JsonParser
 
             var nameToken = Lex(ref state);
             var name = nameToken.Text!; // String tokens (keys) always carry non-null Text
-            if (PropertyNameContainsInvalidCharacters(name))
-            {
-                ThrowError(nameToken, Messages.InvalidCharacter);
-            }
 
             Expect(ref state, ':');
             var valueResult = ParseJsonValueWithSourceInfo(ref state);


### PR DESCRIPTION
While reviewing the 4.14 JSON parser changes (#2718/#2725/#2732) for release, four long-standing deviations from the JSON grammar (ECMA-404 / ECMA-262 §25.5.1) turned up in the touched code. All verified against V8 behavior:

| Input | Before | After (= V8/spec) |
|---|---|---|
| `JSON.parse('-09')`, `'-00'` | `-9`, `-0` | SyntaxError (`int = zero / digit1-9 *DIGIT`) |
| `JSON.parse('1.')`, `'1.e3'` | `1`, `1000` | SyntaxError (`frac = decimal-point 1*DIGIT`) |
| raw U+2028/U+2029 inside a string | SyntaxError | the string — any code point except `"`, `\`, and < 0x20 is legal raw |
| `JSON.parse('{"\u0001":1}')` (escaped control char in a key) | SyntaxError | the object — any string is a valid key; the same content was already accepted as a *value* |

The first two are rejections of previously-accepted lenient input — behavior change worth a release-notes line. The last two accept previously-rejected valid JSON. Raw (unescaped) control characters keep being rejected everywhere by the string scanner, and removing U+2028/U+2029 from the bulk-scan stop set shrinks it by two characters.

Notes:

- The `-0`-sign path keeps flowing through `double.Parse`; a new test locks negative-zero preservation on modern TFMs (net472's `double.Parse` drops the sign of `-0` — a framework quirk fixed in .NET Core 3.0, asserted around).
- `BulkScanPreservesUnicodeLineSeparatorTermination` (added in #2725 to lock the scanner behavior byte-for-byte) asserted the wrong grammar and is replaced by an acceptance test.
- Test262 does not cover any of these forms in either direction — full suite plus Test262 green with no exclusion changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115tQFNyyQqc1HQGPLUgZND