### PR TITLE
Document the constraint helpers' unlimited sentinels

### DIFF
--- a/Jint.Tests/Runtime/ConstraintRegistrationTests.cs
+++ b/Jint.Tests/Runtime/ConstraintRegistrationTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using Jint.Constraints;
+using Jint.Runtime;
 
 namespace Jint.Tests.Runtime;
 
@@ -15,6 +16,63 @@ public class ConstraintRegistrationTests
         var options = new Options();
         configure(options);
         return options.Constraints.Constraints;
+    }
+
+    private static int CountOf<T>(Action<Options> configure) where T : Constraint
+    {
+        return Register(configure).Count(c => c is T);
+    }
+
+    [Theory]
+    [InlineData(int.MinValue)]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(int.MaxValue)]
+    public void MaxStatementsRegistersNothingForValuesThatCannotExpressALimit(int maxStatements)
+    {
+        CountOf<MaxStatementsConstraint>(o => o.MaxStatements(maxStatements)).Should().Be(0);
+    }
+
+    [Fact]
+    public void MaxStatementsWithNoArgumentRegistersNothing()
+    {
+        // the parameter defaults to 0, which means unlimited - not "no statements allowed"
+        CountOf<MaxStatementsConstraint>(o => o.MaxStatements()).Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(1000)]
+    [InlineData(int.MaxValue - 1)]
+    public void MaxStatementsRegistersOneForARealLimit(int maxStatements)
+    {
+        CountOf<MaxStatementsConstraint>(o => o.MaxStatements(maxStatements)).Should().Be(1);
+    }
+
+    [Fact]
+    public void MaxStatementsReplacesAndCanBeCleared()
+    {
+        Register(o => o.MaxStatements(10).MaxStatements(20))
+            .OfType<MaxStatementsConstraint>().Should().ContainSingle().Which.MaxStatements.Should().Be(20);
+
+        CountOf<MaxStatementsConstraint>(o => o.MaxStatements(10).MaxStatements(int.MaxValue)).Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(long.MinValue)]
+    [InlineData(-1L)]
+    [InlineData(0L)]
+    [InlineData(long.MaxValue)]
+    public void LimitMemoryRegistersNothingForValuesThatCannotExpressALimit(long memoryLimit)
+    {
+        CountOf<MemoryLimitConstraint>(o => o.LimitMemory(memoryLimit)).Should().Be(0);
+    }
+
+    [Fact]
+    public void LimitMemoryReplacesAndCanBeCleared()
+    {
+        CountOf<MemoryLimitConstraint>(o => o.LimitMemory(1024).LimitMemory(2048)).Should().Be(1);
+        CountOf<MemoryLimitConstraint>(o => o.LimitMemory(1024).LimitMemory(long.MaxValue)).Should().Be(0);
     }
 
     private static int TimeConstraintCount(Action<Options> configure)
@@ -61,5 +119,55 @@ public class ConstraintRegistrationTests
             .TimeoutInterval(TimeSpan.MaxValue));
 
         engine.Evaluate("var n = 0; for (var i = 0; i < 200000; i++) { n += i; } n").AsNumber().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void CancellationTokenRegistersNothingForTheDefaultToken()
+    {
+        CountOf<CancellationConstraint>(o => o.CancellationToken(default)).Should().Be(0);
+    }
+
+    [Fact]
+    public void CancellationTokenReplacesAndCanBeCleared()
+    {
+        using var source = new System.Threading.CancellationTokenSource();
+        using var other = new System.Threading.CancellationTokenSource();
+
+        CountOf<CancellationConstraint>(o => o.CancellationToken(source.Token)).Should().Be(1);
+        CountOf<CancellationConstraint>(o => o.CancellationToken(source.Token).CancellationToken(other.Token)).Should().Be(1);
+        CountOf<CancellationConstraint>(o => o.CancellationToken(source.Token).CancellationToken(default)).Should().Be(0);
+    }
+
+    [Fact]
+    public void ASaturatedStatementLimitLeavesTheEngineIndistinguishableFromNoLimit()
+    {
+        // The documented consequence of the sentinel: this is not "a very large limit", it is the
+        // unconstrained engine, tight-loop lane and all. Registering the constraint instead would
+        // buy nothing, because the constraint counts statements in an int and so can never reach
+        // int.MaxValue.
+        var saturated = new Engine(o => o.MaxStatements(int.MaxValue));
+        var unlimited = new Engine();
+
+        saturated.Constraints.Find<MaxStatementsConstraint>().Should().BeNull();
+        unlimited.Constraints.Find<MaxStatementsConstraint>().Should().BeNull();
+
+        const string Script = "var n = 0; for (var i = 0; i < 50000; i++) { n += i; } n";
+        saturated.Evaluate(Script).AsNumber().Should().Be(unlimited.Evaluate(Script).AsNumber());
+    }
+
+    [Fact]
+    public void ASaturatedRecursionDepthStillEnablesDepthTracking()
+    {
+        // LimitRecursion is deliberately documented as the exception: any non-negative depth turns
+        // the check on, so a saturated value costs enforcement without ever failing.
+        new Engine(o => o.LimitRecursion(int.MaxValue)).Options.Constraints.MaxRecursionDepth.Should().Be(int.MaxValue);
+        new Engine().Options.Constraints.MaxRecursionDepth.Should().Be(-1);
+
+        // and it really does not fail, unlike a small depth
+        new Engine(o => o.LimitRecursion(int.MaxValue))
+            .Evaluate("function f(n) { return n === 0 ? 0 : f(n - 1); } f(100)").AsNumber().Should().Be(0);
+
+        Invoking(() => new Engine(o => o.LimitRecursion(10)).Evaluate("function f(n) { return n === 0 ? 0 : f(n - 1); } f(100)"))
+            .Should().ThrowExactly<RecursionDepthOverflowException>();
     }
 }

--- a/Jint/Constraints/ConstraintsOptionsExtensions.cs
+++ b/Jint/Constraints/ConstraintsOptionsExtensions.cs
@@ -4,11 +4,39 @@ using Jint.Constraints;
 // ReSharper disable once CheckNamespace
 namespace Jint;
 
+/// <summary>
+/// Registers the built-in execution constraints.
+/// <para>
+/// Each method here <b>replaces</b> the constraint of its own kind, so calling one twice leaves a
+/// single constraint registered, and each treats a value that cannot express a real limit as
+/// "remove the constraint" rather than registering one. That is deliberate: such a constraint could
+/// never fail, so registering it would only add per-check work to every evaluation — and an exact
+/// constraint (<see cref="MaxStatementsConstraint"/>, <see cref="MemoryLimitConstraint"/>)
+/// additionally disables the interpreter's tight-loop lane, which costs every loop in the program.
+/// </para>
+/// <para>
+/// The consequence is worth stating plainly, because it is easy to configure by accident: spelling
+/// "effectively unlimited" as a saturated value produces exactly the same engine as never calling
+/// the method, not an engine carrying a very large limit. A host that sets one believing it has a
+/// limit has none, and a comparison of "with a limit" against "without" written that way compares
+/// an engine against itself.
+/// </para>
+/// </summary>
 public static class ConstraintsOptionsExtensions
 {
     /// <summary>
-    /// Limits the allowed statement count that can be run as part of the program.
+    /// Limits the allowed statement count that can be run as part of the program, replacing any
+    /// limit set by an earlier call.
     /// </summary>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="maxStatements">
+    /// The statement budget. Only <c>1</c> to <see cref="int.MaxValue"/> - 1 registers a constraint;
+    /// every other value removes it and leaves the statement count unlimited. A non-positive budget
+    /// (including the parameter's own default) is removed because the constraint treats it as "no
+    /// limit" internally, and <see cref="int.MaxValue"/> because the constraint counts statements in
+    /// an <see cref="int"/> and so can never reach that many.
+    /// </param>
+    /// <returns>Options instance for fluent syntax.</returns>
     public static Options MaxStatements(this Options options, int maxStatements = 0)
     {
         options.WithoutConstraint(x => x is MaxStatementsConstraint);
@@ -21,8 +49,17 @@ public static class ConstraintsOptionsExtensions
     }
 
     /// <summary>
-    /// Sets constraint based on memory usage in bytes.
+    /// Sets constraint based on memory usage in bytes, replacing any limit set by an earlier call.
     /// </summary>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="memoryLimit">
+    /// The allowed allocation in bytes. Only <c>1</c> to <see cref="long.MaxValue"/> - 1 registers a
+    /// constraint; every other value removes it and leaves allocation unlimited. A non-positive limit
+    /// is removed because the constraint treats it as "no limit" internally, and
+    /// <see cref="long.MaxValue"/> because the measured allocation is itself a <see cref="long"/> and
+    /// so can never exceed it.
+    /// </param>
+    /// <returns>Options instance for fluent syntax.</returns>
     public static Options LimitMemory(this Options options, long memoryLimit)
     {
         options.WithoutConstraint(x => x is MemoryLimitConstraint);
@@ -35,8 +72,17 @@ public static class ConstraintsOptionsExtensions
     }
 
     /// <summary>
-    /// Sets constraint based on fixed time interval.
+    /// Sets constraint based on fixed time interval, replacing any timeout set by an earlier call.
     /// </summary>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="timeoutInterval">
+    /// The allowed execution time. Only an interval strictly between <see cref="TimeSpan.Zero"/> and
+    /// <see cref="TimeSpan.MaxValue"/> registers a constraint; every other value removes it and
+    /// leaves execution untimed. A non-positive interval is removed because it expresses no waiting
+    /// time, and <see cref="TimeSpan.MaxValue"/> because a deadline that far out can never be
+    /// reached.
+    /// </param>
+    /// <returns>Options instance for fluent syntax.</returns>
     public static Options TimeoutInterval(this Options options, TimeSpan timeoutInterval)
     {
         options.WithoutConstraint(x => x is TimeConstraint);
@@ -49,8 +95,15 @@ public static class ConstraintsOptionsExtensions
     }
 
     /// <summary>
-    /// Sets cancellation token to be observed. NOTE that this can be unreliable/imprecise on full framework due to timer logic.
+    /// Sets cancellation token to be observed, replacing any token set by an earlier call.
+    /// NOTE that this can be unreliable/imprecise on full framework due to timer logic.
     /// </summary>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="cancellationToken">
+    /// The token to observe. The default token removes the constraint and leaves execution
+    /// unobserved, because a token that cannot be cancelled has nothing to report.
+    /// </param>
+    /// <returns>Options instance for fluent syntax.</returns>
     public static Options CancellationToken(this Options options, CancellationToken cancellationToken)
     {
         options.WithoutConstraint(x => x is CancellationConstraint);

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -91,7 +91,15 @@ public static class OptionsExtensions
     /// The allowed depth.
     /// a) In case max depth is zero no recursion is allowed.
     /// b) In case max depth is equal to n it means that in one scope function can be called no more than n times.
+    /// c) A negative depth (the default of <see cref="Options.ConstraintOptions.MaxRecursionDepth"/>)
+    /// disables the check, and with it the call-stack depth tracking that feeds it.
     /// </param>
+    /// <remarks>
+    /// Unlike the constraint helpers in <see cref="ConstraintsOptionsExtensions"/>, this one does not
+    /// treat a saturated value as "no limit": any non-negative depth — <see cref="int.MaxValue"/>
+    /// included — turns depth tracking on, so a limit chosen to be unreachable still costs what
+    /// enforcement costs while never failing. Pass a negative depth to mean unlimited.
+    /// </remarks>
     /// <returns>Options instance for fluent syntax</returns>
     public static Options LimitRecursion(this Options options, int maxRecursionDepth = 0)
     {


### PR DESCRIPTION
`MaxStatements(int.MaxValue)` — a natural way to spell "effectively unlimited" — quietly registers nothing. Same for `LimitMemory(long.MaxValue)`, `TimeoutInterval(TimeSpan.MaxValue)` and `CancellationToken(default)`.

That is the right behaviour, not a bug. With `MaxStatements == int.MaxValue`, `++_statementsCount > MaxStatements` on an `int` counter can never be true — the counter wraps first — so registering the constraint would cost a call per statement *and* disarm the interpreter's tight-loop lane (an exact constraint sets `EvaluationContext._shouldRunPerStatementChecks`, which every loop in the program then pays for), all while enforcing nothing. The same reasoning applies to `LimitMemory(long.MaxValue)`, whose measured allocation is itself a `long`; to a non-positive budget in either, which both constraints already treat as "no limit" internally; and to the default `CancellationToken`, which cannot be cancelled.

What is unfortunate is that it is *silent*. A host that sets `int.MaxValue` believing it has a limit has none, and a host that compares "with a limit" against "without" by toggling between `int.MaxValue` and a real value is comparing an engine against itself. So this documents, per helper, exactly which values register nothing and why, with the consequence spelled out once on the class:

> spelling "effectively unlimited" as a saturated value produces exactly the same engine as never calling the method, not an engine carrying a very large limit

`LimitRecursion` is documented as the deliberate exception pointing the other way: any non-negative depth, `int.MaxValue` included, turns depth tracking **on**, so a saturated value there costs what enforcement costs while never failing. A negative depth is how "unlimited" is spelled for that one.

No behaviour change — XML documentation plus tests that pin the documented semantics, including that a saturated statement limit really does leave an engine indistinguishable from the unconstrained one, and that a saturated recursion depth really does keep depth tracking on.

Rebased onto `main` after #2788 landed; the class-level "each method **replaces** the constraint of its own kind" is accurate now that `TimeoutInterval` does too. This branch adds the sibling registration coverage next to the timeout tests #2788 brought in — one copy of each, no overlap.

### Verification

| suite | result |
| --- | --- |
| `Jint.Tests` net10.0 | 4078 passed, 0 failed, 4 skipped |
| `Jint.Tests` net472 | 4015 passed, 0 failed, 4 skipped |
| `Jint.Tests.PublicInterface` | 114/114 on both TFMs |
| Test262 | 99441 passed, 0 failed, 157 skipped (baseline) |

Release build, warnings-as-errors, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
