### PR TITLE
Trim per-call overhead from the interop method fast lane

### DIFF
--- a/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
+++ b/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
@@ -23,6 +23,12 @@ public class InteropCompiledInvokerTests
         public JsValue Echo(JsValue value) => value;
         public int TimesTwo(int x) => x * 2;
 
+        public int IdentityInt(int value) => value;
+        public long IdentityLong(long value) => value;
+        public double IdentityDouble(double value) => value;
+
+        public static int StaticIdentityInt(int value) => value;
+
         public void DoVoid() => VoidCalled = true;
 
         public int Throws() => throw new InvalidOperationException("boom from host");
@@ -427,6 +433,115 @@ public class InteropCompiledInvokerTests
         }
     }
 
+    [Theory]
+    // exact integers, including the int boundaries and negative zero, are exact-type hits
+    [InlineData("host.IdentityInt(0)", 0)]
+    [InlineData("host.IdentityInt(-0)", 0)]
+    [InlineData("host.IdentityInt(1)", 1)]
+    [InlineData("host.IdentityInt(-1)", -1)]
+    [InlineData("host.IdentityInt(2147483647)", int.MaxValue)]
+    [InlineData("host.IdentityInt(-2147483648)", int.MinValue)]
+    public void IntBoundaryValuesBindExactly(string script, int expected)
+    {
+        var engine = CreateEngine();
+        engine.Evaluate(script).AsNumber().Should().Be(expected);
+    }
+
+    [Theory]
+    // non-integral values are declined by the fast lane and rounded by the fallback converter
+    // (banker's rounding) exactly as before the fast lane existed
+    [InlineData("host.IdentityInt(1.5)", 2)]
+    [InlineData("host.IdentityInt(2.5)", 2)]
+    [InlineData("host.IdentityInt(-1.5)", -2)]
+    [InlineData("host.IdentityInt(-0.5)", 0)]
+    [InlineData("host.IdentityInt(0.5)", 0)]
+    public void NonIntegralIntArgumentsFallBackToRoundingConversion(string script, int expected)
+    {
+        var engine = CreateEngine();
+        engine.Evaluate(script).AsNumber().Should().Be(expected);
+    }
+
+    [Theory]
+    // out-of-range and non-finite numbers are declined by the fast lane AND rejected by the
+    // fallback conversion, which surfaces the resolution error
+    [InlineData("host.IdentityInt(2147483648)")]
+    [InlineData("host.IdentityInt(-2147483649)")]
+    [InlineData("host.IdentityInt(NaN)")]
+    [InlineData("host.IdentityInt(Infinity)")]
+    [InlineData("host.IdentityInt(-Infinity)")]
+    [InlineData("host.IdentityLong(NaN)")]
+    [InlineData("host.IdentityLong(Infinity)")]
+    [InlineData("host.IdentityLong(-Infinity)")]
+    // (double) long.MaxValue rounds up to 2^63, which overflows long - the upper bound is exclusive
+    [InlineData("host.IdentityLong(9223372036854775808)")]
+    public void OutOfRangeOrNonFiniteIntegerArgumentsAreRejected(string script)
+    {
+        var engine = CreateEngine();
+        var ex = Invoking(() => engine.Evaluate(script)).Should().ThrowExactly<Jint.Runtime.JavaScriptException>().Which;
+        ex.Message.Should().Contain("No public methods");
+    }
+
+    [Theory]
+    [InlineData("host.IdentityLong(0)", 0d)]
+    [InlineData("host.IdentityLong(-0)", 0d)]
+    [InlineData("host.IdentityLong(1)", 1d)]
+    // a very large integral double still binds exactly
+    [InlineData("host.IdentityLong(1e18)", 1e18)]
+    [InlineData("host.IdentityLong(-1e18)", -1e18)]
+    // long.MinValue is exactly representable as a double, so it is still in range
+    [InlineData("host.IdentityLong(-9223372036854775808)", -9223372036854775808d)]
+    public void LongBoundaryValuesBindExactly(string script, double expected)
+    {
+        var engine = CreateEngine();
+        engine.Evaluate(script).AsNumber().Should().Be(expected);
+    }
+
+    [Fact]
+    public void DoubleParameterAcceptsEveryNumberIncludingNonFinite()
+    {
+        var engine = CreateEngine();
+        // a double parameter has no integrality/range test at all, every JsNumber flows through
+        engine.Evaluate("host.IdentityDouble(1.5)").AsNumber().Should().Be(1.5);
+        engine.Evaluate("host.IdentityDouble(-0.5)").AsNumber().Should().Be(-0.5);
+        engine.Evaluate("host.IdentityDouble(1e300)").AsNumber().Should().Be(1e300);
+        double.IsNaN(engine.Evaluate("host.IdentityDouble(NaN)").AsNumber()).Should().BeTrue();
+        engine.Evaluate("host.IdentityDouble(Infinity)").AsNumber().Should().Be(double.PositiveInfinity);
+        engine.Evaluate("host.IdentityDouble(-Infinity)").AsNumber().Should().Be(double.NegativeInfinity);
+        // negative zero survives the round trip
+        engine.Evaluate("1 / host.IdentityDouble(-0)").AsNumber().Should().Be(double.NegativeInfinity);
+    }
+
+    /// <summary>
+    /// Values that straddle every interesting integrality/range boundary of the interop numeric
+    /// binding: integral and non-integral, the int/long limits, the 2^52 and 2^53 precision steps,
+    /// negative zero, subnormals and the non-finite values.
+    /// </summary>
+    private static double[] IntegralityProbeValues() =>
+    [
+        0d, -0d, 1d, -1d, 0.5, -0.5, 1.5, -1.5, 2.5, -2.5,
+        int.MaxValue, int.MinValue, 2147483648d, -2147483649d, 2147483647.5, -2147483648.5,
+        4503599627370495.5, // largest representable non-integral magnitude (just below 2^52)
+        4503599627370496d,  // 2^52 - every double from here up is integral
+        9007199254740992d,  // 2^53
+        9223372036854775808d, -9223372036854775808d, // +-2^63
+        1e18, -1e18, 1e300, -1e300,
+        double.Epsilon, -double.Epsilon,
+        double.MaxValue, double.MinValue,
+        double.NaN, double.PositiveInfinity, double.NegativeInfinity,
+    ];
+
+    [Fact]
+    public void IsIntegralNumberMatchesRemainderFormulation()
+    {
+        // the Math.Floor(v) == v formulation must agree with the v % 1 == 0 one it replaced on every
+        // value, so no interop or spec boundary can shift
+        foreach (var value in IntegralityProbeValues())
+        {
+            var viaRemainder = !double.IsNaN(value) && !double.IsInfinity(value) && value % 1 == 0;
+            Jint.Runtime.TypeConverter.IsIntegralNumber(value).Should().Be(viaRemainder, "for {0}", value);
+        }
+    }
+
     [Fact]
     public void SharedInvokerCache_OverloadResolutionFromTwoEngines()
     {
@@ -455,5 +570,83 @@ public class InteropCompiledInvokerTests
         first.Evaluate("new Box(3).Value").AsNumber().Should().Be(3);
         second.Evaluate("new Box(4).Value").AsNumber().Should().Be(4);
         first.Evaluate("new Box(5).Value").AsNumber().Should().Be(5);
+    }
+
+    [Fact]
+    public void IsIntegralNumberEquivalenceIsObservableThroughBigIntConversion()
+    {
+        // BigInt(number) is a JS-visible consumer of IsIntegralNumber: it throws a RangeError for
+        // every non-integral (or non-finite) number and succeeds for every integral one
+        var engine = new Engine();
+        var isIntegral = engine.Evaluate("(function (v) { try { BigInt(v); return true; } catch (e) { return false; } })");
+
+        foreach (var value in IntegralityProbeValues())
+        {
+            var viaRemainder = !double.IsNaN(value) && !double.IsInfinity(value) && value % 1 == 0;
+            engine.Invoke(isIntegral, value).AsBoolean().Should().Be(viaRemainder, "for {0}", value);
+        }
+    }
+
+    [Fact]
+    public void CustomTypeConverterInstalledAfterConstructionDisablesFastLane()
+    {
+        // the fast lane gates on a cached "is the stock converter" flag; swapping the converter after
+        // construction has to keep that flag in sync, otherwise the custom converter is skipped
+        var engine = new Engine();
+        engine.SetValue("host", new Host());
+
+        engine._typeConverterIsDefault.Should().BeTrue();
+        engine.Evaluate("host.And(true, true)").AsBoolean().Should().BeTrue();
+
+        engine.TypeConverter = new BoolVetoingTypeConverter(engine);
+        engine._typeConverterIsDefault.Should().BeFalse();
+
+        var ex = Invoking(() => engine.Evaluate("host.And(true, true)")).Should().ThrowExactly<Jint.Runtime.JavaScriptException>().Which;
+        ex.Message.Should().Contain("No public methods");
+        // conversions the veto does not touch keep working through the slow path
+        engine.Evaluate("host.AddInt(2, 3)").AsNumber().Should().Be(5);
+
+        // swapping the stock converter back re-enables the fast lane
+        engine.TypeConverter = new Jint.Runtime.Interop.DefaultTypeConverter(engine);
+        engine._typeConverterIsDefault.Should().BeTrue();
+        engine.Evaluate("host.And(true, true)").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void DefaultEngineUsesTheStockTypeConverterFastLane()
+    {
+        var engine = CreateEngine();
+        engine._typeConverterIsDefault.Should().BeTrue();
+        engine.Evaluate("host.AddInt(2, 3)").AsNumber().Should().Be(5);
+        engine.Evaluate("host.And(true, false)").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void StaticAndInstanceMethodsDispatchThroughCachedReflectionFacts()
+    {
+        var engine = CreateEngine();
+        engine.SetValue("other", new OtherHost());
+
+        // instance method: the receiver type check must still pass
+        engine.Evaluate("host.IdentityInt(7)").AsNumber().Should().Be(7);
+        engine.Evaluate("var f = host.IdentityInt; f.call(host, 8)").AsNumber().Should().Be(8);
+
+        // static method: no receiver type check at all, including through an extracted reference
+        engine.Evaluate("host.StaticIdentityInt(9)").AsNumber().Should().Be(9);
+        engine.Evaluate("var g = host.StaticIdentityInt; g.call(null, 10)").AsNumber().Should().Be(10);
+        engine.Evaluate("var h = host.StaticIdentityInt; h.call(other, 11)").AsNumber().Should().Be(11);
+    }
+
+    [Fact]
+    public void ExtractedInstanceMethodWithWrongReceiverKeepsSurfacingTargetException()
+    {
+        // same guarantee as WrongTypedThisSurfacesReflectionPathException, but for a method whose
+        // receiver check now reads the cached DeclaringType instead of the reflection property
+        var engine = new Engine(options => options.Interop.ExceptionHandler = _ => false);
+        engine.SetValue("host", new Host());
+        engine.SetValue("other", new OtherHost());
+
+        var ex = Invoking(() => engine.Evaluate("var f = host.IdentityInt; f.call(other, 3)")).Should().Throw<Exception>().Which;
+        ex.Should().BeAssignableTo<System.Reflection.TargetException>();
     }
 }

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -174,7 +174,21 @@ public sealed partial class Engine : IDisposable
     internal readonly ObjectTraverseStackPool _objectTraverseStackPool;
     internal readonly ExtensionMethodCache _extensionMethods;
 
-    public ITypeConverter TypeConverter { get; internal set; }
+    private ITypeConverter _typeConverter = null!;
+
+    // kept in sync by the TypeConverter setter so the interop fast lane, which is only valid for the
+    // stock converter, can gate on a bool field instead of a per-call GetType() comparison
+    internal bool _typeConverterIsDefault;
+
+    public ITypeConverter TypeConverter
+    {
+        get => _typeConverter;
+        internal set
+        {
+            _typeConverter = value;
+            _typeConverterIsDefault = value.GetType() == typeof(DefaultTypeConverter);
+        }
+    }
 
     // cache of types used when resolving CLR type names
     internal readonly Dictionary<string, Type?> TypeCache = new(StringComparer.Ordinal);

--- a/Jint/Runtime/Interop/CompiledMethodInvoker.cs
+++ b/Jint/Runtime/Interop/CompiledMethodInvoker.cs
@@ -45,6 +45,7 @@ internal static class CompiledMethodInvoker
     private static readonly MethodInfo _objectToString = typeof(object).GetMethod(nameof(ToString), Type.EmptyTypes)!;
     private static readonly MethodInfo _doubleIsNaN = typeof(double).GetMethod(nameof(double.IsNaN), [typeof(double)])!;
     private static readonly MethodInfo _doubleIsInfinity = typeof(double).GetMethod(nameof(double.IsInfinity), [typeof(double)])!;
+    private static readonly MethodInfo _mathFloor = typeof(Math).GetMethod(nameof(Math.Floor), [typeof(double)])!;
 
     // (double) long.MaxValue rounds up to 2^63 which overflows long, the bound must be exclusive -
     // this mirrors InteropHelper.TryConvertNumberFast exactly.
@@ -281,7 +282,20 @@ internal static class CompiledMethodInvoker
         // the target range, otherwise decline so the fallback reproduces today's behavior.
         var isNaN = Expression.Call(_doubleIsNaN, value);
         var isInfinity = Expression.Call(_doubleIsInfinity, value);
-        var notIntegral = Expression.NotEqual(Expression.Modulo(value, Expression.Constant(1d)), Expression.Constant(0d));
+
+        // Integrality is tested with Math.Floor(v) != v rather than v % 1 != 0: Expression.Modulo on
+        // doubles lowers to a native fmod call inside the generated lambda, while Math.Floor is a JIT
+        // intrinsic that becomes a single vroundsd instruction. The two tests agree on every value
+        // that reaches this point:
+        //   - finite v: v % 1 is the truncated remainder, i.e. v - trunc(v), which is +-0 exactly when
+        //     v has no fractional part; Math.Floor(v) == v likewise holds exactly for such v (for
+        //     negative fractional v, floor rounds away from v, so both tests report "not integral").
+        //     Note -0.0 is integral under both (-0.0 % 1 is -0.0 which == 0.0, and Math.Floor(-0.0) is
+        //     -0.0 which == -0.0), and |v| >= 2^52 values, which are necessarily integral, satisfy both.
+        //   - NaN and +-Infinity never reach this test: isNaN/isInfinity precede it in the OrElse chain
+        //     below and short-circuit the whole decision.
+        // So the composite decline decision is bit-for-bit identical; the OrElse ordering is preserved.
+        var notIntegral = Expression.NotEqual(Expression.Call(_mathFloor, value), value);
 
         Expression belowRange;
         Expression aboveRange;

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -19,6 +19,10 @@ internal sealed class MethodDescriptor
         // MethodBase.IsGenericMethod ends up in RuntimeMethodHandle::HasMethodInstantiation, a
         // non-trivial reflection call; cache it so the per-call binding path never pays for it.
         IsGenericMethod = method.IsGenericMethod;
+        IsGenericMethodDefinition = method is MethodInfo { IsGenericMethodDefinition: true };
+        IsStatic = method.IsStatic;
+        DeclaringType = method.DeclaringType;
+        ReturnType = (method as MethodInfo)?.ReturnType;
 
         foreach (var parameter in Parameters)
         {
@@ -52,6 +56,31 @@ internal sealed class MethodDescriptor
     /// hotspot in argument binding, so it is computed once in the constructor.
     /// </summary>
     public bool IsGenericMethod { get; }
+
+    /// <summary>
+    /// Cached "<see cref="Method"/> is a <see cref="MethodInfo"/> whose
+    /// <see cref="MethodBase.IsGenericMethodDefinition"/> is true" — same rationale as
+    /// <see cref="IsGenericMethod"/>, it is read per call while resolving a generic method.
+    /// </summary>
+    public bool IsGenericMethodDefinition { get; }
+
+    /// <summary>
+    /// Cached <see cref="MethodBase.IsStatic"/> — read on every call to decide whether the receiver
+    /// has to be type-checked, and the virtual reflection property shows up in interop call profiles.
+    /// </summary>
+    public bool IsStatic { get; }
+
+    /// <summary>
+    /// Cached <see cref="MemberInfo.DeclaringType"/> — read on every call to validate the receiver.
+    /// </summary>
+    public Type? DeclaringType { get; }
+
+    /// <summary>
+    /// Cached <see cref="MethodInfo.ReturnType"/>, or <see langword="null"/> when <see cref="Method"/>
+    /// is a <see cref="ConstructorInfo"/> — read on every call to map the CLR result back to a
+    /// <see cref="JsValue"/>.
+    /// </summary>
+    public Type? ReturnType { get; }
 
     /// <summary>
     /// Facts about each parameter type that argument binding consults on every call — computed

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -116,16 +116,13 @@ internal sealed class MethodInfoFunction : Function
         {
             return method;
         }
-        if (!method.IsGenericMethodDefinition)
+        // the cached flag is "Method is a MethodInfo that is a generic method definition", which folds
+        // in the MethodInfo cast the reflection path used to repeat here
+        if (!descriptor.IsGenericMethodDefinition)
         {
             return method;
         }
-        var methodInfo = method as MethodInfo;
-        if (methodInfo == null)
-        {
-            // probably should issue at least a warning here
-            return method;
-        }
+        var methodInfo = (MethodInfo) method;
 
         // TPC: we could also && "(method.Method.IsGenericMethodDefinition)" because we won't create a generic method if that isn't the case
         var methodGenericArgs = method.GetGenericArguments();
@@ -179,9 +176,9 @@ internal sealed class MethodInfoFunction : Function
                 // A wrong-typed receiver (extracted method invoked via .call on a foreign this) also
                 // declines so the reflection path surfaces the same TargetException it always did.
                 if (_engine._objectConverters is null
-                    && _engine.TypeConverter.GetType() == typeof(DefaultTypeConverter)
+                    && _engine._typeConverterIsDefault
                     && method.GetCompiledInvoker() is { } compiledInvoker
-                    && (method.Method.IsStatic || method.Method.DeclaringType?.IsInstanceOfType(thisObj) == true))
+                    && (method.IsStatic || method.DeclaringType?.IsInstanceOfType(thisObj) == true))
                 {
                     JsValue compiledResult = null!;
                     bool handled;
@@ -295,7 +292,7 @@ internal sealed class MethodInfoFunction : Function
         {
             // the resolved parameters differ from the descriptor's, re-classify them
             methodParameters = resolvedMethod.GetParameters();
-            isGenericDefinition = method.Method is MethodInfo { IsGenericMethodDefinition: true };
+            isGenericDefinition = method.IsGenericMethodDefinition;
             parameterFlags = new InteropParameterFlags[methodParameters.Length];
             for (var i = 0; i < methodParameters.Length; i++)
             {
@@ -377,7 +374,7 @@ internal sealed class MethodInfoFunction : Function
             }
 
             var invokeResult = method.Invoke(thisObj, parameters);
-            callResult = FromObjectWithType(Engine, invokeResult, type: (method.Method as MethodInfo)?.ReturnType);
+            callResult = FromObjectWithType(Engine, invokeResult, type: method.ReturnType);
             _engine.CheckAmortizedConstraintsAtHostBoundary();
             return true;
         }

--- a/Jint/Runtime/Interop/Reflection/CompilableMemberAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/CompilableMemberAccessor.cs
@@ -90,8 +90,9 @@ internal abstract class CompilableMemberAccessor : ReflectionAccessor
     {
         // The fallback conversion consults the engine's ITypeConverter for some of these member
         // types (an integer JsNumber assigned to a double member reaches ConvertValueToSet, for
-        // example), so a host-installed converter must keep seeing them.
-        if (engine.TypeConverter.GetType() != typeof(DefaultTypeConverter))
+        // example), so a host-installed converter must keep seeing them. The flag is maintained by
+        // the TypeConverter setter, so this costs a field read instead of a GetType() per write.
+        if (!engine._typeConverterIsDefault)
         {
             return false;
         }

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -1012,7 +1012,13 @@ public static class TypeConverter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool IsIntegralNumber(double value)
     {
-        return !double.IsNaN(value) && !double.IsInfinity(value) && value % 1 == 0;
+        // Math.Floor(value) == value instead of value % 1 == 0: the remainder operator on doubles
+        // compiles to a native fmod call, Math.Floor is a JIT intrinsic (a single vroundsd). The NaN
+        // and infinity guards above still short-circuit, and for every finite value the two tests are
+        // equivalent - value % 1 is value - trunc(value), which is +-0 exactly when value has no
+        // fractional part, which is exactly when Math.Floor(value) == value (-0.0 and magnitudes
+        // >= 2^52, which are necessarily integral, are accepted by both).
+        return !double.IsNaN(value) && !double.IsInfinity(value) && Math.Floor(value) == value;
     }
 
     private static ObjectInstance ToObjectNonObject(Realm realm, JsValue value)


### PR DESCRIPTION
## Summary

Remove an `fmod` call and several per-call reflection reads from the interop method fast lane.

## Details

Four small changes, all on the per-call interop path, all found in an ETW profile of the interop benchmarks:

**1. `fmod` in the compiled invoker.** `CompiledMethodInvoker.BuildArgumentBinding` tested whether a double argument was integral with `Expression.Modulo(value, 1d) != 0`. The remainder operator on doubles lowers to a **native `fmod` call**. It is now `Math.Floor(value) != value`, a JIT intrinsic that compiles to a single `vroundsd`.

The two are equivalent for every value that reaches the test: for finite values, `value % 1` is `value - trunc(value)`, which is `±0` exactly when the value has no fractional part, which is exactly when `Math.Floor(value) == value` (`-0.0` and magnitudes ≥ 2^52, which are necessarily integral, are accepted by both). `NaN` and `±Infinity` are rejected by the `isNaN`/`isInfinity` tests that short-circuit **before** this one in the unchanged `OrElse` chain, so the composite decline decision is bit-for-bit identical.

**2. The same `% 1` in `TypeConverter.IsIntegralNumber`,** which the interop conversion fallback and some spec paths share, with the same substitution and the same equivalence argument (its own `NaN`/infinity guards are retained). All 13 call sites were audited: each consumes only the boolean, and none depends on the remainder formulation.

**3. Per-call reflection property reads.** `MethodInfoFunction.Call` read `method.Method.IsStatic` and `method.Method.DeclaringType` on every invocation, and `TryCall` read `(method.Method as MethodInfo)?.ReturnType`; these are virtual `MethodBase` property calls into the reflection stack. They are now computed once in the `MethodDescriptor` constructor, following the pattern that property already establishes for `IsGenericMethod`. `IsGenericMethodDefinition` is cached the same way, which also folds away a repeated `as MethodInfo` cast in `ResolveMethod`.

**4. The per-call type-converter identity test.** The compiled fast lane is only valid for the stock converter, and gated on `_engine.TypeConverter.GetType() == typeof(DefaultTypeConverter)` on every call. `Engine.TypeConverter` now has an explicit backing field whose setter maintains an `internal bool` flag, and the gate reads the flag. The public shape is unchanged (public get, internal set), and a converter swapped in after construction still flips the flag — there is a test for that. The compiled property-write lane added in #2744 reads the same flag.

## Benchmark numbers

Re-measured against **current `main`** (after #2743 cached the compiled invoker and #2744 compiled property access), on a quiet machine.

**Structural — this part is not subject to timing noise.** An ETW profile of the `interop-method-calls` row: `ucrtbase!fmod` is **3.5% of all CPU samples (5,482 samples) on `main`, and 0 on this branch.** It is a *larger* share than before #2743, because removing the per-engine recompile made every remaining cost a bigger slice. `Math.Floor` emits no call frame, so nothing takes its place, and no other function grew in the profile.

**Timing.** `EngineComparisonInteropBenchmark` mixes all four scripts per run and cannot be filtered to one, so at the suite level a ~4% single-row effect is lost in the ~4% run-to-run noise (the arms are measured minutes apart). Measuring `interop-method-calls` on its own with a fresh-engine harness — identical inner work to the benchmark — run **alternating between the two builds** so drift cancels, 12 pairs, 6 s each:

| Row | `main` (median) | this branch (median) | Δ |
|---|---:|---:|---:|
| interop-method-calls | 1807.8 µs | 1725.1 µs | **−4.6%** (−2.9% on the minimums) |

The result is **paired**: this branch was faster in **11 of the 12 pairs** (sign-test p ≈ 0.003), which is what makes it distinguishable from noise despite the per-run variance.

The other three rows are flat. `interop-string-passing`, measured the same way over two batches, came out at +2.2% then +1.4% with the sign mixed pair-by-pair (this branch faster in 4/12, then 5/14) — statistically indistinguishable from zero and shrinking with more samples, which is expected: `concat`'s string arguments never hit the `fmod` path, so only the cheaper per-call gate applies there. `interop-property-access` and `interop-collection-traversal` are within noise at the suite level.

So the change is a clean win on `interop-method-calls` — the row with the most host calls, and where the `fmod` plus the cached reflection reads live — and neutral elsewhere. None of the four changes can make any path slower: each replaces work with strictly less work.

## Regression net

The `Jint_ParsedScript` script suite (pure JS compute, no interop) was re-measured because `IsIntegralNumber` is shared with spec paths: flat (aggregate ≈ +0.4% across 12 scripts, allocations byte-identical). Consistent with that, the helper is only reached from cold paths — `**` operator edge cases, BigInt, TypedArray and Atomics — while `JsNumber.Create` already avoids it via a `(long)` round-trip.

## Linked issue

None — found by profiling the interop benchmark suite.

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally (`Jint.Tests` passed, `Jint.Tests.PublicInterface` 114 passed)
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions — n/a; `IsIntegralNumber` is provably equivalent and its callers were audited
- [x] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [x] For perf changes: included before/after numbers from `Jint.Benchmark`

New tests sweep the accept/decline boundaries through the compiled lane for `int`/`long`/`double` parameters (range edges, values just outside them, non-integral values, `NaN`, infinities, negative zero, 2^63) to prove changes 1 and 2 shifted nothing, compare `IsIntegralNumber` against the old remainder formulation over 31 probe doubles both directly and through the JS-visible `BigInt` path, and cover a converter swapped in and back out after construction, static versus instance dispatch, and an extracted method invoked with a wrong-typed receiver.

## Breaking change?

No. `Engine.TypeConverter` keeps its public get / internal set shape, as the `Jint.Tests.PublicInterface` gate confirms.

## Related

Follows the merged interop series #2743 (cache interop invokers process-wide) and #2744 (compile CLR property and field access); rebased onto `main` after both landed. This is the small third piece — the profile showed the remaining per-call overhead once recompilation and property-access reflection were gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
