### PR TITLE
Hoist per-call constants out of the call and assignment fast paths

### DIFF
--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -168,6 +168,12 @@ public sealed partial class Engine : IDisposable
     internal readonly bool _customResolver;
     internal readonly IReferenceResolver _referenceResolver;
 
+    // Snapshot of Options.Constraints.MaxRecursionDepth. Every call expression compares the pushed
+    // depth against it, and reaching it through Options.Constraints costs two extra dereferences per
+    // call. The limit is already treated as fixed at construction time — CallStack decides whether to
+    // track depth at all from the same value (see the JintCallStack construction below).
+    internal readonly int _maxRecursionDepth;
+
     internal readonly ReferencePool _referencePool;
     internal readonly ArgumentsInstancePool _argumentsInstancePool;
     internal readonly JsValueArrayPool _jsValueArrayPool;
@@ -287,7 +293,10 @@ public sealed partial class Engine : IDisposable
 
         Options.Apply(this);
 
-        CallStack = new JintCallStack(Options.Constraints.MaxRecursionDepth >= 0);
+        // Read after Options.Apply so the snapshot observes the same value JintCallStack does
+        // (Apply runs the user's configuration callbacks, which can still touch Constraints).
+        _maxRecursionDepth = Options.Constraints.MaxRecursionDepth;
+        CallStack = new JintCallStack(_maxRecursionDepth >= 0);
         _stackGuard = new StackGuard(this);
 
         var scriptParsingDefaults = Options.RetainFunctionSourceText

--- a/Jint/Runtime/CallStack/StackGuard.cs
+++ b/Jint/Runtime/CallStack/StackGuard.cs
@@ -14,14 +14,23 @@ internal sealed class StackGuard
 
     private readonly Engine _engine;
 
+    // Snapshot of Options.Constraints.MaxExecutionStackCount, taken at construction like the
+    // engine's other option-derived fast-check fields. Every call expression enters through
+    // TryEnterOnCurrentStack, and the disabled check previously cost three dereferences
+    // (Options → Constraints → property) before it could return.
+    private readonly int _maxExecutionStackCount;
+    private readonly bool _enabled;
+
     public StackGuard(Engine engine)
     {
         _engine = engine;
+        _maxExecutionStackCount = engine.Options.Constraints.MaxExecutionStackCount;
+        _enabled = _maxExecutionStackCount != Disabled;
     }
 
     public bool TryEnterOnCurrentStack()
     {
-        if (_engine.Options.Constraints.MaxExecutionStackCount == Disabled)
+        if (!_enabled)
         {
             return true;
         }
@@ -42,7 +51,7 @@ internal sealed class StackGuard
         }
 #endif
 
-        if (_engine.CallStack.Count > _engine.Options.Constraints.MaxExecutionStackCount)
+        if (_engine.CallStack.Count > _maxExecutionStackCount)
         {
             Throw.RangeError(_engine.Realm, "Maximum call stack size exceeded");
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -641,6 +641,14 @@ internal sealed class JintAssignmentExpression : JintExpression
         // and box once instead of per binary node; see JintBinaryExpression.SumOfProductsLane.
         private JintBinaryExpression.SumOfProductsLane? _rightSumOfProducts;
 
+        // Right-hand-side shape, decided once in Initialize. Both are pure AST properties, but the
+        // slot-store lane re-tested them on every assignment: `right is JintClassExpression` plus an
+        // IsAnonymousFunctionDefinition() node probe before evaluating, and IsFunctionDefinition()
+        // plus another type test after. Assignment is the most frequently executed expression form
+        // in the interpreter, so both move to fields.
+        private bool _rightIsAnonymousClassExpression;
+        private bool _rightNeedsFunctionName;
+
         public SimpleAssignmentExpression(AssignmentExpression expression) : base(expression)
         {
             _structurallyNumeric = IsNumericAssignmentShape(expression);
@@ -684,6 +692,11 @@ internal sealed class JintAssignmentExpression : JintExpression
             _leftIsCoverParenthesized = _left._expression.Range.Start != assignmentExpression.Range.Start;
 
             _right = Build(assignmentExpression.Right);
+
+            _rightIsAnonymousClassExpression = _right is JintClassExpression
+                                               && _right._expression.IsAnonymousFunctionDefinition();
+            _rightNeedsFunctionName = _right._expression.IsFunctionDefinition()
+                                      && _right is not JintClassExpression;
 
             TryEnableNumericFastPath(assignmentExpression);
             _rightSumOfProducts = JintBinaryExpression.SumOfProductsLane.TryBuild(_right);
@@ -802,9 +815,9 @@ internal sealed class JintAssignmentExpression : JintExpression
 
             JsValue completion;
             var right = _right;
-            if (right is JintClassExpression classExpression && right._expression.IsAnonymousFunctionDefinition())
+            if (_rightIsAnonymousClassExpression)
             {
-                completion = classExpression.EvaluateWithName(context, _leftIdentifier.Identifier.Value.ToString());
+                completion = ((JintClassExpression) right).EvaluateWithName(context, _leftIdentifier.Identifier.Value.ToString());
             }
             else
             {
@@ -819,7 +832,7 @@ internal sealed class JintAssignmentExpression : JintExpression
 
             var rval = completion.Clone();
 
-            if (right._expression.IsFunctionDefinition() && right is not JintClassExpression)
+            if (_rightNeedsFunctionName)
             {
                 ((Function) rval).SetFunctionName(_leftIdentifier.Identifier.Value);
             }

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -14,10 +14,19 @@ internal sealed class JintCallExpression : JintExpression
     private readonly ExpressionCache _arguments = new();
     private readonly JintExpression _calleeExpression;
 
+    // Callee shape is fixed at build time. Keeping it in fields instead of re-testing
+    // `_calleeExpression._expression.Type == NodeType.Super` and `_calleeExpression is
+    // JintMemberExpression` on every evaluation removes two loads and a type check per call;
+    // `_calleeMember` doubles as the already-narrowed receiver for the fast member-call lane.
+    private readonly bool _calleeIsSuper;
+    private readonly JintMemberExpression? _calleeMember;
+
     public JintCallExpression(CallExpression expression) : base(expression)
     {
         _arguments.Initialize(expression.Arguments.AsSpan());
         _calleeExpression = Build(expression.Callee);
+        _calleeIsSuper = _calleeExpression._expression.Type == NodeType.Super;
+        _calleeMember = _calleeExpression as JintMemberExpression;
     }
 
     protected override object EvaluateInternal(EvaluationContext context)
@@ -28,7 +37,7 @@ internal sealed class JintCallExpression : JintExpression
             return StackGuard.RunOnEmptyStack(EvaluateInternal, context);
         }
 
-        if (_calleeExpression._expression.Type == NodeType.Super)
+        if (_calleeIsSuper)
         {
             return SuperCall(context);
         }
@@ -55,7 +64,8 @@ internal sealed class JintCallExpression : JintExpression
         // receiver is side-effect-free, so re-evaluating it on that rare path is unobservable).
         JsValue? fastFunc = null;
         var fastThis = JsValue.Undefined;
-        if (_calleeExpression is JintMemberExpression member
+        var member = _calleeMember;
+        if (member is not null
             && member.IsFastCallEligible
             && !engine._customResolver)
         {
@@ -185,7 +195,7 @@ internal sealed class JintCallExpression : JintExpression
             var callStack = engine.CallStack;
             var recursionDepth = callStack.Push(functionInstance, _calleeExpression, engine.ExecutionContext);
 
-            if (recursionDepth > engine.Options.Constraints.MaxRecursionDepth)
+            if (recursionDepth > engine._maxRecursionDepth)
             {
                 // automatically pops the current element as it was never reached
                 Throw.RecursionDepthOverflowException(callStack);

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -56,6 +56,11 @@ internal sealed class JintMemberExpression : JintExpression
     private PropertyDescriptor? _cachedStringProtoDescriptor;
     private readonly bool _stringReceiverCallEligible;
 
+    // Member-call eligibility is a pure function of this node's shape, so it is decided once in the
+    // constructor instead of re-deriving four type tests on every call this node is the callee of —
+    // JintCallExpression probes it before every member call it dispatches.
+    private readonly bool _fastCallEligible;
+
     // ObjectWrapper member cache: interop receivers carry InternalTypes.ExoticGet (members resolve against
     // the wrapped CLR object), so none of the caches above apply and every host.value read/write walks
     // ObjectWrapper.Get/Set → GetOwnProperty → dictionary probe → reflection accessor. But once
@@ -100,7 +105,13 @@ internal sealed class JintMemberExpression : JintExpression
             _determinedProperty = determined;
         }
 
-        _stringReceiverCallEligible = IsFastCallEligible && !CanBeOwnStringInstanceProperty((JsString) _determinedProperty!);
+        _fastCallEligible = _propertyExpression is null
+                            && _determinedProperty is JsString
+                            && !_memberExpression.Optional
+                            && !_objectExpressionCanShortCircuit
+                            && _objectExpression is JintIdentifierExpression or JintThisExpression;
+
+        _stringReceiverCallEligible = _fastCallEligible && !CanBeOwnStringInstanceProperty((JsString) _determinedProperty!);
     }
 
     /// <summary>
@@ -547,12 +558,7 @@ internal sealed class JintMemberExpression : JintExpression
     /// effect, so the call's slow-path fallback (taken when the resolved value is not callable) never
     /// double-evaluates anything observable.
     /// </summary>
-    internal bool IsFastCallEligible
-        => _propertyExpression is null
-           && _determinedProperty is JsString
-           && !_memberExpression.Optional
-           && !_objectExpressionCanShortCircuit
-           && _objectExpression is JintIdentifierExpression or JintThisExpression;
+    internal bool IsFastCallEligible => _fastCallEligible;
 
     /// <summary>
     /// member call when the receiver is an object, reusing the same version-gated own-property inline


### PR DESCRIPTION
First of five stacked changes from profiling `dromaeo-object-string-modern`, Jint's worst V8 gap in the comparison table (44.4 ms vs 5.85 ms for ClearScript/V8-compiled, ~7.6x).

## What the profile says

~72% of that benchmark is one statement shape — `ret = str.<builtin>(constant args)` in a tight `for`, roughly 200k times per iteration — and **~97% of each such operation is interpreter overhead**, not the string builtin. An isolated `ret = str.charAt(0)` loop (ultra, 8190 Hz, zero GC, zero JIT) attributes:

| symbol | self |
|---|---|
| `JintCallExpression.EvaluateInternal` | 22.8% |
| `SimpleAssignmentExpression.TryAssignSlot` | 22.1% |
| `JintMemberExpression.GetCalleeForCall` | 15.5% |
| `JintForStatement.TightForBody` | 15.2% |
| `__StringPrototypeFunction.Call` (incl. inlined `CharAt`) | 7.4% |

## This change

Part of that overhead is re-deriving, on every evaluation, facts fixed when the handler tree is built:

- `JintMemberExpression.IsFastCallEligible` was a computed property running four type tests, and `JintCallExpression` probes it before every member call it dispatches. It becomes a readonly field, computed in the constructor next to `_stringReceiverCallEligible`, which already folded it in.
- `JintCallExpression` re-tested `_calleeExpression._expression.Type == NodeType.Super` and `_calleeExpression is JintMemberExpression` per call. Both move to fields, and the narrowed member doubles as the fast lane's receiver.
- `SimpleAssignmentExpression`'s slot-store lane ran two AST node probes per assignment — `IsAnonymousFunctionDefinition()` before evaluating the right-hand side and `IsFunctionDefinition()` after, each paired with a type test. Both are pure AST properties and move to fields set in `Initialize`.
- `StackGuard` walked `Options -> Constraints -> MaxExecutionStackCount` on every call expression just to discover the guard is disabled. It now snapshots the limit and an enabled flag at construction, matching how the engine already caches its other option-derived fast-check fields.
- `Engine` caches `MaxRecursionDepth` for the same reason, read after `Options.Apply` so the snapshot observes exactly the value `JintCallStack` uses to decide whether to track depth at all.

No behavior change: every hoisted value is a function of the AST node, or of options already treated as fixed for the engine's lifetime.

## Measured

**−2.3%** on a 190M-op `ret = str.charAt(0)` loop (best of 3, A/B/B/A, run-to-run spread ~0.8%). Also visible at the symbol level: `CastHelpers.IsInstanceOfClass` drops 1.4% -> 0.9% of main-thread self time on the full benchmark, since `IsFastCallEligible`'s type tests were part of it.

## Gate

Jint.Tests 3925, Jint.Tests.PublicInterface 114, Jint.Tests.CommonScripts 28, Test262 **99441 passed / 0 failed** — all Release.

Perf numbers were taken with the `DromaeoBenchmark` harness fix from #2769 applied to both sides; without it that suite's Means swing up to 4x on identical code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)