### PR TITLE
Bypass the array-covariance check on JsObject overflow slot stores

### DIFF
--- a/Jint/Native/JsObject.cs
+++ b/Jint/Native/JsObject.cs
@@ -81,8 +81,30 @@ public sealed class JsObject : ObjectInstance
         }
         else
         {
-            _overflow![slot - InlineCapacity] = value;
+            WriteOverflowUnchecked(_overflow!, slot - InlineCapacity, value);
         }
+    }
+
+    /// <summary>
+    /// Stores into the overflow slot array without the CLR array-covariance check that a plain
+    /// <c>_overflow[index] = value</c> pays on every write (<c>stelem.ref</c> → <c>CastHelpers.StelemRef</c>)
+    /// because <see cref="JsValue"/> is not sealed. Sound because <c>_overflow</c> is always an exact
+    /// <see cref="JsValue"/>[]: every assignment allocates <c>new JsValue[]</c> and growth uses
+    /// <see cref="System.Array.Resize{T}"/>, neither of which yields a covariant subtype. The caller has
+    /// already proven <paramref name="index"/> in range (both invariants asserted in debug builds).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteOverflowUnchecked(JsValue[] overflow, int index, JsValue value)
+    {
+        System.Diagnostics.Debug.Assert(overflow.GetType() == typeof(JsValue[]), "_overflow must be an exact JsValue[]");
+        System.Diagnostics.Debug.Assert((uint) index < (uint) overflow.Length, "overflow index must be in range");
+
+#if NET8_0_OR_GREATER
+        ref var slot = ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(overflow);
+        Unsafe.Add(ref slot, (nint) index) = value;
+#else
+        overflow[index] = value;
+#endif
     }
 
     /// <summary>Drops shape mode back to dictionary mode's starting state (clears the shape and slot
@@ -162,7 +184,7 @@ public sealed class JsObject : ObjectInstance
             {
                 System.Array.Resize(ref _overflow, _overflow.Length * 2);
             }
-            _overflow[overflowIndex] = value;
+            WriteOverflowUnchecked(_overflow, overflowIndex, value);
         }
 
         _shape = shape.Add(key, out created);


### PR DESCRIPTION
### What

A shape-mode `JsObject` keeps its first `InlineCapacity` (4) slot values in an in-object `[InlineArray]` (field-offset access, no array store) and spills the surplus into an `_overflow` `JsValue[]`. The two overflow writers — `SetSlot` and `TryShapeAdd` — used a plain `_overflow[i] = value`, so every write past the fourth property paid the CLR array-covariance check (`stelem.ref` → `CastHelpers.StelemRef` / `StelemRef_Helper`) because `JsValue` isn't sealed.

`_overflow` is always an **exact `JsValue[]`**: every assignment allocates `new JsValue[]` (`InitShape`, the first-overflow case, `TryAdoptShapeFrom`) and growth uses `Array.Resize`, none of which yields a covariant subtype. Route both stores through a `WriteOverflowUnchecked` helper (`MemoryMarshal.GetArrayDataReference` + `Unsafe.Add` on net8.0+, plain store otherwise), asserting the exact-type and in-bounds invariants in Debug. Same technique as the dense-store bypass (#2751) and `JsValueListBuilder` (#2753), here for the hidden-class slot storage that backs every shape-mode object property write beyond the in-object slots.

### Why

Profiled with the [ultra](https://github.com/xoofx/ultra) ETW profiler on a wide-object construction micro (8-property objects, 4 spilling to overflow): `CastHelpers.StelemRef(_Helper)` went from **~2.1%** of self-time to **0** (no longer a sampled function). It's a central path — every shape-mode object write past the in-object slots — so the benefit isn't micro-specific; it also showed up while chasing the residual object-store StelemRef in Kraken `json-parse-financial`.

### Testing

- `dotnet build -c Release`: 0 warnings / 0 errors.
- Test262: **99431 passed, 0 failed** (unchanged).
- `Jint.Tests.Runtime` (Release): net10.0 3866/0, net472 3803/0.
- Targeted script — 40-property objects (deep into overflow + growth), in-place overflow updates, 100 shape-sharing records, mixed value types, object spread, delete/dictionary-deopt, and JSON round-trips of wide records — all values/order match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)