### PR TITLE
Cut dromaeo-object-regexp allocations by 47% via string-concat and RegExp fixes

### DIFF
--- a/Jint.Benchmark/StringConcatLargeBenchmark.cs
+++ b/Jint.Benchmark/StringConcatLargeBenchmark.cs
@@ -9,6 +9,13 @@ namespace Jint.Benchmark;
 /// existing ConcatenatedString sweet spot and serve as the baseline; the large-chunk lanes append
 /// 4 KB pieces, concatenate two 64 KB strings, and scan the built result with charAt afterwards
 /// (the read pattern a lazy/rope representation would have to pay for).
+/// <para>
+/// The Chain* lanes cover multi-operand <c>a + b + c</c> expressions, which are evaluated as one
+/// flattened chain rather than a nested tree of pairwise additions. ChainSmallThree/ChainSmallSix
+/// guard the short-string case (nothing meaningful to save, so they must not get slower),
+/// ChainLargeThree shows the win when the skipped intermediate is large, and ChainNumericThree
+/// guards the numeric fast lanes that must survive on chains that never become strings.
+/// </para>
 /// </summary>
 [MemoryDiagnoser]
 [HideColumns("Error", "Gen0", "Gen1", "Gen2")]
@@ -19,6 +26,10 @@ public class StringConcatLargeBenchmark
     private Prepared<Script> _appendLargeChunks;
     private Prepared<Script> _concatLargePair;
     private Prepared<Script> _buildLargeThenScan;
+    private Prepared<Script> _chainSmallThree;
+    private Prepared<Script> _chainSmallSix;
+    private Prepared<Script> _chainLargeThree;
+    private Prepared<Script> _chainNumericThree;
 
     private const string SetupSource = """
         var chunk16 = 'abcdefghijklmnop';
@@ -86,10 +97,61 @@ public class StringConcatLargeBenchmark
             f();
             """);
 
+        // a + b + c over SMALL strings, no string literal among the operands. The dominant real-world
+        // chain shape, and the one most exposed to per-evaluation overhead in the flattened path:
+        // the saved intermediate is tiny here, so this lane is the guard against paying more than we
+        // save on short chains.
+        _chainSmallThree = Engine.PrepareScript("""
+            function f(a, b, c) { return a + b + c; }
+            function g() {
+                var n = 0;
+                for (var i = 0; i < 20000; i++) { n += f(chunk16, chunk16, chunk16).length; }
+                return n;
+            }
+            g();
+            """);
+
+        // six-operand chain: exercises the string[] path rather than the string.Concat overloads
+        _chainSmallSix = Engine.PrepareScript("""
+            function f(a, b, c, d, e, g) { return a + b + c + d + e + g; }
+            function h() {
+                var n = 0;
+                for (var i = 0; i < 20000; i++) { n += f(chunk16, chunk16, chunk16, chunk16, chunk16, chunk16).length; }
+                return n;
+            }
+            h();
+            """);
+
+        // a + b + c over 64 KB operands: the shape where the skipped intermediate dominates
+        _chainLargeThree = Engine.PrepareScript("""
+            function f(a, b, c) { return a + b + c; }
+            function g() {
+                var n = 0;
+                for (var i = 0; i < 64; i++) { n += f(chunk16, big64k, chunk16).length; }
+                return n;
+            }
+            g();
+            """);
+
+        // numeric 3-operand chain: must keep PlusBinaryExpression's unboxed numeric lanes
+        _chainNumericThree = Engine.PrepareScript("""
+            function f(a, b, c) { return a + b + c; }
+            function g() {
+                var n = 0;
+                for (var i = 0; i < 100000; i++) { n += f(i, i + 1, i + 2); }
+                return n;
+            }
+            g();
+            """);
+
         _engine.Evaluate(_appendSmallChunks);
         _engine.Evaluate(_appendLargeChunks);
         _engine.Evaluate(_concatLargePair);
         _engine.Evaluate(_buildLargeThenScan);
+        _engine.Evaluate(_chainSmallThree);
+        _engine.Evaluate(_chainSmallSix);
+        _engine.Evaluate(_chainLargeThree);
+        _engine.Evaluate(_chainNumericThree);
     }
 
     [Benchmark]
@@ -103,4 +165,16 @@ public class StringConcatLargeBenchmark
 
     [Benchmark]
     public JsValue BuildLargeThenScan() => _engine.Evaluate(_buildLargeThenScan);
+
+    [Benchmark]
+    public JsValue ChainSmallThree() => _engine.Evaluate(_chainSmallThree);
+
+    [Benchmark]
+    public JsValue ChainSmallSix() => _engine.Evaluate(_chainSmallSix);
+
+    [Benchmark]
+    public JsValue ChainLargeThree() => _engine.Evaluate(_chainLargeThree);
+
+    [Benchmark]
+    public JsValue ChainNumericThree() => _engine.Evaluate(_chainNumericThree);
 }

--- a/Jint/Native/RegExp/RegExpConstructor.cs
+++ b/Jint/Native/RegExp/RegExpConstructor.cs
@@ -19,13 +19,16 @@ public sealed partial class RegExpConstructor : Constructor
 
     // B.2.4 RegExp Legacy Static Properties
     internal string _legacyInput = "";
-    internal string _legacyLastMatch = "";
     internal string _legacyLastParen = "";
     internal readonly string[] _legacyParens = new string[9];
-    // Left/right context computed lazily to avoid Substring allocations per exec()
+    // Last match and left/right context are all computed lazily from the match position, so a
+    // successful exec() only stores the input and two offsets. Materializing them eagerly cost a
+    // Substring per exec() — for a match that spans most of a large subject that is a copy of the
+    // whole subject, paid whether or not anything ever reads these Annex B properties.
     private string _legacyContextInput = "";
     private int _legacyMatchIndex;
     private int _legacyMatchEnd;
+    internal string _legacyLastMatch => _legacyContextInput.Length > 0 ? _legacyContextInput.Substring(_legacyMatchIndex, _legacyMatchEnd - _legacyMatchIndex) : "";
     internal string _legacyLeftContext => _legacyContextInput.Length > 0 ? _legacyContextInput.Substring(0, _legacyMatchIndex) : "";
     internal string _legacyRightContext => _legacyContextInput.Length > 0 ? _legacyContextInput.Substring(_legacyMatchEnd) : "";
 

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -606,6 +606,16 @@ internal sealed partial class RegExpPrototype : Prototype
             {
                 int lastIndex = 0;
                 var matchCount = 0;
+
+#if NET8_0_OR_GREATER
+                // Kept in its own method: inlining it here grew RegExp.prototype.split enough to cost
+                // the capture-carrying path ~5% (measured), even though that path never enters it.
+                if (GetRegexGroupCount(R) == 1)
+                {
+                    return SplitWithoutCaptures(R, s, lim, ref builder);
+                }
+#endif
+
                 for (var match = R.Value.Match(s, 0); match.Success; match = match.NextMatch())
                 {
                     if (++matchCount % ConstraintCheckInterval == 0)
@@ -658,6 +668,48 @@ internal sealed partial class RegExpPrototype : Prototype
 
         return SplitSlow(s, splitter, unicodeMatching, lim);
     }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Splits on a pattern that has no capture groups, which makes the caller's group loop dead code
+    /// and leaves nothing in the scan needing a <see cref="Match"/> — only each match's index and
+    /// length. <see cref="Regex.EnumerateMatches(ReadOnlySpan{char})"/> hands those back as a struct,
+    /// so a split matching n times no longer allocates n (Match + Int32[] + Int32[][]) triples: .NET
+    /// reuses its cached runmatch only when a scan FAILS, so on the Match/NextMatch path every
+    /// successful match allocates a fresh one.
+    /// </summary>
+    private JsValue SplitWithoutCaptures(JsRegExp r, string s, long lim, ref JsValueListBuilder builder)
+    {
+        var lastIndex = 0;
+        var matchCount = 0;
+
+        foreach (var match in r.Value.EnumerateMatches(s))
+        {
+            if (++matchCount % ConstraintCheckInterval == 0)
+            {
+                _engine.Constraints.Check();
+            }
+
+            if (match.Length == 0 && (match.Index == 0 || match.Index == s.Length || match.Index == lastIndex))
+            {
+                continue;
+            }
+
+            builder.Add(s.Substring(lastIndex, match.Index - lastIndex));
+
+            if (builder.Length >= lim)
+            {
+                return _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+            }
+
+            lastIndex = match.Index + match.Length;
+        }
+
+        // Add the last part of the split
+        builder.Add(s.Substring(lastIndex));
+        return _realm.Intrinsics.Array.ConstructFromBuilder(ref builder);
+    }
+#endif
 
     private JsArray SplitSlow(string s, ObjectInstance splitter, bool unicodeMatching, long lim)
     {
@@ -1615,6 +1667,17 @@ internal sealed partial class RegExpPrototype : Prototype
     {
 #pragma warning disable CS0618 // Type or member is obsolete
         return rei.UsesDotNetEngine ? rei.ParseResult.ActualRegexGroupCount : match.Groups.Count;
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+
+    /// <summary>
+    /// The group count of a .NET-engine regex, without needing a <see cref="Match"/> to ask. A result
+    /// of 1 means group 0 (the whole match) only, i.e. the pattern has no capture groups.
+    /// </summary>
+    private static int GetRegexGroupCount(JsRegExp rei)
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        return rei.ParseResult.ActualRegexGroupCount;
 #pragma warning restore CS0618 // Type or member is obsolete
     }
 

--- a/Jint/Native/RegExp/RegExpPrototype.cs
+++ b/Jint/Native/RegExp/RegExpPrototype.cs
@@ -1411,7 +1411,7 @@ internal sealed partial class RegExpPrototype : Prototype
     {
         var constructor = engine.Realm.Intrinsics.RegExp;
         constructor._legacyInput = s;
-        constructor._legacyLastMatch = result.Value;
+        // lastMatch/leftContext/rightContext are all derived from this position on read.
         constructor.SetLegacyContext(s, result.Index, result.Length);
 
         var groups = result.Groups;
@@ -1421,8 +1421,9 @@ internal sealed partial class RegExpPrototype : Prototype
             var groupIndex = i + 1;
             if (groups is not null && groupIndex < actualGroupCount && groups[groupIndex].Success)
             {
-                constructor._legacyParens[i] = groups[groupIndex].Value;
-                lastParen = groups[groupIndex].Value;
+                var groupValue = groups[groupIndex].Value;
+                constructor._legacyParens[i] = groupValue;
+                lastParen = groupValue;
             }
             else
             {
@@ -1479,7 +1480,10 @@ internal sealed partial class RegExpPrototype : Prototype
             var capturedValue = Undefined;
             if (capture?.Success == true)
             {
-                capturedValue = capture.Value;
+                // Capture.Value would copy the captured span out of the subject. CreateSliced lets
+                // its retention policy decide: a capture covering most of a large subject becomes a
+                // zero-copy view, while short captures still copy so they cannot pin the subject.
+                capturedValue = JsString.CreateSliced(s, capture.Index, capture.Length);
             }
 
             if (hasIndices)
@@ -1527,7 +1531,7 @@ internal sealed partial class RegExpPrototype : Prototype
     {
         var constructor = engine.Realm.Intrinsics.RegExp;
         constructor._legacyInput = s;
-        constructor._legacyLastMatch = match.Value;
+        // lastMatch/leftContext/rightContext are all derived from this position on read.
         constructor.SetLegacyContext(s, match.Index, match.Length);
 
         // Update $1-$9
@@ -1537,8 +1541,10 @@ internal sealed partial class RegExpPrototype : Prototype
             var groupIndex = i + 1;
             if (groupIndex < actualGroupCount && match.Groups[groupIndex].Success)
             {
-                constructor._legacyParens[i] = match.Groups[groupIndex].Value;
-                lastParen = match.Groups[groupIndex].Value;
+                // Capture.Value builds a fresh string on every read, so take it once.
+                var groupValue = match.Groups[groupIndex].Value;
+                constructor._legacyParens[i] = groupValue;
+                lastParen = groupValue;
             }
             else
             {

--- a/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintBinaryExpression.cs
@@ -819,7 +819,7 @@ internal abstract class JintBinaryExpression : JintExpression
                 result = new GreaterBinaryExpression(expression);
                 break;
             case Operator.Addition:
-                if (TryBuildStringConcatenation(expression, out var concatExpr))
+                if (TryBuildAdditionChain(expression, out var concatExpr))
                 {
                     return concatExpr;
                 }
@@ -992,10 +992,11 @@ internal abstract class JintBinaryExpression : JintExpression
     };
 
     /// <summary>
-    /// Detects left-recursive chains of '+' operations that include at least one string literal,
-    /// and flattens them into a single StringConcatenationExpression to avoid intermediate allocations.
+    /// Detects left-recursive chains of '+' operations and flattens them into a single
+    /// <see cref="AdditionChainExpression"/>, so a string-producing chain allocates its result once
+    /// instead of materializing one intermediate string per '+'.
     /// </summary>
-    private static bool TryBuildStringConcatenation(
+    private static bool TryBuildAdditionChain(
         NonLogicalBinaryExpression expression,
         [NotNullWhen(true)] out JintExpression? result)
     {
@@ -1011,18 +1012,30 @@ internal abstract class JintBinaryExpression : JintExpression
         var operands = new List<Expression>();
         CollectAdditionOperands(expression, operands);
 
-        // Must have a string literal in the first two operands to guarantee string concatenation semantics
-        // from the very first operation. A string literal at index 2+ is not enough because earlier operands
-        // could be numerically added (e.g., 2.0 + 3.0 + 'm' should yield '5m', not '23m').
-        // The early return above guarantees at least 3 operands, so operands[0] and operands[1] are always valid.
-        if (operands.Count < 2 || (operands[0] is not Literal { Value: string } && operands[1] is not Literal { Value: string }))
+        // The early return above guarantees at least 3 operands.
+        if (operands.Count < 3)
         {
             return false;
         }
 
-        result = new StringConcatenationExpression(expression, operands.ToArray());
+        // A chain whose opening pair is statically numeric can never become a string concatenation,
+        // so leave it on PlusBinaryExpression and keep that node's unboxed numeric lanes
+        // (BoxedNumericOperandLane / AreIntegerOperands) which the flattened form does not have.
+        if (IsStaticallyNumeric(operands[0]) && IsStaticallyNumeric(operands[1]))
+        {
+            return false;
+        }
+
+        result = new AdditionChainExpression(expression, operands.ToArray());
         return true;
     }
+
+    /// <summary>
+    /// True when an operand is a literal that is certainly a number, so no ToPrimitive call and no
+    /// string outcome is possible from it.
+    /// </summary>
+    private static bool IsStaticallyNumeric(Expression expression)
+        => expression is NumericLiteral;
 
     private static void CollectAdditionOperands(Expression expression, List<Expression> operands)
     {
@@ -1418,7 +1431,12 @@ internal abstract class JintBinaryExpression : JintExpression
         }
     }
 
-    private sealed class PlusBinaryExpression : JintBinaryExpression
+    /// <summary>
+    /// A single <c>+</c>. Not sealed so <see cref="AdditionChainExpression"/> can derive from it and
+    /// reach the pairwise behaviour — including the unboxed numeric lanes, which are built per operand
+    /// pair and so have no flattened equivalent — through a non-virtual <c>base</c> call.
+    /// </summary>
+    private class PlusBinaryExpression : JintBinaryExpression
     {
         private readonly BoxedNumericOperandLane? _numericLane;
 
@@ -1457,36 +1475,77 @@ internal abstract class JintBinaryExpression : JintExpression
 
             var lprim = TypeConverter.ToPrimitive(left);
             var rprim = TypeConverter.ToPrimitive(right);
-            JsValue result;
-            if (lprim.IsString() || rprim.IsString())
-            {
-                result = JsString.Create(TypeConverter.ToString(lprim) + TypeConverter.ToString(rprim));
-            }
-            else if (AreNonBigIntOperands(left, right))
-            {
-                result = JsNumber.Create(TypeConverter.ToNumber(lprim) + TypeConverter.ToNumber(rprim));
-            }
-            else
-            {
-                AssertValidBigIntArithmeticOperands(lprim, rprim);
-                result = JsBigInt.Create(TypeConverter.ToBigInt(lprim) + TypeConverter.ToBigInt(rprim));
-            }
 
-            return result;
+            return ApplyAdditionToPrimitives(lprim, rprim);
         }
     }
 
     /// <summary>
-    /// Optimized expression for chains of string concatenation (e.g., a + b + c + d).
-    /// Evaluates all operands and concatenates in a single pass using a ValueStringBuilder,
-    /// avoiding intermediate JsString allocations.
+    /// The primitive half of ApplyStringOrNumericBinaryOperator for '+': both operands have already
+    /// been through ToPrimitive. Shared by <see cref="PlusBinaryExpression"/> and the pairwise fold
+    /// in <see cref="AdditionChainExpression"/> so the two stay in lockstep.
     /// </summary>
-    private sealed class StringConcatenationExpression : JintExpression
+    /// <remarks>
+    /// The BigInt test reads the primitives rather than the pre-ToPrimitive operands, matching the
+    /// spec (ApplyStringOrNumericBinaryOperator classifies after ToPrimitive). The only difference
+    /// this makes is which TypeError message a BigInt-wrapper-plus-non-BigInt raises; both spellings
+    /// throw TypeError, as required.
+    /// </remarks>
+    internal static JsValue ApplyAdditionToPrimitives(JsValue lprim, JsValue rprim)
     {
+        if (lprim.IsString() || rprim.IsString())
+        {
+            return JsString.Create(TypeConverter.ToString(lprim) + TypeConverter.ToString(rprim));
+        }
+
+        if (AreNonBigIntOperands(lprim, rprim))
+        {
+            return JsNumber.Create(TypeConverter.ToNumber(lprim) + TypeConverter.ToNumber(rprim));
+        }
+
+        AssertValidBigIntArithmeticOperands(lprim, rprim);
+        return JsBigInt.Create(TypeConverter.ToBigInt(lprim) + TypeConverter.ToBigInt(rprim));
+    }
+
+    /// <summary>
+    /// A left-recursive chain of '+' operations (<c>a + b + c [+ d ...]</c>) flattened into one node.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Left-associativity means that once the first operation yields a string, every later '+' in the
+    /// chain is also a string concatenation. So the chain's kind can be decided once, from the first
+    /// two primitives: if either is a string the whole chain is concatenated in a single pass and the
+    /// result is allocated exactly once. The nested <see cref="PlusBinaryExpression"/> form instead
+    /// materializes one intermediate string per '+' — for a 3-operand chain of large strings that is
+    /// about twice the result's bytes (measured 250 KB per concat against a 125 KB result).
+    /// </para>
+    /// <para>
+    /// Evaluation order matches ApplyStringOrNumericBinaryOperator exactly: evaluate operand 0,
+    /// evaluate operand 1, ToPrimitive 0, ToPrimitive 1, then evaluate-and-ToPrimitive each remaining
+    /// operand in turn. Interleaving matters because ToPrimitive on an object runs user code
+    /// (<c>valueOf</c>/<c>toString</c>/<c>@@toPrimitive</c>), so the relative order of those calls and
+    /// the operand evaluations is observable.
+    /// </para>
+    /// </remarks>
+    private sealed class AdditionChainExpression : PlusBinaryExpression
+    {
+        /// <summary>
+        /// What the opening pair of this chain produced last time it ran. Purely a performance hint:
+        /// both paths compute the same result, so a benign race on this field (handler trees are
+        /// shared between engines) can only cost a mispredicted path, never correctness.
+        /// </summary>
+        private enum ChainKind : byte
+        {
+            Unknown = 0,
+            String,
+            NotString,
+        }
+
         private readonly Expression[] _operandExpressions;
         private JintExpression[]? _operands;
+        private ChainKind _kind;
 
-        public StringConcatenationExpression(Expression expression, Expression[] operandExpressions)
+        public AdditionChainExpression(NonLogicalBinaryExpression expression, Expression[] operandExpressions)
             : base(expression)
         {
             _operandExpressions = operandExpressions;
@@ -1499,64 +1558,232 @@ internal abstract class JintBinaryExpression : JintExpression
                 return;
             }
 
-            _operands = new JintExpression[_operandExpressions.Length];
+            var operands = new JintExpression[_operandExpressions.Length];
             for (var i = 0; i < _operandExpressions.Length; i++)
             {
-                _operands[i] = Build(_operandExpressions[i]);
+                operands[i] = Build(_operandExpressions[i]);
             }
+
+            _operands = operands;
         }
 
         protected override object EvaluateInternal(EvaluationContext context)
         {
             EnsureInitialized();
 
+            // A chain that did not produce a string last time gains nothing from flattening, and
+            // CLR operator overloading hooks the pre-ToPrimitive operand pair of each individual '+',
+            // which the flattened form never forms. Both defer to the nested tree. The overloading
+            // test has to happen at runtime: a Prepared script can be shared between engines that
+            // differ on the option. Nothing has been evaluated yet here, so handing the whole chain
+            // over is side-effect free.
+            if (_kind == ChainKind.NotString || context.OperatorOverloadingAllowed)
+            {
+                return base.EvaluateInternal(context);
+            }
+
             var operands = _operands!;
             var count = operands.Length;
+            var engine = context.Engine;
+            var suspendable = engine.ExecutionContext.Suspendable;
 
-            // Fast path for small chains — use string.Concat overloads
+            // IsSuspended() is `Suspendable?.IsSuspended == true`, so with no suspendable execution
+            // context in scope no operand can suspend and none of the resume bookkeeping below is
+            // reachable. That is the overwhelmingly common case, and it gets to keep its operands in
+            // locals instead of a buffer.
+            if (suspendable is null)
+            {
+                return EvaluateWithoutSuspension(context, operands, count);
+            }
+
+            JsValue[] buffer;
+            int nextEvaluate;
+            int nextPrimitive;
+            if (suspendable is { IsResuming: true }
+                && suspendable.Data.TryGet(this, out AdditionChainSuspendData? suspendData))
+            {
+                buffer = suspendData!.Buffer;
+                nextEvaluate = suspendData.NextEvaluate;
+                nextPrimitive = suspendData.NextPrimitive;
+            }
+            else
+            {
+                buffer = engine._jsValueArrayPool.RentArray(count);
+                nextEvaluate = 0;
+                nextPrimitive = 0;
+            }
+
+            var suspended = false;
+            try
+            {
+                // The opening pair is evaluated before either is coerced; from then on each operand is
+                // coerced before the next one is evaluated.
+                while (nextPrimitive < count)
+                {
+                    var target = System.Math.Min(nextPrimitive == 0 ? 2 : nextPrimitive + 1, count);
+
+                    while (nextEvaluate < target)
+                    {
+                        buffer[nextEvaluate] = operands[nextEvaluate].GetValue(context);
+                        if (context.IsSuspended())
+                        {
+                            suspended = true;
+                            Suspend(suspendable, buffer, nextEvaluate, nextPrimitive);
+                            return JsValue.Undefined;
+                        }
+
+                        nextEvaluate++;
+                    }
+
+                    while (nextPrimitive < target)
+                    {
+                        buffer[nextPrimitive] = TypeConverter.ToPrimitive(buffer[nextPrimitive]);
+                        if (context.IsSuspended())
+                        {
+                            suspended = true;
+                            Suspend(suspendable, buffer, nextEvaluate, nextPrimitive);
+                            return JsValue.Undefined;
+                        }
+
+                        nextPrimitive++;
+                    }
+                }
+
+                if (buffer[0].IsString() || buffer[1].IsString())
+                {
+                    _kind = ChainKind.String;
+                    return JsString.Create(ConcatAll(buffer, count));
+                }
+
+                // Not a string chain: fold pairwise, exactly as the nested tree would. Each step's
+                // accumulator is already a primitive, so it needs no further ToPrimitive. Later
+                // evaluations skip straight to the nested tree.
+                _kind = ChainKind.NotString;
+                var accumulator = ApplyAdditionToPrimitives(buffer[0], buffer[1]);
+                for (var i = 2; i < count; i++)
+                {
+                    accumulator = ApplyAdditionToPrimitives(accumulator, buffer[i]);
+                }
+
+                return accumulator;
+            }
+            finally
+            {
+                if (!suspended)
+                {
+                    // Kept alive in suspend data when suspended; released on both normal completion
+                    // and an exception thrown out of an operand.
+                    suspendable?.Data.Clear(this);
+                    engine._jsValueArrayPool.ReturnArray(buffer);
+                }
+            }
+
+            void Suspend(ISuspendable? target, JsValue[] pending, int evaluateCursor, int primitiveCursor)
+            {
+                if (target is null)
+                {
+                    return;
+                }
+
+                var data = target.Data.GetOrCreate<AdditionChainSuspendData>(this);
+                data.Buffer = pending;
+                data.NextEvaluate = evaluateCursor;
+                data.NextPrimitive = primitiveCursor;
+            }
+        }
+
+        /// <summary>
+        /// The no-suspension path: operands live in locals, so a 3- or 4-operand chain — nearly all of
+        /// them — touches no buffer at all, and a chain that folds numerically allocates nothing
+        /// beyond its result.
+        /// </summary>
+        private object EvaluateWithoutSuspension(EvaluationContext context, JintExpression[] operands, int count)
+        {
+            // Opening pair: both evaluated before either is coerced.
+            var raw0 = operands[0].GetValue(context);
+            var raw1 = operands[1].GetValue(context);
+            var p0 = TypeConverter.ToPrimitive(raw0);
+            var p1 = TypeConverter.ToPrimitive(raw1);
+
+            if (!p0.IsString() && !p1.IsString())
+            {
+                _kind = ChainKind.NotString;
+                var accumulator = ApplyAdditionToPrimitives(p0, p1);
+                for (var i = 2; i < count; i++)
+                {
+                    accumulator = ApplyAdditionToPrimitives(accumulator, TypeConverter.ToPrimitive(operands[i].GetValue(context)));
+                }
+
+                return accumulator;
+            }
+
+            _kind = ChainKind.String;
+            var s0 = TypeConverter.ToString(p0);
+            var s1 = TypeConverter.ToString(p1);
+
             if (count == 3)
             {
-                var v0 = operands[0].GetValue(context);
-                if (context.IsSuspended()) return JsValue.Undefined;
-                var v1 = operands[1].GetValue(context);
-                if (context.IsSuspended()) return JsValue.Undefined;
-                var v2 = operands[2].GetValue(context);
-                if (context.IsSuspended()) return JsValue.Undefined;
-
-                return JsString.Create(string.Concat(
-                    TypeConverter.ToString(TypeConverter.ToPrimitive(v0)),
-                    TypeConverter.ToString(TypeConverter.ToPrimitive(v1)),
-                    TypeConverter.ToString(TypeConverter.ToPrimitive(v2))));
+                var s2 = NextOperandAsString(context, operands[2]);
+                return JsString.Create(string.Concat(s0, s1, s2));
             }
 
             if (count == 4)
             {
-                var v0 = operands[0].GetValue(context);
-                if (context.IsSuspended()) return JsValue.Undefined;
-                var v1 = operands[1].GetValue(context);
-                if (context.IsSuspended()) return JsValue.Undefined;
-                var v2 = operands[2].GetValue(context);
-                if (context.IsSuspended()) return JsValue.Undefined;
-                var v3 = operands[3].GetValue(context);
-                if (context.IsSuspended()) return JsValue.Undefined;
-
-                return JsString.Create(string.Concat(
-                    TypeConverter.ToString(TypeConverter.ToPrimitive(v0)),
-                    TypeConverter.ToString(TypeConverter.ToPrimitive(v1)),
-                    TypeConverter.ToString(TypeConverter.ToPrimitive(v2)),
-                    TypeConverter.ToString(TypeConverter.ToPrimitive(v3))));
+                var s2 = NextOperandAsString(context, operands[2]);
+                var s3 = NextOperandAsString(context, operands[3]);
+                return JsString.Create(string.Concat(s0, s1, s2, s3));
             }
 
-            // General path for 5+ operands
             var strings = new string[count];
-            for (var i = 0; i < count; i++)
+            strings[0] = s0;
+            strings[1] = s1;
+            for (var i = 2; i < count; i++)
             {
-                var val = operands[i].GetValue(context);
-                if (context.IsSuspended()) return JsValue.Undefined;
-                strings[i] = TypeConverter.ToString(TypeConverter.ToPrimitive(val));
+                strings[i] = NextOperandAsString(context, operands[i]);
             }
 
             return JsString.Create(string.Concat(strings));
+        }
+
+        /// <summary>
+        /// Evaluates one trailing operand and coerces it, in that order — past the opening pair each
+        /// operand is coerced before the next one is evaluated.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string NextOperandAsString(EvaluationContext context, JintExpression operand)
+            => TypeConverter.ToString(TypeConverter.ToPrimitive(operand.GetValue(context)));
+
+        /// <summary>
+        /// Joins every operand's string form with a single allocation for the result. The 3- and
+        /// 4-operand overloads avoid the intermediate <see cref="string"/>[] that the general
+        /// <see cref="string.Concat(string[])"/> path needs.
+        /// </summary>
+        private static string ConcatAll(JsValue[] buffer, int count)
+        {
+            if (count == 3)
+            {
+                return string.Concat(
+                    TypeConverter.ToString(buffer[0]),
+                    TypeConverter.ToString(buffer[1]),
+                    TypeConverter.ToString(buffer[2]));
+            }
+
+            if (count == 4)
+            {
+                return string.Concat(
+                    TypeConverter.ToString(buffer[0]),
+                    TypeConverter.ToString(buffer[1]),
+                    TypeConverter.ToString(buffer[2]),
+                    TypeConverter.ToString(buffer[3]));
+            }
+
+            var strings = new string[count];
+            for (var i = 0; i < count; i++)
+            {
+                strings[i] = TypeConverter.ToString(buffer[i]);
+            }
+
+            return string.Concat(strings);
         }
     }
 

--- a/Jint/Runtime/SuspendData.cs
+++ b/Jint/Runtime/SuspendData.cs
@@ -163,6 +163,24 @@ internal sealed class ExpressionBufferSuspendData : SuspendData
 }
 
 /// <summary>
+/// Stores the in-progress operand buffer of a flattened <c>+</c> chain together with the two
+/// cursors that reproduce ApplyStringOrNumericBinaryOperator's evaluate/ToPrimitive interleaving.
+/// Reused on resume so a suspension inside any operand (e.g. <c>a + await x + b</c>) neither
+/// re-evaluates nor re-coerces the operands that already ran — either of which may have
+/// observable side effects.
+/// </summary>
+internal sealed class AdditionChainSuspendData : SuspendData
+{
+    public JsValue[] Buffer { get; set; } = [];
+
+    /// <summary>Index of the next operand to evaluate.</summary>
+    public int NextEvaluate { get; set; }
+
+    /// <summary>Index of the next buffered operand to convert with ToPrimitive.</summary>
+    public int NextPrimitive { get; set; }
+}
+
+/// <summary>
 /// Stores the partial target list and next expression index for an argument
 /// list that contains spread elements (call/new/array-literal). Without
 /// preservation, one-shot iterators (e.g. generators) would be re-iterated


### PR DESCRIPTION
Cuts `dromaeo-object-regexp` from **152.6 to 80.3 MB allocated per iteration (-47%)** and its runtime by **12.6-23.7%**, via three independent allocation fixes. Two of them also apply well outside this benchmark.

Each change was gated separately against the same base commit; measurements are paired runs (baseline, then branch, back to back) on an idle machine with the default BenchmarkDotNet job.

## 1. Flatten multi-operand `+` chains and decide their kind at runtime

`a + b + c` was flattened into a single concatenation only when a string literal appeared in the first two operands. Without one — `randomChar() + str + randomChar()` — it fell back to a nested tree of pairwise `PlusBinaryExpression`, which materializes the intermediate string and then immediately discards it. A 3-operand chain over 65 KB operands allocated 250 KB per concat against a 125 KB result, exactly 2x.

The literal was only ever needed to prove the chain produces a string, and that can be decided at runtime instead: left-associativity means once the first operation yields a string, every later `+` in the chain is a concatenation too. `AdditionChainExpression` derives from `PlusBinaryExpression`, so a chain that turns out *not* to produce strings gets a non-virtual `base` call back to the exact pairwise behaviour — including the unboxed numeric lanes, which are built per operand pair and have no flattened equivalent. A one-shot kind latch means such a chain pays the flattened path only on its first evaluation.

| lane | before | after | time | alloc |
|---|---:|---:|---:|---:|
| ChainSmallThree | 6201.63 us | 5342.04 us | **-13.9%** | -44.1% |
| ChainSmallSix | 8695.77 us | 6710.06 us | **-22.8%** | -60.5% |
| ChainLargeThree | 6335.76 us | 2977.44 us | **-53.0%** | -50.0% |
| ChainNumericThree | 29014 us | 29430 us | +1.4% (noise) | 0 |
| ConcatLargePair | 2410.04 us | 2415.50 us | +0.2% | 0 |

Those `Chain*` lanes are new — no existing lane covered a 3+ operand chain.

Two behaviours are corrected along the way:

- **Evaluation order now matches ApplyStringOrNumericBinaryOperator.** The previous flattened path evaluated every operand before calling `ToPrimitive` on any, which is observable through `valueOf` side effects: `"x" + a + b` ran `eval:a, eval:b, prim:a, prim:b` instead of `eval:a, prim:a, eval:b, prim:b`. Getting this right is a precondition for admitting arbitrary operands to the fast path rather than just literals.
- **The flattened path is now resumable.** Suspending inside an operand (`a + await x + b`) previously re-ran the earlier operands on resume; progress is now kept in `AdditionChainSuspendData`, following the `ExpressionBufferSuspendData` pattern already used for argument lists and array literals.

CLR operator overloading hooks the pre-`ToPrimitive` operand pair of each individual `+`, which the flattened form never forms, so it defers to the base. That test is made at runtime because a `Prepared` script can be shared between engines that disagree on the option.

The BigInt classification now reads the primitives rather than the pre-`ToPrimitive` operands, matching the spec. The only observable difference is which `TypeError` message a BigInt-wrapper-plus-non-BigInt raises; both spellings throw `TypeError`, as required.

## 2. Derive `RegExp.lastMatch` from the match position instead of copying it

Every successful `exec()` through the .NET engine materialized the matched text **twice**: once as group 0's value for the result array, and once more for the Annex B `RegExp.lastMatch` static. `Capture.Value` builds a fresh string on each read, so a match spanning most of a large subject copied that subject twice per call — whether or not anything ever read the legacy statics.

`lastMatch` now works the way `leftContext` and `rightContext` already did: computed on read from the input and offsets that `SetLegacyContext` was storing anyway on the very next line. Updating the statics after a match is now just field stores, on both the .NET and custom-engine paths. Group 0 goes through `JsString.CreateSliced` rather than `Capture.Value`, letting the existing retention policy decide — a capture covering most of a large subject becomes a zero-copy view, while short captures still copy so they cannot pin the subject.

| lane | before | after | alloc |
|---|---:|---:|---:|
| NamedGroupsAccess | 288.0 us | 275.5 us | -5.2% |
| StickyExec | 974.2 us | 917.6 us | -4.0% |
| ExecWhileLoop | 263.4 us | 264.5 us | -5.5% |
| MatchAllIterate | 275.7 us | 272.0 us | -5.1% |

On `dromaeo-object-regexp` this alone is -5.1% to -10.3% across all four Modern/Prepared combinations.

## 3. Scan capture-free RegExp splits without allocating a `Match` per match

`RegExp.prototype.split` walked its subject with `Match`/`NextMatch()`. .NET only reuses its cached runmatch when a scan *fails*, so every successful match handed back a freshly allocated `Match` plus the `Int32[]` and `Int32[][]` backing its group data. Splitting a 64 KB subject on a single character allocated thousands of those triples for information the loop mostly ignores.

When the pattern has no capture groups the loop needs nothing but each match's index and length — the group loop below it is already dead code in that case. `Regex.EnumerateMatches` hands both back as a struct. Patterns that do carry captures keep the existing path.

| lane | before | after | time | alloc |
|---|---:|---:|---:|---:|
| Split | 1.560 / 1.516 / 1.577 ms | 1.068 / 1.043 / 1.037 ms | **-31% to -34%** | 5.55 -> 1.59 MB (**-71%**) |
| SplitWithCaptures | unchanged | | +2.1% / -11.7% / -2.7% across pairs | 0 |
| SplitUnicode | unchanged | | | 0 |

`EnumerateMatches` is .NET 7+, so the fast path is guarded for net8.0 and later; older targets keep the `Match`/`NextMatch` loop. The scan lives in its own method rather than inline: folding it into `RegExp.prototype.split` grew that method enough to measurably cost the capture-carrying path, even though that path never enters the new branch.

## Combined effect on dromaeo-object-regexp

| Modern | Prepared | before | after | mean | alloc | Gen2 |
|---|---|---:|---:|---:|---:|---:|
| False | False | 77.94 ms | 59.45 ms | **-23.7%** | -46.2% | -54% |
| False | True | 71.31 ms | 60.32 ms | **-15.4%** | -46.9% | -56% |
| True | False | 69.07 ms | 60.35 ms | **-12.6%** | -46.3% | -55% |
| True | True | 68.26 ms | 56.39 ms | **-17.4%** | -47.9% | -64% |

Deltas of 8.7-18.5 ms against 1.6-5.9 ms StdDev. `dromaeo-object-string` is unchanged.

## Testing

Green on every change individually and on the combined result:

- `Jint.Tests` — 4027 passed, 0 failed
- `Jint.Tests.Test262` — **99441 passed, 0 failed**
- `Jint.Tests.PublicInterface` — 114 passed, 0 failed
- `Jint.Tests.CommonScripts` — 28 passed, 0 failed

## Notes

The run-to-run variance on `DromaeoBenchmark.ObjectRegExp` is **not** fixed by this, and is not caused by allocation. Cutting allocation 47% and Gen2 55% left relative StdDev unchanged, and separately forcing byte-identical input (a fixed-seed `Math.random`, tested locally only) moved StdDev only from 3.75 to 3.14 ms. The residual ~4-5% appears intrinsic to an op that churns tens of MB of 65 KB strings on the LOH.

Unrelated pre-existing issue noticed while working here, deliberately **not** changed: the empty-regexp fast path in `RegExpBuiltinExec` returns before the Annex B legacy-statics update, so `"abc".match(/(?:)/)` leaves the previous match's `lastMatch`/`leftContext`/`rightContext` in place. Behaviour is identical before and after this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAaVpFDe6MajFkeNp91uHR
