### PR TITLE
Replace xUnit Assert.* with AwesomeAssertions across the test suites

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Acornima.Extras" Version="1.6.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.TestAdapter" Version="0.15.8" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
     <PackageVersion Include="Flurl.Http.Signed" Version="4.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
     <PackageVersion Include="ICU4N" Version="60.1.0-alpha.440" />

--- a/Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj
+++ b/Jint.Tests.CommonScripts/Jint.Tests.CommonScripts.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Acornima.Extras" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
@@ -24,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="AwesomeAssertions" />
     <Using Include="NUnit.Framework" />
   </ItemGroup>
 

--- a/Jint.Tests.CommonScripts/SunSpiderTests.cs
+++ b/Jint.Tests.CommonScripts/SunSpiderTests.cs
@@ -10,7 +10,7 @@ public class SunSpiderTests
     {
         var engine = new Engine()
             .SetValue("log", new Action<object>(Console.WriteLine))
-            .SetValue("assert", new Action<bool, string>((condition, message) => Assert.That(condition, message)));
+            .SetValue("assert", new Action<bool, string>(static (condition, message) => condition.Should().BeTrue(message)));
 
         try
         {

--- a/Jint.Tests.PublicInterface/ArrayBufferTests.cs
+++ b/Jint.Tests.PublicInterface/ArrayBufferTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Runtime.Interop;
 
 namespace Jint.Tests.Runtime;
@@ -16,16 +16,16 @@ public class ArrayBufferTests
         engine.Evaluate("var a = new Uint8Array(buffer)");
 
         var typedArray = (JsTypedArray) engine.GetValue("a");
-        Assert.Equal((uint) 1, typedArray.Length);
-        Assert.Equal(17, typedArray[0]);
-        Assert.Equal(JsValue.Undefined, typedArray[1]);
+        typedArray.Length.Should().Be((uint) 1);
+        typedArray[0].Should().Be(17);
+        typedArray[1].Should().BeUndefined();
 
-        Assert.Equal(1, engine.Evaluate("a.length"));
-        Assert.Equal(17, engine.Evaluate("a[0]"));
-        Assert.Equal(JsValue.Undefined, engine.Evaluate("a[1]"));
+        engine.Evaluate("a.length").Should().Be(1);
+        engine.Evaluate("a[0]").Should().Be(17);
+        engine.Evaluate("a[1]").Should().BeUndefined();
 
         bytes[0] = 42;
-        Assert.Equal(42, engine.Evaluate("a[0]"));
+        engine.Evaluate("a[0]").Should().Be(42);
     }
 
     [Fact]
@@ -41,13 +41,13 @@ public class ArrayBufferTests
         engine.SetValue("a", jsTypedArray);
 
         var typedArray = (JsTypedArray) engine.GetValue("a");
-        Assert.Equal((uint) 1, typedArray.Length);
-        Assert.Equal(17, typedArray[0]);
-        Assert.Equal(JsValue.Undefined, typedArray[1]);
+        typedArray.Length.Should().Be((uint) 1);
+        typedArray[0].Should().Be(17);
+        typedArray[1].Should().BeUndefined();
 
-        Assert.Equal(1, engine.Evaluate("a.length"));
-        Assert.Equal(17, engine.Evaluate("a[0]"));
-        Assert.Equal(JsValue.Undefined, engine.Evaluate("a[1]"));
+        engine.Evaluate("a.length").Should().Be(1);
+        engine.Evaluate("a[0]").Should().Be(17);
+        engine.Evaluate("a[1]").Should().BeUndefined();
     }
 
     /// <summary>

--- a/Jint.Tests.PublicInterface/CallStackTests.cs
+++ b/Jint.Tests.PublicInterface/CallStackTests.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime;
+﻿using Jint.Runtime;
 using SourceMaps;
 
 namespace Jint.Tests.PublicInterface;
@@ -9,7 +9,7 @@ public class CallStackTests
     public void CanInjectTraceFunction()
     {
         var engine = new Engine();
-        Assert.Empty(engine.Advanced.StackTrace);
+        engine.Advanced.StackTrace.Should().BeEmpty();
 
         using var stringWriter = new StringWriter();
         engine.SetValue("console", new Console(engine, stringWriter));
@@ -25,7 +25,7 @@ Trace
 """;
 
         var actual = stringWriter.ToString();
-        Assert.Equal(Expected, actual);
+        actual.Should().Be(Expected);
     }
 
     private class Console
@@ -99,12 +99,12 @@ var b = function (v) {
 };
 b(7);
 //# sourceMappingURL=custom.js.map";
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute(Script, "custom.js"));
+        var ex = Invoking(() => engine.Execute(Script, "custom.js")).Should().ThrowExactly<JavaScriptException>().Which;
 
         var stack = ex.JavaScriptStackTrace!;
-        Assert.Equal(@"    at a (custom.ts:4:7)
+        stack.Replace("\r\n", "\n").Should().Be(@"    at a (custom.ts:4:7)
     at b (custom.ts:8:9)
-    at custom.ts:11:1".Replace("\r\n", "\n"), stack.Replace("\r\n", "\n"));
+    at custom.ts:11:1".Replace("\r\n", "\n"));
     }
 
 }

--- a/Jint.Tests.PublicInterface/ClrProxyHandlerTests.cs
+++ b/Jint.Tests.PublicInterface/ClrProxyHandlerTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using Jint.Native;
 using Jint.Native.Function;
@@ -76,9 +76,9 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        Assert.Equal(42, engine.Evaluate("p.x").AsNumber());
+        engine.Evaluate("p.x").AsNumber().Should().Be(42);
         // non-trapped key forwards to the target
-        Assert.Equal(2, engine.Evaluate("p.y").AsNumber());
+        engine.Evaluate("p.y").AsNumber().Should().Be(2);
     }
 
     [Fact]
@@ -99,9 +99,9 @@ public class ClrProxyHandlerTests
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
         engine.Evaluate("p.x = 42;");
 
-        Assert.Equal(new[] { "x=42" }, writes);
+        writes.Should().Equal(new[] { "x=42" });
         // the trap claimed the write, the target was not touched
-        Assert.True(target.Get("x").IsUndefined());
+        target.Get("x").IsUndefined().Should().BeTrue();
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(CreateTarget(engine), handler));
 
-        Assert.Throws<JavaScriptException>(() => engine.Evaluate("'use strict'; p.x = 1;"));
+        Invoking(() => engine.Evaluate("'use strict'; p.x = 1;")).Should().ThrowExactly<JavaScriptException>();
     }
 
     [Fact]
@@ -130,10 +130,10 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        Assert.True(engine.Evaluate("'phantom' in p").AsBoolean());
+        engine.Evaluate("'phantom' in p").AsBoolean().Should().BeTrue();
         // forwarded to the target
-        Assert.True(engine.Evaluate("'real' in p").AsBoolean());
-        Assert.False(engine.Evaluate("'missing' in p").AsBoolean());
+        engine.Evaluate("'real' in p").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'missing' in p").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -153,10 +153,10 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        Assert.True(engine.Evaluate("delete p.x").AsBoolean());
-        Assert.Equal(new[] { "x" }, deleted);
+        engine.Evaluate("delete p.x").AsBoolean().Should().BeTrue();
+        deleted.Should().Equal(new[] { "x" });
         // the trap claimed the delete without touching the target
-        Assert.Equal(1, target.Get("x").AsNumber());
+        target.Get("x").AsNumber().Should().Be(1);
     }
 
     [Fact]
@@ -176,9 +176,9 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        Assert.Equal(7, engine.Evaluate("Object.getOwnPropertyDescriptor(p, 'phantom').value").AsNumber());
-        Assert.True(engine.Evaluate("Object.getOwnPropertyDescriptor(p, 'hidden') === undefined").AsBoolean());
-        Assert.Equal(2, engine.Evaluate("Object.getOwnPropertyDescriptor(p, 'visible').value").AsNumber());
+        engine.Evaluate("Object.getOwnPropertyDescriptor(p, 'phantom').value").AsNumber().Should().Be(7);
+        engine.Evaluate("Object.getOwnPropertyDescriptor(p, 'hidden') === undefined").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getOwnPropertyDescriptor(p, 'visible').value").AsNumber().Should().Be(2);
     }
 
     [Fact]
@@ -199,8 +199,8 @@ public class ClrProxyHandlerTests
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
         engine.Evaluate("Object.defineProperty(p, 'y', { value: 42, configurable: true });");
 
-        Assert.Equal(new[] { "y=42" }, defined);
-        Assert.True(target.Get("y").IsUndefined());
+        defined.Should().Equal(new[] { "y=42" });
+        target.Get("y").IsUndefined().Should().BeTrue();
     }
 
     [Fact]
@@ -215,7 +215,7 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        Assert.Equal("a,b", engine.Evaluate("Object.getOwnPropertyNames(p).join()").AsString());
+        engine.Evaluate("Object.getOwnPropertyNames(p).join()").AsString().Should().Be("a,b");
     }
 
     [Fact]
@@ -236,11 +236,11 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        Assert.Equal(100, engine.Evaluate("p(2, 3)").AsNumber());
-        Assert.NotNull(capturedArguments);
-        Assert.Equal(2, capturedArguments.Length);
-        Assert.Equal(2, capturedArguments[0].AsNumber());
-        Assert.Equal(3, capturedArguments[1].AsNumber());
+        engine.Evaluate("p(2, 3)").AsNumber().Should().Be(100);
+        capturedArguments.Should().NotBeNull();
+        capturedArguments.Length.Should().Be(2);
+        capturedArguments[0].AsNumber().Should().Be(2);
+        capturedArguments[1].AsNumber().Should().Be(3);
     }
 
     [Fact]
@@ -252,7 +252,7 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        Assert.Equal(5, engine.Evaluate("p(2, 3)").AsNumber());
+        engine.Evaluate("p(2, 3)").AsNumber().Should().Be(5);
     }
 
     [Fact]
@@ -272,11 +272,11 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        Assert.Equal(6, engine.Evaluate("new p(2, 3).marker").AsNumber());
+        engine.Evaluate("new p(2, 3).marker").AsNumber().Should().Be(6);
         // trap not consulted for the forwarding check
         var forwardingHandler = new DelegatingProxyHandler();
         engine.SetValue("pf", engine.Advanced.CreateProxy(target, forwardingHandler));
-        Assert.Equal(5, engine.Evaluate("new pf(2, 3).sum").AsNumber());
+        engine.Evaluate("new pf(2, 3).sum").AsNumber().Should().Be(5);
     }
 
     [Fact]
@@ -290,7 +290,7 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(CreateTarget(engine), handler));
 
-        Assert.True(engine.Evaluate("Object.getPrototypeOf(p) === null").AsBoolean());
+        engine.Evaluate("Object.getPrototypeOf(p) === null").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -311,9 +311,9 @@ public class ClrProxyHandlerTests
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
         engine.Evaluate("Object.setPrototypeOf(p, { a: 1 });");
 
-        Assert.Equal(1, invocations);
+        invocations.Should().Be(1);
         // the trap claimed success without changing the target's prototype
-        Assert.True(engine.Evaluate("Object.getPrototypeOf(p) === Object.prototype").AsBoolean());
+        engine.Evaluate("Object.getPrototypeOf(p) === Object.prototype").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -332,8 +332,8 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(CreateTarget(engine), handler));
 
-        Assert.True(engine.Evaluate("Object.isExtensible(p)").AsBoolean());
-        Assert.Equal(1, invocations);
+        engine.Evaluate("Object.isExtensible(p)").AsBoolean().Should().BeTrue();
+        invocations.Should().Be(1);
     }
 
     [Fact]
@@ -354,7 +354,7 @@ public class ClrProxyHandlerTests
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
         engine.Evaluate("Object.preventExtensions(p);");
 
-        Assert.False(engine.Evaluate("Object.isExtensible(p)").AsBoolean());
+        engine.Evaluate("Object.isExtensible(p)").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -379,15 +379,15 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(ObjectWrapper.Create(engine, person), handler));
 
-        Assert.Equal(42, engine.Evaluate("p.custom").AsNumber());
-        Assert.Equal("Jane", engine.Evaluate("p.Name").AsString());
+        engine.Evaluate("p.custom").AsNumber().Should().Be(42);
+        engine.Evaluate("p.Name").AsString().Should().Be("Jane");
 
         engine.Evaluate("p.blocked = 'nope';");
-        Assert.Equal(new[] { "nope" }, blockedWrites);
+        blockedWrites.Should().Equal(new[] { "nope" });
 
         // untrapped write forwards to the CLR object
         engine.Evaluate("p.Name = 'John';");
-        Assert.Equal("John", person.Name);
+        person.Name.Should().Be("John");
     }
 
     [Fact]
@@ -402,7 +402,7 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        Assert.Equal(6, engine.Evaluate("p(2, 3)").AsNumber());
+        engine.Evaluate("p(2, 3)").AsNumber().Should().Be(6);
     }
 
     [Fact]
@@ -418,7 +418,7 @@ public class ClrProxyHandlerTests
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
         engine.Evaluate("p.x = 1;");
 
-        Assert.Equal(1, target.Get("x").AsNumber());
+        target.Get("x").AsNumber().Should().Be(1);
     }
 
     [Fact]
@@ -433,7 +433,7 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        Assert.True(engine.Evaluate("p.x === undefined").AsBoolean());
+        engine.Evaluate("p.x === undefined").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -448,8 +448,8 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        Assert.Equal(1, engine.Evaluate("p.normal").AsNumber());
-        Assert.Equal(99, engine.Evaluate("p.special").AsNumber());
+        engine.Evaluate("p.normal").AsNumber().Should().Be(1);
+        engine.Evaluate("p.special").AsNumber().Should().Be(99);
     }
 
     [Fact]
@@ -465,8 +465,8 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("p.x"));
-        Assert.Contains("'get' on proxy", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("p.x")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Contain("'get' on proxy");
     }
 
     [Fact]
@@ -482,8 +482,8 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("p.x = 2;"));
-        Assert.Contains("'set' on proxy", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("p.x = 2;")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Contain("'set' on proxy");
     }
 
     [Fact]
@@ -499,8 +499,8 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(target, handler));
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("Object.keys(p)"));
-        Assert.Contains("'ownKeys' on proxy", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("Object.keys(p)")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Contain("'ownKeys' on proxy");
     }
 
     private sealed class MethodLoggingHandler : ProxyHandler
@@ -546,15 +546,15 @@ public class ClrProxyHandlerTests
         engine.SetValue("p", engine.Advanced.CreateProxy(ObjectWrapper.Create(engine, calculator), handler));
 
         // thisObject passthrough: the bound CLR method sees the original Calculator instance
-        Assert.Equal(15, engine.Evaluate("p.Add(2, 3)").AsNumber());
-        Assert.Equal(new[] { "Add" }, handler.Calls);
+        engine.Evaluate("p.Add(2, 3)").AsNumber().Should().Be(15);
+        handler.Calls.Should().Equal(new[] { "Add" });
 
         // memoization preserves function identity
-        Assert.True(engine.Evaluate("p.Add === p.Add").AsBoolean());
-        Assert.Equal(new[] { "Add" }, handler.Calls);
+        engine.Evaluate("p.Add === p.Add").AsBoolean().Should().BeTrue();
+        handler.Calls.Should().Equal(new[] { "Add" });
 
         // plain (non-function) members still forward
-        Assert.Equal(10, engine.Evaluate("p.Offset").AsNumber());
+        engine.Evaluate("p.Offset").AsNumber().Should().Be(10);
     }
 
     [Fact]
@@ -565,18 +565,18 @@ public class ClrProxyHandlerTests
         var revocable = engine.Advanced.CreateRevocableProxy(target, new DelegatingProxyHandler());
 
         engine.SetValue("p", revocable.Proxy);
-        Assert.Equal(1, engine.Evaluate("p.x").AsNumber());
+        engine.Evaluate("p.x").AsNumber().Should().Be(1);
 
         revocable.Revoke();
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("p.x"));
-        Assert.Contains("revoked", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("p.x")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Contain("revoked");
 
         // idempotent
         revocable.Revoke();
 
-        ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("'x' in p"));
-        Assert.Contains("revoked", ex.Message);
+        ex = Invoking(() => engine.Evaluate("'x' in p")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Contain("revoked");
     }
 
     [Fact]
@@ -589,7 +589,7 @@ public class ClrProxyHandlerTests
         engine.SetValue("p", revocable.Proxy);
         revocable.Revoke();
 
-        Assert.Equal("function", engine.Evaluate("typeof p").AsString());
+        engine.Evaluate("typeof p").AsString().Should().Be("function");
     }
 
     [Fact]
@@ -613,13 +613,13 @@ public class ClrProxyHandlerTests
         engine.SetValue("accept", new Action<Calculator>(c => received = c));
 
         // script sees trapped members
-        Assert.Equal(1, engine.Evaluate("calc.intercepted").AsNumber());
+        engine.Evaluate("calc.intercepted").AsNumber().Should().Be(1);
         // untrapped members forward to the wrapped CLR object
-        Assert.Equal(5, engine.Evaluate("calc.Add(2, 3)").AsNumber());
+        engine.Evaluate("calc.Add(2, 3)").AsNumber().Should().Be(5);
 
         // passing the proxied wrapper back into a CLR method parameter unwraps to the original object
         engine.Evaluate("accept(calc);");
-        Assert.Same(calculator, received);
+        received.Should().BeSameAs(calculator);
     }
 
     [Fact]
@@ -639,11 +639,11 @@ public class ClrProxyHandlerTests
         engine.SetValue("p", proxy);
 
         engine.Evaluate("var r = { marker: true }; Reflect.get(p, 'x', r);");
-        Assert.Same(engine.Evaluate("r"), capturedReceiver);
+        capturedReceiver.Should().BeSameAs(engine.Evaluate("r"));
 
         // default receiver is the proxy itself
         engine.Evaluate("p.x");
-        Assert.Same(proxy, capturedReceiver);
+        capturedReceiver.Should().BeSameAs(proxy);
     }
 
     [Fact]
@@ -657,8 +657,8 @@ public class ClrProxyHandlerTests
 
         engine.SetValue("p", engine.Advanced.CreateProxy(CreateTarget(engine), handler));
 
-        var ex = Assert.Throws<InvalidOperationException>(() => engine.Evaluate("p.x"));
-        Assert.Equal("boom", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("p.x")).Should().ThrowExactly<InvalidOperationException>().Which;
+        ex.Message.Should().Be("boom");
     }
 
     [Fact]
@@ -673,7 +673,7 @@ public class ClrProxyHandlerTests
         engine.SetValue("p", engine.Advanced.CreateProxy(CreateTarget(engine), handler));
 
         var result = engine.Evaluate("(function () { try { p.x; return 'no-throw'; } catch (e) { return 'caught: ' + e.message; } })()").AsString();
-        Assert.Equal("caught: boom", result);
+        result.Should().Be("caught: boom");
     }
 
     [Fact]
@@ -683,10 +683,10 @@ public class ClrProxyHandlerTests
         var target = CreateTarget(engine);
         var handler = new DelegatingProxyHandler();
 
-        Assert.Throws<ArgumentNullException>(() => engine.Advanced.CreateProxy(null!, handler));
-        Assert.Throws<ArgumentNullException>(() => engine.Advanced.CreateProxy(target, null!));
-        Assert.Throws<ArgumentNullException>(() => engine.Advanced.CreateRevocableProxy(null!, handler));
-        Assert.Throws<ArgumentNullException>(() => engine.Advanced.CreateRevocableProxy(target, null!));
+        Invoking(() => engine.Advanced.CreateProxy(null!, handler)).Should().ThrowExactly<ArgumentNullException>();
+        Invoking(() => engine.Advanced.CreateProxy(target, null!)).Should().ThrowExactly<ArgumentNullException>();
+        Invoking(() => engine.Advanced.CreateRevocableProxy(null!, handler)).Should().ThrowExactly<ArgumentNullException>();
+        Invoking(() => engine.Advanced.CreateRevocableProxy(target, null!)).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -694,7 +694,7 @@ public class ClrProxyHandlerTests
     {
         var uninitialized = default(RevocableProxy);
 
-        Assert.Throws<InvalidOperationException>(() => uninitialized.Proxy);
-        Assert.Throws<InvalidOperationException>(() => uninitialized.Revoke());
+        Invoking(() => uninitialized.Proxy).Should().ThrowExactly<InvalidOperationException>();
+        Invoking(() => uninitialized.Revoke()).Should().ThrowExactly<InvalidOperationException>();
     }
 }

--- a/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
+++ b/Jint.Tests.PublicInterface/ConstraintUsageTests.cs
@@ -15,16 +15,16 @@ public class ConstraintUsageTests
         var engine = new Engine(new Options().CancellationToken(cts.Token));
 
         // expect constraint to abort execution due to timeout
-        Assert.Throws<ExecutionCanceledException>(WaitAndCompute);
+        Invoking(WaitAndCompute).Should().ThrowExactly<ExecutionCanceledException>();
 
         // ensure constraint can be obtained publicly
         var cancellationConstraint = engine.FindConstraint<CancellationConstraint>();
-        Assert.NotNull(cancellationConstraint);
+        cancellationConstraint.Should().NotBeNull();
 
         // reset constraint, expect computation to finish this time
         using var cts2 = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
         cancellationConstraint.Reset(cts2.Token);
-        Assert.Equal("done", WaitAndCompute());
+        WaitAndCompute().Should().Be("done");
 
         string WaitAndCompute()
         {
@@ -64,6 +64,6 @@ public class ConstraintUsageTests
             return "didn't throw!";
         }));
 
-        Assert.Throws<TimeoutException>(() => engine.Execute("slowFunction()"));
+        Invoking(() => engine.Execute("slowFunction()")).Should().ThrowExactly<TimeoutException>();
     }
 }

--- a/Jint.Tests.PublicInterface/ConstructorTests.cs
+++ b/Jint.Tests.PublicInterface/ConstructorTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime;
@@ -21,35 +21,35 @@ public class ConstructorTests
     {
         var wrapper = (IObjectWrapper) _engine.Evaluate("new DateOnly(1982, 6, 28);");
         var date = (DateOnly) wrapper.Target;
-        Assert.Equal(1982, date.Year);
-        Assert.Equal(6, date.Month);
-        Assert.Equal(28, date.Day);
+        date.Year.Should().Be(1982);
+        date.Month.Should().Be(6);
+        date.Day.Should().Be(28);
 
-        Assert.Equal(1982, _engine.Evaluate("new DateOnly(1982, 6, 28).year").AsNumber());
-        Assert.Equal(6, _engine.Evaluate("new DateOnly(1982, 6, 28).month").AsNumber());
-        Assert.Equal(28, _engine.Evaluate("new DateOnly(1982, 6, 28).day").AsNumber());
+        _engine.Evaluate("new DateOnly(1982, 6, 28).year").AsNumber().Should().Be(1982);
+        _engine.Evaluate("new DateOnly(1982, 6, 28).month").AsNumber().Should().Be(6);
+        _engine.Evaluate("new DateOnly(1982, 6, 28).day").AsNumber().Should().Be(28);
     }
 
     [Fact]
     public void CanConstructWithoutParameters()
     {
-        Assert.Equal(DateTime.Today.Year, _engine.Evaluate("new DateOnly().year").AsNumber());
-        Assert.Equal(DateTime.Today.Month, _engine.Evaluate("new DateOnly().month").AsNumber());
-        Assert.Equal(DateTime.Today.Day, _engine.Evaluate("new DateOnly().day").AsNumber());
+        _engine.Evaluate("new DateOnly().year").AsNumber().Should().Be(DateTime.Today.Year);
+        _engine.Evaluate("new DateOnly().month").AsNumber().Should().Be(DateTime.Today.Month);
+        _engine.Evaluate("new DateOnly().day").AsNumber().Should().Be(DateTime.Today.Day);
     }
 
     [Fact]
     public void CallThrows()
     {
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("DateOnly(1982, 6, 28);"));
-        Assert.Equal("Constructor DateOnly requires 'new'", ex.Message);
+        var ex = Invoking(() => _engine.Evaluate("DateOnly(1982, 6, 28);")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Constructor DateOnly requires 'new'");
     }
 
     [Fact]
     public void CanThrowTypeError()
     {
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("new DateOnly(undefined, 1, 1);"));
-        Assert.Equal("Invalid year NaN", ex.Message);
+        var ex = Invoking(() => _engine.Evaluate("new DateOnly(undefined, 1, 1);")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Invalid year NaN");
     }
 }
 

--- a/Jint.Tests.PublicInterface/InteropTests.Dynamic.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.Dynamic.cs
@@ -1,4 +1,4 @@
-using System.Dynamic;
+﻿using System.Dynamic;
 using Jint.Native;
 using Jint.Native.Symbol;
 
@@ -13,7 +13,7 @@ public partial class InteropTests
         dynamic expando = new ExpandoObject();
         expando.Name = "test";
         engine.SetValue("expando", expando);
-        Assert.Equal("test", engine.Evaluate("expando.Name").ToString());
+        engine.Evaluate("expando.Name").ToString().Should().Be("test");
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public partial class InteropTests
         values["title"] = "abc";
 
         _engine.SetValue("parent", parent);
-        Assert.Equal("abc", _engine.Evaluate("parent.child.item.title"));
+        _engine.Evaluate("parent.child.item.title").Should().Be("abc");
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public partial class InteropTests
 
         var result = _engine.Evaluate("var l = ''; for (var x of dynamic) l += x; return l;").AsString();
 
-        Assert.Equal("a,1b,2", result);
+        result.Should().Be("a,1b,2");
     }
 
     [Fact]
@@ -83,13 +83,13 @@ public partial class InteropTests
 
         dynamic value = result.ToObject();
 
-        Assert.Equal(1, value.a);
-        Assert.Equal("foo", value.b);
+        ((double) value.a).Should().Be(1);
+        ((string) value.b).Should().Be("foo");
 
         var dic = (IDictionary<string, object>) result.ToObject();
 
-        Assert.Equal(1d, dic["a"]);
-        Assert.Equal("foo", dic["b"]);
+        dic["a"].Should().Be(1d);
+        dic["b"].Should().Be("foo");
     }
 
     [Fact]
@@ -100,18 +100,18 @@ public partial class InteropTests
 
         engine.SetValue("test", test);
 
-        Assert.Equal("a", engine.Evaluate("test.a").AsString());
-        Assert.Equal("b", engine.Evaluate("test.b").AsString());
+        engine.Evaluate("test.a").AsString().Should().Be("a");
+        engine.Evaluate("test.b").AsString().Should().Be("b");
 
         engine.Evaluate("test.a = 5; test.b = 10; test.Name = 'Jint'");
 
-        Assert.Equal(5, engine.Evaluate("test.a").AsNumber());
-        Assert.Equal(10, engine.Evaluate("test.b").AsNumber());
+        engine.Evaluate("test.a").AsNumber().Should().Be(5);
+        engine.Evaluate("test.b").AsNumber().Should().Be(10);
 
-        Assert.Equal("Jint", engine.Evaluate("test.Name").AsString());
-        Assert.True(engine.Evaluate("test.ContainsKey('a')").AsBoolean());
-        Assert.True(engine.Evaluate("test.ContainsKey('b')").AsBoolean());
-        Assert.False(engine.Evaluate("test.ContainsKey('c')").AsBoolean());
+        engine.Evaluate("test.Name").AsString().Should().Be("Jint");
+        engine.Evaluate("test.ContainsKey('a')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("test.ContainsKey('b')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("test.ContainsKey('c')").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -125,8 +125,8 @@ public partial class InteropTests
             }
         };
         var e = new Engine().SetValue("dynamicObj", t);
-        Assert.Equal(4, ((dynamic) t).MemberKey.Field);
-        Assert.Equal(4, e.Evaluate("dynamicObj.MemberKey.Field"));
+        ((int) ((dynamic) t).MemberKey.Field).Should().Be(4);
+        e.Evaluate("dynamicObj.MemberKey.Field").Should().Be(4);
     }
 
     private class MemberType

--- a/Jint.Tests.PublicInterface/InteropTests.Json.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.Json.cs
@@ -1,4 +1,4 @@
-using System.Dynamic;
+﻿using System.Dynamic;
 using System.Text;
 using AwesomeAssertions;
 using Jint.Runtime.Interop;
@@ -18,7 +18,7 @@ public partial class InteropTests
         engine.SetValue(nameof(expando), expando);
 
         var result = engine.Evaluate($"JSON.stringify({nameof(expando)})").AsString();
-        Assert.Equal("{\"foo\":5,\"bar\":\"A string\"}", result);
+        result.Should().Be("{\"foo\":5,\"bar\":\"A string\"}");
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public partial class InteropTests
         expando.Values = 1;
         engine.SetValue("expando", expando);
 
-        Assert.Equal("{\"Values\":1}", engine.Evaluate($"JSON.stringify(expando)").AsString());
+        engine.Evaluate($"JSON.stringify(expando)").AsString().Should().Be("{\"Values\":1}");
     }
 
 
@@ -47,7 +47,7 @@ public partial class InteropTests
         engine.SetValue("testSubject", queryResults.ToArray());
         var fromEngine2 = engine.Evaluate("return JSON.stringify(testSubject);");
         var result2 = fromEngine2.ToString();
-        Assert.Equal("[{\"Text\":\"Text1\",\"Value\":1},{\"Text\":\"Text2\",\"Value\":2}]", result2);
+        result2.Should().Be("[{\"Text\":\"Text1\",\"Value\":1},{\"Text\":\"Text2\",\"Value\":2}]");
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public partial class InteropTests
         engine.SetValue("testSubject", objects);
         var fromEngine = engine.Evaluate("return JSON.stringify(testSubject);");
         var result = fromEngine.ToString();
-        Assert.Equal("[{\"Text\":\"Text1\",\"Value\":1},{\"Text\":\"Text2\",\"Value\":2}]", result);
+        result.Should().Be("[{\"Text\":\"Text1\",\"Value\":1},{\"Text\":\"Text2\",\"Value\":2}]");
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public partial class InteropTests
         engine.SetValue("testSubject", source.AsEnumerable());
         var fromEngine = engine.Evaluate("return JSON.stringify(testSubject);");
         var result = fromEngine.ToString();
-        Assert.Equal("[{\"Text\":\"Text1\",\"Value\":1},{\"Text\":\"Text2\",\"Value\":2}]", result);
+        result.Should().Be("[{\"Text\":\"Text1\",\"Value\":1},{\"Text\":\"Text2\",\"Value\":2}]");
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public partial class InteropTests
         engine.SetValue("TimeSpan", TypeReference.CreateTypeReference<TimeSpan>(engine));
         var value = engine.Evaluate("JSON.stringify(TimeSpan.FromSeconds(3));");
 
-        Assert.Equal(expected, value);
+        value.Should().Be(expected);
     }
 
     [Fact]

--- a/Jint.Tests.PublicInterface/InteropTests.NewtonsoftJson.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.NewtonsoftJson.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Runtime;
 using Newtonsoft.Json.Linq;
 
@@ -14,7 +14,7 @@ public partial class InteropTests
             new JProperty("name", "test-name")
         };
         _engine.SetValue("o", o);
-        Assert.True(_engine.Evaluate("return o.name == 'test-name'").AsBoolean());
+        _engine.Evaluate("return o.name == 'test-name'").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -22,8 +22,8 @@ public partial class InteropTests
     {
         var o = new JArray("item1", "item2");
         _engine.SetValue("o", o);
-        Assert.True(_engine.Evaluate("return o[0] == 'item1'").AsBoolean());
-        Assert.True(_engine.Evaluate("return o[1] == 'item2'").AsBoolean());
+        _engine.Evaluate("return o[0] == 'item1'").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("return o[1] == 'item2'").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -37,10 +37,10 @@ public partial class InteropTests
         var typeResult = _engine.Evaluate("o.Type");
 
         // JToken requires conversion
-        Assert.Equal("Cat", TypeConverter.ToString(typeResult));
+        TypeConverter.ToString(typeResult).Should().Be("Cat");
 
         // weak equality does conversions from native types
-        Assert.True(_engine.Evaluate("o.Type == 'Cat'").AsBoolean());
+        _engine.Evaluate("o.Type == 'Cat'").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -60,8 +60,8 @@ public partial class InteropTests
         var obj = JObject.Parse(json);
         engine.SetValue("o", obj);
         var value = engine.Evaluate("o.Properties.expirationDate.Value");
-        var dateInstance = Assert.IsAssignableFrom<JsDate>(value);
-        Assert.Equal(DateTime.Parse("2021-10-09T00:00:00Z").ToUniversalTime(), dateInstance.ToDateTime());
+        var dateInstance = value.Should().BeAssignableTo<JsDate>().Which;
+        dateInstance.ToDateTime().Should().Be(DateTime.Parse("2021-10-09T00:00:00Z").ToUniversalTime());
     }
 
     // https://github.com/OrchardCMS/OrchardCore/issues/10648
@@ -80,9 +80,9 @@ public partial class InteropTests
         var result = fromEngine.ToString();
 
         // currently we do not materialize LINQ enumerables
-        // Assert.Equal("[{\"Text\":\"Text1\",\"Value\":1},{\"Text\":\"Text2\",\"Value\":2}]", result);
+        // result.Should().Be("[{\"Text\":\"Text1\",\"Value\":1},{\"Text\":\"Text2\",\"Value\":2}]");
 
-        Assert.Equal("{\"Current\":null}", result);
+        result.Should().Be("{\"Current\":null}");
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public partial class InteropTests
         var fromEngine = engine.Evaluate("return JSON.stringify(testSubject);");
         var result = fromEngine.ToString();
 
-        Assert.Equal("[{\"Text\":\"Text1\",\"Value\":1},{\"Text\":\"Text2\",\"Value\":2,\"Null\":null,\"Date\":\"2015-06-25T00:00:00.000Z\"}]", result);
+        result.Should().Be("[{\"Text\":\"Text1\",\"Value\":1},{\"Text\":\"Text2\",\"Value\":2,\"Null\":null,\"Date\":\"2015-06-25T00:00:00.000Z\"}]");
     }
 
     [Fact]
@@ -112,8 +112,8 @@ public partial class InteropTests
         });
         _engine.SetValue("test", test);
         var fromInterop = _engine.Evaluate("test.DecimalValue");
-        var number = Assert.IsType<JsNumber>(fromInterop);
-        Assert.Equal(123.456d, number.AsNumber());
+        var number = fromInterop.Should().BeOfType<JsNumber>().Which;
+        number.AsNumber().Should().Be(123.456d);
     }
 
     [Fact]
@@ -127,7 +127,7 @@ public partial class InteropTests
             .Evaluate("input.value = \"CHANGED\"; input.value")
             .AsString();
 
-        Assert.Equal("CHANGED", result);
+        result.Should().Be("CHANGED");
     }
 
     [Fact]
@@ -150,9 +150,9 @@ public partial class InteropTests
 
         var names = engine.Evaluate("o.entries.map(e => e.name)").AsArray();
 
-        Assert.Equal((uint) 3, names.Length);
-        Assert.Equal("One", names[0]);
-        Assert.Equal("Two", names[1]);
-        Assert.Equal("Three", names[2]);
+        names.Length.Should().Be((uint) 3);
+        names[0].Should().Be("One");
+        names[1].Should().Be("Two");
+        names[2].Should().Be("Three");
     }
 }

--- a/Jint.Tests.PublicInterface/InteropTests.SystemTextJson.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.SystemTextJson.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using Jint.Native;
 using Jint.Runtime.Interop;
 using System.Text.Json;
@@ -15,8 +15,8 @@ public partial class InteropTests
         var array = new JsonArray { "A", "B", "C" };
         engine.SetValue("array", array);
 
-        Assert.Equal(1, engine.Evaluate("array.findIndex((x) => x === 'B')"));
-        Assert.Equal('B', engine.Evaluate("array.find((x) => x === 'B')"));
+        engine.Evaluate("array.findIndex((x) => x === 'B')").Should().Be(1);
+        engine.Evaluate("array.find((x) => x === 'B')").Should().Be('B');
     }
 
     [Fact]
@@ -28,9 +28,9 @@ public partial class InteropTests
         engine.SetValue("array", array);
 
         engine.Evaluate("array.push('D')");
-        Assert.Equal(4, array.Count);
-        Assert.Equal("D", array[3]?.ToString());
-        Assert.Equal(3, engine.Evaluate("array.lastIndexOf('D')"));
+        array.Should().HaveCount(4);
+        (array[3]?.ToString()).Should().Be("D");
+        engine.Evaluate("array.lastIndexOf('D')").Should().Be(3);
     }
 
     [Fact]
@@ -41,11 +41,11 @@ public partial class InteropTests
         var array = new JsonArray { "A", "B", "C" };
         engine.SetValue("array", array);
 
-        Assert.Equal(2, engine.Evaluate("array.lastIndexOf('C')"));
-        Assert.Equal(3, array.Count);
-        Assert.Equal("C", engine.Evaluate("array.pop()"));
-        Assert.Equal(2, array.Count);
-        Assert.Equal(-1, engine.Evaluate("array.lastIndexOf('C')"));
+        engine.Evaluate("array.lastIndexOf('C')").Should().Be(2);
+        array.Should().HaveCount(3);
+        engine.Evaluate("array.pop()").Should().Be("C");
+        array.Should().HaveCount(2);
+        engine.Evaluate("array.lastIndexOf('C')").Should().Be(-1);
     }
 
     [Fact]
@@ -101,40 +101,40 @@ public partial class InteropTests
 
         // reading data
         var result = engine.Evaluate("populateFullName()").AsArray();
-        Assert.Equal((uint) 2, result.Length);
-        Assert.Equal("John Doe", result[0].AsObject()["fullName"]);
-        Assert.Equal("Jane Doe", result[1].AsObject()["fullName"]);
-        Assert.True(engine.Evaluate("variables.employees.trueValue == true").AsBoolean());
-        Assert.True(engine.Evaluate("variables.employees.number == 123.456").AsBoolean());
-        Assert.True(engine.Evaluate("variables.employees.other == 'abc'").AsBoolean());
+        result.Length.Should().Be((uint) 2);
+        result[0].AsObject()["fullName"].Should().Be("John Doe");
+        result[1].AsObject()["fullName"].Should().Be("Jane Doe");
+        engine.Evaluate("variables.employees.trueValue == true").AsBoolean().Should().BeTrue();
+        engine.Evaluate("variables.employees.number == 123.456").AsBoolean().Should().BeTrue();
+        engine.Evaluate("variables.employees.other == 'abc'").AsBoolean().Should().BeTrue();
 
         // mutating data via JS
         engine.Evaluate("variables.employees.type = 'array2'");
         engine.Evaluate("variables.employees.value[0].firstName = 'Jake'");
 
-        //Assert.Equal("array2", engine.Evaluate("variables['employees']['type']").ToString());
+        //engine.Evaluate("variables['employees']['type']").ToString().Should().Be("array2");
 
         result = engine.Evaluate("populateFullName()").AsArray();
-        Assert.Equal((uint) 2, result.Length);
-        Assert.Equal("Jake Doe", result[0].AsObject()["fullName"]);
+        result.Length.Should().Be((uint) 2);
+        result[0].AsObject()["fullName"].Should().Be("Jake Doe");
 
         // Validate boolean value in the if condition.
-        Assert.Equal(1, engine.Evaluate("if(!falseValue){ return 1 ;} else {return 0;}").AsNumber());
-        Assert.Equal(1, engine.Evaluate("if(falseValue===false){ return 1 ;} else {return 0;}").AsNumber());
-        Assert.True(engine.Evaluate("!variables.zeroNumber").AsBoolean());
-        Assert.True(engine.Evaluate("!variables.emptyString").AsBoolean());
-        Assert.True(engine.Evaluate("!variables.nullValue").AsBoolean());
+        engine.Evaluate("if(!falseValue){ return 1 ;} else {return 0;}").AsNumber().Should().Be(1);
+        engine.Evaluate("if(falseValue===false){ return 1 ;} else {return 0;}").AsNumber().Should().Be(1);
+        engine.Evaluate("!variables.zeroNumber").AsBoolean().Should().BeTrue();
+        engine.Evaluate("!variables.emptyString").AsBoolean().Should().BeTrue();
+        engine.Evaluate("!variables.nullValue").AsBoolean().Should().BeTrue();
         var result2 = engine.Evaluate("!variables.falseValue");
         var result3 = engine.Evaluate("!falseValue");
         var result4 = engine.Evaluate("variables.falseValue");
         var result5 = engine.Evaluate("falseValue");
-        Assert.NotNull(result2);
+        result2.Should().NotBeNull();
 
-        Assert.Equal(1, engine.Evaluate("if(variables.falseValue===false){ return 1 ;} else {return 0;}").AsNumber());
-        Assert.Equal(1, engine.Evaluate("if(falseValue===variables.falseValue){ return 1 ;} else {return 0;}").AsNumber());
-        Assert.Equal(1, engine.Evaluate("if(!variables.falseValue){ return 1 ;} else {return 0;}").AsNumber());
-        Assert.Equal(1, engine.Evaluate("if(!variables.employees.falseValue){ return 1 ;} else {return 0;}").AsNumber());
-        Assert.Equal(0, engine.Evaluate("if(!variables.employees.trueValue) return 1 ; else return 0;").AsNumber());
+        engine.Evaluate("if(variables.falseValue===false){ return 1 ;} else {return 0;}").AsNumber().Should().Be(1);
+        engine.Evaluate("if(falseValue===variables.falseValue){ return 1 ;} else {return 0;}").AsNumber().Should().Be(1);
+        engine.Evaluate("if(!variables.falseValue){ return 1 ;} else {return 0;}").AsNumber().Should().Be(1);
+        engine.Evaluate("if(!variables.employees.falseValue){ return 1 ;} else {return 0;}").AsNumber().Should().Be(1);
+        engine.Evaluate("if(!variables.employees.trueValue) return 1 ; else return 0;").AsNumber().Should().Be(0);
 
 
         // mutating original object that is wrapped inside the engine
@@ -144,14 +144,14 @@ public partial class InteropTests
         variables["employees"]["type"] = "array";
         variables["employees"]["value"][0]["firstName"] = "John";
 
-        Assert.Equal("array", engine.Evaluate("variables['employees']['type']").ToString());
+        engine.Evaluate("variables['employees']['type']").ToString().Should().Be("array");
 
         result = engine.Evaluate("populateFullName()").AsArray();
-        Assert.Equal((uint) 2, result.Length);
-        Assert.Equal("John Doe", result[0].AsObject()["fullName"]);
-        Assert.True(engine.Evaluate("variables.employees.trueValue == false").AsBoolean());
-        Assert.True(engine.Evaluate("variables.employees.number == 456.789").AsBoolean());
-        Assert.True(engine.Evaluate("variables.employees.other == 'def'").AsBoolean());
+        result.Length.Should().Be((uint) 2);
+        result[0].AsObject()["fullName"].Should().Be("John Doe");
+        engine.Evaluate("variables.employees.trueValue == false").AsBoolean().Should().BeTrue();
+        engine.Evaluate("variables.employees.number == 456.789").AsBoolean().Should().BeTrue();
+        engine.Evaluate("variables.employees.other == 'def'").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -159,9 +159,9 @@ public partial class InteropTests
     {
         var engine = GetEngine();
 
-        Assert.Equal(15, engine.SetValue("int", JsonValue.Create(15)).Evaluate("int"));
-        Assert.Equal(15.0, engine.SetValue("double", JsonValue.Create(15.0)).Evaluate("double"));
-        Assert.Equal(15f, engine.SetValue("float", JsonValue.Create(15.0f)).Evaluate("float"));
+        engine.SetValue("int", JsonValue.Create(15)).Evaluate("int").Should().Be(15);
+        engine.SetValue("double", JsonValue.Create(15.0)).Evaluate("double").Should().Be(15.0);
+        engine.SetValue("float", JsonValue.Create(15.0f)).Evaluate("float").Should().Be(15f);
     }
 
     private static Engine GetEngine()

--- a/Jint.Tests.PublicInterface/InteropTests.cs
+++ b/Jint.Tests.PublicInterface/InteropTests.cs
@@ -12,8 +12,9 @@ public partial class InteropTests : IDisposable
                     typeof(Console).GetTypeInfo().Assembly,
                     typeof(File).GetTypeInfo().Assembly))
                 .SetValue("log", new Action<object>(Console.WriteLine))
-                .SetValue("assert", new Action<bool>(Assert.True))
-                .SetValue("equal", new Action<object, object>(Assert.Equal))
+                .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+                .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())))
             ;
     }
 

--- a/Jint.Tests.PublicInterface/JavaScriptExceptionTests.cs
+++ b/Jint.Tests.PublicInterface/JavaScriptExceptionTests.cs
@@ -20,61 +20,43 @@ public class JavaScriptExceptionTests
             throw new JavaScriptException(new JsString("message 2"));
         });
 
-        Assert.Throws<JavaScriptException>(() =>
+        Invoking(() =>
         {
             engine.Evaluate(@"throw1()");
-        });
+        }).Should().ThrowExactly<JavaScriptException>();
 
         var result1 = engine.Evaluate(@"try { throw1() } catch (e) { return e; }");
-        var error1 = Assert.IsType<JsError>(result1);
-        Assert.Equal("message 1", error1.Get("message").ToString());
+        var error1 = result1.Should().BeOfType<JsError>().Which;
+        error1.Get("message").ToString().Should().Be("message 1");
 
         var result2 = engine.Evaluate(@"try { throw2() } catch (e) { return e; }");
-        var jsString = Assert.IsType<JsString>(result2);
-        Assert.Equal("message 2", jsString.ToString());
+        var jsString = result2.Should().BeOfType<JsString>().Which;
+        jsString.ToString().Should().Be("message 2");
     }
 
     [Fact]
     public void GetBaseExceptionReturnsJavaScriptException()
     {
         // https://github.com/sebastienros/jint/issues/2210
-        try
-        {
-            new Engine().Evaluate("x * x");
-            Assert.Fail("Expected JavaScriptException to be thrown");
-        }
-        catch (Exception ex)
-        {
-            // GetBaseException() should return the JavaScriptException itself,
-            // not the private inner exception
-            var baseException = ex.GetBaseException();
-            Assert.IsType<JavaScriptException>(baseException);
-            Assert.Same(ex, baseException);
-        }
+        var ex = Invoking(() => new Engine().Evaluate("x * x")).Should().Throw<Exception>().Which;
+
+        // GetBaseException() should return the JavaScriptException itself,
+        // not the private inner exception
+        var baseException = ex.GetBaseException();
+        baseException.Should().BeOfType<JavaScriptException>();
+        baseException.Should().BeSameAs(ex);
     }
 
     [Fact]
     public void GetBaseExceptionAllowsPatternMatching()
     {
         // https://github.com/sebastienros/jint/issues/2210
-        try
-        {
-            new Engine().Evaluate("throw new Error('test error')");
-            Assert.Fail("Expected JavaScriptException to be thrown");
-        }
-        catch (Exception ex)
-        {
-            // Pattern matching with GetBaseException() should work
-            if (ex.GetBaseException() is JavaScriptException jsError)
-            {
-                Assert.NotNull(jsError.Error);
-                Assert.Equal("test error", jsError.Error.AsObject().Get("message").ToString());
-            }
-            else
-            {
-                Assert.Fail("GetBaseException() should return JavaScriptException");
-            }
-        }
+        var ex = Invoking(() => new Engine().Evaluate("throw new Error('test error')")).Should().Throw<Exception>().Which;
+
+        // Pattern matching with GetBaseException() should work
+        var jsError = ex.GetBaseException().Should().BeOfType<JavaScriptException>().Which;
+        jsError.Error.Should().NotBeNull();
+        jsError.Error.AsObject().Get("message").ToString().Should().Be("test error");
     }
 
     [Fact]
@@ -88,20 +70,9 @@ public class JavaScriptExceptionTests
             throw new JavaScriptException(engine.Intrinsics.Error, "from .NET");
         });
 
-        try
-        {
-            engine.Evaluate("throwFromDotNet()");
-            Assert.Fail("Expected JavaScriptException to be thrown");
-        }
-        catch (Exception ex)
-        {
-            var baseException = ex.GetBaseException();
-            Assert.IsType<JavaScriptException>(baseException);
+        var ex = Invoking(() => engine.Evaluate("throwFromDotNet()")).Should().Throw<Exception>().Which;
 
-            if (baseException is JavaScriptException jsError)
-            {
-                Assert.Equal("from .NET", jsError.Error.AsObject().Get("message").ToString());
-            }
-        }
+        var jsError = ex.GetBaseException().Should().BeOfType<JavaScriptException>().Which;
+        jsError.Error.AsObject().Get("message").ToString().Should().Be("from .NET");
     }
 }

--- a/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
+++ b/Jint.Tests.PublicInterface/Jint.Tests.PublicInterface.csproj
@@ -30,6 +30,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Shared so that a JsValue can be compared against a CLR value in both test projects. -->
+    <Compile Include="..\Jint.Tests\JsValueAssertions.cs" Link="JsValueAssertions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="AwesomeAssertions" />
+    <Using Include="AwesomeAssertions.FluentActions" Static="true" />
+    <Using Include="Jint.Tests" />
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/Jint.Tests.PublicInterface/MapTests.cs
+++ b/Jint.Tests.PublicInterface/MapTests.cs
@@ -1,4 +1,4 @@
-using AwesomeAssertions;
+﻿using AwesomeAssertions;
 using Jint.Native;
 
 namespace Jint.Tests.Runtime;
@@ -21,23 +21,23 @@ public class MapTests
 
         map.Get(42).Should().Be((JsString) "the meaning of life");
         map.Get("foo").Should().Be((JsString) "bar");
-        map.Get(24).Should().Be(JsValue.Undefined);
+        map.Get(24).Should().BeUndefined();
 
         engine.SetValue("m", map);
-        engine.Evaluate("m.size").Should().Be((JsNumber) 2);
-        engine.Evaluate("m.has(42)").Should().Be(JsBoolean.True);
-        engine.Evaluate("m.has('foo')").Should().Be(JsBoolean.True);
-        engine.Evaluate("m.has(24)").Should().Be(JsBoolean.False);
+        engine.Evaluate("m.size").Should().Be(2);
+        engine.Evaluate("m.has(42)").Should().BeTrue();
+        engine.Evaluate("m.has('foo')").Should().BeTrue();
+        engine.Evaluate("m.has(24)").Should().BeFalse();
 
-        map.Should().Contain((JsNumber) 42, (JsString) "the meaning of life");
+        map.AsEnumerable().Should().Contain((JsNumber) 42, (JsString) "the meaning of life");
         map.Remove(42).Should().BeTrue();
         map.Has(42).Should().BeFalse();
-        engine.Evaluate("m.has(42)").Should().Be(JsBoolean.False);
-        engine.Evaluate("m.size").Should().Be((JsNumber) 1);
+        engine.Evaluate("m.has(42)").Should().BeFalse();
+        engine.Evaluate("m.size").Should().Be(1);
 
         map.Clear();
-        map.Should().BeEmpty();
+        map.AsEnumerable().Should().BeEmpty();
         map.Size.Should().Be(0);
-        engine.Evaluate("m.size").Should().Be((JsNumber) 0);
+        engine.Evaluate("m.size").Should().Be(0);
     }
 }

--- a/Jint.Tests.PublicInterface/ModuleLoaderTests.cs
+++ b/Jint.Tests.PublicInterface/ModuleLoaderTests.cs
@@ -35,8 +35,8 @@ public class ModuleLoaderTests
 
         static void ExpectLoggedValue(ModuleScript executedScript, string expectedValue)
         {
-            Assert.Single(executedScript.Logs);
-            Assert.Equal(expectedValue, executedScript.Logs[0]);
+            executedScript.Logs.Should().ContainSingle();
+            executedScript.Logs[0].Should().Be(expectedValue);
         }
 
         ModuleScript RunModule(string code)
@@ -66,7 +66,7 @@ public class ModuleLoaderTests
             runner.Execute();
         }
 
-        Assert.Equal(1, sharedModules.ModulesParsed);
+        sharedModules.ModulesParsed.Should().Be(1);
     }
 
     [Fact]
@@ -81,8 +81,8 @@ public class ModuleLoaderTests
         var runner = new ModuleScript("import data from 'config.json' with { type: 'json' }; log(data.value);", sharedModules);
         runner.Execute();
 
-        Assert.Single(runner.Logs);
-        Assert.Equal("json", runner.Logs[0]);
+        runner.Logs.Should().ContainSingle();
+        runner.Logs[0].Should().Be("json");
     }
 
     /// <summary>
@@ -210,7 +210,7 @@ public class ModuleLoaderTests
 
         public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
         {
-            Assert.NotNull(resolved.Uri);
+            resolved.Uri.Should().NotBeNull();
             #if NETCOREAPP1_0_OR_GREATER
             var parsedModule = _parsedModules.GetOrAdd(resolved.Uri, _moduleParser, resolved);
             #else

--- a/Jint.Tests.PublicInterface/PublicInterfaceTests.cs
+++ b/Jint.Tests.PublicInterface/PublicInterfaceTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Native.Function;
 
 namespace Jint.Tests.PublicInterface;
@@ -10,7 +10,7 @@ public class PublicInterfaceTests
     {
         var engine = new Engine();
         var value = engine.Intrinsics.Eval.Call("1 + 1");
-        Assert.Equal(2, value);
+        value.Should().Be(2);
     }
 
     [Fact]
@@ -46,8 +46,8 @@ var coolingObject = {
     {
         // debuggers might want to access the information
         var obj = new Engine().Execute("function f() { return arguments; }").Evaluate("f('a', 'b', 'c');");
-        var arguments = Assert.IsType<JsArguments>(obj);
-        Assert.Equal((uint) 3, arguments.Length);
+        var arguments = obj.Should().BeOfType<JsArguments>().Which;
+        arguments.Length.Should().Be((uint) 3);
     }
 
     [Fact]
@@ -55,21 +55,21 @@ var coolingObject = {
     {
         var engine = new Engine();
         var func = engine.Evaluate("(function() {})");
-        Assert.True(func.IsCallable());
+        func.IsCallable().Should().BeTrue();
 
         var arrow = engine.Evaluate("(() => {})");
-        Assert.True(arrow.IsCallable());
+        arrow.IsCallable().Should().BeTrue();
     }
 
     [Fact]
     public void IsCallableReturnsFalseForNonFunctions()
     {
         var engine = new Engine();
-        Assert.False(JsValue.Undefined.IsCallable());
-        Assert.False(JsValue.Null.IsCallable());
-        Assert.False(JsNumber.Create(42).IsCallable());
-        Assert.False(new JsString("hello").IsCallable());
-        Assert.False(engine.Evaluate("({})").IsCallable());
+        JsValue.Undefined.IsCallable().Should().BeFalse();
+        JsValue.Null.IsCallable().Should().BeFalse();
+        JsNumber.Create(42).IsCallable().Should().BeFalse();
+        new JsString("hello").IsCallable().Should().BeFalse();
+        engine.Evaluate("({})").IsCallable().Should().BeFalse();
     }
 
     [Fact]
@@ -77,22 +77,22 @@ var coolingObject = {
     {
         var engine = new Engine();
         var ctor = engine.Evaluate("(class Foo {})");
-        Assert.True(ctor.IsConstructor());
+        ctor.IsConstructor().Should().BeTrue();
 
         var func = engine.Evaluate("(function Bar() {})");
-        Assert.True(func.IsConstructor());
+        func.IsConstructor().Should().BeTrue();
     }
 
     [Fact]
     public void IsConstructorReturnsFalseForNonConstructors()
     {
         var engine = new Engine();
-        Assert.False(JsValue.Undefined.IsConstructor());
-        Assert.False(JsValue.Null.IsConstructor());
-        Assert.False(JsNumber.Create(42).IsConstructor());
+        JsValue.Undefined.IsConstructor().Should().BeFalse();
+        JsValue.Null.IsConstructor().Should().BeFalse();
+        JsNumber.Create(42).IsConstructor().Should().BeFalse();
 
         var arrow = engine.Evaluate("(() => {})");
-        Assert.False(arrow.IsConstructor());
+        arrow.IsConstructor().Should().BeFalse();
     }
 
     private sealed class SetTimeoutEmulator : IDisposable

--- a/Jint.Tests.PublicInterface/RavenApiUsageTests.cs
+++ b/Jint.Tests.PublicInterface/RavenApiUsageTests.cs
@@ -1,4 +1,4 @@
-using Jint.Constraints;
+﻿using Jint.Constraints;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Runtime;
@@ -34,7 +34,7 @@ public class RavenApiUsageTests
             functionExp,
             strict: false);
 
-        Assert.NotNull(functionObject);
+        functionObject.Should().NotBeNull();
     }
 
     [Fact]
@@ -43,13 +43,13 @@ public class RavenApiUsageTests
         var engine = new Engine(options => options.MaxStatements(123));
 
         var constraint = engine.Constraints.Find<MaxStatementsConstraint>();
-        Assert.NotNull(constraint);
+        constraint.Should().NotBeNull();
 
         var oldMaxStatements = constraint.MaxStatements;
         constraint.MaxStatements = 321;
 
-        Assert.Equal(123, oldMaxStatements);
-        Assert.Equal(321, constraint.MaxStatements);
+        oldMaxStatements.Should().Be(123);
+        constraint.MaxStatements.Should().Be(321);
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class RavenApiUsageTests
         var engine = new Engine();
         var obj = new DirectoryInfo("the-path");
         var propertyDescriptor = ObjectWrapper.GetPropertyDescriptor(engine, obj, obj.GetType().GetProperty(nameof(DirectoryInfo.Name)));
-        Assert.Equal("the-path", propertyDescriptor.Value);
+        propertyDescriptor.Value.Should().Be("the-path");
     }
 
     [Fact]
@@ -78,24 +78,24 @@ public class RavenApiUsageTests
         TestArrayAccess(engine, array1, "array1");
 
         engine.SetValue("obj", obj);
-        Assert.Equal("test", engine.Evaluate("obj.name"));
+        engine.Evaluate("obj.name").Should().Be("test");
 
         engine.SetValue("emptyArray", new JsArray(engine));
-        Assert.Equal(0, engine.Evaluate("emptyArray.length"));
-        Assert.Equal(1, engine.Evaluate("emptyArray.push(1); return emptyArray.length"));
+        engine.Evaluate("emptyArray.length").Should().Be(0);
+        engine.Evaluate("emptyArray.push(1); return emptyArray.length").Should().Be(1);
 
         engine.SetValue("emptyArray", new JsArray(engine, []));
-        Assert.Equal(0, engine.Evaluate("emptyArray.length"));
-        Assert.Equal(1, engine.Evaluate("emptyArray.push(1); return emptyArray.length"));
+        engine.Evaluate("emptyArray.length").Should().Be(0);
+        engine.Evaluate("emptyArray.push(1); return emptyArray.length").Should().Be(1);
 
         engine.SetValue("date", new JsDate(engine, new DateTime(2022, 10, 20)));
-        Assert.Equal(2022, engine.Evaluate("date.getFullYear()"));
+        engine.Evaluate("date.getFullYear()").Should().Be(2022);
     }
 
     private static void TestArrayAccess(Engine engine, JsArray array, string name)
     {
-        Assert.Equal(1, engine.Evaluate($"{name}.findIndex(x => x === 2)"));
-        Assert.Equal(2, array.GetOwnProperty("1").Value);
+        engine.Evaluate($"{name}.findIndex(x => x === 2)").Should().Be(1);
+        array.GetOwnProperty("1").Value.Should().Be(2);
 
         array.Push(4);
         array.Push([5, 6]);
@@ -103,31 +103,31 @@ public class RavenApiUsageTests
         var i = 0;
         foreach (var entry in array.GetEntries())
         {
-            Assert.Equal(i.ToString(), entry.Key);
-            Assert.Equal(i + 1, entry.Value);
+            entry.Key.Should().Be(i.ToString());
+            entry.Value.Should().Be(i + 1);
             i++;
         }
 
-        Assert.Equal(6, i);
+        i.Should().Be(6);
 
         array[0] = "";
         array[1] = false;
         array[2] = null;
 
-        Assert.Equal("", array[0]);
-        Assert.Equal(false, array[1]);
-        Assert.Equal(JsValue.Undefined, array[2]);
-        Assert.Equal(4, array[3]);
-        Assert.Equal(5, array[4]);
-        Assert.Equal(6, array[5]);
+        array[0].Should().Be("");
+        array[1].Should().BeFalse();
+        array[2].Should().BeUndefined();
+        array[3].Should().Be(4);
+        array[4].Should().Be(5);
+        array[5].Should().Be(6);
 
         for (i = 0; i < 100; ++i)
         {
             array.Push(JsValue.Undefined);
         }
 
-        Assert.Equal(106L, array.Length);
-        Assert.True(array.All(x => x is JsNumber or JsUndefined or JsNumber or JsString or JsBoolean));
+        array.Length.Should().Be(106);
+        array.All(x => x is JsNumber or JsUndefined or JsNumber or JsString or JsBoolean).Should().BeTrue();
     }
 
     // Checks different ways how string can be checked for equality without the need to materialize lazy value
@@ -151,32 +151,32 @@ public class RavenApiUsageTests
         var array = new JsArray(engine, Enumerable.Range(1, 100).Select(x => new CustomString(x.ToString())).ToArray<JsValue>());
         engine.SetValue("array", array);
 
-        Assert.True(engine.Evaluate("str ? true : false").AsBoolean());
-        Assert.False(engine.Evaluate("empty ? true : false").AsBoolean());
+        engine.Evaluate("str ? true : false").AsBoolean().Should().BeTrue();
+        engine.Evaluate("empty ? true : false").AsBoolean().Should().BeFalse();
 
-        Assert.True(engine.Evaluate("array.includes('2')").AsBoolean());
-        Assert.True(engine.Evaluate("array.filter(x => x === '2').length > 0").AsBoolean());
+        engine.Evaluate("array.includes('2')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("array.filter(x => x === '2').length > 0").AsBoolean().Should().BeTrue();
 
         engine.SetValue("objArray", new JsArray(engine, [obj, obj]));
-        Assert.True(engine.Evaluate("objArray.filter(x => x.name === 'the name').length === 2").AsBoolean());
+        engine.Evaluate("objArray.filter(x => x.name === 'the name').length === 2").AsBoolean().Should().BeTrue();
 
-        Assert.Equal(9, engine.Evaluate("str.length"));
+        engine.Evaluate("str.length").Should().Be(9);
 
-        Assert.True(engine.Evaluate("str == 'the-value'").AsBoolean());
-        Assert.True(engine.Evaluate("str === 'the-value'").AsBoolean());
+        engine.Evaluate("str == 'the-value'").AsBoolean().Should().BeTrue();
+        engine.Evaluate("str === 'the-value'").AsBoolean().Should().BeTrue();
 
-        Assert.True(engine.Evaluate("str.indexOf('value-too-long') === -1").AsBoolean());
-        Assert.True(engine.Evaluate("str.lastIndexOf('value-too-long') === -1").AsBoolean());
-        Assert.False(engine.Evaluate("str.startsWith('value-too-long')").AsBoolean());
-        Assert.False(engine.Evaluate("str.endsWith('value-too-long')").AsBoolean());
-        Assert.False(engine.Evaluate("str.includes('value-too-long')").AsBoolean());
+        engine.Evaluate("str.indexOf('value-too-long') === -1").AsBoolean().Should().BeTrue();
+        engine.Evaluate("str.lastIndexOf('value-too-long') === -1").AsBoolean().Should().BeTrue();
+        engine.Evaluate("str.startsWith('value-too-long')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("str.endsWith('value-too-long')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("str.includes('value-too-long')").AsBoolean().Should().BeFalse();
 
-        Assert.True(engine.Evaluate("empty.trim() === ''").AsBoolean());
-        Assert.True(engine.Evaluate("empty.trimStart() === ''").AsBoolean());
-        Assert.True(engine.Evaluate("empty.trimEnd() === ''").AsBoolean());
+        engine.Evaluate("empty.trim() === ''").AsBoolean().Should().BeTrue();
+        engine.Evaluate("empty.trimStart() === ''").AsBoolean().Should().BeTrue();
+        engine.Evaluate("empty.trimEnd() === ''").AsBoolean().Should().BeTrue();
 
-        Assert.True(engine.Evaluate("str[1] === 'h'").AsBoolean());
-        Assert.True(engine.Evaluate("str[x] === undefined").AsBoolean());
+        engine.Evaluate("str[1] === 'h'").AsBoolean().Should().BeTrue();
+        engine.Evaluate("str[x] === undefined").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public class RavenApiUsageTests
     {
         var engine = new Engine();
         engine.SetValue("value", new CustomNull());
-        Assert.Equal("foo", engine.Evaluate("value ? value + 'bar' : 'foo'"));
+        engine.Evaluate("value ? value + 'bar' : 'foo'").Should().Be("foo");
     }
 
     [Fact]
@@ -192,7 +192,7 @@ public class RavenApiUsageTests
     {
         var engine = new Engine();
         engine.SetValue("value", new CustomUndefined());
-        Assert.Equal("foo", engine.Evaluate("value ? value + 'bar' : 'foo'"));
+        engine.Evaluate("value ? value + 'bar' : 'foo'").Should().Be("foo");
     }
 
     [Fact]
@@ -231,7 +231,7 @@ public class RavenApiUsageTests
         var custom = rows.AsArray()[0].AsObject()["Custom"];
         // With the spec-compliant IsPropertyReference, the custom resolver's TryGetCallable
         // returns a function that produces undefined, so the result is undefined
-        Assert.Equal(JsValue.Undefined, custom);
+        custom.Should().BeUndefined();
     }
 }
 

--- a/Jint.Tests.PublicInterface/SetTests.cs
+++ b/Jint.Tests.PublicInterface/SetTests.cs
@@ -1,4 +1,4 @@
-using AwesomeAssertions;
+﻿using AwesomeAssertions;
 using Jint.Native;
 
 namespace Jint.Tests.Runtime;
@@ -15,26 +15,26 @@ public class SetTests
         set.Add("foo");
         set.Size.Should().Be(2);
 
-        set.Should().ContainInOrder(42, "foo");
+        set.AsEnumerable().Should().ContainInOrder(42, "foo");
 
         set.Has(42).Should().BeTrue();
         set.Has("foo").Should().BeTrue();
         set.Has(24).Should().BeFalse();
 
         engine.SetValue("s", set);
-        engine.Evaluate("s.size").Should().Be((JsNumber) 2);
-        engine.Evaluate("s.has(42)").Should().Be(JsBoolean.True);
-        engine.Evaluate("s.has('foo')").Should().Be(JsBoolean.True);
-        engine.Evaluate("s.has(24)").Should().Be(JsBoolean.False);
+        engine.Evaluate("s.size").Should().Be(2);
+        engine.Evaluate("s.has(42)").Should().BeTrue();
+        engine.Evaluate("s.has('foo')").Should().BeTrue();
+        engine.Evaluate("s.has(24)").Should().BeFalse();
 
         set.Delete(42).Should().BeTrue();
         set.Has(42).Should().BeFalse();
-        engine.Evaluate("s.has(42)").Should().Be(JsBoolean.False);
-        engine.Evaluate("s.size").Should().Be((JsNumber) 1);
+        engine.Evaluate("s.has(42)").Should().BeFalse();
+        engine.Evaluate("s.size").Should().Be(1);
 
         set.Clear();
-        set.Should().BeEmpty();
+        set.AsEnumerable().Should().BeEmpty();
         set.Size.Should().Be(0);
-        engine.Evaluate("s.size").Should().Be((JsNumber) 0);
+        engine.Evaluate("s.size").Should().Be(0);
     }
 }

--- a/Jint.Tests.PublicInterface/ShadowRealmTests.cs
+++ b/Jint.Tests.PublicInterface/ShadowRealmTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native.Object;
+﻿using Jint.Native.Object;
 using Jint.Runtime;
 
 namespace Jint.Tests.PublicInterface;
@@ -12,21 +12,21 @@ public class ShadowRealmTests
         var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
 
         // lexically scoped (let/const) are visible during single call
-        Assert.Equal(123, shadowRealm.Evaluate("const s = 123; const f = () => s; f();"));
-        Assert.Equal(true, shadowRealm.Evaluate("typeof f === 'undefined'"));
+        shadowRealm.Evaluate("const s = 123; const f = () => s; f();").Should().Be(123);
+        shadowRealm.Evaluate("typeof f === 'undefined'").Should().BeTrue();
 
         // vars hold longer
-        Assert.Equal(456, shadowRealm.Evaluate("function foo() { return 456; }; foo();"));
-        Assert.Equal(456, shadowRealm.Evaluate("foo();"));
+        shadowRealm.Evaluate("function foo() { return 456; }; foo();").Should().Be(456);
+        shadowRealm.Evaluate("foo();").Should().Be(456);
 
         // not visible in global engine though
-        Assert.Equal(true, engine.Evaluate("typeof foo === 'undefined'"));
+        engine.Evaluate("typeof foo === 'undefined'").Should().BeTrue();
 
         // modules
         var importValue = shadowRealm.ImportValue("./modules/format-name.js", "formatName");
         var formatName = (ObjectInstance) importValue.UnwrapIfPromise();
         var result = engine.Invoke(formatName, "John", "Doe").AsString();
-        Assert.Equal("John Doe", result);
+        result.Should().Be("John Doe");
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public class ShadowRealmTests
         engine.SetValue("message", "world");
         engine.Evaluate("function hello() {return message}");
 
-        Assert.Equal("world", engine.Evaluate("hello();"));
+        engine.Evaluate("hello();").Should().Be("world");
 
         var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
         shadowRealm.SetValue("message", "realm 1");
@@ -47,8 +47,8 @@ public class ShadowRealmTests
         shadowRealm2.Evaluate("function hello() {return message}");
 
         // Act & Assert
-        Assert.Equal("realm 1", shadowRealm.Evaluate("hello();"));
-        Assert.Equal("realm 2", shadowRealm2.Evaluate("hello();"));
+        shadowRealm.Evaluate("hello();").Should().Be("realm 1");
+        shadowRealm2.Evaluate("hello();").Should().Be("realm 2");
     }
 
     [Fact]
@@ -67,9 +67,9 @@ public class ShadowRealmTests
         shadowRealm2.Evaluate("(function hello() {message += \"realm 2\"})();");
 
         // Act & Assert
-        Assert.Equal("hello engine", engine.Evaluate("message"));
-        Assert.Equal("hello realm 1", shadowRealm.Evaluate("message"));
-        Assert.Equal("hello realm 2", shadowRealm2.Evaluate("message"));
+        engine.Evaluate("message").Should().Be("hello engine");
+        shadowRealm.Evaluate("message").Should().Be("hello realm 1");
+        shadowRealm2.Evaluate("message").Should().Be("hello realm 2");
     }
 
     [Fact]
@@ -87,9 +87,9 @@ public class ShadowRealmTests
         var script = Engine.PrepareScript("(function hello() {return \"hello \" + message})();");
 
         // Act & Assert
-        Assert.Equal("hello engine", engine.Evaluate(script));
-        Assert.Equal("hello realm 1", shadowRealm.Evaluate(script));
-        Assert.Equal("hello realm 2", shadowRealm2.Evaluate(script));
+        engine.Evaluate(script).Should().Be("hello engine");
+        shadowRealm.Evaluate(script).Should().Be("hello realm 1");
+        shadowRealm2.Evaluate(script).Should().Be("hello realm 2");
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class ShadowRealmTests
         var engine = new Engine();
         var shadowRealm = engine.Intrinsics.ShadowRealm.Construct();
 
-        Assert.Equal("derived:base", shadowRealm.Evaluate("""
+        shadowRealm.Evaluate("""
             class Base {
                 greet() { return 'base'; }
             }
@@ -109,36 +109,36 @@ public class ShadowRealmTests
                 greet() { return 'derived:' + super.greet(); }
             }
             new Derived().greet();
-            """));
+            """).Should().Be("derived:base");
 
-        Assert.Equal(3, shadowRealm.Evaluate("""
+        shadowRealm.Evaluate("""
             class A { constructor() { this.x = 1; } }
             class B extends A { constructor() { super(); this.y = 2; } }
             const b = new B();
             b.x + b.y;
-            """));
+            """).Should().Be(3);
 
-        Assert.Equal(42, shadowRealm.Evaluate("""
+        shadowRealm.Evaluate("""
             class C1 { m() { return 40; } }
             class C2 extends C1 { f = super.m() + 2; }
             new C2().f;
-            """));
+            """).Should().Be(42);
 
-        Assert.Equal(1, shadowRealm.Evaluate("""
+        shadowRealm.Evaluate("""
             class S1 { static m() { return 1; } }
             class S2 extends S1 { static v; static { S2.v = super.m(); } }
             S2.v;
-            """));
+            """).Should().Be(1);
 
-        Assert.Equal("[object Object]", shadowRealm.Evaluate("""
+        shadowRealm.Evaluate("""
             const o = { m() { return super.toString(); } };
             o.m();
-            """));
+            """).Should().Be("[object Object]");
 
-        Assert.Equal(true, shadowRealm.Evaluate("""
+        shadowRealm.Evaluate("""
             function f() { return new.target === undefined; }
             f();
-            """));
+            """).Should().BeTrue();
     }
 
     [Fact]
@@ -149,7 +149,7 @@ public class ShadowRealmTests
 
         var script = Engine.PrepareScript("class A { hello() { return 'hi'; } } class B extends A { hello() { return super.hello() + '!'; } } new B().hello();");
 
-        Assert.Equal("hi!", shadowRealm.Evaluate(script));
+        shadowRealm.Evaluate(script).Should().Be("hi!");
     }
 
     [Fact]
@@ -169,8 +169,8 @@ public class ShadowRealmTests
 
     private static void AssertSyntaxError(Native.ShadowRealm.ShadowRealm shadowRealm, string code)
     {
-        var ex = Assert.Throws<JavaScriptException>(() => shadowRealm.Evaluate(code));
-        Assert.Equal("SyntaxError", ex.Error.AsObject().Get("name").ToString());
+        var ex = Invoking(() => shadowRealm.Evaluate(code)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.AsObject().Get("name").ToString().Should().Be("SyntaxError");
     }
 
     private static string GetBasePath()

--- a/Jint.Tests.PublicInterface/TimeSystemTests.cs
+++ b/Jint.Tests.PublicInterface/TimeSystemTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Jint.Runtime;
 using Microsoft.Extensions.Time.Testing;
 using NodaTime;
@@ -32,7 +32,7 @@ public class TimeSystemTests
             options.TimeSystem = new NodaTimeSystem(dateTimeZone, timeZone);
         });
 
-        Assert.Equal(expected, engine.Evaluate($"new Date({input}) * 1").AsNumber());
+        engine.Evaluate($"new Date({input}) * 1").AsNumber().Should().Be(expected);
     }
     
     [Fact]
@@ -47,7 +47,7 @@ public class TimeSystemTests
         var beforeDefault = DateTimeOffset.Now.ToUnixTimeMilliseconds();
         var defaultScriptNow = defaultEngine.Evaluate("new Date() * 1").AsNumber();
         var afterDefault = DateTimeOffset.Now.ToUnixTimeMilliseconds();
-        Assert.InRange(defaultScriptNow, beforeDefault - 100, afterDefault + 100);
+        defaultScriptNow.Should().BeInRange(beforeDefault - 100, afterDefault + 100);
 
         var timeProvider = new FakeTimeProvider();
         timeProvider.SetUtcNow(new DateTimeOffset(2023, 11, 6, 0, 0, 0, 0, TimeSpan.Zero));
@@ -60,9 +60,9 @@ public class TimeSystemTests
         // the fake provider is frozen, so the script must read exactly its instant
         var timeProviderNow = timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
         var timeProviderScriptNow = timeProviderEngine.Evaluate("new Date() * 1").AsNumber();
-        Assert.Equal(timeProviderNow, timeProviderScriptNow);
+        timeProviderScriptNow.Should().Be(timeProviderNow);
 
-        Assert.NotInRange(timeProviderScriptNow, defaultScriptNow - 10000, defaultScriptNow + 10000);
+        timeProviderScriptNow.Should().NotBeInRange(defaultScriptNow - 10000, defaultScriptNow + 10000);
     }
 }
 

--- a/Jint.Tests/Jint.Tests.csproj
+++ b/Jint.Tests/Jint.Tests.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <Using Include="AwesomeAssertions" />
+    <Using Include="AwesomeAssertions.FluentActions" Static="true" />
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/Jint.Tests/JsValueAssertions.cs
+++ b/Jint.Tests/JsValueAssertions.cs
@@ -1,0 +1,82 @@
+﻿#nullable enable
+
+using System.Diagnostics;
+using AwesomeAssertions.Execution;
+using AwesomeAssertions.Primitives;
+using Jint.Native;
+
+namespace Jint.Tests;
+
+/// <summary>
+/// Makes <see cref="JsValue"/> a first-class citizen in assertions, so that a script result can be
+/// compared against a CLR value directly: <c>engine.Evaluate("1 + 1").Should().Be(2)</c>. The implicit
+/// conversions on <see cref="JsValue"/> turn the expectation into the matching JavaScript value, and
+/// the comparison is the same strict equality the engine itself uses.
+/// </summary>
+internal static class JsValueAssertionExtensions
+{
+    public static JsValueAssertions Should(this JsValue? value) => new(value, AssertionChain.GetOrCreate());
+}
+
+/// <inheritdoc cref="JsValueAssertionExtensions" />
+[DebuggerNonUserCode]
+internal sealed class JsValueAssertions(JsValue? subject, AssertionChain assertionChain)
+    : ReferenceTypeAssertions<JsValue?, JsValueAssertions>(subject, assertionChain)
+{
+    protected override string Identifier => "value";
+
+    /// <summary>
+    /// Asserts that the value is strictly equal to <paramref name="expected"/>.
+    /// </summary>
+    [CustomAssertion]
+    public AndConstraint<JsValueAssertions> Be(JsValue? expected, string because = "", params object[] becauseArgs)
+    {
+        CurrentAssertionChain
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(StrictEquals(Subject, expected))
+            .FailWith("Expected {context:value} to be {0}{reason}, but found {1}.", Describe(expected), Describe(Subject));
+
+        return new AndConstraint<JsValueAssertions>(this);
+    }
+
+    /// <summary>
+    /// Asserts that the value is not strictly equal to <paramref name="unexpected"/>.
+    /// </summary>
+    [CustomAssertion]
+    public AndConstraint<JsValueAssertions> NotBe(JsValue? unexpected, string because = "", params object[] becauseArgs)
+    {
+        CurrentAssertionChain
+            .BecauseOf(because, becauseArgs)
+            .ForCondition(!StrictEquals(Subject, unexpected))
+            .FailWith("Did not expect {context:value} to be {0}{reason}.", Describe(unexpected));
+
+        return new AndConstraint<JsValueAssertions>(this);
+    }
+
+    /// <summary>
+    /// Asserts that the value is the JavaScript <c>true</c>.
+    /// </summary>
+    [CustomAssertion]
+    public AndConstraint<JsValueAssertions> BeTrue(string because = "", params object[] becauseArgs) =>
+        Be(JsBoolean.True, because, becauseArgs);
+
+    /// <summary>
+    /// Asserts that the value is the JavaScript <c>false</c>.
+    /// </summary>
+    [CustomAssertion]
+    public AndConstraint<JsValueAssertions> BeFalse(string because = "", params object[] becauseArgs) =>
+        Be(JsBoolean.False, because, becauseArgs);
+
+    /// <summary>
+    /// Asserts that the value is <c>undefined</c>.
+    /// </summary>
+    [CustomAssertion]
+    public AndConstraint<JsValueAssertions> BeUndefined(string because = "", params object[] becauseArgs) =>
+        Be(JsValue.Undefined, because, becauseArgs);
+
+    private static bool StrictEquals(JsValue? left, JsValue? right) => left is null ? right is null : left.Equals(right);
+
+    // The default formatter renders every JsValue as its bare string form, which makes "expected 1 but
+    // found 1" style messages when only the JavaScript type differs. Spell the type out instead.
+    private static string Describe(JsValue? value) => value is null ? "<null>" : $"{value} ({value.Type})";
+}

--- a/Jint.Tests/Parser/JavascriptParserTests.cs
+++ b/Jint.Tests/Parser/JavascriptParserTests.cs
@@ -10,8 +10,8 @@ public class JavascriptParserTests
         var program = new Parser().ParseScript("this");
         var body = program.Body;
 
-        Assert.Single(body);
-        Assert.Equal(NodeType.ThisExpression, body.First().As<ExpressionStatement>().Expression.Type);
+        body.Should().ContainSingle();
+        body.First().As<ExpressionStatement>().Expression.Type.Should().Be(NodeType.ThisExpression);
     }
 
     [Fact]
@@ -20,10 +20,10 @@ public class JavascriptParserTests
         var program = new Parser().ParseScript("null");
         var body = program.Body;
 
-        Assert.Single(body);
-        Assert.Equal(NodeType.Literal, body.First().As<ExpressionStatement>().Expression.Type);
-        Assert.Equal(null, body.First().As<ExpressionStatement>().Expression.As<Literal>().Value);
-        Assert.Equal("null", body.First().As<ExpressionStatement>().Expression.As<Literal>().Raw);
+        body.Should().ContainSingle();
+        body.First().As<ExpressionStatement>().Expression.Type.Should().Be(NodeType.Literal);
+        body.First().As<ExpressionStatement>().Expression.As<Literal>().Value.Should().BeNull();
+        body.First().As<ExpressionStatement>().Expression.As<Literal>().Raw.Should().Be("null");
     }
 
     [Fact]
@@ -35,10 +35,10 @@ public class JavascriptParserTests
         var program = new Parser().ParseScript(code);
         var body = program.Body;
 
-        Assert.Single(body);
-        Assert.Equal(NodeType.Literal, body.First().As<ExpressionStatement>().Expression.Type);
-        Assert.Equal(42d, body.First().As<ExpressionStatement>().Expression.As<Literal>().Value);
-        Assert.Equal("42", body.First().As<ExpressionStatement>().Expression.As<Literal>().Raw);
+        body.Should().ContainSingle();
+        body.First().As<ExpressionStatement>().Expression.Type.Should().Be(NodeType.Literal);
+        body.First().As<ExpressionStatement>().Expression.As<Literal>().Value.Should().Be(42d);
+        body.First().As<ExpressionStatement>().Expression.As<Literal>().Raw.Should().Be("42");
     }
 
     [Fact]
@@ -49,13 +49,13 @@ public class JavascriptParserTests
         var program = new Parser().ParseScript("(1 + 2 ) * 3");
         var body = program.Body;
 
-        Assert.Single(body);
-        Assert.NotNull(binary = body.First().As<ExpressionStatement>().Expression.As<BinaryExpression>());
-        Assert.Equal(3d, binary.Right.As<Literal>().Value);
-        Assert.Equal(Operator.Multiplication, binary.Operator);
-        Assert.Equal(1d, binary.Left.As<BinaryExpression>().Left.As<Literal>().Value);
-        Assert.Equal(2d, binary.Left.As<BinaryExpression>().Right.As<Literal>().Value);
-        Assert.Equal(Operator.Addition, binary.Left.As<BinaryExpression>().Operator);
+        body.Should().ContainSingle();
+        (binary = body.First().As<ExpressionStatement>().Expression.As<BinaryExpression>()).Should().NotBeNull();
+        binary.Right.As<Literal>().Value.Should().Be(3d);
+        binary.Operator.Should().Be(Operator.Multiplication);
+        binary.Left.As<BinaryExpression>().Left.As<Literal>().Value.Should().Be(1d);
+        binary.Left.As<BinaryExpression>().Right.As<Literal>().Value.Should().Be(2d);
+        binary.Left.As<BinaryExpression>().Operator.Should().Be(Operator.Addition);
     }
 
     [Theory]
@@ -85,9 +85,9 @@ public class JavascriptParserTests
         var program = new Parser().ParseScript(code);
         var body = program.Body;
 
-        Assert.Single(body);
-        Assert.NotNull(literal = body.First().As<ExpressionStatement>().Expression.As<Literal>());
-        Assert.Equal(Convert.ToDouble(expected), Convert.ToDouble(literal.Value));
+        body.Should().ContainSingle();
+        (literal = body.First().As<ExpressionStatement>().Expression.As<Literal>()).Should().NotBeNull();
+        Convert.ToDouble(literal.Value).Should().Be(Convert.ToDouble(expected));
     }
 
     [Theory]
@@ -104,9 +104,9 @@ public class JavascriptParserTests
         var program = new Parser().ParseScript(code);
         var body = program.Body;
 
-        Assert.Single(body);
-        Assert.NotNull(literal = body.First().As<ExpressionStatement>().Expression.As<Literal>());
-        Assert.Equal(expected, literal.Value);
+        body.Should().ContainSingle();
+        (literal = body.First().As<ExpressionStatement>().Expression.As<Literal>()).Should().NotBeNull();
+        literal.Value.Should().Be(expected);
     }
 
     [Theory]
@@ -156,17 +156,17 @@ public class JavascriptParserTests
 ";
         var program = new Parser().ParseScript(Code);
         var expr = program.Body.First().As<ExpressionStatement>().Expression;
-        Assert.Equal(1, expr.Location.Start.Line);
-        Assert.Equal(0, expr.Location.Start.Column);
-        Assert.Equal(3, expr.Location.End.Line);
-        Assert.Equal(1, expr.Location.End.Column);
+        expr.Location.Start.Line.Should().Be(1);
+        expr.Location.Start.Column.Should().Be(0);
+        expr.Location.End.Line.Should().Be(3);
+        expr.Location.End.Column.Should().Be(1);
     }
 
     [Fact]
     public void ShouldThrowErrorForInvalidLeftHandOperation()
     {
-        var ex = Assert.Throws<JavaScriptException>(() => new Engine().Execute("~ (WE0=1)--- l('1');"));
-        Assert.Equal("Invalid left-hand side expression in postfix operation (<anonymous>:1:4)", ex.Message);
+        var ex = Invoking(() => new Engine().Execute("~ (WE0=1)--- l('1');")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Invalid left-hand side expression in postfix operation (<anonymous>:1:4)");
     }
 
 
@@ -177,6 +177,6 @@ public class JavascriptParserTests
     [InlineData("-.-")]
     public void ShouldThrowParseErrorExceptionForInvalidCode(string code)
     {
-        Assert.Throws<Acornima.SyntaxErrorException>(() => new Parser().ParseScript(code));
+        Invoking(() => new Parser().ParseScript(code)).Should().ThrowExactly<Acornima.SyntaxErrorException>();
     }
 }

--- a/Jint.Tests/Runtime/ArgumentsCacheBehaviorTests.cs
+++ b/Jint.Tests/Runtime/ArgumentsCacheBehaviorTests.cs
@@ -11,8 +11,8 @@ public class ArgumentsCacheBehaviorTests
         // call runs; the escaped snapshot taken when arguments is materialized must capture that
         // binding value, or the write is silently lost once the call returns.
         var engine = new Engine();
-        Assert.Equal(99, engine.Evaluate("(function(){ function f(a){ arguments[0]=99; return arguments; } return f(1)[0]; })()").AsNumber());
-        Assert.Equal("{\"0\":99}", engine.Evaluate("(function(){ function f(a){ arguments[0]=99; return arguments; } return JSON.stringify(f(1)); })()").AsString());
+        engine.Evaluate("(function(){ function f(a){ arguments[0]=99; return arguments; } return f(1)[0]; })()").AsNumber().Should().Be(99);
+        engine.Evaluate("(function(){ function f(a){ arguments[0]=99; return arguments; } return JSON.stringify(f(1)); })()").AsString().Should().Be("{\"0\":99}");
     }
 
     [Fact]
@@ -21,8 +21,8 @@ public class ArgumentsCacheBehaviorTests
         // The mapping is bidirectional: writing the parameter must also be visible through the
         // escaped arguments object after the call returns.
         var engine = new Engine();
-        Assert.Equal(42, engine.Evaluate("(function(){ function f(a){ a=42; return arguments; } return f(1)[0]; })()").AsNumber());
-        Assert.Equal("1,88", engine.Evaluate("(function(){ function f(a,b){ b=88; return arguments; } var r=f(1,2); return r[0]+','+r[1]; })()").AsString());
+        engine.Evaluate("(function(){ function f(a){ a=42; return arguments; } return f(1)[0]; })()").AsNumber().Should().Be(42);
+        engine.Evaluate("(function(){ function f(a,b){ b=88; return arguments; } var r=f(1,2); return r[0]+','+r[1]; })()").AsString().Should().Be("1,88");
     }
 
     [Fact]
@@ -32,9 +32,9 @@ public class ArgumentsCacheBehaviorTests
         // whether it was materialized virtually (a prior arguments read) or to real descriptors
         // (Object.keys) — must still show through the escaped object once the call returns.
         var engine = new Engine();
-        Assert.Equal(9, engine.Evaluate("(function(){ function f(a){ var s=arguments[0]; a=9; return arguments; } return f(1)[0]; })()").AsNumber());
-        Assert.Equal(9, engine.Evaluate("(function(){ function f(a){ Object.keys(arguments); a=9; return arguments; } return f(1)[0]; })()").AsNumber());
-        Assert.Equal(9, engine.Evaluate("(function(){ function f(a){ arguments[0]=9; Object.keys(arguments); return arguments; } return f(1)[0]; })()").AsNumber());
+        engine.Evaluate("(function(){ function f(a){ var s=arguments[0]; a=9; return arguments; } return f(1)[0]; })()").AsNumber().Should().Be(9);
+        engine.Evaluate("(function(){ function f(a){ Object.keys(arguments); a=9; return arguments; } return f(1)[0]; })()").AsNumber().Should().Be(9);
+        engine.Evaluate("(function(){ function f(a){ arguments[0]=9; Object.keys(arguments); return arguments; } return f(1)[0]; })()").AsNumber().Should().Be(9);
     }
 
     [Fact]
@@ -44,10 +44,10 @@ public class ArgumentsCacheBehaviorTests
         // Freezing its final binding value at return must update only the value, not reset the
         // attribute the script set.
         var engine = new Engine();
-        Assert.Equal("9|false|", engine.Evaluate(
-            "(function(){ function f(a){ Object.defineProperty(arguments,'0',{enumerable:false}); a=9; return arguments; } var r=f(1); return r[0]+'|'+Object.getOwnPropertyDescriptor(r,'0').enumerable+'|'+Object.keys(r).join(','); })()").AsString());
-        Assert.Equal("{}", engine.Evaluate(
-            "(function(){ function f(a){ Object.defineProperty(arguments,'0',{enumerable:false}); a=9; return arguments; } return JSON.stringify(f(1)); })()").AsString());
+        engine.Evaluate(
+            "(function(){ function f(a){ Object.defineProperty(arguments,'0',{enumerable:false}); a=9; return arguments; } var r=f(1); return r[0]+'|'+Object.getOwnPropertyDescriptor(r,'0').enumerable+'|'+Object.keys(r).join(','); })()").AsString().Should().Be("9|false|");
+        engine.Evaluate(
+            "(function(){ function f(a){ Object.defineProperty(arguments,'0',{enumerable:false}); a=9; return arguments; } return JSON.stringify(f(1)); })()").AsString().Should().Be("{}");
     }
 
     [Fact]
@@ -56,8 +56,8 @@ public class ArgumentsCacheBehaviorTests
         // A deleted mapped index must not be resurrected by the detach-time freeze: it is no longer
         // mapped, so a later parameter write does not bring it back.
         var engine = new Engine();
-        Assert.Equal("false:undefined", engine.Evaluate(
-            "(function(){ function f(a){ var s=arguments; delete arguments[0]; a=9; return arguments.hasOwnProperty('0')+':'+arguments[0]; } return f(1); })()").AsString());
+        engine.Evaluate(
+            "(function(){ function f(a){ var s=arguments; delete arguments[0]; a=9; return arguments.hasOwnProperty('0')+':'+arguments[0]; } return f(1); })()").AsString().Should().Be("false:undefined");
     }
 
     [Theory]
@@ -80,7 +80,7 @@ public class ArgumentsCacheBehaviorTests
                 o(1, 2, 3, 4, 5, 6);        // reuses the pooled array
                 return e[0] + ',' + e[1] + ',' + e.length;
             }})()";
-        Assert.Equal("11,22,2", engine.Evaluate(directReturn).AsString());
+        engine.Evaluate(directReturn).AsString().Should().Be("11,22,2");
 
         // escapes via a property store (never re-read as an identifier)
         var propertyStore = $@"
@@ -93,7 +93,7 @@ public class ArgumentsCacheBehaviorTests
                 var y = holder.y;
                 return y[0] + ',' + y[1] + ',' + y.length;
             }})()";
-        Assert.Equal("11,22,2", engine.Evaluate(propertyStore).AsString());
+        engine.Evaluate(propertyStore).AsString().Should().Be("11,22,2");
     }
 
     [Fact]
@@ -102,8 +102,8 @@ public class ArgumentsCacheBehaviorTests
         // `arguments &&= x` never short-circuits (arguments is always truthy): it reassigns the
         // binding to x and yields x. The pooled arguments object never escapes as the result.
         var engine = new Engine();
-        Assert.Equal(99, engine.Evaluate(
-            "(function(){ function f(){ var y = (arguments &&= 99); return y; } return f(11, 22); })()").AsNumber());
+        engine.Evaluate(
+            "(function(){ function f(){ var y = (arguments &&= 99); return y; } return f(11, 22); })()").AsNumber().Should().Be(99);
     }
 
     [Fact]
@@ -112,8 +112,8 @@ public class ArgumentsCacheBehaviorTests
         // The materialize guard must only fire for JsArguments; ordinary compound assignment
         // (including the logical/nullish forms) keeps its exact behavior.
         var engine = new Engine();
-        Assert.Equal("7,4,5,8", engine.Evaluate(
-            "(function(){ var x; x ??= 7; var a = 3; a += 1; var b = 0; b ||= 5; var c = 1; c &&= 8; return x+','+a+','+b+','+c; })()").AsString());
+        engine.Evaluate(
+            "(function(){ var x; x ??= 7; var a = 3; a += 1; var b = 0; b ||= 5; var c = 1; c &&= 8; return x+','+a+','+b+','+c; })()").AsString().Should().Be("7,4,5,8");
     }
 
     [Fact]
@@ -144,12 +144,12 @@ public class ArgumentsCacheBehaviorTests
             """);
 
         // Assert
-        Assert.Equal([
+        logValues.Should().Equal([
             JsNumber.Create(42),
             JsValue.Undefined,
             JsNumber.Create(10),
             JsValue.Undefined,
-        ], logValues);
+        ]);
     }
 
     [Fact]
@@ -180,12 +180,12 @@ public class ArgumentsCacheBehaviorTests
             """);
 
         // Assert
-        Assert.Equal([
+        logValues.Should().Equal([
             JsNumber.Create(42),
             JsValue.Undefined,
             JsNumber.Create(10),
             JsValue.Undefined,
-        ], logValues);
+        ]);
     }
 
     [Fact]
@@ -219,12 +219,12 @@ public class ArgumentsCacheBehaviorTests
             """);
 
         // Assert
-        Assert.Equal([
+        logValues.Should().Equal([
             JsNumber.Create(42),
             JsValue.Undefined,
             JsNumber.Create(10),
             JsValue.Undefined,
-        ], logValues);
+        ]);
     }
 
     [Fact]
@@ -254,11 +254,11 @@ public class ArgumentsCacheBehaviorTests
         engine.RunAvailableContinuations();
 
         // Assert
-        Assert.Equal([
+        logValues.Should().Equal([
             JsNumber.Create(42),
             JsValue.Undefined,
             JsNumber.Create(10),
             JsValue.Undefined,
-        ], logValues);
+        ]);
     }
 }

--- a/Jint.Tests/Runtime/ArrayAppendLaneTests.cs
+++ b/Jint.Tests/Runtime/ArrayAppendLaneTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the dense-append fast path (ArrayInstance.TryAppendDense): computed-index writes at exactly
@@ -23,7 +23,7 @@ public class ArrayAppendLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("0,2,4,6,8,10,12,14,16,18|10|4|undefined|ab", result);
+        result.Should().Be("0,2,4,6,8,10,12,14,16,18|10|4|undefined|ab");
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class ArrayAppendLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("true,true,true|1|1|0", result);
+        result.Should().Be("true,true,true|1|1|0");
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public class ArrayAppendLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("3|a|c|hole", result);
+        result.Should().Be("3|a|c|hole");
     }
 
     [Fact]
@@ -80,6 +80,6 @@ public class ArrayAppendLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("true|100", result);
+        result.Should().Be("true|100");
     }
 }

--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
 
@@ -12,8 +12,9 @@ public class ArrayTests
     {
         _engine = new Engine()
             .SetValue("log", new Action<object>(Console.WriteLine))
-            .SetValue("assert", new Action<bool>(Assert.True))
-            .SetValue("equal", new Action<object, object>(Assert.Equal));
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
     }
 
     [Fact]
@@ -21,7 +22,7 @@ public class ArrayTests
     {
         var result = _engine.Evaluate("JSON.stringify([1,,3].filter(function(x) { return true; }))").AsString();
 
-        Assert.Equal("[1,3]", result);
+        result.Should().Be("[1,3]");
     }
 
     [Fact]
@@ -39,7 +40,7 @@ public class ArrayTests
             JSON.stringify([before, after]);
             """).AsString();
 
-        Assert.Equal("[[null,false,null,false],[\"ap\",true,\"op\",true]]", result);
+        result.Should().Be("[[null,false,null,false],[\"ap\",true,\"op\",true]]");
     }
 
     [Fact]
@@ -53,7 +54,7 @@ public class ArrayTests
             [a[5], 5 in a, a[7] === undefined].join(',');
             """).AsString();
 
-        Assert.Equal("got,true,true", result);
+        result.Should().Be("got,true,true");
     }
 
     [Fact]
@@ -68,7 +69,7 @@ public class ArrayTests
             [a[1], 1 in a, a[2] === undefined, 2 in a].join(',');
             """).AsString();
 
-        Assert.Equal("inherited,true,true,false", result);
+        result.Should().Be("inherited,true,true,false");
     }
 
     [Fact]
@@ -81,7 +82,7 @@ public class ArrayTests
             filtered instanceof A && filtered.length === 2 && filtered[0] === 2 && filtered[1] === 4;
             """).AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -96,16 +97,16 @@ public class ArrayTests
             captured === 0 && filtered.length === 2 && filtered[0] === 3 && filtered[1] === 4;
             """).AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
     public void FilterThrowingCallbackLeavesEngineUsable()
     {
-        Assert.Throws<JavaScriptException>(() => _engine.Evaluate("[1, 2, 3].filter(function(x) { if (x === 2) { throw new Error('boom'); } return true; })"));
+        Invoking(() => _engine.Evaluate("[1, 2, 3].filter(function(x) { if (x === 2) { throw new Error('boom'); } return true; })")).Should().ThrowExactly<JavaScriptException>();
 
         var result = _engine.Evaluate("JSON.stringify([1, 2, 3, 4].filter(function(x) { return x % 2 === 0; }))").AsString();
-        Assert.Equal("[2,4]", result);
+        result.Should().Be("[2,4]");
     }
 
     [Fact]
@@ -117,13 +118,13 @@ public class ArrayTests
             var a = [1, 2, 3];
             JSON.stringify(a.filter(function(x) { a.push(x * 10); return true; }));
             """).AsString();
-        Assert.Equal("[1,2,3]", grow);
+        grow.Should().Be("[1,2,3]");
 
         var shrink = _engine.Evaluate("""
             var b = [1, 2, 3, 4, 5];
             JSON.stringify(b.filter(function(x) { b.length = 2; return true; }));
             """).AsString();
-        Assert.Equal("[1,2]", shrink);
+        shrink.Should().Be("[1,2]");
     }
 
     [Fact]
@@ -131,7 +132,7 @@ public class ArrayTests
     {
         var result = _engine.Evaluate("JSON.stringify([1, [2, , 3], , [4]].flat())").AsString();
 
-        Assert.Equal("[1,2,3,4]", result);
+        result.Should().Be("[1,2,3,4]");
     }
 
     [Fact]
@@ -139,7 +140,7 @@ public class ArrayTests
     {
         var result = _engine.Evaluate("JSON.stringify([1, [2, [3, [4, [5]]]]].flat(Infinity))").AsString();
 
-        Assert.Equal("[1,2,3,4,5]", result);
+        result.Should().Be("[1,2,3,4,5]");
     }
 
     [Fact]
@@ -152,16 +153,16 @@ public class ArrayTests
             flattened instanceof A && flattened.length === 2;
             """).AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
     public void FlatMapThrowingMapperLeavesEngineUsable()
     {
-        Assert.Throws<JavaScriptException>(() => _engine.Evaluate("[1, 2, 3].flatMap(function(x) { if (x === 2) { throw new Error('boom'); } return [x]; })"));
+        Invoking(() => _engine.Evaluate("[1, 2, 3].flatMap(function(x) { if (x === 2) { throw new Error('boom'); } return [x]; })")).Should().ThrowExactly<JavaScriptException>();
 
         var result = _engine.Evaluate("JSON.stringify([1, 2].flatMap(function(x) { return [x, x * 10]; }))").AsString();
-        Assert.Equal("[1,10,2,20]", result);
+        result.Should().Be("[1,10,2,20]");
     }
 
     [Fact]
@@ -176,7 +177,7 @@ public class ArrayTests
             JSON.stringify([r.length, 1 in r, r[0], r[2]]);
             """).AsString();
 
-        Assert.Equal("[3,true,\"a\",\"c\"]", result);
+        result.Should().Be("[3,true,\"a\",\"c\"]");
     }
 
     [Fact]
@@ -189,7 +190,7 @@ public class ArrayTests
             JSON.stringify([r.length, 2 in r, 5 in r, r[0], r[1], r[3], r[4], r[6], r[7]]);
             """).AsString();
 
-        Assert.Equal("[8,false,true,\"x\",1,3,\"a\",\"c\",\"tail\"]", result);
+        result.Should().Be("[8,false,true,\"x\",1,3,\"a\",\"c\",\"tail\"]");
     }
 
     [Fact]
@@ -202,7 +203,7 @@ public class ArrayTests
             JSON.stringify([r.length, 2 in r, r[0], r[1], r[3]]);
             """).AsString();
 
-        Assert.Equal("[4,false,\"x\",1,3]", result);
+        result.Should().Be("[4,false,\"x\",1,3]");
     }
 
     [Fact]
@@ -215,7 +216,7 @@ public class ArrayTests
             JSON.stringify([r.length, r[5000000], r[5000001], 0 in r]);
             """).AsString();
 
-        Assert.Equal("[5000002,1,2,false]", result);
+        result.Should().Be("[5000002,1,2,false]");
     }
 
     [Fact]
@@ -228,7 +229,7 @@ public class ArrayTests
             JSON.stringify([r.length, r[0], r[5000001], 1 in r]);
             """).AsString();
 
-        Assert.Equal("[5000002,\"x\",1,false]", result);
+        result.Should().Be("[5000002,\"x\",1,false]");
     }
 
     [Fact]
@@ -241,7 +242,7 @@ public class ArrayTests
             JSON.stringify([fromSet, fromGen]);
             """).AsString();
 
-        Assert.Equal("[[1,2,3],[\"a\",\"b\"]]", result);
+        result.Should().Be("[[1,2,3],[\"a\",\"b\"]]");
     }
 
     [Fact]
@@ -249,7 +250,7 @@ public class ArrayTests
     {
         var result = _engine.Evaluate("JSON.stringify(Array.from(new Set(['a', 'b']), function (v, i) { return v + i; }))").AsString();
 
-        Assert.Equal("[\"a0\",\"b1\"]", result);
+        result.Should().Be("[\"a0\",\"b1\"]");
     }
 
     [Fact]
@@ -269,7 +270,7 @@ public class ArrayTests
             closed;
             """).AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -281,7 +282,7 @@ public class ArrayTests
             a instanceof A && a.length === 2 && a[0] === 1 && a[1] === 2;
             """).AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -289,7 +290,7 @@ public class ArrayTests
     {
         var result = _engine.Evaluate("Array.prototype.toString.call([1,2,3]);").AsString();
 
-        Assert.Equal("1,2,3", result);
+        result.Should().Be("1,2,3");
     }
 
     [Fact]
@@ -297,7 +298,7 @@ public class ArrayTests
     {
         var result = _engine.Evaluate("Array.prototype.toString.call(1);").AsString();
 
-        Assert.Equal("[object Number]", result);
+        result.Should().Be("[object Number]");
     }
 
     [Fact]
@@ -305,7 +306,7 @@ public class ArrayTests
     {
         var result = _engine.Evaluate("Array.prototype.toString.call({});").AsString();
 
-        Assert.Equal("[object Object]", result);
+        result.Should().Be("[object Object]");
     }
 
     [Fact]
@@ -313,7 +314,7 @@ public class ArrayTests
     {
         var result = _engine.Evaluate("Array.prototype.join.call((c = [1, 2, 3, 4], b = [1, 2, 3, 4], b[1] = c, c[1] = b, c))").AsString();
 
-        Assert.Equal("1,1,,3,4,3,4", result);
+        result.Should().Be("1,1,,3,4,3,4");
     }
 
     [Fact]
@@ -321,7 +322,7 @@ public class ArrayTests
     {
         var result = _engine.Evaluate("Array.prototype.toLocaleString.call((c = [1, 2, 3, 4], b = [1, 2, 3, 4], b[1] = c, c[1] = b, c))").AsString();
 
-        Assert.Equal("1,1,,3,4,3,4", result);
+        result.Should().Be("1,1,,3,4,3,4");
     }
 
     [Fact]
@@ -329,7 +330,7 @@ public class ArrayTests
     {
         var result = _engine.Evaluate("var x=[];x[\"\"]=8;x[\"\"];").AsNumber();
 
-        Assert.Equal(8, result);
+        result.Should().Be(8);
     }
 
     [Fact]
@@ -350,7 +351,7 @@ public class ArrayTests
         var engine = new Engine();
         var array = new JsArray(engine);
         var length = (int) array.Length;
-        Assert.Equal(0, length);
+        length.Should().Be(0);
     }
 
     [Fact]
@@ -405,31 +406,31 @@ public class ArrayTests
 
         _engine.Execute(script);
         _engine.Evaluate("const a = new MyArr(1,2);");
-        Assert.True(_engine.Evaluate("a instanceof MyArr").AsBoolean());
+        _engine.Evaluate("a instanceof MyArr").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void IteratorShouldBeConvertibleToArray()
     {
-        Assert.Equal("hello;again", _engine.Evaluate("Array.from(['hello', 'again'].values()).join(';')"));
-        Assert.Equal("hello;another", _engine.Evaluate("Array.from(new Map([['hello', 'world'], ['another', 'value']]).keys()).join(';')"));
+        _engine.Evaluate("Array.from(['hello', 'again'].values()).join(';')").Should().Be("hello;again");
+        _engine.Evaluate("Array.from(new Map([['hello', 'world'], ['another', 'value']]).keys()).join(';')").Should().Be("hello;another");
     }
 
     [Fact]
     public void ArrayFromShouldNotFlattenInputArray()
     {
-        Assert.Equal("a;b", _engine.Evaluate("[...['a', 'b']].join(';')"));
-        Assert.Equal("0,a;1,b", _engine.Evaluate("[...['a', 'b'].entries()].join(';')"));
-        Assert.Equal("0,c;1,d", _engine.Evaluate("Array.from(['c', 'd'].entries()).join(';')"));
-        Assert.Equal("0,e;1,f", _engine.Evaluate("Array.from([[0, 'e'],[1, 'f']]).join(';')"));
+        _engine.Evaluate("[...['a', 'b']].join(';')").Should().Be("a;b");
+        _engine.Evaluate("[...['a', 'b'].entries()].join(';')").Should().Be("0,a;1,b");
+        _engine.Evaluate("Array.from(['c', 'd'].entries()).join(';')").Should().Be("0,c;1,d");
+        _engine.Evaluate("Array.from([[0, 'e'],[1, 'f']]).join(';')").Should().Be("0,e;1,f");
     }
 
     [Fact]
     public void ArrayEntriesShouldReturnKeyValuePairs()
     {
-        Assert.Equal("0,hello,1,world", _engine.Evaluate("Array.from(['hello', 'world'].entries()).join()"));
-        Assert.Equal("0,hello;1,world", _engine.Evaluate("Array.from(['hello', 'world'].entries()).join(';')"));
-        Assert.Equal("0,;1,1;2,5", _engine.Evaluate("Array.from([,1,5,].entries()).join(';')"));
+        _engine.Evaluate("Array.from(['hello', 'world'].entries()).join()").Should().Be("0,hello,1,world");
+        _engine.Evaluate("Array.from(['hello', 'world'].entries()).join(';')").Should().Be("0,hello;1,world");
+        _engine.Evaluate("Array.from([,1,5,].entries()).join(';')").Should().Be("0,;1,1;2,5");
     }
 
     [Fact]
@@ -447,7 +448,8 @@ public class ArrayTests
         {
             o.DebugMode(true);
         });
-        engine.SetValue("equal", new Action<object, object>(Assert.Equal));
+        engine.SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
 
         const string code = @"
                 var items = [5,2,4,1];
@@ -462,9 +464,9 @@ public class ArrayTests
     public void ArrayConstructorFromHoles()
     {
         _engine.Evaluate("var a = Array(...[,,]);");
-        Assert.True(_engine.Evaluate("\"0\" in a").AsBoolean());
-        Assert.True(_engine.Evaluate("\"1\" in a").AsBoolean());
-        Assert.Equal("undefinedundefined", _engine.Evaluate("'' + a[0] + a[1]"));
+        _engine.Evaluate("\"0\" in a").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("\"1\" in a").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("'' + a[0] + a[1]").Should().Be("undefinedundefined");
     }
 
     [Fact]
@@ -472,7 +474,7 @@ public class ArrayTests
     {
         _engine.Evaluate("class C extends Array {}");
         _engine.Evaluate("var c = new C();");
-        Assert.True(_engine.Evaluate("c.map(Boolean) instanceof C").AsBoolean());
+        _engine.Evaluate("c.map(Boolean) instanceof C").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -488,10 +490,10 @@ public class ArrayTests
 
         var engine = new Engine();
         engine.Execute(Script);
-        Assert.True(engine.Evaluate("proto2.hasOwnProperty(Symbol.iterator)").AsBoolean());
-        Assert.True(engine.Evaluate("!proto1.hasOwnProperty(Symbol.iterator)").AsBoolean());
-        Assert.True(engine.Evaluate("!iterator.hasOwnProperty(Symbol.iterator)").AsBoolean());
-        Assert.True(engine.Evaluate("iterator[Symbol.iterator]() === iterator").AsBoolean());
+        engine.Evaluate("proto2.hasOwnProperty(Symbol.iterator)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("!proto1.hasOwnProperty(Symbol.iterator)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("!iterator.hasOwnProperty(Symbol.iterator)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("iterator[Symbol.iterator]() === iterator").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -506,8 +508,8 @@ public class ArrayTests
         var engine = new Engine();
         engine.Execute(Script);
 
-        Assert.True(engine.Evaluate("get[0] === Symbol.iterator").AsBoolean());
-        Assert.Equal("length,0,1", engine.Evaluate("get.slice(1) + ''").AsString());
+        engine.Evaluate("get[0] === Symbol.iterator").AsBoolean().Should().BeTrue();
+        engine.Evaluate("get.slice(1) + ''").AsString().Should().Be("length,0,1");
     }
 
     [Fact]
@@ -515,10 +517,10 @@ public class ArrayTests
     {
         var engine = new Engine();
         var array = engine.Evaluate("Array.from('fff', (s) => Number.parseInt(s, 16))").AsArray();
-        Assert.Equal((uint) 3, array.Length);
-        Assert.Equal((uint) 15, array[0]);
-        Assert.Equal((uint) 15, array[1]);
-        Assert.Equal((uint) 15, array[2]);
+        array.Length.Should().Be((uint) 3);
+        array[0].Should().Be((uint) 15);
+        array[1].Should().Be((uint) 15);
+        array[2].Should().Be((uint) 15);
     }
 
     [Fact]
@@ -547,7 +549,7 @@ public class ArrayTests
             return true;";
 
         var engine = new Engine();
-        Assert.True(engine.Evaluate(Script).AsBoolean());
+        engine.Evaluate(Script).AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -564,12 +566,12 @@ public class ArrayTests
         var engine = new Engine();
         engine.Execute(Script);
 
-        Assert.Equal("constructor", engine.Evaluate("get[0]"));
-        Assert.True(engine.Evaluate("get[1] === Symbol.isConcatSpreadable").AsBoolean());
-        Assert.Equal("length", engine.Evaluate("get[2]"));
-        Assert.Equal("0", engine.Evaluate("get[3]"));
-        Assert.True(engine.Evaluate("get[4] === get[1] && get[5] === get[2] && get[6] === get[3]").AsBoolean());
-        Assert.Equal(7, engine.Evaluate("get.length"));
+        engine.Evaluate("get[0]").Should().Be("constructor");
+        engine.Evaluate("get[1] === Symbol.isConcatSpreadable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("get[2]").Should().Be("length");
+        engine.Evaluate("get[3]").Should().Be("0");
+        engine.Evaluate("get[4] === get[1] && get[5] === get[2] && get[6] === get[3]").AsBoolean().Should().BeTrue();
+        engine.Evaluate("get.length").Should().Be(7);
     }
 
     [Fact]
@@ -590,11 +592,11 @@ public class ArrayTests
         var a = engine.Evaluate(Code).AsArray();
 
         a.Length.Should().Be(5);
-        a[0].Should().Be(JsValue.Undefined);
-        a[1].Should().Be(JsValue.Undefined);
-        a[2].Should().Be(JsValue.Undefined);
-        a[3].Should().BeOfType<JsArray>().Which.Should().ContainInOrder("#d8b365", "#f5f5f5", "#5ab4ac");
-        a[4].Should().BeOfType<JsArray>().Which.Should().ContainInOrder("#a6611a", "#dfc27d", "#80cdc1", "#018571");
+        a[0].Should().BeUndefined();
+        a[1].Should().BeUndefined();
+        a[2].Should().BeUndefined();
+        a[3].Should().BeOfType<JsArray>().Which.AsEnumerable().Should().ContainInOrder("#d8b365", "#f5f5f5", "#5ab4ac");
+        a[4].Should().BeOfType<JsArray>().Which.AsEnumerable().Should().ContainInOrder("#a6611a", "#dfc27d", "#80cdc1", "#018571");
     }
 
     [Fact]
@@ -608,7 +610,7 @@ Array.prototype.shift.call(p);
 return get + '' === ""length,0,1,2,3"";";
 
         var engine = new Engine();
-        Assert.True(engine.Evaluate(Script).AsBoolean());
+        engine.Evaluate(Script).AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -616,11 +618,11 @@ return get + '' === ""length,0,1,2,3"";";
     {
         var engine = new Engine();
         var propertyDescriptors = new JsArray(engine, [1]).GetOwnProperties().ToArray();
-        Assert.Equal(2, propertyDescriptors.Length);
-        Assert.Equal("0", propertyDescriptors[0].Key);
-        Assert.Equal(1, propertyDescriptors[0].Value.Value);
-        Assert.Equal("length", propertyDescriptors[1].Key);
-        Assert.Equal(1, propertyDescriptors[1].Value.Value);
+        propertyDescriptors.Length.Should().Be(2);
+        propertyDescriptors[0].Key.Should().Be("0");
+        propertyDescriptors[0].Value.Value.Should().Be(1);
+        propertyDescriptors[1].Key.Should().Be("length");
+        propertyDescriptors[1].Value.Value.Should().Be(1);
     }
 
     [Fact]
@@ -651,9 +653,9 @@ return get + '' === ""length,0,1,2,3"";";
         engine.SetValue("list", list);
         var result = engine.Evaluate("list.pop()").AsNumber();
 
-        Assert.Equal(3, result);
-        Assert.Equal(2, list.Count);
-        Assert.Equal(1, list[0]);
-        Assert.Equal(2, list[1]);
+        result.Should().Be(3);
+        list.Should().HaveCount(2);
+        list[0].Should().Be(1);
+        list[1].Should().Be(2);
     }
 }

--- a/Jint.Tests/Runtime/AsyncTests.cs
+++ b/Jint.Tests/Runtime/AsyncTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using Jint.Native;
 using Jint.Native.Promise;
 using Jint.Runtime;
@@ -22,7 +22,7 @@ public class AsyncTests
         var engine = new Engine();
         var result = engine.Evaluate("(async ()=>await '1')()");
         result = result.UnwrapIfPromise();
-        Assert.Equal("1", result);
+        result.Should().Be("1");
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class AsyncTests
             })()
             """).UnwrapIfPromise(TimeSpan.FromSeconds(1));
 
-        Assert.Equal(1, result.AsNumber());
+        result.AsNumber().Should().Be(1);
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public class AsyncTests
             }
             """);
 
-        Assert.Equal("""{"leaked":false,"name":"ReferenceError"}""", result);
+        result.Should().Be("""{"leaked":false,"name":"ReferenceError"}""");
     }
 
     [Fact]
@@ -78,7 +78,7 @@ public class AsyncTests
             }
             """);
 
-        Assert.Equal("""{"value":42}""", result);
+        result.Should().Be("""{"value":42}""");
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public class AsyncTests
             })()
             """).UnwrapIfPromise(TimeSpan.FromSeconds(1));
 
-        Assert.Equal(2, result.AsInteger());
+        result.AsInteger().Should().Be(2);
     }
 
     [Fact]
@@ -120,8 +120,8 @@ public class AsyncTests
             })()
             """);
 
-        var exception = Assert.Throws<PromiseRejectedException>(() => result.UnwrapIfPromise(TimeSpan.FromSeconds(1)));
-        Assert.Equal(4, exception.RejectedValue.AsInteger());
+        var exception = Invoking(() => result.UnwrapIfPromise(TimeSpan.FromSeconds(1))).Should().ThrowExactly<PromiseRejectedException>().Which;
+        exception.RejectedValue.AsInteger().Should().Be(4);
     }
 
     [Fact]
@@ -136,7 +136,7 @@ public class AsyncTests
             return { tests, fellThrough: true };
             """);
 
-        Assert.Equal("""{"tests":1}""", result);
+        result.Should().Be("""{"tests":1}""");
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public class AsyncTests
             return { sideEffects };
             """);
 
-        Assert.Equal("""{"sideEffects":0}""", result);
+        result.Should().Be("""{"sideEffects":0}""");
     }
 
     [Fact]
@@ -168,7 +168,7 @@ public class AsyncTests
             return { tests, bodies, fellThrough: true };
             """);
 
-        Assert.Equal("""{"tests":1,"bodies":1}""", result);
+        result.Should().Be("""{"tests":1,"bodies":1}""");
     }
 
     [Fact]
@@ -187,7 +187,7 @@ public class AsyncTests
             return { inits, tests, updates, bodies, fellThrough: true };
             """);
 
-        Assert.Equal("""{"inits":1,"tests":1,"updates":0,"bodies":1}""", result);
+        result.Should().Be("""{"inits":1,"tests":1,"updates":0,"bodies":1}""");
     }
 
     [Fact]
@@ -201,7 +201,7 @@ public class AsyncTests
             return { bodies };
             """);
 
-        Assert.Equal("""{"bodies":1}""", result);
+        result.Should().Be("""{"bodies":1}""");
     }
 
     [Fact]
@@ -218,7 +218,7 @@ public class AsyncTests
             }
             """);
 
-        Assert.Equal("""{"discriminants":1}""", result);
+        result.Should().Be("""{"discriminants":1}""");
     }
 
     [Fact]
@@ -233,7 +233,7 @@ public class AsyncTests
             }
             """);
 
-        Assert.Equal("""{"matched":false}""", result);
+        result.Should().Be("""{"matched":false}""");
     }
 
     [Fact]
@@ -250,7 +250,7 @@ public class AsyncTests
             }
             """);
 
-        Assert.Equal("""{"x":1}""", result);
+        result.Should().Be("""{"x":1}""");
     }
 
     [Fact]
@@ -270,7 +270,7 @@ public class AsyncTests
             return { values };
             """);
 
-        Assert.Equal("""{"values":[0,1]}""", result);
+        result.Should().Be("""{"values":[0,1]}""");
     }
 
     [Fact]
@@ -285,7 +285,7 @@ public class AsyncTests
             return { tests, bodies };
             """);
 
-        Assert.Equal("""{"tests":1,"bodies":1}""", result);
+        result.Should().Be("""{"tests":1,"bodies":1}""");
     }
 
     [Fact]
@@ -297,7 +297,7 @@ public class AsyncTests
             return { d, sum };
             """);
 
-        Assert.Equal("""{"d":1,"sum":11}""", result);
+        result.Should().Be("""{"d":1,"sum":11}""");
     }
 
     [Fact]
@@ -309,7 +309,7 @@ public class AsyncTests
             return { d, ok };
             """);
 
-        Assert.Equal("""{"d":1,"ok":true}""", result);
+        result.Should().Be("""{"d":1,"ok":true}""");
     }
 
     [Fact]
@@ -321,7 +321,7 @@ public class AsyncTests
             return { d, ok };
             """);
 
-        Assert.Equal("""{"d":1,"ok":true}""", result);
+        result.Should().Be("""{"d":1,"ok":true}""");
     }
 
     [Fact]
@@ -333,7 +333,7 @@ public class AsyncTests
             return { d, value };
             """);
 
-        Assert.Equal("""{"d":1,"value":"yes"}""", result);
+        result.Should().Be("""{"d":1,"value":"yes"}""");
     }
 
     [Fact]
@@ -345,7 +345,7 @@ public class AsyncTests
             return { d, value };
             """);
 
-        Assert.Equal("""{"d":1,"value":"no"}""", result);
+        result.Should().Be("""{"d":1,"value":"no"}""");
     }
 
     [Fact]
@@ -362,7 +362,7 @@ public class AsyncTests
             return { a, b, awaits };
             """);
 
-        Assert.Equal("""{"a":false,"b":1,"awaits":1}""", result);
+        result.Should().Be("""{"a":false,"b":1,"awaits":1}""");
     }
 
     [Fact]
@@ -375,7 +375,7 @@ public class AsyncTests
             return { obj, i };
             """);
 
-        Assert.Equal("""{"obj":{"0":5},"i":0}""", result);
+        result.Should().Be("""{"obj":{"0":5},"i":0}""");
     }
 
     [Fact]
@@ -389,7 +389,7 @@ public class AsyncTests
             return { obj, touches };
             """);
 
-        Assert.Equal("""{"obj":{"x":7},"touches":1}""", result);
+        result.Should().Be("""{"obj":{"x":7},"touches":1}""");
     }
 
     [Fact]
@@ -402,7 +402,7 @@ public class AsyncTests
             return { obj, i };
             """);
 
-        Assert.Equal("""{"obj":{"0":"filled"},"i":0}""", result);
+        result.Should().Be("""{"obj":{"0":"filled"},"i":0}""");
     }
 
     [Fact]
@@ -416,7 +416,7 @@ public class AsyncTests
             return { x };
             """);
 
-        Assert.Equal("""{"x":21}""", result);
+        result.Should().Be("""{"x":21}""");
     }
 
     [Fact]
@@ -429,7 +429,7 @@ public class AsyncTests
             return { r, i };
             """);
 
-        Assert.Equal("""{"r":{"a":1,"b":2,"c":3},"i":3}""", result);
+        result.Should().Be("""{"r":{"a":1,"b":2,"c":3},"i":3}""");
     }
 
     [Fact]
@@ -442,7 +442,7 @@ public class AsyncTests
             return { r, i };
             """);
 
-        Assert.Equal("""{"r":{"a":1,"b":2,"c":3,"d":4},"i":4}""", result);
+        result.Should().Be("""{"r":{"a":1,"b":2,"c":3,"d":4},"i":4}""");
     }
 
     [Fact]
@@ -457,7 +457,7 @@ public class AsyncTests
             return { obj: { a: obj.a, b: obj.b, c: obj.c }, i };
             """);
 
-        Assert.Equal("""{"obj":{"a":1,"b":2,"c":3},"i":3}""", result);
+        result.Should().Be("""{"obj":{"a":1,"b":2,"c":3},"i":3}""");
     }
 
     [Fact]
@@ -473,7 +473,7 @@ public class AsyncTests
             return { first, second, i };
             """);
 
-        Assert.Equal("""{"first":11,"second":22,"i":2}""", result);
+        result.Should().Be("""{"first":11,"second":22,"i":2}""");
     }
 
     [Fact]
@@ -485,7 +485,7 @@ public class AsyncTests
             return { a, i };
             """);
 
-        Assert.Equal("""{"a":[1,2,3],"i":3}""", result);
+        result.Should().Be("""{"a":[1,2,3],"i":3}""");
     }
 
     [Fact]
@@ -497,7 +497,7 @@ public class AsyncTests
             return { a, i };
             """);
 
-        Assert.Equal("""{"a":[1,2,3,4],"i":4}""", result);
+        result.Should().Be("""{"a":[1,2,3,4],"i":4}""");
     }
 
     [Fact]
@@ -510,7 +510,7 @@ public class AsyncTests
             return { first, second, i };
             """);
 
-        Assert.Equal("""{"first":[1,10],"second":[2,20],"i":2}""", result);
+        result.Should().Be("""{"first":[1,10],"second":[2,20],"i":2}""");
     }
 
     [Fact]
@@ -525,7 +525,7 @@ public class AsyncTests
             return { r };
             """);
 
-        Assert.Equal("""{"r":["a","b","c","d"]}""", result);
+        result.Should().Be("""{"r":["a","b","c","d"]}""");
     }
 
     [Fact]
@@ -539,7 +539,7 @@ public class AsyncTests
             return { total };
             """);
 
-        Assert.Equal("""{"total":16}""", result);
+        result.Should().Be("""{"total":16}""");
     }
 
     [Fact]
@@ -556,7 +556,7 @@ public class AsyncTests
             return { a };
             """);
 
-        Assert.Equal("""{"a":["start","x","y","end"]}""", result);
+        result.Should().Be("""{"a":["start","x","y","end"]}""");
     }
 
     [Fact]
@@ -571,7 +571,7 @@ public class AsyncTests
             return { r, j };
             """);
 
-        Assert.Equal("""{"r":[1,"mid",1],"j":1}""", result);
+        result.Should().Be("""{"r":[1,"mid",1],"j":1}""");
     }
 
     [Fact]
@@ -584,7 +584,7 @@ public class AsyncTests
             return { d, v };
             """);
 
-        Assert.Equal("""{"d":1,"v":"filled"}""", result);
+        result.Should().Be("""{"d":1,"v":"filled"}""");
     }
 
     [Fact]
@@ -598,7 +598,7 @@ public class AsyncTests
             return { v, calls };
             """);
 
-        Assert.Equal("""{"v":1,"calls":1}""", result);
+        result.Should().Be("""{"v":1,"calls":1}""");
     }
 
     [Fact]
@@ -612,7 +612,7 @@ public class AsyncTests
             return { v, calls };
             """);
 
-        Assert.Equal("""{"v":42,"calls":1}""", result);
+        result.Should().Be("""{"v":42,"calls":1}""");
     }
 
     [Fact]
@@ -624,7 +624,7 @@ public class AsyncTests
             return { o, i };
             """);
 
-        Assert.Equal("""{"o":{"a":1,"b":2,"c":3},"i":3}""", result);
+        result.Should().Be("""{"o":{"a":1,"b":2,"c":3},"i":3}""");
     }
 
     [Fact]
@@ -641,7 +641,7 @@ public class AsyncTests
             return { o, i };
             """);
 
-        Assert.Equal("""{"o":{"a":1,"b":2,"c":3,"d":4},"i":4}""", result);
+        result.Should().Be("""{"o":{"a":1,"b":2,"c":3,"d":4},"i":4}""");
     }
 
     [Fact]
@@ -654,7 +654,7 @@ public class AsyncTests
             return { o, i };
             """);
 
-        Assert.Equal("""{"o":{"k1":1,"value":"done"},"i":1}""", result);
+        result.Should().Be("""{"o":{"k1":1,"value":"done"},"i":1}""");
     }
 
     [Fact]
@@ -666,7 +666,7 @@ public class AsyncTests
             return { s, i };
             """);
 
-        Assert.Equal("""{"s":"1-x-2","i":2}""", result);
+        result.Should().Be("""{"s":"1-x-2","i":2}""");
     }
 
     [Fact]
@@ -680,7 +680,7 @@ public class AsyncTests
             return { s, j };
             """);
 
-        Assert.Equal("""{"s":"mid-1","j":1}""", result);
+        result.Should().Be("""{"s":"mid-1","j":1}""");
     }
 
     [Fact]
@@ -693,7 +693,7 @@ public class AsyncTests
             return { s, i };
             """);
 
-        Assert.Equal("""{"s":"1|x|2","i":2}""", result);
+        result.Should().Be("""{"s":"1|x|2","i":2}""");
     }
 
     [Fact]
@@ -703,12 +703,12 @@ public class AsyncTests
         engine.SetValue("callable", Callable);
         var result = engine.Evaluate("callable().then(x=>x*2)");
         result = result.UnwrapIfPromise();
-        Assert.Equal(2, result);
+        result.Should().Be(2);
 
         static async Task<int> Callable()
         {
             await Task.Delay(10);
-            Assert.True(true);
+            true.Should().BeTrue();
             return 1;
         }
     }
@@ -730,7 +730,7 @@ public class AsyncTests
         engine.SetValue("asyncTestClass", new AsyncTestClass());
         var result = engine.Evaluate("asyncTestClass.ReturnDelayedTaskAsync().then(x=>x)");
         result = result.UnwrapIfPromise();
-        Assert.Equal(AsyncTestClass.TestString, result);
+        result.Should().Be(AsyncTestClass.TestString);
     }
 
     [Fact]
@@ -742,8 +742,8 @@ public class AsyncTests
         Engine engine = new();
         var result = engine.Evaluate("new Promise(function () {})");
         var timeout = TimeSpan.FromMilliseconds(1);
-        var exception = Assert.Throws<PromiseRejectedException>(() => result.UnwrapIfPromise(timeout));
-        Assert.Equal($"Promise was rejected with value Timeout of {timeout} reached", exception.Message);
+        var exception = Invoking(() => result.UnwrapIfPromise(timeout)).Should().ThrowExactly<PromiseRejectedException>().Which;
+        exception.Message.Should().Be($"Promise was rejected with value Timeout of {timeout} reached");
     }
 
     [Fact]
@@ -759,7 +759,7 @@ public class AsyncTests
         }
         """);
         var result = engine.Invoke("test").UnwrapIfPromise(GenerousPromiseTimeout);
-        Assert.Equal(AsyncTestClass.TestString, result);
+        result.Should().Be(AsyncTestClass.TestString);
     }
 
     [Fact]
@@ -769,7 +769,7 @@ public class AsyncTests
         engine.SetValue("asyncTestClass", new AsyncTestClass());
         var result = engine.Evaluate("asyncTestClass.ReturnCompletedTask().then(x=>x)");
         result = result.UnwrapIfPromise();
-        Assert.Equal(AsyncTestClass.TestString, result);
+        result.Should().Be(AsyncTestClass.TestString);
     }
 
     [Fact]
@@ -785,7 +785,7 @@ public class AsyncTests
 
         engine.Evaluate("callable(token).then(_ => cancelled = false).catch(_ => cancelled = true)").UnwrapIfPromise();
 
-        Assert.Equal(true, engine.Evaluate("cancelled").AsBoolean());
+        engine.Evaluate("cancelled").AsBoolean().Should().BeTrue();
         static async Task Callable(CancellationToken token)
         {
             await Task.FromCanceled(token);
@@ -802,11 +802,11 @@ public class AsyncTests
         engine.SetValue("cancelled", JsValue.Undefined);
         engine.SetValue("token", cancel.Token);
         engine.SetValue("asyncTestClass", new AsyncTestClass());
-        engine.SetValue("assert", new Action<bool>(Assert.True));
+        engine.SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()));
 
         engine.Evaluate("asyncTestClass.ReturnCancelledTask(token).then(_ => cancelled = false).catch(_ => cancelled = true)").UnwrapIfPromise();
 
-        Assert.Equal(true, engine.Evaluate("cancelled").AsBoolean());
+        engine.Evaluate("cancelled").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -816,10 +816,10 @@ public class AsyncTests
 
         engine.SetValue("cancelled", JsValue.Undefined);
         engine.SetValue("callable", Callable);
-        engine.SetValue("assert", new Action<bool>(Assert.True));
+        engine.SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()));
 
         engine.Evaluate("callable().then(_ => cancelled = false).catch(_ => cancelled = true)").UnwrapIfPromise();
-        Assert.Equal(true, engine.Evaluate("cancelled").AsBoolean());
+        engine.Evaluate("cancelled").AsBoolean().Should().BeTrue();
 
         static async Task Callable()
         {
@@ -837,7 +837,7 @@ public class AsyncTests
         engine.SetValue("asyncTestClass", new AsyncTestClass());
 
         engine.Evaluate("asyncTestClass.ThrowAfterDelayAsync().then(_ => cancelled = false).catch(_ => cancelled = true)").UnwrapIfPromise();
-        Assert.Equal(true, engine.Evaluate("cancelled").AsBoolean());
+        engine.Evaluate("cancelled").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -860,7 +860,7 @@ public class AsyncTests
 
         engine.Evaluate("async function hello() {await myAsyncMethod();mySyncMethod2();await asyncTestClass.AddToStringDelayedAsync(\"3\")} hello();").UnwrapIfPromise();
 
-        Assert.Equal("123", asyncTestClass.StringToAppend);
+        asyncTestClass.StringToAppend.Should().Be("123");
     }
 
     [Fact]
@@ -877,7 +877,7 @@ public class AsyncTests
         var result = engine.Evaluate("async function hello() {return await asyncTestMethod(async () =>{ await asyncWork(); })} hello();");
         result = result.UnwrapIfPromise(TimeSpan.FromSeconds(30));
 
-        Assert.Equal("Hello World", result);
+        result.Should().Be("Hello World");
     }
 
     [Fact]
@@ -894,7 +894,7 @@ public class AsyncTests
         var result = engine.Evaluate("async function hello() {return await asyncTestMethod(async () =>{ return await asyncWork(); })} hello();");
         result = result.UnwrapIfPromise(TimeSpan.FromSeconds(30));
 
-        Assert.Equal("Hello World", result);
+        result.Should().Be("Hello World");
     }
 
     [Fact]
@@ -924,7 +924,7 @@ public class AsyncTests
         var main = module.Get("main");
         var result = engine.Invoke(main).UnwrapIfPromise();
 
-        Assert.Equal("success", result);
+        result.Should().Be("success");
     }
 
     [Fact]
@@ -953,7 +953,7 @@ public class AsyncTests
 
         var ns = engine.Modules.Import("main");
 
-        Assert.Equal(42, ns.Get("answer").AsInteger());
+        ns.Get("answer").AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -978,7 +978,7 @@ public class AsyncTests
             export const answer = x;
             """);
 
-        Assert.Throws<JavaScriptException>(() => engine.Modules.Import("main"));
+        Invoking(() => engine.Modules.Import("main")).Should().ThrowExactly<JavaScriptException>();
     }
 
     [Fact]
@@ -1011,11 +1011,11 @@ public class AsyncTests
         cts.CancelAfter(TimeSpan.FromMilliseconds(200));
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
-        Assert.Throws<ExecutionCanceledException>(() => engine.Modules.Import("main"));
+        Invoking(() => engine.Modules.Import("main")).Should().ThrowExactly<ExecutionCanceledException>();
         sw.Stop();
 
         // Prompt: nowhere near the multi-minute PromiseTimeout. A generous ceiling keeps this stable under CI load.
-        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(10), $"Cancellation was not observed promptly: took {sw.Elapsed}.");
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10), $"Cancellation was not observed promptly: took {sw.Elapsed}.");
 
         neverCompletes.TrySetCanceled();
     }
@@ -1042,10 +1042,10 @@ public class AsyncTests
         var sw = System.Diagnostics.Stopwatch.StartNew();
         // The drain gives up at PromiseTimeout with the promise still pending, so evaluation reports a
         // non-fulfilled promise rather than hanging.
-        Assert.Throws<InvalidOperationException>(() => engine.Modules.Import("main"));
+        Invoking(() => engine.Modules.Import("main")).Should().ThrowExactly<InvalidOperationException>();
         sw.Stop();
 
-        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(30), $"Never-settling await was not bounded: took {sw.Elapsed}.");
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(30), $"Never-settling await was not bounded: took {sw.Elapsed}.");
 
         neverCompletes.TrySetCanceled();
     }
@@ -1062,10 +1062,10 @@ public class AsyncTests
         });
         engine.SetValue("asyncTestMethod", new Func<Func<ValueTask>, Task<string>>(async callback => { await Task.Delay(100); await callback(); return "Hello World"; }));
         engine.SetValue("asyncWork", new Func<Task>(() => Task.Delay(100)));
-        engine.SetValue("assert", new Action<bool>(Assert.True));
+        engine.SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()));
         var result = engine.Evaluate("async function hello() {return await asyncTestMethod(async () =>{ await asyncWork(); })} hello();");
         result = result.UnwrapIfPromise(TimeSpan.FromSeconds(30));
-        Assert.Equal("Hello World", result);
+        result.Should().Be("Hello World");
     }
 
     [Fact]
@@ -1078,10 +1078,10 @@ public class AsyncTests
         });
         engine.SetValue("asyncTestMethod", new Func<Func<ValueTask<string>>, Task<string>>(async callback => { await Task.Delay(100); return await callback(); }));
         engine.SetValue("asyncWork", new Func<ValueTask<string>>(async () => { await Task.Delay(100); return "Hello World"; }));
-        engine.SetValue("assert", new Action<bool>(Assert.True));
+        engine.SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()));
         var result = engine.Evaluate("async function hello() {return await asyncTestMethod(async () =>{ return await asyncWork(); })} hello();");
         result = result.UnwrapIfPromise(TimeSpan.FromSeconds(30));
-        Assert.Equal("Hello World", result);
+        result.Should().Be("Hello World");
     }
 
     [Fact]
@@ -1091,12 +1091,12 @@ public class AsyncTests
         engine.SetValue("callable", Callable);
         var result = engine.Evaluate("callable().then(x=>x*2)");
         result = result.UnwrapIfPromise();
-        Assert.Equal(2, result);
+        result.Should().Be(2);
 
         static async ValueTask<int> Callable()
         {
             await Task.Delay(10);
-            Assert.True(true);
+            true.Should().BeTrue();
             return 1;
         }
     }
@@ -1113,7 +1113,7 @@ public class AsyncTests
         engine.SetValue("callable", Callable);
 
         engine.Evaluate("callable(token).then(_ => cancelled = false).catch(_ => cancelled = true)").UnwrapIfPromise();
-        Assert.Equal(true, engine.Evaluate("cancelled").AsBoolean());
+        engine.Evaluate("cancelled").AsBoolean().Should().BeTrue();
         static async ValueTask Callable(CancellationToken token)
         {
             await ValueTask.FromCanceled(token);
@@ -1129,7 +1129,7 @@ public class AsyncTests
         engine.SetValue("callable", Callable);
 
         engine.Evaluate("callable().then(_ => cancelled = false).catch(_ => cancelled = true)").UnwrapIfPromise();
-        Assert.Equal(true, engine.Evaluate("cancelled").AsBoolean());
+        engine.Evaluate("cancelled").AsBoolean().Should().BeTrue();
 
         static async ValueTask Callable()
         {
@@ -1155,7 +1155,7 @@ public class AsyncTests
         }));
         var result = engine.Evaluate("async function hello() {await myAsyncMethod();myAsyncMethod2();} hello();");
         result.UnwrapIfPromise();
-        Assert.Equal("12", log);
+        log.Should().Be("12");
     }
 
     [Fact]
@@ -1165,7 +1165,7 @@ public class AsyncTests
         engine.SetValue("asyncTestClass", new AsyncTestClass());
         var result = engine.Evaluate("asyncTestClass.ReturnDelayedValueTaskAsync().then(x=>x)");
         result = result.UnwrapIfPromise();
-        Assert.Equal(AsyncTestClass.TestString, result);
+        result.Should().Be(AsyncTestClass.TestString);
     }
 
     [Fact]
@@ -1175,7 +1175,7 @@ public class AsyncTests
         engine.SetValue("asyncTestClass", new AsyncTestClass());
         var result = engine.Evaluate("asyncTestClass.ReturnCompletedValueTask().then(x=>x)");
         result = result.UnwrapIfPromise();
-        Assert.Equal(AsyncTestClass.TestString, result);
+        result.Should().Be(AsyncTestClass.TestString);
     }
 
     [Fact]
@@ -1191,7 +1191,7 @@ public class AsyncTests
 
         engine.Evaluate("asyncTestClass.ReturnCancelledValueTask(token).then(_ => cancelled = false).catch(_ => cancelled = true)").UnwrapIfPromise();
 
-        Assert.Equal(true, engine.Evaluate("cancelled").AsBoolean());
+        engine.Evaluate("cancelled").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -1203,7 +1203,7 @@ public class AsyncTests
         engine.SetValue("asyncTestClass", new AsyncTestClass());
 
         engine.Evaluate("asyncTestClass.ThrowAfterDelayValueTaskAsync().then(_ => cancelled = false).catch(_ => cancelled = true)").UnwrapIfPromise();
-        Assert.Equal(true, engine.Evaluate("cancelled").AsBoolean());
+        engine.Evaluate("cancelled").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -1218,7 +1218,7 @@ public class AsyncTests
         }
         """);
         var result = engine.Invoke("test").UnwrapIfPromise(GenerousPromiseTimeout);
-        Assert.Equal(AsyncTestClass.TestString, result);
+        result.Should().Be(AsyncTestClass.TestString);
     }
 
     [Fact]
@@ -1237,7 +1237,7 @@ public class AsyncTests
         }
         """);
         var result = engine.Invoke("test").UnwrapIfPromise();
-        Assert.Equal(AsyncTestClass.TestString, result);
+        result.Should().Be(AsyncTestClass.TestString);
     }
 #endif
 
@@ -1270,7 +1270,7 @@ public class AsyncTests
             "Second end",
         ];
 
-        Assert.Equal(expected, log.Select(x => x.AsString()).ToArray());
+        log.Select(x => x.AsString()).ToArray().Should().Equal(expected);
     }
 
     [Fact]
@@ -1296,9 +1296,9 @@ public class AsyncTests
         var result = engine.Execute(Script);
         var val = result.GetValue("main");
         val.Call().UnwrapIfPromise();
-        Assert.Equal(2, log.Count);
-        Assert.Equal("Promise!", log[0]);
-        Assert.Equal("Resolved!", log[1]);
+        log.Should().HaveCount(2);
+        log[0].Should().Be("Promise!");
+        log[1].Should().Be("Resolved!");
     }
 
     [Fact]
@@ -1320,7 +1320,7 @@ public class AsyncTests
         """;
         var result = engine.Execute(Script);
         var val = result.GetValue("main").Call();
-        Assert.Equal(1, val.UnwrapIfPromise().AsInteger());
+        val.UnwrapIfPromise().AsInteger().Should().Be(1);
     }
 
 #if !NETFRAMEWORK // we are having trouble with timeouts on .NET Framework CI runs
@@ -1372,7 +1372,7 @@ public class AsyncTests
 
                         // Wait for the async function to complete (non-blocking async model)
                         val = val.UnwrapIfPromise(TimeSpan.FromSeconds(30));
-                        Assert.Equal(1, val.AsInteger());
+                        val.AsInteger().Should().Be(1);
 
                         tasks[taskIdx].SetResult(null);
                     }
@@ -1421,8 +1421,8 @@ public class AsyncTests
 
         // The function should return immediately, so x should start with "f() called -"
         // and NOT include "promise resolved -" yet
-        Assert.Equal("f() called - ", x);
-        Assert.False(callbackExecuted, "Promise callback should not have executed yet");
+        x.Should().Be("f() called - ");
+        callbackExecuted.Should().BeFalse("Promise callback should not have executed yet");
     }
 
     [Fact]
@@ -1469,24 +1469,24 @@ public class AsyncTests
 
         // All 3 async operations should have registered callbacks concurrently
         var callbacks = engine.Evaluate("callbacks").AsArray();
-        Assert.Equal(3, (int) callbacks.Length);
+        ((int) callbacks.Length).Should().Be(3);
 
         var log = engine.Evaluate("log").AsArray();
         var logStrings = log.Select(x => x.AsString()).ToArray();
 
         // Verify all wrapped/simple tasks started and registered before any completed
-        Assert.Contains("WrappedAsync A start", logStrings);
-        Assert.Contains("WrappedAsync B start", logStrings);
-        Assert.Contains("WrappedAsync C start", logStrings);
-        Assert.Contains("SimpleAsync A start", logStrings);
-        Assert.Contains("SimpleAsync B start", logStrings);
-        Assert.Contains("SimpleAsync C start", logStrings);
-        Assert.Contains("AsyncOp A registered", logStrings);
-        Assert.Contains("AsyncOp B registered", logStrings);
-        Assert.Contains("AsyncOp C registered", logStrings);
+        logStrings.Should().Contain("WrappedAsync A start");
+        logStrings.Should().Contain("WrappedAsync B start");
+        logStrings.Should().Contain("WrappedAsync C start");
+        logStrings.Should().Contain("SimpleAsync A start");
+        logStrings.Should().Contain("SimpleAsync B start");
+        logStrings.Should().Contain("SimpleAsync C start");
+        logStrings.Should().Contain("AsyncOp A registered");
+        logStrings.Should().Contain("AsyncOp B registered");
+        logStrings.Should().Contain("AsyncOp C registered");
 
         // None should have completed yet (no "got result" messages)
-        Assert.DoesNotContain(logStrings, s => s.Contains("got result"));
+        logStrings.Should().NotContain(s => s.Contains("got result"));
     }
 
     // ========================================================================
@@ -1505,7 +1505,7 @@ public class AsyncTests
             ]).then(results => JSON.stringify(results.map(r => r.status)))
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("[\"fulfilled\",\"rejected\",\"fulfilled\"]", result.AsString());
+        result.AsString().Should().Be("[\"fulfilled\",\"rejected\",\"fulfilled\"]");
     }
 
     [Fact]
@@ -1521,9 +1521,9 @@ public class AsyncTests
             """);
         result = result.UnwrapIfPromise();
         var parsed = result.AsString();
-        Assert.Contains("\"value\":42", parsed);
-        Assert.Contains("\"reason\":\"oops\"", parsed);
-        Assert.Contains("\"value\":\"hello\"", parsed);
+        parsed.Should().Contain("\"value\":42");
+        parsed.Should().Contain("\"reason\":\"oops\"");
+        parsed.Should().Contain("\"value\":\"hello\"");
     }
 
     [Fact]
@@ -1532,7 +1532,7 @@ public class AsyncTests
         var engine = new Engine();
         var result = engine.Evaluate("Promise.allSettled([]).then(r => r.length)");
         result = result.UnwrapIfPromise();
-        Assert.Equal(0, result.AsInteger());
+        result.AsInteger().Should().Be(0);
     }
 
     // ========================================================================
@@ -1551,7 +1551,7 @@ public class AsyncTests
             ])
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -1566,7 +1566,7 @@ public class AsyncTests
             ]).catch(e => e instanceof AggregateError ? 'aggregate' : 'other')
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("aggregate", result.AsString());
+        result.AsString().Should().Be("aggregate");
     }
 
     [Fact]
@@ -1580,7 +1580,7 @@ public class AsyncTests
             ]).catch(e => JSON.stringify(e.errors))
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("[\"e1\",\"e2\"]", result.AsString());
+        result.AsString().Should().Be("[\"e1\",\"e2\"]");
     }
 
     // ========================================================================
@@ -1616,7 +1616,7 @@ public class AsyncTests
             main()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("[1,2,3,true]", result.AsString());
+        result.AsString().Should().Be("[1,2,3,true]");
     }
 
     [Fact]
@@ -1639,7 +1639,7 @@ public class AsyncTests
             main()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal(30, result.AsInteger());
+        result.AsInteger().Should().Be(30);
     }
 
     [Fact]
@@ -1663,7 +1663,7 @@ public class AsyncTests
             main()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("{\"aValue\":1,\"bValue\":42,\"bDone\":true}", result.AsString());
+        result.AsString().Should().Be("{\"aValue\":1,\"bValue\":42,\"bDone\":true}");
     }
 
     // ========================================================================
@@ -1692,7 +1692,7 @@ public class AsyncTests
             main()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("abc", result.AsString());
+        result.AsString().Should().Be("abc");
     }
 
     [Fact]
@@ -1716,7 +1716,7 @@ public class AsyncTests
             main()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal(6, result.AsInteger());
+        result.AsInteger().Should().Be(6);
     }
 
     [Fact]
@@ -1740,7 +1740,7 @@ public class AsyncTests
             gen().next().then(() => log('resolved'));
             """);
 
-        Assert.Equal(new[] { "item:1", "item:2", "done", "resolved" }, log);
+        log.Should().Equal(new[] { "item:1", "item:2", "done", "resolved" });
     }
 
     [Fact]
@@ -1759,7 +1759,7 @@ public class AsyncTests
             gen().next().then(() => log('OK'));
             """);
 
-        Assert.Equal(new[] { "iteration", "OK" }, log);
+        log.Should().Equal(new[] { "iteration", "OK" });
     }
 
     [Fact]
@@ -1788,7 +1788,7 @@ public class AsyncTests
             consumer().next().then(() => log('outer-resolved'));
             """);
 
-        Assert.Equal(new[] { "got:a", "got:b", "got:c", "consumer-done", "outer-resolved" }, log);
+        log.Should().Equal(new[] { "got:a", "got:b", "got:c", "consumer-done", "outer-resolved" });
     }
 
     [Fact]
@@ -1821,7 +1821,7 @@ public class AsyncTests
             );
             """);
 
-        Assert.Equal(new[] { "rejected:iterator-error" }, log);
+        log.Should().Equal(new[] { "rejected:iterator-error" });
     }
 
     [Fact]
@@ -1855,7 +1855,7 @@ public class AsyncTests
             gen().next().then(() => log('resolved'));
             """);
 
-        Assert.Equal(new[] { "caught:iterator-error", "after-catch", "resolved" }, log);
+        log.Should().Equal(new[] { "caught:iterator-error", "after-catch", "resolved" });
     }
 
     // ========================================================================
@@ -1876,7 +1876,7 @@ public class AsyncTests
             Promise.resolve(thenable).then(v => v * 2)
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal(84, result.AsInteger());
+        result.AsInteger().Should().Be(84);
     }
 
     [Fact]
@@ -1893,7 +1893,7 @@ public class AsyncTests
             Promise.resolve(thenable).catch(e => 'caught: ' + e)
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("caught: thenable error", result.AsString());
+        result.AsString().Should().Be("caught: thenable error");
     }
 
     [Fact]
@@ -1914,7 +1914,7 @@ public class AsyncTests
             main()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal(100, result.AsInteger());
+        result.AsInteger().Should().Be(100);
     }
 
     // ========================================================================
@@ -1935,9 +1935,9 @@ public class AsyncTests
         engine.Evaluate("Promise.reject('unhandled')");
         engine.Advanced.ProcessTasks();
 
-        Assert.Single(rejections);
-        Assert.Equal(PromiseRejectionOperation.Reject, rejections[0].Op);
-        Assert.Equal("unhandled", rejections[0].Value.AsString());
+        rejections.Should().ContainSingle();
+        rejections[0].Op.Should().Be(PromiseRejectionOperation.Reject);
+        rejections[0].Value.AsString().Should().Be("unhandled");
     }
 
     [Fact]
@@ -1959,9 +1959,9 @@ public class AsyncTests
         engine.Evaluate("p.catch(() => {})");
         engine.Advanced.ProcessTasks();
 
-        Assert.Equal(2, operations.Count);
-        Assert.Equal(PromiseRejectionOperation.Reject, operations[0]);
-        Assert.Equal(PromiseRejectionOperation.Handle, operations[1]);
+        operations.Should().HaveCount(2);
+        operations[0].Should().Be(PromiseRejectionOperation.Reject);
+        operations[1].Should().Be(PromiseRejectionOperation.Handle);
     }
 
     [Fact]
@@ -1993,7 +1993,7 @@ public class AsyncTests
         // Verify the Handle operation follows the Reject.
         if (rejections.Contains(PromiseRejectionOperation.Reject))
         {
-            Assert.Contains(PromiseRejectionOperation.Handle, rejections);
+            rejections.Should().Contain(PromiseRejectionOperation.Handle);
         }
     }
 
@@ -2012,7 +2012,7 @@ public class AsyncTests
             }
             main()
             """);
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -2020,14 +2020,14 @@ public class AsyncTests
     {
         var engine = new Engine();
         var result = await engine.EvaluateAsync("1 + 2");
-        Assert.Equal(3, result.AsInteger());
+        result.AsInteger().Should().Be(3);
     }
 
     [Fact]
     public async Task EvaluateAsyncShouldRejectOnException()
     {
         var engine = new Engine();
-        await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+        await Awaiting(async () =>
         {
             await engine.EvaluateAsync("""
                 async function main() {
@@ -2035,7 +2035,7 @@ public class AsyncTests
                 }
                 main()
                 """);
-        });
+        }).Should().ThrowExactlyAsync<PromiseRejectedException>();
     }
 
     [Fact]
@@ -2047,7 +2047,7 @@ public class AsyncTests
                 return 'done';
             }
             """);
-        Assert.Same(engine, returnedEngine);
+        returnedEngine.Should().BeSameAs(engine);
     }
 
     [Fact]
@@ -2060,7 +2060,7 @@ public class AsyncTests
             }
             """);
         var result = await engine.InvokeAsync("add", 3, 4);
-        Assert.Equal(7, result.AsInteger());
+        result.AsInteger().Should().Be(7);
     }
 
     [Fact]
@@ -2072,7 +2072,7 @@ public class AsyncTests
         using var cts = new CancellationTokenSource();
         cts.Cancel(); // Cancel immediately
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        await Awaiting(async () =>
         {
             await engine.EvaluateAsync("""
                 async function main() {
@@ -2081,7 +2081,7 @@ public class AsyncTests
                 }
                 main()
                 """, cancellationToken: cts.Token);
-        });
+        }).Should().ThrowAsync<OperationCanceledException>();
     }
 
     [Fact]
@@ -2096,7 +2096,7 @@ public class AsyncTests
             }
             main()
             """);
-        Assert.Equal(AsyncTestClass.TestString, result.AsString());
+        result.AsString().Should().Be(AsyncTestClass.TestString);
     }
 
     [Fact]
@@ -2112,7 +2112,7 @@ public class AsyncTests
             }
             """);
         var result = await engine.InvokeAsync("test");
-        Assert.Equal("Hello World + Hello World", result.AsString());
+        result.AsString().Should().Be("Hello World + Hello World");
     }
 
     // ========================================================================
@@ -2138,7 +2138,7 @@ public class AsyncTests
             main()
             """);
 
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -2177,8 +2177,8 @@ public class AsyncTests
             main()
             """);
 
-        Assert.Equal("ABC", result.AsString());
-        Assert.Equal(["step1", "step2", "step3"], callOrder);
+        result.AsString().Should().Be("ABC");
+        callOrder.Should().Equal(["step1", "step2", "step3"]);
     }
 
     [Fact]
@@ -2208,8 +2208,8 @@ public class AsyncTests
             main()
             """);
 
-        Assert.Equal("result-a,result-b,result-c", result.AsString());
-        Assert.Equal(3, startTimes.Count);
+        result.AsString().Should().Be("result-a,result-b,result-c");
+        startTimes.Should().HaveCount(3);
     }
 
     [Fact]
@@ -2226,7 +2226,7 @@ public class AsyncTests
             return 999;
         }));
 
-        await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+        await Awaiting(async () =>
         {
             await engine.EvaluateAsync("""
                 async function main() {
@@ -2234,7 +2234,7 @@ public class AsyncTests
                 }
                 main()
                 """);
-        });
+        }).Should().ThrowExactlyAsync<PromiseRejectedException>();
     }
 
     [Fact]
@@ -2260,7 +2260,7 @@ public class AsyncTests
             main()
             """);
 
-        Assert.Equal("caught", result.AsString());
+        result.AsString().Should().Be("caught");
     }
 
     [Fact]
@@ -2290,7 +2290,7 @@ public class AsyncTests
             main()
             """);
 
-        Assert.Equal("DATA", result.AsString());
+        result.AsString().Should().Be("DATA");
     }
 
     [Fact]
@@ -2306,7 +2306,7 @@ public class AsyncTests
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        await Awaiting(async () =>
         {
             await engine.EvaluateAsync("""
                 async function main() {
@@ -2314,7 +2314,7 @@ public class AsyncTests
                 }
                 main()
                 """, cancellationToken: cts.Token);
-        });
+        }).Should().ThrowAsync<OperationCanceledException>();
     }
 
     [Fact]
@@ -2344,11 +2344,11 @@ public class AsyncTests
         await ioStarted.Task;
 
         // The evalTask should not be completed yet — IO is in flight
-        Assert.False(evalTask.IsCompleted, "EvaluateAsync should not block; task should still be pending during IO");
+        evalTask.IsCompleted.Should().BeFalse("EvaluateAsync should not block; task should still be pending during IO");
 
         // Now await the result
         var result = await evalTask;
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -2381,7 +2381,7 @@ public class AsyncTests
 
         for (int i = 0; i < EngineCount; i++)
         {
-            Assert.Equal(i * 2, results[i].AsInteger());
+            results[i].AsInteger().Should().Be(i * 2);
         }
     }
 
@@ -2400,7 +2400,7 @@ public class AsyncTests
             """);
 
         var result = await engine.InvokeAsync("fetchAndTransform");
-        Assert.Equal("Hello World!", result.AsString());
+        result.AsString().Should().Be("Hello World!");
     }
 
     [Fact]
@@ -2424,7 +2424,7 @@ public class AsyncTests
             main()
             """);
 
-        Assert.Equal("done", result.AsString());
+        result.AsString().Should().Be("done");
     }
 #endif
 
@@ -2448,13 +2448,13 @@ public class AsyncTests
         }));
 
         var r1 = await engine.EvaluateAsync("(async () => await io(1))()");
-        Assert.Equal(10, r1.AsInteger());
+        r1.AsInteger().Should().Be(10);
 
         var r2 = await engine.EvaluateAsync("(async () => await io(2))()");
-        Assert.Equal(20, r2.AsInteger());
+        r2.AsInteger().Should().Be(20);
 
         var r3 = await engine.EvaluateAsync("(async () => await io(3))()");
-        Assert.Equal(30, r3.AsInteger());
+        r3.AsInteger().Should().Be(30);
     }
 
     [Fact]
@@ -2472,15 +2472,15 @@ public class AsyncTests
 
         // Sync path first
         var syncResult = engine.Evaluate("(async () => await io())()").UnwrapIfPromise();
-        Assert.Equal("hello", syncResult.AsString());
+        syncResult.AsString().Should().Be("hello");
 
         // Async path on same engine
         var asyncResult = await engine.EvaluateAsync("(async () => await io())()");
-        Assert.Equal("hello", asyncResult.AsString());
+        asyncResult.AsString().Should().Be("hello");
 
         // Back to sync to verify no contamination
         var syncResult2 = engine.Evaluate("(async () => await io())()").UnwrapIfPromise();
-        Assert.Equal("hello", syncResult2.AsString());
+        syncResult2.AsString().Should().Be("hello");
     }
 
     [Fact]
@@ -2506,17 +2506,17 @@ public class AsyncTests
         }));
 
         // First call should time out
-        await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+        await Awaiting(async () =>
         {
             await engine.EvaluateAsync("(async () => await slowIO())()");
-        });
+        }).Should().ThrowExactlyAsync<PromiseRejectedException>();
 
         // Increase timeout for recovery (generous — the recovery half asserts success)
         engine.Options.Constraints.PromiseTimeout = GenerousPromiseTimeout;
 
         // Engine should still work
         var result = await engine.EvaluateAsync("(async () => await fastIO())()");
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -2538,15 +2538,15 @@ public class AsyncTests
 
         using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50)))
         {
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await Awaiting(async () =>
             {
                 await engine.EvaluateAsync("(async () => await slowIO())()", cancellationToken: cts.Token);
-            });
+            }).Should().ThrowAsync<OperationCanceledException>();
         }
 
         // Engine must still be usable after cancellation
         var result = await engine.EvaluateAsync("(async () => await fastIO())()");
-        Assert.Equal(7, result.AsInteger());
+        result.AsInteger().Should().Be(7);
     }
 
     // ========================================================================
@@ -2567,12 +2567,12 @@ public class AsyncTests
             throw new InvalidOperationException("backend error");
         }));
 
-        var ex = await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+        var ex = (await Awaiting(async () =>
         {
             await engine.EvaluateAsync("(async () => await failingIO())()");
-        });
+        }).Should().ThrowExactlyAsync<PromiseRejectedException>()).Which;
 
-        Assert.Contains("backend error", ex.Message);
+        ex.Message.Should().Contain("backend error");
     }
 
     [Fact]
@@ -2583,10 +2583,10 @@ public class AsyncTests
         // NOT PromiseRejectedException.
         var engine = new Engine();
 
-        await Assert.ThrowsAsync<JavaScriptException>(async () =>
+        await Awaiting(async () =>
         {
             await engine.EvaluateAsync("throw new Error('sync boom')");
-        });
+        }).Should().ThrowExactlyAsync<JavaScriptException>();
     }
 
     // ========================================================================
@@ -2610,8 +2610,8 @@ public class AsyncTests
         }));
 
         var result = await engine.EvaluateAsync("(async () => { await doWork(); return 'done'; })()");
-        Assert.Equal("done", result.AsString());
-        Assert.True(sideEffect, "Side effect from void Task should have executed");
+        result.AsString().Should().Be("done");
+        sideEffect.Should().BeTrue("Side effect from void Task should have executed");
     }
 
     [Fact]
@@ -2628,7 +2628,7 @@ public class AsyncTests
 
         var script = Engine.PrepareScript("(async () => await io())()");
         var result = await engine.EvaluateAsync(script);
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -2639,7 +2639,7 @@ public class AsyncTests
         // and never enter AwaitPromiseSettlementAsync.
         var engine = new Engine();
         var result = await engine.EvaluateAsync("Promise.resolve(42)");
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 #endif
 
@@ -2658,7 +2658,7 @@ public class AsyncTests
                 .then(v => v + '')
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("6", result.AsString());
+        result.AsString().Should().Be("6");
     }
 
     [Fact]
@@ -2671,7 +2671,7 @@ public class AsyncTests
                 .then(v => v + '!')
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("recovered from: err!", result.AsString());
+        result.AsString().Should().Be("recovered from: err!");
     }
 
     // ========================================================================
@@ -2694,7 +2694,7 @@ public class AsyncTests
             main()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("caught: boom", result.AsString());
+        result.AsString().Should().Be("caught: boom");
     }
 
     [Fact]
@@ -2716,7 +2716,7 @@ public class AsyncTests
             main()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("try,after await,finally", result.AsString());
+        result.AsString().Should().Be("try,after await,finally");
     }
 
     // ========================================================================
@@ -2741,7 +2741,7 @@ public class AsyncTests
             outer()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal(20, result.AsInteger());
+        result.AsInteger().Should().Be(20);
     }
 
     [Fact]
@@ -2755,7 +2755,7 @@ public class AsyncTests
             main()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 
     // ========================================================================
@@ -2774,7 +2774,7 @@ public class AsyncTests
             ]).then(values => JSON.stringify(values))
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("[1,2,3]", result.AsString());
+        result.AsString().Should().Be("[1,2,3]");
     }
 
     [Fact]
@@ -2789,7 +2789,7 @@ public class AsyncTests
             ]).catch(e => 'caught: ' + e)
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("caught: fail", result.AsString());
+        result.AsString().Should().Be("caught: fail");
     }
 
     // ========================================================================
@@ -2808,7 +2808,7 @@ public class AsyncTests
             ])
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("fast", result.AsString());
+        result.AsString().Should().Be("fast");
     }
 
     // ========================================================================
@@ -2830,7 +2830,7 @@ public class AsyncTests
             main()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("abc", result.AsString());
+        result.AsString().Should().Be("abc");
     }
 
     // ========================================================================
@@ -2849,7 +2849,7 @@ public class AsyncTests
             })()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal(30, result.AsInteger());
+        result.AsInteger().Should().Be(30);
     }
 
     // ========================================================================
@@ -2873,7 +2873,7 @@ public class AsyncTests
             """);
         result = result.UnwrapIfPromise();
         // Sum of 0..99 = 4950
-        Assert.Equal(4950, result.AsInteger());
+        result.AsInteger().Should().Be(4950);
     }
 
     // ========================================================================
@@ -2905,7 +2905,7 @@ public class AsyncTests
             })()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("response for a\nresponse for b\nresponse for c\nresponse for d\nresponse for e\nresponse for f\n", result.AsString());
+        result.AsString().Should().Be("response for a\nresponse for b\nresponse for c\nresponse for d\nresponse for e\nresponse for f\n");
     }
 
     [Fact]
@@ -2925,7 +2925,7 @@ public class AsyncTests
             })()
             """);
         result = result.UnwrapIfPromise();
-        Assert.Equal("10,20,30", result.AsString());
+        result.AsString().Should().Be("10,20,30");
     }
 
     [Fact]
@@ -2945,7 +2945,7 @@ public class AsyncTests
             """);
 
         result = result.UnwrapIfPromise();
-        Assert.Equal("a:10,b:20", result.AsString());
+        result.AsString().Should().Be("a:10,b:20");
     }
 
     [Fact]
@@ -2965,7 +2965,7 @@ public class AsyncTests
             """);
 
         result = result.UnwrapIfPromise();
-        Assert.Equal("1", result.AsString());
+        result.AsString().Should().Be("1");
     }
 
     [Fact]
@@ -2985,7 +2985,7 @@ public class AsyncTests
             """);
 
         result = result.UnwrapIfPromise();
-        Assert.Equal("1,2,3", result.AsString());
+        result.AsString().Should().Be("1,2,3");
     }
 
     [Fact]
@@ -3005,7 +3005,7 @@ public class AsyncTests
             """);
 
         result = result.UnwrapIfPromise();
-        Assert.Equal("42", result.AsString());
+        result.AsString().Should().Be("42");
     }
 
     [Fact]
@@ -3026,7 +3026,7 @@ public class AsyncTests
             """);
 
         result = result.UnwrapIfPromise();
-        Assert.Equal("7", result.AsString());
+        result.AsString().Should().Be("7");
     }
 
     [Fact]
@@ -3054,7 +3054,7 @@ public class AsyncTests
             })();
             """);
 
-        Assert.Equal("""[{"meta":{"index":1},"value":"x"}]""", result.AsString());
+        result.AsString().Should().Be("""[{"meta":{"index":1},"value":"x"}]""");
     }
 
     [Fact]
@@ -3070,7 +3070,7 @@ public class AsyncTests
             })()
             """).UnwrapIfPromise(TimeSpan.FromSeconds(5));
 
-        Assert.Equal("""{"meta":{"index":1},"value":"x"}""", result.AsString());
+        result.AsString().Should().Be("""{"meta":{"index":1},"value":"x"}""");
     }
 
     [Fact]
@@ -3088,7 +3088,7 @@ public class AsyncTests
             })()
             """).UnwrapIfPromise(TimeSpan.FromSeconds(5));
 
-        Assert.Equal("""["d",1]""", result.AsString());
+        result.AsString().Should().Be("""["d",1]""");
     }
 
     [Fact]
@@ -3107,7 +3107,7 @@ public class AsyncTests
             })()
             """).UnwrapIfPromise(TimeSpan.FromSeconds(5));
 
-        Assert.Equal(5, result.AsNumber());
+        result.AsNumber().Should().Be(5);
     }
 
     [Fact]
@@ -3123,7 +3123,7 @@ public class AsyncTests
             })()
             """).UnwrapIfPromise(TimeSpan.FromSeconds(5));
 
-        Assert.Equal("12!", result.AsString());
+        result.AsString().Should().Be("12!");
     }
 
     [Fact]
@@ -3147,7 +3147,7 @@ public class AsyncTests
         tcs.SetResult("done");
         var result = await evalTask;
 
-        Assert.Equal("{}", result.AsString());
+        result.AsString().Should().Be("{}");
     }
 
     [Fact]
@@ -3168,7 +3168,7 @@ public class AsyncTests
         tcs.SetResult("done");
         var result = promise.UnwrapIfPromise(TimeSpan.FromSeconds(5));
 
-        Assert.Equal("{}", result.AsString());
+        result.AsString().Should().Be("{}");
     }
 
 #if !NETFRAMEWORK
@@ -3185,16 +3185,16 @@ public class AsyncTests
         var waiter1 = loop.WaitForEventAsync(CancellationToken.None);
         var waiter2 = loop.WaitForEventAsync(CancellationToken.None);
 
-        Assert.False(waiter1.IsCompleted, "waiter1 should be pending until Enqueue");
-        Assert.False(waiter2.IsCompleted, "waiter2 should be pending until Enqueue");
+        waiter1.IsCompleted.Should().BeFalse("waiter1 should be pending until Enqueue");
+        waiter2.IsCompleted.Should().BeFalse("waiter2 should be pending until Enqueue");
 
         loop.Enqueue(static () => { });
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         await Task.WhenAll(waiter1, waiter2).WaitAsync(cts.Token);
 
-        Assert.True(waiter1.IsCompletedSuccessfully);
-        Assert.True(waiter2.IsCompletedSuccessfully);
+        waiter1.IsCompletedSuccessfully.Should().BeTrue();
+        waiter2.IsCompletedSuccessfully.Should().BeTrue();
     }
 #endif
 

--- a/Jint.Tests/Runtime/BigIntTests.cs
+++ b/Jint.Tests/Runtime/BigIntTests.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 using Jint.Native;
 using Jint.Runtime;
 
@@ -27,8 +27,8 @@ public class BigIntTests
         engine.Evaluate(statement);
 
         engine.Evaluate("log(a)");
-        Assert.True(outputValues[0].IsBigInt(), "The type of the value is expected to stay BigInt");
-        Assert.Equal(expected, outputValues[0].ToString());
+        outputValues[0].IsBigInt().Should().BeTrue("The type of the value is expected to stay BigInt");
+        outputValues[0].ToString().Should().Be(expected);
     }
 
     [Theory]
@@ -46,7 +46,7 @@ public class BigIntTests
         var result = engine.Evaluate("Object.is(left, right);");
 
         // Assert
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Theory]
@@ -66,7 +66,7 @@ public class BigIntTests
         var result = engine.Evaluate("Object.is(left, right);");
 
         // Assert
-        Assert.False(result.AsBoolean());
+        result.AsBoolean().Should().BeFalse();
     }
 
     [Theory]
@@ -81,8 +81,8 @@ public class BigIntTests
             options.LimitMemory(16_000_000);
         });
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate(expression));
-        Assert.Contains("Maximum BigInt size exceeded", ex.Message);
+        var ex = Invoking(() => engine.Evaluate(expression)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Contain("Maximum BigInt size exceeded");
     }
 
     [Theory]
@@ -100,8 +100,8 @@ public class BigIntTests
         var parts = expression.Split(new[] { " ** " }, StringSplitOptions.None);
         var script = $"var x = {parts[0]}; x **= {parts[1]}; x";
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate(script));
-        Assert.Contains("Maximum BigInt size exceeded", ex.Message);
+        var ex = Invoking(() => engine.Evaluate(script)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Contain("Maximum BigInt size exceeded");
     }
 
     [Theory]
@@ -114,15 +114,15 @@ public class BigIntTests
     {
         var engine = new Engine();
         var result = engine.Evaluate(expression);
-        Assert.Equal(expected, result.ToString());
+        result.ToString().Should().Be(expected);
     }
 
     [Fact]
     public void NegativeExponentShouldThrowRangeError()
     {
         var engine = new Engine();
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("2n ** -1n"));
-        Assert.Contains("Exponent must be positive", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("2n ** -1n")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Contain("Exponent must be positive");
     }
 
     [Theory]
@@ -132,9 +132,9 @@ public class BigIntTests
     {
         var engine = new Engine();
 
-        var exception = Assert.Throws<JavaScriptException>(() => engine.Evaluate(expression));
+        var exception = Invoking(() => engine.Evaluate(expression)).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.True(exception.Error.InstanceofOperator(engine.Intrinsics.RangeError));
+        exception.Error.InstanceofOperator(engine.Intrinsics.RangeError).Should().BeTrue();
     }
 
     [Theory]
@@ -144,14 +144,14 @@ public class BigIntTests
     {
         var engine = new Engine();
 
-        var exception = Assert.Throws<JavaScriptException>(() => engine.Evaluate($$"""
+        var exception = Invoking(() => engine.Evaluate($$"""
             {{operation}}(2147483648, {
                 [Symbol.toPrimitive]() {
                     throw new Error('boom');
                 }
             });
-            """));
+            """)).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal("boom", exception.Error.AsObject().Get("message").AsString());
+        exception.Error.AsObject().Get("message").AsString().Should().Be("boom");
     }
 }

--- a/Jint.Tests/Runtime/BitwiseLaneTests.cs
+++ b/Jint.Tests/Runtime/BitwiseLaneTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the semantics of the bitwise identifier-operand lane (BitwiseIdentifierLane): unboxed
@@ -45,7 +45,7 @@ public class BitwiseLaneTests
             })()
             """).AsString();
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class BitwiseLaneTests
 
         // ToInt32(3.7)=3, ToInt32(-3.7)=-3 (so -3^5 = 0xFFFFFFF8 = -8), ToInt32(NaN/±Inf)=0,
         // ToInt32(2^32+2)=2, ToUint32(2^32+2)=2
-        Assert.Equal("6,-8,5,5,5,2,6,2", result);
+        result.Should().Be("6,-8,5,5,5,2,6,2");
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class BitwiseLaneTests
             """).AsString();
 
         // ToInt32(-0) = +0: xor gives 7, and (-0 | 0) is +0 so 1/(+0) = Infinity
-        Assert.Equal("7:Infinity", result);
+        result.Should().Be("7:Infinity");
     }
 
     [Fact]
@@ -100,11 +100,11 @@ public class BitwiseLaneTests
             """).AsString();
 
         // reference values verified independently with System.Numerics.BigInteger
-        Assert.Equal("12345678900808999523:706611344", result);
+        result.Should().Be("12345678900808999523:706611344");
 
-        var mixEx = Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            engine.Evaluate("(function () { var a = 1n; var b = 2; return a ^ b; })()"));
-        Assert.Contains("BigInt", mixEx.Message);
+        var mixEx = Invoking(() =>
+            engine.Evaluate("(function () { var a = 1n; var b = 2; return a ^ b; })()")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>().Which;
+        mixEx.Message.Should().Contain("BigInt");
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public class BitwiseLaneTests
 
         // the lane declines (binding holds an object, not a number); generic path calls valueOf
         // once per evaluation — five iterations, five calls
-        Assert.Equal("5:5", result);
+        result.Should().Be("5:5");
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public class BitwiseLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("6:24", result);
+        result.Should().Be("6:24");
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class BitwiseLaneTests
                 return acc;
             })()
             """).AsNumber();
-        Assert.Equal(18, viaLexical);
+        viaLexical.Should().Be(18);
 
         var viaGlobals = engine.Evaluate("""
             gx = 12; gm = 10; gacc = 0;
@@ -168,6 +168,6 @@ public class BitwiseLaneTests
             }
             gacc;
             """).AsNumber();
-        Assert.Equal(18, viaGlobals);
+        viaGlobals.Should().Be(18);
     }
 }

--- a/Jint.Tests/Runtime/CallStackTests.cs
+++ b/Jint.Tests/Runtime/CallStackTests.cs
@@ -21,7 +21,7 @@ public class CallStackTests
                 }
                 "
         );
-        Assert.Equal(0, engine.CallStack.Count);
+        engine.CallStack.Count.Should().Be(0);
     }
 
     [Fact]
@@ -47,6 +47,6 @@ public class CallStackTests
                 {
                 }
             ");
-        Assert.Equal(0, engine.CallStack.Count);
+        engine.CallStack.Count.Should().Be(0);
     }
 }

--- a/Jint.Tests/Runtime/CatchBindingTests.cs
+++ b/Jint.Tests/Runtime/CatchBindingTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the behavior of the pooled fixed-slot catch environment used for a non-escaping single-identifier
@@ -12,9 +12,9 @@ public class CatchBindingTests
     public void CaughtValueAndMutationWork()
     {
         var engine = new Engine();
-        Assert.Equal("m1", engine.Evaluate("try { throw new Error('m1'); } catch (e) { e.message; }").AsString());
-        Assert.Equal(15, engine.Evaluate("try { throw 10; } catch (e) { e = e + 5; e; }").AsNumber());
-        Assert.True(engine.Evaluate("try { throw undefined; } catch (e) { e === undefined; }").AsBoolean());
+        engine.Evaluate("try { throw new Error('m1'); } catch (e) { e.message; }").AsString().Should().Be("m1");
+        engine.Evaluate("try { throw 10; } catch (e) { e = e + 5; e; }").AsNumber().Should().Be(15);
+        engine.Evaluate("try { throw undefined; } catch (e) { e === undefined; }").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -22,7 +22,7 @@ public class CatchBindingTests
     {
         var engine = new Engine();
         var result = engine.Evaluate("try { try { throw 'inner'; } catch (e) { throw e; } } catch (e2) { e2; }").AsString();
-        Assert.Equal("inner", result);
+        result.Should().Be("inner");
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public class CatchBindingTests
 var e = 'outer';
 var caught = (function () { try { throw 'shadow'; } catch (e) { return e; } })();
 caught + '|' + e;").AsString();
-        Assert.Equal("shadow|outer", result);
+        result.Should().Be("shadow|outer");
     }
 
     [Fact]
@@ -44,7 +44,7 @@ caught + '|' + e;").AsString();
 var seq = [];
 for (var i = 0; i < 3; i++) { try { throw i * 2; } catch (e) { seq.push(e); } }
 seq.join(',');").AsString();
-        Assert.Equal("0,2,4", result);
+        result.Should().Be("0,2,4");
     }
 
     [Fact]
@@ -61,7 +61,7 @@ function rec(n) {
   }
 }
 rec(3);").AsNumber();
-        Assert.Equal(6, result); // 3 + 2 + 1 + 0
+        result.Should().Be(6); // 3 + 2 + 1 + 0
     }
 
     [Fact]
@@ -75,7 +75,7 @@ for (var i = 0; i < 3; i++) {
   try { throw 'v' + i; } catch (e) { closures.push(function () { return e; }); }
 }
 closures[0]() + ',' + closures[1]() + ',' + closures[2]();").AsString();
-        Assert.Equal("v0,v1,v2", result);
+        result.Should().Be("v0,v1,v2");
     }
 
     [Fact]
@@ -87,7 +87,7 @@ var saved;
 try { throw 'keepme'; } catch (err) { saved = function () { return err; }; }
 for (var j = 0; j < 5; j++) { try { throw j; } catch (e) { } }
 saved();").AsString();
-        Assert.Equal("keepme", result);
+        result.Should().Be("keepme");
     }
 
     [Fact]
@@ -95,6 +95,6 @@ saved();").AsString();
     {
         var engine = new Engine();
         var result = engine.Evaluate("try { throw 'x'; } catch (e) { let y = e + '!'; y; }").AsString();
-        Assert.Equal("x!", result);
+        result.Should().Be("x!");
     }
 }

--- a/Jint.Tests/Runtime/ClassReEvaluationTests.cs
+++ b/Jint.Tests/Runtime/ClassReEvaluationTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the semantics of the per-engine function-definition cache applied to class evaluation:
@@ -37,7 +37,7 @@ public class ClassReEvaluationTests
             })()
             """).AsString();
 
-        Assert.Equal("true,true,true,a:a,b:b,a!,b!,a,b,A,B,true,false", result);
+        result.Should().Be("true,true,true,a:a,b:b,a!,b!,a,b,A,B,true,false");
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class ClassReEvaluationTests
             })()
             """).AsString();
 
-        Assert.Equal("sub-one|sub-two", result);
+        result.Should().Be("sub-one|sub-two");
     }
 
     [Fact]
@@ -73,8 +73,8 @@ public class ClassReEvaluationTests
             })();
             """);
 
-        Assert.Equal(42, engine.Evaluate(prepared).AsNumber());
-        Assert.Equal(42, engine.Evaluate(prepared).AsNumber());
-        Assert.Equal(42, engine.Evaluate(prepared).AsNumber());
+        engine.Evaluate(prepared).AsNumber().Should().Be(42);
+        engine.Evaluate(prepared).AsNumber().Should().Be(42);
+        engine.Evaluate(prepared).AsNumber().Should().Be(42);
     }
 }

--- a/Jint.Tests/Runtime/ClassTests.cs
+++ b/Jint.Tests/Runtime/ClassTests.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime;
+﻿using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -17,7 +17,7 @@ public class ClassTests
             return C === c1;";
 
         var engine = new Engine();
-        Assert.True(engine.Evaluate(Script).AsBoolean());
+        engine.Evaluate(Script).AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -44,35 +44,35 @@ public class ClassTests
         engine.Execute(Script);
 
         engine.Evaluate("var board = new Board()");
-        Assert.Equal(10, engine.Evaluate("board.width"));
-        Assert.Equal(20, engine.Evaluate("board.doubleWidth "));
+        engine.Evaluate("board.width").Should().Be(10);
+        engine.Evaluate("board.doubleWidth ").Should().Be(20);
     }
 
     [Fact]
     public void PrivateMemberAccessOutsideOfClass()
     {
-        var ex = Assert.Throws<JavaScriptException>(() => new Engine().Evaluate
+        var ex = Invoking(() => new Engine().Evaluate
         (
             """
             class A { }
             new A().#nonexistent = 1;
             """
-        ));
+        )).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal("Private field '#nonexistent' must be declared in an enclosing class (<anonymous>:2:9)", ex.Message);
+        ex.Message.Should().Be("Private field '#nonexistent' must be declared in an enclosing class (<anonymous>:2:9)");
     }
 
     [Fact]
     public void PrivateMemberAccessAgainstUnknownMemberInConstructor()
     {
-        var ex = Assert.Throws<JavaScriptException>(() => new Engine().Evaluate
+        var ex = Invoking(() => new Engine().Evaluate
         (
             """
             class A { constructor() { #nonexistent = 2; } }
             new A();
             """
-        ));
+        )).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal("Unexpected identifier '#nonexistent' (<anonymous>:1:27)", ex.Message);
+        ex.Message.Should().Be("Unexpected identifier '#nonexistent' (<anonymous>:1:27)");
     }
 }

--- a/Jint.Tests/Runtime/CompletionValueTests.cs
+++ b/Jint.Tests/Runtime/CompletionValueTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 
 namespace Jint.Tests.Runtime;
 
@@ -14,77 +14,77 @@ public class CompletionValueTests
     [Fact]
     public void ScriptTopLevelReturnsLastExpressionValue()
     {
-        Assert.Equal(2d, _engine.Evaluate("1; 2;").AsNumber());
-        Assert.Equal(3d, _engine.Evaluate("var x = 1; x + 2;").AsNumber());
-        Assert.Equal(0.5, _engine.Evaluate("var y = 0.25; y + 0.25;").AsNumber());
+        _engine.Evaluate("1; 2;").AsNumber().Should().Be(2d);
+        _engine.Evaluate("var x = 1; x + 2;").AsNumber().Should().Be(3d);
+        _engine.Evaluate("var y = 0.25; y + 0.25;").AsNumber().Should().Be(0.5);
     }
 
     [Fact]
     public void EvalReturnsLastExpressionValue()
     {
-        Assert.Equal(3d, _engine.Evaluate("eval('1;2;3')").AsNumber());
-        Assert.Equal(JsValue.Undefined, _engine.Evaluate("eval('var a = 1;')"));
+        _engine.Evaluate("eval('1;2;3')").AsNumber().Should().Be(3d);
+        _engine.Evaluate("eval('var a = 1;')").Should().BeUndefined();
     }
 
     [Fact]
     public void DirectEvalInsideFunctionReturnsLastExpressionValue()
     {
-        Assert.Equal(3d, _engine.Evaluate("function f() { return eval('1;2;3'); } f()").AsNumber());
-        Assert.Equal(42d, _engine.Evaluate("function g() { var t = 2; return eval('t; 42'); } g()").AsNumber());
+        _engine.Evaluate("function f() { return eval('1;2;3'); } f()").AsNumber().Should().Be(3d);
+        _engine.Evaluate("function g() { var t = 2; return eval('t; 42'); } g()").AsNumber().Should().Be(42d);
     }
 
     [Fact]
     public void IndirectEvalReturnsLastExpressionValue()
     {
-        Assert.Equal(7d, _engine.Evaluate("function f() { var e = eval; return e('5;6;7'); } f()").AsNumber());
+        _engine.Evaluate("function f() { var e = eval; return e('5;6;7'); } f()").AsNumber().Should().Be(7d);
     }
 
     [Fact]
     public void FunctionWithoutReturnGivesUndefined()
     {
-        Assert.Equal(JsValue.Undefined, _engine.Evaluate("function f() { 1; 2; 3; } f()"));
-        Assert.Equal(JsValue.Undefined, _engine.Evaluate("(function () { 42; })()"));
+        _engine.Evaluate("function f() { 1; 2; 3; } f()").Should().BeUndefined();
+        _engine.Evaluate("(function () { 42; })()").Should().BeUndefined();
     }
 
     [Fact]
     public void FunctionReturnValueFlows()
     {
-        Assert.Equal(0.75, _engine.Evaluate("function f() { var s = 0; for (var i = 0; i < 3; i++) { s += 0.25; } return s; } f()").AsNumber());
+        _engine.Evaluate("function f() { var s = 0; for (var i = 0; i < 3; i++) { s += 0.25; } return s; } f()").AsNumber().Should().Be(0.75);
     }
 
     [Fact]
     public void TopLevelLoopProducesLastIterationValue()
     {
-        Assert.Equal(4d, _engine.Evaluate("for (var i = 0; i < 5; i++) { i; }").AsNumber());
-        Assert.Equal(2.5, _engine.Evaluate("var s = 0; for (var i = 0; i < 5; i++) { s += 0.5; }").AsNumber());
+        _engine.Evaluate("for (var i = 0; i < 5; i++) { i; }").AsNumber().Should().Be(4d);
+        _engine.Evaluate("var s = 0; for (var i = 0; i < 5; i++) { s += 0.5; }").AsNumber().Should().Be(2.5);
     }
 
     [Fact]
     public void TopLevelBlockAndIfProduceValues()
     {
-        Assert.Equal(2d, _engine.Evaluate("{ 1; 2; }").AsNumber());
-        Assert.Equal(10d, _engine.Evaluate("if (true) { 10; } else { 20; }").AsNumber());
-        Assert.Equal(5d, _engine.Evaluate("switch (1) { case 1: 5; }").AsNumber());
+        _engine.Evaluate("{ 1; 2; }").AsNumber().Should().Be(2d);
+        _engine.Evaluate("if (true) { 10; } else { 20; }").AsNumber().Should().Be(10d);
+        _engine.Evaluate("switch (1) { case 1: 5; }").AsNumber().Should().Be(5d);
     }
 
     [Fact]
     public void GeneratorAndAsyncResultsFlow()
     {
-        Assert.Equal(1d, _engine.Evaluate("function* g() { 41; yield 1; 43; } g().next().value").AsNumber());
-        Assert.Equal(11d, _engine.Evaluate("async function a() { 1; return 11; } a()").UnwrapIfPromise().AsNumber());
+        _engine.Evaluate("function* g() { 41; yield 1; 43; } g().next().value").AsNumber().Should().Be(1d);
+        _engine.Evaluate("async function a() { 1; return 11; } a()").UnwrapIfPromise().AsNumber().Should().Be(11d);
     }
 
     [Fact]
     public void ClassStaticBlockValuesAreNotObservable()
     {
-        Assert.Equal(9d, _engine.Evaluate("class C { static x; static { 123; C.x = 9; } } C.x").AsNumber());
+        _engine.Evaluate("class C { static x; static { 123; C.x = 9; } } C.x").AsNumber().Should().Be(9d);
     }
 
     [Fact]
     public void EvalSwitchAndTryProduceValues()
     {
-        Assert.Equal(3d, _engine.Evaluate("eval('try { 3; } catch (e) { 4; }')").AsNumber());
-        Assert.Equal(4d, _engine.Evaluate("eval('try { throw 1; } catch (e) { 4; }')").AsNumber());
-        Assert.Equal(8d, _engine.Evaluate("eval('switch (2) { case 2: 8; }')").AsNumber());
+        _engine.Evaluate("eval('try { 3; } catch (e) { 4; }')").AsNumber().Should().Be(3d);
+        _engine.Evaluate("eval('try { throw 1; } catch (e) { 4; }')").AsNumber().Should().Be(4d);
+        _engine.Evaluate("eval('switch (2) { case 2: 8; }')").AsNumber().Should().Be(8d);
     }
 }

--- a/Jint.Tests/Runtime/CompoundAssignmentTests.cs
+++ b/Jint.Tests/Runtime/CompoundAssignmentTests.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime;
+﻿using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -14,7 +14,7 @@ public class CompoundAssignmentTests
         var engine = new Engine(static options => options.Strict());
         var result = engine.Evaluate("function f() { var s = ''; for (var i = 0; i < 100; i++) { s += 'ab'; } return s; } f();").AsString();
 
-        Assert.Equal(string.Concat(Enumerable.Repeat("ab", 100)), result);
+        result.Should().Be(string.Concat(Enumerable.Repeat("ab", 100)));
     }
 
     [Fact]
@@ -26,7 +26,7 @@ public class CompoundAssignmentTests
         var engine = new Engine(static options => options.Strict());
         var result = engine.Evaluate("function f() { var s = ''; s += 'x'; s += (s = 'z', 'a'); return s; } f();").AsString();
 
-        Assert.Equal("z", result);
+        result.Should().Be("z");
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public class CompoundAssignmentTests
         var engine = new Engine(static options => options.Strict());
         var result = engine.Evaluate("function f() { var n = 5; n += (n = 1, 2); return n; } f();").AsNumber();
 
-        Assert.Equal(7, result);
+        result.Should().Be(7);
     }
 
     [Fact]
@@ -43,8 +43,8 @@ public class CompoundAssignmentTests
     {
         var engine = new Engine(static options => options.Strict());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("function f() { const c = 'a'; c += 'b'; } f();"));
-        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.TypeError));
+        var ex = Invoking(() => engine.Execute("function f() { const c = 'a'; c += 'b'; } f();")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.InstanceofOperator(engine.Intrinsics.TypeError).Should().BeTrue();
     }
 
     [Fact]
@@ -52,8 +52,8 @@ public class CompoundAssignmentTests
     {
         var engine = new Engine(static options => options.Strict());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("function f() { { t += 'x'; let t; } } f();"));
-        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.ReferenceError));
+        var ex = Invoking(() => engine.Execute("function f() { { t += 'x'; let t; } } f();")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.InstanceofOperator(engine.Intrinsics.ReferenceError).Should().BeTrue();
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class CompoundAssignmentTests
         var engine = new Engine(static options => options.Strict());
         var result = engine.Evaluate("function f() { var n = 2; n += 'x'; return n; } f();").AsString();
 
-        Assert.Equal("2x", result);
+        result.Should().Be("2x");
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class CompoundAssignmentTests
         var engine = new Engine(static options => options.Strict());
         var result = engine.Evaluate("eval(\"var s = ''; s += 'x'; s += (s = 'z', 'a'); s;\")").AsString();
 
-        Assert.Equal("z", result);
+        result.Should().Be("z");
     }
 
     [Fact]
@@ -81,8 +81,8 @@ public class CompoundAssignmentTests
     {
         var engine = new Engine(static options => options.Strict());
 
-        Assert.Equal("ab", engine.Evaluate("eval(\"var s = 'a'; s += 'b';\")").AsString());
-        Assert.Equal("ab|ab", engine.Evaluate("eval(\"var q = 'a'; var t = (q += 'b'); t + '|' + q;\")").AsString());
+        engine.Evaluate("eval(\"var s = 'a'; s += 'b';\")").AsString().Should().Be("ab");
+        engine.Evaluate("eval(\"var q = 'a'; var t = (q += 'b'); t + '|' + q;\")").AsString().Should().Be("ab|ab");
     }
 
     [Fact]
@@ -90,8 +90,8 @@ public class CompoundAssignmentTests
     {
         var engine = new Engine(static options => options.Strict());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("eval(\"const c = 'a'; c += 'b';\");"));
-        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.TypeError));
+        var ex = Invoking(() => engine.Execute("eval(\"const c = 'a'; c += 'b';\");")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.InstanceofOperator(engine.Intrinsics.TypeError).Should().BeTrue();
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class CompoundAssignmentTests
         for (var i = 0; i < 3; i++)
         {
             engine.Execute("eval(src);");
-            Assert.Equal(new string('q', 50), engine.Evaluate("out").AsString());
+            engine.Evaluate("out").AsString().Should().Be(new string('q', 50));
         }
     }
 }

--- a/Jint.Tests/Runtime/ConstTests.cs
+++ b/Jint.Tests/Runtime/ConstTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 public class ConstTests
 {
@@ -8,8 +8,9 @@ public class ConstTests
     {
         _engine = new Engine()
             .SetValue("log", new Action<object>(Console.WriteLine))
-            .SetValue("assert", new Action<bool>(Assert.True))
-            .SetValue("equal", new Action<object, object>(Assert.Equal));
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/ConstructorShapeEligibilityTests.cs
+++ b/Jint.Tests/Runtime/ConstructorShapeEligibilityTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime;
 
@@ -20,7 +20,7 @@ public class ConstructorShapeEligibilityTests
 
     private static Shape ShapeOf(JsObject o)
     {
-        Assert.True(IsShapeMode(o), "expected a shape-mode object");
+        IsShapeMode(o).Should().BeTrue("expected a shape-mode object");
         return o.ShapeOf;
     }
 
@@ -37,17 +37,17 @@ public class ConstructorShapeEligibilityTests
 
         // instances #1 and #2 stay dictionaries (the interned tree only pays off from ~3 instances,
         // so unrepeated layouts intern no shape state at all); instances #3+ share one hidden class
-        Assert.False(IsShapeMode(t1));
-        Assert.False(IsShapeMode(t2));
-        Assert.True(IsShapeMode(t3));
-        Assert.True(IsShapeMode(t4));
-        Assert.Same(ShapeOf(t3), ShapeOf(t4));
+        IsShapeMode(t1).Should().BeFalse();
+        IsShapeMode(t2).Should().BeFalse();
+        IsShapeMode(t3).Should().BeTrue();
+        IsShapeMode(t4).Should().BeTrue();
+        ShapeOf(t4).Should().BeSameAs(ShapeOf(t3));
 
-        Assert.Equal(1, engine.Evaluate("t1.a").AsNumber());
-        Assert.Equal(2, engine.Evaluate("t3.b").AsNumber());
-        Assert.Equal("a,b", engine.Evaluate("Object.keys(t1).join(',')").AsString());
-        Assert.Equal("a,b", engine.Evaluate("Object.keys(t3).join(',')").AsString());
-        Assert.True(engine.Evaluate("'a' in t3 && 'b' in t3 && !('c' in t3)").AsBoolean());
+        engine.Evaluate("t1.a").AsNumber().Should().Be(1);
+        engine.Evaluate("t3.b").AsNumber().Should().Be(2);
+        engine.Evaluate("Object.keys(t1).join(',')").AsString().Should().Be("a,b");
+        engine.Evaluate("Object.keys(t3).join(',')").AsString().Should().Be("a,b");
+        engine.Evaluate("'a' in t3 && 'b' in t3 && !('c' in t3)").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -57,9 +57,9 @@ public class ConstructorShapeEligibilityTests
         engine.Execute("function T() { this.a = 1; this.b = this.a + 1; } var t1 = new T(); var t2 = new T(); var t3 = new T();");
 
         var t3 = GetObject(engine, "t3");
-        Assert.True(IsShapeMode(t3));
-        Assert.Equal(2, engine.Evaluate("t1.b").AsNumber());
-        Assert.Equal(2, engine.Evaluate("t3.b").AsNumber());
+        IsShapeMode(t3).Should().BeTrue();
+        engine.Evaluate("t1.b").AsNumber().Should().Be(2);
+        engine.Evaluate("t3.b").AsNumber().Should().Be(2);
     }
 
     [Fact]
@@ -69,9 +69,9 @@ public class ConstructorShapeEligibilityTests
         engine.Execute("function T() { this.abs = Math.abs(-5); this.t = Date.now(); return; } var t1 = new T(); var t2 = new T(); var t3 = new T();");
 
         var t3 = GetObject(engine, "t3");
-        Assert.True(IsShapeMode(t3));
-        Assert.Equal(5, engine.Evaluate("t3.abs").AsNumber());
-        Assert.Equal("abs,t", engine.Evaluate("Object.keys(t3).join(',')").AsString());
+        IsShapeMode(t3).Should().BeTrue();
+        engine.Evaluate("t3.abs").AsNumber().Should().Be(5);
+        engine.Evaluate("Object.keys(t3).join(',')").AsString().Should().Be("abs,t");
     }
 
     [Fact]
@@ -81,9 +81,9 @@ public class ConstructorShapeEligibilityTests
         engine.Execute("function T() { 'use strict'; this.a = 1; } var t1 = new T(); var t2 = new T(); var t3 = new T();");
 
         var t3 = GetObject(engine, "t3");
-        Assert.True(IsShapeMode(t3));
-        Assert.Equal(1, engine.Evaluate("t1.a").AsNumber());
-        Assert.Equal(1, engine.Evaluate("t3.a").AsNumber());
+        IsShapeMode(t3).Should().BeTrue();
+        engine.Evaluate("t1.a").AsNumber().Should().Be(1);
+        engine.Evaluate("t3.a").AsNumber().Should().Be(1);
     }
 
     [Fact]
@@ -102,9 +102,9 @@ public class ConstructorShapeEligibilityTests
             """);
 
         var t3 = GetObject(engine, "t3");
-        Assert.True(IsShapeMode(t3));
-        Assert.Equal("self", engine.Evaluate("t1.get()").AsString());
-        Assert.Equal("self", engine.Evaluate("t3.get()").AsString());
+        IsShapeMode(t3).Should().BeTrue();
+        engine.Evaluate("t1.get()").AsString().Should().Be("self");
+        engine.Evaluate("t3.get()").AsString().Should().Be("self");
     }
 
     [Fact]
@@ -115,29 +115,29 @@ public class ConstructorShapeEligibilityTests
         // shape from instance #3 like straight-line ones.
         var engine = new Engine();
         engine.Execute("function T(f) { if (f) this.axis = 0; else this.axis = 2; this.n = 1; } var t1 = new T(true); var t2 = new T(false); var t3 = new T(true); var t4 = new T(false);");
-        Assert.False(IsShapeMode(GetObject(engine, "t1")));
-        Assert.True(IsShapeMode(GetObject(engine, "t3")));
-        Assert.True(IsShapeMode(GetObject(engine, "t4")));
-        Assert.Same(ShapeOf(GetObject(engine, "t3")), ShapeOf(GetObject(engine, "t4")));
-        Assert.Equal(0, engine.Evaluate("t3.axis").AsNumber());
-        Assert.Equal(2, engine.Evaluate("t4.axis").AsNumber());
-        Assert.Equal("axis,n", engine.Evaluate("Object.keys(t3).join(',')").AsString());
+        IsShapeMode(GetObject(engine, "t1")).Should().BeFalse();
+        IsShapeMode(GetObject(engine, "t3")).Should().BeTrue();
+        IsShapeMode(GetObject(engine, "t4")).Should().BeTrue();
+        ShapeOf(GetObject(engine, "t4")).Should().BeSameAs(ShapeOf(GetObject(engine, "t3")));
+        engine.Evaluate("t3.axis").AsNumber().Should().Be(0);
+        engine.Evaluate("t4.axis").AsNumber().Should().Be(2);
+        engine.Evaluate("Object.keys(t3).join(',')").AsString().Should().Be("axis,n");
 
         // divergent key sets per branch: both layouts stay correct, shapes differ per path
         engine = new Engine();
         engine.Execute("function T(f) { if (f) { this.a = 1; } else { this.b = 2; } } var t1 = new T(true); var t2 = new T(true); var t3 = new T(true); var t4 = new T(false);");
-        Assert.True(IsShapeMode(GetObject(engine, "t3")));
-        Assert.True(IsShapeMode(GetObject(engine, "t4")));
-        Assert.Equal(1, engine.Evaluate("t3.a").AsNumber());
-        Assert.False(engine.Evaluate("'b' in t3").AsBoolean());
-        Assert.Equal(2, engine.Evaluate("t4.b").AsNumber());
-        Assert.False(engine.Evaluate("'a' in t4").AsBoolean());
+        IsShapeMode(GetObject(engine, "t3")).Should().BeTrue();
+        IsShapeMode(GetObject(engine, "t4")).Should().BeTrue();
+        engine.Evaluate("t3.a").AsNumber().Should().Be(1);
+        engine.Evaluate("'b' in t3").AsBoolean().Should().BeFalse();
+        engine.Evaluate("t4.b").AsNumber().Should().Be(2);
+        engine.Evaluate("'a' in t4").AsBoolean().Should().BeFalse();
 
         // a this-escaping call in the if TEST still rejects eligibility
         engine = new Engine();
         engine.Execute("function ext(o) { o.dyn = 1; return true; } function T() { if (ext(this)) this.a = 1; } var t1 = new T(); var t2 = new T(); var t3 = new T();");
-        Assert.False(IsShapeMode(GetObject(engine, "t3")));
-        Assert.Equal("dyn,a", engine.Evaluate("Object.keys(t3).join(',')").AsString());
+        IsShapeMode(GetObject(engine, "t3")).Should().BeFalse();
+        engine.Evaluate("Object.keys(t3).join(',')").AsString().Should().Be("dyn,a");
     }
 
     [Fact]
@@ -150,43 +150,43 @@ public class ConstructorShapeEligibilityTests
         var engine = new Engine();
         engine.Execute("function T(k) { this[k] = 42; } var t = new T('dyn'); var t2 = new T('dyn'); var t3 = new T('dyn');");
         var t = GetObject(engine, "t");
-        Assert.False(IsShapeMode(t));
-        Assert.False(IsShapeMode(GetObject(engine, "t3")));
-        Assert.Equal(42, engine.Evaluate("t.dyn").AsNumber());
+        IsShapeMode(t).Should().BeFalse();
+        IsShapeMode(GetObject(engine, "t3")).Should().BeFalse();
+        engine.Evaluate("t.dyn").AsNumber().Should().Be(42);
 
         // this-call in body
         engine = new Engine();
         engine.Execute("function T() { this.init(); } T.prototype.init = function () { this.a = 1; }; var t = new T(); var t2 = new T(); var t3 = new T();");
         t = GetObject(engine, "t");
-        Assert.False(IsShapeMode(t));
-        Assert.False(IsShapeMode(GetObject(engine, "t3")));
-        Assert.Equal(1, engine.Evaluate("t.a").AsNumber());
+        IsShapeMode(t).Should().BeFalse();
+        IsShapeMode(GetObject(engine, "t3")).Should().BeFalse();
+        engine.Evaluate("t.a").AsNumber().Should().Be(1);
 
         // this escaping through a call in an assignment RHS; the escapee's write lands FIRST
         engine = new Engine();
         engine.Execute("function ext(o) { o.dyn = 1; return 2; } function T() { this.a = ext(this); } var t = new T(); var t2 = new T(); var t3 = new T();");
         t = GetObject(engine, "t");
-        Assert.False(IsShapeMode(t));
-        Assert.False(IsShapeMode(GetObject(engine, "t3")));
-        Assert.Equal(2, engine.Evaluate("t.a").AsNumber());
-        Assert.Equal("dyn,a", engine.Evaluate("Object.keys(t).join(',')").AsString());
+        IsShapeMode(t).Should().BeFalse();
+        IsShapeMode(GetObject(engine, "t3")).Should().BeFalse();
+        engine.Evaluate("t.a").AsNumber().Should().Be(2);
+        engine.Evaluate("Object.keys(t).join(',')").AsString().Should().Be("dyn,a");
 
         // this escaping through a call in a var initializer
         engine = new Engine();
         engine.Execute("function grab(o) { o.dyn = 1; return 3; } function T() { var x = grab(this); this.a = x; } var t = new T(); var t2 = new T(); var t3 = new T();");
         t = GetObject(engine, "t");
-        Assert.False(IsShapeMode(t));
-        Assert.False(IsShapeMode(GetObject(engine, "t3")));
-        Assert.Equal(3, engine.Evaluate("t.a").AsNumber());
+        IsShapeMode(t).Should().BeFalse();
+        IsShapeMode(GetObject(engine, "t3")).Should().BeFalse();
+        engine.Evaluate("t.a").AsNumber().Should().Be(3);
 
         // this escaping through a parameter default (runs during construction)
         engine = new Engine();
         engine.Execute("function capture(o) { o.k = 1; return 9; } function T(a = capture(this)) { this.x = a; } var t = new T(); var t2 = new T(); var t3 = new T();");
         t = GetObject(engine, "t");
-        Assert.False(IsShapeMode(t));
-        Assert.False(IsShapeMode(GetObject(engine, "t3")));
-        Assert.Equal(9, engine.Evaluate("t.x").AsNumber());
-        Assert.Equal(1, engine.Evaluate("t.k").AsNumber());
+        IsShapeMode(t).Should().BeFalse();
+        IsShapeMode(GetObject(engine, "t3")).Should().BeFalse();
+        engine.Evaluate("t.x").AsNumber().Should().Be(9);
+        engine.Evaluate("t.k").AsNumber().Should().Be(1);
     }
 
     [Fact]
@@ -200,10 +200,10 @@ public class ConstructorShapeEligibilityTests
             """);
 
         // instances 1..16 build dictionaries (the threshold-tripping 16th included); the 17th starts shaped
-        Assert.False(IsShapeMode(GetObject(engine, "arr[0]")));
-        Assert.False(IsShapeMode(GetObject(engine, "arr[15]")));
-        Assert.True(IsShapeMode(GetObject(engine, "arr[16]")));
-        Assert.True(engine.Evaluate("arr.every(function (x) { return x.a === 1; })").AsBoolean());
+        IsShapeMode(GetObject(engine, "arr[0]")).Should().BeFalse();
+        IsShapeMode(GetObject(engine, "arr[15]")).Should().BeFalse();
+        IsShapeMode(GetObject(engine, "arr[16]")).Should().BeTrue();
+        engine.Evaluate("arr.every(function (x) { return x.a === 1; })").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -216,12 +216,12 @@ public class ConstructorShapeEligibilityTests
         var a2 = GetObject(engine, "a2");
         var a3 = GetObject(engine, "a3");
         var a4 = GetObject(engine, "a4");
-        Assert.False(IsShapeMode(a1));
-        Assert.False(IsShapeMode(a2));
-        Assert.True(IsShapeMode(a3));
-        Assert.Same(ShapeOf(a3), ShapeOf(a4));
-        Assert.Equal(1, engine.Evaluate("a1.x").AsNumber());
-        Assert.Equal(1, engine.Evaluate("a3.x").AsNumber());
+        IsShapeMode(a1).Should().BeFalse();
+        IsShapeMode(a2).Should().BeFalse();
+        IsShapeMode(a3).Should().BeTrue();
+        ShapeOf(a4).Should().BeSameAs(ShapeOf(a3));
+        engine.Evaluate("a1.x").AsNumber().Should().Be(1);
+        engine.Evaluate("a3.x").AsNumber().Should().Be(1);
     }
 
     [Fact]
@@ -231,9 +231,9 @@ public class ConstructorShapeEligibilityTests
         engine.Execute("class D { y = 1; constructor() { this.z = 2; } } var d1 = new D(); var d2 = new D(); var d3 = new D();");
 
         var d3 = GetObject(engine, "d3");
-        Assert.True(IsShapeMode(d3));
-        Assert.Equal("y,z", engine.Evaluate("Object.keys(d1).join(',')").AsString());
-        Assert.Equal("y,z", engine.Evaluate("Object.keys(d3).join(',')").AsString());
+        IsShapeMode(d3).Should().BeTrue();
+        engine.Evaluate("Object.keys(d1).join(',')").AsString().Should().Be("y,z");
+        engine.Evaluate("Object.keys(d3).join(',')").AsString().Should().Be("y,z");
     }
 
     [Fact]
@@ -243,12 +243,12 @@ public class ConstructorShapeEligibilityTests
         engine.Execute("class B { b = 2; ['0'] = 1 } var b1 = new B(); var b2 = new B(); var b3 = new B();");
 
         var b1 = GetObject(engine, "b1");
-        Assert.False(IsShapeMode(b1));
-        Assert.False(IsShapeMode(GetObject(engine, "b3"))); // fields check rejects — sampling path, not #3 shaping
+        IsShapeMode(b1).Should().BeFalse();
+        IsShapeMode(GetObject(engine, "b3")).Should().BeFalse(); // fields check rejects — sampling path, not #3 shaping
         // integer-index keys enumerate first regardless of insertion order
-        Assert.Equal("0,b", engine.Evaluate("Object.keys(b1).join(',')").AsString());
-        Assert.Equal(1, engine.Evaluate("b1[0]").AsNumber());
-        Assert.Equal(2, engine.Evaluate("b1.b").AsNumber());
+        engine.Evaluate("Object.keys(b1).join(',')").AsString().Should().Be("0,b");
+        engine.Evaluate("b1[0]").AsNumber().Should().Be(1);
+        engine.Evaluate("b1.b").AsNumber().Should().Be(2);
     }
 
     [Fact]
@@ -258,11 +258,11 @@ public class ConstructorShapeEligibilityTests
         engine.Execute("class C { #p = 5; x = 1; getP() { return this.#p; } } var c1 = new C(); var c2 = new C(); var c3 = new C();");
 
         var c3 = GetObject(engine, "c3");
-        Assert.True(IsShapeMode(c3));
-        Assert.Equal(1, engine.Evaluate("c3.x").AsNumber());
-        Assert.Equal(5, engine.Evaluate("c1.getP()").AsNumber());
-        Assert.Equal(5, engine.Evaluate("c3.getP()").AsNumber());
-        Assert.Equal("x", engine.Evaluate("Object.keys(c3).join(',')").AsString());
+        IsShapeMode(c3).Should().BeTrue();
+        engine.Evaluate("c3.x").AsNumber().Should().Be(1);
+        engine.Evaluate("c1.getP()").AsNumber().Should().Be(5);
+        engine.Evaluate("c3.getP()").AsNumber().Should().Be(5);
+        engine.Evaluate("Object.keys(c3).join(',')").AsString().Should().Be("x");
     }
 
     [Fact]
@@ -282,14 +282,14 @@ public class ConstructorShapeEligibilityTests
         var b1 = GetObject(engine, "b1");
         var b2 = GetObject(engine, "b2");
         var b3 = GetObject(engine, "b3");
-        Assert.False(IsShapeMode(b1));
-        Assert.False(IsShapeMode(b2));
-        Assert.True(IsShapeMode(b3));
-        Assert.Equal(1, engine.Evaluate("b3.x").AsNumber());
-        Assert.Equal(2, engine.Evaluate("b3.y").AsNumber());
-        Assert.Equal("x,y", engine.Evaluate("Object.keys(b1).join(',')").AsString());
-        Assert.Equal("x,y", engine.Evaluate("Object.keys(b3).join(',')").AsString());
-        Assert.True(engine.Evaluate("b3 instanceof B && b3 instanceof A").AsBoolean());
+        IsShapeMode(b1).Should().BeFalse();
+        IsShapeMode(b2).Should().BeFalse();
+        IsShapeMode(b3).Should().BeTrue();
+        engine.Evaluate("b3.x").AsNumber().Should().Be(1);
+        engine.Evaluate("b3.y").AsNumber().Should().Be(2);
+        engine.Evaluate("Object.keys(b1).join(',')").AsString().Should().Be("x,y");
+        engine.Evaluate("Object.keys(b3).join(',')").AsString().Should().Be("x,y");
+        engine.Evaluate("b3 instanceof B && b3 instanceof A").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -307,14 +307,14 @@ public class ConstructorShapeEligibilityTests
 
         var r = GetObject(engine, "r");
         var a3 = GetObject(engine, "a3");
-        Assert.False(IsShapeMode(GetObject(engine, "a1")));
-        Assert.False(IsShapeMode(GetObject(engine, "a2")));
-        Assert.True(IsShapeMode(r));
-        Assert.True(IsShapeMode(a3));
-        Assert.True(engine.Evaluate("Object.getPrototypeOf(r) === C.prototype").AsBoolean());
-        Assert.Equal(1, engine.Evaluate("r.x").AsNumber());
+        IsShapeMode(GetObject(engine, "a1")).Should().BeFalse();
+        IsShapeMode(GetObject(engine, "a2")).Should().BeFalse();
+        IsShapeMode(r).Should().BeTrue();
+        IsShapeMode(a3).Should().BeTrue();
+        engine.Evaluate("Object.getPrototypeOf(r) === C.prototype").AsBoolean().Should().BeTrue();
+        engine.Evaluate("r.x").AsNumber().Should().Be(1);
         // different prototypes root different transition trees
-        Assert.NotSame(ShapeOf(r), ShapeOf(a3));
+        ShapeOf(a3).Should().NotBeSameAs(ShapeOf(r));
     }
 
     [Fact]
@@ -326,11 +326,11 @@ public class ConstructorShapeEligibilityTests
 
         // eligible, so instance #3 starts shaped — and deopts to dictionary at the 64-property guard
         var t = GetObject(engine, "t");
-        Assert.False(IsShapeMode(t));
+        IsShapeMode(t).Should().BeFalse();
 
         var expectedKeys = string.Join(",", Enumerable.Range(0, 70).Select(i => $"p{i}"));
-        Assert.Equal(expectedKeys, engine.Evaluate("Object.keys(t).join(',')").AsString());
-        Assert.True(engine.Evaluate("(function () { for (var i = 0; i < 70; i++) { if (t['p' + i] !== i) return false; } return true; })()").AsBoolean());
+        engine.Evaluate("Object.keys(t).join(',')").AsString().Should().Be(expectedKeys);
+        engine.Evaluate("(function () { for (var i = 0; i < 70; i++) { if (t['p' + i] !== i) return false; } return true; })()").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -351,14 +351,14 @@ public class ConstructorShapeEligibilityTests
         var t2 = GetObject(engine, "t2");
         var t3 = GetObject(engine, "t3");
 
-        Assert.True(IsShapeMode(t1));
-        Assert.True(IsShapeMode(t2));
-        Assert.NotSame(ShapeOf(t1), ShapeOf(t2)); // different prototype, different root
-        Assert.Same(ShapeOf(t2), ShapeOf(t3));
+        IsShapeMode(t1).Should().BeTrue();
+        IsShapeMode(t2).Should().BeTrue();
+        ShapeOf(t2).Should().NotBeSameAs(ShapeOf(t1)); // different prototype, different root
+        ShapeOf(t3).Should().BeSameAs(ShapeOf(t2));
 
-        Assert.Equal(1, engine.Evaluate("t2.a").AsNumber());
-        Assert.Equal("p2", engine.Evaluate("t2.tag").AsString());
-        Assert.False(engine.Evaluate("'tag' in t1").AsBoolean());
+        engine.Evaluate("t2.a").AsNumber().Should().Be(1);
+        engine.Evaluate("t2.tag").AsString().Should().Be("p2");
+        engine.Evaluate("'tag' in t1").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -366,22 +366,22 @@ public class ConstructorShapeEligibilityTests
     {
         var engine = new Engine();
         engine.Execute("function T() { this.a = 1; this.b = 2; } var t0a = new T(); var t0b = new T(); var t = new T();");
-        Assert.True(IsShapeMode(GetObject(engine, "t")));
+        IsShapeMode(GetObject(engine, "t")).Should().BeTrue();
 
         engine.Execute("delete t.a;");
         var t = GetObject(engine, "t");
-        Assert.False(IsShapeMode(t));
-        Assert.False(engine.Evaluate("'a' in t").AsBoolean());
-        Assert.Equal(2, engine.Evaluate("t.b").AsNumber());
-        Assert.Equal("b", engine.Evaluate("Object.keys(t).join(',')").AsString());
+        IsShapeMode(t).Should().BeFalse();
+        engine.Evaluate("'a' in t").AsBoolean().Should().BeFalse();
+        engine.Evaluate("t.b").AsNumber().Should().Be(2);
+        engine.Evaluate("Object.keys(t).join(',')").AsString().Should().Be("b");
 
         engine.Execute("var u = new T(); Object.defineProperty(u, 'b', { enumerable: false });");
         var u = GetObject(engine, "u");
-        Assert.False(IsShapeMode(u));
-        Assert.Equal(2, engine.Evaluate("u.b").AsNumber());
-        Assert.Equal("a", engine.Evaluate("Object.keys(u).join(',')").AsString());
+        IsShapeMode(u).Should().BeFalse();
+        engine.Evaluate("u.b").AsNumber().Should().Be(2);
+        engine.Evaluate("Object.keys(u).join(',')").AsString().Should().Be("a");
 
         engine.Execute("var v = new T(); Object.defineProperty(v, 'a', { get: function () { return 99; } });");
-        Assert.Equal(99, engine.Evaluate("v.a").AsNumber());
+        engine.Evaluate("v.a").AsNumber().Should().Be(99);
     }
 }

--- a/Jint.Tests/Runtime/ConstructorSignatureTests.cs
+++ b/Jint.Tests/Runtime/ConstructorSignatureTests.cs
@@ -13,24 +13,24 @@ public class ConstructorSignatureTests
         engine.SetValue("A", TypeReference.CreateTypeReference(engine, typeof(A)));
 
         // ParamArray tests
-        Assert.Equal("3", engine.Evaluate("new A(1, 2).Result").AsString());
-        Assert.Equal("3", engine.Evaluate("new A(1, 2, null).Result").AsString());
-        Assert.Equal("3", engine.Evaluate("new A(1, 2, undefined).Result").AsString());
-        Assert.Equal("5", engine.Evaluate("new A(1, 2, null, undefined).Result").AsString());
-        Assert.Equal("9", engine.Evaluate("new A(1, 2, ...'packed').Result").AsString());
-        Assert.Equal("3", engine.Evaluate("new A(1, 2, []).Result").AsString());
-        Assert.Equal("7", engine.Evaluate("new A(1, 2, [...'abcd']).Result").AsString());
+        engine.Evaluate("new A(1, 2).Result").AsString().Should().Be("3");
+        engine.Evaluate("new A(1, 2, null).Result").AsString().Should().Be("3");
+        engine.Evaluate("new A(1, 2, undefined).Result").AsString().Should().Be("3");
+        engine.Evaluate("new A(1, 2, null, undefined).Result").AsString().Should().Be("5");
+        engine.Evaluate("new A(1, 2, ...'packed').Result").AsString().Should().Be("9");
+        engine.Evaluate("new A(1, 2, []).Result").AsString().Should().Be("3");
+        engine.Evaluate("new A(1, 2, [...'abcd']).Result").AsString().Should().Be("7");
 
         // Optional parameter tests
-        Assert.Equal("3", engine.Evaluate("new A(1, 2).Result").AsString());
-        Assert.Equal("6", engine.Evaluate("new A(1).Result").AsString());
-        Assert.Equal("7", engine.Evaluate("new A(2, undefined).Result").AsString());
-        Assert.Equal("8", engine.Evaluate("new A(3, undefined).Result").AsString());
-        Assert.Equal("ab", engine.Evaluate("new A('a').Result").AsString());
-        Assert.Equal("ab", engine.Evaluate("new A('a', undefined).Result").AsString());
-        Assert.Equal("ac", engine.Evaluate("new A('a', 'c').Result").AsString());
-        Assert.Equal("adc", engine.Evaluate("new A('a', 'd', undefined).Result").AsString());
-        Assert.Equal("ade", engine.Evaluate("new A('a', 'd', 'e').Result").AsString());
+        engine.Evaluate("new A(1, 2).Result").AsString().Should().Be("3");
+        engine.Evaluate("new A(1).Result").AsString().Should().Be("6");
+        engine.Evaluate("new A(2, undefined).Result").AsString().Should().Be("7");
+        engine.Evaluate("new A(3, undefined).Result").AsString().Should().Be("8");
+        engine.Evaluate("new A('a').Result").AsString().Should().Be("ab");
+        engine.Evaluate("new A('a', undefined).Result").AsString().Should().Be("ab");
+        engine.Evaluate("new A('a', 'c').Result").AsString().Should().Be("ac");
+        engine.Evaluate("new A('a', 'd', undefined).Result").AsString().Should().Be("adc");
+        engine.Evaluate("new A('a', 'd', 'e').Result").AsString().Should().Be("ade");
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class ConstructorSignatureTests
         var engine = new Engine();
         engine.SetValue("B", typeof(B));
 
-        Assert.Equal("A-30", engine.Evaluate("new B('A', 30).Result"));
+        engine.Evaluate("new B('A', 30).Result").Should().Be("A-30");
     }
 
 
@@ -48,10 +48,10 @@ public class ConstructorSignatureTests
     {
         var engine = new Engine();
         engine.SetValue("Length", TypeReference.CreateTypeReference<Length>(engine));
-        Assert.Equal(12.3, engine.Evaluate("new Length(12.3).Value").AsNumber(), precision: 2);
-        Assert.Equal(12.3, engine.Evaluate("new Length(12.3, 0).Value").AsNumber(), precision: 2);
-        Assert.Equal(0, engine.Evaluate("new Length(12.3, 0).UnitValue").AsInteger());
-        Assert.Equal(LengthUnit.Pixel, (LengthUnit) engine.Evaluate("new Length(12.3, 42).UnitValue").AsInteger());
+        engine.Evaluate("new Length(12.3).Value").AsNumber().Should().BeApproximately(12.3, 0.005);
+        engine.Evaluate("new Length(12.3, 0).Value").AsNumber().Should().BeApproximately(12.3, 0.005);
+        engine.Evaluate("new Length(12.3, 0).UnitValue").AsInteger().Should().Be(0);
+        ((LengthUnit) engine.Evaluate("new Length(12.3, 42).UnitValue").AsInteger()).Should().Be(LengthUnit.Pixel);
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/DateTests.cs
+++ b/Jint.Tests/Runtime/DateTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 
 namespace Jint.Tests.Runtime;
 
@@ -10,67 +10,68 @@ public class DateTests
     {
         _engine = new Engine()
             .SetValue("log", new Action<object>(Console.WriteLine))
-            .SetValue("assert", new Action<bool>(Assert.True))
-            .SetValue("equal", new Action<object, object>(Assert.Equal));
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
     }
 
     [Fact]
     public void NaNToString()
     {
         var value = _engine.Evaluate("new Date(NaN).toString();").AsString();
-        Assert.Equal("Invalid Date", value);
+        value.Should().Be("Invalid Date");
     }
 
     [Fact]
     public void NaNToDateString()
     {
         var value = _engine.Evaluate("new Date(NaN).toDateString();").AsString();
-        Assert.Equal("Invalid Date", value);
+        value.Should().Be("Invalid Date");
     }
 
     [Fact]
     public void NaNToTimeString()
     {
         var value = _engine.Evaluate("new Date(NaN).toTimeString();").AsString();
-        Assert.Equal("Invalid Date", value);
+        value.Should().Be("Invalid Date");
     }
 
     [Fact]
     public void NaNToLocaleString()
     {
         var value = _engine.Evaluate("new Date(NaN).toLocaleString();").AsString();
-        Assert.Equal("Invalid Date", value);
+        value.Should().Be("Invalid Date");
     }
 
     [Fact]
     public void NaNToLocaleDateString()
     {
         var value = _engine.Evaluate("new Date(NaN).toLocaleDateString();").AsString();
-        Assert.Equal("Invalid Date", value);
+        value.Should().Be("Invalid Date");
     }
 
     [Fact]
     public void NaNToLocaleTimeString()
     {
         var value = _engine.Evaluate("new Date(NaN).toLocaleTimeString();").AsString();
-        Assert.Equal("Invalid Date", value);
+        value.Should().Be("Invalid Date");
     }
 
     [Fact]
     public void ToJsonFromNaNObject()
     {
         var result = _engine.Evaluate("JSON.stringify({ date: new Date(NaN) });");
-        Assert.Equal("{\"date\":null}", result.ToString());
+        result.ToString().Should().Be("{\"date\":null}");
     }
 
     [Fact]
     public void ValuePrecisionIsIntegral()
     {
         var number = _engine.Evaluate("new Date() / 1").AsNumber();
-        Assert.Equal((long) number, number);
+        number.Should().Be((long) number);
 
         var dateInstance = _engine.Realm.Intrinsics.Date.Construct(123);
-        Assert.Equal((long) dateInstance.DateValue, dateInstance.DateValue);
+        dateInstance.DateValue.Should().Be((long) dateInstance.DateValue);
     }
 
     [Fact]
@@ -88,8 +89,8 @@ public class DateTests
 
         var engine = new Engine(options => options.LocalTimeZone(timeZoneInfo));
 
-        Assert.Equal("Tue Feb 01 2022 00:00:00 GMT+0800 (China Standard Time)", engine.Evaluate("new Date(2022,1,1).toString()"));
-        Assert.Equal("Tue Feb 01 2022 00:00:00 GMT+0800 (China Standard Time)", engine.Evaluate("new Date(2022,1,1)").ToString());
+        engine.Evaluate("new Date(2022,1,1).toString()").Should().Be("Tue Feb 01 2022 00:00:00 GMT+0800 (China Standard Time)");
+        engine.Evaluate("new Date(2022,1,1)").ToString().Should().Be("Tue Feb 01 2022 00:00:00 GMT+0800 (China Standard Time)");
     }
 
     [Fact]
@@ -108,10 +109,10 @@ public class DateTests
         var engine = new Engine(options => options.LocalTimeZone(timeZoneInfo));
 
         // July 4, 2022 is in summer (EDT = UTC-4, daylight saving time)
-        Assert.Contains("(Eastern Daylight Time)", engine.Evaluate("new Date(2022, 6, 4).toString()").AsString());
+        engine.Evaluate("new Date(2022, 6, 4).toString()").AsString().Should().Contain("(Eastern Daylight Time)");
 
         // January 4, 2022 is in winter (EST = UTC-5, standard time)
-        Assert.Contains("(Eastern Standard Time)", engine.Evaluate("new Date(2022, 0, 4).toString()").AsString());
+        engine.Evaluate("new Date(2022, 0, 4).toString()").AsString().Should().Contain("(Eastern Standard Time)");
     }
 
     [Fact]
@@ -138,7 +139,7 @@ public class DateTests
 
         // Should return "EDT" abbreviation, not "Eastern Daylight Time"
         var result = engine.Evaluate(script).AsString();
-        Assert.Contains("EDT", result);
+        result.Should().Contain("EDT");
 
         const string scriptWinter = """
             (function() {
@@ -149,7 +150,7 @@ public class DateTests
 
         // Should return "EST" abbreviation, not "Eastern Standard Time"
         var resultWinter = engine.Evaluate(scriptWinter).AsString();
-        Assert.Contains("EST", resultWinter);
+        resultWinter.Should().Contain("EST");
     }
 
     [Theory]
@@ -163,7 +164,7 @@ public class DateTests
     [InlineData("December 31 1969 17:00:50 PDT", 50000)]
     public void CanParseLocaleString(string input, long expected)
     {
-        Assert.Equal(expected, _engine.Evaluate($"new Date('{input}') * 1").AsNumber());
+        _engine.Evaluate($"new Date('{input}') * 1").AsNumber().Should().Be(expected);
     }
 
     [Theory]
@@ -184,7 +185,7 @@ public class DateTests
             timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("FLE Standard Time");
         }
         var engine = new Engine(options => options.LocalTimeZone(timeZoneInfo));
-        Assert.Equal(expectedDate, _engine.Evaluate($"new Date('{input}').getDate()").AsNumber());
+        _engine.Evaluate($"new Date('{input}').getDate()").AsNumber().Should().Be(expectedDate);
     }
 
     [Fact]
@@ -194,13 +195,13 @@ public class DateTests
         _engine.Execute(momentJs);
 
         var parsedDate = _engine.Evaluate("moment().format('YYYY')").ToString();
-        Assert.Equal(DateTime.Now.Year.ToString(), parsedDate);
+        parsedDate.Should().Be(DateTime.Now.Year.ToString());
     }
 
     [Fact]
     public void CanParseEmptyDate()
     {
-        Assert.True(double.IsNaN(_engine.Evaluate("Date.parse('')").AsNumber()));
+        double.IsNaN(_engine.Evaluate("Date.parse('')").AsNumber()).Should().BeTrue();
     }
 
     [Fact]
@@ -208,11 +209,11 @@ public class DateTests
     {
         var date = DateTime.MinValue;
         var jsDate = new JsDate(_engine, date);
-        Assert.Equal(DateFlags.DateTimeMinValue, jsDate._dateValue.Flags);
+        jsDate._dateValue.Flags.Should().Be(DateFlags.DateTimeMinValue);
 
         date = date.AddMilliseconds(1);
         jsDate = new JsDate(_engine, date);
-        Assert.Equal(DateFlags.None, jsDate._dateValue.Flags);
+        jsDate._dateValue.Flags.Should().Be(DateFlags.None);
     }
     
     [Fact]
@@ -220,11 +221,11 @@ public class DateTests
     {
         var date = DateTime.MaxValue;
         var jsDate = new JsDate(_engine, date);
-        Assert.Equal(DateFlags.DateTimeMaxValue, jsDate._dateValue.Flags);
+        jsDate._dateValue.Flags.Should().Be(DateFlags.DateTimeMaxValue);
 
         date = date.AddMilliseconds(-1);
         jsDate = new JsDate(_engine, date);
-        Assert.Equal(DateFlags.None, jsDate._dateValue.Flags);
+        jsDate._dateValue.Flags.Should().Be(DateFlags.None);
     }
 
     [Fact]
@@ -245,13 +246,13 @@ public class DateTests
         // NZDT (GMT+13) ends at 3:00 AM on the first Sunday of April 2025.
         // At midnight April 6, we are still in NZDT (GMT+13).
         var result1 = engine.Evaluate("new Date(2025, 3, 6, 0, 0, 0).toString()").AsString();
-        Assert.Contains("GMT+1300", result1);
-        Assert.Contains("Apr 06 2025 00:00:00", result1);
+        result1.Should().Contain("GMT+1300");
+        result1.Should().Contain("Apr 06 2025 00:00:00");
 
         // NZDT (GMT+13) begins at 2:00 AM on the last Sunday of September 2025.
         // At midnight Sep 28, we are still in NZST (GMT+12).
         var result2 = engine.Evaluate("new Date(2025, 8, 28, 0, 0, 0).toString()").AsString();
-        Assert.Contains("GMT+1200", result2);
-        Assert.Contains("Sep 28 2025 00:00:00", result2);
+        result2.Should().Contain("GMT+1200");
+        result2.Should().Contain("Sep 28 2025 00:00:00");
     }
 }

--- a/Jint.Tests/Runtime/Debugger/BreakPointTests.cs
+++ b/Jint.Tests/Runtime/Debugger/BreakPointTests.cs
@@ -11,11 +11,11 @@ public class BreakPointTests
         var loc2 = new BreakLocation(42, 23);
         var loc3 = new BreakLocation(17, 7);
 
-        Assert.Equal(loc1, loc2);
-        Assert.True(loc1 == loc2);
-        Assert.True(loc2 != loc3);
-        Assert.False(loc1 != loc2);
-        Assert.False(loc2 == loc3);
+        loc2.Should().Be(loc1);
+        loc1.Should().Be(loc2);
+        loc2.Should().NotBe(loc3);
+        loc1.Should().Be(loc2);
+        loc2.Should().NotBe(loc3);
     }
 
     [Fact]
@@ -25,11 +25,11 @@ public class BreakPointTests
         var loc2 = new BreakLocation("script1", 42, 23);
         var loc3 = new BreakLocation("script2", 42, 23);
 
-        Assert.Equal(loc1, loc2);
-        Assert.True(loc1 == loc2);
-        Assert.True(loc2 != loc3);
-        Assert.False(loc1 != loc2);
-        Assert.False(loc2 == loc3);
+        loc2.Should().Be(loc1);
+        loc1.Should().Be(loc2);
+        loc2.Should().NotBe(loc3);
+        loc1.Should().Be(loc2);
+        loc2.Should().NotBe(loc3);
     }
 
     [Fact]
@@ -41,13 +41,13 @@ public class BreakPointTests
         var any = new BreakLocation(null, 42, 23);
 
         var comparer = new OptionalSourceBreakLocationEqualityComparer();
-        Assert.True(comparer.Equals(script1, any));
-        Assert.True(comparer.Equals(script2, any));
-        Assert.False(comparer.Equals(script1, script2));
-        Assert.False(comparer.Equals(script2, script2b));
-        Assert.Equal(comparer.GetHashCode(script1), comparer.GetHashCode(any));
-        Assert.Equal(comparer.GetHashCode(script1), comparer.GetHashCode(script2));
-        Assert.NotEqual(comparer.GetHashCode(script2), comparer.GetHashCode(script2b));
+        comparer.Equals(script1, any).Should().BeTrue();
+        comparer.Equals(script2, any).Should().BeTrue();
+        comparer.Equals(script1, script2).Should().BeFalse();
+        comparer.Equals(script2, script2b).Should().BeFalse();
+        comparer.GetHashCode(any).Should().Be(comparer.GetHashCode(script1));
+        comparer.GetHashCode(script2).Should().Be(comparer.GetHashCode(script1));
+        comparer.GetHashCode(script2b).Should().NotBe(comparer.GetHashCode(script2));
     }
 
     [Fact]
@@ -56,21 +56,21 @@ public class BreakPointTests
         var engine = new Engine(options => options.DebugMode());
 
         engine.Debugger.BreakPoints.Set(new BreakPoint(4, 5, "i === 1"));
-        Assert.Collection(engine.Debugger.BreakPoints,
+        engine.Debugger.BreakPoints.Should().SatisfyRespectively(
             breakPoint =>
             {
-                Assert.Equal(4, breakPoint.Location.Line);
-                Assert.Equal(5, breakPoint.Location.Column);
-                Assert.Equal("i === 1", breakPoint.Condition);
+                breakPoint.Location.Line.Should().Be(4);
+                breakPoint.Location.Column.Should().Be(5);
+                breakPoint.Condition.Should().Be("i === 1");
             });
 
         engine.Debugger.BreakPoints.Set(new BreakPoint(4, 5));
-        Assert.Collection(engine.Debugger.BreakPoints,
+        engine.Debugger.BreakPoints.Should().SatisfyRespectively(
             breakPoint =>
             {
-                Assert.Equal(4, breakPoint.Location.Line);
-                Assert.Equal(5, breakPoint.Location.Column);
-                Assert.Equal(null, breakPoint.Condition);
+                breakPoint.Location.Line.Should().Be(4);
+                breakPoint.Location.Column.Should().Be(5);
+                breakPoint.Condition.Should().BeNull();
             });
     }
 
@@ -82,17 +82,17 @@ public class BreakPointTests
         engine.Debugger.BreakPoints.Set(new BreakPoint(4, 5, "i === 1"));
         engine.Debugger.BreakPoints.Set(new BreakPoint(5, 6, "j === 2"));
         engine.Debugger.BreakPoints.Set(new BreakPoint(10, 7, "x > 5"));
-        Assert.Equal(3, engine.Debugger.BreakPoints.Count);
+        engine.Debugger.BreakPoints.Should().HaveCount(3);
 
         engine.Debugger.BreakPoints.RemoveAt(new BreakLocation(null, 4, 5));
         engine.Debugger.BreakPoints.RemoveAt(new BreakLocation(null, 10, 7));
 
-        Assert.Collection(engine.Debugger.BreakPoints,
+        engine.Debugger.BreakPoints.Should().SatisfyRespectively(
             breakPoint =>
             {
-                Assert.Equal(5, breakPoint.Location.Line);
-                Assert.Equal(6, breakPoint.Location.Column);
-                Assert.Equal("j === 2", breakPoint.Condition);
+                breakPoint.Location.Line.Should().Be(5);
+                breakPoint.Location.Column.Should().Be(6);
+                breakPoint.Condition.Should().Be("j === 2");
             });
     }
 
@@ -104,8 +104,8 @@ public class BreakPointTests
         engine.Debugger.BreakPoints.Set(new BreakPoint(4, 5, "i === 1"));
         engine.Debugger.BreakPoints.Set(new BreakPoint(5, 6, "j === 2"));
         engine.Debugger.BreakPoints.Set(new BreakPoint(10, 7, "x > 5"));
-        Assert.True(engine.Debugger.BreakPoints.Contains(new BreakLocation(null, 5, 6)));
-        Assert.False(engine.Debugger.BreakPoints.Contains(new BreakLocation(null, 8, 9)));
+        engine.Debugger.BreakPoints.Contains(new BreakLocation(null, 5, 6)).Should().BeTrue();
+        engine.Debugger.BreakPoints.Contains(new BreakLocation(null, 8, 9)).Should().BeFalse();
     }
 
     [Fact]
@@ -122,15 +122,15 @@ x++; y *= 2;
         bool didBreak = false;
         engine.Debugger.Break += (sender, info) =>
         {
-            Assert.Equal(4, info.Location.Start.Line);
-            Assert.Equal(5, info.Location.Start.Column);
+            info.Location.Start.Line.Should().Be(4);
+            info.Location.Start.Column.Should().Be(5);
             didBreak = true;
             return StepMode.None;
         };
 
         engine.Debugger.BreakPoints.Set(new BreakPoint(4, 5));
         engine.Execute(script);
-        Assert.True(didBreak);
+        didBreak.Should().BeTrue();
     }
 
     [Fact]
@@ -147,8 +147,8 @@ x++; y *= 2;
         bool didBreak = false;
         engine.Debugger.Break += (sender, info) =>
         {
-            Assert.Equal(4, info.Location.Start.Line);
-            Assert.Equal(5, info.Location.Start.Column);
+            info.Location.Start.Line.Should().Be(4);
+            info.Location.Start.Column.Should().Be(5);
             didBreak = true;
             return StepMode.None;
         };
@@ -156,7 +156,7 @@ x++; y *= 2;
         engine.Debugger.BreakPoints.Set(new BreakPoint(4, 5));
         var prepared = Engine.PrepareScript(script);
         engine.Execute(prepared);
-        Assert.True(didBreak);
+        didBreak.Should().BeTrue();
     }
 
     [Fact]
@@ -183,21 +183,21 @@ test(z);";
         bool didBreak = false;
         engine.Debugger.Break += (sender, info) =>
         {
-            Assert.Equal("script2", info.Location.SourceFile);
-            Assert.Equal(3, info.Location.Start.Line);
-            Assert.Equal(0, info.Location.Start.Column);
+            info.Location.SourceFile.Should().Be("script2");
+            info.Location.Start.Line.Should().Be(3);
+            info.Location.Start.Column.Should().Be(0);
             didBreak = true;
             return StepMode.None;
         };
 
         engine.Execute(Engine.PrepareScript(script1, "script1"));
-        Assert.False(didBreak);
+        didBreak.Should().BeFalse();
 
         engine.Execute(Engine.PrepareScript(script2, "script2"));
-        Assert.False(didBreak);
+        didBreak.Should().BeFalse();
 
         engine.Execute(Engine.PrepareScript(script3, "script3"));
-        Assert.True(didBreak);
+        didBreak.Should().BeTrue();
     }
 
     [Fact]
@@ -211,7 +211,7 @@ x++;";
         bool didBreak = false;
         engine.Debugger.Break += (sender, info) =>
         {
-            Assert.Equal("<anonymous>", info.Location.SourceFile);
+            info.Location.SourceFile.Should().Be("<anonymous>");
             didBreak = true;
             return StepMode.None;
         };
@@ -219,7 +219,7 @@ x++;";
         engine.Debugger.BreakPoints.Set(new BreakPoint("<anonymous>", 2, 0));
         var prepared = Engine.PrepareScript(script);
         engine.Execute(prepared);
-        Assert.True(didBreak);
+        didBreak.Should().BeTrue();
     }
 
     [Fact]
@@ -246,9 +246,9 @@ test(z);";
         bool didBreak = false;
         engine.Debugger.Break += (sender, info) =>
         {
-            Assert.Equal("script2", info.Location.SourceFile);
-            Assert.Equal(3, info.Location.Start.Line);
-            Assert.Equal(0, info.Location.Start.Column);
+            info.Location.SourceFile.Should().Be("script2");
+            info.Location.Start.Line.Should().Be(3);
+            info.Location.Start.Column.Should().Be(0);
             didBreak = true;
             return StepMode.None;
         };
@@ -256,15 +256,15 @@ test(z);";
         // We need to specify the source to the parser.
         // And we need locations too (Jint specifies that in its default options)
         engine.Execute(script1, "script1");
-        Assert.False(didBreak);
+        didBreak.Should().BeFalse();
 
         engine.Execute(script2, "script2");
-        Assert.False(didBreak);
+        didBreak.Should().BeFalse();
 
         // Note that it's actually script3 that executes the function in script2
         // and triggers the breakpoint
         engine.Execute(script3, "script3");
-        Assert.True(didBreak);
+        didBreak.Should().BeTrue();
     }
 
     [Fact]
@@ -281,14 +281,14 @@ debugger;
         bool didBreak = false;
         engine.Debugger.Break += (sender, info) =>
         {
-            Assert.Equal(PauseType.DebuggerStatement, info.PauseType);
+            info.PauseType.Should().Be(PauseType.DebuggerStatement);
             didBreak = true;
             return StepMode.None;
         };
 
         engine.Execute(script);
 
-        Assert.True(didBreak);
+        didBreak.Should().BeTrue();
     }
 
     [Fact]
@@ -318,8 +318,8 @@ debugger;
         };
 
         engine.Execute(script);
-        Assert.Equal(3, stepCount);
-        Assert.False(didBreak);
+        stepCount.Should().Be(3);
+        didBreak.Should().BeFalse();
     }
 
     [Fact]
@@ -340,13 +340,13 @@ debugger;
 
         engine.Debugger.Break += (sender, info) =>
         {
-            Assert.Equal(PauseType.Break, info.PauseType);
+            info.PauseType.Should().Be(PauseType.Break);
             breakCount++;
             return StepMode.None;
         };
 
         engine.Execute(script);
-        Assert.Equal(1, breakCount);
+        breakCount.Should().Be(1);
     }
 
     [Fact]
@@ -372,7 +372,7 @@ debugger;
             didBreak = true;
             // first breakpoint shouldn't cause us to get here, because we're stepping,
             // but when we reach the second, we're running:
-            Assert.True(TestHelpers.ReachedLiteral(info, "second breakpoint"));
+            TestHelpers.ReachedLiteral(info, "second breakpoint").Should().BeTrue();
             return StepMode.None;
         };
 
@@ -389,8 +389,8 @@ debugger;
 
         engine.Execute(script);
 
-        Assert.True(didStep);
-        Assert.True(didBreak);
+        didStep.Should().BeTrue();
+        didBreak.Should().BeTrue();
     }
 
     [Fact(Skip = "Non-source breakpoint is triggered before Statement, while debugger statement is now triggered by ExecuteInternal")]
@@ -415,7 +415,7 @@ debugger;
 
         engine.Execute(script);
 
-        Assert.Equal(1, breakTriggered);
+        breakTriggered.Should().Be(1);
     }
 
     [Fact]
@@ -444,7 +444,7 @@ test();";
                 case 1:
                     return StepMode.Out;
                 case 2:
-                    Assert.True(info.ReachedLiteral("target"));
+                    info.ReachedLiteral("target").Should().BeTrue();
                     break;
             }
             return StepMode.None;
@@ -452,7 +452,7 @@ test();";
 
         engine.Execute(script);
 
-        Assert.Equal(2, step);
+        step.Should().Be(2);
     }
 
     [Fact]
@@ -485,13 +485,13 @@ foo();
         {
             if (info.ReachedLiteral("before breakpoint"))
             {
-                Assert.Equal(1, engine.CallStack.Count);
+                engine.CallStack.Count.Should().Be(1);
                 stepsReached++;
                 return StepMode.None;
             }
             else if (info.ReachedLiteral("after breakpoint"))
             {
-                Assert.Equal(1, engine.CallStack.Count);
+                engine.CallStack.Count.Should().Be(1);
                 stepsReached++;
                 return StepMode.None;
             }
@@ -506,8 +506,8 @@ foo();
 
         engine.Execute(script);
 
-        Assert.Equal(1, breakpointsReached);
-        Assert.Equal(2, stepsReached);
+        breakpointsReached.Should().Be(1);
+        stepsReached.Should().Be(2);
     }
 
     private class SimpleHitConditionBreakPoint : BreakPoint
@@ -541,14 +541,14 @@ for (let i = 0; i < 10; i++)
         int numberOfBreaks = 0;
         engine.Debugger.Break += (sender, info) =>
         {
-            Assert.True(info.ReachedLiteral("breakpoint"));
-            var extendedBreakPoint = Assert.IsType<SimpleHitConditionBreakPoint>(info.BreakPoint);
+            info.ReachedLiteral("breakpoint").Should().BeTrue();
+            var extendedBreakPoint = info.BreakPoint.Should().BeOfType<SimpleHitConditionBreakPoint>().Which;
             extendedBreakPoint.HitCount++;
             if (extendedBreakPoint.HitCount == extendedBreakPoint.HitCondition)
             {
                 // Here is where we would normally pause the execution.
                 // the breakpoint is hit for the fifth time, when i is 4 (off by one)
-                Assert.Equal(4, info.CurrentScopeChain[0].GetBindingValue("i").AsInteger());
+                info.CurrentScopeChain[0].GetBindingValue("i").AsInteger().Should().Be(4);
                 numberOfBreaks++;
             }
             return StepMode.None;
@@ -556,6 +556,6 @@ for (let i = 0; i < 10; i++)
 
         engine.Execute(script);
 
-        Assert.Equal(1, numberOfBreaks);
+        numberOfBreaks.Should().Be(1);
     }
 }

--- a/Jint.Tests/Runtime/Debugger/CallStackTests.cs
+++ b/Jint.Tests/Runtime/Debugger/CallStackTests.cs
@@ -22,10 +22,10 @@ public class CallStackTests
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Collection(info.CallStack,
-                frame => Assert.Equal("foo", frame.FunctionName),
-                frame => Assert.Equal("bar", frame.FunctionName),
-                frame => Assert.Equal("(anonymous)", frame.FunctionName)
+            info.CallStack.Should().SatisfyRespectively(
+                frame => frame.FunctionName.Should().Be("foo"),
+                frame => frame.FunctionName.Should().Be("bar"),
+                frame => frame.FunctionName.Should().Be("(anonymous)")
             );
         });
     }
@@ -51,13 +51,13 @@ bar()";
             // The line numbers here may mislead - the positions are, as would be expected,
             // at the position before the currently executing line, not the line after.
             // Remember that Esprima (and hence Jint) line numbers are 1-based, not 0-based.
-            Assert.Collection(info.CallStack,
+            info.CallStack.Should().SatisfyRespectively(
                 // "debugger;"
-                frame => Assert.Equal(Position.From(4, 0), frame.Location.Start),
+                frame => frame.Location.Start.Should().Be(Position.From(4, 0)),
                 // "foo();"
-                frame => Assert.Equal(Position.From(9, 0), frame.Location.Start),
+                frame => frame.Location.Start.Should().Be(Position.From(9, 0)),
                 // "bar();"
-                frame => Assert.Equal(Position.From(12, 0), frame.Location.Start)
+                frame => frame.Location.Start.Should().Be(Position.From(12, 0))
             );
         });
     }
@@ -81,13 +81,13 @@ bar()";
         TestHelpers.TestAtBreak(script, info =>
         {
             // Remember that Esprima (and hence Jint) line numbers are 1-based, not 0-based.
-            Assert.Collection(info.CallStack,
+            info.CallStack.Should().SatisfyRespectively(
                 // function foo()
-                frame => Assert.Equal(Position.From(2, 0), frame.FunctionLocation?.Start),
+                frame => (frame.FunctionLocation?.Start).Should().Be(Position.From(2, 0)),
                 // function bar()
-                frame => Assert.Equal(Position.From(7, 0), frame.FunctionLocation?.Start),
+                frame => (frame.FunctionLocation?.Start).Should().Be(Position.From(7, 0)),
                 // global - no function location
-                frame => Assert.Equal(null, frame.FunctionLocation?.Start)
+                frame => (frame.FunctionLocation?.Start).Should().BeNull()
             );
         });
     }
@@ -112,8 +112,8 @@ bar()";
         {
             if (atReturn)
             {
-                Assert.NotNull(info.CurrentCallFrame.ReturnValue);
-                Assert.Equal("result", info.CurrentCallFrame.ReturnValue.AsString());
+                info.CurrentCallFrame.ReturnValue.Should().NotBeNull();
+                info.CurrentCallFrame.ReturnValue.AsString().Should().Be("result");
                 didCheckReturn = true;
                 atReturn = false;
             }
@@ -128,7 +128,7 @@ bar()";
 
         engine.Execute(script);
 
-        Assert.True(didCheckReturn);
+        didCheckReturn.Should().BeTrue();
     }
 
     [Fact]
@@ -151,9 +151,9 @@ car.test();
 
         TestHelpers.TestAtBreak(script, (engine, info) =>
         {
-            Assert.Collection(info.CallStack,
-                frame => Assert.Equal(engine.Realm.GlobalObject.Get("car"), frame.This),
-                frame => Assert.Equal(engine.Realm.GlobalObject, frame.This)
+            info.CallStack.Should().SatisfyRespectively(
+                frame => frame.This.Should().Be(engine.Realm.GlobalObject.Get("car")),
+                frame => frame.This.Should().Be(engine.Realm.GlobalObject)
             );
         });
     }
@@ -167,7 +167,7 @@ car.test();
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Equal("regularFunction", info.CurrentCallFrame.FunctionName);
+            info.CurrentCallFrame.FunctionName.Should().Be("regularFunction");
         });
     }
 
@@ -180,7 +180,7 @@ car.test();
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Equal("functionExpression", info.CurrentCallFrame.FunctionName);
+            info.CurrentCallFrame.FunctionName.Should().Be("functionExpression");
         });
     }
 
@@ -193,7 +193,7 @@ car.test();
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Equal("namedFunction", info.CurrentCallFrame.FunctionName);
+            info.CurrentCallFrame.FunctionName.Should().Be("namedFunction");
         });
     }
 
@@ -206,7 +206,7 @@ car.test();
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Equal("arrowFunction", info.CurrentCallFrame.FunctionName);
+            info.CurrentCallFrame.FunctionName.Should().Be("arrowFunction");
         });
     }
 
@@ -220,7 +220,7 @@ car.test();
         TestHelpers.TestAtBreak(script, info =>
         {
             // Ideally, this should be "(anonymous)", but FunctionConstructor sets the "anonymous" name.
-            Assert.Equal("anonymous", info.CurrentCallFrame.FunctionName);
+            info.CurrentCallFrame.FunctionName.Should().Be("anonymous");
         });
     }
 
@@ -233,7 +233,7 @@ car.test();
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Equal("memberFunction", info.CurrentCallFrame.FunctionName);
+            info.CurrentCallFrame.FunctionName.Should().Be("memberFunction");
         });
     }
 
@@ -248,7 +248,7 @@ car.test();
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Equal("(anonymous)", info.CurrentCallFrame.FunctionName);
+            info.CurrentCallFrame.FunctionName.Should().Be("(anonymous)");
         });
     }
 
@@ -267,7 +267,7 @@ car.test();
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Equal("get accessor", info.CurrentCallFrame.FunctionName);
+            info.CurrentCallFrame.FunctionName.Should().Be("get accessor");
         });
     }
 
@@ -286,7 +286,7 @@ car.test();
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Equal("set accessor", info.CurrentCallFrame.FunctionName);
+            info.CurrentCallFrame.FunctionName.Should().Be("set accessor");
         });
     }
 }

--- a/Jint.Tests/Runtime/Debugger/DebugHandlerTests.cs
+++ b/Jint.Tests/Runtime/Debugger/DebugHandlerTests.cs
@@ -27,7 +27,7 @@ public class DebugHandlerTests
         {
             // We should never reach "fail", because the only way it's executed is from
             // within this Step handler
-            Assert.False(info.ReachedLiteral("fail"));
+            info.ReachedLiteral("fail").Should().BeFalse();
 
             if (info.ReachedLiteral("target"))
             {
@@ -42,6 +42,6 @@ public class DebugHandlerTests
 
         engine.Execute(script);
 
-        Assert.True(didPropertyAccess);
+        didPropertyAccess.Should().BeTrue();
     }
 }

--- a/Jint.Tests/Runtime/Debugger/EvaluateTests.cs
+++ b/Jint.Tests/Runtime/Debugger/EvaluateTests.cs
@@ -22,8 +22,8 @@ public class EvaluateTests
         TestHelpers.TestAtBreak(script, (engine, info) =>
         {
             var evaluated = engine.Debugger.Evaluate("x");
-            Assert.IsType<JsNumber>(evaluated);
-            Assert.Equal(50, evaluated.AsNumber());
+            evaluated.Should().BeOfType<JsNumber>();
+            evaluated.AsNumber().Should().Be(50);
         });
     }
 
@@ -31,8 +31,8 @@ public class EvaluateTests
     public void ThrowsIfNoCurrentContext()
     {
         var engine = new Engine(options => options.DebugMode());
-        var exception = Assert.Throws<DebugEvaluationException>(() => engine.Debugger.Evaluate("let x = 1;"));
-        Assert.Null(exception.InnerException); // Not a JavaScript or parser exception
+        var exception = Invoking(() => engine.Debugger.Evaluate("let x = 1;")).Should().ThrowExactly<DebugEvaluationException>().Which;
+        exception.InnerException.Should().BeNull(); // Not a JavaScript or parser exception
     }
 
     [Fact]
@@ -50,8 +50,8 @@ public class EvaluateTests
 
         TestHelpers.TestAtBreak(script, (engine, info) =>
         {
-            var exception = Assert.Throws<DebugEvaluationException>(() => engine.Debugger.Evaluate("y"));
-            Assert.IsType<JavaScriptException>(exception.InnerException);
+            var exception = Invoking(() => engine.Debugger.Evaluate("y")).Should().ThrowExactly<DebugEvaluationException>().Which;
+            exception.InnerException.Should().BeOfType<JavaScriptException>();
         });
     }
 
@@ -70,9 +70,9 @@ public class EvaluateTests
 
         TestHelpers.TestAtBreak(script, (engine, info) =>
         {
-            var exception = Assert.Throws<DebugEvaluationException>(() =>
-                engine.Debugger.Evaluate("this is a syntax error"));
-            Assert.IsType<Acornima.SyntaxErrorException>(exception.InnerException);
+            var exception = Invoking(() =>
+                engine.Debugger.Evaluate("this is a syntax error")).Should().ThrowExactly<DebugEvaluationException>().Which;
+            exception.InnerException.Should().BeOfType<Acornima.SyntaxErrorException>();
         });
     }
 
@@ -96,19 +96,19 @@ public class EvaluateTests
 
         TestHelpers.TestAtBreak(script, (engine, info) =>
         {
-            Assert.Equal(1, engine.CallStack.Count);
+            engine.CallStack.Count.Should().Be(1);
             var frameBefore = engine.CallStack.Stack[0];
 
-            Assert.Throws<DebugEvaluationException>(() => engine.Debugger.Evaluate("throws()"));
-            Assert.Equal(1, engine.CallStack.Count);
+            Invoking(() => engine.Debugger.Evaluate("throws()")).Should().ThrowExactly<DebugEvaluationException>();
+            engine.CallStack.Count.Should().Be(1);
             var frameAfter = engine.CallStack.Stack[0];
             // Stack frames and some of their properties are structs - can't check reference equality
             // Besides, even if we could, it would be no guarantee. Neither is the following, but it'll do for now.
-            Assert.Equal(frameBefore.CallingExecutionContext.LexicalEnvironment, frameAfter.CallingExecutionContext.LexicalEnvironment);
-            Assert.Equal(frameBefore.Arguments, frameAfter.Arguments);
-            Assert.Equal(frameBefore.Expression, frameAfter.Expression);
-            Assert.Equal(frameBefore.Location, frameAfter.Location);
-            Assert.Equal(frameBefore.Function, frameAfter.Function);
+            frameAfter.CallingExecutionContext.LexicalEnvironment.Should().Be(frameBefore.CallingExecutionContext.LexicalEnvironment);
+            frameAfter.Arguments.Should().Be(frameBefore.Arguments);
+            frameAfter.Expression.Should().Be(frameBefore.Expression);
+            frameAfter.Location.Should().Be(frameBefore.Location);
+            frameAfter.Function.Should().Be(frameBefore.Function);
         });
     }
 }

--- a/Jint.Tests/Runtime/Debugger/ExceptionThrownTests.cs
+++ b/Jint.Tests/Runtime/Debugger/ExceptionThrownTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using Jint.Native;
 using Jint.Native.Object;
@@ -19,10 +19,10 @@ public class ExceptionThrownTests
             received = args;
         };
 
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Execute("throw new Error('test error');"));
+        Invoking(() => engine.Execute("throw new Error('test error');")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
 
-        Assert.NotNull(received);
-        Assert.True(received.ThrownValue is ObjectInstance);
+        received.Should().NotBeNull();
+        received.ThrownValue.Should().BeAssignableTo<ObjectInstance>();
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public class ExceptionThrownTests
             }
         ");
 
-        Assert.Single(thrownValues);
+        thrownValues.Should().ContainSingle();
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class ExceptionThrownTests
             }
         ");
 
-        Assert.NotNull(received);
+        received.Should().NotBeNull();
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public class ExceptionThrownTests
             }
         ");
 
-        Assert.NotNull(received);
+        received.Should().NotBeNull();
     }
 
     [Fact]
@@ -107,7 +107,7 @@ public class ExceptionThrownTests
             }
         ");
 
-        Assert.Equal(0, count);
+        count.Should().Be(0);
     }
 
     [Fact]
@@ -132,7 +132,7 @@ public class ExceptionThrownTests
             }
         ");
 
-        Assert.Equal(2, count);
+        count.Should().Be(2);
     }
 
     [Fact]
@@ -153,8 +153,8 @@ public class ExceptionThrownTests
             }
         ");
 
-        Assert.NotNull(received);
-        Assert.Equal(42, received.ThrownValue.AsNumber());
+        received.Should().NotBeNull();
+        received.ThrownValue.AsNumber().Should().Be(42);
     }
 
     [Fact]
@@ -177,8 +177,8 @@ public class ExceptionThrownTests
             }
         ");
 
-        Assert.NotNull(callStack);
-        Assert.True(callStack.Count >= 1, $"Expected call stack frames, got {callStack.Count}");
+        callStack.Should().NotBeNull();
+        callStack.Count.Should().BeGreaterThanOrEqualTo(1, $"Expected call stack frames, got {callStack.Count}");
     }
 
     [Fact]
@@ -199,8 +199,8 @@ public class ExceptionThrownTests
             }
         ");
 
-        Assert.NotNull(location);
-        Assert.True(location.Value.Start.Line > 0);
+        location.Should().NotBeNull();
+        location.Value.Start.Line.Should().BeGreaterThan(0);
     }
 
     [Fact]
@@ -220,6 +220,6 @@ public class ExceptionThrownTests
             try { throw 3; } catch (e) {}
         ");
 
-        Assert.Equal(3, count);
+        count.Should().Be(3);
     }
 }

--- a/Jint.Tests/Runtime/Debugger/ScopeTests.cs
+++ b/Jint.Tests/Runtime/Debugger/ScopeTests.cs
@@ -7,23 +7,23 @@ public class ScopeTests
 {
     private static JsValue AssertOnlyScopeContains(DebugScopes scopes, string name, DebugScopeType scopeType)
     {
-        var containingScope = Assert.Single(scopes, s => s.ScopeType == scopeType && s.BindingNames.Contains(name));
-        Assert.DoesNotContain(scopes, s => s != containingScope && s.BindingNames.Contains(name));
+        var containingScope = scopes.Should().ContainSingle(s => s.ScopeType == scopeType && s.BindingNames.Contains(name)).Which;
+        scopes.Should().NotContain(s => s != containingScope && s.BindingNames.Contains(name));
 
         return containingScope.GetBindingValue(name);
     }
 
     private static void AssertScope(DebugScope actual, DebugScopeType expectedType, params string[] expectedBindingNames)
     {
-        Assert.Equal(expectedType, actual.ScopeType);
+        actual.ScopeType.Should().Be(expectedType);
         // Global scope will have a number of intrinsic bindings that are outside the scope [no pun] of these tests
         if (actual.ScopeType != DebugScopeType.Global)
         {
-            Assert.Equal(expectedBindingNames.Length, actual.BindingNames.Count);
+            actual.BindingNames.Should().HaveCount(expectedBindingNames.Length);
         }
         foreach (string expectedName in expectedBindingNames)
         {
-            Assert.Contains(expectedName, actual.BindingNames);
+            actual.BindingNames.Should().Contain(expectedName);
         }
     }
 
@@ -39,8 +39,8 @@ public class ScopeTests
         TestHelpers.TestAtBreak(script, info =>
         {
             // Uninitialized global block scoped ("script scoped") bindings return null (and, just as importantly, don't throw):
-            Assert.Null(info.CurrentScopeChain[0].GetBindingValue("globalConstant"));
-            Assert.Null(info.CurrentScopeChain[0].GetBindingValue("globalLet"));
+            info.CurrentScopeChain[0].GetBindingValue("globalConstant").Should().BeNull();
+            info.CurrentScopeChain[0].GetBindingValue("globalLet").Should().BeNull();
         });
     }
 
@@ -60,8 +60,8 @@ public class ScopeTests
         TestHelpers.TestAtBreak(script, info =>
         {
             // Uninitialized block scoped bindings return null (and, just as importantly, don't throw):
-            Assert.Null(info.CurrentScopeChain[0].GetBindingValue("globalConstant"));
-            Assert.Null(info.CurrentScopeChain[0].GetBindingValue("globalLet"));
+            info.CurrentScopeChain[0].GetBindingValue("globalConstant").Should().BeNull();
+            info.CurrentScopeChain[0].GetBindingValue("globalLet").Should().BeNull();
         });
     }
 
@@ -76,7 +76,7 @@ public class ScopeTests
         TestHelpers.TestAtBreak(script, info =>
         {
             var value = AssertOnlyScopeContains(info.CurrentScopeChain, "globalConstant", DebugScopeType.Script);
-            Assert.Equal("test", value.AsString());
+            value.AsString().Should().Be("test");
         });
     }
 
@@ -90,7 +90,7 @@ public class ScopeTests
         TestHelpers.TestAtBreak(script, info =>
         {
             var value = AssertOnlyScopeContains(info.CurrentScopeChain, "globalLet", DebugScopeType.Script);
-            Assert.Equal("test", value.AsString());
+            value.AsString().Should().Be("test");
         });
     }
 
@@ -104,7 +104,7 @@ public class ScopeTests
         TestHelpers.TestAtBreak(script, info =>
         {
             var value = AssertOnlyScopeContains(info.CurrentScopeChain, "globalVar", DebugScopeType.Global);
-            Assert.Equal("test", value.AsString());
+            value.AsString().Should().Be("test");
         });
     }
 
@@ -121,9 +121,9 @@ public class ScopeTests
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Equal(3, info.CurrentScopeChain.Count);
-            Assert.Equal(DebugScopeType.Block, info.CurrentScopeChain[0].ScopeType);
-            Assert.True(info.CurrentScopeChain[0].IsTopLevel);
+            info.CurrentScopeChain.Should().HaveCount(3);
+            info.CurrentScopeChain[0].ScopeType.Should().Be(DebugScopeType.Block);
+            info.CurrentScopeChain[0].IsTopLevel.Should().BeTrue();
         });
     }
 
@@ -143,9 +143,9 @@ public class ScopeTests
         TestHelpers.TestAtBreak(script, info =>
         {
             // We only have 3 scopes, because the function top level block scope is empty.
-            Assert.Equal(3, info.CurrentScopeChain.Count);
-            Assert.Equal(DebugScopeType.Block, info.CurrentScopeChain[0].ScopeType);
-            Assert.False(info.CurrentScopeChain[0].IsTopLevel);
+            info.CurrentScopeChain.Should().HaveCount(3);
+            info.CurrentScopeChain[0].ScopeType.Should().Be(DebugScopeType.Block);
+            info.CurrentScopeChain[0].IsTopLevel.Should().BeFalse();
         });
     }
 
@@ -165,7 +165,7 @@ public class ScopeTests
         TestHelpers.TestAtBreak(script, info =>
         {
             var value = AssertOnlyScopeContains(info.CurrentScopeChain, "localConst", DebugScopeType.Block);
-            Assert.Equal("test", value.AsString());
+            value.AsString().Should().Be("test");
         });
     }
     [Fact]
@@ -184,7 +184,7 @@ public class ScopeTests
         TestHelpers.TestAtBreak(script, info =>
         {
             var value = AssertOnlyScopeContains(info.CurrentScopeChain, "localLet", DebugScopeType.Block);
-            Assert.Equal("test", value.AsString());
+            value.AsString().Should().Be("test");
         });
     }
 
@@ -271,7 +271,7 @@ public class ScopeTests
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Collection(info.CurrentScopeChain,
+            info.CurrentScopeChain.Should().SatisfyRespectively(
                 scope => AssertScope(scope, DebugScopeType.Local, "arguments", "a", "b"),
                 scope => AssertScope(scope, DebugScopeType.Script, "x", "y", "z"),
                 scope => AssertScope(scope, DebugScopeType.Global, "add"));
@@ -297,7 +297,7 @@ public class ScopeTests
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Collection(info.CurrentScopeChain,
+            info.CurrentScopeChain.Should().SatisfyRespectively(
                 scope => AssertScope(scope, DebugScopeType.Local, "arguments", "a"),
                 // a, arguments shadowed by local - but still exist in this scope
                 scope => AssertScope(scope, DebugScopeType.Closure, "a", "arguments", "b", "power"),
@@ -325,7 +325,7 @@ public class ScopeTests
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Collection(info.CurrentScopeChain,
+            info.CurrentScopeChain.Should().SatisfyRespectively(
                 scope => AssertScope(scope, DebugScopeType.Block, "y"),
                 scope => AssertScope(scope, DebugScopeType.Local, "arguments", "a", "b"),
                 scope => AssertScope(scope, DebugScopeType.Script, "x", "y", "z"), // y is shadowed, but still in the scope
@@ -358,7 +358,7 @@ public class ScopeTests
             },
             info =>
             {
-                Assert.Collection(info.CurrentScopeChain,
+                info.CurrentScopeChain.Should().SatisfyRespectively(
                     scope => AssertScope(scope, DebugScopeType.Local, "arguments", "a", "b"),
                     scope => AssertScope(scope, DebugScopeType.Module, "add"),
                     scope => AssertScope(scope, DebugScopeType.Global));
@@ -388,7 +388,7 @@ public class ScopeTests
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Collection(info.CurrentScopeChain,
+            info.CurrentScopeChain.Should().SatisfyRespectively(
                 scope => AssertScope(scope, DebugScopeType.Block, "x"),
                 scope => AssertScope(scope, DebugScopeType.Block, "y"),
                 scope => AssertScope(scope, DebugScopeType.Local, "arguments", "a", "b"),
@@ -417,7 +417,7 @@ public class ScopeTests
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Collection(info.CurrentScopeChain,
+            info.CurrentScopeChain.Should().SatisfyRespectively(
                 scope => AssertScope(scope, DebugScopeType.Catch, "error"),
                 scope => AssertScope(scope, DebugScopeType.Block, "a"),
                 scope => AssertScope(scope, DebugScopeType.Local, "arguments"),
@@ -438,7 +438,7 @@ public class ScopeTests
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Collection(info.CurrentScopeChain,
+            info.CurrentScopeChain.Should().SatisfyRespectively(
                 scope => AssertScope(scope, DebugScopeType.Block, "x"),
                 scope => AssertScope(scope, DebugScopeType.With, "a", "b"),
                 scope => AssertScope(scope, DebugScopeType.Script, "obj"),
@@ -463,7 +463,7 @@ public class ScopeTests
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Collection(info.CurrentScopeChain,
+            info.CurrentScopeChain.Should().SatisfyRespectively(
                 scope => AssertScope(scope, DebugScopeType.Block, "z"),
                 scope => AssertScope(scope, DebugScopeType.Block, "y"),
                 scope => AssertScope(scope, DebugScopeType.Script, "x"),
@@ -487,7 +487,7 @@ public class ScopeTests
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Collection(info.CurrentScopeChain,
+            info.CurrentScopeChain.Should().SatisfyRespectively(
                 scope => AssertScope(scope, DebugScopeType.Block, "z"),
                 scope => AssertScope(scope, DebugScopeType.Script, "x"),
                 scope => AssertScope(scope, DebugScopeType.Global));
@@ -513,20 +513,20 @@ public class ScopeTests
 
         TestHelpers.TestAtBreak(script, info =>
         {
-            Assert.Collection(info.CallStack,
-                frame => Assert.Collection(frame.ScopeChain,
+            info.CallStack.Should().SatisfyRespectively(
+                frame => frame.ScopeChain.Should().SatisfyRespectively(
                     // in foo()
                     scope => AssertScope(scope, DebugScopeType.Local, "arguments", "a", "c"),
                     scope => AssertScope(scope, DebugScopeType.Script, "x"),
                     scope => AssertScope(scope, DebugScopeType.Global, "foo", "bar")
                 ),
-                frame => Assert.Collection(frame.ScopeChain,
+                frame => frame.ScopeChain.Should().SatisfyRespectively(
                     // in bar()
                     scope => AssertScope(scope, DebugScopeType.Local, "arguments", "b"),
                     scope => AssertScope(scope, DebugScopeType.Script, "x"),
                     scope => AssertScope(scope, DebugScopeType.Global, "foo", "bar")
                 ),
-                frame => Assert.Collection(frame.ScopeChain,
+                frame => frame.ScopeChain.Should().SatisfyRespectively(
                     // in global
                     scope => AssertScope(scope, DebugScopeType.Script, "x"),
                     scope => AssertScope(scope, DebugScopeType.Global, "foo", "bar")
@@ -548,7 +548,7 @@ public class ScopeTests
             {
                 // No need for imports - main module is module scoped too, duh.
                 var value = AssertOnlyScopeContains(info.CurrentScopeChain, "x", DebugScopeType.Module);
-                Assert.Equal(1, value.AsInteger());
+                value.AsInteger().Should().Be(1);
             });
     }
 }

--- a/Jint.Tests/Runtime/Debugger/StepFlowTests.cs
+++ b/Jint.Tests/Runtime/Debugger/StepFlowTests.cs
@@ -35,14 +35,14 @@ public class StepFlowTests
 
         var nodes = CollectStepNodes(script);
 
-        Assert.Collection(nodes,
-            node => Assert.IsType<VariableDeclaration>(node), // let x = 0;
-            node => Assert.IsType<WhileStatement>(node),      // while ...
-            node => Assert.IsType<NonLogicalBinaryExpression>(node),    // x < 2
-            node => Assert.IsType<NonSpecialExpressionStatement>(node), // x++;
-            node => Assert.IsType<NonLogicalBinaryExpression>(node),    // x < 2
-            node => Assert.IsType<NonSpecialExpressionStatement>(node), // x++;
-            node => Assert.IsType<NonLogicalBinaryExpression>(node)     // x < 2 (false)
+        nodes.Should().SatisfyRespectively(
+            node => node.Should().BeOfType<VariableDeclaration>(), // let x = 0;
+            node => node.Should().BeOfType<WhileStatement>(),      // while ...
+            node => node.Should().BeOfType<NonLogicalBinaryExpression>(),    // x < 2
+            node => node.Should().BeOfType<NonSpecialExpressionStatement>(), // x++;
+            node => node.Should().BeOfType<NonLogicalBinaryExpression>(),    // x < 2
+            node => node.Should().BeOfType<NonSpecialExpressionStatement>(), // x++;
+            node => node.Should().BeOfType<NonLogicalBinaryExpression>()     // x < 2 (false)
         );
     }
 
@@ -60,13 +60,13 @@ public class StepFlowTests
 
         var nodes = CollectStepNodes(script);
 
-        Assert.Collection(nodes,
-            node => Assert.IsType<VariableDeclaration>(node), // let x = 0;
-            node => Assert.IsType<DoWhileStatement>(node),    // do ...
-            node => Assert.IsType<NonSpecialExpressionStatement>(node), // x++;
-            node => Assert.IsType<NonLogicalBinaryExpression>(node),    // x < 2
-            node => Assert.IsType<NonSpecialExpressionStatement>(node), // x++;
-            node => Assert.IsType<NonLogicalBinaryExpression>(node)     // x < 2 (false)
+        nodes.Should().SatisfyRespectively(
+            node => node.Should().BeOfType<VariableDeclaration>(), // let x = 0;
+            node => node.Should().BeOfType<DoWhileStatement>(),    // do ...
+            node => node.Should().BeOfType<NonSpecialExpressionStatement>(), // x++;
+            node => node.Should().BeOfType<NonLogicalBinaryExpression>(),    // x < 2
+            node => node.Should().BeOfType<NonSpecialExpressionStatement>(), // x++;
+            node => node.Should().BeOfType<NonLogicalBinaryExpression>()     // x < 2 (false)
         );
     }
 
@@ -82,16 +82,16 @@ public class StepFlowTests
 
         var nodes = CollectStepNodes(script);
 
-        Assert.Collection(nodes,
-            node => Assert.IsType<ForStatement>(node),        // for ...
-            node => Assert.IsType<VariableDeclaration>(node), // let x = 0
-            node => Assert.IsType<NonLogicalBinaryExpression>(node),    // x < 2
-            node => Assert.True(node.IsLiteral("dummy")),     // 'dummy';
-            node => Assert.IsType<UpdateExpression>(node),    // x++;
-            node => Assert.IsType<NonLogicalBinaryExpression>(node),    // x < 2
-            node => Assert.True(node.IsLiteral("dummy")),     // 'dummy';
-            node => Assert.IsType<UpdateExpression>(node),    // x++;
-            node => Assert.IsType<NonLogicalBinaryExpression>(node)     // x < 2 (false)
+        nodes.Should().SatisfyRespectively(
+            node => node.Should().BeOfType<ForStatement>(),        // for ...
+            node => node.Should().BeOfType<VariableDeclaration>(), // let x = 0
+            node => node.Should().BeOfType<NonLogicalBinaryExpression>(),    // x < 2
+            node => node.IsLiteral("dummy").Should().BeTrue(),     // 'dummy';
+            node => node.Should().BeOfType<UpdateExpression>(),    // x++;
+            node => node.Should().BeOfType<NonLogicalBinaryExpression>(),    // x < 2
+            node => node.IsLiteral("dummy").Should().BeTrue(),     // 'dummy';
+            node => node.Should().BeOfType<UpdateExpression>(),    // x++;
+            node => node.Should().BeOfType<NonLogicalBinaryExpression>()     // x < 2 (false)
         );
     }
 
@@ -108,13 +108,13 @@ public class StepFlowTests
 
         var nodes = CollectStepNodes(script);
 
-        Assert.Collection(nodes,
-            node => Assert.IsType<VariableDeclaration>(node), // let arr = [1, 2];
-            node => Assert.IsType<ForOfStatement>(node),      // for ...
-            node => Assert.IsType<VariableDeclaration>(node), // item
-            node => Assert.True(node.IsLiteral("dummy")),     // 'dummy';
-            node => Assert.IsType<VariableDeclaration>(node), // item
-            node => Assert.True(node.IsLiteral("dummy"))      // 'dummy';
+        nodes.Should().SatisfyRespectively(
+            node => node.Should().BeOfType<VariableDeclaration>(), // let arr = [1, 2];
+            node => node.Should().BeOfType<ForOfStatement>(),      // for ...
+            node => node.Should().BeOfType<VariableDeclaration>(), // item
+            node => node.IsLiteral("dummy").Should().BeTrue(),     // 'dummy';
+            node => node.Should().BeOfType<VariableDeclaration>(), // item
+            node => node.IsLiteral("dummy").Should().BeTrue()      // 'dummy';
         );
     }
 
@@ -131,13 +131,13 @@ public class StepFlowTests
 
         var nodes = CollectStepNodes(script);
 
-        Assert.Collection(nodes,
-            node => Assert.IsType<VariableDeclaration>(node), // let obj = { x: 1, y: 2 };
-            node => Assert.IsType<ForInStatement>(node),      // for ...
-            node => Assert.IsType<VariableDeclaration>(node), // key
-            node => Assert.IsType<NonSpecialExpressionStatement>(node), // 'dummy';
-            node => Assert.IsType<VariableDeclaration>(node), // key
-            node => Assert.IsType<NonSpecialExpressionStatement>(node)  // 'dummy';
+        nodes.Should().SatisfyRespectively(
+            node => node.Should().BeOfType<VariableDeclaration>(), // let obj = { x: 1, y: 2 };
+            node => node.Should().BeOfType<ForInStatement>(),      // for ...
+            node => node.Should().BeOfType<VariableDeclaration>(), // key
+            node => node.Should().BeOfType<NonSpecialExpressionStatement>(), // 'dummy';
+            node => node.Should().BeOfType<VariableDeclaration>(), // key
+            node => node.Should().BeOfType<NonSpecialExpressionStatement>()  // 'dummy';
         );
     }
 
@@ -158,12 +158,12 @@ public class StepFlowTests
 
         var nodes = CollectStepNodes(script);
 
-        Assert.Collection(nodes,
-            node => Assert.IsType<ClassDeclaration>(node),          // class Test
-            node => Assert.IsType<NonSpecialExpressionStatement>(node),       // new Test();
-            node => Assert.True(node.IsLiteral("in constructor")),  // 'in constructor()'
-            node => Assert.Null(node),                              // return point
-            node => Assert.True(node.IsLiteral("after construction"))
+        nodes.Should().SatisfyRespectively(
+            node => node.Should().BeOfType<ClassDeclaration>(),          // class Test
+            node => node.Should().BeOfType<NonSpecialExpressionStatement>(),       // new Test();
+            node => node.IsLiteral("in constructor").Should().BeTrue(),  // 'in constructor()'
+            node => node.Should().BeNull(),                              // return point
+            node => node.IsLiteral("after construction").Should().BeTrue()
         );
     }
 
@@ -180,11 +180,11 @@ public class StepFlowTests
 
         var nodes = CollectStepNodes(script);
 
-        Assert.Collection(nodes,
-            node => Assert.IsType<FunctionDeclaration>(node), // function(test) ...;
-            node => Assert.IsType<NonSpecialExpressionStatement>(node), // test();
-            node => Assert.True(node.IsLiteral("dummy")),     // 'dummy';
-            node => Assert.Null(node)                         // return point
+        nodes.Should().SatisfyRespectively(
+            node => node.Should().BeOfType<FunctionDeclaration>(), // function(test) ...;
+            node => node.Should().BeOfType<NonSpecialExpressionStatement>(), // test();
+            node => node.IsLiteral("dummy").Should().BeTrue(),     // 'dummy';
+            node => node.Should().BeNull()                         // return point
         );
     }
 
@@ -200,10 +200,10 @@ public class StepFlowTests
             ";
 
         var nodes = CollectStepNodes(script);
-        Assert.Collection(nodes,
-            node => Assert.IsType<ClassDeclaration>(node),    // class Test
-            node => Assert.IsType<NonSpecialExpressionStatement>(node), // new Test();
-            node => Assert.True(node.IsLiteral("dummy"))      // 'dummy';
+        nodes.Should().SatisfyRespectively(
+            node => node.Should().BeOfType<ClassDeclaration>(),    // class Test
+            node => node.Should().BeOfType<NonSpecialExpressionStatement>(), // new Test();
+            node => node.IsLiteral("dummy").Should().BeTrue()      // 'dummy';
         );
     }
 
@@ -218,15 +218,15 @@ let res = c();
 ";
 
         var steps = StepIntoScript(script);
-        Assert.Collection(steps,
-            step => Assert.Equal("function c( ) { »return b(3) + a(); }", step),
-            step => Assert.Equal("function b(l) { »return l + a(); }", step),
-            step => Assert.Equal("function a( ) { »return 2; }", step),
-            step => Assert.Equal("function a( ) { return 2; }»", step),
-            step => Assert.Equal("function b(l) { return l + a(); }»", step),
-            step => Assert.Equal("function a( ) { »return 2; }", step),
-            step => Assert.Equal("function a( ) { return 2; }»", step),
-            step => Assert.Equal("function c( ) { return b(3) + a(); }»", step));
+        steps.Should().SatisfyRespectively(
+            step => step.Should().Be("function c( ) { »return b(3) + a(); }"),
+            step => step.Should().Be("function b(l) { »return l + a(); }"),
+            step => step.Should().Be("function a( ) { »return 2; }"),
+            step => step.Should().Be("function a( ) { return 2; }»"),
+            step => step.Should().Be("function b(l) { return l + a(); }»"),
+            step => step.Should().Be("function a( ) { »return 2; }"),
+            step => step.Should().Be("function a( ) { return 2; }»"),
+            step => step.Should().Be("function c( ) { return b(3) + a(); }»"));
     }
 
     [Fact]
@@ -240,15 +240,15 @@ let res = c();
 ";
 
         var steps = StepIntoScript(script);
-        Assert.Collection(steps,
-            step => Assert.Equal("const c = ( ) => »b(3) + a();", step),
-            step => Assert.Equal("const b = (l) => »l + a();", step),
-            step => Assert.Equal("const a = ( ) => »2;", step),
-            step => Assert.Equal("const a = ( ) => 2»;", step),
-            step => Assert.Equal("const b = (l) => l + a()»;", step),
-            step => Assert.Equal("const a = ( ) => »2;", step),
-            step => Assert.Equal("const a = ( ) => 2»;", step),
-            step => Assert.Equal("const c = ( ) => b(3) + a()»;", step));
+        steps.Should().SatisfyRespectively(
+            step => step.Should().Be("const c = ( ) => »b(3) + a();"),
+            step => step.Should().Be("const b = (l) => »l + a();"),
+            step => step.Should().Be("const a = ( ) => »2;"),
+            step => step.Should().Be("const a = ( ) => 2»;"),
+            step => step.Should().Be("const b = (l) => l + a()»;"),
+            step => step.Should().Be("const a = ( ) => »2;"),
+            step => step.Should().Be("const a = ( ) => 2»;"),
+            step => step.Should().Be("const c = ( ) => b(3) + a()»;"));
     }
 
     private List<string> StepIntoScript(string script)

--- a/Jint.Tests/Runtime/Debugger/StepModeTests.cs
+++ b/Jint.Tests/Runtime/Debugger/StepModeTests.cs
@@ -46,7 +46,7 @@ public class StepModeTests
         engine.Execute(script);
             
         // Make sure we actually reached the target
-        Assert.True(targetReached);
+        targetReached.Should().BeTrue();
 
         return steps;
     }
@@ -62,7 +62,7 @@ public class StepModeTests
                     'target'; // second step
                 }";
 
-        Assert.Equal(2, StepsFromSourceToTarget(script, StepMode.Into));
+        StepsFromSourceToTarget(script, StepMode.Into).Should().Be(2);
     }
 
     [Fact]
@@ -77,7 +77,7 @@ public class StepModeTests
                     'dummy';
                 }";
 
-        Assert.Equal(2, StepsFromSourceToTarget(script, StepMode.Over));
+        StepsFromSourceToTarget(script, StepMode.Over).Should().Be(2);
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class StepModeTests
                     'dummy';
                 }";
 
-        Assert.Equal(1, StepsFromSourceToTarget(script, StepMode.Out));
+        StepsFromSourceToTarget(script, StepMode.Out).Should().Be(1);
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public class StepModeTests
                 'source';
                 obj.test(); // first step";
 
-        Assert.Equal(2, StepsFromSourceToTarget(script, StepMode.Into));
+        StepsFromSourceToTarget(script, StepMode.Into).Should().Be(2);
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public class StepModeTests
                 obj.test();
                 'target';";
 
-        Assert.Equal(2, StepsFromSourceToTarget(script, StepMode.Over));
+        StepsFromSourceToTarget(script, StepMode.Over).Should().Be(2);
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public class StepModeTests
                 obj.test();
                 'target';";
 
-        Assert.Equal(1, StepsFromSourceToTarget(script, StepMode.Out));
+        StepsFromSourceToTarget(script, StepMode.Out).Should().Be(1);
     }
 
     [Fact]
@@ -158,7 +158,7 @@ public class StepModeTests
                 'source';
                 const x = test(); // first step";
 
-        Assert.Equal(2, StepsFromSourceToTarget(script, StepMode.Into));
+        StepsFromSourceToTarget(script, StepMode.Into).Should().Be(2);
     }
 
     [Fact]
@@ -174,7 +174,7 @@ public class StepModeTests
                 const x = test();
                 'target';";
 
-        Assert.Equal(2, StepsFromSourceToTarget(script, StepMode.Over));
+        StepsFromSourceToTarget(script, StepMode.Over).Should().Be(2);
     }
 
     [Fact]
@@ -190,7 +190,7 @@ public class StepModeTests
                 const x = test();
                 'target';";
 
-        Assert.Equal(1, StepsFromSourceToTarget(script, StepMode.Out));
+        StepsFromSourceToTarget(script, StepMode.Out).Should().Be(1);
     }
 
     [Fact]
@@ -207,7 +207,7 @@ public class StepModeTests
                 'source';
                 const x = obj.test; // first step";
 
-        Assert.Equal(2, StepsFromSourceToTarget(script, StepMode.Into));
+        StepsFromSourceToTarget(script, StepMode.Into).Should().Be(2);
     }
 
     [Fact]
@@ -224,7 +224,7 @@ public class StepModeTests
                 const x = obj.test;
                 'target';";
 
-        Assert.Equal(2, StepsFromSourceToTarget(script, StepMode.Over));
+        StepsFromSourceToTarget(script, StepMode.Over).Should().Be(2);
     }
 
     [Fact]
@@ -242,7 +242,7 @@ public class StepModeTests
                 const x = obj.test;
                 'target';";
 
-        Assert.Equal(1, StepsFromSourceToTarget(script, StepMode.Out));
+        StepsFromSourceToTarget(script, StepMode.Out).Should().Be(1);
     }
 
     [Fact]
@@ -259,7 +259,7 @@ public class StepModeTests
                 'source';
                 obj.test = 37; // first step";
 
-        Assert.Equal(2, StepsFromSourceToTarget(script, StepMode.Into));
+        StepsFromSourceToTarget(script, StepMode.Into).Should().Be(2);
     }
 
     [Fact]
@@ -276,7 +276,7 @@ public class StepModeTests
                 obj.test = 37;
                 'target';";
 
-        Assert.Equal(2, StepsFromSourceToTarget(script, StepMode.Over));
+        StepsFromSourceToTarget(script, StepMode.Over).Should().Be(2);
     }
 
     [Fact]
@@ -294,7 +294,7 @@ public class StepModeTests
                 obj.test = 37;
                 'target';";
 
-        Assert.Equal(1, StepsFromSourceToTarget(script, StepMode.Out));
+        StepsFromSourceToTarget(script, StepMode.Out).Should().Be(1);
     }
 
     [Fact]
@@ -307,7 +307,7 @@ public class StepModeTests
                 }
                 test();
                 'target';";
-        Assert.Equal(2, StepsFromSourceToTarget(script, StepMode.Over));
+        StepsFromSourceToTarget(script, StepMode.Over).Should().Be(2);
     }
 
     [Fact]
@@ -321,7 +321,7 @@ public class StepModeTests
                 }
                 test();
                 'target';";
-        Assert.Equal(3, StepsFromSourceToTarget(script, StepMode.Over));
+        StepsFromSourceToTarget(script, StepMode.Over).Should().Be(3);
     }
 
     [Fact]
@@ -358,7 +358,7 @@ public class StepModeTests
                     }
                     break;
                 case 1:
-                    Assert.True(info.ReachedLiteral("target"));
+                    info.ReachedLiteral("target").Should().BeTrue();
                     step++;
                     break;
             }
@@ -396,7 +396,7 @@ public class StepModeTests
         {
             if (stepping)
             {
-                Assert.True(info.ReachedLiteral("target"));
+                info.ReachedLiteral("target").Should().BeTrue();
             }
             return StepMode.None;
         };
@@ -430,7 +430,7 @@ public class StepModeTests
 
         engine.Execute(script);
 
-        Assert.Equal(1, stepCount);
+        stepCount.Should().Be(1);
     }
 
     [Fact]
@@ -455,7 +455,7 @@ public class StepModeTests
 
         engine.Debugger.Step += (sender, info) =>
         {
-            Assert.True(TestHelpers.IsLiteral(info.CurrentNode, "step"));
+            TestHelpers.IsLiteral(info.CurrentNode, "step").Should().BeTrue();
             stepCount++;
             // Start running after first step
             return stepCount == 1 ? StepMode.None : StepMode.Into;
@@ -463,7 +463,7 @@ public class StepModeTests
 
         engine.Debugger.Skip += (sender, info) =>
         {
-            Assert.True(TestHelpers.IsLiteral(info.CurrentNode, "skip"));
+            TestHelpers.IsLiteral(info.CurrentNode, "skip").Should().BeTrue();
             skipCount++;
             return StepMode.None;
         };
@@ -476,7 +476,7 @@ public class StepModeTests
 
         engine.Execute(script);
 
-        Assert.Equal(2, skipCount);
-        Assert.Equal(3, stepCount);
+        skipCount.Should().Be(2);
+        stepCount.Should().Be(3);
     }
 }

--- a/Jint.Tests/Runtime/Debugger/TestHelpers.cs
+++ b/Jint.Tests/Runtime/Debugger/TestHelpers.cs
@@ -42,7 +42,7 @@ public static class TestHelpers
 
         initialization(engine);
 
-        Assert.True(didBreak, "Test script did not break (e.g. didn't reach debugger statement)");
+        didBreak.Should().BeTrue("Test script did not break (e.g. didn't reach debugger statement)");
     }
 
     /// <inheritdoc cref="TestAtBreak()"/>

--- a/Jint.Tests/Runtime/DecoratorTests.cs
+++ b/Jint.Tests/Runtime/DecoratorTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 public class DecoratorTests
 {
@@ -27,7 +27,7 @@ public class DecoratorTests
             new C().foo();
             """);
 
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class DecoratorTests
             new C().added;
             """);
 
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class DecoratorTests
             new C().x;
             """);
 
-        Assert.Equal(50, result.AsInteger());
+        result.AsInteger().Should().Be(50);
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class DecoratorTests
             JSON.stringify(logs);
             """);
 
-        Assert.Equal("[\"init x\",\"get x\",\"set x\"]", result.AsString());
+        result.AsString().Should().Be("[\"init x\",\"get x\",\"set x\"]");
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public class DecoratorTests
             new C().fromInit;
             """);
 
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -157,8 +157,8 @@ public class DecoratorTests
         // Evaluation order: top-to-bottom (first, second)
         // Application order: bottom-to-top (second applied first, then first)
         // Result: first(second(base)) = first("base_second") = "base_second_first"
-        Assert.Contains("\"result\":\"base_second_first\"", json);
-        Assert.Contains("\"order\":[\"eval_first\",\"eval_second\",\"apply_second\",\"apply_first\"]", json);
+        json.Should().Contain("\"result\":\"base_second_first\"");
+        json.Should().Contain("\"order\":[\"eval_first\",\"eval_second\",\"apply_second\",\"apply_first\"]");
     }
 
     [Fact]
@@ -185,11 +185,11 @@ public class DecoratorTests
             """);
 
         var json = result.AsString();
-        Assert.Contains("\"kind\":\"method\"", json);
-        Assert.Contains("\"name\":\"myMethod\"", json);
-        Assert.Contains("\"isStatic\":false", json);
-        Assert.Contains("\"isPrivate\":false", json);
-        Assert.Contains("\"hasAddInitializer\":true", json);
+        json.Should().Contain("\"kind\":\"method\"");
+        json.Should().Contain("\"name\":\"myMethod\"");
+        json.Should().Contain("\"isStatic\":false");
+        json.Should().Contain("\"isPrivate\":false");
+        json.Should().Contain("\"hasAddInitializer\":true");
     }
 
     [Fact]
@@ -209,7 +209,7 @@ public class DecoratorTests
             ctx.static;
             """);
 
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -231,8 +231,8 @@ public class DecoratorTests
             JSON.stringify({ foo: c.foo(), extra: c.extra });
             """);
 
-        Assert.Contains("\"foo\":1", result.AsString());
-        Assert.Contains("\"extra\":99", result.AsString());
+        result.AsString().Should().Contain("\"foo\":1");
+        result.AsString().Should().Contain("\"extra\":99");
     }
 
     [Fact]
@@ -254,7 +254,7 @@ public class DecoratorTests
             new C().value;
             """);
 
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -279,7 +279,7 @@ public class DecoratorTests
             c.value;
             """);
 
-        Assert.Equal(10, result.AsInteger());
+        result.AsInteger().Should().Be(10);
     }
 
     [Fact]
@@ -298,7 +298,7 @@ public class DecoratorTests
             new C().foo();
             """);
 
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -312,11 +312,11 @@ public class DecoratorTests
             var c = new C();
             """);
 
-        Assert.Equal(1, _engine.Evaluate("c.x").AsInteger());
-        Assert.True(_engine.Evaluate("c.y").IsUndefined());
+        _engine.Evaluate("c.x").AsInteger().Should().Be(1);
+        _engine.Evaluate("c.y").IsUndefined().Should().BeTrue();
 
         _engine.Execute("c.x = 42;");
-        Assert.Equal(42, _engine.Evaluate("c.x").AsInteger());
+        _engine.Evaluate("c.x").AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -331,8 +331,8 @@ public class DecoratorTests
             JSON.stringify({ before: before, after: C.x });
             """);
 
-        Assert.Contains("\"before\":2", result.AsString());
-        Assert.Contains("\"after\":99", result.AsString());
+        result.AsString().Should().Contain("\"before\":2");
+        result.AsString().Should().Contain("\"after\":99");
     }
 
     [Fact]
@@ -350,8 +350,8 @@ public class DecoratorTests
             JSON.stringify({ before: before, after: c.getX() });
             """);
 
-        Assert.Contains("\"before\":5", result.AsString());
-        Assert.Contains("\"after\":42", result.AsString());
+        result.AsString().Should().Contain("\"before\":5");
+        result.AsString().Should().Contain("\"after\":42");
     }
 
     [Fact]
@@ -368,7 +368,7 @@ public class DecoratorTests
             threw;
             """);
 
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -393,7 +393,7 @@ public class DecoratorTests
             new C().x;
             """);
 
-        Assert.Equal(7, result.AsInteger());
+        result.AsInteger().Should().Be(7);
     }
 
     [Fact]
@@ -414,7 +414,7 @@ public class DecoratorTests
             C.initialized;
             """);
 
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -440,6 +440,6 @@ public class DecoratorTests
 
         // Three computed keys, each evaluated exactly once (i === 3), and each decorator saw the
         // same name its element was defined under.
-        Assert.Equal("3;m1|f2|a3;function;field;accessor", result.AsString());
+        result.AsString().Should().Be("3;m1|f2|a3;function;field;accessor");
     }
 }

--- a/Jint.Tests/Runtime/DefaultTypeConverterTests.cs
+++ b/Jint.Tests/Runtime/DefaultTypeConverterTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
@@ -43,7 +43,7 @@ public class DefaultTypeConverterTests
 
         engine.Execute("process({ x: 10, y: 20 });");
 
-        Assert.Equal(new Point(10, 20), received);
+        received.Should().Be(new Point(10, 20));
     }
 
     [Fact]
@@ -59,8 +59,8 @@ public class DefaultTypeConverterTests
         engine.Execute("processArray([{ x: 1, y: 2 }, { x: 3, y: 4 }]);");
         engine.Execute("processList([{ x: 5, y: 6 }]);");
 
-        Assert.Equal(new[] { new Point(1, 2), new Point(3, 4) }, receivedArray);
-        Assert.Equal(new[] { new Point(5, 6) }, receivedList!);
+        receivedArray.Should().Equal(new[] { new Point(1, 2), new Point(3, 4) });
+        (receivedList!).Should().Equal(new[] { new Point(5, 6) });
     }
 
     [Fact]
@@ -72,11 +72,11 @@ public class DefaultTypeConverterTests
         dict["x"] = 1;
         dict["y"] = 2;
 
-        var point = Assert.IsType<Point>(converter.Convert(dict, typeof(Point), CultureInfo.InvariantCulture));
-        Assert.Equal(new Point(1, 2), point);
+        var point = converter.Convert(dict, typeof(Point), CultureInfo.InvariantCulture).Should().BeOfType<Point>().Which;
+        point.Should().Be(new Point(1, 2));
 
         // built-in conversions still work
-        Assert.Equal(42, converter.Convert("42", typeof(int), CultureInfo.InvariantCulture));
+        converter.Convert("42", typeof(int), CultureInfo.InvariantCulture).Should().Be(42);
     }
 
     [Fact]
@@ -88,9 +88,9 @@ public class DefaultTypeConverterTests
 
         engine.SetValue("a", new Person());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("a.age = 'not a number'"));
-        Assert.Contains("input string", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(" was not in a correct format", ex.Message, StringComparison.OrdinalIgnoreCase);
+        var ex = Invoking(() => engine.Execute("a.age = 'not a number'")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().ContainEquivalentOf("input string");
+        ex.Message.Should().ContainEquivalentOf(" was not in a correct format");
     }
 
     [Fact]
@@ -100,6 +100,6 @@ public class DefaultTypeConverterTests
 
         engine.SetValue("callInt", new Action<int>(_ => { }));
 
-        Assert.Throws<FormatException>(() => engine.Execute("callInt('not a number')"));
+        Invoking(() => engine.Execute("callInt('not a number')")).Should().ThrowExactly<FormatException>();
     }
 }

--- a/Jint.Tests/Runtime/DelegateWrapperTests.cs
+++ b/Jint.Tests/Runtime/DelegateWrapperTests.cs
@@ -19,7 +19,7 @@ public class DelegateWrapperTests
                 }, 'test', 'other', 1337);
             ");
 
-        Assert.True(engine.Evaluate("argsConcat == 'string string number'").AsBoolean());
+        engine.Evaluate("argsConcat == 'string string number'").AsBoolean().Should().BeTrue();
     }
 
     private static void RegisterCallback(CallbackAction callback, params object[] arguments)

--- a/Jint.Tests/Runtime/DestructuringTests.cs
+++ b/Jint.Tests/Runtime/DestructuringTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 public class DestructuringTests
 {
@@ -7,7 +7,8 @@ public class DestructuringTests
     public DestructuringTests()
     {
         _engine = new Engine()
-            .SetValue("equal", new Action<object, object>(Assert.Equal));
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
     }
 
     [Fact]
@@ -20,7 +21,7 @@ public class DestructuringTests
               return c === void undefined;
             }('ab');";
 
-        Assert.True(_engine.Evaluate(Script).AsBoolean());
+        _engine.Evaluate(Script).AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -33,7 +34,7 @@ public class DestructuringTests
               return true;
             }(2,'');";
 
-        Assert.True(_engine.Evaluate(Script).AsBoolean());
+        _engine.Evaluate(Script).AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -76,15 +77,15 @@ public class DestructuringTests
         // CopyDataProperties(restObj, value, excludedNames), whose step 2 ToObject's the
         // primitive source (https://tc39.es/ecma262/#sec-copydataproperties) — so a string's
         // index properties are copied while already-destructured keys are excluded.
-        Assert.Equal("""{"0":"a","1":"b"}""", _engine.Evaluate("var { ...r1 } = 'ab'; JSON.stringify(r1)").AsString());
-        Assert.Equal("a|{\"1\":\"b\"}", _engine.Evaluate("var { 0: first, ...r2 } = 'ab'; first + '|' + JSON.stringify(r2)").AsString());
-        Assert.Equal("{}", _engine.Evaluate("var { ...r3 } = 42; JSON.stringify(r3)").AsString());
+        _engine.Evaluate("var { ...r1 } = 'ab'; JSON.stringify(r1)").AsString().Should().Be("""{"0":"a","1":"b"}""");
+        _engine.Evaluate("var { 0: first, ...r2 } = 'ab'; first + '|' + JSON.stringify(r2)").AsString().Should().Be("a|{\"1\":\"b\"}");
+        _engine.Evaluate("var { ...r3 } = 42; JSON.stringify(r3)").AsString().Should().Be("{}");
 
         // Destructuring assignment (non-declaration) form.
-        Assert.Equal("""{"0":"a","1":"b"}""", _engine.Evaluate("var q; (({ ...q } = 'ab')); JSON.stringify(q)").AsString());
+        _engine.Evaluate("var q; (({ ...q } = 'ab')); JSON.stringify(q)").AsString().Should().Be("""{"0":"a","1":"b"}""");
 
         // Function parameter rest.
-        Assert.Equal("""{"0":"a","1":"b"}""", _engine.Evaluate("(function({ ...p }) { return JSON.stringify(p); })('ab')").AsString());
+        _engine.Evaluate("(function({ ...p }) { return JSON.stringify(p); })('ab')").AsString().Should().Be("""{"0":"a","1":"b"}""");
     }
 
     [Fact]
@@ -104,7 +105,7 @@ public class DestructuringTests
             })()
             """);
 
-        Assert.Equal("4,5,6", result.AsString());
+        result.AsString().Should().Be("4,5,6");
     }
 
     [Fact]
@@ -118,7 +119,7 @@ public class DestructuringTests
             })()
             """);
 
-        Assert.Equal("1,2", result.AsString());
+        result.AsString().Should().Be("1,2");
     }
 
     [Fact]
@@ -134,7 +135,7 @@ public class DestructuringTests
             """);
 
         result = result.UnwrapIfPromise();
-        Assert.Equal(1, result.AsInteger());
+        result.AsInteger().Should().Be(1);
     }
 
     [Fact]
@@ -152,7 +153,7 @@ public class DestructuringTests
             function fb(x, { [(calls++, "k")]: v }) { return v; }
             fb(1, { k: 6 }) + ':' + calls;
             """);
-        Assert.Equal("6:1", result.AsString());
+        result.AsString().Should().Be("6:1");
 
         // NewExpression key (key comes from the constructed object's toString).
         result = engine.Evaluate("""
@@ -160,7 +161,7 @@ public class DestructuringTests
             function fc(x, { [new KeyObj()]: v }) { return v; }
             fc(1, { nk: 7 });
             """);
-        Assert.Equal(7, result.AsNumber());
+        result.AsNumber().Should().Be(7);
 
         // Same expression types in object literals and non-parameter destructuring.
         result = engine.Evaluate("""
@@ -169,7 +170,7 @@ public class DestructuringTests
             var { [(calls2++, 'a')]: a } = o;
             [o.a, o.nk, a, calls2].join(',');
             """);
-        Assert.Equal("1,2,1,2", result.AsString());
+        result.AsString().Should().Be("1,2,1,2");
 
         // ChainExpression (optional chaining) and TaggedTemplateExpression keys.
         result = engine.Evaluate("""
@@ -178,6 +179,6 @@ public class DestructuringTests
             var o2 = { [holder?.key]: 3, [tag`x`]: 4 };
             [o2.c, o2.tx].join(',');
             """);
-        Assert.Equal("3,4", result.AsString());
+        result.AsString().Should().Be("3,4");
     }
 }

--- a/Jint.Tests/Runtime/DynamicFunctionTests.cs
+++ b/Jint.Tests/Runtime/DynamicFunctionTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Functions created by the Function constructor share a definition-level call environment
@@ -18,7 +18,7 @@ public class DynamicFunctionTests
             }
             """);
 
-        Assert.Equal("1,1,1,1,1", engine.Evaluate("results.join(',')").AsString());
+        engine.Evaluate("results.join(',')").AsString().Should().Be("1,1,1,1,1");
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public class DynamicFunctionTests
             var results = [counters[0](), counters[0](), counters[1](), counters[2]()];
             """);
 
-        Assert.Equal("1,2,1,1", engine.Evaluate("results.join(',')").AsString());
+        engine.Evaluate("results.join(',')").AsString().Should().Be("1,2,1,1");
     }
 
     [Fact]
@@ -48,6 +48,6 @@ public class DynamicFunctionTests
             var results = [f1(), f2(), f1()];
             """);
 
-        Assert.Equal("10,11,12", engine.Evaluate("results.join(',')").AsString());
+        engine.Evaluate("results.join(',')").AsString().Should().Be("10,11,12");
     }
 }

--- a/Jint.Tests/Runtime/EngineLimitTests.cs
+++ b/Jint.Tests/Runtime/EngineLimitTests.cs
@@ -1,4 +1,4 @@
-#if !NETFRAMEWORK
+﻿#if !NETFRAMEWORK
 #nullable enable
 
 using System.Runtime.ExceptionServices;
@@ -33,8 +33,8 @@ public class EngineLimitTests
 
             var engine = new Engine();
             engine.Execute(script);
-            Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
-            Assert.Equal(FunctionNestingCount, engine.Evaluate("x").AsNumber());
+            engine.Evaluate("func1(123);").AsNumber().Should().Be(123);
+            engine.Evaluate("x").AsNumber().Should().Be(FunctionNestingCount);
         });
     }
 
@@ -67,8 +67,8 @@ public class EngineLimitTests
 
         var engine = new Engine(option => option.Constraints.MaxExecutionStackCount = functionNestingCount);
         engine.Execute(script);
-        Assert.Equal(123, engine.Evaluate("func1(123);").AsNumber());
-        Assert.Equal(functionNestingCount, engine.Evaluate("x").AsNumber());
+        engine.Evaluate("func1(123);").AsNumber().Should().Be(123);
+        engine.Evaluate("x").AsNumber().Should().Be(functionNestingCount);
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class EngineLimitTests
         }
         catch (JavaScriptException jsException)
         {
-            Assert.Equal("Maximum call stack size exceeded", jsException.Message);
+            jsException.Message.Should().Be("Maximum call stack size exceeded");
         }
     }
 

--- a/Jint.Tests/Runtime/EngineTests.cs
+++ b/Jint.Tests/Runtime/EngineTests.cs
@@ -57,8 +57,9 @@ public partial class EngineTests : IDisposable
     {
         _engine = new Engine()
                 .SetValue("log", new Action<object>(o => output.WriteLine(o.ToString())))
-                .SetValue("assert", new Action<bool>(Assert.True))
-                .SetValue("equal", new Action<object, object>(Assert.Equal))
+                .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+                .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())))
             ;
     }
 
@@ -92,7 +93,7 @@ public partial class EngineTests : IDisposable
         var engine = new Engine();
         var result = engine.Evaluate(source).ToObject();
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Fact]
@@ -103,7 +104,7 @@ public partial class EngineTests : IDisposable
             .Evaluate("var foo = 'bar'; foo;")
             .ToObject();
 
-        Assert.Equal("bar", result);
+        result.Should().Be("bar");
     }
 
     [Theory]
@@ -122,7 +123,7 @@ public partial class EngineTests : IDisposable
         var engine = new Engine();
         var result = engine.Evaluate(source).ToObject();
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Theory]
@@ -133,7 +134,7 @@ public partial class EngineTests : IDisposable
         var engine = new Engine();
         var result = engine.Evaluate(source).ToObject();
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Fact]
@@ -181,7 +182,7 @@ public partial class EngineTests : IDisposable
     public void ShouldAllowNullAsStringValue()
     {
         var engine = new Engine().SetValue("name", (string) null);
-        Assert.True(engine.Evaluate("name").IsNull());
+        engine.Evaluate("name").IsNull().Should().BeTrue();
     }
 
     [Fact]
@@ -622,7 +623,7 @@ public partial class EngineTests : IDisposable
                                             }
                                             return str;
                                      """);
-        Assert.Equal("xystrz", result);
+        result.Should().Be("xystrz");
     }
 
     [Fact]
@@ -746,7 +747,7 @@ public partial class EngineTests : IDisposable
         var engine = new Engine();
         var result = engine.Evaluate(source).ToObject();
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Fact]
@@ -773,7 +774,7 @@ public partial class EngineTests : IDisposable
         var engine = new Engine();
         var result = engine.Evaluate(source).ToObject();
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Fact]
@@ -867,8 +868,8 @@ public partial class EngineTests : IDisposable
     [Fact]
     public void ShouldComputeFractionInBase()
     {
-        Assert.Equal("011", NumberPrototype.ToFractionBase(0.375, 2));
-        Assert.Equal("14141414141414141414141414141414141414141414141414", NumberPrototype.ToFractionBase(0.375, 5));
+        NumberPrototype.ToFractionBase(0.375, 2).Should().Be("011");
+        NumberPrototype.ToFractionBase(0.375, 5).Should().Be("14141414141414141414141414141414141414141414141414");
     }
 
     [Fact]
@@ -880,7 +881,7 @@ public partial class EngineTests : IDisposable
 
         var add = _engine.GetValue("add");
 
-        Assert.Equal(3, _engine.Invoke(add, 1, 2));
+        _engine.Invoke(add, 1, 2).Should().Be(3);
     }
 
     [Fact]
@@ -892,7 +893,7 @@ public partial class EngineTests : IDisposable
 
         var add = _engine.GetValue("get");
         string str = null;
-        Assert.Equal(Native.JsValue.Null, _engine.Invoke(add, str));
+        _engine.Invoke(add, str).Should().Be(Native.JsValue.Null);
     }
 
 
@@ -905,8 +906,8 @@ public partial class EngineTests : IDisposable
 
         var x = _engine.GetValue("x");
 
-        var exception = Assert.Throws<JavaScriptException>(() => _engine.Invoke(x, 1, 2));
-        Assert.Equal("Can only invoke functions", exception.Message);
+        var exception = Invoking(() => _engine.Invoke(x, 1, 2)).Should().ThrowExactly<JavaScriptException>().Which;
+        exception.Message.Should().Be("Can only invoke functions");
     }
 
     [Fact]
@@ -919,7 +920,7 @@ public partial class EngineTests : IDisposable
         var obj = _engine.GetValue("obj").AsObject();
         var getFoo = obj.Get("getFoo");
 
-        Assert.Equal("foo is 5, bar is 7", _engine.Invoke(getFoo, obj, new object[] { 7 }).AsString());
+        _engine.Invoke(getFoo, obj, new object[] { 7 }).AsString().Should().Be("foo is 5, bar is 7");
     }
 
     [Fact]
@@ -932,7 +933,7 @@ public partial class EngineTests : IDisposable
         var obj = _engine.GetValue("obj").AsObject();
         var foo = obj.Get("foo");
 
-        Assert.Throws<JavaScriptException>(() => _engine.Invoke(foo, obj, new object[] { }));
+        Invoking(() => _engine.Invoke(foo, obj, new object[] { })).Should().ThrowExactly<JavaScriptException>();
     }
 
     [Fact]
@@ -942,7 +943,7 @@ public partial class EngineTests : IDisposable
         e.Evaluate("var x = { literal: true };");
 
         var pd = e.GetValue("x").AsObject().GetOwnProperty("doesNotExist");
-        Assert.Throws<InvalidOperationException>(() => pd.Value = "oh no, assigning this breaks things");
+        Invoking(() => pd.Value = "oh no, assigning this breaks things").Should().ThrowExactly<InvalidOperationException>();
     }
 
     [Theory]
@@ -955,7 +956,7 @@ public partial class EngineTests : IDisposable
     public void ShouldConvertNumbersToDifferentBase(string expected, long number, int radix)
     {
         var result = NumberPrototype.ToBase(number, radix);
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Fact]
@@ -1069,8 +1070,8 @@ public partial class EngineTests : IDisposable
     [Fact]
     public void JsonParserShouldHandleEmptyString()
     {
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("JSON.parse('');"));
-        Assert.Equal("Unexpected end of JSON input at position 0", ex.Message);
+        var ex = Invoking(() => _engine.Evaluate("JSON.parse('');")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Unexpected end of JSON input at position 0");
     }
 
     [Fact]
@@ -1081,10 +1082,10 @@ public partial class EngineTests : IDisposable
         var engine = new Engine();
 
         var result = engine.Evaluate("1.2 + 2.1").AsNumber();
-        Assert.Equal(3.3d, result);
+        result.Should().Be(3.3d);
 
         result = engine.Evaluate("JSON.parse('{\"x\" : 3.3}').x").AsNumber();
-        Assert.Equal(3.3d, result);
+        result.Should().Be(3.3d);
     }
 
     [Fact]
@@ -1097,9 +1098,9 @@ public partial class EngineTests : IDisposable
         }
         catch (JavaScriptException e)
         {
-            Assert.Equal(1, e.Location.Start.Line);
-            Assert.Equal(8, e.Location.Start.Column);
-            Assert.Equal("jQuery.js", e.Location.SourceFile);
+            e.Location.Start.Line.Should().Be(1);
+            e.Location.Start.Column.Should().Be(8);
+            e.Location.SourceFile.Should().Be("jQuery.js");
         }
     }
     #region DateParsingAndStrings
@@ -1109,7 +1110,7 @@ public partial class EngineTests : IDisposable
         var engine = new Engine();
 
         var result = engine.Evaluate("Date.parse('1970-01-01');").AsNumber();
-        Assert.Equal(0, result);
+        result.Should().Be(0);
     }
 
     [Fact]
@@ -1129,8 +1130,8 @@ public partial class EngineTests : IDisposable
         var date = new DateTime(2016, 1, 1, 13, 0, 0, DateTimeKind.Local);
         var engine = new Engine().SetValue("localDate", date);
         var actual = engine.Evaluate(@"localDate").AsDate().ToDateTime();
-        Assert.Equal(date.ToUniversalTime(), actual.ToUniversalTime());
-        Assert.Equal(date.ToLocalTime(), actual.ToLocalTime());
+        actual.ToUniversalTime().Should().Be(date.ToUniversalTime());
+        actual.ToLocalTime().Should().Be(date.ToLocalTime());
     }
 
     [Fact]
@@ -1141,7 +1142,7 @@ public partial class EngineTests : IDisposable
         var engine = new Engine(cfg => cfg.LocalTimeZone(customTimeZone));
 
         var result = engine.Evaluate("Date.UTC(1970,0,1)").AsNumber();
-        Assert.Equal(0, result);
+        result.Should().Be(0);
     }
 
     [Fact]
@@ -1153,19 +1154,19 @@ public partial class EngineTests : IDisposable
         var engine = new Engine(cfg => cfg.LocalTimeZone(customTimeZone));
 
         var epochGetLocalMinutes = engine.Evaluate("var d = new Date(0); d.getMinutes();").AsNumber();
-        Assert.Equal(11, epochGetLocalMinutes);
+        epochGetLocalMinutes.Should().Be(11);
 
         var localEpochGetUtcMinutes = engine.Evaluate("var d = new Date(1970,0,1); d.getUTCMinutes();").AsNumber();
-        Assert.Equal(49, localEpochGetUtcMinutes);
+        localEpochGetUtcMinutes.Should().Be(49);
 
         var parseLocalEpoch = engine.Evaluate("Date.parse('January 1, 1970');").AsNumber();
-        Assert.Equal(-11 * 60 * 1000, parseLocalEpoch);
+        parseLocalEpoch.Should().Be(-11 * 60 * 1000);
 
         var epochToLocalString = engine.Evaluate("var d = new Date(0); d.toString();").AsString();
-        Assert.Equal("Thu Jan 01 1970 00:11:00 GMT+0011 (Custom Time)", epochToLocalString);
+        epochToLocalString.Should().Be("Thu Jan 01 1970 00:11:00 GMT+0011 (Custom Time)");
 
         var epochToUTCString = engine.Evaluate("var d = new Date(0); d.toUTCString();").AsString();
-        Assert.Equal("Thu, 01 Jan 1970 00:00:00 GMT", epochToUTCString);
+        epochToUTCString.Should().Be("Thu, 01 Jan 1970 00:00:00 GMT");
     }
 
     [Theory]
@@ -1196,7 +1197,7 @@ public partial class EngineTests : IDisposable
         engine.SetValue("d", date);
         var result = engine.Evaluate("Date.parse(d);").AsNumber();
 
-        Assert.Equal(0, result);
+        result.Should().Be(0);
     }
 
     [Theory]
@@ -1229,7 +1230,7 @@ public partial class EngineTests : IDisposable
 
         var result = engine.Evaluate("Date.parse(d);").AsNumber();
 
-        Assert.Equal(msPriorMidnight, result);
+        result.Should().Be(msPriorMidnight);
     }
 
     public static System.Collections.Generic.IEnumerable<object[]> TestDates
@@ -1254,7 +1255,7 @@ public partial class EngineTests : IDisposable
         var testDateTimeOffset = new DateTimeOffset(testDate, customTimeZone.GetUtcOffset(testDate));
         engine.Execute(
             string.Format("var d = new Date({0},{1},{2},{3},{4},{5},{6});", testDateTimeOffset.Year, testDateTimeOffset.Month - 1, testDateTimeOffset.Day, testDateTimeOffset.Hour, testDateTimeOffset.Minute, testDateTimeOffset.Second, testDateTimeOffset.Millisecond));
-        Assert.Equal(testDateTimeOffset.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'", CultureInfo.InvariantCulture), engine.Evaluate("d.toISOString();").ToString());
+        engine.Evaluate("d.toISOString();").ToString().Should().Be(testDateTimeOffset.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'", CultureInfo.InvariantCulture));
     }
 
     [Theory, MemberData(nameof(TestDates))]
@@ -1273,7 +1274,7 @@ public partial class EngineTests : IDisposable
         expected += " (" + tzName + ")";
         var actual = engine.Evaluate("d.toString();").ToString();
 
-        Assert.Equal(expected, actual);
+        actual.Should().Be(expected);
     }
 
     #endregion
@@ -1364,14 +1365,14 @@ var prep = function (fn) { fn(); };
     {
         var code = "if({ __proto__: [], __proto__:[] } instanceof Array) {}";
 
-        Exception ex = Assert.Throws<JavaScriptException>(() => _engine.Execute(code, new ScriptParsingOptions { Tolerant = false }));
-        Assert.Contains("Duplicate __proto__ fields are not allowed in object literals", ex.Message);
+        Exception ex = Invoking(() => _engine.Execute(code, new ScriptParsingOptions { Tolerant = false })).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Contain("Duplicate __proto__ fields are not allowed in object literals");
 
-        ex = Assert.Throws<JavaScriptException>(() => _engine.Execute($"eval('{code}')"));
-        Assert.Contains("Duplicate __proto__ fields are not allowed in object literals", ex.Message);
+        ex = Invoking(() => _engine.Execute($"eval('{code}')")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Contain("Duplicate __proto__ fields are not allowed in object literals");
 
-        Assert.Throws<JavaScriptException>(() => _engine.Execute($"new Function('{code}')"));
-        Assert.Contains("Duplicate __proto__ fields are not allowed in object literals", ex.Message);
+        Invoking(() => _engine.Execute($"new Function('{code}')")).Should().ThrowExactly<JavaScriptException>();
+        ex.Message.Should().Contain("Duplicate __proto__ fields are not allowed in object literals");
     }
 
     [Fact]
@@ -1406,14 +1407,14 @@ var prep = function (fn) { fn(); };
         var engine = new Engine();
 
         var minValue = engine.Evaluate("new Date('0001-01-01T00:00:00.000Z')").ToObject();
-        Assert.Equal(new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc), minValue);
+        minValue.Should().Be(new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc));
 
         var maxValue = engine.Evaluate("new Date('9999-12-31T23:59:59.999Z')").ToObject();
 
 #if NETCOREAPP
-            Assert.Equal(new DateTime(9999, 12, 31, 23, 59, 59, 998, DateTimeKind.Utc), maxValue);
+            maxValue.Should().Be(new DateTime(9999, 12, 31, 23, 59, 59, 998, DateTimeKind.Utc));
 #else
-        Assert.Equal(new DateTime(9999, 12, 31, 23, 59, 59, 999, DateTimeKind.Utc), maxValue);
+        maxValue.Should().Be(new DateTime(9999, 12, 31, 23, 59, 59, 999, DateTimeKind.Utc));
 #endif
     }
 
@@ -1512,7 +1513,7 @@ var prep = function (fn) { fn(); };
                     fractionDigits.ToString(CultureInfo.InvariantCulture)))
             .ToObject();
 
-        Assert.Equal(value, result);
+        value.Should().Be(result);
     }
 
 
@@ -1551,7 +1552,7 @@ var prep = function (fn) { fn(); };
 
         engine.Debugger.Break -= EngineStep;
 
-        Assert.Equal(1, countBreak);
+        countBreak.Should().Be(1);
     }
 
     [Fact]
@@ -1570,7 +1571,7 @@ var prep = function (fn) { fn(); };
 
         engine.Debugger.Step -= EngineStep;
 
-        Assert.Equal(3, countBreak);
+        countBreak.Should().Be(3);
     }
 
     [Fact]
@@ -1589,14 +1590,14 @@ var prep = function (fn) { fn(); };
         engine.Debugger.Step -= EngineStep;
         engine.Debugger.Break -= EngineStep;
 
-        Assert.Equal(1, countBreak);
+        countBreak.Should().Be(1);
     }
 
     private StepMode EngineStep(object sender, DebugInformation debugInfo)
     {
-        Assert.NotNull(sender);
-        Assert.IsType(typeof(Engine), sender);
-        Assert.NotNull(debugInfo);
+        sender.Should().NotBeNull();
+        sender.Should().BeOfType<Engine>();
+        debugInfo.Should().NotBeNull();
 
         countBreak++;
         return stepMode;
@@ -1622,28 +1623,28 @@ var prep = function (fn) { fn(); };
 
         engine.Debugger.Break -= EngineStepVerifyDebugInfo;
 
-        Assert.Equal(1, countBreak);
+        countBreak.Should().Be(1);
     }
 
     private StepMode EngineStepVerifyDebugInfo(object sender, DebugInformation debugInfo)
     {
-        Assert.NotNull(sender);
-        Assert.IsType(typeof(Engine), sender);
-        Assert.NotNull(debugInfo);
+        sender.Should().NotBeNull();
+        sender.Should().BeOfType<Engine>();
+        debugInfo.Should().NotBeNull();
 
-        Assert.NotNull(debugInfo.CallStack);
-        Assert.NotNull(debugInfo.CurrentNode);
-        Assert.NotNull(debugInfo.CurrentScopeChain);
+        debugInfo.CallStack.Should().NotBeNull();
+        debugInfo.CurrentNode.Should().NotBeNull();
+        debugInfo.CurrentScopeChain.Should().NotBeNull();
 
-        Assert.Equal(2, debugInfo.CallStack.Count);
-        Assert.Equal("func1", debugInfo.CurrentCallFrame.FunctionName);
+        debugInfo.CallStack.Should().HaveCount(2);
+        debugInfo.CurrentCallFrame.FunctionName.Should().Be("func1");
         var globalScope = debugInfo.CurrentScopeChain.Single(s => s.ScopeType == DebugScopeType.Global);
         var localScope = debugInfo.CurrentScopeChain.Single(s => s.ScopeType == DebugScopeType.Local);
-        Assert.Contains("global", globalScope.BindingNames);
-        Assert.Equal(true, globalScope.GetBindingValue("global").AsBoolean());
-        Assert.Contains("local", localScope.BindingNames);
-        Assert.Equal(false, localScope.GetBindingValue("local").AsBoolean());
-        Assert.DoesNotContain("global", localScope.BindingNames);
+        globalScope.BindingNames.Should().Contain("global");
+        globalScope.GetBindingValue("global").AsBoolean().Should().BeTrue();
+        localScope.BindingNames.Should().Contain("local");
+        localScope.GetBindingValue("local").AsBoolean().Should().BeFalse();
+        localScope.BindingNames.Should().NotContain("global");
         countBreak++;
         return stepMode;
     }
@@ -1671,7 +1672,7 @@ var prep = function (fn) { fn(); };
 
         engine.Debugger.Break -= EngineStep;
 
-        Assert.Equal(1, countBreak);
+        countBreak.Should().Be(1);
     }
 
     [Fact]
@@ -1694,7 +1695,7 @@ var prep = function (fn) { fn(); };
 
         engine.Debugger.Step -= EngineStep;
 
-        Assert.Equal(1, countBreak);
+        countBreak.Should().Be(1);
     }
 
     [Fact]
@@ -1716,14 +1717,14 @@ var prep = function (fn) { fn(); };
 
         engine.Debugger.Step -= EngineStepOutWhenInsideFunction;
 
-        Assert.Equal(4, countBreak);
+        countBreak.Should().Be(4);
     }
 
     private StepMode EngineStepOutWhenInsideFunction(object sender, DebugInformation debugInfo)
     {
-        Assert.NotNull(sender);
-        Assert.IsType(typeof(Engine), sender);
-        Assert.NotNull(debugInfo);
+        sender.Should().NotBeNull();
+        sender.Should().BeOfType<Engine>();
+        debugInfo.Should().NotBeNull();
 
         countBreak++;
         if (debugInfo.CallStack.Count > 1) // CallStack always has at least one element
@@ -1752,7 +1753,7 @@ var prep = function (fn) { fn(); };
 
         engine.Debugger.Break -= EngineStep;
 
-        Assert.Equal(1, countBreak);
+        countBreak.Should().Be(1);
     }
 
     [Fact]
@@ -1775,7 +1776,7 @@ var prep = function (fn) { fn(); };
 
         engine.Debugger.Step -= EngineStep;
 
-        Assert.Equal(3, countBreak);
+        countBreak.Should().Be(3);
     }
 
     [Fact]
@@ -1797,7 +1798,7 @@ var prep = function (fn) { fn(); };
 
         engine.Debugger.Step -= EngineStep;
 
-        Assert.Equal(4, countBreak);
+        countBreak.Should().Be(4);
     }
 
     [Fact]
@@ -1848,9 +1849,9 @@ var prep = function (fn) { fn(); };
     {
         var engine = new Engine();
         engine.Evaluate("var t = '1234'; var value = null;");
-        Assert.Equal("1", engine.Execute("value = t[0x0];").GetValue("value").AsString());
-        Assert.Equal("1", engine.Execute("value = t[0];").GetValue("value").AsString());
-        Assert.Equal("1", engine.Execute("value = t['0'];").GetValue("value").AsString());
+        engine.Execute("value = t[0x0];").GetValue("value").AsString().Should().Be("1");
+        engine.Execute("value = t[0];").GetValue("value").AsString().Should().Be("1");
+        engine.Execute("value = t['0'];").GetValue("value").AsString().Should().Be("1");
     }
 
     [Fact]
@@ -1876,8 +1877,9 @@ var prep = function (fn) { fn(); };
 
         var engine = new Engine(options => options.LocalTimeZone(PDT).Culture(FR))
                 .SetValue("log", new Action<object>(Console.WriteLine))
-                .SetValue("assert", new Action<bool>(Assert.True))
-                .SetValue("equal", new Action<object, object>(Assert.Equal))
+                .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+                .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())))
             ;
 
         engine.Evaluate(@"
@@ -1899,8 +1901,9 @@ var prep = function (fn) { fn(); };
         var EST = _easternTimeZone;
         var engine = new Engine(options => options.LocalTimeZone(EST))
             .SetValue("log", new Action<object>(Console.WriteLine))
-            .SetValue("assert", new Action<bool>(Assert.True))
-            .SetValue("equal", new Action<object, object>(Assert.Equal));
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
 
         engine.Evaluate($@"
                     var d = new Date(2016, 8, 1);
@@ -1919,8 +1922,9 @@ var prep = function (fn) { fn(); };
 
         new Engine(options => options.LocalTimeZone(PDT).Culture(FR))
             .SetValue("log", new Action<object>(Console.WriteLine))
-            .SetValue("assert", new Action<bool>(Assert.True))
-            .SetValue("equal", new Action<object, object>(Assert.Equal))
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())))
             .Evaluate(@"
                     var d = new Date(1433160000000);
                     equal(Date.parse(d.toString()), d.valueOf());
@@ -1933,7 +1937,7 @@ var prep = function (fn) { fn(); };
     public void ShouldThrowErrorWhenMaxExecutionStackCountLimitExceeded()
     {
         new Engine(options => options.Constraints.MaxExecutionStackCount = 1000)
-            .SetValue("assert", new Action<bool>(Assert.True))
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
             .Evaluate(@"
                     var count = 0;
                     function recurse() {
@@ -1960,9 +1964,8 @@ var prep = function (fn) { fn(); };
         // because an AssignmentPattern node was being cast to Expression without a type check.
         // After the fix, it throws a catchable JavaScriptException (SyntaxError).
         var engine = new Engine();
-        Assert.ThrowsAny<JavaScriptException>(() =>
-            engine.Execute("a=[1,3];aaa={}={}.aap+=[1,3];aaa={}={a=-[]<= []<a.m}.aap+=[,2,3111-1]")
-        );
+        Invoking(() =>
+            engine.Execute("a=[1,3];aaa={}={}.aap+=[1,3];aaa={}={a=-[]<= []<a.m}.aap+=[,2,3111-1]")).Should().Throw<JavaScriptException>();
     }
 
 
@@ -1976,8 +1979,9 @@ var prep = function (fn) { fn(); };
 
         var engine = new Engine(options => options.LocalTimeZone(PDT).Culture(FR))
             .SetValue("log", new Action<object>(Console.WriteLine))
-            .SetValue("assert", new Action<bool>(Assert.True))
-            .SetValue("equal", new Action<object, object>(Assert.Equal));
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
 
         engine.Evaluate("var d = new Number(-1.23);");
         engine.Evaluate("equal('-1.23', d.toString());");
@@ -2045,7 +2049,8 @@ var prep = function (fn) { fn(); };
     public void ShouldSetYearBefore1970()
     {
         new Engine(options => options.LocalTimeZone(TimeZoneInfo.Utc))
-            .SetValue("equal", new Action<object, object>(Assert.Equal))
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())))
             .Execute(@"
                 var d = new Date('1969-01-01T08:17:00Z');
                 d.setYear(2015);
@@ -2075,8 +2080,8 @@ var prep = function (fn) { fn(); };
                 test('arg');
             ";
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate(source));
-        Assert.Equal(3, ex.Location.Start.Line);
+        var ex = Invoking(() => engine.Evaluate(source)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Location.Start.Line.Should().Be(3);
     }
 
     [Fact]
@@ -2109,7 +2114,7 @@ var prep = function (fn) { fn(); };
 
         var result = engine.Evaluate("guid1 == guid2").AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -2130,7 +2135,7 @@ var prep = function (fn) { fn(); };
 
         var result = engine.Evaluate("guid1 == {}").AsBoolean();
 
-        Assert.False(result);
+        result.Should().BeFalse();
     }
 
     [Fact]
@@ -2140,7 +2145,7 @@ var prep = function (fn) { fn(); };
         var engine = new Engine();
         var val = engine.Evaluate("JSON.stringify(53.6841659)");
 
-        Assert.Equal("53.6841659", val.AsString());
+        val.AsString().Should().Be("53.6841659");
     }
 
     [Fact]
@@ -2159,7 +2164,7 @@ var prep = function (fn) { fn(); };
                 JSON.stringify(obj);
             ");
 
-        Assert.True(res == "{\"a\":[],\"a1\":[\"str\"],\"a2\":{},\"a3\":{\"prop\":\"val\"},\"b\":[],\"b1\":[\"str\"]}");
+        res.Should().Be("{\"a\":[],\"a1\":[\"str\"],\"a2\":{},\"a3\":{\"prop\":\"val\"},\"b\":[],\"b1\":[\"str\"]}");
     }
 
     [Fact]
@@ -2179,7 +2184,7 @@ var prep = function (fn) { fn(); };
                 })();
             ");
 
-        Assert.True(res == "Cyclic reference detected.");
+        res.Should().Be("Cyclic reference detected.");
     }
 
     [Fact]
@@ -2193,7 +2198,7 @@ var prep = function (fn) { fn(); };
                 return JSON.stringify(obj);
             ");
 
-        Assert.Equal("{}", res.AsString());
+        res.AsString().Should().Be("{}");
     }
 
     [Theory]
@@ -2213,7 +2218,7 @@ var prep = function (fn) { fn(); };
         var engine = new Engine();
         var result = engine.Evaluate(source).ToObject();
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Theory]
@@ -2424,7 +2429,7 @@ var prep = function (fn) { fn(); };
         var engine = new Engine();
         var result = engine.Evaluate(source).ToObject();
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Theory]
@@ -2445,7 +2450,7 @@ var prep = function (fn) { fn(); };
         var engine = new Engine();
         var result = engine.Evaluate(source).ToObject();
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Theory]
@@ -2459,7 +2464,7 @@ var prep = function (fn) { fn(); };
         var engine = new Engine();
         var result = engine.Evaluate(source).ToObject();
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Theory]
@@ -2471,7 +2476,7 @@ var prep = function (fn) { fn(); };
     {
         var engine = new Engine();
         var result = engine.Evaluate(source).ToObject();
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     /// <summary>
@@ -2514,7 +2519,7 @@ var prep = function (fn) { fn(); };
         var engine = new Engine();
         var result = engine.Evaluate(source).ToObject();
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Theory]
@@ -2525,8 +2530,8 @@ var prep = function (fn) { fn(); };
     public void ShouldAllowNonStringMessage(string source, string expected)
     {
         var engine = new Engine();
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute(source));
-        Assert.Equal(expected, ex.Message);
+        var ex = Invoking(() => engine.Execute(source)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be(expected);
     }
 
     [Theory]
@@ -2624,7 +2629,7 @@ var prep = function (fn) { fn(); };
         var engine = new Engine(o => o.LocalTimeZone(TimeZoneInfo.Utc));
         var expectedValue = engine.Evaluate(expected).ToObject();
         var actualValue = engine.Evaluate(actual).ToObject();
-        Assert.Equal(expectedValue, actualValue);
+        actualValue.Should().Be(expectedValue);
     }
 
     [Fact]
@@ -2639,7 +2644,7 @@ var prep = function (fn) { fn(); };
 
         var concat = _engine.GetValue("concat");
         var result = _engine.Invoke(concat, "concat", "well", "done").ToObject() as string;
-        Assert.Equal("concatwelldone", result);
+        result.Should().Be("concatwelldone");
     }
 
     [Fact]
@@ -2698,37 +2703,37 @@ function output(x) {
         var result1 = (ObjectInstance) _engine.Evaluate("output(x1)");
         var result2 = (ObjectInstance) _engine.Evaluate("output(x2)");
 
-        Assert.Equal(9, TypeConverter.ToNumber(result1.Get("TestDictionarySum1")));
-        Assert.Equal(9, TypeConverter.ToNumber(result1.Get("TestDictionarySum2")));
-        Assert.Equal(9, TypeConverter.ToNumber(result1.Get("TestDictionarySum3")));
+        TypeConverter.ToNumber(result1.Get("TestDictionarySum1")).Should().Be(9);
+        TypeConverter.ToNumber(result1.Get("TestDictionarySum2")).Should().Be(9);
+        TypeConverter.ToNumber(result1.Get("TestDictionarySum3")).Should().Be(9);
 
-        Assert.Equal(3, TypeConverter.ToNumber(result1.Get("TestDictionaryAverage1")));
-        Assert.Equal(3, TypeConverter.ToNumber(result1.Get("TestDictionaryAverage2")));
-        Assert.Equal(3, TypeConverter.ToNumber(result1.Get("TestDictionaryAverage3")));
+        TypeConverter.ToNumber(result1.Get("TestDictionaryAverage1")).Should().Be(3);
+        TypeConverter.ToNumber(result1.Get("TestDictionaryAverage2")).Should().Be(3);
+        TypeConverter.ToNumber(result1.Get("TestDictionaryAverage3")).Should().Be(3);
 
-        Assert.Equal(3, TypeConverter.ToNumber(result1.Get("TestDictionaryFunc1")));
-        Assert.Equal(1, TypeConverter.ToNumber(result1.Get("TestGeneratedDictionary3")));
+        TypeConverter.ToNumber(result1.Get("TestDictionaryFunc1")).Should().Be(3);
+        TypeConverter.ToNumber(result1.Get("TestGeneratedDictionary3")).Should().Be(1);
 
-        Assert.Equal(3.5, TypeConverter.ToNumber(result1.Get("TestGeneratedDictionarySum1")));
-        Assert.Equal(3.5, TypeConverter.ToNumber(result1.Get("TestGeneratedDictionarySum2")));
-        Assert.Equal(3.5, TypeConverter.ToNumber(result1.Get("TestGeneratedDictionaryAverage1")));
-        Assert.Equal(3.5, TypeConverter.ToNumber(result1.Get("TestGeneratedDictionaryAverage2")));
+        TypeConverter.ToNumber(result1.Get("TestGeneratedDictionarySum1")).Should().Be(3.5);
+        TypeConverter.ToNumber(result1.Get("TestGeneratedDictionarySum2")).Should().Be(3.5);
+        TypeConverter.ToNumber(result1.Get("TestGeneratedDictionaryAverage1")).Should().Be(3.5);
+        TypeConverter.ToNumber(result1.Get("TestGeneratedDictionaryAverage2")).Should().Be(3.5);
 
-        Assert.Equal(1, TypeConverter.ToNumber(result1.Get("TestGeneratedDictionaryDirectAccess3")));
+        TypeConverter.ToNumber(result1.Get("TestGeneratedDictionaryDirectAccess3")).Should().Be(1);
 
-        Assert.Equal(6.7, TypeConverter.ToNumber(result1.Get("TestList1")));
-        Assert.Equal(6.7, TypeConverter.ToNumber(result1.Get("TestList2")));
-        Assert.Equal(6.7, TypeConverter.ToNumber(result1.Get("TestList3")));
-        Assert.Equal(3.35, TypeConverter.ToNumber(result1.Get("TestList4")));
-        Assert.Equal(3.35, TypeConverter.ToNumber(result1.Get("TestList5")));
+        TypeConverter.ToNumber(result1.Get("TestList1")).Should().Be(6.7);
+        TypeConverter.ToNumber(result1.Get("TestList2")).Should().Be(6.7);
+        TypeConverter.ToNumber(result1.Get("TestList3")).Should().Be(6.7);
+        TypeConverter.ToNumber(result1.Get("TestList4")).Should().Be(3.35);
+        TypeConverter.ToNumber(result1.Get("TestList5")).Should().Be(3.35);
 
-        Assert.Equal(6, TypeConverter.ToNumber(result2.Get("TestDictionarySum1")));
-        Assert.Equal(6, TypeConverter.ToNumber(result2.Get("TestDictionarySum2")));
-        Assert.Equal(6, TypeConverter.ToNumber(result2.Get("TestDictionarySum3")));
+        TypeConverter.ToNumber(result2.Get("TestDictionarySum1")).Should().Be(6);
+        TypeConverter.ToNumber(result2.Get("TestDictionarySum2")).Should().Be(6);
+        TypeConverter.ToNumber(result2.Get("TestDictionarySum3")).Should().Be(6);
 
-        Assert.Equal(2, TypeConverter.ToNumber(result2.Get("TestDictionaryAverage1")));
-        Assert.Equal(2, TypeConverter.ToNumber(result2.Get("TestDictionaryAverage2")));
-        Assert.Equal(2, TypeConverter.ToNumber(result2.Get("TestDictionaryAverage3")));
+        TypeConverter.ToNumber(result2.Get("TestDictionaryAverage1")).Should().Be(2);
+        TypeConverter.ToNumber(result2.Get("TestDictionaryAverage2")).Should().Be(2);
+        TypeConverter.ToNumber(result2.Get("TestDictionaryAverage3")).Should().Be(2);
     }
     [Fact]
     public void ShouldBeAbleToSpreadArrayLiteralsAndFunctionParameters()
@@ -2747,18 +2752,18 @@ function output(x) {
             ");
 
         var arrayInstance = (ArrayInstance) _engine.GetValue("r");
-        Assert.Equal(arrayInstance[0], 3);
-        Assert.Equal(arrayInstance[1], 4);
-        Assert.Equal(arrayInstance[2], 1);
-        Assert.Equal(arrayInstance[3], 2);
+        arrayInstance[0].Should().Be(3);
+        arrayInstance[1].Should().Be(4);
+        arrayInstance[2].Should().Be(1);
+        arrayInstance[3].Should().Be(2);
 
         arrayInstance = (ArrayInstance) _engine.GetValue("s");
-        Assert.Equal(arrayInstance[0], 'a');
-        Assert.Equal(arrayInstance[1], 'b');
-        Assert.Equal(arrayInstance[2], 'c');
+        arrayInstance[0].Should().Be('a');
+        arrayInstance[1].Should().Be('b');
+        arrayInstance[2].Should().Be('c');
 
         var c = _engine.GetValue("c").ToString();
-        Assert.Equal("1ab", c);
+        c.Should().Be("1ab");
     }
 
     [Fact]
@@ -2767,34 +2772,34 @@ function output(x) {
         // PropertyDefinitionEvaluation for `...AssignmentExpression` performs CopyDataProperties
         // (https://tc39.es/ecma262/#sec-copydataproperties): step 1 skips undefined/null sources,
         // step 2 ToObject's everything else — so spreading a string primitive copies its index properties.
-        Assert.Equal("""{"0":"a","1":"b"}""", _engine.Evaluate("JSON.stringify({...'ab'})").AsString());
-        Assert.Equal("0,1", _engine.Evaluate("Object.keys({...'ab'}).join()").AsString());
-        Assert.Equal("""{"0":"a","1":"b","x":1}""", _engine.Evaluate("JSON.stringify({...'ab', x: 1})").AsString());
+        _engine.Evaluate("JSON.stringify({...'ab'})").AsString().Should().Be("""{"0":"a","1":"b"}""");
+        _engine.Evaluate("Object.keys({...'ab'}).join()").AsString().Should().Be("0,1");
+        _engine.Evaluate("JSON.stringify({...'ab', x: 1})").AsString().Should().Be("""{"0":"a","1":"b","x":1}""");
 
         // Number/boolean/symbol wrappers have no enumerable own keys.
-        Assert.Equal("{}", _engine.Evaluate("JSON.stringify({...42})").AsString());
-        Assert.Equal(0, _engine.Evaluate("Object.keys({...42}).length").AsNumber());
-        Assert.Equal("{}", _engine.Evaluate("JSON.stringify({...true})").AsString());
-        Assert.Equal(0, _engine.Evaluate("Object.getOwnPropertyNames({...Symbol()}).length + Object.getOwnPropertySymbols({...Symbol()}).length").AsNumber());
+        _engine.Evaluate("JSON.stringify({...42})").AsString().Should().Be("{}");
+        _engine.Evaluate("Object.keys({...42}).length").AsNumber().Should().Be(0);
+        _engine.Evaluate("JSON.stringify({...true})").AsString().Should().Be("{}");
+        _engine.Evaluate("Object.getOwnPropertyNames({...Symbol()}).length + Object.getOwnPropertySymbols({...Symbol()}).length").AsNumber().Should().Be(0);
 
         // CopyDataProperties step 1: undefined/null sources are skipped, not thrown.
-        Assert.Equal("{}", _engine.Evaluate("JSON.stringify({...null})").AsString());
-        Assert.Equal("{}", _engine.Evaluate("JSON.stringify({...undefined})").AsString());
+        _engine.Evaluate("JSON.stringify({...null})").AsString().Should().Be("{}");
+        _engine.Evaluate("JSON.stringify({...undefined})").AsString().Should().Be("{}");
 
         // Object.assign skips undefined/null and ToObject's other sources the same way
         // (https://tc39.es/ecma262/#sec-object.assign step 3.a).
-        Assert.Equal("""{"0":"a","1":"b"}""", _engine.Evaluate("JSON.stringify(Object.assign({}, 'ab'))").AsString());
-        Assert.Equal("{}", _engine.Evaluate("JSON.stringify(Object.assign({}, null, undefined, 42, true))").AsString());
+        _engine.Evaluate("JSON.stringify(Object.assign({}, 'ab'))").AsString().Should().Be("""{"0":"a","1":"b"}""");
+        _engine.Evaluate("JSON.stringify(Object.assign({}, null, undefined, 42, true))").AsString().Should().Be("{}");
 
         // Resume path: the literal build suspends inside the spread argument and resumes with a primitive.
-        Assert.Equal("""{"0":"a","1":"b","x":2}""", _engine.Evaluate("""
+        _engine.Evaluate("""
             (function() {
                 function* g() { return { ...(yield), x: 2 }; }
                 var it = g();
                 it.next();
                 return JSON.stringify(it.next('ab').value);
             })()
-            """).AsString());
+            """).AsString().Should().Be("""{"0":"a","1":"b","x":2}""");
     }
 
     [Fact]
@@ -2809,21 +2814,21 @@ function output(x) {
 
         var function = _engine.GetValue("f");
         var result = _engine.Invoke(function, 3).ToString();
-        Assert.Equal("15", result);
+        result.Should().Be("15");
 
         result = _engine.Invoke(function, 3, JsValue.Undefined).ToString();
-        Assert.Equal("15", result);
+        result.Should().Be("15");
     }
 
     [Fact]
     public void ShouldReportErrorForInvalidJson()
     {
         var engine = new Engine();
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("JSON.parse('[01]')"));
-        Assert.Equal("Unexpected token '1' in JSON at position 2", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("JSON.parse('[01]')")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Unexpected token '1' in JSON at position 2");
 
         var voidCompletion = engine.Evaluate("try { JSON.parse('01') } catch (e) {}");
-        Assert.Equal(JsValue.Undefined, voidCompletion);
+        voidCompletion.Should().BeUndefined();
     }
 
     [Fact]
@@ -2841,8 +2846,8 @@ x.test = {
 }";
         engine.Execute(js);
 
-        Assert.Equal("Testificate", obj.Test.Name);
-        Assert.Equal(5, obj.Test.Init(2, 3));
+        obj.Test.Name.Should().Be("Testificate");
+        obj.Test.Init(2, 3).Should().Be(5);
     }
 
     [Fact]
@@ -2851,9 +2856,9 @@ x.test = {
         var engine = new Engine(options => options
             .SetTypeConverter(e => new TestTypeConverter())
         );
-        Assert.IsType<TestTypeConverter>(engine.TypeConverter);
+        engine.TypeConverter.Should().BeOfType<TestTypeConverter>();
         engine.SetValue("x", new Testificate());
-        Assert.Throws<JavaScriptException>(() => engine.Evaluate("c.Name"));
+        Invoking(() => engine.Evaluate("c.Name")).Should().ThrowExactly<JavaScriptException>();
     }
 
     [Fact]
@@ -2876,7 +2881,7 @@ x.test = {
     {
         new Engine((e, options) =>
             {
-                Assert.IsType<Engine>(e);
+                e.Should().BeOfType<Engine>();
                 options
                     .AddObjectConverter(new TestObjectConverter())
                     .AddObjectConverter<TestObjectConverter>();
@@ -2892,8 +2897,8 @@ x.test = {
         var engine1 = new Engine(options);
         var engine2 = new Engine(options);
 
-        Assert.Equal(1, Convert.ToInt32(engine1.GetValue("x").ToObject()));
-        Assert.Equal(1, Convert.ToInt32(engine2.GetValue("x").ToObject()));
+        Convert.ToInt32(engine1.GetValue("x").ToObject()).Should().Be(1);
+        Convert.ToInt32(engine2.GetValue("x").ToObject()).Should().Be(1);
     }
 
     [Fact]
@@ -2906,7 +2911,7 @@ x.test = {
         engine.SetValue("evaluateCode", evaluateCodeValue);
         var result = (int) engine.Evaluate(@"evaluateCode('678 + 711')").AsNumber();
 
-        Assert.Equal(1389, result);
+        result.Should().Be(1389);
     }
 
     [Fact]
@@ -2930,7 +2935,7 @@ x.test = {
             captured;
         ");
 
-        Assert.Equal("B", result.AsString());
+        result.AsString().Should().Be("B");
     }
 
     [Fact]
@@ -2953,9 +2958,9 @@ x.test = {
                 ")
             .ToObject();
 
-        Assert.Equal("Red", result.red);
-        Assert.Equal("Orange", result.orange);
-        Assert.Equal("White", result.white);
+        ((string) result.red).Should().Be("Red");
+        ((string) result.orange).Should().Be("Orange");
+        ((string) result.white).Should().Be("White");
     }
 
     [Fact]
@@ -2970,7 +2975,7 @@ x.test = {
                 ")
             .AsNumber();
 
-        Assert.Equal(1, result);
+        result.Should().Be(1);
     }
 
     [Fact]
@@ -2985,16 +2990,16 @@ x.test = {
             var len = (x = produce()).length;
             ");
 
-        Assert.Equal(1, engine.Evaluate("callCount").AsNumber());
-        Assert.Equal(3, engine.Evaluate("len").AsNumber());
-        Assert.Equal("abc", engine.Evaluate("x").AsString());
+        engine.Evaluate("callCount").AsNumber().Should().Be(1);
+        engine.Evaluate("len").AsNumber().Should().Be(3);
+        engine.Evaluate("x").AsString().Should().Be("abc");
     }
 
     [Fact]
     public void ClassDeclarationHoisting()
     {
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("typeof MyClass; class MyClass {}"));
-        Assert.Equal("Cannot access 'MyClass' before initialization", ex.Message);
+        var ex = Invoking(() => _engine.Evaluate("typeof MyClass; class MyClass {}")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Cannot access 'MyClass' before initialization");
     }
 
     [Fact]
@@ -3002,12 +3007,12 @@ x.test = {
     {
         var engine = new Engine();
         const string source = "'use strict'; var x = () => { delete Boolean.prototype; }; x();";
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate(source));
-        Assert.Equal("Cannot delete property 'prototype' of function Boolean() { [native code] }", ex.Message);
+        var ex = Invoking(() => engine.Evaluate(source)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Cannot delete property 'prototype' of function Boolean() { [native code] }");
 
         const string source2 = "'use strict'; delete foobar;";
-        ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate(source2));
-        Assert.Equal("Delete of an unqualified identifier in strict mode (<anonymous>:1:22)", ex.Message);
+        ex = Invoking(() => engine.Evaluate(source2)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Delete of an unqualified identifier in strict mode (<anonymous>:1:22)");
     }
 
     [Fact]
@@ -3016,8 +3021,8 @@ x.test = {
         var engine = new Engine();
         var script = "class MyClass1 { } class MyClass2 extends MyClass1 { constructor() { } } const x = new MyClass2();";
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate(script));
-        Assert.Equal("Must call super constructor in derived class before accessing 'this' or returning from derived constructor", ex.Message);
+        var ex = Invoking(() => engine.Evaluate(script)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Must call super constructor in derived class before accessing 'this' or returning from derived constructor");
     }
 
     [Fact]
@@ -3025,8 +3030,8 @@ x.test = {
     {
         var engine = new Engine();
         engine.Evaluate("const testObj = { '02100' : true };");
-        Assert.Equal(1, engine.Evaluate("Object.keys(testObj).length;").AsNumber());
-        Assert.Equal("[\"02100\"]", engine.Evaluate("JSON.stringify(Object.getOwnPropertyNames(testObj));").AsString());
+        engine.Evaluate("Object.keys(testObj).length;").AsNumber().Should().Be(1);
+        engine.Evaluate("JSON.stringify(Object.getOwnPropertyNames(testObj));").AsString().Should().Be("[\"02100\"]");
     }
 
     [Fact]
@@ -3041,9 +3046,9 @@ x.test = {
             ";
         var array = engine.Evaluate(Script).AsArray();
 
-        Assert.Equal(2L, array.Length);
-        Assert.True(array[0].IsUndefined());
-        Assert.True(array[1].IsUndefined());
+        array.Length.Should().Be(2);
+        array[0].IsUndefined().Should().BeTrue();
+        array[1].IsUndefined().Should().BeTrue();
     }
 
     [Fact]
@@ -3056,11 +3061,11 @@ x.test = {
 
         const string ExpectedExceptionMessage = "String compilation has been disabled in engine options";
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("eval('1+1');"));
-        Assert.Equal(ExpectedExceptionMessage, ex.Message);
+        var ex = Invoking(() => engine.Evaluate("eval('1+1');")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be(ExpectedExceptionMessage);
 
-        ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("new Function('1+1');"));
-        Assert.Equal(ExpectedExceptionMessage, ex.Message);
+        ex = Invoking(() => engine.Evaluate("new Function('1+1');")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be(ExpectedExceptionMessage);
     }
 
     [Fact]
@@ -3147,20 +3152,20 @@ x.test = {
         engine.Debugger.BeforeEvaluate += (sender, ast) =>
         {
             beforeEvaluateTriggeredCount++;
-            Assert.Equal(engine, sender);
+            sender.Should().Be(engine);
 
             switch (beforeEvaluateTriggeredCount)
             {
                 case 1:
-                    Assert.Equal("module1", ast.Location.SourceFile);
-                    Assert.Collection(ast.Body,
-                        node => Assert.IsType<ImportDeclaration>(node)
+                    ast.Location.SourceFile.Should().Be("module1");
+                    ast.Body.Should().SatisfyRespectively(
+                        node => node.Should().BeOfType<ImportDeclaration>()
                     );
                     break;
                 case 2:
-                    Assert.Equal("module2", ast.Location.SourceFile);
-                    Assert.Collection(ast.Body,
-                        node => Assert.IsType<ExportDefaultDeclaration>(node)
+                    ast.Location.SourceFile.Should().Be("module2");
+                    ast.Body.Should().SatisfyRespectively(
+                        node => node.Should().BeOfType<ExportDefaultDeclaration>()
                     );
                     break;
             }
@@ -3170,7 +3175,7 @@ x.test = {
         engine.Modules.Add("module2", module2);
         engine.Modules.Import("module1");
 
-        Assert.Equal(2, beforeEvaluateTriggeredCount);
+        beforeEvaluateTriggeredCount.Should().Be(2);
     }
 
     [Fact]
@@ -3181,7 +3186,7 @@ x.test = {
         var float32 = new float [] { 42f, 23 };
             
         engine.SetValue("float32", float32); 
-        engine.SetValue("testFloat32Array", new Action<float[]>(v => Assert.Equal(v, float32)));
+        engine.SetValue("testFloat32Array", new Action<float[]>(v => float32.Should().Equal(v)));
             
         engine.Evaluate(@"
                 testFloat32Array(new Float32Array(float32));
@@ -3198,14 +3203,14 @@ x.test = {
         engine.Debugger.BeforeEvaluate += (sender, ast) =>
         {
             beforeEvaluateTriggered = true;
-            Assert.Equal(engine, sender);
-            Assert.Equal(expectedSource, ast.Location.SourceFile);
-            Assert.Collection(ast.Body, node => Assert.True(TestHelpers.IsLiteral(node, "dummy")));
+            sender.Should().Be(engine);
+            ast.Location.SourceFile.Should().Be(expectedSource);
+            ast.Body.Should().SatisfyRespectively(node => TestHelpers.IsLiteral(node, "dummy").Should().BeTrue());
         };
 
         call(engine, script);
 
-        Assert.True(beforeEvaluateTriggered);
+        beforeEvaluateTriggered.Should().BeTrue();
     }
 
     [Fact]
@@ -3221,37 +3226,37 @@ x.test = {
             }
             compute(3, 4);
         ");
-        Assert.Equal(19d, result.AsNumber());
+        result.AsNumber().Should().Be(19d);
     }
 
     [Fact]
     public void ShouldHandleFixedSlotFunctionWithConstReassignmentError()
     {
         var engine = new Engine();
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate(@"
+        var ex = Invoking(() => engine.Evaluate(@"
             function test(x) {
                 const y = x + 1;
                 y = 10;
                 return y;
             }
             test(5);
-        "));
-        Assert.Contains("constant", ex.Message, StringComparison.OrdinalIgnoreCase);
+        ")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().ContainEquivalentOf("constant");
     }
 
     [Fact]
     public void ShouldHandleFixedSlotFunctionWithLetTemporalDeadZone()
     {
         var engine = new Engine();
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate(@"
+        var ex = Invoking(() => engine.Evaluate(@"
             function test() {
                 var x = y;
                 let y = 10;
                 return x;
             }
             test();
-        "));
-        Assert.Contains("has not been initialized", ex.Message, StringComparison.OrdinalIgnoreCase);
+        ")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().ContainEquivalentOf("has not been initialized");
     }
 
     [Fact]
@@ -3270,7 +3275,7 @@ x.test = {
             var counter = makeCounter(10);
             counter() + counter() + counter();
         ");
-        Assert.Equal(36d, result.AsNumber());
+        result.AsNumber().Should().Be(36d);
     }
 
     [Fact]
@@ -3286,7 +3291,7 @@ x.test = {
             }
             swap(3, 7);
         ");
-        Assert.Equal(703d, result.AsNumber());
+        result.AsNumber().Should().Be(703d);
     }
 
     [Fact]
@@ -3302,7 +3307,7 @@ x.test = {
             }
             add(1, 2) + add(3, 4) + add(5, 6);
         ");
-        Assert.Equal(21d, result.AsNumber());
+        result.AsNumber().Should().Be(21d);
     }
 
     [Fact]
@@ -3318,7 +3323,7 @@ x.test = {
             }
             process(1, 2) + process(3, 4);
         ");
-        Assert.Equal(94d, result.AsNumber());
+        result.AsNumber().Should().Be(94d);
     }
 
     [Fact]
@@ -3334,7 +3339,7 @@ x.test = {
             var add10 = makeAdder(10);
             add5(3) + add10(3);
         ");
-        Assert.Equal(21d, result.AsNumber());
+        result.AsNumber().Should().Be(21d);
     }
 
     [Fact]
@@ -3352,7 +3357,7 @@ x.test = {
             }
             outer(42)()();
         ");
-        Assert.Equal(42d, result.AsNumber());
+        result.AsNumber().Should().Be(42d);
     }
 
     [Fact]
@@ -3368,7 +3373,7 @@ x.test = {
             }
             compute(1, 2) + compute(3, 4);
         ");
-        Assert.Equal(210d, result.AsNumber());
+        result.AsNumber().Should().Be(210d);
     }
 
     [Fact]
@@ -3382,7 +3387,7 @@ x.test = {
             var triple = make(3);
             double(5) + triple(5);
         ");
-        Assert.Equal(25d, result.AsNumber());
+        result.AsNumber().Should().Be(25d);
     }
 
     private class Wrapper

--- a/Jint.Tests/Runtime/EqualityLaneTests.cs
+++ b/Jint.Tests/Runtime/EqualityLaneTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the semantics of the unboxed slot-number lane on ==/===/!=/!== (JintBinaryExpression):
@@ -22,7 +22,7 @@ public class EqualityLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("false,true,false,true,true,true,false,true,true,false,false", result);
+        result.Should().Be("false,true,false,true,true,true,false,true,true,false,false");
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class EqualityLaneTests
             })()
             """).AsNumber();
 
-        Assert.Equal(4, result); // '1' == 1 keeps matching through loose coercion
+        result.Should().Be(4); // '1' == 1 keeps matching through loose coercion
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public class EqualityLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("true,false,true,false,true,false,true,false", result);
+        result.Should().Be("true,false,true,false,true,false,true,false");
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class EqualityLaneTests
             })()
             """).AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public class EqualityLaneTests
             """).AsString();
 
         var iteration = "true,true,false,true,true,true,false";
-        Assert.Equal($"{iteration},{iteration},{iteration}", result);
+        result.Should().Be($"{iteration},{iteration},{iteration}");
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class EqualityLaneTests
             hits + ':' + reads;
             """).AsString();
 
-        Assert.Equal("4:2", result);
+        result.Should().Be("4:2");
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public class EqualityLaneTests
             "false,false,true,true,false,true",   // i = 1  → 1
             "true,true,false,false,false,false",  // i = 2  → 0
             "false,false,true,true,false,true");  // i = 3  → 1
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Fact]
@@ -162,7 +162,7 @@ public class EqualityLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("false,true,false,true,true,true", result);
+        result.Should().Be("false,true,false,true,true,true");
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public class EqualityLaneTests
             hits;
             """).AsNumber();
 
-        Assert.Equal(14, result);
+        result.Should().Be(14);
     }
 
     [Fact]
@@ -203,7 +203,7 @@ public class EqualityLaneTests
             })()
             """).AsNumber();
 
-        Assert.Equal(414, result); // 4 even-z hits + one z=3 (+10) + four z<4 (+400)
+        result.Should().Be(414); // 4 even-z hits + one z=3 (+10) + four z<4 (+400)
     }
 
     [Fact]
@@ -226,7 +226,7 @@ public class EqualityLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("ReferenceError", result);
+        result.Should().Be("ReferenceError");
     }
 
     [Fact]
@@ -244,6 +244,6 @@ public class EqualityLaneTests
             hits;
             """).AsNumber();
 
-        Assert.Equal(3, result); // i = 0..2 while g is 1; 'x' == 1 is false afterwards
+        result.Should().Be(3); // i = 0..2 while g is 1; 'x' == 1 is false afterwards
     }
 }

--- a/Jint.Tests/Runtime/ErrorMessageSlotTests.cs
+++ b/Jint.Tests/Runtime/ErrorMessageSlotTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the observable behavior of the virtual <c>message</c> own property on error instances. The message
@@ -13,49 +13,49 @@ public class ErrorMessageSlotTests
     public void MessageIsWritableNonEnumerableConfigurableDataProperty()
     {
         var engine = E();
-        Assert.Equal("hello", engine.Evaluate("new Error('hello').message").AsString());
+        engine.Evaluate("new Error('hello').message").AsString().Should().Be("hello");
 
         engine.Execute("var d = Object.getOwnPropertyDescriptor(new Error('hello'), 'message');");
-        Assert.Equal("hello", engine.Evaluate("d.value").AsString());
-        Assert.True(engine.Evaluate("d.writable").AsBoolean());
-        Assert.False(engine.Evaluate("d.enumerable").AsBoolean());
-        Assert.True(engine.Evaluate("d.configurable").AsBoolean());
+        engine.Evaluate("d.value").AsString().Should().Be("hello");
+        engine.Evaluate("d.writable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("d.enumerable").AsBoolean().Should().BeFalse();
+        engine.Evaluate("d.configurable").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void HasOwnAndInReflectMessagePresence()
     {
         var engine = E();
-        Assert.True(engine.Evaluate("new Error('x').hasOwnProperty('message')").AsBoolean());
-        Assert.True(engine.Evaluate("'message' in new Error('x')").AsBoolean());
+        engine.Evaluate("new Error('x').hasOwnProperty('message')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'message' in new Error('x')").AsBoolean().Should().BeTrue();
         // stack stays an accessor on the prototype, not an own property.
-        Assert.False(engine.Evaluate("new Error('x').hasOwnProperty('stack')").AsBoolean());
+        engine.Evaluate("new Error('x').hasOwnProperty('stack')").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
     public void NoArgumentErrorInheritsEmptyMessage()
     {
         var engine = E();
-        Assert.Equal("", engine.Evaluate("new Error().message").AsString());
-        Assert.False(engine.Evaluate("new Error().hasOwnProperty('message')").AsBoolean());
+        engine.Evaluate("new Error().message").AsString().Should().Be("");
+        engine.Evaluate("new Error().hasOwnProperty('message')").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
     public void WritingMessageKeepsItAWritableDataProperty()
     {
         var engine = E();
-        Assert.Equal("b", engine.Evaluate("var e = new Error('a'); e.message = 'b'; e.message").AsString());
+        engine.Evaluate("var e = new Error('a'); e.message = 'b'; e.message").AsString().Should().Be("b");
         engine.Execute("var d = Object.getOwnPropertyDescriptor(e, 'message');");
-        Assert.True(engine.Evaluate("d.writable && !d.enumerable && d.configurable").AsBoolean());
+        engine.Evaluate("d.writable && !d.enumerable && d.configurable").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void DeletingMessageMakesItInheritEmptyString()
     {
         var engine = E();
-        Assert.True(engine.Evaluate("var e = new Error('x'); delete e.message").AsBoolean());
-        Assert.Equal("", engine.Evaluate("e.message").AsString());
-        Assert.False(engine.Evaluate("e.hasOwnProperty('message')").AsBoolean());
+        engine.Evaluate("var e = new Error('x'); delete e.message").AsBoolean().Should().BeTrue();
+        engine.Evaluate("e.message").AsString().Should().Be("");
+        engine.Evaluate("e.hasOwnProperty('message')").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -63,15 +63,15 @@ public class ErrorMessageSlotTests
     {
         var engine = E();
         var names = engine.Evaluate("var e = new Error('m'); e.foo = 1; e.bar = 2; Object.getOwnPropertyNames(e).join(',')").AsString();
-        Assert.Equal("message,foo,bar", names);
+        names.Should().Be("message,foo,bar");
     }
 
     [Fact]
     public void NonEnumerableMessageIsSkippedByKeysAndJsonStringify()
     {
         var engine = E();
-        Assert.Equal("foo", engine.Evaluate("var e = new Error('m'); e.foo = 1; Object.keys(e).join(',')").AsString());
-        Assert.Equal("{}", engine.Evaluate("JSON.stringify(new Error('secret'))").AsString());
+        engine.Evaluate("var e = new Error('m'); e.foo = 1; Object.keys(e).join(',')").AsString().Should().Be("foo");
+        engine.Evaluate("JSON.stringify(new Error('secret'))").AsString().Should().Be("{}");
     }
 
     [Fact]
@@ -79,9 +79,9 @@ public class ErrorMessageSlotTests
     {
         var engine = E();
         engine.Execute("var e = new Error('orig'); Object.defineProperty(e, 'message', { value: 'redef', enumerable: true });");
-        Assert.Equal("redef", engine.Evaluate("e.message").AsString());
-        Assert.True(engine.Evaluate("var d = Object.getOwnPropertyDescriptor(e, 'message'); d.enumerable && d.writable && d.configurable").AsBoolean());
-        Assert.Equal("message", engine.Evaluate("Object.keys(e).join(',')").AsString());
+        engine.Evaluate("e.message").AsString().Should().Be("redef");
+        engine.Evaluate("var d = Object.getOwnPropertyDescriptor(e, 'message'); d.enumerable && d.writable && d.configurable").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.keys(e).join(',')").AsString().Should().Be("message");
     }
 
     [Fact]
@@ -89,9 +89,9 @@ public class ErrorMessageSlotTests
     {
         var engine = E();
         engine.Execute("var e = new Error('withcause', { cause: 42 });");
-        Assert.Equal(42, engine.Evaluate("e.cause").AsNumber());
-        Assert.Equal("withcause", engine.Evaluate("e.message").AsString());
-        Assert.Equal("message,cause", engine.Evaluate("Object.getOwnPropertyNames(e).join(',')").AsString());
+        engine.Evaluate("e.cause").AsNumber().Should().Be(42);
+        engine.Evaluate("e.message").AsString().Should().Be("withcause");
+        engine.Evaluate("Object.getOwnPropertyNames(e).join(',')").AsString().Should().Be("message,cause");
     }
 
     [Fact]
@@ -99,11 +99,11 @@ public class ErrorMessageSlotTests
     {
         var engine = E();
         engine.Execute("var e = Object.freeze(new Error('frozen'));");
-        Assert.Equal("frozen", engine.Evaluate("e.message").AsString());
-        Assert.True(engine.Evaluate("Object.isFrozen(e)").AsBoolean());
-        Assert.True(engine.Evaluate("var d = Object.getOwnPropertyDescriptor(e, 'message'); !d.writable && !d.configurable").AsBoolean());
+        engine.Evaluate("e.message").AsString().Should().Be("frozen");
+        engine.Evaluate("Object.isFrozen(e)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("var d = Object.getOwnPropertyDescriptor(e, 'message'); !d.writable && !d.configurable").AsBoolean().Should().BeTrue();
         // sloppy-mode write to a frozen property is silently ignored
-        Assert.Equal("frozen", engine.Evaluate("e.message = 'nope'; e.message").AsString());
+        engine.Evaluate("e.message = 'nope'; e.message").AsString().Should().Be("frozen");
     }
 
     [Fact]
@@ -111,9 +111,9 @@ public class ErrorMessageSlotTests
     {
         var engine = E();
         engine.Execute("var e = Object.preventExtensions(new Error('m'));");
-        Assert.Equal("m", engine.Evaluate("e.message").AsString());
-        Assert.Equal("message", engine.Evaluate("Object.getOwnPropertyNames(e).join(',')").AsString());
-        Assert.False(engine.Evaluate("Object.isFrozen(e)").AsBoolean());
+        engine.Evaluate("e.message").AsString().Should().Be("m");
+        engine.Evaluate("Object.getOwnPropertyNames(e).join(',')").AsString().Should().Be("message");
+        engine.Evaluate("Object.isFrozen(e)").AsBoolean().Should().BeFalse();
     }
 
     [Theory]
@@ -127,16 +127,16 @@ public class ErrorMessageSlotTests
     public void SubtypesShareTheVirtualMessageSlot(string type)
     {
         var engine = E();
-        Assert.Equal("boom", engine.Evaluate($"new {type}('boom').message").AsString());
-        Assert.Equal($"{type}: boom", engine.Evaluate($"new {type}('boom').toString()").AsString());
-        Assert.True(engine.Evaluate($"new {type}('boom').hasOwnProperty('message')").AsBoolean());
+        engine.Evaluate($"new {type}('boom').message").AsString().Should().Be("boom");
+        engine.Evaluate($"new {type}('boom').toString()").AsString().Should().Be($"{type}: boom");
+        engine.Evaluate($"new {type}('boom').hasOwnProperty('message')").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void MessageArgumentIsCoercedToString()
     {
         var engine = E();
-        Assert.Equal("42", engine.Evaluate("new Error(42).message").AsString());
+        engine.Evaluate("new Error(42).message").AsString().Should().Be("42");
     }
 
     [Fact]
@@ -147,23 +147,23 @@ public class ErrorMessageSlotTests
 try { null.foo; }
 catch (e) { e.message + '|' + e.hasOwnProperty('message') + '|' + Object.getOwnPropertyNames(e).indexOf('message'); }").AsString();
         // message present, own, and first own key
-        Assert.StartsWith("Cannot read", result);
-        Assert.EndsWith("|true|0", result);
+        result.Should().StartWith("Cannot read");
+        result.Should().EndWith("|true|0");
     }
 
     [Fact]
     public void AssignAndSpreadSkipNonEnumerableMessage()
     {
         var engine = E();
-        Assert.True(engine.Evaluate("Object.assign({}, new Error('m')).message === undefined").AsBoolean());
-        Assert.True(engine.Evaluate("({ ...new Error('m') }).message === undefined").AsBoolean());
+        engine.Evaluate("Object.assign({}, new Error('m')).message === undefined").AsBoolean().Should().BeTrue();
+        engine.Evaluate("({ ...new Error('m') }).message === undefined").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void JavaScriptExceptionMessageReflectsVirtualMessage()
     {
         var engine = E();
-        var ex = Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Execute("throw new Error('surfaced');"));
-        Assert.Equal("surfaced", ex.Message);
+        var ex = Invoking(() => engine.Execute("throw new Error('surfaced');")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>().Which;
+        ex.Message.Should().Be("surfaced");
     }
 }

--- a/Jint.Tests/Runtime/ErrorTests.cs
+++ b/Jint.Tests/Runtime/ErrorTests.cs
@@ -17,10 +17,10 @@ var b = a.user.name;
 ";
 
         var engine = new Engine();
-        var e = Assert.Throws<JavaScriptException>(() => engine.Execute(script));
-        Assert.Equal("Cannot read properties of undefined (reading 'name')", e.Message);
-        Assert.Equal(4, e.Location.Start.Line);
-        Assert.Equal(15, e.Location.Start.Column);
+        var e = Invoking(() => engine.Execute(script)).Should().ThrowExactly<JavaScriptException>().Which;
+        e.Message.Should().Be("Cannot read properties of undefined (reading 'name')");
+        e.Location.Start.Line.Should().Be(4);
+        e.Location.Start.Column.Should().Be(15);
     }
 
     [Fact]
@@ -33,10 +33,10 @@ var c = a(b().Length);
         var engine = new Engine();
         engine.SetValue("a", new Action<string>((_) => { }));
         engine.SetValue("b", new Func<string>(() => null));
-        var e = Assert.Throws<JavaScriptException>(() => engine.Execute(script));
-        Assert.Equal("Cannot read properties of null (reading 'Length')", e.Message);
-        Assert.Equal(2, e.Location.Start.Line);
-        Assert.Equal(14, e.Location.Start.Column);
+        var e = Invoking(() => engine.Execute(script)).Should().ThrowExactly<JavaScriptException>().Which;
+        e.Message.Should().Be("Cannot read properties of null (reading 'Length')");
+        e.Location.Start.Line.Should().Be(2);
+        e.Location.Start.Column.Should().Be(14);
     }
 
     [Fact]
@@ -47,10 +47,10 @@ var c = a(b().Length);
 ";
 
         var engine = new Engine();
-        var e = Assert.Throws<JavaScriptException>(() => engine.Execute(script));
-        Assert.Equal("test is not defined", e.Message);
-        Assert.Equal(2, e.Location.Start.Line);
-        Assert.Equal(1, e.Location.Start.Column);
+        var e = Invoking(() => engine.Execute(script)).Should().ThrowExactly<JavaScriptException>().Which;
+        e.Message.Should().Be("test is not defined");
+        e.Location.Start.Line.Should().Be(2);
+        e.Location.Start.Column.Should().Be(1);
     }
 
     [Fact]
@@ -68,11 +68,11 @@ var b = function(v) {
 }
             ", "custom.js");
 
-        var e = Assert.Throws<JavaScriptException>(() => engine.Execute("var x = b(7);", "main.js"));
-        Assert.Equal("Cannot read properties of undefined (reading 'yyy')", e.Message);
-        Assert.Equal(3, e.Location.Start.Line);
-        Assert.Equal(15, e.Location.Start.Column);
-        Assert.Equal("custom.js", e.Location.SourceFile);
+        var e = Invoking(() => engine.Execute("var x = b(7);", "main.js")).Should().ThrowExactly<JavaScriptException>().Which;
+        e.Message.Should().Be("Cannot read properties of undefined (reading 'yyy')");
+        e.Location.Start.Line.Should().Be(3);
+        e.Location.Start.Column.Should().Be(15);
+        e.Location.SourceFile.Should().Be("custom.js");
 
         var stack = e.JavaScriptStackTrace;
         EqualIgnoringNewLineDifferences(@"    at a (custom.js:3:16)
@@ -95,11 +95,11 @@ var b = function(v) {
 }
             ", "custom.js");
 
-        var e = Assert.Throws<JavaScriptException>(() => engine.Execute("var x = b(7);", "main.js"));
-        Assert.Equal("Error thrown from script", e.Message);
-        Assert.Equal(3, e.Location.Start.Line);
-        Assert.Equal(8, e.Location.Start.Column);
-        Assert.Equal("custom.js", e.Location.SourceFile);
+        var e = Invoking(() => engine.Execute("var x = b(7);", "main.js")).Should().ThrowExactly<JavaScriptException>().Which;
+        e.Message.Should().Be("Error thrown from script");
+        e.Location.Start.Line.Should().Be(3);
+        e.Location.Start.Column.Should().Be(8);
+        e.Location.SourceFile.Should().Be("custom.js");
 
         var stack = e.JavaScriptStackTrace;
         EqualIgnoringNewLineDifferences(@"    at a (custom.js:3:9)
@@ -206,7 +206,7 @@ var wrap = function(v) {
         var first = engine.Evaluate("e.stack").AsString();
         var second = engine.Evaluate("e.stack").AsString();
 
-        Assert.Equal(first, second);
+        second.Should().Be(first);
         EqualIgnoringNewLineDifferences(@"    at makeError (custom.js:3:10)
     at wrap (custom.js:6:10)
     at main.js:1:9", first);
@@ -219,16 +219,16 @@ var wrap = function(v) {
 
         // Per the error-stack-accessor proposal, "stack" is an accessor property on Error.prototype,
         // not an own data property of the instance.
-        Assert.False(engine.Evaluate(@"Error().hasOwnProperty('stack')").AsBoolean());
+        engine.Evaluate(@"Error().hasOwnProperty('stack')").AsBoolean().Should().BeFalse();
 
-        Assert.True(engine.Evaluate(@"Error.prototype.hasOwnProperty('stack')").AsBoolean());
+        engine.Evaluate(@"Error.prototype.hasOwnProperty('stack')").AsBoolean().Should().BeTrue();
 
         var descriptorType = engine.Evaluate(
             @"typeof Object.getOwnPropertyDescriptor(Error.prototype, 'stack').get").AsString();
-        Assert.Equal("function", descriptorType);
+        descriptorType.Should().Be("function");
 
         // The inherited accessor still produces a string for an error instance.
-        Assert.Equal("string", engine.Evaluate(@"typeof Error().stack").AsString());
+        engine.Evaluate(@"typeof Error().stack").AsString().Should().Be("string");
     }
 
     private class Folder
@@ -260,7 +260,7 @@ var wrap = function(v) {
 
         engine.SetValue("folder", folder);
 
-        var javaScriptException = Assert.Throws<JavaScriptException>(() =>
+        var javaScriptException = Invoking(() =>
             engine.Execute(@"
                 var Test = {
                     recursive: function(folderInstance) {
@@ -273,9 +273,9 @@ var wrap = function(v) {
                 }
 
                 Test.recursive(folder);"
-            ));
+            )).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal("Cannot read properties of null (reading 'Name')", javaScriptException.Message);
+        javaScriptException.Message.Should().Be("Cannot read properties of null (reading 'Name')");
         EqualIgnoringNewLineDifferences(@"    at recursive (<anonymous>:6:44)
     at recursive (<anonymous>:8:32)
     at recursive (<anonymous>:8:32)
@@ -286,7 +286,7 @@ var wrap = function(v) {
         {
             "SubFolder2", "SubFolder1", "Root"
         };
-        Assert.Equal(expected, recordedFolderTraversalOrder);
+        recordedFolderTraversalOrder.Should().Equal(expected);
     }
 
     [Fact]
@@ -303,7 +303,7 @@ var b = function(v) {
 
 var x = b(7);";
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute(script));
+        var ex = Invoking(() => engine.Execute(script)).Should().ThrowExactly<JavaScriptException>().Which;
 
         const string expected = @"Error: Cannot read properties of undefined (reading 'yyy')
     at a (<anonymous>:2:18)
@@ -311,8 +311,8 @@ var x = b(7);";
     at <anonymous>:9:9";
 
         EqualIgnoringNewLineDifferences(expected, ex.GetJavaScriptErrorString());
-        Assert.Equal(2, ex.Location.Start.Line);
-        Assert.Equal(17, ex.Location.Start.Column);
+        ex.Location.Start.Line.Should().Be(2);
+        ex.Location.Start.Column.Should().Be(17);
     }
 
     [Fact]
@@ -338,7 +338,7 @@ var x = b(7);";
             CompileRegex = false,
             Tolerant = true
         };
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute(script, "get-item.js", parsingOptions));
+        var ex = Invoking(() => engine.Execute(script, "get-item.js", parsingOptions)).Should().ThrowExactly<JavaScriptException>().Which;
 
         const string expected = @"Error: Cannot read properties of null (reading '5')
     at getItem (get-item.js:2:22)
@@ -347,8 +347,8 @@ var x = b(7);";
 
         EqualIgnoringNewLineDifferences(expected, ex.GetJavaScriptErrorString());
 
-        Assert.Equal(2, ex.Location.Start.Line);
-        Assert.Equal(21, ex.Location.Start.Column);
+        ex.Location.Start.Line.Should().Be(2);
+        ex.Location.Start.Column.Should().Be(21);
     }
 
     // Verify #1202
@@ -397,7 +397,7 @@ try {
         engine.SetValue("HelloWorld", new HelloWorld());
         const string script = @"HelloWorld.ThrowException();";
 
-        var ex = Assert.Throws<DivideByZeroException>(() => engine.Execute(script));
+        var ex = Invoking(() => engine.Execute(script)).Should().ThrowExactly<DivideByZeroException>().Which;
 
         const string expected = "HelloWorld";
 
@@ -413,13 +413,13 @@ try {
 // line 2
 HelloWorld.ThrowException();";
 
-        var ex = Assert.Throws<DivideByZeroException>(() => engine.Execute(script));
+        var ex = Invoking(() => engine.Execute(script)).Should().ThrowExactly<DivideByZeroException>().Which;
 
-        Assert.True(JintException.TryGetJavaScriptLocation(ex, out var location));
-        Assert.Equal(3, location.Start.Line);
+        JintException.TryGetJavaScriptLocation(ex, out var location).Should().BeTrue();
+        location.Start.Line.Should().Be(3);
 
-        Assert.True(JintException.TryGetJavaScriptCallStack(ex, out var callStack));
-        Assert.Contains("3:", callStack);
+        JintException.TryGetJavaScriptCallStack(ex, out var callStack).Should().BeTrue();
+        callStack.Should().Contain("3:");
 
         // Original CLR identity preserved.
         ContainsIgnoringNewLineDifferences("HelloWorld", ex.ToString());
@@ -438,11 +438,11 @@ function inner() {
 function outer() { inner(); }
 outer();";
 
-        var ex = Assert.Throws<NotSupportedException>(() => engine.Execute(script));
+        var ex = Invoking(() => engine.Execute(script)).Should().ThrowExactly<NotSupportedException>().Which;
 
-        Assert.True(JintException.TryGetJavaScriptLocation(ex, out var location));
+        JintException.TryGetJavaScriptLocation(ex, out var location).Should().BeTrue();
         // Innermost JS site is the `new Thrower()...` call on line 3.
-        Assert.Equal(3, location.Start.Line);
+        location.Start.Line.Should().Be(3);
     }
 
     [Fact]
@@ -451,11 +451,11 @@ outer();";
         var engine = new Engine();
         engine.SetValue("Ctor", typeof(ThrowingCtor));
 
-        var ex = Assert.Throws<InvalidOperationException>(() => engine.Execute(@"
-new Ctor();"));
+        var ex = Invoking(() => engine.Execute(@"
+new Ctor();")).Should().ThrowExactly<InvalidOperationException>().Which;
 
-        Assert.True(JintException.TryGetJavaScriptLocation(ex, out var location));
-        Assert.Equal(2, location.Start.Line);
+        JintException.TryGetJavaScriptLocation(ex, out var location).Should().BeTrue();
+        location.Start.Line.Should().Be(2);
     }
 
     [Fact]
@@ -464,22 +464,22 @@ new Ctor();"));
         var engine = new Engine();
         engine.SetValue("instance", new ThrowingGetter());
 
-        var ex = Assert.Throws<InvalidOperationException>(() => engine.Execute(@"
-var x = instance.Boom;"));
+        var ex = Invoking(() => engine.Execute(@"
+var x = instance.Boom;")).Should().ThrowExactly<InvalidOperationException>().Which;
 
-        Assert.True(JintException.TryGetJavaScriptLocation(ex, out var location));
-        Assert.Equal(2, location.Start.Line);
+        JintException.TryGetJavaScriptLocation(ex, out var location).Should().BeTrue();
+        location.Start.Line.Should().Be(2);
     }
 
     [Fact]
     public void TryGetJavaScriptLocationReturnsFalseForUnannotatedException()
     {
         var unrelated = new InvalidOperationException();
-        Assert.False(JintException.TryGetJavaScriptLocation(unrelated, out _));
-        Assert.False(JintException.TryGetJavaScriptCallStack(unrelated, out _));
+        JintException.TryGetJavaScriptLocation(unrelated, out _).Should().BeFalse();
+        JintException.TryGetJavaScriptCallStack(unrelated, out _).Should().BeFalse();
 
-        Assert.False(JintException.TryGetJavaScriptLocation(null, out _));
-        Assert.False(JintException.TryGetJavaScriptCallStack(null, out _));
+        JintException.TryGetJavaScriptLocation(null, out _).Should().BeFalse();
+        JintException.TryGetJavaScriptCallStack(null, out _).Should().BeFalse();
     }
 
     private sealed class ThrowingCtor
@@ -506,8 +506,8 @@ var x = instance.Boom;"));
     {
         var engine = new Engine();
         engine.Execute($"const o = new {type}();");
-        Assert.True(engine.Evaluate($"o.constructor === {type}").AsBoolean());
-        Assert.Equal(type, engine.Evaluate("o.constructor.name").AsString());
+        engine.Evaluate($"o.constructor === {type}").AsBoolean().Should().BeTrue();
+        engine.Evaluate("o.constructor.name").AsString().Should().Be(type);
     }
 
     [Fact]
@@ -522,7 +522,7 @@ var x = instance.Boom;"));
             };
         }
 
-        var e = Assert.Throws<JavaScriptException>(() =>
+        var e = Invoking(() =>
         {
             var engine = new Engine();
 
@@ -544,9 +544,9 @@ executeFile(""first-file.js"");",
                 "main-file.js",
                 CreateParsingOptions()
             );
-        });
+        }).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal("nuм is not defined", e.Message);
+        e.Message.Should().Be("nuм is not defined");
 
         const string Expected = @"    at delegate (second-file.js:2:1)
     at delegate (first-file.js:2:1)
@@ -557,7 +557,7 @@ executeFile(""first-file.js"");",
     [Fact]
     public void ShouldReportCorrectColumn()
     {
-        var e = Assert.Throws<JavaScriptException>(() =>
+        var e = Invoking(() =>
         {
             var engine = new Engine();
             engine.Execute(@"var $variable1 = 611;
@@ -565,11 +565,11 @@ var _variable2 = 711;
 var variable3 = 678;
 
 $variable1 + -variable2 - variable3;");
-        });
+        }).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal(5, e.Location.Start.Line);
-        Assert.Equal(14, e.Location.Start.Column);
-        Assert.Equal("    at <anonymous>:5:15", e.JavaScriptStackTrace);
+        e.Location.Start.Line.Should().Be(5);
+        e.Location.Start.Column.Should().Be(14);
+        e.JavaScriptStackTrace.Should().Be("    at <anonymous>:5:15");
     }
 
     [Fact]
@@ -582,10 +582,10 @@ $variable1 + -variable2 - variable3;");
         engine.SetValue("SetFuncValue", SetFuncValue);
         engine.Execute("SetFuncValue(() => { foo.bar });");
 
-        var ex = Assert.Throws<TargetInvocationException>(() => func?.DynamicInvoke(JsValue.Undefined, Array.Empty<JsValue>()));
+        var ex = Invoking(() => func?.DynamicInvoke(JsValue.Undefined, Array.Empty<JsValue>())).Should().ThrowExactly<TargetInvocationException>().Which;
 
-        var exception = Assert.IsType<JavaScriptException>(ex.InnerException);
-        Assert.Equal("foo is not defined", exception.Message);
+        var exception = ex.InnerException.Should().BeOfType<JavaScriptException>().Which;
+        exception.Message.Should().Be("foo is not defined");
     }
 
     [Fact]
@@ -600,9 +600,9 @@ function throw_error(){
 throw_error();
             ");
 
-        var ex= Assert.Throws<JavaScriptException>(() => engine.Modules.Import("my_module"));
-        Assert.Equal(ex.Location.Start.Line, 3);
-        Assert.Equal(ex.Location.Start.Column, 10);
+        var ex= Invoking(() => engine.Modules.Import("my_module")).Should().ThrowExactly<JavaScriptException>().Which;
+        3.Should().Be(ex.Location.Start.Line);
+        10.Should().Be(ex.Location.Start.Column);
     }
 
     [Fact]
@@ -613,14 +613,14 @@ throw_error();
             SourceOffset = Position.From(234, 36)
         };
 
-        var e = Assert.Throws<JavaScriptException>(() =>
+        var e = Invoking(() =>
         {
             var engine = new Engine();
             engine.Execute("undeclaredVariable.property", "mapping-spec.json", parsingOptions);
-        });
+        }).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal(234, e.Location.Start.Line);
-        Assert.Equal("mapping-spec.json", e.Location.SourceFile);
+        e.Location.Start.Line.Should().Be(234);
+        e.Location.SourceFile.Should().Be("mapping-spec.json");
     }
 
     [Fact]
@@ -631,15 +631,15 @@ throw_error();
             SourceOffset = Position.From(10, 5)
         };
 
-        var e = Assert.Throws<JavaScriptException>(() =>
+        var e = Invoking(() =>
         {
             var engine = new Engine();
             engine.Execute("throw new Error('test error');", "test.json", parsingOptions);
-        });
+        }).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal(10, e.Location.Start.Line);
-        Assert.Equal(11, e.Location.Start.Column); // 5 (column offset) + 6 (position of 'new Error' after 'throw ')
-        Assert.Equal("test.json", e.Location.SourceFile);
+        e.Location.Start.Line.Should().Be(10);
+        e.Location.Start.Column.Should().Be(11); // 5 (column offset) + 6 (position of 'new Error' after 'throw ')
+        e.Location.SourceFile.Should().Be("test.json");
         ContainsIgnoringNewLineDifferences("test.json:10:", e.JavaScriptStackTrace!);
     }
 
@@ -651,14 +651,14 @@ throw_error();
             SourceOffset = Position.From(100, 0)
         };
 
-        var e = Assert.Throws<JavaScriptException>(() =>
+        var e = Invoking(() =>
         {
             var engine = new Engine();
             engine.Evaluate("undeclaredVariable.property", "test.json", parsingOptions);
-        });
+        }).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal(100, e.Location.Start.Line);
-        Assert.Equal("test.json", e.Location.SourceFile);
+        e.Location.Start.Line.Should().Be(100);
+        e.Location.SourceFile.Should().Be("test.json");
     }
 
     [Fact]
@@ -675,27 +675,27 @@ throw_error();
                 }
             });
 
-        var e = Assert.Throws<JavaScriptException>(() =>
+        var e = Invoking(() =>
         {
             var engine = new Engine();
             engine.Execute(preparedScript);
-        });
+        }).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal(50, e.Location.Start.Line);
-        Assert.Equal("mapping-spec.json", e.Location.SourceFile);
+        e.Location.Start.Line.Should().Be(50);
+        e.Location.SourceFile.Should().Be("mapping-spec.json");
     }
 
     private static void EqualIgnoringNewLineDifferences(string expected, string actual)
     {
         expected = expected.Replace("\r\n", "\n");
         actual = actual.Replace("\r\n", "\n");
-        Assert.Equal(expected, actual);
+        actual.Should().Be(expected);
     }
 
     private static void ContainsIgnoringNewLineDifferences(string expectedSubstring, string actualString)
     {
         expectedSubstring = expectedSubstring.Replace("\r\n", "\n");
         actualString = actualString.Replace("\r\n", "\n");
-        Assert.Contains(expectedSubstring, actualString);
+        actualString.Should().Contain(expectedSubstring);
     }
 }

--- a/Jint.Tests/Runtime/EvalTests.cs
+++ b/Jint.Tests/Runtime/EvalTests.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime;
+﻿using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -23,7 +23,7 @@ public class EvalTests
             engine.Execute("eval(src);");
         }
 
-        Assert.False(engine.Evaluate("leaked").AsBoolean());
+        engine.Evaluate("leaked").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -37,7 +37,7 @@ public class EvalTests
             engine.Execute("eval(src);");
         }
 
-        Assert.Equal("1,2,3,4", engine.Evaluate("getters.map(function (g) { return g(); }).join(',')").AsString());
+        engine.Evaluate("getters.map(function (g) { return g(); }).join(',')").AsString().Should().Be("1,2,3,4");
     }
 
     [Fact]
@@ -52,11 +52,11 @@ public class EvalTests
             """);
 
         engine.Execute("run();");
-        Assert.Equal("2,1,0", engine.Evaluate("results.join(',')").AsString());
+        engine.Evaluate("results.join(',')").AsString().Should().Be("2,1,0");
 
         // second round reuses the promoted cache entry (and possibly a pooled environment)
         engine.Execute("n = 0; results = []; run();");
-        Assert.Equal("2,1,0", engine.Evaluate("results.join(',')").AsString());
+        engine.Evaluate("results.join(',')").AsString().Should().Be("2,1,0");
     }
 
     [Fact]
@@ -64,13 +64,13 @@ public class EvalTests
     {
         var engine = NewStrictEngine();
 
-        Assert.Equal(7, engine.Evaluate("eval('function h() { return 7; } h();')").AsNumber());
+        engine.Evaluate("eval('function h() { return 7; } h();')").AsNumber().Should().Be(7);
 
         // var and function declaration sharing a name occupy one binding, function wins at instantiation
-        Assert.Equal(1, engine.Evaluate("eval('var f; function f() { return 1; } f();')").AsNumber());
+        engine.Evaluate("eval('var f; function f() { return 1; } f();')").AsNumber().Should().Be(1);
 
         // hoisting: callable before the declaration's position, sees later var assignment at call time
-        Assert.Equal(5, engine.Evaluate("eval('var r = early(); function early() { return v; } var v = 5; r === undefined ? early() : -1;')").AsNumber());
+        engine.Evaluate("eval('var r = early(); function early() { return v; } var v = 5; r === undefined ? early() : -1;')").AsNumber().Should().Be(5);
     }
 
     [Fact]
@@ -78,8 +78,8 @@ public class EvalTests
     {
         var engine = NewStrictEngine();
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("eval('const c = 1; c = 2;');"));
-        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.TypeError));
+        var ex = Invoking(() => engine.Execute("eval('const c = 1; c = 2;');")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.InstanceofOperator(engine.Intrinsics.TypeError).Should().BeTrue();
     }
 
     [Fact]
@@ -87,8 +87,8 @@ public class EvalTests
     {
         var engine = NewStrictEngine();
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("eval('t; let t = 1;');"));
-        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.ReferenceError));
+        var ex = Invoking(() => engine.Execute("eval('t; let t = 1;');")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.InstanceofOperator(engine.Intrinsics.ReferenceError).Should().BeTrue();
     }
 
     [Fact]
@@ -106,7 +106,7 @@ public class EvalTests
             engine.Execute("eval(src);");
         }
 
-        Assert.Equal(190, engine.Evaluate("total").AsNumber());
+        engine.Evaluate("total").AsNumber().Should().Be(190);
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public class EvalTests
         var engine = new Engine();
         engine.Execute("eval('var sloppyLeak = 5;');");
 
-        Assert.Equal(5, engine.Evaluate("sloppyLeak").AsNumber());
+        engine.Evaluate("sloppyLeak").AsNumber().Should().Be(5);
     }
 
     [Fact]
@@ -124,8 +124,8 @@ public class EvalTests
         var engine = new Engine();
         engine.Execute("var ivResult; (0, eval)(\"'use strict'; var iv = 3; ivResult = iv;\");");
 
-        Assert.Equal(3, engine.Evaluate("ivResult").AsNumber());
-        Assert.Equal("undefined", engine.Evaluate("typeof iv").AsString());
+        engine.Evaluate("ivResult").AsNumber().Should().Be(3);
+        engine.Evaluate("typeof iv").AsString().Should().Be("undefined");
     }
 
     [Fact]
@@ -146,7 +146,7 @@ public class EvalTests
             h();
             """);
 
-        Assert.Equal("q!,h!!", engine.Evaluate("log.join(',')").AsString());
+        engine.Evaluate("log.join(',')").AsString().Should().Be("q!,h!!");
     }
 
     [Fact]
@@ -154,7 +154,7 @@ public class EvalTests
     {
         var engine = NewStrictEngine();
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("""
+        var ex = Invoking(() => engine.Execute("""
             function f() {
                 var x = 'h';
                 eval("x += '!'");
@@ -162,8 +162,8 @@ public class EvalTests
                 { const x = 'q'; eval("x += '!'"); }
             }
             f();
-            """));
-        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.TypeError));
+            """)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.InstanceofOperator(engine.Intrinsics.TypeError).Should().BeTrue();
     }
 
     [Fact]
@@ -179,7 +179,7 @@ public class EvalTests
             eval(src);
             """);
 
-        Assert.Equal("ab,ab,ab,ab", engine.Evaluate("results.join(',')").AsString());
+        engine.Evaluate("results.join(',')").AsString().Should().Be("ab,ab,ab,ab");
     }
 
     [Fact]
@@ -200,7 +200,7 @@ public class EvalTests
             outer();
             """);
 
-        Assert.Equal("A!,B!,outerS=A!", engine.Evaluate("results.join(',')").AsString());
+        engine.Evaluate("results.join(',')").AsString().Should().Be("A!,B!,outerS=A!");
     }
 
     [Fact]
@@ -211,7 +211,7 @@ public class EvalTests
         var engine = new Engine();
         engine.Execute("eval('var undefined;'); eval('var NaN;'); eval('var Infinity;');");
 
-        Assert.Equal("undefined", engine.Evaluate("typeof undefined").AsString());
+        engine.Evaluate("typeof undefined").AsString().Should().Be("undefined");
     }
 
     [Fact]
@@ -225,6 +225,6 @@ public class EvalTests
             engine.Execute($"outer = {i}; eval(src);");
         }
 
-        Assert.Equal("1,2,3,4", engine.Evaluate("seen.join(',')").AsString());
+        engine.Evaluate("seen.join(',')").AsString().Should().Be("1,2,3,4");
     }
 }

--- a/Jint.Tests/Runtime/EvaluationContextTests.cs
+++ b/Jint.Tests/Runtime/EvaluationContextTests.cs
@@ -9,6 +9,6 @@ public class EvaluationContextTests
 
         Expression expression = new Identifier(NodeType.MemberExpression.ToString());
 
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() => AstExtensions.TryGetComputedPropertyKey(expression, mockedEngine));
+        Invoking(() => AstExtensions.TryGetComputedPropertyKey(expression, mockedEngine)).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
     }
 }

--- a/Jint.Tests/Runtime/ExecutionConstraintTests.cs
+++ b/Jint.Tests/Runtime/ExecutionConstraintTests.cs
@@ -1,4 +1,4 @@
-using Jint.Constraints;
+﻿using Jint.Constraints;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Runtime;
@@ -10,9 +10,7 @@ public class ExecutionConstraintTests
     [Fact]
     public void ShouldThrowStatementCountOverflow()
     {
-        Assert.Throws<StatementsCountOverflowException>(
-            () => new Engine(cfg => cfg.MaxStatements(100)).Evaluate("while(true);")
-        );
+        Invoking(() => new Engine(cfg => cfg.MaxStatements(100)).Evaluate("while(true);")).Should().ThrowExactly<StatementsCountOverflowException>();
     }
 
     [Fact]
@@ -24,9 +22,7 @@ public class ExecutionConstraintTests
         new Engine(cfg => cfg.MaxStatements(3)).Execute(script);
 
         // Should throw if MaxStatements is exceeded.
-        Assert.Throws<StatementsCountOverflowException>(
-            () => new Engine(cfg => cfg.MaxStatements(2)).Evaluate(script)
-        );
+        Invoking(() => new Engine(cfg => cfg.MaxStatements(2)).Evaluate(script)).Should().ThrowExactly<StatementsCountOverflowException>();
     }
 
     [Fact]
@@ -36,9 +32,7 @@ public class ExecutionConstraintTests
         // tight for-body lane; MaxStatements counts statements (its call frequency IS its
         // semantics), so it must keep the loop on the per-statement path and trip precisely.
         var engine = new Engine(cfg => cfg.MaxStatements(1_000));
-        Assert.Throws<StatementsCountOverflowException>(
-            () => engine.Evaluate("function f() { var x = 0; for (var i = 0; i < 100000; i++) { x += 1; } return x; } f();")
-        );
+        Invoking(() => engine.Evaluate("function f() { var x = 0; for (var i = 0; i < 100000; i++) { x += 1; } return x; } f();")).Should().ThrowExactly<StatementsCountOverflowException>();
     }
 
     [Fact]
@@ -53,12 +47,12 @@ public class ExecutionConstraintTests
         var engine = new Engine(cfg => cfg.Constraint(constraint));
 
         engine.Evaluate("var x = 0; x++; x + 5");
-        Assert.Equal(3, constraint.CheckCount);
+        constraint.CheckCount.Should().Be(3);
 
         // one more top-level statement -> exactly one more check
         constraint.ResetCount();
         engine.Evaluate("var x = 0; x++; x++; x + 5");
-        Assert.Equal(4, constraint.CheckCount);
+        constraint.CheckCount.Should().Be(4);
     }
 
     [Fact]
@@ -70,7 +64,7 @@ public class ExecutionConstraintTests
         var engine = new Engine(cfg => cfg.Constraint(constraint));
 
         engine.Evaluate("function f() { var x = 0; for (var i = 0; i < 1000; i++) { x += 1; } return x; } f();");
-        Assert.True(constraint.CheckCount >= 1000, $"expected at least one check per loop-body statement, got {constraint.CheckCount}");
+        constraint.CheckCount.Should().BeGreaterThanOrEqualTo(1000, $"expected at least one check per loop-body statement, got {constraint.CheckCount}");
     }
 
     private sealed class CountingConstraint : Constraint
@@ -89,17 +83,13 @@ public class ExecutionConstraintTests
     [Fact]
     public void ShouldThrowMemoryLimitExceeded()
     {
-        Assert.Throws<MemoryLimitExceededException>(
-            () => new Engine(cfg => cfg.LimitMemory(2048)).Evaluate("a=[]; while(true){ a.push(0); }")
-        );
+        Invoking(() => new Engine(cfg => cfg.LimitMemory(2048)).Evaluate("a=[]; while(true){ a.push(0); }")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     [Fact]
     public void ShouldThrowTimeout()
     {
-        Assert.Throws<TimeoutException>(
-            () => new Engine(cfg => cfg.TimeoutInterval(new TimeSpan(0, 0, 0, 0, 500))).Evaluate("while(true);")
-        );
+        Invoking(() => new Engine(cfg => cfg.TimeoutInterval(new TimeSpan(0, 0, 0, 0, 500))).Evaluate("while(true);")).Should().ThrowExactly<TimeoutException>();
     }
 
     [Fact]
@@ -109,9 +99,7 @@ public class ExecutionConstraintTests
         // tight for-body lane; a timeout is amortized (checked every N statements/iterations),
         // and must still fire inside the loop.
         var engine = new Engine(cfg => cfg.TimeoutInterval(new TimeSpan(0, 0, 0, 0, 500)));
-        Assert.Throws<TimeoutException>(
-            () => engine.Evaluate("function f() { var x = 0; for (var i = 0; i < 1; i += 0) { x += 1; } return x; } f();")
-        );
+        Invoking(() => engine.Evaluate("function f() { var x = 0; for (var i = 0; i < 1; i += 0) { x += 1; } return x; } f();")).Should().ThrowExactly<TimeoutException>();
     }
 
     [Fact]
@@ -119,9 +107,7 @@ public class ExecutionConstraintTests
     {
         // Memory limit is amortized too and must interrupt an allocating tight-lane loop.
         var engine = new Engine(cfg => cfg.LimitMemory(2_000_000));
-        Assert.Throws<MemoryLimitExceededException>(
-            () => engine.Evaluate("function f() { var s = ''; for (var i = 0; i < 1; i += 0) { s += 'aaaaaaaaaaaaaaaa'; } return s; } f();")
-        );
+        Invoking(() => engine.Evaluate("function f() { var s = ''; for (var i = 0; i < 1; i += 0) { s += 'aaaaaaaaaaaaaaaa'; } return s; } f();")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     [Fact]
@@ -132,15 +118,14 @@ public class ExecutionConstraintTests
         const string script = "function f() { var s = 0; for (var i = 0; i < 100000; i++) { s += 2; } return s; } f();";
         var unconstrained = new Engine().Evaluate(script).AsNumber();
         var constrained = new Engine(cfg => cfg.TimeoutInterval(TimeSpan.FromSeconds(30))).Evaluate(script).AsNumber();
-        Assert.Equal(unconstrained, constrained);
-        Assert.Equal(200_000, constrained);
+        constrained.Should().Be(unconstrained);
+        constrained.Should().Be(200_000);
     }
 
     [Fact]
     public void ShouldThrowExecutionCanceled()
     {
-        Assert.Throws<ExecutionCanceledException>(
-            () =>
+        Invoking(() =>
             {
                 using (var cts = new CancellationTokenSource())
                 using (var waitHandle = new ManualResetEvent(false))
@@ -195,8 +180,7 @@ public class ExecutionConstraintTests
                             mustNotBeCalled();
                         ");
                 }
-            }
-        );
+            }).Should().ThrowExactly<ExecutionCanceledException>();
     }
 
     [Fact]
@@ -211,9 +195,7 @@ public class ExecutionConstraintTests
             var result = factorial(500);
             ";
 
-        Assert.Throws<RecursionDepthOverflowException>(
-            () => new Engine(cfg => cfg.LimitRecursion()).Execute(script)
-        );
+        Invoking(() => new Engine(cfg => cfg.LimitRecursion()).Execute(script)).Should().ThrowExactly<RecursionDepthOverflowException>();
     }
 
     [Fact]
@@ -230,9 +212,7 @@ public class ExecutionConstraintTests
             });
             ";
 
-        Assert.Throws<RecursionDepthOverflowException>(
-            () => new Engine(cfg => cfg.LimitRecursion()).Execute(script)
-        );
+        Invoking(() => new Engine(cfg => cfg.LimitRecursion()).Execute(script)).Should().ThrowExactly<RecursionDepthOverflowException>();
     }
 
     [Fact]
@@ -263,9 +243,7 @@ public class ExecutionConstraintTests
             funcRoot();
             ";
 
-        Assert.Throws<RecursionDepthOverflowException>(
-            () => new Engine(cfg => cfg.LimitRecursion()).Execute(script)
-        );
+        Invoking(() => new Engine(cfg => cfg.LimitRecursion()).Execute(script)).Should().ThrowExactly<RecursionDepthOverflowException>();
     }
 
     [Fact]
@@ -307,9 +285,9 @@ public class ExecutionConstraintTests
             exception = ex;
         }
 
-        Assert.NotNull(exception);
-        Assert.Equal("funcRoot->funcA->funcB->funcC->funcD", exception.CallChain);
-        Assert.Equal("funcRoot", exception.CallExpressionReference);
+        exception.Should().NotBeNull();
+        exception.CallChain.Should().Be("funcRoot->funcA->funcB->funcC->funcD");
+        exception.CallExpressionReference.Should().Be("funcRoot");
     }
 
     [Fact]
@@ -339,9 +317,7 @@ public class ExecutionConstraintTests
             var result = factorial(38);
             ";
 
-        Assert.Throws<RecursionDepthOverflowException>(
-            () => new Engine(cfg => cfg.LimitRecursion(20)).Execute(script)
-        );
+        Invoking(() => new Engine(cfg => cfg.LimitRecursion(20)).Execute(script)).Should().ThrowExactly<RecursionDepthOverflowException>();
     }
 
     [Fact]
@@ -359,7 +335,7 @@ public class ExecutionConstraintTests
             ";
 
         var engine = new Engine(o => o.LimitRecursion(20));
-        Assert.Throws<RecursionDepthOverflowException>(() => engine.Execute(input));
+        Invoking(() => engine.Execute(input)).Should().ThrowExactly<RecursionDepthOverflowException>();
     }
 
     [Fact]
@@ -372,7 +348,7 @@ public class ExecutionConstraintTests
             cfg.Strict();
         });
 
-        var ex = Assert.Throws<RecursionDepthOverflowException>(() => engine.Evaluate(@"
+        var ex = Invoking(() => engine.Evaluate(@"
 var myarr = new Array(5000);
 for (var i = 0; i < myarr.length; i++) {
     myarr[i] = function(i) {
@@ -381,7 +357,7 @@ for (var i = 0; i < myarr.length; i++) {
 }
 
 myarr[0](0);
-"));
+")).Should().ThrowExactly<RecursionDepthOverflowException>().Which;
     }
 
     [Fact]
@@ -390,63 +366,63 @@ myarr[0](0);
         const string code = @"var obj = { get test() { return this.test + '2';  } }; obj.test;";
         var engine = new Engine(cfg => cfg.LimitRecursion(10));
 
-        Assert.Throws<RecursionDepthOverflowException>(() => engine.Evaluate(code));
+        Invoking(() => engine.Evaluate(code)).Should().ThrowExactly<RecursionDepthOverflowException>();
     }
 
     [Fact]
     public void ShouldLimitArraySizeForConcat()
     {
         var engine = new Engine(o => o.MaxStatements(1_000).MaxArraySize(1_000_000));
-        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("for (let a = [1, 2, 3];; a = a.concat(a)) ;"));
+        Invoking(() => engine.Evaluate("for (let a = [1, 2, 3];; a = a.concat(a)) ;")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     [Fact]
     public void ShouldLimitArraySizeForFill()
     {
         var engine = new Engine(o => o.MaxStatements(1_000).MaxArraySize(1_000_000));
-        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("var arr = Array(1000000000).fill(new Array(1000000000));"));
+        Invoking(() => engine.Evaluate("var arr = Array(1000000000).fill(new Array(1000000000));")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     [Fact]
     public void ShouldLimitArraySizeForJoin()
     {
         var engine = new Engine(o => o.MaxStatements(1_000).MaxArraySize(1_000_000));
-        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("new Array(2147483647).join('*')"));
+        Invoking(() => engine.Evaluate("new Array(2147483647).join('*')")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     [Fact]
     public void ShouldLimitTypedArraySizeForFill()
     {
         var engine = new Engine(o => o.MaxStatements(1_000).LimitMemory(4_000_000));
-        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("var arr = new Uint8Array(100000000); arr.fill(255);"));
+        Invoking(() => engine.Evaluate("var arr = new Uint8Array(100000000); arr.fill(255);")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     [Fact]
     public void ShouldLimitTypedArraySizeForCopyWithin()
     {
         var engine = new Engine(o => o.MaxStatements(1_000).LimitMemory(4_000_000));
-        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("var arr = new Uint8Array(100000000); arr[0] = 1; arr.copyWithin(1, 0);"));
+        Invoking(() => engine.Evaluate("var arr = new Uint8Array(100000000); arr[0] = 1; arr.copyWithin(1, 0);")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     [Fact]
     public void ShouldLimitTypedArraySizeForReverse()
     {
         var engine = new Engine(o => o.MaxStatements(1_000).LimitMemory(4_000_000));
-        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("var arr = new Uint8Array(100000000); arr.reverse();"));
+        Invoking(() => engine.Evaluate("var arr = new Uint8Array(100000000); arr.reverse();")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     [Fact]
     public void ShouldLimitTypedArraySizeForToReversed()
     {
         var engine = new Engine(o => o.MaxStatements(1_000).LimitMemory(4_000_000));
-        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("var arr = new Uint8Array(100000000); arr.toReversed();"));
+        Invoking(() => engine.Evaluate("var arr = new Uint8Array(100000000); arr.toReversed();")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     [Fact]
     public void ShouldLimitTypedArraySizeForWith()
     {
         var engine = new Engine(o => o.MaxStatements(1_000).LimitMemory(4_000_000));
-        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("var arr = new Uint8Array(100000000); arr.with(0, 1);"));
+        Invoking(() => engine.Evaluate("var arr = new Uint8Array(100000000); arr.with(0, 1);")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     // https://github.com/sebastienros/jint/issues/2486
@@ -456,8 +432,8 @@ myarr[0](0);
         // The result length (2147483647) exceeds ClrLimits.MaxArrayLength, so the size cap converts
         // a would-be OutOfMemoryException into a catchable RangeError without any constraints set.
         var engine = new Engine();
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("'x'.padStart(2147483647)"));
-        Assert.Contains("Invalid string length", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("'x'.padStart(2147483647)")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Contain("Invalid string length");
     }
 
     // https://github.com/sebastienros/jint/issues/2486
@@ -467,7 +443,7 @@ myarr[0](0);
         // The result (536870911) is below the size cap, so it must be built incrementally and the
         // memory limit must be able to interrupt it instead of allocating ~1 GB up front.
         var engine = new Engine(o => o.LimitMemory(4_000_000));
-        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("'x'.padEnd(536870911, 'ab')"));
+        Invoking(() => engine.Evaluate("'x'.padEnd(536870911, 'ab')")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     // https://github.com/sebastienros/jint/issues/2486
@@ -475,14 +451,14 @@ myarr[0](0);
     public void ShouldLimitArraySizeForArrayFrom()
     {
         var engine = new Engine(o => o.LimitMemory(4_000_000));
-        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("Array.from({ length: 50000000 });"));
+        Invoking(() => engine.Evaluate("Array.from({ length: 50000000 });")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     [Fact]
     public void ShouldLimitStringSizeForStringRaw()
     {
         var engine = new Engine(o => o.LimitMemory(4_000_000));
-        Assert.Throws<MemoryLimitExceededException>(() => engine.Evaluate("String.raw({ raw: { length: 50000000 } });"));
+        Invoking(() => engine.Evaluate("String.raw({ raw: { length: 50000000 } });")).Should().ThrowExactly<MemoryLimitExceededException>();
     }
 
     [Fact]
@@ -490,7 +466,7 @@ myarr[0](0);
     {
         // The element-collection loop in sort is interruptible: a low statement budget aborts it.
         var engine = new Engine(o => o.MaxStatements(1_000));
-        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("new Array(50000000).sort();"));
+        Invoking(() => engine.Evaluate("new Array(50000000).sort();")).Should().ThrowExactly<StatementsCountOverflowException>();
     }
 
     [Fact]
@@ -500,22 +476,22 @@ myarr[0](0);
         // runs for holes. A sparse array is used so the guard exercised is forEach's own loop, not
         // fill's (fill on a dense 50M array would trip the limit before forEach was ever reached).
         var engine = new Engine(o => o.MaxStatements(1_000));
-        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("new Array(50000000).forEach(function () {});"));
+        Invoking(() => engine.Evaluate("new Array(50000000).forEach(function () {});")).Should().ThrowExactly<StatementsCountOverflowException>();
     }
 
     [Fact]
     public void PadStartAndPadEndProduceCorrectResults()
     {
         var engine = new Engine();
-        Assert.Equal("005", engine.Evaluate("'5'.padStart(3, '0')").AsString());
-        Assert.Equal("500", engine.Evaluate("'5'.padEnd(3, '0')").AsString());
-        Assert.Equal("ab", engine.Evaluate("'ab'.padStart(1)").AsString());
-        Assert.Equal("    x", engine.Evaluate("'x'.padStart(5)").AsString());
-        Assert.Equal("x    ", engine.Evaluate("'x'.padEnd(5)").AsString());
+        engine.Evaluate("'5'.padStart(3, '0')").AsString().Should().Be("005");
+        engine.Evaluate("'5'.padEnd(3, '0')").AsString().Should().Be("500");
+        engine.Evaluate("'ab'.padStart(1)").AsString().Should().Be("ab");
+        engine.Evaluate("'x'.padStart(5)").AsString().Should().Be("    x");
+        engine.Evaluate("'x'.padEnd(5)").AsString().Should().Be("x    ");
         // Empty fill string returns the input unchanged.
-        Assert.Equal("x", engine.Evaluate("'x'.padEnd(5, '')").AsString());
-        Assert.Equal("1231231abc", engine.Evaluate("'abc'.padStart(10, '123')").AsString());
-        Assert.Equal("abc1231231", engine.Evaluate("'abc'.padEnd(10, '123')").AsString());
+        engine.Evaluate("'x'.padEnd(5, '')").AsString().Should().Be("x");
+        engine.Evaluate("'abc'.padStart(10, '123')").AsString().Should().Be("1231231abc");
+        engine.Evaluate("'abc'.padEnd(10, '123')").AsString().Should().Be("abc1231231");
     }
 
     [Fact]
@@ -529,7 +505,7 @@ myarr[0](0);
             "var fill = { toString() { sideEffect = true; return '0'; } };" +
             "'abc'.padStart(2, fill);" +
             "sideEffect;");
-        Assert.False(result.AsBoolean());
+        result.AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -544,12 +520,12 @@ myarr[0](0);
         var maxStatements = engine.Constraints.Find<MaxStatementsConstraint>()!;
         maxStatements.MaxStatements = 1;
         engine.Constraints.Reset();
-        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("a.join(',')"));
+        Invoking(() => engine.Evaluate("a.join(',')")).Should().ThrowExactly<StatementsCountOverflowException>();
 
         // With a generous budget the same array must join correctly (not the empty string).
         maxStatements.MaxStatements = 10_000_000;
         engine.Constraints.Reset();
-        Assert.StartsWith("0,1,2,3,", engine.Evaluate("a.join(',')").AsString());
+        engine.Evaluate("a.join(',')").AsString().Should().StartWith("0,1,2,3,");
     }
 
     [Fact]
@@ -563,7 +539,7 @@ myarr[0](0);
         var maxStatements = engine.Constraints.Find<MaxStatementsConstraint>()!;
         maxStatements.MaxStatements = 1;
         engine.Constraints.Reset();
-        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("Array.from(s);"));
+        Invoking(() => engine.Evaluate("Array.from(s);")).Should().ThrowExactly<StatementsCountOverflowException>();
     }
 
     [Fact]
@@ -577,7 +553,7 @@ myarr[0](0);
         var maxStatements = engine.Constraints.Find<MaxStatementsConstraint>()!;
         maxStatements.MaxStatements = 1;
         engine.Constraints.Reset();
-        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("Object.keys(a);"));
+        Invoking(() => engine.Evaluate("Object.keys(a);")).Should().ThrowExactly<StatementsCountOverflowException>();
     }
 
     [Fact]
@@ -591,7 +567,7 @@ myarr[0](0);
         var maxStatements = engine.Constraints.Find<MaxStatementsConstraint>()!;
         maxStatements.MaxStatements = 1;
         engine.Constraints.Reset();
-        Assert.Throws<StatementsCountOverflowException>(() => engine.Evaluate("m.forEach(Math.max);"));
+        Invoking(() => engine.Evaluate("m.forEach(Math.max);")).Should().ThrowExactly<StatementsCountOverflowException>();
     }
 
     [Fact]
@@ -622,25 +598,25 @@ myarr[0](0);
         void InvokeAction(Engine engine) => engine.Invoke("recursion");
 
         List<int> expected = [6, 6, 6, 6, 6];
-        Assert.Equal(expected, RunLoop(CreateEngine(), ExecuteAction));
-        Assert.Equal(expected, RunLoop(CreateEngine(), InvokeAction));
+        RunLoop(CreateEngine(), ExecuteAction).Should().Equal(expected);
+        RunLoop(CreateEngine(), InvokeAction).Should().Equal(expected);
 
         var e1 = CreateEngine();
-        Assert.Equal(expected, RunLoop(e1, ExecuteAction));
-        Assert.Equal(expected, RunLoop(e1, InvokeAction));
+        RunLoop(e1, ExecuteAction).Should().Equal(expected);
+        RunLoop(e1, InvokeAction).Should().Equal(expected);
 
         var e2 = CreateEngine();
-        Assert.Equal(expected, RunLoop(e2, InvokeAction));
-        Assert.Equal(expected, RunLoop(e2, ExecuteAction));
+        RunLoop(e2, InvokeAction).Should().Equal(expected);
+        RunLoop(e2, ExecuteAction).Should().Equal(expected);
 
         var e3 = CreateEngine();
-        Assert.Equal(expected, RunLoop(e3, InvokeAction));
-        Assert.Equal(expected, RunLoop(e3, ExecuteAction));
-        Assert.Equal(expected, RunLoop(e3, InvokeAction));
+        RunLoop(e3, InvokeAction).Should().Equal(expected);
+        RunLoop(e3, ExecuteAction).Should().Equal(expected);
+        RunLoop(e3, InvokeAction).Should().Equal(expected);
 
         var e4 = CreateEngine();
-        Assert.Equal(expected, RunLoop(e4, InvokeAction));
-        Assert.Equal(expected, RunLoop(e4, InvokeAction));
+        RunLoop(e4, InvokeAction).Should().Equal(expected);
+        RunLoop(e4, InvokeAction).Should().Equal(expected);
     }
 
     [Fact]
@@ -656,7 +632,7 @@ myarr[0](0);
         sb.Append("1");
         for (int i = 0; i < nestingDepth; i++) sb.Append("}");
 
-        Assert.Throws<ScriptPreparationException>(() => new Engine().Execute(sb.ToString()));
+        Invoking(() => new Engine().Execute(sb.ToString())).Should().ThrowExactly<ScriptPreparationException>();
     }
 
     // https://github.com/sebastienros/jint/discussions/2707
@@ -673,8 +649,8 @@ myarr[0](0);
         var engine = new Engine(cfg => cfg.CancellationToken(cts.Token));
         var hostCallCount = setup(cts, engine);
 
-        Assert.Throws<ExecutionCanceledException>(() => engine.Execute(script));
-        Assert.Equal(3, hostCallCount());
+        Invoking(() => engine.Execute(script)).Should().ThrowExactly<ExecutionCanceledException>();
+        hostCallCount().Should().Be(3);
     }
 
     [Fact]
@@ -793,8 +769,8 @@ myarr[0](0);
         var calls = 0;
         engine.SetValue("work", new Action(() => { calls++; cts.Cancel(); }));
 
-        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("work(); work();"));
-        Assert.Equal(1, calls);
+        Invoking(() => engine.Execute("work(); work();")).Should().ThrowExactly<ExecutionCanceledException>();
+        calls.Should().Be(1);
     }
 
     [Fact]
@@ -811,7 +787,7 @@ myarr[0](0);
         cts.Cancel();
 
         var wrapper = engine.GetValue("probe").AsObject();
-        Assert.Equal(42, wrapper.Get("value").AsNumber());
+        wrapper.Get("value").AsNumber().Should().Be(42);
     }
 
     [Fact]
@@ -828,7 +804,7 @@ myarr[0](0);
         Thread.Sleep(200);
 
         var wrapper = engine.GetValue("probe").AsObject();
-        Assert.Equal(42, wrapper.Get("value").AsNumber());
+        wrapper.Get("value").AsNumber().Should().Be(42);
     }
 
     [Fact]
@@ -858,8 +834,8 @@ myarr[0](0);
             }
         }));
 
-        Assert.Throws<TimeoutException>(() => engine.Execute("work(); work();"));
-        Assert.Equal(1, calls);
+        Invoking(() => engine.Execute("work(); work();")).Should().ThrowExactly<TimeoutException>();
+        calls.Should().Be(1);
     }
 
     [Fact]
@@ -878,10 +854,10 @@ myarr[0](0);
         var gate = engine.Advanced.RegisterPromise();
         engine.SetValue("gate", gate.Promise);
         engine.Evaluate("(async () => { await gate; for (var i = 0; i < 40; i++) { work(); } })()");
-        Assert.Equal(0, calls);
+        calls.Should().Be(0);
 
-        Assert.Throws<ExecutionCanceledException>(() => gate.Resolve(JsValue.Undefined));
-        Assert.Equal(3, calls);
+        Invoking(() => gate.Resolve(JsValue.Undefined)).Should().ThrowExactly<ExecutionCanceledException>();
+        calls.Should().Be(3);
     }
 
     [Fact]
@@ -931,8 +907,8 @@ myarr[0](0);
         // a dictionary target keeps member resolution uncached, so the accessor runs per read
         engine.SetValue("cfg", new Dictionary<string, object>());
 
-        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("for (var i = 0; i < 40; i++) { var v = cfg.missingKey; }"));
-        Assert.Equal(3, accesses);
+        Invoking(() => engine.Execute("for (var i = 0; i < 40; i++) { var v = cfg.missingKey; }")).Should().ThrowExactly<ExecutionCanceledException>();
+        accesses.Should().Be(3);
     }
 
     [Fact]
@@ -946,8 +922,8 @@ myarr[0](0);
         var calls = 0;
         engine.SetValue("work", new Action(() => { if (++calls == 3) { cts.Cancel(); } }));
 
-        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("for (var i = 0; i < 40; i++) { work(); }"));
-        Assert.Equal(3, calls);
+        Invoking(() => engine.Execute("for (var i = 0; i < 40; i++) { work(); }")).Should().ThrowExactly<ExecutionCanceledException>();
+        calls.Should().Be(3);
     }
 
     [Fact]
@@ -967,9 +943,9 @@ myarr[0](0);
             evaluated = engine.Debugger.Evaluate("probe.value");
         }));
 
-        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("work(); work();"));
-        Assert.Equal(42, evaluated.AsNumber());
-        Assert.Equal(1, probe.Accesses);
+        Invoking(() => engine.Execute("work(); work();")).Should().ThrowExactly<ExecutionCanceledException>();
+        evaluated.AsNumber().Should().Be(42);
+        probe.Accesses.Should().Be(1);
     }
 
     [Fact]
@@ -985,11 +961,11 @@ myarr[0](0);
         engine.SetValue("cancel", new Action(cts.Cancel));
 
         engine.Execute("function* g() { cancel(); while (true) { } } var it = g();");
-        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("it.next();"));
+        Invoking(() => engine.Execute("it.next();")).Should().ThrowExactly<ExecutionCanceledException>();
 
         // the token stays cancelled; only a leaked frame would make this idle read observe it
         var wrapper = engine.GetValue("probe").AsObject();
-        Assert.Equal(42, wrapper.Get("value").AsNumber());
+        wrapper.Get("value").AsNumber().Should().Be(42);
     }
 
     [Fact]
@@ -1005,10 +981,10 @@ myarr[0](0);
         engine.SetValue("gate", gate.Promise);
         engine.Evaluate("(async () => { await gate; cancel(); })()");
 
-        Assert.Throws<ExecutionCanceledException>(() => gate.Resolve(JsValue.Undefined));
+        Invoking(() => gate.Resolve(JsValue.Undefined)).Should().ThrowExactly<ExecutionCanceledException>();
 
         var wrapper = engine.GetValue("probe").AsObject();
-        Assert.Equal(42, wrapper.Get("value").AsNumber());
+        wrapper.Get("value").AsNumber().Should().Be(42);
     }
 
     [Fact]
@@ -1021,10 +997,10 @@ myarr[0](0);
         engine.SetValue("cancel", new Action(cts.Cancel));
 
         engine.Execute("async function* ag() { cancel(); yield 1; } var it = ag();");
-        Assert.Throws<ExecutionCanceledException>(() => engine.Execute("it.next();"));
+        Invoking(() => engine.Execute("it.next();")).Should().ThrowExactly<ExecutionCanceledException>();
 
         var wrapper = engine.GetValue("probe").AsObject();
-        Assert.Equal(42, wrapper.Get("value").AsNumber());
+        wrapper.Get("value").AsNumber().Should().Be(42);
     }
 
     [Fact]
@@ -1038,11 +1014,11 @@ myarr[0](0);
         engine.SetValue("probe", probe);
 
         engine.Execute("var sr = new ShadowRealm();");
-        Assert.ThrowsAny<Exception>(() => engine.Evaluate("sr.importValue('./does-not-exist.js', 'x')"));
+        Invoking(() => engine.Evaluate("sr.importValue('./does-not-exist.js', 'x')")).Should().Throw<Exception>();
 
         cts.Cancel();
         var wrapper = engine.GetValue("probe").AsObject();
-        Assert.Equal(42, wrapper.Get("value").AsNumber());
+        wrapper.Get("value").AsNumber().Should().Be(42);
     }
 
     [Fact]
@@ -1063,8 +1039,8 @@ myarr[0](0);
             engine.Evaluate("1;");
         }));
 
-        Assert.Throws<StatementsCountOverflowException>(() => engine.Execute("while (true) { reenter(); }"));
-        Assert.True(calls < 5000);
+        Invoking(() => engine.Execute("while (true) { reenter(); }")).Should().ThrowExactly<StatementsCountOverflowException>();
+        calls.Should().BeLessThan(5000);
     }
 
     [Fact]
@@ -1074,7 +1050,7 @@ myarr[0](0);
         var engine = new Engine(cfg => cfg.MaxStatements(100));
         for (var i = 0; i < 5; i++)
         {
-            Assert.Equal(90, engine.Evaluate("var x = 0; for (var j = 0; j < 30; j++) { x += 3; } x;").AsNumber());
+            engine.Evaluate("var x = 0; for (var j = 0; j < 30; j++) { x += 3; } x;").AsNumber().Should().Be(90);
         }
     }
 

--- a/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
+++ b/Jint.Tests/Runtime/ExtensionMethods/ExtensionMethodsTest.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Tests.Runtime.Domain;
 
 namespace Jint.Tests.Runtime.ExtensionMethods;
@@ -19,7 +19,7 @@ public class ExtensionMethodsTest
         engine.SetValue("person", person);
         var age = engine.Evaluate("person.MultiplyAge(2)").AsInteger();
 
-        Assert.Equal(70, age);
+        age.Should().Be(70);
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public class ExtensionMethodsTest
         var engine = new Engine(options);
         var result = engine.Evaluate("\"Hello World!\".Backwards()").AsString();
 
-        Assert.Equal("!dlroW olleH", result);
+        result.Should().Be("!dlroW olleH");
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class ExtensionMethodsTest
         var engine = new Engine(options);
         var result = engine.Evaluate("let numb = 27; numb.Add(13)").AsInteger();
 
-        Assert.Equal(40, result);
+        result.Should().Be(40);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class ExtensionMethodsTest
         var engine = new Engine(options);
         var result = engine.Evaluate("\"{'name':'Mickey'}\".DeserializeObject()").ToObject() as dynamic;
 
-        Assert.Equal("Mickey", result.name);
+        ((string) result.name).Should().Be("Mickey");
     }
 
     [Fact]
@@ -72,13 +72,13 @@ public class ExtensionMethodsTest
 
         //uses split function from StringPrototype
         var arr = engine.Evaluate("'yes,no'.split(',')").AsArray();
-        Assert.Equal("yes", arr[0]);
-        Assert.Equal("no", arr[1]);
+        arr[0].Should().Be("yes");
+        arr[1].Should().Be("no");
 
         //uses split function from CustomStringExtensions
         var arr2 = engine.Evaluate("'yes,no'.split(2)").AsArray();
-        Assert.Equal("ye", arr2[0]);
-        Assert.Equal("s,no", arr2[1]);
+        arr2[0].Should().Be("ye");
+        arr2[1].Should().Be("s,no");
     }
 
     [Fact]
@@ -94,8 +94,8 @@ public class ExtensionMethodsTest
 
         //uses the overridden split function from OverrideStringPrototypeExtensions
         var arr = engine.Evaluate("'yes,no'.split(',')").AsArray();
-        Assert.Equal("YES", arr[0]);
-        Assert.Equal("NO", arr[1]);
+        arr[0].Should().Be("YES");
+        arr[1].Should().Be("NO");
     }
 
     [Fact]
@@ -110,10 +110,10 @@ public class ExtensionMethodsTest
         engine.SetValue("person", person);
 
         var isBogusInPerson = engine.Evaluate("'bogus' in person").AsBoolean();
-        Assert.False(isBogusInPerson);
+        isBogusInPerson.Should().BeFalse();
 
         var propertyValue = engine.Evaluate("person.bogus");
-        Assert.Equal(JsValue.Undefined, propertyValue);
+        propertyValue.Should().BeUndefined();
     }
 
     private Engine GetLinqEngine(Action<Options> additionalConfiguration = null)
@@ -133,7 +133,7 @@ public class ExtensionMethodsTest
 
         engine.SetValue("intList", intList);
         var intSumRes = engine.Evaluate("intList.Sum()").AsNumber();
-        Assert.Equal(6, intSumRes);
+        intSumRes.Should().Be(6);
     }
 
     // TODO this fails due to double -> long assignment on FW
@@ -146,7 +146,7 @@ public class ExtensionMethodsTest
             engine.SetValue("stringList", stringList);
 
             var stringSumRes = engine.Evaluate("stringList.Sum(x => x.length)").AsNumber();
-            Assert.Equal(11, stringSumRes);
+            stringSumRes.Should().Be(11);
         }
 #endif
 
@@ -163,7 +163,7 @@ public class ExtensionMethodsTest
         engine.SetValue("stringList", stringList);
 
         var stringRes = engine.Evaluate("stringList.Select((x) => x + 'a').ToArray().join()").AsString();
-        Assert.Equal("workinga,linqa", stringRes);
+        stringRes.Should().Be("workinga,linqa");
 
         // The method ambiguity resolver is not so smart to choose the Select method with the correct number of parameters
         // Thus, the following script will not work as expected.
@@ -193,7 +193,7 @@ public class ExtensionMethodsTest
                 log('after');
             ");
 
-        Assert.Equal("foobar", observable.Last);
+        observable.Last.Should().Be("foobar");
     }
 
     [Fact]
@@ -217,7 +217,7 @@ public class ExtensionMethodsTest
 
         //System.Console.WriteLine("GenericExtensionMethodOnGenericType: result: " + result + " result.ToString(): " + result.ToString());
 
-        Assert.Equal("some text", result);
+        result.Should().Be("some text");
     }
 
     [Fact]
@@ -246,8 +246,8 @@ public class ExtensionMethodsTest
             ");
 
         var nameObservableResult = result.ToObject() as NameObservable;
-        Assert.NotNull(nameObservableResult);
-        Assert.Equal("testing yo", nameObservableResult.Last);
+        nameObservableResult.Should().NotBeNull();
+        nameObservableResult.Last.Should().Be("testing yo");
     }
 
     [Fact]
@@ -280,8 +280,8 @@ public class ExtensionMethodsTest
         var baseObservableResult = result.ToObject() as BaseObservable<string>;
 
         System.Console.WriteLine("GenericExtensionMethodOnOpenGenericType: baseObservableResult: " + baseObservableResult);
-        Assert.NotNull(baseObservableResult);
-        Assert.Equal("testing yo", baseObservableResult.Last);
+        baseObservableResult.Should().NotBeNull();
+        baseObservableResult.Last.Should().Be("testing yo");
     }
 
     [Fact]
@@ -314,8 +314,8 @@ public class ExtensionMethodsTest
         var baseObservableResult = result.ToObject() as BaseObservable<bool>;
 
         System.Console.WriteLine("GenericExtensionMethodOnOpenGenericType: baseObservableResult: " + baseObservableResult);
-        Assert.NotNull(baseObservableResult);
-        Assert.Equal(false, baseObservableResult.Last);
+        baseObservableResult.Should().NotBeNull();
+        baseObservableResult.Last.Should().BeFalse();
     }
 
     [Fact]
@@ -333,10 +333,10 @@ public class ExtensionMethodsTest
         engine.Execute("var a = [ 2, 4 ];");
 
         var selected = engine.Evaluate("JSON.stringify(a.Select(m => ({a:m,b:m})).ToArray());").AsString();
-        Assert.Equal("""[{"a":2,"b":2},{"a":4,"b":4}]""", selected);
+        selected.Should().Be("""[{"a":2,"b":2},{"a":4,"b":4}]""");
 
         var grouped1 = engine.Evaluate("a.GroupBy(m => ({a:m,b:m})).ToArray()").AsArray();
         var grouped = engine.Evaluate("JSON.stringify(a.GroupBy(m => ({a:m,b:m})).Select(x => x.Key).ToArray());").AsString();
-        Assert.Equal("""[{"a":2,"b":2},{"a":4,"b":4}]""", grouped);
+        grouped.Should().Be("""[{"a":2,"b":2},{"a":4,"b":4}]""");
     }
 }

--- a/Jint.Tests/Runtime/ForInEnumerationTests.cs
+++ b/Jint.Tests/Runtime/ForInEnumerationTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins for-in enumeration semantics against the allocation-reduction work in the for-in lane:
@@ -21,7 +21,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("a,b,c,d,e,f", result);
+        result.Should().Be("a,b,c,d,e,f");
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class ForInEnumerationTests
             s;
             """).AsNumber();
 
-        Assert.Equal(600, result);
+        result.Should().Be(600);
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("a=2,y=20,x=10", result);
+        result.Should().Be("a=2,y=20,x=10");
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("", result);
+        result.Should().Be("");
     }
 
     [Fact]
@@ -90,7 +90,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("a,b", result);
+        result.Should().Be("a,b");
     }
 
     [Fact]
@@ -110,7 +110,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("a,b", result);
+        result.Should().Be("a,b");
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("x,z,y", result);
+        result.Should().Be("x,z,y");
     }
 
     [Fact]
@@ -154,7 +154,7 @@ public class ForInEnumerationTests
             out.join(' | ');
             """).AsString();
 
-        Assert.Equal("type,id | type,id | type,id", result);
+        result.Should().Be("type,id | type,id | type,id");
     }
 
     [Fact]
@@ -169,7 +169,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("a", result);
+        result.Should().Be("a");
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("a,b", result);
+        result.Should().Be("a,b");
     }
 
     [Fact]
@@ -203,7 +203,7 @@ public class ForInEnumerationTests
             JSON.stringify([out, calls]);
             """).AsString();
 
-        Assert.Equal("[[\"a\",\"b\"],[\"ownKeys\",\"gopd:a\",\"gopd:b\"]]", result);
+        result.Should().Be("[[\"a\",\"b\"],[\"ownKeys\",\"gopd:a\",\"gopd:b\"]]");
     }
 
     [Fact]
@@ -220,7 +220,7 @@ public class ForInEnumerationTests
             """).AsString();
 
         // 6 * 6 = 36 pairs; pairs[0]=aa, pairs[7]=bb, pairs[35]=ff
-        Assert.Equal("36,aa,bb,ff", result);
+        result.Should().Be("36,aa,bb,ff");
     }
 
     [Fact]
@@ -238,7 +238,7 @@ public class ForInEnumerationTests
             """).AsString();
 
         // p -> [p,q]; q -> [p,q]  =>  p,p,q,q,p,q
-        Assert.Equal("p,p,q,q,p,q", result);
+        result.Should().Be("p,p,q,q,p,q");
     }
 
     [Fact]
@@ -263,7 +263,7 @@ public class ForInEnumerationTests
             """).AsString();
 
         // g1/g2 independently yield a,b,c; g1's 4th next() is done => the JS boolean true joins as "true".
-        Assert.Equal("a,a,b,b,c,c,true", result);
+        result.Should().Be("a,a,b,b,c,c,true");
     }
 
     [Fact]
@@ -282,7 +282,7 @@ public class ForInEnumerationTests
             rounds.join(',');
             """).AsString();
 
-        Assert.Equal("ab,ab,ab", result);
+        result.Should().Be("ab,ab,ab");
     }
 
     [Fact]
@@ -301,7 +301,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("1,2,10,key0,key1,key2,key3,key4", result);
+        result.Should().Be("1,2,10,key0,key1,key2,key3,key4");
     }
 
     [Fact]
@@ -316,7 +316,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("0,1,2,foo", result);
+        result.Should().Be("0,1,2,foo");
     }
 
     [Fact]
@@ -337,7 +337,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("0,1,5", result);
+        result.Should().Be("0,1,5");
     }
 
     [Fact]
@@ -351,7 +351,7 @@ public class ForInEnumerationTests
             allStrings;
             """).AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -370,7 +370,7 @@ public class ForInEnumerationTests
             ok;
             """).AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -384,7 +384,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("string:0,string:1,string:2,string:3", result);
+        result.Should().Be("string:0,string:1,string:2,string:3");
     }
 
     [Fact]
@@ -399,7 +399,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("0,3,7", result);
+        result.Should().Be("0,3,7");
     }
 
     [Fact]
@@ -414,7 +414,7 @@ public class ForInEnumerationTests
             n;
             """).AsNumber();
 
-        Assert.Equal(0, result);
+        result.Should().Be(0);
     }
 
     [Fact]
@@ -429,7 +429,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("0,1,zzz", result);
+        result.Should().Be("0,1,zzz");
     }
 
     [Fact]
@@ -443,7 +443,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("0,1,3", result);
+        result.Should().Be("0,1,3");
     }
 
     [Fact]
@@ -459,7 +459,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("0,1", result);
+        result.Should().Be("0,1");
     }
 
     [Fact]
@@ -473,7 +473,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("0,1,2", result);
+        result.Should().Be("0,1,2");
     }
 
     [Fact]
@@ -488,7 +488,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("0,2", result);
+        result.Should().Be("0,2");
     }
 
     [Fact]
@@ -507,7 +507,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("0,1,3", result);
+        result.Should().Be("0,1,3");
     }
 
     [Fact]
@@ -523,7 +523,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("0,1,2,3", result);
+        result.Should().Be("0,1,2,3");
     }
 
     [Fact]
@@ -537,7 +537,7 @@ public class ForInEnumerationTests
             pairs.join(',');
             """).AsString();
 
-        Assert.Equal("00,01,02,10,11,12,20,21,22", result);
+        result.Should().Be("00,01,02,10,11,12,20,21,22");
     }
 
     [Fact]
@@ -559,7 +559,7 @@ public class ForInEnumerationTests
             seq.join(',');
             """).AsString();
 
-        Assert.Equal("0,0,1,1,2,2,true", result);
+        result.Should().Be("0,0,1,1,2,2,true");
     }
 
     [Fact]
@@ -577,7 +577,7 @@ public class ForInEnumerationTests
             out.join(',');
             """).AsString();
 
-        Assert.Equal("0,1", result);
+        result.Should().Be("0,1");
     }
 
     [Fact]
@@ -595,7 +595,7 @@ public class ForInEnumerationTests
             rounds.join(',');
             """).AsString();
 
-        Assert.Equal("01,01,01", result);
+        result.Should().Be("01,01,01");
     }
 
     [Fact]
@@ -610,6 +610,6 @@ public class ForInEnumerationTests
             out.length;
             """).AsNumber();
 
-        Assert.Equal(0, result);
+        result.Should().Be(0);
     }
 }

--- a/Jint.Tests/Runtime/FunctionTests.cs
+++ b/Jint.Tests/Runtime/FunctionTests.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Jint.Native;
 using Jint.Native.Function;
 using Jint.Runtime;
@@ -13,7 +13,8 @@ public class FunctionTests
     public FunctionTests()
     {
         _engine = new Engine()
-            .SetValue("equal", new Action<object, object>(Assert.Equal));
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
     }
 
     [Fact]
@@ -22,10 +23,9 @@ public class FunctionTests
         var engine = new Engine();
         var length = ClrLimits.MaxArrayLength + 1UL;
 
-        var exception = Assert.Throws<JavaScriptException>(
-            () => engine.Evaluate($"(function(){{}}).apply(null, {{ length: {length} }});"));
+        var exception = Invoking(() => engine.Evaluate($"(function(){{}}).apply(null, {{ length: {length} }});")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.True(exception.Error.InstanceofOperator(engine.Intrinsics.RangeError));
+        exception.Error.InstanceofOperator(engine.Intrinsics.RangeError).Should().BeTrue();
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class FunctionTests
             threw
         ".Replace("LENGTH", length.ToString());
 
-        Assert.True(((JsBoolean) engine.Evaluate(script))._value);
+        ((JsBoolean) engine.Evaluate(script))._value.Should().BeTrue();
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class FunctionTests
             threw
         ";
 
-        Assert.True(((JsBoolean) engine.Evaluate(script))._value);
+        ((JsBoolean) engine.Evaluate(script))._value.Should().BeTrue();
     }
 
     [Fact]
@@ -81,15 +81,15 @@ public class FunctionTests
     {
         _engine.Evaluate("var testFunc = function (a, b, c) { return a + ', ' + b + ', ' + c + ', ' + JSON.stringify(arguments); }");
 
-        Assert.Equal("a, 1, a, {\"0\":\"a\",\"1\":1,\"2\":\"a\"}", _engine.Evaluate("testFunc('a', 1, 'a');").AsString());
-        Assert.Equal("a, 1, a, {\"0\":\"a\",\"1\":1,\"2\":\"a\"}", _engine.Evaluate("testFunc.bind('anything')('a', 1, 'a');").AsString());
+        _engine.Evaluate("testFunc('a', 1, 'a');").AsString().Should().Be("a, 1, a, {\"0\":\"a\",\"1\":1,\"2\":\"a\"}");
+        _engine.Evaluate("testFunc.bind('anything')('a', 1, 'a');").AsString().Should().Be("a, 1, a, {\"0\":\"a\",\"1\":1,\"2\":\"a\"}");
     }
 
     [Fact]
     public void ArrowFunctionShouldBeExtensible()
     {
         new Engine()
-            .SetValue("assert", new Action<bool>(Assert.True))
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
             .Execute(@"
                     var a = () => null
                     Object.defineProperty(a, 'hello', { enumerable: true, get: () => 'world' })
@@ -124,7 +124,7 @@ function execute(doc, args){
 
         var obj = engine.Evaluate("var obj = {}; execute(obj); return obj;").AsObject();
 
-        Assert.Equal("ayende", obj.Get("Name").AsString());
+        obj.Get("Name").AsString().Should().Be("ayende");
     }
 
     [Fact]
@@ -147,14 +147,14 @@ assertEqual(booleanCount, 1);
             {
                 return engine.Invoke(thisValue, "then", [JsValue.Undefined, args.At(0)]);
             }))
-            .SetValue("assertEqual", new Action<object, object>((a, b) => Assert.Equal(b, a)))
+            .SetValue("assertEqual", new Action<object, object>((a, b) => a.Should().Be(b)))
             .Execute(Script);
     }
 
     [Fact]
     public void AnonymousLambdaShouldHaveNameDefined()
     {
-        Assert.True(_engine.Evaluate("(()=>{}).hasOwnProperty('name')").AsBoolean());
+        _engine.Evaluate("(()=>{}).hasOwnProperty('name')").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -164,17 +164,17 @@ assertEqual(booleanCount, 1);
         _engine.Evaluate("function TestFunction(a, b) { this.a = a; this.b = b; }");
 
         var instanceFromClass = _engine.Construct("TestClass", "abc", 123).AsObject();
-        Assert.Equal("abc", instanceFromClass.Get("a"));
-        Assert.Equal(123, instanceFromClass.Get("b"));
+        instanceFromClass.Get("a").Should().Be("abc");
+        instanceFromClass.Get("b").Should().Be(123);
 
         var instanceFromFunction = _engine.Construct("TestFunction", "abc", 123).AsObject();
-        Assert.Equal("abc", instanceFromFunction.Get("a"));
-        Assert.Equal(123, instanceFromFunction.Get("b"));
+        instanceFromFunction.Get("a").Should().Be("abc");
+        instanceFromFunction.Get("b").Should().Be(123);
 
         var arrayInstance = (JsArray) _engine.Construct("Array", "abc", 123).AsObject();
-        Assert.Equal((uint) 2, arrayInstance.Length);
-        Assert.Equal("abc", arrayInstance[0]);
-        Assert.Equal(123, arrayInstance[1]);
+        arrayInstance.Length.Should().Be((uint) 2);
+        arrayInstance[0].Should().Be("abc");
+        arrayInstance[1].Should().Be(123);
     }
 
     [Fact]
@@ -201,13 +201,13 @@ assertEqual(booleanCount, 1);
                 })();
 ");
 
-        Assert.Equal(5, engine.Evaluate("a"));
+        engine.Evaluate("a").Should().Be(5);
 
         ev(null, []);
-        Assert.Equal(10, engine.Evaluate("a"));
+        engine.Evaluate("a").Should().Be(10);
 
         ev(null, [20]);
-        Assert.Equal(30, engine.Evaluate("a"));
+        engine.Evaluate("a").Should().Be(30);
     }
 
     [Fact]
@@ -222,7 +222,7 @@ assertEqual(booleanCount, 1);
             Object.defineProperty(target, "prop", { get: holder.getter.bind(holder) });
             target.prop;
             """);
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -248,13 +248,13 @@ assertEqual(booleanCount, 1);
                 })();
             ");
 
-        Assert.Equal(5, engine.Evaluate("a"));
+        engine.Evaluate("a").Should().Be(5);
 
         ev(null, []);
-        Assert.Equal(10, engine.Evaluate("a"));
+        engine.Evaluate("a").Should().Be(10);
 
         ev(null, [20]);
-        Assert.Equal(30, engine.Evaluate("a"));
+        engine.Evaluate("a").Should().Be(30);
     }
 
     [Fact]
@@ -272,17 +272,18 @@ assertEqual(booleanCount, 1);
 
         engine.Execute(@"addListener(Boolean)");
 
-        Assert.Equal(true, ev(JsValue.Undefined, ["test"]));
-        Assert.Equal(true, ev(JsValue.Undefined, [5]));
-        Assert.Equal(false, ev(JsValue.Undefined, [false]));
-        Assert.Equal(false, ev(JsValue.Undefined, [0]));
-        Assert.Equal(false, ev(JsValue.Undefined, [JsValue.Undefined]));
+        ev(JsValue.Undefined, ["test"]).Should().BeTrue();
+        ev(JsValue.Undefined, [5]).Should().BeTrue();
+        ev(JsValue.Undefined, [false]).Should().BeFalse();
+        ev(JsValue.Undefined, [0]).Should().BeFalse();
+        ev(JsValue.Undefined, [JsValue.Undefined]).Should().BeFalse();
     }
 
     [Fact]
     public void FunctionsShouldResolveToSameReference()
     {
-        _engine.SetValue("equal", new Action<object, object>(Assert.Equal));
+        _engine.SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
         _engine.Execute(@"
                 function testFn() {}
                 equal(testFn, testFn);
@@ -307,8 +308,8 @@ assertEqual(booleanCount, 1);
                 })")
             .As<Function>().Call();
 
-        Assert.True(result.IsInteger());
-        Assert.Equal(123, result.AsInteger());
+        result.IsInteger().Should().BeTrue();
+        result.AsInteger().Should().Be(123);
     }
 
     [Fact]
@@ -316,11 +317,11 @@ assertEqual(booleanCount, 1);
     {
         _engine.Execute("function foo() { return Array.from(arguments).join(','); }");
         var function = _engine.GetValue("foo");
-        Assert.Equal("", function.Call());
-        Assert.Equal("1", function.Call(1));
-        Assert.Equal("1,2", function.Call(1, 2));
-        Assert.Equal("1,2,3", function.Call(1, 2, 3));
-        Assert.Equal("1,2,3,4", function.Call(1, 2, 3, 4));
+        function.Call().Should().Be("");
+        function.Call(1).Should().Be("1");
+        function.Call(1, 2).Should().Be("1,2");
+        function.Call(1, 2, 3).Should().Be("1,2,3");
+        function.Call(1, 2, 3, 4).Should().Be("1,2,3,4");
     }
 
     [Fact]
@@ -328,8 +329,8 @@ assertEqual(booleanCount, 1);
     {
         var function = _engine.Evaluate("function bar(a) { return a; }; bar;");
 
-        Assert.Equal(123, _engine.Call(function, 123));
-        Assert.Equal(123, _engine.Call("bar", 123));
+        _engine.Call(function, 123).Should().Be(123);
+        _engine.Call("bar", 123).Should().Be(123);
     }
 
     [Fact]
@@ -337,8 +338,8 @@ assertEqual(booleanCount, 1);
     {
         var function = _engine.Evaluate("function baz() { return this; }; baz;");
 
-        Assert.Equal("I'm this!", TypeConverter.ToString(_engine.Call(function, "I'm this!", Arguments.Empty)));
-        Assert.Equal("I'm this!", TypeConverter.ToString(function.Call("I'm this!", Arguments.Empty)));
+        TypeConverter.ToString(_engine.Call(function, "I'm this!", Arguments.Empty)).Should().Be("I'm this!");
+        TypeConverter.ToString(function.Call("I'm this!", Arguments.Empty)).Should().Be("I'm this!");
     }
 
     [Fact]
@@ -393,8 +394,8 @@ assertEqual(booleanCount, 1);
             ])
             .ToObject();
 
-        Assert.Equal(values[0], found1);
-        Assert.Equal(values[1], found2);
+        found1.Should().Be(values[0]);
+        found2.Should().Be(values[1]);
     }
 
     [Theory]
@@ -779,14 +780,14 @@ assertEqual(booleanCount, 1);
 
         var returnValue = new Engine(options => options.RetainFunctionSourceText()).Evaluate(code);
 
-        var actualResults = Assert.IsType<JsArray>(returnValue);
-        Assert.Equal(2u, actualResults.Length);
+        var actualResults = returnValue.Should().BeOfType<JsArray>().Which;
+        actualResults.Length.Should().Be(2u);
 
-        var actualResult1 = Assert.IsType<JsString>(actualResults[0]).ToString();
-        Assert.Equal(expectedResult, actualResult1);
+        var actualResult1 = actualResults[0].Should().BeOfType<JsString>().Which.ToString();
+        actualResult1.Should().Be(expectedResult);
 
-        var actualResult2 = Assert.IsType<JsString>(actualResults[1]).ToString();
-        Assert.Same(actualResult1, actualResult2);
+        var actualResult2 = actualResults[1].Should().BeOfType<JsString>().Which.ToString();
+        actualResult2.Should().BeSameAs(actualResult1);
     }
 
     [Fact]
@@ -796,9 +797,9 @@ assertEqual(booleanCount, 1);
         // native-code placeholder rather than the original source. See issue #2560.
         var engine = new Engine();
 
-        Assert.Equal("function fn() { [native code] }", engine.Evaluate("function fn() { return 0; } fn.toString();").AsString());
-        Assert.Equal("function foo() { [native code] }", engine.Evaluate("var foo = function () {}; foo.toString();").AsString());
-        Assert.Equal("function () { [native code] }", engine.Evaluate("(() => 0).toString();").AsString());
+        engine.Evaluate("function fn() { return 0; } fn.toString();").AsString().Should().Be("function fn() { [native code] }");
+        engine.Evaluate("var foo = function () {}; foo.toString();").AsString().Should().Be("function foo() { [native code] }");
+        engine.Evaluate("(() => 0).toString();").AsString().Should().Be("function () { [native code] }");
     }
 
     [Fact]
@@ -808,14 +809,12 @@ assertEqual(booleanCount, 1);
         var engine = new Engine();
         var parsingOptions = new ScriptParsingOptions { RetainFunctionSourceText = true };
 
-        Assert.Equal(
-            "function fn() { return 0; }",
-            engine.Evaluate("function fn() { return 0; } fn.toString();", parsingOptions).AsString());
+        engine.Evaluate("function fn() { return 0; } fn.toString();", parsingOptions).AsString().Should().Be("function fn() { return 0; }");
 
         var prepared = Engine.PrepareScript(
             "function fn() { return 42; } fn.toString();",
             options: new ScriptPreparationOptions { ParsingOptions = parsingOptions });
-        Assert.Equal("function fn() { return 42; }", new Engine().Evaluate(prepared).AsString());
+        new Engine().Evaluate(prepared).AsString().Should().Be("function fn() { return 42; }");
     }
 
     [Fact]
@@ -823,7 +822,7 @@ assertEqual(booleanCount, 1);
     {
         // A prepared script must not retain its source by default: toString() falls back to native code.
         var prepared = Engine.PrepareScript("function fn() { return 0; } fn.toString();");
-        Assert.Equal("function fn() { [native code] }", new Engine().Evaluate(prepared).AsString());
+        new Engine().Evaluate(prepared).AsString().Should().Be("function fn() { [native code] }");
     }
 
     [Fact]
@@ -841,7 +840,7 @@ assertEqual(booleanCount, 1);
             var g2 = f(2);
             [g1(), g2()].join(',');
             """);
-        Assert.Equal("1,2", result.AsString());
+        result.AsString().Should().Be("1,2");
 
         // Arrow variant + repeated calls so the reuse cache (had it been populated) would be exercised.
         result = engine.Evaluate("""
@@ -850,7 +849,7 @@ assertEqual(booleanCount, 1);
             for (var i = 0; i < 3; i++) { h(i); }
             getters.map(g => g()).join(',');
             """);
-        Assert.Equal("0,1,2", result.AsString());
+        result.AsString().Should().Be("0,1,2");
     }
 
     [Fact]
@@ -867,7 +866,7 @@ assertEqual(booleanCount, 1);
             var h2 = f.call({ name: 'o2' }, 2);
             [h1().name, h2().name].join(',');
             """);
-        Assert.Equal("o1,o2", result.AsString());
+        result.AsString().Should().Be("o1,o2");
 
         // new.target variant: constructing must not rebind the escaped arrow's captured new.target.
         result = engine.Evaluate("""
@@ -876,6 +875,6 @@ assertEqual(booleanCount, 1);
             new F(2);
             '' + h1();
             """);
-        Assert.Equal("undefined", result.AsString());
+        result.AsString().Should().Be("undefined");
     }
 }

--- a/Jint.Tests/Runtime/GarbageCollectionTests.cs
+++ b/Jint.Tests/Runtime/GarbageCollectionTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using Acornima.Ast;
 
 namespace Jint.Tests.Runtime;
@@ -43,9 +43,7 @@ public class GarbageCollectionTests
         // Assert
         var usedMemoryBytesAfterJsScript = CurrentlyUsedMemory();
         var epsilon = 10 * 1024 * 1024; // allowing up to 10 MB of other allocations should be enough to prevent false positives
-        Assert.True(
-            usedMemoryBytesAfterJsScript - usedMemoryBytesBaseline < epsilon,
-            userMessage: $"""
+        (usedMemoryBytesAfterJsScript - usedMemoryBytesBaseline).Should().BeLessThan(epsilon, $"""
                           The garbage collector did not free the allocated but unreachable 200 MB from the script.;
                           Before Call : {BytesToString(usedMemoryBytesBaseline)}
                           After Call  : {BytesToString(usedMemoryBytesAfterJsScript)}
@@ -74,9 +72,7 @@ public class GarbageCollectionTests
         // Theoretical savings ≈ count * commentChars * 2 (UTF-16). Assert at least half to absorb noise.
         var minimumSavings = (long) count * commentChars; // bytes; conservative lower bound (< chars * 2)
         var actualSavings = retained - notRetained;
-        Assert.True(
-            actualSavings > minimumSavings,
-            userMessage: $"""
+        actualSavings.Should().BeGreaterThan(minimumSavings, $"""
                           Disabling RetainFunctionSourceText did not free the expected source text.
                           Retained     : {BytesToString(retained)}
                           Not retained : {BytesToString(notRetained)}
@@ -156,9 +152,7 @@ public class GarbageCollectionTests
         var aliveCount = references.Count(static r => r.IsAlive);
         GC.KeepAlive(prepared);
 
-        Assert.True(
-            aliveCount == 0,
-            userMessage: $"{aliveCount} of {count} engines were not collected — the shared prepared script still pins engines.");
+        aliveCount.Should().Be(0, $"{aliveCount} of {count} engines were not collected — the shared prepared script still pins engines.");
 
         // NoInlining so the engine reference cannot be stack-rooted in this frame across the GC.Collect calls.
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]

--- a/Jint.Tests/Runtime/GeneratorTests.cs
+++ b/Jint.Tests/Runtime/GeneratorTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 public class GeneratorTests
 {
@@ -24,7 +24,7 @@ public class GeneratorTests
             return str;
         """;
 
-        Assert.Equal("01234", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("01234");
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public class GeneratorTests
           return str;
       """;
 
-        Assert.Equal("abc", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("abc");
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class GeneratorTests
           return str;
       """;
 
-        Assert.Equal("a", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("a");
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class GeneratorTests
           return str;
       """;
 
-        Assert.Equal("", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("");
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public class GeneratorTests
           return str;
       """;
 
-        Assert.Equal("", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("");
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class GeneratorTests
           return str;
       """;
 
-        Assert.Equal("undefined", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("undefined");
     }
 
     [Fact]
@@ -136,7 +136,7 @@ public class GeneratorTests
           return str;
       """;
 
-        Assert.Equal("", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("");
     }
 
     [Fact]
@@ -144,14 +144,14 @@ public class GeneratorTests
     {
         _engine.Execute("function * generator() { yield 5; yield 6; };");
         _engine.Execute("var iterator = generator(); var item = iterator.next();");
-        Assert.Equal(5, _engine.Evaluate("item.value"));
-        Assert.False(_engine.Evaluate("item.done").AsBoolean());
+        _engine.Evaluate("item.value").Should().Be(5);
+        _engine.Evaluate("item.done").AsBoolean().Should().BeFalse();
         _engine.Execute("item = iterator.next();");
-        Assert.Equal(6, _engine.Evaluate("item.value"));
-        Assert.False(_engine.Evaluate("item.done").AsBoolean());
+        _engine.Evaluate("item.value").Should().Be(6);
+        _engine.Evaluate("item.done").AsBoolean().Should().BeFalse();
         _engine.Execute("item = iterator.next();");
-        Assert.True(_engine.Evaluate("item.value === void undefined").AsBoolean());
-        Assert.True(_engine.Evaluate("item.done").AsBoolean());
+        _engine.Evaluate("item.value === void undefined").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("item.done").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -159,14 +159,14 @@ public class GeneratorTests
     {
         _engine.Execute("var generator = function * () { yield 5; yield 6; };");
         _engine.Execute("var iterator = generator(); var item = iterator.next();");
-        Assert.Equal(5, _engine.Evaluate("item.value"));
-        Assert.False(_engine.Evaluate("item.done").AsBoolean());
+        _engine.Evaluate("item.value").Should().Be(5);
+        _engine.Evaluate("item.done").AsBoolean().Should().BeFalse();
         _engine.Execute("item = iterator.next();");
-        Assert.Equal(6, _engine.Evaluate("item.value"));
-        Assert.False(_engine.Evaluate("item.done").AsBoolean());
+        _engine.Evaluate("item.value").Should().Be(6);
+        _engine.Evaluate("item.done").AsBoolean().Should().BeFalse();
         _engine.Execute("item = iterator.next();");
-        Assert.True(_engine.Evaluate("item.value === void undefined").AsBoolean());
-        Assert.True(_engine.Evaluate("item.done").AsBoolean());
+        _engine.Evaluate("item.value === void undefined").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("item.done").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -174,14 +174,14 @@ public class GeneratorTests
     {
         _engine.Execute("var generator = function * () { yield 5; yield 6; };");
         _engine.Execute("var iterator = { g: generator, x: 5, y: 6 }.g(); var item = iterator.next();");
-        Assert.Equal(5, _engine.Evaluate("item.value"));
-        Assert.False(_engine.Evaluate("item.done").AsBoolean());
+        _engine.Evaluate("item.value").Should().Be(5);
+        _engine.Evaluate("item.done").AsBoolean().Should().BeFalse();
         _engine.Execute("item = iterator.next();");
-        Assert.Equal(6, _engine.Evaluate("item.value"));
-        Assert.False(_engine.Evaluate("item.done").AsBoolean());
+        _engine.Evaluate("item.value").Should().Be(6);
+        _engine.Evaluate("item.done").AsBoolean().Should().BeFalse();
         _engine.Execute("item = iterator.next();");
-        Assert.True(_engine.Evaluate("item.value === void undefined").AsBoolean());
-        Assert.True(_engine.Evaluate("item.done").AsBoolean());
+        _engine.Evaluate("item.value === void undefined").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("item.done").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -200,8 +200,8 @@ public class GeneratorTests
 
         _engine.Execute(Script);
 
-        Assert.Equal("foo", _engine.Evaluate("sent[0]"));
-        Assert.Equal("bar", _engine.Evaluate("sent[1]"));
+        _engine.Evaluate("sent[0]").Should().Be("foo");
+        _engine.Evaluate("sent[1]").Should().Be("bar");
     }
 
     [Fact]
@@ -223,13 +223,13 @@ public class GeneratorTests
 
         _engine.Execute(Script);
 
-        Assert.Equal(0, _engine.Evaluate("generatorFunc.next().value")); // 0
-        Assert.Equal(1, _engine.Evaluate("generatorFunc.next().value")); // 1
-        Assert.Equal(2, _engine.Evaluate("generatorFunc.next().value")); // 2
-        Assert.Equal(3, _engine.Evaluate("generatorFunc.next().value")); // 3
-        Assert.Equal(14, _engine.Evaluate("generatorFunc.next(10).value")); // 14
-        Assert.Equal(15, _engine.Evaluate("generatorFunc.next().value")); // 15
-        Assert.Equal(26, _engine.Evaluate("generatorFunc.next(10).value")); // 26
+        _engine.Evaluate("generatorFunc.next().value").Should().Be(0); // 0
+        _engine.Evaluate("generatorFunc.next().value").Should().Be(1); // 1
+        _engine.Evaluate("generatorFunc.next().value").Should().Be(2); // 2
+        _engine.Evaluate("generatorFunc.next().value").Should().Be(3); // 3
+        _engine.Evaluate("generatorFunc.next(10).value").Should().Be(14); // 14
+        _engine.Evaluate("generatorFunc.next().value").Should().Be(15); // 15
+        _engine.Evaluate("generatorFunc.next(10).value").Should().Be(26); // 26
     }
 
     [Fact]
@@ -254,17 +254,17 @@ public class GeneratorTests
 
         _engine.Execute(Script);
 
-        Assert.Equal(0, _engine.Evaluate("sequence.next().value"));
-        Assert.Equal(1, _engine.Evaluate("sequence.next().value"));
-        Assert.Equal(1, _engine.Evaluate("sequence.next().value"));
-        Assert.Equal(2, _engine.Evaluate("sequence.next().value"));
-        Assert.Equal(3, _engine.Evaluate("sequence.next().value"));
-        Assert.Equal(5, _engine.Evaluate("sequence.next().value"));
-        Assert.Equal(8, _engine.Evaluate("sequence.next().value"));
-        Assert.Equal(0, _engine.Evaluate("sequence.next(true).value"));
-        Assert.Equal(1, _engine.Evaluate("sequence.next().value"));
-        Assert.Equal(1, _engine.Evaluate("sequence.next().value"));
-        Assert.Equal(2, _engine.Evaluate("sequence.next().value"));
+        _engine.Evaluate("sequence.next().value").Should().Be(0);
+        _engine.Evaluate("sequence.next().value").Should().Be(1);
+        _engine.Evaluate("sequence.next().value").Should().Be(1);
+        _engine.Evaluate("sequence.next().value").Should().Be(2);
+        _engine.Evaluate("sequence.next().value").Should().Be(3);
+        _engine.Evaluate("sequence.next().value").Should().Be(5);
+        _engine.Evaluate("sequence.next().value").Should().Be(8);
+        _engine.Evaluate("sequence.next(true).value").Should().Be(0);
+        _engine.Evaluate("sequence.next().value").Should().Be(1);
+        _engine.Evaluate("sequence.next().value").Should().Be(1);
+        _engine.Evaluate("sequence.next().value").Should().Be(2);
     }
 
     // The following tests mirror PR #2469's AsyncTests for control-flow resume but
@@ -293,7 +293,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal(1, _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be(1);
     }
 
     [Fact]
@@ -315,7 +315,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal(1, _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be(1);
     }
 
     [Fact]
@@ -338,7 +338,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal("[1,1,0,1]", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("[1,1,0,1]");
     }
 
     [Fact]
@@ -362,7 +362,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal(1, _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be(1);
     }
 
     [Fact]
@@ -381,7 +381,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal("[1,6]", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("[1,6]");
     }
 
     [Fact]
@@ -400,7 +400,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal("[1,7]", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("[1,7]");
     }
 
     [Fact]
@@ -420,7 +420,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal("""[[1,2,"done"],3]""", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("""[[1,2,"done"],3]""");
     }
 
     [Fact]
@@ -440,7 +440,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal("""[{"0":5},0]""", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("""[{"0":5},0]""");
     }
 
     [Fact]
@@ -464,7 +464,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal(1, _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be(1);
     }
 
     [Fact]
@@ -492,7 +492,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal("[0,1]", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("[0,1]");
     }
 
     [Fact]
@@ -511,7 +511,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal("""[[1,2,"done"],3]""", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("""[[1,2,"done"],3]""");
     }
 
     [Fact]
@@ -531,7 +531,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal("""["a","b","c","d"]""", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("""["a","b","c","d"]""");
     }
 
     [Fact]
@@ -550,7 +550,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal("""["1-X-2",2]""", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("""["1-X-2",2]""");
     }
 
     [Fact]
@@ -569,7 +569,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal("""[{"a":1,"b":2,"c":"done"},3]""", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("""[{"a":1,"b":2,"c":"done"},3]""");
     }
 
     [Fact]
@@ -590,7 +590,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal("[1,1]", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("[1,1]");
     }
 
     [Fact]
@@ -610,7 +610,7 @@ public class GeneratorTests
             })()
             """;
 
-        Assert.Equal("""[1,"done"]""", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("""[1,"done"]""");
     }
 
     [Fact]
@@ -636,7 +636,7 @@ public class GeneratorTests
             })()
             """).UnwrapIfPromise(TimeSpan.FromSeconds(1));
 
-        Assert.Equal(1, result.AsNumber());
+        result.AsNumber().Should().Be(1);
     }
 
     [Fact]
@@ -663,7 +663,7 @@ public class GeneratorTests
             return JSON.stringify(out);
             """;
 
-        Assert.Equal("""[1,false,1,false,2,false,2,false,"sm",true,"sm",true]""", _engine.Evaluate(Script).AsString());
+        _engine.Evaluate(Script).AsString().Should().Be("""[1,false,1,false,2,false,2,false,"sm",true,"sm",true]""");
     }
 
     [Fact]
@@ -692,7 +692,7 @@ public class GeneratorTests
             return JSON.stringify(out);
             """;
 
-        Assert.Equal("""[1,false,1,false,2,false,2,false,"ab",true,"ab",true]""", _engine.Evaluate(Script).AsString());
+        _engine.Evaluate(Script).AsString().Should().Be("""[1,false,1,false,2,false,2,false,"ab",true,"ab",true]""");
     }
 
     [Fact]
@@ -715,7 +715,7 @@ public class GeneratorTests
             return JSON.stringify(out);
             """;
 
-        Assert.Equal("[1,1,2,2,true]", _engine.Evaluate(Script).AsString());
+        _engine.Evaluate(Script).AsString().Should().Be("[1,1,2,2,true]");
     }
 
     [Fact]
@@ -742,6 +742,6 @@ public class GeneratorTests
             })()
             """).UnwrapIfPromise(TimeSpan.FromSeconds(5));
 
-        Assert.Equal("""[1,false,1,false,2,false,2,false,"sm",true,"sm",true]""", result.AsString());
+        result.AsString().Should().Be("""[1,false,1,false,2,false,2,false,"sm",true,"sm",true]""");
     }
 }

--- a/Jint.Tests/Runtime/GenericMethodTests.cs
+++ b/Jint.Tests/Runtime/GenericMethodTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 public class GenericMethodTests
 {
@@ -16,8 +16,8 @@ public class GenericMethodTests
                 testGeneric.Add('blah');
             ");
 
-        Assert.Equal(true, TestGenericClass.BarInvoked);
-        Assert.Equal(true, TestGenericClass.FooInvoked);
+        TestGenericClass.BarInvoked.Should().BeTrue();
+        TestGenericClass.FooInvoked.Should().BeTrue();
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public class GenericMethodTests
                 testGenericObj.Add('blah');
             ");
 
-        Assert.Equal(1, testGenericObj.Count);
+        testGenericObj.Count.Should().Be(1);
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class GenericMethodTests
                 testGenericObj.Fancy('test', 42, 'foo');
             ");
 
-        Assert.Equal(true, testGenericObj.FancyInvoked);
+        testGenericObj.FancyInvoked.Should().BeTrue();
     }
 
     [Fact]
@@ -57,15 +57,15 @@ public class GenericMethodTests
         var testGenericObj = new TestGenericClass();
         engine.SetValue("testGenericObj", testGenericObj);
 
-        var argException = Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
+        var argException = Invoking(() =>
         {
             engine.Execute(@"
                     testGenericObj.Fancy('test', 'foo', 42);
                 ");
-        });
+        }).Should().ThrowExactly<Jint.Runtime.JavaScriptException>().Which;
 
         // detailed resolution errors are off by default, so the terse message is used
-        Assert.Equal("No public methods with the specified arguments were found.", argException.Message);
+        argException.Message.Should().Be("No public methods with the specified arguments were found.");
     }
 
     // TPC: TODO: tldr; typescript transpiled to javascript does not include the types in the constructors - JINT should allow you to use generics without specifying type
@@ -114,7 +114,7 @@ public class GenericMethodTests
             const result = playerChoiceManager.Store.Select(testSelectorWithoutProps);
         ");
 
-        Assert.Equal(true, ReduxStore<PlayerChoiceState>.SelectInvoked);
+        ReduxStore<PlayerChoiceState>.SelectInvoked.Should().BeTrue();
     }
 
 

--- a/Jint.Tests/Runtime/GlobalTests.cs
+++ b/Jint.Tests/Runtime/GlobalTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 public class GlobalTests
 {
@@ -7,10 +7,10 @@ public class GlobalTests
     {
         var e = new Engine();
 
-        Assert.Equal("@", e.Evaluate("unescape('%40');").AsString());
-        Assert.Equal("@_", e.Evaluate("unescape('%40_');").AsString());
-        Assert.Equal("@@", e.Evaluate("unescape('%40%40');").AsString());
-        Assert.Equal("@", e.Evaluate("unescape('%u0040');").AsString());
-        Assert.Equal("@@", e.Evaluate("unescape('%u0040%u0040');").AsString());
+        e.Evaluate("unescape('%40');").AsString().Should().Be("@");
+        e.Evaluate("unescape('%40_');").AsString().Should().Be("@_");
+        e.Evaluate("unescape('%40%40');").AsString().Should().Be("@@");
+        e.Evaluate("unescape('%u0040');").AsString().Should().Be("@");
+        e.Evaluate("unescape('%u0040%u0040');").AsString().Should().Be("@@");
     }
 }

--- a/Jint.Tests/Runtime/GuardFusionTests.cs
+++ b/Jint.Tests/Runtime/GuardFusionTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the build-time fused guard comparisons (`x === undefined`, `x === null`,
@@ -21,7 +21,7 @@ public class GuardFusionTests
             ].join(',');
             """).AsString();
 
-        Assert.Equal("true,true,false,true,true,false,false,false,false,false,false", result);
+        result.Should().Be("true,true,false,true,true,false,false,false,false,false,false");
     }
 
     [Fact]
@@ -44,15 +44,15 @@ public class GuardFusionTests
             ].join(',');
             """).AsString();
 
-        Assert.Equal("true,true,true,true,true,true,true,true,true,true,true", result);
+        result.Should().Be("true,true,true,true,true,true,true,true,true,true,true");
     }
 
     [Fact]
     public void TypeofUndeclaredIdentifierDoesNotThrow()
     {
         var engine = new Engine();
-        Assert.True(engine.Evaluate("typeof notDeclaredAnywhere === 'undefined'").AsBoolean());
-        Assert.False(engine.Evaluate("typeof notDeclaredAnywhere !== 'undefined'").AsBoolean());
+        engine.Evaluate("typeof notDeclaredAnywhere === 'undefined'").AsBoolean().Should().BeTrue();
+        engine.Evaluate("typeof notDeclaredAnywhere !== 'undefined'").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class GuardFusionTests
             [matched, calls].join(',');
             """).AsString();
 
-        Assert.Equal("false,1", result);
+        result.Should().Be("false,1");
     }
 
     [Fact]
@@ -74,8 +74,8 @@ public class GuardFusionTests
     {
         var engine = new Engine();
         engine.SetValue("clrCallback", new Func<int>(() => 42));
-        Assert.True(engine.Evaluate("typeof clrCallback === 'function'").AsBoolean());
-        Assert.False(engine.Evaluate("typeof clrCallback === 'object'").AsBoolean());
+        engine.Evaluate("typeof clrCallback === 'function'").AsBoolean().Should().BeTrue();
+        engine.Evaluate("typeof clrCallback === 'object'").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class GuardFusionTests
             f();
             """).UnwrapIfPromise().AsString();
 
-        Assert.Equal("true,true,true", result);
+        result.Should().Be("true,true,true");
     }
 
     [Fact]
@@ -112,7 +112,7 @@ public class GuardFusionTests
             log.join('');
             """).AsString();
 
-        Assert.Equal("unso", result);
+        result.Should().Be("unso");
     }
 
     [Fact]
@@ -137,15 +137,13 @@ public class GuardFusionTests
             ].join(',');
             """).AsString();
 
-        Assert.Equal(
-            "true,true,true,true," +
+        result.Should().Be("true,true,true,true," +
             "true,true,true,true," +
             "true,true," +
             "false,false,false,true," +
             "false,false,false,false,false,false," +
             "false,false,false,false," +
-            "false,false,false",
-            result);
+            "false,false,false");
     }
 
     [Fact]
@@ -169,7 +167,7 @@ public class GuardFusionTests
             ok;
             """).AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -185,7 +183,7 @@ public class GuardFusionTests
             [a, b, c, calls].join(',');
             """).AsString();
 
-        Assert.Equal("true,true,false,3", result);
+        result.Should().Be("true,true,false,3");
     }
 
     [Fact]
@@ -202,7 +200,7 @@ public class GuardFusionTests
             f();
             """).UnwrapIfPromise().AsString();
 
-        Assert.Equal("true,true,true", result);
+        result.Should().Be("true,true,true");
     }
 
     [Fact]
@@ -221,7 +219,7 @@ public class GuardFusionTests
             log.join('');
             """).AsString();
 
-        Assert.Equal("nnsoo", result);
+        result.Should().Be("nnsoo");
     }
 
     [Fact]
@@ -233,20 +231,20 @@ public class GuardFusionTests
         engine.SetValue("htmlDDA", (Jint.Native.JsValue) htmlDDA);
 
         // Annex B: loose equality with null/undefined is true (both orientations, both operators)
-        Assert.True(engine.Evaluate("htmlDDA == null").AsBoolean());
-        Assert.True(engine.Evaluate("null == htmlDDA").AsBoolean());
-        Assert.True(engine.Evaluate("htmlDDA == undefined").AsBoolean());
-        Assert.True(engine.Evaluate("undefined == htmlDDA").AsBoolean());
-        Assert.False(engine.Evaluate("htmlDDA != null").AsBoolean());
-        Assert.False(engine.Evaluate("htmlDDA != undefined").AsBoolean());
+        engine.Evaluate("htmlDDA == null").AsBoolean().Should().BeTrue();
+        engine.Evaluate("null == htmlDDA").AsBoolean().Should().BeTrue();
+        engine.Evaluate("htmlDDA == undefined").AsBoolean().Should().BeTrue();
+        engine.Evaluate("undefined == htmlDDA").AsBoolean().Should().BeTrue();
+        engine.Evaluate("htmlDDA != null").AsBoolean().Should().BeFalse();
+        engine.Evaluate("htmlDDA != undefined").AsBoolean().Should().BeFalse();
 
         // strict equality must remain false — the strict fusion path is untouched
-        Assert.False(engine.Evaluate("htmlDDA === null").AsBoolean());
-        Assert.False(engine.Evaluate("htmlDDA === undefined").AsBoolean());
-        Assert.True(engine.Evaluate("htmlDDA !== null").AsBoolean());
+        engine.Evaluate("htmlDDA === null").AsBoolean().Should().BeFalse();
+        engine.Evaluate("htmlDDA === undefined").AsBoolean().Should().BeFalse();
+        engine.Evaluate("htmlDDA !== null").AsBoolean().Should().BeTrue();
 
         // a plain object is never loosely equal to null/undefined
-        Assert.False(engine.Evaluate("({}) == null").AsBoolean());
-        Assert.False(engine.Evaluate("({}) == undefined").AsBoolean());
+        engine.Evaluate("({}) == null").AsBoolean().Should().BeFalse();
+        engine.Evaluate("({}) == undefined").AsBoolean().Should().BeFalse();
     }
 }

--- a/Jint.Tests/Runtime/InstanceOfTests.cs
+++ b/Jint.Tests/Runtime/InstanceOfTests.cs
@@ -14,16 +14,16 @@ public class InstanceOfTests
         engine.SetValue("B", TypeReference.CreateTypeReference(engine, typeof(B)));
         engine.SetValue("C", TypeReference.CreateTypeReference(engine, typeof(C)));
 
-        Assert.True(engine.Evaluate("A == A").AsBoolean());
-        Assert.True(engine.Evaluate("A === A").AsBoolean());
-        Assert.True(engine.Evaluate("A == AToo").AsBoolean());
-        Assert.True(engine.Evaluate("A === AToo").AsBoolean());
+        engine.Evaluate("A == A").AsBoolean().Should().BeTrue();
+        engine.Evaluate("A === A").AsBoolean().Should().BeTrue();
+        engine.Evaluate("A == AToo").AsBoolean().Should().BeTrue();
+        engine.Evaluate("A === AToo").AsBoolean().Should().BeTrue();
 
-        Assert.True(engine.Evaluate("A.prototype instanceof A").AsBoolean());
-        Assert.True(engine.Evaluate("B.prototype instanceof A").AsBoolean());
-        Assert.False(engine.Evaluate("A.prototype instanceof B").AsBoolean());
-        Assert.True(engine.Evaluate("C.prototype instanceof A").AsBoolean());
-        Assert.True(engine.Evaluate("C.prototype instanceof B").AsBoolean());
+        engine.Evaluate("A.prototype instanceof A").AsBoolean().Should().BeTrue();
+        engine.Evaluate("B.prototype instanceof A").AsBoolean().Should().BeTrue();
+        engine.Evaluate("A.prototype instanceof B").AsBoolean().Should().BeFalse();
+        engine.Evaluate("C.prototype instanceof A").AsBoolean().Should().BeTrue();
+        engine.Evaluate("C.prototype instanceof B").AsBoolean().Should().BeTrue();
 
         var a = new A();
         var b = new B();
@@ -33,29 +33,29 @@ public class InstanceOfTests
         engine.SetValue("b", b);
         engine.SetValue("c", c);
 
-        Assert.True(engine.Evaluate("a instanceof A").AsBoolean());
-        Assert.False(engine.Evaluate("a instanceof B").AsBoolean());
-        Assert.False(engine.Evaluate("a instanceof C").AsBoolean());
+        engine.Evaluate("a instanceof A").AsBoolean().Should().BeTrue();
+        engine.Evaluate("a instanceof B").AsBoolean().Should().BeFalse();
+        engine.Evaluate("a instanceof C").AsBoolean().Should().BeFalse();
 
-        Assert.True(engine.Evaluate("b instanceof A").AsBoolean());
-        Assert.True(engine.Evaluate("b instanceof B").AsBoolean());
-        Assert.False(engine.Evaluate("b instanceof C").AsBoolean());
+        engine.Evaluate("b instanceof A").AsBoolean().Should().BeTrue();
+        engine.Evaluate("b instanceof B").AsBoolean().Should().BeTrue();
+        engine.Evaluate("b instanceof C").AsBoolean().Should().BeFalse();
 
-        Assert.True(engine.Evaluate("c instanceof A").AsBoolean());
-        Assert.True(engine.Evaluate("c instanceof B").AsBoolean());
-        Assert.True(engine.Evaluate("c instanceof C").AsBoolean());
+        engine.Evaluate("c instanceof A").AsBoolean().Should().BeTrue();
+        engine.Evaluate("c instanceof B").AsBoolean().Should().BeTrue();
+        engine.Evaluate("c instanceof C").AsBoolean().Should().BeTrue();
 
-        Assert.True(engine.Evaluate("new A() instanceof A").AsBoolean());
-        Assert.False(engine.Evaluate("new A() instanceof B").AsBoolean());
-        Assert.False(engine.Evaluate("new A() instanceof C").AsBoolean());
+        engine.Evaluate("new A() instanceof A").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new A() instanceof B").AsBoolean().Should().BeFalse();
+        engine.Evaluate("new A() instanceof C").AsBoolean().Should().BeFalse();
 
-        Assert.True(engine.Evaluate("new B() instanceof A").AsBoolean());
-        Assert.True(engine.Evaluate("new B() instanceof B").AsBoolean());
-        Assert.False(engine.Evaluate("new B() instanceof C").AsBoolean());
+        engine.Evaluate("new B() instanceof A").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new B() instanceof B").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new B() instanceof C").AsBoolean().Should().BeFalse();
 
-        Assert.True(engine.Evaluate("new C() instanceof A").AsBoolean());
-        Assert.True(engine.Evaluate("new C() instanceof B").AsBoolean());
-        Assert.True(engine.Evaluate("new C() instanceof C").AsBoolean());
+        engine.Evaluate("new C() instanceof A").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new C() instanceof B").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new C() instanceof C").AsBoolean().Should().BeTrue();
     }
 
     public class A { }

--- a/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
+++ b/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using Jint.Native;
 
 namespace Jint.Tests.Runtime;
@@ -59,56 +59,56 @@ public class InteropCompiledInvokerTests
     public void FastLane_IntArgsAndReturn()
     {
         var engine = CreateEngine();
-        Assert.Equal(5, engine.Evaluate("host.AddInt(2, 3)").AsNumber());
+        engine.Evaluate("host.AddInt(2, 3)").AsNumber().Should().Be(5);
         // negative and zero still exact-type integers
-        Assert.Equal(-1, engine.Evaluate("host.AddInt(-4, 3)").AsNumber());
+        engine.Evaluate("host.AddInt(-4, 3)").AsNumber().Should().Be(-1);
     }
 
     [Fact]
     public void FastLane_LongArgsAndReturn()
     {
         var engine = CreateEngine();
-        Assert.Equal(7, engine.Evaluate("host.AddLong(3, 4)").AsNumber());
+        engine.Evaluate("host.AddLong(3, 4)").AsNumber().Should().Be(7);
     }
 
     [Fact]
     public void FastLane_DoubleArgsAndReturn()
     {
         var engine = CreateEngine();
-        Assert.Equal(3.75, engine.Evaluate("host.AddDouble(1.5, 2.25)").AsNumber());
+        engine.Evaluate("host.AddDouble(1.5, 2.25)").AsNumber().Should().Be(3.75);
         // integral JS numbers bind to a double parameter as well
-        Assert.Equal(5.0, engine.Evaluate("host.AddDouble(2, 3)").AsNumber());
+        engine.Evaluate("host.AddDouble(2, 3)").AsNumber().Should().Be(5.0);
     }
 
     [Fact]
     public void FastLane_BoolArgsAndReturn()
     {
         var engine = CreateEngine();
-        Assert.True(engine.Evaluate("host.And(true, true)").AsBoolean());
-        Assert.False(engine.Evaluate("host.And(true, false)").AsBoolean());
+        engine.Evaluate("host.And(true, true)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("host.And(true, false)").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
     public void FastLane_StringArgsAndReturn()
     {
         var engine = CreateEngine();
-        Assert.Equal("ab", engine.Evaluate("host.Concat('a', 'b')").AsString());
+        engine.Evaluate("host.Concat('a', 'b')").AsString().Should().Be("ab");
     }
 
     [Fact]
     public void FastLane_JsValuePassthrough()
     {
         var engine = CreateEngine();
-        Assert.Equal(42, engine.Evaluate("host.Echo(42)").AsNumber());
-        Assert.Equal("x", engine.Evaluate("host.Echo('x')").AsString());
-        Assert.True(engine.Evaluate("host.Echo(true)").AsBoolean());
+        engine.Evaluate("host.Echo(42)").AsNumber().Should().Be(42);
+        engine.Evaluate("host.Echo('x')").AsString().Should().Be("x");
+        engine.Evaluate("host.Echo(true)").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void FastLane_StaticMethod()
     {
         var engine = CreateEngine();
-        Assert.Equal(9, engine.Evaluate("host.StaticAdd(4, 5)").AsNumber());
+        engine.Evaluate("host.StaticAdd(4, 5)").AsNumber().Should().Be(9);
     }
 
     [Fact]
@@ -120,16 +120,16 @@ public class InteropCompiledInvokerTests
 
         var result = engine.Evaluate("host.DoVoid()");
         // CLR void is exposed to JS as null (not undefined) - preserved by the fast lane
-        Assert.True(result.IsNull());
-        Assert.True(host.VoidCalled);
+        result.IsNull().Should().BeTrue();
+        host.VoidCalled.Should().BeTrue();
     }
 
     [Fact]
     public void HostExceptionSurfacesAsSameClrException()
     {
         var engine = CreateEngine();
-        var ex = Assert.Throws<InvalidOperationException>(() => engine.Evaluate("host.Throws()"));
-        Assert.Equal("boom from host", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("host.Throws()")).Should().ThrowExactly<InvalidOperationException>().Which;
+        ex.Message.Should().Be("boom from host");
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class InteropCompiledInvokerTests
         // fractional numbers are not exact-type integers: the fast lane declines and the fallback
         // converter rounds (banker's rounding, 2.5 -> 2), so 2 * 2 == 4. This locks in the behavior
         // that predates the fast lane.
-        Assert.Equal(4, engine.Evaluate("host.TimesTwo(2.5)").AsNumber());
+        engine.Evaluate("host.TimesTwo(2.5)").AsNumber().Should().Be(4);
     }
 
     [Fact]
@@ -148,30 +148,30 @@ public class InteropCompiledInvokerTests
         var engine = CreateEngine();
         // a non-number argument to an int parameter is not an exact-type hit; the fallback coerces
         // the string "5" to 5, so 5 * 2 == 10.
-        Assert.Equal(10, engine.Evaluate("host.TimesTwo('5')").AsNumber());
+        engine.Evaluate("host.TimesTwo('5')").AsNumber().Should().Be(10);
     }
 
     [Fact]
     public void Fallback_OverloadedMethod()
     {
         var engine = CreateEngine();
-        Assert.Equal(6, engine.Evaluate("host.Over(5)").AsNumber());
-        Assert.Equal("hi!", engine.Evaluate("host.Over('hi')").AsString());
+        engine.Evaluate("host.Over(5)").AsNumber().Should().Be(6);
+        engine.Evaluate("host.Over('hi')").AsString().Should().Be("hi!");
     }
 
     [Fact]
     public void Fallback_ParamsMethod()
     {
         var engine = CreateEngine();
-        Assert.Equal(6, engine.Evaluate("host.SumParams(1, 2, 3)").AsNumber());
+        engine.Evaluate("host.SumParams(1, 2, 3)").AsNumber().Should().Be(6);
     }
 
     [Fact]
     public void Fallback_OptionalArgMethod()
     {
         var engine = CreateEngine();
-        Assert.Equal(15, engine.Evaluate("host.WithOptional(5)").AsNumber());
-        Assert.Equal(9, engine.Evaluate("host.WithOptional(5, 4)").AsNumber());
+        engine.Evaluate("host.WithOptional(5)").AsNumber().Should().Be(15);
+        engine.Evaluate("host.WithOptional(5, 4)").AsNumber().Should().Be(9);
     }
 
     [Fact]
@@ -183,7 +183,7 @@ public class InteropCompiledInvokerTests
         engine.SetValue("host", new Host());
 
         // AddInt returns 5, the converter turns any int into int+1 => 6
-        Assert.Equal(6, engine.Evaluate("host.AddInt(2, 3)").AsNumber());
+        engine.Evaluate("host.AddInt(2, 3)").AsNumber().Should().Be(6);
     }
 
     private sealed class PlusOneIntConverter : Jint.Runtime.Interop.IObjectConverter
@@ -209,11 +209,11 @@ public class InteropCompiledInvokerTests
         var engine = new Engine(options => options.SetTypeConverter(e => new BoolVetoingTypeConverter(e)));
         engine.SetValue("host", new Host());
 
-        var ex = Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("host.And(true, true)"));
-        Assert.Contains("No public methods", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("host.And(true, true)")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>().Which;
+        ex.Message.Should().Contain("No public methods");
 
         // conversions the veto does not touch keep working
-        Assert.Equal(5, engine.Evaluate("host.AddInt(2, 3)").AsNumber());
+        engine.Evaluate("host.AddInt(2, 3)").AsNumber().Should().Be(5);
     }
 
     private sealed class BoolVetoingTypeConverter : Jint.Runtime.Interop.DefaultTypeConverter
@@ -244,11 +244,11 @@ public class InteropCompiledInvokerTests
         engine.SetValue("host", new Host());
         engine.SetValue("other", new OtherHost());
 
-        var ex = Assert.ThrowsAny<Exception>(() => engine.Evaluate("var f = host.TimesTwo; f.call(other, 21)"));
-        Assert.IsAssignableFrom<System.Reflection.TargetException>(ex);
+        var ex = Invoking(() => engine.Evaluate("var f = host.TimesTwo; f.call(other, 21)")).Should().Throw<Exception>().Which;
+        ex.Should().BeAssignableTo<System.Reflection.TargetException>();
 
         // a correctly-typed extracted call still uses the fast lane and works
-        Assert.Equal(42, engine.Evaluate("var g = host.TimesTwo; g.call(host, 21)").AsNumber());
+        engine.Evaluate("var g = host.TimesTwo; g.call(host, 21)").AsNumber().Should().Be(42);
     }
 
     public sealed class OtherHost

--- a/Jint.Tests/Runtime/InteropDisposeTests.cs
+++ b/Jint.Tests/Runtime/InteropDisposeTests.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime;
+﻿using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -151,7 +151,7 @@ public class InteropDisposeTests
         var disposable = new FaultingAsyncDisposable();
         engine.SetValue("makeDisposable", new Func<FaultingAsyncDisposable>(() => disposable));
 
-        var error = await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+        var error = (await Awaiting(async () =>
         {
             await engine.EvaluateAsync("""
                 (async () => {
@@ -159,7 +159,7 @@ public class InteropDisposeTests
                     throw new Error("body error");
                 })()
                 """);
-        });
+        }).Should().ThrowExactlyAsync<PromiseRejectedException>()).Which;
 
         // The rejected value should be a SuppressedError. .error is the (later) dispose
         // failure — a .NET AggregateException wrapper since the Task was faulted, so its
@@ -202,7 +202,7 @@ public class InteropDisposeTests
         var disposable = new AsyncDisposable();
         engine.SetValue("makeDisposable", new Func<AsyncDisposable>(() => disposable));
 
-        var error = await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+        var error = (await Awaiting(async () =>
         {
             await engine.EvaluateAsync("""
                 (async () => {
@@ -210,7 +210,7 @@ public class InteropDisposeTests
                     throw new Error("body error");
                 })()
                 """);
-        });
+        }).Should().ThrowExactlyAsync<PromiseRejectedException>()).Which;
 
         error.RejectedValue.AsObject().Get("message").AsString().Should().Be("body error");
         disposable.Disposed.Should().BeTrue();
@@ -342,7 +342,7 @@ public class InteropDisposeTests
         engine.SetValue("makeOk", new Func<string, DelayedTrackedDisposable>(name => new DelayedTrackedDisposable(name, order)));
         engine.SetValue("makeBad", new Func<FaultingAsyncDisposable>(() => new FaultingAsyncDisposable()));
 
-        await Assert.ThrowsAsync<PromiseRejectedException>(async () =>
+        await Awaiting(async () =>
         {
             await engine.EvaluateAsync("""
                 (async () => {
@@ -351,7 +351,7 @@ public class InteropDisposeTests
                     }
                 })()
                 """);
-        });
+        }).Should().ThrowExactlyAsync<PromiseRejectedException>();
 
         // 'A' disposed first (LIFO of one), then 'makeBad' threw — 'C' should not be
         // reached because the loop's iteration aborts on dispose rejection.

--- a/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
+++ b/Jint.Tests/Runtime/InteropExplicitTypeTests.cs
@@ -93,43 +93,44 @@ public class InteropExplicitTypeTests
                     typeof(Console).Assembly,
                     typeof(File).Assembly))
                 .SetValue("log", new Action<object>(Console.WriteLine))
-                .SetValue("assert", new Action<bool>(Assert.True))
-                .SetValue("equal", new Action<object, object>(Assert.Equal))
+                .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+                .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())))
                 .SetValue("holder", holder)
         ;
     }
     [Fact]
     public void EqualTest()
     {
-        Assert.Equal(_engine.Evaluate("holder.I1"), _engine.Evaluate("holder.i1"));
-        Assert.Equal(_engine.Evaluate("holder.Super"), _engine.Evaluate("holder.super"));
+        _engine.Evaluate("holder.i1").Should().Be(_engine.Evaluate("holder.I1"));
+        _engine.Evaluate("holder.super").Should().Be(_engine.Evaluate("holder.Super"));
     }
 
     [Fact]
     public void ExplicitInterfaceFromField()
     {
-        Assert.Equal(holder.i1.Name, _engine.Evaluate("holder.i1.Name"));
-        Assert.NotEqual(holder.i1.Name, _engine.Evaluate("holder.ci1.Name"));
+        _engine.Evaluate("holder.i1.Name").Should().Be(holder.i1.Name);
+        _engine.Evaluate("holder.ci1.Name").Should().NotBe(holder.i1.Name);
     }
 
     [Fact]
     public void ExplicitInterfaceFromProperty()
     {
-        Assert.Equal(holder.I1.Name, _engine.Evaluate("holder.I1.Name"));
-        Assert.NotEqual(holder.I1.Name, _engine.Evaluate("holder.CI1.Name"));
+        _engine.Evaluate("holder.I1.Name").Should().Be(holder.I1.Name);
+        _engine.Evaluate("holder.CI1.Name").Should().NotBe(holder.I1.Name);
     }
 
     [Fact]
     public void ExplicitInterfaceFromMethod()
     {
-        Assert.Equal(holder.GetI1().Name, _engine.Evaluate("holder.GetI1().Name"));
-        Assert.NotEqual(holder.GetI1().Name, _engine.Evaluate("holder.GetCI1().Name"));
+        _engine.Evaluate("holder.GetI1().Name").Should().Be(holder.GetI1().Name);
+        _engine.Evaluate("holder.GetCI1().Name").Should().NotBe(holder.GetI1().Name);
     }
 
     [Fact]
     public void ExplicitInterfaceFromIndexer()
     {
-        Assert.Equal(holder.IndexerI1[0].Name, _engine.Evaluate("holder.IndexerI1[0].Name"));
+        _engine.Evaluate("holder.IndexerI1[0].Name").Should().Be(holder.IndexerI1[0].Name);
     }
 
     [Fact]
@@ -137,42 +138,42 @@ public class InteropExplicitTypeTests
     {
         // the default recent-wrapper cache (see #2729) reuses wrappers by object identity; the same
         // instance exposed under different CLR types must still resolve each view's own members
-        Assert.Equal("CI1", _engine.Evaluate("holder.ci1.Name").AsString());
-        Assert.Equal("CI1 as I1", _engine.Evaluate("holder.i1.Name").AsString());
-        Assert.Equal("Super", _engine.Evaluate("holder.super.Name").AsString());
+        _engine.Evaluate("holder.ci1.Name").AsString().Should().Be("CI1");
+        _engine.Evaluate("holder.i1.Name").AsString().Should().Be("CI1 as I1");
+        _engine.Evaluate("holder.super.Name").AsString().Should().Be("Super");
 
         // and in reverse order against the now-populated cache slots
-        Assert.Equal("Super", _engine.Evaluate("holder.super.Name").AsString());
-        Assert.Equal("CI1 as I1", _engine.Evaluate("holder.i1.Name").AsString());
-        Assert.Equal("CI1", _engine.Evaluate("holder.ci1.Name").AsString());
+        _engine.Evaluate("holder.super.Name").AsString().Should().Be("Super");
+        _engine.Evaluate("holder.i1.Name").AsString().Should().Be("CI1 as I1");
+        _engine.Evaluate("holder.ci1.Name").AsString().Should().Be("CI1");
     }
 
 
     [Fact]
     public void SuperClassFromField()
     {
-        Assert.Equal(holder.super.Name, _engine.Evaluate("holder.super.Name"));
-        Assert.NotEqual(holder.super.Name, _engine.Evaluate("holder.ci1.Name"));
+        _engine.Evaluate("holder.super.Name").Should().Be(holder.super.Name);
+        _engine.Evaluate("holder.ci1.Name").Should().NotBe(holder.super.Name);
     }
 
     [Fact]
     public void SuperClassFromProperty()
     {
-        Assert.Equal(holder.Super.Name, _engine.Evaluate("holder.Super.Name"));
-        Assert.NotEqual(holder.Super.Name, _engine.Evaluate("holder.CI1.Name"));
+        _engine.Evaluate("holder.Super.Name").Should().Be(holder.Super.Name);
+        _engine.Evaluate("holder.CI1.Name").Should().NotBe(holder.Super.Name);
     }
 
     [Fact]
     public void SuperClassFromMethod()
     {
-        Assert.Equal(holder.GetSuper().Name, _engine.Evaluate("holder.GetSuper().Name"));
-        Assert.NotEqual(holder.GetSuper().Name, _engine.Evaluate("holder.GetCI1().Name"));
+        _engine.Evaluate("holder.GetSuper().Name").Should().Be(holder.GetSuper().Name);
+        _engine.Evaluate("holder.GetCI1().Name").Should().NotBe(holder.GetSuper().Name);
     }
 
     [Fact]
     public void SuperClassFromIndexer()
     {
-        Assert.Equal(holder.IndexerSuper[0].Name, _engine.Evaluate("holder.IndexerSuper[0].Name"));
+        _engine.Evaluate("holder.IndexerSuper[0].Name").Should().Be(holder.IndexerSuper[0].Name);
     }
 
     [Fact]
@@ -182,9 +183,9 @@ public class InteropExplicitTypeTests
         var holder = new BaseValueHolder();
         engine.SetValue("holder", holder);
 
-        Assert.Equal("base", engine.Evaluate("holder.Value.BaseOnly"));
+        engine.Evaluate("holder.Value.BaseOnly").Should().Be("base");
         engine.Execute("const obj = holder.Value; obj.DerivedOnlyProperty = 123;");
-        Assert.Equal(123, ((DerivedValue) holder.Value).DerivedOnlyProperty);
+        ((DerivedValue) holder.Value).DerivedOnlyProperty.Should().Be(123);
     }
 
     public struct NullabeStruct : I1
@@ -212,24 +213,24 @@ public class InteropExplicitTypeTests
         _engine.SetValue("nullableHolder", nullableHolder);
         _engine.SetValue("nullabeStruct", new NullabeStruct());
 
-        Assert.Equal(_engine.Evaluate("nullableHolder.NullabeStruct"), JsValue.Null);
+        _engine.Evaluate("nullableHolder.NullabeStruct").Should().Be(JsValue.Null);
         _engine.Evaluate("nullableHolder.NullabeStruct = nullabeStruct");
-        Assert.Equal(_engine.Evaluate("nullableHolder.NullabeStruct.Name"), nullableHolder.NullabeStruct?.Name);
+        _engine.Evaluate("nullableHolder.NullabeStruct.Name").Should().Be(nullableHolder.NullabeStruct?.Name);
     }
 
     [Fact]
     public void ClrHelperUnwrap()
     {
-        Assert.NotEqual(holder.CI1.Name, _engine.Evaluate("holder.I1.Name"));
-        Assert.Equal(holder.CI1.Name, _engine.Evaluate("clrHelper.unwrap(holder.I1).Name"));
+        _engine.Evaluate("holder.I1.Name").Should().NotBe(holder.CI1.Name);
+        _engine.Evaluate("clrHelper.unwrap(holder.I1).Name").Should().Be(holder.CI1.Name);
     }
 
     [Fact]
     public void ClrHelperWrap()
     {
         _engine.Execute("Jint = importNamespace('Jint');");
-        Assert.NotEqual(holder.I1.Name, _engine.Evaluate("holder.CI1.Name"));
-        Assert.Equal(holder.I1.Name, _engine.Evaluate("clrHelper.wrap(holder.CI1, Jint.Tests.Runtime.InteropExplicitTypeTests.I1).Name"));
+        _engine.Evaluate("holder.CI1.Name").Should().NotBe(holder.I1.Name);
+        _engine.Evaluate("clrHelper.wrap(holder.CI1, Jint.Tests.Runtime.InteropExplicitTypeTests.I1).Name").Should().Be(holder.I1.Name);
     }
 
     [Fact]
@@ -238,7 +239,7 @@ public class InteropExplicitTypeTests
         Action<Engine> runner = engine =>
         {
             engine.SetValue("clrobj", new object());
-            Assert.Equal(engine.Evaluate("System.Object"), engine.Evaluate("clrHelper.typeOf(clrobj)"));
+            engine.Evaluate("clrHelper.typeOf(clrobj)").Should().Be(engine.Evaluate("System.Object"));
         };
 
         runner.Invoke(new Engine(cfg =>
@@ -247,14 +248,14 @@ public class InteropExplicitTypeTests
             cfg.Interop.AllowGetType = true;
         }));
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Invoking(() =>
         {
             runner.Invoke(new Engine(cfg =>
             {
                 cfg.AllowClr();
             }));
-        });
-        Assert.Equal("Invalid when Engine.Options.Interop.AllowGetType == false", ex.Message);
+        }).Should().ThrowExactly<InvalidOperationException>().Which;
+        ex.Message.Should().Be("Invalid when Engine.Options.Interop.AllowGetType == false");
     }
 
     [Fact]
@@ -268,8 +269,8 @@ public class InteropExplicitTypeTests
 
         engine.SetValue("holder", holder);
         engine.Execute("Jint = importNamespace('Jint');");
-        Assert.Equal(engine.Evaluate("Jint.Tests.Runtime.InteropExplicitTypeTests.CI1"), engine.Evaluate("clrHelper.typeOf(holder.CI1)"));
-        Assert.Equal(engine.Evaluate("Jint.Tests.Runtime.InteropExplicitTypeTests.I1"), engine.Evaluate("clrHelper.typeOf(holder.I1)"));
+        engine.Evaluate("clrHelper.typeOf(holder.CI1)").Should().Be(engine.Evaluate("Jint.Tests.Runtime.InteropExplicitTypeTests.CI1"));
+        engine.Evaluate("clrHelper.typeOf(holder.I1)").Should().Be(engine.Evaluate("Jint.Tests.Runtime.InteropExplicitTypeTests.I1"));
     }
 
     public class TypeHolder
@@ -283,8 +284,8 @@ public class InteropExplicitTypeTests
         Action<Engine> runner = engine =>
         {
             engine.SetValue("TypeHolder", typeof(TypeHolder));
-            Assert.True(engine.Evaluate("TypeHolder") is TypeReference);
-            Assert.True(engine.Evaluate("clrHelper.typeToObject(TypeHolder)") is ObjectWrapper);
+            engine.Evaluate("TypeHolder").Should().BeAssignableTo<TypeReference>();
+            engine.Evaluate("clrHelper.typeToObject(TypeHolder)").Should().BeAssignableTo<ObjectWrapper>();
         };
 
         runner.Invoke(new Engine(cfg =>
@@ -293,14 +294,14 @@ public class InteropExplicitTypeTests
             cfg.Interop.AllowGetType = true;
         }));
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Invoking(() =>
         {
             runner.Invoke(new Engine(cfg =>
             {
                 cfg.AllowClr();
             }));
-        });
-        Assert.Equal("Invalid when Engine.Options.Interop.AllowGetType == false", ex.Message);
+        }).Should().ThrowExactly<InvalidOperationException>().Which;
+        ex.Message.Should().Be("Invalid when Engine.Options.Interop.AllowGetType == false");
     }
 
     [Fact]
@@ -309,8 +310,8 @@ public class InteropExplicitTypeTests
         Action<Engine> runner = engine =>
         {
             engine.SetValue("TypeHolder", typeof(TypeHolder));
-            Assert.True(engine.Evaluate("TypeHolder.Type") is ObjectWrapper);
-            Assert.True(engine.Evaluate("clrHelper.objectToType(TypeHolder.Type)") is TypeReference);
+            engine.Evaluate("TypeHolder.Type").Should().BeAssignableTo<ObjectWrapper>();
+            engine.Evaluate("clrHelper.objectToType(TypeHolder.Type)").Should().BeAssignableTo<TypeReference>();
         };
 
         runner.Invoke(new Engine(cfg =>
@@ -319,14 +320,14 @@ public class InteropExplicitTypeTests
             cfg.Interop.AllowGetType = true;
         }));
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Invoking(() =>
         {
             runner.Invoke(new Engine(cfg =>
             {
                 cfg.AllowClr();
             }));
-        });
-        Assert.Equal("Invalid when Engine.Options.Interop.AllowGetType == false", ex.Message);
+        }).Should().ThrowExactly<InvalidOperationException>().Which;
+        ex.Message.Should().Be("Invalid when Engine.Options.Interop.AllowGetType == false");
     }
 
     public interface ICallObjectMethodFromInterface
@@ -351,7 +352,7 @@ public class InteropExplicitTypeTests
     {
         var inst = new CallObjectMethodFromInterface();
         _engine.SetValue("inst", inst);
-        Assert.Equal(inst.Instance.ToString(), _engine.Evaluate("inst.Instance.ToString()"));
+        _engine.Evaluate("inst.Instance.ToString()").Should().Be(inst.Instance.ToString());
     }
 
     [Fact]
@@ -359,7 +360,7 @@ public class InteropExplicitTypeTests
     {
         var inst = new CallObjectMethodFromInterface();
         _engine.SetValue("inst", inst);
-        Assert.Equal(inst.Instance.GetHashCode(), _engine.Evaluate("inst.Instance.GetHashCode()"));
+        _engine.Evaluate("inst.Instance.GetHashCode()").Should().Be(inst.Instance.GetHashCode());
     }
 
     [Fact(Skip = "TODO, no solution now.")]
@@ -367,10 +368,7 @@ public class InteropExplicitTypeTests
     {
         var inst = new CallObjectMethodFromInterface();
         _engine.SetValue("inst", inst);
-        Assert.Equal(
-            (inst.Instance as object).GetHashCode(),
-            _engine.Evaluate("clrHelper.unwrap(inst.Instance).GetHashCode()")
-        );
+        _engine.Evaluate("clrHelper.unwrap(inst.Instance).GetHashCode()").Should().Be((inst.Instance as object).GetHashCode());
     }
 
     [Fact]
@@ -378,7 +376,7 @@ public class InteropExplicitTypeTests
     {
         var inst = new CallObjectMethodFromInterface();
         _engine.SetValue("inst", inst);
-        Assert.Equal(inst.Instance.Equals(), _engine.Evaluate("inst.Instance.Equals()"));
-        Assert.Equal(inst.Instance.Equals(inst), _engine.Evaluate("inst.Instance.Equals(inst)"));
+        _engine.Evaluate("inst.Instance.Equals()").Should().Be(inst.Instance.Equals());
+        _engine.Evaluate("inst.Instance.Equals(inst)").Should().Be(inst.Instance.Equals(inst));
     }
 }

--- a/Jint.Tests/Runtime/InteropInterfaceExtendTests.cs
+++ b/Jint.Tests/Runtime/InteropInterfaceExtendTests.cs
@@ -106,8 +106,9 @@ public class InterfaceTests
                     typeof(Console).Assembly,
                     typeof(File).Assembly))
                 .SetValue("log", new Action<object>(Console.WriteLine))
-                .SetValue("assert", new Action<bool>(Assert.True))
-                .SetValue("equal", new Action<object, object>(Assert.Equal))
+                .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+                .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())))
                 .SetValue("holder", holder)
             ;
     }
@@ -115,37 +116,29 @@ public class InterfaceTests
     [Fact]
     public void CallSuperPropertyFromInterface()
     {
-        Assert.Equal(holder.I1.NameI0, _engine.Evaluate("holder.I1.NameI0"));
+        _engine.Evaluate("holder.I1.NameI0").Should().Be(holder.I1.NameI0);
     }
 
     [Fact]
     public void CallOverloadSuperMethod()
     {
-        Assert.Equal(
-            holder.I1.OverloadSuperMethod(1),
-            _engine.Evaluate("holder.I1.OverloadSuperMethod(1)"));
-        Assert.Equal(
-            holder.I1.OverloadSuperMethod(),
-            _engine.Evaluate("holder.I1.OverloadSuperMethod()"));
+        _engine.Evaluate("holder.I1.OverloadSuperMethod(1)").Should().Be(holder.I1.OverloadSuperMethod(1));
+        _engine.Evaluate("holder.I1.OverloadSuperMethod()").Should().Be(holder.I1.OverloadSuperMethod());
     }
 
     [Fact]
     public void CallSubPropertySuperMethod_SubProperty()
     {
-        Assert.Equal(
-            holder.I1.SubPropertySuperMethod,
-            _engine.Evaluate("holder.I1.SubPropertySuperMethod"));
+        _engine.Evaluate("holder.I1.SubPropertySuperMethod").Should().Be(holder.I1.SubPropertySuperMethod);
     }
 
     [Fact]
     public void CallSubPropertySuperMethod_SuperMethod()
     {
-        var ex = Assert.Throws<JavaScriptException>(() =>
+        var ex = Invoking(() =>
         {
-            Assert.Equal(
-                holder.I1.SubPropertySuperMethod(),
-                _engine.Evaluate("holder.I1.SubPropertySuperMethod()"));
-        });
-        Assert.Equal("Property 'SubPropertySuperMethod' of object is not a function", ex.Message);
+            _engine.Evaluate("holder.I1.SubPropertySuperMethod()").Should().Be(holder.I1.SubPropertySuperMethod());
+        }).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Property 'SubPropertySuperMethod' of object is not a function");
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
+++ b/Jint.Tests/Runtime/InteropTests.ArrayIdentityCache.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime.Interop;
+﻿using Jint.Runtime.Interop;
 
 namespace Jint.Tests.Runtime;
 
@@ -21,10 +21,10 @@ public partial class InteropTests
         });
         engine.SetValue("host", new ArrayConversionHost());
 
-        Assert.False(engine.Evaluate("host.Numbers === host.Numbers").AsBoolean());
+        engine.Evaluate("host.Numbers === host.Numbers").AsBoolean().Should().BeFalse();
 
         // a script-side mutation of one snapshot is not visible in the next read
-        Assert.Equal(1, engine.Evaluate("var a = host.Numbers; a[0] = 42; host.Numbers[0]").AsNumber());
+        engine.Evaluate("var a = host.Numbers; a[0] = 42; host.Numbers[0]").AsNumber().Should().Be(1);
     }
 
     [Fact]
@@ -38,14 +38,14 @@ public partial class InteropTests
         });
         engine.SetValue("host", host);
 
-        Assert.True(engine.Evaluate("host.Numbers === host.Numbers").AsBoolean());
+        engine.Evaluate("host.Numbers === host.Numbers").AsBoolean().Should().BeTrue();
 
         // script-side mutations persist across reads (the identity contract)
-        Assert.Equal(42, engine.Evaluate("host.Numbers[0] = 42; host.Numbers[0]").AsNumber());
+        engine.Evaluate("host.Numbers[0] = 42; host.Numbers[0]").AsNumber().Should().Be(42);
 
         // CLR-side mutations after the first conversion are not re-copied (documented staleness)
         host.Numbers[1] = 99;
-        Assert.Equal(2, engine.Evaluate("host.Numbers[1]").AsNumber());
+        engine.Evaluate("host.Numbers[1]").AsNumber().Should().Be(2);
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public partial class InteropTests
         });
         engine.SetValue("host", new ArrayConversionHost());
 
-        Assert.True(engine.Evaluate("host.Numbers === host.Numbers").AsBoolean());
+        engine.Evaluate("host.Numbers === host.Numbers").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -75,11 +75,11 @@ public partial class InteropTests
 
         var array = new[] { 1, 2, 3 };
         engine.SetValue("a", array);
-        Assert.Equal(1, engine.Evaluate("a[0]").AsNumber());
+        engine.Evaluate("a[0]").AsNumber().Should().Be(1);
 
         engine.Options.Interop.WrapObjectHandler = static (e, target, type) => ObjectWrapper.Create(e, target, type);
         engine.SetValue("b", array);
-        Assert.Equal(1, engine.Evaluate("b[0]").AsNumber());
+        engine.Evaluate("b[0]").AsNumber().Should().Be(1);
     }
 
     [Fact]
@@ -90,9 +90,9 @@ public partial class InteropTests
         var engine = new Engine();
         engine.SetValue("host", new ArrayConversionHost());
         engine.Evaluate("host.Numbers[0]");
-        Assert.NotNull(engine._recentObjectWrapperCache);
+        engine._recentObjectWrapperCache.Should().NotBeNull();
 
         engine.Dispose();
-        Assert.Null(engine._recentObjectWrapperCache);
+        engine._recentObjectWrapperCache.Should().BeNull();
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
+++ b/Jint.Tests/Runtime/InteropTests.ClrArrayLiveView.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
@@ -22,14 +22,14 @@ public partial class InteropTests
     [Fact]
     public void ArrayConversionDefaultsToLiveView()
     {
-        Assert.Equal(ArrayConversionMode.LiveView, new Options().Interop.ArrayConversion);
+        new Options().Interop.ArrayConversion.Should().Be(ArrayConversionMode.LiveView);
 
         // LiveView mode (the default since 4.14): a CLR array crosses as a live wrapper view, not a
         // native JS array snapshot, so it is not an Array and repeated crossings share wrapper identity
         var engine = new Engine();
         engine.SetValue("h", new ArrayHolder());
-        Assert.False(engine.Evaluate("Array.isArray(h.Numbers)").AsBoolean());
-        Assert.True(engine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
+        engine.Evaluate("Array.isArray(h.Numbers)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("h.Numbers === h.Numbers").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -47,28 +47,28 @@ public partial class InteropTests
         engine.SetValue("intList", new List<int> { 7, 8 });
         engine.SetValue("stringList", (IReadOnlyList<string>) new List<string> { "a", null });
 
-        Assert.Equal(int.MaxValue, engine.Evaluate("ints[1]").AsNumber());
-        Assert.Equal(-1, engine.Evaluate("ints[2]").AsNumber());
-        Assert.Equal(0.5, engine.Evaluate("doubles[0]").AsNumber());
-        Assert.Equal(double.MaxValue, engine.Evaluate("doubles[1]").AsNumber());
-        Assert.True(engine.Evaluate("Object.is(doubles[2], -0)").AsBoolean());
-        Assert.Equal((double) long.MaxValue, engine.Evaluate("longs[1]").AsNumber());
-        Assert.Equal((double) 0.1f, engine.Evaluate("floats[0]").AsNumber());
-        Assert.Equal((double) float.MaxValue, engine.Evaluate("floats[1]").AsNumber());
-        Assert.True(engine.Evaluate("bools[0]").AsBoolean());
-        Assert.False(engine.Evaluate("bools[1]").AsBoolean());
-        Assert.Equal(255, engine.Evaluate("bytes[1]").AsNumber());
-        Assert.Equal("ö", engine.Evaluate("chars[1]").AsString());
-        Assert.Equal("x", engine.Evaluate("strings[0]").AsString());
-        Assert.True(engine.Evaluate("strings[1] === null").AsBoolean());
-        Assert.Equal("", engine.Evaluate("strings[2]").AsString());
-        Assert.Equal(8, engine.Evaluate("intList[1]").AsNumber());
-        Assert.True(engine.Evaluate("stringList[1] === null").AsBoolean());
+        engine.Evaluate("ints[1]").AsNumber().Should().Be(int.MaxValue);
+        engine.Evaluate("ints[2]").AsNumber().Should().Be(-1);
+        engine.Evaluate("doubles[0]").AsNumber().Should().Be(0.5);
+        engine.Evaluate("doubles[1]").AsNumber().Should().Be(double.MaxValue);
+        engine.Evaluate("Object.is(doubles[2], -0)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("longs[1]").AsNumber().Should().Be((double) long.MaxValue);
+        engine.Evaluate("floats[0]").AsNumber().Should().Be((double) 0.1f);
+        engine.Evaluate("floats[1]").AsNumber().Should().Be((double) float.MaxValue);
+        engine.Evaluate("bools[0]").AsBoolean().Should().BeTrue();
+        engine.Evaluate("bools[1]").AsBoolean().Should().BeFalse();
+        engine.Evaluate("bytes[1]").AsNumber().Should().Be(255);
+        engine.Evaluate("chars[1]").AsString().Should().Be("ö");
+        engine.Evaluate("strings[0]").AsString().Should().Be("x");
+        engine.Evaluate("strings[1] === null").AsBoolean().Should().BeTrue();
+        engine.Evaluate("strings[2]").AsString().Should().Be("");
+        engine.Evaluate("intList[1]").AsNumber().Should().Be(8);
+        engine.Evaluate("stringList[1] === null").AsBoolean().Should().BeTrue();
 
         // out-of-range and negative indices read like JS array holes
-        Assert.True(engine.Evaluate("ints[99] === undefined").AsBoolean());
-        Assert.True(engine.Evaluate("ints[-1] === undefined").AsBoolean());
-        Assert.True(engine.Evaluate("intList[99] === undefined").AsBoolean());
+        engine.Evaluate("ints[99] === undefined").AsBoolean().Should().BeTrue();
+        engine.Evaluate("ints[-1] === undefined").AsBoolean().Should().BeTrue();
+        engine.Evaluate("intList[99] === undefined").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -79,16 +79,16 @@ public partial class InteropTests
         engine.SetValue("h", host);
 
         // reads are live views over the underlying array
-        Assert.Equal(2, engine.Evaluate("h.Data[1]").AsNumber());
+        engine.Evaluate("h.Data[1]").AsNumber().Should().Be(2);
         host.Mutate(1, 42);
-        Assert.Equal(42, engine.Evaluate("h.Data[1]").AsNumber());
+        engine.Evaluate("h.Data[1]").AsNumber().Should().Be(42);
 
         // an array exposed under a read-only declared type must not produce a writable view
         engine.Evaluate("h.Data[0] = 99;");
-        Assert.Equal(1, host.Raw[0]);
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("'use strict'; h.Data[0] = 99;"));
-        Assert.Contains("read only", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal(1, host.Raw[0]);
+        host.Raw[0].Should().Be(1);
+        var ex = Invoking(() => engine.Evaluate("'use strict'; h.Data[0] = 99;")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().ContainEquivalentOf("read only");
+        host.Raw[0].Should().Be(1);
     }
 
     private class ReadOnlyDeclaredArrayHolder
@@ -107,10 +107,10 @@ public partial class InteropTests
         // InvalidCastException — and poison every engine in the process
         var engine = new Engine();
         engine.SetValue("a", new EnumerableHolder { Data = [1] });
-        Assert.Equal(1, engine.Evaluate("a.Data[0]").AsNumber());
+        engine.Evaluate("a.Data[0]").AsNumber().Should().Be(1);
 
         engine.SetValue("b", new EnumerableHolder { Data = new List<int> { 2 } });
-        Assert.Equal(2, engine.Evaluate("b.Data[0]").AsNumber());
+        engine.Evaluate("b.Data[0]").AsNumber().Should().Be(2);
     }
 
     private class EnumerableHolder
@@ -125,18 +125,18 @@ public partial class InteropTests
         engine.SetValue("a", new[] { 1, 2, 3 });
         engine.SetValue("l", new List<int> { 1, 2, 3 });
 
-        Assert.True(engine.Evaluate("0 in a").AsBoolean());
-        Assert.True(engine.Evaluate("2 in a").AsBoolean());
-        Assert.False(engine.Evaluate("3 in a").AsBoolean());
-        Assert.False(engine.Evaluate("-1 in a").AsBoolean());
-        Assert.False(engine.Evaluate("'-1' in a").AsBoolean());
-        Assert.False(engine.Evaluate("4000000000 in a").AsBoolean());
-        Assert.True(engine.Evaluate("'1' in a").AsBoolean());
-        Assert.False(engine.Evaluate("'08' in a").AsBoolean());
+        engine.Evaluate("0 in a").AsBoolean().Should().BeTrue();
+        engine.Evaluate("2 in a").AsBoolean().Should().BeTrue();
+        engine.Evaluate("3 in a").AsBoolean().Should().BeFalse();
+        engine.Evaluate("-1 in a").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'-1' in a").AsBoolean().Should().BeFalse();
+        engine.Evaluate("4000000000 in a").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'1' in a").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'08' in a").AsBoolean().Should().BeFalse();
 
-        Assert.True(engine.Evaluate("0 in l").AsBoolean());
-        Assert.False(engine.Evaluate("3 in l").AsBoolean());
-        Assert.False(engine.Evaluate("-1 in l").AsBoolean());
+        engine.Evaluate("0 in l").AsBoolean().Should().BeTrue();
+        engine.Evaluate("3 in l").AsBoolean().Should().BeFalse();
+        engine.Evaluate("-1 in l").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -146,14 +146,14 @@ public partial class InteropTests
         engine.SetValue("a", new[] { 1, 2, 3 });
         engine.SetValue("l", new List<string> { "x", "y" });
 
-        Assert.Equal("0,1,2", engine.Evaluate("Object.keys(a).join()").AsString());
-        Assert.Equal("0,1", engine.Evaluate("Object.keys(l).join()").AsString());
-        Assert.Equal("0,1,2", engine.Evaluate("var s=[];for(var k in a)s.push(k);s.join()").AsString());
-        Assert.Equal("1,2,3", engine.Evaluate("Object.values(a).join()").AsString());
-        Assert.Equal("""{"0":1,"1":2,"2":3}""", engine.Evaluate("JSON.stringify({...a})").AsString());
+        engine.Evaluate("Object.keys(a).join()").AsString().Should().Be("0,1,2");
+        engine.Evaluate("Object.keys(l).join()").AsString().Should().Be("0,1");
+        engine.Evaluate("var s=[];for(var k in a)s.push(k);s.join()").AsString().Should().Be("0,1,2");
+        engine.Evaluate("Object.values(a).join()").AsString().Should().Be("1,2,3");
+        engine.Evaluate("JSON.stringify({...a})").AsString().Should().Be("""{"0":1,"1":2,"2":3}""");
 
         // members stay accessible even though they no longer enumerate
-        Assert.Equal(3, engine.Evaluate("a.length").AsNumber());
+        engine.Evaluate("a.length").AsNumber().Should().Be(3);
     }
 
     private static Engine CreateCopyEngine(Action<Options> additionalConfiguration = null)
@@ -172,14 +172,14 @@ public partial class InteropTests
         // crossing then produces an independent JsArray snapshot
         var engine = CreateCopyEngine(options => options.Interop.CacheRecentObjectWrappers = false);
         engine.SetValue("h", new ArrayHolder());
-        Assert.True(engine.Evaluate("Array.isArray(h.Numbers)").AsBoolean());
-        Assert.False(engine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
+        engine.Evaluate("Array.isArray(h.Numbers)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("h.Numbers === h.Numbers").AsBoolean().Should().BeFalse();
 
         // with the default (cached) Copy engine the same snapshot is reused while cached
         var cachedEngine = CreateCopyEngine();
         cachedEngine.SetValue("h", new ArrayHolder());
-        Assert.True(cachedEngine.Evaluate("Array.isArray(h.Numbers)").AsBoolean());
-        Assert.True(cachedEngine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
+        cachedEngine.Evaluate("Array.isArray(h.Numbers)").AsBoolean().Should().BeTrue();
+        cachedEngine.Evaluate("h.Numbers === h.Numbers").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public partial class InteropTests
 
         engine.Execute("arr[1] = 42;");
 
-        Assert.Equal(2, numbers[1]);
+        numbers[1].Should().Be(2);
     }
 
     [Fact]
@@ -200,18 +200,18 @@ public partial class InteropTests
         // wrapper equality is by wrapped target, so === holds even without any identity cache flag
         var engine = CreateLiveViewEngine();
         engine.SetValue("h", new ArrayHolder());
-        Assert.True(engine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
+        engine.Evaluate("h.Numbers === h.Numbers").AsBoolean().Should().BeTrue();
 
         // with the identity map the same wrapper instance is also reused
         var trackingEngine = CreateLiveViewEngine(options => options.Interop.TrackObjectWrapperIdentity = true);
         trackingEngine.SetValue("h", new ArrayHolder());
-        Assert.True(trackingEngine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
-        Assert.Same(trackingEngine.Evaluate("h.Numbers"), trackingEngine.Evaluate("h.Numbers"));
+        trackingEngine.Evaluate("h.Numbers === h.Numbers").AsBoolean().Should().BeTrue();
+        trackingEngine.Evaluate("h.Numbers").Should().BeSameAs(trackingEngine.Evaluate("h.Numbers"));
 
         var recentCacheEngine = CreateLiveViewEngine(options => options.Interop.CacheRecentObjectWrappers = true);
         recentCacheEngine.SetValue("h", new ArrayHolder());
-        Assert.True(recentCacheEngine.Evaluate("h.Numbers === h.Numbers").AsBoolean());
-        Assert.Same(recentCacheEngine.Evaluate("h.Numbers"), recentCacheEngine.Evaluate("h.Numbers"));
+        recentCacheEngine.Evaluate("h.Numbers === h.Numbers").AsBoolean().Should().BeTrue();
+        recentCacheEngine.Evaluate("h.Numbers").Should().BeSameAs(recentCacheEngine.Evaluate("h.Numbers"));
     }
 
     [Fact]
@@ -223,7 +223,7 @@ public partial class InteropTests
 
         engine.Execute("arr[1] = 42;");
 
-        Assert.Equal(42, numbers[1]);
+        numbers[1].Should().Be(42);
     }
 
     [Fact]
@@ -233,11 +233,11 @@ public partial class InteropTests
         var numbers = new[] { 1, 2, 3 };
         engine.SetValue("arr", numbers);
 
-        Assert.Equal(3, engine.Evaluate("arr[2]").AsNumber());
+        engine.Evaluate("arr[2]").AsNumber().Should().Be(3);
 
         numbers[2] = 99;
 
-        Assert.Equal(99, engine.Evaluate("arr[2]").AsNumber());
+        engine.Evaluate("arr[2]").AsNumber().Should().Be(99);
     }
 
     [Fact]
@@ -249,8 +249,8 @@ public partial class InteropTests
 
         engine.Execute("arr[0] = 'hello';");
 
-        Assert.Equal("hello", strings[0]);
-        Assert.Equal("b", strings[1]);
+        strings[0].Should().Be("hello");
+        strings[1].Should().Be("b");
     }
 
     [Theory]
@@ -274,8 +274,8 @@ public partial class InteropTests
         var result = engine.Evaluate(
             $"(function() {{ try {{ {operation}; return 'no-throw'; }} catch (e) {{ return e instanceof TypeError ? 'TypeError' : 'unexpected: ' + e; }} }})()");
 
-        Assert.Equal("TypeError", result.AsString());
-        Assert.Equal(3, engine.Evaluate("arr.length").AsNumber());
+        result.AsString().Should().Be("TypeError");
+        engine.Evaluate("arr.length").AsNumber().Should().Be(3);
     }
 
     [Fact]
@@ -286,7 +286,7 @@ public partial class InteropTests
 
         engine.Execute("arr.length = 3;");
 
-        Assert.Equal(3, engine.Evaluate("arr.length").AsNumber());
+        engine.Evaluate("arr.length").AsNumber().Should().Be(3);
     }
 
     [Fact]
@@ -295,8 +295,8 @@ public partial class InteropTests
         var engine = CreateLiveViewEngine();
         engine.SetValue("arr", new[] { 1, 2, 3 });
 
-        Assert.False(engine.Evaluate("Array.isArray(arr)").AsBoolean());
-        Assert.Equal("object", engine.Evaluate("typeof arr").AsString());
+        engine.Evaluate("Array.isArray(arr)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("typeof arr").AsString().Should().Be("object");
     }
 
     [Fact]
@@ -307,8 +307,8 @@ public partial class InteropTests
         engine.SetValue("arr", new[] { 1, 2, 3 });
         engine.SetValue("holder", new ArrayHolder());
 
-        Assert.Equal("[1,2,3]", engine.Evaluate("JSON.stringify(arr)").AsString());
-        Assert.Equal("""{"Numbers":[10,20,30]}""", engine.Evaluate("JSON.stringify(holder)").AsString());
+        engine.Evaluate("JSON.stringify(arr)").AsString().Should().Be("[1,2,3]");
+        engine.Evaluate("JSON.stringify(holder)").AsString().Should().Be("""{"Numbers":[10,20,30]}""");
     }
 
     [Fact]
@@ -317,12 +317,12 @@ public partial class InteropTests
         var engine = CreateLiveViewEngine();
         engine.SetValue("arr", new[] { 1, 2, 3 });
 
-        Assert.Equal("1,2,3,", engine.Evaluate("var s = ''; for (var x of arr) { s += x + ','; } s").AsString());
-        Assert.Equal("[1,2,3]", engine.Evaluate("JSON.stringify([...arr])").AsString());
+        engine.Evaluate("var s = ''; for (var x of arr) { s += x + ','; } s").AsString().Should().Be("1,2,3,");
+        engine.Evaluate("JSON.stringify([...arr])").AsString().Should().Be("[1,2,3]");
 
         // Array.prototype is attached by default, so array methods work against the live view
-        Assert.Equal("[2,4,6]", engine.Evaluate("JSON.stringify(arr.map(function (x) { return x * 2; }))").AsString());
-        Assert.Equal(1, engine.Evaluate("arr.indexOf(2)").AsNumber());
+        engine.Evaluate("JSON.stringify(arr.map(function (x) { return x * 2; }))").AsString().Should().Be("[2,4,6]");
+        engine.Evaluate("arr.indexOf(2)").AsNumber().Should().Be(1);
     }
 
     [Fact]
@@ -334,15 +334,15 @@ public partial class InteropTests
 
         // in-range elements cannot be removed from a fixed-size array: delete returns false
         // and must not reset the slot to a default value
-        Assert.False(engine.Evaluate("delete arr[0]").AsBoolean());
-        Assert.Equal(1, numbers[0]);
+        engine.Evaluate("delete arr[0]").AsBoolean().Should().BeFalse();
+        numbers[0].Should().Be(1);
 
         // out-of-range delete is a JS no-op that reports success
-        Assert.True(engine.Evaluate("delete arr[100]").AsBoolean());
+        engine.Evaluate("delete arr[100]").AsBoolean().Should().BeTrue();
 
         // strict mode surfaces the refusal as a TypeError
-        Assert.Equal("TypeError", engine.Evaluate(
-            "(function() { 'use strict'; try { delete arr[0]; return 'no-throw'; } catch (e) { return e instanceof TypeError ? 'TypeError' : 'unexpected: ' + e; } })()").AsString());
+        engine.Evaluate(
+            "(function() { 'use strict'; try { delete arr[0]; return 'no-throw'; } catch (e) { return e instanceof TypeError ? 'TypeError' : 'unexpected: ' + e; } })()").AsString().Should().Be("TypeError");
     }
 
     [Fact]
@@ -354,7 +354,7 @@ public partial class InteropTests
 
         engine.Execute("arr[1] = 42;");
 
-        Assert.Equal(2, numbers[1]);
+        numbers[1].Should().Be(2);
     }
 
     [Fact]
@@ -368,7 +368,7 @@ public partial class InteropTests
 
         engine.Execute("receive(arr);");
 
-        Assert.Same(numbers, received);
+        received.Should().BeSameAs(numbers);
     }
 
     [Fact]
@@ -377,10 +377,10 @@ public partial class InteropTests
         // multi-dimensional arrays have never been convertible (Array.GetValue with a single
         // flat index throws) and LiveView must not change that failure mode
         var copyEngine = new Engine();
-        Assert.Throws<ArgumentException>(() => copyEngine.SetValue("md", new int[2, 2]));
+        Invoking(() => copyEngine.SetValue("md", new int[2, 2])).Should().ThrowExactly<ArgumentException>();
 
         var liveViewEngine = CreateLiveViewEngine();
-        Assert.Throws<ArgumentException>(() => liveViewEngine.SetValue("md", new int[2, 2]));
+        Invoking(() => liveViewEngine.SetValue("md", new int[2, 2])).Should().ThrowExactly<ArgumentException>();
     }
 
     [Fact]
@@ -392,7 +392,7 @@ public partial class InteropTests
 
         engine.Execute("list.push(4);");
 
-        Assert.Equal(4, list.Count);
-        Assert.Equal(4, list[3]);
+        list.Should().HaveCount(4);
+        list[3].Should().Be(4);
     }
 }

--- a/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
+++ b/Jint.Tests/Runtime/InteropTests.ErrorMessages.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Jint.Runtime;
 using Jint.Runtime.Interop;
 using Jint.Tests.Runtime.Domain;
@@ -17,11 +17,9 @@ public partial class InteropTests
         var engine = DetailedErrorsEngine();
         engine.SetValue("speaker", new Speaker());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+        var ex = Invoking(() => engine.Evaluate("speaker.Say('Hello', 'World')")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal(
-            "No public methods with the specified arguments were found. Target: Jint.Tests.Runtime.Speaker.Say; provided arguments: (string, string); candidate signatures: Say(String message)",
-            ex.Message);
+        ex.Message.Should().Be("No public methods with the specified arguments were found. Target: Jint.Tests.Runtime.Speaker.Say; provided arguments: (string, string); candidate signatures: Say(String message)");
     }
 
     [Fact]
@@ -31,11 +29,9 @@ public partial class InteropTests
         engine.SetValue("holder", new GreeterHolder(new Greeter()));
 
         // Greeter.Greet is collected both from the class and from IGreeter, it must be reported once
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("holder.Greeter.Greet()"));
+        var ex = Invoking(() => engine.Evaluate("holder.Greeter.Greet()")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal(
-            "No public methods with the specified arguments were found. Target: Jint.Tests.Runtime.Greeter.Greet; provided arguments: (); candidate signatures: Greet(String name)",
-            ex.Message);
+        ex.Message.Should().Be("No public methods with the specified arguments were found. Target: Jint.Tests.Runtime.Greeter.Greet; provided arguments: (); candidate signatures: Greet(String name)");
     }
 
     [Fact]
@@ -45,10 +41,10 @@ public partial class InteropTests
         engine.SetValue("speaker", new Speaker());
         engine.SetValue("other", new Speaker());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate(
-            "speaker.Say(null, undefined, [1, 2, 3], x => x, {}, new Date(), other)"));
+        var ex = Invoking(() => engine.Evaluate(
+            "speaker.Say(null, undefined, [1, 2, 3], x => x, {}, new Date(), other)")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Contains("(null, undefined, Array, function, object, Date, Speaker)", ex.Message);
+        ex.Message.Should().Contain("(null, undefined, Array, function, object, Date, Speaker)");
     }
 
     [Fact]
@@ -57,11 +53,11 @@ public partial class InteropTests
         var engine = DetailedErrorsEngine();
         engine.SetValue("picker", new OverloadPicker());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("picker.Pick()"));
+        var ex = Invoking(() => engine.Evaluate("picker.Pick()")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.StartsWith("No public methods with the specified arguments were found.", ex.Message);
-        Assert.Contains("Pick(Int32 a)", ex.Message);
-        Assert.Contains(" and 2 more", ex.Message);
+        ex.Message.Should().StartWith("No public methods with the specified arguments were found.");
+        ex.Message.Should().Contain("Pick(Int32 a)");
+        ex.Message.Should().Contain(" and 2 more");
     }
 
     [Fact]
@@ -74,10 +70,10 @@ public partial class InteropTests
         var engine = new Engine(options);
         engine.SetValue("person", new Person());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("person.MultiplyAge()"));
+        var ex = Invoking(() => engine.Evaluate("person.MultiplyAge()")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.StartsWith("No public methods with the specified arguments were found.", ex.Message);
-        Assert.Contains("PersonExtensions.MultiplyAge(this Person person, Int32 factor)", ex.Message);
+        ex.Message.Should().StartWith("No public methods with the specified arguments were found.");
+        ex.Message.Should().Contain("PersonExtensions.MultiplyAge(this Person person, Int32 factor)");
     }
 
     [Fact]
@@ -86,11 +82,11 @@ public partial class InteropTests
         var engine = DetailedErrorsEngine();
         engine.SetValue("CtorFails", TypeReference.CreateTypeReference<CtorFails>(engine));
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CtorFails(1, 2)"));
+        var ex = Invoking(() => engine.Evaluate("new CtorFails(1, 2)")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.StartsWith("Could not resolve a constructor for type Jint.Tests.Runtime.CtorFails for given arguments", ex.Message);
-        Assert.Contains("provided arguments: (number, number)", ex.Message);
-        Assert.Contains("candidate signatures: CtorFails(String name)", ex.Message);
+        ex.Message.Should().StartWith("Could not resolve a constructor for type Jint.Tests.Runtime.CtorFails for given arguments");
+        ex.Message.Should().Contain("provided arguments: (number, number)");
+        ex.Message.Should().Contain("candidate signatures: CtorFails(String name)");
     }
 
     [Fact]
@@ -99,10 +95,10 @@ public partial class InteropTests
         var engine = new Engine();
         engine.SetValue("speaker", new Speaker());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+        var ex = Invoking(() => engine.Evaluate("speaker.Say('Hello', 'World')")).Should().ThrowExactly<JavaScriptException>().Which;
 
         // the script-visible message must not leak the CLR type, member, argument types or signatures
-        Assert.Equal("No public methods with the specified arguments were found.", ex.Message);
+        ex.Message.Should().Be("No public methods with the specified arguments were found.");
     }
 
     [Fact]
@@ -111,12 +107,12 @@ public partial class InteropTests
         var engine = new Engine();
         engine.SetValue("CtorFails", TypeReference.CreateTypeReference<CtorFails>(engine));
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CtorFails(1, 2)"));
+        var ex = Invoking(() => engine.Evaluate("new CtorFails(1, 2)")).Should().ThrowExactly<JavaScriptException>().Which;
 
         // historical terse text (names the type, as it always has) but none of the added detail
-        Assert.Equal("Could not resolve a constructor for type Jint.Tests.Runtime.CtorFails for given arguments", ex.Message);
-        Assert.DoesNotContain("provided arguments", ex.Message);
-        Assert.DoesNotContain("candidate signatures", ex.Message);
+        ex.Message.Should().Be("Could not resolve a constructor for type Jint.Tests.Runtime.CtorFails for given arguments");
+        ex.Message.Should().NotContain("provided arguments");
+        ex.Message.Should().NotContain("candidate signatures");
     }
 
     [Fact]
@@ -126,13 +122,13 @@ public partial class InteropTests
         var engine = new Engine();
         engine.SetValue("speaker", new Speaker());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+        var ex = Invoking(() => engine.Evaluate("speaker.Say('Hello', 'World')")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.True(JintException.TryGetClrType(ex, out var type));
-        Assert.Equal(typeof(Speaker), type);
+        JintException.TryGetClrType(ex, out var type).Should().BeTrue();
+        type.Should().Be(typeof(Speaker));
 
-        Assert.True(JintException.TryGetClrMemberName(ex, out var member));
-        Assert.Equal("Say", member);
+        JintException.TryGetClrMemberName(ex, out var member).Should().BeTrue();
+        member.Should().Be("Say");
     }
 
     [Fact]
@@ -141,13 +137,13 @@ public partial class InteropTests
         var engine = new Engine();
         engine.SetValue("CtorFails", TypeReference.CreateTypeReference<CtorFails>(engine));
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CtorFails(1, 2)"));
+        var ex = Invoking(() => engine.Evaluate("new CtorFails(1, 2)")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.True(JintException.TryGetClrType(ex, out var type));
-        Assert.Equal(typeof(CtorFails), type);
+        JintException.TryGetClrType(ex, out var type).Should().BeTrue();
+        type.Should().Be(typeof(CtorFails));
 
         // constructors carry no member name
-        Assert.False(JintException.TryGetClrMemberName(ex, out _));
+        JintException.TryGetClrMemberName(ex, out _).Should().BeFalse();
     }
 
     [Fact]
@@ -163,11 +159,11 @@ public partial class InteropTests
 
         // a script-side try/catch sees the rewritten message, not the detailed one with the fully-qualified type
         var scriptVisible = engine.Evaluate("try { speaker.Say('Hello', 'World'); } catch (e) { e.message }");
-        Assert.Equal("Speaker.Say: no matching overload", scriptVisible.AsString());
+        scriptVisible.AsString().Should().Be("Speaker.Say: no matching overload");
 
         // and the host-side exception message matches
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
-        Assert.Equal("Speaker.Say: no matching overload", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("speaker.Say('Hello', 'World')")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Speaker.Say: no matching overload");
     }
 
     [Fact]
@@ -178,13 +174,13 @@ public partial class InteropTests
         engine.SetValue("speaker", new Speaker());
 
         var errorCode = engine.Evaluate("try { speaker.Say('Hello', 'World'); } catch (e) { e.errorCode }");
-        Assert.Equal("USR-001", errorCode.AsString());
+        errorCode.AsString().Should().Be("USR-001");
 
         // without a decorator the property does not exist
         var undecorated = new Engine();
         undecorated.SetValue("speaker", new Speaker());
         var missing = undecorated.Evaluate("try { speaker.Say('Hello', 'World'); } catch (e) { e.errorCode === undefined }");
-        Assert.True(missing.AsBoolean());
+        missing.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -195,23 +191,21 @@ public partial class InteropTests
         var engine = new Engine(options => options.Interop.ClrResolutionErrorDecorator = (_, _, info) => capturedInfo = info);
         engine.SetValue("speaker", new Speaker());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+        var ex = Invoking(() => engine.Evaluate("speaker.Say('Hello', 'World')")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal("No public methods with the specified arguments were found.", ex.Message);
+        ex.Message.Should().Be("No public methods with the specified arguments were found.");
 
-        Assert.NotNull(capturedInfo);
-        Assert.Equal(typeof(Speaker), capturedInfo.Type);
-        Assert.Equal("Say", capturedInfo.MemberName);
-        Assert.False(capturedInfo.IsConstructor);
-        Assert.Equal(2, capturedInfo.Arguments.Count);
-        Assert.Equal("Hello", capturedInfo.Arguments[0].AsString());
-        Assert.Equal("World", capturedInfo.Arguments[1].AsString());
-        var candidate = Assert.Single(capturedInfo.Candidates);
-        Assert.Equal("Say", candidate.Name);
-        Assert.Equal("Say(String message)", Assert.Single(capturedInfo.CandidateSignatures));
-        Assert.Equal(
-            "No public methods with the specified arguments were found. Target: Jint.Tests.Runtime.Speaker.Say; provided arguments: (string, string); candidate signatures: Say(String message)",
-            capturedInfo.DetailedMessage);
+        capturedInfo.Should().NotBeNull();
+        capturedInfo.Type.Should().Be(typeof(Speaker));
+        capturedInfo.MemberName.Should().Be("Say");
+        capturedInfo.IsConstructor.Should().BeFalse();
+        capturedInfo.Arguments.Should().HaveCount(2);
+        capturedInfo.Arguments[0].AsString().Should().Be("Hello");
+        capturedInfo.Arguments[1].AsString().Should().Be("World");
+        var candidate = capturedInfo.Candidates.Should().ContainSingle().Which;
+        candidate.Name.Should().Be("Say");
+        capturedInfo.CandidateSignatures.Should().ContainSingle().Which.Should().Be("Say(String message)");
+        capturedInfo.DetailedMessage.Should().Be("No public methods with the specified arguments were found. Target: Jint.Tests.Runtime.Speaker.Say; provided arguments: (string, string); candidate signatures: Say(String message)");
     }
 
     [Fact]
@@ -221,16 +215,16 @@ public partial class InteropTests
         var engine = new Engine(options => options.DecorateClrResolutionErrors((_, _, info) => capturedInfo = info));
         engine.SetValue("CtorFails", TypeReference.CreateTypeReference<CtorFails>(engine));
 
-        Assert.Throws<JavaScriptException>(() => engine.Evaluate("new CtorFails(1, 2)"));
+        Invoking(() => engine.Evaluate("new CtorFails(1, 2)")).Should().ThrowExactly<JavaScriptException>();
 
-        Assert.NotNull(capturedInfo);
-        Assert.Equal(typeof(CtorFails), capturedInfo.Type);
-        Assert.Null(capturedInfo.MemberName);
-        Assert.True(capturedInfo.IsConstructor);
-        Assert.Equal(2, capturedInfo.Arguments.Count);
-        var candidate = Assert.Single(capturedInfo.Candidates);
-        Assert.IsAssignableFrom<ConstructorInfo>(candidate);
-        Assert.Equal("CtorFails(String name)", Assert.Single(capturedInfo.CandidateSignatures));
+        capturedInfo.Should().NotBeNull();
+        capturedInfo.Type.Should().Be(typeof(CtorFails));
+        capturedInfo.MemberName.Should().BeNull();
+        capturedInfo.IsConstructor.Should().BeTrue();
+        capturedInfo.Arguments.Should().HaveCount(2);
+        var candidate = capturedInfo.Candidates.Should().ContainSingle().Which;
+        candidate.Should().BeAssignableTo<ConstructorInfo>();
+        capturedInfo.CandidateSignatures.Should().ContainSingle().Which.Should().Be("CtorFails(String name)");
     }
 
     [Fact]
@@ -242,8 +236,8 @@ public partial class InteropTests
 
         var result = engine.Evaluate("speaker.Say('Hello')");
 
-        Assert.Equal("Speaker says: Hello", result.AsString());
-        Assert.False(called);
+        result.AsString().Should().Be("Speaker says: Hello");
+        called.Should().BeFalse();
     }
 
     [Fact]
@@ -253,13 +247,13 @@ public partial class InteropTests
             static (_, error, _) => error.Set("message", "rewritten")));
         engine.SetValue("speaker", new Speaker());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+        var ex = Invoking(() => engine.Evaluate("speaker.Say('Hello', 'World')")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.Equal("rewritten", ex.Message);
-        Assert.True(JintException.TryGetClrType(ex, out var type));
-        Assert.Equal(typeof(Speaker), type);
-        Assert.True(JintException.TryGetClrMemberName(ex, out var member));
-        Assert.Equal("Say", member);
+        ex.Message.Should().Be("rewritten");
+        JintException.TryGetClrType(ex, out var type).Should().BeTrue();
+        type.Should().Be(typeof(Speaker));
+        JintException.TryGetClrMemberName(ex, out var member).Should().BeTrue();
+        member.Should().Be("Say");
     }
 
     [Fact]
@@ -269,12 +263,12 @@ public partial class InteropTests
         var engine = new Engine(options => options.DecorateClrResolutionErrors((_, _, info) => capturedInfo = info));
         engine.SetValue("speaker", new Speaker());
 
-        Assert.Throws<JavaScriptException>(() => engine.Evaluate("speaker.Say('Hello', 'World')"));
+        Invoking(() => engine.Evaluate("speaker.Say('Hello', 'World')")).Should().ThrowExactly<JavaScriptException>();
         // churn the engine's pooled/cached argument arrays; the captured copy must be unaffected
         engine.Evaluate("for (var i = 0; i < 100; i++) { Math.max(i, i + 1, i + 2); }");
 
-        Assert.Equal("Hello", capturedInfo.Arguments[0].AsString());
-        Assert.Equal("World", capturedInfo.Arguments[1].AsString());
+        capturedInfo.Arguments[0].AsString().Should().Be("Hello");
+        capturedInfo.Arguments[1].AsString().Should().Be("World");
     }
 }
 

--- a/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
+++ b/Jint.Tests/Runtime/InteropTests.MemberAccess.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using Jint.Native;
 using Jint.Native.Object;
@@ -28,11 +28,11 @@ public partial class InteropTests
 
         engine.SetValue("m", new HiddenMembers());
 
-        Assert.Equal("Member1", engine.Evaluate("m.Member1").ToString());
-        Assert.Equal("undefined", engine.Evaluate("m.Member2").ToString());
-        Assert.Equal("Method1", engine.Evaluate("m.Method1()").ToString());
+        engine.Evaluate("m.Member1").ToString().Should().Be("Member1");
+        engine.Evaluate("m.Member2").ToString().Should().Be("undefined");
+        engine.Evaluate("m.Method1()").ToString().Should().Be("Method1");
         // check the method itself, not its invokation as it would mean invoking "undefined"
-        Assert.Equal("undefined", engine.Evaluate("m.Method2").ToString());
+        engine.Evaluate("m.Method2").ToString().Should().Be("undefined");
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public partial class InteropTests
 
         engine.SetValue("m", new HiddenMembers());
 
-        Assert.Equal("Orange", engine.Evaluate("m.Member1").ToString());
+        engine.Evaluate("m.Member1").ToString().Should().Be("Orange");
     }
 
     [Fact]
@@ -65,16 +65,16 @@ public partial class InteropTests
 
         engine.SetValue("m", new HiddenMembers());
 
-        Assert.True(engine.Evaluate("m.Field1").IsUndefined());
-        Assert.True(engine.Evaluate("m.Member1").IsUndefined());
-        Assert.True(engine.Evaluate("m.Method1").IsUndefined());
+        engine.Evaluate("m.Field1").IsUndefined().Should().BeTrue();
+        engine.Evaluate("m.Member1").IsUndefined().Should().BeTrue();
+        engine.Evaluate("m.Method1").IsUndefined().Should().BeTrue();
 
-        Assert.True(engine.Evaluate("m.Field2").IsString());
-        Assert.True(engine.Evaluate("m.Member2").IsString());
-        Assert.True(engine.Evaluate("m.Method2()").IsString());
+        engine.Evaluate("m.Field2").IsString().Should().BeTrue();
+        engine.Evaluate("m.Member2").IsString().Should().BeTrue();
+        engine.Evaluate("m.Method2()").IsString().Should().BeTrue();
 
         // we forbid GetType by default
-        Assert.True(engine.Evaluate("m.GetType").IsUndefined());
+        engine.Evaluate("m.GetType").IsUndefined().Should().BeTrue();
     }
 
     [Fact]
@@ -103,10 +103,10 @@ public partial class InteropTests
             options.Interop.AllowSystemReflection = true;
         });
         engine.SetValue("m", new HiddenMembers());
-        Assert.True(engine.Evaluate("m.GetType").IsCallable);
+        engine.Evaluate("m.GetType").IsCallable.Should().BeTrue();
 
         // reflection could bypass some safeguards
-        Assert.Equal("Method1", engine.Evaluate("m.GetType().GetMethod('Method1').Invoke(m, [])").AsString());
+        engine.Evaluate("m.GetType().GetMethod('Method1').Invoke(m, [])").AsString().Should().Be("Method1");
     }
 
     [Fact]
@@ -123,10 +123,10 @@ public partial class InteropTests
             return result;
         }
 
-        Assert.Equal("System.Uri", TestAllowGetTypeOption(allowGetType: true));
+        TestAllowGetTypeOption(allowGetType: true).Should().Be("System.Uri");
 
-        var ex = Assert.Throws<JavaScriptException>(() => TestAllowGetTypeOption(allowGetType: false));
-        Assert.Equal("Property 'GetType' of object is not a function", ex.Message);
+        var ex = Invoking(() => TestAllowGetTypeOption(allowGetType: false)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Property 'GetType' of object is not a function");
     }
 
     [Fact]
@@ -137,10 +137,10 @@ public partial class InteropTests
 
         // we can get a type reference if it's exposed via property, bypassing GetType
         var type = engine.Evaluate("m.Type");
-        Assert.IsType<ObjectWrapper>(type);
+        type.Should().BeOfType<ObjectWrapper>();
 
-        var ex = Assert.Throws<InvalidOperationException>(() => engine.Evaluate("m.Type.Module.GetType().Module.GetType('System.DateTime')"));
-        Assert.Equal("Cannot access System.Reflection namespace, check Engine's interop options", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("m.Type.Module.GetType().Module.GetType('System.DateTime')")).Should().ThrowExactly<InvalidOperationException>().Which;
+        ex.Message.Should().Be("Cannot access System.Reflection namespace, check Engine's interop options");
     }
 
     [Fact]
@@ -154,11 +154,11 @@ public partial class InteropTests
             });
         });
         engine.SetValue("EchoService", TypeReference.CreateTypeReference(engine, typeof(EchoService)));
-        Assert.Equal("anyone there", engine.Evaluate("EchoService.Echo('anyone there')").AsString());
-        Assert.Equal("anyone there", engine.Evaluate("EchoService.echo('anyone there')").AsString());
-        Assert.True(engine.Evaluate("EchoService.ECHO").IsUndefined());
+        engine.Evaluate("EchoService.Echo('anyone there')").AsString().Should().Be("anyone there");
+        engine.Evaluate("EchoService.echo('anyone there')").AsString().Should().Be("anyone there");
+        engine.Evaluate("EchoService.ECHO").IsUndefined().Should().BeTrue();
 
-        Assert.True(engine.Evaluate("EchoService.Hidden").IsUndefined());
+        engine.Evaluate("EchoService.Hidden").IsUndefined().Should().BeTrue();
     }
 
     [Fact]
@@ -174,16 +174,16 @@ public partial class InteropTests
 
         engine.SetValue("dc", dc);
 
-        Assert.Equal(1, engine.Evaluate("dc.a"));
-        Assert.Equal(1, engine.Evaluate("dc['a']"));
-        Assert.NotEqual(JsValue.Undefined, engine.Evaluate("dc.Add"));
-        Assert.NotEqual(0, engine.Evaluate("dc.Add"));
-        Assert.Equal(JsValue.Undefined, engine.Evaluate("dc.b"));
+        engine.Evaluate("dc.a").Should().Be(1);
+        engine.Evaluate("dc['a']").Should().Be(1);
+        engine.Evaluate("dc.Add").Should().NotBe(JsValue.Undefined);
+        engine.Evaluate("dc.Add").Should().NotBe(0);
+        engine.Evaluate("dc.b").Should().BeUndefined();
 
         engine.Execute("dc.b = 5");
         engine.Execute("dc.Add('c', 10)");
-        Assert.Equal(5, engine.Evaluate("dc.b"));
-        Assert.Equal(10, engine.Evaluate("dc.c"));
+        engine.Evaluate("dc.b").Should().Be(5);
+        engine.Evaluate("dc.c").Should().Be(10);
     }
 
     [Fact]
@@ -195,8 +195,8 @@ public partial class InteropTests
         });
 
         engine.SetValue("B", TypeReference.CreateTypeReference(engine, typeof(InheritingFromClassWithStatics)));
-        Assert.Equal(42, engine.Evaluate("B.a").AsNumber());
-        Assert.Equal(24, engine.Evaluate("B.a = 24; B.a").AsNumber());
+        engine.Evaluate("B.a").AsNumber().Should().Be(42);
+        engine.Evaluate("B.a = 24; B.a").AsNumber().Should().Be(24);
     }
 
     private class BaseClassWithStatics
@@ -276,7 +276,7 @@ public partial class InteropTests
         engine.Execute("obj.Data = { Value: '123' };");
         var obj = engine.Evaluate("obj").ToObject() as ClassWithData;
 
-        Assert.Equal("123", obj?.Data.Value);
+        (obj?.Data.Value).Should().Be("123");
     }
 
     [Fact]
@@ -286,7 +286,7 @@ public partial class InteropTests
 
         engine.SetValue("obj", new ClassWithData());
         engine.Evaluate("obj.Age").AsNumber().Should().Be(42);
-        engine.Evaluate("obj.AgeMissing").Should().Be(JsValue.Undefined);
+        engine.Evaluate("obj.AgeMissing").Should().BeUndefined();
 
         engine = new Engine(options =>
         {
@@ -368,7 +368,7 @@ public partial class InteropTests
         engine.SetValue("dict", new Dictionary<string, string> { ["Foo"] = "bar" });
 
         engine.Evaluate("dict['Foo']").AsString().Should().Be("bar");
-        engine.Evaluate("dict['Missing']").Should().Be(JsValue.Undefined);
+        engine.Evaluate("dict['Missing']").Should().BeUndefined();
 
         // real CLR members on the dictionary still resolve
         engine.Evaluate("dict.Count").AsNumber().Should().Be(1);
@@ -383,7 +383,7 @@ public partial class InteropTests
         engine.SetValue("dict", hashtable);
 
         engine.Evaluate("dict['Foo']").AsString().Should().Be("bar");
-        engine.Evaluate("dict['Missing']").Should().Be(JsValue.Undefined);
+        engine.Evaluate("dict['Missing']").Should().BeUndefined();
     }
 
     [Fact]
@@ -395,7 +395,7 @@ public partial class InteropTests
         engine.SetValue("dict", dict);
 
         engine.Evaluate("dict['answer']").AsNumber().Should().Be(42);
-        engine.Evaluate("dict['missing']").Should().Be(JsValue.Undefined);
+        engine.Evaluate("dict['missing']").Should().BeUndefined();
     }
 
     public class ClassWithPropertyToHide

--- a/Jint.Tests/Runtime/InteropTests.TypeReference.cs
+++ b/Jint.Tests/Runtime/InteropTests.TypeReference.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Runtime.Interop;
 using Jint.Tests.Runtime.Domain;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,16 +40,16 @@ public partial class InteropTests
 
         _engine.Evaluate("obj.setString('Hello World!');");
 
-        Assert.Equal("Hello World!", _engine.Evaluate("obj.string"));
-        Assert.Equal(1, _engine.Evaluate("obj.a"));
-        Assert.Equal(2, _engine.Evaluate("obj.b"));
+        _engine.Evaluate("obj.string").Should().Be("Hello World!");
+        _engine.Evaluate("obj.a").Should().Be(1);
+        _engine.Evaluate("obj.b").Should().Be(2);
 
-        Assert.Equal("A", _engine.Evaluate("obj.aProp"));
-        Assert.Equal("B", _engine.Evaluate("obj.bProp"));
+        _engine.Evaluate("obj.aProp").Should().Be("A");
+        _engine.Evaluate("obj.bProp").Should().Be("B");
 
         // TODO we should have a special prototype based on wrapped type so we could differentiate between own and type properties
-        // Assert.Equal("[\"a\"]", _engine.Evaluate("JSON.stringify(Object.getOwnPropertyNames(new ExtendedType()))"));
-        // Assert.Equal("[\"a\",\"b\"]", _engine.Evaluate("JSON.stringify(Object.getOwnPropertyNames(new MyExtendedType()))"));
+        // _engine.Evaluate("JSON.stringify(Object.getOwnPropertyNames(new ExtendedType()))").Should().Be("[\"a\"]");
+        // _engine.Evaluate("JSON.stringify(Object.getOwnPropertyNames(new MyExtendedType()))").Should().Be("[\"a\",\"b\"]");
     }
 
     [Fact]
@@ -82,12 +82,12 @@ public partial class InteropTests
             ");
 
         var extendsFromJs = _engine.Construct("ExtendsFromJs");
-        Assert.Equal(1, _engine.Evaluate("new ExtendsFromJs().getA();"));
-        Assert.NotEqual(JsValue.Undefined, extendsFromJs.Get("getA"));
+        _engine.Evaluate("new ExtendsFromJs().getA();").Should().Be(1);
+        extendsFromJs.Get("getA").Should().NotBe(JsValue.Undefined);
 
         var extendsFromClr = _engine.Construct("ExtendsFromClr");
-        Assert.Equal(1, _engine.Evaluate("new ExtendsFromClr().getA();"));
-        Assert.NotEqual(JsValue.Undefined, extendsFromClr.Get("getA"));
+        _engine.Evaluate("new ExtendsFromClr().getA();").Should().Be(1);
+        extendsFromClr.Get("getA").Should().NotBe(JsValue.Undefined);
     }
 
 
@@ -108,7 +108,7 @@ public partial class InteropTests
         var engine = new Engine(options => options.AllowClr(GetType().Assembly));
         engine.SetValue("a", new OverLoading());
         engine.SetValue("E", TypeReference.CreateTypeReference(engine, typeof(IntegerEnum)));
-        Assert.Equal("integer-enum", engine.Evaluate("a.testFunc(E.a);").AsString());
+        engine.Evaluate("a.testFunc(E.a);").AsString().Should().Be("integer-enum");
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public partial class InteropTests
     {
         var engine = new Engine(options => options.AllowClr(GetType().Assembly));
         engine.SetValue("E", TypeReference.CreateTypeReference(engine, typeof(UintEnum)));
-        Assert.Equal(1, engine.Evaluate("E.b;").AsNumber());
+        engine.Evaluate("E.b;").AsNumber().Should().Be(1);
     }
 
 
@@ -124,8 +124,8 @@ public partial class InteropTests
     public void ExceptionFromConstructorShouldPropagate()
     {
         _engine.SetValue("Class", TypeReference.CreateTypeReference(_engine, typeof(MemberExceptionTest)));
-        var ex = Assert.Throws<InvalidOperationException>(() => _engine.Evaluate("new Class(true);"));
-        Assert.Equal("thrown as requested", ex.Message);
+        var ex = Invoking(() => _engine.Evaluate("new Class(true);")).Should().ThrowExactly<InvalidOperationException>().Which;
+        ex.Message.Should().Be("thrown as requested");
     }
 
 
@@ -138,7 +138,7 @@ public partial class InteropTests
         engine.SetValue("Math2", mathTypeReference);
         var result = engine.Evaluate("Math2.Max(5.37, 5.56)").AsNumber();
 
-        Assert.Equal(5.56d, result);
+        result.Should().Be(5.56d);
     }
 
     [Fact]
@@ -158,7 +158,7 @@ public partial class InteropTests
         engine.Execute("z['bar'] = 20;");
         engine.Execute("log(z['bar']);");
 
-        Assert.Equal("called#5#20", string.Join("#", calls));
+        string.Join("#", calls).Should().Be("called#5#20");
     }
 
     [Fact]
@@ -178,7 +178,7 @@ public partial class InteropTests
             };
         });
         engine.SetValue("Injectable", TypeReference.CreateTypeReference<Injectable>(engine));
-        Assert.Equal("Hello world", engine.Evaluate("new Injectable(123, 'abc').getInjectedValue();"));
+        engine.Evaluate("new Injectable(123, 'abc').getInjectedValue();").Should().Be("Hello world");
     }
 
     [Fact]
@@ -189,11 +189,11 @@ public partial class InteropTests
         _engine.SetValue("MyClass", reference);
         _engine.Execute("var c = new MyClass();");
 
-        Assert.Equal("[object Dependency]", _engine.Evaluate("Object.prototype.toString.call(c);"));
+        _engine.Evaluate("Object.prototype.toString.call(c);").Should().Be("[object Dependency]");
 
         // engine uses registered type reference
         _engine.SetValue("c2", new Dependency());
-        Assert.Equal("[object Dependency]", _engine.Evaluate("Object.prototype.toString.call(c2);"));
+        _engine.Evaluate("Object.prototype.toString.call(c2);").Should().Be("[object Dependency]");
     }
 
     private class Injectable

--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -26,8 +26,9 @@ public partial class InteropTests : IDisposable
                     typeof(Console).GetTypeInfo().Assembly,
                     typeof(File).GetTypeInfo().Assembly))
                 .SetValue("log", new Action<object>(Console.WriteLine))
-                .SetValue("assert", new Action<bool>(Assert.True))
-                .SetValue("equal", new Action<object, object>(Assert.Equal))
+                .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+                .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())))
             ;
     }
 
@@ -58,7 +59,7 @@ public partial class InteropTests : IDisposable
     {
         _engine.SetValue("foo", typeof(Foo));
         var json = _engine.Evaluate("JSON.stringify(foo.GetBar())").AsString();
-        Assert.Equal("{\"Test\":\"123\"}", json);
+        json.Should().Be("{\"Test\":\"123\"}");
     }
 
 
@@ -71,7 +72,7 @@ public partial class InteropTests : IDisposable
         d["Values"] = 1;
         engine.SetValue("d", d);
 
-        Assert.Equal("{\"Values\":1}", engine.Evaluate($"JSON.stringify(d)").AsString());
+        engine.Evaluate($"JSON.stringify(d)").AsString().Should().Be("{\"Values\":1}");
     }
 
     [Fact]
@@ -87,7 +88,7 @@ public partial class InteropTests : IDisposable
         engine.SetValue(nameof(dictionary), dictionary);
 
         var result = engine.Evaluate($"JSON.stringify({nameof(dictionary)})").AsString();
-        Assert.Equal("{\"foo\":5,\"bar\":\"A string\"}", result);
+        result.Should().Be("{\"foo\":5,\"bar\":\"A string\"}");
     }
 
     [Fact]
@@ -103,10 +104,10 @@ public partial class InteropTests : IDisposable
         engine.SetValue(nameof(dictionary), dictionary);
 
         var result = engine.Evaluate($"JSON.stringify({nameof(dictionary)})").AsString();
-        Assert.Equal("{\"foo\":5,\"bar\":\"A string\"}", result);
+        result.Should().Be("{\"foo\":5,\"bar\":\"A string\"}");
 
         var keys = engine.Evaluate($"Object.keys({nameof(dictionary)})").AsArray();
-        Assert.Equal((uint) 2, keys.Length);
+        keys.Length.Should().Be((uint) 2);
     }
 
     [Fact]
@@ -119,7 +120,7 @@ public partial class InteropTests : IDisposable
         engine.SetValue(nameof(parsed), parsed);
 
         var result = engine.Evaluate($"JSON.stringify({nameof(parsed)})").AsString();
-        Assert.Equal(json, result);
+        result.Should().Be(json);
     }
 
     [Fact]
@@ -146,7 +147,7 @@ public partial class InteropTests : IDisposable
             .Evaluate("userclass.TypeProperty.Name;")
             .AsString();
 
-        Assert.Equal("Person", result);
+        result.Should().Be("Person");
     }
 
     [Fact]
@@ -171,15 +172,15 @@ public partial class InteropTests : IDisposable
             { "Item", "Item value" }
         };
 
-        Assert.Equal("item2 value", _engine.Invoke("item2", argument));
-        Assert.Equal("item value", _engine.Invoke("item1", argument));
-        Assert.Equal("Item value", _engine.Invoke("item3", argument));
+        _engine.Invoke("item2", argument).Should().Be("item2 value");
+        _engine.Invoke("item1", argument).Should().Be("item value");
+        _engine.Invoke("item3", argument).Should().Be("Item value");
 
         var company = new Company("Acme Ltd");
         _engine.SetValue("c", company);
-        Assert.Equal("item thingie", _engine.Evaluate("c.Item"));
-        Assert.Equal("item thingie", _engine.Evaluate("c.item"));
-        Assert.Equal("value", _engine.Evaluate("c['key']"));
+        _engine.Evaluate("c.Item").Should().Be("item thingie");
+        _engine.Evaluate("c.item").Should().Be("item thingie");
+        _engine.Evaluate("c['key']").Should().Be("value");
     }
 
     [Fact]
@@ -429,7 +430,7 @@ public partial class InteropTests : IDisposable
                 assert(p.Name === 'Donald Duck');
             ");
 
-        Assert.Equal("Donald Duck", p.Name);
+        p.Name.Should().Be("Donald Duck");
     }
 
     [Fact]
@@ -461,7 +462,7 @@ public partial class InteropTests : IDisposable
                 assert(dictionary['person2'].Name === 'Donald Duck');
             ");
 
-        Assert.Equal("Donald Duck", dictionary["person2"].Name);
+        dictionary["person2"].Name.Should().Be("Donald Duck");
     }
 
     [Fact]
@@ -493,8 +494,8 @@ public partial class InteropTests : IDisposable
                 assert(dictionary[2] === 'Donald Duck');
             ");
 
-        Assert.Equal("Mickey Mouse", dictionary[1]);
-        Assert.Equal("Donald Duck", dictionary[2]);
+        dictionary[1].Should().Be("Mickey Mouse");
+        dictionary[2].Should().Be("Donald Duck");
     }
 
     private class DoubleIndexedClass
@@ -531,8 +532,8 @@ public partial class InteropTests : IDisposable
                 assert(dictionary[2] === 'Goofy');
             ");
 
-        Assert.Equal("Mickey Mouse", dictionary[1]);
-        Assert.Equal("Goofy", dictionary[2]);
+        dictionary[1].Should().Be("Mickey Mouse");
+        dictionary[2].Should().Be("Goofy");
     }
 
     [Fact]
@@ -575,7 +576,7 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("model", model);
 
         var result = _engine.Evaluate("'' + obj[model]");
-        Assert.Equal("value1", result.AsString());
+        result.AsString().Should().Be("value1");
     }
 
     [Fact]
@@ -590,7 +591,7 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("model", model);
 
         _engine.Execute("obj[model] = 'updated';");
-        Assert.Equal("updated", dictionary[model]);
+        dictionary[model].Should().Be("updated");
     }
 
     [Fact]
@@ -606,8 +607,8 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("present", model);
         _engine.SetValue("absent", other);
 
-        Assert.Equal("value1", _engine.Evaluate("obj[present]").AsString());
-        Assert.True(_engine.Evaluate("obj[absent] === undefined").AsBoolean());
+        _engine.Evaluate("obj[present]").AsString().Should().Be("value1");
+        _engine.Evaluate("obj[absent] === undefined").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -623,8 +624,8 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("present", present);
         _engine.SetValue("absent", absent);
 
-        Assert.True(_engine.Evaluate("present in obj").AsBoolean());
-        Assert.False(_engine.Evaluate("absent in obj").AsBoolean());
+        _engine.Evaluate("present in obj").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("absent in obj").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -639,7 +640,7 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("model", model);
 
         _engine.Execute("delete obj[model];");
-        Assert.False(dictionary.ContainsKey(model));
+        dictionary.ContainsKey(model).Should().BeFalse();
     }
 
     [Fact]
@@ -654,7 +655,7 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("obj", readOnly);
         _engine.SetValue("model", model);
 
-        Assert.Equal("value1", _engine.Evaluate("'' + obj[model]").AsString());
+        _engine.Evaluate("'' + obj[model]").AsString().Should().Be("value1");
     }
 
     [Fact]
@@ -670,8 +671,8 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("present", present);
         _engine.SetValue("absent", absent);
 
-        Assert.True(_engine.Evaluate("present in obj").AsBoolean());
-        Assert.False(_engine.Evaluate("absent in obj").AsBoolean());
+        _engine.Evaluate("present in obj").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("absent in obj").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -685,7 +686,7 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("obj", dictionary);
         _engine.SetValue("model", derived);
 
-        Assert.Equal("fromDerived", _engine.Evaluate("'' + obj[model]").AsString());
+        _engine.Evaluate("'' + obj[model]").AsString().Should().Be("fromDerived");
     }
 
     [Fact]
@@ -699,7 +700,7 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("obj", dictionary);
         _engine.SetValue("key", key);
 
-        Assert.Equal("valueForGuid", _engine.Evaluate("'' + obj[key]").AsString());
+        _engine.Evaluate("'' + obj[key]").AsString().Should().Be("valueForGuid");
     }
 
     [Fact]
@@ -715,7 +716,7 @@ public partial class InteropTests : IDisposable
 
         // assigning a non-numeric string to an int-valued dictionary must not throw and must not corrupt the entry
         _engine.Execute("obj[model] = 'not an int';");
-        Assert.Equal(42, dictionary[model]);
+        dictionary[model].Should().Be(42);
     }
 
     [Fact]
@@ -730,8 +731,8 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("foo", DictionaryKeyEnum.Foo);
         _engine.SetValue("bar", DictionaryKeyEnum.Bar);
 
-        Assert.Equal("fooValue", _engine.Evaluate("'' + obj[foo]").AsString());
-        Assert.Equal("barValue", _engine.Evaluate("'' + obj[bar]").AsString());
+        _engine.Evaluate("'' + obj[foo]").AsString().Should().Be("fooValue");
+        _engine.Evaluate("'' + obj[bar]").AsString().Should().Be("barValue");
     }
 
     [Fact]
@@ -746,7 +747,7 @@ public partial class InteropTests : IDisposable
         };
         _engine.SetValue("obj", dictionary);
 
-        Assert.True(_engine.Evaluate("obj[42] === undefined").AsBoolean());
+        _engine.Evaluate("obj[42] === undefined").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -762,17 +763,17 @@ public partial class InteropTests : IDisposable
         };
         _engine.SetValue("obj", dictionary);
 
-        Assert.Equal("one", _engine.Evaluate("'' + obj[1]").AsString());
-        Assert.Equal("two", _engine.Evaluate("'' + obj[2]").AsString());
-        Assert.True(_engine.Evaluate("obj[3] === undefined").AsBoolean());
-        Assert.True(_engine.Evaluate("1 in obj").AsBoolean());
-        Assert.False(_engine.Evaluate("3 in obj").AsBoolean());
+        _engine.Evaluate("'' + obj[1]").AsString().Should().Be("one");
+        _engine.Evaluate("'' + obj[2]").AsString().Should().Be("two");
+        _engine.Evaluate("obj[3] === undefined").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("1 in obj").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("3 in obj").AsBoolean().Should().BeFalse();
 
         _engine.Execute("obj[3] = 'three';");
-        Assert.Equal("three", dictionary[3]);
+        dictionary[3].Should().Be("three");
 
         _engine.Execute("delete obj[1];");
-        Assert.False(dictionary.ContainsKey(1));
+        dictionary.ContainsKey(1).Should().BeFalse();
     }
 
     [Fact]
@@ -787,7 +788,7 @@ public partial class InteropTests : IDisposable
         };
         _engine.SetValue("obj", dictionary);
 
-        Assert.Equal("function", _engine.Evaluate("typeof obj[Symbol.iterator]").AsString());
+        _engine.Evaluate("typeof obj[Symbol.iterator]").AsString().Should().Be("function");
     }
 
     [Fact]
@@ -801,10 +802,10 @@ public partial class InteropTests : IDisposable
         };
         _engine.SetValue("obj", dictionary);
 
-        Assert.True(_engine.Evaluate("obj[null] === undefined").AsBoolean());
-        Assert.True(_engine.Evaluate("obj[undefined] === undefined").AsBoolean());
-        Assert.False(_engine.Evaluate("null in obj").AsBoolean());
-        Assert.False(_engine.Evaluate("delete obj[null]; null in obj").AsBoolean());
+        _engine.Evaluate("obj[null] === undefined").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("obj[undefined] === undefined").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("null in obj").AsBoolean().Should().BeFalse();
+        _engine.Evaluate("delete obj[null]; null in obj").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -820,8 +821,8 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("obj", dictionary);
 
         _engine.Execute("obj[null] = 'should not stick';");
-        Assert.Single(dictionary);
-        Assert.DoesNotContain("should not stick", dictionary.Values);
+        dictionary.Should().ContainSingle();
+        dictionary.Values.Should().NotContain("should not stick");
     }
 
     [Fact]
@@ -835,8 +836,8 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("model", model);
 
         _engine.Execute("obj[model] = 'hello';");
-        Assert.Equal("hello", dictionary[model]);
-        Assert.IsType<string>(dictionary[model]);
+        dictionary[model].Should().Be("hello");
+        dictionary[model].Should().BeOfType<string>();
     }
 
     [Fact]
@@ -851,9 +852,9 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("obj", dictionary);
         _engine.SetValue("model", model);
 
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Execute("'use strict'; obj[model] = 'not an int';"));
-        Assert.Contains("Cannot assign", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal(42, dictionary[model]);
+        var ex = Invoking(() => _engine.Execute("'use strict'; obj[model] = 'not an int';")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().ContainEquivalentOf("Cannot assign");
+        dictionary[model].Should().Be(42);
     }
 
     [Fact]
@@ -874,11 +875,11 @@ public partial class InteropTests : IDisposable
 
         // sloppy mode: silent failure, value unchanged
         _engine.Execute("obj[model] = 'updated';");
-        Assert.Equal("value1", dictionary[model]);
+        dictionary[model].Should().Be("value1");
 
         // strict mode: TypeError, value unchanged
-        Assert.Throws<JavaScriptException>(() => _engine.Execute("'use strict'; obj[model] = 'updated';"));
-        Assert.Equal("value1", dictionary[model]);
+        Invoking(() => _engine.Execute("'use strict'; obj[model] = 'updated';")).Should().ThrowExactly<JavaScriptException>();
+        dictionary[model].Should().Be("value1");
     }
 
     [Fact]
@@ -920,11 +921,11 @@ public partial class InteropTests : IDisposable
 
         var before = engine.Evaluate("context.property[0]");
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("context.property[0] = {};"));
-        Assert.Contains("Cannot assign", ex.Message, StringComparison.OrdinalIgnoreCase);
+        var ex = Invoking(() => engine.Evaluate("context.property[0] = {};")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().ContainEquivalentOf("Cannot assign");
 
         // the element must be left untouched (the issue's other symptom was a silent overwrite)
-        Assert.Equal(before, engine.Evaluate("context.property[0]"));
+        engine.Evaluate("context.property[0]").Should().Be(before);
     }
 
     [Fact]
@@ -958,7 +959,7 @@ public partial class InteropTests : IDisposable
         engine.Evaluate("context.property[0] = {};");
 
         // ...but the assignment must not have taken effect
-        Assert.Equal(before, engine.Evaluate("context.property[0]"));
+        engine.Evaluate("context.property[0]").Should().Be(before);
     }
 
     private static void LockDescriptorHelper(JsValue jsValue, HashSet<JsValue> visited)
@@ -999,9 +1000,9 @@ public partial class InteropTests : IDisposable
         engine.SetValue("list", list);
         engine.Execute("Object.freeze(list);");
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("list[0] = 'changed';"));
-        Assert.Contains("Cannot assign", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal("a", list[0]); // not mutated
+        var ex = Invoking(() => engine.Evaluate("list[0] = 'changed';")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().ContainEquivalentOf("Cannot assign");
+        list[0].Should().Be("a"); // not mutated
     }
 
     [Fact]
@@ -1013,7 +1014,7 @@ public partial class InteropTests : IDisposable
         engine.Execute("Object.freeze(list);");
 
         engine.Evaluate("list[0] = 'changed';"); // no throw in sloppy mode
-        Assert.Equal("a", list[0]); // ...but silently ignored, not mutated
+        list[0].Should().Be("a"); // ...but silently ignored, not mutated
     }
 
     [Fact]
@@ -1025,7 +1026,7 @@ public partial class InteropTests : IDisposable
         engine.SetValue("list", list);
 
         engine.Evaluate("list[0] = 'changed';");
-        Assert.Equal("changed", list[0]);
+        list[0].Should().Be("changed");
     }
 
     [Fact]
@@ -1039,14 +1040,14 @@ public partial class InteropTests : IDisposable
 
         var strict = new Engine(x => x.Strict());
         strict.SetValue("a", readOnly);
-        var ex = Assert.Throws<JavaScriptException>(() => strict.Evaluate("a[0] = 9;"));
-        Assert.Contains("Cannot assign", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal(1, readOnly[0]);
+        var ex = Invoking(() => strict.Evaluate("a[0] = 9;")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().ContainEquivalentOf("Cannot assign");
+        readOnly[0].Should().Be(1);
 
         var sloppy = new Engine();
         sloppy.SetValue("a", readOnly);
         sloppy.Evaluate("a[0] = 9;"); // silently ignored, no throw
-        Assert.Equal(1, readOnly[0]);
+        readOnly[0].Should().Be(1);
     }
 
     [Fact]
@@ -1063,8 +1064,8 @@ public partial class InteropTests : IDisposable
                 assert(dictionary[1] === 'Donald Duck');
             ");
 
-        Assert.Equal("Mickey Mouse", collection[0]);
-        Assert.Equal("Donald Duck", collection[1]);
+        collection[0].Should().Be("Mickey Mouse");
+        collection[1].Should().Be("Donald Duck");
     }
 
     [Fact]
@@ -1077,9 +1078,9 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("list", list);
         _engine.Evaluate("list[1] = 'Donald Duck';");
 
-        Assert.Equal("Donald Duck", _engine.Evaluate("list[1]").AsString());
-        Assert.Equal("Mickey Mouse", list[0]);
-        Assert.Equal("Donald Duck", list[1]);
+        _engine.Evaluate("list[1]").AsString().Should().Be("Donald Duck");
+        list[0].Should().Be("Mickey Mouse");
+        list[1].Should().Be("Donald Duck");
     }
 
     [Fact]
@@ -1089,7 +1090,7 @@ public partial class InteropTests : IDisposable
 
         var result = _engine.Evaluate("var l = ''; for (var x of list) l += x; return l;").AsString();
 
-        Assert.Equal("ab", result);
+        result.Should().Be("ab");
     }
 
     [Fact]
@@ -1099,7 +1100,7 @@ public partial class InteropTests : IDisposable
 
         var result = _engine.Evaluate("var l = ''; for (var x of arr) l += x; return l;").AsString();
 
-        Assert.Equal("ab", result);
+        result.Should().Be("ab");
     }
 
     [Fact]
@@ -1109,7 +1110,7 @@ public partial class InteropTests : IDisposable
 
         var result = _engine.Evaluate("var l = ''; for (var x of dict) l += x; return l;").AsString();
 
-        Assert.Equal("a,1b,2", result);
+        result.Should().Be("a,1b,2");
     }
 
     [Fact]
@@ -1119,7 +1120,7 @@ public partial class InteropTests : IDisposable
 
         var result = _engine.Evaluate("var l = ''; for (var x of c.getNameChars()) l += x + ','; return l;").AsString();
 
-        Assert.Equal("n,a,m,e,", result);
+        result.Should().Be("n,a,m,e,");
     }
 
     [Fact]
@@ -1129,8 +1130,8 @@ public partial class InteropTests : IDisposable
         var o = new { A = 1, B = 2 };
         _engine.SetValue("anonymous", o);
 
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("for (var x of anonymous) {}"));
-        Assert.Equal("The value is not iterable", ex.Message);
+        var ex = Invoking(() => _engine.Evaluate("for (var x of anonymous) {}")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("The value is not iterable");
     }
 
     [Fact]
@@ -1139,11 +1140,11 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("list", new List<string> { "a", "b" });
 
         var result = _engine.Evaluate("var l = ''; for (var x of new Proxy(list, {})) l += x; return l;").AsString();
-        Assert.Equal("ab", result);
+        result.Should().Be("ab");
 
         // nested proxies unwrap all the way down to the wrapper
         result = _engine.Evaluate("var l = ''; for (var x of new Proxy(new Proxy(list, {}), {})) l += x; return l;").AsString();
-        Assert.Equal("ab", result);
+        result.Should().Be("ab");
     }
 
     [Fact]
@@ -1151,12 +1152,12 @@ public partial class InteropTests : IDisposable
     {
         _engine.SetValue("list", new List<string> { "a", "b" });
 
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("var f = list[Symbol.iterator]; f.call({});"));
-        Assert.Equal("Method '[Symbol.iterator]' called on incompatible receiver", ex.Message);
+        var ex = Invoking(() => _engine.Evaluate("var f = list[Symbol.iterator]; f.call({});")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Method '[Symbol.iterator]' called on incompatible receiver");
 
         // the error is a proper TypeError catchable from script
         var result = _engine.Evaluate("var f = list[Symbol.iterator]; try { f.call({}); 'no error' } catch (e) { e instanceof TypeError }");
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -1166,7 +1167,7 @@ public partial class InteropTests : IDisposable
 
         // primitive receiver has no engine attached, error is materialized as TypeError by the interpreter
         var result = _engine.Evaluate("var f = list[Symbol.iterator]; try { f.call('x'); 'no error' } catch (e) { e instanceof TypeError }");
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -1174,11 +1175,11 @@ public partial class InteropTests : IDisposable
     {
         _engine.SetValue("list", new List<string> { "a", "b" });
 
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("Object.getOwnPropertyDescriptor(list, 'length').get.call({});"));
-        Assert.Equal("Method 'length' called on incompatible receiver", ex.Message);
+        var ex = Invoking(() => _engine.Evaluate("Object.getOwnPropertyDescriptor(list, 'length').get.call({});")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Method 'length' called on incompatible receiver");
 
         var result = _engine.Evaluate("var g = Object.getOwnPropertyDescriptor(list, 'length').get; try { g.call('x'); 'no error' } catch (e) { e instanceof TypeError }");
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -1188,20 +1189,20 @@ public partial class InteropTests : IDisposable
         _engine.SetValue("array", new[] { 1, 2, 3 });
 
         // plain reads (served by the ICollection fast path) and own-property reflection agree
-        Assert.Equal(2, _engine.Evaluate("list.length").AsNumber());
-        Assert.Equal(3, _engine.Evaluate("array.length").AsNumber());
-        Assert.True(_engine.Evaluate("'length' in list").AsBoolean());
-        Assert.True(_engine.Evaluate("list.hasOwnProperty('length')").AsBoolean());
-        Assert.True(_engine.Evaluate("array.hasOwnProperty('length')").AsBoolean());
+        _engine.Evaluate("list.length").AsNumber().Should().Be(2);
+        _engine.Evaluate("array.length").AsNumber().Should().Be(3);
+        _engine.Evaluate("'length' in list").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("list.hasOwnProperty('length')").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("array.hasOwnProperty('length')").AsBoolean().Should().BeTrue();
 
         // the accessor descriptor keeps its eager-era shape
-        Assert.Equal("function", _engine.Evaluate("typeof Object.getOwnPropertyDescriptor(list, 'length').get").AsString());
-        Assert.True(_engine.Evaluate("Object.getOwnPropertyDescriptor(list, 'length').configurable").AsBoolean());
-        Assert.True(_engine.Evaluate("Object.getOwnPropertyDescriptor(list, 'length').set === undefined").AsBoolean());
+        _engine.Evaluate("typeof Object.getOwnPropertyDescriptor(list, 'length').get").AsString().Should().Be("function");
+        _engine.Evaluate("Object.getOwnPropertyDescriptor(list, 'length').configurable").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("Object.getOwnPropertyDescriptor(list, 'length').set === undefined").AsBoolean().Should().BeTrue();
 
         // deleting the forwarder removes the own property for good
-        Assert.True(_engine.Evaluate("delete list.length").AsBoolean());
-        Assert.False(_engine.Evaluate("list.hasOwnProperty('length')").AsBoolean());
+        _engine.Evaluate("delete list.length").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("list.hasOwnProperty('length')").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -1211,12 +1212,12 @@ public partial class InteropTests : IDisposable
 
         // the proxy's own [[Get]] rejects the revoked proxy before the iterator helper runs,
         // actual message: "Cannot perform 'get' on a proxy that has been revoked" (matches V8/node)
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("""
+        var ex = Invoking(() => _engine.Evaluate("""
             var r = Proxy.revocable(list, {});
             r.revoke();
             for (var x of r.proxy) {}
-        """));
-        Assert.Same(_engine.Realm.Intrinsics.TypeError.PrototypeObject, ex.Error.AsObject().Prototype);
+        """)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.AsObject().Prototype.Should().BeSameAs(_engine.Realm.Intrinsics.TypeError.PrototypeObject);
     }
 
     [Fact]
@@ -1226,14 +1227,14 @@ public partial class InteropTests : IDisposable
 
         // extract while alive, revoke, then re-invoke with the revoked proxy as receiver;
         // this bypasses the proxy [[Get]] guard and exercises the iterator helper directly
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("""
+        var ex = Invoking(() => _engine.Evaluate("""
             var r = Proxy.revocable(list, {});
             var f = r.proxy[Symbol.iterator];
             r.revoke();
             f.call(r.proxy);
-        """));
-        Assert.Equal("Cannot perform '[Symbol.iterator]' on a proxy that has been revoked", ex.Message);
-        Assert.Same(_engine.Realm.Intrinsics.TypeError.PrototypeObject, ex.Error.AsObject().Prototype);
+        """)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Cannot perform '[Symbol.iterator]' on a proxy that has been revoked");
+        ex.Error.AsObject().Prototype.Should().BeSameAs(_engine.Realm.Intrinsics.TypeError.PrototypeObject);
     }
 
     [Fact]
@@ -1351,8 +1352,8 @@ public partial class InteropTests : IDisposable
                 p.Age = 10;
             ");
 
-        Assert.Equal("bar", p.Name);
-        Assert.Equal(10, p.Age);
+        p.Name.Should().Be("bar");
+        p.Age.Should().Be(10);
     }
 
     [Fact]
@@ -1370,8 +1371,8 @@ public partial class InteropTests : IDisposable
                 p.Age = '20';
             ");
 
-        Assert.Equal("10", p.Name);
-        Assert.Equal(20, p.Age);
+        p.Name.Should().Be("10");
+        p.Age.Should().Be(20);
     }
 
     [Fact]
@@ -1406,7 +1407,7 @@ public partial class InteropTests : IDisposable
                 assert(p.Name === 'foo');
             ");
 
-        Assert.Equal("foo", p.Name);
+        p.Name.Should().Be("foo");
     }
 
     [Fact]
@@ -1421,7 +1422,7 @@ public partial class InteropTests : IDisposable
                 assert(p.Name === 'Mickey Mouse');
             ");
 
-        Assert.Equal("Mickey Mouse", p.Name);
+        p.Name.Should().Be("Mickey Mouse");
     }
 
     [Fact]
@@ -1435,7 +1436,7 @@ public partial class InteropTests : IDisposable
                 assert(p.Age === 1);
             ");
 
-        Assert.Equal(1, p.Age);
+        p.Age.Should().Be(1);
     }
 
     [Fact]
@@ -1553,7 +1554,7 @@ public partial class InteropTests : IDisposable
         e.SetValue("o", obj);
 
         var name = e.Evaluate("o.values.filter(x => x.age == 12)[0].name").ToString();
-        Assert.Equal("John", name);
+        name.Should().Be("John");
     }
 
 
@@ -1568,25 +1569,25 @@ public partial class InteropTests : IDisposable
             .Execute("var array1 = ['A', 'B', 'C'];")
             .Execute("var array2 = ['D', 'E', 'F'];");
 
-        Assert.True(engine.Evaluate("list1[Symbol.isConcatSpreadable] = true; list1[Symbol.isConcatSpreadable];").AsBoolean());
-        Assert.True(engine.Evaluate("list2[Symbol.isConcatSpreadable] = true; list2[Symbol.isConcatSpreadable];").AsBoolean());
+        engine.Evaluate("list1[Symbol.isConcatSpreadable] = true; list1[Symbol.isConcatSpreadable];").AsBoolean().Should().BeTrue();
+        engine.Evaluate("list2[Symbol.isConcatSpreadable] = true; list2[Symbol.isConcatSpreadable];").AsBoolean().Should().BeTrue();
 
-        Assert.Equal("[\"A\",\"B\",\"C\"]", engine.Evaluate("JSON.stringify(array1);"));
-        Assert.Equal("[\"D\",\"E\",\"F\"]", engine.Evaluate("JSON.stringify(array2);"));
-        Assert.Equal("[\"A\",\"B\",\"C\"]", engine.Evaluate("JSON.stringify(list1);"));
-        Assert.Equal("[\"D\",\"E\",\"F\"]", engine.Evaluate("JSON.stringify(list2);"));
+        engine.Evaluate("JSON.stringify(array1);").Should().Be("[\"A\",\"B\",\"C\"]");
+        engine.Evaluate("JSON.stringify(array2);").Should().Be("[\"D\",\"E\",\"F\"]");
+        engine.Evaluate("JSON.stringify(list1);").Should().Be("[\"A\",\"B\",\"C\"]");
+        engine.Evaluate("JSON.stringify(list2);").Should().Be("[\"D\",\"E\",\"F\"]");
 
         const string Concatenated = "[\"A\",\"B\",\"C\",\"D\",\"E\",\"F\"]";
-        Assert.Equal(Concatenated, engine.Evaluate("JSON.stringify(array1.concat(array2));"));
-        Assert.Equal(Concatenated, engine.Evaluate("JSON.stringify(array1.concat(list2));"));
-        Assert.Equal(Concatenated, engine.Evaluate("JSON.stringify(list1.concat(array2));"));
-        Assert.Equal(Concatenated, engine.Evaluate("JSON.stringify(list1.concat(list2));"));
+        engine.Evaluate("JSON.stringify(array1.concat(array2));").Should().Be(Concatenated);
+        engine.Evaluate("JSON.stringify(array1.concat(list2));").Should().Be(Concatenated);
+        engine.Evaluate("JSON.stringify(list1.concat(array2));").Should().Be(Concatenated);
+        engine.Evaluate("JSON.stringify(list1.concat(list2));").Should().Be(Concatenated);
 
-        Assert.False(engine.Evaluate("list1[Symbol.isConcatSpreadable] = false; list1[Symbol.isConcatSpreadable];").AsBoolean());
-        Assert.False(engine.Evaluate("list2[Symbol.isConcatSpreadable] = false; list2[Symbol.isConcatSpreadable];").AsBoolean());
+        engine.Evaluate("list1[Symbol.isConcatSpreadable] = false; list1[Symbol.isConcatSpreadable];").AsBoolean().Should().BeFalse();
+        engine.Evaluate("list2[Symbol.isConcatSpreadable] = false; list2[Symbol.isConcatSpreadable];").AsBoolean().Should().BeFalse();
 
-        Assert.Equal("[[\"A\",\"B\",\"C\"]]", engine.Evaluate("JSON.stringify([].concat(list1));"));
-        Assert.Equal("[[\"A\",\"B\",\"C\"],[\"D\",\"E\",\"F\"]]", engine.Evaluate("JSON.stringify(list1.concat(list2));"));
+        engine.Evaluate("JSON.stringify([].concat(list1));").Should().Be("[[\"A\",\"B\",\"C\"]]");
+        engine.Evaluate("JSON.stringify(list1.concat(list2));").Should().Be("[[\"A\",\"B\",\"C\"],[\"D\",\"E\",\"F\"]]");
     }
 
     [Fact]
@@ -1598,11 +1599,11 @@ public partial class InteropTests : IDisposable
 
         var parts = result.ToObject();
 
-        Assert.True(parts.GetType().IsArray);
-        Assert.Equal(3, ((object[]) parts).Length);
-        Assert.Equal(2d, ((object[]) parts)[0]);
-        Assert.Equal(4d, ((object[]) parts)[1]);
-        Assert.Equal(6d, ((object[]) parts)[2]);
+        parts.GetType().IsArray.Should().BeTrue();
+        ((object[]) parts).Length.Should().Be(3);
+        ((object[]) parts)[0].Should().Be(2d);
+        ((object[]) parts)[1].Should().Be(4d);
+        ((object[]) parts)[2].Should().Be(6d);
     }
 
     [Fact]
@@ -1614,11 +1615,11 @@ public partial class InteropTests : IDisposable
 
         var parts = result.ToObject();
 
-        Assert.True(parts.GetType().IsArray);
-        Assert.Equal(3, ((object[]) parts).Length);
-        Assert.Equal(2d, ((object[]) parts)[0]);
-        Assert.Equal(4d, ((object[]) parts)[1]);
-        Assert.Equal(6d, ((object[]) parts)[2]);
+        parts.GetType().IsArray.Should().BeTrue();
+        ((object[]) parts).Length.Should().Be(3);
+        ((object[]) parts)[0].Should().Be(2d);
+        ((object[]) parts)[1].Should().Be(4d);
+        ((object[]) parts)[2].Should().Be(6d);
     }
 
     [Fact]
@@ -1626,10 +1627,10 @@ public partial class InteropTests : IDisposable
     {
         var parts = _engine.Evaluate("'foo@bar.com'.split('@');").ToObject();
 
-        Assert.True(parts.GetType().IsArray);
-        Assert.Equal(2, ((object[]) parts).Length);
-        Assert.Equal("foo", ((object[]) parts)[0]);
-        Assert.Equal("bar.com", ((object[]) parts)[1]);
+        parts.GetType().IsArray.Should().BeTrue();
+        ((object[]) parts).Length.Should().Be(2);
+        ((object[]) parts)[0].Should().Be("foo");
+        ((object[]) parts)[1].Should().Be("bar.com");
     }
 
     [Fact]
@@ -1653,7 +1654,7 @@ public partial class InteropTests : IDisposable
         var result = _engine.SetValue("getSum", new Func<JsValue, JsValue>(adder))
             .Evaluate("getSum([1,2,3]);");
 
-        Assert.True(result == 6);
+        result.Should().Be(6);
     }
 
     [Fact]
@@ -1661,8 +1662,8 @@ public partial class InteropTests : IDisposable
     {
         var value = _engine.Evaluate("new Boolean(true)").ToObject();
 
-        Assert.Equal(typeof(bool), value.GetType());
-        Assert.Equal(true, value);
+        value.GetType().Should().Be(typeof(bool));
+        value.Should().Be(true);
     }
 
     [Fact]
@@ -1671,28 +1672,28 @@ public partial class InteropTests : IDisposable
         var engine = new Engine(options => { options.Interop.ValueCoercion = ValueCoercionType.Boolean; });
 
         engine.SetValue("o", new TestClass());
-        Assert.True(engine.Evaluate("o.Bool = 1; return o.Bool;").AsBoolean());
-        Assert.True(engine.Evaluate("o.Bool = 'dog'; return o.Bool;").AsBoolean());
-        Assert.True(engine.Evaluate("o.Bool = {}; return o.Bool;").AsBoolean());
-        Assert.False(engine.Evaluate("o.Bool = 0; return o.Bool;").AsBoolean());
-        Assert.False(engine.Evaluate("o.Bool = ''; return o.Bool;").AsBoolean());
-        Assert.False(engine.Evaluate("o.Bool = null; return o.Bool;").AsBoolean());
-        Assert.False(engine.Evaluate("o.Bool = undefined; return o.Bool;").AsBoolean());
+        engine.Evaluate("o.Bool = 1; return o.Bool;").AsBoolean().Should().BeTrue();
+        engine.Evaluate("o.Bool = 'dog'; return o.Bool;").AsBoolean().Should().BeTrue();
+        engine.Evaluate("o.Bool = {}; return o.Bool;").AsBoolean().Should().BeTrue();
+        engine.Evaluate("o.Bool = 0; return o.Bool;").AsBoolean().Should().BeFalse();
+        engine.Evaluate("o.Bool = ''; return o.Bool;").AsBoolean().Should().BeFalse();
+        engine.Evaluate("o.Bool = null; return o.Bool;").AsBoolean().Should().BeFalse();
+        engine.Evaluate("o.Bool = undefined; return o.Bool;").AsBoolean().Should().BeFalse();
 
         engine.Evaluate("class MyClass { valueOf() { return 42; } }");
-        Assert.Equal(true, engine.Evaluate("let obj = new MyClass(); o.Bool = obj; return o.Bool;").AsBoolean());
+        engine.Evaluate("let obj = new MyClass(); o.Bool = obj; return o.Bool;").AsBoolean().Should().BeTrue();
 
         engine.SetValue("func3", new Action<bool, bool, bool>((param1, param2, param3) =>
         {
-            Assert.True(param1);
-            Assert.True(param2);
-            Assert.True(param3);
+            param1.Should().BeTrue();
+            param2.Should().BeTrue();
+            param3.Should().BeTrue();
         }));
         engine.Evaluate("func3(true, obj, [ 1, 2, 3])");
 
-        Assert.Equal(true, engine.Evaluate("o.SetBool(42); return o.Bool;").AsBoolean());
-        Assert.Equal(true, engine.Evaluate("o.SetBool(obj); return o.Bool;").AsBoolean());
-        Assert.Equal(true, engine.Evaluate("o.SetBool([ 1, 2, 3].length); return o.Bool;").AsBoolean());
+        engine.Evaluate("o.SetBool(42); return o.Bool;").AsBoolean().Should().BeTrue();
+        engine.Evaluate("o.SetBool(obj); return o.Bool;").AsBoolean().Should().BeTrue();
+        engine.Evaluate("o.SetBool([ 1, 2, 3].length); return o.Bool;").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -1701,27 +1702,27 @@ public partial class InteropTests : IDisposable
         var engine = new Engine(options => { options.Interop.ValueCoercion = ValueCoercionType.Number; });
 
         engine.SetValue("o", new TestClass());
-        Assert.Equal(1, engine.Evaluate("o.Int = true; return o.Int;").AsNumber());
-        Assert.Equal(0, engine.Evaluate("o.Int = false; return o.Int;").AsNumber());
+        engine.Evaluate("o.Int = true; return o.Int;").AsNumber().Should().Be(1);
+        engine.Evaluate("o.Int = false; return o.Int;").AsNumber().Should().Be(0);
 
         engine.Evaluate("class MyClass { valueOf() { return 42; } }");
-        Assert.Equal(42, engine.Evaluate("let obj = new MyClass(); o.Int = obj; return o.Int;").AsNumber());
+        engine.Evaluate("let obj = new MyClass(); o.Int = obj; return o.Int;").AsNumber().Should().Be(42);
 
         // but null and undefined should be injected as nulls to nullable objects
-        Assert.True(engine.Evaluate("o.NullableInt = null; return o.NullableInt;").IsNull());
-        Assert.True(engine.Evaluate("o.NullableInt = undefined; return o.NullableInt;").IsNull());
+        engine.Evaluate("o.NullableInt = null; return o.NullableInt;").IsNull().Should().BeTrue();
+        engine.Evaluate("o.NullableInt = undefined; return o.NullableInt;").IsNull().Should().BeTrue();
 
         engine.SetValue("func3", new Action<int, double, long>((param1, param2, param3) =>
         {
-            Assert.Equal(1, param1);
-            Assert.Equal(42, param2);
-            Assert.Equal(3, param3);
+            param1.Should().Be(1);
+            param2.Should().Be(42);
+            param3.Should().Be(3);
         }));
         engine.Evaluate("func3(true, obj, [ 1, 2, 3].length)");
 
-        Assert.Equal(1, engine.Evaluate("o.SetInt(true); return o.Int;").AsNumber());
-        Assert.Equal(42, engine.Evaluate("o.SetInt(obj); return o.Int;").AsNumber());
-        Assert.Equal(3, engine.Evaluate("o.SetInt([ 1, 2, 3].length); return o.Int;").AsNumber());
+        engine.Evaluate("o.SetInt(true); return o.Int;").AsNumber().Should().Be(1);
+        engine.Evaluate("o.SetInt(obj); return o.Int;").AsNumber().Should().Be(42);
+        engine.Evaluate("o.SetInt([ 1, 2, 3].length); return o.Int;").AsNumber().Should().Be(3);
     }
 
     [Fact]
@@ -1730,41 +1731,41 @@ public partial class InteropTests : IDisposable
         var engine = new Engine(options => { options.Interop.ValueCoercion = ValueCoercionType.String; });
 
         // basic premise, booleans in JS are lower-case, so should the the toString under interop
-        Assert.Equal("true", engine.Evaluate("'' + true").AsString());
+        engine.Evaluate("'' + true").AsString().Should().Be("true");
 
         engine.SetValue("o", new TestClass());
-        Assert.Equal("false", engine.Evaluate("'' + o.Bool").AsString());
+        engine.Evaluate("'' + o.Bool").AsString().Should().Be("false");
 
-        Assert.Equal("true", engine.Evaluate("o.Bool = true; o.String = o.Bool; return o.String;").AsString());
+        engine.Evaluate("o.Bool = true; o.String = o.Bool; return o.String;").AsString().Should().Be("true");
 
-        Assert.Equal("true", engine.Evaluate("o.String = true; return o.String;").AsString());
+        engine.Evaluate("o.String = true; return o.String;").AsString().Should().Be("true");
 
         engine.SetValue("func1", new Func<bool>(() => true));
-        Assert.Equal("true", engine.Evaluate("'' + func1()").AsString());
+        engine.Evaluate("'' + func1()").AsString().Should().Be("true");
 
         engine.SetValue("func2", new Func<JsValue>(() => JsBoolean.True));
-        Assert.Equal("true", engine.Evaluate("'' + func2()").AsString());
+        engine.Evaluate("'' + func2()").AsString().Should().Be("true");
 
         // but null and undefined should be injected as nulls to c# objects
-        Assert.True(engine.Evaluate("o.String = null; return o.String;").IsNull());
-        Assert.True(engine.Evaluate("o.String = undefined; return o.String;").IsNull());
+        engine.Evaluate("o.String = null; return o.String;").IsNull().Should().BeTrue();
+        engine.Evaluate("o.String = undefined; return o.String;").IsNull().Should().BeTrue();
 
-        Assert.Equal("1,2,3", engine.Evaluate("o.String = [ 1, 2, 3 ]; return o.String;").AsString());
+        engine.Evaluate("o.String = [ 1, 2, 3 ]; return o.String;").AsString().Should().Be("1,2,3");
 
         engine.Evaluate("class MyClass { toString() { return 'hello world'; } }");
-        Assert.Equal("hello world", engine.Evaluate("let obj = new MyClass(); o.String = obj; return o.String;").AsString());
+        engine.Evaluate("let obj = new MyClass(); o.String = obj; return o.String;").AsString().Should().Be("hello world");
 
         engine.SetValue("func3", new Action<string, string, string>((param1, param2, param3) =>
         {
-            Assert.Equal("true", param1);
-            Assert.Equal("hello world", param2);
-            Assert.Equal("1,2,3", param3);
+            param1.Should().Be("true");
+            param2.Should().Be("hello world");
+            param3.Should().Be("1,2,3");
         }));
         engine.Evaluate("func3(true, obj, [ 1, 2, 3])");
 
-        Assert.Equal("true", engine.Evaluate("o.SetString(true); return o.String;").AsString());
-        Assert.Equal("hello world", engine.Evaluate("o.SetString(obj); return o.String;").AsString());
-        Assert.Equal("1,2,3", engine.Evaluate("o.SetString([ 1, 2, 3]); return o.String;").AsString());
+        engine.Evaluate("o.SetString(true); return o.String;").AsString().Should().Be("true");
+        engine.Evaluate("o.SetString(obj); return o.String;").AsString().Should().Be("hello world");
+        engine.Evaluate("o.SetString([ 1, 2, 3]); return o.String;").AsString().Should().Be("1,2,3");
     }
 
     [Fact]
@@ -1773,8 +1774,8 @@ public partial class InteropTests : IDisposable
         var result = _engine.Evaluate("new Date(0)");
         var value = result.ToObject() is DateTime ? (DateTime) result.ToObject() : default;
 
-        Assert.Equal(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc), value);
-        Assert.Equal(DateTimeKind.Utc, value.Kind);
+        value.Should().Be(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        value.Kind.Should().Be(DateTimeKind.Utc);
     }
 
     [Fact]
@@ -1799,8 +1800,8 @@ public partial class InteropTests : IDisposable
         var result = engine.Evaluate("new Date(0)");
         var value = result.ToObject() is DateTime ? (DateTime) result.ToObject() : default;
 
-        Assert.Equal(new DateTime(1970, 1, 1, 2, 0, 0, DateTimeKind.Local), value);
-        Assert.Equal(DateTimeKind.Local, value.Kind);
+        value.Should().Be(new DateTime(1970, 1, 1, 2, 0, 0, DateTimeKind.Local));
+        value.Kind.Should().Be(DateTimeKind.Local);
     }
 
     [Fact]
@@ -1809,8 +1810,8 @@ public partial class InteropTests : IDisposable
         var result = _engine.Evaluate("new Number(10)");
         var value = result.ToObject();
 
-        Assert.Equal(typeof(double), value.GetType());
-        Assert.Equal(10d, value);
+        value.GetType().Should().Be(typeof(double));
+        value.Should().Be(10d);
     }
 
     [Fact]
@@ -1818,8 +1819,8 @@ public partial class InteropTests : IDisposable
     {
         var value = _engine.Evaluate("new String('foo')").ToObject();
 
-        Assert.Equal(typeof(string), value.GetType());
-        Assert.Equal("foo", value);
+        value.GetType().Should().Be(typeof(string));
+        value.Should().Be("foo");
     }
 
     [Fact]
@@ -1941,7 +1942,7 @@ public partial class InteropTests : IDisposable
     public void ShouldExecuteActionCallbackOnEventChanged()
     {
         var collection = new System.Collections.ObjectModel.ObservableCollection<string>();
-        Assert.True(collection.Count == 0);
+        collection.Should().HaveCount(0);
 
         _engine.SetValue("collection", collection);
 
@@ -1957,11 +1958,11 @@ public partial class InteropTests : IDisposable
             ");
 
         var callCount = (int) _engine.GetValue("callCount").AsNumber();
-        Assert.Equal(1, callCount);
-        Assert.Equal(2, collection.Count);
+        callCount.Should().Be(1);
+        collection.Should().HaveCount(2);
 
         // make sure our delegate holder is hidden
-        Assert.Equal("[]", _engine.Evaluate("json"));
+        _engine.Evaluate("json").Should().Be("[]");
     }
 
     [Fact]
@@ -2034,7 +2035,7 @@ public partial class InteropTests : IDisposable
                 function add(x, y) { return x + y; }
             ");
 
-        Assert.Equal(3, _engine.Invoke("add", 1, 2));
+        _engine.Invoke("add", 1, 2).Should().Be(3);
     }
 
     [Fact]
@@ -2044,7 +2045,7 @@ public partial class InteropTests : IDisposable
                 var x= 10;
             ");
 
-        Assert.Throws<JavaScriptException>(() => _engine.Invoke("x", 1, 2));
+        Invoking(() => _engine.Invoke("x", 1, 2)).Should().ThrowExactly<JavaScriptException>();
     }
 
     [Fact]
@@ -2074,7 +2075,7 @@ public partial class InteropTests : IDisposable
                 assert(o.Field === 'Mickey Mouse');
             ");
 
-        Assert.Equal("Mickey Mouse", o.Field);
+        o.Field.Should().Be("Mickey Mouse");
     }
 
     [Fact]
@@ -2097,7 +2098,7 @@ public partial class InteropTests : IDisposable
                 assert(statics.Set == 'hello');
             ");
 
-        Assert.Equal(ClassWithStaticFields.Set, "hello");
+        "hello".Should().Be(ClassWithStaticFields.Set);
     }
 
     [Fact]
@@ -2120,7 +2121,7 @@ public partial class InteropTests : IDisposable
                 assert(statics.Setter == 'hello');
             ");
 
-        Assert.Equal(ClassWithStaticFields.Setter, "hello");
+        "hello".Should().Be(ClassWithStaticFields.Setter);
     }
 
     [Fact]
@@ -2133,7 +2134,7 @@ public partial class InteropTests : IDisposable
                 assert(statics.Readonly == 'Readonly');
             ");
 
-        Assert.Equal(ClassWithStaticFields.Readonly, "Readonly");
+        "Readonly".Should().Be(ClassWithStaticFields.Readonly);
     }
 
     [Fact]
@@ -2142,23 +2143,23 @@ public partial class InteropTests : IDisposable
         var engine1 = new Engine();
         engine1.SetValue("p", new { Test = true });
         engine1.Execute("var result = p.Test;");
-        Assert.True((bool) engine1.GetValue("result").ToObject());
+        ((bool) engine1.GetValue("result").ToObject()).Should().BeTrue();
 
         var engine2 = new Engine(o => o.AddObjectConverter(new NegateBoolConverter()));
         engine2.SetValue("p", new { Test = true });
         engine2.Execute("var result = p.Test;");
-        Assert.False((bool) engine2.GetValue("result").ToObject());
+        ((bool) engine2.GetValue("result").ToObject()).Should().BeFalse();
     }
 
     [Fact]
     public void CanConvertEnumsToString()
     {
         var engine1 = new Engine(o => o.AddObjectConverter(new EnumsToStringConverter()))
-            .SetValue("assert", new Action<bool>(Assert.True));
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()));
         engine1.SetValue("p", new { Comparison = StringComparison.CurrentCulture });
         engine1.Execute("assert(p.Comparison === 'CurrentCulture');");
         engine1.Execute("var result = p.Comparison;");
-        Assert.Equal("CurrentCulture", (string) engine1.GetValue("result").ToObject());
+        ((string) engine1.GetValue("result").ToObject()).Should().Be("CurrentCulture");
     }
 
     [Fact]
@@ -2175,7 +2176,7 @@ public partial class InteropTests : IDisposable
                 assert(++p.Age === 2);
             ");
 
-        Assert.Equal(2, p.Age);
+        p.Age.Should().Be(2);
     }
 
     [Fact]
@@ -2213,7 +2214,7 @@ public partial class InteropTests : IDisposable
         };
 
         _engine.SetValue("o", o);
-        _engine.SetValue("assertFalse", new Action<bool>(Assert.False));
+        _engine.SetValue("assertFalse", new Action<bool>(static value => value.Should().BeFalse()));
 
         RunTest(@"
                 var domain = importNamespace('Jint.Tests.Runtime.Domain');
@@ -2250,7 +2251,7 @@ public partial class InteropTests : IDisposable
                 assert(s.Color === colors.Blue | colors.Green);
             ");
 
-        Assert.Equal(Colors.Blue | Colors.Green, s.Color);
+        s.Color.Should().Be(Colors.Blue | Colors.Green);
     }
 
     private enum TestEnumInt32 : int
@@ -2372,14 +2373,14 @@ public partial class InteropTests : IDisposable
                 assert(s.Color === 11);
             ");
 
-        Assert.Equal(Colors.Blue | Colors.Green, s.Color);
+        s.Color.Should().Be(Colors.Blue | Colors.Green);
     }
 
     [Fact]
     public void ShouldUseExplicitPropertyGetter()
     {
         _engine.SetValue("c", new Company("ACME"));
-        Assert.Equal("ACME", _engine.Evaluate("c.Name"));
+        _engine.Evaluate("c.Name").Should().Be("ACME");
     }
 
     [Fact]
@@ -2388,14 +2389,14 @@ public partial class InteropTests : IDisposable
         var company = new Company("ACME");
         ((ICompany) company)["Foo"] = "Bar";
         _engine.SetValue("c", company);
-        Assert.Equal("Bar", _engine.Evaluate("c.Foo"));
+        _engine.Evaluate("c.Foo").Should().Be("Bar");
     }
 
     [Fact]
     public void ShouldUseExplicitPropertySetter()
     {
         _engine.SetValue("c", new Company("ACME"));
-        Assert.Equal("Foo", _engine.Evaluate("c.Name = 'Foo'; c.Name;"));
+        _engine.Evaluate("c.Name = 'Foo'; c.Name;").Should().Be("Foo");
     }
 
     [Fact]
@@ -2480,7 +2481,7 @@ public partial class InteropTests : IDisposable
                 assert(p.Name == null);
             ");
 
-        Assert.True(p.Name == null);
+        p.Name.Should().Be(null);
     }
 
     [Fact]
@@ -2521,7 +2522,7 @@ public partial class InteropTests : IDisposable
         engine.Execute(@"function f2(obj) { return obj[1]; }");
 
         var failingObject = new FailingObject2();
-        Assert.Throws<ArgumentException>(() => engine.Invoke("f2", failingObject));
+        Invoking(() => engine.Invoke("f2", failingObject)).Should().ThrowExactly<ArgumentException>();
     }
 
     [Fact]
@@ -2618,7 +2619,7 @@ public partial class InteropTests : IDisposable
                 assert(statics.Set == 'hello');
             ");
 
-        Assert.Equal(Nested.ClassWithStaticFields.Set, "hello");
+        "hello".Should().Be(Nested.ClassWithStaticFields.Set);
     }
 
     [Fact]
@@ -2641,7 +2642,7 @@ public partial class InteropTests : IDisposable
                 assert(statics.Setter == 'hello');
             ");
 
-        Assert.Equal(Nested.ClassWithStaticFields.Setter, "hello");
+        "hello".Should().Be(Nested.ClassWithStaticFields.Setter);
     }
 
     [Fact]
@@ -2654,7 +2655,7 @@ public partial class InteropTests : IDisposable
                 assert(statics.Readonly == 'Readonly');
             ");
 
-        Assert.Equal(Nested.ClassWithStaticFields.Readonly, "Readonly");
+        "Readonly".Should().Be(Nested.ClassWithStaticFields.Readonly);
     }
 
     [Fact]
@@ -2717,8 +2718,8 @@ public partial class InteropTests : IDisposable
                     }
                 ");
 
-        Assert.ThrowsAny<NotSupportedException>(() => engine.Invoke("throwException1"));
-        Assert.ThrowsAny<NotSupportedException>(() => engine.Invoke("throwException2"));
+        Invoking(() => engine.Invoke("throwException1")).Should().Throw<NotSupportedException>();
+        Invoking(() => engine.Invoke("throwException2")).Should().Throw<NotSupportedException>();
     }
 
     [Fact]
@@ -2751,8 +2752,8 @@ public partial class InteropTests : IDisposable
                     }
                 ");
 
-        Assert.Equal(engine.Invoke("throwException1").AsString(), exceptionMessage);
-        Assert.Equal(engine.Invoke("throwException2").AsString(), exceptionMessage);
+        exceptionMessage.Should().Be(engine.Invoke("throwException1").AsString());
+        exceptionMessage.Should().Be(engine.Invoke("throwException2").AsString());
     }
 
     [Fact]
@@ -2765,22 +2766,23 @@ public partial class InteropTests : IDisposable
 // line 2
 new Thrower().ThrowExceptionWithMessage('boom');";
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute(script));
-        Assert.Equal("boom", ex.Message);
-        Assert.NotEqual(default, ex.Location);
-        Assert.Equal(3, ex.Location.Start.Line);
-        Assert.NotNull(ex.JavaScriptStackTrace);
-        Assert.Contains("3:", ex.JavaScriptStackTrace);
+        var ex = Invoking(() => engine.Execute(script)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("boom");
+        ex.Location.Should().NotBe(default);
+        ex.Location.Start.Line.Should().Be(3);
+        ex.JavaScriptStackTrace.Should().NotBeNull();
+        ex.JavaScriptStackTrace.Should().Contain("3:");
     }
 
     [Fact]
     public void ShouldNotCatchClrFromApply()
     {
+        var handlerCalled = false;
         var engine = new Engine(options =>
         {
             options.CatchClrExceptions(e =>
             {
-                Assert.Fail("was called");
+                handlerCalled = true;
                 return true;
             });
         });
@@ -2796,6 +2798,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
                 // does cause ExceptionDelegateHandler call
                 try { throwError.apply(); } catch {}
             ");
+
+        handlerCalled.Should().BeFalse();
     }
 
     private class MemberExceptionTest
@@ -2835,7 +2839,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             cfg.CatchClrExceptions();
         });
 
-        engine.SetValue("assert", new Action<bool>(Assert.True));
+        engine.SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()));
         engine.SetValue("log", new Action<object>(Console.WriteLine));
         engine.SetValue("create", typeof(MemberExceptionTest));
         engine.SetValue("instance", new MemberExceptionTest(false));
@@ -2954,10 +2958,10 @@ new Thrower().ThrowExceptionWithMessage('boom');";
                     }
                 ");
 
-        Assert.Equal(engine.Invoke("throwException1").AsString(), exceptionMessage);
-        Assert.Throws<ArgumentNullException>(() => engine.Invoke("throwException2"));
-        Assert.Equal(engine.Invoke("throwException3").AsString(), exceptionMessage);
-        Assert.Throws<ArgumentNullException>(() => engine.Invoke("throwException4"));
+        exceptionMessage.Should().Be(engine.Invoke("throwException1").AsString());
+        Invoking(() => engine.Invoke("throwException2")).Should().ThrowExactly<ArgumentNullException>();
+        exceptionMessage.Should().Be(engine.Invoke("throwException3").AsString());
+        Invoking(() => engine.Invoke("throwException4")).Should().ThrowExactly<ArgumentNullException>();
     }
 
     [Fact]
@@ -2997,15 +3001,15 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             caughtError;
         ");
 
-        Assert.True(decoratorCalled, "Decorator should have been called");
-        Assert.NotNull(capturedOriginalException);
-        Assert.IsType<InvalidOperationException>(capturedOriginalException);
-        Assert.Equal(exceptionMessage, capturedOriginalException.Message);
+        decoratorCalled.Should().BeTrue("Decorator should have been called");
+        capturedOriginalException.Should().NotBeNull();
+        capturedOriginalException.Should().BeOfType<InvalidOperationException>();
+        capturedOriginalException.Message.Should().Be(exceptionMessage);
         
         var errorObject = result.AsObject();
-        Assert.Equal("decorated", errorObject.Get("customProperty").AsString());
-        Assert.Equal("System.InvalidOperationException", errorObject.Get("clrType").AsString());
-        Assert.Equal($"[Decorated] {exceptionMessage}", errorObject.Get("message").AsString());
+        errorObject.Get("customProperty").AsString().Should().Be("decorated");
+        errorObject.Get("clrType").AsString().Should().Be("System.InvalidOperationException");
+        errorObject.Get("message").AsString().Should().Be($"[Decorated] {exceptionMessage}");
     }
 
     [Fact]
@@ -3036,7 +3040,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             }
         ");
 
-        Assert.Equal(1, decoratorCallCount);
+        decoratorCallCount.Should().Be(1);
     }
 
     [Fact]
@@ -3056,8 +3060,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         engine.SetValue("throwException", new Action(() => { throw new InvalidOperationException(); }));
 
         // Should throw because InvalidOperationException is not caught
-        Assert.Throws<InvalidOperationException>(() => engine.Evaluate("throwException()"));
-        Assert.False(decoratorCalled, "Decorator should not be called when exception is not caught");
+        Invoking(() => engine.Evaluate("throwException()")).Should().ThrowExactly<InvalidOperationException>();
+        decoratorCalled.Should().BeFalse("Decorator should not be called when exception is not caught");
     }
 
     [Fact]
@@ -3084,8 +3088,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             }
         ").AsObject();
 
-        Assert.True(result.Get("hasRealm").AsBoolean());
-        Assert.True(result.Get("hasTimestamp").AsBoolean());
+        result.Get("hasRealm").AsBoolean().Should().BeTrue();
+        result.Get("hasTimestamp").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -3172,7 +3176,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         engine.SetValue("P", p);
         engine.Evaluate("P.Name = 'b';");
         engine.Evaluate("P.Name += 'c';");
-        Assert.Equal("bc", p.Name);
+        p.Name.Should().Be("bc");
     }
 
     [Fact]
@@ -3185,8 +3189,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
                 return new domain.FloatIndexer();
             ");
 
-        Assert.NotNull(c.ToString());
-        Assert.Equal((uint) 0, c.AsObject().GetLength());
+        c.ToString().Should().NotBeNull();
+        c.AsObject().GetLength().Should().Be((uint) 0);
     }
 
     private class DictionaryWrapper
@@ -3198,23 +3202,23 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     {
         public void Test1(IDictionary<string, object> values)
         {
-            Assert.Equal(1, Convert.ToInt32(values["a"]));
+            Convert.ToInt32(values["a"]).Should().Be(1);
         }
 
         public void Test2(DictionaryWrapper dictionaryObject)
         {
-            Assert.Equal(1, Convert.ToInt32(dictionaryObject.Values["a"]));
+            Convert.ToInt32(dictionaryObject.Values["a"]).Should().Be(1);
         }
 
         public void Test3(Dictionary<string, object> values)
         {
-            Assert.Equal(1, Convert.ToInt32(values["a"]));
+            Convert.ToInt32(values["a"]).Should().Be(1);
         }
 
         public void Test4(Dictionary<string, object> values = null)
         {
-            Assert.NotNull(values);
-            Assert.Equal("world", values["value"]);
+            values.Should().NotBeNull();
+            values["value"].Should().Be("world");
         }
     }
 
@@ -3263,7 +3267,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             """);
 
         var result = engine.Evaluate("globalScope.fuzzyScore('abc', 'xyz');");
-        Assert.Equal("abc:xyz", result.AsString());
+        result.AsString().Should().Be("abc:xyz");
     }
 
     [Fact]
@@ -3280,8 +3284,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             .Evaluate("({ supplier: 'S1', ...state.invoice })")
             .ToObject();
 
-        Assert.Equal("S1", result["supplier"]);
-        Assert.Equal("42", result["number"]);
+        result["supplier"].Should().Be("S1");
+        result["number"].Should().Be("42");
     }
 
     [Fact]
@@ -3299,8 +3303,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             .Invoke("getValue")
             .ToObject();
 
-        Assert.Equal("S1", result["supplier"]);
-        Assert.Equal("42", result["number"]);
+        result["supplier"].Should().Be("S1");
+        result["number"].Should().Be("42");
     }
 
     [Fact]
@@ -3318,9 +3322,9 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             .Evaluate("({ supplier: 'S1', ...p })")
             .ToObject();
 
-        Assert.Equal("S1", result["supplier"]);
-        Assert.Equal("Mike", result["Name"]);
-        Assert.Equal(20d, result["Age"]);
+        result["supplier"].Should().Be("S1");
+        result["Name"].Should().Be("Mike");
+        result["Age"].Should().Be(20d);
     }
 
     [Fact]
@@ -3338,11 +3342,11 @@ new Thrower().ThrowExceptionWithMessage('boom');";
 
         var jsValue = engine.Evaluate("jsObj['key1']").AsString();
         var clrValue = engine.Evaluate("netObj['key1']").AsString();
-        Assert.Equal(jsValue, clrValue);
+        clrValue.Should().Be(jsValue);
 
         jsValue = engine.Evaluate("JSON.stringify(jsObj)").AsString();
         clrValue = engine.Evaluate("JSON.stringify(netObj)").AsString();
-        Assert.Equal(jsValue, clrValue);
+        clrValue.Should().Be(jsValue);
 
         // Write properties on screen using showProps function defined on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects
         engine.Execute(@"function showProps(obj, objName) {
@@ -3356,7 +3360,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
 }");
         jsValue = engine.Evaluate("showProps(jsObj, 'theObject')").AsString();
         clrValue = engine.Evaluate("showProps(jsObj, 'theObject')").AsString();
-        Assert.Equal(jsValue, clrValue);
+        clrValue.Should().Be(jsValue);
     }
 
     [Fact]
@@ -3370,9 +3374,9 @@ new Thrower().ThrowExceptionWithMessage('boom');";
                 log(fia[0]);
             ");
 
-        Assert.Equal(123, engine.Evaluate("fia[0]").AsNumber());
+        engine.Evaluate("fia[0]").AsNumber().Should().Be(123);
         engine.Evaluate("fia[0] = 678;");
-        Assert.Equal(678, engine.Evaluate("fia[0]").AsNumber());
+        engine.Evaluate("fia[0]").AsNumber().Should().Be(678);
     }
 
     [Fact]
@@ -3384,8 +3388,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         _engine.SetValue("animals", bsonAnimals["Animals"]);
 
         // weak equality does conversions from native types
-        Assert.True(_engine.Evaluate("animals[0].Type == 'Cat'").AsBoolean());
-        Assert.True(_engine.Evaluate("animals[0].Id == 1").AsBoolean());
+        _engine.Evaluate("animals[0].Type == 'Cat'").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("animals[0].Id == 1").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -3393,8 +3397,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     {
         var engine = new Engine(options => options.AllowClr(GetType().Assembly));
         engine.SetValue("a", new OverLoading());
-        Assert.Equal("int-val", engine.Evaluate("a.testFunc(123);").AsString());
-        Assert.Equal("float-val", engine.Evaluate("a.testFunc(12.3);").AsString());
+        engine.Evaluate("a.testFunc(123);").AsString().Should().Be("int-val");
+        engine.Evaluate("a.testFunc(12.3);").AsString().Should().Be("float-val");
     }
 
     [Fact]
@@ -3402,11 +3406,11 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     {
         var engine = new Engine(options => options.AllowClr());
         engine.SetValue("IntValueInput", TypeReference.CreateTypeReference(engine, typeof(IntValueInput)));
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("new IntValueInput().testFunc(NaN);").AsString());
+        var ex = Invoking(() => engine.Evaluate("new IntValueInput().testFunc(NaN);").AsString()).Should().ThrowExactly<JavaScriptException>().Which;
         // detailed resolution errors are off by default, so the terse message is used
-        Assert.Equal("No public methods with the specified arguments were found.", ex.Message);
+        ex.Message.Should().Be("No public methods with the specified arguments were found.");
 
-        Assert.Equal(123, engine.Evaluate("new IntValueInput().testFunc(123);").AsNumber());
+        engine.Evaluate("new IntValueInput().testFunc(123);").AsNumber().Should().Be(123);
     }
 
     [Fact]
@@ -3414,7 +3418,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     {
         var engine = new Engine(options => options.AllowClr());
         engine.SetValue("IntValueInput", TypeReference.CreateTypeReference(engine, typeof(IntValueInput)));
-        Assert.Equal(12, engine.Evaluate("new IntValueInput().testFunc(12.3);").AsNumber());
+        engine.Evaluate("new IntValueInput().testFunc(12.3);").AsNumber().Should().Be(12);
     }
 
     public class IntValueInput
@@ -3476,10 +3480,10 @@ new Thrower().ThrowExceptionWithMessage('boom');";
 
         engine.SetValue("lst", lst);
 
-        Assert.Equal(5, engine.Evaluate("lst.Sum(x => x.Cost);").AsNumber());
-        Assert.Equal(50, engine.Evaluate("lst.Sum(x => x.Age);").AsNumber());
-        Assert.Equal(3, engine.Evaluate("lst.Where(x => x.Name == 'b').Count;").AsNumber());
-        Assert.Equal(30, engine.Evaluate("lst.Where(x => x.Name == 'b').Sum(x => x.Age);").AsNumber());
+        engine.Evaluate("lst.Sum(x => x.Cost);").AsNumber().Should().Be(5);
+        engine.Evaluate("lst.Sum(x => x.Age);").AsNumber().Should().Be(50);
+        engine.Evaluate("lst.Where(x => x.Name == 'b').Count;").AsNumber().Should().Be(3);
+        engine.Evaluate("lst.Where(x => x.Name == 'b').Sum(x => x.Age);").AsNumber().Should().Be(30);
     }
 
     [Fact]
@@ -3490,24 +3494,24 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         _engine.SetValue("b", new Person { Name = "Name" });
         _engine.Evaluate("const arr = [ null, a, undefined ];");
 
-        Assert.Equal(1, _engine.Evaluate("arr.filter(x => x == b).length").AsNumber());
-        Assert.Equal(1, _engine.Evaluate("arr.filter(x => x === b).length").AsNumber());
+        _engine.Evaluate("arr.filter(x => x == b).length").AsNumber().Should().Be(1);
+        _engine.Evaluate("arr.filter(x => x === b).length").AsNumber().Should().Be(1);
 
-        Assert.True(_engine.Evaluate("arr.find(x => x == b) === a").AsBoolean());
-        Assert.True(_engine.Evaluate("arr.find(x => x === b) == a").AsBoolean());
+        _engine.Evaluate("arr.find(x => x == b) === a").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("arr.find(x => x === b) == a").AsBoolean().Should().BeTrue();
 
-        Assert.Equal(1, _engine.Evaluate("arr.findIndex(x => x == b)").AsNumber());
-        Assert.Equal(1, _engine.Evaluate("arr.findIndex(x => x === b)").AsNumber());
+        _engine.Evaluate("arr.findIndex(x => x == b)").AsNumber().Should().Be(1);
+        _engine.Evaluate("arr.findIndex(x => x === b)").AsNumber().Should().Be(1);
 
-        Assert.Equal(1, _engine.Evaluate("arr.indexOf(b)").AsNumber());
-        Assert.True(_engine.Evaluate("arr.includes(b)").AsBoolean());
+        _engine.Evaluate("arr.indexOf(b)").AsNumber().Should().Be(1);
+        _engine.Evaluate("arr.includes(b)").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void ObjectWrapperWrappingDictionaryShouldNotBeArrayLike()
     {
         var wrapper = ObjectWrapper.Create(_engine, new Dictionary<string, object>());
-        Assert.False(wrapper.IsArrayLike);
+        wrapper.IsArrayLike.Should().BeFalse();
     }
 
     [Theory]
@@ -3549,8 +3553,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             """
         );
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute($"delete context.{access}"));
-        Assert.StartsWith($"Cannot delete property '{names[^1]}'", ex.Message);
+        var ex = Invoking(() => engine.Execute($"delete context.{access}")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().StartWith($"Cannot delete property '{names[^1]}'");
     }
 
     [Fact]
@@ -3567,12 +3571,12 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         engine.Realm.GlobalObject.FastSetDataProperty("test", new DelegateWrapper(engine, (Action<string, object>) Test));
 
         {
-            var ex = Assert.Throws<JavaScriptException>(() => engine.Realm.GlobalObject.ToObject());
-            Assert.Equal("Cyclic reference detected.", ex.Message);
+            var ex = Invoking(() => engine.Realm.GlobalObject.ToObject()).Should().ThrowExactly<JavaScriptException>().Which;
+            ex.Message.Should().Be("Cyclic reference detected.");
         }
 
         {
-            var ex = Assert.Throws<JavaScriptException>(() =>
+            var ex = Invoking(() =>
                 engine.Execute(@"
                     var demo={};
                     demo.value=1;
@@ -3581,9 +3585,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
                     demo.demo=demo;
                     test('Test 3', demo);
                     test('Test 4', global);"
-                )
-            );
-            Assert.Equal("Cyclic reference detected.", ex.Message);
+                )).Should().ThrowExactly<JavaScriptException>().Which;
+            ex.Message.Should().Be("Cyclic reference detected.");
         }
     }
 
@@ -3593,9 +3596,9 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         // defaults
         var e = new Engine();
         e.SetValue("a", new A());
-        Assert.True(e.Evaluate("a.call1").IsObject());
-        Assert.True(e.Evaluate("a.Call1").IsObject());
-        Assert.True(e.Evaluate("a.CALL1").IsUndefined());
+        e.Evaluate("a.call1").IsObject().Should().BeTrue();
+        e.Evaluate("a.Call1").IsObject().Should().BeTrue();
+        e.Evaluate("a.CALL1").IsUndefined().Should().BeTrue();
 
         e = new Engine(options =>
         {
@@ -3605,9 +3608,9 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             });
         });
         e.SetValue("a", new A());
-        Assert.True(e.Evaluate("a.call1").IsUndefined());
-        Assert.True(e.Evaluate("a.Call1").IsObject());
-        Assert.True(e.Evaluate("a.CALL1").IsUndefined());
+        e.Evaluate("a.call1").IsUndefined().Should().BeTrue();
+        e.Evaluate("a.Call1").IsObject().Should().BeTrue();
+        e.Evaluate("a.CALL1").IsUndefined().Should().BeTrue();
 
         e = new Engine(options =>
         {
@@ -3617,9 +3620,9 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             });
         });
         e.SetValue("a", new A());
-        Assert.True(e.Evaluate("a.call1").IsObject());
-        Assert.True(e.Evaluate("a.Call1").IsObject());
-        Assert.True(e.Evaluate("a.CALL1").IsObject());
+        e.Evaluate("a.call1").IsObject().Should().BeTrue();
+        e.Evaluate("a.Call1").IsObject().Should().BeTrue();
+        e.Evaluate("a.CALL1").IsObject().Should().BeTrue();
     }
 
     [Fact]
@@ -3635,12 +3638,12 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         engine.SetValue("dictionary", dictionary);
 
         var result = engine.Evaluate($"Object.keys(dictionary).join(',')").AsString();
-        Assert.Equal("foo,bar", result);
+        result.Should().Be("foo,bar");
 
 
         engine.Execute("dictionary.ContainsKey('foo')");
         result = engine.Evaluate($"Object.keys(dictionary).join(',')").AsString();
-        Assert.Equal("foo,bar", result);
+        result.Should().Be("foo,bar");
     }
 
     [Fact]
@@ -3649,7 +3652,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         var engine = new Engine(cfg => cfg.AddExtensionMethods(typeof(Enumerable)));
 
         var result = engine.Evaluate("Object.keys({ ...[1,2,3] }).join(',')").AsString();
-        Assert.Equal("0,1,2", result);
+        result.Should().Be("0,1,2");
 
         var script = @"
                 var arr = [1,2,3];
@@ -3658,7 +3661,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
                 keys.join(',');
             ";
         result = engine.Evaluate(script).ToString();
-        Assert.Equal("0,1,2", result);
+        result.Should().Be("0,1,2");
     }
 
     [Fact]
@@ -3676,7 +3679,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         engine.SetValue("people", people);
 
         // indexer access keeps working
-        Assert.Equal("person1", engine.Evaluate("people['person1'].Name").AsString());
+        engine.Evaluate("people['person1'].Name").AsString().Should().Be("person1");
 
         // for...in now enumerates the reported keys and the body resolves values via the indexer
         var forIn = engine.Evaluate(@"
@@ -3684,13 +3687,13 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             for (var p in people) { result += people[p].Name + ' '; }
             result.trim();
         ").AsString();
-        Assert.Equal("person1 person2", forIn);
+        forIn.Should().Be("person1 person2");
 
         // Object.keys shares the same enumeration path
-        Assert.Equal("person1,person2", engine.Evaluate("Object.keys(people).join(',')").AsString());
+        engine.Evaluate("Object.keys(people).join(',')").AsString().Should().Be("person1,person2");
 
         // regular CLR members remain accessible alongside the reported keys
-        Assert.Equal(2d, engine.Evaluate("people.Count").AsNumber());
+        engine.Evaluate("people.Count").AsNumber().Should().Be(2d);
     }
 
     [Fact]
@@ -3704,14 +3707,14 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         });
 
         // default delegate returns null, so dictionary enumeration is unchanged
-        Assert.Equal("foo,bar", engine.Evaluate("Object.keys(dictionary).join(',')").AsString());
+        engine.Evaluate("Object.keys(dictionary).join(',')").AsString().Should().Be("foo,bar");
 
         var forIn = engine.Evaluate(@"
             var keys = [];
             for (var k in dictionary) keys.push(k);
             keys.join(',');
         ").AsString();
-        Assert.Equal("foo,bar", forIn);
+        forIn.Should().Be("foo,bar");
     }
 
     public sealed class ReportedKeysPerson(string name)
@@ -3737,10 +3740,10 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         engine.Evaluate("var f = () => true;");
 
         var result = engine.GetValue("f");
-        Assert.True(result.IsCallable);
+        result.IsCallable.Should().BeTrue();
 
-        Assert.True(result.Call([]).AsBoolean());
-        Assert.True(result.Call().AsBoolean());
+        result.Call([]).AsBoolean().Should().BeTrue();
+        result.Call().AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -3774,30 +3777,30 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         });
 
         engine.SetValue("o", new CustomNamed());
-        Assert.Equal("StringField", engine.Evaluate("o.jsStringField").AsString());
-        Assert.Equal("StringField", engine.Evaluate("o.jsStringField2").AsString());
-        Assert.Equal("StringProperty", engine.Evaluate("o.jsStringProperty").AsString());
-        Assert.Equal("Method", engine.Evaluate("o.jsMethod()").AsString());
-        Assert.Equal("InterfaceStringProperty", engine.Evaluate("o.jsInterfaceStringProperty").AsString());
-        Assert.Equal("InterfaceMethod", engine.Evaluate("o.jsInterfaceMethod()").AsString());
-        Assert.Equal("ExtensionMethod", engine.Evaluate("o.jsExtensionMethod()").AsString());
+        engine.Evaluate("o.jsStringField").AsString().Should().Be("StringField");
+        engine.Evaluate("o.jsStringField2").AsString().Should().Be("StringField");
+        engine.Evaluate("o.jsStringProperty").AsString().Should().Be("StringProperty");
+        engine.Evaluate("o.jsMethod()").AsString().Should().Be("Method");
+        engine.Evaluate("o.jsInterfaceStringProperty").AsString().Should().Be("InterfaceStringProperty");
+        engine.Evaluate("o.jsInterfaceMethod()").AsString().Should().Be("InterfaceMethod");
+        engine.Evaluate("o.jsExtensionMethod()").AsString().Should().Be("ExtensionMethod");
 
         // static methods are reported by default, unlike properties and fields
-        Assert.Equal("StaticMethod", engine.Evaluate("o.jsStaticMethod()").AsString());
+        engine.Evaluate("o.jsStaticMethod()").AsString().Should().Be("StaticMethod");
 
         engine.SetValue("CustomNamed", typeof(CustomNamed));
-        Assert.Equal("StaticStringField", engine.Evaluate("CustomNamed.jsStaticStringField").AsString());
-        Assert.Equal("StaticMethod", engine.Evaluate("CustomNamed.jsStaticMethod()").AsString());
+        engine.Evaluate("CustomNamed.jsStaticStringField").AsString().Should().Be("StaticStringField");
+        engine.Evaluate("CustomNamed.jsStaticMethod()").AsString().Should().Be("StaticMethod");
 
         engine.SetValue("XmlHttpRequest", typeof(CustomNamedEnum));
         engine.Evaluate("o.jsEnumProperty = XmlHttpRequest.HEADERS_RECEIVED;");
-        Assert.Equal((int) CustomNamedEnum.HeadersReceived, engine.Evaluate("o.jsEnumProperty").AsNumber());
+        engine.Evaluate("o.jsEnumProperty").AsNumber().Should().Be((int) CustomNamedEnum.HeadersReceived);
 
         // can get static members with different configuration
         var engineWithStaticsReported = new Engine(options => options.Interop.ObjectWrapperReportedFieldBindingFlags |= BindingFlags.Static);
         engineWithStaticsReported.SetValue("o", new CustomNamed());
-        Assert.Equal("StaticMethod", engineWithStaticsReported.Evaluate("o.staticMethod()").AsString());
-        Assert.Equal("StaticStringField", engineWithStaticsReported.Evaluate("o.staticStringField").AsString());
+        engineWithStaticsReported.Evaluate("o.staticMethod()").AsString().Should().Be("StaticMethod");
+        engineWithStaticsReported.Evaluate("o.staticStringField").AsString().Should().Be("StaticStringField");
     }
 
     [Fact]
@@ -3805,17 +3808,17 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     {
         var engine = new Engine(cfg => cfg.CatchClrExceptions());
         engine.SetValue("a", new Person());
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("a.age = 'It will not work, but it is normal'"));
-        Assert.Contains("input string ", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(" was not in a correct format", ex.Message, StringComparison.OrdinalIgnoreCase);
+        var ex = Invoking(() => engine.Execute("a.age = 'It will not work, but it is normal'")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().ContainEquivalentOf("input string ");
+        ex.Message.Should().ContainEquivalentOf(" was not in a correct format");
     }
 
     [Fact]
     public void ShouldLetNotSupportedExceptionBubble()
     {
         _engine.SetValue("profile", new Profile());
-        var ex = Assert.Throws<NotSupportedException>(() => _engine.Evaluate("profile.AnyProperty"));
-        Assert.Equal("NOT SUPPORTED", ex.Message);
+        var ex = Invoking(() => _engine.Evaluate("profile.AnyProperty")).Should().ThrowExactly<NotSupportedException>().Which;
+        ex.Message.Should().Be("NOT SUPPORTED");
     }
 
     [Fact]
@@ -3824,9 +3827,9 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         _engine.SetValue("test", new DiscordTestClass());
         _engine.SetValue("id", new DiscordId("12345"));
 
-        Assert.Equal("12345", _engine.Evaluate("String(id)").AsString());
-        Assert.Equal("12345", _engine.Evaluate("test.echo('12345')").AsString());
-        Assert.Equal("12345", _engine.Evaluate("test.create(12345)").AsString());
+        _engine.Evaluate("String(id)").AsString().Should().Be("12345");
+        _engine.Evaluate("test.echo('12345')").AsString().Should().Be("12345");
+        _engine.Evaluate("test.create(12345)").AsString().Should().Be("12345");
     }
 
     [Fact]
@@ -3843,10 +3846,10 @@ new Thrower().ThrowExceptionWithMessage('boom');";
                 return str;";
 
         _engine.SetValue("collection", new List<string> { "a", "b", "c" });
-        Assert.Equal("abc", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("abc");
 
         _engine.SetValue("collection", new Dictionary<string, object> { { "a", 1 }, { "b", 2 }, { "c", 3 } });
-        Assert.Equal("a,1b,2c,3", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("a,1b,2c,3");
     }
 
     [Fact]
@@ -3854,28 +3857,28 @@ new Thrower().ThrowExceptionWithMessage('boom');";
     {
         _engine.SetValue("x", new Dictionary<string, int> { { "First", 1 }, { "Second", 2 } });
 
-        Assert.Equal("[\"First\",\"Second\"]", _engine.Evaluate("JSON.stringify(Object.keys(x))"));
+        _engine.Evaluate("JSON.stringify(Object.keys(x))").Should().Be("[\"First\",\"Second\"]");
 
-        Assert.Equal("x['First']: 1", _engine.Evaluate("\"x['First']: \" + x['First']"));
-        Assert.Equal("[\"First\",\"Second\"]", _engine.Evaluate("JSON.stringify(Object.keys(x))"));
+        _engine.Evaluate("\"x['First']: \" + x['First']").Should().Be("x['First']: 1");
+        _engine.Evaluate("JSON.stringify(Object.keys(x))").Should().Be("[\"First\",\"Second\"]");
 
-        Assert.Equal("x['Third']: undefined", _engine.Evaluate("\"x['Third']: \" + x['Third']"));
-        Assert.Equal("[\"First\",\"Second\"]", _engine.Evaluate("JSON.stringify(Object.keys(x))"));
+        _engine.Evaluate("\"x['Third']: \" + x['Third']").Should().Be("x['Third']: undefined");
+        _engine.Evaluate("JSON.stringify(Object.keys(x))").Should().Be("[\"First\",\"Second\"]");
 
-        Assert.Equal(JsValue.Undefined, _engine.Evaluate("x.length"));
-        Assert.Equal("[\"First\",\"Second\"]", _engine.Evaluate("JSON.stringify(Object.keys(x))"));
+        _engine.Evaluate("x.length").Should().BeUndefined();
+        _engine.Evaluate("JSON.stringify(Object.keys(x))").Should().Be("[\"First\",\"Second\"]");
 
-        Assert.Equal(2, _engine.Evaluate("x.Count").AsNumber());
-        Assert.Equal("[\"First\",\"Second\"]", _engine.Evaluate("JSON.stringify(Object.keys(x))"));
+        _engine.Evaluate("x.Count").AsNumber().Should().Be(2);
+        _engine.Evaluate("JSON.stringify(Object.keys(x))").Should().Be("[\"First\",\"Second\"]");
 
         _engine.Evaluate("x.Clear();");
 
-        Assert.Equal("[]", _engine.Evaluate("JSON.stringify(Object.keys(x))"));
+        _engine.Evaluate("JSON.stringify(Object.keys(x))").Should().Be("[]");
 
         _engine.Evaluate("x['Fourth'] = 4;");
-        Assert.Equal("[\"Fourth\"]", _engine.Evaluate("JSON.stringify(Object.keys(x))"));
+        _engine.Evaluate("JSON.stringify(Object.keys(x))").Should().Be("[\"Fourth\"]");
 
-        Assert.False(_engine.Evaluate("Object.prototype.hasOwnProperty.call(x, 'Third')").AsBoolean());
+        _engine.Evaluate("Object.prototype.hasOwnProperty.call(x, 'Third')").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -3891,9 +3894,9 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         engine.SetValue("callback", callback);
         engine.Evaluate("callback(({'a': 'b'}));");
 
-        Assert.IsType<Dictionary<string, object>>(capture);
+        capture.Should().BeOfType<Dictionary<string, object>>();
         var dictionary = (Dictionary<string, object>) capture;
-        Assert.Equal("b", dictionary["a"]);
+        dictionary["a"].Should().Be("b");
     }
 
     [Fact]
@@ -3903,11 +3906,11 @@ new Thrower().ThrowExceptionWithMessage('boom');";
 
         engine.SetValue("list", new List<string> { "A", "B", "C" });
 
-        Assert.Equal(1, engine.Evaluate("list.indexOf('B')"));
-        Assert.Equal(1, engine.Evaluate("list.lastIndexOf('B')"));
+        engine.Evaluate("list.indexOf('B')").Should().Be(1);
+        engine.Evaluate("list.lastIndexOf('B')").Should().Be(1);
 
-        Assert.Equal(1, engine.Evaluate("Array.prototype.indexOf.call(list, 'B')"));
-        Assert.Equal(1, engine.Evaluate("Array.prototype.lastIndexOf.call(list, 'B')"));
+        engine.Evaluate("Array.prototype.indexOf.call(list, 'B')").Should().Be(1);
+        engine.Evaluate("Array.prototype.lastIndexOf.call(list, 'B')").Should().Be(1);
     }
 
     [Fact]
@@ -3918,8 +3921,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
 
         engine.SetValue("list", list);
 
-        Assert.Equal(1, engine.Evaluate("list.findIndex((x) => x === 'B')"));
-        Assert.Equal('B', engine.Evaluate("list.find((x) => x === 'B')"));
+        engine.Evaluate("list.findIndex((x) => x === 'B')").Should().Be(1);
+        engine.Evaluate("list.find((x) => x === 'B')").Should().Be('B');
     }
 
     [Fact]
@@ -3932,9 +3935,9 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         engine.SetValue("list", list);
 
         engine.Evaluate("list.push('D')");
-        Assert.Equal(4, list.Count);
-        Assert.Equal("D", list[3]);
-        Assert.Equal(3, engine.Evaluate("list.lastIndexOf('D')"));
+        list.Should().HaveCount(4);
+        list[3].Should().Be("D");
+        engine.Evaluate("list.lastIndexOf('D')").Should().Be(3);
     }
 
     [Fact]
@@ -3945,11 +3948,11 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         var list = new List<string> { "A", "B", "C" };
         engine.SetValue("list", list);
 
-        Assert.Equal(2, engine.Evaluate("list.lastIndexOf('C')"));
-        Assert.Equal(3, list.Count);
-        Assert.Equal("C", engine.Evaluate("list.pop()"));
-        Assert.Equal(2, list.Count);
-        Assert.Equal(-1, engine.Evaluate("list.lastIndexOf('C')"));
+        engine.Evaluate("list.lastIndexOf('C')").Should().Be(2);
+        list.Should().HaveCount(3);
+        engine.Evaluate("list.pop()").Should().Be("C");
+        list.Should().HaveCount(2);
+        engine.Evaluate("list.lastIndexOf('C')").Should().Be(-1);
     }
 
     [Fact]
@@ -3962,8 +3965,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         engine.SetValue("list", list);
 
         var result = engine.Evaluate("list.reverse()");
-        Assert.True(result.IsNull());
-        Assert.Equal(new[] { 3, 2, 1 }, list);
+        result.IsNull().Should().BeTrue();
+        list.Should().Equal(new[] { 3, 2, 1 });
     }
 
     [Fact]
@@ -3973,8 +3976,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         var list = new List<int> { 1, 2, 3 };
         engine.SetValue("list", list);
 
-        Assert.True(engine.Evaluate("list.reverse() === list").AsBoolean());
-        Assert.Equal(new[] { 3, 2, 1 }, list);
+        engine.Evaluate("list.reverse() === list").AsBoolean().Should().BeTrue();
+        list.Should().Equal(new[] { 3, 2, 1 });
     }
 
     [Fact]
@@ -3987,7 +3990,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         var list = new List<int> { 10, 2, 1 };
         engine.SetValue("list", list);
 
-        Assert.Equal("[1,10,2]", engine.Evaluate("JSON.stringify(list.sort())").AsString());
+        engine.Evaluate("JSON.stringify(list.sort())").AsString().Should().Be("[1,10,2]");
     }
 
     [Fact]
@@ -3999,11 +4002,11 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         engine.SetValue("list", list);
 
         engine.Evaluate("list.Add('C')");
-        Assert.Equal(3, list.Count);
-        Assert.Equal("C", list[2]);
+        list.Should().HaveCount(3);
+        list[2].Should().Be("C");
 
         engine.Evaluate("list.RemoveAt(0)");
-        Assert.Equal(new[] { "B", "C" }, list);
+        list.Should().Equal(new[] { "B", "C" });
     }
 
     [Fact]
@@ -4014,7 +4017,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         var list = new List<int> { 10, 20, 30, 40 };
         engine.SetValue("list", list);
 
-        Assert.Equal(4, engine.Evaluate("list.length").AsNumber());
+        engine.Evaluate("list.length").AsNumber().Should().Be(4);
     }
 
     [Fact]
@@ -4024,7 +4027,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         var engine = new Jint.Engine(cfg => cfg.PreferJsPrototypeMethods());
         engine.SetValue("obj", new ClassWithToString());
 
-        Assert.Equal("Test", engine.Evaluate("obj.toString()").AsString());
+        engine.Evaluate("obj.toString()").AsString().Should().Be("Test");
     }
 
     [Fact]
@@ -4048,8 +4051,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         var list = new List<int> { 1, 2, 3 };
         engine.SetValue("list", list);
 
-        Assert.True(engine.Evaluate("list.reverse() === list").AsBoolean());
-        Assert.Equal(new[] { 3, 2, 1 }, list);
+        engine.Evaluate("list.reverse() === list").AsBoolean().Should().BeTrue();
+        list.Should().Equal(new[] { 3, 2, 1 });
     }
 
     [Fact]
@@ -4065,14 +4068,14 @@ new Thrower().ThrowExceptionWithMessage('boom');";
 					return result;
 				}");
         // checking working custom type
-        Assert.Equal(new Dimensional("kg", 90), (new Dimensional("kg", 30) + new Dimensional("kg", 60)));
-        Assert.Equal(new Dimensional("kg", 90), engine.Invoke("Eval", new object[] { new Dimensional("kg", 30), new Dimensional("kg", 60) }).ToObject());
-        Assert.Throws<InvalidOperationException>(() => new Dimensional("kg", 30) + new Dimensional("piece", 70));
+        (new Dimensional("kg", 30) + new Dimensional("kg", 60)).Should().Be(new Dimensional("kg", 90));
+        engine.Invoke("Eval", new object[] { new Dimensional("kg", 30), new Dimensional("kg", 60) }).ToObject().Should().Be(new Dimensional("kg", 90));
+        Invoking(() => new Dimensional("kg", 30) + new Dimensional("piece", 70)).Should().ThrowExactly<InvalidOperationException>();
 
         // checking throwing exception in override operator
         string errorMsg = string.Empty;
-        errorMsg = Assert.Throws<JavaScriptException>(() => engine.Invoke("Eval", new object[] { new Dimensional("kg", 30), new Dimensional("piece", 70) })).Message;
-        Assert.Equal("Dimensionals with different measure types are non-summable", errorMsg);
+        errorMsg = Invoking(() => engine.Invoke("Eval", new object[] { new Dimensional("kg", 30), new Dimensional("piece", 70) })).Should().ThrowExactly<JavaScriptException>().Which.Message;
+        errorMsg.Should().Be("Dimensionals with different measure types are non-summable");
     }
 
     private class Profile
@@ -4088,7 +4091,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
             .Evaluate("JintCommon.sum(1, null)")
             .AsNumber();
 
-        Assert.Equal(2, result);
+        result.Should().Be(2);
     }
 
     public class JintCommon
@@ -4131,7 +4134,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         GC.Collect();
 
         // make sure no dangling reference is left
-        Assert.False(reference.IsAlive);
+        reference.IsAlive.Should().BeFalse();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -4145,8 +4148,8 @@ new Thrower().ThrowExceptionWithMessage('boom');";
         var wrapper1 = (ObjectWrapper) engine.GetValue("o");
         var reference = new WeakReference(wrapper1);
 
-        Assert.Same(wrapper1, engine.GetValue("o"));
-        Assert.Same(o, wrapper1.Target);
+        engine.GetValue("o").Should().BeSameAs(wrapper1);
+        wrapper1.Target.Should().BeSameAs(o);
 
         // reset
         engine.Realm.GlobalObject.RemoveOwnProperty("o");
@@ -4161,7 +4164,7 @@ new Thrower().ThrowExceptionWithMessage('boom');";
 
         var result = engine.Evaluate("fn(1)");
 
-        Assert.Equal(2, result);
+        result.Should().Be(2);
     }
 
     [Fact]
@@ -4176,7 +4179,7 @@ function wrap() {
 wrap();
 ";
 
-        Assert.Throws<InvalidOperationException>(() => engine.Execute(Source));
+        Invoking(() => engine.Execute(Source)).Should().ThrowExactly<InvalidOperationException>();
     }
 
     [Fact]
@@ -4191,8 +4194,8 @@ function wrap() {
 wrap();
 ";
 
-        var exc = Assert.Throws<JavaScriptException>(() => engine.Execute(Source));
-        Assert.Equal(exc.Message, "This is a C# error");
+        var exc = Invoking(() => engine.Execute(Source)).Should().ThrowExactly<JavaScriptException>().Which;
+        "This is a C# error".Should().Be(exc.Message);
     }
 
     [Fact]
@@ -4208,8 +4211,8 @@ try {
 }
 ";
 
-        var exc = Assert.Throws<JavaScriptException>(() => engine.Execute(Source));
-        Assert.Equal(exc.Message, "Caught: This is a C# error");
+        var exc = Invoking(() => engine.Execute(Source)).Should().ThrowExactly<JavaScriptException>().Which;
+        "Caught: This is a C# error".Should().Be(exc.Message);
     }
 
     class Baz
@@ -4241,7 +4244,7 @@ try {
 for (let i of baz.Enumerator) {
 }";
         engine.Execute(Source);
-        Assert.Equal(1, baz.DisposeCalls);
+        baz.DisposeCalls.Should().Be(1);
     }
 
     [Fact]
@@ -4255,7 +4258,7 @@ for (let i of baz.Enumerator) {
   if (i == 2) break;
 }";
         engine.Execute(Source);
-        Assert.Equal(1, baz.DisposeCalls);
+        baz.DisposeCalls.Should().Be(1);
     }
 
     [Fact]
@@ -4272,7 +4275,7 @@ try {
 } catch (e) {
 }";
         engine.Execute(Source);
-        Assert.Equal(1, baz.DisposeCalls);
+        baz.DisposeCalls.Should().Be(1);
     }
 
     public class PropertyTestClass
@@ -4304,20 +4307,20 @@ try {
 
         engine.SetValue("data", dictionary);
 
-        Assert.True(engine.Evaluate("Object.hasOwn(data, 'a')").AsBoolean());
-        Assert.True(engine.Evaluate("data['a'] === 1").AsBoolean());
+        engine.Evaluate("Object.hasOwn(data, 'a')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("data['a'] === 1").AsBoolean().Should().BeTrue();
 
         engine.Evaluate("data['a'] = 42");
-        Assert.True(engine.Evaluate("data['a'] === 42").AsBoolean());
+        engine.Evaluate("data['a'] === 42").AsBoolean().Should().BeTrue();
 
-        Assert.Equal(42, dictionary["a"]);
+        dictionary["a"].Should().Be(42);
 
         engine.Execute("delete data['a'];");
 
-        Assert.False(engine.Evaluate("Object.hasOwn(data, 'a')").AsBoolean());
-        Assert.False(engine.Evaluate("data['a'] === 42").AsBoolean());
+        engine.Evaluate("Object.hasOwn(data, 'a')").AsBoolean().Should().BeFalse();
+        engine.Evaluate("data['a'] === 42").AsBoolean().Should().BeFalse();
 
-        Assert.False(dictionary.ContainsKey("a"));
+        dictionary.ContainsKey("a").Should().BeFalse();
 
         var engineNoWrite = new Engine(options => options.Strict().AllowClrWrite(false));
 
@@ -4329,14 +4332,14 @@ try {
 
         engineNoWrite.SetValue("data", dictionary);
 
-        var ex1 = Assert.Throws<JavaScriptException>(() => engineNoWrite.Evaluate("data['a'] = 42"));
-        Assert.Equal("Cannot assign to read only property 'a' of System.Collections.Generic.Dictionary`2[System.String,System.Int32]", ex1.Message);
+        var ex1 = Invoking(() => engineNoWrite.Evaluate("data['a'] = 42")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex1.Message.Should().Be("Cannot assign to read only property 'a' of System.Collections.Generic.Dictionary`2[System.String,System.Int32]");
 
         // no changes
-        Assert.True(engineNoWrite.Evaluate("data['a'] === 1").AsBoolean());
+        engineNoWrite.Evaluate("data['a'] === 1").AsBoolean().Should().BeTrue();
 
-        var ex2 = Assert.Throws<JavaScriptException>(() => engineNoWrite.Execute("delete data['a'];"));
-        Assert.Equal("Cannot delete property 'a' of System.Collections.Generic.Dictionary`2[System.String,System.Int32]", ex2.Message);
+        var ex2 = Invoking(() => engineNoWrite.Execute("delete data['a'];")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex2.Message.Should().Be("Cannot delete property 'a' of System.Collections.Generic.Dictionary`2[System.String,System.Int32]");
     }
 
     public record RecordTestClass(object Value = null);
@@ -4362,18 +4365,18 @@ try {
         var engine = new Engine();
 
         engine.SetValue("obj", new ClassWithIndexerAndProperty());
-        Assert.Equal("Jint.Tests.Runtime.InteropTests+ClassWithIndexerAndProperty", engine.Evaluate("obj + ''").AsString());
+        engine.Evaluate("obj + ''").AsString().Should().Be("Jint.Tests.Runtime.InteropTests+ClassWithIndexerAndProperty");
 
         engine.SetValue("obj", new Company("name"));
-        Assert.Equal("Jint.Tests.Runtime.Domain.Company", engine.Evaluate("obj + ''").AsString());
+        engine.Evaluate("obj + ''").AsString().Should().Be("Jint.Tests.Runtime.Domain.Company");
     }
 
     [Fact]
     public void CanConstructOptionalRecordClass()
     {
         _engine.SetValue("Context", new RecordTestClassContext());
-        Assert.Equal(null, _engine.Evaluate("Context.method({});").ToObject());
-        Assert.Equal(5, _engine.Evaluate("Context.method({ value: 5 });").AsInteger());
+        _engine.Evaluate("Context.method({});").ToObject().Should().BeNull();
+        _engine.Evaluate("Context.method({ value: 5 });").AsInteger().Should().Be(5);
     }
 
     [Fact]
@@ -4386,11 +4389,11 @@ try {
 
         engine.SetValue("minDate", DateTime.MinValue);
         engine.Execute("capture(minDate);");
-        Assert.Equal(DateTime.MinValue, dt);
+        dt.Should().Be(DateTime.MinValue);
 
         engine.SetValue("maxDate", DateTime.MaxValue);
         engine.Execute("capture(maxDate);");
-        Assert.Equal(DateTime.MaxValue, dt);
+        dt.Should().Be(DateTime.MaxValue);
     }
 
     private class Container
@@ -4414,7 +4417,7 @@ try {
         var engine = new Engine().SetValue("container", new Container());
         var res = engine.Evaluate("container.Child === container.Get()"); // These two should be the same object. But this PR makes `container.Get()` return a different object
 
-        Assert.True(res.AsBoolean());
+        res.AsBoolean().Should().BeTrue();
     }
 
     public interface IIndexer<out T>
@@ -4457,7 +4460,7 @@ try {
         var engine = new Engine();
         engine.SetValue("Utils", new Utils());
         var result = engine.Evaluate("const strings = Utils.GetStrings(); strings.Count;").AsNumber();
-        Assert.Equal(3, result);
+        result.Should().Be(3);
     }
 
     [Fact]
@@ -4466,7 +4469,7 @@ try {
         var engine = new Engine();
         engine.SetValue("Utils", new Utils());
         var result = engine.Evaluate("const strings = Utils.GetStrings(); strings[2];");
-        Assert.Equal("c", result);
+        result.Should().Be("c");
     }
 
     [Fact]
@@ -4475,7 +4478,7 @@ try {
         var engine = new Engine();
         engine.SetValue("test", new Utils());
         var result = engine.Evaluate("const { getStrings } = test; getStrings().Count;");
-        Assert.Equal(3, result);
+        result.Should().Be(3);
     }
 
     private class MetadataWrapper : IDictionary<string, object>
@@ -4586,7 +4589,7 @@ try {
 
         engine.Evaluate("test.metadata['abc'] = 123");
         var result = engine.Evaluate("test.metadata['abc']");
-        Assert.Equal("from-wrapper", result);
+        result.Should().Be("from-wrapper");
     }
 
     [Fact]
@@ -4610,11 +4613,11 @@ try {
         engine.Execute("var t = dict.last(kvp => { debug(kvp); debug(kvp.key); return kvp.key != null; } );");
         engine.Execute("debug(t); debug(t.key);");
 
-        Assert.Equal(4, result.Count);
-        Assert.Equal("KeyValuePair`2: [test, val]", result[0]);
-        Assert.Equal("String: test", result[1]);
-        Assert.Equal("KeyValuePair`2: [test, val]", result[2]);
-        Assert.Equal("String: test", result[3]);
+        result.Should().HaveCount(4);
+        result[0].Should().Be("KeyValuePair`2: [test, val]");
+        result[1].Should().Be("String: test");
+        result[2].Should().Be("KeyValuePair`2: [test, val]");
+        result[3].Should().Be("String: test");
     }
 
     private class ClrMembersVisibilityTestClass
@@ -4779,7 +4782,7 @@ try {
         var engine = new Engine();
         engine.SetValue("zoo", new Zoo());
         var kingManeLength = engine.Evaluate("zoo.King.maneLength");
-        Assert.Equal(10, kingManeLength.AsNumber());
+        kingManeLength.AsNumber().Should().Be(10);
     }
 
     [Fact]
@@ -4788,22 +4791,22 @@ try {
         var engine = new Engine();
         engine.SetValue("zoo", new Zoo());
         var lionManeLength = engine.Evaluate("zoo.animals[0].maneLength");
-        Assert.Equal(10, lionManeLength.AsNumber());
+        lionManeLength.AsNumber().Should().Be(10);
     }
 
     [Fact]
     public void StaticFieldsShouldFollowJsSemantics()
     {
         _engine.Evaluate("Number.MAX_SAFE_INTEGER").AsNumber().Should().Be(NumberConstructor.MaxSafeInteger);
-        _engine.Evaluate("new Number().MAX_SAFE_INTEGER").Should().Be(JsValue.Undefined);
+        _engine.Evaluate("new Number().MAX_SAFE_INTEGER").Should().BeUndefined();
 
         _engine.Execute("class MyJsClass { static MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER; }");
         _engine.Evaluate("MyJsClass.MAX_SAFE_INTEGER").AsNumber().Should().Be(NumberConstructor.MaxSafeInteger);
-        _engine.Evaluate("new MyJsClass().MAX_SAFE_INTEGER").Should().Be(JsValue.Undefined);
+        _engine.Evaluate("new MyJsClass().MAX_SAFE_INTEGER").Should().BeUndefined();
 
         _engine.SetValue("MyCsClass", typeof(MyClass));
         _engine.Evaluate("MyCsClass.MAX_SAFE_INTEGER").AsNumber().Should().Be(NumberConstructor.MaxSafeInteger);
-        _engine.Evaluate("new MyCsClass().MAX_SAFE_INTEGER").Should().Be(JsValue.Undefined);
+        _engine.Evaluate("new MyCsClass().MAX_SAFE_INTEGER").Should().BeUndefined();
     }
 
     private class MyClass
@@ -4869,8 +4872,8 @@ try {
             ])
             .ToObject();
 
-        Assert.Equal(values[0], found1);
-        Assert.Equal(values[1], found2);
+        found1.Should().Be(values[0]);
+        found2.Should().Be(values[1]);
     }
 
     [Fact]
@@ -4972,10 +4975,10 @@ try {
 
         // Should access the X property from GeometryWrapperWithProperty, not the indexer from WrapperWithIndexer
         var result = engine.Evaluate("feature.Geometry.x").AsNumber();
-        Assert.Equal(10.5, result);
+        result.Should().Be(10.5);
 
         var resultY = engine.Evaluate("feature.Geometry.y").AsNumber();
-        Assert.Equal(20.5, resultY);
+        resultY.Should().Be(20.5);
     }
 
     [Fact]
@@ -4988,7 +4991,7 @@ try {
         engine.SetValue("feature", feature);
 
         var result = engine.Evaluate("feature.Geometry.customKey");
-        Assert.Equal("customValue", result.AsString());
+        result.AsString().Should().Be("customValue");
     }
 
     [Fact]
@@ -5001,7 +5004,7 @@ try {
         engine.Evaluate("feature.Geometry.x = 99.9");
 
         var geometry = (GeometryWrapperWithProperty) feature.Geometry;
-        Assert.Equal(99.9, geometry.X);
+        geometry.X.Should().Be(99.9);
     }
 
     public class TypeWithListConstructor
@@ -5038,11 +5041,11 @@ try {
         var result = engine.Evaluate("new TypeWithListConstructor(['a', 'b', 'c'])");
         var obj = result.ToObject() as TypeWithListConstructor;
 
-        Assert.NotNull(obj);
-        Assert.Equal(3, obj.Items.Count);
-        Assert.Equal("a", obj.Items[0]);
-        Assert.Equal("b", obj.Items[1]);
-        Assert.Equal("c", obj.Items[2]);
+        obj.Should().NotBeNull();
+        obj.Items.Should().HaveCount(3);
+        obj.Items[0].Should().Be("a");
+        obj.Items[1].Should().Be("b");
+        obj.Items[2].Should().Be("c");
     }
 
     [Fact]
@@ -5054,8 +5057,8 @@ try {
         var result = engine.Evaluate("new TypeWithListConstructor([])");
         var obj = result.ToObject() as TypeWithListConstructor;
 
-        Assert.NotNull(obj);
-        Assert.Empty(obj.Items);
+        obj.Should().NotBeNull();
+        obj.Items.Should().BeEmpty();
     }
 
     [Fact]
@@ -5066,20 +5069,20 @@ try {
         engine.SetValue("target", target);
 
         engine.Evaluate("target.SetIListItems(['a', 'b'])");
-        Assert.Equal(2, target.IListItems.Count);
-        Assert.Equal("a", target.IListItems[0]);
+        target.IListItems.Should().HaveCount(2);
+        target.IListItems[0].Should().Be("a");
 
         engine.Evaluate("target.SetICollectionItems(['c', 'd'])");
-        Assert.Equal(2, target.ICollectionItems.Count);
+        target.ICollectionItems.Should().HaveCount(2);
 
         engine.Evaluate("target.SetIEnumerableItems(['e', 'f'])");
-        Assert.Equal(2, target.IEnumerableItems.Count());
+        target.IEnumerableItems.Count().Should().Be(2);
 
         engine.Evaluate("target.SetIReadOnlyListItems(['g', 'h'])");
-        Assert.Equal(2, target.IReadOnlyListItems.Count);
-        Assert.Equal("g", target.IReadOnlyListItems[0]);
+        target.IReadOnlyListItems.Should().HaveCount(2);
+        target.IReadOnlyListItems[0].Should().Be("g");
 
         engine.Evaluate("target.SetIReadOnlyCollectionItems(['i', 'j'])");
-        Assert.Equal(2, target.IReadOnlyCollectionItems.Count);
+        target.IReadOnlyCollectionItems.Should().HaveCount(2);
     }
 }

--- a/Jint.Tests/Runtime/InteropWrapperMemberCacheTests.cs
+++ b/Jint.Tests/Runtime/InteropWrapperMemberCacheTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the ObjectWrapper member inline cache (the wrapper lane in JintMemberExpression): cached
@@ -55,11 +55,11 @@ public class InteropWrapperMemberCacheTests
             sum;
             """).AsNumber();
 
-        Assert.Equal(45, sum);
+        sum.Should().Be(45);
         // every JS-side read must have invoked the CLR getter (the cache holds the descriptor, never the value)
-        Assert.Equal(10, host.Reads);
+        host.Reads.Should().Be(10);
         // every JS-side write must have reached the CLR setter
-        Assert.Equal(Enumerable.Range(0, 10), host.WrittenValues);
+        host.WrittenValues.Should().Equal(Enumerable.Range(0, 10));
     }
 
     [Fact]
@@ -79,8 +79,8 @@ public class InteropWrapperMemberCacheTests
             r.join(',');
             """).AsString();
 
-        Assert.Equal("0,100,200,300,400", result);
-        Assert.Equal(5, host.Reads);
+        result.Should().Be("0,100,200,300,400");
+        host.Reads.Should().Be(5);
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public class InteropWrapperMemberCacheTests
             r.join(',');
             """).AsString();
 
-        Assert.Equal("first,first,first,redefined,redefined,redefined", result);
+        result.Should().Be("first,first,first,redefined,redefined,redefined");
     }
 
     [Fact]
@@ -119,7 +119,7 @@ public class InteropWrapperMemberCacheTests
             r.join(',');
             """).AsString();
 
-        Assert.Equal("5,5,5,6,6,6", result);
+        result.Should().Be("5,5,5,6,6,6");
     }
 
     [Fact]
@@ -146,9 +146,9 @@ public class InteropWrapperMemberCacheTests
             r.join(',');
             """).AsString();
 
-        Assert.Equal("1,2,11,12,21,22", result);
-        Assert.Equal(31, first.value);
-        Assert.Equal(32, second.value);
+        result.Should().Be("1,2,11,12,21,22");
+        first.value.Should().Be(31);
+        second.value.Should().Be(32);
     }
 
     [Fact]
@@ -168,7 +168,7 @@ public class InteropWrapperMemberCacheTests
             r.join(',');
             """).AsString();
 
-        Assert.Equal("7,p,7,p,7,p", result);
+        result.Should().Be("7,p,7,p,7,p");
     }
 
     [Fact]
@@ -193,8 +193,8 @@ public class InteropWrapperMemberCacheTests
             r.join(',');
             """).AsString();
 
-        Assert.Equal("0,1,2,3,4,clr,gone", result);
-        Assert.False(dictionary.ContainsKey("key"));
+        result.Should().Be("0,1,2,3,4,clr,gone");
+        dictionary.ContainsKey("key").Should().BeFalse();
     }
 
     [Fact]
@@ -212,7 +212,7 @@ public class InteropWrapperMemberCacheTests
             r.join(',');
             """).AsString();
 
-        Assert.Equal("42,42,42,42,42,42", result);
+        result.Should().Be("42,42,42,42,42,42");
     }
 
     [Fact]
@@ -238,7 +238,7 @@ public class InteropWrapperMemberCacheTests
             r.join(',');
             """).AsString();
 
-        Assert.Equal("42,42,true,true,true,42", result);
+        result.Should().Be("42,42,true,true,true,42");
     }
 
     [Fact]
@@ -263,7 +263,7 @@ public class InteropWrapperMemberCacheTests
             r.join(',');
             """).AsString();
 
-        Assert.Equal(string.Join(",", Enumerable.Repeat("true", 10)), result);
+        result.Should().Be(string.Join(",", Enumerable.Repeat("true", 10)));
     }
 
     [Fact]
@@ -293,7 +293,7 @@ public class InteropWrapperMemberCacheTests
             """).AsString();
 
         // the custom accessor must be consulted on every read
-        Assert.Equal("1,2,3", result);
-        Assert.Equal(3, calls);
+        result.Should().Be("1,2,3");
+        calls.Should().Be(3);
     }
 }

--- a/Jint.Tests/Runtime/IntlTests.cs
+++ b/Jint.Tests/Runtime/IntlTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 public class IntlTests
 {
@@ -13,48 +13,48 @@ public class IntlTests
     public void IntlObjectExists()
     {
         var result = _engine.Evaluate("typeof Intl");
-        Assert.Equal("object", result.AsString());
+        result.AsString().Should().Be("object");
     }
 
     [Fact]
     public void IntlHasGetCanonicalLocales()
     {
         var result = _engine.Evaluate("typeof Intl.getCanonicalLocales");
-        Assert.Equal("function", result.AsString());
+        result.AsString().Should().Be("function");
     }
 
     [Fact]
     public void IntlHasSupportedValuesOf()
     {
         var result = _engine.Evaluate("typeof Intl.supportedValuesOf");
-        Assert.Equal("function", result.AsString());
+        result.AsString().Should().Be("function");
     }
 
     [Fact]
     public void GetCanonicalLocalesWithUndefined()
     {
         var result = _engine.Evaluate("Intl.getCanonicalLocales(undefined)");
-        Assert.True(result.IsArray());
-        Assert.Equal((uint) 0, result.AsArray().Length);
+        result.IsArray().Should().BeTrue();
+        result.AsArray().Length.Should().Be((uint) 0);
     }
 
     [Fact]
     public void GetCanonicalLocalesWithString()
     {
         var result = _engine.Evaluate("Intl.getCanonicalLocales('en-US')");
-        Assert.True(result.IsArray());
+        result.IsArray().Should().BeTrue();
         var array = result.AsArray();
-        Assert.Equal((uint) 1, array.Length);
-        Assert.Equal("en-US", array[0].AsString());
+        array.Length.Should().Be((uint) 1);
+        array[0].AsString().Should().Be("en-US");
     }
 
     [Fact]
     public void GetCanonicalLocalesWithArray()
     {
         var result = _engine.Evaluate("Intl.getCanonicalLocales(['en-US', 'de-DE'])");
-        Assert.True(result.IsArray());
+        result.IsArray().Should().BeTrue();
         var array = result.AsArray();
-        Assert.Equal((uint) 2, array.Length);
+        array.Length.Should().Be((uint) 2);
     }
 
     [Fact]
@@ -62,60 +62,60 @@ public class IntlTests
     {
         // Should canonicalize 'en-us' to 'en-US'
         var result = _engine.Evaluate("Intl.getCanonicalLocales('en-us')");
-        Assert.True(result.IsArray());
+        result.IsArray().Should().BeTrue();
         var array = result.AsArray();
-        Assert.Equal((uint) 1, array.Length);
+        array.Length.Should().Be((uint) 1);
         // Result should be canonicalized
-        Assert.NotNull(array[0].AsString());
+        array[0].AsString().Should().NotBeNull();
     }
 
     [Fact]
     public void SupportedValuesOfCalendar()
     {
         var result = _engine.Evaluate("Intl.supportedValuesOf('calendar')");
-        Assert.True(result.IsArray());
+        result.IsArray().Should().BeTrue();
         var array = result.AsArray();
-        Assert.True(array.Length > 0);
+        array.Length.Should().BeGreaterThan(0);
     }
 
     [Fact]
     public void SupportedValuesOfCurrency()
     {
         var result = _engine.Evaluate("Intl.supportedValuesOf('currency')");
-        Assert.True(result.IsArray());
+        result.IsArray().Should().BeTrue();
         var array = result.AsArray();
-        Assert.True(array.Length > 0);
+        array.Length.Should().BeGreaterThan(0);
     }
 
     [Fact]
     public void SupportedValuesOfUnit()
     {
         var result = _engine.Evaluate("Intl.supportedValuesOf('unit')");
-        Assert.True(result.IsArray());
+        result.IsArray().Should().BeTrue();
         var array = result.AsArray();
-        Assert.True(array.Length > 0);
+        array.Length.Should().BeGreaterThan(0);
         // Should contain common units
         var units = new List<string>();
         for (uint i = 0; i < array.Length; i++)
         {
             units.Add(array[i].AsString());
         }
-        Assert.Contains("meter", units);
-        Assert.Contains("second", units);
+        units.Should().Contain("meter");
+        units.Should().Contain("second");
     }
 
     [Fact]
     public void SupportedValuesOfInvalidKeyThrows()
     {
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            _engine.Evaluate("Intl.supportedValuesOf('invalid')"));
+        Invoking(() =>
+            _engine.Evaluate("Intl.supportedValuesOf('invalid')")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
     }
 
     [Fact]
     public void IntlToStringTag()
     {
         var result = _engine.Evaluate("Object.prototype.toString.call(Intl)");
-        Assert.Equal("[object Intl]", result.AsString());
+        result.AsString().Should().Be("[object Intl]");
     }
 
     // Intl.Locale tests
@@ -123,106 +123,106 @@ public class IntlTests
     public void LocaleConstructorExists()
     {
         var result = _engine.Evaluate("typeof Intl.Locale");
-        Assert.Equal("function", result.AsString());
+        result.AsString().Should().Be("function");
     }
 
     [Fact]
     public void LocaleCanBeConstructed()
     {
         var result = _engine.Evaluate("new Intl.Locale('en-US')");
-        Assert.NotNull(result);
-        Assert.True(result.IsObject());
+        result.Should().NotBeNull();
+        result.IsObject().Should().BeTrue();
     }
 
     [Fact]
     public void LocaleRequiresNew()
     {
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            _engine.Evaluate("Intl.Locale('en-US')"));
+        Invoking(() =>
+            _engine.Evaluate("Intl.Locale('en-US')")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
     }
 
     [Fact]
     public void LocaleToStringReturnsTag()
     {
         var result = _engine.Evaluate("new Intl.Locale('en-US').toString()");
-        Assert.Equal("en-US", result.AsString());
+        result.AsString().Should().Be("en-US");
     }
 
     [Fact]
     public void LocaleLanguageProperty()
     {
         var result = _engine.Evaluate("new Intl.Locale('en-US').language");
-        Assert.Equal("en", result.AsString());
+        result.AsString().Should().Be("en");
     }
 
     [Fact]
     public void LocaleRegionProperty()
     {
         var result = _engine.Evaluate("new Intl.Locale('en-US').region");
-        Assert.Equal("US", result.AsString());
+        result.AsString().Should().Be("US");
     }
 
     [Fact]
     public void LocaleScriptProperty()
     {
         var result = _engine.Evaluate("new Intl.Locale('zh-Hans-CN').script");
-        Assert.Equal("Hans", result.AsString());
+        result.AsString().Should().Be("Hans");
     }
 
     [Fact]
     public void LocaleBaseNameProperty()
     {
         var result = _engine.Evaluate("new Intl.Locale('en-US').baseName");
-        Assert.Equal("en-US", result.AsString());
+        result.AsString().Should().Be("en-US");
     }
 
     [Fact]
     public void LocaleWithCalendarOption()
     {
         var result = _engine.Evaluate("new Intl.Locale('en-US', { calendar: 'gregory' }).calendar");
-        Assert.Equal("gregory", result.AsString());
+        result.AsString().Should().Be("gregory");
     }
 
     [Fact]
     public void LocaleWithHourCycleOption()
     {
         var result = _engine.Evaluate("new Intl.Locale('en-US', { hourCycle: 'h12' }).hourCycle");
-        Assert.Equal("h12", result.AsString());
+        result.AsString().Should().Be("h12");
     }
 
     [Fact]
     public void LocaleWithNumericOption()
     {
         var result = _engine.Evaluate("new Intl.Locale('en-US', { numeric: true }).numeric");
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void LocaleToStringTagIsCorrect()
     {
         var result = _engine.Evaluate("Object.prototype.toString.call(new Intl.Locale('en-US'))");
-        Assert.Equal("[object Intl.Locale]", result.AsString());
+        result.AsString().Should().Be("[object Intl.Locale]");
     }
 
     [Fact]
     public void LocaleMinimize()
     {
         var result = _engine.Evaluate("new Intl.Locale('en-US').minimize().toString()");
-        Assert.Equal("en", result.AsString());
+        result.AsString().Should().Be("en");
     }
 
     [Fact]
     public void LocaleWithUnicodeExtension()
     {
         var result = _engine.Evaluate("new Intl.Locale('en-US-u-ca-gregory').calendar");
-        Assert.Equal("gregory", result.AsString());
+        result.AsString().Should().Be("gregory");
     }
 
     [Fact]
     public void LocaleInvalidTagThrows()
     {
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            _engine.Evaluate("new Intl.Locale('invalid tag with spaces')"));
+        Invoking(() =>
+            _engine.Evaluate("new Intl.Locale('invalid tag with spaces')")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
     }
 
     // Intl.Collator tests
@@ -230,29 +230,29 @@ public class IntlTests
     public void CollatorConstructorExists()
     {
         var result = _engine.Evaluate("typeof Intl.Collator");
-        Assert.Equal("function", result.AsString());
+        result.AsString().Should().Be("function");
     }
 
     [Fact]
     public void CollatorCanBeConstructed()
     {
         var result = _engine.Evaluate("new Intl.Collator('en-US')");
-        Assert.NotNull(result);
-        Assert.True(result.IsObject());
+        result.Should().NotBeNull();
+        result.IsObject().Should().BeTrue();
     }
 
     [Fact]
     public void CollatorToStringTagIsCorrect()
     {
         var result = _engine.Evaluate("Object.prototype.toString.call(new Intl.Collator('en-US'))");
-        Assert.Equal("[object Intl.Collator]", result.AsString());
+        result.AsString().Should().Be("[object Intl.Collator]");
     }
 
     [Fact]
     public void CollatorCompareReturnsFunction()
     {
         var result = _engine.Evaluate("typeof new Intl.Collator('en-US').compare");
-        Assert.Equal("function", result.AsString());
+        result.AsString().Should().Be("function");
     }
 
     [Fact]
@@ -263,7 +263,7 @@ public class IntlTests
             var compare = collator.compare;
             compare('a', 'b')
         ");
-        Assert.True(result.AsNumber() < 0);
+        result.AsNumber().Should().BeLessThan(0);
     }
 
     [Fact]
@@ -274,7 +274,7 @@ public class IntlTests
             collator.compare('a', 'A')
         ");
         // With 'case' sensitivity, 'a' and 'A' should be different
-        Assert.True(result.AsNumber() != 0);
+        result.AsNumber().Should().NotBe(0);
     }
 
     [Fact]
@@ -285,7 +285,7 @@ public class IntlTests
             collator.compare('a', 'A')
         ");
         // With 'base' sensitivity, 'a' and 'A' should be equal
-        Assert.Equal(0, result.AsNumber());
+        result.AsNumber().Should().Be(0);
     }
 
     [Fact]
@@ -295,14 +295,14 @@ public class IntlTests
             var options = new Intl.Collator('en-US', { usage: 'search' }).resolvedOptions();
             options.usage
         ");
-        Assert.Equal("search", result.AsString());
+        result.AsString().Should().Be("search");
     }
 
     [Fact]
     public void CollatorSupportedLocalesOf()
     {
         var result = _engine.Evaluate("Intl.Collator.supportedLocalesOf(['en-US', 'de-DE'])");
-        Assert.True(result.IsArray());
+        result.IsArray().Should().BeTrue();
     }
 
     [Fact]
@@ -313,7 +313,7 @@ public class IntlTests
             items.sort(new Intl.Collator('en-US').compare);
             items.join(',')
         ");
-        Assert.Equal("a,b,c,z", result.AsString());
+        result.AsString().Should().Be("a,b,c,z");
     }
 
     // Intl.NumberFormat tests
@@ -321,37 +321,37 @@ public class IntlTests
     public void NumberFormatConstructorExists()
     {
         var result = _engine.Evaluate("typeof Intl.NumberFormat");
-        Assert.Equal("function", result.AsString());
+        result.AsString().Should().Be("function");
     }
 
     [Fact]
     public void NumberFormatCanBeConstructed()
     {
         var result = _engine.Evaluate("new Intl.NumberFormat('en-US')");
-        Assert.NotNull(result);
-        Assert.True(result.IsObject());
+        result.Should().NotBeNull();
+        result.IsObject().Should().BeTrue();
     }
 
     [Fact]
     public void NumberFormatToStringTagIsCorrect()
     {
         var result = _engine.Evaluate("Object.prototype.toString.call(new Intl.NumberFormat('en-US'))");
-        Assert.Equal("[object Intl.NumberFormat]", result.AsString());
+        result.AsString().Should().Be("[object Intl.NumberFormat]");
     }
 
     [Fact]
     public void NumberFormatReturnsFunction()
     {
         var result = _engine.Evaluate("typeof new Intl.NumberFormat('en-US').format");
-        Assert.Equal("function", result.AsString());
+        result.AsString().Should().Be("function");
     }
 
     [Fact]
     public void NumberFormatFormatsDecimal()
     {
         var result = _engine.Evaluate("new Intl.NumberFormat('en-US').format(1234.567)");
-        Assert.Contains("1", result.AsString());
-        Assert.Contains("234", result.AsString());
+        result.AsString().Should().Contain("1");
+        result.AsString().Should().Contain("234");
     }
 
     [Fact]
@@ -359,7 +359,7 @@ public class IntlTests
     {
         var result = _engine.Evaluate("new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(1234.56)");
         // Should contain the dollar sign and the number
-        Assert.Contains("1", result.AsString());
+        result.AsString().Should().Contain("1");
     }
 
     [Fact]
@@ -367,7 +367,7 @@ public class IntlTests
     {
         var result = _engine.Evaluate("new Intl.NumberFormat('en-US', { style: 'percent' }).format(0.5)");
         // Should contain "50" for 50%
-        Assert.Contains("50", result.AsString());
+        result.AsString().Should().Contain("50");
     }
 
     [Fact]
@@ -377,7 +377,7 @@ public class IntlTests
             var options = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'EUR' }).resolvedOptions();
             options.currency
         ");
-        Assert.Equal("EUR", result.AsString());
+        result.AsString().Should().Be("EUR");
     }
 
     [Fact]
@@ -387,36 +387,36 @@ public class IntlTests
             var options = new Intl.NumberFormat('en-US', { style: 'percent' }).resolvedOptions();
             options.style
         ");
-        Assert.Equal("percent", result.AsString());
+        result.AsString().Should().Be("percent");
     }
 
     [Fact]
     public void NumberFormatSupportedLocalesOf()
     {
         var result = _engine.Evaluate("Intl.NumberFormat.supportedLocalesOf(['en-US', 'de-DE'])");
-        Assert.True(result.IsArray());
+        result.IsArray().Should().BeTrue();
     }
 
     [Fact]
     public void NumberFormatWithUnit()
     {
         var result = _engine.Evaluate("new Intl.NumberFormat('en-US', { style: 'unit', unit: 'kilometer' }).format(100)");
-        Assert.Contains("100", result.AsString());
-        Assert.Contains("km", result.AsString());
+        result.AsString().Should().Contain("100");
+        result.AsString().Should().Contain("km");
     }
 
     [Fact]
     public void NumberFormatCurrencyRequiresCurrency()
     {
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            _engine.Evaluate("new Intl.NumberFormat('en-US', { style: 'currency' })"));
+        Invoking(() =>
+            _engine.Evaluate("new Intl.NumberFormat('en-US', { style: 'currency' })")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
     }
 
     [Fact]
     public void NumberFormatUnitRequiresUnit()
     {
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            _engine.Evaluate("new Intl.NumberFormat('en-US', { style: 'unit' })"));
+        Invoking(() =>
+            _engine.Evaluate("new Intl.NumberFormat('en-US', { style: 'unit' })")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
     }
 
     // Intl.DateTimeFormat tests
@@ -424,29 +424,29 @@ public class IntlTests
     public void DateTimeFormatConstructorExists()
     {
         var result = _engine.Evaluate("typeof Intl.DateTimeFormat");
-        Assert.Equal("function", result.AsString());
+        result.AsString().Should().Be("function");
     }
 
     [Fact]
     public void DateTimeFormatCanBeConstructed()
     {
         var result = _engine.Evaluate("new Intl.DateTimeFormat('en-US')");
-        Assert.NotNull(result);
-        Assert.True(result.IsObject());
+        result.Should().NotBeNull();
+        result.IsObject().Should().BeTrue();
     }
 
     [Fact]
     public void DateTimeFormatToStringTagIsCorrect()
     {
         var result = _engine.Evaluate("Object.prototype.toString.call(new Intl.DateTimeFormat('en-US'))");
-        Assert.Equal("[object Intl.DateTimeFormat]", result.AsString());
+        result.AsString().Should().Be("[object Intl.DateTimeFormat]");
     }
 
     [Fact]
     public void DateTimeFormatFormatReturnsFunction()
     {
         var result = _engine.Evaluate("typeof new Intl.DateTimeFormat('en-US').format");
-        Assert.Equal("function", result.AsString());
+        result.AsString().Should().Be("function");
     }
 
     [Fact]
@@ -454,26 +454,26 @@ public class IntlTests
     {
         var result = _engine.Evaluate("new Intl.DateTimeFormat('en-US').format(new Date(2024, 0, 15, 12, 0, 0))");
         // Should contain the date components - use noon to avoid timezone issues
-        Assert.Contains("1", result.AsString()); // Month or day
-        Assert.Contains("2024", result.AsString()); // Year
+        result.AsString().Should().Contain("1"); // Month or day
+        result.AsString().Should().Contain("2024"); // Year
         // Day could be 14, 15, or 16 depending on timezone, just check it's a valid date
-        Assert.True(result.AsString().Length > 0);
+        result.AsString().Length.Should().BeGreaterThan(0);
     }
 
     [Fact]
     public void DateTimeFormatWithDateStyle()
     {
         var result = _engine.Evaluate("new Intl.DateTimeFormat('en-US', { dateStyle: 'short' }).format(new Date(2024, 0, 15))");
-        Assert.NotNull(result.AsString());
-        Assert.True(result.AsString().Length > 0);
+        result.AsString().Should().NotBeNull();
+        result.AsString().Length.Should().BeGreaterThan(0);
     }
 
     [Fact]
     public void DateTimeFormatWithTimeStyle()
     {
         var result = _engine.Evaluate("new Intl.DateTimeFormat('en-US', { timeStyle: 'short' }).format(new Date(2024, 0, 15, 14, 30, 0))");
-        Assert.NotNull(result.AsString());
-        Assert.True(result.AsString().Length > 0);
+        result.AsString().Should().NotBeNull();
+        result.AsString().Length.Should().BeGreaterThan(0);
     }
 
     [Fact]
@@ -483,7 +483,7 @@ public class IntlTests
             var options = new Intl.DateTimeFormat('en-US', { dateStyle: 'full' }).resolvedOptions();
             options.dateStyle
         ");
-        Assert.Equal("full", result.AsString());
+        result.AsString().Should().Be("full");
     }
 
     [Fact]
@@ -494,7 +494,7 @@ public class IntlTests
             options.locale
         ");
         // Should return a locale string
-        Assert.NotNull(result.AsString());
+        result.AsString().Should().NotBeNull();
     }
 
     [Fact]
@@ -505,14 +505,14 @@ public class IntlTests
             options.calendar
         ");
         // Default calendar should be 'gregory'
-        Assert.Equal("gregory", result.AsString());
+        result.AsString().Should().Be("gregory");
     }
 
     [Fact]
     public void DateTimeFormatSupportedLocalesOf()
     {
         var result = _engine.Evaluate("Intl.DateTimeFormat.supportedLocalesOf(['en-US', 'de-DE'])");
-        Assert.True(result.IsArray());
+        result.IsArray().Should().BeTrue();
     }
 
     [Fact]
@@ -525,7 +525,7 @@ public class IntlTests
                 day: 'numeric'
             }).format(new Date(2024, 0, 15))
         ");
-        Assert.Contains("2024", result.AsString());
+        result.AsString().Should().Contain("2024");
     }
 
     [Fact]
@@ -538,7 +538,7 @@ public class IntlTests
             }).format(new Date(2024, 0, 15, 14, 30, 0))
         ");
         // Should contain time components
-        Assert.True(result.AsString().Contains("30") || result.AsString().Contains(":"));
+        (result.AsString().Contains("30") || result.AsString().Contains(":")).Should().BeTrue();
     }
 
     [Fact]
@@ -548,7 +548,7 @@ public class IntlTests
             var parts = new Intl.DateTimeFormat('en-US').formatToParts(new Date(2024, 0, 15));
             Array.isArray(parts)
         ");
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -558,7 +558,7 @@ public class IntlTests
             var parts = new Intl.DateTimeFormat('en-US').formatToParts(new Date(2024, 0, 15));
             parts.length > 0 && parts[0].type !== undefined && parts[0].value !== undefined
         ");
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -573,7 +573,7 @@ public class IntlTests
             }).format(new Date(2024, 0, 15))
         ");
         // Should contain a weekday name (Monday, January 15, 2024)
-        Assert.True(result.AsString().Length > 10);
+        result.AsString().Length.Should().BeGreaterThan(10);
     }
 
     [Fact]
@@ -586,7 +586,7 @@ public class IntlTests
             }).resolvedOptions();
             options.hourCycle
         ");
-        Assert.Equal("h23", result.AsString());
+        result.AsString().Should().Be("h23");
     }
 
     [Fact]
@@ -598,14 +598,14 @@ public class IntlTests
             }).resolvedOptions();
             options.timeZone
         ");
-        Assert.Equal("UTC", result.AsString());
+        result.AsString().Should().Be("UTC");
     }
 
     [Fact]
     public void DateTimeFormatInvalidTimeZoneThrows()
     {
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            _engine.Evaluate("new Intl.DateTimeFormat('en-US', { timeZone: 'Invalid/TimeZone' })"));
+        Invoking(() =>
+            _engine.Evaluate("new Intl.DateTimeFormat('en-US', { timeZone: 'Invalid/TimeZone' })")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
     }
 
     [Fact]
@@ -613,16 +613,16 @@ public class IntlTests
     {
         var result = _engine.Evaluate("new Intl.DateTimeFormat('en-US').format()");
         // Should return a non-empty string (current date formatted)
-        Assert.NotNull(result.AsString());
-        Assert.True(result.AsString().Length > 0);
+        result.AsString().Should().NotBeNull();
+        result.AsString().Length.Should().BeGreaterThan(0);
     }
 
     [Fact]
     public void DateTimeFormatFormatsTimestamp()
     {
         var result = _engine.Evaluate("new Intl.DateTimeFormat('en-US').format(1705363200000)"); // Jan 15, 2024 UTC
-        Assert.NotNull(result.AsString());
-        Assert.True(result.AsString().Length > 0);
+        result.AsString().Should().NotBeNull();
+        result.AsString().Length.Should().BeGreaterThan(0);
     }
 
     [Fact]
@@ -636,21 +636,21 @@ public class IntlTests
             }).format(new Date(2024, 0, 5))
         ");
         // With 2-digit, should have leading zeros
-        Assert.Contains("01", result.AsString()); // Month
+        result.AsString().Should().Contain("01"); // Month
     }
 
     [Fact]
     public void DateTimeFormatInvalidDateStyleThrows()
     {
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            _engine.Evaluate("new Intl.DateTimeFormat('en-US', { dateStyle: 'invalid' })"));
+        Invoking(() =>
+            _engine.Evaluate("new Intl.DateTimeFormat('en-US', { dateStyle: 'invalid' })")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
     }
 
     [Fact]
     public void DateTimeFormatInvalidWeekdayThrows()
     {
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            _engine.Evaluate("new Intl.DateTimeFormat('en-US', { weekday: 'invalid' })"));
+        Invoking(() =>
+            _engine.Evaluate("new Intl.DateTimeFormat('en-US', { weekday: 'invalid' })")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
     }
 
     // Boundary tests for the precision-aware string-input paths in NumberFormatPrototype.
@@ -662,14 +662,14 @@ public class IntlTests
     public void NumberFormat_LargeIntegerString_PreservesAllDigits()
     {
         var result = _engine.Evaluate("new Intl.NumberFormat('en-US').format('987654321987654321')");
-        Assert.Equal("987,654,321,987,654,321", result.AsString());
+        result.AsString().Should().Be("987,654,321,987,654,321");
     }
 
     [Fact]
     public void NumberFormat_NegativeLargeIntegerString_PreservesAllDigits()
     {
         var result = _engine.Evaluate("new Intl.NumberFormat('en-US').format('-987654321987654321')");
-        Assert.Equal("-987,654,321,987,654,321", result.AsString());
+        result.AsString().Should().Be("-987,654,321,987,654,321");
     }
 
     [Fact]
@@ -679,14 +679,14 @@ public class IntlTests
         // the existing double pipeline. The chosen value is exactly representable as a
         // double (≤ 2^53) so this also asserts no regression in the small-integer path.
         var result = _engine.Evaluate("new Intl.NumberFormat('en-US').format('1000000000000000')");
-        Assert.Equal("1,000,000,000,000,000", result.AsString());
+        result.AsString().Should().Be("1,000,000,000,000,000");
     }
 
     [Fact]
     public void NumberFormat_HighPrecisionDecimal_PreservesAllFractionDigits()
     {
         var result = _engine.Evaluate("new Intl.NumberFormat('en-US', {maximumFractionDigits: 20}).format('1.0000000000000001')");
-        Assert.Equal("1.0000000000000001", result.AsString());
+        result.AsString().Should().Be("1.0000000000000001");
     }
 
     [Fact]
@@ -695,7 +695,7 @@ public class IntlTests
         // 15 total digits — under the 16-digit precision boundary; format result still matches
         // because the double can represent 1.23 exactly enough for a 2-fraction-digit display.
         var result = _engine.Evaluate("new Intl.NumberFormat('en-US').format('1.23')");
-        Assert.Equal("1.23", result.AsString());
+        result.AsString().Should().Be("1.23");
     }
 
     [Fact]
@@ -706,7 +706,7 @@ public class IntlTests
         var result = _engine.Evaluate(
             "new Intl.NumberFormat('en-US', {minimumFractionDigits: 3, maximumFractionDigits: 3})" +
             ".format('-0.00000000000000000000000000000123')");
-        Assert.Equal("-0.000", result.AsString());
+        result.AsString().Should().Be("-0.000");
     }
 
     [Fact]
@@ -715,7 +715,7 @@ public class IntlTests
         var result = _engine.Evaluate(
             "new Intl.NumberFormat('en-US', {useGrouping: false, maximumSignificantDigits: 5})" +
             ".format('12344501000000000000000000000000000')");
-        Assert.Equal("12345000000000000000000000000000000", result.AsString());
+        result.AsString().Should().Be("12345000000000000000000000000000000");
     }
 
     [Fact]
@@ -723,14 +723,14 @@ public class IntlTests
     {
         var result = _engine.Evaluate(
             "new Intl.NumberFormat('en-US').formatRange('987654321987654321', '987654321987654322')");
-        Assert.Equal("987,654,321,987,654,321–987,654,321,987,654,322", result.AsString());
+        result.AsString().Should().Be("987,654,321,987,654,321–987,654,321,987,654,322");
     }
 
     [Fact]
     public void NumberFormat_FormatRange_NaN_Throws()
     {
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() =>
-            _engine.Evaluate("new Intl.NumberFormat('en-US').formatRange(NaN, 5)"));
+        Invoking(() =>
+            _engine.Evaluate("new Intl.NumberFormat('en-US').formatRange(NaN, 5)")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
     }
 
     [Fact]
@@ -739,6 +739,6 @@ public class IntlTests
         var result = _engine.Evaluate(
             "new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', signDisplay: 'always'})" +
             ".formatRange(2.9, 3.1)");
-        Assert.Equal("+$2.90–3.10", result.AsString());
+        result.AsString().Should().Be("+$2.90–3.10");
     }
 }

--- a/Jint.Tests/Runtime/IteratorHelpersTests.cs
+++ b/Jint.Tests/Runtime/IteratorHelpersTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 public class IteratorHelpersTests
 {
@@ -15,7 +15,7 @@ public class IteratorHelpersTests
             ]);
             """).AsString();
 
-        Assert.Equal("[[1,2,3],[1,2,3],[\"a\",\"b\"]]", result);
+        result.Should().Be("[[1,2,3],[1,2,3],[\"a\",\"b\"]]");
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public class IteratorHelpersTests
         var engine = new Engine();
         var result = engine.Evaluate("JSON.stringify([1, 2, 3, 4, 5].values().drop(1).take(3).map(x => x * 10).toArray())").AsString();
 
-        Assert.Equal("[20,30,40]", result);
+        result.Should().Be("[20,30,40]");
     }
 
     [Fact]
@@ -33,6 +33,6 @@ public class IteratorHelpersTests
         var engine = new Engine();
         var result = engine.Evaluate("Array.isArray([].values().toArray()) && [].values().toArray().length === 0").AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 }

--- a/Jint.Tests/Runtime/JsValueConversionTests.cs
+++ b/Jint.Tests/Runtime/JsValueConversionTests.cs
@@ -16,170 +16,170 @@ public class JsValueConversionTests
     public void ShouldBeAnArray()
     {
         var value = new JsArray(_engine);
-        Assert.Equal(false, value.IsBoolean());
-        Assert.Equal(true, value.IsArray());
-        Assert.Equal(false, value.IsDate());
-        Assert.Equal(false, value.IsNull());
-        Assert.Equal(false, value.IsNumber());
-        Assert.Equal(true, value.IsObject());
-        Assert.Equal(false, value.IsPrimitive());
-        Assert.Equal(false, value.IsRegExp());
-        Assert.Equal(false, value.IsString());
-        Assert.Equal(false, value.IsUndefined());
+        value.IsBoolean().Should().BeFalse();
+        value.IsArray().Should().BeTrue();
+        value.IsDate().Should().BeFalse();
+        value.IsNull().Should().BeFalse();
+        value.IsNumber().Should().BeFalse();
+        value.IsObject().Should().BeTrue();
+        value.IsPrimitive().Should().BeFalse();
+        value.IsRegExp().Should().BeFalse();
+        value.IsString().Should().BeFalse();
+        value.IsUndefined().Should().BeFalse();
 
-        Assert.Equal(true, value.AsArray() != null);
+        (value.AsArray() != null).Should().BeTrue();
     }
 
     [Fact]
     public void ShouldBeABoolean()
     {
         var value = JsBoolean.True;
-        Assert.Equal(true, value.IsBoolean());
-        Assert.Equal(false, value.IsArray());
-        Assert.Equal(false, value.IsDate());
-        Assert.Equal(false, value.IsNull());
-        Assert.Equal(false, value.IsNumber());
-        Assert.Equal(false, value.IsObject());
-        Assert.Equal(true, value.IsPrimitive());
-        Assert.Equal(false, value.IsRegExp());
-        Assert.Equal(false, value.IsString());
-        Assert.Equal(false, value.IsUndefined());
+        value.IsBoolean().Should().BeTrue();
+        value.IsArray().Should().BeFalse();
+        value.IsDate().Should().BeFalse();
+        value.IsNull().Should().BeFalse();
+        value.IsNumber().Should().BeFalse();
+        value.IsObject().Should().BeFalse();
+        value.IsPrimitive().Should().BeTrue();
+        value.IsRegExp().Should().BeFalse();
+        value.IsString().Should().BeFalse();
+        value.IsUndefined().Should().BeFalse();
 
-        Assert.Equal(true, value.AsBoolean());
+        value.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void ShouldBeADate()
     {
         var value = new JsDate(_engine, double.NaN);
-        Assert.Equal(false, value.IsBoolean());
-        Assert.Equal(false, value.IsArray());
-        Assert.Equal(true, value.IsDate());
-        Assert.Equal(false, value.IsNull());
-        Assert.Equal(false, value.IsNumber());
-        Assert.Equal(true, value.IsObject());
-        Assert.Equal(false, value.IsPrimitive());
-        Assert.Equal(false, value.IsRegExp());
-        Assert.Equal(false, value.IsString());
-        Assert.Equal(false, value.IsUndefined());
+        value.IsBoolean().Should().BeFalse();
+        value.IsArray().Should().BeFalse();
+        value.IsDate().Should().BeTrue();
+        value.IsNull().Should().BeFalse();
+        value.IsNumber().Should().BeFalse();
+        value.IsObject().Should().BeTrue();
+        value.IsPrimitive().Should().BeFalse();
+        value.IsRegExp().Should().BeFalse();
+        value.IsString().Should().BeFalse();
+        value.IsUndefined().Should().BeFalse();
 
-        Assert.Equal(true, value.AsDate() != null);
+        (value.AsDate() != null).Should().BeTrue();
     }
 
     [Fact]
     public void ShouldBeNull()
     {
         var value = JsValue.Null;
-        Assert.Equal(false, value.IsBoolean());
-        Assert.Equal(false, value.IsArray());
-        Assert.Equal(false, value.IsDate());
-        Assert.Equal(true, value.IsNull());
-        Assert.Equal(false, value.IsNumber());
-        Assert.Equal(false, value.IsObject());
-        Assert.Equal(true, value.IsPrimitive());
-        Assert.Equal(false, value.IsRegExp());
-        Assert.Equal(false, value.IsString());
-        Assert.Equal(false, value.IsUndefined());
+        value.IsBoolean().Should().BeFalse();
+        value.IsArray().Should().BeFalse();
+        value.IsDate().Should().BeFalse();
+        value.IsNull().Should().BeTrue();
+        value.IsNumber().Should().BeFalse();
+        value.IsObject().Should().BeFalse();
+        value.IsPrimitive().Should().BeTrue();
+        value.IsRegExp().Should().BeFalse();
+        value.IsString().Should().BeFalse();
+        value.IsUndefined().Should().BeFalse();
     }
 
     [Fact]
     public void ShouldBeANumber()
     {
         var value = new JsNumber(2);
-        Assert.Equal(false, value.IsBoolean());
-        Assert.Equal(false, value.IsArray());
-        Assert.Equal(false, value.IsDate());
-        Assert.Equal(false, value.IsNull());
-        Assert.Equal(true, value.IsNumber());
-        Assert.Equal(2, value.AsNumber());
-        Assert.Equal(false, value.IsObject());
-        Assert.Equal(true, value.IsPrimitive());
-        Assert.Equal(false, value.IsRegExp());
-        Assert.Equal(false, value.IsString());
-        Assert.Equal(false, value.IsUndefined());
+        value.IsBoolean().Should().BeFalse();
+        value.IsArray().Should().BeFalse();
+        value.IsDate().Should().BeFalse();
+        value.IsNull().Should().BeFalse();
+        value.IsNumber().Should().BeTrue();
+        value.AsNumber().Should().Be(2);
+        value.IsObject().Should().BeFalse();
+        value.IsPrimitive().Should().BeTrue();
+        value.IsRegExp().Should().BeFalse();
+        value.IsString().Should().BeFalse();
+        value.IsUndefined().Should().BeFalse();
     }
 
     [Fact]
     public void ShouldBeAnObject()
     {
         var value = new JsObject(_engine);
-        Assert.Equal(false, value.IsBoolean());
-        Assert.Equal(false, value.IsArray());
-        Assert.Equal(false, value.IsDate());
-        Assert.Equal(false, value.IsNull());
-        Assert.Equal(false, value.IsNumber());
-        Assert.Equal(true, value.IsObject());
-        Assert.Equal(true, value.AsObject() != null);
-        Assert.Equal(false, value.IsPrimitive());
-        Assert.Equal(false, value.IsRegExp());
-        Assert.Equal(false, value.IsString());
-        Assert.Equal(false, value.IsUndefined());
+        value.IsBoolean().Should().BeFalse();
+        value.IsArray().Should().BeFalse();
+        value.IsDate().Should().BeFalse();
+        value.IsNull().Should().BeFalse();
+        value.IsNumber().Should().BeFalse();
+        value.IsObject().Should().BeTrue();
+        (value.AsObject() != null).Should().BeTrue();
+        value.IsPrimitive().Should().BeFalse();
+        value.IsRegExp().Should().BeFalse();
+        value.IsString().Should().BeFalse();
+        value.IsUndefined().Should().BeFalse();
     }
 
     [Fact]
     public void ShouldBeARegExp()
     {
         var value = new JsRegExp(_engine);
-        Assert.Equal(false, value.IsBoolean());
-        Assert.Equal(false, value.IsArray());
-        Assert.Equal(false, value.IsDate());
-        Assert.Equal(false, value.IsNull());
-        Assert.Equal(false, value.IsNumber());
-        Assert.Equal(true, value.IsObject());
-        Assert.Equal(false, value.IsPrimitive());
-        Assert.Equal(true, value.IsRegExp());
-        Assert.Equal(true, value.AsRegExp() != null);
-        Assert.Equal(false, value.IsString());
-        Assert.Equal(false, value.IsUndefined());
+        value.IsBoolean().Should().BeFalse();
+        value.IsArray().Should().BeFalse();
+        value.IsDate().Should().BeFalse();
+        value.IsNull().Should().BeFalse();
+        value.IsNumber().Should().BeFalse();
+        value.IsObject().Should().BeTrue();
+        value.IsPrimitive().Should().BeFalse();
+        value.IsRegExp().Should().BeTrue();
+        (value.AsRegExp() != null).Should().BeTrue();
+        value.IsString().Should().BeFalse();
+        value.IsUndefined().Should().BeFalse();
     }
 
     [Fact]
     public void ShouldBeAString()
     {
         var value = new JsString("a");
-        Assert.Equal(false, value.IsBoolean());
-        Assert.Equal(false, value.IsArray());
-        Assert.Equal(false, value.IsDate());
-        Assert.Equal(false, value.IsNull());
-        Assert.Equal(false, value.IsNumber());
-        Assert.Equal(false, value.IsObject());
-        Assert.Equal(true, value.IsPrimitive());
-        Assert.Equal(false, value.IsRegExp());
-        Assert.Equal(true, value.IsString());
-        Assert.Equal("a", value.AsString());
-        Assert.Equal(false, value.IsUndefined());
+        value.IsBoolean().Should().BeFalse();
+        value.IsArray().Should().BeFalse();
+        value.IsDate().Should().BeFalse();
+        value.IsNull().Should().BeFalse();
+        value.IsNumber().Should().BeFalse();
+        value.IsObject().Should().BeFalse();
+        value.IsPrimitive().Should().BeTrue();
+        value.IsRegExp().Should().BeFalse();
+        value.IsString().Should().BeTrue();
+        value.AsString().Should().Be("a");
+        value.IsUndefined().Should().BeFalse();
     }
 
     [Fact]
     public void ShouldBeUndefined()
     {
         var value = JsValue.Undefined;
-        Assert.Equal(false, value.IsBoolean());
-        Assert.Equal(false, value.IsArray());
-        Assert.Equal(false, value.IsDate());
-        Assert.Equal(false, value.IsNull());
-        Assert.Equal(false, value.IsNumber());
-        Assert.Equal(false, value.IsObject());
-        Assert.Equal(true, value.IsPrimitive());
-        Assert.Equal(false, value.IsRegExp());
-        Assert.Equal(false, value.IsString());
-        Assert.Equal(true, value.IsUndefined());
+        value.IsBoolean().Should().BeFalse();
+        value.IsArray().Should().BeFalse();
+        value.IsDate().Should().BeFalse();
+        value.IsNull().Should().BeFalse();
+        value.IsNumber().Should().BeFalse();
+        value.IsObject().Should().BeFalse();
+        value.IsPrimitive().Should().BeTrue();
+        value.IsRegExp().Should().BeFalse();
+        value.IsString().Should().BeFalse();
+        value.IsUndefined().Should().BeTrue();
     }
 
     [Fact]
     public void ShouldConvertArrayBuffer()
     {
         var value = _engine.Evaluate("new Uint8Array([102, 111, 111]).buffer");
-        Assert.Equal(true, value.IsArrayBuffer());
-        Assert.Equal([102, 111, 111], value.AsArrayBuffer());
-        Assert.Equal([102, 111, 111], value.ToObject() as byte[]);
+        value.IsArrayBuffer().Should().BeTrue();
+        value.AsArrayBuffer().Should().Equal([102, 111, 111]);
+        (value.ToObject() as byte[]).Should().Equal([102, 111, 111]);
 
         (value as JsArrayBuffer).DetachArrayBuffer();
 
-        Assert.Equal(true, value.IsArrayBuffer());
-        Assert.Equal(null, value.AsArrayBuffer());
-        Assert.Throws<JavaScriptException>(value.ToObject);
-        Assert.Throws<ArgumentException>(JsValue.Undefined.AsArrayBuffer);
+        value.IsArrayBuffer().Should().BeTrue();
+        value.AsArrayBuffer().Should().BeNull();
+        Invoking(value.ToObject).Should().ThrowExactly<JavaScriptException>();
+        Invoking(JsValue.Undefined.AsArrayBuffer).Should().ThrowExactly<ArgumentException>();
     }
 
     [Fact]
@@ -187,15 +187,15 @@ public class JsValueConversionTests
     {
         var value = _engine.Evaluate("new DataView(new Uint8Array([102, 102, 111, 111, 111]).buffer, 1, 3)");
 
-        Assert.Equal(true, value.IsDataView());
-        Assert.Equal([102, 111, 111], value.AsDataView());
-        Assert.Equal([102, 111, 111], value.ToObject() as byte[]);
+        value.IsDataView().Should().BeTrue();
+        value.AsDataView().Should().Equal([102, 111, 111]);
+        (value.ToObject() as byte[]).Should().Equal([102, 111, 111]);
 
         (value as JsDataView)._viewedArrayBuffer.DetachArrayBuffer();
 
-        Assert.Equal(true, value.IsDataView());
-        Assert.Equal(null, value.AsDataView());
-        Assert.Throws<JavaScriptException>(value.ToObject);
-        Assert.Throws<ArgumentException>(JsValue.Undefined.AsDataView);
+        value.IsDataView().Should().BeTrue();
+        value.AsDataView().Should().BeNull();
+        Invoking(value.ToObject).Should().ThrowExactly<JavaScriptException>();
+        Invoking(JsValue.Undefined.AsDataView).Should().ThrowExactly<ArgumentException>();
     }
 }

--- a/Jint.Tests/Runtime/JsValueListBuilderTests.cs
+++ b/Jint.Tests/Runtime/JsValueListBuilderTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Pooling;
 
 namespace Jint.Tests.Runtime;
@@ -16,13 +16,13 @@ public class JsValueListBuilderTests
                 builder.Add(JsNumber.Create(i));
             }
 
-            Assert.Equal(1000, builder.Length);
+            builder.Length.Should().Be(1000);
 
             var array = builder.ToArray();
-            Assert.Equal(1000, array.Length);
+            array.Length.Should().Be(1000);
             for (var i = 0; i < array.Length; i++)
             {
-                Assert.Equal(i, ((JsNumber) array[i]).AsNumber());
+                ((JsNumber) array[i]).AsNumber().Should().Be(i);
             }
         }
         finally
@@ -44,9 +44,9 @@ public class JsValueListBuilderTests
             }
 
             var array = builder.ToArray();
-            Assert.Equal(Count, array.Length);
-            Assert.Equal(0, ((JsNumber) array[0]).AsNumber());
-            Assert.Equal((Count - 1) % 7, ((JsNumber) array[Count - 1]).AsNumber());
+            array.Length.Should().Be(Count);
+            ((JsNumber) array[0]).AsNumber().Should().Be(0);
+            ((JsNumber) array[Count - 1]).AsNumber().Should().Be((Count - 1) % 7);
         }
         finally
         {
@@ -64,14 +64,14 @@ public class JsValueListBuilderTests
             builder.AddHole();
             builder.Add(JsNumber.Create(3));
 
-            Assert.Equal(3, builder.Length);
-            Assert.NotNull(builder[0]);
-            Assert.Null(builder[1]);
-            Assert.NotNull(builder[2]);
+            builder.Length.Should().Be(3);
+            builder[0].Should().NotBeNull();
+            builder[1].Should().BeNull();
+            builder[2].Should().NotBeNull();
 
             var array = builder.ToArray();
-            Assert.Equal(3, array.Length);
-            Assert.Null(array[1]);
+            array.Length.Should().Be(3);
+            array[1].Should().BeNull();
         }
         finally
         {
@@ -94,12 +94,12 @@ public class JsValueListBuilderTests
             builder.Add(JsNumber.Create(-1));
             builder.AddRange(source);
 
-            Assert.Equal(101, builder.Length);
+            builder.Length.Should().Be(101);
 
             var array = builder.ToArray();
-            Assert.Equal(-1, ((JsNumber) array[0]).AsNumber());
-            Assert.Equal(2, ((JsNumber) array[3]).AsNumber());
-            Assert.Null(array[2]);
+            ((JsNumber) array[0]).AsNumber().Should().Be(-1);
+            ((JsNumber) array[3]).AsNumber().Should().Be(2);
+            array[2].Should().BeNull();
         }
         finally
         {
@@ -114,8 +114,8 @@ public class JsValueListBuilderTests
         try
         {
             var array = builder.ToArray();
-            Assert.Empty(array);
-            Assert.Same(System.Array.Empty<JsValue>(), array);
+            array.Should().BeEmpty();
+            array.Should().BeSameAs(System.Array.Empty<JsValue>());
         }
         finally
         {

--- a/Jint.Tests/Runtime/JsonSerializerTests.cs
+++ b/Jint.Tests/Runtime/JsonSerializerTests.cs
@@ -11,17 +11,17 @@ public class JsonSerializerTests
         using var engine = new Engine();
         var serializer = new JsonSerializer(engine);
 
-        Assert.Equal("null", serializer.Serialize(JsValue.Null).ToString());
-        Assert.Equal("true", serializer.Serialize(JsBoolean.True).ToString());
-        Assert.Equal("false", serializer.Serialize(JsBoolean.False).ToString());
-        Assert.Equal("\"\"", serializer.Serialize(new JsString("")).ToString());
-        Assert.Equal("\"abc\"", serializer.Serialize(new JsString("abc")).ToString());
-        Assert.Equal("1", serializer.Serialize(new JsNumber(1)).ToString());
-        Assert.Equal("0.5", serializer.Serialize(new JsNumber(0.5)).ToString());
-        Assert.Equal("{}", serializer.Serialize(new JsObject(engine)).ToString());
-        Assert.Equal("[]", serializer.Serialize(new JsArray(engine)).ToString());
+        serializer.Serialize(JsValue.Null).ToString().Should().Be("null");
+        serializer.Serialize(JsBoolean.True).ToString().Should().Be("true");
+        serializer.Serialize(JsBoolean.False).ToString().Should().Be("false");
+        serializer.Serialize(new JsString("")).ToString().Should().Be("\"\"");
+        serializer.Serialize(new JsString("abc")).ToString().Should().Be("\"abc\"");
+        serializer.Serialize(new JsNumber(1)).ToString().Should().Be("1");
+        serializer.Serialize(new JsNumber(0.5)).ToString().Should().Be("0.5");
+        serializer.Serialize(new JsObject(engine)).ToString().Should().Be("{}");
+        serializer.Serialize(new JsArray(engine)).ToString().Should().Be("[]");
 
-        Assert.Same(JsValue.Undefined, serializer.Serialize(JsValue.Undefined));
+        serializer.Serialize(JsValue.Undefined).Should().BeSameAs(JsValue.Undefined);
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public class JsonSerializerTests
     {
         using var engine = new Engine();
         var serializer = new JsonSerializer(engine);
-        Assert.Equal("{}", serializer.Serialize(new JsObject(engine), JsValue.Undefined, new JsString("  ")).ToString());
+        serializer.Serialize(new JsObject(engine), JsValue.Undefined, new JsString("  ")).ToString().Should().Be("{}");
     }
 
     [Fact]
@@ -37,7 +37,7 @@ public class JsonSerializerTests
     {
         using var engine = new Engine();
         var serializer = new JsonSerializer(engine);
-        Assert.Equal("[]", serializer.Serialize(new JsArray(engine), JsValue.Undefined, new JsString("  ")).ToString());
+        serializer.Serialize(new JsArray(engine), JsValue.Undefined, new JsString("  ")).ToString().Should().Be("[]");
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class JsonSerializerTests
         var serializer = new JsonSerializer(engine);
 
         string actual = serializer.Serialize(new JsString("\"\\\t\r\n\f\r\b\ud834")).ToString();
-        Assert.Equal("\"\\\"\\\\\\t\\r\\n\\f\\r\\b\\ud834\"", actual);
+        actual.Should().Be("\"\\\"\\\\\\t\\r\\n\\f\\r\\b\\ud834\"");
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public class JsonSerializerTests
         instance["d"] = true;
 
         string actual = serializer.Serialize(instance, JsValue.Undefined, new JsNumber(2)).ToString();
-        Assert.Equal("{\n  \"a\": \"b\",\n  \"b\": 2,\n  \"c\": [\n    4,\n    5,\n    6\n  ],\n  \"d\": true\n}", actual);
+        actual.Should().Be("{\n  \"a\": \"b\",\n  \"b\": 2,\n  \"c\": [\n    4,\n    5,\n    6\n  ],\n  \"d\": true\n}");
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class JsonSerializerTests
         instance["d"] = true;
 
         string actual = serializer.Serialize(instance, JsValue.Undefined, JsValue.Undefined).ToString();
-        Assert.Equal("{\"a\":\"b\",\"b\":2,\"c\":[4,5,6],\"d\":true}", actual);
+        actual.Should().Be("{\"a\":\"b\",\"b\":2,\"c\":[4,5,6],\"d\":true}");
     }
 
     [Fact]
@@ -90,7 +90,7 @@ public class JsonSerializerTests
 
         JsArray array = new JsArray(engine, [JsValue.Undefined, new JsNumber(42)]);
         string actual = serializer.Serialize(array, JsValue.Undefined, JsValue.Undefined).ToString();
-        Assert.Equal("[null,42]", actual);
+        actual.Should().Be("[null,42]");
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class JsonSerializerTests
         instance["a"] = JsValue.Undefined;
         instance["b"] = 42;
         string actual = serializer.Serialize(instance, JsValue.Undefined, JsValue.Undefined).ToString();
-        Assert.Equal("{\"b\":42}", actual);
+        actual.Should().Be("{\"b\":42}");
     }
 
     [Fact]
@@ -117,7 +117,7 @@ public class JsonSerializerTests
         instance[JsValue.Null] = 21;
         instance[new JsNumber(10)] = 42;
         string actual = serializer.Serialize(instance, JsValue.Undefined, JsValue.Undefined).ToString();
-        Assert.Equal("{\"10\":42,\"undefined\":10,\"null\":21}", actual);
+        actual.Should().Be("{\"10\":42,\"undefined\":10,\"null\":21}");
     }
 
     [Fact]
@@ -127,7 +127,7 @@ public class JsonSerializerTests
         var serializer = new JsonSerializer(engine);
         JsArray array = new JsArray(engine, [JsNumber.DoubleNegativeInfinity, JsNumber.DoublePositiveInfinity, JsNumber.DoubleNaN]);
         string actual = serializer.Serialize(array, JsValue.Undefined, JsValue.Undefined).ToString();
-        Assert.Equal("[null,null,null]", actual);
+        actual.Should().Be("[null,null,null]");
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public class JsonSerializerTests
         instance["b"] = 42;
         JsValue replacer = new JsArray(engine, [new JsString("b"), new JsString("z")]);
         string actual = serializer.Serialize(instance, replacer, JsValue.Undefined).ToString();
-        Assert.Equal("{\"b\":42}", actual);
+        actual.Should().Be("{\"b\":42}");
     }
 
     [Theory]
@@ -157,7 +157,7 @@ public class JsonSerializerTests
         var serializer = new JsonSerializer(engine);
 
         string actual = serializer.Serialize(new JsString(inputString)).ToString();
-        Assert.Equal(expectedOutput, actual);
+        actual.Should().Be(expectedOutput);
     }
 
     [Fact]
@@ -171,7 +171,7 @@ public class JsonSerializerTests
             JSON.stringify(a, ["b", "a"]) === '[{"b":2,"a":1},{"b":5,"a":4}]';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public class JsonSerializerTests
             JSON.stringify(a) === '["record-0",{"x":3,"y":4}]';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -200,7 +200,7 @@ public class JsonSerializerTests
             JSON.stringify(o) === '{"a":1,"b":"B"}';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -217,7 +217,7 @@ public class JsonSerializerTests
                 && JSON.stringify(shaped) === '{"a":1,"b":"x","c":[1,2],"d":{"e":null},"f":1.5,"g":true}';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -231,7 +231,7 @@ public class JsonSerializerTests
             JSON.stringify(o) === '{"a":1,"b":2}';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -246,7 +246,7 @@ public class JsonSerializerTests
             JSON.stringify(o) === '{"3":3,"b":1,"c":2}' && Object.keys(o).join() === '3,b,c';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -258,6 +258,6 @@ public class JsonSerializerTests
             JSON.stringify(a, function (k, v) { return k === 'b' ? undefined : v; }) === '[{"a":1},{"a":3}]';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 }

--- a/Jint.Tests/Runtime/JsonTests.cs
+++ b/Jint.Tests/Runtime/JsonTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Jint.Native;
 using Jint.Native.Json;
 using Jint.Native.Object;
@@ -20,7 +20,7 @@ public class JsonTests
         var json = "[" + string.Join(",", Enumerable.Range(0, size)) + "]";
         var ok = engine.Evaluate($"var a = JSON.parse('{json}'); a.length === {size} && ({size} === 0 || a[{size - 1}] === {size - 1})").AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Theory]
@@ -35,7 +35,7 @@ public class JsonTests
         var json = "[" + string.Join(",", Enumerable.Range(0, size)) + "]";
         var ok = engine.Evaluate($"var a = JSON.parse('{json}', function (k, v) {{ return v; }}); a.length === {size} && ({size} === 0 || a[{size - 1}] === {size - 1})").AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class JsonTests
             JSON.stringify(a) === '[[1,2,3],[4,5,[6,7,[8]]],9]';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Theory]
@@ -62,7 +62,7 @@ public class JsonTests
     {
         var engine = new Engine();
         var obj = engine.Evaluate(script).AsObject();
-        Assert.True(obj.HasOwnProperty(expectedPropertyName));
+        obj.HasOwnProperty(expectedPropertyName).Should().BeTrue();
     }
 
     [Theory]
@@ -88,7 +88,7 @@ public class JsonTests
 
         var parsedCharacter = parser.Parse(json).AsObject().Get("a").AsString();
 
-        Assert.Equal(expectedCharacter, parsedCharacter);
+        parsedCharacter.Should().Be(expectedCharacter);
     }
 
     [Theory]
@@ -121,16 +121,16 @@ public class JsonTests
     {
         var engine = new Engine();
         var parser = new JsonParser(engine);
-        var ex = Assert.ThrowsAny<JavaScriptException>(() =>
+        var ex = Invoking(() =>
         {
             parser.Parse(json);
-        });
+        }).Should().Throw<JavaScriptException>().Which;
 
-        Assert.Equal(expectedMessage, ex.Message);
+        ex.Message.Should().Be(expectedMessage);
 
         var error = ex.Error as Native.Error.ErrorInstance;
-        Assert.NotNull(error);
-        Assert.Equal("SyntaxError", error.Get("name"));
+        error.Should().NotBeNull();
+        error.Get("name").Should().Be("SyntaxError");
     }
 
     [Theory]
@@ -144,7 +144,7 @@ public class JsonTests
 
         var result = engine.Evaluate("JSON.stringify(x, null, 2);").AsString();
 
-        Assert.Equal(expectedJson, result);
+        result.Should().Be(expectedJson);
     }
 
     [Theory]
@@ -159,11 +159,11 @@ public class JsonTests
         var parser = new JsonParser(engine);
 
         JsValue result = parser.Parse(json);
-        JsArray array = Assert.IsType<JsArray>(result);
-        Assert.Equal((uint)numberOfElements, array.Length);
+        JsArray array = result.Should().BeOfType<JsArray>().Which;
+        array.Length.Should().Be((uint)numberOfElements);
         for (int i = 0; i < numberOfElements; i++)
         {
-            Assert.Equal(i, (int)array[i].AsNumber());
+            ((int)array[i].AsNumber()).Should().Be(i);
         }
     }
 
@@ -180,7 +180,7 @@ public class JsonTests
         var parser = new JsonParser(engine);
 
         string value = parser.Parse(json).AsString();
-        Assert.Equal(generatedString, value, StringComparer.Ordinal);
+        value.Should().Be(generatedString);
     }
 
     [Fact]
@@ -189,9 +189,9 @@ public class JsonTests
         var engine = new Engine();
         var parser = new JsonParser(engine);
 
-        Assert.Same(JsBoolean.True, parser.Parse("true"));
-        Assert.Same(JsBoolean.False, parser.Parse("false"));
-        Assert.Same(JsValue.Null, parser.Parse("null"));
+        parser.Parse("true").Should().BeSameAs(JsBoolean.True);
+        parser.Parse("false").Should().BeSameAs(JsBoolean.False);
+        parser.Parse("null").Should().BeSameAs(JsValue.Null);
     }
 
     [Fact]
@@ -200,10 +200,10 @@ public class JsonTests
         var engine = new Engine();
         var parser = new JsonParser(engine);
 
-        Assert.Equal(-1, (int)parser.Parse("-1").AsNumber());
-        Assert.Equal(0, (int)parser.Parse("-0").AsNumber());
-        Assert.Equal(0, (int)parser.Parse("0").AsNumber());
-        Assert.Equal(1, (int)parser.Parse("1").AsNumber());
+        ((int)parser.Parse("-1").AsNumber()).Should().Be(-1);
+        ((int)parser.Parse("-0").AsNumber()).Should().Be(0);
+        ((int)parser.Parse("0").AsNumber()).Should().Be(0);
+        ((int)parser.Parse("1").AsNumber()).Should().Be(1);
     }
 
     [Fact]
@@ -214,7 +214,7 @@ public class JsonTests
         var engine = new Engine();
         var parser = new JsonParser(engine);
 
-        Assert.Equal(maxSafeInteger, (long)parser.Parse("9007199254740991").AsNumber());
+        ((long)parser.Parse("9007199254740991").AsNumber()).Should().Be(maxSafeInteger);
     }
 
     [Fact]
@@ -223,9 +223,9 @@ public class JsonTests
         var engine = new Engine();
         var parser = new JsonParser(engine);
 
-        Assert.Equal(0.1d, parser.Parse("0.1").AsNumber());
-        Assert.Equal(1.1d, parser.Parse("1.1").AsNumber());
-        Assert.Equal(-1.1d, parser.Parse("-1.1").AsNumber());
+        parser.Parse("0.1").AsNumber().Should().Be(0.1d);
+        parser.Parse("1.1").AsNumber().Should().Be(1.1d);
+        parser.Parse("-1.1").AsNumber().Should().Be(-1.1d);
     }
 
     [Fact]
@@ -234,8 +234,8 @@ public class JsonTests
         var engine = new Engine();
         var parser = new JsonParser(engine);
 
-        Assert.Equal(100d, parser.Parse("1E2").AsNumber());
-        Assert.Equal(0.01d, parser.Parse("1E-2").AsNumber());
+        parser.Parse("1E2").AsNumber().Should().Be(100d);
+        parser.Parse("1E-2").AsNumber().Should().Be(0.01d);
     }
 
     [Fact]
@@ -246,8 +246,8 @@ public class JsonTests
         var engine = new Engine();
         var parser = new JsonParser(engine);
 
-        JavaScriptException ex = Assert.Throws<JavaScriptException>(() => parser.Parse(json));
-        Assert.Equal("Max. depth level of JSON reached at position 64", ex.Message);
+        JavaScriptException ex = Invoking(() => parser.Parse(json)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Max. depth level of JSON reached at position 64");
     }
 
     [Fact]
@@ -258,8 +258,8 @@ public class JsonTests
         var engine = new Engine();
         var parser = new JsonParser(engine);
 
-        JavaScriptException ex = Assert.Throws<JavaScriptException>(() => parser.Parse(json));
-        Assert.Equal("Max. depth level of JSON reached at position 320", ex.Message);
+        JavaScriptException ex = Invoking(() => parser.Parse(json)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Max. depth level of JSON reached at position 320");
     }
 
     [Fact]
@@ -273,8 +273,8 @@ public class JsonTests
         var parser = new JsonParser(engine);
 
         ObjectInstance parsed = parser.Parse(json).AsObject();
-        Assert.True(parsed["a"].IsObject());
-        Assert.True(parsed["b"].IsObject());
+        parsed["a"].IsObject().Should().BeTrue();
+        parsed["b"].IsObject().Should().BeTrue();
     }
 
     [Fact]
@@ -288,8 +288,8 @@ public class JsonTests
         var parser = new JsonParser(engine);
 
         ObjectInstance parsed = parser.Parse(json).AsObject();
-        Assert.True(parsed["a"].IsArray());
-        Assert.True(parsed["b"].IsArray());
+        parsed["a"].IsArray().Should().BeTrue();
+        parsed["b"].IsArray().Should().BeTrue();
     }
 
     [Fact]
@@ -303,8 +303,8 @@ public class JsonTests
         var engine = new Engine();
         var parser = new JsonParser(engine);
 
-        JavaScriptException ex = Assert.Throws<JavaScriptException>(() => parser.Parse(json));
-        Assert.Equal("Max. depth level of JSON reached at position 224", ex.Message);
+        JavaScriptException ex = Invoking(() => parser.Parse(json)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Max. depth level of JSON reached at position 224");
     }
 
     [Fact]
@@ -313,8 +313,8 @@ public class JsonTests
         var engine = new Engine();
         var parser = new JsonParser(engine, maxDepth: 0);
 
-        JavaScriptException ex = Assert.Throws<JavaScriptException>(() => parser.Parse("{}"));
-        Assert.Equal("Max. depth level of JSON reached at position 0", ex.Message);
+        JavaScriptException ex = Invoking(() => parser.Parse("{}")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Max. depth level of JSON reached at position 0");
     }
 
     [Fact]
@@ -323,8 +323,8 @@ public class JsonTests
         var engine = new Engine();
         var parser = new JsonParser(engine, maxDepth: 0);
 
-        JavaScriptException ex = Assert.Throws<JavaScriptException>(() => parser.Parse("[]"));
-        Assert.Equal("Max. depth level of JSON reached at position 0", ex.Message);
+        JavaScriptException ex = Invoking(() => parser.Parse("[]")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Message.Should().Be("Max. depth level of JSON reached at position 0");
     }
 
     [Fact]
@@ -334,10 +334,10 @@ public class JsonTests
         var parser = new JsonParser(engine, maxDepth: 1);
 
         ObjectInstance parsed = parser.Parse("{\"a\": 2, \"b\": true, \"c\": null, \"d\": \"test\"}").AsObject();
-        Assert.True(parsed["a"].IsNumber());
-        Assert.True(parsed["b"].IsBoolean());
-        Assert.True(parsed["c"].IsNull());
-        Assert.True(parsed["d"].IsString());
+        parsed["a"].IsNumber().Should().BeTrue();
+        parsed["b"].IsBoolean().Should().BeTrue();
+        parsed["c"].IsNull().Should().BeTrue();
+        parsed["d"].IsString().Should().BeTrue();
     }
 
     [Fact]
@@ -346,7 +346,7 @@ public class JsonTests
         var engine = new Engine(options => options.MaxJsonParseDepth(0));
         var parser = new JsonParser(engine);
 
-        Assert.Throws<JavaScriptException>(() => parser.Parse("[]"));
+        Invoking(() => parser.Parse("[]")).Should().ThrowExactly<JavaScriptException>();
     }
 
     [Fact]
@@ -362,7 +362,7 @@ public class JsonTests
                 && Object.prototype.a === undefined;
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -378,7 +378,7 @@ public class JsonTests
                 && Object.prototype.a === undefined;
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -392,7 +392,7 @@ public class JsonTests
                 && Object.getPrototypeOf(o) === Object.prototype;
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -406,7 +406,7 @@ public class JsonTests
                 && JSON.stringify(o) === '{"a":2,"b":9}';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Theory]
@@ -420,7 +420,7 @@ public class JsonTests
         engine.SetValue("json", json);
         var keys = engine.Evaluate("JSON.stringify(Object.keys(JSON.parse(json)))").AsString();
 
-        Assert.Equal(expectedKeys, keys);
+        keys.Should().Be(expectedKeys);
     }
 
     [Fact]
@@ -443,7 +443,7 @@ public class JsonTests
             ok && o.extra === 'x' && !('p0' in o) && Object.keys(o).length === 100;
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -460,7 +460,7 @@ public class JsonTests
                 && JSON.stringify(Object.keys(o)) === '["keep","double"]';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -475,7 +475,7 @@ public class JsonTests
                 && a[0].id === 1 && a[2].id === 3;
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -491,7 +491,7 @@ public class JsonTests
             sources.a === '1' && sources.b === '"x"';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -512,7 +512,7 @@ public class JsonTests
             ok && o.a === 1 && Object.isFrozen(o);
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -533,7 +533,7 @@ public class JsonTests
             ok;
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -562,7 +562,7 @@ public class JsonTests
             ok;
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -570,11 +570,11 @@ public class JsonTests
     {
         var engine = new Engine();
         var array = engine.Evaluate("""JSON.parse('[{"a":1,"b":2},{"a":3,"b":4}]')""").AsArray();
-        var first = Assert.IsType<JsObject>(array[0]);
-        var second = Assert.IsType<JsObject>(array[1]);
+        var first = array[0].Should().BeOfType<JsObject>().Which;
+        var second = array[1].Should().BeOfType<JsObject>().Which;
 
-        Assert.NotNull(first.ShapeOf);
-        Assert.Same(first.ShapeOf, second.ShapeOf);
+        first.ShapeOf.Should().NotBeNull();
+        second.ShapeOf.Should().BeSameAs(first.ShapeOf);
     }
 
     [Fact]
@@ -585,7 +585,7 @@ public class JsonTests
             JSON.stringify(JSON.parse('[{"a":1,"b":"x"},{"a":2,"b":"y"}]')) === '[{"a":1,"b":"x"},{"a":2,"b":"y"}]';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -600,7 +600,7 @@ public class JsonTests
                 && JSON.stringify(Object.keys(o.outer)) === '["inner","z"]';
             """).AsBoolean();
 
-        Assert.True(ok);
+        ok.Should().BeTrue();
     }
 
     [Fact]
@@ -609,18 +609,18 @@ public class JsonTests
         var parser = new JsonParser(new Engine());
 
         // escape at the very start, in the middle and at the end of the bulk run
-        Assert.Equal("\nabc", parser.Parse("\"\\nabc\"").AsString());
-        Assert.Equal("abc\ndef", parser.Parse("\"abc\\ndef\"").AsString());
-        Assert.Equal("abc\n", parser.Parse("\"abc\\n\"").AsString());
+        parser.Parse("\"\\nabc\"").AsString().Should().Be("\nabc");
+        parser.Parse("\"abc\\ndef\"").AsString().Should().Be("abc\ndef");
+        parser.Parse("\"abc\\n\"").AsString().Should().Be("abc\n");
 
         // every simple escape back-to-back: JSON "\"\\\/\n\r\t\b\f"
-        Assert.Equal("\"\\/\n\r\t\b\f", parser.Parse("\"\\\"\\\\\\/\\n\\r\\t\\b\\f\"").AsString());
+        parser.Parse("\"\\\"\\\\\\/\\n\\r\\t\\b\\f\"").AsString().Should().Be("\"\\/\n\r\t\b\f");
 
         // \uXXXX escapes (BMP)
-        Assert.Equal("Aé中", parser.Parse("\"\\u0041\\u00e9\\u4e2d\"").AsString());
+        parser.Parse("\"\\u0041\\u00e9\\u4e2d\"").AsString().Should().Be("Aé中");
 
         // a run with no escapes at all takes the pure bulk path
-        Assert.Equal("plain text with spaces", parser.Parse("\"plain text with spaces\"").AsString());
+        parser.Parse("\"plain text with spaces\"").AsString().Should().Be("plain text with spaces");
     }
 
     [Fact]
@@ -632,17 +632,17 @@ public class JsonTests
 
         // a single content run far longer than the 64-char buffer
         var long1 = new string('a', 200);
-        Assert.Equal(long1, parser.Parse("\"" + long1 + "\"").AsString());
+        parser.Parse("\"" + long1 + "\"").AsString().Should().Be(long1);
 
         // escape just before the boundary, then a long run after it
         var before = new string('a', 60);
         var after = new string('b', 60);
-        Assert.Equal(before + "\n" + after, parser.Parse("\"" + before + "\\n" + after + "\"").AsString());
+        parser.Parse("\"" + before + "\\n" + after + "\"").AsString().Should().Be(before + "\n" + after);
 
         // escape just after the boundary
         var before3 = new string('c', 70);
         var after3 = new string('d', 5);
-        Assert.Equal(before3 + "\t" + after3, parser.Parse("\"" + before3 + "\\t" + after3 + "\"").AsString());
+        parser.Parse("\"" + before3 + "\\t" + after3 + "\"").AsString().Should().Be(before3 + "\t" + after3);
 
         // many escapes interspersed straddling the boundary
         var json = new System.Text.StringBuilder("\"");
@@ -653,7 +653,7 @@ public class JsonTests
             expected.Append('x').Append('\n');
         }
         json.Append('"');
-        Assert.Equal(expected.ToString(), parser.Parse(json.ToString()).AsString());
+        parser.Parse(json.ToString()).AsString().Should().Be(expected.ToString());
     }
 
     [Fact]
@@ -664,8 +664,8 @@ public class JsonTests
         // accepts too); they historically terminated the scan with an UnexpectedEOS error
         var parser = new JsonParser(new Engine());
 
-        Assert.Equal("ab\u2028cd", parser.Parse("\"ab\u2028cd\"").AsString());
-        Assert.Equal("ab\u2029cd", parser.Parse("\"ab\u2029cd\"").AsString());
+        parser.Parse("\"ab\u2028cd\"").AsString().Should().Be("ab\u2028cd");
+        parser.Parse("\"ab\u2029cd\"").AsString().Should().Be("ab\u2029cd");
     }
 
     [Fact]
@@ -675,11 +675,11 @@ public class JsonTests
         // while being accepted in values
         var parser = new JsonParser(new Engine());
 
-        Assert.Equal(1, parser.Parse("{\"\\u0001\":1}").AsObject().Get("\u0001").AsNumber());
-        Assert.Equal(2, parser.Parse("{\"a\\u0000b\":2}").AsObject().Get("a\u0000b").AsNumber());
+        parser.Parse("{\"\\u0001\":1}").AsObject().Get("\u0001").AsNumber().Should().Be(1);
+        parser.Parse("{\"a\\u0000b\":2}").AsObject().Get("a\u0000b").AsNumber().Should().Be(2);
 
         // raw (unescaped) control characters keep being rejected, in keys and values alike
-        Assert.ThrowsAny<JavaScriptException>(() => parser.Parse("{\"\u0001\":1}"));
+        Invoking(() => parser.Parse("{\"\u0001\":1}")).Should().Throw<JavaScriptException>();
     }
 
     [Theory]
@@ -693,7 +693,7 @@ public class JsonTests
     {
         // int = zero / (digit1-9 *DIGIT) - also after a sign; frac = decimal-point 1*DIGIT
         var parser = new JsonParser(new Engine());
-        Assert.ThrowsAny<JavaScriptException>(() => parser.Parse(json));
+        Invoking(() => parser.Parse(json)).Should().Throw<JavaScriptException>();
     }
 
     [Theory]
@@ -706,10 +706,10 @@ public class JsonTests
     {
         var parser = new JsonParser(new Engine());
         var value = parser.Parse(json).AsNumber();
-        Assert.Equal(expected, value);
+        value.Should().Be(expected);
 #if !NETFRAMEWORK
         // .NET Framework's double.Parse loses the sign of negative zero (fixed in .NET Core 3.0)
-        Assert.Equal(double.IsNegativeInfinity(1 / expected), double.IsNegativeInfinity(1 / value));
+        double.IsNegativeInfinity(1 / value).Should().Be(double.IsNegativeInfinity(1 / expected));
 #endif
     }
 
@@ -727,7 +727,7 @@ public class JsonTests
             var json = GenerateRandomJsonNumber(random);
             var expected = BitConverter.DoubleToInt64Bits(double.Parse(json, JsonNumberStyles, CultureInfo.InvariantCulture));
             var actual = BitConverter.DoubleToInt64Bits(parser.Parse(json).AsNumber());
-            Assert.True(expected == actual, $"Bit mismatch for '{json}': expected 0x{expected:X16}, actual 0x{actual:X16}");
+            expected.Should().Be(actual, $"Bit mismatch for '{json}': expected 0x{expected:X16}, actual 0x{actual:X16}");
         }
     }
 
@@ -758,7 +758,7 @@ public class JsonTests
         var parser = new JsonParser(new Engine());
         var expected = BitConverter.DoubleToInt64Bits(double.Parse(json, JsonNumberStyles, CultureInfo.InvariantCulture));
         var actual = BitConverter.DoubleToInt64Bits(parser.Parse(json).AsNumber());
-        Assert.Equal(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Theory]
@@ -771,7 +771,7 @@ public class JsonTests
         // (+0.0 on .NET Framework, -0.0 on .NET Core) is preserved exactly rather than normalized.
         var expected = BitConverter.DoubleToInt64Bits(double.Parse(json, JsonNumberStyles, CultureInfo.InvariantCulture));
         var parser = new JsonParser(new Engine());
-        Assert.Equal(expected, BitConverter.DoubleToInt64Bits(parser.Parse(json).AsNumber()));
+        BitConverter.DoubleToInt64Bits(parser.Parse(json).AsNumber()).Should().Be(expected);
     }
 
     [Theory]
@@ -785,11 +785,11 @@ public class JsonTests
         var bits = BitConverter.DoubleToInt64Bits(parser.Parse(json).AsNumber());
         if (json == "0.5")
         {
-            Assert.NotEqual(positiveZeroBits, bits);
+            bits.Should().NotBe(positiveZeroBits);
         }
         else
         {
-            Assert.Equal(positiveZeroBits, bits);
+            bits.Should().Be(positiveZeroBits);
         }
     }
 
@@ -799,22 +799,22 @@ public class JsonTests
         var parser = new JsonParser(new Engine());
 
         var arr = parser.Parse("""["alpha","alpha","beta","alpha"]""").AsArray();
-        Assert.Equal("alpha", arr.Get("0").AsString());
-        Assert.Same(arr.Get("0"), arr.Get("1"));
-        Assert.Same(arr.Get("0"), arr.Get("3"));
-        Assert.Equal("beta", arr.Get("2").AsString());
-        Assert.NotSame(arr.Get("0"), arr.Get("2"));
+        arr.Get("0").AsString().Should().Be("alpha");
+        arr.Get("1").Should().BeSameAs(arr.Get("0"));
+        arr.Get("3").Should().BeSameAs(arr.Get("0"));
+        arr.Get("2").AsString().Should().Be("beta");
+        arr.Get("2").Should().NotBeSameAs(arr.Get("0"));
 
         var obj = parser.Parse("""{"a":"repeat","b":"repeat","c":"other"}""").AsObject();
-        Assert.Same(obj.Get("a"), obj.Get("b"));
-        Assert.Equal("repeat", obj.Get("a").AsString());
-        Assert.Equal("other", obj.Get("c").AsString());
+        obj.Get("b").Should().BeSameAs(obj.Get("a"));
+        obj.Get("a").AsString().Should().Be("repeat");
+        obj.Get("c").AsString().Should().Be("other");
 
         // Values interned once per parse are shared across nested arrays and objects within that parse.
         var root = parser.Parse("""{"list":["x-marker","x-marker"],"val":"x-marker"}""").AsObject();
         var list = root.Get("list").AsArray();
-        Assert.Same(list.Get("0"), list.Get("1"));
-        Assert.Same(list.Get("0"), root.Get("val"));
+        list.Get("1").Should().BeSameAs(list.Get("0"));
+        root.Get("val").Should().BeSameAs(list.Get("0"));
     }
 
     [Fact]
@@ -825,18 +825,18 @@ public class JsonTests
         // "AB" written three ways: plain, fully-escaped, and partially-escaped. All decode to the same
         // content, so interning (which keys off the DECODED span) must return one shared instance.
         var arr = parser.Parse("""["AB","AB","AB"]""").AsArray();
-        Assert.Equal("AB", arr.Get("0").AsString());
-        Assert.Equal("AB", arr.Get("1").AsString());
-        Assert.Equal("AB", arr.Get("2").AsString());
-        Assert.Same(arr.Get("0"), arr.Get("1"));
-        Assert.Same(arr.Get("0"), arr.Get("2"));
+        arr.Get("0").AsString().Should().Be("AB");
+        arr.Get("1").AsString().Should().Be("AB");
+        arr.Get("2").AsString().Should().Be("AB");
+        arr.Get("1").Should().BeSameAs(arr.Get("0"));
+        arr.Get("2").Should().BeSameAs(arr.Get("0"));
 
         // An escape sequence that decodes to content differing only by the escape must not collide.
         var arr2 = parser.Parse("""["line\nbreak","line\nbreak","linebreak"]""").AsArray();
-        Assert.Equal("line\nbreak", arr2.Get("0").AsString());
-        Assert.Same(arr2.Get("0"), arr2.Get("1"));
-        Assert.NotSame(arr2.Get("0"), arr2.Get("2"));
-        Assert.Equal("linebreak", arr2.Get("2").AsString());
+        arr2.Get("0").AsString().Should().Be("line\nbreak");
+        arr2.Get("1").Should().BeSameAs(arr2.Get("0"));
+        arr2.Get("2").Should().NotBeSameAs(arr2.Get("0"));
+        arr2.Get("2").AsString().Should().Be("linebreak");
     }
 
     [Fact]
@@ -845,14 +845,14 @@ public class JsonTests
         var parser = new JsonParser(new Engine());
 
         var arr = parser.Parse("""["","","x","x","y"]""").AsArray();
-        Assert.Equal("", arr.Get("0").AsString());
+        arr.Get("0").AsString().Should().Be("");
         // Empty routes through JsString.Create -> the shared JsString.Empty singleton.
-        Assert.Same(JsString.Empty, arr.Get("0"));
-        Assert.Same(arr.Get("0"), arr.Get("1"));
-        Assert.Equal("x", arr.Get("2").AsString());
-        Assert.Same(arr.Get("2"), arr.Get("3"));
-        Assert.Equal("y", arr.Get("4").AsString());
-        Assert.NotSame(arr.Get("2"), arr.Get("4"));
+        arr.Get("0").Should().BeSameAs(JsString.Empty);
+        arr.Get("1").Should().BeSameAs(arr.Get("0"));
+        arr.Get("2").AsString().Should().Be("x");
+        arr.Get("3").Should().BeSameAs(arr.Get("2"));
+        arr.Get("4").AsString().Should().Be("y");
+        arr.Get("4").Should().NotBeSameAs(arr.Get("2"));
     }
 
     [Fact]
@@ -878,7 +878,7 @@ public class JsonTests
         var arr = parser.Parse(sb.ToString()).AsArray();
         for (var i = 0; i < count; i++)
         {
-            Assert.Equal("value_" + i, arr.Get(i.ToString(CultureInfo.InvariantCulture)).AsString());
+            arr.Get(i.ToString(CultureInfo.InvariantCulture)).AsString().Should().Be("value_" + i);
         }
     }
 
@@ -891,9 +891,9 @@ public class JsonTests
         // huge unique strings can never thrash it. Still parsed exactly, just not deduplicated.
         var longVal = new string('z', 100);
         var arr = parser.Parse($"[\"{longVal}\",\"{longVal}\"]").AsArray();
-        Assert.Equal(longVal, arr.Get("0").AsString());
-        Assert.Equal(longVal, arr.Get("1").AsString());
-        Assert.NotSame(arr.Get("0"), arr.Get("1"));
+        arr.Get("0").AsString().Should().Be(longVal);
+        arr.Get("1").AsString().Should().Be(longVal);
+        arr.Get("1").Should().NotBeSameAs(arr.Get("0"));
     }
 
     [Fact]
@@ -904,9 +904,9 @@ public class JsonTests
         var parser = new JsonParser(new Engine());
         var first = parser.Parse("""["shared-token"]""").AsArray().Get("0");
         var second = parser.Parse("""["shared-token"]""").AsArray().Get("0");
-        Assert.Equal("shared-token", first.AsString());
-        Assert.Equal(first.AsString(), second.AsString());
-        Assert.NotSame(first, second);
+        first.AsString().Should().Be("shared-token");
+        second.AsString().Should().Be(first.AsString());
+        second.Should().NotBeSameAs(first);
     }
 
     [Theory]
@@ -926,7 +926,7 @@ public class JsonTests
         var expected = BitConverter.DoubleToInt64Bits(double.Parse(json, JsonNumberStyles, CultureInfo.InvariantCulture));
         var parser = new JsonParser(new Engine());
         var actual = BitConverter.DoubleToInt64Bits(parser.Parse(json).AsNumber());
-        Assert.Equal(expected, actual);
+        actual.Should().Be(expected);
     }
 
     [Fact]
@@ -935,8 +935,8 @@ public class JsonTests
         // Number tokens no longer carry an eager Text string; the diagnostic reconstructs the raw text
         // from the token range. Lock in that the reported token is byte-identical to the source.
         var parser = new JsonParser(new Engine());
-        var ex = Assert.ThrowsAny<JavaScriptException>(() => parser.Parse("1 23"));
-        Assert.Equal("Unexpected token '23' in JSON at position 2", ex.Message);
+        var ex = Invoking(() => parser.Parse("1 23")).Should().Throw<JavaScriptException>().Which;
+        ex.Message.Should().Be("Unexpected token '23' in JSON at position 2");
     }
 
     private static string GenerateRandomJsonNumber(Random random)

--- a/Jint.Tests/Runtime/LeafCallTests.cs
+++ b/Jint.Tests/Runtime/LeafCallTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the semantics of env-less leaf calls (State.SupportsLeafCall): frames that run against
@@ -31,7 +31,7 @@ public class LeafCallTests
             })()
             """).AsString();
 
-        Assert.Equal("100:50", result);
+        result.Should().Be("100:50");
     }
 
     [Fact]
@@ -51,7 +51,7 @@ public class LeafCallTests
             })()
             """).AsString();
 
-        Assert.Contains("leafBoom", result);
+        result.Should().Contain("leafBoom");
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class LeafCallTests
             })()
             """).AsString();
 
-        Assert.Contains("leafSnap", result);
+        result.Should().Contain("leafSnap");
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class LeafCallTests
             })()
             """).AsString();
 
-        Assert.Equal("true:object:true", result);
+        result.Should().Be("true:object:true");
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class LeafCallTests
             })()
             """).AsNumber();
 
-        Assert.Equal(7, result);
+        result.Should().Be(7);
     }
 
     [Fact]
@@ -132,7 +132,7 @@ public class LeafCallTests
             })()
             """).AsString();
 
-        Assert.Equal("leaf,leaf,ctor-end,dispose", result);
+        result.Should().Be("leaf,leaf,ctor-end,dispose");
     }
 
     [Fact]
@@ -158,7 +158,7 @@ public class LeafCallTests
             })()
             """).AsString();
 
-        Assert.Equal("u,d,after,u,d,after", result);
+        result.Should().Be("u,d,after,u,d,after");
     }
 
     [Fact]
@@ -179,7 +179,7 @@ public class LeafCallTests
             })()
             """).AsString();
 
-        Assert.Equal("ReferenceError", result);
+        result.Should().Be("ReferenceError");
     }
 
     [Fact]
@@ -198,7 +198,7 @@ public class LeafCallTests
             })()
             """).AsNumber();
 
-        Assert.Equal(42, result);
+        result.Should().Be(42);
     }
 
     [Fact]
@@ -220,7 +220,7 @@ public class LeafCallTests
             })()
             """).AsString();
 
-        Assert.Equal("50:50", result);
+        result.Should().Be("50:50");
     }
 
     [Fact]
@@ -245,11 +245,11 @@ public class LeafCallTests
             return fn._functionDefinition!.Initialize().SupportsLeafCall;
         }
 
-        Assert.True(SupportsLeafCall(engine, "h.leaf"));
-        Assert.False(SupportsLeafCall(engine, "h.usesThis"));
-        Assert.False(SupportsLeafCall(engine, "h.usesArguments"));
-        Assert.False(SupportsLeafCall(engine, "h.makesClosure"));
-        Assert.False(SupportsLeafCall(engine, "h.hasParam"));
+        SupportsLeafCall(engine, "h.leaf").Should().BeTrue();
+        SupportsLeafCall(engine, "h.usesThis").Should().BeFalse();
+        SupportsLeafCall(engine, "h.usesArguments").Should().BeFalse();
+        SupportsLeafCall(engine, "h.makesClosure").Should().BeFalse();
+        SupportsLeafCall(engine, "h.hasParam").Should().BeFalse();
     }
 
     [Fact]
@@ -267,6 +267,6 @@ public class LeafCallTests
             })()
             """).AsString();
 
-        Assert.Equal("undefined", result);
+        result.Should().Be("undefined");
     }
 }

--- a/Jint.Tests/Runtime/LengthBoundLaneTests.cs
+++ b/Jint.Tests/Runtime/LengthBoundLaneTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the semantics of the member-bound arm of the comparison lane (`i &lt; arr.length` /
@@ -24,7 +24,7 @@ public class LengthBoundLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("5:5", result);
+        result.Should().Be("5:5");
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class LengthBoundLaneTests
             })()
             """).AsNumber();
 
-        Assert.Equal(4, result);
+        result.Should().Be(4);
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class LengthBoundLaneTests
             })()
             """).AsNumber();
 
-        Assert.Equal(5, result);
+        result.Should().Be(5);
     }
 
     [Fact]
@@ -78,7 +78,7 @@ public class LengthBoundLaneTests
             })()
             """).AsNumber();
 
-        Assert.Equal(15, result);
+        result.Should().Be(15);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class LengthBoundLaneTests
             })()
             """).AsNumber();
 
-        Assert.Equal(3, result);
+        result.Should().Be(3);
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public class LengthBoundLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("3:4", result);
+        result.Should().Be("3:4");
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public class LengthBoundLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("3:4", result);
+        result.Should().Be("3:4");
     }
 
     [Fact]
@@ -156,7 +156,7 @@ public class LengthBoundLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("TypeError", result);
+        result.Should().Be("TypeError");
     }
 
     [Fact]
@@ -176,7 +176,7 @@ public class LengthBoundLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("4:3", result);
+        result.Should().Be("4:3");
     }
 
     [Fact]
@@ -192,7 +192,7 @@ public class LengthBoundLaneTests
             n;
             """).AsNumber();
 
-        Assert.Equal(3, result);
+        result.Should().Be(3);
     }
 
     [Fact]
@@ -211,7 +211,7 @@ public class LengthBoundLaneTests
             })()
             """).AsNumber();
 
-        Assert.Equal(31, result);
+        result.Should().Be(31);
     }
 
     [Fact]
@@ -228,6 +228,6 @@ public class LengthBoundLaneTests
             })()
             """).AsNumber();
 
-        Assert.Equal(2, result);
+        result.Should().Be(2);
     }
 }

--- a/Jint.Tests/Runtime/LoopBodyFlatteningTests.cs
+++ b/Jint.Tests/Runtime/LoopBodyFlatteningTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the loop-body lexical flattening (JintForStatement): an eligible body block's let/const
@@ -26,7 +26,7 @@ public class LoopBodyFlatteningTests
             """).AsNumber();
 
         // z values: 1,0,3,2,5,4,7,6 → even z (0,2,4,6) add 2z = 0+4+8+12 = 24; z=3 adds 100
-        Assert.Equal(124, result);
+        result.Should().Be(124);
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("tdz0,0,tdz1,10,tdz2,20", result);
+        result.Should().Be("tdz0,0,tdz1,10,tdz2,20");
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("tdz,v1,1,tdz,v3,3", result);
+        result.Should().Be("tdz,v1,1,tdz,v3,3");
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("0,inner,1,inner,2,inner|10,11", result);
+        result.Should().Be("0,inner,1,inner,2,inner|10,11");
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("0,2,4", result);
+        result.Should().Be("0,2,4");
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("8:1", result); // 0+1+3+4, one catch
+        result.Should().Be("8:1"); // 0+1+3+4, one catch
     }
 
     [Fact]
@@ -161,7 +161,7 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("50,60,70", result);
+        result.Should().Be("50,60,70");
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("0,10,20", result);
+        result.Should().Be("0,10,20");
     }
 
     [Fact]
@@ -199,7 +199,7 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("0,20,40", result);
+        result.Should().Be("0,20,40");
     }
 
     [Fact]
@@ -222,7 +222,7 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("ok:true", result);
+        result.Should().Be("ok:true");
     }
 
     [Fact]
@@ -241,7 +241,7 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("b0,d0,b1,d1", result);
+        result.Should().Be("b0,d0,b1,d1");
     }
 
     [Fact]
@@ -259,7 +259,7 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("0,0", result);
+        result.Should().Be("0,0");
     }
 
     [Fact]
@@ -274,7 +274,7 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("0,0", result);
+        result.Should().Be("0,0");
     }
 
     [Fact]
@@ -296,6 +296,6 @@ public class LoopBodyFlatteningTests
             })()
             """).AsString();
 
-        Assert.Equal("0,0", result);
+        result.Should().Be("0,0");
     }
 }

--- a/Jint.Tests/Runtime/MapTests.cs
+++ b/Jint.Tests/Runtime/MapTests.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime;
+﻿using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -7,8 +7,8 @@ public class MapTests
     [Fact]
     public void ShouldThrowWhenCalledWithoutNew()
     {
-        var e = Assert.Throws<JavaScriptException>(() => new Engine().Execute("const m = new Map(); Map.call(m,[]);"));
-        Assert.Equal("Constructor Map requires 'new'", e.Message);
+        var e = Invoking(() => new Engine().Execute("const m = new Map(); Map.call(m,[]);")).Should().ThrowExactly<JavaScriptException>().Which;
+        e.Message.Should().Be("Constructor Map requires 'new'");
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public class MapTests
             });
             return k === Infinity && map.get(+0) === ""foo"";";
 
-        Assert.True(new Engine().Evaluate(Script).AsBoolean());
+        new Engine().Evaluate(Script).AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public class MapTests
             for (var key of map.keys()) { map.delete(key); count++; }
             return count + '/' + map.size;";
 
-        Assert.Equal("3/0", new Engine().Evaluate(Script).AsString());
+        new Engine().Evaluate(Script).AsString().Should().Be("3/0");
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class MapTests
             for (var value of map.values()) { map.delete(keys[count]); count++; }
             return count + '/' + map.size;";
 
-        Assert.Equal("3/0", new Engine().Evaluate(Script).AsString());
+        new Engine().Evaluate(Script).AsString().Should().Be("3/0");
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public class MapTests
             for (var key of map.keys()) { seen.push(key); if (key === 'a') map.set('b', 2); }
             return seen.join(',');";
 
-        Assert.Equal("a,b", new Engine().Evaluate(Script).AsString());
+        new Engine().Evaluate(Script).AsString().Should().Be("a,b");
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class MapTests
             for (var value of map.values()) { seen.push(value); if (value === 1) map.delete('b'); }
             return seen.join(',');";
 
-        Assert.Equal("1,3", new Engine().Evaluate(Script).AsString());
+        new Engine().Evaluate(Script).AsString().Should().Be("1,3");
     }
 
     [Fact]
@@ -80,8 +80,8 @@ public class MapTests
     {
         var engine = new Engine();
         engine.Execute("var map = new Map([['a', 1], ['b', 2], ['c', 3]]);");
-        Assert.Equal("a,b,c", engine.Evaluate("[...map.keys()].join(',')").AsString());
-        Assert.Equal("1,2,3", engine.Evaluate("[...map.values()].join(',')").AsString());
+        engine.Evaluate("[...map.keys()].join(',')").AsString().Should().Be("a,b,c");
+        engine.Evaluate("[...map.values()].join(',')").AsString().Should().Be("1,2,3");
     }
 
     [Fact]
@@ -97,9 +97,9 @@ public class MapTests
 
         var engine = new Engine();
         engine.Execute(Script);
-        Assert.True(engine.Evaluate("proto2.hasOwnProperty(Symbol.iterator)").AsBoolean());
-        Assert.True(engine.Evaluate("!proto1.hasOwnProperty(Symbol.iterator)").AsBoolean());
-        Assert.True(engine.Evaluate("!iterator.hasOwnProperty(Symbol.iterator)").AsBoolean());
-        Assert.True(engine.Evaluate("iterator[Symbol.iterator]() === iterator").AsBoolean());
+        engine.Evaluate("proto2.hasOwnProperty(Symbol.iterator)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("!proto1.hasOwnProperty(Symbol.iterator)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("!iterator.hasOwnProperty(Symbol.iterator)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("iterator[Symbol.iterator]() === iterator").AsBoolean().Should().BeTrue();
     }
 }

--- a/Jint.Tests/Runtime/MethodAmbiguityTests.cs
+++ b/Jint.Tests/Runtime/MethodAmbiguityTests.cs
@@ -13,10 +13,11 @@ public class MethodAmbiguityTests : IDisposable
         _engine = new Engine(cfg => cfg
                     .AllowOperatorOverloading())
                 .SetValue("log", new Action<object>(Console.WriteLine))
-                .SetValue("throws", new Func<Action, Exception>(Assert.Throws<Exception>))
-                .SetValue("assert", new Action<bool>(Assert.True))
-                .SetValue("assertFalse", new Action<bool>(Assert.False))
-                .SetValue("equal", new Action<object, object>(Assert.Equal))
+                .SetValue("throws", new Func<Action, Exception>(static action => action.Should().Throw<Exception>().Which))
+                .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+                .SetValue("assertFalse", new Action<bool>(static value => value.Should().BeFalse()))
+                .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())))
                 .SetValue("TestClass", typeof(TestClass))
                 .SetValue("ChildTestClass", typeof(ChildTestClass))
             ;
@@ -91,13 +92,13 @@ public class MethodAmbiguityTests : IDisposable
         engine.SetValue("Class1", TypeReference.CreateTypeReference<Class1>(engine));
         engine.SetValue("Class2", TypeReference.CreateTypeReference<Class2>(engine));
 
-        Assert.Equal("Class1.Double[]", engine.Evaluate("Class1.Print([ 1, 2 ]);"));
-        Assert.Equal("Class1.ExpandoObject", engine.Evaluate("Class1.Print({ x: 1, y: 2 });"));
-        Assert.Equal("Class1.Int32", engine.Evaluate("Class1.Print(5);"));
-        Assert.Equal("Class2.Double[]", engine.Evaluate("Class2.Print([ 1, 2 ]); "));
-        Assert.Equal("Class2.ExpandoObject", engine.Evaluate("Class2.Print({ x: 1, y: 2 });"));
-        Assert.Equal("Class2.Int32", engine.Evaluate("Class2.Print(5);"));
-        Assert.Equal("Class2.Object", engine.Evaluate("Class2.Print(() => '');"));
+        engine.Evaluate("Class1.Print([ 1, 2 ]);").Should().Be("Class1.Double[]");
+        engine.Evaluate("Class1.Print({ x: 1, y: 2 });").Should().Be("Class1.ExpandoObject");
+        engine.Evaluate("Class1.Print(5);").Should().Be("Class1.Int32");
+        engine.Evaluate("Class2.Print([ 1, 2 ]); ").Should().Be("Class2.Double[]");
+        engine.Evaluate("Class2.Print({ x: 1, y: 2 });").Should().Be("Class2.ExpandoObject");
+        engine.Evaluate("Class2.Print(5);").Should().Be("Class2.Int32");
+        engine.Evaluate("Class2.Print(() => '');").Should().Be("Class2.Object");
     }
 
     [Fact]
@@ -128,11 +129,11 @@ public class MethodAmbiguityTests : IDisposable
 
         // When passing a TypeReference, should select the TypeReference overload
         var typeRefResult = engine.Evaluate("Player.GetArmorPenetration(DamageClass);");
-        Assert.Equal("TypeReference", typeRefResult.AsString());
+        typeRefResult.AsString().Should().Be("TypeReference");
 
         // When passing a domain object instance, should select the domain class overload
         var instanceResult = engine.Evaluate("Player.GetArmorPenetration(damageClassInstance);");
-        Assert.Equal("DamageClass", instanceResult.AsString());
+        instanceResult.AsString().Should().Be("DamageClass");
     }
 
     [Fact]
@@ -152,11 +153,11 @@ public class MethodAmbiguityTests : IDisposable
 
         // When calling extension method with TypeReference, should select TypeReference overload
         var typeRefResult = engine.Evaluate("player.GetPenetration(DamageClass);");
-        Assert.Equal("TypeReference:10", typeRefResult.AsString());
+        typeRefResult.AsString().Should().Be("TypeReference:10");
 
         // When calling extension method with instance, should select DamageClass overload
         var instanceResult = engine.Evaluate("player.GetPenetration(damageClassInstance);");
-        Assert.Equal("DamageClass:20", instanceResult.AsString());
+        instanceResult.AsString().Should().Be("DamageClass:20");
     }
 
     private struct Class1

--- a/Jint.Tests/Runtime/ModuleTests.cs
+++ b/Jint.Tests/Runtime/ModuleTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Runtime;
 using Jint.Runtime.Modules;
 
@@ -21,7 +21,7 @@ public class ModuleTests
         _engine.Modules.Add("my-module", "export const value = 'exported value';");
         var ns = _engine.Modules.Import("my-module");
 
-        Assert.Equal("exported value", ns.Get("value").AsString());
+        ns.Get("value").AsString().Should().Be("exported value");
     }
 
     [Fact]
@@ -30,8 +30,8 @@ public class ModuleTests
         _engine.Modules.Add("my-module", "const value1 = 1; const value2 = 2; export { value1 as renamed1, value2 as renamed2 }");
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal(1, ns.Get("renamed1").AsInteger());
-        Assert.Equal(2, ns.Get("renamed2").AsInteger());
+        ns.Get("renamed1").AsInteger().Should().Be(1);
+        ns.Get("renamed2").AsInteger().Should().Be(2);
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class ModuleTests
         _engine.Modules.Add("my-module", "export default 'exported value';");
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal("exported value", ns.Get("default").AsString());
+        ns.Get("default").AsString().Should().Be("exported value");
     }
 
     [Fact]
@@ -51,12 +51,12 @@ public class ModuleTests
         var ns = _engine.Modules.Import("module1");
 
         var func = ns.Get("default");
-        Assert.Equal(1, func.Call());
+        func.Call().Should().Be(1);
 
         ns = _engine.Modules.Import("module2");
 
         func = ns.Get("default");
-        Assert.Equal(1, func.Call());
+        func.Call().Should().Be(1);
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class ModuleTests
         _engine.Modules.Add("module2", "export * from 'module1';");
         var ns =  _engine.Modules.Import("module2");
 
-        Assert.Equal("exported value", ns.Get("value").AsString());
+        ns.Get("value").AsString().Should().Be("exported value");
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class ModuleTests
         _engine.Modules.Add("my-module", "import { value } from 'imported-module'; export const exported = value;");
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal("exported value", ns.Get("exported").AsString());
+        ns.Get("exported").AsString().Should().Be("exported value");
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public class ModuleTests
         _engine.Modules.Add("my-module", "import { value as renamed } from 'imported-module'; export const exported = renamed;");
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal("exported value", ns.Get("exported").AsString());
+        ns.Get("exported").AsString().Should().Be("exported value");
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class ModuleTests
         _engine.Modules.Add("my-module", "import imported from 'imported-module'; export const exported = imported;");
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal("exported value", ns.Get("exported").AsString());
+        ns.Get("exported").AsString().Should().Be("exported value");
     }
 
     [Fact]
@@ -106,7 +106,7 @@ public class ModuleTests
         _engine.Modules.Add("my-module", "import * as imported from 'imported-module'; export const exported = imported.value;");
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal("exported value", ns.Get("exported").AsString());
+        ns.Get("exported").AsString().Should().Be("exported value");
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class ModuleTests
 
          _engine.Modules.Import("my-module");
 
-        Assert.True(received);
+        received.Should().BeTrue();
     }
 
     [Fact]
@@ -133,7 +133,7 @@ public class ModuleTests
 
         _engine.Evaluate("import('imported-module').then(ns => { globalThis.result = ns.add(1, 2); });");
 
-        Assert.Equal(3, _engine.Evaluate("globalThis.result").AsInteger());
+        _engine.Evaluate("globalThis.result").AsInteger().Should().Be(3);
     }
 
     [Fact]
@@ -149,7 +149,7 @@ public class ModuleTests
         ");
         _engine.Advanced.ProcessTasks();
 
-        Assert.Equal("exported value", _engine.Evaluate("globalThis.result").AsString());
+        _engine.Evaluate("globalThis.result").AsString().Should().Be("exported value");
     }
 
     [Fact]
@@ -162,7 +162,7 @@ public class ModuleTests
         var ns = _engine.Modules.Import("imported-module");
         _engine.SetValue("lib", ns);
 
-        Assert.Equal(3, _engine.Evaluate("lib.add(1, 2)").AsInteger());
+        _engine.Evaluate("lib.add(1, 2)").AsInteger().Should().Be(3);
     }
 
     [Fact]
@@ -216,7 +216,7 @@ public class ModuleTests
             result;
         ").AsObject();
 
-        Assert.Equal("", result.Get("someText").AsString());
+        result.Get("someText").AsString().Should().Be("");
     }
 
     [Fact]
@@ -225,9 +225,9 @@ public class ModuleTests
         _engine.Modules.Add("imported", "export const invalid;");
         _engine.Modules.Add("my-module", "import { invalid } from 'imported';");
 
-        var exc = Assert.Throws<JavaScriptException>(() =>  _engine.Modules.Import("my-module"));
-        Assert.Equal("Error while loading module: error in module 'imported': Missing initializer in const declaration (imported:1:21)", exc.Message);
-        Assert.Equal("imported", exc.Location.SourceFile);
+        var exc = Invoking(() =>  _engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>().Which;
+        exc.Message.Should().Be("Error while loading module: error in module 'imported': Missing initializer in const declaration (imported:1:21)");
+        exc.Location.SourceFile.Should().Be("imported");
     }
 
     [Fact]
@@ -236,9 +236,9 @@ public class ModuleTests
         _engine.Modules.Add("imported", "export invalid;");
         _engine.Modules.Add("my-module", "import { value } from 'imported';");
 
-        var exc = Assert.Throws<JavaScriptException>(() =>  _engine.Modules.Import("my-module"));
-        Assert.Equal("Error while loading module: error in module 'imported': Unexpected identifier 'invalid' (imported:1:8)", exc.Message);
-        Assert.Equal("imported", exc.Location.SourceFile);
+        var exc = Invoking(() =>  _engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>().Which;
+        exc.Message.Should().Be("Error while loading module: error in module 'imported': Unexpected identifier 'invalid' (imported:1:8)");
+        exc.Location.SourceFile.Should().Be("imported");
     }
 
     [Fact]
@@ -246,9 +246,9 @@ public class ModuleTests
     {
         _engine.Modules.Add("my-module", "throw new Error('imported successfully');");
 
-        var exc = Assert.Throws<JavaScriptException>(() =>  _engine.Modules.Import("my-module"));
-        Assert.Equal("imported successfully", exc.Message);
-        Assert.Equal("my-module", exc.Location.SourceFile);
+        var exc = Invoking(() =>  _engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>().Which;
+        exc.Message.Should().Be("imported successfully");
+        exc.Location.SourceFile.Should().Be("my-module");
     }
 
     [Fact]
@@ -257,8 +257,8 @@ public class ModuleTests
         _engine.Modules.Add("imported-module", "throw new Error('imported successfully');");
         _engine.Modules.Add("my-module", "import 'imported-module';");
 
-        var exc = Assert.Throws<JavaScriptException>(() =>  _engine.Modules.Import("my-module"));
-        Assert.Equal("imported successfully", exc.Message);
+        var exc = Invoking(() =>  _engine.Modules.Import("my-module")).Should().ThrowExactly<JavaScriptException>().Which;
+        exc.Message.Should().Be("imported successfully");
     }
 
     [Fact]
@@ -267,7 +267,7 @@ public class ModuleTests
         _engine.Modules.Add("my-module", builder => builder.ExportValue("value", JsString.Create("hello world")));
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal("hello world", ns.Get("value").AsString());
+        ns.Get("value").AsString().Should().Be("hello world");
     }
 
     [Fact]
@@ -280,7 +280,7 @@ public class ModuleTests
         _engine.Modules.Add("my-module", "import { value } from 'imported-module'; export const exported = value.value;");
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal("instance value", ns.Get("exported").AsString());
+        ns.Get("exported").AsString().Should().Be("instance value");
     }
 
     [Fact]
@@ -291,7 +291,7 @@ public class ModuleTests
         var instance = _engine.Construct(ctor, JsString.Create("world"));
         var result = instance.GetMethod("hello").Call(instance, JsString.Create("!"));
 
-        Assert.Equal("hello world!", result);
+        result.Should().Be("hello world!");
     }
 
     [Fact]
@@ -301,7 +301,7 @@ public class ModuleTests
         _engine.Modules.Add("my-module", "import { ImportedClass } from 'imported-module'; export const exported = new ImportedClass().value;");
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal("hello world", ns.Get("exported").AsString());
+        ns.Get("exported").AsString().Should().Be("hello world");
     }
 
     [Fact]
@@ -327,18 +327,18 @@ import * as fns from 'imported-module';
 export const result = [fns.act_noargs(), fns.act_args('ok'), fns.fn_noargs(), fns.fn_args('ok')];");
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal([
+        received.ToArray().Should().Equal([
             "act_noargs",
             "act_args:ok",
             "fn_noargs",
             "fn_args:ok"
-        ], received.ToArray());
-        Assert.Equal([
+        ]);
+        ns.Get("result").AsArray().Select(x => x.ToString()).ToArray().Should().Equal([
             "undefined",
             "undefined",
             "ret",
             "ret"
-        ], ns.Get("result").AsArray().Select(x => x.ToString()).ToArray());
+        ]);
     }
 
     private class ImportedClass
@@ -355,7 +355,7 @@ export const result = [fns.act_noargs(), fns.act_args('ok'), fns.fn_noargs(), fn
         _engine.Modules.Add("app", "import { value1, value2 } from '@mine'; export const result = `${value1} ${value2}`");
         var ns =  _engine.Modules.Import("app");
 
-        Assert.Equal("1 2", ns.Get("result").AsString());
+        ns.Get("result").AsString().Should().Be("1 2");
     }
 
     [Fact]
@@ -365,7 +365,7 @@ export const result = [fns.act_noargs(), fns.act_args('ok'), fns.fn_noargs(), fn
         _engine.Modules.Add("my-module", "export * as ns from 'imported-module';");
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal(5, ns.Get("ns").Get("value1").AsNumber());
+        ns.Get("ns").Get("value1").AsNumber().Should().Be(5);
     }
 
     [Fact]
@@ -379,8 +379,8 @@ export const result = [fns.act_noargs(), fns.act_args('ok'), fns.fn_noargs(), fn
         );
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal(2, ns.Get("output").AsInteger());
-        Assert.Equal(-1, ns.Get("num").AsInteger());
+        ns.Get("output").AsInteger().Should().Be(2);
+        ns.Get("num").AsInteger().Should().Be(-1);
     }
 
     [Fact]
@@ -392,7 +392,7 @@ export const result = [fns.act_noargs(), fns.act_args('ok'), fns.fn_noargs(), fn
          _engine.Modules.Import("my-module");
          _engine.Modules.Import("my-module");
 
-        Assert.Equal(1, called);
+        called.Should().Be(1);
     }
 
     [Fact]
@@ -407,7 +407,7 @@ export const count = globals.counter;
 ");
         var ns =  _engine.Modules.Import("my-module");
 
-        Assert.Equal(1, ns.Get("count").AsInteger());
+        ns.Get("count").AsInteger().Should().Be(1);
     }
 
     [Fact]
@@ -421,8 +421,8 @@ export const count = globals.counter;
         var nsA =  _engine.Modules.Import("A");
         var nsB =  _engine.Modules.Import("B");
 
-        Assert.Equal("a", nsA.Get("a").AsString());
-        Assert.Equal("b", nsB.Get("b").AsString());
+        nsA.Get("a").AsString().Should().Be("a");
+        nsB.Get("b").AsString().Should().Be("b");
     }
 
     [Fact]
@@ -432,7 +432,7 @@ export const count = globals.counter;
 
         engine.Modules.Add("sleep", builder => builder.ExportFunction("sleep", () => Thread.Sleep(100)));
         engine.Modules.Add("my-module", "import { sleep } from 'sleep'; for(var i = 0; i < 100; i++) { sleep(); } export const result = 'ok';");
-        Assert.Throws<TimeoutException>(() => engine.Modules.Import("my-module"));
+        Invoking(() => engine.Modules.Import("my-module")).Should().ThrowExactly<TimeoutException>();
     }
 
     [Fact]
@@ -442,7 +442,7 @@ export const count = globals.counter;
         engine.Modules.Add("my-module", "import { User } from './modules/user.js'; export const user = new User('John', 'Doe');");
         var ns = engine.Modules.Import("my-module");
 
-        Assert.Equal("John Doe", ns["user"].Get("name").AsString());
+        ns["user"].Get("name").AsString().Should().Be("John Doe");
     }
 
     [Fact]
@@ -452,7 +452,7 @@ export const count = globals.counter;
         var ns = engine.Modules.Import("./modules/format-name.js");
         var result = engine.Invoke(ns.Get("formatName"), "John", "Doe").AsString();
 
-        Assert.Equal("John Doe", result);
+        result.Should().Be("John Doe");
     }
 
     [Fact]
@@ -462,7 +462,7 @@ export const count = globals.counter;
         var ns = engine.Modules.Import("./dir with spaces/format name.js");
         var result = engine.Invoke(ns.Get("formatName"), "John", "Doe").AsString();
 
-        Assert.Equal("John Doe", result);
+        result.Should().Be("John Doe");
     }
 
     [Fact]
@@ -476,7 +476,7 @@ export const count = globals.counter;
             engine.Modules.Add("__main__", x => x.AddModule(module));
             var ns = engine.Modules.Import("__main__");
             var result = engine.Invoke(ns.Get("formatName"), "John" + i, "Doe").AsString();
-            Assert.Equal($"John{i} Doe", result);
+            result.Should().Be($"John{i} Doe");
         }
     }
 
@@ -500,9 +500,8 @@ export const count = globals.counter;
         engine.Execute(code, source: "file:///folder/main.js");
         engine.Advanced.ProcessTasks();
 
-        Assert.Collection(
-            logStatements,
-            s => Assert.Equal("myModuleConst", s));
+        logStatements.Should().SatisfyRespectively(
+            s => s.Should().Be("myModuleConst"));
     }
 
     [Fact]
@@ -526,9 +525,8 @@ export const count = globals.counter;
         engine.Execute(script);
         engine.Advanced.ProcessTasks();
 
-        Assert.Collection(
-            logStatements,
-            s => Assert.Equal("myModuleConst", s));
+        logStatements.Should().SatisfyRespectively(
+            s => s.Should().Be("myModuleConst"));
     }
 
     [Fact]
@@ -551,9 +549,8 @@ export const count = globals.counter;
         engine.Evaluate(code, source: "file:///folder/main.js");
         engine.Advanced.ProcessTasks();
 
-        Assert.Collection(
-            logStatements,
-            s => Assert.Equal("myModuleConst", s));
+        logStatements.Should().SatisfyRespectively(
+            s => s.Should().Be("myModuleConst"));
     }
 
     [Fact]
@@ -577,9 +574,8 @@ export const count = globals.counter;
         engine.Evaluate(script);
         engine.Advanced.ProcessTasks();
 
-        Assert.Collection(
-            logStatements,
-            s => Assert.Equal("myModuleConst", s));
+        logStatements.Should().SatisfyRespectively(
+            s => s.Should().Be("myModuleConst"));
     }
 
     private sealed class EnforceRelativeModuleLoader : IModuleLoader
@@ -593,17 +589,17 @@ export const count = globals.counter;
 
         public ResolvedSpecifier Resolve(string referencingModuleLocation, ModuleRequest moduleRequest)
         {
-            Assert.False(string.IsNullOrEmpty(referencingModuleLocation), "Referencing module location is null or empty");
+            string.IsNullOrEmpty(referencingModuleLocation).Should().BeFalse("Referencing module location is null or empty");
             var target = new Uri(new Uri(referencingModuleLocation, UriKind.Absolute), moduleRequest.Specifier);
-            Assert.True(_modules.ContainsKey(target.ToString()), $"Resolve was called with unexpected module request, {moduleRequest.Specifier} relative to {referencingModuleLocation}");
+            _modules.ContainsKey(target.ToString()).Should().BeTrue($"Resolve was called with unexpected module request, {moduleRequest.Specifier} relative to {referencingModuleLocation}");
             return new ResolvedSpecifier(moduleRequest, target.ToString(), target, SpecifierType.Bare);
         }
 
         public Module LoadModule(Engine engine, ResolvedSpecifier resolved)
         {
-            Assert.NotNull(resolved.Uri);
+            resolved.Uri.Should().NotBeNull();
             var source = resolved.Uri.ToString();
-            Assert.True(_modules.TryGetValue(source, out var script), $"Resolved module does not exist: {source}");
+            _modules.TryGetValue(source, out var script).Should().BeTrue($"Resolved module does not exist: {source}");
             return ModuleFactory.BuildSourceTextModule(engine, Engine.PrepareModule(script, source));
         }
     }
@@ -664,10 +660,9 @@ export const count = globals.counter;
 
         engine.Modules.Import("library2/entry_point_module.js");
 
-        Assert.Collection(
-            logStatements,
-            s => Assert.Equal("builder_module", s),
-            s => Assert.Equal("entry_point_module", s));
+        logStatements.Should().SatisfyRespectively(
+            s => s.Should().Be("builder_module"),
+            s => s.Should().Be("entry_point_module"));
     }
 
     [Fact]
@@ -678,7 +673,7 @@ export const count = globals.counter;
             var result = moduleRequest.Specifier;
             if (moduleRequest.Specifier == "../library1/builder_module.js")
             {
-                Assert.Equal("library2/entry_point_module.js", referencingModuleLocation);
+                referencingModuleLocation.Should().Be("library2/entry_point_module.js");
                 result = "library1/builder_module.js";
             }
             return result;
@@ -693,10 +688,9 @@ export const count = globals.counter;
 
         engine.Modules.Import("library2/entry_point_module.js");
 
-        Assert.Collection(
-            logStatements,
-            s => Assert.Equal("builder_module", s),
-            s => Assert.Equal("entry_point_module", s));
+        logStatements.Should().SatisfyRespectively(
+            s => s.Should().Be("builder_module"),
+            s => s.Should().Be("entry_point_module"));
     }
 
     /// <summary>
@@ -739,9 +733,9 @@ export const count = globals.counter;
 
         engine.Modules.Import($"code/lib/module.js");
 
-        Assert.Collection(logs,
-            s => Assert.Equal("code/execute.js", s),
-            s => Assert.Equal("code/lib/module.js", s));
+        logs.Should().SatisfyRespectively(
+            s => s.Should().Be("code/execute.js"),
+            s => s.Should().Be("code/lib/module.js"));
     }
     public class ModuleLoaderForEngineShouldTransmitSourceModuleForModuleLoaderTest : ModuleLoader
     {
@@ -752,7 +746,7 @@ export const count = globals.counter;
             // to resolve this statement requires information about source module
             if (moduleSpec == "../execute.js")
             {
-                Assert.True(!string.IsNullOrEmpty(referencingModuleLocation), "module loader cannot resolve referensing module - has no referencing module location");
+                (!string.IsNullOrEmpty(referencingModuleLocation)).Should().BeTrue("module loader cannot resolve referensing module - has no referencing module location");
                 moduleSpec = $"code/execute.js";
             }
 
@@ -809,7 +803,7 @@ export const count = globals.counter;
 
         var mainModule = engine.Modules.Import(MainModuleSpecifier);
 
-        Assert.Equal("hello", mainModule.Get("msg").AsString());
+        mainModule.Get("msg").AsString().Should().Be("hello");
     }
 
     [Theory]
@@ -848,7 +842,7 @@ export const count = globals.counter;
 
         var mainModule = engine.Modules.Import(MainModuleSpecifier);
 
-        Assert.Equal("hello", (await completionTcs.Task).AsString());
+        (await completionTcs.Task).AsString().Should().Be("hello");
     }
 
     [Theory]
@@ -881,7 +875,7 @@ export const count = globals.counter;
 
         var mainModule = engine.Modules.Import(MainModuleSpecifier);
 
-        Assert.Equal(TextModuleContent, mainModule.Get("msg").AsString());
+        mainModule.Get("msg").AsString().Should().Be(TextModuleContent);
     }
 
     [Theory]
@@ -917,7 +911,7 @@ export const count = globals.counter;
 
         var mainModule = engine.Modules.Import(MainModuleSpecifier);
 
-        Assert.Equal(TextModuleContent, (await completionTcs.Task).AsString());
+        (await completionTcs.Task).AsString().Should().Be(TextModuleContent);
     }
 
     private sealed class TestModuleLoader : IModuleLoader
@@ -958,10 +952,10 @@ export const count = globals.counter;
         };
         var engine = new Engine(o => o.EnableModules(new TestModuleLoader(loaderModules)));
 
-        var ex = Assert.ThrowsAny<Exception>(() => engine.Modules.Import("main"));
+        var ex = Invoking(() => engine.Modules.Import("main")).Should().Throw<Exception>().Which;
         // Should fail with a module loading error for './does-not-exist',
         // not with a SyntaxError/linking error from 'has-linking-error'
-        Assert.DoesNotContain("Ambiguous", ex.Message);
+        ex.Message.Should().NotContain("Ambiguous");
     }
 
     [Fact]
@@ -979,10 +973,10 @@ export const count = globals.counter;
 
         // C# ToString() should not trigger JS evaluation side effects
         var str = ns.ToString();
-        Assert.Equal("[object Module]", str);
+        str.Should().Be("[object Module]");
 
         var callsAfter = _engine.Evaluate("globalThis.toStringCalls").AsInteger();
-        Assert.Equal(initialCalls, callsAfter);
+        callsAfter.Should().Be(initialCalls);
     }
 
     [Fact]
@@ -1000,11 +994,11 @@ export const count = globals.counter;
 
         _engine.Modules.Import("main");
 
-        Assert.Equal(0, _engine.Evaluate("globalThis.phase1").AsInteger());
-        Assert.Equal(42, _engine.Evaluate("globalThis.accessed").AsInteger());
-        Assert.Equal(1, _engine.Evaluate("globalThis.phase2").AsInteger());
-        Assert.Equal(1, _engine.Evaluate("globalThis.log.length").AsInteger());
-        Assert.Equal("dep", _engine.Evaluate("globalThis.log[0]").AsString());
+        _engine.Evaluate("globalThis.phase1").AsInteger().Should().Be(0);
+        _engine.Evaluate("globalThis.accessed").AsInteger().Should().Be(42);
+        _engine.Evaluate("globalThis.phase2").AsInteger().Should().Be(1);
+        _engine.Evaluate("globalThis.log.length").AsInteger().Should().Be(1);
+        _engine.Evaluate("globalThis.log[0]").AsString().Should().Be("dep");
     }
 
     [Fact]
@@ -1018,7 +1012,7 @@ export const count = globals.counter;
 
         _engine.Modules.Import("main");
 
-        Assert.Equal("Deferred Module", _engine.Evaluate("globalThis.tag").AsString());
+        _engine.Evaluate("globalThis.tag").AsString().Should().Be("Deferred Module");
     }
 
     [Fact]
@@ -1038,9 +1032,9 @@ export const count = globals.counter;
 
         _engine.Modules.Import("main");
 
-        Assert.False(_engine.Evaluate("globalThis.afterDefer").AsBoolean());
-        Assert.True(_engine.Evaluate("globalThis.thenValue").IsUndefined());
-        Assert.False(_engine.Evaluate("globalThis.afterThenAccess").AsBoolean());
+        _engine.Evaluate("globalThis.afterDefer").AsBoolean().Should().BeFalse();
+        _engine.Evaluate("globalThis.thenValue").IsUndefined().Should().BeTrue();
+        _engine.Evaluate("globalThis.afterThenAccess").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -1066,10 +1060,10 @@ export const count = globals.counter;
 
         _engine.Modules.Import("main");
 
-        Assert.Equal("Deferred Module", _engine.Evaluate("globalThis.tag").AsString());
-        Assert.False(_engine.Evaluate("globalThis.beforeAccess").AsBoolean());
-        Assert.Equal("leaf", _engine.Evaluate("globalThis.x").AsString());
-        Assert.True(_engine.Evaluate("globalThis.afterAccess").AsBoolean());
+        _engine.Evaluate("globalThis.tag").AsString().Should().Be("Deferred Module");
+        _engine.Evaluate("globalThis.beforeAccess").AsBoolean().Should().BeFalse();
+        _engine.Evaluate("globalThis.x").AsString().Should().Be("leaf");
+        _engine.Evaluate("globalThis.afterAccess").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -1087,9 +1081,9 @@ export const count = globals.counter;
 
         _engine.Modules.Import("main");
 
-        Assert.True(_engine.Evaluate("globalThis.rejected").AsBoolean());
+        _engine.Evaluate("globalThis.rejected").AsBoolean().Should().BeTrue();
         // SourceTextModules don't have a source representation; rejection type is host-defined.
-        Assert.False(_engine.Evaluate("globalThis.errorName").IsNull());
+        _engine.Evaluate("globalThis.errorName").IsNull().Should().BeFalse();
     }
 
     [Fact]
@@ -1098,8 +1092,8 @@ export const count = globals.counter;
         _engine.Modules.Add("dep", "export const x = 1;");
         _engine.Modules.Add("main", "import source x from 'dep';");
 
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Modules.Import("main"));
+        var ex = Invoking(() => _engine.Modules.Import("main")).Should().ThrowExactly<JavaScriptException>().Which;
         // Must not be SyntaxError per test262 expectations for SourceTextModule source phase.
-        Assert.NotEqual("SyntaxError", ex.Error.Get("name").AsString());
+        ex.Error.Get("name").AsString().Should().NotBe("SyntaxError");
     }
 }

--- a/Jint.Tests/Runtime/Modules/DefaultModuleLoaderTests.cs
+++ b/Jint.Tests/Runtime/Modules/DefaultModuleLoaderTests.cs
@@ -15,10 +15,10 @@ public class DefaultModuleLoaderTests
 
         var resolved = resolver.Resolve("file:///project/folder/script.js", new ModuleRequest(specifier, []));
 
-        Assert.Equal(specifier, resolved.ModuleRequest.Specifier);
-        Assert.Equal(expectedUri, resolved.Key);
-        Assert.Equal(expectedUri, resolved.Uri?.AbsoluteUri);
-        Assert.Equal(SpecifierType.RelativeOrAbsolute, resolved.Type);
+        resolved.ModuleRequest.Specifier.Should().Be(specifier);
+        resolved.Key.Should().Be(expectedUri);
+        (resolved.Uri?.AbsoluteUri).Should().Be(expectedUri);
+        resolved.Type.Should().Be(SpecifierType.RelativeOrAbsolute);
     }
 
     [Theory]
@@ -30,9 +30,9 @@ public class DefaultModuleLoaderTests
     {
         var resolver = new DefaultModuleLoader("file:///project");
 
-        var exc = Assert.Throws<ModuleResolutionException>(() => resolver.Resolve("file:///project/folder/script.js", new ModuleRequest(specifier, [])));
-        Assert.StartsWith(exc.ResolverAlgorithmError, "Unauthorized Module Path");
-        Assert.StartsWith(exc.Specifier, specifier);
+        var exc = Invoking(() => resolver.Resolve("file:///project/folder/script.js", new ModuleRequest(specifier, []))).Should().ThrowExactly<ModuleResolutionException>().Which;
+        "Unauthorized Module Path".Should().StartWith(exc.ResolverAlgorithmError);
+        specifier.Should().StartWith(exc.Specifier);
     }
 
     [Fact]
@@ -42,9 +42,9 @@ public class DefaultModuleLoaderTests
 
         var resolved = resolver.Resolve(null, new ModuleRequest("my-module", []));
 
-        Assert.Equal("my-module", resolved.ModuleRequest.Specifier);
-        Assert.Equal("my-module", resolved.Key);
-        Assert.Equal(null, resolved.Uri?.AbsoluteUri);
-        Assert.Equal(SpecifierType.Bare, resolved.Type);
+        resolved.ModuleRequest.Specifier.Should().Be("my-module");
+        resolved.Key.Should().Be("my-module");
+        (resolved.Uri?.AbsoluteUri).Should().BeNull();
+        resolved.Type.Should().Be(SpecifierType.Bare);
     }
 }

--- a/Jint.Tests/Runtime/NestedGlobalMemoTests.cs
+++ b/Jint.Tests/Runtime/NestedGlobalMemoTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the semantics of the nested-scope global-read chain memo in JintIdentifierExpression:
@@ -30,7 +30,7 @@ public class NestedGlobalMemoTests
             host();
             """).AsString();
 
-        Assert.Equal("number;number;number;string;string;string;", result);
+        result.Should().Be("number;number;number;string;string;string;");
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class NestedGlobalMemoTests
             """).AsString();
 
         // after injection the write must land on host's binding; the global keeps run(1)'s value
-        Assert.Equal("2:1", result);
+        result.Should().Be("2:1");
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class NestedGlobalMemoTests
             host3();
             """).AsString();
 
-        Assert.Equal("undefined;undefined;function;function;", result);
+        result.Should().Be("undefined;undefined;function;function;");
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class NestedGlobalMemoTests
             f();
             """).AsString();
 
-        Assert.Equal("global;global;with;with;global;global;", result);
+        result.Should().Be("global;global;with;with;global;global;");
     }
 
     [Fact]
@@ -117,8 +117,8 @@ public class NestedGlobalMemoTests
 
         for (var i = 0; i < 3; i++)
         {
-            Assert.Equal("aaa", engine1.Evaluate(prepared).AsString());
-            Assert.Equal("bbb", engine2.Evaluate(prepared).AsString());
+            engine1.Evaluate(prepared).AsString().Should().Be("aaa");
+            engine2.Evaluate(prepared).AsString().Should().Be("bbb");
         }
     }
 
@@ -135,11 +135,11 @@ public class NestedGlobalMemoTests
             }
             """);
 
-        Assert.Equal("propprop", engine.Evaluate("r();").AsString());
+        engine.Evaluate("r();").AsString().Should().Be("propprop");
 
         // a global let now shadows the plain global property; _lexicalMutations invalidates
         engine.Execute("let gp = 'lexical';");
-        Assert.Equal("lexicallexical", engine.Evaluate("r();").AsString());
+        engine.Evaluate("r();").AsString().Should().Be("lexicallexical");
     }
 
     [Fact]
@@ -155,11 +155,11 @@ public class NestedGlobalMemoTests
             }
             """);
 
-        Assert.Equal("herehere", engine.Evaluate("r();").AsString());
+        engine.Evaluate("r();").AsString().Should().Be("herehere");
 
         engine.Execute("delete globalThis.gd;");
-        var ex = Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("r();"));
-        Assert.Contains("gd is not defined", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("r();")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>().Which;
+        ex.Message.Should().Contain("gd is not defined");
     }
 
     [Fact]
@@ -182,6 +182,6 @@ public class NestedGlobalMemoTests
             acc;
             """).AsString();
 
-        Assert.Equal("a:X;a:X;b:X;b:X;a:X;a:X;", result);
+        result.Should().Be("a:X;a:X;b:X;b:X;a:X;a:X;");
     }
 }

--- a/Jint.Tests/Runtime/NewExpressionCacheTests.cs
+++ b/Jint.Tests/Runtime/NewExpressionCacheTests.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime;
+﻿using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -26,7 +26,7 @@ public class NewExpressionCacheTests
             })()
             """).AsNumber();
 
-        Assert.Equal(1000, result);
+        result.Should().Be(1000);
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class NewExpressionCacheTests
             })()
             """).AsString();
 
-        Assert.Equal("true:42", result);
+        result.Should().Be("true:42");
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class NewExpressionCacheTests
             })()
             """).AsString();
 
-        Assert.Equal("true:true", result);
+        result.Should().Be("true:true");
     }
 
     [Fact]
@@ -81,8 +81,8 @@ public class NewExpressionCacheTests
         var engine2 = new Engine();
         for (var i = 0; i < 5; i++)
         {
-            Assert.True(engine1.Evaluate(prepared).AsBoolean());
-            Assert.True(engine2.Evaluate(prepared).AsBoolean());
+            engine1.Evaluate(prepared).AsBoolean().Should().BeTrue();
+            engine2.Evaluate(prepared).AsBoolean().Should().BeTrue();
         }
     }
 
@@ -102,15 +102,15 @@ public class NewExpressionCacheTests
             })()
             """).AsNumber();
 
-        Assert.Equal(100, result);
+        result.Should().Be(100);
     }
 
     [Fact]
     public void ThrowingCustomTimeSystemSurfacesExceptionPerConstruct()
     {
         var engine = new Engine(options => options.TimeSystem = new ThrowingTimeSystem());
-        var ex = Assert.Throws<InvalidOperationException>(() => engine.Evaluate("new Date()"));
-        Assert.Equal("clock is broken", ex.Message);
+        var ex = Invoking(() => engine.Evaluate("new Date()")).Should().ThrowExactly<InvalidOperationException>().Which;
+        ex.Message.Should().Be("clock is broken");
     }
 
     private sealed class FixedTimeSystem : ITimeSystem

--- a/Jint.Tests/Runtime/NullPropagation.cs
+++ b/Jint.Tests/Runtime/NullPropagation.cs
@@ -56,7 +56,7 @@ var output = { Tags : input.Tags.filter(x=>x!=null) };
 
         var output = engine.GetValue("output").AsObject();
 
-        Assert.True(output.Get("Tags").IsArray());
+        output.Get("Tags").IsArray().Should().BeTrue();
     }
 
     [Fact]
@@ -86,12 +86,12 @@ var output = {
         var length = engine.GetValue("length");
         var output = engine.GetValue("output").AsObject();
 
-        Assert.Equal(JsValue.Null, address);
-        Assert.Equal(JsValue.Null, city);
-        Assert.Equal(JsValue.Null, length);
+        address.Should().Be(JsValue.Null);
+        city.Should().Be(JsValue.Null);
+        length.Should().Be(JsValue.Null);
 
-        Assert.Equal(JsValue.Null, output.Get("Count1"));
-        Assert.Equal(JsValue.Undefined, output.Get("Count2"));
+        output.Get("Count1").Should().Be(JsValue.Null);
+        output.Get("Count2").Should().BeUndefined();
     }
 
     [Fact]
@@ -112,11 +112,11 @@ function test2(arg) {
         engine.Execute(Script);
         var result = engine.Invoke("test", JsValue.Null);
 
-        Assert.Equal(JsValue.Null, result);
+        result.Should().Be(JsValue.Null);
 
         result = engine.Invoke("test2", JsValue.Null);
 
-        Assert.Equal(JsValue.Null, result);
+        result.Should().Be(JsValue.Null);
     }
 
     [Fact]
@@ -139,8 +139,8 @@ this.has_emptyfield_not_null = this.EmptyField !== null;
 
         engine.Invoke("ExecutePatchScript", jsObject);
 
-        Assert.False(jsObject.Get("is_nullfield_not_null").AsBoolean());
-        Assert.True(jsObject.Get("is_notnullfield_not_null").AsBoolean());
-        Assert.True(jsObject.Get("has_emptyfield_not_null").AsBoolean());
+        jsObject.Get("is_nullfield_not_null").AsBoolean().Should().BeFalse();
+        jsObject.Get("is_notnullfield_not_null").AsBoolean().Should().BeTrue();
+        jsObject.Get("has_emptyfield_not_null").AsBoolean().Should().BeTrue();
     }
 }

--- a/Jint.Tests/Runtime/NumberTests.cs
+++ b/Jint.Tests/Runtime/NumberTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 public class NumberTests
 {
@@ -8,8 +8,9 @@ public class NumberTests
     {
         _engine = new Engine()
             .SetValue("log", new Action<object>(Console.WriteLine))
-            .SetValue("assert", new Action<bool>(Assert.True))
-            .SetValue("equal", new Action<object, object>(Assert.Equal));
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
     }
 
     private void RunTest(string source)
@@ -24,7 +25,7 @@ public class NumberTests
     public void ToExponential(int fractionDigits, string result)
     {
         var value = _engine.Evaluate($"(3).toExponential({fractionDigits}).toString()").AsString();
-        Assert.Equal(result, value);
+        value.Should().Be(result);
     }
 
     [Theory]
@@ -34,14 +35,14 @@ public class NumberTests
     public void ToFixed(int fractionDigits, string result)
     {
         var value = _engine.Evaluate($"(3).toFixed({fractionDigits}).toString()").AsString();
-        Assert.Equal(result, value);
+        value.Should().Be(result);
     }
 
     [Fact]
     public void ToFixedWith100FractionDigitsWorks()
     {
         var value = _engine.Evaluate("(3).toFixed(100)").AsString();
-        Assert.Equal("3." + new string('0', 100), value);
+        value.Should().Be("3." + new string('0', 100));
     }
 
     [Theory]
@@ -51,7 +52,7 @@ public class NumberTests
     public void ToPrecision(int fractionDigits, string result)
     {
         var value = _engine.Evaluate($"(3).toPrecision({fractionDigits}).toString()").AsString();
-        Assert.Equal(result, value);
+        value.Should().Be(result);
     }
 
     [Theory]
@@ -59,7 +60,7 @@ public class NumberTests
     public void ParseFloat(string input, double result)
     {
         var value = _engine.Evaluate($"parseFloat('{input}')").AsNumber();
-        Assert.Equal(result, value);
+        value.Should().Be(result);
     }
 
     // Results from node -v v18.18.0.
@@ -131,7 +132,7 @@ public class NumberTests
     public void ToLocaleString(string parseNumber, string culture, string result)
     {
         var value = _engine.Evaluate($"({parseNumber}).toLocaleString('{culture}')").AsString();
-        Assert.Equal(result, value);
+        value.Should().Be(result);
     }
 
     [Theory]
@@ -140,7 +141,7 @@ public class NumberTests
     public void ToLocaleStringNoArg(string parseNumber)
     {
         var value = _engine.Evaluate($"({parseNumber}).toLocaleString()").AsString();
-        Assert.DoesNotContain(".0", value);
+        value.Should().NotContain(".0");
     }
 
     [Fact]
@@ -148,21 +149,21 @@ public class NumberTests
     {
         var engine = new Engine();
 
-        Assert.Equal(double.PositiveInfinity, engine.Evaluate("Number(1e1000)").ToObject());
-        Assert.Equal(double.PositiveInfinity, engine.Evaluate("+1e1000").ToObject());
-        Assert.Equal("Infinity", engine.Evaluate("(+1e1000).toString()").ToObject());
+        engine.Evaluate("Number(1e1000)").ToObject().Should().Be(double.PositiveInfinity);
+        engine.Evaluate("+1e1000").ToObject().Should().Be(double.PositiveInfinity);
+        engine.Evaluate("(+1e1000).toString()").ToObject().Should().Be("Infinity");
 
-        Assert.Equal(double.PositiveInfinity, engine.Evaluate("Number('1e1000')").ToObject());
-        Assert.Equal(double.PositiveInfinity, engine.Evaluate("+'1e1000'").ToObject());
-        Assert.Equal("Infinity", engine.Evaluate("(+'1e1000').toString()").ToObject());
+        engine.Evaluate("Number('1e1000')").ToObject().Should().Be(double.PositiveInfinity);
+        engine.Evaluate("+'1e1000'").ToObject().Should().Be(double.PositiveInfinity);
+        engine.Evaluate("(+'1e1000').toString()").ToObject().Should().Be("Infinity");
 
-        Assert.Equal(double.NegativeInfinity, engine.Evaluate("Number(-1e1000)").ToObject());
-        Assert.Equal(double.NegativeInfinity, engine.Evaluate("-1e1000").ToObject());
-        Assert.Equal("-Infinity", engine.Evaluate("(-1e1000).toString()").ToObject());
+        engine.Evaluate("Number(-1e1000)").ToObject().Should().Be(double.NegativeInfinity);
+        engine.Evaluate("-1e1000").ToObject().Should().Be(double.NegativeInfinity);
+        engine.Evaluate("(-1e1000).toString()").ToObject().Should().Be("-Infinity");
 
-        Assert.Equal(double.NegativeInfinity, engine.Evaluate("Number('-1e1000')").ToObject());
-        Assert.Equal(double.NegativeInfinity, engine.Evaluate("-'1e1000'").ToObject());
-        Assert.Equal("-Infinity", engine.Evaluate("(-'1e1000').toString()").ToObject());
+        engine.Evaluate("Number('-1e1000')").ToObject().Should().Be(double.NegativeInfinity);
+        engine.Evaluate("-'1e1000'").ToObject().Should().Be(double.NegativeInfinity);
+        engine.Evaluate("(-'1e1000').toString()").ToObject().Should().Be("-Infinity");
     }
 
     [Fact]
@@ -172,18 +173,18 @@ public class NumberTests
 
         // internally Integer-tagged int.MinValue / int.MaxValue values must widen
         // to double on arithmetic instead of wrapping or raising hardware overflows
-        Assert.Equal(2147483648d, engine.Evaluate("var x = (1<<31)|0; -x").AsNumber());
-        Assert.Equal(2147483648d, engine.Evaluate("var x = (1<<31)|0; x / -1").AsNumber());
-        Assert.Equal(0d, engine.Evaluate("var x = (1<<31)|0; x % -1").AsNumber());
-        Assert.True(engine.Evaluate("var x = (1<<31)|0; Object.is(x % -1, -0)").AsBoolean());
+        engine.Evaluate("var x = (1<<31)|0; -x").AsNumber().Should().Be(2147483648d);
+        engine.Evaluate("var x = (1<<31)|0; x / -1").AsNumber().Should().Be(2147483648d);
+        engine.Evaluate("var x = (1<<31)|0; x % -1").AsNumber().Should().Be(0d);
+        engine.Evaluate("var x = (1<<31)|0; Object.is(x % -1, -0)").AsBoolean().Should().BeTrue();
 
-        Assert.Equal(2147483648d, engine.Evaluate("var a = 2147483647; a++; a").AsNumber());
-        Assert.Equal(2147483648d, engine.Evaluate("var a = 2147483647; ++a").AsNumber());
-        Assert.Equal(-2147483649d, engine.Evaluate("var b = (1<<31)|0; b--; b").AsNumber());
-        Assert.Equal(-2147483649d, engine.Evaluate("var b = (1<<31)|0; --b").AsNumber());
+        engine.Evaluate("var a = 2147483647; a++; a").AsNumber().Should().Be(2147483648d);
+        engine.Evaluate("var a = 2147483647; ++a").AsNumber().Should().Be(2147483648d);
+        engine.Evaluate("var b = (1<<31)|0; b--; b").AsNumber().Should().Be(-2147483649d);
+        engine.Evaluate("var b = (1<<31)|0; --b").AsNumber().Should().Be(-2147483649d);
 
-        Assert.Equal(-2147483649d, engine.Evaluate("var c = (1<<31)|0; c -= 1; c").AsNumber());
-        Assert.Equal(2147483648d, engine.Evaluate("var d = 2147483647; d += 1; d").AsNumber());
+        engine.Evaluate("var c = (1<<31)|0; c -= 1; c").AsNumber().Should().Be(-2147483649d);
+        engine.Evaluate("var d = 2147483647; d += 1; d").AsNumber().Should().Be(2147483648d);
     }
 
     [Fact]
@@ -192,34 +193,34 @@ public class NumberTests
         var engine = new Engine();
 
         // undefined operands must coerce to NaN, not stay undefined
-        Assert.True(engine.Evaluate("var u; u *= 2; Number.isNaN(u)").AsBoolean());
-        Assert.True(engine.Evaluate("var u; u /= 2; Number.isNaN(u)").AsBoolean());
-        Assert.True(engine.Evaluate("var u; u -= 2; Number.isNaN(u)").AsBoolean());
+        engine.Evaluate("var u; u *= 2; Number.isNaN(u)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("var u; u /= 2; Number.isNaN(u)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("var u; u -= 2; Number.isNaN(u)").AsBoolean().Should().BeTrue();
 
         // ** has spec semantics that differ from IEEE pow: (+/-1) ** Infinity is NaN
-        Assert.True(engine.Evaluate("var x = 1; x **= Infinity; Number.isNaN(x)").AsBoolean());
-        Assert.True(engine.Evaluate("var x = -1; x **= -Infinity; Number.isNaN(x)").AsBoolean());
-        Assert.Equal(8d, engine.Evaluate("var x = 2; x **= 3; x").AsNumber());
+        engine.Evaluate("var x = 1; x **= Infinity; Number.isNaN(x)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("var x = -1; x **= -Infinity; Number.isNaN(x)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("var x = 2; x **= 3; x").AsNumber().Should().Be(8d);
 
         // compound bitwise/shift operators support BigInt like their binary forms
-        Assert.Equal("1", engine.Evaluate("var b = 3n; b &= 1n; b.toString()").AsString());
-        Assert.Equal("3", engine.Evaluate("var b = 2n; b |= 1n; b.toString()").AsString());
-        Assert.Equal("2", engine.Evaluate("var b = 3n; b ^= 1n; b.toString()").AsString());
-        Assert.Equal("8", engine.Evaluate("var b = 2n; b <<= 2n; b.toString()").AsString());
-        Assert.Equal("2", engine.Evaluate("var b = 8n; b >>= 2n; b.toString()").AsString());
+        engine.Evaluate("var b = 3n; b &= 1n; b.toString()").AsString().Should().Be("1");
+        engine.Evaluate("var b = 2n; b |= 1n; b.toString()").AsString().Should().Be("3");
+        engine.Evaluate("var b = 3n; b ^= 1n; b.toString()").AsString().Should().Be("2");
+        engine.Evaluate("var b = 2n; b <<= 2n; b.toString()").AsString().Should().Be("8");
+        engine.Evaluate("var b = 8n; b >>= 2n; b.toString()").AsString().Should().Be("2");
 
         // mixing BigInt and Number must throw TypeError for compound forms too
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("var b = 3n; b &= 1;"));
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("var b = 3; b &= 1n;"));
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("var b = 1n; b >>>= 1n;"));
+        Invoking(() => engine.Evaluate("var b = 3n; b &= 1;")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
+        Invoking(() => engine.Evaluate("var b = 3; b &= 1n;")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
+        Invoking(() => engine.Evaluate("var b = 1n; b >>>= 1n;")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
 
         // compound assignment to an uninitialized (TDZ) binding must be a ReferenceError,
         // not a NullReferenceException from the identifier fast path
-        var tdz = Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("(function() { { x += 1; let x; } })()"));
-        Assert.Equal("ReferenceError", tdz.Error.AsObject().Get("constructor").AsObject().Get("name").AsString());
+        var tdz = Invoking(() => engine.Evaluate("(function() { { x += 1; let x; } })()")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>().Which;
+        tdz.Error.AsObject().Get("constructor").AsObject().Get("name").AsString().Should().Be("ReferenceError");
 
-        var tdzUpdate = Assert.Throws<Jint.Runtime.JavaScriptException>(() => engine.Evaluate("(function() { { y++; let y; } })()"));
-        Assert.Equal("ReferenceError", tdzUpdate.Error.AsObject().Get("constructor").AsObject().Get("name").AsString());
+        var tdzUpdate = Invoking(() => engine.Evaluate("(function() { { y++; let y; } })()")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>().Which;
+        tdzUpdate.Error.AsObject().Get("constructor").AsObject().Get("name").AsString().Should().Be("ReferenceError");
     }
 
     [Fact]
@@ -263,7 +264,7 @@ public class NumberTests
             })()
             """).AsString();
 
-        Assert.Equal("true,true,true,true,true,true,true,true,true,true,true,true,true,true", result);
+        result.Should().Be("true,true,true,true,true,true,true,true,true,true,true,true,true,true");
     }
 
     [Fact]
@@ -337,7 +338,7 @@ public class NumberTests
             })()
             """).AsString();
 
-        Assert.Equal(string.Join(",", Enumerable.Repeat("true", 63)), result);
+        result.Should().Be(string.Join(",", Enumerable.Repeat("true", 63)));
     }
 
     // The following tests guard the primitive-receiver method resolution that skips allocating a
@@ -350,21 +351,21 @@ public class NumberTests
     {
         var engine = new Engine();
 
-        Assert.Equal("3.14", engine.Evaluate("(3.14159).toFixed(2)").AsString());
-        Assert.Equal("3.14", engine.Evaluate("(3.14159).toPrecision(3)").AsString());
-        Assert.Equal("ff", engine.Evaluate("(255).toString(16)").AsString());
-        Assert.Equal("101", engine.Evaluate("(5).toString(2)").AsString());
-        Assert.Equal("10", engine.Evaluate("(10).toString()").AsString());
-        Assert.Equal(42d, engine.Evaluate("(42).valueOf()").AsNumber());
-        Assert.Equal("1.23e+3", engine.Evaluate("(1234).toExponential(2)").AsString());
-        Assert.Equal("-3", engine.Evaluate("(-2.5).toFixed(0)").AsString());
+        engine.Evaluate("(3.14159).toFixed(2)").AsString().Should().Be("3.14");
+        engine.Evaluate("(3.14159).toPrecision(3)").AsString().Should().Be("3.14");
+        engine.Evaluate("(255).toString(16)").AsString().Should().Be("ff");
+        engine.Evaluate("(5).toString(2)").AsString().Should().Be("101");
+        engine.Evaluate("(10).toString()").AsString().Should().Be("10");
+        engine.Evaluate("(42).valueOf()").AsNumber().Should().Be(42d);
+        engine.Evaluate("(1234).toExponential(2)").AsString().Should().Be("1.23e+3");
+        engine.Evaluate("(-2.5).toFixed(0)").AsString().Should().Be("-3");
 
         // computed-key and identifier-base (read-then-call) resolution paths
-        Assert.Equal("ff", engine.Evaluate("(255)['toString'](16)").AsString());
-        Assert.Equal("ff", engine.Evaluate("var n = 255; var f = n.toString; f.call(255, 16)").AsString());
+        engine.Evaluate("(255)['toString'](16)").AsString().Should().Be("ff");
+        engine.Evaluate("var n = 255; var f = n.toString; f.call(255, 16)").AsString().Should().Be("ff");
 
         // absent property resolves to undefined (not a throw)
-        Assert.Equal("undefined", engine.Evaluate("typeof (5).nope").AsString());
+        engine.Evaluate("typeof (5).nope").AsString().Should().Be("undefined");
     }
 
     [Fact]
@@ -374,14 +375,14 @@ public class NumberTests
         engine.Execute("Number.prototype.typ = function () { return typeof this; };");
 
         // Sloppy-mode user function boxes the primitive this-value, so it must observe an object.
-        Assert.Equal("object", engine.Evaluate("(5).typ()").AsString());
+        engine.Evaluate("(5).typ()").AsString().Should().Be("object");
         // and can still unwrap the underlying number
         engine.Execute("Number.prototype.dbl = function () { return this.valueOf() * 2; };");
-        Assert.Equal(42d, engine.Evaluate("(21).dbl()").AsNumber());
+        engine.Evaluate("(21).dbl()").AsNumber().Should().Be(42d);
 
         // resolution stays live after the method is reassigned
         engine.Execute("Number.prototype.typ = function () { return 'reassigned'; };");
-        Assert.Equal("reassigned", engine.Evaluate("(5).typ()").AsString());
+        engine.Evaluate("(5).typ()").AsString().Should().Be("reassigned");
     }
 
     [Fact]
@@ -391,9 +392,9 @@ public class NumberTests
         engine.Execute("Number.prototype.styp = function () { 'use strict'; return typeof this; };");
 
         // Strict-mode user function does not box the this-value, so it must observe the primitive.
-        Assert.Equal("number", engine.Evaluate("(5).styp()").AsString());
+        engine.Evaluate("(5).styp()").AsString().Should().Be("number");
         engine.Execute("Number.prototype.sinc = function () { 'use strict'; return this + 1; };");
-        Assert.Equal(42d, engine.Evaluate("(41).sinc()").AsNumber());
+        engine.Evaluate("(41).sinc()").AsNumber().Should().Be(42d);
     }
 
     [Fact]
@@ -403,8 +404,8 @@ public class NumberTests
         engine.Execute("Object.defineProperty(Number.prototype, 'gs', { get: function () { return typeof this; }, configurable: true });");
         engine.Execute("Object.defineProperty(Number.prototype, 'gt', { get: function () { 'use strict'; return typeof this; }, configurable: true });");
 
-        Assert.Equal("object", engine.Evaluate("(7).gs").AsString());
-        Assert.Equal("number", engine.Evaluate("(7).gt").AsString());
+        engine.Evaluate("(7).gs").AsString().Should().Be("object");
+        engine.Evaluate("(7).gt").AsString().Should().Be("number");
     }
 
     [Fact]
@@ -414,8 +415,8 @@ public class NumberTests
         engine.Execute("Object.prototype.op = function () { return 'fromObjectProto'; };");
 
         // property inherited from Object.prototype (past Number.prototype) still resolves
-        Assert.Equal("fromObjectProto", engine.Evaluate("(5).op()").AsString());
-        Assert.False(engine.Evaluate("(5).hasOwnProperty('x')").AsBoolean());
+        engine.Evaluate("(5).op()").AsString().Should().Be("fromObjectProto");
+        engine.Evaluate("(5).hasOwnProperty('x')").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -429,8 +430,8 @@ public class NumberTests
 
         // spec: GetValue passes the primitive base as the receiver to [[Get]], so a Proxy get trap
         // on the prototype chain observes the primitive - identical to the boxed path.
-        Assert.Equal("viaProxy:number", engine.Evaluate("(5).trapped").AsString());
-        Assert.Equal(1d, engine.Evaluate("(5).base").AsNumber());
+        engine.Evaluate("(5).trapped").AsString().Should().Be("viaProxy:number");
+        engine.Evaluate("(5).base").AsNumber().Should().Be(1d);
     }
 
     [Fact]
@@ -438,14 +439,14 @@ public class NumberTests
     {
         var engine = new Engine();
 
-        Assert.Equal("true", engine.Evaluate("(true).toString()").AsString());
-        Assert.Equal("false", engine.Evaluate("(false).toString()").AsString());
-        Assert.True(engine.Evaluate("(true).valueOf()").AsBoolean());
+        engine.Evaluate("(true).toString()").AsString().Should().Be("true");
+        engine.Evaluate("(false).toString()").AsString().Should().Be("false");
+        engine.Evaluate("(true).valueOf()").AsBoolean().Should().BeTrue();
 
         engine.Execute("Boolean.prototype.typ = function () { return typeof this; };");
-        Assert.Equal("object", engine.Evaluate("(true).typ()").AsString());
+        engine.Evaluate("(true).typ()").AsString().Should().Be("object");
         engine.Execute("Boolean.prototype.styp = function () { 'use strict'; return typeof this; };");
-        Assert.Equal("boolean", engine.Evaluate("(true).styp()").AsString());
+        engine.Evaluate("(true).styp()").AsString().Should().Be("boolean");
     }
 
     [Fact]
@@ -453,13 +454,13 @@ public class NumberTests
     {
         var engine = new Engine();
 
-        Assert.Equal("ff", engine.Evaluate("(255n).toString(16)").AsString());
-        Assert.Equal("10", engine.Evaluate("(10n).valueOf().toString()").AsString());
-        Assert.Equal("12345678901234567890", engine.Evaluate("(12345678901234567890n).toString()").AsString());
+        engine.Evaluate("(255n).toString(16)").AsString().Should().Be("ff");
+        engine.Evaluate("(10n).valueOf().toString()").AsString().Should().Be("10");
+        engine.Evaluate("(12345678901234567890n).toString()").AsString().Should().Be("12345678901234567890");
 
         engine.Execute("BigInt.prototype.typ = function () { return typeof this; };");
-        Assert.Equal("object", engine.Evaluate("(5n).typ()").AsString());
+        engine.Evaluate("(5n).typ()").AsString().Should().Be("object");
         engine.Execute("BigInt.prototype.styp = function () { 'use strict'; return typeof this; };");
-        Assert.Equal("bigint", engine.Evaluate("(5n).styp()").AsString());
+        engine.Evaluate("(5n).styp()").AsString().Should().Be("bigint");
     }
 }

--- a/Jint.Tests/Runtime/ObjectInstanceTests.cs
+++ b/Jint.Tests/Runtime/ObjectInstanceTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 
 namespace Jint.Tests.Runtime;
 
@@ -13,7 +13,7 @@ public class ObjectInstanceTests
             JSON.stringify([Object.keys(o), Object.values(o), Object.entries(o)]);
             """).AsString();
 
-        Assert.Equal("[[\"a\",\"b\"],[1,2],[[\"a\",1],[\"b\",2]]]", result);
+        result.Should().Be("[[\"a\",\"b\"],[1,2],[[\"a\",1],[\"b\",2]]]");
     }
 
     [Fact]
@@ -28,7 +28,7 @@ public class ObjectInstanceTests
             JSON.stringify([Object.keys(o), Object.values(o), Object.entries(o).length]);
             """).AsString();
 
-        Assert.Equal("[[\"a\",\"b\"],[1,4],2]", result);
+        result.Should().Be("[[\"a\",\"b\"],[1,4],2]");
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class ObjectInstanceTests
             Array.isArray(e) && e.length === 2 && (e.push(3), e.length === 3);
             """).AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class ObjectInstanceTests
             JSON.stringify([Object.keys(p), calls]);
             """).AsString();
 
-        Assert.Equal("[[\"a\",\"b\"],[\"ownKeys\",\"gopd:a\",\"gopd:b\"]]", result);
+        result.Should().Be("[[\"a\",\"b\"],[\"ownKeys\",\"gopd:a\",\"gopd:b\"]]");
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class ObjectInstanceTests
         instance.FastSetDataProperty("scope", JsValue.Null);
         instance.RemoveOwnProperty("bare");
         var propertyNames = instance.GetOwnProperties().Select(x => x.Key).ToList();
-        Assert.Equal(new JsValue[] { "scope" }, propertyNames);
+        propertyNames.Should().Equal(new JsValue[] { "scope" });
     }
 
     [Theory]
@@ -91,7 +91,7 @@ public class ObjectInstanceTests
                 o.constructor === My{baseType}";
 
         var engine = new Engine();
-        Assert.True(engine.Evaluate(code).AsBoolean());
+        engine.Evaluate(code).AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public class ObjectInstanceTests
     {
         var engine = new Engine();
         var instance = new JsObject(engine);
-        Assert.NotNull(instance.GetPrototypeOf());
-        Assert.Equal("[object Object]", instance.ToString());
+        instance.GetPrototypeOf().Should().NotBeNull();
+        instance.ToString().Should().Be("[object Object]");
     }
 }

--- a/Jint.Tests/Runtime/ObjectSpreadShapeTests.cs
+++ b/Jint.Tests/Runtime/ObjectSpreadShapeTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
@@ -25,17 +25,17 @@ public class ObjectSpreadShapeTests
         var engine = new Engine();
 
         // Non-fast (function-valued property), no spread => must NOT be shape mode.
-        var general = Assert.IsType<JsObject>(engine.Evaluate("({ a: 1, b: 2, fn: function () {} })"));
-        Assert.True((general._type & InternalTypes.ShapeMode) == InternalTypes.Empty);
-        Assert.True((general._type & InternalTypes.ShapeBuilding) == InternalTypes.Empty);
+        var general = engine.Evaluate("({ a: 1, b: 2, fn: function () {} })").Should().BeOfType<JsObject>().Which;
+        (general._type & InternalTypes.ShapeMode).Should().Be(InternalTypes.Empty);
+        (general._type & InternalTypes.ShapeBuilding).Should().Be(InternalTypes.Empty);
 
         // The same key set reached through a spread => shape mode (the intended optimization).
         engine.Execute("var src = { a: 1, b: 2 };");
-        var spread = Assert.IsType<JsObject>(engine.Evaluate("({ ...src, fn: function () {} })"));
-        Assert.True((spread._type & InternalTypes.ShapeMode) != InternalTypes.Empty);
+        var spread = engine.Evaluate("({ ...src, fn: function () {} })").Should().BeOfType<JsObject>().Which;
+        (spread._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
 
         // Behavior is identical either way.
-        Assert.Equal("1,2", engine.Evaluate("(function () { var o = { a: 1, b: 2, fn: function () {} }; return o.a + ',' + o.b; })()").AsString());
+        engine.Evaluate("(function () { var o = { a: 1, b: 2, fn: function () {} }; return o.a + ',' + o.b; })()").AsString().Should().Be("1,2");
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["a","b","c"],"values":[1,2,3],"calls":1,"hasHidden":false,"symCopied":"symval","bIsData":true}""", result);
+        result.Should().Be("""{"keys":["a","b","c"],"values":[1,2,3],"calls":1,"hasHidden":false,"symCopied":"symval","bIsData":true}""");
     }
 
     [Fact]
@@ -78,7 +78,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("a,b,c,d,e,f|1,2,3,4,5,6", result);
+        result.Should().Be("a,b,c,d,e,f|1,2,3,4,5,6");
     }
 
     [Fact]
@@ -87,12 +87,12 @@ public class ObjectSpreadShapeTests
         var engine = new Engine();
         // Integer-like keys never enter a shape (the CreateDataProperty pre-check routes them to the
         // dictionary), so spec enumeration order — integer indices ascending, then string keys — holds.
-        Assert.Equal("0,1,2", engine.Evaluate("Object.keys({ ...[10, 20, 30] }).join()").AsString());
-        Assert.Equal("10,20,30", engine.Evaluate("Object.values({ ...[10, 20, 30] }).join()").AsString());
-        Assert.Equal("0,1,x", engine.Evaluate("Object.keys({ ...[1, 2], x: 3 }).join()").AsString());
+        engine.Evaluate("Object.keys({ ...[10, 20, 30] }).join()").AsString().Should().Be("0,1,2");
+        engine.Evaluate("Object.values({ ...[10, 20, 30] }).join()").AsString().Should().Be("10,20,30");
+        engine.Evaluate("Object.keys({ ...[1, 2], x: 3 }).join()").AsString().Should().Be("0,1,x");
         // String wrapper object: index-like own keys take the same dictionary fallback.
-        Assert.Equal("a,b", engine.Evaluate("Object.values({ ...Object('ab') }).join()").AsString());
-        Assert.Equal("0,1", engine.Evaluate("Object.keys({ ...Object('ab') }).join()").AsString());
+        engine.Evaluate("Object.values({ ...Object('ab') }).join()").AsString().Should().Be("a,b");
+        engine.Evaluate("Object.keys({ ...Object('ab') }).join()").AsString().Should().Be("0,1");
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"before":["x","b","c"],"after":["b","c","x"],"dupKeys":["a"],"dupValue":2}""", result);
+        result.Should().Be("""{"before":["x","b","c"],"after":["b","c","x"],"dupKeys":["a"],"dupValue":2}""");
     }
 
     [Fact]
@@ -138,7 +138,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["a","b","g"],"g":3,"hasGetter":true,"enumerable":true,"configurable":true}""", result);
+        result.Should().Be("""{"keys":["a","b","g"],"g":3,"hasGetter":true,"enumerable":true,"configurable":true}""");
     }
 
     [Fact]
@@ -158,7 +158,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["a"],"protoOk":true,"ownProto":false,"inherited":"yes"}""", result);
+        result.Should().Be("""{"keys":["a"],"protoOk":true,"ownProto":false,"inherited":"yes"}""");
     }
 
     [Fact]
@@ -181,7 +181,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"ownProto":true,"protoUnchanged":true,"value":true}""", result);
+        result.Should().Be("""{"ownProto":true,"protoUnchanged":true,"value":true}""");
     }
 
     [Fact]
@@ -203,7 +203,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["b","c"],"b":2,"c":3,"hasA":false,"emptyKeys":[],"emptyIsObject":true}""", result);
+        result.Should().Be("""{"keys":["b","c"],"b":2,"c":3,"hasA":false,"emptyKeys":[],"emptyIsObject":true}""");
     }
 
     [Fact]
@@ -227,7 +227,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"inner":["z","w"],"outer":["q"],"z":2,"q":4,"member":["b","c"],"memberB":2}""", result);
+        result.Should().Be("""{"inner":["z","w"],"outer":["q"],"z":2,"q":4,"member":["b","c"],"memberB":2}""");
     }
 
     [Fact]
@@ -241,7 +241,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["b","c"],"b":2,"c":3}""", result);
+        result.Should().Be("""{"keys":["b","c"],"b":2,"c":3}""");
     }
 
     [Fact]
@@ -255,16 +255,16 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"first":"x","keys":["1","2"],"one":"y","two":"z"}""", result);
+        result.Should().Be("""{"first":"x","keys":["1","2"],"one":"y","two":"z"}""");
     }
 
     [Fact]
     public void FromEntriesKeepsOrderAndDuplicateKeysLastValueWinsFirstPosition()
     {
         var engine = new Engine();
-        Assert.Equal("x,y,z", engine.Evaluate("""Object.keys(Object.fromEntries([['x', 1], ['y', 2], ['z', 3]])).join()""").AsString());
+        engine.Evaluate("""Object.keys(Object.fromEntries([['x', 1], ['y', 2], ['z', 3]])).join()""").AsString().Should().Be("x,y,z");
         // Duplicate key re-add on the building shape: value overwritten in place.
-        Assert.Equal("""{"a":3,"b":2}""", engine.Evaluate("""JSON.stringify(Object.fromEntries([['a', 1], ['b', 2], ['a', 3]]))""").AsString());
+        engine.Evaluate("""JSON.stringify(Object.fromEntries([['a', 1], ['b', 2], ['a', 3]]))""").AsString().Should().Be("""{"a":3,"b":2}""");
     }
 
     [Fact]
@@ -286,7 +286,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"symVal":1,"a":2,"keys2":["0","5","a"],"five":"five","zero":"zero"}""", result);
+        result.Should().Be("""{"symVal":1,"a":2,"keys2":["0","5","a"],"five":"five","zero":"zero"}""");
     }
 
     [Fact]
@@ -310,7 +310,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -324,7 +324,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["a","b","c"],"a":1,"b":3,"c":4}""", result);
+        result.Should().Be("""{"keys":["a","b","c"],"a":1,"b":3,"c":4}""");
     }
 
     [Fact]
@@ -351,7 +351,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"srcOwn":true,"protoOk":true,"ownProto":false,"marker":"proto","keys":[]}""", result);
+        result.Should().Be("""{"srcOwn":true,"protoOk":true,"ownProto":false,"marker":"proto","keys":[]}""");
     }
 
     [Fact]
@@ -366,7 +366,7 @@ public class ObjectSpreadShapeTests
                 return JSON.stringify({ same: r === t, keys: Object.keys(t), a: t.a });
             })()
             """).AsString();
-        Assert.Equal("""{"same":true,"keys":["x","a"],"a":1}""", result);
+        result.Should().Be("""{"same":true,"keys":["x","a"],"a":1}""");
 
         var frozen = engine.Evaluate("""
             (function () {
@@ -374,7 +374,7 @@ public class ObjectSpreadShapeTests
                 catch (e) { return e instanceof TypeError ? 'TypeError' : 'other'; }
             })()
             """).AsString();
-        Assert.Equal("TypeError", frozen);
+        frozen.Should().Be("TypeError");
 
         var frozenEmpty = engine.Evaluate("""
             (function () {
@@ -382,7 +382,7 @@ public class ObjectSpreadShapeTests
                 catch (e) { return e instanceof TypeError ? 'TypeError' : 'other'; }
             })()
             """).AsString();
-        Assert.Equal("TypeError", frozenEmpty);
+        frozenEmpty.Should().Be("TypeError");
     }
 
     [Fact]
@@ -398,7 +398,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["a","c"],"a":1,"d":4,"hasB":false}""", result);
+        result.Should().Be("""{"keys":["a","c"],"a":1,"d":4,"hasB":false}""");
     }
 
     [Fact]
@@ -429,7 +429,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"first":"suspended","keys":["a","b","c"],"a":1,"b":2,"c":3,"late":false}""", result);
+        result.Should().Be("""{"first":"suspended","keys":["a","b","c"],"a":1,"b":2,"c":3,"late":false}""");
     }
 
     [Fact]
@@ -450,7 +450,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["x","y","z"],"x":1,"y":2,"z":9}""", result);
+        result.Should().Be("""{"keys":["x","y","z"],"x":1,"y":2,"z":9}""");
     }
 
     [Fact]
@@ -459,21 +459,21 @@ public class ObjectSpreadShapeTests
         var engine = new Engine();
         engine.Execute("var src = { a: 1, b: 2, c: 3 };");
 
-        var spread1 = Assert.IsType<JsObject>(engine.Evaluate("({ ...src })"));
-        var spread2 = Assert.IsType<JsObject>(engine.Evaluate("({ ...src })"));
-        var rest = Assert.IsType<JsObject>(engine.Evaluate("(function () { var { x, ...r } = { x: 0, a: 1, b: 2, c: 3 }; return r; })()"));
-        var fromEntries = Assert.IsType<JsObject>(engine.Evaluate("Object.fromEntries([['a', 1], ['b', 2], ['c', 3]])"));
-        var assigned = Assert.IsType<JsObject>(engine.Evaluate("Object.assign({}, src)"));
+        var spread1 = engine.Evaluate("({ ...src })").Should().BeOfType<JsObject>().Which;
+        var spread2 = engine.Evaluate("({ ...src })").Should().BeOfType<JsObject>().Which;
+        var rest = engine.Evaluate("(function () { var { x, ...r } = { x: 0, a: 1, b: 2, c: 3 }; return r; })()").Should().BeOfType<JsObject>().Which;
+        var fromEntries = engine.Evaluate("Object.fromEntries([['a', 1], ['b', 2], ['c', 3]])").Should().BeOfType<JsObject>().Which;
+        var assigned = engine.Evaluate("Object.assign({}, src)").Should().BeOfType<JsObject>().Which;
 
-        Assert.NotSame(spread1, spread2);
-        Assert.True((spread1._type & InternalTypes.ShapeMode) != InternalTypes.Empty);
+        spread2.Should().NotBeSameAs(spread1);
+        (spread1._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
 
         // Same prototype + same key sequence => the very same interned Shape instance, across all
         // four copy idioms.
-        Assert.Same(spread1.ShapeOf, spread2.ShapeOf);
-        Assert.Same(spread1.ShapeOf, rest.ShapeOf);
-        Assert.Same(spread1.ShapeOf, fromEntries.ShapeOf);
-        Assert.Same(spread1.ShapeOf, assigned.ShapeOf);
+        spread2.ShapeOf.Should().BeSameAs(spread1.ShapeOf);
+        rest.ShapeOf.Should().BeSameAs(spread1.ShapeOf);
+        fromEntries.ShapeOf.Should().BeSameAs(spread1.ShapeOf);
+        assigned.ShapeOf.Should().BeSameAs(spread1.ShapeOf);
     }
 
     [Fact]
@@ -491,7 +491,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["x"],"x":2}""", result);
+        result.Should().Be("""{"keys":["x"],"x":2}""");
     }
 
     [Fact]
@@ -511,7 +511,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["b","c","d"],"c":3,"d":4,"dWritable":false}""", result);
+        result.Should().Be("""{"keys":["b","c","d"],"c":3,"d":4,"dWritable":false}""");
     }
 
     // ---- Source-shape adoption fast path: `{ ...src }` where src is itself a shape-mode object ----
@@ -522,26 +522,26 @@ public class ObjectSpreadShapeTests
         var engine = new Engine();
         engine.Execute("var src = { a: 1, b: 2, c: 3, d: 4 };");
 
-        var src = Assert.IsType<JsObject>(engine.Evaluate("src"));
-        var clone1 = Assert.IsType<JsObject>(engine.Evaluate("({ ...src })"));
-        var clone2 = Assert.IsType<JsObject>(engine.Evaluate("({ ...src })"));
+        var src = engine.Evaluate("src").Should().BeOfType<JsObject>().Which;
+        var clone1 = engine.Evaluate("({ ...src })").Should().BeOfType<JsObject>().Which;
+        var clone2 = engine.Evaluate("({ ...src })").Should().BeOfType<JsObject>().Which;
 
         // The clone reuses the source's exact interned leaf shape (same prototype + same key
         // sequence + same attributes), so the member inline cache stays monomorphic across the
         // source and every clone. Distinct objects, one shape.
-        Assert.NotSame(src, clone1);
-        Assert.NotSame(clone1, clone2);
-        Assert.True((clone1._type & InternalTypes.ShapeMode) != InternalTypes.Empty);
-        Assert.Same(src.ShapeOf, clone1.ShapeOf);
-        Assert.Same(clone1.ShapeOf, clone2.ShapeOf);
+        clone1.Should().NotBeSameAs(src);
+        clone2.Should().NotBeSameAs(clone1);
+        (clone1._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
+        clone1.ShapeOf.Should().BeSameAs(src.ShapeOf);
+        clone2.ShapeOf.Should().BeSameAs(clone1.ShapeOf);
 
         // `{ ...src, x }` extends the adopted shape by one interned transition — the same shape a
         // streamed build would land on — so those clones also share a shape with each other.
-        var ext1 = Assert.IsType<JsObject>(engine.Evaluate("({ ...src, x: 1 })"));
-        var ext2 = Assert.IsType<JsObject>(engine.Evaluate("({ ...src, x: 2 })"));
-        Assert.Same(ext1.ShapeOf, ext2.ShapeOf);
-        Assert.NotSame(src.ShapeOf, ext1.ShapeOf);
-        Assert.Equal("a,b,c,d,x", engine.Evaluate("Object.keys({ ...src, x: 1 }).join()").AsString());
+        var ext1 = engine.Evaluate("({ ...src, x: 1 })").Should().BeOfType<JsObject>().Which;
+        var ext2 = engine.Evaluate("({ ...src, x: 2 })").Should().BeOfType<JsObject>().Which;
+        ext2.ShapeOf.Should().BeSameAs(ext1.ShapeOf);
+        ext1.ShapeOf.Should().NotBeSameAs(src.ShapeOf);
+        engine.Evaluate("Object.keys({ ...src, x: 1 }).join()").AsString().Should().Be("a,b,c,d,x");
     }
 
     [Fact]
@@ -565,7 +565,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"srcA":1,"srcF":6,"tA":99,"tF":88,"sharedNested":42,"sameNestedRef":true}""", result);
+        result.Should().Be("""{"srcA":1,"srcF":6,"tA":99,"tF":88,"sharedNested":42,"sameNestedRef":true}""");
     }
 
     [Fact]
@@ -592,7 +592,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["a","b"],"hasInheritedOwn":false,"protoIsObjectProto":true,"a":1,"b":2}""", result);
+        result.Should().Be("""{"keys":["a","b"],"hasInheritedOwn":false,"protoIsObjectProto":true,"a":1,"b":2}""");
     }
 
     [Fact]
@@ -610,7 +610,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["0","a","b"],"zero":2,"a":1,"b":3}""", result);
+        result.Should().Be("""{"keys":["0","a","b"],"zero":2,"a":1,"b":3}""");
     }
 
     [Fact]
@@ -635,7 +635,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["a","b"],"a":1,"b":2,"enumSym":"enum","hiddenSym":true}""", result);
+        result.Should().Be("""{"keys":["a","b"],"a":1,"b":2,"enumSym":"enum","hiddenSym":true}""");
     }
 
     [Fact]
@@ -652,7 +652,7 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"keys":["a","b","c","d"],"values":[1,2,3,4]}""", result);
+        result.Should().Be("""{"keys":["a","b","c","d"],"values":[1,2,3,4]}""");
     }
 
     [Fact]
@@ -672,6 +672,6 @@ public class ObjectSpreadShapeTests
             })()
             """).AsString();
 
-        Assert.Equal("""{"cloneKeys":["a","b","c"],"srcKeys":["a","b"],"srcHasC":false}""", result);
+        result.Should().Be("""{"cloneKeys":["a","b","c"],"srcKeys":["a","b"],"srcHasC":false}""");
     }
 }

--- a/Jint.Tests/Runtime/OperatorOverloadingTests.cs
+++ b/Jint.Tests/Runtime/OperatorOverloadingTests.cs
@@ -12,9 +12,10 @@ public class OperatorOverloadingTests
         _engine = new Engine(cfg => cfg
                 .AllowOperatorOverloading())
             .SetValue("log", new Action<object>(Console.WriteLine))
-            .SetValue("assert", new Action<bool>(Assert.True))
-            .SetValue("assertFalse", new Action<bool>(Assert.False))
-            .SetValue("equal", new Action<object, object>(Assert.Equal))
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+            .SetValue("assertFalse", new Action<bool>(static value => value.Should().BeFalse()))
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())))
             .SetValue("Vector2", typeof(Vector2))
             .SetValue("Vector3", typeof(Vector3))
             .SetValue("Vector2Child", typeof(Vector2Child));
@@ -365,8 +366,8 @@ public class OperatorOverloadingTests
         engine.SetValue("log", new Action<object>(Console.WriteLine));
 
         engine.Evaluate("let v1 = new Vector2D(1, 2);");
-        Assert.Equal("(1, 2)", engine.Evaluate("new String(v1)").As<StringInstance>().StringData.ToString());
-        Assert.Equal("### (1, 2) ###", engine.Evaluate("'### ' + v1 + ' ###'"));
+        engine.Evaluate("new String(v1)").As<StringInstance>().StringData.ToString().Should().Be("(1, 2)");
+        engine.Evaluate("'### ' + v1 + ' ###'").Should().Be("### (1, 2) ###");
     }
 
     [Fact]
@@ -386,10 +387,10 @@ public class OperatorOverloadingTests
         // The RHS expression (Promise.resolve(new Vector2(++counter, 10))) must run
         // exactly once even though _right.GetValue is structurally called twice
         // (once in EvaluateOperatorOverloading, once in the operator switch).
-        Assert.Equal(1, sideEffectCount);
+        sideEffectCount.Should().Be(1);
 
         var arr = result.As<Native.JsArray>();
-        Assert.Equal(2.0, arr.Get(0).AsNumber());   // v.X = 1 + 1 = 2
-        Assert.Equal(12.0, arr.Get(1).AsNumber());  // v.Y = 2 + 10 = 12
+        arr.Get(0).AsNumber().Should().Be(2.0);   // v.X = 1 + 1 = 2
+        arr.Get(1).AsNumber().Should().Be(12.0);  // v.Y = 2 + 10 = 12
     }
 }

--- a/Jint.Tests/Runtime/ParserOptionsPropagationTests.cs
+++ b/Jint.Tests/Runtime/ParserOptionsPropagationTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using Jint.Native;
 using Jint.Runtime;
@@ -148,12 +148,12 @@ public class ParserOptionsPropagationTests
 
         if (expectedReturnValue is not null)
         {
-            Assert.Equal(expectedReturnValue, evalAction());
+            evalAction().Should().Be(expectedReturnValue);
         }
         else
         {
-            var ex = Assert.ThrowsAny<Exception>(evalAction);
-            Assert.True(ex is JavaScriptException or ParseErrorException);
+            var ex = Invoking(evalAction).Should().Throw<Exception>().Which;
+            (ex is JavaScriptException or ParseErrorException).Should().BeTrue();
         }
     }
 
@@ -176,12 +176,12 @@ public class ParserOptionsPropagationTests
 
         if (expectedReturnValue is not null)
         {
-            Assert.Equal(expectedReturnValue, evalAction());
+            evalAction().Should().Be(expectedReturnValue);
         }
         else
         {
-            var ex = Assert.Throws<JavaScriptException>(evalAction);
-            Assert.True(ex.Error.InstanceofOperator(engine.Realm.Intrinsics.SyntaxError));
+            var ex = Invoking(evalAction).Should().ThrowExactly<JavaScriptException>().Which;
+            ex.Error.InstanceofOperator(engine.Realm.Intrinsics.SyntaxError).Should().BeTrue();
         }
     }
 
@@ -191,24 +191,24 @@ public class ParserOptionsPropagationTests
         var engine = new Engine();
 
         var parsingOptions = ScriptParsingOptions.Default with { AllowReturnOutsideFunction = true, Tolerant = true };
-        Assert.Equal("2", engine.Evaluate("return '' + eval('(1, 2,)')", parsingOptions));
+        engine.Evaluate("return '' + eval('(1, 2,)')", parsingOptions).Should().Be("2");
 
         var shadowRealm1 = engine.Intrinsics.ShadowRealm.Construct();
         var shadowRealm2 = engine.Intrinsics.ShadowRealm.Construct();
 
-        var ex = Assert.Throws<JavaScriptException>(() => shadowRealm1.Evaluate("'' + eval('(1, 2,)')", parsingOptions with { Tolerant = false }));
-        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.TypeError));
+        var ex = Invoking(() => shadowRealm1.Evaluate("'' + eval('(1, 2,)')", parsingOptions with { Tolerant = false })).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.InstanceofOperator(engine.Intrinsics.TypeError).Should().BeTrue();
 
-        Assert.Equal("2", engine.Evaluate("'' + eval('(1, 2,)')", parsingOptions));
+        engine.Evaluate("'' + eval('(1, 2,)')", parsingOptions).Should().Be("2");
 
-        ex = Assert.Throws<JavaScriptException>(() => shadowRealm2.Evaluate("'' + eval('(1, 2,)')", parsingOptions with { Tolerant = false }));
-        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.TypeError));
+        ex = Invoking(() => shadowRealm2.Evaluate("'' + eval('(1, 2,)')", parsingOptions with { Tolerant = false })).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.InstanceofOperator(engine.Intrinsics.TypeError).Should().BeTrue();
 
-        Assert.Equal("2", shadowRealm1.Evaluate("'' + eval('(1, 2,)')", parsingOptions));
+        shadowRealm1.Evaluate("'' + eval('(1, 2,)')", parsingOptions).Should().Be("2");
 
-        ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("'' + eval('(1, 2,)')", parsingOptions with { Tolerant = false }));
-        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.SyntaxError));
+        ex = Invoking(() => engine.Evaluate("'' + eval('(1, 2,)')", parsingOptions with { Tolerant = false })).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.InstanceofOperator(engine.Intrinsics.SyntaxError).Should().BeTrue();
 
-        Assert.Equal("2", shadowRealm2.Evaluate("'' + new Function('return (1, 2,)')()", parsingOptions));
+        shadowRealm2.Evaluate("'' + new Function('return (1, 2,)')()", parsingOptions).Should().Be("2");
     }
 }

--- a/Jint.Tests/Runtime/PlainAssignmentTests.cs
+++ b/Jint.Tests/Runtime/PlainAssignmentTests.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime;
+﻿using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -24,7 +24,7 @@ public class PlainAssignmentTests
             f();
             """).AsString();
 
-        Assert.Equal("g|C|realName|arrow", result);
+        result.Should().Be("g|C|realName|arrow");
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class PlainAssignmentTests
             f();
             """).AsString();
 
-        Assert.Equal("11", result);
+        result.Should().Be("11");
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class PlainAssignmentTests
             f();
             """).AsString();
 
-        Assert.Equal("initial", result);
+        result.Should().Be("initial");
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class PlainAssignmentTests
         var engine = new Engine(static options => options.Strict());
         var result = engine.Evaluate("function f() { var b = 0; b = (b = 5, 9); return b; } f();").AsNumber();
 
-        Assert.Equal(9, result);
+        result.Should().Be(9);
     }
 
     [Fact]
@@ -73,16 +73,16 @@ public class PlainAssignmentTests
     {
         var engine = new Engine(static options => options.Strict());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("""
+        var ex = Invoking(() => engine.Execute("""
             function f() {
                 const c = 1;
                 var order = [];
                 try { c = (order.push('rhs'), 2); } finally { globalThis.order = order.join(','); }
             }
             f();
-            """));
-        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.TypeError));
-        Assert.Equal("rhs", engine.Evaluate("globalThis.order").AsString());
+            """)).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.InstanceofOperator(engine.Intrinsics.TypeError).Should().BeTrue();
+        engine.Evaluate("globalThis.order").AsString().Should().Be("rhs");
     }
 
     [Fact]
@@ -90,7 +90,7 @@ public class PlainAssignmentTests
     {
         var engine = new Engine(static options => options.Strict());
 
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Execute("function f() { { x = 1; let x; } } f();"));
-        Assert.True(ex.Error.InstanceofOperator(engine.Intrinsics.ReferenceError));
+        var ex = Invoking(() => engine.Execute("function f() { { x = 1; let x; } } f();")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.InstanceofOperator(engine.Intrinsics.ReferenceError).Should().BeTrue();
     }
 }

--- a/Jint.Tests/Runtime/PromiseTests.cs
+++ b/Jint.Tests/Runtime/PromiseTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Native.Object;
 using Jint.Native.Promise;
 using Jint.Runtime;
@@ -26,7 +26,7 @@ public class PromiseTests
         var promise = engine.Evaluate("f();");
 
         resolveFunc(66);
-        Assert.Equal(66, promise.UnwrapIfPromise());
+        promise.UnwrapIfPromise().Should().Be(66);
     }
 
     [Fact]
@@ -48,9 +48,9 @@ public class PromiseTests
 
         rejectFunc("oops!");
 
-        var ex = Assert.Throws<PromiseRejectedException>(() => { completion.UnwrapIfPromise(); });
+        var ex = Invoking(() => { completion.UnwrapIfPromise(); }).Should().ThrowExactly<PromiseRejectedException>().Which;
 
-        Assert.Equal("oops!", ex.RejectedValue.AsString());
+        ex.RejectedValue.AsString().Should().Be("oops!");
     }
 
     [Fact]
@@ -79,12 +79,12 @@ public class PromiseTests
         resolve1("first");
 
         // still not finished but the promise is fulfilled
-        Assert.Equal("first", completion.UnwrapIfPromise());
+        completion.UnwrapIfPromise().Should().Be("first");
 
         resolve2("second");
 
         // completion value hasn't changed
-        Assert.Equal("first", completion.UnwrapIfPromise());
+        completion.UnwrapIfPromise().Should().Be("first");
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public class PromiseTests
 
         engine.Execute("f();");
 
-        Assert.Equal(true, engine.Evaluate(" 1 + 1 === 2"));
+        engine.Evaluate(" 1 + 1 === 2").Should().BeTrue();
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        Assert.Throws<JavaScriptException>(() => { engine.Execute("new Promise();"); });
+        Invoking(() => { engine.Execute("new Promise();"); }).Should().ThrowExactly<JavaScriptException>();
     }
 
     [Fact]
@@ -111,7 +111,7 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        Assert.Throws<JavaScriptException>(() => { engine.Execute("new Promise({});"); });
+        Invoking(() => { engine.Execute("new Promise({});"); }).Should().ThrowExactly<JavaScriptException>();
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class PromiseTests
         var engine = new Engine();
         var promise = engine.Evaluate("new Promise((resolve, reject)=>{});");
 
-        Assert.IsType<JsPromise>(promise);
+        promise.Should().BeOfType<JsPromise>();
     }
 
     [Fact]
@@ -136,14 +136,14 @@ public class PromiseTests
     {
         var engine = new Engine();
         var res = engine.Evaluate("new Promise((resolve, reject)=>{resolve(66);});").UnwrapIfPromise();
-        Assert.Equal(66, res);
+        res.Should().Be(66);
     }
 
     [Fact]
     public void PromiseResolveViaStatic_ReturnsCorrectValue()
     {
         var engine = new Engine();
-        Assert.Equal(66, engine.Evaluate("Promise.resolve(66);").UnwrapIfPromise());
+        engine.Evaluate("Promise.resolve(66);").UnwrapIfPromise().Should().Be(66);
     }
 
     [Fact]
@@ -151,12 +151,12 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        var ex = Assert.Throws<PromiseRejectedException>(() =>
+        var ex = Invoking(() =>
         {
             engine.Evaluate("new Promise((resolve, reject)=>{reject('Could not connect');});").UnwrapIfPromise();
-        });
+        }).Should().ThrowExactly<PromiseRejectedException>().Which;
 
-        Assert.Equal("Could not connect", ex.RejectedValue.AsString());
+        ex.RejectedValue.AsString().Should().Be("Could not connect");
     }
 
     [Fact]
@@ -164,12 +164,12 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        var ex = Assert.Throws<PromiseRejectedException>(() =>
+        var ex = Invoking(() =>
         {
             engine.Evaluate("Promise.reject('Could not connect');").UnwrapIfPromise();
-        });
+        }).Should().ThrowExactly<PromiseRejectedException>().Which;
 
-        Assert.Equal("Could not connect", ex.RejectedValue.AsString());
+        ex.RejectedValue.AsString().Should().Be("Could not connect");
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => 44).then(result => resolve(result)); });").UnwrapIfPromise();
 
-        Assert.Equal(44, res);
+        res.Should().Be(44);
     }
 
     [Fact]
@@ -190,7 +190,7 @@ public class PromiseTests
         var res = engine.Evaluate(
             "var promise1 = new Promise((resolve, reject) => { resolve(1); }); var promise2 = promise1.then();  promise1 === promise2").UnwrapIfPromise();
 
-        Assert.Equal(false, res);
+        res.Should().BeFalse();
     }
 
     [Fact]
@@ -200,7 +200,7 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(result => resolve(result)); });").UnwrapIfPromise();
 
-        Assert.Equal(66, res);
+        res.Should().Be(66);
     }
 
     [Fact]
@@ -208,7 +208,7 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        Assert.Equal(JsValue.Undefined, engine.Evaluate("Promise.resolve(33).then(() => {});").UnwrapIfPromise());
+        engine.Evaluate("Promise.resolve(33).then(() => {});").UnwrapIfPromise().Should().BeUndefined();
     }
 
     [Fact]
@@ -218,7 +218,7 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then().then(result => resolve(result)); });").UnwrapIfPromise();
 
-        Assert.Equal(66, res);
+        res.Should().Be(66);
     }
 
     [Fact]
@@ -228,7 +228,7 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => {}).then(result => resolve(result)); });").UnwrapIfPromise();
 
-        Assert.Equal(JsValue.Undefined, res);
+        res.Should().BeUndefined();
     }
 
     [Fact]
@@ -238,7 +238,7 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => { throw 'Thrown Error'; }).catch(result => resolve(result)); });").UnwrapIfPromise();
 
-        Assert.Equal("Thrown Error", res);
+        res.Should().Be("Thrown Error");
     }
 
     [Fact]
@@ -248,7 +248,7 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => Promise.resolve(55)).then(result => resolve(result)); });").UnwrapIfPromise();
 
-        Assert.Equal(55, res);
+        res.Should().Be(55);
     }
 
     [Fact]
@@ -258,7 +258,7 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).then(() => Promise.reject('Error Message')).catch(result => resolve(result)); });").UnwrapIfPromise();
 
-        Assert.Equal("Error Message", res);
+        res.Should().Be("Error Message");
     }
 
     [Fact]
@@ -268,7 +268,7 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch(result => resolve(result)); });").UnwrapIfPromise();
 
-        Assert.Equal("Could not connect", res);
+        res.Should().Be("Could not connect");
     }
 
     [Fact]
@@ -278,14 +278,14 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).then(undefined, result => resolve(result)); });").UnwrapIfPromise();
 
-        Assert.Equal("Could not connect", res);
+        res.Should().Be("Could not connect");
     }
 
     [Fact]
     public void PromiseChainedWithHandler_ResolvedAsUndefined()
     {
         var engine = new Engine();
-        Assert.Equal(JsValue.Undefined, engine.Evaluate("Promise.reject('error').catch(() => {});").UnwrapIfPromise());
+        engine.Evaluate("Promise.reject('error').catch(() => {});").UnwrapIfPromise().Should().BeUndefined();
     }
 
     [Fact]
@@ -295,7 +295,7 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch(ex => {}).then(result => resolve(result)); });").UnwrapIfPromise();
 
-        Assert.Equal(JsValue.Undefined, res);
+        res.Should().BeUndefined();
     }
 
     [Fact]
@@ -305,7 +305,7 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerReject('Could not connect')}).catch().catch(result => resolve(result)); });").UnwrapIfPromise();
 
-        Assert.Equal("Could not connect", res);
+        res.Should().Be("Could not connect");
     }
 
     [Fact]
@@ -315,7 +315,7 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(66)}).finally(() => resolve(16)); });").UnwrapIfPromise();
 
-        Assert.Equal(16, res);
+        res.Should().Be(16);
     }
 
     [Fact]
@@ -325,21 +325,21 @@ public class PromiseTests
         var res = engine.Evaluate(
             "var promise1 = new Promise((resolve, reject) => { resolve(1); }); var promise2 = promise1.finally();  promise1 === promise2");
 
-        Assert.Equal(false, res);
+        res.Should().BeFalse();
     }
 
     [Fact]
     public void PromiseFinally_ResolvesWithCorrectValue()
     {
         var engine = new Engine();
-        Assert.Equal(2, engine.Evaluate("Promise.resolve(2).finally(() => {})").UnwrapIfPromise());
+        engine.Evaluate("Promise.resolve(2).finally(() => {})").UnwrapIfPromise().Should().Be(2);
     }
 
     [Fact]
     public void PromiseFinallyWithNoCallback_ResolvesWithCorrectValue()
     {
         var engine = new Engine();
-        Assert.Equal(2, engine.Evaluate("Promise.resolve(2).finally()").UnwrapIfPromise());
+        engine.Evaluate("Promise.resolve(2).finally()").UnwrapIfPromise().Should().Be(2);
     }
 
     [Fact]
@@ -347,7 +347,7 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        Assert.Equal(2, engine.Evaluate("Promise.resolve(2).finally(() => 6).finally(() => 9);").UnwrapIfPromise());
+        engine.Evaluate("Promise.resolve(2).finally(() => 6).finally(() => 9);").UnwrapIfPromise().Should().Be(2);
     }
 
     [Fact]
@@ -357,14 +357,14 @@ public class PromiseTests
         var res = engine.Evaluate(
             "new Promise((resolve, reject) => { new Promise((innerResolve, innerReject) => {innerResolve(5)}).finally(() => {throw 'Could not connect';}).catch(result => resolve(result)); });").UnwrapIfPromise();
 
-        Assert.Equal("Could not connect", res);
+        res.Should().Be("Could not connect");
     }
 
     [Fact]
     public void PromiseAll_BadIterable_Rejects()
     {
         var engine = new Engine();
-        Assert.Throws<PromiseRejectedException>(() => { engine.Evaluate("Promise.all();").UnwrapIfPromise(); });
+        Invoking(() => { engine.Evaluate("Promise.all();").UnwrapIfPromise(); }).Should().ThrowExactly<PromiseRejectedException>();
     }
 
 
@@ -373,15 +373,16 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        Assert.Equal(new object[] {1d, 2d, 3d}, engine.Evaluate("Promise.all([1,2,3]);").UnwrapIfPromise().ToObject());
+        engine.Evaluate("Promise.all([1,2,3]);").UnwrapIfPromise().ToObject().Should()
+            .BeEquivalentTo(new object[] { 1d, 2d, 3d }, static options => options.WithStrictOrdering());
     }
 
     [Fact]
     public void PromiseAll_MixturePromisesNoPromises_ResolvesCorrectly()
     {
         var engine = new Engine();
-        Assert.Equal(new object[] {1d, 2d, 3d},
-            engine.Evaluate("Promise.all([1,Promise.resolve(2),3]);").UnwrapIfPromise().ToObject());
+        engine.Evaluate("Promise.all([1,Promise.resolve(2),3]);").UnwrapIfPromise().ToObject().Should()
+            .BeEquivalentTo(new object[] { 1d, 2d, 3d }, static options => options.WithStrictOrdering());
     }
 
     [Fact]
@@ -389,10 +390,10 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        Assert.Throws<PromiseRejectedException>(() =>
+        Invoking(() =>
         {
             engine.Evaluate("Promise.all([1,Promise.resolve(2),3, Promise.reject('Cannot connect')]);").UnwrapIfPromise();
-        });
+        }).Should().ThrowExactly<PromiseRejectedException>();
     }
 
     [Fact]
@@ -400,7 +401,7 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        Assert.Throws<PromiseRejectedException>(() => { engine.Evaluate("Promise.race();").UnwrapIfPromise(); });
+        Invoking(() => { engine.Evaluate("Promise.race();").UnwrapIfPromise(); }).Should().ThrowExactly<PromiseRejectedException>();
     }
 
     [Fact]
@@ -408,7 +409,7 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        Assert.Throws<PromiseRejectedException>(() => { engine.Evaluate("Promise.race({});").UnwrapIfPromise(); });
+        Invoking(() => { engine.Evaluate("Promise.race({});").UnwrapIfPromise(); }).Should().ThrowExactly<PromiseRejectedException>();
     }
 
     [Fact]
@@ -416,7 +417,7 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        Assert.Equal(12d, engine.Evaluate("Promise.race([12,2,3]);").UnwrapIfPromise().ToObject());
+        engine.Evaluate("Promise.race([12,2,3]);").UnwrapIfPromise().ToObject().Should().Be(12d);
     }
 
     [Fact]
@@ -424,7 +425,7 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        Assert.Equal(12d, engine.Evaluate("Promise.race([12,Promise.resolve(2),3]);").UnwrapIfPromise().ToObject());
+        engine.Evaluate("Promise.race([12,Promise.resolve(2),3]);").UnwrapIfPromise().ToObject().Should().Be(12d);
     }
 
     [Fact]
@@ -432,7 +433,7 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        Assert.Equal(2d, engine.Evaluate("Promise.race([Promise.resolve(2),6,3]);").UnwrapIfPromise().ToObject());
+        engine.Evaluate("Promise.race([Promise.resolve(2),6,3]);").UnwrapIfPromise().ToObject().Should().Be(2d);
     }
 
     [Fact]
@@ -441,7 +442,7 @@ public class PromiseTests
         var engine = new Engine();
         var res = engine.Evaluate("Promise.race([new Promise((resolve,reject)=>{}),Promise.resolve(55),3]);").UnwrapIfPromise();
 
-        Assert.Equal(55d, res.ToObject());
+        res.ToObject().Should().Be(55d);
     }
 
     [Fact]
@@ -449,11 +450,11 @@ public class PromiseTests
     {
         var engine = new Engine();
 
-        Assert.Throws<PromiseRejectedException>(() =>
+        Invoking(() =>
         {
             engine.Evaluate(
                 "Promise.race([new Promise((resolve,reject)=>{}),Promise.reject('Could not connect'),3]);").UnwrapIfPromise();
-        });
+        }).Should().ThrowExactly<PromiseRejectedException>();
     }
 
     [Fact]
@@ -476,8 +477,8 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
 
         var result = (object[]) resultAsObject;
 
-        Assert.Single(result);
-        Assert.IsType<Dictionary<string, object>>(result[0]);
+        result.Should().ContainSingle();
+        result[0].Should().BeOfType<Dictionary<string, object>>();
     }
 
     [Fact]
@@ -496,7 +497,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
         // Calling this method will execute the JavaScript again.
         promise.Resolve(JsValue.Undefined);
 
-        Assert.Equal("at <anonymous>:1:56", logMessage?.Trim());
+        (logMessage?.Trim()).Should().Be("at <anonymous>:1:56");
     }
 
     [Fact]
@@ -522,7 +523,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
 
         // Assert
         List<string> expected = ["start", "end", "resolved"];
-        Assert.Equal(expected, logMessages);
+        logMessages.Should().Equal(expected);
     }
 
     [Fact]
@@ -548,7 +549,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
 
         // Assert
         List<string> expected = ["start", "end", "rejected"];
-        Assert.Equal(expected, logMessages);
+        logMessages.Should().Equal(expected);
     }
 
     [Fact]
@@ -568,7 +569,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
 
         using var cts = new CancellationTokenSource();
         resolveFunc(42);
-        Assert.Equal(42, promise.UnwrapIfPromise(cts.Token));
+        promise.UnwrapIfPromise(cts.Token).Should().Be(42);
     }
 
     [Fact]
@@ -586,7 +587,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMilliseconds(50));
 
-        Assert.Throws<OperationCanceledException>(() => promise.UnwrapIfPromise(cts.Token));
+        Invoking(() => promise.UnwrapIfPromise(cts.Token)).Should().ThrowExactly<OperationCanceledException>();
     }
 
     [Fact]
@@ -596,7 +597,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
         var result = engine.Evaluate("42");
 
         using var cts = new CancellationTokenSource();
-        Assert.Equal(42, result.UnwrapIfPromise(cts.Token));
+        result.UnwrapIfPromise(cts.Token).Should().Be(42);
     }
 
     [Fact]
@@ -617,8 +618,8 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
         using var cts = new CancellationTokenSource();
         rejectFunc("error!");
 
-        var ex = Assert.Throws<PromiseRejectedException>(() => promise.UnwrapIfPromise(cts.Token));
-        Assert.Equal("error!", ex.RejectedValue.AsString());
+        var ex = Invoking(() => promise.UnwrapIfPromise(cts.Token)).Should().ThrowExactly<PromiseRejectedException>().Which;
+        ex.RejectedValue.AsString().Should().Be("error!");
     }
 
     [Fact]
@@ -638,7 +639,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
 
         resolveFunc(42);
         var result = await promise.UnwrapIfPromiseAsync();
-        Assert.Equal(42, result.AsInteger());
+        result.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -658,8 +659,8 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
 
         rejectFunc("error!");
 
-        var ex = await Assert.ThrowsAsync<PromiseRejectedException>(async () => await promise.UnwrapIfPromiseAsync());
-        Assert.Equal("error!", ex.RejectedValue.AsString());
+        var ex = (await Awaiting(async () => await promise.UnwrapIfPromiseAsync()).Should().ThrowExactlyAsync<PromiseRejectedException>()).Which;
+        ex.RejectedValue.AsString().Should().Be("error!");
     }
 
     [Fact]
@@ -669,7 +670,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
         var result = engine.Evaluate("42");
 
         var unwrapped = await result.UnwrapIfPromiseAsync();
-        Assert.Equal(42, unwrapped.AsInteger());
+        unwrapped.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -686,7 +687,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await promise.UnwrapIfPromiseAsync(cts.Token));
+        await Awaiting(async () => await promise.UnwrapIfPromiseAsync(cts.Token)).Should().ThrowAsync<OperationCanceledException>();
     }
 
     [Fact]
@@ -711,10 +712,10 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
         await ioStarted.Task;
 
         // The unwrap task should still be pending while IO is in flight
-        Assert.False(unwrapTask.IsCompleted, "UnwrapIfPromiseAsync should not block; task should still be pending during IO");
+        unwrapTask.IsCompleted.Should().BeFalse("UnwrapIfPromiseAsync should not block; task should still be pending during IO");
 
         var result = await unwrapTask;
-        Assert.Equal(99, result.AsInteger());
+        result.AsInteger().Should().Be(99);
     }
 
     // ========================================================================
@@ -749,7 +750,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
 
         var log = engine.GetValue("log").AsArray();
         string[] expected = ["a1", "t1", "a2", "t2", "a3", "t3"];
-        Assert.Equal(expected, log.Select(x => x.AsString()).ToArray());
+        log.Select(x => x.AsString()).ToArray().Should().Equal(expected);
     }
 
     [Fact]
@@ -777,7 +778,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
 
         var log = engine.GetValue("log").AsArray();
         string[] expected = ["a1", "t1", "a2", "t2", "a3", "t3"];
-        Assert.Equal(expected, log.Select(x => x.AsString()).ToArray());
+        log.Select(x => x.AsString()).ToArray().Should().Equal(expected);
     }
 
     [Fact]
@@ -799,12 +800,12 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
         """);
         engine.Advanced.ProcessTasks();
 
-        Assert.Equal("boom", engine.GetValue("caught").AsString());
+        engine.GetValue("caught").AsString().Should().Be("boom");
         // Promise.reject creates an already-rejected promise (fires Reject), and the await's
         // internal continuation attaches a handler via PerformPromiseThen (fires Handle).
         // The internal-continuation path must keep firing BOTH tracker operations, exactly
         // like an explicit .catch() would — the rejection is ultimately handled.
-        Assert.Equal([PromiseRejectionOperation.Reject, PromiseRejectionOperation.Handle], operations);
+        operations.Should().Equal([PromiseRejectionOperation.Reject, PromiseRejectionOperation.Handle]);
     }
 
     [Fact]
@@ -818,8 +819,8 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
             })();
         """);
 
-        var ex = Assert.Throws<PromiseRejectedException>(() => result.UnwrapIfPromise());
-        Assert.Equal("propagated", ex.RejectedValue.AsString());
+        var ex = Invoking(() => result.UnwrapIfPromise()).Should().ThrowExactly<PromiseRejectedException>().Which;
+        ex.RejectedValue.AsString().Should().Be("propagated");
     }
 
     [Fact]
@@ -834,7 +835,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
             })();
         """);
 
-        Assert.Equal(42, result.UnwrapIfPromise().AsInteger());
+        result.UnwrapIfPromise().AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -855,7 +856,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
         """);
         engine.Advanced.ProcessTasks();
 
-        Assert.Equal("getter-boom", engine.GetValue("caught").AsString());
+        engine.GetValue("caught").AsString().Should().Be("getter-boom");
     }
 
     [Fact]
@@ -873,8 +874,8 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
         """);
         engine.Advanced.ProcessTasks();
 
-        Assert.True(engine.GetValue("subIsMy").AsBoolean());
-        Assert.Equal(8, engine.GetValue("subVal").AsInteger());
+        engine.GetValue("subIsMy").AsBoolean().Should().BeTrue();
+        engine.GetValue("subVal").AsInteger().Should().Be(8);
     }
 
     [Fact]
@@ -896,10 +897,10 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
             meta;
         """);
         // meta captured before the .then microtask runs
-        Assert.Equal("function/1/\"\"/function/false", result.AsString());
+        result.AsString().Should().Be("function/1/\"\"/function/false");
 
         var settled = engine.GetValue("p");
-        Assert.Equal(11, settled.UnwrapIfPromise().AsInteger());
+        settled.UnwrapIfPromise().AsInteger().Should().Be(11);
     }
 
     [Fact]
@@ -917,9 +918,9 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
             wr.reject('nope');    // idempotent
             meta;
         """);
-        Assert.Equal("function/1/\"\"/true", result.AsString());
+        result.AsString().Should().Be("function/1/\"\"/true");
 
-        Assert.Equal("first", engine.GetValue("wr").AsObject().Get("promise").UnwrapIfPromise().AsString());
+        engine.GetValue("wr").AsObject().Get("promise").UnwrapIfPromise().AsString().Should().Be("first");
     }
 
     [Fact]
@@ -930,7 +931,7 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
             Promise.all([Promise.resolve(1), 2, Promise.resolve(3)]).then(function (r) { return r.join('-'); });
         """);
 
-        Assert.Equal("1-2-3", result.UnwrapIfPromise().AsString());
+        result.UnwrapIfPromise().AsString().Should().Be("1-2-3");
     }
 
     [Fact]
@@ -946,6 +947,6 @@ return Promise.all(promiseArray);") // Returning and array through Promise.any()
             })();
         """);
 
-        Assert.Equal(1000, result.UnwrapIfPromise().AsInteger());
+        result.UnwrapIfPromise().AsInteger().Should().Be(1000);
     }
 }

--- a/Jint.Tests/Runtime/PropertyDescriptorTests.cs
+++ b/Jint.Tests/Runtime/PropertyDescriptorTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Native.Global;
 using Jint.Native.Symbol;
 using Jint.Runtime.Descriptors;
@@ -42,8 +42,9 @@ public class PropertyDescriptorTests
                     typeof(Console).Assembly,
                     typeof(File).Assembly))
                 .SetValue("log", new Action<object>(Console.WriteLine))
-                .SetValue("assert", new Action<bool>(Assert.True))
-                .SetValue("equal", new Action<object, object>(Assert.Equal))
+                .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+                .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())))
                 .SetValue("testClass", TestClass.Instance)
         ;
     }
@@ -57,11 +58,11 @@ public class PropertyDescriptorTests
               writable: false
             })
         """).AsObject().GetOwnProperty("value");
-        Assert.Equal(false, pd.IsAccessorDescriptor());
-        Assert.Equal(true, pd.IsDataDescriptor());
-        Assert.Equal(false, pd.Writable);
-        Assert.Null(pd.Get);
-        Assert.Null(pd.Set);
+        pd.IsAccessorDescriptor().Should().BeFalse();
+        pd.IsDataDescriptor().Should().BeTrue();
+        pd.Writable.Should().BeFalse();
+        pd.Get.Should().BeNull();
+        pd.Set.Should().BeNull();
     }
 
     [Fact]
@@ -73,11 +74,11 @@ public class PropertyDescriptorTests
               writable: true
             })
         """).AsObject().GetOwnProperty("value");
-        Assert.Equal(false, pd.IsAccessorDescriptor());
-        Assert.Equal(true, pd.IsDataDescriptor());
-        Assert.Equal(true, pd.Writable);
-        Assert.Null(pd.Get);
-        Assert.Null(pd.Set);
+        pd.IsAccessorDescriptor().Should().BeFalse();
+        pd.IsDataDescriptor().Should().BeTrue();
+        pd.Writable.Should().BeTrue();
+        pd.Get.Should().BeNull();
+        pd.Set.Should().BeNull();
     }
 
     [Fact]
@@ -85,18 +86,18 @@ public class PropertyDescriptorTests
     {
         var pd = PropertyDescriptor.Undefined;
         // PropertyDescriptor.UndefinedPropertyDescriptor is private
-        //if (checkType) Assert.IsType<PropertyDescriptor.UndefinedPropertyDescriptor>(pd);
-        Assert.Equal(false, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
+        //if (checkType) pd.Should().BeOfType<PropertyDescriptor.UndefinedPropertyDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeFalse();
+        pd.IsDataDescriptor().Should().BeFalse();
     }
 
     [Fact]
     public void AllForbiddenDescriptor()
     {
         var pd = _engine.Evaluate("Object.getPrototypeOf('s')").AsObject().GetOwnProperty("length");
-        if (checkType) Assert.IsType<PropertyDescriptor.AllForbiddenDescriptor>(pd);
-        Assert.Equal(false, pd.IsAccessorDescriptor());
-        Assert.Equal(true, pd.IsDataDescriptor());
+        if (checkType) pd.Should().BeOfType<PropertyDescriptor.AllForbiddenDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeFalse();
+        pd.IsDataDescriptor().Should().BeTrue();
     }
 
     [Fact]
@@ -105,13 +106,13 @@ public class PropertyDescriptorTests
         // Math uses builtin-shape storage; a raw property store of a non-shape name joins the
         // hybrid side dictionary, which every read/enumeration surface must consult — without
         // that, the property silently doesn't exist.
-        Assert.Equal(4, _engine.Evaluate("Math.floor(4.7)").AsNumber()); // initialize the shaped host
+        _engine.Evaluate("Math.floor(4.7)").AsNumber().Should().Be(4); // initialize the shaped host
         var math = _engine.Evaluate("Math").AsObject();
         math.FastSetProperty("custom", new PropertyDescriptor(42, PropertyFlag.ConfigurableEnumerableWritable));
 
-        Assert.Equal(42, _engine.Evaluate("Math.custom").AsNumber());
-        Assert.True(_engine.Evaluate("Object.getOwnPropertyNames(Math).includes('custom')").AsBoolean());
-        Assert.Equal(4, _engine.Evaluate("Math.floor(4.7)").AsNumber());
+        _engine.Evaluate("Math.custom").AsNumber().Should().Be(42);
+        _engine.Evaluate("Object.getOwnPropertyNames(Math).includes('custom')").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("Math.floor(4.7)").AsNumber().Should().Be(4);
     }
 
     [Fact]
@@ -122,8 +123,8 @@ public class PropertyDescriptorTests
         var regExp = _engine.Evaluate("RegExp").AsObject();
         regExp.FastSetProperty("custom", new PropertyDescriptor(42, PropertyFlag.ConfigurableEnumerableWritable));
 
-        Assert.Equal(42, _engine.Evaluate("RegExp.custom").AsNumber());
-        Assert.True(_engine.Evaluate("typeof RegExp.escape === 'function'").AsBoolean());
+        _engine.Evaluate("RegExp.custom").AsNumber().Should().Be(42);
+        _engine.Evaluate("typeof RegExp.escape === 'function'").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -133,9 +134,9 @@ public class PropertyDescriptorTests
         var math = _engine.Evaluate("Math").AsObject();
         math.FastSetProperty("custom", new PropertyDescriptor(42, PropertyFlag.ConfigurableEnumerableWritable));
 
-        Assert.Equal(42, _engine.Evaluate("Math.custom").AsNumber());
-        Assert.True(_engine.Evaluate("Object.getOwnPropertyNames(Math).includes('custom')").AsBoolean());
-        Assert.Equal(4, _engine.Evaluate("Math.floor(4.7)").AsNumber());
+        _engine.Evaluate("Math.custom").AsNumber().Should().Be(42);
+        _engine.Evaluate("Object.getOwnPropertyNames(Math).includes('custom')").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("Math.floor(4.7)").AsNumber().Should().Be(4);
     }
 
     [Fact]
@@ -145,8 +146,8 @@ public class PropertyDescriptorTests
         var math = _engine.Evaluate("Math").AsObject();
         math.SetProperty(GlobalSymbolRegistry.Iterator, new PropertyDescriptor(42, PropertyFlag.ConfigurableEnumerableWritable));
 
-        Assert.Equal(42, _engine.Evaluate("Math[Symbol.iterator]").AsNumber());
-        Assert.Equal("Math", _engine.Evaluate("Math[Symbol.toStringTag]").AsString());
+        _engine.Evaluate("Math[Symbol.iterator]").AsNumber().Should().Be(42);
+        _engine.Evaluate("Math[Symbol.toStringTag]").AsString().Should().Be("Math");
     }
 
     [Fact]
@@ -156,18 +157,18 @@ public class PropertyDescriptorTests
         var pd = _engine.Evaluate("globalThis").AsObject().GetOwnProperty("decodeURI");
         if (checkType)
         {
-            Assert.IsType<PropertyDescriptor>(pd);
+            pd.Should().BeOfType<PropertyDescriptor>();
         }
-        Assert.Equal(false, pd.IsAccessorDescriptor());
-        Assert.Equal(true, pd.IsDataDescriptor());
+        pd.IsAccessorDescriptor().Should().BeFalse();
+        pd.IsDataDescriptor().Should().BeTrue();
 
         // parseInt is a host-filled instance slot carrying a LazyPropertyDescriptor
         var lazy = _engine.Evaluate("globalThis").AsObject().GetOwnProperty("parseInt");
         if (checkType)
         {
-            Assert.IsType<LazyPropertyDescriptor<GlobalObject>>(lazy);
+            lazy.Should().BeOfType<LazyPropertyDescriptor<GlobalObject>>();
         }
-        Assert.Equal(true, lazy.IsDataDescriptor());
+        lazy.IsDataDescriptor().Should().BeTrue();
 
         // deleting a shape name deopts the global; untouched function slots must survive
         // as lazy wrappers instead of eagerly instantiating every built-in dispatcher
@@ -175,19 +176,19 @@ public class PropertyDescriptorTests
         var afterDeopt = _engine.Evaluate("globalThis").AsObject().GetOwnProperty("encodeURI");
         if (checkType)
         {
-            Assert.IsType<LazyBuiltinSlotDescriptor>(afterDeopt);
+            afterDeopt.Should().BeOfType<LazyBuiltinSlotDescriptor>();
         }
-        Assert.Equal(true, afterDeopt.IsDataDescriptor());
-        Assert.Equal("test", _engine.Evaluate("encodeURI('test')").AsString());
+        afterDeopt.IsDataDescriptor().Should().BeTrue();
+        _engine.Evaluate("encodeURI('test')").AsString().Should().Be("test");
     }
 
     [Fact]
     public void ThrowerPropertyDescriptor()
     {
         var pd = _engine.Evaluate("Object.getPrototypeOf(function() {})").AsObject().GetOwnProperty("arguments");
-        if (checkType) Assert.IsType<GetSetPropertyDescriptor.ThrowerPropertyDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
+        if (checkType) pd.Should().BeOfType<GetSetPropertyDescriptor.ThrowerPropertyDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
     }
 
     [Fact]
@@ -198,11 +199,11 @@ public class PropertyDescriptorTests
               get() {}
             })
         """).AsObject().GetOwnProperty("value");
-        if (checkType) Assert.IsType<GetSetPropertyDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
-        Assert.NotNull(pd.Get);
-        Assert.Null(pd.Set);
+        if (checkType) pd.Should().BeOfType<GetSetPropertyDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
+        pd.Get.Should().NotBeNull();
+        pd.Set.Should().BeNull();
     }
 
     [Fact]
@@ -213,11 +214,11 @@ public class PropertyDescriptorTests
               set() {}
             })
         """).AsObject().GetOwnProperty("value");
-        if (checkType) Assert.IsType<GetSetPropertyDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
-        Assert.Null(pd.Get);
-        Assert.NotNull(pd.Set);
+        if (checkType) pd.Should().BeOfType<GetSetPropertyDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
+        pd.Get.Should().BeNull();
+        pd.Set.Should().NotBeNull();
     }
 
     [Fact]
@@ -229,11 +230,11 @@ public class PropertyDescriptorTests
               set() {}
             })
         """).AsObject().GetOwnProperty("value");
-        if (checkType) Assert.IsType<GetSetPropertyDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
-        Assert.NotNull(pd.Get);
-        Assert.NotNull(pd.Set);
+        if (checkType) pd.Should().BeOfType<GetSetPropertyDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
+        pd.Get.Should().NotBeNull();
+        pd.Set.Should().NotBeNull();
     }
 
     [Fact]
@@ -251,9 +252,9 @@ public class PropertyDescriptorTests
             })(42)
         """);
         var pd = (PropertyDescriptor) ((ObjectWrapper) pdobj).Target;
-        if (checkType) Assert.IsType<ClrAccessDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
+        if (checkType) pd.Should().BeOfType<ClrAccessDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
     }
 
     [Fact]
@@ -264,9 +265,9 @@ public class PropertyDescriptorTests
 
         var pd = _engine.Evaluate("testClass").AsObject().GetOwnProperty("Method");
         // use PropertyDescriptor to wrap method directly
-        //if (checkType) Assert.IsType<PropertyDescriptor>(pd);
-        Assert.Equal(false, pd.IsAccessorDescriptor());
-        Assert.Equal(true, pd.IsDataDescriptor());
+        //if (checkType) pd.Should().BeOfType<PropertyDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeFalse();
+        pd.IsDataDescriptor().Should().BeTrue();
     }
 
     [Fact]
@@ -277,9 +278,9 @@ public class PropertyDescriptorTests
 
         var pd = _engine.Evaluate("testClass").AsObject().GetOwnProperty("NestedType");
         // use PropertyDescriptor to wrap nested type directly
-        //if (checkType) Assert.IsType<PropertyDescriptor>(pd);
-        Assert.Equal(false, pd.IsAccessorDescriptor());
-        Assert.Equal(true, pd.IsDataDescriptor());
+        //if (checkType) pd.Should().BeOfType<PropertyDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeFalse();
+        pd.IsDataDescriptor().Should().BeTrue();
     }
 
     [Fact]
@@ -289,9 +290,9 @@ public class PropertyDescriptorTests
         CheckPropertyDescriptor(pdField, false, true, false, false, true, false);
 
         var pd = _engine.Evaluate("testClass").AsObject().GetOwnProperty("fieldReadOnly");
-        if (checkType) Assert.IsType<ReflectionDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
+        if (checkType) pd.Should().BeOfType<ReflectionDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
     }
 
     [Fact]
@@ -301,9 +302,9 @@ public class PropertyDescriptorTests
         CheckPropertyDescriptor(pdField, false, true, true, false, true, true);
 
         var pd = _engine.Evaluate("testClass").AsObject().GetOwnProperty("field");
-        if (checkType) Assert.IsType<ReflectionDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
+        if (checkType) pd.Should().BeOfType<ReflectionDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
     }
 
     [Fact]
@@ -313,9 +314,9 @@ public class PropertyDescriptorTests
         CheckPropertyDescriptor(pdPropertyReadOnly, false, true, false, false, true, false);
 
         var pd = _engine.Evaluate("testClass").AsObject().GetOwnProperty("PropertyReadOnly");
-        if (checkType) Assert.IsType<ReflectionDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
+        if (checkType) pd.Should().BeOfType<ReflectionDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
     }
 
     [Fact]
@@ -325,9 +326,9 @@ public class PropertyDescriptorTests
         CheckPropertyDescriptor(pdPropertyWriteOnly, false, true, true, false, false, true);
 
         var pd = _engine.Evaluate("testClass").AsObject().GetOwnProperty("PropertyWriteOnly");
-        if (checkType) Assert.IsType<ReflectionDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
+        if (checkType) pd.Should().BeOfType<ReflectionDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
     }
 
     [Fact]
@@ -337,9 +338,9 @@ public class PropertyDescriptorTests
         CheckPropertyDescriptor(pdPropertyReadWrite, false, true, true, false, true, true);
 
         var pd = _engine.Evaluate("testClass").AsObject().GetOwnProperty("PropertyReadWrite");
-        if (checkType) Assert.IsType<ReflectionDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
+        if (checkType) pd.Should().BeOfType<ReflectionDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
     }
 
     [Fact]
@@ -350,9 +351,9 @@ public class PropertyDescriptorTests
 
         var pd1 = _engine.Evaluate("testClass.IndexerReadOnly");
         var pd = pd1.AsObject().GetOwnProperty("1");
-        if (checkType) Assert.IsType<ReflectionDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
+        if (checkType) pd.Should().BeOfType<ReflectionDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
     }
 
     [Fact]
@@ -362,9 +363,9 @@ public class PropertyDescriptorTests
         CheckPropertyDescriptor(pdIndexerWriteOnly, false, true, true, false, false, true);
 
         var pd = _engine.Evaluate("testClass.IndexerWriteOnly").AsObject().GetOwnProperty("1");
-        if (checkType) Assert.IsType<ReflectionDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
+        if (checkType) pd.Should().BeOfType<ReflectionDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
     }
 
     [Fact]
@@ -374,9 +375,9 @@ public class PropertyDescriptorTests
         CheckPropertyDescriptor(pdIndexerReadWrite, false, true, true, false, true, true);
 
         var pd = _engine.Evaluate("testClass.IndexerReadWrite").AsObject().GetOwnProperty("1");
-        if (checkType) Assert.IsType<ReflectionDescriptor>(pd);
-        Assert.Equal(true, pd.IsAccessorDescriptor());
-        Assert.Equal(false, pd.IsDataDescriptor());
+        if (checkType) pd.Should().BeOfType<ReflectionDescriptor>();
+        pd.IsAccessorDescriptor().Should().BeTrue();
+        pd.IsDataDescriptor().Should().BeFalse();
     }
 
     private void CheckPropertyDescriptor(
@@ -391,20 +392,20 @@ public class PropertyDescriptorTests
     {
         var pd = jsPropertyDescriptor.AsObject();
 
-        Assert.Equal(configurable, pd["configurable"].AsBoolean());
-        Assert.Equal(enumerable, pd["enumerable"].AsBoolean());
+        pd["configurable"].AsBoolean().Should().Be(configurable);
+        pd["enumerable"].AsBoolean().Should().Be(enumerable);
         if (writable)
         {
             var writableActual = pd["writable"];
             if (!writableActual.IsUndefined())
             {
-                Assert.True(writableActual.AsBoolean());
+                writableActual.AsBoolean().Should().BeTrue();
             }
         }
 
-        Assert.Equal(hasValue, !pd["value"].IsUndefined());
-        Assert.Equal(hasGet, !pd["get"].IsUndefined());
-        Assert.Equal(hasSet, !pd["set"].IsUndefined());
+        (!pd["value"].IsUndefined()).Should().Be(hasValue);
+        (!pd["get"].IsUndefined()).Should().Be(hasGet);
+        (!pd["set"].IsUndefined()).Should().Be(hasSet);
     }
 
     [Fact]
@@ -421,7 +422,7 @@ public class PropertyDescriptorTests
             });
             return Object.getOwnPropertyDescriptor(o, 'foo');
         """);
-        Assert.Equal(101, pd.AsObject().Get("value").AsInteger());
+        pd.AsObject().Get("value").AsInteger().Should().Be(101);
         CheckPropertyDescriptor(pd, true, false, false, true, false, false);
     }
 }

--- a/Jint.Tests/Runtime/PrototypeMethodCacheTests.cs
+++ b/Jint.Tests/Runtime/PrototypeMethodCacheTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Jint.Native;
 using Jint.Native.Array;
 using Jint.Native.Object;
@@ -72,7 +72,7 @@ public class PrototypeMethodCacheTests
 
         var expected = exoticGet.Concat(safeWithoutFlag).OrderBy(n => n, StringComparer.Ordinal).ToArray();
 
-        Assert.Equal(expected, overriders);
+        overriders.Should().Equal(expected);
     }
 
     [Fact]
@@ -85,7 +85,7 @@ public class PrototypeMethodCacheTests
             for (var i = 0; i < 50; i++) { last = c.inc(); }
             last;
             """;
-        Assert.Equal(50, new Engine().Evaluate(script).AsNumber());
+        new Engine().Evaluate(script).AsNumber().Should().Be(50);
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class PrototypeMethodCacheTests
             }
             out.join(',');
             """;
-        Assert.Equal("proto,proto,proto,own,own", new Engine().Evaluate(script).AsString());
+        new Engine().Evaluate(script).AsString().Should().Be("proto,proto,proto,own,own");
     }
 
     [Fact]
@@ -119,7 +119,7 @@ public class PrototypeMethodCacheTests
             }
             out.join(',');
             """;
-        Assert.Equal("v1,v1,v2,v2", new Engine().Evaluate(script).AsString());
+        new Engine().Evaluate(script).AsString().Should().Be("v1,v1,v2,v2");
     }
 
     [Fact]
@@ -135,7 +135,7 @@ public class PrototypeMethodCacheTests
             }
             out.join(',');
             """;
-        Assert.Equal("v1,v1,gone,gone", new Engine().Evaluate(script).AsString());
+        new Engine().Evaluate(script).AsString().Should().Be("v1,v1,gone,gone");
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public class PrototypeMethodCacheTests
             }
             out.join(',');
             """;
-        Assert.Equal("A,A,B,B", new Engine().Evaluate(script).AsString());
+        new Engine().Evaluate(script).AsString().Should().Be("A,A,B,B");
     }
 
     [Fact]
@@ -166,6 +166,6 @@ public class PrototypeMethodCacheTests
             for (var i = 0; i < 4; i++) { out.push(o.next); }
             out.join(',');
             """;
-        Assert.Equal("1,2,3,4", new Engine().Evaluate(script).AsString());
+        new Engine().Evaluate(script).AsString().Should().Be("1,2,3,4");
     }
 }

--- a/Jint.Tests/Runtime/ProxyTests.cs
+++ b/Jint.Tests/Runtime/ProxyTests.cs
@@ -10,7 +10,8 @@ public class ProxyTests
     public ProxyTests()
     {
         _engine = new Engine()
-            .SetValue("equal", new Action<object, object>(Assert.Equal));
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
     }
 
     [Fact]
@@ -26,7 +27,7 @@ public class ProxyTests
     [Fact]
     public void GetTrapIsCalledForPropertyNamedRevoke()
     {
-        Assert.Equal("trapped", _engine.Evaluate("new Proxy({}, { get: () => 'trapped' }).revoke").AsString());
+        _engine.Evaluate("new Proxy({}, { get: () => 'trapped' }).revoke").AsString().Should().Be("trapped");
     }
 
     [Fact]
@@ -37,7 +38,7 @@ public class ProxyTests
             var proxy = revocable.proxy;
             revocable.revoke();
         ");
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("proxy.foo"));
+        var ex = Invoking(() => _engine.Evaluate("proxy.foo")).Should().ThrowExactly<JavaScriptException>().Which;
         AssertJsTypeError(_engine, ex, "Cannot perform 'get' on a proxy that has been revoked");
     }
 
@@ -51,7 +52,7 @@ public class ProxyTests
             r.proxy.x = 1;
             'ok';
             """).AsString();
-        Assert.Equal("ok", result);
+        result.Should().Be("ok");
     }
 
     [Fact]
@@ -61,7 +62,7 @@ public class ProxyTests
             var r = Proxy.revocable({ a: 1 }, { deleteProperty: (t, k) => { r.revoke(); return true; } });
             delete r.proxy.a;
             """);
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -71,7 +72,7 @@ public class ProxyTests
             var r = Proxy.revocable({ a: 1 }, { has: (t, k) => { r.revoke(); return false; } });
             'a' in r.proxy;
             """);
-        Assert.False(result.AsBoolean());
+        result.AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -82,14 +83,14 @@ public class ProxyTests
             var r = new p(42);
             r.len + ':' + r.first;
             """).AsString();
-        Assert.Equal("1:42", result);
+        result.Should().Be("1:42");
     }
 
     [Fact]
     public void ConstructTrapAcceptsSingleFractionalArgument()
     {
         var result = _engine.Evaluate("new (new Proxy(function () {}, { construct: (t, args) => ({ v: args[0] }) }))(1.5).v");
-        Assert.Equal(1.5, result.AsNumber());
+        result.AsNumber().Should().Be(1.5);
     }
 
     [Fact]
@@ -102,16 +103,16 @@ public class ProxyTests
             var pPrevent = new Proxy({}, { preventExtensions: () => true });
             """);
 
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("'a' in pHas"));
+        var ex = Invoking(() => _engine.Evaluate("'a' in pHas")).Should().ThrowExactly<JavaScriptException>().Which;
         AssertJsTypeError(_engine, ex, "'has' on proxy: trap returned falsish for property 'a' which exists in the proxy target as non-configurable");
 
-        ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("Object.keys(pOwnKeys)"));
+        ex = Invoking(() => _engine.Evaluate("Object.keys(pOwnKeys)")).Should().ThrowExactly<JavaScriptException>().Which;
         AssertJsTypeError(_engine, ex, "'ownKeys' on proxy: trap result did not include non-configurable property 'a' of the proxy target");
 
-        ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("Object.preventExtensions(pPrevent)"));
+        ex = Invoking(() => _engine.Evaluate("Object.preventExtensions(pPrevent)")).Should().ThrowExactly<JavaScriptException>().Which;
         AssertJsTypeError(_engine, ex, "'preventExtensions' on proxy: trap returned truish but the proxy target is extensible");
 
-        ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("new Proxy({}, { get: 1 }).x"));
+        ex = Invoking(() => _engine.Evaluate("new Proxy({}, { get: 1 }).x")).Should().ThrowExactly<JavaScriptException>().Which;
         AssertJsTypeError(_engine, ex, "'get' trap of proxy handler is not a function");
     }
 
@@ -121,8 +122,8 @@ public class ProxyTests
         _engine.Execute(@"
             const targetWithToString = {toString: () => 'target'}
         ");
-        Assert.Equal("target", _engine.Evaluate("new Proxy(targetWithToString, {}).toString()").AsString());
-        Assert.Equal("target", _engine.Evaluate("`${new Proxy(targetWithToString, {})}`").AsString());
+        _engine.Evaluate("new Proxy(targetWithToString, {}).toString()").AsString().Should().Be("target");
+        _engine.Evaluate("`${new Proxy(targetWithToString, {})}`").AsString().Should().Be("target");
     }
 
     [Fact]
@@ -133,10 +134,10 @@ public class ProxyTests
             const targetWithToString = {toString: () => 'target'}
         ");
 
-        Assert.Equal("handler", _engine.Evaluate("new Proxy({}, handler).toString()").AsString());
-        Assert.Equal("handler", _engine.Evaluate("new Proxy(targetWithToString, handler).toString()").AsString());
-        Assert.Equal("handler", _engine.Evaluate("`${new Proxy({}, handler)}`").AsString());
-        Assert.Equal("handler", _engine.Evaluate("`${new Proxy(targetWithToString, handler)}`").AsString());
+        _engine.Evaluate("new Proxy({}, handler).toString()").AsString().Should().Be("handler");
+        _engine.Evaluate("new Proxy(targetWithToString, handler).toString()").AsString().Should().Be("handler");
+        _engine.Evaluate("`${new Proxy({}, handler)}`").AsString().Should().Be("handler");
+        _engine.Evaluate("`${new Proxy(targetWithToString, handler)}`").AsString().Should().Be("handler");
     }
 
     [Fact]
@@ -157,7 +158,7 @@ public class ProxyTests
             }
             return 'did not fail as expected'";
 
-        Assert.Equal("enumerable,configurable,value,writable,get,set", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("enumerable,configurable,value,writable,get,set");
     }
 
     [Fact]
@@ -170,7 +171,7 @@ public class ProxyTests
             Object.defineProperties({}, p);
             return get + '';";
 
-        Assert.Equal("foo,bar", _engine.Evaluate(Script));
+        _engine.Evaluate(Script).Should().Be("foo,bar");
     }
 
     [Fact]
@@ -222,7 +223,7 @@ public class ProxyTests
             catch(e) {}
             return passed;";
 
-        Assert.True(_engine.Evaluate(Script).AsBoolean());
+        _engine.Evaluate(Script).AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -244,7 +245,7 @@ public class ProxyTests
             } catch(e) {}
             return passed;";
 
-        Assert.True(_engine.Evaluate(Script).AsBoolean());
+        _engine.Evaluate(Script).AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -276,7 +277,7 @@ public class ProxyTests
             } catch(e) {}
             return passed;";
 
-        Assert.True(_engine.Evaluate(Script).AsBoolean());
+        _engine.Evaluate(Script).AsBoolean().Should().BeTrue();
     }
 
     // https://tc39.es/ecma262/#sec-proxycreate
@@ -285,22 +286,22 @@ public class ProxyTests
     [Fact]
     public void ProxyWithNonConstructorTargetIsNotConstructor()
     {
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("new (new Proxy(() => {}, { construct: () => ({}) }))()"));
-        Assert.Same(TypeErrorPrototype(_engine), ex.Error.AsObject().Prototype);
+        var ex = Invoking(() => _engine.Evaluate("new (new Proxy(() => {}, { construct: () => ({}) }))()")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.AsObject().Prototype.Should().BeSameAs(TypeErrorPrototype(_engine));
     }
 
     [Fact]
     public void ProxyWithConstructorTargetUsesConstructTrap()
     {
         var result = _engine.Evaluate("new (new Proxy(function(){}, { construct: () => ({ x: 1 }) }))().x");
-        Assert.Equal(1, result.AsInteger());
+        result.AsInteger().Should().Be(1);
     }
 
     [Fact]
     public void ReflectConstructRequiresConstructorNewTarget()
     {
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("Reflect.construct(function(){ return; }, [], new Proxy(() => {}, { construct: () => ({}) }))"));
-        Assert.Same(TypeErrorPrototype(_engine), ex.Error.AsObject().Prototype);
+        var ex = Invoking(() => _engine.Evaluate("Reflect.construct(function(){ return; }, [], new Proxy(() => {}, { construct: () => ({}) }))")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.AsObject().Prototype.Should().BeSameAs(TypeErrorPrototype(_engine));
     }
 
     [Fact]
@@ -309,11 +310,11 @@ public class ProxyTests
         _engine.Execute("var r = Proxy.revocable(function(){}, {}); r.revoke();");
 
         // typeof relies on the [[Call]] slot captured at creation, revocation does not remove it
-        Assert.Equal("function", _engine.Evaluate("typeof r.proxy").AsString());
+        _engine.Evaluate("typeof r.proxy").AsString().Should().Be("function");
 
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("new r.proxy()"));
-        Assert.Same(TypeErrorPrototype(_engine), ex.Error.AsObject().Prototype);
-        Assert.Contains("revoked", ex.Message);
+        var ex = Invoking(() => _engine.Evaluate("new r.proxy()")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.AsObject().Prototype.Should().BeSameAs(TypeErrorPrototype(_engine));
+        ex.Message.Should().Contain("revoked");
     }
 
     [Fact]
@@ -393,7 +394,7 @@ public class ProxyTests
             const p = new Proxy(testClass, handler);
             return p.StringValue;
         """);
-        Assert.Equal(TestClass.Instance.StringValue, result.AsString());
+        result.AsString().Should().Be(TestClass.Instance.StringValue);
     }
 
     [Fact]
@@ -409,7 +410,7 @@ public class ProxyTests
             const p = new Proxy(testClass, handler);
             return p.IntValue;
         """);
-        Assert.Equal(TestClass.Instance.IntValue, result.AsInteger());
+        result.AsInteger().Should().Be(TestClass.Instance.IntValue);
     }
 
     [Fact]
@@ -432,8 +433,8 @@ public class ProxyTests
 
     private static void AssertJsTypeError(Engine engine, JavaScriptException ex, string msg)
     {
-        Assert.Same(TypeErrorPrototype(engine), ex.Error.AsObject().Prototype);
-        Assert.Equal(msg, ex.Message);
+        ex.Error.AsObject().Prototype.Should().BeSameAs(TypeErrorPrototype(engine));
+        ex.Message.Should().Be(msg);
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/get#invariants
@@ -457,7 +458,7 @@ public class ProxyTests
             };
             let p = new Proxy(o, handler);
         """);
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("p.value"));
+        var ex = Invoking(() => _engine.Evaluate("p.value")).Should().ThrowExactly<JavaScriptException>().Which;
         AssertJsTypeError(_engine, ex, "'get' on proxy: property 'value' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value (expected '42' but got '32')");
     }
 
@@ -481,7 +482,7 @@ public class ProxyTests
             };
             let p = new Proxy(o, handler);
         """);
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("p.value"));
+        var ex = Invoking(() => _engine.Evaluate("p.value")).Should().ThrowExactly<JavaScriptException>().Which;
         AssertJsTypeError(_engine, ex, "'get' on proxy: property 'value' is a non-configurable accessor property on the proxy target and does not have a getter function, but the trap did not return 'undefined' (got '32')");
     }
 
@@ -508,7 +509,7 @@ public class ProxyTests
     public void ProxyHandlerSetInvariantsDataPropertyImmutableChangeValue()
     {
         _engine.Execute(ScriptProxyHandlerSetInvariantsDataPropertyImmutable);
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("p.value = 32"));
+        var ex = Invoking(() => _engine.Evaluate("p.value = 32")).Should().ThrowExactly<JavaScriptException>().Which;
         AssertJsTypeError(_engine, ex, "'set' on proxy: trap returned truish for property 'value' which exists in the proxy target as a non-configurable and non-writable data property with a different value");
     }
 
@@ -539,7 +540,7 @@ public class ProxyTests
             };
             let p = new Proxy(o, handler);
         """);
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("p.value = 42"));
+        var ex = Invoking(() => _engine.Evaluate("p.value = 42")).Should().ThrowExactly<JavaScriptException>().Which;
         AssertJsTypeError(_engine, ex, "'set' on proxy: trap returned truish for property 'value' which exists in the proxy target as a non-configurable and non-writable accessor property without a setter");
     }
 
@@ -549,11 +550,11 @@ public class ProxyTests
     [Fact]
     public void ProxyHandlerSetInvariantsReturnsFalseInStrictMode()
     {
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("""
+        var ex = Invoking(() => _engine.Evaluate("""
             'use strict';
             let p = new Proxy({}, { set: () => false });
             p.value = 42;
-        """));
+        """)).Should().ThrowExactly<JavaScriptException>().Which;
         // V8: "'set' on proxy: trap returned falsish for property 'value'",
         AssertJsTypeError(_engine, ex, "Cannot assign to read only property 'value' of [object Object]");
     }
@@ -572,18 +573,18 @@ public class ProxyTests
     [Fact]
     public void ProxyHandlerGetPrototypeOfCanReturnNull()
     {
-        Assert.True(_engine.Evaluate("Object.getPrototypeOf(new Proxy({}, { getPrototypeOf: () => null }))").IsNull());
-        Assert.True(_engine.Evaluate("Reflect.getPrototypeOf(new Proxy({}, { getPrototypeOf: () => null }))").IsNull());
+        _engine.Evaluate("Object.getPrototypeOf(new Proxy({}, { getPrototypeOf: () => null }))").IsNull().Should().BeTrue();
+        _engine.Evaluate("Reflect.getPrototypeOf(new Proxy({}, { getPrototypeOf: () => null }))").IsNull().Should().BeTrue();
     }
 
     [Fact]
     public void ProxyHandlerGetPrototypeOfCanReturnNullForNonExtensibleTargetWithNullPrototype()
     {
-        Assert.True(_engine.Evaluate("""
+        _engine.Evaluate("""
             const t = Object.create(null);
             Object.preventExtensions(t);
             Object.getPrototypeOf(new Proxy(t, { getPrototypeOf: () => null }));
-        """).IsNull());
+        """).IsNull().Should().BeTrue();
     }
 
     // https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v
@@ -595,10 +596,10 @@ public class ProxyTests
             Object.preventExtensions(t);
         """);
 
-        Assert.True(_engine.Evaluate("let p1 = new Proxy(t, {}); Object.setPrototypeOf(p1, null) === p1").AsBoolean());
-        Assert.True(_engine.Evaluate("let p2 = new Proxy(t, { setPrototypeOf: () => true }); Object.setPrototypeOf(p2, null) === p2").AsBoolean());
-        Assert.True(_engine.Evaluate("Reflect.setPrototypeOf(new Proxy(t, {}), null)").AsBoolean());
-        Assert.True(_engine.Evaluate("Reflect.setPrototypeOf(new Proxy(t, { setPrototypeOf: () => true }), null)").AsBoolean());
+        _engine.Evaluate("let p1 = new Proxy(t, {}); Object.setPrototypeOf(p1, null) === p1").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("let p2 = new Proxy(t, { setPrototypeOf: () => true }); Object.setPrototypeOf(p2, null) === p2").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("Reflect.setPrototypeOf(new Proxy(t, {}), null)").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("Reflect.setPrototypeOf(new Proxy(t, { setPrototypeOf: () => true }), null)").AsBoolean().Should().BeTrue();
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getPrototypeOf#invariants
@@ -612,8 +613,8 @@ public class ProxyTests
             Object.preventExtensions(t);
             let p = new Proxy(t, { getPrototypeOf: () => ({}) });
         """);
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("Object.getPrototypeOf(p)"));
-        Assert.Same(TypeErrorPrototype(_engine), ex.Error.AsObject().Prototype);
+        var ex = Invoking(() => _engine.Evaluate("Object.getPrototypeOf(p)")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.AsObject().Prototype.Should().BeSameAs(TypeErrorPrototype(_engine));
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/setPrototypeOf#invariants
@@ -626,8 +627,8 @@ public class ProxyTests
             Object.preventExtensions(t);
             let p = new Proxy(t, { setPrototypeOf: () => true });
         """);
-        var ex = Assert.Throws<JavaScriptException>(() => _engine.Evaluate("Object.setPrototypeOf(p, null)"));
-        Assert.Same(TypeErrorPrototype(_engine), ex.Error.AsObject().Prototype);
+        var ex = Invoking(() => _engine.Evaluate("Object.setPrototypeOf(p, null)")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.AsObject().Prototype.Should().BeSameAs(TypeErrorPrototype(_engine));
     }
 
     [Fact]
@@ -643,9 +644,9 @@ public class ProxyTests
             const p = new Proxy(testClass, handler);
         """);
 
-        Assert.Equal(1, TestClass.Instance.PropertySideEffect); // first call to PropertySideEffect
-        Assert.Equal(2, _engine.Evaluate("p.PropertySideEffect").AsInteger()); // no call to PropertySideEffect
-        Assert.Equal(2, TestClass.Instance.PropertySideEffect); // second call to PropertySideEffect
+        TestClass.Instance.PropertySideEffect.Should().Be(1); // first call to PropertySideEffect
+        _engine.Evaluate("p.PropertySideEffect").AsInteger().Should().Be(2); // no call to PropertySideEffect
+        TestClass.Instance.PropertySideEffect.Should().Be(2); // second call to PropertySideEffect
     }
 
     [Fact]
@@ -711,7 +712,7 @@ public class ProxyTests
                 return arr;
             """);
 
-        Assert.Equal([1, 2, 3, 3], res.AsArray());
+        res.AsArray().AsEnumerable().Should().Equal(1, 2, 3, 3);
     }
 
     [Fact]
@@ -737,7 +738,7 @@ public class ProxyTests
                              // (expected 'function Jint.Tests.Runtime.ProxyTests+TestClass.Add() { [native code] }' but got 'function () { [native code] }')
              """);
 
-        Assert.Equal(42, res.AsInteger());
+        res.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -763,7 +764,7 @@ public class ProxyTests
                              // (expected 'function Jint.Tests.Runtime.ProxyTests+TestClass.Add() { [native code] }' but got 'function () { [native code] }')
              """);
 
-        Assert.Equal(42, res.AsInteger());
+        res.AsInteger().Should().Be(42);
     }
 
     [Fact]
@@ -796,6 +797,6 @@ public class ProxyTests
                  name + " " + res
              """);
 
-        Assert.Equal("My Name is Test 42", res.AsString());
+        res.AsString().Should().Be("My Name is Test 42");
     }
 }

--- a/Jint.Tests/Runtime/ReflectTests.cs
+++ b/Jint.Tests/Runtime/ReflectTests.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime;
+﻿using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -20,8 +20,8 @@ public class ReflectTests
         engine.Evaluate("Reflect.construct(C, [])");
 
         // newTarget explicitly undefined — IsConstructor(undefined) is false, throws TypeError
-        var ex = Assert.Throws<JavaScriptException>(() => engine.Evaluate("Reflect.construct(C, [], undefined)"));
-        Assert.Equal("TypeError", ex.Error.Get("name").AsString());
+        var ex = Invoking(() => engine.Evaluate("Reflect.construct(C, [], undefined)")).Should().ThrowExactly<JavaScriptException>().Which;
+        ex.Error.Get("name").AsString().Should().Be("TypeError");
     }
 
     [Fact]
@@ -30,10 +30,10 @@ public class ReflectTests
         var engine = new Engine();
 
         // receiver not present — defaults to target, set succeeds
-        Assert.True(engine.Evaluate("Reflect.set({}, 'p', 1)").AsBoolean());
+        engine.Evaluate("Reflect.set({}, 'p', 1)").AsBoolean().Should().BeTrue();
 
         // receiver explicitly undefined — non-Object receiver, [[Set]] returns false
-        Assert.False(engine.Evaluate("Reflect.set({}, 'p', 1, undefined)").AsBoolean());
+        engine.Evaluate("Reflect.set({}, 'p', 1, undefined)").AsBoolean().Should().BeFalse();
     }
 
     [Fact]
@@ -49,10 +49,10 @@ public class ReflectTests
 
         // receiver not present — defaults to target, getter sees `this === obj`
         engine.Evaluate("Reflect.get(obj, 'p')");
-        Assert.True(engine.Evaluate("seen === obj").AsBoolean());
+        engine.Evaluate("seen === obj").AsBoolean().Should().BeTrue();
 
         // receiver explicitly undefined — getter sees `this === undefined`
         engine.Evaluate("Reflect.get(obj, 'p', undefined)");
-        Assert.True(engine.Evaluate("seen === undefined").AsBoolean());
+        engine.Evaluate("seen === undefined").AsBoolean().Should().BeTrue();
     }
 }

--- a/Jint.Tests/Runtime/RegExpTests.cs
+++ b/Jint.Tests/Runtime/RegExpTests.cs
@@ -12,7 +12,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate("'abc'.match(/\\d/gu) === null").AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -21,7 +21,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate("JSON.stringify('a1b22c333'.match(/\\d+/gu))").AsString();
 
-        Assert.Equal("[\"1\",\"22\",\"333\"]", result);
+        result.Should().Be("[\"1\",\"22\",\"333\"]");
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public class RegExpTests
         // 2 astral code points (4 UTF-16 units): empty matches at positions 0, 2, 4
         var result = engine.Evaluate("'\\u{1F600}\\u{1F600}'.match(/(?:)/gu).length").AsNumber();
 
-        Assert.Equal(3, result);
+        result.Should().Be(3);
     }
 
     [Theory]
@@ -56,7 +56,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate($"JSON.stringify(/{pattern}/.exec({JsonString(input)}))").AsString();
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     private static string JsonString(string s) => System.Text.Json.JsonSerializer.Serialize(s);
@@ -70,7 +70,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate($"JSON.stringify(['aaa'.match(/a/{flags}), 'ababab'.match(/ab/{flags})])").AsString();
 
-        Assert.Equal("[[\"a\",\"a\",\"a\"],[\"ab\",\"ab\",\"ab\"]]", result);
+        result.Should().Be("[[\"a\",\"a\",\"a\"],[\"ab\",\"ab\",\"ab\"]]");
     }
 
     [Theory]
@@ -82,7 +82,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate($"JSON.stringify(['aabaa'.match(/a/{flags}), 'baa'.match(/a/{flags})])").AsString();
 
-        Assert.Equal("[[\"a\",\"a\"],null]", result);
+        result.Should().Be("[[\"a\",\"a\"],null]");
     }
 
     [Theory]
@@ -93,7 +93,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate($"JSON.stringify('aab'.match(/a*/{flags}))").AsString();
 
-        Assert.Equal("[\"aa\",\"\",\"\"]", result);
+        result.Should().Be("[\"aa\",\"\",\"\"]");
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate("var r = /a/gy; r.lastIndex = 2; JSON.stringify(['aaa'.match(r), r.lastIndex])").AsString();
 
-        Assert.Equal("[[\"a\",\"a\",\"a\"],0]", result);
+        result.Should().Be("[[\"a\",\"a\",\"a\"],0]");
     }
 
     [Theory]
@@ -114,7 +114,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate($"JSON.stringify('a1b22c'.split(/(\\d+)/{flags}))").AsString();
 
-        Assert.Equal("[\"a\",\"1\",\"b\",\"22\",\"c\"]", result);
+        result.Should().Be("[\"a\",\"1\",\"b\",\"22\",\"c\"]");
     }
 
     [Theory]
@@ -125,7 +125,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate($"JSON.stringify(['a,b,c'.split(/,/{flags}, 2), 'a1b2c'.split(/(\\d)/{flags}, 2)])").AsString();
 
-        Assert.Equal("[[\"a\",\"b\"],[\"a\",\"1\"]]", result);
+        result.Should().Be("[[\"a\",\"b\"],[\"a\",\"1\"]]");
     }
 
     [Theory]
@@ -136,7 +136,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate($"JSON.stringify([',a,'.split(/,/{flags}), ''.split(/x/{flags}), ''.split(/(?:)/{flags})])").AsString();
 
-        Assert.Equal("[[\"\",\"a\",\"\"],[\"\"],[]]", result);
+        result.Should().Be("[[\"\",\"a\",\"\"],[\"\"],[]]");
     }
 
     private const string TestRegex = "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w\\.-]*)*\\/?$";
@@ -147,10 +147,10 @@ public class RegExpTests
     {
         var engine = new Engine(e => e.RegexTimeoutInterval(TimeSpan.FromSeconds(1)));
 
-        Assert.Throws<RegexMatchTimeoutException>(() =>
+        Invoking(() =>
         {
             engine.Execute($"'{TestedValue}'.match(/{TestRegex}/)");
-        });
+        }).Should().ThrowExactly<RegexMatchTimeoutException>();
     }
 
     [Fact]
@@ -158,10 +158,10 @@ public class RegExpTests
     {
         var engine = new Engine(e => e.RegexTimeoutInterval(TimeSpan.FromSeconds(1)));
 
-        Assert.Throws<RegexMatchTimeoutException>(() =>
+        Invoking(() =>
         {
             engine.Execute($"'{TestedValue}'.match(new RegExp(/{TestRegex}/))");
-        });
+        }).Should().ThrowExactly<RegexMatchTimeoutException>();
     }
 
     [Fact]
@@ -169,9 +169,9 @@ public class RegExpTests
     {
         var engine = new Engine();
         var result = (JsArray) engine.Evaluate("'x'.match(/|/g);");
-        Assert.Equal((uint) 2, result.Length);
-        Assert.Equal("", result[0]);
-        Assert.Equal("", result[1]);
+        result.Length.Should().Be((uint) 2);
+        result[0].Should().Be("");
+        result[1].Should().Be("");
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate("/./['toString'].call({})").AsString();
 
-        Assert.Equal("/undefined/undefined", result);
+        result.Should().Be("/undefined/undefined");
     }
 
     [Fact]
@@ -189,7 +189,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate("/./['toString'].call({ source: 'a', flags: 'b' })").AsString();
 
-        Assert.Equal("/a/b", result);
+        result.Should().Be("/a/b");
     }
 
     [Fact]
@@ -198,7 +198,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate("[...'one two three'.matchAll(/t/g)].length").AsInteger();
 
-        Assert.Equal(2, result);
+        result.Should().Be(2);
     }
 
     [Fact]
@@ -207,7 +207,7 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate("/./['toString'].call(/test/g)").AsString();
 
-        Assert.Equal("/test/g", result);
+        result.Should().Be("/test/g");
     }
 
     [Fact]
@@ -216,9 +216,9 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate("/^x\\/\\\\r\\n\\u2028\\u2029\\0\0|[x/\\\\r\\n\\u2028\\u2029\\0\0]$/");
 
-        var jsRegExp = Assert.IsType<JsRegExp>(result);
-        Assert.Equal("^x\\/\\\\r\\n\\u2028\\u2029\\0\0|[x/\\\\r\\n\\u2028\\u2029\\0\0]$", jsRegExp.Source);
-        Assert.Equal("/^x\\/\\\\r\\n\\u2028\\u2029\\0\0|[x/\\\\r\\n\\u2028\\u2029\\0\0]$/", jsRegExp.ToString());
+        var jsRegExp = result.Should().BeOfType<JsRegExp>().Which;
+        jsRegExp.Source.Should().Be("^x\\/\\\\r\\n\\u2028\\u2029\\0\0|[x/\\\\r\\n\\u2028\\u2029\\0\0]$");
+        jsRegExp.ToString().Should().Be("/^x\\/\\\\r\\n\\u2028\\u2029\\0\0|[x/\\\\r\\n\\u2028\\u2029\\0\0]$/");
     }
 
     [Fact]
@@ -227,28 +227,28 @@ public class RegExpTests
         var engine = new Engine();
         var result = engine.Evaluate(@"new RegExp('^x/\\\r\n\u2028\u2029\\0\0|[x/\\\r\n\u2028\u2029\\0\0]$')");
 
-        var jsRegExp = Assert.IsType<JsRegExp>(result);
-        Assert.Equal("^x\\/\\r\\n\\u2028\\u2029\\0\0|[x/\\r\\n\\u2028\\u2029\\0\0]$", jsRegExp.Source);
-        Assert.Equal("/^x\\/\\r\\n\\u2028\\u2029\\0\0|[x/\\r\\n\\u2028\\u2029\\0\0]$/", jsRegExp.ToString());
+        var jsRegExp = result.Should().BeOfType<JsRegExp>().Which;
+        jsRegExp.Source.Should().Be("^x\\/\\r\\n\\u2028\\u2029\\0\0|[x/\\r\\n\\u2028\\u2029\\0\0]$");
+        jsRegExp.ToString().Should().Be("/^x\\/\\r\\n\\u2028\\u2029\\0\0|[x/\\r\\n\\u2028\\u2029\\0\0]$/");
     }
 
     [Fact]
     public void ShouldNotThrowErrorOnIncompatibleRegex()
     {
         var engine = new Engine();
-        Assert.NotNull(engine.Evaluate(@"/[^]*?(:[rp][el]a[\w-]+)[^]*/"));
-        Assert.NotNull(engine.Evaluate("/[^]a/"));
-        Assert.NotNull(engine.Evaluate("new RegExp('[^]a')"));
+        engine.Evaluate(@"/[^]*?(:[rp][el]a[\w-]+)[^]*/").Should().NotBeNull();
+        engine.Evaluate("/[^]a/").Should().NotBeNull();
+        engine.Evaluate("new RegExp('[^]a')").Should().NotBeNull();
 
-        Assert.NotNull(engine.Evaluate("/[]/"));
-        Assert.NotNull(engine.Evaluate("new RegExp('[]')"));
+        engine.Evaluate("/[]/").Should().NotBeNull();
+        engine.Evaluate("new RegExp('[]')").Should().NotBeNull();
     }
 
     [Fact]
     public void ShouldNotThrowErrorOnRegExNumericNegation()
     {
         var engine = new Engine();
-        Assert.True(ReferenceEquals(JsNumber.DoubleNaN, engine.Evaluate("-/[]/")));
+        ReferenceEquals(JsNumber.DoubleNaN, engine.Evaluate("-/[]/")).Should().BeTrue();
     }
 
     [Fact]
@@ -256,7 +256,7 @@ public class RegExpTests
     {
         var engine = new Engine();
         var source = engine.Evaluate(@"/\/\//.source");
-        Assert.Equal("\\/\\/", source);
+        source.Should().Be("\\/\\/");
     }
 
     [Theory]
@@ -269,9 +269,9 @@ public class RegExpTests
     {
         var engine = new Engine();
         var matches = engine.Evaluate($"[...'{input}'.matchAll({pattern})]").AsArray();
-        Assert.Equal((ulong) expectedCaptures.Length, matches.Length);
-        Assert.Equal(expectedCaptures, matches.Select((m, i) => m.Get(0).AsString()));
-        Assert.Equal(expectedIndices, matches.Select(m => m.Get("index").AsInteger()));
+        matches.Length.Should().Be((uint) expectedCaptures.Length);
+        matches.Select((m, i) => m.Get(0).AsString()).Should().Equal(expectedCaptures);
+        matches.Select(m => m.Get("index").AsInteger()).Should().Equal(expectedIndices);
     }
 
     [Fact]
@@ -281,11 +281,11 @@ public class RegExpTests
 
         var match = engine.Evaluate("'abc'.match(/(?<$group>b)/)").AsArray();
         var groups = match.Get("groups").AsObject();
-        Assert.Equal(["$group"], groups.GetOwnPropertyKeys().Select(k => k.AsString()));
-        Assert.Equal("b", groups["$group"]);
+        groups.GetOwnPropertyKeys().Select(k => k.AsString()).Should().Equal(["$group"]);
+        groups["$group"].Should().Be("b");
 
         var result = engine.Evaluate("'abc'.replace(/(?<$group>b)/g, '-$<$group>-')").AsString();
-        Assert.Equal("a-b-c", result);
+        result.Should().Be("a-b-c");
     }
 
     [Fact]
@@ -310,7 +310,7 @@ public class RegExpTests
     {
         var engine = new Engine();
         var result = engine.Evaluate(@"new RegExp('/-', 'v').test('/-')");
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -318,7 +318,7 @@ public class RegExpTests
     {
         var engine = new Engine();
         var result = engine.Evaluate(@"new RegExp('&&!!##%%,,::;;<<==>>@@``~~', 'v').test('&&!!##%%,,::;;<<==>>@@``~~')");
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -326,7 +326,7 @@ public class RegExpTests
     {
         var engine = new Engine();
         var result = engine.Evaluate(@"new RegExp('[\\!\\#\\%\\&\\,\\-\\:\\;\\<\\=\\>\\@\\`\\~]{14}', 'v').test('!#%&,-:;<=>@`~')");
-        Assert.True(result.AsBoolean());
+        result.AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -334,7 +334,7 @@ public class RegExpTests
     {
         var engine = new Engine();
         var result = engine.Evaluate("/[^]?(:[rp][el]a[\\w-]+)[^]/.test(':reagent-')").AsBoolean();
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     // Engine routing tests for RegExpConstructor.NeedCustomEngine: .NET Regex is preferred
@@ -369,7 +369,7 @@ public class RegExpTests
         var engine = new Engine();
         var regExp = (JsRegExp) engine.Realm.Intrinsics.RegExp.Construct([pattern, flags]);
 
-        Assert.True(regExp.UsesDotNetEngine);
+        regExp.UsesDotNetEngine.Should().BeTrue();
     }
 
     [Theory]
@@ -407,7 +407,7 @@ public class RegExpTests
         var engine = new Engine();
         var regExp = (JsRegExp) engine.Realm.Intrinsics.RegExp.Construct([pattern, flags]);
 
-        Assert.False(regExp.UsesDotNetEngine);
+        regExp.UsesDotNetEngine.Should().BeFalse();
     }
 
     [Fact]
@@ -416,8 +416,8 @@ public class RegExpTests
         var engine = new Engine();
 
         // the last iteration matches 'b', so the inner capture must be undefined
-        Assert.Equal("[\"ab\",\"b\",null]", engine.Evaluate("JSON.stringify(/((a)|b)+/.exec('ab'))").AsString());
-        Assert.Equal("[\"ab\",null]", engine.Evaluate("JSON.stringify(/(?:(a)|b)+/.exec('ab'))").AsString());
+        engine.Evaluate("JSON.stringify(/((a)|b)+/.exec('ab'))").AsString().Should().Be("[\"ab\",\"b\",null]");
+        engine.Evaluate("JSON.stringify(/(?:(a)|b)+/.exec('ab'))").AsString().Should().Be("[\"ab\",null]");
     }
 
     [Fact]
@@ -427,10 +427,10 @@ public class RegExpTests
 
         // an iteration matching the empty string fails per RepeatMatcher, so the capture
         // never participates and must not report an empty string
-        Assert.Equal("[\"\",null]", engine.Evaluate("JSON.stringify(/(a*)*/.exec('b'))").AsString());
-        Assert.Equal("[\"a\",\"a\"]", engine.Evaluate("JSON.stringify(/(a*)*/.exec('ab'))").AsString());
-        Assert.Equal("[\"\",null]", engine.Evaluate("JSON.stringify(/(a|)*/.exec('b'))").AsString());
-        Assert.Equal("[\"\",null]", engine.Evaluate("JSON.stringify(/(\\b)*/.exec('a'))").AsString());
+        engine.Evaluate("JSON.stringify(/(a*)*/.exec('b'))").AsString().Should().Be("[\"\",null]");
+        engine.Evaluate("JSON.stringify(/(a*)*/.exec('ab'))").AsString().Should().Be("[\"a\",\"a\"]");
+        engine.Evaluate("JSON.stringify(/(a|)*/.exec('b'))").AsString().Should().Be("[\"\",null]");
+        engine.Evaluate("JSON.stringify(/(\\b)*/.exec('a'))").AsString().Should().Be("[\"\",null]");
     }
 
     [Fact]
@@ -442,13 +442,13 @@ public class RegExpTests
         // and backtracks into the later consuming alternative, matching fully.
         var engine = new Engine();
 
-        Assert.Equal("aaabbb", engine.Evaluate("/(?:a*|b)*/.exec('aaabbb')[0]").AsString());
-        Assert.Equal("aaa", engine.Evaluate("/(?:|a)*/.exec('aaa')[0]").AsString());
-        Assert.Equal("aabb", engine.Evaluate("/(?:a||b)*/.exec('aabb')[0]").AsString());
-        Assert.Equal("a", engine.Evaluate("/(?:^|a)+/m.exec('abc')[0]").AsString());
-        Assert.Equal("aaa", engine.Evaluate("/(?:a??)*/.exec('aaa')[0]").AsString());
-        Assert.Equal("aaa", engine.Evaluate("/(?:\\b|a)*/.exec('aaa')[0]").AsString());
-        Assert.Equal("XX", engine.Evaluate("'aaa'.replace(/(?:|a)*/g, 'X')").AsString());
+        engine.Evaluate("/(?:a*|b)*/.exec('aaabbb')[0]").AsString().Should().Be("aaabbb");
+        engine.Evaluate("/(?:|a)*/.exec('aaa')[0]").AsString().Should().Be("aaa");
+        engine.Evaluate("/(?:a||b)*/.exec('aabb')[0]").AsString().Should().Be("aabb");
+        engine.Evaluate("/(?:^|a)+/m.exec('abc')[0]").AsString().Should().Be("a");
+        engine.Evaluate("/(?:a??)*/.exec('aaa')[0]").AsString().Should().Be("aaa");
+        engine.Evaluate("/(?:\\b|a)*/.exec('aaa')[0]").AsString().Should().Be("aaa");
+        engine.Evaluate("'aaa'.replace(/(?:|a)*/g, 'X')").AsString().Should().Be("XX");
     }
 
     [Theory]
@@ -459,9 +459,9 @@ public class RegExpTests
     {
         var engine = new Engine();
 
-        Assert.Equal("[\":  [[\",\",  [\"]", engine.Evaluate($"JSON.stringify('a:  [[x,  [y'.match(/(?:^|:|,)(?:\\s*\\[)+/g{flags}))").AsString());
-        Assert.Equal("[\"12.5e3\",\"7\",\"2E-3\"]", engine.Evaluate($"JSON.stringify('12.5e3 7 2E-3'.match(/-?\\d+(?:\\.\\d*)?(:?[eE][+\\-]?\\d+)?/g{flags}))").AsString());
-        Assert.Equal("[\"aa\",\"a\"]", engine.Evaluate($"JSON.stringify('aabxa'.match(/(?:a|)+/g{flags}).filter(function (s) {{ return s !== ''; }}))").AsString());
+        engine.Evaluate($"JSON.stringify('a:  [[x,  [y'.match(/(?:^|:|,)(?:\\s*\\[)+/g{flags}))").AsString().Should().Be("[\":  [[\",\",  [\"]");
+        engine.Evaluate($"JSON.stringify('12.5e3 7 2E-3'.match(/-?\\d+(?:\\.\\d*)?(:?[eE][+\\-]?\\d+)?/g{flags}))").AsString().Should().Be("[\"12.5e3\",\"7\",\"2E-3\"]");
+        engine.Evaluate($"JSON.stringify('aabxa'.match(/(?:a|)+/g{flags}).filter(function (s) {{ return s !== ''; }}))").AsString().Should().Be("[\"aa\",\"a\"]");
     }
 
     [Fact]
@@ -477,7 +477,7 @@ public class RegExpTests
                 replace(/(?:^|:|,)(?:\s*\[)+/g, ''))
             """).AsBoolean();
 
-        Assert.True(result);
+        result.Should().BeTrue();
     }
 
     // Regression tests for https://github.com/sebastienros/jint/issues/2454
@@ -527,11 +527,10 @@ public class RegExpTests
         engine.Modules.Add("__main__", x => x.AddModule(preparedModule));
 
         var sw = Stopwatch.StartNew();
-        Assert.Throws<RegexMatchTimeoutException>(() => engine.Modules.Import("__main__"));
+        Invoking(() => engine.Modules.Import("__main__")).Should().ThrowExactly<RegexMatchTimeoutException>();
         sw.Stop();
 
-        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(MaxAcceptableTimeoutSeconds),
-            $"Expected RegexMatchTimeoutException within {MaxAcceptableTimeoutSeconds}s, took {sw.Elapsed.TotalSeconds:F1}s");
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(MaxAcceptableTimeoutSeconds), $"Expected RegexMatchTimeoutException within {MaxAcceptableTimeoutSeconds}s, took {sw.Elapsed.TotalSeconds:F1}s");
     }
 
     private const int EngineRegexTimeoutSeconds = 30;
@@ -557,10 +556,9 @@ public class RegExpTests
         var engine = new Engine(o => o.RegexTimeoutInterval(TimeSpan.FromSeconds(EngineRegexTimeoutSeconds)));
 
         var sw = Stopwatch.StartNew();
-        Assert.Throws<RegexMatchTimeoutException>(() => engine.Execute(preparedScript));
+        Invoking(() => engine.Execute(preparedScript)).Should().ThrowExactly<RegexMatchTimeoutException>();
         sw.Stop();
 
-        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(MaxAcceptableTimeoutSeconds),
-            $"Expected RegexMatchTimeoutException within {MaxAcceptableTimeoutSeconds}s, took {sw.Elapsed.TotalSeconds:F1}s");
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(MaxAcceptableTimeoutSeconds), $"Expected RegexMatchTimeoutException within {MaxAcceptableTimeoutSeconds}s, took {sw.Elapsed.TotalSeconds:F1}s");
     }
 }

--- a/Jint.Tests/Runtime/RelationalComparisonTests.cs
+++ b/Jint.Tests/Runtime/RelationalComparisonTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Relational comparisons against slot-stored numbers take an unboxed fast lane in both boolean
@@ -26,7 +26,7 @@ public class RelationalComparisonTests
             f();
             """).AsString();
 
-        Assert.Equal("|falsefalsefalsefalse", result);
+        result.Should().Be("|falsefalsefalsefalse");
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class RelationalComparisonTests
             f();
             """).AsString();
 
-        Assert.Equal("13", result);
+        result.Should().Be("13");
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class RelationalComparisonTests
             f();
             """).AsString();
 
-        Assert.Equal("false,true,true,false,false,true,true,false", result);
+        result.Should().Be("false,true,true,false,false,true,true,false");
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public class RelationalComparisonTests
             f();
             """).AsString();
 
-        Assert.Equal("abcabc", result);
+        result.Should().Be("abcabc");
     }
 
     [Fact]
@@ -111,7 +111,7 @@ public class RelationalComparisonTests
             f();
             """).AsString();
 
-        Assert.Equal("true,false,false,true,false,true,false,false,true,false,false,true", result);
+        result.Should().Be("true,false,false,true,false,true,false,false,true,false,false,true");
     }
 
     [Fact]
@@ -131,6 +131,6 @@ public class RelationalComparisonTests
             h();
             """);
 
-        Assert.Equal("outer:1,outer:1,inner:100", engine.Evaluate("log.join(',')").AsString());
+        engine.Evaluate("log.join(',')").AsString().Should().Be("outer:1,outer:1,inner:100");
     }
 }

--- a/Jint.Tests/Runtime/SamplesTests.cs
+++ b/Jint.Tests/Runtime/SamplesTests.cs
@@ -8,7 +8,7 @@ public class SamplesTests : IDisposable
     {
         _engine = new Engine()
                 .SetValue("log", new Action<object>(Console.WriteLine))
-                .SetValue("assert", new Action<bool>(Assert.True))
+                .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
             ;
     }
 
@@ -29,6 +29,6 @@ public class SamplesTests : IDisposable
             .Evaluate("x * x")
             .ToObject();
 
-        Assert.Equal(9d, square);
+        square.Should().Be(9d);
     }
 }

--- a/Jint.Tests/Runtime/ScriptModulePreparationTests.ScriptPreparation.cs
+++ b/Jint.Tests/Runtime/ScriptModulePreparationTests.ScriptPreparation.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Jint.Native;
 using Jint.Runtime.Interpreter;
 using Jint.Runtime.Interpreter.Expressions;
@@ -19,8 +19,8 @@ public class ScriptModulePreparationTests
     public void CanPreCompileRegex()
     {
         var script = Engine.PrepareScript("var x = /[cgt]/ig; var y = /[cgt]/ig; 'g'.match(x).length;");
-        var declaration = Assert.IsType<VariableDeclaration>(script.Program.Body[0]);
-        var init = Assert.IsType<RegExpLiteral>(declaration.Declarations[0].Init);
+        var declaration = script.Program.Body[0].Should().BeOfType<VariableDeclaration>().Which;
+        var init = declaration.Declarations[0].Init.Should().BeOfType<RegExpLiteral>().Which;
 
         // Regex is pre-compiled during preparation with Compiled flag
         var conversionOptions = init.ParseResult.AdditionalData as Engine.RegexConversionOptions;
@@ -35,8 +35,8 @@ public class ScriptModulePreparationTests
     public void ScriptPreparationFoldsConstants()
     {
         var preparedScript = Engine.PrepareScript("return 1 + 2;");
-        var returnStatement = Assert.IsType<ReturnStatement>(preparedScript.Program.Body[0]);
-        var constant = Assert.IsType<JintConstantExpression>(returnStatement.Argument?.UserData);
+        var returnStatement = preparedScript.Program.Body[0].Should().BeOfType<ReturnStatement>().Which;
+        var constant = (returnStatement.Argument?.UserData).Should().BeOfType<JintConstantExpression>().Which;
 
         constant.GetValue(null!).AsNumber().Should().Be(3);
         new Engine().Evaluate(preparedScript).AsNumber().Should().Be(3);
@@ -46,9 +46,9 @@ public class ScriptModulePreparationTests
     public void ScriptPreparationOptimizesNegatingUnaryExpression()
     {
         var preparedScript = Engine.PrepareScript("-1");
-        var expression = Assert.IsType<NonSpecialExpressionStatement>(preparedScript.Program.Body[0]);
-        var unaryExpression = Assert.IsType<NonUpdateUnaryExpression>(expression.Expression);
-        var constant = Assert.IsType<JintConstantExpression>(unaryExpression.UserData);
+        var expression = preparedScript.Program.Body[0].Should().BeOfType<NonSpecialExpressionStatement>().Which;
+        var unaryExpression = expression.Expression.Should().BeOfType<NonUpdateUnaryExpression>().Which;
+        var constant = unaryExpression.UserData.Should().BeOfType<JintConstantExpression>().Which;
 
         constant.GetValue(null!).AsNumber().Should().Be(-1);
         new Engine().Evaluate(preparedScript).AsNumber().Should().Be(-1);
@@ -58,8 +58,8 @@ public class ScriptModulePreparationTests
     public void ScriptPreparationOptimizesConstantReturn()
     {
         var preparedScript = Engine.PrepareScript("return false;");
-        var statement = Assert.IsType<ReturnStatement>(preparedScript.Program.Body[0]);
-        var returnStatement = Assert.IsType<ConstantStatement>(statement.UserData);
+        var statement = preparedScript.Program.Body[0].Should().BeOfType<ReturnStatement>().Which;
+        var returnStatement = statement.UserData.Should().BeOfType<ConstantStatement>().Which;
 
         var builtStatement = JintStatement.Build(statement);
         returnStatement.Should().BeSameAs(builtStatement);
@@ -83,7 +83,7 @@ public class ScriptModulePreparationTests
     [Fact]
     public void PrepareScriptShouldNotLeakAcornimaException()
     {
-        var ex = Assert.Throws<ScriptPreparationException>(() => Engine.PrepareScript("class A { } A().#nonexistent = 1;"));
+        var ex = Invoking(() => Engine.PrepareScript("class A { } A().#nonexistent = 1;")).Should().ThrowExactly<ScriptPreparationException>().Which;
         ex.Message.Should().Be("Could not prepare script: Private field '#nonexistent' must be declared in an enclosing class (<anonymous>:1:17)");
         ex.InnerException.Should().BeOfType<SyntaxErrorException>();
     }
@@ -91,7 +91,7 @@ public class ScriptModulePreparationTests
     [Fact]
     public void PrepareModuleShouldNotLeakAcornimaException()
     {
-        var ex = Assert.Throws<ScriptPreparationException>(() => Engine.PrepareModule("class A { } A().#nonexistent = 1;"));
+        var ex = Invoking(() => Engine.PrepareModule("class A { } A().#nonexistent = 1;")).Should().ThrowExactly<ScriptPreparationException>().Which;
         ex.Message.Should().Be("Could not prepare script: Private field '#nonexistent' must be declared in an enclosing class (<anonymous>:1:17)");
         ex.InnerException.Should().BeOfType<SyntaxErrorException>();
     }

--- a/Jint.Tests/Runtime/ScriptStatementListReuseTests.cs
+++ b/Jint.Tests/Runtime/ScriptStatementListReuseTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the semantics of the per-engine top-level (Program) statement-list cache: re-evaluating the
@@ -34,13 +34,13 @@ public class ScriptStatementListReuseTests
         var prepared = Engine.PrepareScript(source);
 
         // Baseline: a first evaluation on a fresh engine (the uncached path).
-        Assert.Equal(expected, new Engine().Evaluate(prepared).ToString());
+        new Engine().Evaluate(prepared).ToString().Should().Be(expected);
 
         // Re-evaluations on a single engine must produce the identical value every time.
         var engine = new Engine();
         for (var i = 0; i < 5; i++)
         {
-            Assert.Equal(expected, engine.Evaluate(prepared).ToString());
+            engine.Evaluate(prepared).ToString().Should().Be(expected);
         }
     }
 
@@ -58,13 +58,13 @@ public class ScriptStatementListReuseTests
             """);
 
         engine.SetValue("seed", 1);
-        Assert.Equal(11, engine.Evaluate(prepared).AsNumber()); // base=10, add(1)=11
+        engine.Evaluate(prepared).AsNumber().Should().Be(11); // base=10, add(1)=11
 
         engine.SetValue("seed", 5);
-        Assert.Equal(55, engine.Evaluate(prepared).AsNumber()); // base=50, add(5)=55
+        engine.Evaluate(prepared).AsNumber().Should().Be(55); // base=50, add(5)=55
 
         engine.SetValue("seed", 9);
-        Assert.Equal(99, engine.Evaluate(prepared).AsNumber()); // base=90, add(9)=99
+        engine.Evaluate(prepared).AsNumber().Should().Be(99); // base=90, add(9)=99
     }
 
     [Fact]
@@ -85,7 +85,7 @@ public class ScriptStatementListReuseTests
 
         for (var i = 0; i < 4; i++)
         {
-            Assert.Equal(3, engine.Evaluate(prepared).AsNumber());
+            engine.Evaluate(prepared).AsNumber().Should().Be(3);
         }
     }
 }

--- a/Jint.Tests/Runtime/SetTests.cs
+++ b/Jint.Tests/Runtime/SetTests.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime;
+﻿using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -7,8 +7,8 @@ public class SetTests
     [Fact]
     public void ShouldThrowWhenCalledWithoutNew()
     {
-        var e = Assert.Throws<JavaScriptException>(() => new Engine().Execute("const m = new Set(); Set.call(m,[]);"));
-        Assert.Equal("Constructor Set requires 'new'", e.Message);
+        var e = Invoking(() => new Engine().Execute("const m = new Set(); Set.call(m,[]);")).Should().ThrowExactly<JavaScriptException>().Which;
+        e.Message.Should().Be("Constructor Set requires 'new'");
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public class SetTests
             });
             return k === Infinity && set.has(+0);";
 
-        Assert.True(new Engine().Evaluate(Script).AsBoolean());
+        new Engine().Evaluate(Script).AsBoolean().Should().BeTrue();
     }
 
     [Fact]
@@ -39,9 +39,9 @@ public class SetTests
 
         var engine = new Engine();
         engine.Execute(Script);
-        Assert.True(engine.Evaluate("proto2.hasOwnProperty(Symbol.iterator)").AsBoolean());
-        Assert.True(engine.Evaluate("!proto1.hasOwnProperty(Symbol.iterator)").AsBoolean());
-        Assert.True(engine.Evaluate("!iterator.hasOwnProperty(Symbol.iterator)").AsBoolean());
-        Assert.True(engine.Evaluate("iterator[Symbol.iterator]() === iterator").AsBoolean());
+        engine.Evaluate("proto2.hasOwnProperty(Symbol.iterator)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("!proto1.hasOwnProperty(Symbol.iterator)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("!iterator.hasOwnProperty(Symbol.iterator)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("iterator[Symbol.iterator]() === iterator").AsBoolean().Should().BeTrue();
     }
 }

--- a/Jint.Tests/Runtime/SlotLocationCacheTests.cs
+++ b/Jint.Tests/Runtime/SlotLocationCacheTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins SlotLocationCache behavior for handler trees shared across function instances
@@ -25,7 +25,7 @@ public class SlotLocationCacheTests
         // evaluation; each must resolve slots against its own chain
         for (var e = 0; e < 5; e++)
         {
-            Assert.Equal(499500, engine.Evaluate(prepared).AsNumber());
+            engine.Evaluate(prepared).AsNumber().Should().Be(499500);
         }
     }
 
@@ -52,7 +52,7 @@ public class SlotLocationCacheTests
             })()
             """).AsNumber();
 
-        Assert.Equal(4 * (100 + 100_000), result);
+        result.Should().Be(4 * (100 + 100_000));
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class SlotLocationCacheTests
             })()
             """).AsString();
 
-        Assert.Equal("AAAAAAAA|BBBBBBBB;AAAAAAAA|BBBBBBBB;AAAAAAAA|BBBBBBBB;", result);
+        result.Should().Be("AAAAAAAA|BBBBBBBB;AAAAAAAA|BBBBBBBB;AAAAAAAA|BBBBBBBB;");
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class SlotLocationCacheTests
         // i=0..2 read the outer binding (the eval at i===2 runs AFTER the read); the
         // injected var initializes to 'inner' and shadows from the i=3 read onward, and
         // the outer binding must remain untouched
-        Assert.Equal("outer,outer,outer,inner,inner,inner,|outer", result);
+        result.Should().Be("outer,outer,outer,inner,inner,inner,|outer");
     }
 
     [Fact]
@@ -133,7 +133,7 @@ public class SlotLocationCacheTests
             })()
             """).AsString();
 
-        Assert.Equal("outer,outer,undefined,undefined,", result);
+        result.Should().Be("outer,outer,undefined,undefined,");
     }
 
     [Fact]
@@ -166,7 +166,7 @@ public class SlotLocationCacheTests
             })()
             """).AsString();
 
-        Assert.Equal("free,free,|free,free,shadowed,shadowed,|free,free,", result);
+        result.Should().Be("free,free,|free,free,shadowed,shadowed,|free,free,");
     }
 
     [Fact]
@@ -205,7 +205,7 @@ public class SlotLocationCacheTests
             })()
             """).AsString();
 
-        Assert.Equal("root10root10root10|root10root10root10", result);
+        result.Should().Be("root10root10root10|root10root10root10");
     }
 
     [Fact]
@@ -233,7 +233,7 @@ public class SlotLocationCacheTests
             })()
             """).AsNumber();
 
-        Assert.Equal(50 * 11 + 50 * 1001 + 50 * 11, result);
+        result.Should().Be(50 * 11 + 50 * 1001 + 50 * 11);
     }
 
 #if NET
@@ -263,9 +263,7 @@ public class SlotLocationCacheTests
         engine.Evaluate(prepared);
         var perEvaluation = GC.GetAllocatedBytesForCurrentThread() - before;
 
-        Assert.True(
-            perEvaluation < 150_000,
-            $"expected slot lanes to stay live across re-evaluations; allocated {perEvaluation} bytes in one evaluation");
+        perEvaluation.Should().BeLessThan(150_000, $"expected slot lanes to stay live across re-evaluations; allocated {perEvaluation} bytes in one evaluation");
     }
 #endif
 }

--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -1,4 +1,4 @@
-using Jint.Runtime;
+﻿using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -8,8 +8,9 @@ public class StringTests
     {
         _engine = new Engine()
             .SetValue("log", new Action<object>(Console.WriteLine))
-            .SetValue("assert", new Action<bool>(Assert.True))
-            .SetValue("equal", new Action<object, object>(Assert.Equal));
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
     }
 
     private readonly Engine _engine;
@@ -19,15 +20,15 @@ public class StringTests
     {
         var engine = new Engine();
         // Numbers before a string literal must be added numerically first
-        Assert.Equal("5m", engine.Evaluate("2.0 + 3.0 + 'm'").AsString());
-        Assert.Equal("5m", engine.Evaluate("2 + 3 + 'm'").AsString());
-        Assert.Equal("5mx", engine.Evaluate("2.0 + 3.0 + 'm' + 'x'").AsString());
-        Assert.Equal("64", engine.Evaluate("1 + 2 + 3 + '4'").AsString());
+        engine.Evaluate("2.0 + 3.0 + 'm'").AsString().Should().Be("5m");
+        engine.Evaluate("2 + 3 + 'm'").AsString().Should().Be("5m");
+        engine.Evaluate("2.0 + 3.0 + 'm' + 'x'").AsString().Should().Be("5mx");
+        engine.Evaluate("1 + 2 + 3 + '4'").AsString().Should().Be("64");
 
         // String literal first: all ops are string concatenation
-        Assert.Equal("m23", engine.Evaluate("'m' + 2 + 3").AsString());
+        engine.Evaluate("'m' + 2 + 3").AsString().Should().Be("m23");
         // String literal at index 1: correct too
-        Assert.Equal("2m3", engine.Evaluate("2 + 'm' + 3").AsString());
+        engine.Evaluate("2 + 'm' + 3").AsString().Should().Be("2m3");
     }
 
     [Fact]
@@ -42,8 +43,8 @@ bar += 'bar';
         var value = _engine.Execute(script);
         var foo = _engine.Evaluate("foo").AsString();
         var bar = _engine.Evaluate("bar").AsString();
-        Assert.Equal("foofoo", foo);
-        Assert.Equal("foofoobar", bar);
+        foo.Should().Be("foofoo");
+        bar.Should().Be("foofoobar");
     }
 
     [Fact]
@@ -68,18 +69,18 @@ bar += 'bar';
 
         var engine = new Engine();
         engine.Execute(Script);
-        Assert.True(engine.Evaluate("proto2.hasOwnProperty(Symbol.iterator)").AsBoolean());
-        Assert.True(engine.Evaluate("!proto1.hasOwnProperty(Symbol.iterator)").AsBoolean());
-        Assert.True(engine.Evaluate("!iterator.hasOwnProperty(Symbol.iterator)").AsBoolean());
-        Assert.True(engine.Evaluate("iterator[Symbol.iterator]() === iterator").AsBoolean());
+        engine.Evaluate("proto2.hasOwnProperty(Symbol.iterator)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("!proto1.hasOwnProperty(Symbol.iterator)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("!iterator.hasOwnProperty(Symbol.iterator)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("iterator[Symbol.iterator]() === iterator").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void IndexOf()
     {
         var engine = new Engine();
-        Assert.Equal(0, engine.Evaluate("''.indexOf('', 0)"));
-        Assert.Equal(0, engine.Evaluate("''.indexOf('', 1)"));
+        engine.Evaluate("''.indexOf('', 0)").Should().Be(0);
+        engine.Evaluate("''.indexOf('', 1)").Should().Be(0);
     }
 
     [Fact]
@@ -88,10 +89,9 @@ bar += 'bar';
         var engine = new Engine();
         var repeatCount = ClrLimits.MaxArrayLength / 2 + 1UL;
 
-        var exception = Assert.Throws<JavaScriptException>(
-            () => engine.Evaluate($"'xx'.repeat({repeatCount});"));
+        var exception = Invoking(() => engine.Evaluate($"'xx'.repeat({repeatCount});")).Should().ThrowExactly<JavaScriptException>().Which;
 
-        Assert.True(exception.Error.InstanceofOperator(engine.Intrinsics.RangeError));
+        exception.Error.InstanceofOperator(engine.Intrinsics.RangeError).Should().BeTrue();
     }
 
     [Fact]
@@ -99,8 +99,8 @@ bar += 'bar';
     {
         var engine = new Engine();
         engine.Execute("var a = [1,2,'three',true];");
-        Assert.Equal("test 1,2,three,true", engine.Evaluate("'test ' + a"));
-        Assert.Equal("test 1,2,three,true", engine.Evaluate("`test ${a}`"));
+        engine.Evaluate("'test ' + a").Should().Be("test 1,2,three,true");
+        engine.Evaluate("`test ${a}`").Should().Be("test 1,2,three,true");
     }
 
     [Fact]
@@ -108,8 +108,8 @@ bar += 'bar';
     {
         var engine=new Engine();
         var result = engine.Evaluate("({ [`key`]: 'value' })").AsObject();
-        Assert.True(result.HasOwnProperty("key"));
-        Assert.Equal("value", result["key"]);
+        result.HasOwnProperty("key").Should().BeTrue();
+        result["key"].Should().Be("value");
     }
 
     [Fact]
@@ -136,9 +136,7 @@ bar += 'bar';
             });
             """).AsString();
 
-        Assert.Equal(
-            """{"r1":"a 1\n","r2":"a 2\n","sameIdentity":true,"frozen":true,"cooked":true,"raw":true,"distinctSites":true}""",
-            result);
+        result.Should().Be("""{"r1":"a 1\n","r2":"a 2\n","sameIdentity":true,"frozen":true,"cooked":true,"raw":true,"distinctSites":true}""");
     }
 
     [Fact]
@@ -147,41 +145,41 @@ bar += 'bar';
         var engine = new Engine();
 
         // https://tc39.es/ecma262/#sec-evaluatecall : a member-expression tag is called with its receiver as `this`
-        Assert.Equal("x 6 y", engine.Evaluate("""
+        engine.Evaluate("""
             var obj = { mul: 3, tag: function (strings, v) { return strings[0] + (v * this.mul) + strings[1]; } };
             obj.tag`x ${2} y`;
-            """).AsString());
+            """).AsString().Should().Be("x 6 y");
 
         // computed member tag
-        Assert.Equal("x 12 y", engine.Evaluate("obj['tag']`x ${4} y`;").AsString());
+        engine.Evaluate("obj['tag']`x ${4} y`;").AsString().Should().Be("x 12 y");
 
         // super property tag: GetThisValue returns the reference's [[ThisValue]] (the instance), not the home object
-        Assert.Equal("b:q1", engine.Evaluate("""
+        engine.Evaluate("""
             class A { tag(strings, v) { return this.name + ':' + strings[0] + v; } }
             class B extends A { constructor() { super(); this.name = 'b'; } m() { return super.tag`q${1}`; } }
             new B().m();
-            """).AsString());
+            """).AsString().Should().Be("b:q1");
 
         // `with`-scoped tag: this is the with-statement binding object (WithBaseObject)
-        Assert.True(engine.Evaluate("""
+        engine.Evaluate("""
             var box = { tag: function (strings) { return this === box; } };
             var wr; with (box) { wr = tag`x`; }
             wr;
-            """).AsBoolean());
+            """).AsBoolean().Should().BeTrue();
 
         // plain identifier tag in sloppy mode: this is undefined, coerced to globalThis by the call
-        Assert.True(engine.Evaluate("""
+        engine.Evaluate("""
             function gt() { return this === globalThis; }
             gt`x`;
-            """).AsBoolean());
+            """).AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void ShouldCompareWithLocale()
     {
         var engine = new Engine();
-        Assert.Equal(1, engine.Evaluate("'王五'.localeCompare('张三')").AsInteger());
-        Assert.Equal(-1, engine.Evaluate("'王五'.localeCompare('张三', 'zh-CN')").AsInteger());
+        engine.Evaluate("'王五'.localeCompare('张三')").AsInteger().Should().Be(1);
+        engine.Evaluate("'王五'.localeCompare('张三', 'zh-CN')").AsInteger().Should().Be(-1);
     }
 
     [Fact]
@@ -238,7 +236,7 @@ var abs = sub.charAt(0) === 'x'
 
 first + '|' + second + '|' + (abs ? 'ok' : 'absfail');
 ";
-        Assert.Equal("ok|ok|ok", _engine.Evaluate(script).AsString());
+        _engine.Evaluate(script).AsString().Should().Be("ok|ok|ok");
     }
 
     [Fact]
@@ -261,7 +259,7 @@ last + '|' + sum + '|' + upper + '|' + deep;
 ";
         // 10000 = 1666 full cycles of 6 (sum 597 each) + 4 leftovers (97+98+99+100)
         var engine = new Engine();
-        Assert.Equal("bcdef|" + (1666 * 597 + 394) + "|ABCDEF|true", engine.Evaluate(script).AsString());
+        engine.Evaluate(script).AsString().Should().Be("bcdef|" + (1666 * 597 + 394) + "|ABCDEF|true");
     }
 
     [Fact]
@@ -309,7 +307,7 @@ delete String.prototype.accfn;
 assignPhase + '|' + definePhase + '|' + deletePhase + '|' + accResult + '|' + getterCalls;
 ";
         var engine = new Engine();
-        Assert.Equal("bbbbbXXXXX|cccccYYYYY|TypeError|g:abcdef|5", engine.Evaluate(script).AsString());
+        engine.Evaluate(script).AsString().Should().Be("bbbbbXXXXX|cccccYYYYY|TypeError|g:abcdef|5");
     }
 
     [Fact]
@@ -326,7 +324,7 @@ try { s.length(); } catch (e) { error = (e instanceof TypeError) ? 'TypeError' :
 len + '|' + error;
 ";
         var engine = new Engine();
-        Assert.Equal("3|TypeError", engine.Evaluate(script).AsString());
+        engine.Evaluate(script).AsString().Should().Be("3|TypeError");
     }
 
     [Fact]
@@ -345,7 +343,7 @@ delete String.prototype['0'];
 ownChar + '|' + error;
 ";
         var engine = new Engine();
-        Assert.Equal("a|TypeError", engine.Evaluate(script).AsString());
+        engine.Evaluate(script).AsString().Should().Be("a|TypeError");
     }
 
     [Fact]
@@ -388,7 +386,7 @@ var ed = JSON.parse(JSON.stringify(s.slice(500, 70000)));
 
 ok && d.length === ed.length && d === ed ? 'ok' : 'fail';
 ";
-        Assert.Equal("ok", _engine.Evaluate(script).AsString());
+        _engine.Evaluate(script).AsString().Should().Be("ok");
     }
 
     [Fact]
@@ -402,8 +400,8 @@ var s = seed;
 while (s.length < 131072) s += s;
 var v1 = s.slice(0, 100000);");
 
-        Assert.Contains("Sliced", _engine.Evaluate("v1").GetType().Name);
-        Assert.Contains("Sliced", _engine.Evaluate("v1.slice(1000, 60000)").GetType().Name);
+        _engine.Evaluate("v1").GetType().Name.Should().Contain("Sliced");
+        _engine.Evaluate("v1.slice(1000, 60000)").GetType().Name.Should().Contain("Sliced");
     }
 
     [Fact]
@@ -421,52 +419,52 @@ var v1 = s.slice(0, 262144);              // half -> view
 var small = v1.slice(0, 200000);          // rebased; copies against the 512K source");
 
         // v1 is a view, but the chained slice is copied (flat JsString), not a compounded view.
-        Assert.Contains("Sliced", _engine.Evaluate("v1").GetType().Name);
-        Assert.DoesNotContain("Sliced", _engine.Evaluate("small").GetType().Name);
+        _engine.Evaluate("v1").GetType().Name.Should().Contain("Sliced");
+        _engine.Evaluate("small").GetType().Name.Should().NotContain("Sliced");
 
         // and the value is still exactly s[0..200000]
-        Assert.Equal("ok", _engine.Evaluate(
-            "small.length === 200000 && small === JSON.parse(JSON.stringify(s.slice(0, 200000))) ? 'ok' : 'fail'").AsString());
+        _engine.Evaluate(
+            "small.length === 200000 && small === JSON.parse(JSON.stringify(s.slice(0, 200000))) ? 'ok' : 'fail'").AsString().Should().Be("ok");
     }
 
     [Fact]
     public void SplitEmptySeparatorAscii()
     {
-        Assert.Equal(@"[""h"",""e"",""l"",""l"",""o""]", _engine.Evaluate(@"JSON.stringify('hello'.split(''))").AsString());
-        Assert.Equal(5, _engine.Evaluate("'hello'.split('').length").AsNumber());
+        _engine.Evaluate(@"JSON.stringify('hello'.split(''))").AsString().Should().Be(@"[""h"",""e"",""l"",""l"",""o""]");
+        _engine.Evaluate("'hello'.split('').length").AsNumber().Should().Be(5);
         // limit truncates
-        Assert.Equal(@"[""h"",""e"",""l""]", _engine.Evaluate(@"JSON.stringify('hello'.split('', 3))").AsString());
+        _engine.Evaluate(@"JSON.stringify('hello'.split('', 3))").AsString().Should().Be(@"[""h"",""e"",""l""]");
         // empty string splits to an empty array
-        Assert.Equal(0, _engine.Evaluate("''.split('').length").AsNumber());
+        _engine.Evaluate("''.split('').length").AsNumber().Should().Be(0);
         // cached single-char instances still compare equal by value
-        Assert.True(_engine.Evaluate("'aba'.split('')[0] === 'a' && 'aba'.split('')[2] === 'a'").AsBoolean());
+        _engine.Evaluate("'aba'.split('')[0] === 'a' && 'aba'.split('')[2] === 'a'").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void SplitEmptySeparatorNonAscii()
     {
         // BMP chars above the ASCII cache (é = U+00E9, Greek U+03B1..) must round-trip correctly.
-        Assert.Equal(@"[""c"",""a"",""f"",""é""]", _engine.Evaluate(@"JSON.stringify('café'.split(''))").AsString());
-        Assert.Equal(@"[""α"",""β"",""γ""]", _engine.Evaluate(@"JSON.stringify('αβγ'.split(''))").AsString());
-        Assert.Equal(3, _engine.Evaluate("'αβγ'.split('').length").AsNumber());
+        _engine.Evaluate(@"JSON.stringify('café'.split(''))").AsString().Should().Be(@"[""c"",""a"",""f"",""é""]");
+        _engine.Evaluate(@"JSON.stringify('αβγ'.split(''))").AsString().Should().Be(@"[""α"",""β"",""γ""]");
+        _engine.Evaluate("'αβγ'.split('').length").AsNumber().Should().Be(3);
 
         // split('') splits by UTF-16 code unit: an astral char (surrogate pair) becomes two elements.
-        Assert.Equal(2, _engine.Evaluate("'😀'.split('').length").AsNumber());
-        Assert.True(_engine.Evaluate(
-            "var p = '😀'.split(''); p[0] === '\uD83D' && p[1] === '\uDE00'").AsBoolean());
+        _engine.Evaluate("'😀'.split('').length").AsNumber().Should().Be(2);
+        _engine.Evaluate(
+            "var p = '😀'.split(''); p[0] === '\uD83D' && p[1] === '\uDE00'").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void SplitTailAndSegmentsAreCorrect()
     {
         // Small segments and tail
-        Assert.Equal(@"[""a"",""b"",""cdefghij""]", _engine.Evaluate(@"JSON.stringify('a,b,cdefghij'.split(','))").AsString());
+        _engine.Evaluate(@"JSON.stringify('a,b,cdefghij'.split(','))").AsString().Should().Be(@"[""a"",""b"",""cdefghij""]");
         // consecutive separators produce empty segments
-        Assert.Equal(@"[""a"","""",""b""]", _engine.Evaluate(@"JSON.stringify('a,,b'.split(','))").AsString());
+        _engine.Evaluate(@"JSON.stringify('a,,b'.split(','))").AsString().Should().Be(@"[""a"","""",""b""]");
         // multi-char separator
-        Assert.Equal(@"[""a"",""b"",""c""]", _engine.Evaluate(@"JSON.stringify('a<>b<>c'.split('<>'))").AsString());
+        _engine.Evaluate(@"JSON.stringify('a<>b<>c'.split('<>'))").AsString().Should().Be(@"[""a"",""b"",""c""]");
         // trailing separator yields a trailing empty segment
-        Assert.Equal(@"[""a"",""b"",""""]", _engine.Evaluate(@"JSON.stringify('a,b,'.split(','))").AsString());
+        _engine.Evaluate(@"JSON.stringify('a,b,'.split(','))").AsString().Should().Be(@"[""a"",""b"",""""]");
 
         // Large tail segment: the final piece of a large string, routed through the retention policy,
         // must still equal the exact backing substring.
@@ -481,7 +479,7 @@ parts.length === 2 &&
     tail.length === s.length &&
     tail === JSON.parse(JSON.stringify(s)) ? 'ok' : 'fail';
 ";
-        Assert.Equal("ok", _engine.Evaluate(script).AsString());
+        _engine.Evaluate(script).AsString().Should().Be("ok");
     }
 
     [Fact]
@@ -495,10 +493,10 @@ var small = 'a,b,c'.split(',');
 var big = (s + '|tail').split('|');       // [s, 'tail']: first segment is ~the whole source -> view");
 
         // small segments are copied (not views)
-        Assert.DoesNotContain("Sliced", _engine.Evaluate("small[0]").GetType().Name);
+        _engine.Evaluate("small[0]").GetType().Name.Should().NotContain("Sliced");
         // a large-enough segment of a large string is kept as a zero-copy view
-        Assert.Contains("Sliced", _engine.Evaluate("big[0]").GetType().Name);
-        Assert.True(_engine.Evaluate("big.length === 2 && big[0] === s && big[1] === 'tail'").AsBoolean());
+        _engine.Evaluate("big[0]").GetType().Name.Should().Contain("Sliced");
+        _engine.Evaluate("big.length === 2 && big[0] === s && big[1] === 'tail'").AsBoolean().Should().BeTrue();
     }
 
     public static TheoryData<string, string> GetLithuaniaTestsData()
@@ -516,6 +514,6 @@ var big = (s + '|tail').split('|');       // [s, 'tail']: first segment is ~the 
     public void LithuanianToLocaleUpperCase(string parseStr, string result)
     {
         var value = _engine.Evaluate($"('{parseStr}').toLocaleUpperCase('lt')").AsString();
-        Assert.Equal(result, value);
+        value.Should().Be(result);
     }
 }

--- a/Jint.Tests/Runtime/SumOfProductsLaneTests.cs
+++ b/Jint.Tests/Runtime/SumOfProductsLaneTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the sum-of-products arithmetic lane (JintBinaryExpression.SumOfProductsLane): assignments
@@ -28,7 +28,7 @@ public class SumOfProductsLaneTests
 
         // row0: [1.5*0.5+2*2+3*4+4*6, 1.5*1+2*3+3*5+4*7] = [40.75, 50.5]
         // row1: [5*0.5+6*2+7*4+8*6, 5*1+6*3+7*5+8*7] = [90.5, 114]
-        Assert.Equal("40.75,50.5;90.5,114", result);
+        result.Should().Be("40.75,50.5;90.5,114");
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class SumOfProductsLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("0.5,2.75,-3", result); // 1.5-1=0.5; 0.75+2=2.75; 4-9+2=-3
+        result.Should().Be("0.5,2.75,-3"); // 1.5-1=0.5; 0.75+2=2.75; 4-9+2=-3
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class SumOfProductsLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("NaN,Infinity,NaN,0", result);
+        result.Should().Be("NaN,Infinity,NaN,0");
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class SumOfProductsLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("164,13011000:true:true", result);
+        result.Should().Be("164,13011000:true:true");
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class SumOfProductsLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("NaN,10", result);
+        result.Should().Be("NaN,10");
     }
 
     [Fact]
@@ -122,7 +122,7 @@ public class SumOfProductsLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("23:2", result);
+        result.Should().Be("23:2");
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class SumOfProductsLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("NaN,NaN", result);
+        result.Should().Be("NaN,NaN");
     }
 
     [Fact]
@@ -157,6 +157,6 @@ public class SumOfProductsLaneTests
             })()
             """).AsString();
 
-        Assert.Equal("true:true", result);
+        result.Should().Be("true:true");
     }
 }

--- a/Jint.Tests/Runtime/SwitchTests.cs
+++ b/Jint.Tests/Runtime/SwitchTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 public class JintFailureTest
 {
@@ -24,7 +24,7 @@ public class JintFailureTest
         }
         ");
 
-        Assert.Equal("coffee", engine.Evaluate("myFunc()"));
+        engine.Evaluate("myFunc()").Should().Be("coffee");
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class JintFailureTest
                 return f(1);
             })();");
 
-        Assert.Equal(8, result);
+        result.Should().Be(8);
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class JintFailureTest
                 return f(1);
             })();");
 
-        Assert.Equal(100, result);
+        result.Should().Be(100);
     }
 
     [Fact]
@@ -89,6 +89,6 @@ public class JintFailureTest
                 return f(5);
             })();");
 
-        Assert.Equal(2, result);
+        result.Should().Be(2);
     }
 }

--- a/Jint.Tests/Runtime/TdzResetSkipTests.cs
+++ b/Jint.Tests/Runtime/TdzResetSkipTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the semantics of the flattened for-loop body TDZ reset skip: when the body block's
@@ -41,7 +41,7 @@ public class TdzResetSkipTests
             })()
             """).AsString();
 
-        Assert.Equal("0,2,4|0,2,4|0,2,4", result);
+        result.Should().Be("0,2,4|0,2,4|0,2,4");
     }
 
     [Fact]
@@ -69,7 +69,7 @@ public class TdzResetSkipTests
             expected = expected + (i ^ (i * 3));
         }
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Fact]
@@ -90,7 +90,7 @@ public class TdzResetSkipTests
             })()
             """).AsNumber();
 
-        Assert.Equal(3, result);
+        result.Should().Be(3);
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public class TdzResetSkipTests
             })()
             """).AsString();
 
-        Assert.Equal("tdz-write", result);
+        result.Should().Be("tdz-write");
     }
 
     [Fact]
@@ -135,7 +135,7 @@ public class TdzResetSkipTests
             })()
             """).AsString();
 
-        Assert.Equal("2:4", result);
+        result.Should().Be("2:4");
     }
 
     [Fact]
@@ -155,7 +155,7 @@ public class TdzResetSkipTests
             })()
             """).AsString();
 
-        Assert.Equal("0,10,20", result);
+        result.Should().Be("0,10,20");
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public class TdzResetSkipTests
             })()
             """).AsNumber();
 
-        Assert.Equal(70, result);
+        result.Should().Be(70);
     }
 
     [Fact]
@@ -203,7 +203,7 @@ public class TdzResetSkipTests
                 return hits.join(',');
             })()
             """).AsString();
-        Assert.Equal("true,true", immediate);
+        immediate.Should().Be("true,true");
 
         // conditional self-reference: iteration 0 initializes z without reading it, iteration 1's
         // initializer reads z. The scan must treat the initializer as running before its own name
@@ -218,7 +218,7 @@ public class TdzResetSkipTests
                 return 'no-throw';
             })()
             """).AsString();
-        Assert.Equal("tdz", conditional);
+        conditional.Should().Be("tdz");
     }
 
     [Fact]
@@ -237,7 +237,7 @@ public class TdzResetSkipTests
                 return acc.join(',');
             })()
             """).AsString();
-        Assert.Equal("0,3", header);
+        header.Should().Be("0,3");
 
         // body slot shadowing an outer binding: body reads see the freshly initialized inner
         // binding every iteration and the outer binding stays untouched
@@ -253,7 +253,7 @@ public class TdzResetSkipTests
                 return acc.join(',');
             })()
             """).AsString();
-        Assert.Equal("inner0,inner1,outer", shadow);
+        shadow.Should().Be("inner0,inner1,outer");
 
         // shadow read before the declaration, conditionally so iteration 0 completes: the body's
         // own binding covers the whole block in TDZ, so iteration 1 must throw — never fall back
@@ -273,7 +273,7 @@ public class TdzResetSkipTests
                 return 'no-throw:' + seen;
             })()
             """).AsString();
-        Assert.Equal("true:none", beforeDeclaration);
+        beforeDeclaration.Should().Be("true:none");
     }
 
     [Fact]
@@ -291,7 +291,7 @@ public class TdzResetSkipTests
                 return acc.join('|');
             })()
             """).AsString();
-        Assert.Equal("1:10|2:20", forward);
+        forward.Should().Be("1:10|2:20");
 
         // ...but an earlier declarator referencing a later one is before-use: the scan rejects,
         // the reset stays, and iteration 1's read throws instead of seeing iteration 0's value
@@ -307,7 +307,7 @@ public class TdzResetSkipTests
                 return 'no-throw';
             })()
             """).AsString();
-        Assert.Equal("tdz", backward);
+        backward.Should().Be("tdz");
     }
 
     [Fact]
@@ -333,6 +333,6 @@ public class TdzResetSkipTests
             })()
             """).AsString();
 
-        Assert.Equal("0:1:set|1:3:undefined|2:5:undefined", result);
+        result.Should().Be("0:1:set|1:3:undefined|2:5:undefined");
     }
 }

--- a/Jint.Tests/Runtime/TextTests.cs
+++ b/Jint.Tests/Runtime/TextTests.cs
@@ -11,8 +11,9 @@ public sealed class TextTests
     {
         _engine = new Engine()
                .SetValue("log", new Action<object>(Console.WriteLine))
-               .SetValue("assert", new Action<bool>(Assert.True))
-               .SetValue("equal", new Action<object, object>(Assert.Equal));
+               .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+               .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
         _engine
                .SetValue("TextDecoder", TypeReference.CreateTypeReference<TextDecoder>(_engine))
            ;
@@ -25,9 +26,9 @@ public sealed class TextTests
     [Fact]
     public void CanDecode()
     {
-        Assert.Equal("", RunTest($"new TextDecoder().decode()"));
-        Assert.Equal("foo", RunTest($"new TextDecoder().decode(new Uint8Array([102,111,111]))"));
-        Assert.Equal("foo", RunTest($"new TextDecoder().decode(new Uint8Array([102,111,111]).buffer)"));
-        Assert.Equal("foo", RunTest($"new TextDecoder().decode(new DataView(new Uint8Array([0,102,111,111,0]).buffer,1,3))"));
+        RunTest($"new TextDecoder().decode()").Should().Be("");
+        RunTest($"new TextDecoder().decode(new Uint8Array([102,111,111]))").Should().Be("foo");
+        RunTest($"new TextDecoder().decode(new Uint8Array([102,111,111]).buffer)").Should().Be("foo");
+        RunTest($"new TextDecoder().decode(new DataView(new Uint8Array([0,102,111,111,0]).buffer,1,3))").Should().Be("foo");
     }
 }

--- a/Jint.Tests/Runtime/ThisBindingElisionTests.cs
+++ b/Jint.Tests/Runtime/ThisBindingElisionTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the semantics of State.CanSkipThisBinding: functions that provably never resolve
@@ -27,7 +27,7 @@ public class ThisBindingElisionTests
             })()
             """).AsNumber();
 
-        Assert.Equal(5, result);
+        result.Should().Be(5);
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public class ThisBindingElisionTests
             """).AsString();
 
         // sloppy: primitive receiver boxed to object; null falls back to globalThis
-        Assert.Equal("object:5:object", result);
+        result.Should().Be("object:5:object");
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class ThisBindingElisionTests
             })()
             """).AsString();
 
-        Assert.Equal("number:undefined", result);
+        result.Should().Be("number:undefined");
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class ThisBindingElisionTests
             })()
             """).AsString();
 
-        Assert.Equal("object", result);
+        result.Should().Be("object");
     }
 
     [Fact]
@@ -91,7 +91,7 @@ public class ThisBindingElisionTests
             })()
             """).AsString();
 
-        Assert.Equal("true:object", result);
+        result.Should().Be("true:object");
     }
 
     [Fact]
@@ -111,7 +111,7 @@ public class ThisBindingElisionTests
             })()
             """).AsString();
 
-        Assert.Equal("7:2", result);
+        result.Should().Be("7:2");
     }
 
     [Fact]
@@ -136,6 +136,6 @@ public class ThisBindingElisionTests
             })()
             """).AsString();
 
-        Assert.Equal("100:50", result);
+        result.Should().Be("100:50");
     }
 }

--- a/Jint.Tests/Runtime/TightLoopTests.cs
+++ b/Jint.Tests/Runtime/TightLoopTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 /// <summary>
 /// Pins the semantics of the for-statement tight loop (JintForStatement.TightForBody): it engages
@@ -23,7 +23,7 @@ public class TightLoopTests
             })()
             """).AsString();
 
-        Assert.Equal("01234:4950:3:3", result);
+        result.Should().Be("01234:4950:3:3");
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class TightLoopTests
         // last body statement's value, so the tight loop must not engage and eat it
         var result = engine.Evaluate("var s = ''; for (var i = 0; i < 3; i++) { s += i; }").AsString();
 
-        Assert.Equal("012", result);
+        result.Should().Be("012");
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class TightLoopTests
             })()
             """).AsString();
 
-        Assert.Equal("true:0", result);
+        result.Should().Be("true:0");
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class TightLoopTests
             })()
             """).AsString();
 
-        Assert.Equal("60:012", result);
+        result.Should().Be("60:012");
     }
 
     [Fact]
@@ -82,10 +82,10 @@ public class TightLoopTests
         // the trailing expression statement makes the for's completion value dead at script top
         // level, unlocking the tight path there; the script value comes from the trailing read
         var result = engine.Evaluate("var s = ''; for (var i = 0; i < 3; i++) { s += i; } s;").AsString();
-        Assert.Equal("012", result);
+        result.Should().Be("012");
 
         var evalResult = engine.Evaluate("eval(\"var t = 0; for (var i = 0; i < 5; i++) { t += i; } t;\")").AsNumber();
-        Assert.Equal(10, evalResult);
+        evalResult.Should().Be(10);
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class TightLoopTests
         // completion) jumps over the trailing 'b', so dead-value marking must NOT apply there —
         // UpdateEmpty surfaces the loop's accumulated 'v' as the script value
         var result = engine.Evaluate("foo: { for (var i = 0; ; i++) { 'v'; break foo; } 'b'; }").AsString();
-        Assert.Equal("v", result);
+        result.Should().Be("v");
     }
 
     [Fact]
@@ -107,7 +107,7 @@ public class TightLoopTests
         // overwrites the loop's value regardless of dead-marking; pins that the conservative
         // analysis (which does not count if statements as always-valued) changes nothing here
         var result = engine.Evaluate("for (var i = 0; i < 1; i++) { 'v'; } if (false) 'b';");
-        Assert.True(result.IsUndefined());
+        result.IsUndefined().Should().BeTrue();
     }
 
     [Fact]
@@ -116,8 +116,8 @@ public class TightLoopTests
         var engine = new Engine(options => options.MaxStatements(50));
         // constraint-configured contexts must keep per-statement accounting (tight loop is
         // gated off), so a runaway loop still trips MaxStatements
-        Assert.Throws<Jint.Runtime.StatementsCountOverflowException>(() =>
-            engine.Evaluate("(function () { var x = 0; for (var i = 0; i < 100000; i++) { x += 1; } })()"));
+        Invoking(() =>
+            engine.Evaluate("(function () { var x = 0; for (var i = 0; i < 100000; i++) { x += 1; } })()")).Should().ThrowExactly<Jint.Runtime.StatementsCountOverflowException>();
     }
 
     [Fact]
@@ -162,7 +162,7 @@ public class TightLoopTests
             })()
             """).AsString();
 
-        Assert.StartsWith("true:", result);
+        result.Should().StartWith("true:");
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public class TightLoopTests
             else if (z % 3 == 0) expected--;
         }
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Fact]
@@ -215,7 +215,7 @@ public class TightLoopTests
             """).AsString();
 
         // i=0 → z=1 → else branch throws before any increment
-        Assert.Equal("true:0:0", result);
+        result.Should().Be("true:0:0");
     }
 
     [Fact]
@@ -237,7 +237,7 @@ public class TightLoopTests
             })()
             """).AsString();
 
-        Assert.Equal("1:0", result);
+        result.Should().Be("1:0");
     }
 
     [Fact]
@@ -264,7 +264,7 @@ public class TightLoopTests
             })()
             """).AsString();
 
-        Assert.Equal("013:4:r3", result);
+        result.Should().Be("013:4:r3");
     }
 
     [Fact]
@@ -285,7 +285,7 @@ public class TightLoopTests
                 return total;
             })()
             """).AsNumber();
-        Assert.Equal(6, untaken);
+        untaken.Should().Be(6);
 
         var secondIteration = engine.Evaluate("""
             (function () {
@@ -300,15 +300,15 @@ public class TightLoopTests
                 return 'no-throw';
             })()
             """).AsString();
-        Assert.Equal("true:tdz", secondIteration);
+        secondIteration.Should().Be("true:tdz");
     }
 
     [Fact]
     public void ConstraintConfiguredEngineStillEnforcesInsideIfChainLoops()
     {
         var engine = new Engine(options => options.MaxStatements(50));
-        Assert.Throws<Jint.Runtime.StatementsCountOverflowException>(() =>
-            engine.Evaluate("(function () { var x = 0; for (var i = 0; i < 100000; i++) { if (i % 2 == 0) x += 1; else x -= 1; } })()"));
+        Invoking(() =>
+            engine.Evaluate("(function () { var x = 0; for (var i = 0; i < 100000; i++) { if (i % 2 == 0) x += 1; else x -= 1; } })()")).Should().ThrowExactly<Jint.Runtime.StatementsCountOverflowException>();
     }
 
     [Fact]
@@ -328,6 +328,6 @@ public class TightLoopTests
             })()
             """).AsString();
 
-        Assert.Equal("u0,d0,u1,d1", result);
+        result.Should().Be("u0,d0,u1,d1");
     }
 }

--- a/Jint.Tests/Runtime/TypeConverterTests.cs
+++ b/Jint.Tests/Runtime/TypeConverterTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
@@ -11,8 +11,9 @@ public class TypeConverterTests
     {
         _engine = new Engine()
                 .SetValue("log", new Action<object>(o => output.WriteLine(o.ToString())))
-                .SetValue("assert", new Action<bool>(Assert.True))
-                .SetValue("equal", new Action<object, object>(Assert.Equal))
+                .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+                .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())))
             ;
     }
 
@@ -74,8 +75,8 @@ public class TypeConverterTests
     public void ConvertNumberToInt32AndUint32(double value, int expectedResult)
     {
         JsValue jsval = value;
-        Assert.Equal(expectedResult, TypeConverter.ToInt32(jsval));
-        Assert.Equal((uint)expectedResult, TypeConverter.ToUint32(jsval));
+        TypeConverter.ToInt32(jsval).Should().Be(expectedResult);
+        TypeConverter.ToUint32(jsval).Should().Be((uint)expectedResult);
     }
 
     [Fact]

--- a/Jint.Tests/Runtime/TypedArrayInteropTests.cs
+++ b/Jint.Tests/Runtime/TypedArrayInteropTests.cs
@@ -1,4 +1,4 @@
-namespace Jint.Tests.Runtime;
+﻿namespace Jint.Tests.Runtime;
 
 public class TypedArrayInteropTests
 {
@@ -11,8 +11,8 @@ public class TypedArrayInteropTests
         ValidateCreatedTypeArray(engine, "Int8Array");
 
         var fromEngine = engine.GetValue("testSubject");
-        Assert.True(fromEngine.IsInt8Array());
-        Assert.Equal(source, fromEngine.AsInt8Array());
+        fromEngine.IsInt8Array().Should().BeTrue();
+        fromEngine.AsInt8Array().Should().Equal(source);
     }
 
     [Fact]
@@ -24,8 +24,8 @@ public class TypedArrayInteropTests
         ValidateCreatedTypeArray(engine, "Uint8Array");
 
         var fromEngine = engine.GetValue("testSubject");
-        Assert.True(fromEngine.IsUint8Array());
-        Assert.Equal(source, fromEngine.AsUint8Array());
+        fromEngine.IsUint8Array().Should().BeTrue();
+        fromEngine.AsUint8Array().Should().Equal(source);
     }
 
     [Fact]
@@ -37,8 +37,8 @@ public class TypedArrayInteropTests
         ValidateCreatedTypeArray(engine, "Uint8ClampedArray");
 
         var fromEngine = engine.GetValue("testSubject");
-        Assert.True(fromEngine.IsUint8ClampedArray());
-        Assert.Equal(source, fromEngine.AsUint8ClampedArray());
+        fromEngine.IsUint8ClampedArray().Should().BeTrue();
+        fromEngine.AsUint8ClampedArray().Should().Equal(source);
     }
 
     [Fact]
@@ -50,8 +50,8 @@ public class TypedArrayInteropTests
         ValidateCreatedTypeArray(engine, "Int16Array");
 
         var fromEngine = engine.GetValue("testSubject");
-        Assert.True(fromEngine.IsInt16Array());
-        Assert.Equal(source, fromEngine.AsInt16Array());
+        fromEngine.IsInt16Array().Should().BeTrue();
+        fromEngine.AsInt16Array().Should().Equal(source);
     }
 
     [Fact]
@@ -63,8 +63,8 @@ public class TypedArrayInteropTests
         ValidateCreatedTypeArray(engine, "Uint16Array");
 
         var fromEngine = engine.GetValue("testSubject");
-        Assert.True(fromEngine.IsUint16Array());
-        Assert.Equal(source, fromEngine.AsUint16Array());
+        fromEngine.IsUint16Array().Should().BeTrue();
+        fromEngine.AsUint16Array().Should().Equal(source);
     }
 
     [Fact]
@@ -76,8 +76,8 @@ public class TypedArrayInteropTests
         ValidateCreatedTypeArray(engine, "Int32Array");
 
         var fromEngine = engine.GetValue("testSubject");
-        Assert.True(fromEngine.IsInt32Array());
-        Assert.Equal(source, fromEngine.AsInt32Array());
+        fromEngine.IsInt32Array().Should().BeTrue();
+        fromEngine.AsInt32Array().Should().Equal(source);
     }
 
     [Fact]
@@ -90,8 +90,8 @@ public class TypedArrayInteropTests
         ValidateCreatedTypeArray(engine, "Uint32Array");
 
         var fromEngine = engine.GetValue("testSubject");
-        Assert.True(fromEngine.IsUint32Array());
-        Assert.Equal(source, fromEngine.AsUint32Array());
+        fromEngine.IsUint32Array().Should().BeTrue();
+        fromEngine.AsUint32Array().Should().Equal(source);
     }
 
     [Fact]
@@ -103,8 +103,8 @@ public class TypedArrayInteropTests
         ValidateCreatedBigIntegerTypeArray(engine, "BigInt64Array");
 
         var fromEngine = engine.GetValue("testSubject");
-        Assert.True(fromEngine.IsBigInt64Array());
-        Assert.Equal(source, fromEngine.AsBigInt64Array());
+        fromEngine.IsBigInt64Array().Should().BeTrue();
+        fromEngine.AsBigInt64Array().Should().Equal(source);
     }
 
     [Fact]
@@ -116,8 +116,8 @@ public class TypedArrayInteropTests
         ValidateCreatedBigIntegerTypeArray(engine, "BigUint64Array");
 
         var fromEngine = engine.GetValue("testSubject");
-        Assert.True(fromEngine.IsBigUint64Array());
-        Assert.Equal(source, fromEngine.AsBigUint64Array());
+        fromEngine.IsBigUint64Array().Should().BeTrue();
+        fromEngine.AsBigUint64Array().Should().Equal(source);
     }
 
 #if NET6_0_OR_GREATER
@@ -131,11 +131,11 @@ public class TypedArrayInteropTests
             ValidateCreatedTypeArray(engine, "Float16Array");
             
             var fromEngine = engine.GetValue("testSubject");
-            Assert.True(fromEngine.IsFloat16Array());
-            Assert.Equal(source, fromEngine.AsFloat16Array());
+            fromEngine.IsFloat16Array().Should().BeTrue();
+            fromEngine.AsFloat16Array().Should().Equal(source);
 
             engine.SetValue("testFunc", new Func<Native.JsTypedArray, Native.JsTypedArray>(v => v));
-            Assert.Equal(source, engine.Evaluate("testFunc(testSubject)").AsFloat16Array());
+            engine.Evaluate("testFunc(testSubject)").AsFloat16Array().Should().Equal(source);
         }
 #endif
 
@@ -149,8 +149,8 @@ public class TypedArrayInteropTests
         ValidateCreatedTypeArray(engine, "Float32Array");
 
         var fromEngine = engine.GetValue("testSubject");
-        Assert.True(fromEngine.IsFloat32Array());
-        Assert.Equal(source, fromEngine.AsFloat32Array());
+        fromEngine.IsFloat32Array().Should().BeTrue();
+        fromEngine.AsFloat32Array().Should().Equal(source);
     }
 
     [Fact]
@@ -163,23 +163,23 @@ public class TypedArrayInteropTests
         ValidateCreatedTypeArray(engine, "Float64Array");
             
         var fromEngine = engine.GetValue("testSubject");
-        Assert.True(fromEngine.IsFloat64Array());
-        Assert.Equal(source, fromEngine.AsFloat64Array());
+        fromEngine.IsFloat64Array().Should().BeTrue();
+        fromEngine.AsFloat64Array().Should().Equal(source);
     }
         
     private static void ValidateCreatedTypeArray(Engine engine, string arrayName)
     {
-        Assert.Equal(arrayName, engine.Evaluate("testSubject.constructor.name").AsString());
-        Assert.Equal(2, engine.Evaluate("testSubject.length").AsNumber());
-        Assert.Equal(42, engine.Evaluate("testSubject[0]").AsNumber());
-        Assert.Equal(12, engine.Evaluate("testSubject[1]").AsNumber());
+        engine.Evaluate("testSubject.constructor.name").AsString().Should().Be(arrayName);
+        engine.Evaluate("testSubject.length").AsNumber().Should().Be(2);
+        engine.Evaluate("testSubject[0]").AsNumber().Should().Be(42);
+        engine.Evaluate("testSubject[1]").AsNumber().Should().Be(12);
     }
 
     private static void ValidateCreatedBigIntegerTypeArray(Engine engine, string arrayName)
     {
-        Assert.Equal(arrayName, engine.Evaluate("testSubject.constructor.name").AsString());
-        Assert.Equal(2, engine.Evaluate("testSubject.length").AsNumber());
-        Assert.Equal(42, engine.Evaluate("testSubject[0]").AsBigInt());
-        Assert.Equal(12, engine.Evaluate("testSubject[1]").AsBigInt());
+        engine.Evaluate("testSubject.constructor.name").AsString().Should().Be(arrayName);
+        engine.Evaluate("testSubject.length").AsNumber().Should().Be(2);
+        engine.Evaluate("testSubject[0]").AsBigInt().Should().Be(42);
+        engine.Evaluate("testSubject[1]").AsBigInt().Should().Be(12);
     }
 }

--- a/Jint.Tests/Runtime/UnboxedBindingTests.cs
+++ b/Jint.Tests/Runtime/UnboxedBindingTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 
 namespace Jint.Tests.Runtime;
 
@@ -15,121 +15,121 @@ public class UnboxedBindingTests
     [Fact]
     public void DoubleAccumulatorProducesExactResult()
     {
-        Assert.Equal(1.0, _engine.Evaluate("function f() { var s = 0.5; s += 0.25; s += 0.25; return s; } f()").AsNumber());
-        Assert.Equal(2500d, _engine.Evaluate("function f() { var s = 0; for (var i = 0; i < 10000; i++) { s += 0.25; } return s; } f()").AsNumber());
+        _engine.Evaluate("function f() { var s = 0.5; s += 0.25; s += 0.25; return s; } f()").AsNumber().Should().Be(1.0);
+        _engine.Evaluate("function f() { var s = 0; for (var i = 0; i < 10000; i++) { s += 0.25; } return s; } f()").AsNumber().Should().Be(2500d);
     }
 
     [Fact]
     public void AllCompoundOperatorsWork()
     {
-        Assert.Equal(7d, _engine.Evaluate("function f() { var x = 10; x -= 3; return x; } f()").AsNumber());
-        Assert.Equal(2.5, _engine.Evaluate("function f() { var x = 5; x *= 0.5; return x; } f()").AsNumber());
-        Assert.Equal(2.5, _engine.Evaluate("function f() { var x = 5; x /= 2; return x; } f()").AsNumber());
-        Assert.Equal(1d, _engine.Evaluate("function f() { var x = 7; x %= 3; return x; } f()").AsNumber());
-        Assert.Equal(4d, _engine.Evaluate("function f() { var x = 6; x &= 12; return x; } f()").AsNumber());
-        Assert.Equal(14d, _engine.Evaluate("function f() { var x = 6; x |= 12; return x; } f()").AsNumber());
-        Assert.Equal(10d, _engine.Evaluate("function f() { var x = 6; x ^= 12; return x; } f()").AsNumber());
-        Assert.Equal(24d, _engine.Evaluate("function f() { var x = 6; x <<= 2; return x; } f()").AsNumber());
-        Assert.Equal(1d, _engine.Evaluate("function f() { var x = 6; x >>= 2; return x; } f()").AsNumber());
-        Assert.Equal(1073741822d, _engine.Evaluate("function f() { var x = -6; x >>>= 2; return x; } f()").AsNumber());
-        Assert.Equal(8d, _engine.Evaluate("function f() { var x = 2; x **= 3; return x; } f()").AsNumber());
+        _engine.Evaluate("function f() { var x = 10; x -= 3; return x; } f()").AsNumber().Should().Be(7d);
+        _engine.Evaluate("function f() { var x = 5; x *= 0.5; return x; } f()").AsNumber().Should().Be(2.5);
+        _engine.Evaluate("function f() { var x = 5; x /= 2; return x; } f()").AsNumber().Should().Be(2.5);
+        _engine.Evaluate("function f() { var x = 7; x %= 3; return x; } f()").AsNumber().Should().Be(1d);
+        _engine.Evaluate("function f() { var x = 6; x &= 12; return x; } f()").AsNumber().Should().Be(4d);
+        _engine.Evaluate("function f() { var x = 6; x |= 12; return x; } f()").AsNumber().Should().Be(14d);
+        _engine.Evaluate("function f() { var x = 6; x ^= 12; return x; } f()").AsNumber().Should().Be(10d);
+        _engine.Evaluate("function f() { var x = 6; x <<= 2; return x; } f()").AsNumber().Should().Be(24d);
+        _engine.Evaluate("function f() { var x = 6; x >>= 2; return x; } f()").AsNumber().Should().Be(1d);
+        _engine.Evaluate("function f() { var x = -6; x >>>= 2; return x; } f()").AsNumber().Should().Be(1073741822d);
+        _engine.Evaluate("function f() { var x = 2; x **= 3; return x; } f()").AsNumber().Should().Be(8d);
     }
 
     [Fact]
     public void UpdateExpressionsWork()
     {
-        Assert.Equal(3d, _engine.Evaluate("function f() { var i = 0; i++; i++; ++i; return i; } f()").AsNumber());
-        Assert.Equal(-3d, _engine.Evaluate("function f() { var i = 0; i--; i--; --i; return i; } f()").AsNumber());
-        Assert.Equal(0.5, _engine.Evaluate("function f() { var i = -0.5; i++; return i; } f()").AsNumber());
+        _engine.Evaluate("function f() { var i = 0; i++; i++; ++i; return i; } f()").AsNumber().Should().Be(3d);
+        _engine.Evaluate("function f() { var i = 0; i--; i--; --i; return i; } f()").AsNumber().Should().Be(-3d);
+        _engine.Evaluate("function f() { var i = -0.5; i++; return i; } f()").AsNumber().Should().Be(0.5);
     }
 
     [Fact]
     public void Int32BoundaryWidensCorrectly()
     {
-        Assert.Equal(2147483648d, _engine.Evaluate("function f() { var i = 2147483647; i++; return i; } f()").AsNumber());
-        Assert.Equal(-2147483649d, _engine.Evaluate("function f() { var i = (1<<31)|0; i--; return i; } f()").AsNumber());
-        Assert.Equal(2147483648d, _engine.Evaluate("function f() { var i = (1<<31)|0; i /= -1; return i; } f()").AsNumber());
+        _engine.Evaluate("function f() { var i = 2147483647; i++; return i; } f()").AsNumber().Should().Be(2147483648d);
+        _engine.Evaluate("function f() { var i = (1<<31)|0; i--; return i; } f()").AsNumber().Should().Be(-2147483649d);
+        _engine.Evaluate("function f() { var i = (1<<31)|0; i /= -1; return i; } f()").AsNumber().Should().Be(2147483648d);
     }
 
     [Fact]
     public void SpecialValuesSurviveMaterialization()
     {
-        Assert.True(_engine.Evaluate("function f() { var z = 0; z *= -1; return Object.is(z, -0); } f()").AsBoolean());
-        Assert.True(_engine.Evaluate("function f() { var n = 0; n /= 0; return Number.isNaN(n); } f()").AsBoolean());
-        Assert.Equal(double.PositiveInfinity, _engine.Evaluate("function f() { var x = 1; x /= 0; return x; } f()").AsNumber());
-        Assert.Equal(double.NegativeInfinity, _engine.Evaluate("function f() { var x = -1; x /= 0; return x; } f()").AsNumber());
-        Assert.True(_engine.Evaluate("function f() { var x = -6; x %= 3; return Object.is(x, -0); } f()").AsBoolean());
+        _engine.Evaluate("function f() { var z = 0; z *= -1; return Object.is(z, -0); } f()").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("function f() { var n = 0; n /= 0; return Number.isNaN(n); } f()").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("function f() { var x = 1; x /= 0; return x; } f()").AsNumber().Should().Be(double.PositiveInfinity);
+        _engine.Evaluate("function f() { var x = -1; x /= 0; return x; } f()").AsNumber().Should().Be(double.NegativeInfinity);
+        _engine.Evaluate("function f() { var x = -6; x %= 3; return Object.is(x, -0); } f()").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void ReadAfterUnboxedWriteReturnsCorrectValue()
     {
         // materializing consumers (call arguments, comparisons, returns) after unboxed writes
-        Assert.Equal(0.75, _engine.Evaluate("function g(v) { return v; } function f() { var s = 0.5; s += 0.25; return g(s); } f()").AsNumber());
-        Assert.True(_engine.Evaluate("function f() { var s = 0.5; s += 0.25; return s === 0.75; } f()").AsBoolean());
-        Assert.Equal("0.75", _engine.Evaluate("function f() { var s = 0.5; s += 0.25; return '' + s; } f()").AsString());
+        _engine.Evaluate("function g(v) { return v; } function f() { var s = 0.5; s += 0.25; return g(s); } f()").AsNumber().Should().Be(0.75);
+        _engine.Evaluate("function f() { var s = 0.5; s += 0.25; return s === 0.75; } f()").AsBoolean().Should().BeTrue();
+        _engine.Evaluate("function f() { var s = 0.5; s += 0.25; return '' + s; } f()").AsString().Should().Be("0.75");
     }
 
     [Fact]
     public void RepeatedReadsReturnSameInstance()
     {
         // write-back memoization: two reads of the same unboxed binding observe one value
-        Assert.True(_engine.Evaluate("function f() { var s = 0.5; s += 0.25; var a = s; var b = s; return a === b; } f()").AsBoolean());
+        _engine.Evaluate("function f() { var s = 0.5; s += 0.25; var a = s; var b = s; return a === b; } f()").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void NonNumberRightHandSideCompletesCorrectly()
     {
-        Assert.Equal("0.5x", _engine.Evaluate("function f() { var s = 0.5; s += 'x'; return s; } f()").AsString());
-        Assert.Equal(0.5, _engine.Evaluate("function f() { var s = 1; s *= { valueOf: function() { return 0.5; } }; return s; } f()").AsNumber());
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() => _engine.Evaluate("function f() { var s = 1; s += 1n; return s; } f()"));
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() => _engine.Evaluate("function f() { var s = 1; s &= 1n; return s; } f()"));
+        _engine.Evaluate("function f() { var s = 0.5; s += 'x'; return s; } f()").AsString().Should().Be("0.5x");
+        _engine.Evaluate("function f() { var s = 1; s *= { valueOf: function() { return 0.5; } }; return s; } f()").AsNumber().Should().Be(0.5);
+        Invoking(() => _engine.Evaluate("function f() { var s = 1; s += 1n; return s; } f()")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
+        Invoking(() => _engine.Evaluate("function f() { var s = 1; s &= 1n; return s; } f()")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
     }
 
     [Fact]
     public void ExponentiationKeepsSpecSemantics()
     {
-        Assert.True(_engine.Evaluate("function f() { var x = 1; x **= Infinity; return Number.isNaN(x); } f()").AsBoolean());
+        _engine.Evaluate("function f() { var x = 1; x **= Infinity; return Number.isNaN(x); } f()").AsBoolean().Should().BeTrue();
     }
 
     [Fact]
     public void RightHandSideRunsExactlyOnce()
     {
-        Assert.Equal(1d, _engine.Evaluate("function f() { var calls = 0; function g() { calls++; return 2; } var s = 1; s += g(); return calls; } f()").AsNumber());
-        Assert.Equal("1x|1", _engine.Evaluate("function f() { var calls = 0; function g() { calls++; return 'x'; } var s = 1; s += g(); return s + '|' + calls; } f()").AsString());
+        _engine.Evaluate("function f() { var calls = 0; function g() { calls++; return 2; } var s = 1; s += g(); return calls; } f()").AsNumber().Should().Be(1d);
+        _engine.Evaluate("function f() { var calls = 0; function g() { calls++; return 'x'; } var s = 1; s += g(); return s + '|' + calls; } f()").AsString().Should().Be("1x|1");
     }
 
     [Fact]
     public void ConstAndTdzKeepProperErrors()
     {
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() => _engine.Evaluate("function f() { 'use strict'; const c = 1.5; c += 1; } f()"));
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() => _engine.Evaluate("function f() { { x += 1.5; let x; } } f()"));
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() => _engine.Evaluate("function f() { { y++; let y; } } f()"));
+        Invoking(() => _engine.Evaluate("function f() { 'use strict'; const c = 1.5; c += 1; } f()")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
+        Invoking(() => _engine.Evaluate("function f() { { x += 1.5; let x; } } f()")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
+        Invoking(() => _engine.Evaluate("function f() { { y++; let y; } } f()")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
 
         // const bindings reject compound assignment in sloppy mode too (binding-level strictness)
-        Assert.Throws<Jint.Runtime.JavaScriptException>(() => _engine.Evaluate("function f() { const c = 2.5; c += 1; return c; } f()"));
+        Invoking(() => _engine.Evaluate("function f() { const c = 2.5; c += 1; return c; } f()")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>();
     }
 
     [Fact]
     public void ObservableContextsKeepMaterializedResults()
     {
         // value-producing positions never take the discard path
-        Assert.Equal(1.5, _engine.Evaluate("function f() { var s = 1; var y = (s += 0.5); return y; } f()").AsNumber());
-        Assert.Equal(2d, _engine.Evaluate("function f() { var i = 1; var y = i++; return i; } f()").AsNumber());
-        Assert.Equal(1d, _engine.Evaluate("function f() { var i = 1; var y = i++; return y; } f()").AsNumber());
+        _engine.Evaluate("function f() { var s = 1; var y = (s += 0.5); return y; } f()").AsNumber().Should().Be(1.5);
+        _engine.Evaluate("function f() { var i = 1; var y = i++; return i; } f()").AsNumber().Should().Be(2d);
+        _engine.Evaluate("function f() { var i = 1; var y = i++; return y; } f()").AsNumber().Should().Be(1d);
     }
 
     [Fact]
     public void GeneratorsAndAsyncKeepFullSemantics()
     {
-        Assert.Equal(1.5, _engine.Evaluate("function* g() { var s = 1; s += 0.5; yield s; } g().next().value").AsNumber());
-        Assert.Equal(2.5, _engine.Evaluate("async function a() { var s = 2; s += 0.5; return s; } a()").UnwrapIfPromise().AsNumber());
+        _engine.Evaluate("function* g() { var s = 1; s += 0.5; yield s; } g().next().value").AsNumber().Should().Be(1.5);
+        _engine.Evaluate("async function a() { var s = 2; s += 0.5; return s; } a()").UnwrapIfPromise().AsNumber().Should().Be(2.5);
     }
 
     [Fact]
     public void ClosureObservesUnboxedWrites()
     {
-        Assert.Equal(0.75, _engine.Evaluate("function f() { var s = 0.5; var get = function() { return s; }; s += 0.25; return get(); } f()").AsNumber());
+        _engine.Evaluate("function f() { var s = 0.5; var get = function() { return s; }; s += 0.25; return get(); } f()").AsNumber().Should().Be(0.75);
     }
 
     [Fact]
@@ -137,43 +137,43 @@ public class UnboxedBindingTests
     {
         // write paths: the slot-location cache must not skip a with-object that gains
         // the property after the cache was populated
-        Assert.Equal("2|101", _engine.Evaluate(
-            "function f() { var i = 0; var r = ''; for (var k = 0; k < 3; k++) { var obj = (k === 1) ? { i: 100 } : {}; with (obj) { i++; } if (k === 1) { r = '' + obj.i; } } return i + '|' + r; } f();").AsString());
+        _engine.Evaluate(
+            "function f() { var i = 0; var r = ''; for (var k = 0; k < 3; k++) { var obj = (k === 1) ? { i: 100 } : {}; with (obj) { i++; } if (k === 1) { r = '' + obj.i; } } return i + '|' + r; } f();").AsString().Should().Be("2|101");
 
-        Assert.Equal("2|101", _engine.Evaluate(
-            "function g() { var i = 0; var r = ''; for (var k = 0; k < 3; k++) { var obj = (k === 1) ? { i: 100 } : {}; with (obj) { i += 1; } if (k === 1) { r = '' + obj.i; } } return i + '|' + r; } g();").AsString());
+        _engine.Evaluate(
+            "function g() { var i = 0; var r = ''; for (var k = 0; k < 3; k++) { var obj = (k === 1) ? { i: 100 } : {}; with (obj) { i += 1; } if (k === 1) { r = '' + obj.i; } } return i + '|' + r; } g();").AsString().Should().Be("2|101");
 
         // read path: the identifier slot cache has the same obligation
-        Assert.Equal("42;999;", _engine.Evaluate(
-            "function h() { var i = 42; var out = ''; for (var k = 0; k < 2; k++) { var obj = (k === 1) ? { i: 999 } : {}; with (obj) { out += i + ';'; } } return out; } h();").AsString());
+        _engine.Evaluate(
+            "function h() { var i = 42; var out = ''; for (var k = 0; k < 2; k++) { var obj = (k === 1) ? { i: 999 } : {}; with (obj) { out += i + ';'; } } return out; } h();").AsString().Should().Be("42;999;");
 
         // a with-object that owns the property from the start
-        Assert.Equal("1|105", _engine.Evaluate(
-            "function w() { var s = 1; var o = { s: 100 }; with (o) { s += 5; } return s + '|' + o.s; } w();").AsString());
+        _engine.Evaluate(
+            "function w() { var s = 1; var o = { s: 100 }; with (o) { s += 5; } return s + '|' + o.s; } w();").AsString().Should().Be("1|105");
     }
 
     [Fact]
     public void SequenceExpressionUpdatesInForLoop()
     {
-        Assert.Equal("5|5", _engine.Evaluate(
-            "function f() { var i = 0, j = 10; for (; i < j; i++, j--) { } return i + '|' + j; } f();").AsString());
-        Assert.Equal(2.5, _engine.Evaluate(
-            "function f() { var a = 0, b = 0; for (var k = 0; k < 5; k++, a += 0.25, b += 0.25) { } return a + b; } f();").AsNumber());
+        _engine.Evaluate(
+            "function f() { var i = 0, j = 10; for (; i < j; i++, j--) { } return i + '|' + j; } f();").AsString().Should().Be("5|5");
+        _engine.Evaluate(
+            "function f() { var a = 0, b = 0; for (var k = 0; k < 5; k++, a += 0.25, b += 0.25) { } return a + b; } f();").AsNumber().Should().Be(2.5);
     }
 
     [Fact]
     public void SwitchBodiesInsideFunctionsStayCorrect()
     {
-        Assert.Equal(0.75, _engine.Evaluate(
-            "function f() { var s = 0; switch (1) { case 1: s += 0.5; s += 0.25; break; } return s; } f();").AsNumber());
-        Assert.Equal(50d, _engine.Evaluate(
-            "function f() { var acc = 0; for (var i = 0; i < 100; i++) { switch (i % 2) { case 0: acc += 1; break; default: acc -= 0; break; } } return acc; } f();").AsNumber());
+        _engine.Evaluate(
+            "function f() { var s = 0; switch (1) { case 1: s += 0.5; s += 0.25; break; } return s; } f();").AsNumber().Should().Be(0.75);
+        _engine.Evaluate(
+            "function f() { var acc = 0; for (var i = 0; i < 100; i++) { switch (i % 2) { case 0: acc += 1; break; default: acc -= 0; break; } } return acc; } f();").AsNumber().Should().Be(50d);
     }
 
     [Fact]
     public void ForLoopCountersStayCorrect()
     {
-        Assert.Equal(100000d, _engine.Evaluate("function f() { var i; for (i = 0; i < 100000; i++) { } return i; } f()").AsNumber());
-        Assert.Equal(12502500d, _engine.Evaluate("function f() { var s = 0; for (var i = 0; i <= 5000; i++) { s += i * 0.5; } return s * 2; } f()").AsNumber());
+        _engine.Evaluate("function f() { var i; for (i = 0; i < 100000; i++) { } return i; } f()").AsNumber().Should().Be(100000d);
+        _engine.Evaluate("function f() { var s = 0; for (var i = 0; i <= 5000; i++) { s += i * 0.5; } return s * 2; } f()").AsNumber().Should().Be(12502500d);
     }
 }

--- a/Jint.Tests/Runtime/UnicodeTests.cs
+++ b/Jint.Tests/Runtime/UnicodeTests.cs
@@ -8,8 +8,9 @@ public class UnicodeTests
     {
         _engine = new Engine()
             .SetValue("log", new Action<object>(Console.WriteLine))
-            .SetValue("assert", new Action<bool>(Assert.True))
-            .SetValue("equal", new Action<object, object>(Assert.Equal));
+            .SetValue("assert", new Action<bool>(static value => value.Should().BeTrue()))
+            .SetValue("equal", new Action<object, object>(static (expected, actual) =>
+                    actual.Should().BeEquivalentTo(expected, static options => options.WithStrictOrdering())));
     }
 
     private void RunTest(string source)
@@ -21,42 +22,42 @@ public class UnicodeTests
     public void EscapeUnicodeUnits()
     {
         var value = _engine.Evaluate(@"var a = '\uD83D\uDE80'; return a;").AsString();
-        Assert.Equal("🚀", value);
+        value.Should().Be("🚀");
     }
 
     [Fact]
     public void EscapeUnicodeEscaped()
     {
         var value = _engine.Evaluate(@"var a = '\u{1F680}'; return a;").AsString();
-        Assert.Equal("🚀", value);
+        value.Should().Be("🚀");
     }
 
     [Fact]
     public void UnicodeIdentifiers()
     {
         var value = _engine.Evaluate(@"const hello = 123; return hell\u{6F}").AsNumber();
-        Assert.Equal(123, value);
+        value.Should().Be(123);
     }
 
     [Fact]
     public void RegexDontParseUnicodeEscapesWithoutFlag()
     {
         var value = _engine.Evaluate(@"return /^\u{3}$/.test('uuu')").AsBoolean();
-        Assert.True(value);
+        value.Should().BeTrue();
     }
 
     [Fact]
     public void RegexParseUnicodeEscapesWithFlag()
     {
         var value = _engine.Evaluate(@"return /^\u{3}$/u.test('uuu')").AsBoolean();
-        Assert.False(value);
+        value.Should().BeFalse();
     }
 
     [Fact]
     public void RegexParseUnicodeDoesntChangeSource()
     {
         var value = _engine.Evaluate(@"return /a\u0041/.source").AsString();
-        Assert.Equal("a\\u0041", value);
+        value.Should().Be("a\\u0041");
     }
 
 }

--- a/Jint.Tests/Runtime/UuidTests.cs
+++ b/Jint.Tests/Runtime/UuidTests.cs
@@ -26,22 +26,22 @@ public class UuidTests : IDisposable
     [Fact]
     public void Empty()
     {
-        Assert.Equal(Guid.Empty, RunTest($"Uuid.parse('{Guid.Empty}')"));
-        Assert.Equal(Guid.Empty, RunTest($"Uuid.Empty"));
+        RunTest($"Uuid.parse('{Guid.Empty}')").Should().Be(Guid.Empty);
+        RunTest($"Uuid.Empty").Should().Be(Guid.Empty);
     }
 
     [Fact]
     public void Random()
     {
         var actual = RunTest($"new Uuid()");
-        Assert.NotEqual(Guid.Empty, actual);
-        Assert.IsType<Guid>(actual);
+        actual.Should().NotBe(Guid.Empty);
+        actual.Should().BeOfType<Guid>();
     }
 
     [Fact]
     public void Copy()
     {
         _engine.Evaluate("const g = new Uuid();");
-        Assert.Equal(_engine.Evaluate("copy(g).toString()").AsString(), _engine.Evaluate("g.toString()").AsString());
+        _engine.Evaluate("g.toString()").AsString().Should().Be(_engine.Evaluate("copy(g).toString()").AsString());
     }
 }

--- a/Jint.Tests/Runtime/WeakSetMapTests.cs
+++ b/Jint.Tests/Runtime/WeakSetMapTests.cs
@@ -1,4 +1,4 @@
-using Jint.Native;
+﻿using Jint.Native;
 using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
@@ -9,16 +9,16 @@ public class WeakSetMapTests
     public void WeakMapShouldThrowWhenCalledWithoutNew()
     {
         var engine = new Engine();
-        var e = Assert.Throws<JavaScriptException>(() => engine.Execute("{ const m = new WeakMap(); WeakMap.call(m,[]); }"));
-        Assert.Equal("Constructor WeakMap requires 'new'", e.Message);
+        var e = Invoking(() => engine.Execute("{ const m = new WeakMap(); WeakMap.call(m,[]); }")).Should().ThrowExactly<JavaScriptException>().Which;
+        e.Message.Should().Be("Constructor WeakMap requires 'new'");
     }
 
     [Fact]
     public void WeakSetShouldThrowWhenCalledWithoutNew()
     {
         var engine = new Engine();
-        var e = Assert.Throws<JavaScriptException>(() => engine.Execute("{ const s = new WeakSet(); WeakSet.call(s,[]); }"));
-        Assert.Equal("Constructor WeakSet requires 'new'", e.Message);
+        var e = Invoking(() => engine.Execute("{ const s = new WeakSet(); WeakSet.call(s,[]); }")).Should().ThrowExactly<JavaScriptException>().Which;
+        e.Message.Should().Be("Constructor WeakSet requires 'new'");
     }
 
     public static TheoryData<JsValue> PrimitiveKeys = new()
@@ -39,10 +39,10 @@ public class WeakSetMapTests
         var engine = new Engine();
         var weakSet = new JsWeakSet(engine);
 
-        var e = Assert.Throws<JavaScriptException>(() => weakSet.WeakSetAdd(key));
-        Assert.StartsWith("WeakSet value must be an object or symbol, got ", e.Message);
+        var e = Invoking(() => weakSet.WeakSetAdd(key)).Should().ThrowExactly<JavaScriptException>().Which;
+        e.Message.Should().StartWith("WeakSet value must be an object or symbol, got ");
 
-        Assert.False(weakSet.WeakSetHas(key));
+        weakSet.WeakSetHas(key).Should().BeFalse();
     }
 
     [Theory]
@@ -52,10 +52,10 @@ public class WeakSetMapTests
         var engine = new Engine();
         var weakMap = new JsWeakMap(engine);
 
-        var e = Assert.Throws<JavaScriptException>(() => weakMap.WeakMapSet(key, new JsObject(engine)));
-        Assert.StartsWith("WeakMap key must be an object, got ", e.Message);
+        var e = Invoking(() => weakMap.WeakMapSet(key, new JsObject(engine))).Should().ThrowExactly<JavaScriptException>().Which;
+        e.Message.Should().StartWith("WeakMap key must be an object, got ");
 
-        Assert.False(weakMap.WeakMapHas(key));
+        weakMap.WeakMapHas(key).Should().BeFalse();
     }
 
     [Fact]
@@ -65,18 +65,18 @@ public class WeakSetMapTests
 
         engine.SetValue("context", new { Item = new Item { Value = "Test" } });
 
-        Assert.Equal(true, engine.Evaluate(@"
+        engine.Evaluate(@"
 		    var set1 = new WeakSet();
 		    set1.add(context.Item);
 		    return set1.has(context.Item);
-	    "));
+	    ").Should().BeTrue();
 
-        Assert.Equal(true, engine.Evaluate(@"
+        engine.Evaluate(@"
 		    var item = context.Item;
 		    var set2 = new WeakSet();
 		    set2.add(item);
 		    return set2.has(item);
-    	"));
+    	").Should().BeTrue();
     }
 
     [Fact]
@@ -86,13 +86,13 @@ public class WeakSetMapTests
 
         engine.SetValue("context", new { Item = new Item { Value = "Test" } });
 
-        Assert.Equal(true, engine.Evaluate("return context.Item === context.Item;"));
+        engine.Evaluate("return context.Item === context.Item;").Should().BeTrue();
 
-        Assert.Equal(true, engine.Evaluate(@"
+        engine.Evaluate(@"
 		    var set1 = new WeakSet();
 		    set1.add(context.Item);
 		    return set1.has(context.Item);
-	    "));
+	    ").Should().BeTrue();
     }
 
     [Fact]
@@ -109,14 +109,14 @@ public class WeakSetMapTests
         engine.SetValue("items", items);
 
         // touching more distinct objects than the cache holds must stay correct (oldest evicted)
-        Assert.Equal(true, engine.Evaluate(@"
+        engine.Evaluate(@"
 		    for (var i = 0; i < 16; i++) {
 		      if (items[i].Value !== '' + i) {
 		        return false;
 		      }
 		    }
 		    return items[15] === items[15];
-	    "));
+	    ").Should().BeTrue();
     }
 
     [Fact]
@@ -151,10 +151,10 @@ public class WeakSetMapTests
 
         // If I use Set, everything works as expected
         const string Expected = "{\"Value\":\"Parent\",\"Child\":{\"Value\":\"Child\"}}";
-        Assert.Equal(Expected, engine.Evaluate("stringifyWithoutCircularReferences(context.Parent, Set)"));
+        engine.Evaluate("stringifyWithoutCircularReferences(context.Parent, Set)").Should().Be(Expected);
 
         // With WeakSet I get an error
-        Assert.Equal(Expected, engine.Evaluate("stringifyWithoutCircularReferences(context.Parent, WeakSet)"));
+        engine.Evaluate("stringifyWithoutCircularReferences(context.Parent, WeakSet)").Should().Be(Expected);
     }
 
     private class Item


### PR DESCRIPTION
The test suites used xUnit's classic `Assert.*` API, which reads inside-out and produces failure messages like `Assert.Equal() Failure: Values differ`. This converts all **4,021** call sites in `Jint.Tests` and `Jint.Tests.PublicInterface` to AwesomeAssertions, and bumps the package to **9.5.0**.

```diff
-Assert.Equal("hello world", ns.Get("exported").AsString());
-Assert.True(engine.Evaluate("a instanceof MyArr").AsBoolean());
-Assert.Throws<JavaScriptException>(() => engine.Modules.Import("main"));
-Assert.Collection(logs, s => Assert.Equal("code/execute.js", s));
+ns.Get("exported").AsString().Should().Be("hello world");
+engine.Evaluate("a instanceof MyArr").AsBoolean().Should().BeTrue();
+Invoking(() => engine.Modules.Import("main")).Should().ThrowExactly<JavaScriptException>();
+logs.Should().SatisfyRespectively(s => s.Should().Be("code/execute.js"));
```

## Mapping

Following the [migration guidance](https://awesomeassertions.org/tips/), conditions are expressed with the most specific assertion available rather than being funnelled through `BeTrue()`:

| xUnit | AwesomeAssertions |
| --- | --- |
| `Assert.Equal(e, a)` | `a.Should().Be(e)` — `.Equal(e)` for collections |
| `Assert.True(a > b)` | `a.Should().BeGreaterThan(b)` |
| `Assert.True(a == b)` | `a.Should().Be(b)` |
| `Assert.True(x is T)` | `x.Should().BeAssignableTo<T>()` |
| `Assert.IsType<T>(x)` | `x.Should().BeOfType<T>()` |
| `Assert.Throws<T>(f)` | `Invoking(f).Should().ThrowExactly<T>()` |
| `Assert.ThrowsAny<T>(f)` | `Invoking(f).Should().Throw<T>()` |
| `Assert.Collection(c, …)` | `c.Should().SatisfyRespectively(…)` |
| `Assert.Single(c)` | `c.Should().ContainSingle()` |
| `c.Count.Should().Be(n)` | `c.Should().HaveCount(n)` |

`Assert.Throws<T>` is **exact-typed** in xUnit, so it maps to `ThrowExactly` rather than `Throw`. That distinction matters here: `PromiseRejectedException` derives from `JavaScriptException`, and several tests depend on not accepting the derived type. `Assert.ThrowsAny<T>` gets the permissive `Throw<T>`.

`Invoking`/`Awaiting` come from `AwesomeAssertions.FluentActions`, imported as a global static using, which keeps each throw assertion on one line instead of needing an `Action act = …` local per call site.

## `JsValue` assertions

`Assert.Equal<T>` inferred `T` as `JsValue` and let the implicit conversions turn the expected value into a JS value, so `Assert.Equal("foo", engine.Evaluate(…))` compared two `JsString`s. `ObjectAssertions.Be` compares the *boxed CLR value* instead — `JsValue.Equals(object)` does `obj as JsValue`, so every such assertion would compile and then silently never match. That is a nasty footgun to leave behind for the next contributor.

A small shared `JsValueAssertions` (linked into both test projects) takes a `JsValue`, so the implicit conversions still apply and the call sites stay in their natural form:

```csharp
engine.Evaluate("1 + 1").Should().Be(2);
engine.Evaluate("x === y").Should().BeTrue();
engine.Evaluate("o.missing").Should().BeUndefined();
```

It derives from `ReferenceTypeAssertions`, so `BeOfType`/`BeNull`/`BeSameAs` come along for free, and it names the JavaScript type on failure — otherwise a string/number mismatch renders as `Expected 1, but found 1`. It also lets `MapTests`/`SetTests` drop the `(JsNumber)`/`JsBoolean.True` casts they previously needed.

## Rewritten by hand

* `Assert.Fail` in try/catch blocks became `Invoking(…).Should().Throw<T>()`; the one inside a `CatchClrExceptions` callback became a recorded flag, which is stricter — the previous exception could be swallowed by the surrounding JS `catch`.
* `Assert.Equal(e, a, precision: 2)` → `BeApproximately(e, 0.005)`; `Assert.Equal(e, a, StringComparer.Ordinal)` → `Be(e)`, which is already ordinal.
* The `assert`/`equal`/`throws` helpers handed to the script engine are now lambdas. `Assert.Equal<object>` compares collections element-wise, so `equal` uses `BeEquivalentTo` with strict ordering.
* Two type-reference comparisons had to keep evaluating the expected side first, since swapping subject and expectation changed which `TypeReference` instance was created first.
* `dynamic` members need a static type before an extension method can bind, so those few sites got an explicit cast.

`Jint.Tests.Test262` keeps its single NUnit `Assert.Fail` — there is no AwesomeAssertions counterpart, and it is harness code.

## Verification

| Suite | Result |
| --- | --- |
| `Jint.Tests` net10.0 | 3805 passed, 0 failed |
| `Jint.Tests` net472 | 3742 passed, 0 failed |
| `Jint.Tests.PublicInterface` net10.0 / net472 | 114 passed, 0 failed each |
| `Jint.Tests.CommonScripts` | 28 passed, 0 failed |

Builds clean on both target frameworks with warnings-as-errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
