### PR TITLE
Thread the member resolution requirement through the API it came from

### DIFF
--- a/Jint/Runtime/Interop/MemberResolutionRequirement.cs
+++ b/Jint/Runtime/Interop/MemberResolutionRequirement.cs
@@ -1,0 +1,50 @@
+using Jint.Runtime.Interop.Reflection;
+
+namespace Jint.Runtime.Interop;
+
+/// <summary>
+/// What a member resolution requires of the member it accepts. Resolution is filtered by this
+/// (a member that cannot satisfy the requirement is skipped in favour of an indexer, an explicit
+/// interface implementation, an extension method, ...), so it is part of the accessor cache key:
+/// the accessor a read settles on is not necessarily the one a write settles on.
+/// </summary>
+[Flags]
+internal enum MemberResolutionRequirement : byte
+{
+    /// <summary>
+    /// The caller does not know yet whether it will read or write, so any resolved member answers.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Only a member that can be read answers.
+    /// </summary>
+    Readable = 1,
+
+    /// <summary>
+    /// Only a member that can be written answers.
+    /// </summary>
+    Writable = 2,
+}
+
+internal static class MemberResolutionRequirementExtensions
+{
+    /// <summary>
+    /// Whether <paramref name="accessor"/> may answer for a resolution carrying this requirement.
+    /// <see cref="MemberResolutionRequirement.None"/> is satisfied by every accessor.
+    /// </summary>
+    public static bool IsSatisfiedBy(this MemberResolutionRequirement requirement, ReflectionAccessor accessor)
+    {
+        if ((requirement & MemberResolutionRequirement.Readable) != MemberResolutionRequirement.None && !accessor.Readable)
+        {
+            return false;
+        }
+
+        if ((requirement & MemberResolutionRequirement.Writable) != MemberResolutionRequirement.None && !accessor.Writable)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -244,7 +244,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             if (_properties is null || !_properties.ContainsKey(member))
             {
                 // can try utilize fast path
-                var accessor = ResolveMemberAccessor(member, mustBeWritable: true);
+                var accessor = ResolveMemberAccessor(member, MemberResolutionRequirement.Writable);
 
                 if (ReferenceEquals(accessor, ConstantValueAccessor.NullAccessor))
                 {
@@ -257,7 +257,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
                     // JS-side own property that hides the CLR member from every later read.
                     // https://tc39.es/ecma262/#sec-ordinarysetwithowndescriptor
                     // https://tc39.es/ecma262/#sec-putvalue
-                    if (!ReferenceEquals(ResolveMemberAccessor(member, mustBeWritable: false), ConstantValueAccessor.NullAccessor))
+                    if (!ReferenceEquals(ResolveMemberAccessor(member, MemberResolutionRequirement.None), ConstantValueAccessor.NullAccessor))
                     {
                         return false;
                     }
@@ -326,14 +326,14 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
     }
 
     /// <summary>
-    /// Resolves the accessor the write lane in <see cref="Set"/> consults, optionally requiring the
-    /// resolved member to be writable. Falls back to the runtime type when the exposed type differs,
-    /// mirroring <see cref="GetOwnProperty(JsValue, bool, bool, bool)"/>.
+    /// Resolves the accessor the write lane in <see cref="Set"/> consults, under the given
+    /// <paramref name="requirement"/>. Falls back to the runtime type when the exposed type differs,
+    /// mirroring <see cref="GetOwnProperty(JsValue, MemberResolutionRequirement, bool)"/>.
     /// </summary>
-    private ReflectionAccessor ResolveMemberAccessor(string member, bool mustBeWritable)
+    private ReflectionAccessor ResolveMemberAccessor(string member, MemberResolutionRequirement requirement)
     {
         var typeResolver = _engine.Options.Interop.TypeResolver;
-        var accessor = typeResolver.GetAccessor(_engine, ClrType, member, mustBeReadable: false, mustBeWritable: mustBeWritable, throwOnError: false);
+        var accessor = typeResolver.GetAccessor(_engine, ClrType, member, requirement, throwOnError: false);
 
         var actualType = Target.GetType();
         if (ClrType == actualType)
@@ -346,7 +346,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         // that should take precedence over the indexer
         if (accessor is IndexerAccessor)
         {
-            var runtimeAccessor = typeResolver.GetAccessor(_engine, actualType, member, mustBeReadable: false, mustBeWritable: mustBeWritable, throwOnError: false);
+            var runtimeAccessor = typeResolver.GetAccessor(_engine, actualType, member, requirement, throwOnError: false);
             if (runtimeAccessor is not IndexerAccessor && runtimeAccessor != ConstantValueAccessor.NullAccessor)
             {
                 accessor = runtimeAccessor;
@@ -354,7 +354,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         }
         else if (ReferenceEquals(accessor, ConstantValueAccessor.NullAccessor))
         {
-            accessor = typeResolver.GetAccessor(_engine, actualType, member, mustBeReadable: false, mustBeWritable: mustBeWritable, throwOnError: false);
+            accessor = typeResolver.GetAccessor(_engine, actualType, member, requirement, throwOnError: false);
         }
 
         return accessor;
@@ -540,7 +540,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         // slow path requires us to create a property descriptor that might get cached or not
         // suppress ThrowOnUnresolvedMember here so we can fall back to the prototype chain
         // (e.g. valueOf/toString from Object.prototype during implicit coercion)
-        var desc = GetOwnProperty(property, mustBeReadable: true, mustBeWritable: false, throwOnError: false);
+        var desc = GetOwnProperty(property, MemberResolutionRequirement.Readable, throwOnError: false);
         if (desc != PropertyDescriptor.Undefined)
         {
             return UnwrapJsValue(desc, receiver);
@@ -683,10 +683,10 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
     public override PropertyDescriptor GetOwnProperty(JsValue property)
     {
         // we do not know if we need to read or write
-        return GetOwnProperty(property, mustBeReadable: false, mustBeWritable: false);
+        return GetOwnProperty(property, MemberResolutionRequirement.None);
     }
 
-    private PropertyDescriptor GetOwnProperty(JsValue property, bool mustBeReadable, bool mustBeWritable, bool throwOnError = true)
+    private PropertyDescriptor GetOwnProperty(JsValue property, MemberResolutionRequirement requirement, bool throwOnError = true)
     {
         if (TryGetProperty(property, out var x))
         {
@@ -779,7 +779,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             return new PropertyDescriptor(result, PropertyFlag.OnlyEnumerable);
         }
 
-        var accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, ClrType, member, mustBeReadable, mustBeWritable, throwOnError);
+        var accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, ClrType, member, requirement, throwOnError);
         var actualType = Target.GetType();
         if (ClrType != actualType)
         {
@@ -789,11 +789,11 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             //   that should take precedence over the indexer
             if (accessor == ConstantValueAccessor.NullAccessor)
             {
-                accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, mustBeReadable, mustBeWritable, throwOnError);
+                accessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, requirement, throwOnError);
             }
             else if (accessor is IndexerAccessor)
             {
-                var runtimeAccessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, mustBeReadable, mustBeWritable, throwOnError);
+                var runtimeAccessor = _engine.Options.Interop.TypeResolver.GetAccessor(_engine, actualType, member, requirement, throwOnError);
                 if (runtimeAccessor is not IndexerAccessor && runtimeAccessor != ConstantValueAccessor.NullAccessor)
                 {
                     // Prefer direct property/field/method from runtime type over indexer from declared type
@@ -804,8 +804,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         var descriptor = accessor.CreatePropertyDescriptor(_engine, Target, member, enumerable: !isDictionary);
         if (!isDictionary
             && !ReferenceEquals(descriptor, PropertyDescriptor.Undefined)
-            && (!mustBeReadable || accessor.Readable)
-            && (!mustBeWritable || accessor.Writable))
+            && requirement.IsSatisfiedBy(accessor))
         {
             // cache the accessor for faster subsequent accesses
             SetProperty(member, descriptor);
@@ -873,7 +872,7 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
             };
         }
 
-        var accessor = engine.Options.Interop.TypeResolver.GetAccessor(engine, target.GetType(), member.Name, mustBeReadable: false, mustBeWritable: false, accessorFactory: Factory);
+        var accessor = engine.Options.Interop.TypeResolver.GetAccessor(engine, target.GetType(), member.Name, MemberResolutionRequirement.None, accessorFactory: Factory);
         return accessor.CreatePropertyDescriptor(engine, target, member.Name);
     }
 

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -13,20 +13,6 @@ using Jint.Runtime.Interop.Reflection;
 namespace Jint.Runtime.Interop;
 
 /// <summary>
-/// What a member resolution requires of the member it accepts. Resolution is filtered by this
-/// (a member that cannot satisfy the requirement is skipped in favour of an indexer, an explicit
-/// interface implementation, an extension method, ...), so it is part of the accessor cache key:
-/// the accessor a read settles on is not necessarily the one a write settles on.
-/// </summary>
-[Flags]
-internal enum MemberResolutionRequirement : byte
-{
-    None = 0,
-    Readable = 1,
-    Writable = 2,
-}
-
-/// <summary>
 /// Interop strategy for resolving types and members.
 /// </summary>
 public sealed class TypeResolver
@@ -88,21 +74,10 @@ public sealed class TypeResolver
         Engine engine,
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)] Type type,
         string member,
-        bool mustBeReadable,
-        bool mustBeWritable,
+        MemberResolutionRequirement requirement,
         bool throwOnError = true,
         Func<ReflectionAccessor?>? accessorFactory = null)
     {
-        var requirement = MemberResolutionRequirement.None;
-        if (mustBeReadable)
-        {
-            requirement |= MemberResolutionRequirement.Readable;
-        }
-        if (mustBeWritable)
-        {
-            requirement |= MemberResolutionRequirement.Writable;
-        }
-
         var key = new Engine.ClrPropertyDescriptorFactoriesKey(type, member, requirement);
 
         var factories = engine._reflectionAccessors;
@@ -117,7 +92,7 @@ public sealed class TypeResolver
             return accessor;
         }
 
-        accessor = accessorFactory?.Invoke() ?? ResolvePropertyDescriptorFactory(engine, type, member, mustBeReadable, mustBeWritable, throwOnError);
+        accessor = accessorFactory?.Invoke() ?? ResolvePropertyDescriptorFactory(engine, type, member, requirement, throwOnError);
 
         // don't cache if numeric indexer
         if (uint.TryParse(member, out _))
@@ -139,8 +114,7 @@ public sealed class TypeResolver
         Engine engine,
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)] Type type,
         string memberName,
-        bool mustBeReadable,
-        bool mustBeWritable,
+        MemberResolutionRequirement requirement,
         bool throwOnError)
     {
         var isInteger = long.TryParse(memberName, NumberStyles.Integer, CultureInfo.InvariantCulture, out _);
@@ -151,8 +125,7 @@ public sealed class TypeResolver
         // properties and fields cannot be numbers
         if (!isInteger
             && TryFindMemberAccessor(engine, type, memberName, bindingFlags: null, indexer, out var temp)
-            && (!mustBeReadable || temp.Readable)
-            && (!mustBeWritable || temp.Writable))
+            && requirement.IsSatisfiedBy(temp))
         {
             return temp;
         }


### PR DESCRIPTION
Follow-up to #2786, which has since merged — this branch is rebased directly onto `main` and the
diff is the refactor alone, one commit.

## What this changes

#2786 extracted `MemberResolutionRequirement` from the pair of booleans that CLR member
resolution is filtered by, but only consumed the enum in the accessor cache key. The API
*around* it still threaded `mustBeReadable` and `mustBeWritable` separately, so the same idea
was expressed in two shapes at once and `GetAccessor` opened by translating one into the other.

This replaces the boolean pairs with the enum at every site — 24 occurrences across
`TypeResolver.cs` and `ObjectWrapper.cs`:

- `TypeResolver.GetAccessor` and `TypeResolver.ResolvePropertyDescriptorFactory`
- the private `ObjectWrapper.GetOwnProperty` and `ObjectWrapper.ResolveMemberAccessor` overloads
- every call site

`TypeResolver.TryFindMemberAccessor` never took the booleans and is untouched.

The filter itself was open-coded **identically** in both files:

```csharp
(!mustBeReadable || accessor.Readable) && (!mustBeWritable || accessor.Writable)
```

Having confirmed the two occurrences really were the same predicate (modulo the local's name),
it now lives once as `requirement.IsSatisfiedBy(accessor)`, next to the enum. The enum moved out
of `TypeResolver.cs` into its own file: the repo's co-location rule asks for a separate file once
a supporting type has multiple independent consumers across the assembly — resolution, the
wrapper and the cache key in `Engine.cs` all name it now — and `TypeResolver.cs` was already past
the ~500-line threshold the same rule cites.

Representative call sites:

```csharp
// before
var desc = GetOwnProperty(property, mustBeReadable: true, mustBeWritable: false, throwOnError: false);
var accessor = ResolveMemberAccessor(member, mustBeWritable: true);

// after
var desc = GetOwnProperty(property, MemberResolutionRequirement.Readable, throwOnError: false);
var accessor = ResolveMemberAccessor(member, MemberResolutionRequirement.Writable);
```

The `false` that used to mean "I don't care about this one" read like a positive assertion that
the member must *not* be readable/writable; naming only the requirement that actually applies
removes that ambiguity rather than costing the argument labels the booleans provided.

## No public API change

Every member involved is `internal` or `private`. The public `ObjectWrapper.GetOwnProperty(JsValue)`
and `ObjectWrapper.GetPropertyDescriptor(Engine, object, MemberInfo)` signatures are untouched —
only the private overloads behind them changed.

Verified mechanically rather than by inspection: a reflection dump of every public and protected
type and member of `Jint.dll`, built from this branch and from its merge base, is **identical
across all 2477 entries**. `Jint.Tests.PublicInterface` (which has no `InternalsVisibleTo` and so
compiles against the public surface only) builds and passes unchanged.

## No behaviour change

Only three of the four flag combinations are reachable, and each maps one-to-one onto the boolean
pair it replaces:

| `mustBeReadable` | `mustBeWritable` | requirement | call sites |
| --- | --- | --- | --- |
| `false` | `false` | `None` | `GetOwnProperty(JsValue)`, the unfiltered probe in `Set`, `GetPropertyDescriptor` |
| `true` | `false` | `Readable` | the read lane in `Get` |
| `false` | `true` | `Writable` | the write lane in `Set` |

That is precisely what `GetAccessor` computed internally from the two booleans before, so the
`ClrPropertyDescriptorFactoriesKey` produced for any given call is identical to the one produced
before — the translation simply moved from the callee to the callers. `(true, true)` was
unreachable before and remains unreachable; the enum still expresses it.

`IsSatisfiedBy` is the same predicate rewritten as early-return guards, and `None` short-circuits
both guards, so the "don't care" path stays a pair of flag tests.

## Verification

Release build, warnings-as-errors, 0 warnings. Every suite was run twice — once on the merge base
and once on this branch — so the comparison is against a freshly measured baseline rather than an
assumed one. All four numbers match exactly.

| Suite | Merge base (`aada6c145`) | This branch |
| --- | --- | --- |
| `Jint.Tests` (net10.0) | 4100 passed, 0 failed, 4 skipped | 4100 passed, 0 failed, 4 skipped |
| `Jint.Tests` (net472) | 4037 passed, 0 failed, 4 skipped | 4037 passed, 0 failed, 4 skipped |
| `Jint.Tests.PublicInterface` (net10.0 / net472) | 149 / 149 passed, 0 failed | 149 / 149 passed, 0 failed |
| `Jint.Tests.Test262` | 99441 passed, 0 failed, 157 skipped | 99441 passed, 0 failed, 157 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
