### PR TITLE
Promote zero-violation Meziantou performance rules to warning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -89,6 +89,30 @@ dotnet_diagnostic.MA0089.severity = warning
 # MA0209: Use 'in' keyword for readonly struct parameters passed by value
 dotnet_diagnostic.MA0209.severity = warning
 
+# Enabled as guardrails: the codebase currently has zero violations of each.
+# MA0020: Use direct methods instead of LINQ methods
+dotnet_diagnostic.MA0020.severity = warning
+# MA0028: Optimize StringBuilder usage
+dotnet_diagnostic.MA0028.severity = warning
+# MA0031: Optimize Enumerable.Count() usage
+dotnet_diagnostic.MA0031.severity = warning
+# MA0052: Replace constant Enum.ToString with nameof
+dotnet_diagnostic.MA0052.severity = warning
+# MA0078: Use 'Cast' instead of 'Select' to cast
+dotnet_diagnostic.MA0078.severity = warning
+# MA0098: Use indexer instead of LINQ methods (First/Last/ElementAt on IList)
+dotnet_diagnostic.MA0098.severity = warning
+# MA0111: Use string.Create instead of FormattableString
+dotnet_diagnostic.MA0111.severity = warning
+# MA0112: Use 'Count > 0' instead of 'Any()' when a Count/Length is available
+dotnet_diagnostic.MA0112.severity = warning
+# MA0179: Use Attribute.IsDefined instead of GetCustomAttribute(s)
+dotnet_diagnostic.MA0179.severity = warning
+# MA0185: Simplify string.Create when all parameters are culture invariant
+dotnet_diagnostic.MA0185.severity = warning
+# MA0210: Use the in keyword when calling a method whose parameter is declared in
+dotnet_diagnostic.MA0210.severity = warning
+
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false


### PR DESCRIPTION
Eleven performance-category rules ship **disabled** or at **info** severity in Meziantou.Analyzer, so `TreatWarningsAsErrors` never enforced them — they silently passed. The codebase currently has **zero violations** of each, so promoting them to `warning` is a pure regression guardrail with **no code change**:

| Rule | |
|---|---|
| MA0020 | direct methods instead of LINQ |
| MA0028 | optimize `StringBuilder` usage |
| MA0031 | optimize `Enumerable.Count()` usage |
| MA0052 | constant `Enum.ToString` → `nameof` |
| MA0078 | `Cast` instead of `Select` for casts |
| MA0098 | indexer instead of LINQ (`First`/`Last`/`ElementAt` on `IList`) |
| MA0111 | `string.Create` instead of `FormattableString` |
| MA0112 | `Count > 0` instead of `Any()` when a count is available |
| MA0179 | `Attribute.IsDefined` instead of `GetCustomAttribute(s)` |
| MA0185 | simplify culture-invariant `string.Create` |
| MA0210 | use the `in` keyword to call the `in` overload |

### Verification
`dotnet build -c Release` is clean across all five target frameworks (net462, netstandard2.0, netstandard2.1, net8.0, net10.0) with these enforced.

Part of a series enabling the modern Meziantou performance-rule catalog (follows #2764).