### PR TITLE
Compile CLR property and field access instead of reflecting per hit

### DIFF
--- a/Jint.Tests/Runtime/InteropCompiledMemberAccessorTests.cs
+++ b/Jint.Tests/Runtime/InteropCompiledMemberAccessorTests.cs
@@ -1,0 +1,1113 @@
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Exercises the compiled property/field accessor fast lanes (see <c>CompiledMemberAccessor</c> and
+/// <c>CompilableMemberAccessor</c>) together with the reflection fallback they decline to. Every
+/// assertion is written against the behavior that predates the fast lanes — the value of this file
+/// is entirely in catching a divergence between the two, so nothing here may be "adjusted" to what
+/// the fast lane happens to produce.
+/// </summary>
+public class InteropCompiledMemberAccessorTests
+{
+    #region hosts
+
+    public enum Level
+    {
+        Zero = 0,
+        One = 1,
+        Two = 2,
+    }
+
+    public sealed class Nested
+    {
+        public int N { get; set; }
+    }
+
+    /// <summary>Members whose types are eligible for the JsValue lane, as both properties and fields.</summary>
+    public sealed class Host
+    {
+        public int IntProp { get; set; }
+        public long LongProp { get; set; }
+        public double DoubleProp { get; set; }
+        public bool BoolProp { get; set; }
+        public string? StringProp { get; set; }
+        public JsValue? JsValueProp { get; set; }
+
+        public int IntField;
+        public long LongField;
+        public double DoubleField;
+        public bool BoolField;
+        public string? StringField;
+        public JsValue? JsValueField;
+    }
+
+    /// <summary>Members whose types are not eligible for the JsValue lane (raw lane / reflection).</summary>
+    public sealed class RawHost
+    {
+        public int[]? IntArrayProp { get; set; }
+        public Level EnumProp { get; set; }
+        public int? NullableIntProp { get; set; }
+        public Nested? NestedProp { get; set; }
+        public object? ObjectProp { get; set; }
+        public DateTime DateTimeProp { get; set; }
+        public decimal DecimalProp { get; set; }
+
+        public int[]? IntArrayField;
+        public Level EnumField;
+        public int? NullableIntField;
+        public Nested? NestedField;
+        public object? ObjectField;
+        public DateTime DateTimeField;
+        public decimal DecimalField;
+    }
+
+    public sealed class ThrowingHost
+    {
+        // JsValue lane member types
+        public int ThrowingIntGetter => throw new InvalidOperationException("int getter boom");
+
+        public int ThrowingIntSetter
+        {
+            get => 0;
+            set => throw new InvalidOperationException("int setter boom");
+        }
+
+        // raw lane member types
+        public decimal ThrowingDecimalGetter => throw new InvalidOperationException("decimal getter boom");
+
+        public decimal ThrowingDecimalSetter
+        {
+            get => 0m;
+            set => throw new InvalidOperationException("decimal setter boom");
+        }
+    }
+
+    public sealed class ReadOnlyHost
+    {
+        public int ReadOnlyIntProp { get; } = 11;
+        public readonly int ReadOnlyIntField = 22;
+        public readonly string ReadOnlyStringField = "fixed";
+    }
+
+    public sealed class NonPublicGetterHost
+    {
+        private int _value = 5;
+
+        // CanRead is true but there is no public get accessor
+        public int HalfHidden
+        {
+            private get => _value;
+            set => _value = value;
+        }
+
+        public int Observe() => _value;
+    }
+
+    public struct StructHost
+    {
+        public int IntProp { get; set; }
+        public string? StringProp { get; set; }
+        public int IntField;
+
+        public StructHost(int value)
+        {
+            IntProp = value;
+            StringProp = null;
+            IntField = value;
+        }
+    }
+
+    public sealed class IndexerHost
+    {
+        public int Value { get; set; } = 7;
+
+        public int this[string key] => 99;
+    }
+
+    public interface IValueHolder
+    {
+        int Value { get; set; }
+        string? Name { get; set; }
+    }
+
+    public sealed class ValueHolder : IValueHolder
+    {
+        public int Value { get; set; }
+        public string? Name { get; set; }
+    }
+
+    public sealed class HolderOwner
+    {
+        public IValueHolder Holder { get; } = new ValueHolder();
+    }
+
+    public sealed class StaticHost
+    {
+        public static int StaticIntProp { get; set; }
+        public static string? StaticStringField;
+    }
+
+    public sealed class JsSubtypeHost
+    {
+        public JsString? JsStringProp { get; set; }
+        public JsNumber? JsNumberField;
+    }
+
+    public sealed class IsolationHost
+    {
+        public int IntProp { get; set; }
+        public long LongProp { get; set; }
+    }
+
+    #endregion
+
+    private static Engine CreateEngine(object host, Action<Options>? configure = null)
+    {
+        var engine = configure is null ? new Engine() : new Engine(configure);
+        engine.SetValue("host", host);
+        return engine;
+    }
+
+    // the CLR's own runtime double->integer semantics (saturating on .NET Core, wrapping on the
+    // .NET Framework JIT); computed here rather than spelled out so the expectation always matches
+    // whatever the coercion path itself performs on this runtime
+    private static int ToInt(double value) => unchecked((int) value);
+
+    private static long ToLong(double value) => unchecked((long) value);
+
+    private static bool IsNegativeZero(double value)
+        => BitConverter.DoubleToInt64Bits(value) == BitConverter.DoubleToInt64Bits(-0d);
+
+    private static Host Assign(string script, ValueCoercionType? coercion = null)
+    {
+        var host = new Host();
+        var engine = CreateEngine(host, coercion is null ? null : options => options.Interop.ValueCoercion = coercion.Value);
+        engine.Execute(script);
+        return host;
+    }
+
+    private static Exception AssignThrows(string script, ValueCoercionType? coercion = null)
+    {
+        var host = new Host();
+        var engine = CreateEngine(host, coercion is null ? null : options => options.Interop.ValueCoercion = coercion.Value);
+        return Invoking(() => engine.Execute(script)).Should().Throw<Exception>().Which;
+    }
+
+    #region 1. round-trip per supported member type
+
+    [Fact]
+    public void RoundTrip_Int()
+    {
+        var host = new Host { IntProp = 1, IntField = 2 };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.IntProp").Should().Be(1);
+        engine.Evaluate("host.IntField").Should().Be(2);
+
+        engine.Execute("host.IntProp = 42; host.IntField = 43;");
+        host.IntProp.Should().Be(42);
+        host.IntField.Should().Be(43);
+
+        // the descriptor stays live: a host-side change is visible to a later read
+        host.IntProp = 100;
+        host.IntField = 101;
+        engine.Evaluate("host.IntProp").Should().Be(100);
+        engine.Evaluate("host.IntField").Should().Be(101);
+    }
+
+    [Fact]
+    public void RoundTrip_Long()
+    {
+        var host = new Host { LongProp = 1L, LongField = 2L };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.LongProp").Should().Be(1);
+        engine.Evaluate("host.LongField").Should().Be(2);
+
+        engine.Execute("host.LongProp = 42; host.LongField = 43;");
+        host.LongProp.Should().Be(42L);
+        host.LongField.Should().Be(43L);
+
+        host.LongProp = 8589934592L; // 2^33, outside int range
+        host.LongField = -8589934592L;
+        engine.Evaluate("host.LongProp").Should().Be(8589934592d);
+        engine.Evaluate("host.LongField").Should().Be(-8589934592d);
+    }
+
+    [Fact]
+    public void RoundTrip_Double()
+    {
+        var host = new Host { DoubleProp = 1.25, DoubleField = 2.5 };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.DoubleProp").Should().Be(1.25);
+        engine.Evaluate("host.DoubleField").Should().Be(2.5);
+
+        engine.Execute("host.DoubleProp = 3.75; host.DoubleField = -0.5;");
+        host.DoubleProp.Should().Be(3.75);
+        host.DoubleField.Should().Be(-0.5);
+
+        host.DoubleProp = 9.5;
+        engine.Evaluate("host.DoubleProp").Should().Be(9.5);
+    }
+
+    [Fact]
+    public void RoundTrip_Bool()
+    {
+        var host = new Host { BoolProp = true, BoolField = false };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.BoolProp").Should().BeTrue();
+        engine.Evaluate("host.BoolField").Should().BeFalse();
+
+        engine.Execute("host.BoolProp = false; host.BoolField = true;");
+        host.BoolProp.Should().BeFalse();
+        host.BoolField.Should().BeTrue();
+
+        host.BoolProp = true;
+        engine.Evaluate("host.BoolProp").Should().BeTrue();
+    }
+
+    [Fact]
+    public void RoundTrip_String()
+    {
+        var host = new Host { StringProp = "a", StringField = "b" };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.StringProp").Should().Be("a");
+        engine.Evaluate("host.StringField").Should().Be("b");
+
+        engine.Execute("host.StringProp = 'x'; host.StringField = 'y';");
+        host.StringProp.Should().Be("x");
+        host.StringField.Should().Be("y");
+
+        host.StringProp = "live";
+        engine.Evaluate("host.StringProp").Should().Be("live");
+    }
+
+    [Fact]
+    public void RoundTrip_JsValue()
+    {
+        var host = new Host { JsValueProp = JsNumber.Create(1), JsValueField = new JsString("f") };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.JsValueProp").Should().Be(1);
+        engine.Evaluate("host.JsValueField").Should().Be("f");
+
+        engine.Execute("host.JsValueProp = 'set'; host.JsValueField = 5;");
+        host.JsValueProp!.AsString().Should().Be("set");
+        host.JsValueField!.AsNumber().Should().Be(5);
+
+        // objects survive the round-trip by identity
+        engine.Execute("host.JsValueProp = { a: 1 };");
+        engine.Evaluate("host.JsValueProp.a").Should().Be(1);
+
+        // a host side change is visible, including undefined and null
+        host.JsValueProp = JsValue.Undefined;
+        engine.Evaluate("host.JsValueProp").Should().BeUndefined();
+        host.JsValueProp = JsValue.Null;
+        engine.Evaluate("host.JsValueProp === null").Should().BeTrue();
+        host.JsValueProp = null;
+        engine.Evaluate("host.JsValueProp === null").Should().BeTrue();
+    }
+
+    [Fact]
+    public void RoundTrip_JsValueSubtype_Read()
+    {
+        var host = new JsSubtypeHost { JsStringProp = new JsString("s"), JsNumberField = JsNumber.Create(4) };
+        var engine = new Engine();
+        engine.SetValue("host", host);
+
+        engine.Evaluate("host.JsStringProp").Should().Be("s");
+        engine.Evaluate("host.JsNumberField").Should().Be(4);
+
+        host.JsStringProp = null;
+        engine.Evaluate("host.JsStringProp === null").Should().BeTrue();
+    }
+
+    [Fact]
+    public void JsValueSubtypeWriteKeepsTheConversionPath()
+    {
+        // A member typed as a JsValue *subtype* is not `_memberType == typeof(JsValue)` in
+        // ReflectionAccessor.SetValue, so it has always gone through ToObject() plus the type
+        // converter - which cannot turn the resulting System.String back into a JsString. The fast
+        // lane must not "fix" that, or the write would start succeeding where it used to throw.
+        var host = new JsSubtypeHost();
+        var engine = new Engine();
+        engine.SetValue("host", host);
+
+        Invoking(() => engine.Execute("host.JsStringProp = 'abc';"))
+            .Should().ThrowExactly<InvalidCastException>();
+        host.JsStringProp.Should().BeNull();
+
+        Invoking(() => engine.Execute("host.JsNumberField = 1;"))
+            .Should().ThrowExactly<InvalidCastException>();
+        host.JsNumberField.Should().BeNull();
+    }
+
+    #endregion
+
+    #region 2. unsupported member types still work (raw lane)
+
+    [Fact]
+    public void RawLane_IntArray()
+    {
+        var host = new RawHost { IntArrayProp = [1, 2, 3], IntArrayField = [4, 5] };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.IntArrayProp.length").Should().Be(3);
+        engine.Evaluate("host.IntArrayProp[1]").Should().Be(2);
+        engine.Evaluate("host.IntArrayField[0]").Should().Be(4);
+
+        engine.Execute("host.IntArrayProp = [9, 8];");
+        host.IntArrayProp.Should().BeEquivalentTo(new[] { 9, 8 });
+    }
+
+    [Fact]
+    public void RawLane_Enum()
+    {
+        var host = new RawHost { EnumProp = Level.Two, EnumField = Level.One };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.EnumProp").Should().Be(2);
+        engine.Evaluate("host.EnumField").Should().Be(1);
+
+        engine.Execute("host.EnumProp = 1; host.EnumField = 2;");
+        host.EnumProp.Should().Be(Level.One);
+        host.EnumField.Should().Be(Level.Two);
+    }
+
+    [Fact]
+    public void RawLane_NullableInt()
+    {
+        var host = new RawHost { NullableIntProp = 5, NullableIntField = null };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.NullableIntProp").Should().Be(5);
+        engine.Evaluate("host.NullableIntField === null").Should().BeTrue();
+
+        engine.Execute("host.NullableIntProp = 9;");
+        host.NullableIntProp.Should().Be(9);
+    }
+
+    [Fact]
+    public void RawLane_CustomClass()
+    {
+        var host = new RawHost { NestedProp = new Nested { N = 3 }, NestedField = null };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.NestedProp.N").Should().Be(3);
+        // a null reference member reads as null, not undefined
+        engine.Evaluate("host.NestedField === null").Should().BeTrue();
+        engine.Evaluate("typeof host.NestedField").Should().Be("object");
+    }
+
+    [Fact]
+    public void RawLane_Object()
+    {
+        var host = new RawHost { ObjectProp = "text", ObjectField = 12 };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.ObjectProp").Should().Be("text");
+        engine.Evaluate("host.ObjectField").Should().Be(12);
+
+        host.ObjectProp = null;
+        engine.Evaluate("host.ObjectProp === null").Should().BeTrue();
+    }
+
+    [Fact]
+    public void RawLane_DateTime()
+    {
+        var host = new RawHost { DateTimeProp = new DateTime(2020, 5, 6, 0, 0, 0, DateTimeKind.Utc) };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.DateTimeProp.getUTCFullYear()").Should().Be(2020);
+        engine.Evaluate("host.DateTimeProp.getUTCMonth()").Should().Be(4);
+    }
+
+    [Fact]
+    public void RawLane_Decimal()
+    {
+        var host = new RawHost { DecimalProp = 1.5m, DecimalField = 2m };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.DecimalProp").Should().Be(1.5);
+        engine.Evaluate("host.DecimalField").Should().Be(2);
+
+        engine.Execute("host.DecimalProp = 3.25;");
+        host.DecimalProp.Should().Be(3.25m);
+    }
+
+    #endregion
+
+    #region 3. write conversion edge cases - int
+
+    [Fact]
+    public void IntWrite_Bounds()
+    {
+        var host = Assign("host.IntProp = 2147483647; host.IntField = -2147483648;");
+        host.IntProp.Should().Be(int.MaxValue);
+        host.IntField.Should().Be(int.MinValue);
+    }
+
+    [Fact]
+    public void IntWrite_JustPastUpperBound_Throws()
+    {
+        // 2^31 is not representable, the reflection path's Convert.ChangeType overflows and the
+        // default ExceptionHandler lets the CLR exception bubble
+        AssignThrows("host.IntProp = 2147483648;").Should().BeOfType<OverflowException>();
+        AssignThrows("host.IntField = 2147483648;").Should().BeOfType<OverflowException>();
+    }
+
+    [Fact]
+    public void IntWrite_JustPastLowerBound_Throws()
+    {
+        AssignThrows("host.IntProp = -2147483649;").Should().BeOfType<OverflowException>();
+    }
+
+    [Fact]
+    public void IntWrite_FractionalUsesBankersRoundingByDefault()
+    {
+        // the default (String-only) coercion routes fractional values through
+        // Convert.ChangeType, which rounds half to even
+        Assign("host.IntProp = 1.5;").IntProp.Should().Be(2);
+        Assign("host.IntProp = 2.5;").IntProp.Should().Be(2);
+        Assign("host.IntProp = -1.5;").IntProp.Should().Be(-2);
+
+        Assign("host.IntField = 1.5;").IntField.Should().Be(2);
+        Assign("host.IntField = 2.5;").IntField.Should().Be(2);
+        Assign("host.IntField = -1.5;").IntField.Should().Be(-2);
+    }
+
+    [Fact]
+    public void IntWrite_FractionalTruncatesUnderNumberCoercion()
+    {
+        // ValueCoercionType.Number takes the AsNumberOfType path instead, which is a C# cast
+        Assign("host.IntProp = 1.5;", ValueCoercionType.All).IntProp.Should().Be(1);
+        Assign("host.IntProp = 2.5;", ValueCoercionType.All).IntProp.Should().Be(2);
+        Assign("host.IntProp = -1.5;", ValueCoercionType.All).IntProp.Should().Be(-1);
+
+        Assign("host.IntField = 1.5;", ValueCoercionType.All).IntField.Should().Be(1);
+        Assign("host.IntField = -1.5;", ValueCoercionType.All).IntField.Should().Be(-1);
+    }
+
+    [Fact]
+    public void IntWrite_NaNAndInfinities_Throw()
+    {
+        AssignThrows("host.IntProp = NaN;").Should().BeOfType<OverflowException>();
+        AssignThrows("host.IntProp = Infinity;").Should().BeOfType<OverflowException>();
+        AssignThrows("host.IntProp = -Infinity;").Should().BeOfType<OverflowException>();
+        AssignThrows("host.IntField = NaN;").Should().BeOfType<OverflowException>();
+    }
+
+    [Fact]
+    public void IntWrite_NaNAndInfinitiesUnderNumberCoercion()
+    {
+        // the coercion path is a plain C# cast, so the runtime's own double->int semantics apply
+        Assign("host.IntProp = NaN;", ValueCoercionType.All).IntProp.Should().Be(ToInt(double.NaN));
+        Assign("host.IntProp = Infinity;", ValueCoercionType.All).IntProp.Should().Be(ToInt(double.PositiveInfinity));
+        Assign("host.IntProp = -Infinity;", ValueCoercionType.All).IntProp.Should().Be(ToInt(double.NegativeInfinity));
+        Assign("host.IntProp = 2147483648;", ValueCoercionType.All).IntProp.Should().Be(ToInt(2147483648d));
+    }
+
+    [Fact]
+    public void IntWrite_NegativeZero()
+    {
+        Assign("host.IntProp = -0; host.IntField = -0;").IntProp.Should().Be(0);
+        Assign("host.IntProp = -0;", ValueCoercionType.All).IntProp.Should().Be(0);
+    }
+
+    [Fact]
+    public void IntWrite_NumericString()
+    {
+        Assign("host.IntProp = '42'; host.IntField = '43';").IntProp.Should().Be(42);
+        Assign("host.IntProp = '42';").IntProp.Should().Be(42);
+        Assign("host.IntProp = '42';", ValueCoercionType.All).IntProp.Should().Be(42);
+    }
+
+    [Fact]
+    public void IntWrite_Boolean()
+    {
+        Assign("host.IntProp = true; host.IntField = true;").IntProp.Should().Be(1);
+        Assign("host.IntProp = true;", ValueCoercionType.All).IntProp.Should().Be(1);
+    }
+
+    [Fact]
+    public void IntWrite_NullAndUndefined()
+    {
+        // null/undefined convert to a CLR null, and reflection assigns the default value of a
+        // value-type member for a null - no exception, the member ends up at 0
+        Assign("host.IntProp = 3; host.IntProp = null;").IntProp.Should().Be(0);
+        Assign("host.IntProp = 3; host.IntProp = undefined;").IntProp.Should().Be(0);
+        Assign("host.IntField = 3; host.IntField = null;").IntField.Should().Be(0);
+        Assign("host.IntField = 3; host.IntField = undefined;").IntField.Should().Be(0);
+    }
+
+    [Fact]
+    public void IntWrite_NullAndUndefinedUnderNumberCoercion()
+    {
+        Assign("host.IntProp = null;", ValueCoercionType.All).IntProp.Should().Be(0);
+        Assign("host.IntProp = undefined;", ValueCoercionType.All).IntProp.Should().Be(ToInt(double.NaN));
+    }
+
+    #endregion
+
+    #region 3. write conversion edge cases - long
+
+    [Fact]
+    public void LongWrite_SmallAndLargeValues()
+    {
+        // a small integral value reaches the member as a boxed int on the reflection path and is
+        // widened by reflection; a large one arrives as a double
+        var host = Assign("host.LongProp = 5; host.LongField = 6;");
+        host.LongProp.Should().Be(5L);
+        host.LongField.Should().Be(6L);
+
+        host = Assign("host.LongProp = 4294967296; host.LongField = -4294967296;");
+        host.LongProp.Should().Be(4294967296L);
+        host.LongField.Should().Be(-4294967296L);
+    }
+
+    [Fact]
+    public void LongWrite_Boundaries()
+    {
+        Assign("host.LongProp = -9223372036854775808;").LongProp.Should().Be(long.MinValue);
+        Assign("host.LongProp = 1e18;").LongProp.Should().Be(1000000000000000000L);
+        Assign("host.LongProp = 1e18;", ValueCoercionType.All).LongProp.Should().Be(1000000000000000000L);
+    }
+
+    [Fact]
+    public void LongWrite_TwoToThe63_Throws()
+    {
+        AssignThrows("host.LongProp = Math.pow(2, 63);").Should().BeOfType<OverflowException>();
+        AssignThrows("host.LongField = Math.pow(2, 63);").Should().BeOfType<OverflowException>();
+    }
+
+    [Fact]
+    public void LongWrite_TwoToThe63UnderNumberCoercion()
+    {
+        Assign("host.LongProp = Math.pow(2, 63);", ValueCoercionType.All).LongProp.Should().Be(ToLong(9223372036854775808d));
+    }
+
+    [Fact]
+    public void LongWrite_Fractional()
+    {
+        Assign("host.LongProp = 1.5;").LongProp.Should().Be(2L);
+        Assign("host.LongProp = 1.5;", ValueCoercionType.All).LongProp.Should().Be(1L);
+    }
+
+    #endregion
+
+    #region 3. write conversion edge cases - double
+
+    [Fact]
+    public void DoubleWrite_NonIntegral()
+    {
+        var host = Assign("host.DoubleProp = 1.25; host.DoubleField = -7.125;");
+        host.DoubleProp.Should().Be(1.25);
+        host.DoubleField.Should().Be(-7.125);
+    }
+
+    [Fact]
+    public void DoubleWrite_NaNAndInfinities()
+    {
+        var host = Assign("host.DoubleProp = NaN;");
+        double.IsNaN(host.DoubleProp).Should().BeTrue();
+
+        Assign("host.DoubleProp = Infinity;").DoubleProp.Should().Be(double.PositiveInfinity);
+        Assign("host.DoubleProp = -Infinity;").DoubleProp.Should().Be(double.NegativeInfinity);
+        Assign("host.DoubleField = Infinity;").DoubleField.Should().Be(double.PositiveInfinity);
+
+        var coerced = Assign("host.DoubleProp = NaN;", ValueCoercionType.All);
+        double.IsNaN(coerced.DoubleProp).Should().BeTrue();
+        Assign("host.DoubleProp = Infinity;", ValueCoercionType.All).DoubleProp.Should().Be(double.PositiveInfinity);
+    }
+
+    [Fact]
+    public void DoubleWrite_NegativeZeroKeepsSign()
+    {
+        var host = Assign("host.DoubleProp = -0; host.DoubleField = -0;");
+        IsNegativeZero(host.DoubleProp).Should().BeTrue();
+        IsNegativeZero(host.DoubleField).Should().BeTrue();
+
+        var engine = CreateEngine(host);
+        engine.Evaluate("1 / host.DoubleProp === -Infinity").Should().BeTrue();
+        engine.Evaluate("1 / host.DoubleField === -Infinity").Should().BeTrue();
+
+        var coerced = Assign("host.DoubleProp = -0;", ValueCoercionType.All);
+        IsNegativeZero(coerced.DoubleProp).Should().BeTrue();
+    }
+
+    [Fact]
+    public void DoubleWrite_IntegralAndString()
+    {
+        Assign("host.DoubleProp = 5;").DoubleProp.Should().Be(5d);
+        Assign("host.DoubleProp = '5.5';").DoubleProp.Should().Be(5.5);
+        Assign("host.DoubleProp = '5.5';", ValueCoercionType.All).DoubleProp.Should().Be(5.5);
+        Assign("host.DoubleProp = true;").DoubleProp.Should().Be(1d);
+    }
+
+    #endregion
+
+    #region 3. write conversion edge cases - string
+
+    [Fact]
+    public void StringWrite_Number()
+    {
+        var host = Assign("host.StringProp = 42; host.StringField = 1.5;");
+        host.StringProp.Should().Be("42");
+        host.StringField.Should().Be("1.5");
+
+        Assign("host.StringProp = 42;", ValueCoercionType.All).StringProp.Should().Be("42");
+    }
+
+    [Fact]
+    public void StringWrite_Boolean()
+    {
+        Assign("host.StringProp = true;").StringProp.Should().Be("true");
+        Assign("host.StringProp = true;", ValueCoercionType.All).StringProp.Should().Be("true");
+    }
+
+    [Fact]
+    public void StringWrite_NullAndUndefined()
+    {
+        var host = Assign("host.StringProp = 'x'; host.StringProp = null;");
+        host.StringProp.Should().BeNull();
+
+        host = Assign("host.StringField = 'x'; host.StringField = undefined;");
+        host.StringField.Should().BeNull();
+
+        Assign("host.StringProp = 'x'; host.StringProp = null;", ValueCoercionType.All).StringProp.Should().BeNull();
+        Assign("host.StringProp = 'x'; host.StringProp = undefined;", ValueCoercionType.All).StringProp.Should().BeNull();
+    }
+
+    [Fact]
+    public void StringWrite_ConcatenatedString()
+    {
+        // a concatenated (lazily materialized) JsString is still a JsString; it must reach the
+        // member as the same text the conversion path produced
+        var host = Assign("var b = 'b'; host.StringProp = 'a' + b + 'c'; host.StringField = 'x'.repeat(3);");
+        host.StringProp.Should().Be("abc");
+        host.StringField.Should().Be("xxx");
+    }
+
+    [Fact]
+    public void WritesBeforeAndAfterTheFirstReadAgree()
+    {
+        // a write before any read takes ObjectWrapper's accessor fast path, a write afterwards goes
+        // through the cached ReflectionDescriptor - both must land on the same member
+        var host = new Host();
+        var engine = CreateEngine(host);
+
+        engine.Execute("host.IntProp = 1; host.StringProp = 'a'; host.DoubleProp = 1.5; host.LongProp = 2; host.BoolProp = true;");
+        host.IntProp.Should().Be(1);
+        host.StringProp.Should().Be("a");
+
+        engine.Evaluate("host.IntProp").Should().Be(1);
+        engine.Evaluate("host.StringProp").Should().Be("a");
+
+        engine.Execute("host.IntProp = 2; host.StringProp = 'b'; host.DoubleProp = 2.5; host.LongProp = 3; host.BoolProp = false;");
+        host.IntProp.Should().Be(2);
+        host.StringProp.Should().Be("b");
+        host.DoubleProp.Should().Be(2.5);
+        host.LongProp.Should().Be(3L);
+        host.BoolProp.Should().BeFalse();
+    }
+
+    [Fact]
+    public void StringWrite_PlainString()
+    {
+        Assign("host.StringProp = 'hello'; host.StringField = '';").StringProp.Should().Be("hello");
+        Assign("host.StringField = '';").StringField.Should().Be("");
+    }
+
+    #endregion
+
+    #region 4. bool writes under both coercion settings
+
+    [Fact]
+    public void BoolWrite_UnderBothCoercionSettings()
+    {
+        Assign("host.BoolProp = true; host.BoolField = true;").BoolProp.Should().BeTrue();
+        Assign("host.BoolProp = true;", ValueCoercionType.All).BoolProp.Should().BeTrue();
+
+        // non-boolean values decline the fast lane and take the pre-existing conversion
+        Assign("host.BoolProp = 1;").BoolProp.Should().BeTrue();
+        Assign("host.BoolProp = 1;", ValueCoercionType.All).BoolProp.Should().BeTrue();
+        Assign("host.BoolProp = 0;").BoolProp.Should().BeFalse();
+        Assign("host.BoolProp = 'true';").BoolProp.Should().BeTrue();
+        Assign("host.BoolProp = 'dog';", ValueCoercionType.All).BoolProp.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region 5. read equivalence with JsValue.FromObjectWithType
+
+    [Fact]
+    public void Read_MatchesFromObjectWithType()
+    {
+        var host = new Host
+        {
+            IntProp = 42,
+            LongProp = 8589934592L,
+            DoubleProp = 1.25,
+            BoolProp = true,
+            StringProp = "abc",
+            JsValueProp = new JsString("js"),
+        };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.IntProp").Should().Be(JsValue.FromObjectWithType(engine, host.IntProp, typeof(int)));
+        engine.Evaluate("host.LongProp").Should().Be(JsValue.FromObjectWithType(engine, host.LongProp, typeof(long)));
+        engine.Evaluate("host.DoubleProp").Should().Be(JsValue.FromObjectWithType(engine, host.DoubleProp, typeof(double)));
+        engine.Evaluate("host.BoolProp").Should().Be(JsValue.FromObjectWithType(engine, host.BoolProp, typeof(bool)));
+        engine.Evaluate("host.StringProp").Should().Be(JsValue.FromObjectWithType(engine, host.StringProp, typeof(string)));
+        engine.Evaluate("host.JsValueProp").Should().BeSameAs(host.JsValueProp);
+
+        // int members produce a cached JsNumber, exactly as the conversion path does
+        engine.Evaluate("host.IntProp").Should().BeSameAs(JsValue.FromObjectWithType(engine, host.IntProp, typeof(int)));
+        engine.Evaluate("host.BoolProp").Should().BeSameAs(JsBoolean.True);
+    }
+
+    [Fact]
+    public void Read_IntBehavesAsNumber()
+    {
+        var host = new Host { IntProp = 42, IntField = 7 };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("typeof host.IntProp").Should().Be("number");
+        engine.Evaluate("host.IntProp === 42").Should().BeTrue();
+        engine.Evaluate("host.IntProp + 1").Should().Be(43);
+        engine.Evaluate("host.IntProp / 4").Should().Be(10.5);
+        engine.Evaluate("host.IntField.toFixed(2)").Should().Be("7.00");
+        engine.Evaluate("host.IntProp | 0").Should().Be(42);
+    }
+
+    [Fact]
+    public void Read_NullStringIsNullNotUndefined()
+    {
+        var host = new Host { StringProp = null, StringField = null };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.StringProp === null").Should().BeTrue();
+        engine.Evaluate("host.StringProp === undefined").Should().BeFalse();
+        engine.Evaluate("typeof host.StringProp").Should().Be("object");
+        engine.Evaluate("host.StringField === null").Should().BeTrue();
+
+        engine.Evaluate("host.StringProp").Should().Be(JsValue.FromObjectWithType(engine, null, typeof(string)));
+    }
+
+    [Fact]
+    public void Read_LongPrecision()
+    {
+        var host = new Host { LongProp = 9007199254740993L }; // 2^53 + 1, not representable as a double
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.LongProp").Should().Be(JsValue.FromObjectWithType(engine, host.LongProp, typeof(long)));
+    }
+
+    #endregion
+
+    #region 6. exception fidelity
+
+    [Fact]
+    public void ThrowingGetter_JsValueLane()
+    {
+        var engine = CreateEngine(new ThrowingHost());
+        Invoking(() => engine.Evaluate("host.ThrowingIntGetter"))
+            .Should().ThrowExactly<InvalidOperationException>()
+            .WithMessage("int getter boom");
+    }
+
+    [Fact]
+    public void ThrowingSetter_JsValueLane()
+    {
+        var engine = CreateEngine(new ThrowingHost());
+        Invoking(() => engine.Execute("host.ThrowingIntSetter = 1;"))
+            .Should().ThrowExactly<InvalidOperationException>()
+            .WithMessage("int setter boom");
+    }
+
+    [Fact]
+    public void ThrowingGetter_RawLane()
+    {
+        var engine = CreateEngine(new ThrowingHost());
+        Invoking(() => engine.Evaluate("host.ThrowingDecimalGetter"))
+            .Should().ThrowExactly<InvalidOperationException>()
+            .WithMessage("decimal getter boom");
+    }
+
+    [Fact]
+    public void ThrowingSetter_RawLane()
+    {
+        var engine = CreateEngine(new ThrowingHost());
+        Invoking(() => engine.Execute("host.ThrowingDecimalSetter = 1;"))
+            .Should().ThrowExactly<InvalidOperationException>()
+            .WithMessage("decimal setter boom");
+    }
+
+    [Fact]
+    public void ThrowingMembers_ExceptionHandlerStillConsulted()
+    {
+        var seen = new List<Exception>();
+        var engine = CreateEngine(new ThrowingHost(), options => options.Interop.ExceptionHandler = e =>
+        {
+            seen.Add(e);
+            return true;
+        });
+
+        engine.Evaluate("try { host.ThrowingIntGetter; 'no throw' } catch (e) { e.message }").Should().Be("int getter boom");
+        engine.Evaluate("try { host.ThrowingDecimalGetter; 'no throw' } catch (e) { e.message }").Should().Be("decimal getter boom");
+        engine.Evaluate("try { host.ThrowingIntSetter = 1; 'no throw' } catch (e) { e.message }").Should().Be("int setter boom");
+        engine.Evaluate("try { host.ThrowingDecimalSetter = 1; 'no throw' } catch (e) { e.message }").Should().Be("decimal setter boom");
+
+        seen.Should().AllSatisfy(e => e.Should().BeOfType<InvalidOperationException>());
+        seen.Should().HaveCount(4);
+    }
+
+    #endregion
+
+    #region 7. declining conditions
+
+    [Fact]
+    public void ObjectConverterStillConsultedForSupportedType()
+    {
+        var host = new Host { IntProp = 41, StringProp = "raw", BoolProp = true, LongProp = 1, DoubleProp = 1.5 };
+        var engine = CreateEngine(host, options => options.Interop.ObjectConverters.Add(new PlusOneIntConverter()));
+
+        engine.Evaluate("host.IntProp").Should().Be(42);
+        // the converter declines everything else, which still converts as before
+        engine.Evaluate("host.StringProp").Should().Be("raw");
+        engine.Evaluate("host.BoolProp").Should().BeTrue();
+        engine.Evaluate("host.DoubleProp").Should().Be(1.5);
+    }
+
+    private sealed class PlusOneIntConverter : IObjectConverter
+    {
+        public bool TryConvert(Engine engine, object value, [NotNullWhen(true)] out JsValue? result)
+        {
+            if (value is int i)
+            {
+                result = JsNumber.Create(i + 1);
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+    }
+
+    [Fact]
+    public void CustomTypeConverterStillConsultedOnWrite()
+    {
+        var host = new Host();
+        var engine = CreateEngine(host, options => options.SetTypeConverter(e => new LongPinningTypeConverter(e)));
+
+        // an integral value above int range reaches ConvertValueToSet on the reflection path
+        engine.Execute("host.LongProp = 4294967296;");
+        host.LongProp.Should().Be(42L);
+
+        // -0 is a Number-typed JsNumber, so the int member also reaches the converter
+        engine.Execute("host.IntProp = -0;");
+        host.IntProp.Should().Be(7);
+
+        // and the conversions the converter does not touch keep working
+        engine.Execute("host.StringProp = 'ok'; host.BoolProp = true; host.IntField = 3;");
+        host.StringProp.Should().Be("ok");
+        host.BoolProp.Should().BeTrue();
+        host.IntField.Should().Be(3);
+    }
+
+    private sealed class LongPinningTypeConverter : DefaultTypeConverter
+    {
+        public LongPinningTypeConverter(Engine engine) : base(engine)
+        {
+        }
+
+        public override bool TryConvert(object? value, Type type, IFormatProvider formatProvider, [NotNullWhen(true)] out object? converted)
+        {
+            if (type == typeof(long))
+            {
+                converted = 42L;
+                return true;
+            }
+
+            if (type == typeof(int))
+            {
+                converted = 7;
+                return true;
+            }
+
+            return base.TryConvert(value, type, formatProvider, out converted);
+        }
+    }
+
+    [Fact]
+    public void IndexerIsResolvedBeforeTheMember()
+    {
+        var host = new IndexerHost();
+        var engine = new Engine();
+        engine.SetValue("host", host);
+
+        // the indexer is probed first and answers for "Value", shadowing the int property
+        engine.Evaluate("host.Value").Should().Be(99);
+
+        // a write still lands on the property
+        engine.Execute("host.Value = 9;");
+        host.Value.Should().Be(9);
+    }
+
+    [Fact]
+    public void StructHostStillWorks()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new StructHost(3));
+
+        engine.Evaluate("host.IntProp").Should().Be(3);
+        engine.Evaluate("host.IntField").Should().Be(3);
+
+        engine.Execute("host.IntProp = 8; host.StringProp = 'v';");
+        engine.Evaluate("host.IntProp").Should().Be(8);
+        engine.Evaluate("host.StringProp").Should().Be("v");
+    }
+
+    [Fact]
+    public void ReadOnlyFieldAndPropertyWritesFail()
+    {
+        var host = new ReadOnlyHost();
+        var engine = new Engine();
+        engine.SetValue("host", host);
+
+        engine.Evaluate("host.ReadOnlyIntProp").Should().Be(11);
+        engine.Evaluate("host.ReadOnlyIntField").Should().Be(22);
+        engine.Evaluate("host.ReadOnlyStringField").Should().Be("fixed");
+
+        // sloppy mode silently ignores the write
+        engine.Execute("host.ReadOnlyIntProp = 1; host.ReadOnlyIntField = 2; host.ReadOnlyStringField = 'x';");
+        host.ReadOnlyIntProp.Should().Be(11);
+        host.ReadOnlyIntField.Should().Be(22);
+        host.ReadOnlyStringField.Should().Be("fixed");
+
+        // strict mode throws a TypeError
+        Invoking(() => engine.Execute("'use strict'; host.ReadOnlyIntProp = 1;"))
+            .Should().Throw<JavaScriptException>();
+        Invoking(() => engine.Execute("'use strict'; host.ReadOnlyIntField = 2;"))
+            .Should().Throw<JavaScriptException>();
+    }
+
+    [Fact]
+    public void StaticMembersStillWork()
+    {
+        StaticHost.StaticIntProp = 3;
+        StaticHost.StaticStringField = "s";
+
+        var engine = new Engine();
+        engine.SetValue("Statics", TypeReference.CreateTypeReference(engine, typeof(StaticHost)));
+
+        engine.Evaluate("Statics.StaticIntProp").Should().Be(3);
+        engine.Evaluate("Statics.StaticStringField").Should().Be("s");
+
+        engine.Execute("Statics.StaticIntProp = 9; Statics.StaticStringField = 't';");
+        StaticHost.StaticIntProp.Should().Be(9);
+        StaticHost.StaticStringField.Should().Be("t");
+    }
+
+    [Fact]
+    public void InterfaceDeclaredPropertyWorksThroughTheInterface()
+    {
+        var owner = new HolderOwner();
+        var engine = new Engine();
+        engine.SetValue("owner", owner);
+
+        engine.Execute("owner.Holder.Value = 5; owner.Holder.Name = 'n';");
+        owner.Holder.Value.Should().Be(5);
+        owner.Holder.Name.Should().Be("n");
+
+        engine.Evaluate("owner.Holder.Value").Should().Be(5);
+        engine.Evaluate("owner.Holder.Name").Should().Be("n");
+
+        owner.Holder.Value = 6;
+        engine.Evaluate("owner.Holder.Value").Should().Be(6);
+    }
+
+    #endregion
+
+    #region 8. cross-engine isolation
+
+    [Fact]
+    public void TypeConverterPolicyIsPerEngine_ConverterFirst()
+    {
+        var withConverter = new IsolationHost();
+        var engineWithConverter = CreateEngine(withConverter, options => options.SetTypeConverter(e => new LongPinningTypeConverter(e)));
+        engineWithConverter.Execute("host.LongProp = 4294967296;");
+        withConverter.LongProp.Should().Be(42L);
+
+        var plain = new IsolationHost();
+        var plainEngine = CreateEngine(plain);
+        plainEngine.Execute("host.LongProp = 4294967296;");
+        plain.LongProp.Should().Be(4294967296L);
+    }
+
+    [Fact]
+    public void TypeConverterPolicyIsPerEngine_PlainFirst()
+    {
+        var plain = new IsolationHost();
+        var plainEngine = CreateEngine(plain);
+        plainEngine.Execute("host.LongProp = 8589934592;");
+        plain.LongProp.Should().Be(8589934592L);
+
+        var withConverter = new IsolationHost();
+        var engineWithConverter = CreateEngine(withConverter, options => options.SetTypeConverter(e => new LongPinningTypeConverter(e)));
+        engineWithConverter.Execute("host.LongProp = 8589934592;");
+        withConverter.LongProp.Should().Be(42L);
+    }
+
+    [Fact]
+    public void ObjectConverterPolicyIsPerEngine_ConverterFirst()
+    {
+        var host = new IsolationHost { IntProp = 41 };
+
+        var converting = CreateEngine(host, options => options.Interop.ObjectConverters.Add(new PlusOneIntConverter()));
+        converting.Evaluate("host.IntProp").Should().Be(42);
+
+        var plain = CreateEngine(host);
+        plain.Evaluate("host.IntProp").Should().Be(41);
+    }
+
+    [Fact]
+    public void ObjectConverterPolicyIsPerEngine_PlainFirst()
+    {
+        var host = new IsolationHost { IntProp = 41 };
+
+        var plain = CreateEngine(host);
+        plain.Evaluate("host.IntProp").Should().Be(41);
+
+        var converting = CreateEngine(host, options => options.Interop.ObjectConverters.Add(new PlusOneIntConverter()));
+        converting.Evaluate("host.IntProp").Should().Be(42);
+    }
+
+    #endregion
+
+    #region 9. non-public getter
+
+    [Fact]
+    public void PropertyWithNonPublicGetter()
+    {
+        var host = new NonPublicGetterHost();
+        var engine = new Engine();
+        engine.SetValue("host", host);
+
+        engine.Execute("host.HalfHidden = 9;");
+        host.Observe().Should().Be(9);
+
+        engine.Evaluate("host.HalfHidden").Should().Be(9);
+    }
+
+    #endregion
+}

--- a/Jint/Runtime/Descriptors/Specialized/ReflectionDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/ReflectionDescriptor.cs
@@ -64,6 +64,15 @@ internal sealed class ReflectionDescriptor : PropertyDescriptor
 
     private JsValue DoGet(JsValue? thisObj)
     {
+        // compiled fast lane: produces the JsValue straight off the CLR member, skipping the boxed
+        // value and the FromObjectWithType dispatch below. Only the member shapes whose conversion
+        // it reproduces exactly take it; everything else declines.
+        if (_reflectionAccessor.TryGetJsValue(_engine, _target, out var fastResult))
+        {
+            _engine.CheckAmortizedConstraintsAtHostBoundary();
+            return fastResult;
+        }
+
         var value = _reflectionAccessor.GetValue(_engine, _target, _propertyName);
         var type = _reflectionAccessor.MemberType ?? value?.GetType();
         // conversion before the check so an awaitable result gets its continuation attached

--- a/Jint/Runtime/Interop/Reflection/CompilableMemberAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/CompilableMemberAccessor.cs
@@ -1,0 +1,190 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Jint.Native;
+
+namespace Jint.Runtime.Interop.Reflection;
+
+/// <summary>
+/// Base for the accessors that read and write a single CLR property or field, adding the compiled
+/// fast lanes built by <see cref="CompiledMemberAccessor"/> on top of the reflection path each
+/// subclass still provides as the fallback.
+/// <para>
+/// Two lanes exist. The <b>JsValue lane</b> (<see cref="TryGetJsValue"/> / <see cref="TrySetJsValue"/>)
+/// short-circuits the whole conversion round-trip for the common member types, so a read never
+/// boxes and a write of an exact-typed value goes straight to the CLR member. The <b>raw lane</b>
+/// only replaces the reflection call inside <see cref="DoGetValue"/> / <see cref="DoSetValue"/>,
+/// leaving every surrounding conversion exactly as it was; it covers every other member type.
+/// </para>
+/// <para>
+/// The compiled delegates themselves are cached process-wide by <see cref="CompiledMemberAccessor"/>;
+/// the fields here are only per-accessor L1 caches so the steady-state path is a field read. They
+/// are resolved lazily and racily — the delegates are pure, so a duplicate resolve is harmless.
+/// </para>
+/// </summary>
+internal abstract class CompilableMemberAccessor : ReflectionAccessor
+{
+    private readonly MemberInfo _member;
+
+    private Func<object, JsValue>? _jsValueGetter;
+    private bool _jsValueGetterResolved;
+
+    private Func<object, object?>? _rawGetter;
+    private bool _rawGetterResolved;
+
+    private CompiledMemberAccessor.JsValueSetter? _jsValueSetter;
+    private bool _jsValueSetterResolved;
+
+    private Action<object, object?>? _rawSetter;
+    private bool _rawSetterResolved;
+
+    protected CompilableMemberAccessor(MemberInfo member, Type memberType, PropertyInfo? indexer)
+        : base(memberType, indexer)
+    {
+        _member = member;
+    }
+
+    /// <summary>Reads the member through reflection (the fallback when no lane applies).</summary>
+    protected abstract object? ReflectionGetValue(object target);
+
+    /// <summary>Writes the member through reflection (the fallback when no lane applies).</summary>
+    protected abstract void ReflectionSetValue(object target, object? value);
+
+    public sealed override bool TryGetJsValue(Engine engine, object target, [NotNullWhen(true)] out JsValue? value)
+    {
+        value = null;
+
+        // An indexer is probed before the member itself (see GetValue), and registered object
+        // converters must see every CLR value before it becomes a JsValue - the JsValue lane
+        // produces the JsValue itself, so it cannot run in either case. These accessors never
+        // expose a ConstantValue, the third thing GetValue would consult.
+        if (HasIndexer || engine._objectConverters is not null)
+        {
+            return false;
+        }
+
+        if (!_jsValueGetterResolved)
+        {
+            _jsValueGetter = CompiledMemberAccessor.GetJsValueGetter(_member);
+            _jsValueGetterResolved = true;
+        }
+
+        var getter = _jsValueGetter;
+        if (getter is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            value = getter(target);
+        }
+        catch (Exception exception)
+        {
+            ThrowMeaningful(engine, exception);
+        }
+
+        return true;
+    }
+
+    public sealed override bool TrySetJsValue(Engine engine, object target, JsValue value)
+    {
+        // The fallback conversion consults the engine's ITypeConverter for some of these member
+        // types (an integer JsNumber assigned to a double member reaches ConvertValueToSet, for
+        // example), so a host-installed converter must keep seeing them.
+        if (engine.TypeConverter.GetType() != typeof(DefaultTypeConverter))
+        {
+            return false;
+        }
+
+        if (!_jsValueSetterResolved)
+        {
+            _jsValueSetter = CompiledMemberAccessor.GetJsValueSetter(_member);
+            _jsValueSetterResolved = true;
+        }
+
+        var setter = _jsValueSetter;
+        if (setter is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return setter(target, value);
+        }
+        catch (Exception exception)
+        {
+            ThrowMeaningful(engine, exception);
+            return false; // unreachable, ThrowMeaningful does not return
+        }
+    }
+
+    protected sealed override object? DoGetValue(object target, string memberName)
+    {
+        if (!_rawGetterResolved)
+        {
+            _rawGetter = CompiledMemberAccessor.GetRawGetter(_member);
+            _rawGetterResolved = true;
+        }
+
+        var getter = _rawGetter;
+        if (getter is null)
+        {
+            return ReflectionGetValue(target);
+        }
+
+        try
+        {
+            return getter(target);
+        }
+        catch (Exception exception) when (exception is not TargetInvocationException)
+        {
+            // reflection wraps whatever the member throws, the compiled delegate rethrows it as-is:
+            // normalize so the callers' TargetInvocationException handling stays identical
+            throw new TargetInvocationException(exception);
+        }
+    }
+
+    protected sealed override void DoSetValue(object target, string memberName, object? value)
+    {
+        if (!_rawSetterResolved)
+        {
+            _rawSetter = CompiledMemberAccessor.GetRawSetter(_member);
+            _rawSetterResolved = true;
+        }
+
+        // The compiled setter casts the incoming value straight to the member type, so it can only
+        // accept a value whose runtime type is exactly that. Reflection additionally performs
+        // widening conversions - and the coercion path above produces exactly such a case, handing
+        // a boxed int to a long member - which an unbox.any cannot do, so those keep the
+        // reflection path. A null for a value-type member likewise stays on reflection, whose
+        // ArgumentException is the established behaviour (unbox.any would throw a
+        // NullReferenceException instead).
+        var setter = _rawSetter;
+        if (setter is null || value is null || value.GetType() != MemberType)
+        {
+            ReflectionSetValue(target, value);
+            return;
+        }
+
+        try
+        {
+            setter(target, value);
+        }
+        catch (Exception exception) when (exception is not TargetInvocationException)
+        {
+            throw new TargetInvocationException(exception);
+        }
+    }
+
+    [DoesNotReturn]
+    private static void ThrowMeaningful(Engine engine, Exception exception)
+    {
+        // mirrors GetValue/SetValue: the boundary check runs before the throw so a constraint
+        // violation is reported the same way it is on the reflection path
+        engine.CheckAmortizedConstraintsAtHostBoundary();
+        var normalized = exception as TargetInvocationException ?? new TargetInvocationException(exception);
+        Throw.MeaningfulException(engine, normalized);
+        throw normalized; // unreachable, MeaningfulException does not return
+    }
+}

--- a/Jint/Runtime/Interop/Reflection/CompiledMemberAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/CompiledMemberAccessor.cs
@@ -1,0 +1,535 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Jint.Native;
+
+#if NET8_0_OR_GREATER
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using Expression = System.Linq.Expressions.Expression;
+using ConditionalExpression = System.Linq.Expressions.ConditionalExpression;
+#endif
+
+// The delegates are compiled with System.Linq.Expressions; every member they reference is public
+// (JsValue implicit operators, JsValueExtensions accessors, JsValue.Null, Math.Floor) so the
+// generated dynamic methods need no reflection-visibility relaxation. IL2075/IL3050 cover the
+// reflection + dynamic-code use, which is gated behind RuntimeFeature.IsDynamicCodeCompiled.
+#pragma warning disable IL2075
+#pragma warning disable IL3050
+
+namespace Jint.Runtime.Interop.Reflection;
+
+/// <summary>
+/// Builds and caches strongly-typed delegates that read and write CLR properties and fields, so a
+/// member access does not go through <see cref="PropertyInfo.GetValue(object, object[])"/> /
+/// <see cref="PropertyInfo.SetValue(object, object, object[])"/> reflection on every hit.
+/// <para>
+/// Two lanes are built per member. The <b>JsValue lane</b> covers the dominant member shapes
+/// (<see cref="int"/>, <see cref="long"/>, <see cref="double"/>, <see cref="bool"/>,
+/// <see cref="string"/>, <see cref="JsValue"/>) and produces or consumes the
+/// <see cref="JsValue"/> directly — no boxing, and no <see cref="JsValue.FromObjectWithType"/>
+/// dispatch on reads. The <b>raw lane</b> covers every other member type and merely replaces the
+/// reflection call, leaving the surrounding conversion untouched.
+/// </para>
+/// <para>
+/// Like <c>CompiledMethodInvoker</c>, the JsValue write lane only accepts exact-type hits:
+/// any value that is not the exact expected JavaScript type (including a fractional number bound to
+/// an integer member, or a number outside the target range) makes it return <see langword="false"/>
+/// so the caller falls back to the full conversion path, preserving today's behaviour bit-for-bit.
+/// </para>
+/// <para>
+/// The compiled delegates are cached process-wide keyed by the <see cref="MemberInfo"/>, because
+/// they are engine-independent: nothing they close over is affine to an <see cref="Engine"/>. This
+/// matters because <see cref="ReflectionAccessor"/> instances live in a per-engine cache
+/// (<c>Engine._reflectionAccessors</c>), so a per-accessor cache would recompile every member for
+/// every engine — the cost this type exists to remove. The trade-off is the same one the other
+/// process-wide reflection caches in this assembly make (<see cref="TypeDescriptor"/>,
+/// <see cref="TypeReference"/>, <c>JintBinaryExpression._knownOperators</c>): the cached
+/// <see cref="MemberInfo"/> keeps its declaring assembly alive for the process lifetime.
+/// </para>
+/// </summary>
+internal static class CompiledMemberAccessor
+{
+    /// <summary>
+    /// Writes an exact-typed <paramref name="value"/> to the member of <paramref name="target"/>.
+    /// Returns <see langword="false"/> (declining, writing nothing) when the value is not the exact
+    /// expected JavaScript type, so the caller can run the full conversion path instead.
+    /// </summary>
+    internal delegate bool JsValueSetter(object target, JsValue value);
+
+#if NET8_0_OR_GREATER
+    private static readonly ConcurrentDictionary<MemberInfo, Func<object, JsValue>?> _jsValueGetters = new();
+    private static readonly ConcurrentDictionary<MemberInfo, Func<object, object?>?> _rawGetters = new();
+    private static readonly ConcurrentDictionary<MemberInfo, JsValueSetter?> _jsValueSetters = new();
+    private static readonly ConcurrentDictionary<MemberInfo, Action<object, object?>?> _rawSetters = new();
+
+    private static readonly MethodInfo _asNumber = typeof(JsValueExtensions).GetMethod(nameof(JsValueExtensions.AsNumber), [typeof(JsValue)])!;
+    private static readonly MethodInfo _asBoolean = typeof(JsValueExtensions).GetMethod(nameof(JsValueExtensions.AsBoolean), [typeof(JsValue)])!;
+    private static readonly MethodInfo _objectToString = typeof(object).GetMethod(nameof(ToString), Type.EmptyTypes)!;
+    private static readonly MethodInfo _doubleIsNaN = typeof(double).GetMethod(nameof(double.IsNaN), [typeof(double)])!;
+    private static readonly MethodInfo _doubleIsInfinity = typeof(double).GetMethod(nameof(double.IsInfinity), [typeof(double)])!;
+    private static readonly MethodInfo _mathFloor = typeof(Math).GetMethod(nameof(Math.Floor), [typeof(double)])!;
+
+    // (double) long.MaxValue rounds up to 2^63 which overflows long, the bound must be exclusive -
+    // this mirrors InteropHelper.TryConvertNumberFast exactly.
+    private const double LongMaxValueExclusiveUpperBound = 9223372036854775808d;
+#endif
+
+    /// <summary>
+    /// Returns a delegate producing the member value as a <see cref="JsValue"/> without boxing, or
+    /// <see langword="null"/> when the member is not eligible for the JsValue lane.
+    /// </summary>
+    internal static Func<object, JsValue>? GetJsValueGetter(MemberInfo member)
+    {
+#if NET8_0_OR_GREATER
+        return _jsValueGetters.GetOrAdd(member, static m => BuildJsValueGetter(m));
+#else
+        return null;
+#endif
+    }
+
+    /// <summary>
+    /// Returns a delegate reading the member into a boxed CLR value (replacing the reflection call
+    /// only), or <see langword="null"/> when the member is not eligible.
+    /// </summary>
+    internal static Func<object, object?>? GetRawGetter(MemberInfo member)
+    {
+#if NET8_0_OR_GREATER
+        return _rawGetters.GetOrAdd(member, static m => BuildRawGetter(m));
+#else
+        return null;
+#endif
+    }
+
+    /// <summary>
+    /// Returns a delegate writing an exact-typed <see cref="JsValue"/> to the member without
+    /// boxing, or <see langword="null"/> when the member is not eligible for the JsValue lane.
+    /// </summary>
+    internal static JsValueSetter? GetJsValueSetter(MemberInfo member)
+    {
+#if NET8_0_OR_GREATER
+        return _jsValueSetters.GetOrAdd(member, static m => BuildJsValueSetter(m));
+#else
+        return null;
+#endif
+    }
+
+    /// <summary>
+    /// Returns a delegate writing an already-converted CLR value whose runtime type is exactly the
+    /// member type (replacing the reflection call only), or <see langword="null"/> when the member
+    /// is not eligible.
+    /// </summary>
+    internal static Action<object, object?>? GetRawSetter(MemberInfo member)
+    {
+#if NET8_0_OR_GREATER
+        return _rawSetters.GetOrAdd(member, static m => BuildRawSetter(m));
+#else
+        return null;
+#endif
+    }
+
+#if NET8_0_OR_GREATER
+    private static Func<object, JsValue>? BuildJsValueGetter(MemberInfo member)
+    {
+        if (!TryBuildRead(member, out var target, out var access, out var memberType)
+            || !IsSupportedMemberType(memberType))
+        {
+            return null;
+        }
+
+        return Expression.Lambda<Func<object, JsValue>>(BuildJsValueConversion(access, memberType), target).Compile();
+    }
+
+    private static Func<object, object?>? BuildRawGetter(MemberInfo member)
+    {
+        if (!TryBuildRead(member, out var target, out var access, out _))
+        {
+            return null;
+        }
+
+        return Expression.Lambda<Func<object, object?>>(Expression.Convert(access, typeof(object)), target).Compile();
+    }
+
+    private static JsValueSetter? BuildJsValueSetter(MemberInfo member)
+    {
+        if (!TryGetEligibleMember(member, out var declaringType, out var memberType)
+            || !IsSupportedWrittenMemberType(memberType))
+        {
+            return null;
+        }
+
+        var targetParameter = Expression.Parameter(typeof(object), "target");
+        var valueParameter = Expression.Parameter(typeof(JsValue), "value");
+        var returnLabel = Expression.Label(typeof(bool), "return");
+
+        var locals = new List<ParameterExpression>();
+        var body = new List<Expression>();
+
+        // emits the type test; a non-exact match jumps to the label with false, writing nothing
+        var bound = BuildValueBinding(memberType, valueParameter, returnLabel, locals, body);
+
+        if (!TryBuildWrite(member, declaringType, memberType, targetParameter, bound, out var write))
+        {
+            return null;
+        }
+
+        body.Add(write);
+        body.Add(Expression.Return(returnLabel, Expression.Constant(true)));
+        body.Add(Expression.Label(returnLabel, Expression.Constant(false)));
+
+        var lambda = Expression.Lambda<JsValueSetter>(
+            Expression.Block(typeof(bool), locals, body), targetParameter, valueParameter);
+
+        return lambda.Compile();
+    }
+
+    private static Action<object, object?>? BuildRawSetter(MemberInfo member)
+    {
+        if (!TryGetEligibleMember(member, out var declaringType, out var memberType))
+        {
+            return null;
+        }
+
+        var targetParameter = Expression.Parameter(typeof(object), "target");
+        var valueParameter = Expression.Parameter(typeof(object), "value");
+
+        // the caller only takes this lane when the value's runtime type is exactly the member type,
+        // so the unbox/cast can never fail (see CompilableMemberAccessor.DoSetValue)
+        var typedValue = Expression.Convert(valueParameter, memberType);
+        if (!TryBuildWrite(member, declaringType, memberType, targetParameter, typedValue, out var write))
+        {
+            return null;
+        }
+
+        return Expression.Lambda<Action<object, object?>>(write, targetParameter, valueParameter).Compile();
+    }
+
+    /// <summary>
+    /// Builds the expression reading <paramref name="member"/> off an <see cref="object"/> typed
+    /// target parameter, as a value of the member's own type.
+    /// </summary>
+    private static bool TryBuildRead(
+        MemberInfo member,
+        [NotNullWhen(true)] out ParameterExpression? target,
+        [NotNullWhen(true)] out Expression? access,
+        [NotNullWhen(true)] out Type? memberType)
+    {
+        target = null;
+        access = null;
+        memberType = null;
+
+        if (!TryGetEligibleMember(member, out var declaringType, out var type))
+        {
+            return false;
+        }
+
+        var targetParameter = Expression.Parameter(typeof(object), "target");
+        var typedTarget = Expression.Convert(targetParameter, declaringType);
+
+        if (member is PropertyInfo property)
+        {
+            var getMethod = property.GetGetMethod();
+            if (getMethod is null || getMethod.IsStatic)
+            {
+                return false;
+            }
+
+            // The getter is invoked through an open delegate (built once, embedded as a constant)
+            // rather than a direct call: a direct call lets the JIT inline the host getter into the
+            // compiled lambda, which erases the getter's frame from the stack trace of an exception
+            // it throws. The reflection path never inlines, so bubbling CLR exceptions would stop
+            // looking identical. (Same reasoning as CompiledMethodInvoker.)
+            if (!TryCreateOpenDelegate(getMethod, [declaringType], type, out var accessorDelegate, out var delegateType))
+            {
+                return false;
+            }
+
+            access = Expression.Invoke(Expression.Constant(accessorDelegate, delegateType), typedTarget);
+        }
+        else
+        {
+            access = Expression.Field(typedTarget, (FieldInfo) member);
+        }
+
+        target = targetParameter;
+        memberType = type;
+        return true;
+    }
+
+    /// <summary>
+    /// Builds the expression writing <paramref name="value"/> (already of the member's type) to
+    /// <paramref name="member"/> on an <see cref="object"/> typed target parameter.
+    /// </summary>
+    private static bool TryBuildWrite(
+        MemberInfo member,
+        Type declaringType,
+        Type memberType,
+        ParameterExpression target,
+        Expression value,
+        [NotNullWhen(true)] out Expression? write)
+    {
+        write = null;
+        var typedTarget = Expression.Convert(target, declaringType);
+
+        if (member is PropertyInfo property)
+        {
+            var setMethod = property.GetSetMethod();
+            if (setMethod is null || setMethod.IsStatic)
+            {
+                return false;
+            }
+
+            // open delegate for the same stack-trace-fidelity reason as the read path
+            if (!TryCreateOpenDelegate(setMethod, [declaringType, memberType], returnType: null, out var accessorDelegate, out var delegateType))
+            {
+                return false;
+            }
+
+            write = Expression.Invoke(Expression.Constant(accessorDelegate, delegateType), typedTarget, value);
+            return true;
+        }
+
+        var field = (FieldInfo) member;
+        if (field.IsInitOnly || field.IsLiteral)
+        {
+            return false;
+        }
+
+        write = Expression.Assign(Expression.Field(typedTarget, field), value);
+        return true;
+    }
+
+    /// <summary>
+    /// Members reachable through a compiled delegate: an instance property or field of a visible
+    /// reference type. Value-type receivers are excluded because an open-instance delegate over one
+    /// needs a by-ref receiver, and a write through the boxed copy would not reach the original.
+    /// </summary>
+    private static bool TryGetEligibleMember(
+        MemberInfo member,
+        [NotNullWhen(true)] out Type? declaringType,
+        [NotNullWhen(true)] out Type? memberType)
+    {
+        declaringType = null;
+        memberType = null;
+
+        // Under AOT and an interpreted-only Expression.Compile (e.g. the Mono interpreter) an
+        // interpreted lambda is slower than the reflection path it replaces, so decline entirely.
+        if (!RuntimeFeature.IsDynamicCodeCompiled)
+        {
+            return false;
+        }
+
+        var type = member.DeclaringType;
+        if (type is null || !type.IsVisible || type.IsValueType)
+        {
+            return false;
+        }
+
+        switch (member)
+        {
+            case PropertyInfo property:
+                // indexed properties are served by IndexerAccessor, not by this lane
+                if (property.GetIndexParameters().Length != 0)
+                {
+                    return false;
+                }
+                memberType = property.PropertyType;
+                break;
+
+            case FieldInfo field:
+                if (field.IsStatic)
+                {
+                    return false;
+                }
+                memberType = field.FieldType;
+                break;
+
+            default:
+                return false;
+        }
+
+        if (memberType.IsByRef || memberType.IsPointer)
+        {
+            return false;
+        }
+
+        declaringType = type;
+        return true;
+    }
+
+    private static bool TryCreateOpenDelegate(
+        MethodInfo method,
+        Type[] argumentTypes,
+        Type? returnType,
+        [NotNullWhen(true)] out Delegate? accessorDelegate,
+        [NotNullWhen(true)] out Type? delegateType)
+    {
+        accessorDelegate = null;
+        delegateType = null;
+
+        if (returnType is null)
+        {
+            if (!Expression.TryGetActionType(argumentTypes, out delegateType))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            var typeArguments = new Type[argumentTypes.Length + 1];
+            Array.Copy(argumentTypes, typeArguments, argumentTypes.Length);
+            typeArguments[argumentTypes.Length] = returnType;
+            if (!Expression.TryGetFuncType(typeArguments, out delegateType))
+            {
+                return false;
+            }
+        }
+
+        try
+        {
+            accessorDelegate = method.CreateDelegate(delegateType);
+        }
+        catch (Exception)
+        {
+            // an accessibility/binding quirk the eligibility checks did not anticipate
+            accessorDelegate = null;
+            delegateType = null;
+            return false;
+        }
+
+        return true;
+    }
+
+    // On reads a JsValue of any subtype flows straight through, matching FromObjectWithType's
+    // "value is JsValue" short-circuit.
+    private static bool IsSupportedMemberType(Type type)
+    {
+        return type == typeof(int)
+               || type == typeof(long)
+               || type == typeof(double)
+               || type == typeof(bool)
+               || type == typeof(string)
+               || typeof(JsValue).IsAssignableFrom(type);
+    }
+
+    // Writes accept exactly JsValue and no subtype: ReflectionAccessor.SetValue only assigns the
+    // JsValue straight through for `_memberType == typeof(JsValue)`, and routes a member typed as a
+    // JsValue subtype through ToObject() + the type converter instead. Accepting subtypes here
+    // would change that (a JsString assigned to a JsString-typed member would start succeeding),
+    // so they keep the existing path.
+    private static bool IsSupportedWrittenMemberType(Type type)
+    {
+        return type == typeof(int)
+               || type == typeof(long)
+               || type == typeof(double)
+               || type == typeof(bool)
+               || type == typeof(string)
+               || type == typeof(JsValue);
+    }
+
+    /// <summary>
+    /// Converts the read value to a <see cref="JsValue"/> exactly as
+    /// <see cref="JsValue.FromObjectWithType"/> would for these types: the public implicit
+    /// operators produce the same instances as <c>DefaultObjectConverter</c>, and a null reference
+    /// becomes <see cref="JsValue.Null"/>.
+    /// </summary>
+    private static Expression BuildJsValueConversion(Expression access, Type memberType)
+    {
+        if (memberType == typeof(int)
+            || memberType == typeof(long)
+            || memberType == typeof(double)
+            || memberType == typeof(bool)
+            || memberType == typeof(string))
+        {
+            // the string operator maps null to JsValue.Null internally
+            var op = typeof(JsValue).GetMethod("op_Implicit", [memberType])!;
+            return Expression.Call(op, access);
+        }
+
+        return Expression.Coalesce(
+            Expression.Convert(access, typeof(JsValue)),
+            Expression.Constant(JsValue.Null, typeof(JsValue)));
+    }
+
+    /// <summary>
+    /// Emits the type test + typed read for the assigned value, returning an expression of the
+    /// member type. A non-exact match jumps to <paramref name="returnLabel"/> with
+    /// <see langword="false"/>. Mirrors <see cref="CompiledMethodInvoker"/>'s argument binding.
+    /// </summary>
+    private static Expression BuildValueBinding(
+        Type memberType,
+        ParameterExpression value,
+        LabelTarget returnLabel,
+        List<ParameterExpression> locals,
+        List<Expression> body)
+    {
+        if (memberType == typeof(JsValue))
+        {
+            // matches SetValue's `_memberType == typeof(JsValue)` branch: assigned as-is,
+            // JsValue.Null and JsValue.Undefined included
+            return value;
+        }
+
+        if (memberType == typeof(string))
+        {
+            // accept only JsString; ToString() returns the underlying string without a copy
+            body.Add(DeclineIfNotType(value, typeof(JsString), returnLabel));
+            return Expression.Call(value, _objectToString);
+        }
+
+        if (memberType == typeof(bool))
+        {
+            body.Add(DeclineIfNotType(value, typeof(JsBoolean), returnLabel));
+            return Expression.Call(_asBoolean, value);
+        }
+
+        // int / long / double
+        body.Add(DeclineIfNotType(value, typeof(JsNumber), returnLabel));
+
+        var number = Expression.Variable(typeof(double), "d");
+        locals.Add(number);
+        body.Add(Expression.Assign(number, Expression.Call(_asNumber, value)));
+
+        if (memberType == typeof(double))
+        {
+            return number;
+        }
+
+        // Only convert integral values within the target range, otherwise decline so the fallback
+        // reproduces today's conversion behaviour. Math.Floor(v) == v is the integral test (a JIT
+        // intrinsic, unlike v % 1 == 0 which lowers to a native fmod call); NaN and infinities are
+        // rejected by the tests that short-circuit before it.
+        var isNaN = Expression.Call(_doubleIsNaN, number);
+        var isInfinity = Expression.Call(_doubleIsInfinity, number);
+        var notIntegral = Expression.NotEqual(Expression.Call(_mathFloor, number), number);
+
+        Expression belowRange;
+        Expression aboveRange;
+        if (memberType == typeof(int))
+        {
+            belowRange = Expression.LessThan(number, Expression.Constant((double) int.MinValue));
+            aboveRange = Expression.GreaterThan(number, Expression.Constant((double) int.MaxValue));
+        }
+        else
+        {
+            belowRange = Expression.LessThan(number, Expression.Constant((double) long.MinValue));
+            aboveRange = Expression.GreaterThanOrEqual(number, Expression.Constant(LongMaxValueExclusiveUpperBound));
+        }
+
+        var decline = Expression.OrElse(
+            Expression.OrElse(Expression.OrElse(isNaN, isInfinity), notIntegral),
+            Expression.OrElse(belowRange, aboveRange));
+
+        body.Add(Expression.IfThen(decline, Expression.Return(returnLabel, Expression.Constant(false))));
+
+        return Expression.Convert(number, memberType);
+    }
+
+    private static ConditionalExpression DeclineIfNotType(Expression value, Type jsType, LabelTarget returnLabel)
+    {
+        return Expression.IfThen(
+            Expression.Not(Expression.TypeIs(value, jsType)),
+            Expression.Return(returnLabel, Expression.Constant(false)));
+    }
+#endif
+}

--- a/Jint/Runtime/Interop/Reflection/FieldAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/FieldAccessor.cs
@@ -2,24 +2,24 @@ using System.Reflection;
 
 namespace Jint.Runtime.Interop.Reflection;
 
-internal sealed class FieldAccessor : ReflectionAccessor
+internal sealed class FieldAccessor : CompilableMemberAccessor
 {
     private readonly FieldInfo _fieldInfo;
 
     public FieldAccessor(FieldInfo fieldInfo, PropertyInfo? indexer = null)
-        : base(fieldInfo.FieldType, indexer)
+        : base(fieldInfo, fieldInfo.FieldType, indexer)
     {
         _fieldInfo = fieldInfo;
     }
 
     public override bool Writable => (_fieldInfo.Attributes & FieldAttributes.InitOnly) == (FieldAttributes) 0;
 
-    protected override object? DoGetValue(object target, string memberName)
+    protected override object? ReflectionGetValue(object target)
     {
         return _fieldInfo.GetValue(target);
     }
 
-    protected override void DoSetValue(object target, string memberName, object? value)
+    protected override void ReflectionSetValue(object target, object? value)
     {
         _fieldInfo.SetValue(target, value);
     }

--- a/Jint/Runtime/Interop/Reflection/PropertyAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/PropertyAccessor.cs
@@ -2,14 +2,14 @@ using System.Reflection;
 
 namespace Jint.Runtime.Interop.Reflection;
 
-internal sealed class PropertyAccessor : ReflectionAccessor
+internal sealed class PropertyAccessor : CompilableMemberAccessor
 {
     private readonly PropertyInfo _propertyInfo;
 
     public PropertyAccessor(
         PropertyInfo propertyInfo,
         PropertyInfo? indexerToTry = null)
-        : base(propertyInfo.PropertyType, indexerToTry)
+        : base(propertyInfo, propertyInfo.PropertyType, indexerToTry)
     {
         _propertyInfo = propertyInfo;
     }
@@ -18,12 +18,12 @@ internal sealed class PropertyAccessor : ReflectionAccessor
 
     public override bool Writable => _propertyInfo.CanWrite;
 
-    protected override object? DoGetValue(object target, string memberName)
+    protected override object? ReflectionGetValue(object target)
     {
         return _propertyInfo.GetValue(target, index: null);
     }
 
-    protected override void DoSetValue(object target, string memberName, object? value)
+    protected override void ReflectionSetValue(object target, object? value)
     {
         _propertyInfo.SetValue(target, value, index: null);
     }

--- a/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
@@ -34,9 +34,35 @@ internal abstract class ReflectionAccessor
 
     public abstract bool Writable { get; }
 
+    /// <summary>
+    /// An indexer is probed before the member itself (see <see cref="GetValue"/>), so the compiled
+    /// lanes in <see cref="CompilableMemberAccessor"/> must decline when one is present.
+    /// </summary>
+    protected bool HasIndexer => _indexer is not null;
+
     protected abstract object? DoGetValue(object target, string memberName);
 
     protected abstract void DoSetValue(object target, string memberName, object? value);
+
+    /// <summary>
+    /// Compiled fast lane: reads the member and produces the <see cref="JsValue"/> directly,
+    /// skipping the boxed round-trip through <see cref="JsValue.FromObjectWithType"/>. Returns
+    /// <see langword="false"/> when this accessor has no such lane, leaving the caller to run
+    /// <see cref="GetValue"/> plus its conversion.
+    /// </summary>
+    public virtual bool TryGetJsValue(Engine engine, object target, [NotNullWhen(true)] out JsValue? value)
+    {
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Compiled fast lane: writes an exact-typed <see cref="JsValue"/> straight to the member.
+    /// Returns <see langword="false"/> — having written nothing — when this accessor has no such
+    /// lane or the value is not the exact expected JavaScript type, leaving the caller to run the
+    /// full conversion path.
+    /// </summary>
+    public virtual bool TrySetJsValue(Engine engine, object target, JsValue value) => false;
 
     public object? GetValue(Engine engine, object target, string memberName)
     {
@@ -90,6 +116,14 @@ internal abstract class ReflectionAccessor
 
     public void SetValue(Engine engine, object target, string memberName, JsValue value)
     {
+        // compiled fast lane: an exact-typed value is written without boxing and without the
+        // conversion dispatch below; anything else declines here having written nothing
+        if (TrySetJsValue(engine, target, value))
+        {
+            engine.CheckAmortizedConstraintsAtHostBoundary();
+            return;
+        }
+
         object? converted;
         if (_memberType == typeof(JsValue))
         {


### PR DESCRIPTION
## Summary

Read and write CLR properties and fields through compiled delegates instead of reflecting per hit.

## Details

Reading a host member went through `PropertyInfo.GetValue` / `FieldInfo.GetValue` on every hit, boxed the result, and re-dispatched it through `JsValue.FromObjectWithType`; writing went through the mirror path. On `interop-property-access` that reflection and boxing accounted for roughly 15–18% of the row in an ETW profile (`RuntimeMethodInfo.Invoke`, the emitted `InvokeStub_*` frames, `ReflectionAccessor.GetValue`/`SetValue` and `FromObjectWithType`).

Both are now served by delegates compiled once per member, in two lanes:

* The **JsValue lane** covers members typed `int`, `long`, `double`, `bool`, `string` or `JsValue`, and produces or consumes the `JsValue` directly — a read never boxes and never dispatches through `FromObjectWithType`.
* The **raw lane** covers every other member type and only replaces the reflection call, leaving the surrounding conversion untouched.

**Behaviour preservation** is the whole design constraint here, so the write lane takes an exact JavaScript type match only — an integral in-range `JsNumber` for `int`/`long`, any `JsNumber` for `double`, `JsBoolean` for `bool`, `JsString` for `string` — and otherwise **declines**, writing nothing and falling back to the existing conversion path. That is the same decline discipline `CompiledMethodInvoker` uses. The read lane is equivalent by construction: `JsValue`'s public implicit operators produce exactly what `DefaultObjectConverter`'s type mappers produce for these five types, including `string` null → `JsValue.Null`.

Three specific hazards are handled explicitly, and each has a test:

* A member typed as a **`JsValue` subtype** (e.g. `JsString`) does *not* take the write lane. `ReflectionAccessor.SetValue` only assigns straight through for `_memberType == typeof(JsValue)`; a subtype-typed member goes through `ToObject()` and the type converter, which throws. Accepting subtypes would have silently turned that throw into a success.
* The **raw** write lane requires the value's runtime type to be exactly the member type. Reflection performs widening conversions — and the coercion path produces exactly such a case, handing a boxed `int` to a `long` member — which an `unbox.any` cannot do.
* A **null assigned to a value-type member** stays on the reflection path, whose `ArgumentException` is the established behaviour; the compiled path would raise `NullReferenceException`.

The lanes also decline when the accessor has an indexer to probe first (preserving indexer precedence), when object converters are registered (they must see the CLR value), when a custom `ITypeConverter` is installed (the fallback conversion consults it), for static members, value-type receivers, non-visible declaring types, indexed properties and `readonly`/`const` fields.

The compiled delegates are cached process-wide keyed by `MemberInfo`, because `ReflectionAccessor` instances live in the per-engine `Engine._reflectionAccessors` cache — a per-accessor cache would recompile every member for every engine, which is the cost this change exists to remove.

## Benchmark numbers

`EngineComparisonInteropBenchmark`, `Jint` lane, default job:

| Script | Before | After | Δ | Allocated |
|---|---:|---:|---:|---|
| interop-property-access | 1891.8 µs | 1585.0 µs | **−16.2%** | 798.08 → 329.36 KB (**−59%**) |
| interop-collection-traversal | 1559.8 µs | 1469.7 µs | −5.8% | unchanged |
| interop-method-calls | 2180.4 µs | 2185.7 µs | +0.2% (noise) | unchanged |
| interop-string-passing | 907.9 µs | 897.3 µs | −1.2% (noise) | unchanged |

The allocation figure is the most reliable number here, being deterministic rather than timing-based: removing the boxing on both the read and the write side cuts `interop-property-access` allocation by 59%.

<details>
<summary>Measurement protocol</summary>

All arms measured in one session on one machine (AMD Ryzen 9 5950X, .NET 10.0.10, default BenchmarkDotNet job). The baseline figure is the mean of two baseline runs executed **first and last** in the sequence as a drift check; they agree within 1.2–4.9%, which is this session's noise floor — deltas smaller than that are reported as noise above.

Every arm ran against a pre-built worktree after a discarded warm-up pass. In a first pass where BenchmarkDotNet still had to build its generated projects, runs took 5–8.5 min instead of 1.6–2.6 min and baseline-vs-baseline disagreed by up to 74%; those results were discarded.

</details>

This is one of three related interop-performance changes; combined they move `interop-string-passing` −37%, `interop-method-calls` −29%, `interop-property-access` −15% (−59% allocation) and `interop-collection-traversal` −6%. Measured with every engine in the same session, `interop-property-access` goes from 20% behind YantraJS to 4.5%, and from tied with NiL.JS to 14% ahead of it.

The `Jint_ParsedScript` script suite was re-measured as a regression net and is flat (aggregate ≈ +0.4% across 12 scripts, allocations byte-identical).

## Linked issue

None — found by profiling the interop benchmark suite.

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally (`Jint.Tests` 3869 passed, `Jint.Tests.PublicInterface` 114 passed)
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions — n/a, no spec behaviour touched
- [x] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [x] For perf changes: included before/after numbers from `Jint.Benchmark`

64 new tests in `InteropCompiledMemberAccessorTests`, written against the reflection path they replace: round-trips for every supported member type as both property and field, the raw lane for arrays/enums/nullables/reference types, and the full write-conversion boundary matrix (`int`/`long` range edges, non-integral values, `NaN`, infinities, negative zero, null and undefined) under **both** the default and `ValueCoercionType.All` settings, where the two genuinely differ. Exception fidelity is covered for throwing getters and setters on both lanes, as are all the declining conditions and cross-engine policy isolation in both creation orders. The suite was additionally validated against a manual revert of the production change, and runs a second time on `net472` where the lanes are compiled out entirely.

## Breaking change?

No. No public API change, and the fast lanes are declined wherever behaviour could differ.


## Related

Part of a three-PR interop series, each independently useful and mergeable in any order:

* #2743 — cache interop invokers process-wide (drives `interop-method-calls` and `interop-string-passing`)
* #2744 — compile CLR property and field access (drives `interop-property-access` and its allocation)
* #2745 — trim per-call overhead from the method fast lane (small; see the note in that PR)

I verified all three merged together: `Jint.Tests` 3910 passed, `Jint.Tests.PublicInterface` 114, `Jint.Tests.CommonScripts` 28. One caveat if you take both #2743 and #2745: they each append tests to `Jint.Tests/Runtime/InteropCompiledInvokerTests.cs`, which conflicts textually — the resolution is simply to keep both blocks, as neither side's tests overlap. `MethodDescriptor.cs`, which both also touch, merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
