### PR TITLE
Stop DromaeoBenchmark from measuring its own JIT warmup

### DIFF
--- a/Jint.Benchmark/DromaeoBenchmark.cs
+++ b/Jint.Benchmark/DromaeoBenchmark.cs
@@ -19,8 +19,6 @@ public class DromaeoBenchmark
 
     private readonly Dictionary<string, Prepared<Script>> _prepared = new();
 
-    private Engine _engine;
-
     [GlobalSetup]
     public void Setup()
     {
@@ -36,13 +34,23 @@ public class DromaeoBenchmark
         }
     }
 
-    [IterationSetup]
-    public void IterationSetup()
-    {
-        _engine = CreteEngine();
-    }
-
-    private static Engine CreteEngine()
+    // Deliberately NOT an [IterationSetup]. Each op needs a fresh engine (the modern scripts
+    // declare top-level `let`, so the same script cannot run twice in one engine), but
+    // [IterationSetup] forces InvocationCount=1 and UnrollFactor=1, which BenchmarkDotNet
+    // documents as unsuitable for anything under ~100ms. With one op per iteration, BDN's
+    // adaptive warmup judged convergence from single-op samples: tier-0 code is uniformly slow,
+    // so eight flat 17.8ms warmup samples looked converged, warmup ended, and tiered
+    // compilation then completed *inside* WorkloadActual — a measured ramp from 17.8ms down to
+    // 3.4ms still descending at iteration 45. The reported Mean averaged that ramp, so identical
+    // code produced 2.489ms in one run and 9.811ms in another.
+    //
+    // Building the engine inside the benchmark method instead lets BDN auto-scale
+    // InvocationCount (the pilot targets ~500ms per iteration), so tiering finishes during the
+    // pilot and both warmup and measurement run tier-1 code. This is what
+    // EngineComparisonBenchmark already does, which is why its results are stable. Engine
+    // construction now counts toward the measurement: ~0.1-0.3ms against a 5-70ms op, constant
+    // across revisions, so A/B comparisons stay valid.
+    private static Engine CreateEngine()
     {
         var engine = new Engine()
             .SetValue("log", new Action<object>(Console.WriteLine))
@@ -105,14 +113,15 @@ public class DromaeoBenchmark
     private void Run(string fileName)
     {
         var finalName = Modern ? fileName + "-modern" : fileName;
+        var engine = CreateEngine();
 
         if (Prepared)
         {
-            _engine.Execute(_prepared[finalName]);
+            engine.Execute(_prepared[finalName]);
         }
         else
         {
-            _engine.Execute(_files[finalName], finalName);
+            engine.Execute(_files[finalName], finalName);
         }
     }
 }


### PR DESCRIPTION
`DromaeoBenchmark` reports Means that swing up to 4x between runs of **identical code**. On `799e76a52`, `CoreEval(Modern=False, Prepared=False)` measured **2.489 ms** in one run and **9.811 ms** in another; `Cube(Modern=False, Prepared=False)` alternated between ~5.7 and ~8.6 ms — and the two modes showed up on both revisions of an A/B, just swapped. That makes the suite unusable as a perf gate, and it has been silently inflating every number it produces.

## Cause

Visible in the BenchmarkDotNet artifact log. `[IterationSetup]` forces `InvocationCount=1` and `UnrollFactor=1` — [the docs](https://benchmarkdotnet.org/articles/features/setup-and-cleanup.html) call the attribute unsuitable below ~100 ms for exactly this reason, and these cases are 2–70 ms. With one op per iteration, BDN's adaptive warmup judges convergence from single-op samples, and tier-0 code is *uniformly* slow, so a flat plateau reads as converged:

```
WorkloadJitting  1:  62.65 ms
WorkloadWarmup 1-8:  17.7 - 18.2 ms   <- flat, so warmup ends here
WorkloadActual 1-6:  17.7 - 17.9 ms
WorkloadActual   7:  22.67 ms         <- tiering spike
WorkloadActual   8:  11.51 ms
WorkloadActual 9-15:  6.4 -> 5.1 ms
WorkloadActual 17+:   4.3 -> 3.39 ms  <- still descending at iteration 45
```

Tiered compilation completes *inside* `WorkloadActual`, so the reported Mean averages a 5x ramp and its value depends only on where the ramp happens to fall. `Prepared=False` suffers most, since re-parsing every op drags the parser through tiering too.

## Fix

Each op does need a fresh engine — the modern scripts declare top-level `let`, so one script cannot run twice in the same engine — but that does not require `[IterationSetup]`. Constructing the engine inside the benchmark method lets BDN auto-scale `InvocationCount` (the pilot targets ~500 ms per iteration), so tiering finishes during the pilot and both warmup and measurement run tier-1 code.

This is what `EngineComparisonBenchmark` already does, which is why its results have always been stable; the two classes now share one pattern.

## Effect on stability

Same commit, same `--filter`, before vs after:

| row | before (two runs) | after | StdDev |
|---|---|---|---|
| CoreEval False/False | 2.489 / **9.811** ms | 1.763 ms | 34% -> **0.7%** |
| CoreEval True/True | 4.761 / 4.404 ms | 1.695 ms | 3.9% -> **0.8%** |
| Cube False/False | 5.700 / **8.620** ms | 5.147 ms | 26% -> **0.5%** |
| Cube True/False | 8.612 / 6.293 ms | 5.151 ms | 15% -> **0.6%** |

StdDev drops from 3–34% to 0.5–0.8%, and the four CoreEval variants now agree with each other rather than scattering across 2.4–9.8 ms. The `Gen0`/`Gen1` columns also populate, which `InvocationCount=1` had suppressed.

## Note on absolute numbers

Engine construction now counts toward the measurement (~0.1–0.3 ms against a 5–70 ms op, constant across revisions, so A/B stays valid). More significantly, GC of what the scripts allocate now falls inside the measured window, so some rows get slower and more honest — `ObjectString(Modern: True, Prepared: True)` goes 34 -> 44 ms, and its Gen2 column becomes non-zero for the first time. The README comparison table comes from `EngineComparisonBenchmark` and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)