### PR TITLE
Decline for-loop environment reuse when a pattern default embeds a closure

### DIFF
--- a/Jint.Tests/Runtime/LoopBodyFlatteningTests.cs
+++ b/Jint.Tests/Runtime/LoopBodyFlatteningTests.cs
@@ -243,4 +243,59 @@ public class LoopBodyFlatteningTests
 
         Assert.Equal("b0,d0,b1,d1", result);
     }
+
+    [Fact]
+    public void ClosureInDestructuringDefaultDeclinesEnvironmentReuse()
+    {
+        var engine = new Engine();
+        // a closure embedded in a destructuring pattern's DEFAULT value captures the loop's
+        // initial per-iteration environment; reusing/pooling the environment in place makes it
+        // observe the final i (or a reset binding) instead of the captured iteration's value
+        var result = engine.Evaluate("""
+            (function () {
+                const fns = [];
+                for (let i = 0, { f = () => i } = {}; i < 3; i++) { fns.push(f); }
+                return fns[0]() + ',' + fns[2]();
+            })()
+            """).AsString();
+
+        Assert.Equal("0,0", result);
+    }
+
+    [Fact]
+    public void ClosureInArrayPatternDefaultDeclinesEnvironmentReuse()
+    {
+        var engine = new Engine();
+        var result = engine.Evaluate("""
+            (function () {
+                const fns = [];
+                for (let i = 0, [f = () => i] = []; i < 3; i++) { fns.push(f); }
+                return fns[0]() + ',' + fns[2]();
+            })()
+            """).AsString();
+
+        Assert.Equal("0,0", result);
+    }
+
+    [Fact]
+    public void ReenteringLoopWithEscapedPatternClosureKeepsBindingAlive()
+    {
+        var engine = new Engine();
+        // re-entering the loop must not reset the binding the escaped closure captured
+        // (a pooled environment would make the earlier closure throw or observe garbage)
+        var result = engine.Evaluate("""
+            (function () {
+                function run() {
+                    const fns = [];
+                    for (let i = 0, { f = () => i } = {}; i < 2; i++) { fns.push(f); }
+                    return fns;
+                }
+                const first = run();
+                const second = run();
+                return first[0]() + ',' + second[0]();
+            })()
+            """).AsString();
+
+        Assert.Equal("0,0", result);
+    }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -786,6 +786,15 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         {
             foreach (var decl in vd.Declarations)
             {
+                // a destructuring pattern's default values can embed closures too:
+                // for (let i = 0, {f = () => i} = {}; ...)
+                if (decl.Id is not Identifier
+                    && (JintFunctionDefinition.EnvironmentEscapeAstVisitor.IsCapturing(decl.Id)
+                        || JintFunctionDefinition.EnvironmentEscapeAstVisitor.MayEscape(decl.Id)))
+                {
+                    return true;
+                }
+
                 if (decl.Init is not null)
                 {
                     if (JintFunctionDefinition.EnvironmentEscapeAstVisitor.IsCapturing(decl.Init)


### PR DESCRIPTION
Pre-release review find in the same eligibility-scan family as #2709. `ForLoopMayCapture` scanned the init declarators' *initializers* (plus test/update/body) for capturing closures, but never the declarator binding patterns themselves. A destructuring default embeds an expression the scan missed:

```js
const fns = [];
for (let i = 0, { f = () => i } = {}; i < 3; i++) { fns.push(f); }
fns[0]();  // V8/spec: 0 — Jint before this fix: 3
```

With the closure invisible to the scan, the loop reused/pooled its per-iteration environment in place, so the escaped closure observed the final `i` — and with environment pooling, re-entering the loop could reset the binding the closure captured. The fix runs the existing escape visitor over non-identifier declarator ids; the gate only declines an optimization, so generic per-iteration semantics take over.

Repro verified against V8 before/after. Full suite plus Test262 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115tQFNyyQqc1HQGPLUgZND