### PR TITLE
Convert an indexer hit by the indexer type, not the member type

### DIFF
--- a/Jint.Tests/Runtime/InteropTests.cs
+++ b/Jint.Tests/Runtime/InteropTests.cs
@@ -2393,6 +2393,32 @@ public partial class InteropTests : IDisposable
     }
 
     [Fact]
+    public void ShouldConvertIndexerHitByTheIndexersOwnType()
+    {
+        // The indexer is probed before the member itself, so it can answer for a name that a
+        // declared member also carries. The value then has the indexer's type, not the member's,
+        // and converting it as the member's type used to throw an InvalidCastException.
+        _engine.SetValue("h", new IndexerShadowingMember());
+        _engine.Evaluate("h.Value").Should().Be("from indexer");
+    }
+
+    [Fact]
+    public void ShouldFallBackToMemberWhenIndexerDoesNotAnswer()
+    {
+        // the same object, on a name the indexer returns null for: the declared member wins and is
+        // still converted by its own type
+        _engine.SetValue("h", new IndexerShadowingMember());
+        _engine.Evaluate("h.Other").Should().Be(7);
+    }
+
+    private sealed class IndexerShadowingMember
+    {
+        public int Value { get; set; } = 1;
+        public int Other { get; set; } = 7;
+        public string this[string key] => key == "Value" ? "from indexer" : null;
+    }
+
+    [Fact]
     public void ShouldUseExplicitPropertySetter()
     {
         _engine.SetValue("c", new Company("ACME"));

--- a/Jint/Runtime/Descriptors/Specialized/ReflectionDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/ReflectionDescriptor.cs
@@ -73,8 +73,8 @@ internal sealed class ReflectionDescriptor : PropertyDescriptor
             return fastResult;
         }
 
-        var value = _reflectionAccessor.GetValue(_engine, _target, _propertyName);
-        var type = _reflectionAccessor.MemberType ?? value?.GetType();
+        var value = _reflectionAccessor.GetValue(_engine, _target, _propertyName, out var valueType);
+        var type = valueType ?? value?.GetType();
         // conversion before the check so an awaitable result gets its continuation attached
         var result = JsValue.FromObjectWithType(_engine, value, type);
         _engine.CheckAmortizedConstraintsAtHostBoundary();

--- a/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/ReflectionAccessor.cs
@@ -64,8 +64,17 @@ internal abstract class ReflectionAccessor
     /// </summary>
     public virtual bool TrySetJsValue(Engine engine, object target, JsValue value) => false;
 
-    public object? GetValue(Engine engine, object target, string memberName)
+    /// <summary>
+    /// Reads the member. <paramref name="valueType"/> receives the declared type of whatever
+    /// produced the value: the member's own type normally, or the indexer's when the indexer probe
+    /// below answered instead. They are not interchangeable — an indexer can answer for a name a
+    /// declared member also carries, and its value is then described by the indexer's type — so the
+    /// caller must convert by this type rather than by <see cref="MemberType"/>.
+    /// </summary>
+    public object? GetValue(Engine engine, object target, string memberName, out Type? valueType)
     {
+        valueType = _memberType;
+
         var constantValue = ConstantValue;
         if (constantValue is not null)
         {
@@ -86,6 +95,10 @@ internal abstract class ReflectionAccessor
                 engine.CheckAmortizedConstraintsAtHostBoundary();
                 Throw.MeaningfulException(engine, tie);
             }
+        }
+        else
+        {
+            valueType = _indexer!.PropertyType;
         }
 
         // the success-path boundary check runs in ReflectionDescriptor.DoGet after result


### PR DESCRIPTION
## Summary

Fix an `InvalidCastException` when an indexer answers for a name a declared member also carries.

## Details

`ReflectionAccessor.GetValue` probes the type's indexer **before** the member itself (deliberately — that is how explicitly implemented interface properties are reached, as `ShouldUseExplicitIndexerPropertyGetter` covers). But `ReflectionDescriptor.DoGet` then converted whatever came back using `MemberType`, the declared type of the *member* — which describes a different value entirely when the indexer is what answered.

Reading such a member threw out of `DefaultObjectConverter`'s type mappers:

```csharp
public sealed class Host
{
    public int Value { get; set; } = 1;
    public string this[string key] => key == "Value" ? "from indexer" : null;
}

engine.SetValue("h", new Host());
engine.Evaluate("h.Value");
// System.InvalidCastException: Unable to cast object of type 'System.String' to type 'System.Int32'
//   at Jint.DefaultObjectConverter.TryConvert -> _typeMappers[typeof(int)]
//   at Jint.Native.JsValue.FromObjectWithType
//   at Jint.Runtime.Descriptors.Specialized.ReflectionDescriptor.DoGet
```

`GetValue` now reports the declared type of whatever actually produced the value — the member's own type, or the indexer's `PropertyType` when the indexer answered — and the descriptor converts by that.

The indexer's *declared* type is used rather than `value.GetType()`, to stay consistent with how declared types govern conversion elsewhere in interop (an `object`-typed indexer still resolves to the runtime type via `ObjectWrapper.GetClrType`, and an interface- or array-typed one keeps its declared contract, which the array/live-view decisions depend on).

**Precedence is unchanged** — the indexer still wins when it answers, and the declared member is still used when the indexer returns null. Only the type used for the conversion is corrected. Nullable members are unaffected: they keep flowing through `MemberType`, which `GetClrType` already unwraps.

This is pre-existing and unrelated to the recent interop performance work; I found it while writing tests for #2744.

## Linked issue

None — found while testing #2744.

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally (`Jint.Tests` 3879 passed, `Jint.Tests.PublicInterface` 114 passed)
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions — n/a, interop only
- [x] For interop changes: covered in `Jint.Tests/Runtime/Interop`
- [ ] For perf changes: included before/after numbers from `Jint.Benchmark` — n/a, not a perf change

Two tests: `ShouldConvertIndexerHitByTheIndexersOwnType` (the crash above, which fails on `main` with exactly that `InvalidCastException`) and `ShouldFallBackToMemberWhenIndexerDoesNotAnswer` (the same object on a name the indexer returns null for, pinning the unchanged precedence and the member's own conversion).

## Breaking change?

No. The changed `GetValue` overload is `internal`, and the only behaviour difference is that a read which used to throw now returns the indexer's value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
