### PR TITLE
Give the callback-free array methods a dense fast path, and make fill throw as the spec requires

### DIFF
--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -715,6 +715,86 @@ return get + '' === ""length,0,1,2,3"";";
 
         // an extra non-index property does not disturb the element reversal
         engine.Evaluate("var q = [1,2,3]; q.foo = 1; q.reverse().join(',')").AsString().Should().Be("3,2,1");
+
+        engine.Evaluate("var r = [1,2,3]; r.copyWithin(0,1) === r").AsBoolean().Should().BeTrue();
+
+        engine.Evaluate("""
+            var s = { length: 5, 0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e' };
+            Array.prototype.copyWithin.call(s, 0, 3);
+            s[0] + s[1] + s[2] + s[3] + s[4];
+            """).AsString().Should().Be("decde");
+
+        engine.Evaluate("""
+            var u = { length: 3, 0: 'a', 2: 'a' };
+            Array.prototype.lastIndexOf.call(u, 'a');
+            """).AsNumber().Should().Be(2);
+    }
+
+    /// <summary>
+    /// copyWithin and lastIndexOf take the same dense fast path. copyWithin relies on Array.Copy
+    /// behaving as if the source were staged in a temporary, which is what the generic path's
+    /// direction flip exists for, so overlap in both directions is covered here; a hole in the source
+    /// range makes the spec delete the target index, so those cases must decline the lane. Every
+    /// expectation was verified against V8.
+    /// </summary>
+    [Theory]
+    // copyWithin, no overlap
+    [InlineData("[1,2,3,4,5].copyWithin(0,3)", "[4,5,3,4,5]len=5")]
+    [InlineData("[1,2,3,4,5].copyWithin(1,3)", "[1,4,5,4,5]len=5")]
+    // copyWithin, overlapping in both directions
+    [InlineData("[1,2,3,4,5].copyWithin(3,0)", "[1,2,3,1,2]len=5")]
+    [InlineData("[1,2,3,4,5].copyWithin(0,1)", "[2,3,4,5,5]len=5")]
+    [InlineData("[1,2,3,4,5].copyWithin(1,0,3)", "[1,1,2,3,5]len=5")]
+    [InlineData("[1,2,3,4,5].copyWithin(-2,-3,-1)", "[1,2,3,3,4]len=5")]
+    // no-op, empty and clamped ranges
+    [InlineData("[1,2,3,4,5].copyWithin(0,0)", "[1,2,3,4,5]len=5")]
+    [InlineData("[1,2,3,4,5].copyWithin(2,2,2)", "[1,2,3,4,5]len=5")]
+    [InlineData("[1,2,3,4,5].copyWithin(10,0)", "[1,2,3,4,5]len=5")]
+    [InlineData("[1,2,3,4,5].copyWithin(0,10)", "[1,2,3,4,5]len=5")]
+    [InlineData("[].copyWithin(0,0)", "[]len=0")]
+    [InlineData("[1,2,3].copyWithin(0,1.6,2.9)", "[2,2,3]len=3")]
+    // a hole in the source range deletes the target index, so the lane must decline
+    [InlineData("[1,,3,4].copyWithin(0,1,3)", "[<hole>,3,3,4]len=4")]
+    [InlineData("[1,2,,4].copyWithin(1,2)", "[1,<hole>,4,4]len=4")]
+    [InlineData("(function(){var a=[1,2,3];a[8]=9;return a.copyWithin(0,7,9);})()", "[<hole>,9,3,<hole>,<hole>,<hole>,<hole>,<hole>,9]len=9")]
+    [InlineData("(function(){var a=[1,2,3,4,5];a.length=3;return a.copyWithin(0,1);})()", "[2,3,3]len=3")]
+    public void CopyWithinPreservesOverlapAndHoleSemantics(string expression, string expected)
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            function d(a) {
+                var parts = [];
+                for (var i = 0; i < a.length; i++) parts.push(i in a ? String(a[i]) : "<hole>");
+                return "[" + parts.join(",") + "]len=" + a.length;
+            }
+            """);
+        engine.Evaluate($"d({expression})").AsString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("[1,2,3,2,1].lastIndexOf(2)", 3)]
+    [InlineData("[1,2,3,2,1].lastIndexOf(2,2)", 1)]
+    [InlineData("[1,2,3].lastIndexOf(9)", -1)]
+    [InlineData("[1,2,3,2].lastIndexOf(2,-1)", 3)]
+    [InlineData("[1,2,3,2].lastIndexOf(2,-3)", 1)]
+    [InlineData("[1,2,3].lastIndexOf(1,-100)", -1)]
+    [InlineData("[1,2,3].lastIndexOf(3,100)", 2)]
+    [InlineData("[].lastIndexOf(1)", -1)]
+    [InlineData("[1,2,3].lastIndexOf(2,1.9)", 1)]
+    // a hole is not undefined
+    [InlineData("[1,,1].lastIndexOf(undefined)", -1)]
+    [InlineData("[1,undefined,1].lastIndexOf(undefined)", 1)]
+    // strict equality: NaN never matches, +0 matches -0, no coercion
+    [InlineData("[NaN].lastIndexOf(NaN)", -1)]
+    [InlineData("[0].lastIndexOf(-0)", 0)]
+    [InlineData("['1'].lastIndexOf(1)", -1)]
+    // a match beyond the dense backing store
+    [InlineData("(function(){var a=[1,2,3];a[8]=2;return a.lastIndexOf(2);})()", 8)]
+    // length shortened below the backing store hides the trailing elements
+    [InlineData("(function(){var a=[1,2,3,4,5];a.length=2;return a.lastIndexOf(3);})()", -1)]
+    public void LastIndexOfMatchesStrictEqualityAndHoles(string expression, int expected)
+    {
+        new Engine().Evaluate(expression).AsNumber().Should().Be(expected);
     }
 
     /// <summary>

--- a/Jint.Tests/Runtime/ArrayTests.cs
+++ b/Jint.Tests/Runtime/ArrayTests.cs
@@ -645,6 +645,106 @@ return get + '' === ""length,0,1,2,3"";";
         enumerableResult[1].Key.Should().Be(item1.Key);
     }
 
+    /// <summary>
+    /// reverse and fill take a dense fast path that works on the backing store directly. reverse must
+    /// decline it whenever the range contains a hole, since the spec creates and deletes properties
+    /// there and a plain swap cannot express that; fill may keep it, because filling makes every index
+    /// in the range present. Every expectation was verified against V8.
+    /// </summary>
+    [Theory]
+    // reverse, fully populated: takes the fast path
+    [InlineData("[1,2,3].reverse()", "[3,2,1]len=3")]
+    [InlineData("[1,2,3,4].reverse()", "[4,3,2,1]len=4")]
+    [InlineData("[].reverse()", "[]len=0")]
+    [InlineData("[7].reverse()", "[7]len=1")]
+    // undefined is a present value, not a hole, so it still qualifies
+    [InlineData("[1,undefined,3].reverse()", "[3,undefined,1]len=3")]
+    // reverse with holes: must fall through and preserve them
+    [InlineData("[1,,3].reverse()", "[3,<hole>,1]len=3")]
+    [InlineData("[,,3].reverse()", "[3,<hole>,<hole>]len=3")]
+    [InlineData("new Array(3).reverse()", "[<hole>,<hole>,<hole>]len=3")]
+    [InlineData("(function(){var a=[1,2,3];a[10]=11;return a.reverse();})()", "[11,<hole>,<hole>,<hole>,<hole>,<hole>,<hole>,<hole>,3,2,1]len=11")]
+    // length shortened below the backing store
+    [InlineData("(function(){var a=[1,2,3,4,5];a.length=3;return a.reverse();})()", "[3,2,1]len=3")]
+    // fill: ranges, clamping, fractional and inverted
+    [InlineData("[1,2,3,4].fill(0)", "[0,0,0,0]len=4")]
+    [InlineData("[1,2,3,4].fill(0,1,3)", "[1,0,0,4]len=4")]
+    [InlineData("[1,2,3].fill(0,-2)", "[1,0,0]len=3")]
+    [InlineData("[1,2,3].fill(0,-100,100)", "[0,0,0]len=3")]
+    [InlineData("[1,2,3].fill(0,2,1)", "[1,2,3]len=3")]
+    [InlineData("[1,2,3].fill(0,1.7,2.9)", "[1,0,3]len=3")]
+    [InlineData("[].fill(1)", "[]len=0")]
+    [InlineData("[1,2,3].fill(undefined,1)", "[1,undefined,undefined]len=3")]
+    // fill turns holes into present values
+    [InlineData("[1,,3].fill(9,1,2)", "[1,9,3]len=3")]
+    [InlineData("new Array(3).fill(5)", "[5,5,5]len=3")]
+    [InlineData("(function(){var a=[1,2,3];a[8]=9;return a.fill(7,2,6);})()", "[1,2,7,7,7,7,<hole>,<hole>,9]len=9")]
+    public void ReverseAndFillPreserveHoleSemantics(string expression, string expected)
+    {
+        var engine = new Engine();
+        engine.Execute("""
+            function d(a) {
+                var parts = [];
+                for (var i = 0; i < a.length; i++) parts.push(i in a ? String(a[i]) : "<hole>");
+                return "[" + parts.join(",") + "]len=" + a.length;
+            }
+            """);
+        engine.Evaluate($"d({expression})").AsString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void ReverseAndFillReturnTheSameObjectAndHandleArrayLikes()
+    {
+        var engine = new Engine();
+
+        engine.Evaluate("var a = [1,2,3]; a.reverse() === a").AsBoolean().Should().BeTrue();
+        engine.Evaluate("var b = [1,2,3]; b.fill(0) === b").AsBoolean().Should().BeTrue();
+
+        // array-likes never reach the dense path
+        engine.Evaluate("""
+            var o = { length: 3, 0: 'a', 2: 'c' };
+            Array.prototype.reverse.call(o);
+            o[0] + '|' + (1 in o) + '|' + o[2];
+            """).AsString().Should().Be("c|false|a");
+
+        engine.Evaluate("""
+            var p = { length: 3, 0: 'a' };
+            Array.prototype.fill.call(p, 'z', 1);
+            p[0] + p[1] + p[2];
+            """).AsString().Should().Be("azz");
+
+        // an extra non-index property does not disturb the element reversal
+        engine.Evaluate("var q = [1,2,3]; q.foo = 1; q.reverse().join(',')").AsString().Should().Be("3,2,1");
+    }
+
+    /// <summary>
+    /// https://tc39.es/ecma262/#sec-array.prototype.fill step 8.c is <c>Set(O, Pk, value, true)</c>, so a
+    /// write that cannot succeed must throw. fill previously passed <c>throwOnError: false</c> and silently
+    /// did nothing, unlike reverse next to it. Verified against V8: frozen throws, sealed succeeds (its
+    /// existing elements stay writable).
+    /// </summary>
+    [Fact]
+    public void FillThrowsWhenAnElementCannotBeWritten()
+    {
+        var engine = new Engine();
+
+        Invoking(() => engine.Evaluate("var a = [1,2,3]; Object.freeze(a); a.fill(0);"))
+            .Should().Throw<JavaScriptException>().WithMessage("*not*");
+
+        // the frozen array is left untouched
+        engine.Evaluate("a.join(',')").AsString().Should().Be("1,2,3");
+
+        // a single non-writable element is enough to fail the whole fill
+        Invoking(() => engine.Evaluate("""
+            var b = [1,2,3];
+            Object.defineProperty(b, '1', { value: 2, writable: false, enumerable: true, configurable: true });
+            b.fill(0);
+            """)).Should().Throw<JavaScriptException>();
+
+        // sealed keeps its elements writable, so fill still succeeds
+        engine.Evaluate("var c = [1,2,3]; Object.seal(c); c.fill(0); c.join(',')").AsString().Should().Be("0,0,0");
+    }
+
     [Fact]
     public void PopWrappedGenericList()
     {

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -205,10 +205,29 @@ public sealed partial class ArrayPrototype : ArrayInstance
             final = (ulong) System.Math.Min(relativeEnd, length);
         }
 
+        // Fast path: fill the dense backing store directly instead of paying a Set (and its
+        // property-protocol dispatch) per element. Fill makes every index in the range present, so
+        // holes inside it need no special handling — unlike reverse/copyWithin, which must preserve
+        // them. Span.Fill is vectorized where the runtime supports it.
+        // `final` can land below `k` for an inverted range (fill(v, 2, 1)), which the loop below
+        // treats as a no-op, so the range must be checked as non-empty before it becomes a span length.
+        if (k <= final
+            && o is JsArray { CanUseFastAccess: true } fast
+            && fast._dense is { } dense
+            && final <= (ulong) dense.Length)
+        {
+            dense.AsSpan((int) k, (int) (final - k)).Fill(value);
+            return o;
+        }
+
         // Check constraints periodically to prevent memory exhaustion in large fills
         for (var i = k; i < final; ++i)
         {
-            operations.Set(i, value, throwOnError: false);
+            // https://tc39.es/ecma262/#sec-array.prototype.fill step 8.c is `Set(O, Pk, value, true)`,
+            // so a failed write must throw rather than be swallowed — reverse above already does this.
+            // Only the generic path can fail: the dense lane requires CanUseFastAccess, which a frozen
+            // or otherwise non-default-descriptor array does not have.
+            operations.Set(i, value, throwOnError: true);
 
             if (i > k && (i - k) % ConstraintCheckInterval == 0)
             {
@@ -1667,6 +1686,24 @@ public sealed partial class ArrayPrototype : ArrayInstance
     {
         var o = ArrayOperations.For(_realm, thisObject, forWrite: true);
         var len = o.GetLongLength();
+
+        // Fast path: reverse the dense backing store in place instead of paying two HasProperty and
+        // up to two Set/Delete calls per swapped pair. Only a fully populated range qualifies — a
+        // hole makes the spec create and delete properties, which the swap below cannot express — so
+        // a single missing element falls through to the generic path. Span.Reverse is vectorized
+        // where the runtime supports it.
+        if (o.Target is JsArray { CanUseFastAccess: true } fast
+            && fast._dense is { } dense
+            && len <= (ulong) dense.Length)
+        {
+            var count = (int) len;
+            if (System.Array.IndexOf(dense, null, 0, count) < 0)
+            {
+                dense.AsSpan(0, count).Reverse();
+                return fast;
+            }
+        }
+
         var middle = (ulong) System.Math.Floor(len / 2.0);
         uint lower = 0;
         while (lower != middle)

--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -294,6 +294,21 @@ public sealed partial class ArrayPrototype : ArrayInstance
         var count = (long) System.Math.Min(final - from, len - to);
         var initialCount = count;
 
+        // Fast path: move the elements inside the dense backing store with a single Array.Copy, which
+        // already behaves as if the source were staged in a temporary — exactly the overlapping case
+        // the direction flip below exists to handle. Only a hole-free source range qualifies, since a
+        // hole makes the spec delete the target index rather than write it.
+        if (count > 0
+            && o is JsArray { CanUseFastAccess: true } fast
+            && fast._dense is { } dense
+            && from + count <= dense.Length
+            && to + count <= dense.Length
+            && System.Array.IndexOf(dense, null, (int) from, (int) count) < 0)
+        {
+            System.Array.Copy(dense, (int) from, dense, (int) to, (int) count);
+            return o;
+        }
+
         long direction = 1;
 
         if (from < to && to < from + count)
@@ -361,6 +376,25 @@ public sealed partial class ArrayPrototype : ArrayInstance
         }
 
         var searchElement = arguments.At(0);
+
+        // Fast path: dense JsArray scan avoids the per-element HasProperty + Get virtual call pair,
+        // mirroring indexOf's lane. Indices at or beyond _dense are holes, so the scan starts at the
+        // last dense slot within the requested range and a null slot is skipped as a hole.
+        if (thisObject is JsArray { CanUseFastAccess: true } fast && fast._dense is { } dense)
+        {
+            var start = (int) System.Math.Min(k, dense.Length - 1);
+            for (var index = start; index >= 0; index--)
+            {
+                var v = dense[index];
+                if (v is not null && v == searchElement)
+                {
+                    return JsNumber.Create((uint) index);
+                }
+            }
+
+            return JsNumber.IntegerNegativeOne;
+        }
+
         var i = (ulong) k;
         for (; ; i--)
         {


### PR DESCRIPTION
Found by auditing which `ArrayPrototype` methods still lack the dense lane the file already uses elsewhere. Two commits — review them separately if easier.

## The gap

`ArrayPrototype` keeps a dense fast path in `filter`, `map`, `flat`, `flatMap`, `includes`, `indexOf`, `splice`, `unshift`, `shift` and `concat` — when the receiver is a `JsArray { CanUseFastAccess: true }` with a `_dense` backing store, work goes straight to that array instead of through the property protocol.

The four callback-free methods that move or scan elements were all missing it, despite being the best-suited candidates — no user callback, and an exact BCL equivalent each:

| method | was paying, per element | now |
|---|---|---|
| `reverse` | 2 × `HasProperty` + up to 2 × `Set`/`Delete` **per pair** | `Span.Reverse` |
| `fill` | a `Set` | `Span.Fill` |
| `copyWithin` | `HasProperty` + `Get` + `Set`/`Delete` | one `Array.Copy` |
| `lastIndexOf` | `HasProperty` + `Get` | backward scan over the store |

`copyWithin` is the nicest of the four: `Array.Copy` already behaves as if the source were staged in a temporary, which is exactly what the generic path's direction flip exists to handle, so the whole loop collapses.

Both index lanes are bounded by the array's length rather than the backing store's, since `_dense` carries spare capacity beyond the length.

## Hole semantics differ per method

- `reverse` and `copyWithin` take the lane **only for a hole-free range** — a hole makes the spec create/delete properties, which a swap or a bulk copy cannot express, so a single missing element falls through to the generic path.
- `fill` may keep holes inside the range, because filling makes every index present anyway.
- `lastIndexOf` skips null slots as holes, like `indexOf` already does.

(`undefined` is a present value, not a hole, and still qualifies.)

## A spec bug in the same method

While adding the `fill` lane, the surrounding code turned out to disagree with the spec. [Step 8.c](https://tc39.es/ecma262/#sec-array.prototype.fill) is `Set(O, Pk, value, true)`, but `fill` passed `throwOnError: false` and silently did nothing when a write could not succeed — while `reverse` immediately above it already passed `true`:

```js
var a = [1, 2, 3];
Object.freeze(a);
a.fill(0);   // before: returns [1,2,3] silently.  V8 and now Jint: TypeError
```

Fixed here since it is the same functionality being touched. Only the generic path can fail: a frozen or otherwise non-default-descriptor array does not have `CanUseFastAccess`, so the dense lane never hides the error.

Also: an inverted range (`fill(v, 2, 1)`) makes `final` land below `k`, which the loop treats as a no-op. The dense lane checks that before it becomes a span length — caught by the differential run below, not by reasoning.

## Deliberately not changed

The callback-taking methods (`every`, `some`, `find*`, `forEach`, `reduce*`) are left alone. Their per-element read already reaches the dense store through `JsArrayOperations.TryGetValue`, so a dedicated lane would save one virtual call per element while duplicating the hole and mutation handling — and the JS callback dominates each iteration by two orders of magnitude.

## Correctness

Every expectation was verified against V8 before being pinned — 28 cases for `reverse`/`fill`, 35 for `copyWithin`/`lastIndexOf` — covering overlap in both directions, no-op/empty/clamped/fractional ranges, holes in every position, sparse tails, a length shortened below the backing store, array-like receivers, identity of the returned object, and for `lastIndexOf` the strict-equality edges (`NaN` never matches, `+0` matches `-0`, no coercion) plus hole-versus-`undefined`.

`FillThrowsWhenAnElementCannotBeWritten` pins the corrected behaviour: frozen throws and is left untouched, a single non-writable element fails the whole fill, and sealed still succeeds because its elements stay writable — all matching V8.

Jint.Tests **4027**, Jint.Tests.PublicInterface 114, Jint.Tests.CommonScripts 28, Test262 **99441 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)