### PR TITLE
Publish to nuget.org with trusted publishing instead of an API key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,24 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
+
+    # Must match the Environment field of the nuget.org trusted publishing policy.
+    # Also the place to add required reviewers if releases should be approval-gated.
+    environment: nuget
+
+    permissions:
+      contents: read
+      # Lets the job request a GitHub OIDC token, which is exchanged below for a short-lived
+      # nuget.org API key. Without this the NuGet/login step fails.
+      id-token: write
+
     steps:
 
     - name: Setup NET
@@ -32,13 +46,32 @@ jobs:
     - name: Test
       run: dotnet test --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"
 
-    - name: Pack with dotnet
+    - name: Determine version from tag
+      id: version
       run: |
-        arrTag=(${GITHUB_REF//\// })
-        VERSION="${arrTag[2]}"
-        VERSION="${VERSION//v}"
-        echo "$VERSION"
-        dotnet pack Jint/Jint.csproj --output artifacts --configuration Release -p:Version=$VERSION -p:ContinuousIntegrationBuild=True
+        # The tag is the single source of truth: v4.14.0 -> 4.14.0, v5.0.0-rc.1 -> 5.0.0-rc.1.
+        # Strips only the leading 'v' ("${VERSION//v}" removed every 'v', mangling e.g. v5.0.0-preview).
+        VERSION="${GITHUB_REF_NAME#v}"
+        # AssemblyVersion/FileVersion must be numeric, so drop any prerelease label.
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "numeric=${VERSION%%-*}" >> "$GITHUB_OUTPUT"
+        echo "Releasing $VERSION"
+
+    - name: Pack with dotnet
+      run: >
+        dotnet pack Jint/Jint.csproj --output artifacts --configuration Release
+        -p:Version=${{ steps.version.outputs.version }}
+        -p:AssemblyVersion=${{ steps.version.outputs.numeric }}
+        -p:FileVersion=${{ steps.version.outputs.numeric }}
+        -p:ContinuousIntegrationBuild=True
+
+    # Kept next to the push: the minted key is short-lived, so it must not be requested
+    # before the (slow) test and pack steps.
+    - name: NuGet login
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: sebastienros
 
     - name: Push with dotnet
-      run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push artifacts/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,9 +11,8 @@
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
 
     <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>
-    <VersionPrefix>4.5.0</VersionPrefix>
+    <VersionPrefix>4.15.0</VersionPrefix>
     <VersionSuffix>beta-$(BuildNumber)</VersionSuffix>
-    <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Moves nuget.org publishing off the long-lived `NUGET_API_KEY` secret and onto [Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing): the release job asks GitHub for a short-lived OIDC token and exchanges it for a nuget.org API key that expires within the hour. Nothing long-lived is stored, so there is no key to rotate and nothing useful to leak.

While in there, the tag is now fully authoritative for the version — see the second half below, which fixes a real bug in what we've been shipping: **every release since 4.5.0 carries `FileVersion 4.5.0.0`.**

Two commits, reviewable separately:

1. `release.yml` — trusted publishing + tag-driven version
2. `Directory.Build.props` — stop pinning `FileVersion` to a stale `VersionPrefix`

---

## 👋 @sebastienros — this needs ~5 minutes of setup from you before it can merge

Two things, both one-time. **Do these before merging**, otherwise the first tag after merge fails at the push step.

### 1. Create the `nuget` environment

Repo → **Settings** → **Environments** → **New environment** → name it exactly `nuget` → Configure.

Nothing needs to be configured inside it — an empty environment is enough. Two optional extras while you're there:

- **Deployment branches and tags** → *Selected* → add rule `v*.*.*`, so only tag refs can use it.
- **Required reviewers** → add yourself, if you'd like releases to wait for an approval click.

### 2. Create the trusted publishing policy on nuget.org

nuget.org → click your username (top right) → **Trusted Publishing** → **Add**:

| Field | Value |
| --- | --- |
| Policy owner | `sebastienros` |
| Repository Owner | `sebastienros` |
| Repository | `jint` |
| Workflow File | `release.yml` |
| Environment | `nuget` |

Notes on the fields that trip people up:

- **Workflow File is the filename only** — `release.yml`, *not* `.github/workflows/release.yml`.
- **Environment must match** the `environment: nuget` line in the workflow exactly, or the exchange returns 401.
- The policy applies to **every package owned by the policy owner** — there is no per-package scoping. Worth knowing if you own others under the same account.
- The workflow sends `user: sebastienros` in the exchange. That has to be the nuget.org profile name of **whoever creates the policy**. If you'd rather @lahma owned it, it's a one-line change here.
- If it shows as *temporarily active for 7 days*: that's the private-repo path, where nuget.org needs a successful publish to capture GitHub's immutable repo/owner IDs. `jint` is public, so it should activate immediately.

### 3. After the first green release

Delete the `NUGET_API_KEY` repo secret and revoke the corresponding key on nuget.org. **Keep both until then** — they're the rollback path (revert this PR, re-tag).

Nothing changes about how you cut a release: still `git tag v4.15.0 && git push --tags`.

---

## What changed in `release.yml`

### Trusted publishing

```yaml
environment: nuget

permissions:
  contents: read
  id-token: write        # lets the job request the OIDC token

- name: NuGet login
  uses: NuGet/login@v1
  id: login
  with:
    user: sebastienros

- name: Push with dotnet
  run: dotnet nuget push artifacts/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} ...
```

`NuGet/login` is maintained by the NuGet team. The login step deliberately sits immediately before the push rather than at the top of the job: the minted key is short-lived and the test + pack steps are slow.

This works because `release.yml` is already tag-only. A trusted publishing policy is scoped by *repository + workflow filename* (+ environment), and nuget.org offers no branch or tag filter — so pointing it at a workflow that also runs on every branch push would be much weaker. `build.yml` is untouched and keeps using `MYGET_API_KEY` for previews.

### The tag is now the whole version

Two problems, both invisible until you look:

**1. The `v` strip removed every `v`, not just the leading one.**

```console
$ VERSION="v5.0.0-preview.1"; echo "${VERSION//v}"
5.0.0-preiew.1
```

Fine for `v4.14.0`, silently wrong for any prerelease tag containing a `v`. Now uses `"${GITHUB_REF_NAME#v}"`, which strips one leading `v` and nothing else.

**2. `FileVersion` never followed the tag — every release since 4.5.0 has shipped the wrong one.**

Only `-p:Version` was derived from the tag. `AssemblyVersion` follows `Version` by MSBuild's own default, so that one was fine. But `Directory.Build.props` assigned `FileVersion` explicitly:

```xml
<VersionPrefix>4.5.0</VersionPrefix>
<FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
```

An explicit assignment beats the derived value, and that `VersionPrefix` has read `4.5.0` since 4.5.0 was current. So the package published as 4.14.0 actually ships:

```
AssemblyVersion: 4.14.0.0
FileVersion:     4.5.0.0     ← nine minor versions stale
ProductVersion:  4.14.0+a19544d
```

That's read out of the real `jint.4.14.0.nupkg` from nuget.org, not inferred.

Fixed on both sides:

- **`Directory.Build.props`** drops the `FileVersion` line, so it follows `Version` like `AssemblyVersion` already did. This is what fixes local and `build.yml` preview builds, which were reporting 4.5.0 too. `VersionPrefix` is bumped to `4.15.0` so untagged builds carry a plausible number — **change this if the next release is meant to be something else**.
- **`release.yml`** passes both explicitly anyway, so a release can never again depend on that file being up to date:

  ```yaml
  -p:Version=${{ steps.version.outputs.version }}          # 5.0.0-rc.1
  -p:AssemblyVersion=${{ steps.version.outputs.numeric }}  # 5.0.0  (must be numeric)
  -p:FileVersion=${{ steps.version.outputs.numeric }}      # 5.0.0
  ```

Verified by packing `Jint.csproj` locally, three ways:

| build | package | AssemblyVersion | FileVersion |
| --- | --- | --- | --- |
| release, as the workflow runs it | `9.9.9-rc.1` | `9.9.9.0` | `9.9.9` |
| release, props alone (no `-p:` overrides) | `9.9.9-rc.1` | `9.9.9.0` | `9.9.9.0` |
| preview, as `build.yml` runs it | `4.15.0-preview-456` | `4.15.0.0` | `4.15.0.0` |

The middle row is the one that proves the props change stands on its own — before it, that build produced `FileVersion 4.5.0.0`.
