### PR TITLE
Search backwards for lastIndexOf with the vectorized span search

### DIFF
--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -523,6 +523,45 @@ var big = (s + '|tail').split('|');       // [s, 'tail']: first segment is ~the 
         _engine.Evaluate($"('{input}').toLowerCase()").AsString().Should().Be(lower);
     }
 
+    /// <summary>
+    /// lastIndexOf's position argument bounds where a match may <em>start</em>, not where the search
+    /// begins, which is easy to get off by one. Every expectation here was verified against V8.
+    /// </summary>
+    [Theory]
+    // no position: whole string
+    [InlineData("'abcabc'.lastIndexOf('abc')", 3)]
+    [InlineData("'abcabc'.lastIndexOf('abcabc')", 0)]
+    [InlineData("'abcabc'.lastIndexOf('x')", -1)]
+    [InlineData("'abc'.lastIndexOf('abcd')", -1)]
+    [InlineData("'aaa'.lastIndexOf('aa')", 1)]
+    // position clamps the start of the match, so a match may extend past it
+    [InlineData("'abcabc'.lastIndexOf('abc', 2)", 0)]
+    [InlineData("'abcabc'.lastIndexOf('abc', 3)", 3)]
+    [InlineData("'abcabc'.lastIndexOf('bc', 1)", 1)]
+    [InlineData("'abcabc'.lastIndexOf('bc', 0)", -1)]
+    [InlineData("'abcabc'.lastIndexOf('c', 4)", 2)]
+    [InlineData("'hello world hello'.lastIndexOf('hello', 11)", 0)]
+    [InlineData("'hello world hello'.lastIndexOf('hello', 12)", 12)]
+    // out-of-range, fractional and negative-zero positions
+    [InlineData("'abcabc'.lastIndexOf('abc', 0)", 0)]
+    [InlineData("'abcabc'.lastIndexOf('abc', -1)", 0)]
+    [InlineData("'abcabc'.lastIndexOf('abc', -100)", 0)]
+    [InlineData("'abcabc'.lastIndexOf('abc', -0)", 0)]
+    [InlineData("'abcabc'.lastIndexOf('abc', 1.9)", 0)]
+    [InlineData("'abcabc'.lastIndexOf('abc', 100)", 3)]
+    [InlineData("'abcabc'.lastIndexOf('abc', NaN)", 3)]
+    // the empty needle matches at the clamped position
+    [InlineData("'abcabc'.lastIndexOf('')", 6)]
+    [InlineData("'abcabc'.lastIndexOf('', 3)", 3)]
+    [InlineData("'abcabc'.lastIndexOf('', 100)", 6)]
+    [InlineData("'abcabc'.lastIndexOf('', -5)", 0)]
+    [InlineData("''.lastIndexOf('')", 0)]
+    [InlineData("''.lastIndexOf('a')", -1)]
+    public void LastIndexOfMatchesSpecPositionSemantics(string expression, int expected)
+    {
+        _engine.Evaluate(expression).AsNumber().Should().Be(expected);
+    }
+
     public static TheoryData<string, string> GetLithuaniaTestsData()
     {
         return new StringTetsLithuaniaData().TestData();

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -1556,34 +1556,20 @@ internal sealed partial class StringPrototype : StringInstance
             return JsNumber.IntegerNegativeOne;
         }
 
-        var s = jsString.ToString();
-        var i = start;
-        bool found;
-
-        do
+        // An empty search string matches at the clamped position itself.
+        if (searchLen == 0)
         {
-            found = true;
-            var j = 0;
+            return JsNumber.Create(start);
+        }
 
-            while (found && j < searchLen)
-            {
-                if (i + searchLen > len || s[i + j] != searchStr[j])
-                {
-                    found = false;
-                }
-                else
-                {
-                    j++;
-                }
-            }
-            if (!found)
-            {
-                i--;
-            }
+        // The spec asks for the greatest k <= start at which searchStr occurs, so a match must lie
+        // entirely within s[0 .. start + searchLen). Searching that prefix with the vectorized span
+        // search replaces a hand-rolled backward character-by-character scan that was O(len * searchLen)
+        // whenever the needle was absent or far from `start`.
+        var end = System.Math.Min(start + searchLen, len);
+        var index = jsString.ToString().AsSpan(0, end).LastIndexOf(searchStr.AsSpan());
 
-        } while (!found && i >= 0);
-
-        return i;
+        return index < 0 ? JsNumber.IntegerNegativeOne : JsNumber.Create(index);
     }
 
     /// <summary>


### PR DESCRIPTION
Phase 2 of the `dromaeo-object-string-modern` campaign. **Stacks on #2775** — review the last commit.

## Why

`String.prototype.lastIndexOf` hand-rolled a backward, character-by-character scan, so it was **O(len × searchLen)** whenever the needle was absent or far from the requested position. It is 1.4% of main-thread CPU on `dromaeo-object-string-modern`, where every needle happens to sit near the end of the string — a workload that searches for something *not* present pays far more.

## This change

The spec asks for the greatest `k <= position` at which `searchStr` occurs, so any match lies entirely within `s[0 .. position + searchLen)`. Searching exactly that prefix with the framework's vectorized span search gives the same answer. An empty needle (which matches at the clamped position itself) is handled up front rather than falling out of the loop.

Net effect is ~25 lines of manual scanning replaced by a clamp and one span call.

## Correctness

`lastIndexOf`'s position argument bounds where a match may **start**, not where the search begins — a match may extend past the position — which makes this easy to get off by one. So rather than reason it out, I ran a 44-case differential against node (V8) covering the position clamp, matches extending past the position, out-of-range / fractional / negative-zero positions, the empty-needle cases, and long strings with the needle absent / present / at a bound. **All 44 matched exactly.**

The semantically interesting cases are pinned in `LastIndexOfMatchesSpecPositionSemantics`, with a comment noting the expectations came from V8. Highlights:

```js
'abcabc'.lastIndexOf('abc', 2)   // 0  — position bounds the match START
'abcabc'.lastIndexOf('bc', 1)    // 1  — match extends past position 1
'abcabc'.lastIndexOf('bc', 0)    // -1
'abcabc'.lastIndexOf('', -5)     // 0  — empty needle at the clamped position
'abcabc'.lastIndexOf('', 100)    // 6
''.lastIndexOf('')               // 0
```

Jint.Tests 3958, PublicInterface 114, CommonScripts 28, Test262 **99441 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)