### PR TITLE
Bypass the array-covariance check on callback argument arrays (sort, groupBy, array iteration)

### DIFF
--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -1624,14 +1624,16 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
         var callable = GetCallable(callbackfn);
         var a = _engine.Realm.Intrinsics.Array.ArrayCreate(len);
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = this;
+        Arguments.WriteNoTypeCheck(args, 2, this);
         for (uint k = 0; k < len; k++)
         {
             if (TryGetValue(k, out var kvalue))
             {
-                args[0] = kvalue;
-                args[1] = k;
+                Arguments.WriteNoTypeCheck(args, 0, kvalue);
+                Arguments.WriteNoTypeCheck(args, 1, k);
                 var mappedValue = callable.Call(thisArg, args);
                 if (a._dense != null && k < (uint) a._dense.Length)
                 {
@@ -1661,8 +1663,10 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         // materialize an exact-size result instead of growing the result's dense backing by
         // doubling. Capped initial rent so a large low-selectivity source doesn't rent ~len slots.
         var builder = new JsValueListBuilder((int) System.Math.Min(len, 1024));
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = this;
+        Arguments.WriteNoTypeCheck(args, 2, this);
 
         // try/finally so the rented args array and the pooled builder buffer are released
         // when the callback or a periodic Check() throws.
@@ -1677,8 +1681,8 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
 
                 if (TryGetValue(k, out var kvalue))
                 {
-                    args[0] = kvalue;
-                    args[1] = k;
+                    Arguments.WriteNoTypeCheck(args, 0, kvalue);
+                    Arguments.WriteNoTypeCheck(args, 1, k);
                     var selected = callable.Call(thisArg, args);
                     if (TypeConverter.ToBoolean(selected))
                     {
@@ -1716,8 +1720,10 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
             return false;
         }
 
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = this;
+        Arguments.WriteNoTypeCheck(args, 2, this);
 
         // try/finally so the rented pool array is returned on every exit path: the early
         // return-on-match below and a periodic Check() throw both previously leaked it.
@@ -1735,8 +1741,8 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
                     if (TryGetValue(k, out var kvalue) || visitUnassigned)
                     {
                         kvalue ??= Undefined;
-                        args[0] = kvalue;
-                        args[1] = k;
+                        Arguments.WriteNoTypeCheck(args, 0, kvalue);
+                        Arguments.WriteNoTypeCheck(args, 1, k);
                         var testResult = callable.Call(thisArg, args);
                         if (TypeConverter.ToBoolean(testResult))
                         {
@@ -1760,8 +1766,8 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
                     if (TryGetValue(idx, out var kvalue) || visitUnassigned)
                     {
                         kvalue ??= Undefined;
-                        args[0] = kvalue;
-                        args[1] = idx;
+                        Arguments.WriteNoTypeCheck(args, 0, kvalue);
+                        Arguments.WriteNoTypeCheck(args, 1, idx);
                         var testResult = callable.Call(thisArg, args);
                         if (TypeConverter.ToBoolean(testResult))
                         {

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -419,8 +419,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
             }
         }
 
+        // args is a freshly allocated exact JsValue[4], so the per-element fills below bypass the
+        // covariant array store type check.
         var args = new JsValue[4];
-        args[3] = o.Target;
+        Arguments.WriteNoTypeCheck(args, 3, o.Target);
         while (k < len)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
@@ -431,9 +433,9 @@ public sealed partial class ArrayPrototype : ArrayInstance
             var i = (uint) k;
             if (o.TryGetValue(i, out var kvalue))
             {
-                args[0] = accumulator;
-                args[1] = kvalue;
-                args[2] = i;
+                Arguments.WriteNoTypeCheck(args, 0, accumulator);
+                Arguments.WriteNoTypeCheck(args, 1, kvalue);
+                Arguments.WriteNoTypeCheck(args, 2, i);
                 accumulator = callable.Call(Undefined, args);
             }
 
@@ -467,8 +469,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var operations = ArrayOperations.For(a, forWrite: true);
 
         uint to = 0;
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = o.Target;
+        Arguments.WriteNoTypeCheck(args, 2, o.Target);
         for (uint k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
@@ -478,8 +482,8 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
             if (o.TryGetValue(k, out var kvalue))
             {
-                args[0] = kvalue;
-                args[1] = k;
+                Arguments.WriteNoTypeCheck(args, 0, kvalue);
+                Arguments.WriteNoTypeCheck(args, 1, k);
                 var selected = callable.Call(thisArg, args);
                 if (TypeConverter.ToBoolean(selected))
                 {
@@ -520,8 +524,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var callable = GetCallable(callbackfn);
 
         var a = ArrayOperations.For(_realm.Intrinsics.Array.ArraySpeciesCreate(TypeConverter.ToObject(_realm, thisObject), (uint) len), forWrite: true);
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = o.Target;
+        Arguments.WriteNoTypeCheck(args, 2, o.Target);
         for (uint k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
@@ -531,8 +537,8 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
             if (o.TryGetValue(k, out var kvalue))
             {
-                args[0] = kvalue;
-                args[1] = k;
+                Arguments.WriteNoTypeCheck(args, 0, kvalue);
+                Arguments.WriteNoTypeCheck(args, 1, k);
                 var mappedValue = callable.Call(thisArg, args);
                 a.CreateDataPropertyOrThrow(k, mappedValue);
             }
@@ -638,8 +644,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var callArguments = System.Array.Empty<JsValue>();
         if (mapperFunction is not null)
         {
+            // callArguments is rented from the pool whose factory allocates new JsValue[3], so it is an
+            // exact JsValue[]; the per-element fills below bypass the covariant array store type check.
             callArguments = _engine._jsValueArrayPool.RentArray(3);
-            callArguments[2] = source.Target;
+            Arguments.WriteNoTypeCheck(callArguments, 2, source.Target);
         }
 
         while (sourceIndex < sourceLen)
@@ -655,8 +663,8 @@ public sealed partial class ArrayPrototype : ArrayInstance
                 var element = source.Get(sourceIndex);
                 if (mapperFunction is not null)
                 {
-                    callArguments[0] = element;
-                    callArguments[1] = JsNumber.Create(sourceIndex);
+                    Arguments.WriteNoTypeCheck(callArguments, 0, element);
+                    Arguments.WriteNoTypeCheck(callArguments, 1, JsNumber.Create(sourceIndex));
                     element = mapperFunction.Call(thisArg ?? Undefined, callArguments);
                 }
 
@@ -719,8 +727,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var callArguments = System.Array.Empty<JsValue>();
         if (mapperFunction is not null)
         {
+            // callArguments is rented from the pool whose factory allocates new JsValue[3], so it is an
+            // exact JsValue[]; the per-element fills below bypass the covariant array store type check.
             callArguments = _engine._jsValueArrayPool.RentArray(3);
-            callArguments[2] = source.Target;
+            Arguments.WriteNoTypeCheck(callArguments, 2, source.Target);
         }
 
         try
@@ -738,8 +748,8 @@ public sealed partial class ArrayPrototype : ArrayInstance
                     var element = source.Get(sourceIndex);
                     if (mapperFunction is not null)
                     {
-                        callArguments[0] = element;
-                        callArguments[1] = JsNumber.Create(sourceIndex);
+                        Arguments.WriteNoTypeCheck(callArguments, 0, element);
+                        Arguments.WriteNoTypeCheck(callArguments, 1, JsNumber.Create(sourceIndex));
                         element = mapperFunction.Call(thisArg ?? Undefined, callArguments);
                     }
 
@@ -788,8 +798,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
         var callable = GetCallable(callbackfn);
 
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = o.Target;
+        Arguments.WriteNoTypeCheck(args, 2, o.Target);
         for (uint k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
@@ -799,8 +811,8 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
             if (o.TryGetValue(k, out var kvalue))
             {
-                args[0] = kvalue;
-                args[1] = k;
+                Arguments.WriteNoTypeCheck(args, 0, kvalue);
+                Arguments.WriteNoTypeCheck(args, 1, k);
                 callable.Call(thisArg, args);
             }
         }
@@ -913,8 +925,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var thisArg = arguments.At(1);
         var callable = GetCallable(callbackfn);
 
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = o.Target;
+        Arguments.WriteNoTypeCheck(args, 2, o.Target);
         for (uint k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
@@ -924,8 +938,8 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
             if (o.TryGetValue(k, out var kvalue))
             {
-                args[0] = kvalue;
-                args[1] = k;
+                Arguments.WriteNoTypeCheck(args, 0, kvalue);
+                Arguments.WriteNoTypeCheck(args, 1, k);
                 var testResult = callable.Call(thisArg, args);
                 if (!TypeConverter.ToBoolean(testResult))
                 {
@@ -2336,8 +2350,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
             }
         }
 
+        // jsValues is a freshly allocated exact JsValue[4], so the per-element fills below bypass the
+        // covariant array store type check.
         var jsValues = new JsValue[4];
-        jsValues[3] = o.Target;
+        Arguments.WriteNoTypeCheck(jsValues, 3, o.Target);
         for (; k >= 0; k--)
         {
             if (k % ConstraintCheckInterval == 0)
@@ -2347,9 +2363,9 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
             if (o.TryGetValue((ulong) k, out var kvalue))
             {
-                jsValues[0] = accumulator;
-                jsValues[1] = kvalue;
-                jsValues[2] = k;
+                Arguments.WriteNoTypeCheck(jsValues, 0, accumulator);
+                Arguments.WriteNoTypeCheck(jsValues, 1, kvalue);
+                Arguments.WriteNoTypeCheck(jsValues, 2, k);
                 accumulator = callable.Call(Undefined, jsValues);
             }
         }

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -2488,8 +2488,10 @@ public sealed partial class ArrayPrototype : ArrayInstance
             {
                 _engine!.RunBeforeExecuteStatementChecks(null);
 
-                _comparableArray[0] = x!;
-                _comparableArray[1] = y!;
+                // _comparableArray is an exact JsValue[2]; bypass the per-comparison covariance check
+                // (stelem.ref -> CastHelpers.StelemRef) a plain store pays because JsValue is not sealed.
+                Arguments.WriteNoTypeCheck(_comparableArray, 0, x!);
+                Arguments.WriteNoTypeCheck(_comparableArray, 1, y!);
 
                 var s = TypeConverter.ToNumber(_compare.Call(Undefined, _comparableArray));
                 if (s < 0)

--- a/Jint/Native/GroupByHelper.cs
+++ b/Jint/Native/GroupByHelper.cs
@@ -49,8 +49,10 @@ internal static class GroupByHelper
                 Throw.TypeError(_engine.Realm);
             }
 
-            _callArgs[0] = currentValue;
-            _callArgs[1] = _k;
+            // _callArgs is an exact JsValue[2]; bypass the per-element covariance check
+            // (stelem.ref -> CastHelpers.StelemRef) a plain store pays because JsValue is not sealed.
+            Arguments.WriteNoTypeCheck(_callArgs, 0, currentValue);
+            Arguments.WriteNoTypeCheck(_callArgs, 1, _k);
 
             var value = _callable.Call(JsValue.Undefined, _callArgs);
             JsValue key;

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1848,8 +1848,10 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         var thisArg = arguments.At(1);
         var callable = GetCallable(callbackfn);
 
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = this;
+        Arguments.WriteNoTypeCheck(args, 2, this);
 
         // try/finally so the rented pool array is returned on every exit path: the early
         // return-on-match below and a periodic Check() throw both previously leaked it.
@@ -1866,8 +1868,8 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
 
                     if (TryGetValue(k, out var kvalue) || visitUnassigned)
                     {
-                        args[0] = kvalue;
-                        args[1] = k;
+                        Arguments.WriteNoTypeCheck(args, 0, kvalue);
+                        Arguments.WriteNoTypeCheck(args, 1, k);
                         var testResult = callable.Call(thisArg, args);
                         if (TypeConverter.ToBoolean(testResult))
                         {
@@ -1890,8 +1892,8 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                     if (TryGetValue((ulong) k, out var kvalue) || visitUnassigned)
                     {
                         kvalue ??= Undefined;
-                        args[0] = kvalue;
-                        args[1] = k;
+                        Arguments.WriteNoTypeCheck(args, 0, kvalue);
+                        Arguments.WriteNoTypeCheck(args, 1, k);
                         var testResult = callable.Call(thisArg, args);
                         if (TypeConverter.ToBoolean(testResult))
                         {

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -361,8 +361,10 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         var predicate = GetCallable(callbackFn);
 
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = o;
+        Arguments.WriteNoTypeCheck(args, 2, o);
         for (var k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
@@ -370,8 +372,8 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
                 _engine.Constraints.Check();
             }
 
-            args[0] = o[k];
-            args[1] = k;
+            Arguments.WriteNoTypeCheck(args, 0, o[k]);
+            Arguments.WriteNoTypeCheck(args, 1, k);
             if (!TypeConverter.ToBoolean(predicate.Call(thisArg, args)))
             {
                 return JsBoolean.False;
@@ -487,8 +489,10 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var kept = new List<JsValue>();
         var captured = 0;
 
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = o;
+        Arguments.WriteNoTypeCheck(args, 2, o);
         for (var k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
@@ -497,8 +501,8 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
             }
 
             var kValue = o[k];
-            args[0] = kValue;
-            args[1] = k;
+            Arguments.WriteNoTypeCheck(args, 0, kValue);
+            Arguments.WriteNoTypeCheck(args, 1, k);
             var selected = callbackfn.Call(thisArg, args);
             if (TypeConverter.ToBoolean(selected))
             {
@@ -561,8 +565,10 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
             return new KeyValuePair<JsValue, JsValue>(JsNumber.IntegerNegativeOne, Undefined);
         }
 
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = o;
+        Arguments.WriteNoTypeCheck(args, 2, o);
         if (!fromEnd)
         {
             for (var k = 0; k < len; k++)
@@ -574,8 +580,8 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
                 var kNumber = JsNumber.Create(k);
                 var kValue = o[k];
-                args[0] = kValue;
-                args[1] = kNumber;
+                Arguments.WriteNoTypeCheck(args, 0, kValue);
+                Arguments.WriteNoTypeCheck(args, 1, kNumber);
                 if (TypeConverter.ToBoolean(predicate.Call(thisArg, args)))
                 {
                     return new KeyValuePair<JsValue, JsValue>(kNumber, kValue);
@@ -593,8 +599,8 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
                 var kNumber = JsNumber.Create(k);
                 var kValue = o[k];
-                args[0] = kValue;
-                args[1] = kNumber;
+                Arguments.WriteNoTypeCheck(args, 0, kValue);
+                Arguments.WriteNoTypeCheck(args, 1, kNumber);
                 if (TypeConverter.ToBoolean(predicate.Call(thisArg, args)))
                 {
                     return new KeyValuePair<JsValue, JsValue>(kNumber, kValue);
@@ -617,8 +623,10 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var o = taRecord.Object;
         var len = taRecord.TypedArrayLength;
 
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = o;
+        Arguments.WriteNoTypeCheck(args, 2, o);
         for (var k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
@@ -627,8 +635,8 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
             }
 
             var kValue = o[k];
-            args[0] = kValue;
-            args[1] = k;
+            Arguments.WriteNoTypeCheck(args, 0, kValue);
+            Arguments.WriteNoTypeCheck(args, 1, k);
             callbackfn.Call(thisArg, args);
         }
 
@@ -900,8 +908,10 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
         var callable = GetCallable(callbackFn);
 
         var a = _realm.Intrinsics.TypedArray.TypedArraySpeciesCreate(o, [len], isWrite: true);
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = o;
+        Arguments.WriteNoTypeCheck(args, 2, o);
         for (var k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
@@ -909,8 +919,8 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
                 _engine.Constraints.Check();
             }
 
-            args[0] = o[k];
-            args[1] = k;
+            Arguments.WriteNoTypeCheck(args, 0, o[k]);
+            Arguments.WriteNoTypeCheck(args, 1, k);
             var mappedValue = callable.Call(thisArg, args);
             a[k] = mappedValue;
         }
@@ -951,8 +961,10 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
             k++;
         }
 
+        // args is rented from the pool whose factory allocates new JsValue[4], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(4);
-        args[3] = o;
+        Arguments.WriteNoTypeCheck(args, 3, o);
         while (k < len)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
@@ -961,9 +973,9 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
             }
 
             var kValue = o[k];
-            args[0] = accumulator;
-            args[1] = kValue;
-            args[2] = k;
+            Arguments.WriteNoTypeCheck(args, 0, accumulator);
+            Arguments.WriteNoTypeCheck(args, 1, kValue);
+            Arguments.WriteNoTypeCheck(args, 2, k);
             accumulator = callbackfn.Call(Undefined, args);
             k++;
         }
@@ -1004,8 +1016,10 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
             k--;
         }
 
+        // jsValues is rented from the pool whose factory allocates new JsValue[4], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var jsValues = _engine._jsValueArrayPool.RentArray(4);
-        jsValues[3] = o;
+        Arguments.WriteNoTypeCheck(jsValues, 3, o);
         for (; k >= 0; k--)
         {
             if (k % ConstraintCheckInterval == 0)
@@ -1013,9 +1027,9 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
                 _engine.Constraints.Check();
             }
 
-            jsValues[0] = accumulator;
-            jsValues[1] = o[(int) k];
-            jsValues[2] = k;
+            Arguments.WriteNoTypeCheck(jsValues, 0, accumulator);
+            Arguments.WriteNoTypeCheck(jsValues, 1, o[(int) k]);
+            Arguments.WriteNoTypeCheck(jsValues, 2, k);
             accumulator = callbackfn.Call(Undefined, jsValues);
         }
 
@@ -1391,8 +1405,10 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
         var callbackfn = GetCallable(callbackFn);
 
+        // args is rented from the pool whose factory allocates new JsValue[3], so it is an exact
+        // JsValue[]; the per-element fills below bypass the covariant array store type check.
         var args = _engine._jsValueArrayPool.RentArray(3);
-        args[2] = o;
+        Arguments.WriteNoTypeCheck(args, 2, o);
         for (var k = 0; k < len; k++)
         {
             if (k > 0 && k % ConstraintCheckInterval == 0)
@@ -1400,8 +1416,8 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
                 _engine.Constraints.Check();
             }
 
-            args[0] = o[k];
-            args[1] = k;
+            Arguments.WriteNoTypeCheck(args, 0, o[k]);
+            Arguments.WriteNoTypeCheck(args, 1, k);
             if (TypeConverter.ToBoolean(callbackfn.Call(thisArg, args)))
             {
                 return JsBoolean.True;

--- a/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
+++ b/Jint/Native/TypedArray/IntrinsicTypedArrayPrototype.cs
@@ -1888,8 +1888,10 @@ internal sealed partial class IntrinsicTypedArrayPrototype : Prototype
 
             if (_compare is not null)
             {
-                _comparableArray[0] = x;
-                _comparableArray[1] = y;
+                // _comparableArray is an exact JsValue[2]; bypass the per-comparison covariance check
+                // (stelem.ref -> CastHelpers.StelemRef) a plain store pays because JsValue is not sealed.
+                Arguments.WriteNoTypeCheck(_comparableArray, 0, x);
+                Arguments.WriteNoTypeCheck(_comparableArray, 1, y);
 
                 var v = TypeConverter.ToNumber(_compare.Call(Undefined, _comparableArray));
 


### PR DESCRIPTION
### What

Several hot paths pass a **reusable, fixed-layout `JsValue[]`** to a user callback and refill it before each invocation with plain `array[i] = value` stores. Because `JsValue` isn't sealed, every such store emits a CLR array-covariance check (`stelem.ref` → `CastHelpers.StelemRef` / `StelemRef_Helper`) — pure overhead, since these arrays are always an exact `JsValue[]` (allocated as `new JsValue[n]` or via `JsValueArrayPool.RentArray`, whose factories only `new JsValue[n]`).

This routes those stores through the existing `Arguments.WriteNoTypeCheck` (`MemoryMarshal.GetArrayDataReference` + `Unsafe.Add`) — the same bypass already used for interpreter call-argument arrays and RegExp replace — at two families of call sites:

1. **Sort / groupBy comparators** — `Array.prototype.sort`, `%TypedArray%.prototype.sort`, and the Array/Map/Object `groupBy` helper each hold a `new JsValue[2]` refilled on every comparison / element.
2. **Array iteration callbacks** — `map`, `filter`, `forEach`, `reduce`, `reduceRight`, `some`, `every`, `find`/`findIndex`/`findLast`/`findLastIndex`, `flatMap` on both `Array.prototype` (generic path) and the `ArrayInstance` fast path, plus the `%TypedArray%.prototype` equivalents. These refill a `RentArray(3)`/`RentArray(4)` with the element/index/array on every element.

Only arrays that are provably an exact locally-allocated `JsValue[]` were converted; `JsCallArguments` parameters and any `Unsafe.As`-reinterpreted arrays were deliberately left untouched.

### Why

Profiled with the [ultra](https://github.com/xoofx/ultra) ETW profiler on micros over a build that already has the dense-store bypass:
- **comparator sort** (200 sorts of 2000 elements/op): `CastHelpers.StelemRef(_Helper)` **4.9% → 0.6%**, **~6% faster** wall.
- **array iteration** (map/filter/forEach/reduce over 2000 elements): **3.5% → 0.6%**, **~3.6% faster** wall.

Both are ubiquitous operations, so the benefit is broad.

### Testing

- `dotnet build -c Release`: 0 warnings / 0 errors.
- Test262: **99431 passed, 0 failed** (unchanged).
- `Jint.Tests.Runtime` (Release): net10.0 3866/0, net472 3803/0; full `Jint.Tests` (incl. Array/TypedArray) 3916/0.
- Targeted scripts — comparator sorts (asc/desc/string/object/large), `Float64`/`Int32` TypedArray sort, `Object.groupBy`/`Map.groupBy`; and map/filter/forEach/reduce/reduceRight/some/every/find*/flatMap on both arrays and typed arrays — all results match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)