### PR TITLE
Reinterpret non-Reference evaluation results without a checked cast

### DIFF
--- a/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintExpression.cs
@@ -26,7 +26,11 @@ internal abstract class JintExpression
         var result = Evaluate(context);
         if (result is not Reference reference)
         {
-            return (JsValue) result;
+            // Not a Reference, so the evaluation protocol guarantees a JsValue (asserted for
+            // every node in Evaluate). An unchecked reinterpret keeps CastHelpers.ChkCastClass off
+            // the value path, which every expression read and every assignment right-hand side
+            // travels through.
+            return Unsafe.As<JsValue>(result);
         }
 
         // Set LastSyntaxElement for proper error location if GetValue throws
@@ -41,6 +45,7 @@ internal abstract class JintExpression
         context.PrepareFor(_expression);
 
         var result = EvaluateInternal(context);
+        AssertEvaluationResult(result);
 
         context.LastSyntaxElement = oldSyntaxElement;
 
@@ -50,7 +55,22 @@ internal abstract class JintExpression
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal object EvaluateWithoutNodeTracking(EvaluationContext context)
     {
-        return EvaluateInternal(context);
+        var result = EvaluateInternal(context);
+        AssertEvaluationResult(result);
+        return result;
+    }
+
+    /// <summary>
+    /// The evaluation protocol: every <see cref="EvaluateInternal"/> implementation returns either a
+    /// <see cref="JsValue"/> or a <see cref="Reference"/>, never anything else. Callers that have
+    /// ruled out <see cref="Reference"/> rely on that to reinterpret the result as a
+    /// <see cref="JsValue"/> without a checked cast, so the contract is enforced here — in one place
+    /// for all node types — rather than trusted at each of those call sites.
+    /// </summary>
+    [Conditional("DEBUG")]
+    private static void AssertEvaluationResult(object result)
+    {
+        Debug.Assert(result is JsValue or Reference, $"expression evaluation produced {result?.GetType().ToString() ?? "null"}, which is neither a JsValue nor a Reference");
     }
 
     protected abstract object EvaluateInternal(EvaluationContext context);

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -489,7 +489,8 @@ internal sealed class JintMemberExpression : JintExpression
         var result = Evaluate(context);
         if (result is not Reference reference)
         {
-            return (JsValue) result;
+            // see JintExpression.GetValue: not a Reference means the protocol guarantees a JsValue
+            return Unsafe.As<JsValue>(result);
         }
 
         return CompleteReadFromReference(context, engine, reference);

--- a/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintUnaryExpression.cs
@@ -85,7 +85,8 @@ internal sealed class JintUnaryExpression : JintExpression
             }
             else
             {
-                v = (JsValue) result;
+                // see JintExpression.GetValue: not a Reference means the protocol guarantees a JsValue
+                v = Unsafe.As<JsValue>(result);
             }
 
             return GetTypeOfString(v);


### PR DESCRIPTION
Last of five stacked changes from the `dromaeo-object-string-modern` profiling. **Stacks on #2770, #2771, #2772, #2773** — review the last commit.

## Why

Expression evaluation returns `object` so a node can produce either a value or a `Reference`, and every value-producing caller pays `CastHelpers.ChkCastClass` to get back to `JsValue` — **0.8% of main-thread CPU** on this benchmark, the bulk of it inlined into `SimpleAssignmentExpression.TryAssignSlot` via the right-hand side's `GetValue`.

## This change

The obvious fix is a second, `JsValue`-typed evaluation protocol across all 54 expression node types. That is a large diff with two paths to keep in sync, so instead this pins the contract that already holds: **`EvaluateInternal` returns a `JsValue` or a `Reference` and nothing else.**

`AssertEvaluationResult` states and enforces that in one place for every node, on both `Evaluate` and `EvaluateWithoutNodeTracking`, so the callers that have already ruled out `Reference` can reinterpret with `Unsafe.As` instead of a checked cast.

Three call sites change: `JintExpression.GetValue`, `JintMemberExpression.GetValue`, and `JintTypeOfExpression`'s argument read. The two constant-folding casts in `Engine.Ast` and `JintBinaryExpression` stay checked — they run once at build time, where a checked cast is a free safety net — and `JintTypeOfExpression.GetValue` keeps its checked cast for the same reason, since `typeof` is not on the hot path and that call bypasses `Evaluate`'s assert.

## Measured

`ChkCastClass` disappears from the full-benchmark profile (0.4% -> 3 samples). Wall-clock effect on the isolated op loop is ~0.7%, at that instrument's resolution limit.

## Gate

Jint.Tests 3925, PublicInterface 114, CommonScripts 28, Test262 99441/0 in Release — **and** the full suite re-run in Debug with the contract assert armed: Jint.Tests 3925 and Test262 **99441 with zero assert failures**, so no node type among the 54 violates the contract.

## Campaign total

Across all five: **−13.7%** on the targeted op shape (67 -> 57.6 ns/op, A/B/B/A with <1% spread), **−5.6%** on the whole script with a warm engine, and on BDN with the #2769 harness fix, `ObjectString(Modern: True)` −1.6/−2.0% and `StringBase64(Modern: True)` −10%. The targeted `CastHelpers` + `SlotLocationCache` symbols go from **6.7% -> 1.0%** of main-thread self time.

The ObjectString figure is diluted because that row is now ~25% GC of the 21.4 MB/op the benchmark allocates, which none of these five touch — that is the next phase of the campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)