### PR TITLE
Enable MA0212 and use MemoryMarshal.GetReference in the sum-of-products lane

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -78,6 +78,11 @@ dotnet_diagnostic.MA0025.severity = none
 #  Error MA0091 : Sender parameter should be 'this' for instance events
 dotnet_diagnostic.MA0091.severity = none
 
+# --- Performance rules promoted above their (disabled/info) defaults ---
+
+# MA0212: Use MemoryMarshal.GetReference instead of indexing at 0 (disabled by default; regression guardrail)
+dotnet_diagnostic.MA0212.severity = warning
+
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Object;
@@ -547,9 +548,12 @@ internal abstract class JintBinaryExpression : JintExpression
             var negated = _negated;
 
             // the first term seeds the accumulator (never negated in a left-deep chain) — seeding
-            // with +0 would inject a phantom term and lose a -0 sum's sign
-            if (!TryReadLeaf(ref leaves[0], engine, env, out var seedLeft)
-                || !TryReadLeaf(ref leaves[1], engine, env, out var seedRight))
+            // with +0 would inject a phantom term and lose a -0 sum's sign.
+            // The lane always carries at least the two seed leaves, so take a bounds-check-free
+            // reference to element 0 (MA0212) and reach element 1 through Unsafe.Add.
+            ref var seedLeaf = ref MemoryMarshal.GetReference(leaves.AsSpan());
+            if (!TryReadLeaf(ref seedLeaf, engine, env, out var seedLeft)
+                || !TryReadLeaf(ref Unsafe.Add(ref seedLeaf, 1), engine, env, out var seedRight))
             {
                 return false;
             }


### PR DESCRIPTION
`MA0212` (*use `MemoryMarshal.GetReference` instead of indexing at 0*) is **disabled by default** in Meziantou.Analyzer, so it never ran against the codebase — it wasn't that the code was clean or that the older target frameworks hid it. This enables the rule as a `warning` (which `TreatWarningsAsErrors` promotes to a build break) so it acts as a **regression guardrail** going forward.

The single existing violation is in `JintBinaryExpression`'s multiply-add chain evaluator (`SumOfProductsLane.TryEvaluate`), where the lane always carries at least the two seed leaves. The fix takes a bounds-check-free reference to element 0 via `MemoryMarshal.GetReference` and reaches element 1 through `Unsafe.Add` — the idiom already used in `RegExpInterpreter`, available on every target framework (net462 → net10.0) via `System.Memory`. No `#if` needed.

This is the first of several small PRs enabling the modern Meziantou performance-rule catalog.

### Verification
- `dotnet build Jint/Jint.csproj -c Release` clean across all 5 TFMs with MA0212 enforced.
- `Jint.Tests` green (net10.0 + net472), `Jint.Tests.CommonScripts` green (heavy float-math scripts exercise this exact lane).
- REPL: multiply-add chains including the `-0` sign-preservation edge case verified (`Object.is(-1*0 + -1*0, -0) === true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)