### PR TITLE
Enable MA0209 and pass in-parameters explicitly at call sites

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -86,6 +86,9 @@ dotnet_diagnostic.MA0212.severity = warning
 # MA0089: Optimize string method usage (e.g. char separators/args over single-char strings)
 dotnet_diagnostic.MA0089.severity = warning
 
+# MA0209: Use 'in' keyword for readonly struct parameters passed by value
+dotnet_diagnostic.MA0209.severity = warning
+
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false

--- a/Jint/AstExtensions.cs
+++ b/Jint/AstExtensions.cs
@@ -504,7 +504,7 @@ public static class AstExtensions
     /// </summary>
     internal static Node CreateLocationNode(in SourceLocation location)
     {
-        return new MinimalSyntaxElement(location);
+        return new MinimalSyntaxElement(in location);
     }
 
     /// <summary>

--- a/Jint/Collections/HybridDictionary.cs
+++ b/Jint/Collections/HybridDictionary.cs
@@ -206,7 +206,7 @@ internal sealed class HybridDictionary<TValue> : IEngineDictionary<Key, TValue>,
     {
         if (_dictionary != null)
         {
-            _dictionary.AddDangerous(key, value);
+            _dictionary.AddDangerous(in key, value);
         }
         else
         {

--- a/Jint/Engine.Async.cs
+++ b/Jint/Engine.Async.cs
@@ -33,7 +33,7 @@ public partial class Engine
     /// <returns>The resolved value if the result is a promise, otherwise the direct result.</returns>
     public Task<JsValue> EvaluateAsync(in Prepared<Script> preparedScript, CancellationToken cancellationToken = default)
     {
-        var result = Evaluate(preparedScript);
+        var result = Evaluate(in preparedScript);
         return UnwrapResultAsync(result, cancellationToken);
     }
 

--- a/Jint/Engine.Modules.cs
+++ b/Jint/Engine.Modules.cs
@@ -105,7 +105,7 @@ public partial class Engine
         {
             var parsedModule = moduleBuilder.Parse();
             var hasTopLevelAwait = HoistingScope.HasTopLevelAwait(parsedModule.Program!);
-            var module = new BuilderModule(_engine, _engine.Realm, parsedModule, location: parsedModule.Program!.Location.SourceFile, async: hasTopLevelAwait);
+            var module = new BuilderModule(_engine, _engine.Realm, in parsedModule, location: parsedModule.Program!.Location.SourceFile, async: hasTopLevelAwait);
             _modules[cacheKey] = module;
             moduleBuilder.BindExportedValues(module);
             _builders.Remove(specifier);
@@ -225,7 +225,7 @@ public partial class Engine
                     ? cyclicModuleRecord.AbnormalCompletionLocation
                     : SourceLocation.From(new Position(), new Position());
 
-                var node = AstExtensions.CreateLocationNode(location);
+                var node = AstExtensions.CreateLocationNode(in location);
                 Throw.JavaScriptException(_engine, promise.Value, node.Location);
             }
             else if (promise.State != PromiseState.Fulfilled)

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -383,12 +383,12 @@ public sealed partial class Engine : IDisposable
             null,
             strict: strict);
 
-        _executionContexts.Push(context);
+        _executionContexts.Push(in context);
     }
 
     internal void EnterExecutionContext(in ExecutionContext context)
     {
-        _executionContexts.Push(context);
+        _executionContexts.Push(in context);
     }
 
     /// <summary>
@@ -547,7 +547,7 @@ public sealed partial class Engine : IDisposable
     /// Evaluates code and returns last return value.
     /// </summary>
     public JsValue Evaluate(in Prepared<Script> preparedScript)
-        => ExecuteForCompletion(preparedScript);
+        => ExecuteForCompletion(in preparedScript);
 
     /// <summary>
     /// Executes code into engine and returns the engine instance (useful for chaining).
@@ -579,7 +579,7 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     public Engine Execute(in Prepared<Script> preparedScript)
     {
-        ExecuteForCompletion(preparedScript);
+        ExecuteForCompletion(in preparedScript);
         return this;
     }
 
@@ -620,7 +620,7 @@ public sealed partial class Engine : IDisposable
             parserOptions: parserOptions,
             strict: _isStrict || scriptRecord.EcmaScriptCode.Strict);
 
-        EnterExecutionContext(scriptContext);
+        EnterExecutionContext(in scriptContext);
         try
         {
             var script = scriptRecord.EcmaScriptCode;

--- a/Jint/Extensions/AcornimaExtensions.cs
+++ b/Jint/Extensions/AcornimaExtensions.cs
@@ -48,7 +48,7 @@ internal static class AcornimaExtensions
         }
         catch (Exception)
         {
-            Throw.JavaScriptException(engine, $"Could not load module {source}", AstExtensions.DefaultLocation);
+            Throw.JavaScriptException(engine, $"Could not load module {source}", in AstExtensions.DefaultLocation);
             return default;
         }
     }

--- a/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
+++ b/Jint/Native/AsyncGenerator/AsyncGeneratorInstance.cs
@@ -250,7 +250,7 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
         _currentPromiseCapability = promiseCapability;
 
         var genContext = _asyncGeneratorContext;
-        _engine.EnterExecutionContext(genContext);
+        _engine.EnterExecutionContext(in genContext);
 
         var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);
         Completion result;
@@ -471,7 +471,7 @@ internal sealed class AsyncGeneratorInstance : ObjectInstance, ISuspendable
         _asyncGeneratorState = AsyncGeneratorState.Executing;
 
         // Resume execution - enter the generator context and continue
-        _engine.EnterExecutionContext(_asyncGeneratorContext);
+        _engine.EnterExecutionContext(in _asyncGeneratorContext);
 
         try
         {

--- a/Jint/Native/Disposable/DisposableStack.cs
+++ b/Jint/Native/Disposable/DisposableStack.cs
@@ -41,7 +41,7 @@ internal sealed class DisposableStack : ObjectInstance
         var completion = _disposeCapability.DisposeResources(new Completion(CompletionType.Normal, Undefined, _engine.GetLastSyntaxElement()));
         if (completion.Type == CompletionType.Throw)
         {
-            Throw.JavaScriptException(_engine, completion.Value, completion);
+            Throw.JavaScriptException(_engine, completion.Value, in completion);
         }
         return completion.Value;
     }

--- a/Jint/Native/Function/ClassDefinition.cs
+++ b/Jint/Native/Function/ClassDefinition.cs
@@ -735,7 +735,7 @@ internal sealed class ClassDefinition
         public ClassFieldFunction(Expression expression) : base(NodeType.ExpressionStatement)
         {
             var nodeList = NodeList.From<Statement>(new ReturnStatement(expression));
-            _statement = new FunctionBody(nodeList, strict: true);
+            _statement = new FunctionBody(in nodeList, strict: true);
         }
 
         protected override object Accept(AstVisitor visitor) => throw new NotImplementedException();

--- a/Jint/Native/Function/EvalFunction.cs
+++ b/Jint/Native/Function/EvalFunction.cs
@@ -338,7 +338,7 @@ public sealed class EvalFunction : Function
 
             if (result.Type == CompletionType.Throw)
             {
-                Throw.JavaScriptException(_engine, value, result);
+                Throw.JavaScriptException(_engine, value, in result);
                 return null!;
             }
 

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -503,7 +503,7 @@ public abstract partial class Function : ObjectInstance, ICallable
         // NOTE: Any exception objects produced after this point are associated with calleeRealm.
         // Return calleeContext.
 
-        _engine.EnterExecutionContext(calleeContext);
+        _engine.EnterExecutionContext(in calleeContext);
         return ref _engine.ExecutionContext;
     }
 

--- a/Jint/Native/Function/ScriptFunction.cs
+++ b/Jint/Native/Function/ScriptFunction.cs
@@ -177,7 +177,7 @@ public sealed class ScriptFunction : Function, IConstructor
             // so debug mode always binds.
             if (!state.CanSkipThisBinding || _engine._isDebugMode)
             {
-                OrdinaryCallBindThis(calleeContext, thisObject);
+                OrdinaryCallBindThis(in calleeContext, thisObject);
             }
 
             // actual call
@@ -195,7 +195,7 @@ public sealed class ScriptFunction : Function, IConstructor
 
             if (result.Type == CompletionType.Throw)
             {
-                Throw.JavaScriptException(_engine, result.Value, result);
+                Throw.JavaScriptException(_engine, result.Value, in result);
             }
 
             // The DebugHandler needs the current execution context before the return for stepping through the return point
@@ -290,7 +290,7 @@ public sealed class ScriptFunction : Function, IConstructor
 
             if (result.Type == CompletionType.Throw)
             {
-                Throw.JavaScriptException(engine, result.Value, result);
+                Throw.JavaScriptException(engine, result.Value, in result);
             }
 
             return result.Type == CompletionType.Return ? result.Value : Undefined;
@@ -381,7 +381,7 @@ public sealed class ScriptFunction : Function, IConstructor
         {
             if (kind == ConstructorKind.Base)
             {
-                OrdinaryCallBindThis(calleeContext, thisArgument);
+                OrdinaryCallBindThis(in calleeContext, thisArgument);
                 ((ObjectInstance) thisArgument).InitializeInstanceElements(this);
             }
 
@@ -424,7 +424,7 @@ public sealed class ScriptFunction : Function, IConstructor
             }
             else if (result.Type == CompletionType.Throw)
             {
-                Throw.JavaScriptException(_engine, result.Value, result);
+                Throw.JavaScriptException(_engine, result.Value, in result);
             }
         }
         finally

--- a/Jint/Native/Generator/GeneratorInstance.cs
+++ b/Jint/Native/Generator/GeneratorInstance.cs
@@ -186,7 +186,7 @@ internal sealed class GeneratorInstance : ObjectInstance, ISuspendable
         _suspendedValue = null;
 
         var context = _engine._activeEvaluationContext;
-        return ResumeExecution(genContext, context ?? new EvaluationContext(_engine));
+        return ResumeExecution(in genContext, context ?? new EvaluationContext(_engine));
     }
 
     /// <summary>
@@ -208,7 +208,7 @@ internal sealed class GeneratorInstance : ObjectInstance, ISuspendable
                 return new IteratorResult(_engine, abruptCompletion.Value, JsBoolean.True);
             }
 
-            Throw.JavaScriptException(_engine, abruptCompletion.Value, AstExtensions.DefaultLocation);
+            Throw.JavaScriptException(_engine, abruptCompletion.Value, in AstExtensions.DefaultLocation);
         }
 
         var genContext = _generatorContext;
@@ -232,13 +232,13 @@ internal sealed class GeneratorInstance : ObjectInstance, ISuspendable
         _suspendedValue = null;
 
         var context = _engine._activeEvaluationContext;
-        return ResumeExecution(genContext, context ?? new EvaluationContext(_engine));
+        return ResumeExecution(in genContext, context ?? new EvaluationContext(_engine));
     }
 
     private ObjectInstance ResumeExecution(in ExecutionContext genContext, EvaluationContext context)
     {
         _generatorState = GeneratorState.Executing;
-        _engine.EnterExecutionContext(genContext);
+        _engine.EnterExecutionContext(in genContext);
 
         Completion result;
         try
@@ -293,7 +293,7 @@ internal sealed class GeneratorInstance : ObjectInstance, ISuspendable
         if (result.Type == CompletionType.Throw)
         {
             _generatorState = GeneratorState.Completed;
-            Throw.JavaScriptException(_engine, result.Value, result);
+            Throw.JavaScriptException(_engine, result.Value, in result);
         }
 
         return resultValue!;

--- a/Jint/Native/Generator/GeneratorPrototype.cs
+++ b/Jint/Native/Generator/GeneratorPrototype.cs
@@ -53,7 +53,7 @@ internal sealed partial class GeneratorPrototype : BuiltinShapeObject
     {
         var g = AssertGeneratorInstance(thisObject);
         var C = new Completion(CompletionType.Return, value, null!);
-        return g.GeneratorResumeAbrupt(C, null);
+        return g.GeneratorResumeAbrupt(in C, null);
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ internal sealed partial class GeneratorPrototype : BuiltinShapeObject
     {
         var g = AssertGeneratorInstance(thisObject);
         var C = new Completion(CompletionType.Throw, exception, null!);
-        return g.GeneratorResumeAbrupt(C, null);
+        return g.GeneratorResumeAbrupt(in C, null);
     }
 
     private GeneratorInstance AssertGeneratorInstance(JsValue thisObj)

--- a/Jint/Native/Intl/CollatorConstructor.cs
+++ b/Jint/Native/Intl/CollatorConstructor.cs
@@ -84,7 +84,7 @@ internal sealed partial class CollatorConstructor : Constructor
         var optionsObj = IntlUtilities.CoerceOptionsToObject(_engine, options);
 
         // Validate localeMatcher option first (must be done before other processing)
-        GetStringOption(optionsObj, "localeMatcher", LocaleMatcherValues, "best fit");
+        GetStringOption(optionsObj, "localeMatcher", in LocaleMatcherValues, "best fit");
 
         // Resolve locale
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
@@ -101,7 +101,7 @@ internal sealed partial class CollatorConstructor : Constructor
         }
 
         // Get options (options override unicode extensions)
-        var usage = GetStringOption(optionsObj, "usage", UsageValues, "sort");
+        var usage = GetStringOption(optionsObj, "usage", in UsageValues, "sort");
         var sensitivity = GetSensitivity(optionsObj);
         var collation = GetCollationOption(optionsObj, uCollation, resolvedLocale);
         var numeric = GetNumericOption(optionsObj, uNumeric);
@@ -422,7 +422,7 @@ internal sealed partial class CollatorConstructor : Constructor
 
         // Validate localeMatcher option
         var optionsObj = IntlUtilities.CoerceOptionsToObject(_engine, options);
-        GetStringOption(optionsObj, "localeMatcher", LocaleMatcherValues, "best fit");
+        GetStringOption(optionsObj, "localeMatcher", in LocaleMatcherValues, "best fit");
 
         // For now, return all requested locales that are available
         List<JsValue> supported = [];

--- a/Jint/Native/Intl/DateTimeFormatConstructor.cs
+++ b/Jint/Native/Intl/DateTimeFormatConstructor.cs
@@ -108,7 +108,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         var optionsObj = IntlUtilities.CoerceOptionsToObject(_engine, options);
 
         // Step 5: Get localeMatcher option first
-        var localeMatcher = GetStringOption(optionsObj, "localeMatcher", LocaleMatcherValues, "best fit") ?? "best fit";
+        var localeMatcher = GetStringOption(optionsObj, "localeMatcher", in LocaleMatcherValues, "best fit") ?? "best fit";
 
         // Resolve locale (uses pre-read localeMatcher)
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
@@ -280,7 +280,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
         }
 
         // Step 14: Get hourCycle option
-        var hourCycleOption = GetStringOption(optionsObj, "hourCycle", HourCycleValues, null);
+        var hourCycleOption = GetStringOption(optionsObj, "hourCycle", in HourCycleValues, null);
         string? hourCycle;
 
         if (hourCycleOption != null || hour12.HasValue)
@@ -350,17 +350,17 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
 
         // Step 36: Get component options in order (per Table 7 of ECMA-402)
         // Order: weekday, era, year, month, day, dayPeriod, hour, minute, second, fractionalSecondDigits, timeZoneName
-        var weekday = GetStringOption(optionsObj, "weekday", WeekdayValues, null);
-        var era = GetStringOption(optionsObj, "era", EraValues, null);
-        var year = GetStringOption(optionsObj, "year", YearValues, null);
-        var month = GetStringOption(optionsObj, "month", MonthValues, null);
-        var day = GetStringOption(optionsObj, "day", DayValues, null);
-        var dayPeriod = GetStringOption(optionsObj, "dayPeriod", DayPeriodValues, null);
-        var hour = GetStringOption(optionsObj, "hour", HourValues, null);
-        var minute = GetStringOption(optionsObj, "minute", MinuteValues, null);
-        var second = GetStringOption(optionsObj, "second", SecondValues, null);
+        var weekday = GetStringOption(optionsObj, "weekday", in WeekdayValues, null);
+        var era = GetStringOption(optionsObj, "era", in EraValues, null);
+        var year = GetStringOption(optionsObj, "year", in YearValues, null);
+        var month = GetStringOption(optionsObj, "month", in MonthValues, null);
+        var day = GetStringOption(optionsObj, "day", in DayValues, null);
+        var dayPeriod = GetStringOption(optionsObj, "dayPeriod", in DayPeriodValues, null);
+        var hour = GetStringOption(optionsObj, "hour", in HourValues, null);
+        var minute = GetStringOption(optionsObj, "minute", in MinuteValues, null);
+        var second = GetStringOption(optionsObj, "second", in SecondValues, null);
         var fractionalSecondDigits = GetNumberOption(optionsObj, "fractionalSecondDigits", 1, 3, null);
-        var timeZoneName = GetStringOption(optionsObj, "timeZoneName", TimeZoneNameValues, null);
+        var timeZoneName = GetStringOption(optionsObj, "timeZoneName", in TimeZoneNameValues, null);
 
         // Track whether user explicitly specified any core component option (before defaults are applied).
         // Per spec, era and timeZoneName are supplementary options - they don't participate in
@@ -370,11 +370,11 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
             minute != null || second != null || fractionalSecondDigits != null;
 
         // Step 37: Get formatMatcher option
-        GetStringOption(optionsObj, "formatMatcher", FormatMatcherValues, null);
+        GetStringOption(optionsObj, "formatMatcher", in FormatMatcherValues, null);
 
         // Date/time style options
-        var dateStyle = GetStringOption(optionsObj, "dateStyle", DateStyleValues, null);
-        var timeStyle = GetStringOption(optionsObj, "timeStyle", TimeStyleValues, null);
+        var dateStyle = GetStringOption(optionsObj, "dateStyle", in DateStyleValues, null);
+        var timeStyle = GetStringOption(optionsObj, "timeStyle", in TimeStyleValues, null);
 
         // If dateStyle or timeStyle is specified, component options must NOT be specified
         if (dateStyle != null || timeStyle != null)
@@ -709,7 +709,7 @@ internal sealed partial class DateTimeFormatConstructor : Constructor
 
         // Validate localeMatcher option
         var optionsObj = IntlUtilities.CoerceOptionsToObject(_engine, options);
-        GetStringOption(optionsObj, "localeMatcher", LocaleMatcherValues, fallback: null);
+        GetStringOption(optionsObj, "localeMatcher", in LocaleMatcherValues, fallback: null);
 
         List<JsValue> supported = [];
         foreach (var locale in requestedLocales)

--- a/Jint/Native/Intl/DisplayNamesConstructor.cs
+++ b/Jint/Native/Intl/DisplayNamesConstructor.cs
@@ -71,10 +71,10 @@ internal sealed partial class DisplayNamesConstructor : Constructor
 
         // Per spec: Get options in the correct order
         // Step 8: localeMatcher
-        var localeMatcher = GetStringOption(optionsObj, "localeMatcher", LocaleMatcherValues, "best fit");
+        var localeMatcher = GetStringOption(optionsObj, "localeMatcher", in LocaleMatcherValues, "best fit");
 
         // Step 11: style (comes before type per spec)
-        var style = GetStringOption(optionsObj, "style", StyleValues, "long");
+        var style = GetStringOption(optionsObj, "style", in StyleValues, "long");
 
         // Step 13: type (required)
         var typeValue = optionsObj.Get("type");
@@ -82,16 +82,16 @@ internal sealed partial class DisplayNamesConstructor : Constructor
         {
             Throw.TypeError(_realm, "Required option 'type' is undefined");
         }
-        var type = GetStringOption(optionsObj, "type", TypeValues, "");
+        var type = GetStringOption(optionsObj, "type", in TypeValues, "");
 
         // Step 15: fallback
-        var fallback = GetStringOption(optionsObj, "fallback", FallbackValues, "code");
+        var fallback = GetStringOption(optionsObj, "fallback", in FallbackValues, "code");
 
         // Step 17: languageDisplay (only valid for type: "language")
         string? languageDisplay = null;
         if (string.Equals(type, "language", StringComparison.Ordinal))
         {
-            languageDisplay = GetStringOption(optionsObj, "languageDisplay", LanguageDisplayValues, "dialect");
+            languageDisplay = GetStringOption(optionsObj, "languageDisplay", in LanguageDisplayValues, "dialect");
         }
 
         // Resolve locale
@@ -148,7 +148,7 @@ internal sealed partial class DisplayNamesConstructor : Constructor
 
         // Validate localeMatcher option
         var optionsObj = IntlUtilities.CoerceOptionsToObject(_engine, options);
-        GetStringOption(optionsObj, "localeMatcher", LocaleMatcherValues, "best fit");
+        GetStringOption(optionsObj, "localeMatcher", in LocaleMatcherValues, "best fit");
 
         List<JsValue> supported = [];
         foreach (var locale in requestedLocales)

--- a/Jint/Native/Intl/JsDateTimeFormat.cs
+++ b/Jint/Native/Intl/JsDateTimeFormat.cs
@@ -605,7 +605,7 @@ internal sealed class JsDateTimeFormat : ObjectInstance
         try
         {
             var isoDate = new IsoDate(originalYear ?? dateTime.Year, dateTime.Month, dateTime.Day);
-            var calDate = NonIsoCalendars.IsoToCalendarDate(Calendar, isoDate);
+            var calDate = NonIsoCalendars.IsoToCalendarDate(Calendar, in isoDate);
             year = calDate.Year;
             month = calDate.Month;
             day = calDate.Day;

--- a/Jint/Native/Intl/ListFormatConstructor.cs
+++ b/Jint/Native/Intl/ListFormatConstructor.cs
@@ -57,13 +57,13 @@ internal sealed partial class ListFormatConstructor : Constructor
 
         // Per ECMA-402 13.1.1: Get options in the correct order
         // Step 8: localeMatcher
-        var localeMatcher = GetStringOption(optionsObj, "localeMatcher", LocaleMatcherValues, "best fit");
+        var localeMatcher = GetStringOption(optionsObj, "localeMatcher", in LocaleMatcherValues, "best fit");
 
         // Step 10: type
-        var type = GetStringOption(optionsObj, "type", TypeValues, "conjunction");
+        var type = GetStringOption(optionsObj, "type", in TypeValues, "conjunction");
 
         // Step 12: style
-        var style = GetStringOption(optionsObj, "style", StyleValues, "long");
+        var style = GetStringOption(optionsObj, "style", in StyleValues, "long");
 
         // Resolve locale (don't re-read localeMatcher from options)
         var requestedLocales = IntlUtilities.CanonicalizeLocaleList(_engine, locales);
@@ -121,7 +121,7 @@ internal sealed partial class ListFormatConstructor : Constructor
 
         // Validate localeMatcher option
         var optionsObj = IntlUtilities.CoerceOptionsToObject(_engine, options);
-        GetStringOption(optionsObj, "localeMatcher", LocaleMatcherValues, "best fit");
+        GetStringOption(optionsObj, "localeMatcher", in LocaleMatcherValues, "best fit");
 
         List<JsValue> supported = [];
         foreach (var locale in requestedLocales)

--- a/Jint/Native/Intl/LocaleConstructor.cs
+++ b/Jint/Native/Intl/LocaleConstructor.cs
@@ -109,8 +109,8 @@ internal sealed class LocaleConstructor : Constructor
         var calendar = GetUnicodeExtensionOption(optionsObj, "calendar", parsedLocale.Calendar);
         var collation = GetUnicodeExtensionOption(optionsObj, "collation", parsedLocale.Collation);
         var firstDayOfWeek = GetFirstDayOfWeekOption(optionsObj, parsedLocale.FirstDayOfWeek);
-        var hourCycle = GetOptionString(optionsObj, "hourCycle", parsedLocale.HourCycle, HourCycleValues);
-        var caseFirst = GetOptionString(optionsObj, "caseFirst", parsedLocale.CaseFirst, CaseFirstValues);
+        var hourCycle = GetOptionString(optionsObj, "hourCycle", parsedLocale.HourCycle, in HourCycleValues);
+        var caseFirst = GetOptionString(optionsObj, "caseFirst", parsedLocale.CaseFirst, in CaseFirstValues);
         var numericValue = IntlUtilities.GetOption(_engine, optionsObj, "numeric", IntlUtilities.OptionType.Boolean, null, JsValue.Undefined);
         bool? numeric = numericValue.IsUndefined() ? parsedLocale.Numeric : TypeConverter.ToBoolean(numericValue);
         var numberingSystem = GetUnicodeExtensionOption(optionsObj, "numberingSystem", parsedLocale.NumberingSystem);

--- a/Jint/Native/Intl/PluralRulesConstructor.cs
+++ b/Jint/Native/Intl/PluralRulesConstructor.cs
@@ -68,14 +68,14 @@ internal sealed partial class PluralRulesConstructor : Constructor
         var resolvedLocale = ResolvePluralRulesLocale(_engine, availableLocales, requestedLocales, optionsObj);
 
         // Get type option
-        var type = GetStringOption(optionsObj, "type", TypeValues, "cardinal");
+        var type = GetStringOption(optionsObj, "type", in TypeValues, "cardinal");
 
         // Read notation option
-        var notation = GetStringOption(optionsObj, "notation", NotationValues, "standard");
+        var notation = GetStringOption(optionsObj, "notation", in NotationValues, "standard");
 
         // Read compactDisplay option (always read for option-validation/observable-getter order, but
         // only retained as [[CompactDisplay]] when notation is "compact").
-        var compactDisplay = GetStringOption(optionsObj, "compactDisplay", CompactDisplayValues, "short");
+        var compactDisplay = GetStringOption(optionsObj, "compactDisplay", in CompactDisplayValues, "short");
 
         // Digit options - must be read in spec order (SetNumberFormatDigitOptions)
         var minimumIntegerDigits = GetNumberOption(optionsObj, "minimumIntegerDigits", 1, 21, 1);
@@ -114,9 +114,9 @@ internal sealed partial class PluralRulesConstructor : Constructor
 
         // Rounding options (in spec order)
         var roundingIncrement = GetNumberOption(optionsObj, "roundingIncrement", 1, 5000, 1);
-        var roundingMode = GetStringOption(optionsObj, "roundingMode", RoundingModeValues, "halfExpand");
-        var roundingPriority = GetStringOption(optionsObj, "roundingPriority", RoundingPriorityValues, "auto");
-        var trailingZeroDisplay = GetStringOption(optionsObj, "trailingZeroDisplay", TrailingZeroDisplayValues, "auto");
+        var roundingMode = GetStringOption(optionsObj, "roundingMode", in RoundingModeValues, "halfExpand");
+        var roundingPriority = GetStringOption(optionsObj, "roundingPriority", in RoundingPriorityValues, "auto");
+        var trailingZeroDisplay = GetStringOption(optionsObj, "trailingZeroDisplay", in TrailingZeroDisplayValues, "auto");
 
         // Get CultureInfo for the locale
         var culture = IntlUtilities.GetCultureInfo(resolvedLocale) ?? CultureInfo.InvariantCulture;
@@ -211,7 +211,7 @@ internal sealed partial class PluralRulesConstructor : Constructor
 
         // Validate localeMatcher option
         var optionsObj = IntlUtilities.CoerceOptionsToObject(_engine, options);
-        GetStringOption(optionsObj, "localeMatcher", LocaleMatcherValues, "best fit");
+        GetStringOption(optionsObj, "localeMatcher", in LocaleMatcherValues, "best fit");
 
         List<JsValue> supported = [];
         foreach (var locale in requestedLocales)

--- a/Jint/Native/JsObject.cs
+++ b/Jint/Native/JsObject.cs
@@ -152,7 +152,7 @@ public sealed class JsObject : ObjectInstance
     /// so the caller deopts to the dictionary representation. The key must be known-absent (callers check).
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal bool TryShapeAdd(in Key key, JsValue value) => TryShapeAdd(key, value, out _);
+    internal bool TryShapeAdd(in Key key, JsValue value) => TryShapeAdd(in key, value, out _);
 
     /// <summary>
     /// Same as <see cref="TryShapeAdd(in Key, JsValue)"/>, additionally reporting whether the shape
@@ -187,7 +187,7 @@ public sealed class JsObject : ObjectInstance
             WriteOverflowUnchecked(_overflow, overflowIndex, value);
         }
 
-        _shape = shape.Add(key, out created);
+        _shape = shape.Add(in key, out created);
         unchecked { _propertiesVersion++; }
         return true;
     }

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -987,7 +987,7 @@ public sealed class JsonParser
             if (!digitLeading)
             {
                 Key key = name;
-                if (obj.ShapeOf.TryGetSlot(key, out var slot))
+                if (obj.ShapeOf.TryGetSlot(in key, out var slot))
                 {
                     // Duplicate key: last value wins at the first occurrence's position, matching the
                     // dictionary representation's replace-in-place.
@@ -995,7 +995,7 @@ public sealed class JsonParser
                     return;
                 }
 
-                if (obj.TryShapeAdd(key, value, out var created))
+                if (obj.TryShapeAdd(in key, value, out var created))
                 {
                     if (created)
                     {

--- a/Jint/Native/Number/Dtoa/FastDtoa.cs
+++ b/Jint/Native/Number/Dtoa/FastDtoa.cs
@@ -433,7 +433,7 @@ internal sealed class FastDtoa
         var tooHigh = new DiyFp(high.F + unit, high.E);
         // too_low and too_high are guaranteed to lie outside the interval we want the
         // generated number in.
-        var unsafeInterval = DiyFp.Minus(tooHigh, tooLow);
+        var unsafeInterval = DiyFp.Minus(in tooHigh, in tooLow);
         // We now cut the input number into two parts: the integral digits and the
         // fractionals. We will not write any decimal separator though, but adapt
         // kappa instead.
@@ -474,7 +474,7 @@ internal sealed class FastDtoa
                 // that lies within the unsafe interval.
                 return RoundWeed(
                     ref buffer,
-                    DiyFp.Minus(tooHigh, w).F,
+                    DiyFp.Minus(in tooHigh, in w).F,
                     unsafeInterval.F,
                     rest,
                     (ulong) divider << -one.E,
@@ -512,7 +512,7 @@ internal sealed class FastDtoa
             {
                 return RoundWeed(
                     ref buffer,
-                    DiyFp.Minus(tooHigh, w).F * unit,
+                    DiyFp.Minus(in tooHigh, in w).F * unit,
                     unsafeInterval.F,
                     fractionals,
                     one.F,
@@ -664,7 +664,7 @@ internal sealed class FastDtoa
         // In fact: scaled_w - w*10^k < 1ulp (unit in the last place) of scaled_w.
         // In other words: let f = scaled_w.f() and e = scaled_w.e(), then
         //           (f-1) * 2^e < w*10^k < (f+1) * 2^e
-        DiyFp scaledW = DiyFp.Times(w, tenMk);
+        DiyFp scaledW = DiyFp.Times(in w, in tenMk);
         Debug.Assert(scaledW.E ==
                      boundaryPlus.E + tenMk.E + DiyFp.KSignificandSize);
         // In theory it would be possible to avoid some recomputations by computing
@@ -672,8 +672,8 @@ internal sealed class FastDtoa
         // compute scaled_boundary_minus/plus by subtracting/adding from
         // scaled_w. However the code becomes much less readable and the speed
         // enhancements are not terriffic.
-        DiyFp scaledBoundaryMinus = DiyFp.Times(boundaryMinus, tenMk);
-        DiyFp scaledBoundaryPlus = DiyFp.Times(boundaryPlus, tenMk);
+        DiyFp scaledBoundaryMinus = DiyFp.Times(in boundaryMinus, in tenMk);
+        DiyFp scaledBoundaryPlus = DiyFp.Times(in boundaryPlus, in tenMk);
 
         // DigitGen will generate the digits of scaled_w. Therefore we have
         // v == (double) (scaled_w * 10^-mk).
@@ -682,7 +682,7 @@ internal sealed class FastDtoa
         // the buffer will be filled with "123" und the decimal_exponent will be
         // decreased by 2.
         int kappa;
-        var digitGen = DigitGen(scaledBoundaryMinus, scaledW, scaledBoundaryPlus, ref buffer, mk, out kappa);
+        var digitGen = DigitGen(in scaledBoundaryMinus, in scaledW, in scaledBoundaryPlus, ref buffer, mk, out kappa);
         decimal_exponent = -mk + kappa;
         return digitGen;
     }
@@ -719,14 +719,14 @@ internal sealed class FastDtoa
         // In fact: scaled_w - w*10^k < 1ulp (unit in the last place) of scaled_w.
         // In other words: let f = scaled_w.f() and e = scaled_w.e(), then
         //           (f-1) * 2^e < w*10^k < (f+1) * 2^e
-        DiyFp scaled_w = DiyFp.Times(w, ten_mk);
+        DiyFp scaled_w = DiyFp.Times(in w, in ten_mk);
 
         // We now have (double) (scaled_w * 10^-mk).
         // DigitGen will generate the first requested_digits digits of scaled_w and
         // return together with a kappa such that scaled_w ~= buffer * 10^kappa. (It
         // will not always be exactly the same since DigitGenCounted only produces a
         // limited number of digits.)
-        bool result = DigitGenCounted(scaled_w, requested_digits, ref buffer, out var kappa);
+        bool result = DigitGenCounted(in scaled_w, requested_digits, ref buffer, out var kappa);
         decimal_exponent = -mk + kappa;
         return result;
     }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1172,7 +1172,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
             {
                 var jo = Unsafe.As<JsObject>(this);
-                if (jo.ShapeOf.TryGetSlot(key, out var slot))
+                if (jo.ShapeOf.TryGetSlot(in key, out var slot))
                 {
                     jo.SetSlot(slot, value); // shape-mode properties are always writable (CEW)
                     return true;
@@ -2071,7 +2071,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
             if ((_type & InternalTypes.ShapeMode) != InternalTypes.Empty)
             {
                 var jo = Unsafe.As<JsObject>(this);
-                if (jo.ShapeOf.TryGetSlot(key, out var slot))
+                if (jo.ShapeOf.TryGetSlot(in key, out var slot))
                 {
                     // Existing CEW data property: CreateDataProperty just updates the value (spec: a CEW
                     // DefineOwnProperty overwrite — last value wins, first-occurrence position kept). This
@@ -2094,7 +2094,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                 // they take the dictionary fallback below instead.
                 if ((_type & InternalTypes.ShapeBuilding) != InternalTypes.Empty
                     && (key.Name.Length == 0 || !char.IsDigit(key.Name[0]))
-                    && jo.TryShapeAdd(key, v))
+                    && jo.TryShapeAdd(in key, v))
                 {
                     return true;
                 }

--- a/Jint/Native/Object/Shape.cs
+++ b/Jint/Native/Object/Shape.cs
@@ -89,7 +89,7 @@ internal sealed class Shape
     /// with the same key return the same instance, so identical layouts share their whole chain.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal Shape Add(in Key key) => Add(key, out _);
+    internal Shape Add(in Key key) => Add(in key, out _);
 
     /// <summary>
     /// Same as <see cref="Add(in Key)"/>, additionally reporting whether a new transition node was
@@ -101,7 +101,7 @@ internal sealed class Shape
         var transitions = _transitions ??= new Dictionary<Key, Shape>();
         if (!transitions.TryGetValue(key, out var child))
         {
-            child = new Shape(this, key);
+            child = new Shape(this, in key);
             transitions[key] = child;
             created = true;
         }

--- a/Jint/Native/RegExp/RegExpParseCache.cs
+++ b/Jint/Native/RegExp/RegExpParseCache.cs
@@ -97,14 +97,14 @@ internal static class RegExpParseCache
 
         if (compilation == RegexCompilation.Compiled)
         {
-            return _cache.TryGetValue(compiledKey, out var cached) ? cached.Result : Adapt(compiledKey);
+            return _cache.TryGetValue(compiledKey, out var cached) ? cached.Result : Adapt(in compiledKey);
         }
 
         var interpretedKey = compiledKey with { Compiled = false };
 
         if (compilation == RegexCompilation.Interpreted)
         {
-            return _cache.TryGetValue(interpretedKey, out var cached) ? cached.Result : Adapt(interpretedKey);
+            return _cache.TryGetValue(interpretedKey, out var cached) ? cached.Result : Adapt(in interpretedKey);
         }
 
         // RegexCompilation.Adaptive
@@ -122,7 +122,7 @@ internal static class RegExpParseCache
 
             // Repeated construction of the same pattern: reuse is proven, so the one-time compilation cost
             // is amortized from here on. Upgrade and drop the now-redundant interpreted entry.
-            var result = Adapt(compiledKey);
+            var result = Adapt(in compiledKey);
             if (!result.Success)
             {
                 // Shouldn't happen (the same pattern already adapted successfully), but never trade a
@@ -134,7 +134,7 @@ internal static class RegExpParseCache
             return result;
         }
 
-        return Adapt(interpretedKey);
+        return Adapt(in interpretedKey);
     }
 
     private static RegExpParseResult Adapt(in Key key)
@@ -152,7 +152,7 @@ internal static class RegExpParseCache
                 _cache.Clear();
             }
 
-            _cache.TryAdd(key, new Entry(result));
+            _cache.TryAdd(key, new Entry(in result));
         }
 
         return result;

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -1243,7 +1243,7 @@ internal sealed partial class RegExpPrototype : Prototype
             R.Set(JsRegExp.PropertyLastIndex, e, true);
         }
 
-        return CreateReturnValueArrayFromCustom(R, result, s, hasIndices);
+        return CreateReturnValueArrayFromCustom(R, in result, s, hasIndices);
     }
 
     /// <summary>
@@ -1402,7 +1402,7 @@ internal sealed partial class RegExpPrototype : Prototype
         }
 
         // B.2.4 Update legacy RegExp static properties
-        UpdateLegacyStaticPropertiesFromCustom(engine, result, s, actualGroupCount);
+        UpdateLegacyStaticPropertiesFromCustom(engine, in result, s, actualGroupCount);
 
         return array;
     }

--- a/Jint/Native/ShadowRealm/ShadowRealm.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealm.cs
@@ -44,7 +44,7 @@ public sealed class ShadowRealm : ObjectInstance
         }
 
         var callerRealm = _engine.Realm;
-        return PerformShadowRealmEval(preparedScript, callerRealm);
+        return PerformShadowRealmEval(in preparedScript, callerRealm);
     }
 
     public JsValue ImportValue(string specifier, string exportName)
@@ -135,7 +135,7 @@ public sealed class ShadowRealm : ObjectInstance
 
         _engine._host.EnsureCanCompileStrings(callerRealm, evalRealm);
 
-        return PerformShadowRealmEvalInternal(preparedScript, callerRealm);
+        return PerformShadowRealmEvalInternal(in preparedScript, callerRealm);
     }
 
     internal JsValue PerformShadowRealmEvalInternal(in Prepared<Script> preparedScript, Realm callerRealm)
@@ -165,7 +165,7 @@ public sealed class ShadowRealm : ObjectInstance
         // If runningContext is not already suspended, suspend runningContext.
 
         var evalContext = new ExecutionContext(null, lexEnv, varEnv, null, evalRealm, null, parserOptions: preparedScript.ParserOptions, strict: strictEval);
-        _engine.EnterExecutionContext(evalContext);
+        _engine.EnterExecutionContext(in evalContext);
 
         Completion result;
         try
@@ -287,7 +287,7 @@ public sealed class ShadowRealm : ObjectInstance
         // var runningContext = _engine.ExecutionContext;
         // 4. If runningContext is not already suspended, suspend runningContext.
 
-        _engine.EnterExecutionContext(_executionContext);
+        _engine.EnterExecutionContext(in _executionContext);
         try
         {
             _engine._host.LoadImportedModule(null, new ModuleRequest(specifierString, []), innerCapability);

--- a/Jint/Native/ShadowRealm/ShadowRealmConstructor.cs
+++ b/Jint/Native/ShadowRealm/ShadowRealmConstructor.cs
@@ -53,7 +53,7 @@ public sealed class ShadowRealmConstructor : Constructor
                     // strict-correct contexts. Mirror the host realm's default strictness.
                     strict: engine.Options.Strict);
 
-                return new ShadowRealm(engine, context, realmRec);
+                return new ShadowRealm(engine, in context, realmRec);
             },
             realmRec);
 

--- a/Jint/Native/Temporal/NonIsoCalendars.cs
+++ b/Jint/Native/Temporal/NonIsoCalendars.cs
@@ -81,17 +81,17 @@ internal static class NonIsoCalendars
         {
             return calendar switch
             {
-                "chinese" => LunisolarToCalendarDate(ChineseCal, isoDate),
-                "dangi" => LunisolarToCalendarDate(DangiCal, isoDate),
-                "hebrew" => HebrewToCalendarDate(isoDate),
-                "persian" => PersianToCalendarDate(isoDate),
-                "coptic" => FixedEpochToCalendarDate(CopticEpochDays, isoDate),
-                "ethiopic" => FixedEpochToCalendarDate(EthiopicEpochDays, isoDate),
-                "ethioaa" => FixedEpochToCalendarDate(EthioAAEpochDays, isoDate),
-                "indian" => IndianToCalendarDate(isoDate),
-                "islamic-umalqura" => IslamicUmalquraToCalendarDate(isoDate),
-                "islamic-civil" => IslamicCivilToCalendarDate(isoDate, 1948439L),
-                "islamic-tbla" => IslamicCivilToCalendarDate(isoDate, 1948438L),
+                "chinese" => LunisolarToCalendarDate(ChineseCal, in isoDate),
+                "dangi" => LunisolarToCalendarDate(DangiCal, in isoDate),
+                "hebrew" => HebrewToCalendarDate(in isoDate),
+                "persian" => PersianToCalendarDate(in isoDate),
+                "coptic" => FixedEpochToCalendarDate(CopticEpochDays, in isoDate),
+                "ethiopic" => FixedEpochToCalendarDate(EthiopicEpochDays, in isoDate),
+                "ethioaa" => FixedEpochToCalendarDate(EthioAAEpochDays, in isoDate),
+                "indian" => IndianToCalendarDate(in isoDate),
+                "islamic-umalqura" => IslamicUmalquraToCalendarDate(in isoDate),
+                "islamic-civil" => IslamicCivilToCalendarDate(in isoDate, 1948439L),
+                "islamic-tbla" => IslamicCivilToCalendarDate(in isoDate, 1948438L),
                 _ => throw new NotSupportedException($"Calendar '{calendar}' not supported by NonIsoCalendars")
             };
         }
@@ -176,21 +176,21 @@ internal static class NonIsoCalendars
         // or Indian calendar, handle them directly
         if (calendar is "coptic" or "ethiopic" or "ethioaa")
         {
-            return FixedEpochCalendarDateAdd(calendar, isoDate, years, months, overflow);
+            return FixedEpochCalendarDateAdd(calendar, in isoDate, years, months, overflow);
         }
 
         if (calendar is "indian")
         {
-            return IndianCalendarDateAdd(isoDate, years, months, overflow);
+            return IndianCalendarDateAdd(in isoDate, years, months, overflow);
         }
 
         if (calendar is "islamic-civil" or "islamic-tbla" or "islamic-umalqura")
         {
-            return IslamicTabularCalendarDateAdd(calendar, isoDate, years, months, overflow);
+            return IslamicTabularCalendarDateAdd(calendar, in isoDate, years, months, overflow);
         }
 
         var cal = GetCalendar(calendar);
-        var calDate = IsoToCalendarDate(calendar, isoDate);
+        var calDate = IsoToCalendarDate(calendar, in isoDate);
         var newYear = calDate.Year + years;
         int newOrdinalMonth;
 
@@ -316,8 +316,8 @@ internal static class NonIsoCalendars
         // Spec convention: sign = +1 if two > one (forward), -1 if backward.
         var sign = -rawSign;
 
-        var calOne = IsoToCalendarDate(calendar, one);
-        var calTwo = IsoToCalendarDate(calendar, two);
+        var calOne = IsoToCalendarDate(calendar, in one);
+        var calTwo = IsoToCalendarDate(calendar, in two);
 
         var years = 0;
         var diffYears = calTwo.Year - calOne.Year;
@@ -340,8 +340,8 @@ internal static class NonIsoCalendars
             // day-overflow within the same year boundary all flow through this check.
             if (years != 0)
             {
-                var check = CalendarDateAdd(calendar, one, years, 0, "constrain");
-                var checkCal = IsoToCalendarDate(calendar, check);
+                var check = CalendarDateAdd(calendar, in one, years, 0, "constrain");
+                var checkCal = IsoToCalendarDate(calendar, in check);
                 var notional = checkCal.Day != calOne.Day ? calOne.Day : checkCal.Day;
                 var ccd = CompareCalendarFields(calTwo.Year, calTwo.MonthCode, calTwo.Day, checkCal.Year, checkCal.MonthCode, notional);
                 if (ccd * sign < 0)
@@ -365,15 +365,15 @@ internal static class NonIsoCalendars
         }
 
         var currentIso = years != 0 || months != 0
-            ? CalendarDateAdd(calendar, one, years, months, "constrain")
+            ? CalendarDateAdd(calendar, in one, years, months, "constrain")
             : one;
 
         while (true)
         {
             var prevMonths = months;
             months += sign;
-            var nextIso = CalendarDateAdd(calendar, one, years, months, "constrain");
-            var nextCal = IsoToCalendarDate(calendar, nextIso);
+            var nextIso = CalendarDateAdd(calendar, in one, years, months, "constrain");
+            var nextCal = IsoToCalendarDate(calendar, in nextIso);
             // Un-constrain the day in calendar-field space: if AddCalendar forced day down
             // to fit the target month, we still want to consider "next" as standing at the
             // source's original day for comparison (matches polyfill behavior).
@@ -1487,14 +1487,14 @@ internal static class NonIsoCalendars
         // we cannot construct a DateTime at all, so route directly to the algorithmic path.
         if (isoDate.Year < 1 || isoDate.Year > 9999)
         {
-            return HebrewAlgorithmicFromIso(isoDate);
+            return HebrewAlgorithmicFromIso(in isoDate);
         }
 
         var dt = new DateTime(isoDate.Year, isoDate.Month, isoDate.Day);
 
         if (dt < cal.MinSupportedDateTime || dt > cal.MaxSupportedDateTime)
         {
-            return HebrewAlgorithmicFromIso(isoDate);
+            return HebrewAlgorithmicFromIso(in isoDate);
         }
 
         var year = cal.GetYear(dt);
@@ -1763,14 +1763,14 @@ internal static class NonIsoCalendars
 
         if (isoDate.Year < 1 || isoDate.Year > 9999)
         {
-            return PersianAlgorithmicFromIso(isoDate);
+            return PersianAlgorithmicFromIso(in isoDate);
         }
 
         var dt = new DateTime(isoDate.Year, isoDate.Month, isoDate.Day);
 
         if (dt < cal.MinSupportedDateTime || dt > cal.MaxSupportedDateTime)
         {
-            return PersianAlgorithmicFromIso(isoDate);
+            return PersianAlgorithmicFromIso(in isoDate);
         }
 
         var year = cal.GetYear(dt);
@@ -2418,7 +2418,7 @@ internal static class NonIsoCalendars
     /// </summary>
     private static IsoDate IndianCalendarDateAdd(in IsoDate isoDate, int years, int months, string overflow)
     {
-        var calDate = IndianToCalendarDate(isoDate);
+        var calDate = IndianToCalendarDate(in isoDate);
         var newYear = calDate.Year + years;
         var newMonth = calDate.Month;
 
@@ -2531,7 +2531,7 @@ internal static class NonIsoCalendars
         // outer catch return ISO-like fields.
         if (isoDate.Year < 1 || isoDate.Year > 9999)
         {
-            return IslamicCivilToCalendarDate(isoDate);
+            return IslamicCivilToCalendarDate(in isoDate);
         }
 
         var dt = new DateTime(isoDate.Year, isoDate.Month, isoDate.Day);
@@ -2551,7 +2551,7 @@ internal static class NonIsoCalendars
         }
 
         // Fall back to islamic-civil algorithm for dates outside UmAlQura range
-        return IslamicCivilToCalendarDate(isoDate);
+        return IslamicCivilToCalendarDate(in isoDate);
     }
 
     /// <summary>
@@ -2863,7 +2863,7 @@ internal static class NonIsoCalendars
     /// </summary>
     private static IsoDate IslamicTabularCalendarDateAdd(string calendar, in IsoDate isoDate, int years, int months, string overflow)
     {
-        var calDate = IsoToCalendarDate(calendar, isoDate);
+        var calDate = IsoToCalendarDate(calendar, in isoDate);
         var newYear = calDate.Year + years;
         var newMonth = calDate.Month;
 

--- a/Jint/Native/Temporal/TemporalHelpers.cs
+++ b/Jint/Native/Temporal/TemporalHelpers.cs
@@ -2014,7 +2014,7 @@ internal static class TemporalHelpers
 
         if (NonIsoCalendars.IsNonIsoCalendar(calendar))
         {
-            return NonIsoCalendars.IsoToCalendarDate(calendar, isoDate, engine).Year;
+            return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).Year;
         }
 
         return isoDate.Year;
@@ -2032,7 +2032,7 @@ internal static class TemporalHelpers
 
         if (NonIsoCalendars.IsNonIsoCalendar(calendar))
         {
-            return NonIsoCalendars.IsoToCalendarDate(calendar, isoDate, engine).Month;
+            return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).Month;
         }
 
         return isoDate.Month;
@@ -2050,7 +2050,7 @@ internal static class TemporalHelpers
 
         if (NonIsoCalendars.IsNonIsoCalendar(calendar))
         {
-            return NonIsoCalendars.IsoToCalendarDate(calendar, isoDate, engine).MonthCode;
+            return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).MonthCode;
         }
 
         return $"M{isoDate.Month:D2}";
@@ -2068,7 +2068,7 @@ internal static class TemporalHelpers
 
         if (NonIsoCalendars.IsNonIsoCalendar(calendar))
         {
-            return NonIsoCalendars.IsoToCalendarDate(calendar, isoDate, engine).Day;
+            return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).Day;
         }
 
         return isoDate.Day;
@@ -2090,7 +2090,7 @@ internal static class TemporalHelpers
 
         if (NonIsoCalendars.IsNonIsoCalendar(calendar))
         {
-            var calDate = NonIsoCalendars.IsoToCalendarDate(calendar, isoDate, engine);
+            var calDate = NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine);
             var firstOfMonth = NonIsoCalendars.CalendarDateToIso(calendar, calDate.Year, calDate.MonthCode, calDate.Month, 1, "constrain", engine);
             if (firstOfMonth is not null)
             {
@@ -2117,7 +2117,7 @@ internal static class TemporalHelpers
 
         if (NonIsoCalendars.IsNonIsoCalendar(calendar))
         {
-            var calDate = NonIsoCalendars.IsoToCalendarDate(calendar, isoDate, engine);
+            var calDate = NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine);
             // Find the first day of the calendar year
             var firstDay = NonIsoCalendars.CalendarDateToIso(calendar, calDate.Year, "M01", 0, 1, "constrain", engine);
             if (firstDay is not null)
@@ -2143,7 +2143,7 @@ internal static class TemporalHelpers
 
         if (NonIsoCalendars.IsNonIsoCalendar(calendar))
         {
-            return NonIsoCalendars.IsoToCalendarDate(calendar, isoDate, engine).DaysInMonth;
+            return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).DaysInMonth;
         }
 
         return isoDate.DaysInMonth();
@@ -2161,7 +2161,7 @@ internal static class TemporalHelpers
 
         if (NonIsoCalendars.IsNonIsoCalendar(calendar))
         {
-            return NonIsoCalendars.IsoToCalendarDate(calendar, isoDate, engine).DaysInYear;
+            return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).DaysInYear;
         }
 
         return isoDate.DaysInYear();
@@ -2179,7 +2179,7 @@ internal static class TemporalHelpers
 
         if (NonIsoCalendars.IsNonIsoCalendar(calendar))
         {
-            return NonIsoCalendars.IsoToCalendarDate(calendar, isoDate, engine).MonthsInYear;
+            return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).MonthsInYear;
         }
 
         return 12;
@@ -2197,7 +2197,7 @@ internal static class TemporalHelpers
 
         if (NonIsoCalendars.IsNonIsoCalendar(calendar))
         {
-            return NonIsoCalendars.IsoToCalendarDate(calendar, isoDate, engine).InLeapYear;
+            return NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate, engine).InLeapYear;
         }
 
         return IsoDate.IsLeapYear(isoDate.Year);
@@ -2210,7 +2210,7 @@ internal static class TemporalHelpers
     {
         if (calendar is "japanese")
         {
-            return JapaneseEra(isoDate);
+            return JapaneseEra(in isoDate);
         }
 
         if (IsGregorianBasedCalendar(calendar))
@@ -2220,8 +2220,8 @@ internal static class TemporalHelpers
 
         if (NonIsoCalendars.IsNonIsoCalendar(calendar))
         {
-            var calDate = NonIsoCalendars.IsoToCalendarDate(calendar, isoDate);
-            return NonIsoCalendars.CalendarEra(calendar, calDate);
+            var calDate = NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate);
+            return NonIsoCalendars.CalendarEra(calendar, in calDate);
         }
 
         return CalendarEra(calendar, isoDate.Year);
@@ -2234,7 +2234,7 @@ internal static class TemporalHelpers
     {
         if (calendar is "japanese")
         {
-            return JapaneseEraYear(isoDate);
+            return JapaneseEraYear(in isoDate);
         }
 
         if (IsGregorianBasedCalendar(calendar))
@@ -2244,8 +2244,8 @@ internal static class TemporalHelpers
 
         if (NonIsoCalendars.IsNonIsoCalendar(calendar))
         {
-            var calDate = NonIsoCalendars.IsoToCalendarDate(calendar, isoDate);
-            return NonIsoCalendars.CalendarEraYear(calendar, calDate);
+            var calDate = NonIsoCalendars.IsoToCalendarDate(calendar, in isoDate);
+            return NonIsoCalendars.CalendarEraYear(calendar, in calDate);
         }
 
         return CalendarEraYear(calendar, isoDate.Year);
@@ -2276,7 +2276,7 @@ internal static class TemporalHelpers
 
     private static int JapaneseEraYear(in IsoDate d)
     {
-        var era = JapaneseEra(d);
+        var era = JapaneseEra(in d);
         return era switch
         {
             "reiwa" => d.Year - 2018,
@@ -2739,7 +2739,7 @@ internal static class TemporalHelpers
             try
             {
                 // Add years and months using calendar-specific reckoning
-                var result = NonIsoCalendars.CalendarDateAdd(calendar, isoDate, (int) duration.Years, (int) duration.Months, overflow);
+                var result = NonIsoCalendars.CalendarDateAdd(calendar, in isoDate, (int) duration.Years, (int) duration.Months, overflow);
 
                 // Add weeks and days using ISO arithmetic
                 var days = duration.Days + 7 * duration.Weeks;
@@ -6830,7 +6830,7 @@ internal static class TemporalHelpers
         {
             if (NonIsoCalendars.IsNonIsoCalendar(calendar))
             {
-                return NonIsoCalendars.CalendarDateUntil(calendar, one, two, largestUnit);
+                return NonIsoCalendars.CalendarDateUntil(calendar, in one, in two, largestUnit);
             }
 
             throw new NotSupportedException($"Calendar '{calendar}' not yet supported");

--- a/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
+++ b/Jint/Native/Temporal/ZonedDateTime/ZonedDateTimePrototype.cs
@@ -159,7 +159,7 @@ internal sealed partial class ZonedDateTimePrototype : Prototype
     {
         var zdt = ValidateZonedDateTime(thisObject);
         var date = zdt.GetIsoDateTime().Date;
-        return JsNumber.Create(TemporalHelpers.CalendarDayOfYear(zdt.Calendar, date, _engine));
+        return JsNumber.Create(TemporalHelpers.CalendarDayOfYear(zdt.Calendar, in date, _engine));
     }
 
     [JsAccessor("weekOfYear")]

--- a/Jint/Runtime/CallStack/JintCallStack.cs
+++ b/Jint/Runtime/CallStack/JintCallStack.cs
@@ -56,8 +56,8 @@ internal sealed class JintCallStack
 
     public int Push(Function function, JintExpression? expression, in ExecutionContext executionContext)
     {
-        var item = new CallStackElement(function, expression, new CallStackExecutionContext(executionContext));
-        _stack.Push(item);
+        var item = new CallStackElement(function, expression, new CallStackExecutionContext(in executionContext));
+        _stack.Push(in item);
         if (_statistics is not null)
         {
 #pragma warning disable CA1854
@@ -191,7 +191,7 @@ internal sealed class JintCallStack
         var element = index >= 0 ? frames[index] : (CallStackElement?) null;
         var shortDescription = element?.ToString() ?? "";
 
-        AppendLocation(ref builder, shortDescription, location, element, customCallStackBuilder);
+        AppendLocation(ref builder, shortDescription, in location, in element, customCallStackBuilder);
 
         location = element?.Location ?? default;
         index--;
@@ -201,7 +201,7 @@ internal sealed class JintCallStack
             element = index >= 0 ? frames[index] : null;
             shortDescription = element?.ToString() ?? "";
 
-            AppendLocation(ref builder, shortDescription, location, element, customCallStackBuilder);
+            AppendLocation(ref builder, shortDescription, in location, in element, customCallStackBuilder);
 
             location = element?.Location ?? default;
             index--;

--- a/Jint/Runtime/Debugger/DebugCallStack.cs
+++ b/Jint/Runtime/Debugger/DebugCallStack.cs
@@ -14,13 +14,13 @@ public sealed class DebugCallStack : IReadOnlyList<CallFrame>
         var executionContext = new CallStackExecutionContext(engine.ExecutionContext);
         foreach (var element in callStack.Stack)
         {
-            _stack.Add(new CallFrame(element, executionContext, location, returnValue));
+            _stack.Add(new CallFrame(element, in executionContext, in location, returnValue));
             location = element.Location;
             returnValue = null;
             executionContext = element.CallingExecutionContext;
         }
         // Add root location
-        _stack.Add(new CallFrame(null, executionContext, location, returnValue: null));
+        _stack.Add(new CallFrame(null, in executionContext, in location, returnValue: null));
     }
 
     public CallFrame this[int index] => _stack[index];

--- a/Jint/Runtime/Debugger/DebugHandler.cs
+++ b/Jint/Runtime/Debugger/DebugHandler.cs
@@ -169,7 +169,7 @@ public class DebugHandler
             return;
         }
 
-        var args = new ExceptionThrownEventArgs(_engine, thrownValue, location);
+        var args = new ExceptionThrownEventArgs(_engine, thrownValue, in location);
         ExceptionThrown.Invoke(_engine, args);
     }
 
@@ -206,7 +206,7 @@ public class DebugHandler
         var functionBodyEnd = bodyLocation.End;
         var location = SourceLocation.From(functionBodyEnd, functionBodyEnd, bodyLocation.SourceFile);
 
-        CheckBreakPointAndPause(node: null, location, returnValue);
+        CheckBreakPointAndPause(node: null, in location, returnValue);
     }
 
     private void CheckBreakPointAndPause(
@@ -242,7 +242,7 @@ public class DebugHandler
             pauseType = PauseType.Skip;
         }
 
-        Pause(pauseType, node, location, returnValue, breakPoint);
+        Pause(pauseType, node, in location, returnValue, breakPoint);
 
         _paused = false;
     }
@@ -257,7 +257,7 @@ public class DebugHandler
         var info = new DebugInformation(
             engine: _engine,
             currentNode: node,
-            currentLocation: location,
+            currentLocation: in location,
             returnValue: returnValue,
             currentMemoryUsage: _engine.CurrentMemoryUsage,
             pauseType: type,

--- a/Jint/Runtime/ExceptionDataHelper.cs
+++ b/Jint/Runtime/ExceptionDataHelper.cs
@@ -29,7 +29,7 @@ internal static class ExceptionDataHelper
 
             if (!data.Contains(JintExceptionDataKeys.Location))
             {
-                data[JintExceptionDataKeys.Location] = JintExceptionLocation.FromSourceLocation(location);
+                data[JintExceptionDataKeys.Location] = JintExceptionLocation.FromSourceLocation(in location);
             }
 
             if (!data.Contains(JintExceptionDataKeys.CallStack))

--- a/Jint/Runtime/Host.cs
+++ b/Jint/Runtime/Host.cs
@@ -61,7 +61,7 @@ public class Host
             // argument handling). _isStrict is assigned after this runs, so read Options directly.
             strict: Engine.Options.Strict);
 
-        Engine.EnterExecutionContext(newContext);
+        Engine.EnterExecutionContext(in newContext);
     }
 
     internal virtual GlobalEnvironment CreateGlobalEnvironment(ObjectInstance globalObject)

--- a/Jint/Runtime/IScriptOrModule.Extensions.cs
+++ b/Jint/Runtime/IScriptOrModule.Extensions.cs
@@ -8,7 +8,7 @@ internal static class ScriptOrModuleExtensions
     {
         if (scriptOrModule is not Module module)
         {
-            Throw.SyntaxError(engine.Realm, "Cannot use import/export statements outside a module", location);
+            Throw.SyntaxError(engine.Realm, "Cannot use import/export statements outside a module", in location);
             return default!;
         }
         return module;

--- a/Jint/Runtime/Interop/InteropHelper.cs
+++ b/Jint/Runtime/Interop/InteropHelper.cs
@@ -393,7 +393,7 @@ internal sealed class InteropHelper
 
         public static MethodMatches Empty => default;
 
-        public static MethodMatches Single(in MethodMatch match) => new(match, list: null, hasSingle: true);
+        public static MethodMatches Single(in MethodMatch match) => new(in match, list: null, hasSingle: true);
 
         public static MethodMatches Sorted(List<MethodMatch> list) => new(default, list, hasSingle: false);
 
@@ -407,7 +407,7 @@ internal sealed class InteropHelper
             return _list is { Count: > 0 } ? _list[0] : default;
         }
 
-        public Enumerator GetEnumerator() => new(this);
+        public Enumerator GetEnumerator() => new(in this);
 
         internal struct Enumerator
         {

--- a/Jint/Runtime/Interop/MethodInfoFunction.cs
+++ b/Jint/Runtime/Interop/MethodInfoFunction.cs
@@ -162,7 +162,7 @@ internal sealed class MethodInfoFunction : Function
             // single candidate, no overload resolution needed - bind directly and skip scoring
             var method = _methods[0];
             var parameterInfos = method.Parameters;
-            var arguments = ArgumentProvider(method, state);
+            var arguments = ArgumentProvider(method, in state);
             if (arguments.Length <= parameterInfos.Length
                 && arguments.Length >= parameterInfos.Length - method.ParameterDefaultValuesCount
                 && CanBindNullArguments(parameterInfos, arguments))
@@ -212,7 +212,7 @@ internal sealed class MethodInfoFunction : Function
         }
         else
         {
-            foreach (var (method, arguments, _) in InteropHelper.FindBestMatch(_engine, _methods, static (method, state) => ArgumentProvider(method, state), state))
+            foreach (var (method, arguments, _) in InteropHelper.FindBestMatch(_engine, _methods, static (method, state) => ArgumentProvider(method, in state), state))
             {
                 if (TryCall(method, arguments, thisObj, converter, out var result))
                 {

--- a/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAwaitExpression.cs
@@ -225,7 +225,7 @@ internal sealed class JintAwaitExpression : JintExpression
         asyncInstance._state = AsyncFunctionState.Executing;
         asyncInstance._isResuming = true;
 
-        engine.EnterExecutionContext(asyncInstance._savedContext);
+        engine.EnterExecutionContext(in asyncInstance._savedContext);
 
         var context = engine._activeEvaluationContext ?? new EvaluationContext(engine);
 

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -347,7 +347,7 @@ internal sealed class JintObjectExpression : JintExpression
             shape = engine.GetEmptyShape(proto);
             for (var i = 0; i < keys.Length; i++)
             {
-                shape = shape.Add(keys[i]);
+                shape = shape.Add(in keys[i]);
             }
 
             _cachedShape = shape;

--- a/Jint/Runtime/Interpreter/Expressions/JintYieldExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintYieldExpression.cs
@@ -50,7 +50,7 @@ internal sealed class JintYieldExpression : JintExpression
                 if (generator._resumeCompletionType == CompletionType.Throw)
                 {
                     generator._resumeCompletionType = CompletionType.Normal; // Reset for future
-                    Throw.JavaScriptException(context.Engine, returnValue, AstExtensions.DefaultLocation);
+                    Throw.JavaScriptException(context.Engine, returnValue, in AstExtensions.DefaultLocation);
                 }
 
                 // If we're resuming with a Return completion, signal return request
@@ -103,7 +103,7 @@ internal sealed class JintYieldExpression : JintExpression
                 if (asyncGenerator._resumeCompletionType == CompletionType.Throw)
                 {
                     asyncGenerator._resumeCompletionType = CompletionType.Normal;
-                    Throw.JavaScriptException(context.Engine, returnValue, AstExtensions.DefaultLocation);
+                    Throw.JavaScriptException(context.Engine, returnValue, in AstExtensions.DefaultLocation);
                 }
 
                 // If this was a Return completion from the inner iterator,
@@ -136,7 +136,7 @@ internal sealed class JintYieldExpression : JintExpression
                 if (asyncGenerator._resumeCompletionType == CompletionType.Throw)
                 {
                     asyncGenerator._resumeCompletionType = CompletionType.Normal;
-                    Throw.JavaScriptException(context.Engine, returnValue, AstExtensions.DefaultLocation);
+                    Throw.JavaScriptException(context.Engine, returnValue, in AstExtensions.DefaultLocation);
                 }
 
                 // If we're resuming with a Return completion, signal return request.

--- a/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
+++ b/Jint/Runtime/Interpreter/JintFunctionDefinition.cs
@@ -214,7 +214,7 @@ internal sealed class JintFunctionDefinition
         // Step 5: "Push asyncContext onto the execution context stack"
         // We leave the old context and push the new one (equivalent to spec's push operation)
         engine.LeaveExecutionContext();
-        engine.EnterExecutionContext(asyncContext);
+        engine.EnterExecutionContext(in asyncContext);
 
         // Step 6: "Resume the suspended evaluation of asyncContext"
         // Perform AsyncBlockStart to begin executing the async function body

--- a/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForInForOfStatement.cs
@@ -274,7 +274,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
         }
 
         var iteratorKind = _iterationKind == IterationKind.AsyncIterate ? IteratorKind.Async : IteratorKind.Sync;
-        return BodyEvaluation(context, _expr, _body, keyResult!, _iterationKind, _lhsKind, suspendData, resuming, iteratorKind);
+        return BodyEvaluation(context, _expr, in _body, keyResult!, _iterationKind, _lhsKind, suspendData, resuming, iteratorKind);
     }
 
     /// <summary>
@@ -1249,7 +1249,7 @@ internal sealed class JintForInForOfStatement : JintStatement<Statement>
         // BodyEvaluation's `v` init).
         suspendable.Data.Clear(this);
         var carrier = new ForOfSuspendData { Iterator = iteratorRecord, AccumulatedValue = v };
-        return BodyEvaluation(context, _expr, _body, iteratorRecord, _iterationKind, _lhsKind, carrier, resuming: false, iteratorKind);
+        return BodyEvaluation(context, _expr, in _body, iteratorRecord, _iterationKind, _lhsKind, carrier, resuming: false, iteratorKind);
     }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintSwitchBlock.cs
@@ -47,7 +47,7 @@ internal sealed class JintSwitchBlock
         for (var i = 0; i < temp.Length; i++)
         {
             var clause = temp[i];
-            if (clause.TestRange is { } testRange && JintStatement.IsNodeInsideRange(suspensionNode, testRange))
+            if (clause.TestRange is { } testRange && JintStatement.IsNodeInsideRange(suspensionNode, in testRange))
             {
                 return Execute(
                     context,
@@ -58,7 +58,7 @@ internal sealed class JintSwitchBlock
                     initialValue: suspendData?.AccumulatedValue ?? JsValue.Undefined);
             }
 
-            if (JintStatement.IsNodeInsideRange(suspensionNode, clause.Range))
+            if (JintStatement.IsNodeInsideRange(suspensionNode, in clause.Range))
             {
                 return Execute(
                     context,

--- a/Jint/Runtime/JavaScriptException.cs
+++ b/Jint/Runtime/JavaScriptException.cs
@@ -57,13 +57,13 @@ public class JavaScriptException : JintException
 
     public JavaScriptException SetJavaScriptCallstack(Engine engine, in SourceLocation location, bool overwriteExisting = false)
     {
-        _jsErrorException.SetCallstack(engine, location, overwriteExisting);
+        _jsErrorException.SetCallstack(engine, in location, overwriteExisting);
         return this;
     }
 
     public JavaScriptException SetJavaScriptLocation(in SourceLocation location)
     {
-        _jsErrorException.SetLocation(location);
+        _jsErrorException.SetLocation(in location);
         return this;
     }
 

--- a/Jint/Runtime/Modules/BuilderModule.cs
+++ b/Jint/Runtime/Modules/BuilderModule.cs
@@ -10,7 +10,7 @@ internal sealed class BuilderModule : SourceTextModule
     private List<KeyValuePair<string, JsValue>> _exportBuilderDeclarations = new();
 
     internal BuilderModule(Engine engine, Realm realm, in Prepared<AstModule> source, string? location, bool async)
-        : base(engine, realm, source, location, async)
+        : base(engine, realm, in source, location, async)
     {
     }
 

--- a/Jint/Runtime/Modules/ModuleBuilder.cs
+++ b/Jint/Runtime/Modules/ModuleBuilder.cs
@@ -148,7 +148,7 @@ public sealed class ModuleBuilder
         catch (ParseErrorException ex)
         {
             var location = SourceLocation.From(Position.From(ex.LineNumber, ex.Column), Position.From(ex.LineNumber, ex.Column), _specifier);
-            Throw.SyntaxError(_engine.Realm, $"Error while loading module: error in module '{_specifier}': {ex.Error}", location);
+            Throw.SyntaxError(_engine.Realm, $"Error while loading module: error in module '{_specifier}': {ex.Error}", in location);
             return default;
         }
     }

--- a/Jint/Runtime/Modules/ModuleFactory.cs
+++ b/Jint/Runtime/Modules/ModuleFactory.cs
@@ -45,7 +45,7 @@ public static class ModuleFactory
         }
 
         var hasTopLevelAwait = HoistingScope.HasTopLevelAwait(preparedModule.Program!);
-        return new SourceTextModule(engine, engine.Realm, preparedModule, preparedModule.Program!.Location.SourceFile, isAsync: hasTopLevelAwait);
+        return new SourceTextModule(engine, engine.Realm, in preparedModule, preparedModule.Program!.Location.SourceFile, isAsync: hasTopLevelAwait);
     }
 
     /// <summary>

--- a/Jint/Runtime/Modules/ModuleLoader.cs
+++ b/Jint/Runtime/Modules/ModuleLoader.cs
@@ -19,7 +19,7 @@ public abstract class ModuleLoader : IModuleLoader
             }
             catch (Exception)
             {
-                Throw.JavaScriptException(engine, $"Could not load module {resolved.ModuleRequest.Specifier}", AstExtensions.DefaultLocation);
+                Throw.JavaScriptException(engine, $"Could not load module {resolved.ModuleRequest.Specifier}", in AstExtensions.DefaultLocation);
                 return default!;
             }
 
@@ -34,7 +34,7 @@ public abstract class ModuleLoader : IModuleLoader
             }
             catch (Exception)
             {
-                Throw.JavaScriptException(engine, $"Could not load module {resolved.ModuleRequest.Specifier}", AstExtensions.DefaultLocation);
+                Throw.JavaScriptException(engine, $"Could not load module {resolved.ModuleRequest.Specifier}", in AstExtensions.DefaultLocation);
                 return default!;
             }
 

--- a/Jint/Runtime/Modules/SourceTextModule.cs
+++ b/Jint/Runtime/Modules/SourceTextModule.cs
@@ -290,7 +290,7 @@ internal class SourceTextModule : CyclicModule
         var moduleContext = new ExecutionContext(this, _environment, _environment, null, realm, null, strict: true);
         _context = moduleContext;
 
-        _engine.EnterExecutionContext(_context);
+        _engine.EnterExecutionContext(in _context);
 
         var hoistingScope = HoistingScope.GetModuleLevelDeclarations(_source);
 
@@ -369,7 +369,7 @@ internal class SourceTextModule : CyclicModule
         if (!_hasTLA)
         {
             var result = Completion.Empty();
-            _engine.EnterExecutionContext(moduleContext);
+            _engine.EnterExecutionContext(in moduleContext);
             try
             {
                 var statementList = new JintStatementList(statement: null, _source.Body);
@@ -392,7 +392,7 @@ internal class SourceTextModule : CyclicModule
             // https://tc39.es/ecma262/#sec-source-text-module-record-execute-module
             // Top-Level Await: execute module asynchronously. Module code is always strict; the
             // moduleContext (and the async context derived from it) carries strict:true.
-            _engine.EnterExecutionContext(moduleContext);
+            _engine.EnterExecutionContext(in moduleContext);
 
             // Create the statement list and async instance once, reuse for resumption
             if (_tlaStatementList is null)
@@ -418,7 +418,7 @@ internal class SourceTextModule : CyclicModule
 
             // Replace the current execution context with the updated one
             _engine.LeaveExecutionContext();
-            _engine.EnterExecutionContext(asyncContext);
+            _engine.EnterExecutionContext(in asyncContext);
 
             // Create evaluation context
             var context = _engine._activeEvaluationContext ?? new EvaluationContext(_engine);

--- a/Jint/Runtime/Modules/SyntheticModule.cs
+++ b/Jint/Runtime/Modules/SyntheticModule.cs
@@ -52,7 +52,7 @@ internal sealed class SyntheticModule : Module
             strict: true);
 
         // 7.Suspend the currently running execution context.
-        _engine.EnterExecutionContext(moduleContext);
+        _engine.EnterExecutionContext(in moduleContext);
 
         _environment.SetMutableBinding(KnownKeys.Default, _obj, strict: true);
 

--- a/Jint/Runtime/RegExp/JintRegExpEngine.cs
+++ b/Jint/Runtime/RegExp/JintRegExpEngine.cs
@@ -56,7 +56,7 @@ internal sealed class JintRegExpEngine
     /// </summary>
     public RegExpMatchResult Execute(string input, int startIndex, long deadline = NoDeadline)
     {
-        var captures = RegExpInterpreter.Execute(_bytecode, input, startIndex, _scanInfo, deadline);
+        var captures = RegExpInterpreter.Execute(_bytecode, input, startIndex, in _scanInfo, deadline);
         if (captures is null)
         {
             return RegExpMatchResult.NoMatch;
@@ -68,7 +68,7 @@ internal sealed class JintRegExpEngine
     /// <summary>Test if the regex matches the input string. See <see cref="Execute"/> for <paramref name="deadline"/>.</summary>
     public bool IsMatch(string input, int startIndex = 0, long deadline = NoDeadline)
     {
-        return RegExpInterpreter.ExecuteIsMatch(_bytecode, input, startIndex, _scanInfo, deadline);
+        return RegExpInterpreter.ExecuteIsMatch(_bytecode, input, startIndex, in _scanInfo, deadline);
     }
 
     private RegExpMatchResult BuildResult(string input, int[] captures)

--- a/Jint/Runtime/RegExp/RegExpInterpreter.cs
+++ b/Jint/Runtime/RegExp/RegExpInterpreter.cs
@@ -129,7 +129,7 @@ internal static class RegExpInterpreter
 
         try
         {
-            int ret = ExecBacktrack(bc, input, capture, cindex, captureCount, isUnicode, scanInfo, deadline);
+            int ret = ExecBacktrack(bc, input, capture, cindex, captureCount, isUnicode, in scanInfo, deadline);
 
             int[]? result = null;
             if (ret == 1)
@@ -187,7 +187,7 @@ internal static class RegExpInterpreter
 
         try
         {
-            return ExecBacktrack(bc, input, capture, cindex, captureCount, isUnicode, scanInfo, deadline) == 1;
+            return ExecBacktrack(bc, input, capture, cindex, captureCount, isUnicode, in scanInfo, deadline) == 1;
         }
         finally
         {
@@ -946,7 +946,7 @@ internal static class RegExpInterpreter
             }
             else
             {
-                int pos = FindScanChar(input, cindex, effectiveScanInfo);
+                int pos = FindScanChar(input, cindex, in effectiveScanInfo);
                 if (pos < 0)
                 {
                     ReturnStack(stackPooled);
@@ -1766,7 +1766,7 @@ noMatch:
                             return 0;
                         }
 
-                        int nextPos = FindScanChar(input, nextStart, effectiveScanInfo);
+                        int nextPos = FindScanChar(input, nextStart, in effectiveScanInfo);
                         if (nextPos < 0)
                         {
                             return 0;

--- a/Jint/Runtime/Throw.cs
+++ b/Jint/Runtime/Throw.cs
@@ -25,7 +25,7 @@ internal static class Throw
     [DoesNotReturn]
     public static void SyntaxError(Realm realm, string message, in SourceLocation location)
     {
-        throw CreateSyntaxError(realm, message).SetJavaScriptLocation(location);
+        throw CreateSyntaxError(realm, message).SetJavaScriptLocation(in location);
     }
 
     public static JavaScriptException CreateSyntaxError(Realm realm, string? message)
@@ -62,7 +62,7 @@ internal static class Throw
     public static void ReferenceError(Realm realm, string? message)
     {
         var location = realm.GlobalObject.Engine.GetLastSyntaxElement()?.Location ?? default;
-        throw new JavaScriptException(realm.Intrinsics.ReferenceError, message).SetJavaScriptLocation(location);
+        throw new JavaScriptException(realm.Intrinsics.ReferenceError, message).SetJavaScriptLocation(in location);
     }
 
     [DoesNotReturn]
@@ -81,7 +81,7 @@ internal static class Throw
     public static void TypeError(Realm realm, string? message = null)
     {
         var location = realm.GlobalObject.Engine.GetLastSyntaxElement()?.Location ?? default;
-        throw new JavaScriptException(realm.Intrinsics.TypeError, message).SetJavaScriptLocation(location);
+        throw new JavaScriptException(realm.Intrinsics.TypeError, message).SetJavaScriptLocation(in location);
     }
 
     /// <summary>
@@ -121,14 +121,14 @@ internal static class Throw
             decorator(engine, error, new ClrResolutionErrorInfo(clrType, memberName, arguments, candidates));
         }
 
-        throw new JavaScriptException(error).SetJavaScriptLocation(location);
+        throw new JavaScriptException(error).SetJavaScriptLocation(in location);
     }
 
     [DoesNotReturn]
     public static void RangeError(Realm realm, string? message = null)
     {
         var location = realm.GlobalObject.Engine.GetLastSyntaxElement()?.Location ?? default;
-        throw new JavaScriptException(realm.Intrinsics.RangeError, message).SetJavaScriptLocation(location);
+        throw new JavaScriptException(realm.Intrinsics.RangeError, message).SetJavaScriptLocation(in location);
     }
 
     public static ErrorDispatchInfo CreateUriError(Realm realm, string message)
@@ -200,7 +200,7 @@ internal static class Throw
     [DoesNotReturn]
     public static void JavaScriptException(Engine engine, JsValue value, in SourceLocation location)
     {
-        throw new JavaScriptException(value).SetJavaScriptCallstack(engine, location);
+        throw new JavaScriptException(value).SetJavaScriptCallstack(engine, in location);
     }
 
     [DoesNotReturn]
@@ -226,7 +226,7 @@ internal static class Throw
         {
             // overwriteExisting:false preserves a "stack" property a decorator may have written
             // (e.g. copying clrException.StackTrace onto the JS Error).
-            jsException.SetJavaScriptCallstack(engine, location, overwriteExisting: false);
+            jsException.SetJavaScriptCallstack(engine, in location, overwriteExisting: false);
         }
         throw jsException;
     }

--- a/Jint/Test262AgentManager.cs
+++ b/Jint/Test262AgentManager.cs
@@ -225,7 +225,7 @@ internal sealed class Test262AgentManager : IDisposable
                 {
                     ParsingOptions = ScriptParsingOptions.Default with { Tolerant = false },
                 });
-                engine.Execute(script);
+                engine.Execute(in script);
 
                 // Drain the event loop for async agent scripts (e.g., await Atomics.waitAsync).
                 // Without this, the worker thread exits before promise resolutions are processed.

--- a/Jint/Test262Object.cs
+++ b/Jint/Test262Object.cs
@@ -38,7 +38,7 @@ internal static class Test262Object
                     ParsingOptions = ScriptParsingOptions.Default with { Tolerant = false, RetainFunctionSourceText = true },
                 });
 
-                return engine.Evaluate(script);
+                return engine.Evaluate(in script);
             }), true, true, true));
 
         o.FastSetProperty("createRealm", new PropertyDescriptor(new ClrFunction(engine, "createRealm",
@@ -99,10 +99,10 @@ internal static class Test262Object
             // The harness scripts pushed via engine.Evaluate below carry their own strictness.
             strict: false);
 
-        engine.EnterExecutionContext(context);
+        engine.EnterExecutionContext(in context);
         try
         {
-            return engine.Evaluate(script);
+            return engine.Evaluate(in script);
         }
         finally
         {


### PR DESCRIPTION
`MA0209` (*use the `in` keyword when calling a method whose parameter is declared `in`*) is disabled by default. This enables it as a `warning` and applies the analyzer's code fix across the codebase: **204 call sites** now pass their argument with an explicit `in`, making the pass-by-readonly-reference intent visible at the call — e.g. `Push(context)` → `Push(in context)`, `Evaluate(preparedScript)` → `Evaluate(in preparedScript)`.

**This is a caller-side change only.** No method signatures change, so there is no API or ABI impact, and the codegen for an explicit `in` argument is identical to the implicit form — it's purely about making the aliasing intent explicit (and guarding future call sites). The fix was produced mechanically via `dotnet format analyzers --diagnostics MA0209`.

### Verification
- Clean build across all five TFMs with MA0209 enforced (0 remaining).
- `Jint.Tests` green and `Jint.Tests.PublicInterface` green on net10.0 — the public API surface is unchanged.

Large but entirely mechanical; happy to drop it if the churn isn't wanted. Follows #2764–#2767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)