### PR TITLE
Sort integer-index property keys by value instead of re-parsing each key

### DIFF
--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -593,6 +593,11 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         var keys = new List<JsValue>((_properties?.Count ?? 0) + (_symbols?.Count ?? 0) + initialOwnPropertyKeys.Count);
         if (returningStringKeys && _properties != null)
         {
+            // Integer-index keys must come first in ascending numeric order. Collect their already-parsed
+            // uint indices and sort those directly, instead of materializing JsStrings and re-parsing each
+            // one back to a Number on every sort comparison — TypeConverter.ToNumber → Number.TryParseNumber
+            // dominated JSON.stringify / enumeration of index-keyed objects (Kraken json-stringify-tinderbox).
+            List<uint>? indices = null;
             foreach (var pair in _properties)
             {
                 var propertyName = pair.Key.Name;
@@ -600,16 +605,24 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
 
                 if (arrayIndex < ArrayOperations.MaxArrayLength)
                 {
-                    keys.Add(JsString.Create(arrayIndex));
+                    (indices ??= new List<uint>(_properties.Count)).Add(arrayIndex);
                 }
                 else
                 {
                     initialOwnPropertyKeys.Add(new JsString(propertyName));
                 }
             }
+
+            if (indices != null)
+            {
+                indices.Sort();
+                foreach (var arrayIndex in indices)
+                {
+                    keys.Add(JsString.Create(arrayIndex));
+                }
+            }
         }
 
-        keys.Sort((v1, v2) => TypeConverter.ToNumber(v1).CompareTo(TypeConverter.ToNumber(v2)));
         keys.AddRange(initialOwnPropertyKeys);
 
         if (returningSymbols)


### PR DESCRIPTION
### What

`ObjectInstance.GetOwnPropertyKeysSorted` sorted the integer-index keys with:

```csharp
keys.Sort((v1, v2) => TypeConverter.ToNumber(v1).CompareTo(TypeConverter.ToNumber(v2)));
```

so **every sort comparison re-parsed both key strings back to a `Number`** (`TypeConverter.ToNumber` → `Number.TryParseNumber`, with a `NumberFormatInfo` lookup and a full numeric-string scan) — O(N log N) string→number parses per enumeration, even though each key's numeric value was already computed one line earlier by `ArrayInstance.ParseArrayIndex` and then discarded.

This collects the already-parsed `uint` indices and sorts the `uint`s directly, then materializes the `JsString`s in order. The keys are canonical array-index strings, so numeric order **is** `uint` order — the result ordering is identical (integer indices ascending, then string keys in insertion order, then symbols). As a bonus the sort lane is now skipped entirely when the digit-first heuristic deopted but no key was actually a canonical index (`indices` stays null), where the old code always called `keys.Sort`.

### Why

Profiled with the [ultra](https://github.com/xoofx/ultra) ETW profiler on the Mozilla Kraken `json-stringify-tinderbox` workload. `Number.TryParseNumber` was **~8.5%** of self-time — entirely inside the key-sort comparator — plus the object-comparison `IntroSort<__Canon>` it drove.

After the change, `TryParseNumber`/`ToNumber` are **gone** from the profile and the whole `GetOwnPropertyKeysSorted` subtree drops to **~2.7% inclusive**, with the sort now a `GenericArraySortHelper<UInt32>` at ~0.5%. That's ~10% of stringify CPU on this workload (~9% faster wall at the GC-free minimum), and it also cuts allocation — no boxed `ToNumber` results or comparison-delegate churn — reducing GC pressure. Benefits any `JSON.stringify` / `for-in` / `Object.keys` over objects with integer-index keys.

### Testing

- `dotnet build -c Release`: 0 warnings / 0 errors.
- Test262: **99431 passed, 0 failed** (unchanged).
- `Jint.Tests.Runtime` (Release): net10.0 3866/0, net472 3803/0.
- Targeted key-ordering script (mixed integer+string, non-canonical digit-first, all-non-canonical → no-sort branch, 501-key numeric sort, string-only fast path): ordering matches the prior behavior exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)