### PR TITLE
Bypass the array-covariance check on exact-JsValue[] dense element stores

### DIFF
--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -91,7 +91,23 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
     {
         InitializePrototypeAndValidateCapacity(engine, capacity: 0);
 
-        _dense = items;
+        // _dense must be an exact JsValue[] so the dense element-write fast paths can store any JsValue
+        // without paying a per-write CLR array-covariance check (see WriteDenseUnchecked). Array covariance
+        // lets a caller hand us a subtype array (e.g. a JsString[]) through the JsValue[] parameter, so
+        // normalize anything that is not exactly JsValue[] into a real one. This costs a single type check
+        // on the common (already-exact) path and also removes a latent ArrayTypeMismatchException that a
+        // subtype-backed array would throw on the first heterogeneous element write.
+        if (items.GetType() == typeof(JsValue[]))
+        {
+            _dense = items;
+        }
+        else
+        {
+            var exact = new JsValue?[items.Length];
+            System.Array.Copy(items, exact, items.Length);
+            _dense = exact;
+        }
+
         _lengthValue = JsNumber.Create(items.Length);
     }
 
@@ -1010,6 +1026,30 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
     }
 
     /// <summary>
+    /// Stores <paramref name="value"/> into <paramref name="dense"/> without the CLR array-covariance
+    /// check that a plain <c>dense[index] = value</c> pays on every write (<c>stelem.ref</c> →
+    /// <c>CastHelpers.StelemRef_Helper</c>) because <see cref="JsValue"/> is not sealed. Sound only because
+    /// <c>_dense</c> is always an exact <see cref="JsValue"/>[]: the <c>items</c> constructor normalizes any
+    /// covariant input, every other assignment allocates <c>new JsValue?[]</c>, and
+    /// <see cref="System.Array.Resize{T}"/> yields an exact array. Callers must have already bounds-checked
+    /// <paramref name="index"/> (both invariants are asserted in debug builds). Mirrors
+    /// <see cref="Jint.Runtime.Arguments.WriteNoTypeCheck"/> for the dense backing store.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteDenseUnchecked(JsValue?[] dense, uint index, JsValue? value)
+    {
+        System.Diagnostics.Debug.Assert(dense.GetType() == typeof(JsValue[]), "_dense must be an exact JsValue[]");
+        System.Diagnostics.Debug.Assert(index < (uint) dense.Length, "index must be within the dense backing");
+
+#if NET8_0_OR_GREATER
+        ref var slot = ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(dense);
+        Unsafe.Add(ref slot, (nint) index) = value;
+#else
+        dense[index] = value;
+#endif
+    }
+
+    /// <summary>
     /// Fast overwrite of an existing dense element: returns true only when <paramref name="index"/>
     /// is in range and the slot is already non-null. This never grows the array, fills a hole, or
     /// changes length, so growing/hole-filling writes return false and defer to the full set path.
@@ -1034,7 +1074,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
                 return false;
             }
 
-            temp[index] = value;
+            WriteDenseUnchecked(temp, index, value);
             return true;
         }
 
@@ -1065,7 +1105,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
         if (index < (uint) temp.Length)
         {
-            temp[index] = value;
+            WriteDenseUnchecked(temp, index, value);
         }
         else
         {
@@ -1077,7 +1117,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
             }
 
             EnsureCapacity(newSize);
-            _dense![index] = value;
+            WriteDenseUnchecked(_dense!, index, value);
         }
 
         SetLengthValue(JsNumber.Create(index + 1));
@@ -1147,7 +1187,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         {
             if (index < (uint) temp.Length)
             {
-                temp[index] = descriptor.Value;
+                WriteDenseUnchecked(temp, index, descriptor.Value);
             }
             else
             {
@@ -1168,7 +1208,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         {
             if (index < (uint) temp.Length)
             {
-                temp[index] = value;
+                WriteDenseUnchecked(temp, index, value);
                 return;
             }
         }
@@ -1199,7 +1239,7 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         if (canUseDense)
         {
             EnsureCapacity((uint) newSize);
-            _dense![index] = value;
+            WriteDenseUnchecked(_dense!, index, value);
         }
         else
         {


### PR DESCRIPTION
### What

Storing into `ArrayInstance._dense` (a `JsValue?[]`) with a concrete element such as `JsNumber` paid the CLR covariant array-store helper (`CastHelpers.StelemRef` / `StelemRef_Helper`) on **every write**, because `JsValue` is a non-sealed base type and the JIT can't prove the stored value matches the array's exact element type.

`_dense`'s element type wasn't guaranteed exact — the `JsValue[] items` constructor assigned it directly and C# array covariance lets a caller pass a subtype array (e.g. `JsString[]`) through that parameter. This PR makes it exact at that single ingestion point (copy into a fresh `JsValue[]` only when the incoming runtime type isn't exactly `JsValue[]`; the common case is one type check, no copy). With `_dense` provably exactly `JsValue[]`, the covariance check is pure overhead, so the hot in-range dense stores now route through a small `WriteDenseUnchecked` helper (`MemoryMarshal.GetArrayDataReference` + `Unsafe.Add` on net8.0+, plain store otherwise), with the exactness and in-bounds invariants asserted in Debug. It mirrors the existing `Arguments.WriteNoTypeCheck` precedent, for the dense backing store.

Converted sites: `TryWriteExistingDense`, `TryAppendDense`, `WriteArrayValueUnlikely`, and both `WriteArrayValue` overloads (the `Set` / `SetIndexValue` / `Engine.PutValue` assignment path). Grow / sparse / hole paths are unchanged. As a bonus the normalization also removes a latent `ArrayTypeMismatchException` that a subtype-backed `_dense` would throw on the first heterogeneous element write.

### Why

Profiled with the [ultra](https://github.com/xoofx/ultra) ETW profiler on the Mozilla Kraken `audio-fft` / `audio-beat-detection` workloads (tight numeric loops that write JS arrays heavily). `CastHelpers.StelemRef(_Helper)` was ~**1.05%** of self-time and split evenly between the dense fast paths and the `Engine.PutValue` array-index assignment path.

After the change it's **gone** from the sampled hotspots (~0%), `Engine.PutValue` self stayed flat, and steady-state execution improved **~1.5–2.7%** wall on both scenarios (min-of-N, measured in both orderings to rule out thermal bias).

### Testing

- `dotnet build -c Release`: 0 warnings / 0 errors, all TFMs.
- Test262: **99431 passed, 0 failed** (unchanged from baseline).
- `Jint.Tests.Runtime` (Release): net10.0 3866/0, net472 3803/0.
- Debug run with the new `Debug.Assert`s live across the array / engine / TypedArray suites: **no assertion fired**, empirically confirming `_dense` is exact and every converted store is in bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)