### PR TITLE
Decide callability and receiver kind by type flag instead of type check

### DIFF
--- a/Jint.Tests/Runtime/CallableFlagTests.cs
+++ b/Jint.Tests/Runtime/CallableFlagTests.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+using Jint.Native;
+using Jint.Native.Function;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.Runtime;
+
+public class CallableFlagTests
+{
+    /// <summary>
+    /// Call sites decide callability from <c>InternalTypes.Callable</c> rather than an
+    /// <c>is ICallable</c> interface check, so every <see cref="JsValue"/> that implements
+    /// <c>ICallable</c> must set the flag in its constructor chain. Rather than enumerate every
+    /// concrete function class (there are dozens, and the list would churn), this pins the actual
+    /// invariant: each one derives from a root that sets the flag. A new <c>ICallable</c> value type
+    /// that skips the flag fails here instead of silently throwing "x is not a function" at runtime.
+    /// </summary>
+    [Fact]
+    public void EveryCallableJsValueDerivesFromAFlagSettingRoot()
+    {
+        var flagSettingRoots = new[]
+        {
+            typeof(Function),
+            typeof(BindFunction),
+            typeof(NamespaceReference),
+            // internal: JsProxy and IsHTMLDDA are resolved by name below
+        };
+
+        var assembly = typeof(Engine).Assembly;
+        var callableInterface = assembly.GetType("Jint.Native.ICallable", throwOnError: true)!;
+        var roots = flagSettingRoots
+            .Concat(new[] { assembly.GetType("Jint.Native.JsProxy", throwOnError: true)!, assembly.GetType("Jint.Native.IsHTMLDDA", throwOnError: true)! })
+            .ToArray();
+
+        var unflagged = assembly.GetTypes()
+            .Where(t => !t.IsAbstract
+                        && !t.IsInterface
+                        && typeof(JsValue).IsAssignableFrom(t)
+                        && callableInterface.IsAssignableFrom(t)
+                        && !Array.Exists(roots, r => r.IsAssignableFrom(t)))
+            .Select(t => t.FullName)
+            .ToArray();
+
+        unflagged.Should().BeEmpty(
+            "every ICallable JsValue must set InternalTypes.Callable in its constructor (add it, then add the type here as a root if it is a new root)");
+    }
+
+    /// <summary>
+    /// The flag is only meaningful if it agrees with the interface check for values that actually
+    /// reach a call site, so exercise the four shapes that are easy to get wrong: an ordinary
+    /// function, a bound function, a proxy over a function, and the interop namespace reference
+    /// (which is callable purely to bind generic types).
+    /// </summary>
+    [Fact]
+    public void FlaggedCallablesAreCallableFromScript()
+    {
+        var engine = new Engine(options => options.AllowClr(typeof(System.Collections.Generic.List<>).Assembly));
+
+        Assert.Equal(3d, engine.Evaluate("(function (a, b) { return a + b; })(1, 2)").AsNumber());
+        Assert.Equal(3d, engine.Evaluate("(function (a, b) { return a + b; }).bind(null, 1)(2)").AsNumber());
+        Assert.Equal(3d, engine.Evaluate("new Proxy(function (a, b) { return a + b; }, {})(1, 2)").AsNumber());
+
+        // NamespaceReference.Call: binds the generic type argument, so the result is constructible.
+        Assert.Equal(1d, engine.Evaluate("""
+            var listType = importNamespace('System.Collections.Generic').List(System.String);
+            var list = new listType();
+            list.Add('x');
+            list.Count;
+            """).AsNumber());
+    }
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -168,6 +168,12 @@ public sealed partial class Engine : IDisposable
     internal readonly bool _customResolver;
     internal readonly IReferenceResolver _referenceResolver;
 
+    // Snapshot of Options.Constraints.MaxRecursionDepth. Every call expression compares the pushed
+    // depth against it, and reaching it through Options.Constraints costs two extra dereferences per
+    // call. The limit is already treated as fixed at construction time — CallStack decides whether to
+    // track depth at all from the same value (see the JintCallStack construction below).
+    internal readonly int _maxRecursionDepth;
+
     internal readonly ReferencePool _referencePool;
     internal readonly ArgumentsInstancePool _argumentsInstancePool;
     internal readonly JsValueArrayPool _jsValueArrayPool;
@@ -287,7 +293,10 @@ public sealed partial class Engine : IDisposable
 
         Options.Apply(this);
 
-        CallStack = new JintCallStack(Options.Constraints.MaxRecursionDepth >= 0);
+        // Read after Options.Apply so the snapshot observes the same value JintCallStack does
+        // (Apply runs the user's configuration callbacks, which can still touch Constraints).
+        _maxRecursionDepth = Options.Constraints.MaxRecursionDepth;
+        CallStack = new JintCallStack(_maxRecursionDepth >= 0);
         _stackGuard = new StackGuard(this);
 
         var scriptParsingDefaults = Options.RetainFunctionSourceText

--- a/Jint/JsValueExtensions.cs
+++ b/Jint/JsValueExtensions.cs
@@ -247,6 +247,34 @@ public static class JsValueExtensions
         return (int) ((JsNumber) value)._value;
     }
 
+    /// <summary>
+    /// Reinterprets a value the caller has already proven to be an object with <see cref="IsObject"/>.
+    /// <see cref="InternalTypes.Object"/> is set by <see cref="ObjectInstance"/>'s constructors and
+    /// nowhere else — the same invariant <see cref="IsObject"/> and <see cref="AsObject"/> already rely
+    /// on — so this is exactly as sound as `is ObjectInstance` but costs a flag test instead of a
+    /// <c>CastHelpers.IsInstanceOfClass</c> hierarchy walk. Mirrors <see cref="AsNumber"/>'s shape.
+    /// </summary>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static ObjectInstance AsObjectNoTypeCheck(this JsValue value)
+    {
+        Debug.Assert(value.IsObject() && value is ObjectInstance);
+        return Unsafe.As<ObjectInstance>(value);
+    }
+
+    /// <summary>
+    /// Reinterprets a value the caller has already proven to be a string with <see cref="IsString"/>.
+    /// <see cref="InternalTypes.String"/> is set only by <see cref="JsString"/> and its two nested
+    /// subclasses (ConcatenatedString, SlicedString), all of which are <see cref="JsString"/>.
+    /// </summary>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static JsString AsStringNoTypeCheck(this JsValue value)
+    {
+        Debug.Assert(value.IsString() && value is JsString);
+        return Unsafe.As<JsString>(value);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static BigInteger AsBigInt(this JsValue value)
     {

--- a/Jint/Native/Function/BindFunction.cs
+++ b/Jint/Native/Function/BindFunction.cs
@@ -18,6 +18,7 @@ public sealed class BindFunction : ObjectInstance, IConstructor, ICallable
         JsValue[] boundArgs)
         : base(engine, ObjectClass.Function)
     {
+        _type |= InternalTypes.Callable;
         _realm = realm;
         _prototype = proto;
         BoundTargetFunction = targetFunction;

--- a/Jint/Native/Function/Function.cs
+++ b/Jint/Native/Function/Function.cs
@@ -91,6 +91,8 @@ public abstract partial class Function : ObjectInstance, ICallable
         FunctionThisMode thisMode = FunctionThisMode.Global)
         : base(engine, ObjectClass.Function)
     {
+        // every Function is an ICallable; the flag lets call sites skip the interface-map scan
+        _type |= InternalTypes.Callable;
         if (name is not null)
         {
             _nameDescriptor = new PropertyDescriptor(name, PropertyFlag.Configurable);

--- a/Jint/Native/IsHTMLDDA.cs
+++ b/Jint/Native/IsHTMLDDA.cs
@@ -12,7 +12,7 @@ namespace Jint.Native;
 /// </summary>
 internal sealed class IsHTMLDDA : ObjectInstance, ICallable
 {
-    internal IsHTMLDDA(Engine engine) : base(engine, ObjectClass.Object, InternalTypes.Object | InternalTypes.IsHTMLDDA)
+    internal IsHTMLDDA(Engine engine) : base(engine, ObjectClass.Object, InternalTypes.Object | InternalTypes.IsHTMLDDA | InternalTypes.Callable)
     {
     }
 

--- a/Jint/Native/JsProxy.cs
+++ b/Jint/Native/JsProxy.cs
@@ -65,7 +65,10 @@ internal sealed class JsProxy : ObjectInstance, IConstructor, ICallable
         ProxyHandler? clrHandler)
         : base(engine, target.Class)
     {
-        _type |= InternalTypes.ExoticGet;
+        // JsProxy always implements ICallable; whether it is *callable* is reported by IsCallable
+        // from the target. The flag mirrors `is ICallable`, so a proxy over a non-callable target
+        // still carries it and still throws from Call, exactly as before.
+        _type |= InternalTypes.ExoticGet | InternalTypes.Callable;
         _target = target;
         _handler = handler;
         _clrHandler = clrHandler;

--- a/Jint/Runtime/CallStack/StackGuard.cs
+++ b/Jint/Runtime/CallStack/StackGuard.cs
@@ -14,14 +14,23 @@ internal sealed class StackGuard
 
     private readonly Engine _engine;
 
+    // Snapshot of Options.Constraints.MaxExecutionStackCount, taken at construction like the
+    // engine's other option-derived fast-check fields. Every call expression enters through
+    // TryEnterOnCurrentStack, and the disabled check previously cost three dereferences
+    // (Options → Constraints → property) before it could return.
+    private readonly int _maxExecutionStackCount;
+    private readonly bool _enabled;
+
     public StackGuard(Engine engine)
     {
         _engine = engine;
+        _maxExecutionStackCount = engine.Options.Constraints.MaxExecutionStackCount;
+        _enabled = _maxExecutionStackCount != Disabled;
     }
 
     public bool TryEnterOnCurrentStack()
     {
-        if (_engine.Options.Constraints.MaxExecutionStackCount == Disabled)
+        if (!_enabled)
         {
             return true;
         }
@@ -42,7 +51,7 @@ internal sealed class StackGuard
         }
 #endif
 
-        if (_engine.CallStack.Count > _engine.Options.Constraints.MaxExecutionStackCount)
+        if (_engine.CallStack.Count > _maxExecutionStackCount)
         {
             Throw.RangeError(_engine.Realm, "Maximum call stack size exceeded");
         }

--- a/Jint/Runtime/InternalTypes.cs
+++ b/Jint/Runtime/InternalTypes.cs
@@ -51,7 +51,15 @@ internal enum InternalTypes
     // to dictionary mode. Mutually exclusive with ShapeMode; lets ObjectInstance's property virtuals
     // discriminate built-in-shape vs dictionary storage with a single flag test on the already-loaded _type.
     BuiltinShapeMode = 524288,
+    // the value implements ICallable. Set by every ICallable root (Function, BindFunction,
+    // IsHTMLDDA, JsProxy) so a call site can decide callability with a flag test on the
+    // already-loaded _type plus an Unsafe.As, instead of an `is ICallable` interface-map scan —
+    // measured at 1.2% of dromaeo-object-string-modern, all of it from JintCallExpression, which
+    // tests it twice per call. Note this is strictly "implements ICallable", NOT "is callable":
+    // a JsProxy over a non-callable target carries the flag and reports IsCallable == false,
+    // matching what `is ICallable` answers today.
+    Callable = 1048576,
 
     Primitive = Boolean | String | Number | Integer | BigInt | Symbol,
-    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode
+    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode | Callable
 }

--- a/Jint/Runtime/Interop/NamespaceReference.cs
+++ b/Jint/Runtime/Interop/NamespaceReference.cs
@@ -24,7 +24,9 @@ public class NamespaceReference : ObjectInstance, ICallable
     {
         // Member access resolves namespace/type segments, not ordinary property lookup, so the
         // prototype-method inline cache must skip this receiver. See InternalTypes.ExoticGet.
-        _type |= InternalTypes.ExoticGet;
+        // Callable: `importNamespace('System.Collections.Generic').List(...)` calls through
+        // ICallable to bind a generic type, so call sites must see this as callable.
+        _type |= InternalTypes.ExoticGet | InternalTypes.Callable;
         _path = path;
     }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintAssignmentExpression.cs
@@ -641,6 +641,14 @@ internal sealed class JintAssignmentExpression : JintExpression
         // and box once instead of per binary node; see JintBinaryExpression.SumOfProductsLane.
         private JintBinaryExpression.SumOfProductsLane? _rightSumOfProducts;
 
+        // Right-hand-side shape, decided once in Initialize. Both are pure AST properties, but the
+        // slot-store lane re-tested them on every assignment: `right is JintClassExpression` plus an
+        // IsAnonymousFunctionDefinition() node probe before evaluating, and IsFunctionDefinition()
+        // plus another type test after. Assignment is the most frequently executed expression form
+        // in the interpreter, so both move to fields.
+        private bool _rightIsAnonymousClassExpression;
+        private bool _rightNeedsFunctionName;
+
         public SimpleAssignmentExpression(AssignmentExpression expression) : base(expression)
         {
             _structurallyNumeric = IsNumericAssignmentShape(expression);
@@ -684,6 +692,11 @@ internal sealed class JintAssignmentExpression : JintExpression
             _leftIsCoverParenthesized = _left._expression.Range.Start != assignmentExpression.Range.Start;
 
             _right = Build(assignmentExpression.Right);
+
+            _rightIsAnonymousClassExpression = _right is JintClassExpression
+                                               && _right._expression.IsAnonymousFunctionDefinition();
+            _rightNeedsFunctionName = _right._expression.IsFunctionDefinition()
+                                      && _right is not JintClassExpression;
 
             TryEnableNumericFastPath(assignmentExpression);
             _rightSumOfProducts = JintBinaryExpression.SumOfProductsLane.TryBuild(_right);
@@ -802,9 +815,9 @@ internal sealed class JintAssignmentExpression : JintExpression
 
             JsValue completion;
             var right = _right;
-            if (right is JintClassExpression classExpression && right._expression.IsAnonymousFunctionDefinition())
+            if (_rightIsAnonymousClassExpression)
             {
-                completion = classExpression.EvaluateWithName(context, _leftIdentifier.Identifier.Value.ToString());
+                completion = ((JintClassExpression) right).EvaluateWithName(context, _leftIdentifier.Identifier.Value.ToString());
             }
             else
             {
@@ -819,7 +832,7 @@ internal sealed class JintAssignmentExpression : JintExpression
 
             var rval = completion.Clone();
 
-            if (right._expression.IsFunctionDefinition() && right is not JintClassExpression)
+            if (_rightNeedsFunctionName)
             {
                 ((Function) rval).SetFunctionName(_leftIdentifier.Identifier.Value);
             }

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Jint.Native;
@@ -74,7 +75,7 @@ internal sealed class JintCallExpression : JintExpression
             {
                 return fastFunc;
             }
-            if (fastFunc is not ICallable)
+            if (!IsCallableFlagged(fastFunc))
             {
                 fastFunc = null;
             }
@@ -175,11 +176,12 @@ internal sealed class JintCallExpression : JintExpression
             ThrowMemberIsNotFunction(referenceRecord, reference, engine);
         }
 
-        var callable = func as ICallable;
-        if (callable is null)
+        if (!IsCallableFlagged(func))
         {
             ThrowReferenceNotFunction(referenceRecord, reference, engine);
         }
+
+        var callable = Unsafe.As<ICallable>(func);
 
         if (tailCall)
         {
@@ -226,6 +228,21 @@ internal sealed class JintCallExpression : JintExpression
 
         engine._referencePool.Return(referenceRecord);
         return result;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="value"/> implements <see cref="ICallable"/>, decided by the
+    /// <see cref="InternalTypes.Callable"/> flag instead of an `is ICallable` interface-map scan.
+    /// Every <see cref="ICallable"/> root sets the flag in its constructor, so the two answers are
+    /// equivalent by construction — asserted here so a future ICallable implementer that forgets
+    /// the flag trips in debug builds rather than silently losing callability.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsCallableFlagged(JsValue value)
+    {
+        var flagged = (value._type & InternalTypes.Callable) != InternalTypes.Empty;
+        Debug.Assert(flagged == value is ICallable, $"InternalTypes.Callable disagrees with `is ICallable` for {value.GetType()}");
+        return flagged;
     }
 
     [DoesNotReturn]

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -14,10 +14,19 @@ internal sealed class JintCallExpression : JintExpression
     private readonly ExpressionCache _arguments = new();
     private readonly JintExpression _calleeExpression;
 
+    // Callee shape is fixed at build time. Keeping it in fields instead of re-testing
+    // `_calleeExpression._expression.Type == NodeType.Super` and `_calleeExpression is
+    // JintMemberExpression` on every evaluation removes two loads and a type check per call;
+    // `_calleeMember` doubles as the already-narrowed receiver for the fast member-call lane.
+    private readonly bool _calleeIsSuper;
+    private readonly JintMemberExpression? _calleeMember;
+
     public JintCallExpression(CallExpression expression) : base(expression)
     {
         _arguments.Initialize(expression.Arguments.AsSpan());
         _calleeExpression = Build(expression.Callee);
+        _calleeIsSuper = _calleeExpression._expression.Type == NodeType.Super;
+        _calleeMember = _calleeExpression as JintMemberExpression;
     }
 
     protected override object EvaluateInternal(EvaluationContext context)
@@ -28,7 +37,7 @@ internal sealed class JintCallExpression : JintExpression
             return StackGuard.RunOnEmptyStack(EvaluateInternal, context);
         }
 
-        if (_calleeExpression._expression.Type == NodeType.Super)
+        if (_calleeIsSuper)
         {
             return SuperCall(context);
         }
@@ -55,7 +64,8 @@ internal sealed class JintCallExpression : JintExpression
         // receiver is side-effect-free, so re-evaluating it on that rare path is unobservable).
         JsValue? fastFunc = null;
         var fastThis = JsValue.Undefined;
-        if (_calleeExpression is JintMemberExpression member
+        var member = _calleeMember;
+        if (member is not null
             && member.IsFastCallEligible
             && !engine._customResolver)
         {
@@ -185,7 +195,7 @@ internal sealed class JintCallExpression : JintExpression
             var callStack = engine.CallStack;
             var recursionDepth = callStack.Push(functionInstance, _calleeExpression, engine.ExecutionContext);
 
-            if (recursionDepth > engine.Options.Constraints.MaxRecursionDepth)
+            if (recursionDepth > engine._maxRecursionDepth)
             {
                 // automatically pops the current element as it was never reached
                 Throw.RecursionDepthOverflowException(callStack);

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -56,6 +56,11 @@ internal sealed class JintMemberExpression : JintExpression
     private PropertyDescriptor? _cachedStringProtoDescriptor;
     private readonly bool _stringReceiverCallEligible;
 
+    // Member-call eligibility is a pure function of this node's shape, so it is decided once in the
+    // constructor instead of re-deriving four type tests on every call this node is the callee of —
+    // JintCallExpression probes it before every member call it dispatches.
+    private readonly bool _fastCallEligible;
+
     // ObjectWrapper member cache: interop receivers carry InternalTypes.ExoticGet (members resolve against
     // the wrapped CLR object), so none of the caches above apply and every host.value read/write walks
     // ObjectWrapper.Get/Set → GetOwnProperty → dictionary probe → reflection accessor. But once
@@ -100,7 +105,13 @@ internal sealed class JintMemberExpression : JintExpression
             _determinedProperty = determined;
         }
 
-        _stringReceiverCallEligible = IsFastCallEligible && !CanBeOwnStringInstanceProperty((JsString) _determinedProperty!);
+        _fastCallEligible = _propertyExpression is null
+                            && _determinedProperty is JsString
+                            && !_memberExpression.Optional
+                            && !_objectExpressionCanShortCircuit
+                            && _objectExpression is JintIdentifierExpression or JintThisExpression;
+
+        _stringReceiverCallEligible = _fastCallEligible && !CanBeOwnStringInstanceProperty((JsString) _determinedProperty!);
     }
 
     /// <summary>
@@ -547,12 +558,7 @@ internal sealed class JintMemberExpression : JintExpression
     /// effect, so the call's slow-path fallback (taken when the resolved value is not callable) never
     /// double-evaluates anything observable.
     /// </summary>
-    internal bool IsFastCallEligible
-        => _propertyExpression is null
-           && _determinedProperty is JsString
-           && !_memberExpression.Optional
-           && !_objectExpressionCanShortCircuit
-           && _objectExpression is JintIdentifierExpression or JintThisExpression;
+    internal bool IsFastCallEligible => _fastCallEligible;
 
     /// <summary>
     /// member call when the receiver is an object, reusing the same version-gated own-property inline

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -385,8 +385,9 @@ internal sealed class JintMemberExpression : JintExpression
 
             context.LastSyntaxElement = _expression;
 
-            if (baseValue is ObjectInstance baseObject)
+            if (baseValue.IsObject())
             {
+                var baseObject = baseValue.AsObjectNoTypeCheck();
                 if ((baseObject._type & InternalTypes.ShapeMode) != InternalTypes.Empty)
                 {
                     // Shape-keyed read: a matching shape proves the slot index; read it straight out of
@@ -451,9 +452,9 @@ internal sealed class JintMemberExpression : JintExpression
             // wrapper is needed for spec-compliant numeric-index lookup like t['0'] returning
             // the indexed char via StringInstance.GetOwnProperty's ToNumber coercion. v4.8.0
             // allocated for these too via Engine.GetValue's ToObject path.
-            if (baseValue is JsString jsString && CommonProperties.Length.Equals(determinedProperty))
+            if (baseValue.IsString() && CommonProperties.Length.Equals(determinedProperty))
             {
-                return JsNumber.Create((uint) jsString.Length);
+                return JsNumber.Create((uint) baseValue.AsStringNoTypeCheck().Length);
             }
 
             return baseValue.GetV(engine.Realm, determinedProperty);
@@ -588,8 +589,9 @@ internal sealed class JintMemberExpression : JintExpression
         // (number/boolean/...) return undefined here so the caller falls through to the Reference path.
         // The identifier/`this` receiver is side-effect-free, so re-evaluating it on that path is
         // unobservable.
-        if (baseValue is ObjectInstance baseObject)
+        if (baseValue.IsObject())
         {
+            var baseObject = baseValue.AsObjectNoTypeCheck();
             thisObject = baseObject;
 
             if ((baseObject._type & InternalTypes.ShapeMode) != InternalTypes.Empty)
@@ -639,8 +641,10 @@ internal sealed class JintMemberExpression : JintExpression
             return ReadFromNonPlainReceiver(baseObject, determinedProperty);
         }
 
-        if (_stringReceiverCallEligible && baseValue is JsString jsString)
+        if (_stringReceiverCallEligible && baseValue.IsString())
         {
+            var jsString = baseValue.AsStringNoTypeCheck();
+
             // Primitive-string member call (str.slice(...)): the name can never be an own property of a
             // boxed string (build-time proof), so resolve straight off the realm's %String.prototype% —
             // the same object and receiver-binding Engine.GetValue's string lane uses — guarded by
@@ -810,8 +814,9 @@ internal sealed class JintMemberExpression : JintExpression
 
         context.LastSyntaxElement = _expression;
 
-        if (baseValue is ObjectInstance baseObject)
+        if (baseValue.IsObject())
         {
+            var baseObject = baseValue.AsObjectNoTypeCheck();
             if ((baseObject._type & InternalTypes.ShapeMode) != InternalTypes.Empty)
             {
                 // Shape-keyed write: shape-mode properties are always writable data, so a slot match is


### PR DESCRIPTION
Second of five stacked changes from the `dromaeo-object-string-modern` profiling. **Stacks on #2770** — it edits the same lines of `JintCallExpression`, so review only the last commit.

## Why

`CastHelpers` accounts for **3.8% of main-thread CPU** on this benchmark. The largest single contributor is `IsInstanceOfInterface` at 1.2%, and all of it comes from one place: `JintCallExpression` tests `is ICallable` and then `as ICallable` on every call it dispatches. An interface check is an interface-map scan the JIT cannot fold.

## This change

A new `InternalTypes.Callable` bit, set by every `ICallable` root — `Function` (which covers every function class), `BindFunction`, `IsHTMLDDA`, `JsProxy` and `NamespaceReference` — so the call site decides callability from the already-loaded `_type` and reinterprets with `Unsafe.As`.

The flag means "implements `ICallable`", not "is callable": a `JsProxy` over a non-callable target carries it and still throws from `Call`, which is exactly what `is ICallable` answered before.

The same treatment applies to `JintMemberExpression`'s three receiver lanes (`GetValue`, `GetCalleeForCall`, `TryAssignFast`), which each opened with `baseValue is ObjectInstance` or `baseValue is JsString`. `InternalTypes.Object` is set only by `ObjectInstance`'s constructors and `InternalTypes.String` only by `JsString` and its two nested subclasses — invariants `IsObject()`/`IsString()` and `AsObject()` already depend on — so `AsObjectNoTypeCheck`/`AsStringNoTypeCheck` are as sound as the type test while costing a flag test. Both mirror the shape of the existing `AsNumber()`: flag test, `Debug.Assert`, `Unsafe.As`.

## Guarding an unchecked cast

An incorrect `Unsafe.As` is memory corruption rather than an exception, so the flag carries two guards:

- `IsCallableFlagged` asserts the flag agrees with `is ICallable` on every call in debug builds. That is how `NamespaceReference` was caught — `importNamespace('System.Collections.Generic').List(T)` calls through `ICallable` to bind a generic type, and two `InteropTests` failed with "List is not a function" until it got the flag.
- `CallableFlagTests` pins the actual invariant by reflection: every `ICallable` `JsValue` must derive from a root that sets the flag. A future implementer that forgets it fails a test instead of throwing at runtime. Checking the roots rather than enumerating every concrete function class keeps the test stable.

## Measured

`IsInstanceOfInterface` disappears from the profile entirely, and `IsInstanceOfClass` falls 1.4% -> 0.9% (together with #2770). Wall-clock effect on the isolated op loop is ~0.9%, at the edge of that instrument's resolution — note a monomorphic micro cannot measure this well, since dynamic PGO already folds those checks there; the 3.8% figure is from the full benchmark.

## Gate

Jint.Tests 3925, PublicInterface 114, CommonScripts 28, Test262 99441/0 in Release — **and** the full suite re-run in Debug with the asserts armed: Jint.Tests 3925 and Test262 99441 with zero assert failures, so no `ICallable` value reaches a call site without the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)