### PR TITLE
Enable MA0089 and use char separators/args for string methods

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -83,6 +83,9 @@ dotnet_diagnostic.MA0091.severity = none
 # MA0212: Use MemoryMarshal.GetReference instead of indexing at 0 (disabled by default; regression guardrail)
 dotnet_diagnostic.MA0212.severity = warning
 
+# MA0089: Optimize string method usage (e.g. char separators/args over single-char strings)
+dotnet_diagnostic.MA0089.severity = warning
+
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false

--- a/Jint/Extensions/Polyfills.cs
+++ b/Jint/Extensions/Polyfills.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace Jint;
@@ -10,6 +11,14 @@ internal static class Polyfills
 
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     internal static bool StartsWith(this string source, char c) => source.Length > 0 && source[0] == c;
+
+    // The string.Join(char, ...) overloads were added in .NET Core 2.1 / netstandard2.1.
+    // Backfill the IEnumerable<string> overload the codebase uses so call sites can pass a char
+    // separator uniformly on every target framework, without a per-call-site #if.
+    extension(string)
+    {
+        public static string Join(char separator, IEnumerable<string?> values) => string.Join(separator.ToString(), values);
+    }
 #endif
 
 #if NETFRAMEWORK

--- a/Jint/Native/Intl/CollatorConstructor.cs
+++ b/Jint/Native/Intl/CollatorConstructor.cs
@@ -180,7 +180,7 @@ internal sealed partial class CollatorConstructor : Constructor
 
         // Sort extensions alphabetically (co, kf, kn order)
         extensions.Sort(StringComparer.Ordinal);
-        return baseLocale + "-u-" + string.Join("-", extensions);
+        return baseLocale + "-u-" + string.Join('-', extensions);
     }
 
     private string GetStringOption(ObjectInstance options, string property, in StringSearchValues values, string fallback)

--- a/Jint/Native/Intl/Data/LikelySubtags.cs
+++ b/Jint/Native/Intl/Data/LikelySubtags.cs
@@ -273,7 +273,7 @@ internal static class LikelySubtags
             return string.Empty;
         }
 
-        return "-" + string.Join("-", variants);
+        return "-" + string.Join('-', variants);
     }
 
     private static bool IsAllLetters(string s)

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -786,7 +786,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
             return baseLocale;
         }
 
-        return $"{baseLocale}-u-{string.Join("-", extensions)}";
+        return $"{baseLocale}-u-{string.Join('-', extensions)}";
     }
 
     /// <summary>

--- a/Jint/Native/Intl/IntlUtilities.cs
+++ b/Jint/Native/Intl/IntlUtilities.cs
@@ -1315,7 +1315,7 @@ internal static class IntlUtilities
                     if (LocaleData.UnicodeMappings.TryGetValue(kw.Key, out var valueAliases))
                     {
                         // First try looking up the full joined value (for hyphenated aliases like "ethiopic-amete-alem")
-                        var fullValue = string.Join("-", kw.Values);
+                        var fullValue = string.Join('-', kw.Values);
                         if (valueAliases.TryGetValue(fullValue, out var aliasedValue))
                         {
                             // Replace all parts with the new value (may also be hyphenated)
@@ -1405,7 +1405,7 @@ internal static class IntlUtilities
             }
         }
 
-        return string.Join("-", result);
+        return string.Join('-', result);
     }
 
     private sealed class ParsedLanguageTag

--- a/Jint/Native/Intl/JsDurationFormat.cs
+++ b/Jint/Native/Intl/JsDurationFormat.cs
@@ -756,7 +756,7 @@ internal sealed class JsDurationFormat : ObjectInstance
         // Join parts based on style
         if (string.Equals(Style, "narrow", StringComparison.Ordinal))
         {
-            return string.Join(" ", parts);
+            return string.Join(' ', parts);
         }
 
         // For long and short, use comma-separated

--- a/Jint/Native/Intl/LocaleConstructor.cs
+++ b/Jint/Native/Intl/LocaleConstructor.cs
@@ -733,7 +733,7 @@ internal sealed class LocaleConstructor : Constructor
                                     }
                                     if (result.FirstDayOfWeek == null)
                                     {
-                                        result.FirstDayOfWeek = string.Join("-", fwParts);
+                                        result.FirstDayOfWeek = string.Join('-', fwParts);
                                     }
                                     handled = true;
                                 }
@@ -834,7 +834,7 @@ internal sealed class LocaleConstructor : Constructor
                     }
 
                     // Store this extension as (singleton, content)
-                    result.OtherExtensions.Add(new ExtensionEntry(singleton, string.Join("-", extParts)));
+                    result.OtherExtensions.Add(new ExtensionEntry(singleton, string.Join('-', extParts)));
                 }
             }
             else
@@ -950,7 +950,7 @@ internal sealed class LocaleConstructor : Constructor
             index++;
         }
 
-        return string.Join("-", valueParts);
+        return string.Join('-', valueParts);
     }
 
     private static string BuildBaseName(string? language, string? script, string? region, List<string>? variants = null)
@@ -977,7 +977,7 @@ internal sealed class LocaleConstructor : Constructor
             parts.AddRange(variants);
         }
 
-        return string.Join("-", parts);
+        return string.Join('-', parts);
     }
 
     private static string BuildLocaleString(
@@ -1093,7 +1093,7 @@ internal sealed class LocaleConstructor : Constructor
         // Add the Unicode extension to the list if it has content
         if (unicodeExtParts.Count > 0)
         {
-            allExtensions.Add(new ExtensionEntry('u', string.Join("-", unicodeExtParts)));
+            allExtensions.Add(new ExtensionEntry('u', string.Join('-', unicodeExtParts)));
         }
 
         // Add other extensions

--- a/Jint/Native/Intl/LocalePrototype.cs
+++ b/Jint/Native/Intl/LocalePrototype.cs
@@ -166,7 +166,7 @@ internal sealed partial class LocalePrototype : Prototype
             return Undefined;
         }
 
-        return string.Join("-", variants);
+        return string.Join('-', variants);
     }
 
     [JsAccessor("firstDayOfWeek")]

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -220,8 +220,8 @@ internal sealed partial class StringPrototype : StringInstance
             // Code specific to .NET Framework 4.6.2.
             // For no good reason this verison does not upper case these characters correctly.
             return new JsString(ToUpperCaseWithSpecialCasing(s, culture)
-                .Replace("ϳ", "Ϳ")
-                .Replace("ʝ", "Ʝ"));
+                .Replace('ϳ', 'Ϳ')
+                .Replace('ʝ', 'Ʝ'));
 #endif
         }
 


### PR DESCRIPTION
`MA0089` (*optimize string method usage*) runs at **info** by default, so it never tripped the build. This enables it as a `warning` and fixes the existing violations.

- The `Intl` locale-building helpers used `string.Join("-", …)` / `Join(" ", …)`. Switch them to the char-separator overload (fewer allocations, no single-char-string comparison). Those overloads only exist from netstandard2.1 onward, so a small `string.Join(char, IEnumerable<string?>)` **polyfill** is added for net462/netstandard2.0 using a **C# 14 static extension member** — colocated with the existing `Polyfills` shims. Call sites then read identically on every target framework, with no per-site `#if`.
- `StringPrototype`'s net462-only Lithuanian upper-casing used `Replace(string, string)` with single-character arguments → `Replace(char, char)`.

This demonstrates the extension-member technique for centralizing a framework polyfill so business-logic call sites stay unconditional.

### Verification
- `dotnet build -c Release` clean across all five TFMs; net462/netstandard2.0 exercise the polyfill.
- `Jint.Tests` green on net10.0 and net472.
- `Intl.Locale` round-trips (extensions, `maximize()`, `baseName`, variants) verified in the REPL.

Follows #2764, #2765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)