### PR TITLE
Cache interop invokers process-wide instead of per-Engine

### DIFF
--- a/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
+++ b/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
@@ -255,4 +255,205 @@ public class InteropCompiledInvokerTests
     {
         public int Unrelated => 1;
     }
+
+    // -----------------------------------------------------------------------------------------
+    // Process-wide invoker cache.
+    //
+    // The compiled invoker and the BCL MethodInvoker/ConstructorInvoker are cached by MethodBase in
+    // static dictionaries, shared by every Engine, because MethodDescriptor instances themselves are
+    // per-Engine (Engine._reflectionAccessors). These tests prove that sharing carries no
+    // Engine-specific state - above all that one Engine's interop policy (a custom ITypeConverter or
+    // registered object converters, both of which must decline the compiled lane) never leaks into
+    // another Engine through the shared cache, in either order.
+    // -----------------------------------------------------------------------------------------
+
+    public enum Season
+    {
+        Spring = 0,
+        Summer = 1,
+    }
+
+    public sealed class Box
+    {
+        public Box(int value) => Value = value;
+
+        public int Value { get; }
+    }
+
+    public struct StructHost
+    {
+        public int Value { get; set; }
+
+        // instance method on a value-type receiver -> ineligible for the compiled lane
+        public int Doubled() => Value * 2;
+    }
+
+    public sealed class IneligibleHost
+    {
+        // generic -> ineligible for the compiled lane
+        public T Identity<T>(T value) => value;
+
+        // enum parameter -> unsupported parameter type
+        public string Name(Season season) => season.ToString();
+
+        // custom class parameter -> unsupported parameter type
+        public int Unwrap(Box box) => box.Value;
+    }
+
+    [Fact]
+    public void SharedInvokerCache_SameMethodsFromTwoIndependentEngines()
+    {
+        var first = CreateEngine();
+        var second = CreateEngine();
+
+        // interleave so each engine both populates and consumes the shared cache entries
+        first.Evaluate("host.AddInt(2, 3)").AsNumber().Should().Be(5);
+        second.Evaluate("host.AddInt(20, 30)").AsNumber().Should().Be(50);
+        second.Evaluate("host.Concat('a', 'b')").AsString().Should().Be("ab");
+        first.Evaluate("host.Concat('c', 'd')").AsString().Should().Be("cd");
+        first.Evaluate("host.AddLong(3, 4)").AsNumber().Should().Be(7);
+        second.Evaluate("host.AddDouble(1.5, 2.25)").AsNumber().Should().Be(3.75);
+        second.Evaluate("host.And(true, false)").AsBoolean().Should().BeFalse();
+        first.Evaluate("host.And(true, true)").AsBoolean().Should().BeTrue();
+        first.Evaluate("host.Echo('x')").AsString().Should().Be("x");
+        second.Evaluate("host.StaticAdd(4, 5)").AsNumber().Should().Be(9);
+    }
+
+    [Fact]
+    public void SharedInvokerCache_CustomTypeConverterEngineCreatedAfterDefaultEngine()
+    {
+        // default engine first: it populates the shared compiled-invoker entry for And
+        var plain = CreateEngine();
+        plain.Evaluate("host.And(true, true)").AsBoolean().Should().BeTrue();
+
+        var custom = new Engine(options => options.SetTypeConverter(e => new BoolVetoingTypeConverter(e)));
+        custom.SetValue("host", new Host());
+
+        // the vetoing converter must still be consulted - the cached invoker is available but the
+        // call site declines the lane for this engine
+        Invoking(() => custom.Evaluate("host.And(true, true)"))
+            .Should().ThrowExactly<Jint.Runtime.JavaScriptException>()
+            .Which.Message.Should().Contain("No public methods");
+
+        // and the default engine is unaffected by the other engine's policy
+        plain.Evaluate("host.And(true, true)").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void SharedInvokerCache_DefaultEngineCreatedAfterCustomTypeConverterEngine()
+    {
+        // reverse order: the custom-converter engine runs first and never builds a compiled invoker
+        var custom = new Engine(options => options.SetTypeConverter(e => new BoolVetoingTypeConverter(e)));
+        custom.SetValue("host", new Host());
+
+        Invoking(() => custom.Evaluate("host.And(true, true)"))
+            .Should().ThrowExactly<Jint.Runtime.JavaScriptException>()
+            .Which.Message.Should().Contain("No public methods");
+
+        // a plain engine created afterwards must still get the fast lane and the correct result
+        var plain = CreateEngine();
+        plain.Evaluate("host.And(true, true)").AsBoolean().Should().BeTrue();
+        plain.Evaluate("host.And(true, false)").AsBoolean().Should().BeFalse();
+
+        // and the custom engine keeps vetoing after the plain engine populated the shared cache
+        Invoking(() => custom.Evaluate("host.And(false, true)"))
+            .Should().ThrowExactly<Jint.Runtime.JavaScriptException>()
+            .Which.Message.Should().Contain("No public methods");
+    }
+
+    [Fact]
+    public void SharedInvokerCache_ObjectConverterPolicyDoesNotLeakBetweenEngines()
+    {
+        var converting = new Engine(options => options.Interop.ObjectConverters.Add(new PlusOneIntConverter()));
+        converting.SetValue("host", new Host());
+        converting.Evaluate("host.AddInt(2, 3)").AsNumber().Should().Be(6);
+
+        var plain = CreateEngine();
+        plain.Evaluate("host.AddInt(2, 3)").AsNumber().Should().Be(5);
+
+        // both policies survive repeated interleaving over the shared cache entry
+        converting.Evaluate("host.AddInt(2, 3)").AsNumber().Should().Be(6);
+        plain.Evaluate("host.AddInt(2, 3)").AsNumber().Should().Be(5);
+    }
+
+    [Fact]
+    public void SharedInvokerCache_ThrowingHostMethodFromTwoEngines()
+    {
+        var first = CreateEngine();
+        var second = CreateEngine();
+
+        Invoking(() => first.Evaluate("host.Throws()"))
+            .Should().ThrowExactly<InvalidOperationException>()
+            .Which.Message.Should().Be("boom from host");
+
+        Invoking(() => second.Evaluate("host.Throws()"))
+            .Should().ThrowExactly<InvalidOperationException>()
+            .Which.Message.Should().Be("boom from host");
+
+        // the first engine still surfaces the same shape after the second engine used the same entry
+        Invoking(() => first.Evaluate("host.Throws()"))
+            .Should().ThrowExactly<InvalidOperationException>()
+            .Which.Message.Should().Be("boom from host");
+    }
+
+    [Fact]
+    public void SharedInvokerCache_IneligibleMethodsFromTwoEngines()
+    {
+        // exercises the null "known ineligible" sentinel in the shared cache: params, optional
+        // arguments, generic methods, a value-type receiver, an enum parameter and a custom class
+        // parameter all decline the compiled lane and must keep working from every engine.
+        static Engine Create()
+        {
+            var engine = new Engine();
+            engine.SetValue("host", new Host());
+            engine.SetValue("ineligible", new IneligibleHost());
+            engine.SetValue("point", new StructHost { Value = 21 });
+            engine.SetValue("box", new Box(7));
+            return engine;
+        }
+
+        var first = Create();
+        var second = Create();
+
+        foreach (var engine in new[] { first, second, first, second })
+        {
+            engine.Evaluate("host.SumParams(1, 2, 3)").AsNumber().Should().Be(6);
+            engine.Evaluate("host.WithOptional(5)").AsNumber().Should().Be(15);
+            engine.Evaluate("host.WithOptional(5, 4)").AsNumber().Should().Be(9);
+            engine.Evaluate("ineligible.Identity('abc')").AsString().Should().Be("abc");
+            engine.Evaluate("ineligible.Name(1)").AsString().Should().Be("Summer");
+            engine.Evaluate("ineligible.Unwrap(box)").AsNumber().Should().Be(7);
+            engine.Evaluate("point.Doubled()").AsNumber().Should().Be(42);
+        }
+    }
+
+    [Fact]
+    public void SharedInvokerCache_OverloadResolutionFromTwoEngines()
+    {
+        var first = CreateEngine();
+        var second = CreateEngine();
+
+        first.Evaluate("host.Over(5)").AsNumber().Should().Be(6);
+        second.Evaluate("host.Over('hi')").AsString().Should().Be("hi!");
+        first.Evaluate("host.Over('hi')").AsString().Should().Be("hi!");
+        second.Evaluate("host.Over(5)").AsNumber().Should().Be(6);
+    }
+
+    [Fact]
+    public void SharedInvokerCache_ConstructorInvokerFromTwoEngines()
+    {
+        static Engine Create()
+        {
+            var engine = new Engine();
+            engine.SetValue("Box", typeof(Box));
+            return engine;
+        }
+
+        var first = Create();
+        var second = Create();
+
+        first.Evaluate("new Box(3).Value").AsNumber().Should().Be(3);
+        second.Evaluate("new Box(4).Value").AsNumber().Should().Be(4);
+        first.Evaluate("new Box(5).Value").AsNumber().Should().Be(5);
+    }
 }

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -1,4 +1,5 @@
 using Jint.Native;
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -79,13 +80,49 @@ internal sealed class MethodDescriptor
     }
 
 #if NET8_0_OR_GREATER
-    // lazily initialized fast invokers, benign race - last writer wins
+    // Process-wide L2 caches for the invoker machinery, keyed by the reflected member.
+    //
+    // MethodDescriptor instances are per-Engine: TypeResolver.GetAccessor caches the
+    // ReflectionAccessor that owns them in Engine._reflectionAccessors. With a purely per-instance
+    // cache every new Engine therefore re-emitted an invoke stub and re-compiled the whole
+    // expression tree for every host method it called, which dominates the common
+    // fresh-Engine-per-operation embedding pattern.
+    //
+    // Keying on the MethodBase is sound because every input the builders consume is derived purely
+    // from that MethodBase - CompiledMethodInvoker.TryBuild reads Method, Parameters
+    // (== method.GetParameters()), HasParams / ParameterDefaultValuesCount (parameter attributes),
+    // IsGenericMethod and IsExtensionMethod, all computed from the MethodBase in the constructor -
+    // and the delegate it produces closes over nothing Engine-specific: only the open invocation
+    // delegate created from the same MethodBase, the JsValue.Undefined / JsValue.Null process-wide
+    // singletons, the public JsValue implicit operators and JsValueExtensions accessors. The
+    // Engine-affine policy decisions (custom object converters, a custom ITypeConverter, receiver
+    // type checks) live at the call site in MethodInfoFunction.Call and gate *use* of the invoker,
+    // never its construction, so one Engine's policy can never leak into another through this cache.
+    //
+    // Trade-off: a static cache keyed by MethodBase pins that MethodBase - and therefore its
+    // declaring assembly - for the lifetime of the process. That matches the precedent already set
+    // by this codebase's other process-wide reflection caches (TypeDescriptor._cache,
+    // TypeReference._memberAccessors, JintBinaryExpression._knownOperators,
+    // DefaultTypeConverter._knownCastOperators).
+    //
+    // A concurrent duplicate build for the same key is benign (both produce equivalent invokers and
+    // one is discarded), matching the existing lazy-init contract; the dictionaries themselves are
+    // thread-safe.
+    private static readonly ConcurrentDictionary<MethodInfo, MethodInvoker> _sharedMethodInvokers = new();
+    private static readonly ConcurrentDictionary<ConstructorInfo, ConstructorInvoker> _sharedConstructorInvokers = new();
+
+    // A null value is the "known ineligible" sentinel so an ineligible method is never re-probed.
+    private static readonly ConcurrentDictionary<MethodBase, CompiledMethodInvoker.Invoker?> _sharedCompiledInvokers = new();
+
+    // Per-instance L1 caches over the shared dictionaries, so the steady-state per-call path stays a
+    // plain field read with no dictionary probe - only a descriptor's first miss consults L2.
+    // Benign race - last writer wins.
     private MethodInvoker? _methodInvoker;
     private ConstructorInvoker? _constructorInvoker;
 
-    // lazily built strongly-typed invoker for the exact-type numeric/string/bool fast lane,
-    // benign race - last writer wins. Once _compiledInvokerUnavailable is set the method is
-    // permanently ineligible (or the runtime cannot JIT the lambda) and we never retry.
+    // lazily built strongly-typed invoker for the exact-type numeric/string/bool fast lane.
+    // Once _compiledInvokerUnavailable is set the method is permanently ineligible (or the runtime
+    // cannot JIT the lambda) and we never retry.
     private CompiledMethodInvoker.Invoker? _compiledInvoker;
     private bool _compiledInvokerUnavailable;
 
@@ -107,12 +144,25 @@ internal sealed class MethodDescriptor
             return null;
         }
 
-        // Build the delegate ONLY when the runtime will JIT it to native code. Under AOT and under
-        // an interpreted-only Expression.Compile (e.g. Mono interpreter) IsDynamicCodeCompiled is
-        // false, and an interpreted lambda is slower than the cached MethodInvoker reflection path,
-        // so we decline and keep that path.
-        if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeCompiled
-            || !CompiledMethodInvoker.TryBuild(this, out var built))
+        var built = _sharedCompiledInvokers.GetOrAdd(
+            Method,
+            static (_, descriptor) =>
+            {
+                // Build the delegate ONLY when the runtime will JIT it to native code. Under AOT and
+                // under an interpreted-only Expression.Compile (e.g. Mono interpreter)
+                // IsDynamicCodeCompiled is false, and an interpreted lambda is slower than the
+                // cached MethodInvoker reflection path, so we decline and keep that path.
+                if (!RuntimeFeature.IsDynamicCodeCompiled
+                    || !CompiledMethodInvoker.TryBuild(descriptor, out var compiled))
+                {
+                    return null;
+                }
+
+                return compiled;
+            },
+            this);
+
+        if (built is null)
         {
             _compiledInvokerUnavailable = true;
             return null;
@@ -170,13 +220,16 @@ internal sealed class MethodDescriptor
         {
             if (Method is MethodInfo methodInfo)
             {
-                var invoker = _methodInvoker ??= MethodInvoker.Create(methodInfo);
+                // MethodInvoker is thread-safe and designed for reuse (the BCL itself keeps one per
+                // MethodInfo), so the emitted invoke stub is shared process-wide instead of being
+                // re-emitted for every Engine that happens to call this method.
+                var invoker = _methodInvoker ??= _sharedMethodInvokers.GetOrAdd(methodInfo, static m => MethodInvoker.Create(m));
                 return invoker.Invoke(instance, parameters);
             }
 
             if (Method is ConstructorInfo constructorInfo)
             {
-                var invoker = _constructorInvoker ??= ConstructorInvoker.Create(constructorInfo);
+                var invoker = _constructorInvoker ??= _sharedConstructorInvokers.GetOrAdd(constructorInfo, static c => ConstructorInvoker.Create(c));
                 return invoker.Invoke(parameters);
             }
         }


### PR DESCRIPTION
## Summary

Cache interop invokers process-wide by `MethodBase` so a new `Engine` does not recompile them.

## Details

The compiled interop invoker (#2733) builds a `System.Linq.Expressions` delegate that binds and invokes a CLR method without the `object?[]` parameter array, the argument boxes, the boxed return and the return-mapper lookup. It was cached in a field on `MethodDescriptor` — but `MethodDescriptor` instances are **per-`Engine`**, because `TypeResolver.GetAccessor` caches the `ReflectionAccessor` that owns them in `Engine._reflectionAccessors`.

So every new engine re-ran `Expression.Compile()` — and re-emitted a BCL invoke stub — for every host method it called. In the fresh-engine-per-operation pattern that the interop benchmarks measure, and that many embeddings use, that compilation dominated the row. An ETW profile attributed **21% of `interop-method-calls` and 35% of `interop-string-passing`** to `CompiledMethodInvoker.TryBuild` → `Expression.Compile` → `MethodDesc::DoPrestub`, with thousands of distinct `lambda_method` symbols in a 22-second capture.

The compiled invoker and the BCL `MethodInvoker`/`ConstructorInvoker` now live in static dictionaries keyed by the reflected member. The existing per-instance fields are kept as an L1 cache, so the steady-state per-call path is still a plain field read and only a descriptor's first miss consults the shared dictionary.

**Why keying on `MethodBase` is sound.** Everything `CompiledMethodInvoker.TryBuild` consumes is derived purely from the `MethodBase` (`Parameters` is `method.GetParameters()`; `HasParams` / `ParameterDefaultValuesCount` come from those parameters' attributes; `IsGenericMethod` and `IsExtensionMethod` likewise), and the delegate it produces closes over nothing engine-specific — only the open delegate created from the same `MethodBase`, the `JsValue.Undefined` / `JsValue.Null` singletons, and public `JsValue` operators. The engine-affine policy — registered object converters, a custom `ITypeConverter`, the receiver type check — is applied at the call site in `MethodInfoFunction.Call` and gates *use* of the invoker, never its construction. One engine's policy therefore cannot leak into another through the cache; the tests assert exactly that, in both creation orders.

**Trade-off.** A static cache keyed by `MethodBase` pins that member, and hence its declaring assembly, for the process lifetime. That matches the precedent already set by `TypeDescriptor._cache`, `TypeReference._memberAccessors`, `JintBinaryExpression._knownOperators` and `DefaultTypeConverter._knownCastOperators`.

## Benchmark numbers

`EngineComparisonInteropBenchmark`, `Jint` lane, default job:

| Script | Before | After | Δ | Allocated |
|---|---:|---:|---:|---|
| interop-string-passing | 907.9 µs | 578.7 µs | **−36.3%** | 317.09 → 304.91 KB |
| interop-method-calls | 2180.4 µs | 1689.5 µs | **−22.5%** | 347.24 → 329.26 KB |
| interop-property-access | 1891.8 µs | 1840.2 µs | −2.7% (noise) | unchanged |
| interop-collection-traversal | 1559.8 µs | 1605.4 µs | +2.9% (noise) | unchanged |

<details>
<summary>Measurement protocol</summary>

All arms measured in one session on one machine (AMD Ryzen 9 5950X, .NET 10.0.10, default BenchmarkDotNet job). The baseline figure is the mean of two baseline runs executed **first and last** in the sequence as a drift check; they agree within 1.2–4.9%, which is this session's noise floor — deltas smaller than that are reported as noise above.

Every arm ran against a pre-built worktree after a discarded warm-up pass. That matters: in a first pass where BenchmarkDotNet still had to build its generated projects, runs took 5–8.5 min instead of 1.6–2.6 min, baseline-vs-baseline disagreed by up to 74%, and BenchmarkDotNet flagged `MultimodalDistribution (mValue = 3.84)`. Those results were discarded.

</details>

This is one of three related interop-performance changes; combined they move `interop-string-passing` −37%, `interop-method-calls` −29%, `interop-property-access` −15% (−59% allocation) and `interop-collection-traversal` −6%. Measured with every engine in the same session, that makes Jint the fastest engine on `interop-string-passing` (544 µs vs YantraJS 643 and NiL.JS 861), and closes the gap to NiL.JS on `interop-method-calls` from 71% to 17%.

The `Jint_ParsedScript` script suite was re-measured as a regression net and is flat (aggregate ≈ +0.4% across 12 scripts, allocations byte-identical).

## Linked issue

None — found by profiling the interop benchmark suite.

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally (`Jint.Tests` 3813 passed, `Jint.Tests.PublicInterface` 114 passed)
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions — n/a, no spec behaviour touched
- [x] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [x] For perf changes: included before/after numbers from `Jint.Benchmark`

New tests cover two engines sharing the cache with differing interop policies (custom `ITypeConverter`, registered object converters) in both creation orders, throwing host methods, methods ineligible for the compiled lane (`params`, optional arguments, generic, struct receiver, enum and custom-class parameters — exercising the "known ineligible" sentinel), overload resolution and the constructor invoker.

## Breaking change?

No. No public API change; behaviour is identical, only the caching scope changes.


## Related

Part of a three-PR interop series, each independently useful and mergeable in any order:

* #2743 — cache interop invokers process-wide (drives `interop-method-calls` and `interop-string-passing`)
* #2744 — compile CLR property and field access (drives `interop-property-access` and its allocation)
* #2745 — trim per-call overhead from the method fast lane (small; see the note in that PR)

I verified all three merged together: `Jint.Tests` 3910 passed, `Jint.Tests.PublicInterface` 114, `Jint.Tests.CommonScripts` 28. One caveat if you take both #2743 and #2745: they each append tests to `Jint.Tests/Runtime/InteropCompiledInvokerTests.cs`, which conflicts textually — the resolution is simply to keep both blocks, as neither side's tests overlap. `MethodDescriptor.cs`, which both also touch, merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
