### PR TITLE
Measure the execution timeout against an inline deadline

### DIFF
--- a/Jint.Tests/Runtime/ExecutionConstraintTests.cs
+++ b/Jint.Tests/Runtime/ExecutionConstraintTests.cs
@@ -93,6 +93,43 @@ public class ExecutionConstraintTests
     }
 
     [Fact]
+    public void TimeoutIsNotObservedBeforeAnyExecutionStarts()
+    {
+        // The constraint is armed by Reset, which runs when a top-level execution begins. Probing
+        // it before that must not fail, however long the engine has been sitting idle.
+        var engine = new Engine(cfg => cfg.TimeoutInterval(TimeSpan.FromMilliseconds(1)));
+        Thread.Sleep(50);
+        Invoking(() => engine.Constraints.Check()).Should().NotThrow();
+    }
+
+    [Fact]
+    public void TimeoutIsRearmedForEachTopLevelExecution()
+    {
+        // Each execution gets the full interval, so a sequence of short scripts separated by pauses
+        // longer than the timeout must all succeed.
+        var engine = new Engine(cfg => cfg.TimeoutInterval(TimeSpan.FromMilliseconds(200)));
+        for (var i = 0; i < 3; i++)
+        {
+            engine.Evaluate("var x = 1 + 1;");
+            Thread.Sleep(250);
+        }
+
+        engine.Evaluate("1 + 1").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void TimeoutIsObservedWithoutWaitingForATimerCallback()
+    {
+        // The deadline is compared inline, so once the interval has elapsed the very next check
+        // fails - detection does not wait on a thread-pool timer callback. The engine is kept out
+        // of the picture between arming and checking so nothing but elapsed time can trip it.
+        var engine = new Engine(cfg => cfg.TimeoutInterval(TimeSpan.FromMilliseconds(20)));
+        engine.Constraints.Reset();
+        Thread.Sleep(60);
+        Invoking(() => engine.Constraints.Check()).Should().ThrowExactly<TimeoutException>();
+    }
+
+    [Fact]
     public void ShouldThrowTimeoutInsideFunctionLocalTightLoop()
     {
         // The function-local expression-body for loop is the shape that arms the interpreter's

--- a/Jint/Constraints/TimeConstraint.cs
+++ b/Jint/Constraints/TimeConstraint.cs
@@ -1,23 +1,42 @@
+using System.Diagnostics;
 using Jint.Runtime;
-using System.Threading;
 
 namespace Jint.Constraints;
 
-#pragma warning disable CA1001
+/// <summary>
+/// Fails execution once a fixed interval has elapsed, measured against a deadline captured when the
+/// constraint is reset.
+/// </summary>
+/// <remarks>
+/// The deadline is compared inline rather than observed through a <c>CancellationTokenSource</c>
+/// timer. A timer only makes the elapsed time visible once its callback has run on the thread pool,
+/// so detection was bounded by scheduling rather than by the timeout itself — the same reason the
+/// regular expression timeout moved to an inline deadline. Reading the timestamp costs a
+/// <see cref="Stopwatch.GetTimestamp"/> per check, which the amortized check cadence already bounds,
+/// and in exchange every execution stops allocating a token source and registering (then cancelling)
+/// a timer.
+/// </remarks>
 internal sealed class TimeConstraint : Constraint
-#pragma warning restore CA1001
 {
-    private readonly TimeSpan _timeout;
-    private CancellationTokenSource? _cts;
+    private readonly long _timeoutTicks;
+
+    // Stopwatch timestamp the current execution must not pass; 0 means "no execution has started",
+    // which mirrors the previous null-CancellationTokenSource state where Check never failed.
+    private long _deadline;
 
     internal TimeConstraint(TimeSpan timeout)
     {
-        _timeout = timeout;
+        // Options.TimeoutInterval only constructs this for 0 < timeout < TimeSpan.MaxValue. The
+        // clamp keeps `now + _timeoutTicks` from overflowing for very large intervals, which would
+        // otherwise wrap to a deadline already in the past.
+        var ticks = timeout.Ticks * ((double) Stopwatch.Frequency / TimeSpan.TicksPerSecond);
+        _timeoutTicks = ticks >= long.MaxValue / 2.0 ? long.MaxValue / 2 : (long) ticks;
     }
 
     public override void Check()
     {
-        if (_cts?.IsCancellationRequested == true)
+        var deadline = _deadline;
+        if (deadline != 0 && Stopwatch.GetTimestamp() >= deadline)
         {
             Throw.TimeoutException();
         }
@@ -25,11 +44,9 @@ internal sealed class TimeConstraint : Constraint
 
     public override void Reset()
     {
-        _cts?.Dispose();
+        var deadline = Stopwatch.GetTimestamp() + _timeoutTicks;
 
-        // This cancellation token source is very likely not disposed property, but it only allocates a timer, so not a big deal.
-        // But using the cancellation token source is faster because we do not have to check the current time for each statement,
-        // which means less system calls.
-        _cts = new CancellationTokenSource(_timeout);
+        // 0 is the not-started sentinel, so never store it as a real deadline
+        _deadline = deadline == 0 ? 1 : deadline;
     }
 }


### PR DESCRIPTION
## Summary

Measure the execution timeout against an inline deadline instead of a `CancellationTokenSource` timer.

## Details

`TimeConstraint` allocated a `CancellationTokenSource` with a timer on every `Reset` — that is, on every top-level execution — and `Check` reported a timeout only once that timer's callback had run on the thread pool. Detection was therefore bounded by callback scheduling rather than by the timeout itself.

It now captures a `Stopwatch` deadline in `Reset` and compares timestamps in `Check`. This is the same shape the regular expression timeout already uses.

The original comment justified the token source as avoiding a time check per statement. That trade-off predates amortized constraint checking: with `EvaluationContext.AmortizedConstraintCheckInterval = 64`, the per-statement cost is a countdown decrement and the timestamp is read once per 64 statements, not once per statement.

## Numbers

Measured against `main` with a harness that runs both configurations in the same process (`Jint` referenced from a pristine `main` worktree vs this branch):

| Measurement | main | this branch |
|---|---:|---:|
| Per-execution allocation, timeout configured | 1708.3 B | **1420.3 B** |
| Per-execution allocation, no timeout configured | 1420.3 B | 1420.3 B |

So a configured timeout costs **288 bytes per top-level execution** on `main` — the token source plus its timer registration — and costs nothing here: the figure is now identical to an engine with no timeout at all. That number is deterministic and reproduced byte-for-byte across runs.

**On throughput I have no claim to make.** I measured a statement-heavy script (a 300k-iteration loop) with and without a timeout, five passes per arm, and the timeout tax came out at +1.46% on `main` (range −2.19% to +10.33%) and −3.46% here (range −25.66% to +4.65%). A −25% "tax" is obviously noise, so the harness cannot resolve the difference on my machine; I am not going to dress that up as a win. The mechanism says the change trades one allocation plus a timer registration per execution for one `Stopwatch.GetTimestamp()` per 64 statements, and the measurement is consistent with that being below the noise floor.

## Honest note on motivation

I looked at this because `ModuleTests.ShouldSupportConstraints` failed once on a Windows CI run (asserting a `TimeoutException` that was never thrown) and a timer-scheduling delay was my hypothesis. **I could not reproduce that.** A repro against unmodified `main` that forces `ThreadPool.SetMinThreads(1, …)` and parks 256 blocked work items still threw the `TimeoutException` every time, so I make no claim that this fixes that failure. The change stands on the allocation figure above and on detection no longer depending on when a callback happens to run.

## Linked issue

None.

## Test plan

- [x] Added or updated unit tests in `Jint.Tests`
- [x] Ran `dotnet test --configuration Release` locally (`Jint.Tests` 3880 passed, `Jint.Tests.PublicInterface` 114 passed, `Jint.Tests.CommonScripts` 28 passed)
- [ ] For ECMAScript spec changes: ran `Jint.Tests.Test262` and confirmed no regressions — n/a, no spec behaviour touched
- [ ] For interop changes: covered in `Jint.Tests/Runtime/Interop` — n/a
- [x] For perf changes: included before/after numbers from `Jint.Benchmark` — see above (a dedicated harness rather than a suite benchmark, since no existing benchmark configures a timeout)

Three tests pin the contract that the rewrite has to keep: a `Check` before any execution does not fail (the previous null-token-source state, now a not-started sentinel); each top-level execution is re-armed with the full interval; and once the interval has elapsed the next `Check` fails. The existing timeout tests — including the tight-loop and `Invoke` ones — continue to pass unchanged.

## Breaking change?

No. `TimeConstraint` is internal and the observable behaviour — when a `TimeoutException` is raised — is unchanged apart from being detected promptly rather than when a timer callback runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
