### PR TITLE
Vectorize the special-casing pre-scans

### DIFF
--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -499,6 +499,30 @@ var big = (s + '|tail').split('|');       // [s, 'tail']: first segment is ~the 
         _engine.Evaluate("big.length === 2 && big[0] === s && big[1] === 'tail'").AsBoolean().Should().BeTrue();
     }
 
+    /// <summary>
+    /// The special-casing pre-scans decide whether a conversion can delegate to the plain
+    /// framework ToUpper/ToLower or must walk the string character by character. The upper scan
+    /// rejects a string outright when every character sits below U+00DF, since no SpecialCasing.txt
+    /// expansion exists below that point — so U+00DF itself is the boundary that must NOT be
+    /// rejected, and these cases pin both sides of it.
+    /// </summary>
+    [Theory]
+    // below the boundary: plain framework casing
+    [InlineData("abc", "ABC", "abc")]
+    [InlineData("Þ", "Þ", "þ")]                      // U+00DE, last character with no expansion
+    // at and above the boundary: must reach the per-character expansion path
+    [InlineData("ß", "SS", "ß")]                     // U+00DF LATIN SMALL LETTER SHARP S
+    [InlineData("aßb", "ASSB", "aßb")]               // expansion in the middle of ASCII
+    [InlineData("ﬄ", "FFL", "ﬄ")]                    // U+FB04 LATIN SMALL LIGATURE FFL
+    [InlineData("İ", "İ", "i̇")]                // U+0130, lower-cases to an expansion
+    [InlineData("ΑΣ", "ΑΣ", "ας")]                   // Final_Sigma: sigma at end lower-cases to final form
+    [InlineData("ΑΣΒ", "ΑΣΒ", "ασβ")]                // non-final sigma keeps the medial form
+    public void CasingHandlesTheSpecialCasingBoundary(string input, string upper, string lower)
+    {
+        _engine.Evaluate($"('{input}').toUpperCase()").AsString().Should().Be(upper);
+        _engine.Evaluate($"('{input}').toLowerCase()").AsString().Should().Be(lower);
+    }
+
     public static TheoryData<string, string> GetLithuaniaTestsData()
     {
         return new StringTetsLithuaniaData().TestData();

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -283,6 +283,18 @@ internal sealed partial class StringPrototype : StringInstance
 
     private static bool NeedsUpperSpecialCasing(string s)
     {
+#if NET8_0_OR_GREATER
+        // No SpecialCasing.txt expansion exists below U+00DF — exactly the short-circuit
+        // GetSpecialUpperCasing already performs per character. Asking that question once with a
+        // vectorized range scan rejects any string made only of such characters (ASCII text being
+        // the overwhelmingly common case) without ever entering the per-character switch below,
+        // which is then only reached for strings that really do carry a high code point.
+        if (!s.AsSpan().ContainsAnyExceptInRange('\0', 'Þ'))
+        {
+            return false;
+        }
+#endif
+
         foreach (var c in s)
         {
             if (GetSpecialUpperCasing(c) is not null)
@@ -579,6 +591,10 @@ internal sealed partial class StringPrototype : StringInstance
     /// </summary>
     private static bool NeedsSpecialCasing(string s)
     {
+#if NET8_0_OR_GREATER
+        // GREEK CAPITAL LETTER SIGMA (Final_Sigma) and LATIN CAPITAL LETTER I WITH DOT ABOVE.
+        return s.AsSpan().ContainsAny('\u03A3', '\u0130');
+#else
         foreach (var c in s)
         {
             if (c == '\u03A3' || c == '\u0130')
@@ -587,6 +603,7 @@ internal sealed partial class StringPrototype : StringInstance
             }
         }
         return false;
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
Phase 2 of the `dromaeo-object-string-modern` campaign (Phase 1 landed as #2770–#2774), now targeting the parts of the benchmark that are real string work rather than interpreter dispatch.

## Why

`toUpperCase`/`toLowerCase` first ask whether the string contains any code point needing SpecialCasing.txt treatment, and only walk it character by character if so. Both questions were answered with a **scalar loop over the whole string** — before the framework's own (vectorized) `ToUpper`/`ToLower` then scans it again.

On `dromaeo-object-string-modern` those two scans plus the per-character helper they call are **3.3% of main-thread CPU**, for only ten conversions per iteration:

| symbol | self |
|---|---|
| `NeedsUpperSpecialCasing` | 1.5% |
| `NeedsSpecialCasing` | 1.0% |
| `GetSpecialUpperCasing` | 0.8% |

## This change

- `NeedsSpecialCasing` looks for exactly two characters, so it becomes a `ContainsAny` over the span.
- `NeedsUpperSpecialCasing` gets a range prefilter. No SpecialCasing.txt expansion exists below U+00DF — exactly the short-circuit `GetSpecialUpperCasing` already performs per character — so asking "is every character below U+00DF?" once with a vectorized range scan rejects such strings outright, and the per-character switch is only reached for strings that really do carry a high code point.

Both span APIs are net8.0+, so the pre-net8 target frameworks keep the existing scalar loops.

## Correctness

`CasingHandlesTheSpecialCasingBoundary` pins both sides of the U+00DF boundary the prefilter turns on — U+00DE must still take the plain framework path, U+00DF (sharp s -> `SS`) must still reach the expansion path — along with the ligature, dotted-I and Final_Sigma cases. It runs on net10.0 and net472, so it exercises the vectorized and the scalar implementation.

Jint.Tests 3958, Jint.Tests.PublicInterface 114, Jint.Tests.CommonScripts 28, Test262 **99441 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)