### PR TITLE
Remove the unreachable enum branch from the default object converter

### DIFF
--- a/Jint.Tests/Runtime/InteropEnumConversionTests.cs
+++ b/Jint.Tests/Runtime/InteropEnumConversionTests.cs
@@ -1,0 +1,183 @@
+#nullable enable
+using Jint.Native;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the CLR-enum to <see cref="JsValue"/> conversion across every underlying-type route.
+/// An enum is an <see cref="IConvertible"/> whose <see cref="IConvertible.GetTypeCode"/> reports the
+/// underlying type, so the conversion is served by the shared convertible lane in
+/// <c>DefaultObjectConverter</c> rather than by any enum-specific handling.
+/// </summary>
+public class InteropEnumConversionTests
+{
+    private enum PlainEnum
+    {
+        Zero,
+        One,
+        Big = int.MaxValue,
+        Negative = -5,
+    }
+
+    [Flags]
+    private enum FlagsEnum
+    {
+        None = 0,
+        A = 1,
+        B = 2,
+        C = 4,
+    }
+
+    private enum ByteEnum : byte
+    {
+        Zero,
+        One,
+        Max = byte.MaxValue,
+    }
+
+    private enum SByteEnum : sbyte
+    {
+        Min = sbyte.MinValue,
+        Zero = 0,
+        Max = sbyte.MaxValue,
+    }
+
+    private enum ShortEnum : short
+    {
+        Min = short.MinValue,
+        Max = short.MaxValue,
+    }
+
+    private enum UShortEnum : ushort
+    {
+        Zero,
+        Max = ushort.MaxValue,
+    }
+
+    private enum UIntEnum : uint
+    {
+        Zero,
+        Max = uint.MaxValue,
+    }
+
+    private enum LongEnum : long
+    {
+        Min = long.MinValue,
+        Zero = 0,
+        Max = long.MaxValue,
+    }
+
+    private enum ULongEnum : ulong
+    {
+        Zero,
+        Max = ulong.MaxValue,
+    }
+
+    private sealed class Host
+    {
+        public PlainEnum PlainProperty { get; set; } = PlainEnum.One;
+        public ByteEnum ByteField = ByteEnum.Max;
+        public LongEnum? NullableProperty { get; set; } = LongEnum.Max;
+        public LongEnum? NullProperty { get; set; }
+
+        public FlagsEnum ReturnsFlags() => FlagsEnum.A | FlagsEnum.C;
+        public ULongEnum ReturnsULong() => ULongEnum.Max;
+        public UIntEnum? ReturnsNullableUInt() => UIntEnum.Max;
+    }
+
+    public static TheoryData<object, double> EnumValues() => new()
+    {
+        { PlainEnum.Zero, 0 },
+        { PlainEnum.One, 1 },
+        { PlainEnum.Big, int.MaxValue },
+        { PlainEnum.Negative, -5 },
+        { FlagsEnum.None, 0 },
+        { FlagsEnum.A | FlagsEnum.B, 3 },
+        { FlagsEnum.A | FlagsEnum.B | FlagsEnum.C, 7 },
+        { ByteEnum.Zero, 0 },
+        { ByteEnum.Max, byte.MaxValue },
+        { SByteEnum.Min, sbyte.MinValue },
+        { SByteEnum.Max, sbyte.MaxValue },
+        { ShortEnum.Min, short.MinValue },
+        { ShortEnum.Max, short.MaxValue },
+        { UShortEnum.Max, ushort.MaxValue },
+        { UIntEnum.Max, uint.MaxValue },
+        { LongEnum.Min, long.MinValue },
+        { LongEnum.Max, long.MaxValue },
+        { ULongEnum.Max, ulong.MaxValue },
+    };
+
+    [Theory]
+    [MemberData(nameof(EnumValues))]
+    public void FromObjectConvertsEnumToNumber(object enumValue, double expected)
+    {
+        var engine = new Engine();
+
+        var converted = JsValue.FromObject(engine, enumValue);
+
+        converted.IsNumber().Should().BeTrue();
+        converted.AsNumber().Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(EnumValues))]
+    public void NullableEnumConvertsLikeItsUnderlyingValue(object enumValue, double expected)
+    {
+        var engine = new Engine();
+
+        // a boxed Nullable<TEnum> with a value boxes as the enum itself, so it takes the same route
+        var nullable = Activator.CreateInstance(typeof(Nullable<>).MakeGenericType(enumValue.GetType()), enumValue);
+
+        var converted = JsValue.FromObject(engine, nullable);
+
+        converted.IsNumber().Should().BeTrue();
+        converted.AsNumber().Should().Be(expected);
+    }
+
+    [Fact]
+    public void NullNullableEnumConvertsToNull()
+    {
+        var engine = new Engine();
+        LongEnum? value = null;
+
+        JsValue.FromObject(engine, value).Should().Be(JsValue.Null);
+    }
+
+    [Fact]
+    public void EnumMembersAndReturnValuesConvertToNumbers()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new Host());
+
+        engine.Evaluate("host.PlainProperty").AsNumber().Should().Be(1);
+        engine.Evaluate("host.ByteField").AsNumber().Should().Be(byte.MaxValue);
+        engine.Evaluate("host.NullableProperty").AsNumber().Should().Be(long.MaxValue);
+        engine.Evaluate("host.NullProperty").Should().Be(JsValue.Null);
+        engine.Evaluate("host.ReturnsFlags()").AsNumber().Should().Be(5);
+        engine.Evaluate("host.ReturnsULong()").AsNumber().Should().Be(ulong.MaxValue);
+        engine.Evaluate("host.ReturnsNullableUInt()").AsNumber().Should().Be(uint.MaxValue);
+    }
+
+    [Fact]
+    public void EnumInsideCollectionsConvertsToNumbers()
+    {
+        var engine = new Engine();
+        engine.SetValue("values", new object[] { PlainEnum.One, ByteEnum.Max, ULongEnum.Max });
+
+        engine.Evaluate("values[0]").AsNumber().Should().Be(1);
+        engine.Evaluate("values[1]").AsNumber().Should().Be(byte.MaxValue);
+        engine.Evaluate("values[2]").AsNumber().Should().Be(ulong.MaxValue);
+    }
+
+    [Fact]
+    public void EnumExposedAsObjectTypeStillConvertsToNumber()
+    {
+        var engine = new Engine();
+
+        // an exposed type of object resolves the CLR type from the value itself
+        JsValue.FromObjectWithType(engine, PlainEnum.Big, typeof(object)).AsNumber().Should().Be(int.MaxValue);
+        JsValue.FromObjectWithType(engine, PlainEnum.Big, typeof(PlainEnum)).AsNumber().Should().Be(int.MaxValue);
+        JsValue.FromObjectWithType(engine, PlainEnum.Big, typeof(Enum)).AsNumber().Should().Be(int.MaxValue);
+        JsValue.FromObjectWithType(engine, LongEnum.Max, typeof(LongEnum?)).AsNumber().Should().Be(long.MaxValue);
+    }
+}

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Jint.Native;
@@ -141,67 +140,49 @@ internal static class DefaultObjectConverter
                 Throw.InvalidOperationException(Message);
             }
 
-            if (t.IsEnum)
-            {
-                var ut = Enum.GetUnderlyingType(t);
+            // NOTE: enums never reach this point. Every enum is an IConvertible whose GetTypeCode()
+            // reports its underlying type, so the convertible lane above already converted it to the
+            // JsNumber for its underlying value and returned. Any enum-specific handling therefore
+            // belongs in TryConvertConvertible (or ahead of the convertible check), never here.
 
-                if (ut == typeof(ulong))
-                {
-                    result = JsNumber.Create(Convert.ToDouble(value, CultureInfo.InvariantCulture));
-                }
-                else
-                {
-                    if (ut == typeof(uint) || ut == typeof(long))
-                    {
-                        result = JsNumber.Create(Convert.ToInt64(value, CultureInfo.InvariantCulture));
-                    }
-                    else
-                    {
-                        result = JsNumber.Create(Convert.ToInt32(value, CultureInfo.InvariantCulture));
-                    }
-                }
+            // check global cache, have we already wrapped the value? A cached wrapper is only
+            // valid for the same exposed CLR type — the same object may also cross as an
+            // explicit interface/superclass view, which resolves a different member set.
+            if (engine._objectWrapperCache?.TryGetValue(value, out var cached) == true
+                && (cached is not ObjectWrapper cachedWrapper || cachedWrapper.ClrType == valueType))
+            {
+                result = cached;
+            }
+            else if (engine._recentObjectWrapperCache?.TryGet(value, valueType) is { } recentlyWrapped)
+            {
+                result = recentlyWrapped;
             }
             else
             {
-                // check global cache, have we already wrapped the value? A cached wrapper is only
-                // valid for the same exposed CLR type — the same object may also cross as an
-                // explicit interface/superclass view, which resolves a different member set.
-                if (engine._objectWrapperCache?.TryGetValue(value, out var cached) == true
-                    && (cached is not ObjectWrapper cachedWrapper || cachedWrapper.ClrType == valueType))
-                {
-                    result = cached;
-                }
-                else if (engine._recentObjectWrapperCache?.TryGet(value, valueType) is { } recentlyWrapped)
-                {
-                    result = recentlyWrapped;
-                }
-                else
-                {
-                    var wrapped = engine.Options.Interop.WrapObjectHandler.Invoke(engine, value, type);
+                var wrapped = engine.Options.Interop.WrapObjectHandler.Invoke(engine, value, type);
 
-                    if (ReferenceEquals(wrapped?.GetPrototypeOf(), engine.Realm.Intrinsics.Object.PrototypeObject)
-                        && engine._typeReferences?.TryGetValue(t, out var typeReference) == true)
+                if (ReferenceEquals(wrapped?.GetPrototypeOf(), engine.Realm.Intrinsics.Object.PrototypeObject)
+                    && engine._typeReferences?.TryGetValue(t, out var typeReference) == true)
+                {
+                    wrapped.SetPrototypeOf(typeReference);
+                }
+
+                result = wrapped;
+
+                if (wrapped is not null)
+                {
+                    if (engine.Options.Interop.TrackObjectWrapperIdentity)
                     {
-                        wrapped.SetPrototypeOf(typeReference);
+                        engine._objectWrapperCache ??= new ConditionalWeakTable<object, ObjectInstance>();
+                        // the table may hold a wrapper for a different exposed view of the same
+                        // object (the type-guarded lookup above missed it) — last view wins
+                        engine._objectWrapperCache.Remove(value);
+                        engine._objectWrapperCache.Add(value, wrapped);
                     }
-
-                    result = wrapped;
-
-                    if (wrapped is not null)
+                    else if (engine.Options.Interop.CacheRecentObjectWrappers)
                     {
-                        if (engine.Options.Interop.TrackObjectWrapperIdentity)
-                        {
-                            engine._objectWrapperCache ??= new ConditionalWeakTable<object, ObjectInstance>();
-                            // the table may hold a wrapper for a different exposed view of the same
-                            // object (the type-guarded lookup above missed it) — last view wins
-                            engine._objectWrapperCache.Remove(value);
-                            engine._objectWrapperCache.Add(value, wrapped);
-                        }
-                        else if (engine.Options.Interop.CacheRecentObjectWrappers)
-                        {
-                            engine._recentObjectWrapperCache ??= new RecentObjectWrapperCache();
-                            engine._recentObjectWrapperCache.Add(value, wrapped);
-                        }
+                        engine._recentObjectWrapperCache ??= new RecentObjectWrapperCache();
+                        engine._recentObjectWrapperCache.Add(value, wrapped);
                     }
                 }
             }


### PR DESCRIPTION
`DefaultObjectConverter.TryConvert` has an `if (t.IsEnum)` branch that converts an enum to a `JsNumber` of its underlying value. It cannot be reached.

### The proof

`t.IsEnum` is tested ~60 lines *after* the convertible lane:

```csharp
if (value is IConvertible convertible && TryConvertConvertible(engine, convertible, out result))
{
    return true;
}
...
if (t.IsEnum) { /* unreachable */ }
```

Every enum is an `IConvertible`, and `Enum.GetTypeCode()` reports the **underlying** type, not `TypeCode.Object`. C# allows exactly eight underlying types — `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong` — and `TryConvertConvertible` handles all eight (`TypeCode.Byte`, `SByte`, `Int16`, `UInt16`, `Int32`, `UInt32`, `Int64`, `UInt64`), each producing a `JsNumber` of the underlying value. So any boxed enum converts and returns before the branch is evaluated.

Nothing ahead of the convertible check can claim an enum either: `_typeMappers` is keyed on concrete framework types only, and its single runtime addition is memoized array conversion under an array-typed key.

Nullable enums take the same route — a `Nullable<TEnum>` with a value boxes as the enum itself, and a null one is handled before conversion.

And the branch already agreed with the lane shadowing it: both yield the numeric value, so there was never an observable difference to preserve.

### Verified empirically, not just by reading

Built with the branch body replaced by `throw new InvalidOperationException("PROBE: the enum branch was reached for " + t.FullName)` and ran the entire suite, including the 40 new enum test cases below. Everything passed — 4096 `net10.0` / 4033 `net472`, zero failures — i.e. nothing entered the branch. Removing it produces identical counts. (A swallowed probe exception would still have failed the new tests, since they assert exact numeric results.)

The removal also lets the wrapper lane that the branch used to shadow lose a level of nesting, which is most of the diff's line count. A comment now records why enum handling belongs in `TryConvertConvertible` and not here.

### Verification

| suite | result |
| --- | --- |
| `Jint.Tests` net10.0 | 4096 passed, 0 failed, 4 skipped |
| `Jint.Tests` net472 | 4033 passed, 0 failed, 4 skipped |
| `Jint.Tests.PublicInterface` | 114/114 on both TFMs |
| Test262 | not applicable — dead-code removal on a CLR-interop path Test262 does not exercise; run over the final state anyway and clean at the 99441/0/157 baseline |

Adds `InteropEnumConversionTests`, which pins the conversion for a plain enum, a `[Flags]` enum, every legal underlying type, nullable enums (valued and null), enum fields/properties/method return values through the interop wrappers, enums inside collections, and enums exposed under `object` / `Enum` / `Nullable<TEnum>` — so the behaviour is nailed down whether or not the branch exists.

Release build, warnings-as-errors, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
