### PR TITLE
Hoist the separator decision out of Array.prototype.join's loop

### DIFF
--- a/Jint/Native/Array/ArrayPrototype.cs
+++ b/Jint/Native/Array/ArrayPrototype.cs
@@ -1822,6 +1822,14 @@ public sealed partial class ArrayPrototype : ArrayInstance
 
             using var sb = new ValueStringBuilder();
             sb.Append(s);
+
+            // Hoisted out of the loop: the separator is fixed for the whole join, so its emptiness was
+            // being re-decided with a string comparison once per element. A single-character separator
+            // — the default "," and by far the most common — then appends as a char, which keeps it in
+            // a register instead of re-loading the string's length and first character every element.
+            var separatorLength = sep.Length;
+            var singleCharSeparator = separatorLength == 1 ? sep[0] : '\0';
+
             for (uint k = 1; k < len; k++)
             {
                 if (k % ConstraintCheckInterval == 0)
@@ -1829,10 +1837,15 @@ public sealed partial class ArrayPrototype : ArrayInstance
                     _engine.Constraints.Check();
                 }
 
-                if (sep != "")
+                if (separatorLength == 1)
+                {
+                    sb.Append(singleCharSeparator);
+                }
+                else if (separatorLength != 0)
                 {
                     sb.Append(sep);
                 }
+
                 sb.Append(StringFromJsValue(o.Get(k)));
             }
 


### PR DESCRIPTION
Follow-up to #2779, where I said I would weigh `Array.prototype.join`. **The honest answer is that join is already close to its floor**, so this is a much smaller change than that suggested — and I removed the larger idea after measuring it.

## What I found

A join micro (min-of-4, 8M element-joins per case, warmed to tier-1 first) puts the current cost at roughly:

| case | ns/element |
|---|---|
| `strs.join('')` | ~4.7 |
| `strs.join(',')` | ~6 |
| `smallInts.join(',')` | ~8 |
| `bigInts.join(',')` | ~18 |

The `bigInts` gap is the per-element string allocation for integers above `TypeConverter`'s 1024-entry cache — inherent to producing the digits. I deliberately did **not** route that through `ValueStringBuilder.Append(int)` / `Append<T>`: those format with `provider: null` (current culture), whereas JS number→string must be invariant, and `TypeConverter.ToString` is the spec-correct path.

## What this change does

`join` re-decided `sep != ""` — a string comparison against a constant — once per element, though the separator is fixed for the whole join. The emptiness test now happens once, and a single-character separator (the default `,` and by far the most common) appends as a `char`, keeping it in a register instead of reloading the string's length and first character every element.

## What I removed again

I also tried a dense-array lane here, matching #2779. **It measured as contributing nothing** — `join('')` and `join('--')` did not move at all — because `JsArrayOperations.TryGetValue` already reaches the dense backing store. So it only added a hole-semantics argument to maintain for no gain, and it is gone.

## On the numbers

I am not claiming a figure. It looked like −8..11% on the single-character cases, but a later run of the same build moved `join('--')` — a code path this change does not touch, so an in-run control — by 15%. That means the harness cannot resolve a change of this size, and any number I quoted would be noise. The case for the change is simply that a loop-invariant comparison does not belong in the loop.

If you would rather not take an unmeasurable change, I am happy to close it.

## Correctness

Behaviour is unchanged, verified by a 27-case differential run against V8: separator lengths 0/1/2, the default and explicit `undefined`, `null`/`0`/object separators via `ToString`, holes and nullish elements rendering empty, element coercion (`-0`, `NaN`, `Infinity`, booleans, objects, nested arrays), a cyclic self-reference hitting the join stack, an array-like receiver, integers above the string cache, `toString` delegation, and that a side-effecting separator's `ToString` runs exactly once even for an empty array.

Jint.Tests **4027**, Jint.Tests.PublicInterface 114, Jint.Tests.CommonScripts 28, Test262 **99441 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)