### PR TITLE
Enable MA0168 (readonly struct for in/ref readonly parameter)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -112,6 +112,8 @@ dotnet_diagnostic.MA0179.severity = warning
 dotnet_diagnostic.MA0185.severity = warning
 # MA0210: Use the in keyword when calling a method whose parameter is declared in
 dotnet_diagnostic.MA0210.severity = warning
+# MA0168: Use readonly struct for in or ref readonly parameter
+dotnet_diagnostic.MA0168.severity = warning
 
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -836,7 +836,11 @@ public sealed partial class RegExpConstructor : Constructor
                     }
                 }
 
+                // GroupScanState is a deliberately mutable scan cursor (updated in place via ref while
+                // scanning the group body), so it cannot be a readonly struct as MA0168 would prefer.
+#pragma warning disable MA0168
                 groupStack.Push(new GroupScanState { Number = groupNumber, Type = groupType, CurrentBranchNullable = true });
+#pragma warning restore MA0168
                 continue;
             }
 

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -151,7 +151,7 @@ internal sealed class JintCallStack
             ref ValueStringBuilder sb,
             string shortDescription,
             in SourceLocation loc,
-            in CallStackElement? element,
+            CallStackElement? element,
             Options.BuildCallStackDelegate? callStackBuilder)
         {
             if (callStackBuilder != null && TryInvokeCustomCallStackHandler(callStackBuilder, element, shortDescription, loc, ref sb))
@@ -191,7 +191,7 @@ internal sealed class JintCallStack
         var element = index >= 0 ? frames[index] : (CallStackElement?) null;
         var shortDescription = element?.ToString() ?? "";
 
-        AppendLocation(ref builder, shortDescription, in location, in element, customCallStackBuilder);
+        AppendLocation(ref builder, shortDescription, in location, element, customCallStackBuilder);
 
         location = element?.Location ?? default;
         index--;
@@ -201,7 +201,7 @@ internal sealed class JintCallStack
             element = index >= 0 ? frames[index] : null;
             shortDescription = element?.ToString() ?? "";
 
-            AppendLocation(ref builder, shortDescription, in location, in element, customCallStackBuilder);
+            AppendLocation(ref builder, shortDescription, in location, element, customCallStackBuilder);
 
             location = element?.Location ?? default;
             index--;

--- a/Jint/Runtime/ExecutionContextStack.cs
+++ b/Jint/Runtime/ExecutionContextStack.cs
@@ -58,7 +58,11 @@ internal sealed class ExecutionContextStack
         // case where strictness changes without pushing a new context (a class body evaluated in
         // the enclosing context); returns the previous value so the caller can restore it.
         var previous = executionContext.Strict;
+        // MA0168 (net462/netstandard2.0 only): the older Unsafe.AsRef(in T) overload flags this
+        // intentional in-place write of a readonly field on the deliberately mutable ExecutionContext.
+#pragma warning disable MA0168
         Unsafe.AsRef(in executionContext.Strict) = strict;
+#pragma warning restore MA0168
         return previous;
     }
 


### PR DESCRIPTION
Enables `MA0168` (*use readonly struct for `in`/`ref readonly` parameter*) as a `warning`. The three existing violations:

- **`JintCallStack.AppendLocation`** took `in CallStackElement? element`. `CallStackElement` is already a `readonly struct`, but `in` on a small *nullable* readonly struct buys nothing and trips the rule → drop the `in`, pass by value. (`in SourceLocation loc` on the previous line is **not** flagged — Acornima's type is already readonly.)
- **`RegExpConstructor`** pushes a `GroupScanState` into `RefStack<T>.Push(in T)`. `GroupScanState` is a deliberately mutable scan cursor (updated in place via `ref` while scanning), so it can't be a readonly struct → suppressed at that one call with a comment.
- **`ExecutionContextStack.ReplaceTopStrict`** writes a `readonly` field in place via the older `Unsafe.AsRef(in T)` overload (net462/netstandard2.0 only) on the intentionally mutable `ExecutionContext` struct → suppressed with a comment.

Two of three are genuine intentional exceptions (documented), one is a real cleanup.

### Verification
- Clean build across all five TFMs with MA0168 enforced.
- `Jint.Tests` green on net10.0 (call-stack string building exercises the changed parameter).

Follows #2764, #2765, #2766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)