### PR TITLE
CI: reliably seed the cross-OS Test262 cache and bump actions to latest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,15 @@ updates:
         patterns:
           - "Microsoft.*"
           - "System.*"
+
+  # GitHub Actions used by the workflows under .github/workflows. Kept in a single
+  # grouped PR so the whole workflow tooling moves together instead of one PR per action.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,15 +19,23 @@ jobs:
     steps:
 
     - name: Setup NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0
 
     - name: Checkout source code
       uses: actions/checkout@v7
 
-    - name: Cache Test262 generated suite
-      uses: actions/cache@v6
+    # This job (push to main) is the only one that seeds a cache the PR workflow can read: PR jobs
+    # can restore caches from the base branch, but a cache saved inside a PR is scoped to that PR
+    # and invisible to other PRs. Restore/save are split (rather than the combined actions/cache)
+    # so the suite is cached even when a later step fails. The combined action saves in a post-step
+    # gated on success(); the "Push with dotnet" publish can fail (e.g. MyGet quota) and would then
+    # skip the save, leaving the main-scoped cache empty so no PR ever gets a hit. The explicit save
+    # below runs right after the suite is generated, before publishing.
+    - name: Restore Test262 generated suite
+      id: cache-test262
+      uses: actions/cache/restore@v6
       with:
         path: Jint.Tests.Test262/Generated
         key: test262-generated-${{ hashFiles('Jint.Tests.Test262/Test262Harness.settings.json') }}
@@ -36,6 +44,14 @@ jobs:
 
     - name: Test
       run: dotnet test --configuration Release --logger "console;verbosity=quiet" --logger "GitHubActions;summary-include-passed=false;summary-include-skipped=false"
+
+    - name: Save Test262 generated suite
+      if: steps.cache-test262.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: Jint.Tests.Test262/Generated
+        key: test262-generated-${{ hashFiles('Jint.Tests.Test262/Test262Harness.settings.json') }}
+        enableCrossOsArchive: true
 
     - name: Pack with dotnet
       run: dotnet pack Jint/Jint.csproj --output artifacts --configuration Release -p:VersionSuffix=preview-$GITHUB_RUN_NUMBER -p:ContinuousIntegrationBuild=True

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
 
     - name: Setup NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,15 +16,15 @@ jobs:
     steps:
 
     - name: Setup NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0
 
     - name: Checkout source code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Cache Test262 generated suite
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: Jint.Tests.Test262/Generated
         key: test262-generated-${{ hashFiles('Jint.Tests.Test262/Test262Harness.settings.json') }}


### PR DESCRIPTION
## Problem

Only the Windows PR job gets a Test262-suite cache hit; the Linux, Linux-ARM and macOS jobs miss and regenerate the whole ~99.5k-case suite every run (~25 s/job). See [run 30093896255](https://github.com/sebastienros/jint/actions/runs/30093896255) (PR #2757), where **windows restored** and **linux / linux-ARM / macos all missed** the identical key `test262-generated-8046dd…`.

## Root cause

The cache **key** is fine — it is content-hashed and forced to LF, so it is byte-identical on every OS. The problem is that the cache is never **saved** to a scope the PR jobs can read.

- GitHub scopes a cache saved inside a PR to that PR; it is invisible to other PRs. The only cache all PRs can read is one on the **base branch (`main`)**.
- The **Build** workflow (push to `main`) is the only job that can seed that `main`-scoped cache. But it uses the combined `actions/cache`, whose save is a **post-step gated on `post-if: success()`**. Build's `Push with dotnet` step fails (`MyGet` returns `413`, the feed is over quota), so the post-save is **skipped** and the `main` cache stays empty.
- With no `main` cache, PR runs only ever self-seed a PR-scoped cache. When a **Windows** job wins that save race the entry is not cross-OS readable, so Linux/macOS/ARM miss while Windows hits — the documented asymmetry of `enableCrossOsArchive` (it exists to let *Windows* read *non-Windows* caches, not the reverse).

A Linux-seeded cross-OS cache **is** restorable by every platform — already observed on runs where a Linux job happened to seed it (all four OSes then hit). Seeding reliably from the Linux `main` build is the fix.

## Changes

- **build.yml** — split the cache into `actions/cache/restore` + `actions/cache/save`, running the save right after the suite is generated and **before** the publish steps, so seeding no longer depends on the publish succeeding. `enableCrossOsArchive` is kept so Windows/macOS/ARM can restore the Linux-seeded cache.
- **Action version bumps to latest majors** (all three workflows now consistent):
  - `actions/setup-dotnet` v5 → **v6** (build/pr/release)
  - `actions/checkout` v6 → **v7**, `actions/cache` v5 → **v6** (release; build/pr were already on v7/v6)
- **dependabot.yml** — add a `github-actions` ecosystem so action updates land automatically in one grouped weekly PR.

## Notes

- The `MyGet 413` publish failure is a separate, pre-existing feed-quota issue and is intentionally left visible (not suppressed); this change simply decouples cache seeding from it.
- Checked the major bumps for breaking changes: setup-dotnet v6 is an ESM/dependency upgrade only; checkout v7's sole behavioral change blocks fork checkout for `pull_request_target`/`workflow_run`, neither of which is used here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)