### PR TITLE
Refuse writes to read-only CLR members instead of shadowing them

### DIFF
--- a/Jint.Tests.PublicInterface/ReadOnlyClrMemberWriteTests.cs
+++ b/Jint.Tests.PublicInterface/ReadOnlyClrMemberWriteTests.cs
@@ -1,0 +1,393 @@
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A CLR member that cannot be written must behave like a non-writable ordinary property:
+/// <c>[[Set]]</c> returns <c>false</c>, which makes the assignment a silent no-op in sloppy mode and a
+/// <c>TypeError</c> in strict mode (https://tc39.es/ecma262/#sec-ordinarysetwithowndescriptor,
+/// https://tc39.es/ecma262/#sec-putvalue). It must never leave a JS-side own property shadowing the
+/// CLR member, and the host object must be untouched. These have to hold whether or not the member was
+/// read before the write, and a refused write must not disturb reads on other wrappers of the same type.
+/// </summary>
+public class ReadOnlyClrMemberWriteTests
+{
+    private const string Initial = "initial";
+
+    public class Host
+    {
+        public string GetterOnly { get; } = Initial;
+
+        public string Computed => Initial;
+
+        public readonly string ReadOnlyField = Initial;
+
+        public string PrivateSetter { get; private set; } = Initial;
+
+        public string Writable { get; set; } = Initial;
+
+        public string Method() => Initial;
+    }
+
+    public class IndexerWithoutSetter
+    {
+        private readonly Dictionary<string, string> _values = new(StringComparer.Ordinal) { ["a"] = Initial };
+
+        public string this[string key] => _values.TryGetValue(key, out var value) ? value : null;
+    }
+
+    public class SetterOnlyHost
+    {
+        public string Written;
+
+        public string Value
+        {
+            set => Written = value;
+        }
+    }
+
+    public static class StaticHost
+    {
+        public static string GetterOnly { get; } = Initial;
+
+        public static readonly string ReadOnlyField = Initial;
+
+        public const string Constant = Initial;
+    }
+
+    private static Engine CreateEngine(object host) => new Engine().SetValue("host", host);
+
+    private static void AssertTypeError(Engine engine, string script, string memberName)
+    {
+        var exception = Invoking(() => engine.Evaluate(script)).Should().Throw<JavaScriptException>().Which;
+        exception.Error.Get("name").AsString().Should().Be("TypeError");
+        exception.Message.Should().Contain(memberName);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // instance members, write before any read (the resolution lane that produced the original defect)
+    // ---------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("GetterOnly")]
+    [InlineData("Computed")]
+    [InlineData("ReadOnlyField")]
+    public void SloppyWriteToReadOnlyMemberIsSilentlyIgnored(string member)
+    {
+        var host = new Host();
+        var engine = CreateEngine(host);
+
+        engine.Evaluate($"host.{member} = 'written';");
+
+        engine.Evaluate($"host.{member}").AsString().Should().Be(Initial);
+        host.GetterOnly.Should().Be(Initial);
+        host.Computed.Should().Be(Initial);
+        host.ReadOnlyField.Should().Be(Initial);
+    }
+
+    [Theory]
+    [InlineData("GetterOnly")]
+    [InlineData("Computed")]
+    [InlineData("ReadOnlyField")]
+    public void StrictWriteToReadOnlyMemberThrowsTypeErrorNamingTheMember(string member)
+    {
+        var host = new Host();
+        var engine = CreateEngine(host);
+
+        AssertTypeError(engine, $"'use strict'; host.{member} = 'written';", member);
+
+        engine.Evaluate($"host.{member}").AsString().Should().Be(Initial);
+        host.GetterOnly.Should().Be(Initial);
+        host.Computed.Should().Be(Initial);
+        host.ReadOnlyField.Should().Be(Initial);
+    }
+
+    [Theory]
+    [InlineData("GetterOnly")]
+    [InlineData("Computed")]
+    [InlineData("ReadOnlyField")]
+    public void RefusedWriteLeavesNoShadowingOwnProperty(string member)
+    {
+        var engine = CreateEngine(new Host());
+
+        engine.Evaluate($"host.{member} = 'written';");
+
+        // the member must still be described by the live CLR accessor, not by a data property
+        // carrying the value the script tried to write
+        engine.Evaluate($"var d = Object.getOwnPropertyDescriptor(host, '{member}');");
+        engine.Evaluate("typeof d.get").AsString().Should().Be("function");
+        engine.Evaluate("d.set === undefined").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'value' in d").AsBoolean().Should().BeFalse();
+
+        // and the reported key set must not have grown
+        engine.Evaluate($"Object.getOwnPropertyNames(host).filter(function (n) {{ return n === '{member}'; }}).length")
+            .AsNumber().Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("GetterOnly")]
+    [InlineData("Computed")]
+    [InlineData("ReadOnlyField")]
+    public void ReflectSetReportsFailureForReadOnlyMember(string member)
+    {
+        var engine = CreateEngine(new Host());
+
+        engine.Evaluate($"Reflect.set(host, '{member}', 'written')").AsBoolean().Should().BeFalse();
+        engine.Evaluate($"host.{member}").AsString().Should().Be(Initial);
+    }
+
+    [Theory]
+    [InlineData("GetterOnly")]
+    [InlineData("Computed")]
+    [InlineData("ReadOnlyField")]
+    public void WriteBeforeAnyReadBehavesLikeWriteAfterRead(string member)
+    {
+        var writeFirst = CreateEngine(new Host());
+        var readFirst = CreateEngine(new Host());
+        readFirst.Evaluate($"host.{member}");
+
+        foreach (var engine in new[] { writeFirst, readFirst })
+        {
+            engine.Evaluate($"host.{member} = 'written';");
+            engine.Evaluate($"host.{member}").AsString().Should().Be(Initial);
+            AssertTypeError(engine, $"'use strict'; host.{member} = 'written';", member);
+        }
+    }
+
+    [Fact]
+    public void RefusedWriteDoesNotDisturbReadsOnOtherWrappersOfTheSameType()
+    {
+        var engine = new Engine()
+            .SetValue("first", new Host())
+            .SetValue("second", new Host());
+
+        engine.Evaluate("first.GetterOnly = 'written';");
+
+        // member resolution is cached per engine and per CLR type: a refused write must not leave a
+        // "no such member" verdict behind that later reads of any wrapper of that type pick up
+        engine.Evaluate("second.GetterOnly").AsString().Should().Be(Initial);
+        engine.Evaluate("first.GetterOnly").AsString().Should().Be(Initial);
+    }
+
+    [Fact]
+    public void ReadOfWriteOnlyMemberDoesNotDisturbLaterWrites()
+    {
+        var host = new SetterOnlyHost();
+        var engine = CreateEngine(host);
+
+        // the read resolves nothing (the member is not readable) and must not be remembered as the
+        // answer for the write that follows
+        engine.Evaluate("host.Value").IsUndefined().Should().BeTrue();
+
+        engine.Evaluate("host.Value = 'written';");
+
+        host.Written.Should().Be("written");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // indexers
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void SloppyWriteThroughIndexerWithoutSetterIsSilentlyIgnored()
+    {
+        var host = new IndexerWithoutSetter();
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.a = 'written';");
+
+        engine.Evaluate("host.a").AsString().Should().Be(Initial);
+        host["a"].Should().Be(Initial);
+    }
+
+    [Fact]
+    public void StrictWriteThroughIndexerWithoutSetterThrowsTypeError()
+    {
+        var host = new IndexerWithoutSetter();
+        var engine = CreateEngine(host);
+
+        AssertTypeError(engine, "'use strict'; host.a = 'written';", "a");
+
+        engine.Evaluate("host.a").AsString().Should().Be(Initial);
+        host["a"].Should().Be(Initial);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // static members exposed through a type reference
+    // ---------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("GetterOnly")]
+    [InlineData("ReadOnlyField")]
+    [InlineData("Constant")]
+    public void SloppyWriteToReadOnlyStaticMemberIsSilentlyIgnored(string member)
+    {
+        var engine = new Engine();
+        engine.SetValue("Host", TypeReference.CreateTypeReference(engine, typeof(StaticHost)));
+
+        engine.Evaluate($"Host.{member} = 'written';");
+
+        engine.Evaluate($"Host.{member}").AsString().Should().Be(Initial);
+        StaticHost.GetterOnly.Should().Be(Initial);
+        StaticHost.ReadOnlyField.Should().Be(Initial);
+    }
+
+    [Theory]
+    [InlineData("GetterOnly")]
+    [InlineData("ReadOnlyField")]
+    [InlineData("Constant")]
+    public void StrictWriteToReadOnlyStaticMemberThrowsTypeError(string member)
+    {
+        var engine = new Engine();
+        engine.SetValue("Host", TypeReference.CreateTypeReference(engine, typeof(StaticHost)));
+
+        AssertTypeError(engine, $"'use strict'; Host.{member} = 'written';", member);
+
+        engine.Evaluate($"Host.{member}").AsString().Should().Be(Initial);
+        StaticHost.GetterOnly.Should().Be(Initial);
+        StaticHost.ReadOnlyField.Should().Be(Initial);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // array-like and dictionary-backed wrappers use the same lane
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void SloppyWriteToReadOnlyMemberOfArrayLikeWrapperIsSilentlyIgnored()
+    {
+        var list = new List<int> { 1, 2, 3 };
+        var engine = CreateEngine(list);
+
+        engine.Evaluate("host.Count = 99;");
+
+        engine.Evaluate("host.Count").AsNumber().Should().Be(3);
+        list.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void StrictWriteToReadOnlyMemberOfArrayLikeWrapperThrowsTypeError()
+    {
+        var list = new List<int> { 1, 2, 3 };
+        var engine = CreateEngine(list);
+
+        AssertTypeError(engine, "'use strict'; host.Count = 99;", "Count");
+
+        engine.Evaluate("host.Count").AsNumber().Should().Be(3);
+        list.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void SloppyWriteToReadOnlyMemberOfCollectionWrapperIsSilentlyIgnored()
+    {
+        var set = new HashSet<int> { 1, 2, 3 };
+        var engine = CreateEngine(set);
+
+        engine.Evaluate("host.Count = 99;");
+
+        engine.Evaluate("host.Count").AsNumber().Should().Be(3);
+        set.Count.Should().Be(3);
+    }
+
+    [Fact]
+    public void DictionaryBackedWrapperKeepsWritingEntries()
+    {
+        var dictionary = new Dictionary<string, int>(StringComparer.Ordinal) { ["a"] = 1 };
+        var engine = CreateEngine(dictionary);
+
+        engine.Evaluate("host.a = 42; host.b = 7;");
+
+        dictionary["a"].Should().Be(42);
+        dictionary["b"].Should().Be(7);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // controls: nothing about writable members or wrapper extension may change
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void WritableMemberIsStillWritten()
+    {
+        var host = new Host();
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("host.Writable = 'sloppy';");
+        host.Writable.Should().Be("sloppy");
+
+        engine.Evaluate("'use strict'; host.Writable = 'strict';");
+        host.Writable.Should().Be("strict");
+
+        engine.Evaluate("Reflect.set(host, 'Writable', 'reflected')").AsBoolean().Should().BeTrue();
+        host.Writable.Should().Be("reflected");
+    }
+
+    [Fact]
+    public void PropertyWithNonPublicSetterIsStillWritten()
+    {
+        // a property whose setter exists but is not public still reports CanWrite, so the write
+        // reaches the CLR object; it is not a read-only member and is unaffected here
+        var host = new Host();
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("'use strict'; host.PrivateSetter = 'written';");
+
+        host.PrivateSetter.Should().Be("written");
+    }
+
+    [Fact]
+    public void UnknownMemberStillExtendsTheWrapper()
+    {
+        var engine = CreateEngine(new Host());
+
+        engine.Evaluate("host.brandNew = 1;");
+        engine.Evaluate("host.brandNew").AsNumber().Should().Be(1);
+
+        engine.Evaluate("'use strict'; host.alsoNew = 2;");
+        engine.Evaluate("host.alsoNew").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void DefinePropertyKeepsItsExistingAnswers()
+    {
+        var host = new Host();
+        var engine = CreateEngine(host);
+
+        // a reflected CLR member is reported as non-configurable, so redefining it is refused - the
+        // refused assignment must not have turned it into a configurable JS-side data property
+        Invoking(() => engine.Evaluate("host.GetterOnly = 'written'; Object.defineProperty(host, 'GetterOnly', { value: 'redefined' });"))
+            .Should().Throw<JavaScriptException>();
+        engine.Evaluate("host.GetterOnly").AsString().Should().Be(Initial);
+        host.GetterOnly.Should().Be(Initial);
+
+        // defining a name the CLR type does not carry stays allowed
+        engine.Evaluate("Object.defineProperty(host, 'extra', { value: 'defined', configurable: true });");
+        engine.Evaluate("host.extra").AsString().Should().Be("defined");
+    }
+
+    [Fact]
+    public void DisallowingClrWritesStillRefusesWritableMembers()
+    {
+        var host = new Host();
+        var engine = new Engine(options => options.AllowClrWrite(false)).SetValue("host", host);
+
+        engine.Evaluate("host.Writable = 'written';");
+        host.Writable.Should().Be(Initial);
+
+        AssertTypeError(engine, "'use strict'; host.Writable = 'written';", "Writable");
+        host.Writable.Should().Be(Initial);
+    }
+
+    [Fact]
+    public void ThrowOnUnresolvedMemberOnlyFiresForGenuinelyUnknownNames()
+    {
+        var host = new Host();
+        var engine = new Engine(options => options.Interop.ThrowOnUnresolvedMember = true).SetValue("host", host);
+
+        // the member resolves, it merely cannot be written: an ordinary refusal, not a missing member
+        engine.Evaluate("host.GetterOnly = 'written';");
+        host.GetterOnly.Should().Be(Initial);
+
+        Invoking(() => engine.Evaluate("host.noSuchMember = 1;")).Should().Throw<MissingMemberException>();
+    }
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -220,8 +220,10 @@ public sealed partial class Engine : IDisposable
     internal Intrinsics _originalIntrinsics = null!;
     internal Host _host = null!;
 
-    // we need to cache reflection accessors on engine level as configuration options can affect outcome
-    internal readonly record struct ClrPropertyDescriptorFactoriesKey(Type Type, Key PropertyName);
+    // we need to cache reflection accessors on engine level as configuration options can affect outcome.
+    // The requirement is part of the key because member resolution is filtered by it (see TypeResolver):
+    // a member that failed a readable/writable requirement must not answer for lookups carrying another one.
+    internal readonly record struct ClrPropertyDescriptorFactoriesKey(Type Type, Key PropertyName, MemberResolutionRequirement Requirement);
     internal Dictionary<ClrPropertyDescriptorFactoriesKey, ReflectionAccessor> _reflectionAccessors = new();
 
     /// <summary>

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -244,29 +244,24 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             if (_properties is null || !_properties.ContainsKey(member))
             {
                 // can try utilize fast path
-                var accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, ClrType, member, mustBeReadable: false, mustBeWritable: true, throwOnError: false);
-                var actualType = Target.GetType();
-                if (ClrType != actualType)
-                {
-                    // When the declared type differs from the actual runtime type:
-                    // If only an indexer was found, check if the runtime type has a direct property/field/method
-                    // that should take precedence over the indexer
-                    if (accessor is IndexerAccessor)
-                    {
-                        var runtimeAccessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, mustBeReadable: false, mustBeWritable: true, throwOnError: false);
-                        if (runtimeAccessor is not IndexerAccessor && runtimeAccessor != ConstantValueAccessor.NullAccessor)
-                        {
-                            accessor = runtimeAccessor;
-                        }
-                    }
-                    else if (ReferenceEquals(accessor, ConstantValueAccessor.NullAccessor))
-                    {
-                        accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, mustBeReadable: false, mustBeWritable: true, throwOnError: false);
-                    }
-                }
+                var accessor = ResolveMemberAccessor(member, mustBeWritable: true);
 
                 if (ReferenceEquals(accessor, ConstantValueAccessor.NullAccessor))
                 {
+                    // The writable-filtered resolution answers with the same NullAccessor for "no such
+                    // member" and for "the member exists but nothing writable answers for it", so probe
+                    // again without the requirement before treating this as an unknown name. A member
+                    // that exists but cannot be written must behave like a non-writable ordinary
+                    // property - [[Set]] returns false, which PutValue turns into a silent no-op in
+                    // sloppy mode and a TypeError in strict mode - rather than being shadowed by a
+                    // JS-side own property that hides the CLR member from every later read.
+                    // https://tc39.es/ecma262/#sec-ordinarysetwithowndescriptor
+                    // https://tc39.es/ecma262/#sec-putvalue
+                    if (!ReferenceEquals(ResolveMemberAccessor(member, mustBeWritable: false), ConstantValueAccessor.NullAccessor))
+                    {
+                        return false;
+                    }
+
                     if (_engine.Options.Interop.ThrowOnUnresolvedMember)
                     {
                         throw new MissingMemberException($"Cannot access property '{member}' on type '{ClrType.FullName}");
@@ -328,6 +323,41 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         }
 
         return SetSlow(property, value);
+    }
+
+    /// <summary>
+    /// Resolves the accessor the write lane in <see cref="Set"/> consults, optionally requiring the
+    /// resolved member to be writable. Falls back to the runtime type when the exposed type differs,
+    /// mirroring <see cref="GetOwnProperty(JsValue, bool, bool, bool)"/>.
+    /// </summary>
+    private ReflectionAccessor ResolveMemberAccessor(string member, bool mustBeWritable)
+    {
+        var typeResolver = _engine.Options.Interop.TypeResolver;
+        var accessor = typeResolver.GetAccessor(_engine, ClrType, member, mustBeReadable: false, mustBeWritable: mustBeWritable, throwOnError: false);
+
+        var actualType = Target.GetType();
+        if (ClrType == actualType)
+        {
+            return accessor;
+        }
+
+        // When the declared type differs from the actual runtime type:
+        // If only an indexer was found, check if the runtime type has a direct property/field/method
+        // that should take precedence over the indexer
+        if (accessor is IndexerAccessor)
+        {
+            var runtimeAccessor = typeResolver.GetAccessor(_engine, actualType, member, mustBeReadable: false, mustBeWritable: mustBeWritable, throwOnError: false);
+            if (runtimeAccessor is not IndexerAccessor && runtimeAccessor != ConstantValueAccessor.NullAccessor)
+            {
+                accessor = runtimeAccessor;
+            }
+        }
+        else if (ReferenceEquals(accessor, ConstantValueAccessor.NullAccessor))
+        {
+            accessor = typeResolver.GetAccessor(_engine, actualType, member, mustBeReadable: false, mustBeWritable: mustBeWritable, throwOnError: false);
+        }
+
+        return accessor;
     }
 
     private bool SetSlow(JsValue property, JsValue value)

--- a/Jint/Runtime/Interop/Reflection/FieldAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/FieldAccessor.cs
@@ -12,7 +12,10 @@ internal sealed class FieldAccessor : CompilableMemberAccessor
         _fieldInfo = fieldInfo;
     }
 
-    public override bool Writable => (_fieldInfo.Attributes & FieldAttributes.InitOnly) == (FieldAttributes) 0;
+    // InitOnly is a readonly field, Literal is a compile-time constant. Reflection refuses to write
+    // either one: omitting Literal here let a constant look writable and surfaced the resulting
+    // FieldAccessException to the host instead of the ordinary non-writable [[Set]] answer.
+    public override bool Writable => (_fieldInfo.Attributes & (FieldAttributes.InitOnly | FieldAttributes.Literal)) == (FieldAttributes) 0;
 
     protected override object? ReflectionGetValue(object target)
     {

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -13,6 +13,20 @@ using Jint.Runtime.Interop.Reflection;
 namespace Jint.Runtime.Interop;
 
 /// <summary>
+/// What a member resolution requires of the member it accepts. Resolution is filtered by this
+/// (a member that cannot satisfy the requirement is skipped in favour of an indexer, an explicit
+/// interface implementation, an extension method, ...), so it is part of the accessor cache key:
+/// the accessor a read settles on is not necessarily the one a write settles on.
+/// </summary>
+[Flags]
+internal enum MemberResolutionRequirement : byte
+{
+    None = 0,
+    Readable = 1,
+    Writable = 2,
+}
+
+/// <summary>
 /// Interop strategy for resolving types and members.
 /// </summary>
 public sealed class TypeResolver
@@ -79,7 +93,17 @@ public sealed class TypeResolver
         bool throwOnError = true,
         Func<ReflectionAccessor?>? accessorFactory = null)
     {
-        var key = new Engine.ClrPropertyDescriptorFactoriesKey(type, member);
+        var requirement = MemberResolutionRequirement.None;
+        if (mustBeReadable)
+        {
+            requirement |= MemberResolutionRequirement.Readable;
+        }
+        if (mustBeWritable)
+        {
+            requirement |= MemberResolutionRequirement.Writable;
+        }
+
+        var key = new Engine.ClrPropertyDescriptorFactoriesKey(type, member, requirement);
 
         var factories = engine._reflectionAccessors;
         if (factories.TryGetValue(key, out var accessor))


### PR DESCRIPTION
Writing to a getter-only CLR member from script did not behave like writing to a non-writable property. It silently created a JS-side own property on the wrapper that shadowed the CLR member, so the script read back the value it had just written while the host object never changed — and strict mode did not throw.

## Spec

For an ordinary object, `[[Set]]` on a non-writable data property, or on an accessor with no setter, returns **false** — [OrdinarySetWithOwnDescriptor](https://tc39.es/ecma262/#sec-ordinarysetwithowndescriptor) steps 2.a and 3.b. [PutValue](https://tc39.es/ecma262/#sec-putvalue) step 6.d then throws a `TypeError` when the reference is strict, and does nothing otherwise. `ObjectWrapper` is an exotic object, but there is no reason for a reflected CLR member to diverge here, and it already behaves correctly whenever the member happened to be read before the write.

## Where it went wrong

`ObjectWrapper.Set` resolves the member with `mustBeWritable: true`. `TypeResolver.ResolvePropertyDescriptorFactory` applies that requirement only at its first step and, when the declared member fails it, keeps searching (indexer, explicit interface implementation, extension method) and ultimately answers `ConstantValueAccessor.NullAccessor`. `Set` cannot distinguish that from "no such member", so it fell through to `base.Set`, which extends the wrapper.

`TypeResolver.GetAccessor` then cached that requirement-filtered verdict under a `(type, member)` key that does not include the requirement. So the refused write also poisoned the shared cache: every later *read* of that member — on any wrapper of that type in the engine — returned `undefined`. The mirror case existed too: reading a setter-only property cached a `NullAccessor` that made later writes to it shadow instead of reaching the CLR setter.

The behaviour was therefore order-dependent. A read before the write stores a `ReflectionDescriptor` in the wrapper's own properties, which routes the write through `CanPut` and refuses it correctly — that ordering is already pinned by `InteropWrapperMemberCacheTests`. Only the write-first ordering was wrong.

## Before / after

Sloppy mode unless noted. `Host` has `GetterOnly { get; } = "initial"`.

| Scenario | Before | After |
| --- | --- | --- |
| `host.GetterOnly = 'x'` then `host.GetterOnly` | `'x'`, CLR still `initial` | `'initial'` |
| strict `host.GetterOnly = 'x'` | no throw | `TypeError: Cannot assign to read only property 'GetterOnly' of …` |
| `Reflect.set(host, 'GetterOnly', 'x')` | `true` | `false` |
| `Object.getOwnPropertyDescriptor(host, 'GetterOnly')` after a write | data property `{value:'x', writable:true}` | accessor property, `set === undefined` |
| `a.GetterOnly = 'x'` then `b.GetterOnly` (same type, other instance) | `undefined` | `'initial'` |
| read setter-only `host.Value`, then `host.Value = 'x'` | CLR setter never runs | CLR setter runs |
| `readonly` field, get-only indexer, `List<T>.Count`, `HashSet<T>.Count` | same shadowing | refused |
| strict `TypeRef.SomeConst = 'x'` | raw CLR `FieldAccessException` | `TypeError` |
| read-only member write with `ThrowOnUnresolvedMember = true` | `MissingMemberException` | refused (the member *is* resolved) |
| writable member, dictionary entry write, new name on the wrapper | — | unchanged |

## The change

* the readable/writable requirement is part of the accessor cache key, so a requirement-filtered resolution can no longer answer a lookup carrying a different one;
* `ObjectWrapper.Set` probes the unfiltered resolution before extending the wrapper and returns `false` when the member exists but nothing writable answers for it;
* `FieldAccessor.Writable` excludes `FieldAttributes.Literal` — a compile-time constant looked writable and surfaced a raw `FieldAccessException` to the host in both modes.

`TypeReference` uses its own unfiltered accessor cache and already answered correctly through `CanPut`; only the constant-field case needed the `FieldAccessor` fix. `ArrayLikeWrapper` and the dictionary-backed wrappers reach named members through the same `ObjectWrapper.Set` lane and are fixed with it.

## Back-compat

Unconditional, no new option. I looked for anything pinning the old behaviour and found the opposite: `InteropWrapperMemberCacheTests.ReadOnlyClrPropertyWriteIsIgnoredInSloppyMode` / `…ThrowsTypeErrorInStrictMode` assert exactly the behaviour this change extends to the write-first ordering (they read the member first, one with an explicit comment that the reads populate the cache). Nothing asserts that a read-only member write succeeds or shadows. An option would only preserve a shape that silently drops host data, so gating is not warranted.

Deliberate behaviour changes beyond the fix itself, all narrow:

* assigning to a **CLR method name** on a wrapper that has not been read is now refused rather than shadowing. Reading it first already refused, so this is a consistency fix; `Object.defineProperty` is unaffected and remains the way to override a member.
* on **dictionary-backed** wrappers, a name that collides with a get-only CLR member (`Count`, `Keys`, `Values`, `Comparer`) now writes the dictionary entry in both orderings, where before a prior read made it refuse. Entry writes for every other name are untouched.
* `ThrowOnUnresolvedMember` no longer fires for a member that resolves but cannot be written; it still fires for genuinely unknown names.

Writable members, `AllowClrWrite(false)`, adding a genuinely new property to a wrapper (including from a JS class extending a CLR type), and indexer-based writes are all unchanged.

The accessor cache can now hold more than one entry per `(type, member)`, but only for members actually looked up under different requirements, and the count is bounded by a type's member surface.

## Tests

New `Jint.Tests.PublicInterface/ReadOnlyClrMemberWriteTests.cs`: every member shape (getter-only property, expression-bodied property, `readonly` field, non-public setter, get-only indexer, static getter-only property, static `readonly` field, `const`, array-like and collection wrappers) × sloppy/strict, asserting the throw behaviour, that no shadowing own property is created (`Object.getOwnPropertyNames`, the descriptor shape, a read-back) and that the CLR object is unchanged — plus the cross-instance cache regression, the write-only mirror, and controls for writable members, dictionary writes and wrapper extension.

* `dotnet build --configuration Release` — 0 warnings, 0 errors
* `Jint.Tests` — 4042 passed (net10.0), 3979 passed (net472), 0 failed
* `Jint.Tests.PublicInterface` — 149 passed on both TFMs, 0 failed
* `Jint.Tests.Test262` — 99441 passed / 0 failed / 157 skipped, unchanged from baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
