### PR TITLE
Bypass the array-covariance check on JsValueListBuilder element stores

### DIFF
--- a/Jint/Pooling/JsValueListBuilder.cs
+++ b/Jint/Pooling/JsValueListBuilder.cs
@@ -41,13 +41,34 @@ internal ref struct JsValueListBuilder
         var array = _array;
         if ((uint) pos < (uint) array.Length)
         {
-            array[pos] = value;
+            WriteUnchecked(array, pos, value);
             _pos = pos + 1;
         }
         else
         {
             GrowAndAdd(value);
         }
+    }
+
+    /// <summary>
+    /// Stores into the backing buffer without the CLR array-covariance check that a plain
+    /// <c>array[index] = value</c> pays on every write (<c>stelem.ref</c> → <c>CastHelpers.StelemRef</c>)
+    /// because <see cref="JsValue"/> is not sealed. Sound because <c>_array</c> is always an exact
+    /// <see cref="JsValue"/>[]: <see cref="ArrayPool{T}"/>.Rent never hands back a covariant subtype array.
+    /// Callers have already bounds-checked <paramref name="index"/> (both invariants asserted in debug builds).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteUnchecked(JsValue?[] array, int index, JsValue? value)
+    {
+        Debug.Assert(array.GetType() == typeof(JsValue[]), "backing buffer must be an exact JsValue[]");
+        Debug.Assert((uint) index < (uint) array.Length, "index must be within the backing buffer");
+
+#if NET8_0_OR_GREATER
+        ref var slot = ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(array);
+        Unsafe.Add(ref slot, (nint) index) = value;
+#else
+        array[index] = value;
+#endif
     }
 
     /// <summary>
@@ -60,7 +81,7 @@ internal ref struct JsValueListBuilder
         var array = _array;
         if ((uint) pos < (uint) array.Length)
         {
-            array[pos] = null;
+            WriteUnchecked(array, pos, null);
             _pos = pos + 1;
         }
         else
@@ -103,7 +124,8 @@ internal ref struct JsValueListBuilder
     private void GrowAndAdd(JsValue? value)
     {
         Grow(1);
-        _array[_pos++] = value;
+        WriteUnchecked(_array, _pos, value);
+        _pos++;
     }
 
     private void Grow(int additionalCapacityBeyondPos)


### PR DESCRIPTION
### What

`JsValueListBuilder` accumulates array contents into a `JsValue?[]` rented from `ArrayPool<JsValue?>.Shared` — which is always an **exact `JsValue[]`** at runtime (`Rent` never returns a covariant subtype array). But its per-element stores (`Add`, `AddHole`, `GrowAndAdd`) used a plain `array[pos] = value`, so every write paid the CLR array-covariance check (`stelem.ref` → `CastHelpers.StelemRef` / `StelemRef_Helper`) because `JsValue` isn't sealed. (`AddRange`/`ToArray`/`Grow` already use bulk `Span`/`Array.Copy` and were unaffected.)

Route the three element stores through a `WriteUnchecked` helper (`MemoryMarshal.GetArrayDataReference` + `Unsafe.Add` on net8.0+, plain store otherwise), with the exact-type and in-bounds invariants asserted in Debug. Same technique as the dense-store bypass in #2751, here for the pooled builder that backs array construction across the engine — spread, `Array.from`/`of`, `Array.prototype` `map`/`filter`/`concat`, and `JSON.parse` arrays.

### Why

Profiled with the [ultra](https://github.com/xoofx/ultra) ETW profiler on Kraken `json-parse-financial`: the `StelemRef` driven by the AggressiveInlined `builder.Add` inside `JsonParser.ParseJsonArray` is **gone** (StelemRef there 1.39% → 0.89%; the residual is a separate object shape-slot store, not this path), ~2–3% faster wall on the parse loop and less GC pressure. Because the builder is used by all the array-construction paths above, the benefit isn't JSON-specific.

### Testing

- `dotnet build -c Release`: 0 warnings / 0 errors.
- Test262: **99431 passed, 0 failed** (unchanged).
- `Jint.Tests.Runtime` (Release): net10.0 3866/0, net472 3803/0.
- Targeted script — `JSON.parse` round-trips, sparse-array holes (`AddHole`), spread, `Array.from`/`of`, `map`/`filter`/`concat`, and a 5000-element grow-heavy build — all values/holes/order match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)