### PR TITLE
Skip materialization on mismatched-length string compares and whole-string substrings

### DIFF
--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -220,7 +220,8 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
     {
         if (start == 0 && length == source.Length)
         {
-            return new JsString(source);
+            // Create keeps 0/1-char sources on the cached instances (e.g. ''.split('x'))
+            return Create(source);
         }
 
         if (length >= 512
@@ -385,6 +386,13 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
         if (ReferenceEquals(this, other))
         {
             return true;
+        }
+
+        if (Length != other.Length)
+        {
+            // every Length override answers without materializing, so a mismatched compare
+            // (e.g. a short literal against a large unmaterialized view) stays allocation-free
+            return false;
         }
 
         return string.Equals(_value, other.ToString(), StringComparison.Ordinal);

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -941,6 +941,12 @@ internal sealed partial class StringPrototype : StringInstance
             return JsString.Create(s[from]);
         }
 
+        if (from == 0 && length == len)
+        {
+            // whole-string substring: strings are immutable, the receiver can be returned as-is
+            return s;
+        }
+
         return JsString.CreateSliced(s, from, length);
     }
 
@@ -969,6 +975,11 @@ internal sealed partial class StringPrototype : StringInstance
         if (l == 1)
         {
             return TypeConverter.ToString(s[startIndex]);
+        }
+        if (startIndex == 0 && l == s.Length)
+        {
+            // whole-string substr: strings are immutable, the receiver can be returned as-is
+            return s;
         }
         return JsString.CreateSliced(s, startIndex, l);
     }


### PR DESCRIPTION
Three small follow-ups from the pre-release review of the #2720 zero-copy slices:

- **`JsString.Equals(JsString)` length pre-check** — comparing a short string against a large unmaterialized view materialized the entire view just to fail the compare (`'END' === bigDoc.slice(...)`). Every `Length` override (flat, concatenated, sliced, CustomString) answers without materializing, so the mismatch case is now allocation-free. `SlicedString`'s own override already did this on its receiver side; the base didn't.
- **`substring()`/`substr()` whole-string identity shortcut** — `slice()` already returned the receiver for a whole-string result; the two siblings allocated a duplicate wrapper (or a second identical view) for the same case.
- **`CreateSliced` whole-string branch routes through `Create`** so 0/1-char sources (`''.split('x')` segments) reuse the cached instances instead of allocating.

Allocation probe (prepared script, 200 iterations, net10.0 Release):

| case | before | after |
|---|---:|---:|
| `probe === freshView` (150K-char unmaterialized view) | 300,087 B/iter | 63 B/iter |
| `big.substring(0)` (200K chars) | 42 B/iter | 10 B/iter |
| `big.substr(0)` | 42 B/iter | 10 B/iter |

Full suite green on net10.0 + net472 (Jint.Tests, PublicInterface — including the CustomString no-materialization gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115tQFNyyQqc1HQGPLUgZND