### PR TITLE
Make TimeoutInterval replace the previous timeout instead of accumulating

### DIFF
--- a/Jint.Tests/Runtime/ConstraintRegistrationTests.cs
+++ b/Jint.Tests/Runtime/ConstraintRegistrationTests.cs
@@ -1,0 +1,65 @@
+#nullable enable
+using Jint.Constraints;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the registration semantics of the built-in constraint helpers, as distinct from what the
+/// constraints do once registered: which values register a constraint at all, and that calling a
+/// helper twice replaces rather than accumulates.
+/// </summary>
+public class ConstraintRegistrationTests
+{
+    private static List<Constraint> Register(Action<Options> configure)
+    {
+        var options = new Options();
+        configure(options);
+        return options.Constraints.Constraints;
+    }
+
+    private static int TimeConstraintCount(Action<Options> configure)
+    {
+        // TimeConstraint is internal, so it is counted by exclusion rather than by type
+        return Register(configure).Count(c => c is not MaxStatementsConstraint and not MemoryLimitConstraint and not CancellationConstraint);
+    }
+
+    [Fact]
+    public void TimeoutIntervalRegistersNothingForIntervalsThatCannotExpressALimit()
+    {
+        TimeConstraintCount(o => o.TimeoutInterval(TimeSpan.Zero)).Should().Be(0);
+        TimeConstraintCount(o => o.TimeoutInterval(TimeSpan.FromSeconds(-1))).Should().Be(0);
+        TimeConstraintCount(o => o.TimeoutInterval(TimeSpan.MaxValue)).Should().Be(0);
+    }
+
+    [Fact]
+    public void TimeoutIntervalReplacesInsteadOfAccumulating()
+    {
+        // the second call must win outright; two live time constraints would silently leave the
+        // stricter of the two in charge
+        TimeConstraintCount(o => o.TimeoutInterval(TimeSpan.FromSeconds(1))).Should().Be(1);
+        TimeConstraintCount(o => o.TimeoutInterval(TimeSpan.FromSeconds(1)).TimeoutInterval(TimeSpan.FromSeconds(5))).Should().Be(1);
+        TimeConstraintCount(o => o.TimeoutInterval(TimeSpan.FromSeconds(1)).TimeoutInterval(TimeSpan.MaxValue)).Should().Be(0);
+    }
+
+    [Fact]
+    public void TheLaterTimeoutIsTheOneEnforced()
+    {
+        // a widened timeout must actually take effect, which it cannot while the earlier, stricter
+        // constraint is still registered alongside it
+        var engine = new Engine(o => o
+            .TimeoutInterval(TimeSpan.FromMilliseconds(1))
+            .TimeoutInterval(TimeSpan.FromSeconds(30)));
+
+        engine.Evaluate("var n = 0; for (var i = 0; i < 200000; i++) { n += i; } n").AsNumber().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void ARemovedTimeoutNoLongerApplies()
+    {
+        var engine = new Engine(o => o
+            .TimeoutInterval(TimeSpan.FromMilliseconds(1))
+            .TimeoutInterval(TimeSpan.MaxValue));
+
+        engine.Evaluate("var n = 0; for (var i = 0; i < 200000; i++) { n += i; } n").AsNumber().Should().BeGreaterThan(0);
+    }
+}

--- a/Jint/Constraints/ConstraintsOptionsExtensions.cs
+++ b/Jint/Constraints/ConstraintsOptionsExtensions.cs
@@ -39,6 +39,8 @@ public static class ConstraintsOptionsExtensions
     /// </summary>
     public static Options TimeoutInterval(this Options options, TimeSpan timeoutInterval)
     {
+        options.WithoutConstraint(x => x is TimeConstraint);
+
         if (timeoutInterval > TimeSpan.Zero && timeoutInterval < TimeSpan.MaxValue)
         {
             options.Constraint(new TimeConstraint(timeoutInterval));


### PR DESCRIPTION
`TimeoutInterval` is the only constraint helper that does not remove its own kind before registering, so it accumulates instead of replacing. Two calls leave two live `TimeConstraint`s and the stricter one silently wins:

```csharp
var engine = new Engine(options => options
    .TimeoutInterval(TimeSpan.FromSeconds(1))
    .TimeoutInterval(TimeSpan.FromSeconds(30)));
// still times out after 1 second
```

Widening a timeout does not widen it, and `TimeSpan.MaxValue` — which the helper already treats as "no timeout" — does not clear an earlier one either. This bites embedders that build options in layers: a base configuration sets a conservative timeout and a caller that overrides it for a long-running script gets no override at all, with no diagnostic.

Every sibling helper (`MaxStatements`, `LimitMemory`, `CancellationToken`) calls `WithoutConstraint` for its own type first. This one now does the same. `TimeConstraint` is `internal sealed` with an `internal` constructor and this helper is the only thing in the assembly that constructs one, so removal by type is complete — nothing else can have registered one that the caller did not ask for.

The fix is one line; the rest is test coverage.

### Verification

Confirmed by reverting the one line and re-running the new tests: 3 of the 4 fail, on both `net10.0` and `net472`.

- `TimeoutIntervalReplacesInsteadOfAccumulating` — *Expected ... to be 1, but found 2*
- `TheLaterTimeoutIsTheOneEnforced` — real `System.TimeoutException` thrown from `Throw.TimeoutException()`, i.e. the stale 1 ms constraint is genuinely still enforcing
- `ARemovedTimeoutNoLongerApplies` — same, `TimeSpan.MaxValue` did not clear it

With the line restored, all four pass.

| suite | result |
| --- | --- |
| `Jint.Tests` net10.0 | 4060 passed, 0 failed, 4 skipped |
| `Jint.Tests` net472 | 3997 passed, 0 failed, 4 skipped |
| `Jint.Tests.PublicInterface` | 114/114 on both TFMs |
| Test262 | 99441 passed, 0 failed, 157 skipped (baseline) |

Release build, warnings-as-errors, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
