### PR TITLE
Box a coerced JS integer as the declared CLR type, not always as int

### DIFF
--- a/Jint.Tests/Runtime/InteropIntegerCoercionBoxingTests.cs
+++ b/Jint.Tests/Runtime/InteropIntegerCoercionBoxingTests.cs
@@ -1,0 +1,215 @@
+#nullable enable
+using Jint.Extensions;
+using Jint.Native;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A JavaScript integer bound to a CLR member, parameter or collection element declared as
+/// <see cref="long"/> must be boxed as a <see cref="long"/>, not as an <see cref="int"/> that merely
+/// carries the right numeric value. Reflection binders widen a boxed <see cref="int"/> to a
+/// <see cref="long"/> member or parameter silently, so the difference is invisible on those paths,
+/// but a consumer that unboxes directly — an element write into a wrapped <c>IList&lt;long&gt;</c> or
+/// <c>long[]</c> — rejects it with an <see cref="InvalidCastException"/>.
+/// </summary>
+public class InteropIntegerCoercionBoxingTests
+{
+    #region hosts
+
+    public sealed class Host
+    {
+        public long LongField;
+        public int IntField;
+
+        public long LongProperty { get; set; }
+        public int IntProperty { get; set; }
+
+        public Type? LastParameterType;
+
+        public void TakeLong(long value) => LastParameterType = ((object) value).GetType();
+
+        public void TakeInt(int value) => LastParameterType = ((object) value).GetType();
+    }
+
+    public sealed class CollectionHost
+    {
+        public List<long> Longs { get; } = [0L, 0L];
+        public List<int> Ints { get; } = [0, 0];
+        public long[] LongArray { get; } = new long[2];
+        public int[] IntArray { get; } = new int[2];
+    }
+
+    public delegate void LongCallback(long value);
+
+    public delegate void IntCallback(int value);
+
+    /// <summary>
+    /// A converter that is not <see cref="DefaultTypeConverter"/> itself, which is what turns the
+    /// compiled member-write fast lane off.
+    /// </summary>
+    private sealed class CustomTypeConverter : DefaultTypeConverter
+    {
+        public CustomTypeConverter(Engine engine) : base(engine)
+        {
+        }
+    }
+
+    #endregion
+
+    /// <summary>
+    /// The coercion helper is the origin of the boxed value; assert its runtime type directly,
+    /// because every downstream consumer that widens hides a wrong one.
+    /// </summary>
+    [Fact]
+    public void CoercionBoxesIntegerAsTheDeclaredMemberType()
+    {
+        Assert.True(ReflectionExtensions.TryConvertViaTypeCoercion(typeof(long), ValueCoercionType.None, JsNumber.Create(42), out var asLong));
+        asLong.Should().BeOfType<long>().And.Be(42L);
+
+        Assert.True(ReflectionExtensions.TryConvertViaTypeCoercion(typeof(int), ValueCoercionType.None, JsNumber.Create(42), out var asInt));
+        asInt.Should().BeOfType<int>().And.Be(42);
+    }
+
+    /// <summary>
+    /// <see cref="Nullable{T}"/> member types are declined by the helper (they are neither
+    /// <c>typeof(int)</c>/<c>typeof(long)</c> nor CLR-numeric-coercible) and keep converting through
+    /// the general <c>ToObject</c> + type-converter path.
+    /// </summary>
+    [Fact]
+    public void CoercionDeclinesNullableIntegerMemberTypes()
+    {
+        Assert.False(ReflectionExtensions.TryConvertViaTypeCoercion(typeof(long?), ValueCoercionType.All, JsNumber.Create(42), out _));
+        Assert.False(ReflectionExtensions.TryConvertViaTypeCoercion(typeof(int?), ValueCoercionType.All, JsNumber.Create(42), out _));
+    }
+
+    [Fact]
+    public void CanAssignIntegerToLongField()
+    {
+        var host = new Host();
+        var engine = new Engine().SetValue("host", host);
+
+        engine.Execute("host.LongField = 42;");
+        host.LongField.Should().Be(42L);
+
+        engine.Execute("host.IntField = 42;");
+        host.IntField.Should().Be(42);
+    }
+
+    [Fact]
+    public void CanAssignIntegerToLongProperty()
+    {
+        var host = new Host();
+        var engine = new Engine().SetValue("host", host);
+
+        engine.Execute("host.LongProperty = 42;");
+        host.LongProperty.Should().Be(42L);
+
+        engine.Execute("host.IntProperty = 42;");
+        host.IntProperty.Should().Be(42);
+    }
+
+    [Fact]
+    public void CanPassIntegerToLongParameter()
+    {
+        var host = new Host();
+        var engine = new Engine().SetValue("host", host);
+
+        engine.Execute("host.TakeLong(42);");
+        host.LastParameterType.Should().Be(typeof(long));
+
+        engine.Execute("host.TakeInt(42);");
+        host.LastParameterType.Should().Be(typeof(int));
+    }
+
+    [Fact]
+    public void CanPassIntegerToLongDelegateParameter()
+    {
+        Type? observed = null;
+        var engine = new Engine()
+            .SetValue("takeLong", new LongCallback(value => observed = ((object) value).GetType()))
+            .SetValue("takeInt", new IntCallback(value => observed = ((object) value).GetType()));
+
+        engine.Execute("takeLong(42);");
+        observed.Should().Be(typeof(long));
+
+        engine.Execute("takeInt(42);");
+        observed.Should().Be(typeof(int));
+    }
+
+    [Fact]
+    public void CanAssignIntegerToGenericListOfLongElement()
+    {
+        var host = new CollectionHost();
+        var engine = new Engine().SetValue("host", host);
+
+        engine.Execute("host.Longs[0] = 42;");
+        host.Longs[0].Should().Be(42L);
+
+        engine.Execute("host.Ints[0] = 42;");
+        host.Ints[0].Should().Be(42);
+    }
+
+    [Fact]
+    public void CanAppendIntegerToGenericListOfLong()
+    {
+        var host = new CollectionHost();
+        var engine = new Engine().SetValue("host", host);
+
+        engine.Execute("host.Longs.push(42);");
+        host.Longs[2].Should().Be(42L);
+
+        engine.Execute("host.Ints.push(42);");
+        host.Ints[2].Should().Be(42);
+    }
+
+    /// <summary>
+    /// Array.prototype operations write elements back through the same element-conversion path as a
+    /// direct index assignment on a fixed-size view, so they need the element type just as much.
+    /// </summary>
+    [Fact]
+    public void CanFillGenericListOfLong()
+    {
+        var host = new CollectionHost();
+        var engine = new Engine().SetValue("host", host);
+
+        engine.Execute("host.Longs.fill(42);");
+        host.Longs.Should().Equal(42L, 42L);
+
+        engine.Execute("host.Ints.fill(42);");
+        host.Ints.Should().Equal(42, 42);
+    }
+
+    [Fact]
+    public void CanAssignIntegerToLongArrayElement()
+    {
+        var host = new CollectionHost();
+        var engine = new Engine().SetValue("host", host);
+
+        engine.Execute("host.LongArray[0] = 42;");
+        host.LongArray[0].Should().Be(42L);
+
+        engine.Execute("host.IntArray[0] = 42;");
+        host.IntArray[0].Should().Be(42);
+    }
+
+    /// <summary>
+    /// A host-installed <see cref="ITypeConverter"/> turns off the compiled member-write fast lane,
+    /// so the field and property writes below really do take the coercion path (and then the
+    /// reflection setter, which widens either way).
+    /// </summary>
+    [Fact]
+    public void CanAssignIntegerToLongMemberWithCustomTypeConverter()
+    {
+        var host = new Host();
+        var engine = new Engine(options => options.SetTypeConverter(e => new CustomTypeConverter(e)))
+            .SetValue("host", host);
+
+        engine.Execute("host.LongField = 42; host.LongProperty = 43; host.IntField = 44; host.IntProperty = 45;");
+
+        host.LongField.Should().Be(42L);
+        host.LongProperty.Should().Be(43L);
+        host.IntField.Should().Be(44);
+        host.IntProperty.Should().Be(45);
+    }
+}

--- a/Jint/Extensions/ReflectionExtensions.cs
+++ b/Jint/Extensions/ReflectionExtensions.cs
@@ -141,11 +141,22 @@ internal static class ReflectionExtensions
         JsValue value,
         [NotNullWhen(true)] out object? converted)
     {
-        if (value.IsInteger() && (memberType == typeof(int) || memberType == typeof(long)))
+        if (value.IsInteger())
         {
-            // safe and doesn't require configuration
-            converted = value.AsInteger();
-            return true;
+            // safe and doesn't require configuration. The box must carry the declared member type:
+            // reflection binders widen a boxed int to a long parameter, but a direct unbox (a
+            // generic collection element write, a compiled setter, a plain cast) does not.
+            if (memberType == typeof(int))
+            {
+                converted = value.AsInteger();
+                return true;
+            }
+
+            if (memberType == typeof(long))
+            {
+                converted = (long) value.AsInteger();
+                return true;
+            }
         }
 
         if (memberType == typeof(bool) && (valueCoercionType & ValueCoercionType.Boolean) != ValueCoercionType.None)

--- a/Jint/Runtime/Interop/Reflection/CompilableMemberAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/CompilableMemberAccessor.cs
@@ -156,9 +156,8 @@ internal abstract class CompilableMemberAccessor : ReflectionAccessor
 
         // The compiled setter casts the incoming value straight to the member type, so it can only
         // accept a value whose runtime type is exactly that. Reflection additionally performs
-        // widening conversions - and the coercion path above produces exactly such a case, handing
-        // a boxed int to a long member - which an unbox.any cannot do, so those keep the
-        // reflection path. A null for a value-type member likewise stays on reflection, whose
+        // widening conversions, which an unbox.any cannot do, so anything not exactly typed keeps
+        // the reflection path. A null for a value-type member likewise stays on reflection, whose
         // ArgumentException is the established behaviour (unbox.any would throw a
         // NullReferenceException instead).
         var setter = _rawSetter;


### PR DESCRIPTION
## The bug

`ReflectionExtensions.TryConvertViaTypeCoercion` has an early short-circuit for an integral `JsValue` bound to an `int` or `long` member, and it boxed **`int`** for both:

```csharp
if (value.IsInteger() && (memberType == typeof(int) || memberType == typeof(long)))
{
    // safe and doesn't require configuration
    converted = value.AsInteger();
    return true;
}
```

The numeric value is always right; the box's *runtime type* is not. The general numeric path further down already does it correctly via `number.AsNumberOfType(Type.GetTypeCode(memberType))` — only this short-circuit was wrong.

## Why it is mostly invisible — and where it is not

Most consumers hand the boxed value to a reflection binder (`MethodBase.Invoke`, `MethodInvoker`, `PropertyInfo`/`FieldInfo.SetValue`, an indexer setter's `Invoke`, `Delegate.DynamicInvoke`), and every one of those silently widens a boxed `int` to a `long`. Consumers that **unbox directly** do not, and those throw today:

```csharp
// long[] and IList<long> both blow up
engine.SetValue("host", host);
engine.Execute("host.LongArray[0] = 42;");  // InvalidCastException
engine.Execute("host.Longs.push(42);");     // InvalidCastException
engine.Execute("host.Longs.fill(42);");     // InvalidCastException
```

`ArrayWrapper<T>.DoSetAt` and `GenericListWrapper<T>.DoSetAt`/`Add` cast with `(T) value!`, which is an `unbox.any` — it cannot widen. Single-rank CLR arrays are exposed as live views by default since 4.14, so `long[]` element assignment fails out of the box rather than only in an opt-in mode. Reproduced on both `net10.0` and `net472`.

## The fix

Box as the declared member type:

```csharp
if (value.IsInteger())
{
    if (memberType == typeof(int))  { converted = value.AsInteger();        return true; }
    if (memberType == typeof(long)) { converted = (long) value.AsInteger(); return true; }
}
```

Worth flagging for reviewers: the obvious one-line fix `converted = memberType == typeof(int) ? value.AsInteger() : (long) value.AsInteger()` is a silent no-op in the wrong direction — C# unifies both ternary branches to `long`, so the `int` case would start boxing a `long`. Separate early-return guards avoid that and match the repo's no-nested-ternaries convention.

### `Nullable<T>`

`int?`/`long?` member types do reach this helper but are declined, both before and after: they match neither guard, and `Type.GetTypeCode` returns `TypeCode.Object` for `Nullable<T>` so `IsClrNumericCoercible` declines too. They keep converting through the general `ToObject` + type-converter path. Deliberately not widened here; covered by a test that locks the decline in.

## Consumer audit

All seven call sites, and what each does with the boxed value:

| # | Call site | What receives the box | Verdict |
|---|---|---|---|
| 1 | `DelegateWrapper.cs:77` | `Delegate.DynamicInvoke` | Latent — binder widens |
| 2 | `DelegateWrapper.cs:120` | `Array.SetValue` into the params array | Latent — widens |
| 3 | `InteropHelper.cs:244` | nothing (`out _`, overload-score probe) | No effect |
| 4 | `MethodDescriptor.cs:472` | `MethodInvoker`/`MethodBase.Invoke` | Latent, and in fact unreachable for `int`/`long`: `InteropHelper.TryConvertNumberFast` at `:468` already boxes those correctly and runs first for every `JsNumber` |
| 5 | `MethodInfoFunction.cs:350` | same | Latent + unreachable, same reason (`:344`) |
| 6 | `ObjectWrapper.Specialized.cs:364` (`ConvertToItemType`) | `ArrayWrapper<T>`/`GenericListWrapper<T>` `DoSetAt`/`Add` → `(T) value!` | **LIVE — `InvalidCastException`** |
| 7 | `Reflection/ReflectionAccessor.cs:145` | `CompilableMemberAccessor.DoSetValue` (compiled raw setter) or `IndexerAccessor.DoSetValue` | Latent — the compiled lane's `value.GetType() != MemberType` guard sends exactly this case back to reflection, which widens |

So: **one live user-visible bug** (wrapped `long[]` / `IList<long>` element writes), the rest hardening plus one less `int` box on paths that were relying on binder widening.

Site 7 is worth a note: `CompilableMemberAccessor.DoSetValue`'s comment cited *this exact case* ("handing a boxed int to a long member") as the reason its exact-type guard exists. That guard is what kept the emitted setter off the mis-typed box. The guard stays — it still covers every other inexact conversion — but the comment's example is no longer produced, so it has been reworded.

## Tests

`Jint.Tests/Runtime/InteropIntegerCoercionBoxingTests.cs` — 10 tests, run on `net10.0` and `net472`. Where the runtime type is observable it is asserted directly (`BeOfType<long>()`), since the numeric value was always correct and only the type was not; elsewhere the assertion is the absence of the `InvalidCastException`. Every `long` case has an `int` control.

Failing before this change, passing after:

- `CoercionBoxesIntegerAsTheDeclaredMemberType` — asserts `converted.GetType()` at the source
- `CanAssignIntegerToLongArrayElement` — `host.LongArray[0] = 42` on a wrapped `long[]`
- `CanAppendIntegerToGenericListOfLong` — `host.Longs.push(42)` on a wrapped `List<long>`
- `CanFillGenericListOfLong` — `host.Longs.fill(42)`

Passing both before and after (regression cover for the binder-widened paths): `long`/`int` field, property, method parameter, delegate parameter, `IList<long>` index assignment, member writes under a custom `ITypeConverter` (which disables the compiled write lane and forces the coercion path), and the `Nullable<T>` decline.

## Verification

- `dotnet build -c Release` — 0 warnings, 0 errors
- `Jint.Tests` — 4053 passed / 0 failed / 4 skipped (net10.0), 3990 / 0 / 4 (net472)
- `Jint.Tests.PublicInterface` — 114 passed / 0 failed (net10.0 and net472)
- `Jint.Tests.Test262` — 99441 passed / 0 failed / 157 skipped, matching baseline. The full run initially reported 8 failures, all 30s `TimeoutException` on `language/literals/regexp/S7.8.5_*_T2.js` under concurrent machine load; re-run isolated, all 476 `Literals_regexp` tests pass (99433 + 8 = 99441).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
