### PR TITLE
Stop the shared static member accessor cache from pinning engines

### DIFF
--- a/Jint.Tests/Runtime/GarbageCollectionTests.cs
+++ b/Jint.Tests/Runtime/GarbageCollectionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using Acornima.Ast;
+using Jint.Runtime.Interop;
 
 namespace Jint.Tests.Runtime;
 
@@ -161,6 +162,46 @@ public class GarbageCollectionTests
             var engine = new Engine();
             engine.Execute(prepared);
             return new WeakReference(engine);
+        }
+    }
+
+    [Fact]
+    public void NestedTypeAccessDoesNotRetainEngines()
+    {
+        // Regression test: the accessors backing static member access on a type reference live in a cache
+        // shared by the whole process and keyed only by (declaring type, member name). A nested type
+        // resolves to an accessor that holds a type reference — an object owned by the engine that created
+        // it — so caching that accessor kept the engine, its realm and all of its intrinsics reachable for
+        // the lifetime of the process. Only the engine that first resolved the member was pinned, so a
+        // single engine is enough to observe it: with the leak in place this one is never collected.
+
+        var reference = RunOnceAndForget();
+
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+
+        reference.IsAlive.Should().BeFalse("the engine is still pinned by the shared static member accessor cache.");
+
+        // NoInlining so the engine reference cannot be stack-rooted in this frame across the GC.Collect calls.
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static WeakReference RunOnceAndForget()
+        {
+            var engine = new Engine();
+            engine.SetValue("Holder", TypeReference.CreateTypeReference<NestedTypeLeakHolder>(engine));
+            engine.Evaluate("Holder.Inner");
+            return new WeakReference(engine);
+        }
+    }
+
+    /// <summary>
+    /// Only ever used by <see cref="NestedTypeAccessDoesNotRetainEngines"/>: the accessor cache is
+    /// process-wide, so a type another test also resolves would let that test's engine take the blame.
+    /// </summary>
+    private sealed class NestedTypeLeakHolder
+    {
+        public sealed class Inner
+        {
         }
     }
 

--- a/Jint.Tests/Runtime/InteropStaticMemberCacheTests.cs
+++ b/Jint.Tests/Runtime/InteropStaticMemberCacheTests.cs
@@ -1,0 +1,84 @@
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The accessors backing static member access on a type reference live in a cache shared by the whole
+/// process and keyed only by (declaring type, member name). Entries must therefore capture nothing that
+/// belongs to a single engine. A nested type is the exception: it resolves to an accessor holding a
+/// <see cref="TypeReference"/>, which is an object owned by the engine that created it.
+/// </summary>
+public class InteropStaticMemberCacheTests
+{
+    [Fact]
+    public void NestedTypeIsResolvedPerEngine()
+    {
+        var first = new Engine();
+        first.SetValue("Holder", TypeReference.CreateTypeReference<CrossEngineHolder>(first));
+        var firstInner = first.Evaluate("Holder.Inner").Should().BeOfType<TypeReference>().Which;
+
+        var second = new Engine();
+        second.SetValue("Holder", TypeReference.CreateTypeReference<CrossEngineHolder>(second));
+        var secondInner = second.Evaluate("Holder.Inner").Should().BeOfType<TypeReference>().Which;
+
+        ReferenceEquals(firstInner, secondInner).Should().BeFalse(
+            "an object created by one engine must never be handed to another one.");
+
+        firstInner.Engine.Should().BeSameAs(first);
+        secondInner.Engine.Should().BeSameAs(second);
+
+        firstInner.ReferenceType.Should().Be<CrossEngineHolder.Inner>();
+        secondInner.ReferenceType.Should().Be<CrossEngineHolder.Inner>();
+    }
+
+    [Fact]
+    public void OrdinaryStaticMemberResolutionIsStillCached()
+    {
+        // The cache is keyed by (type, member name) alone, so an engine that finds an entry never runs its
+        // own resolution. A second engine performing no member name lookups at all is therefore proof that
+        // the entry the first one produced was reused, and that excluding nested types did not quietly turn
+        // the cache off for everything else.
+
+        var firstLookups = 0;
+        var secondLookups = 0;
+
+        ReadStaticMember(() => firstLookups++).Should().Be(42);
+        ReadStaticMember(() => secondLookups++).Should().Be(42);
+
+        firstLookups.Should().BeGreaterThan(0, "the first engine has to resolve the member itself.");
+        secondLookups.Should().Be(0, "the second engine must be served from the shared accessor cache.");
+
+        static double ReadStaticMember(Action onLookup)
+        {
+            var resolver = new TypeResolver
+            {
+                MemberNameCreator = member =>
+                {
+                    onLookup();
+                    return new[] { member.Name };
+                }
+            };
+
+            var engine = new Engine(options => options.SetTypeResolver(resolver));
+            engine.SetValue("Holder", TypeReference.CreateTypeReference<CachedMemberHolder>(engine));
+            return engine.Evaluate("Holder.Value").AsNumber();
+        }
+    }
+
+    /// <summary>
+    /// Only used by <see cref="NestedTypeIsResolvedPerEngine"/>: the cache is process-wide, so a type
+    /// another test also resolves would make the outcome depend on which test ran first.
+    /// </summary>
+    private sealed class CrossEngineHolder
+    {
+        public sealed class Inner
+        {
+        }
+    }
+
+    /// <summary>Only used by <see cref="OrdinaryStaticMemberResolutionIsStillCached"/>, same reason.</summary>
+    private sealed class CachedMemberHolder
+    {
+        public static int Value => 42;
+    }
+}

--- a/Jint/Runtime/Interop/TypeReference.cs
+++ b/Jint/Runtime/Interop/TypeReference.cs
@@ -308,7 +308,25 @@ public sealed class TypeReference : Constructor, IObjectWrapper
     private PropertyDescriptor CreatePropertyDescriptor(string name)
     {
         var key = new MemberAccessorKey(ReferenceType, name);
-        var accessor = _memberAccessors.GetOrAdd(key, x => ResolveMemberAccessor(_engine, x.Type, x.PropertyName));
+        if (!_memberAccessors.TryGetValue(key, out var accessor))
+        {
+            accessor = ResolveMemberAccessor(_engine, key.Type, key.PropertyName);
+
+            // The cache is process-wide, so an accessor may only enter it when it captures nothing bound to
+            // a single engine. Everything this path can produce is derived from the reflected type alone — a
+            // PropertyInfo or FieldInfo and the delegates compiled from it, a MethodDescriptor set, or a
+            // ConstantValueAccessor over a primitive enum value — and the engine-affine parts are built per
+            // call in CreatePropertyDescriptor below. The one exception is a nested type: it resolves to an
+            // accessor holding a TypeReference, an object owned by this engine, so caching it would keep the
+            // engine, its realm and all of its intrinsics alive for the lifetime of the process and hand this
+            // engine's object to any other engine that later asks for the same member. Those are re-resolved.
+            if (accessor is not NestedTypeAccessor)
+            {
+                // racy, we don't care: both racers resolved the same member the same way
+                _memberAccessors.TryAdd(key, accessor);
+            }
+        }
+
         return accessor.CreatePropertyDescriptor(_engine, ReferenceType, name, enumerable: true);
     }
 


### PR DESCRIPTION
`TypeReference` resolves a static member once and stores the accessor in a `ConcurrentDictionary` that is **`static`** — shared by every engine in the process — and keyed only by `(declaring type, member name)`:

```csharp
var key = new MemberAccessorKey(ReferenceType, name);
var accessor = _memberAccessors.GetOrAdd(key, x => ResolveMemberAccessor(_engine, x.Type, x.PropertyName));
```

A nested type resolves to a `NestedTypeAccessor`, and that accessor holds a `TypeReference` — an `ObjectInstance` bound to the engine that created it (`TypeResolver.TryFindMemberAccessor` ends with `TypeReference.CreateTypeReference(engine, nestedType)`).

Two consequences:

1. **Retention.** The first script anywhere in the process to evaluate `Outer.Inner` writes its own engine into a cache entry that lives as long as the process, keeping that engine, its realm and every one of its intrinsics reachable forever. A host that builds a fresh engine per operation never gets that first engine back.
2. **Cross-engine aliasing.** Any later engine resolving the same `(type, member)` is handed the *first* engine's `TypeReference` rather than one of its own, so an object belonging to a foreign engine and realm leaks into its scripts.

## Reproducing

Both halves are covered by the new tests, and both fail on `main`:

```
Failed Jint.Tests.Runtime.GarbageCollectionTests.NestedTypeAccessDoesNotRetainEngines
  Expected reference.IsAlive to be False ..., but found True.

Failed Jint.Tests.Runtime.InteropStaticMemberCacheTests.NestedTypeIsResolvedPerEngine
  Expected boolean to be False because an object created by one engine must never be
  handed to another one., but found True.
```

The shape is: create an engine, expose a type with a public nested type, evaluate `Holder.Inner`, drop the engine, force a full collection — the engine is still alive. And: two engines evaluating `Holder.Inner` get the very same `TypeReference` instance back, whose `Engine` is the first engine.

## The fix

Resolve first, then cache only when the accessor captures nothing engine-bound. Nested types are re-resolved instead, which costs one lookup per type reference — the resulting `PropertyDescriptor` is still cached on the `TypeReference` instance, so a script reading `Outer.Inner` in a loop resolves once as before.

## Accessor-kind audit

Every accessor kind reachable from `TypeReference.ResolveMemberAccessor`, which goes through `TypeResolver.TryFindMemberAccessor` with `bindingFlags: Public | Static | FlattenHierarchy` and `indexerToTry: null`:

| Accessor | What it captures | Engine-bound? |
| --- | --- | --- |
| `PropertyAccessor` | `PropertyInfo`, plus lazily compiled delegates cached process-wide by `CompiledMemberAccessor` | No |
| `FieldAccessor` | `FieldInfo`, same compiled lanes | No |
| `MethodAccessor` | target `Type` + `MethodDescriptor[]` (`MethodBase`/`ParameterInfo` and flags derived from them); the `MethodInfoFunction` is built per call in `CreatePropertyDescriptor` | No |
| `NestedTypeAccessor` | a `TypeReference`, i.e. an `ObjectInstance` with `_engine`/realm | **Yes — excluded** |
| `ConstantValueAccessor` | a `JsNumber` for an enum member, or the shared `NullAccessor`; a `JsNumber` is a primitive with no engine reference | No |

Not reachable from this path, listed so the guard can be called complete rather than ad hoc:

| Accessor | Why not reachable |
| --- | --- |
| `IndexerAccessor` | only constructed by `IndexerAccessor.TryFindIndexer`, which `TypeResolver.ResolvePropertyDescriptorFactory` calls — `TypeReference` calls `TryFindMemberAccessor` directly and passes `indexerToTry: null`, so no indexer is ever attached or returned here. Worth naming because an `IndexerAccessor` *does* bake in an index key produced by `engine.TypeConverter`, which a host-installed `ITypeConverter` could make engine-bound; that concern belongs to the instance-member path, not to this cache. |
| `DynamicObjectAccessor` | likewise only produced by `ResolvePropertyDescriptorFactory` |

The engine-affine parts of a member — the `ReflectionDescriptor`, the `MethodInfoFunction` — are built per call inside `ReflectionAccessor.CreatePropertyDescriptor`, which is why everything above except the nested type is safe to keep sharing.

I kept the predicate self-contained (a single `is not NestedTypeAccessor` in `TypeReference`) rather than introducing a shared helper: the only other exclusion such a helper would carry is the `IndexerAccessor` case above, which is dead on this path, and a one-line check keeps the change inside the file that owns the cache.

## Non-nested members remain cached

`OrdinaryStaticMemberResolutionIsStillCached` guards against the fix quietly disabling the cache for everything: two engines with their own counting `MemberNameCreator` read the same static property, and the second must perform **zero** member-name lookups, proving it was served the entry the first one produced.

## Verification

- `dotnet build --configuration Release` — 0 warnings, 0 errors
- `Jint.Tests` — 4045 passed / 0 failed / 4 skipped (net10.0), 3982 passed / 0 failed / 4 skipped (net472)
- `Jint.Tests.PublicInterface` — 114 passed / 0 failed on both TFMs
- `Jint.Tests.Test262` — 99441 passed / 0 failed / 157 skipped, matching baseline (the full run reported 8 regexp-literal tests hitting the 30 s engine timeout under load; all 476 `Literals_regexp` cases pass in 25 s when run isolated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
