### PR TITLE
Stop toWellFormed from rebuilding already well-formed strings

### DIFF
--- a/Jint.Tests/Runtime/StringTests.cs
+++ b/Jint.Tests/Runtime/StringTests.cs
@@ -562,6 +562,51 @@ var big = (s + '|tail').split('|');       // [s, 'tail']: first segment is ~the 
         _engine.Evaluate(expression).AsNumber().Should().Be(expected);
     }
 
+    /// <summary>
+    /// isWellFormed/toWellFormed short-circuit on a vectorized "does this string contain any surrogate
+    /// code unit at all?" scan, and toWellFormed additionally hands back the receiver's own string when
+    /// nothing needs replacing. These cases pin the surrogate range boundary and every unpaired shape;
+    /// all expectations were verified against V8.
+    /// </summary>
+    [Theory]
+    // no surrogates at all — the vectorized reject path
+    [InlineData("''", true, "")]
+    [InlineData("'abc'", true, "abc")]
+    // just outside the surrogate range on both sides, so still well-formed
+    [InlineData("'\\uD7FF\\uE000'", true, "퟿")]
+    // valid pairs
+    [InlineData("'a\\uD83D\\uDE00b'", true, "a😀b")]
+    // unpaired leading surrogate
+    [InlineData("'a\\uD800'", false, "a�")]
+    [InlineData("'ab\\uD83D'", false, "ab�")]
+    [InlineData("'\\uD800\\uD800'", false, "��")]
+    // unpaired trailing surrogate
+    [InlineData("'a\\uDC00b'", false, "a�b")]
+    [InlineData("'x\\uDFFFy'", false, "x�y")]
+    // reversed pair: both halves are unpaired
+    [InlineData("'\\uDC00\\uD800'", false, "��")]
+    [InlineData("'\\uD800a\\uDC00'", false, "�a�")]
+    // an unpaired lead immediately followed by a valid pair
+    [InlineData("'\\uD83D\\uD83D\\uDE00'", false, "�😀")]
+    public void WellFormedHandlesSurrogateBoundaries(string literal, bool wellFormed, string toWellFormed)
+    {
+        _engine.Evaluate($"({literal}).isWellFormed()").AsBoolean().Should().Be(wellFormed);
+        _engine.Evaluate($"({literal}).toWellFormed()").AsString().Should().Be(toWellFormed);
+    }
+
+    [Fact]
+    public void ToWellFormedReturnsAnEquivalentPrimitiveForObjectReceivers()
+    {
+        // toWellFormed must produce a primitive string even when `this` is a String object, including
+        // on the already-well-formed path where the receiver's own value is reused.
+        _engine.Evaluate("typeof new String('abc').toWellFormed()").AsString().Should().Be("string");
+        _engine.Evaluate("new String('abc').toWellFormed()").AsString().Should().Be("abc");
+        _engine.Evaluate("new String('a\\uD800b').toWellFormed()").AsString().Should().Be("a�b");
+
+        // an already-well-formed primitive maps to the same sequence of code units
+        _engine.Evaluate("var s = 'abcde'.repeat(1000); s.toWellFormed() === s").AsBoolean().Should().BeTrue();
+    }
+
     public static TheoryData<string, string> GetLithuaniaTestsData()
     {
         return new StringTetsLithuaniaData().TestData();

--- a/Jint/Native/String/StringPrototype.cs
+++ b/Jint/Native/String/StringPrototype.cs
@@ -2004,6 +2004,14 @@ internal sealed partial class StringPrototype : StringInstance
     {
         var s = TypeConverter.ToString(thisObject);
 
+        // An already well-formed string maps to the same sequence of code units, so there is nothing
+        // to rebuild — hand back the receiver's own string instead of copying it through the builder.
+        // This is the overwhelmingly common case, and it was previously paying a full copy.
+        if (IsStringWellFormedUnicode(s))
+        {
+            return thisObject.IsString() ? thisObject : JsString.Create(s);
+        }
+
         var strLen = s.Length;
         var k = 0;
 
@@ -2034,6 +2042,15 @@ internal sealed partial class StringPrototype : StringInstance
 
     private static bool IsStringWellFormedUnicode(string s)
     {
+#if NET8_0_OR_GREATER
+        // Only a surrogate code unit can make a string ill-formed, and most strings contain none.
+        // One vectorized range scan settles those, leaving the pairing walk below for the rest.
+        if (!s.AsSpan().ContainsAnyInRange('\uD800', '\uDFFF'))
+        {
+            return true;
+        }
+#endif
+
         for (var i = 0; i < s.Length; ++i)
         {
             var isSurrogate = (s.CharCodeAt(i) & 0xF800) == 0xD800;


### PR DESCRIPTION
Found by auditing for scalar character loops **outside** the paths the `dromaeo-object-string-modern` profile happened to surface — so unlike #2775/#2776 this one is not backed by a profile share, it is a straightforward "this does obviously redundant work" finding.

## What was wrong

`toWellFormed()` built a whole new string through a `ValueStringBuilder` **unconditionally**, even though a well-formed input maps to the very same sequence of code units. That is the overwhelmingly common case, and it was paying a full copy to produce an identical result.

Separately, `IsStringWellFormedUnicode` walked every character scalar-ly, reading each one up to three times through the indexer.

## This change

- Only a surrogate code unit can make a string ill-formed, so `IsStringWellFormedUnicode` gets a vectorized range scan over `[U+D800, U+DFFF]` and settles surrogate-free strings in one pass. The pairing walk stays for the rest.
- `toWellFormed` reuses that answer and hands back the receiver's own string when nothing needs replacing — no copy, and **no allocation at all** when the receiver is already a primitive string. A `String` object receiver still yields a primitive, as the spec requires.

The range scan is net8.0+, so earlier target frameworks keep the scalar walk.

## Correctness

Surrogate handling is fiddly, so every expectation in `WellFormedHandlesSurrogateBoundaries` was verified against V8 first. It covers:

- both edges of the surrogate range — `U+D7FF` and `U+E000` must stay well-formed, which is exactly what an off-by-one in the range scan would break
- valid pairs, unpaired leads, unpaired trails
- a reversed pair (`\uDC00\uD800`) where *both* halves are unpaired
- an unpaired lead immediately followed by a valid pair (`\uD83D\uD83D\uDE00`)

A wider 19-case differential run against node matched exactly, including the `String`-object receiver and identity on a long well-formed string.

## Gate

Jint.Tests **3946**, Jint.Tests.PublicInterface 114, Jint.Tests.CommonScripts 28, Test262 **99441 passed / 0 failed**.

## Note on the rest of the audit

Most other scalar character loops in the codebase are already fine and I left them alone: JSON string escaping routes through `JavaScriptEncoder.FindFirstCharacterToEncode` (SIMD) on .NET Core, `unescape` short-circuits on a vectorized `Contains('%')`, `escape` uses `SearchValues`, and `SlicedString`'s searches already operate on spans. The remaining loops are either per-character *transformations* (inherently scalar) or cold Intl locale parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)