### PR TITLE
Consult reference resolver for a call to an unresolvable identifier

### DIFF
--- a/Jint.Tests/Runtime/NullPropagation.cs
+++ b/Jint.Tests/Runtime/NullPropagation.cs
@@ -120,6 +120,20 @@ function test2(arg) {
     }
 
     [Fact]
+    public void CanCallUnresolvableReference()
+    {
+        // A call to an unresolvable identifier must be routed through the reference resolver,
+        // like a read is, rather than throwing. Regression: the unresolvable reference base is a
+        // sentinel (not undefined), so the call path stopped consulting the resolver and cast the
+        // sentinel to an Environment, throwing InvalidCastException.
+        var engine = new Engine(cfg => cfg.SetReferencesResolver(new NullPropagationReferenceResolver()));
+
+        var act = () => engine.Execute("var read = missing; var called = missing();");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
     public void NullPropagationShouldNotAffectOperators()
     {
         var engine = new Engine(cfg => cfg.SetReferencesResolver(new NullPropagationReferenceResolver()));

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -120,8 +120,11 @@ internal sealed class JintCallExpression : JintExpression
                 {
                     var baseValue = referenceRecord.Base;
 
-                    // deviation from the spec to support null-propagation helper
-                    if (baseValue.IsNullOrUndefined()
+                    // deviation from the spec to support null-propagation helper;
+                    // since the unresolvable reference base is a sentinel (not undefined), also
+                    // consult the resolver for unresolvable references so a call to an undefined
+                    // name is routed through it instead of casting the sentinel to an Environment
+                    if ((baseValue.IsNullOrUndefined() || referenceRecord.IsUnresolvableReference)
                         && engine._referenceResolver.TryUnresolvableReference(engine, referenceRecord, out var value))
                     {
                         thisObject = value;


### PR DESCRIPTION
## Summary

Consult the reference resolver for a call to an unresolvable identifier.

## Details

Since #2266 the base of an unresolvable reference is the `Reference.Unresolvable` sentinel rather
than `undefined`. `JintCallExpression` only consulted a custom `IReferenceResolver` when
`baseValue.IsNullOrUndefined()`, so a call to an undefined name (base = sentinel) skipped the
resolver and hit `(Environment) baseValue`, throwing `InvalidCastException`. A read of the same name
still went through the resolver, so only calls were affected.

This extends the existing "null-propagation helper" deviation to also fire for unresolvable
references (`referenceRecord.IsUnresolvableReference`), restoring the behavior the #1041 fix
established. A call to an undefined name is now routed through the resolver (e.g. resolved via
`TryGetCallable`) instead of throwing a CLR cast exception.

## Linked issue

Fixes #2749

## Test plan

- [x] Added a unit test in `Jint.Tests` (`Runtime/NullPropagation.CanCallUnresolvableReference`)
- [x] Ran `dotnet test --configuration Release` locally. `NullPropagation` passes on net10.0 and net472; the new test fails without the fix with the exact `InvalidCastException`
- [ ] ECMAScript spec change. N/A
- [ ] Interop change. N/A
- [ ] Perf change. N/A

## Breaking change?

No. It restores the pre-#2266 behavior for custom `IReferenceResolver` implementations and does not change the public API.
