### PR TITLE
Compile the dictionary TryGetValue lane instead of invoking it reflectively

### DIFF
--- a/Jint.Tests/Runtime/InteropDictionaryValueAccessTests.cs
+++ b/Jint.Tests/Runtime/InteropDictionaryValueAccessTests.cs
@@ -1,0 +1,331 @@
+#nullable enable
+using Jint.Native;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Exercises reading values out of dictionary-shaped host objects, which go through a compiled
+/// <c>TryGetValue</c> delegate where one can be built and through reflection everywhere else. Every
+/// assertion here is written against the behavior that predates the compiled lane — a hit, a miss, a stored
+/// null and a value-typed value must be indistinguishable between the two, in particular a miss on a
+/// value-typed dictionary must never surface the default value the out parameter carries.
+/// </summary>
+public class InteropDictionaryValueAccessTests
+{
+    private static Engine CreateEngine(object host)
+    {
+        var engine = new Engine();
+        engine.SetValue("d", host);
+        return engine;
+    }
+
+    #region 1. reference-typed values
+
+    [Fact]
+    public void ReadsAStringValue()
+    {
+        var engine = CreateEngine(new Dictionary<string, string> { ["a"] = "one" });
+
+        engine.Evaluate("d.a").Should().Be("one");
+        engine.Evaluate("d['a']").Should().Be("one");
+    }
+
+    [Fact]
+    public void MissingKeyIsUndefined()
+    {
+        var engine = CreateEngine(new Dictionary<string, string> { ["a"] = "one" });
+
+        engine.Evaluate("typeof d.missing").Should().Be("undefined");
+        engine.Evaluate("d.missing === undefined").Should().Be(true);
+        engine.Evaluate("'missing' in d").Should().Be(false);
+        engine.Evaluate("'a' in d").Should().Be(true);
+    }
+
+    [Fact]
+    public void StoredNullIsNull()
+    {
+        var engine = CreateEngine(new Dictionary<string, string?> { ["a"] = null });
+
+        engine.Evaluate("d.a").Should().Be(JsValue.Null);
+        engine.Evaluate("d.a === null").Should().Be(true);
+        engine.Evaluate("'a' in d").Should().Be(true);
+    }
+
+    [Fact]
+    public void ReadsAfterMutation()
+    {
+        var dictionary = new Dictionary<string, string>();
+        var engine = CreateEngine(dictionary);
+
+        engine.Evaluate("typeof d.a").Should().Be("undefined");
+        dictionary["a"] = "added";
+        engine.Evaluate("d.a").Should().Be("added");
+        dictionary["a"] = "changed";
+        engine.Evaluate("d.a").Should().Be("changed");
+        dictionary.Remove("a");
+        engine.Evaluate("typeof d.a").Should().Be("undefined");
+    }
+
+    #endregion
+
+    #region 2. value-typed values
+
+    [Fact]
+    public void ReadsAnIntValue()
+    {
+        var engine = CreateEngine(new Dictionary<string, int> { ["a"] = 1, ["zero"] = 0 });
+
+        engine.Evaluate("d.a").Should().Be(1);
+        engine.Evaluate("d.zero").Should().Be(0);
+    }
+
+    [Fact]
+    public void MissingValueTypedKeyIsUndefinedNotTheDefaultValue()
+    {
+        var engine = CreateEngine(new Dictionary<string, int> { ["a"] = 1 });
+
+        engine.Evaluate("typeof d.missing").Should().Be("undefined");
+        engine.Evaluate("d.missing === 0").Should().Be(false);
+    }
+
+    [Fact]
+    public void ReadsAStructValue()
+    {
+        var engine = CreateEngine(new Dictionary<string, DateTimeOffset>
+        {
+            ["a"] = new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.Zero),
+        });
+
+        engine.Evaluate("d.a.getUTCFullYear()").Should().Be(2020);
+        engine.Evaluate("typeof d.missing").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ReadsANullableValue()
+    {
+        var engine = CreateEngine(new Dictionary<string, int?> { ["a"] = 1, ["b"] = null });
+
+        engine.Evaluate("d.a").Should().Be(1);
+        engine.Evaluate("d.b").Should().Be(JsValue.Null);
+        engine.Evaluate("typeof d.missing").Should().Be("undefined");
+    }
+
+    #endregion
+
+    #region 3. dictionary shapes
+
+    [Fact]
+    public void ReadsThroughAReadOnlyDictionary()
+    {
+        IReadOnlyDictionary<string, string> host = new Dictionary<string, string> { ["a"] = "one" };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("d.a").Should().Be("one");
+        engine.Evaluate("typeof d.missing").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ReadsThroughAnExplicitInterfaceImplementation()
+    {
+        var engine = CreateEngine(new ExplicitDictionary());
+
+        engine.Evaluate("d.a").Should().Be("one");
+        engine.Evaluate("typeof d.missing").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ReadsFromANonStringKeyedDictionary()
+    {
+        var engine = CreateEngine(new Dictionary<int, string> { [1] = "one" });
+
+        engine.Evaluate("d[1]").Should().Be("one");
+        engine.Evaluate("typeof d[2]").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ReadsFromANonPublicValueTypedDictionary()
+    {
+        // the compiled lane declines when the closed generic interface is not visible, the reflection
+        // fallback still has to answer
+        var engine = CreateEngine(new Dictionary<string, Hidden> { ["a"] = new Hidden { Value = 3 } });
+
+        engine.Evaluate("d.a.Value").Should().Be(3);
+        engine.Evaluate("typeof d.missing").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void TraversesNestedDictionaries()
+    {
+        var host = new Dictionary<string, object>
+        {
+            ["b"] = new Dictionary<string, object>
+            {
+                ["c"] = new Dictionary<string, object>
+                {
+                    ["d"] = 42,
+                },
+            },
+        };
+        var engine = CreateEngine(host);
+
+        engine.Evaluate("d.b.c.d").Should().Be(42);
+        engine.Evaluate("typeof d.b.c.missing").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void EnumerationStillWorks()
+    {
+        var engine = CreateEngine(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 });
+
+        engine.Evaluate("Object.keys(d).join(',')").Should().Be("a,b");
+        engine.Evaluate("JSON.stringify(d)").Should().Be("{\"a\":1,\"b\":2}");
+    }
+
+    [Fact]
+    public void WritesAndDeletesStillWork()
+    {
+        var dictionary = new Dictionary<string, int> { ["a"] = 1 };
+        var engine = CreateEngine(dictionary);
+
+        engine.Evaluate("d.b = 2");
+        dictionary["b"].Should().Be(2);
+        engine.Evaluate("d.b").Should().Be(2);
+
+        engine.Evaluate("delete d.b");
+        dictionary.ContainsKey("b").Should().BeFalse();
+        engine.Evaluate("typeof d.b").Should().Be("undefined");
+    }
+
+    #endregion
+
+    #region 4. throwing implementations
+
+    [Fact]
+    public void KeyNotFoundFromTheImplementationIsAMiss()
+    {
+        var engine = CreateEngine(new ThrowingDictionary(new KeyNotFoundException()));
+
+        engine.Evaluate("typeof d.anything").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void OtherFailuresStillSurface()
+    {
+        var engine = CreateEngine(new ThrowingDictionary(new InvalidOperationException("boom")));
+
+        var act = () => engine.Evaluate("d.anything");
+        act.Should().Throw<Exception>();
+    }
+
+    #endregion
+
+    #region 5. the compiled reader itself
+
+#if NET8_0_OR_GREATER
+
+    [Fact]
+    public void CompiledReaderIsBuiltForAVisibleDictionary()
+    {
+        var getter = Jint.Runtime.Interop.Reflection.CompiledDictionaryAccessor.GetValueGetter(
+            typeof(IDictionary<string, string>).GetMethod("TryGetValue"));
+
+        // this is the engagement probe: the behavioral tests above pass either way, only this says the
+        // reflection Invoke was actually replaced
+        getter.Should().NotBeNull();
+
+        var dictionary = new Dictionary<string, string> { ["a"] = "one" };
+        getter!(dictionary, "a", out var value).Should().BeTrue();
+        value.Should().Be("one");
+        getter(dictionary, "missing", out value).Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void CompiledReaderBoxesValueTypedValues()
+    {
+        var getter = Jint.Runtime.Interop.Reflection.CompiledDictionaryAccessor.GetValueGetter(
+            typeof(IReadOnlyDictionary<string, int>).GetMethod("TryGetValue"));
+        getter.Should().NotBeNull();
+
+        IReadOnlyDictionary<string, int> dictionary = new Dictionary<string, int> { ["a"] = 1 };
+        getter!(dictionary, "a", out var value).Should().BeTrue();
+        value.Should().Be(1);
+
+        // a miss still fills the out parameter with default(TValue), exactly as reflection did — the caller
+        // is what has to ignore it
+        getter(dictionary, "missing", out value).Should().BeFalse();
+        value.Should().Be(0);
+    }
+
+    [Fact]
+    public void CompiledReaderDeclinesWhenTheClosedGenericIsNotVisible()
+    {
+        var method = typeof(IDictionary<,>).MakeGenericType(typeof(string), typeof(Hidden)).GetMethod("TryGetValue");
+
+        Jint.Runtime.Interop.Reflection.CompiledDictionaryAccessor.GetValueGetter(method).Should().BeNull();
+    }
+
+    [Fact]
+    public void CompiledReaderDeclinesWithoutAMethod()
+    {
+        Jint.Runtime.Interop.Reflection.CompiledDictionaryAccessor.GetValueGetter(null).Should().BeNull();
+    }
+
+#endif
+
+    #endregion
+
+    #region hosts
+
+    private struct Hidden
+    {
+        public int Value { get; set; }
+    }
+
+    private sealed class ExplicitDictionary : IReadOnlyDictionary<string, string>
+    {
+        private readonly Dictionary<string, string> _inner = new() { ["a"] = "one" };
+
+        string IReadOnlyDictionary<string, string>.this[string key] => _inner[key];
+
+        IEnumerable<string> IReadOnlyDictionary<string, string>.Keys => _inner.Keys;
+
+        IEnumerable<string> IReadOnlyDictionary<string, string>.Values => _inner.Values;
+
+        int IReadOnlyCollection<KeyValuePair<string, string>>.Count => _inner.Count;
+
+        bool IReadOnlyDictionary<string, string>.ContainsKey(string key) => _inner.ContainsKey(key);
+
+        bool IReadOnlyDictionary<string, string>.TryGetValue(string key, out string value) => _inner.TryGetValue(key, out value!);
+
+        IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator() => _inner.GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _inner.GetEnumerator();
+    }
+
+    public sealed class ThrowingDictionary : IReadOnlyDictionary<string, string>
+    {
+        private readonly Exception _exception;
+
+        public ThrowingDictionary(Exception exception) => _exception = exception;
+
+        public string this[string key] => throw _exception;
+
+        public IEnumerable<string> Keys => [];
+
+        public IEnumerable<string> Values => [];
+
+        public int Count => 0;
+
+        // only TryGetValue misbehaves, so the failure observed is the one under test
+        public bool ContainsKey(string key) => false;
+
+        public bool TryGetValue(string key, out string value) => throw _exception;
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => Enumerable.Empty<KeyValuePair<string, string>>().GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    #endregion
+}

--- a/Jint/Runtime/Interop/Reflection/CompiledDictionaryAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/CompiledDictionaryAccessor.cs
@@ -1,0 +1,127 @@
+using System.Reflection;
+
+#if NET8_0_OR_GREATER
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using Expression = System.Linq.Expressions.Expression;
+#endif
+
+// The delegate is compiled with System.Linq.Expressions and only references the reflected dictionary
+// interface, whose visibility is checked before anything is emitted. IL2075/IL3050 cover the reflection +
+// dynamic-code use, which is gated behind RuntimeFeature.IsDynamicCodeCompiled.
+#pragma warning disable IL2075
+#pragma warning disable IL3050
+
+namespace Jint.Runtime.Interop.Reflection;
+
+/// <summary>
+/// Builds and caches a delegate that calls <c>TryGetValue</c> on a closed generic
+/// <see cref="IDictionary{TKey,TValue}"/> / <see cref="IReadOnlyDictionary{TKey,TValue}"/>, so that reading a
+/// property off a dictionary-shaped host object does not go through <see cref="MethodBase.Invoke(object, object[])"/>
+/// — which costs a boxed argument array and a reflection dispatch on <b>every</b> property read, there being
+/// no inline-cache backstop for dictionaries.
+/// <para>
+/// Keyed by the <c>TryGetValue</c> <see cref="MethodInfo"/>, which is the one declared on the generic
+/// interface and therefore already shared by every implementation of it, and cached process-wide because
+/// nothing the delegate closes over is affine to an <see cref="Engine"/>. Same trade-off as the other
+/// process-wide reflection caches here: the cached <see cref="MethodInfo"/> keeps its declaring assembly
+/// alive for the process lifetime.
+/// </para>
+/// </summary>
+internal static class CompiledDictionaryAccessor
+{
+    /// <summary>
+    /// Reads <paramref name="key"/> out of the dictionary <paramref name="target"/>, boxing the value.
+    /// </summary>
+    internal delegate bool DictionaryValueGetter(object target, object key, out object? value);
+
+#if NET8_0_OR_GREATER
+    // a null value is the "known ineligible" sentinel so an ineligible dictionary shape is never re-probed
+    private static readonly ConcurrentDictionary<MethodInfo, DictionaryValueGetter?> _valueGetters = new();
+#endif
+
+    /// <summary>
+    /// Returns the compiled reader for <paramref name="tryGetValue"/>, or <see langword="null"/> when the
+    /// dictionary shape is not eligible and the caller has to keep using reflection.
+    /// </summary>
+    internal static DictionaryValueGetter? GetValueGetter(MethodInfo? tryGetValue)
+    {
+#if NET8_0_OR_GREATER
+        if (tryGetValue is null)
+        {
+            return null;
+        }
+
+        return _valueGetters.GetOrAdd(tryGetValue, static m => Build(m));
+#else
+        return null;
+#endif
+    }
+
+#if NET8_0_OR_GREATER
+    private static DictionaryValueGetter? Build(MethodInfo tryGetValue)
+    {
+        // Under AOT and an interpreted-only Expression.Compile (e.g. the Mono interpreter) an interpreted
+        // lambda is slower than the reflection path it replaces, so decline entirely.
+        if (!RuntimeFeature.IsDynamicCodeCompiled)
+        {
+            return null;
+        }
+
+        // the constructed generic interface is only visible when its type arguments are, so this single
+        // check also covers a non-public key or value type
+        var declaringType = tryGetValue.DeclaringType;
+        if (declaringType is null || !declaringType.IsVisible || tryGetValue.ReturnType != typeof(bool))
+        {
+            return null;
+        }
+
+        var parameters = tryGetValue.GetParameters();
+        if (parameters.Length != 2)
+        {
+            return null;
+        }
+
+        var keyType = parameters[0].ParameterType;
+        var valueType = parameters[1].ParameterType.GetElementType();
+        if (valueType is null || keyType.IsByRef || keyType.IsPointer || valueType.IsPointer)
+        {
+            return null;
+        }
+
+        var targetParameter = Expression.Parameter(typeof(object), "target");
+        var keyParameter = Expression.Parameter(typeof(object), "key");
+        var valueParameter = Expression.Parameter(typeof(object).MakeByRefType(), "value");
+
+        // the caller only takes this lane when the key's runtime type matches, so the cast cannot fail
+        var typedValue = Expression.Variable(valueType, "typedValue");
+        var found = Expression.Variable(typeof(bool), "found");
+
+        var call = Expression.Call(
+            Expression.Convert(targetParameter, declaringType),
+            tryGetValue,
+            Expression.Convert(keyParameter, keyType),
+            typedValue);
+
+        // the out local is default-initialized exactly like the Activator.CreateInstance the reflection
+        // path needs for a value-typed TValue, and boxing it here reproduces that path's boxed result
+        var body = Expression.Block(
+            typeof(bool),
+            [typedValue, found],
+            Expression.Assign(found, call),
+            Expression.Assign(valueParameter, Expression.Convert(typedValue, typeof(object))),
+            found);
+
+        try
+        {
+            return Expression.Lambda<DictionaryValueGetter>(body, targetParameter, keyParameter, valueParameter).Compile();
+        }
+        catch (Exception)
+        {
+            // an accessibility/binding quirk the eligibility checks did not anticipate
+            return null;
+        }
+    }
+#endif
+}

--- a/Jint/Runtime/Interop/TypeDescriptor.cs
+++ b/Jint/Runtime/Interop/TypeDescriptor.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Jint.Runtime.Interop.Reflection;
 
 #pragma warning disable IL2067
 #pragma warning disable IL2075
@@ -28,6 +29,10 @@ internal sealed class TypeDescriptor
     private readonly MethodInfo? _genericContainsKeyMethod;
     private readonly MethodInfo? _genericIndexerSetMethod;
     private readonly MethodInfo? _genericRemoveMethod;
+
+    // per-descriptor L1 cache over the process-wide compiled reader, so a dictionary read is a field read
+    private CompiledDictionaryAccessor.DictionaryValueGetter? _compiledValueGetter;
+    private bool _compiledValueGetterResolved;
 
     private TypeDescriptor(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)]
@@ -249,6 +254,50 @@ internal sealed class TypeDescriptor
     }
 
     public bool TryGetDictionaryValue(object target, object key, out object? o)
+    {
+        // resolved lazily and racily - the delegate is pure, so a duplicate resolve is harmless
+        if (!_compiledValueGetterResolved)
+        {
+            _compiledValueGetter = CompiledDictionaryAccessor.GetValueGetter(_tryGetValueMethod);
+            _compiledValueGetterResolved = true;
+        }
+
+        // The compiled reader casts the key straight to the dictionary's key type, so it can only accept a
+        // key whose runtime type is already assignable to it. Anything else keeps the reflection path, whose
+        // ArgumentException for a mismatched key is the established behaviour.
+        var getter = _compiledValueGetter;
+        if (getter is not null && (IsStringKeyedGenericDictionary ? key is string : _keyType!.IsInstanceOfType(key)))
+        {
+            return TryGetDictionaryValueCompiled(getter, target, key, out o);
+        }
+
+        return TryGetDictionaryValueReflection(target, key, out o);
+    }
+
+    private static bool TryGetDictionaryValueCompiled(
+        CompiledDictionaryAccessor.DictionaryValueGetter getter,
+        object target,
+        object key,
+        out object? o)
+    {
+        try
+        {
+            return getter(target, key, out o);
+        }
+        catch (KeyNotFoundException)
+        {
+            o = null;
+            return false;
+        }
+        catch (Exception exception) when (exception is not TargetInvocationException)
+        {
+            // reflection wraps whatever the dictionary throws, the compiled delegate rethrows it as-is:
+            // normalize so the callers' TargetInvocationException handling stays identical
+            throw new TargetInvocationException(exception);
+        }
+    }
+
+    private bool TryGetDictionaryValueReflection(object target, object key, out object? o)
     {
         // IDictionary<,>.TryGetValue / IReadOnlyDictionary<,>.TryGetValue do not throw KeyNotFoundException,
         // but a custom implementation of either interface might — keep the catch defensively.


### PR DESCRIPTION
Reading a property off a dictionary-shaped host object goes through
`TypeDescriptor.TryGetDictionaryValue`, which calls `IDictionary<,>.TryGetValue` /
`IReadOnlyDictionary<,>.TryGetValue` via `MethodInfo.Invoke`. That costs a boxed
`object?[]` parameter array, an `Activator.CreateInstance` for a value-typed
`TValue`, and a reflection dispatch on **every** property read — and unlike CLR
member reads there is no inline-cache backstop for dictionaries, so `o.a.b.c.d`
pays it four times.

Compile the call instead. `CompiledDictionaryAccessor` builds a
`(object target, object key, out object? value) => bool` delegate with
`System.Linq.Expressions`, keyed process-wide by the `TryGetValue` `MethodInfo`.
That key is the method declared on the *generic interface*, so every
implementation of a given closed `IDictionary<TKey,TValue>` shares one compiled
delegate rather than one per implementing type. `TypeDescriptor` keeps an L1
field over it so the steady-state read is a field read plus a delegate call.

Behavior is meant to be indistinguishable from the reflection path:

- **Eligibility** is gated on `NET8_0_OR_GREATER`, `RuntimeFeature.IsDynamicCodeCompiled`
  (an interpreted-only `Expression.Compile` would be slower than the reflection it
  replaces) and `declaringType.IsVisible`. The visibility check on the *constructed*
  generic interface also covers a non-public key or value type, since a constructed
  generic is only visible when its type arguments are. Anything ineligible caches a
  null sentinel so the shape is never re-probed, and keeps the reflection path.
- **Key type mismatches** stay on reflection. The compiled reader casts the key
  straight to `TKey`, so it is only taken when the key's runtime type is already
  assignable; a mismatched key keeps reflection's established `ArgumentException`.
- **Exception shapes are preserved.** Reflection wraps whatever the dictionary
  throws in a `TargetInvocationException`; the compiled delegate rethrows as-is, so
  the compiled lane re-wraps to keep every caller's `TargetInvocationException`
  handling identical. A `KeyNotFoundException` from a custom implementation is still
  treated as a miss.
- **A miss still fills `out value` with `default(TValue)`**, exactly as the
  `Activator.CreateInstance` did — the caller is what has to ignore it. The tests pin
  that a missing key on a `Dictionary<string,int>` is `undefined` and not `0`.

`InteropDictionaryValueAccessTests` covers reference-typed, value-typed, struct and
nullable values, read-only/explicit-interface/non-string-keyed/non-public dictionary
shapes, nested traversal, enumeration, writes and deletes, and throwing
implementations — every assertion written against the behavior that predates the
compiled lane. Four further tests probe the compiled reader directly: they are the
engagement check, since the behavioral tests pass whether or not the delegate was
actually built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
