### PR TITLE
Route JsString's value-observing members through ToString()

### DIFF
--- a/Jint.Tests.PublicInterface/LazyHostStringTests.cs
+++ b/Jint.Tests.PublicInterface/LazyHostStringTests.cs
@@ -1,0 +1,194 @@
+using System.Text;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// A host can expose its own string representation by deriving from <see cref="JsString"/> and passing a
+/// null backing value to the base constructor, materializing the flat .NET string only when something
+/// actually asks for it. These tests pin that contract for the engine paths a script can reach.
+/// </summary>
+public class LazyHostStringTests
+{
+    private const string Text = "abc";
+
+    private static Engine CreateEngine(out LazyHostString host, string value = Text)
+    {
+        host = new LazyHostString(value);
+        var engine = new Engine();
+        engine.SetValue("host", host);
+        return engine;
+    }
+
+    [Fact]
+    public void CanConcatWithoutMaterializedBackingValue()
+    {
+        // String.prototype.concat asks the receiver for a growable buffer first; the base
+        // implementation used to hand the (still null) backing value to the buffer and blow up.
+        var engine = CreateEngine(out var host);
+
+        engine.Evaluate("host.concat('def', 'ghi')").AsString().Should().Be("abcdefghi");
+        engine.Evaluate("host.concat()").AsString().Should().Be(Text);
+        host.MaterializationCount.Should().Be(1, "the flat value is produced once and cached");
+    }
+
+    [Fact]
+    public void CanBuildUpWithCompoundAssignmentChain()
+    {
+        var engine = CreateEngine(out _);
+
+        var result = engine.Evaluate("var s = host; s += '-1'; s += '-2'; s += '-3'; s").AsString();
+
+        result.Should().Be("abc-1-2-3");
+    }
+
+    [Fact]
+    public void CanBeConcatenatedWithPlusOperator()
+    {
+        var engine = CreateEngine(out _);
+
+        engine.Evaluate("host + 'def'").AsString().Should().Be("abcdef");
+        engine.Evaluate("'xyz' + host").AsString().Should().Be("xyzabc");
+    }
+
+    [Fact]
+    public void CanBeUsedInTemplateLiteral()
+    {
+        var engine = CreateEngine(out _);
+
+        engine.Evaluate("`[${host}]`").AsString().Should().Be("[abc]");
+        engine.Evaluate("`${host}${host}`").AsString().Should().Be("abcabc");
+    }
+
+    [Fact]
+    public void ReportsLengthWithoutMaterializing()
+    {
+        var engine = CreateEngine(out var host);
+
+        engine.Evaluate("host.length").AsNumber().Should().Be(3);
+
+        host.MaterializationCount.Should().Be(0, "an overridden Length must not force the flat value");
+    }
+
+    [Fact]
+    public void SupportsCharacterAccess()
+    {
+        var engine = CreateEngine(out _);
+
+        engine.Evaluate("host[0]").AsString().Should().Be("a");
+        engine.Evaluate("host.charAt(1)").AsString().Should().Be("b");
+        engine.Evaluate("host.charCodeAt(2)").AsNumber().Should().Be('c');
+    }
+
+    [Fact]
+    public void IsEqualToTheEquivalentPlainString()
+    {
+        var engine = CreateEngine(out _);
+
+        engine.Evaluate("host === 'abc'").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'abc' === host").AsBoolean().Should().BeTrue();
+        engine.Evaluate("host == 'abc'").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'abc' == host").AsBoolean().Should().BeTrue();
+
+        engine.Evaluate("host === 'abd'").AsBoolean().Should().BeFalse();
+        engine.Evaluate("host !== 'abcd'").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasTheSameEqualityAndHashAsTheEquivalentPlainString()
+    {
+        // the base Equals/GetHashCode implementations are what an unspecialized host subclass
+        // inherits, so they have to answer from the materialized value rather than the raw field
+        var host = new LazyHostString(Text);
+        var flat = new JsString(Text);
+
+        host.Equals(flat).Should().BeTrue();
+        flat.Equals(host).Should().BeTrue();
+        host.Equals(Text).Should().BeTrue();
+        host.GetHashCode().Should().Be(flat.GetHashCode());
+    }
+
+    [Fact]
+    public void CanBeUsedAsPropertyKey()
+    {
+        var engine = CreateEngine(out _);
+
+        engine.Evaluate("var o = {}; o[host] = 42; o.abc").AsNumber().Should().Be(42);
+        engine.Evaluate("Object.keys(o)[0]").AsString().Should().Be(Text);
+        engine.Evaluate("({ abc: 7 })[host]").AsNumber().Should().Be(7);
+        engine.Evaluate("host in { abc: 1 }").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanBeUsedAsCollectionKey()
+    {
+        var engine = CreateEngine(out _);
+
+        engine.Evaluate("var m = new Map(); m.set(host, 1); m.get('abc')").AsNumber().Should().Be(1);
+        engine.Evaluate("new Set([host, 'abc']).size").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void CanBeSerializedToJson()
+    {
+        var engine = CreateEngine(out _);
+
+        engine.Evaluate("JSON.stringify(host)").AsString().Should().Be("\"abc\"");
+        engine.Evaluate("JSON.stringify({ value: host })").AsString().Should().Be("{\"value\":\"abc\"}");
+        engine.Evaluate("JSON.stringify({ [host]: 1 })").AsString().Should().Be("{\"abc\":1}");
+        engine.Evaluate("JSON.stringify([host])").AsString().Should().Be("[\"abc\"]");
+    }
+
+    [Fact]
+    public void SupportsCommonStringPrototypeMethods()
+    {
+        var engine = CreateEngine(out _);
+
+        engine.Evaluate("host.toUpperCase()").AsString().Should().Be("ABC");
+        engine.Evaluate("host.indexOf('b')").AsNumber().Should().Be(1);
+        engine.Evaluate("host.slice(1)").AsString().Should().Be("bc");
+        engine.Evaluate("host.split('b').join('-')").AsString().Should().Be("a-c");
+        engine.Evaluate("String(host)").AsString().Should().Be(Text);
+        engine.Evaluate("host.toString()").AsString().Should().Be(Text);
+    }
+
+    /// <summary>
+    /// Stands in for a host string backed by a native handle: the payload is kept encoded and only
+    /// decoded on demand. The backing value handed to the base constructor is null, so every member
+    /// that needs the text has to route through <see cref="ToString"/>.
+    /// </summary>
+    private sealed class LazyHostString : JsString
+    {
+        // ASCII only, which keeps the encoded length equal to the character length so that Length
+        // can be answered without decoding - the whole point of holding the payload encoded.
+        private readonly byte[] _encoded;
+        private string _materialized;
+        private int _materializationCount;
+
+        public LazyHostString(string value) : base(null)
+        {
+            _encoded = Encoding.ASCII.GetBytes(value);
+        }
+
+        /// <summary>
+        /// How many times the flat value had to be produced. Used by the tests to assert that
+        /// members which can answer lazily really do.
+        /// </summary>
+        public int MaterializationCount => _materializationCount;
+
+        public override string ToString()
+        {
+            if (_materialized is null)
+            {
+                _materializationCount++;
+                _materialized = Encoding.ASCII.GetString(_encoded);
+            }
+
+            return _materialized;
+        }
+
+        public override int Length => _encoded.Length;
+
+        public override char this[int index] => (char) _encoded[index];
+    }
+}

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -8,6 +8,40 @@ using Jint.Runtime;
 
 namespace Jint.Native;
 
+/// <summary>
+/// A JavaScript string value.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type is designed to be subclassed so that a host can expose its own string representation
+/// (a native handle, an encoded buffer, a view over a larger buffer) without eagerly producing a
+/// .NET <see cref="string"/>. Jint's own sliced and concatenated string representations use the same
+/// mechanism.
+/// </para>
+/// <para>
+/// <b>Subclassing contract.</b> Passing a <see langword="null"/> backing value to the constructor is
+/// supported and is the intended way to express "not materialized yet". A subclass that does so
+/// <b>must</b> override every member that would otherwise observe the backing value:
+/// <list type="bullet">
+/// <item><see cref="ToString()"/> — produces (and normally caches) the flat value. Every other
+/// member of this class that needs the text routes through it, so overriding it alone is enough for
+/// correctness; the remaining overrides exist only to avoid materializing.</item>
+/// <item><see cref="Length"/> — must answer without materializing, otherwise a length comparison
+/// (which <see cref="Equals(JsString)"/> performs first) defeats the laziness.</item>
+/// <item><see cref="this[int]"/> — character access.</item>
+/// <item><see cref="Equals(JsString)"/>, <see cref="Equals(string)"/> and
+/// <see cref="GetHashCode()"/> — only needed to stay allocation-free; the base implementations are
+/// correct but materialize. An overridden <see cref="GetHashCode()"/> must produce the same hash as
+/// the equivalent flat string (<see cref="StringComparer.Ordinal"/>), otherwise the value cannot be
+/// used interchangeably as a property key or collection key.</item>
+/// </list>
+/// </para>
+/// <para>
+/// A subclass that leaves the backing value <see langword="null"/> and does not override
+/// <see cref="ToString()"/> is not usable — the base implementation returns
+/// <see langword="null"/>.
+/// </para>
+/// </remarks>
 [DebuggerDisplay("{ToString()}")]
 public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
 {
@@ -304,7 +338,10 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
 
     internal virtual JsString EnsureCapacity(int capacity)
     {
-        return new ConcatenatedString(_value, capacity);
+        // ToString() rather than _value: a subclass can carry a null backing value until it
+        // materializes, and ConcatenatedString cannot start from null. For a flat string
+        // ToString() just returns _value, so the common path is unchanged.
+        return new ConcatenatedString(ToString(), capacity);
     }
 
     public sealed override object ToObject() => ToString();
@@ -395,7 +432,9 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
             return false;
         }
 
-        return string.Equals(_value, other.ToString(), StringComparison.Ordinal);
+        // both sides go through ToString() so a subclass carrying a null backing value compares by
+        // content instead of silently reporting "not equal"
+        return string.Equals(ToString(), other.ToString(), StringComparison.Ordinal);
     }
 
     protected internal override bool IsLooselyEqual(JsValue value)
@@ -413,7 +452,9 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
         return base.IsLooselyEqual(value);
     }
 
-    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(_value);
+    // ToString() rather than _value so a subclass with a null backing value hashes its content
+    // instead of throwing; a flat string returns _value from ToString(), so nothing changes there
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(ToString());
 
     internal sealed class ConcatenatedString : JsString
     {
@@ -593,12 +634,6 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
         internal override bool Contains(char c)
         {
             return c != 0 && AsSpan().IndexOf(c) >= 0;
-        }
-
-        internal override JsString EnsureCapacity(int capacity)
-        {
-            // base implementation reads _value directly, which may not be materialized yet
-            return new ConcatenatedString(ToString(), capacity);
         }
 
         public override bool Equals(string? other)


### PR DESCRIPTION
`JsString` is public and non-sealed, its constructor accepts a `null` backing value, and Jint's own `SlicedString` / `ConcatenatedString` use exactly that to stay lazy. A host can do the same to expose its own string representation — a native handle, an encoded buffer, a view over a larger buffer — and produce the flat .NET string only when something actually asks for it.

Three members broke that by reading the `_value` field directly instead of routing through `ToString()`.

| member | failure mode |
| --- | --- |
| `EnsureCapacity` | hands `_value` straight to a `ConcatenatedString`, which dereferences it. `String.prototype.concat` on such a value throws `NullReferenceException` from `ConcatenatedString.Append`. |
| `Equals(JsString?)` | compares `_value` against `other.ToString()`, so a lazy receiver compares `null` against real text and **silently reports two equal strings as unequal**. Nothing throws — `host === 'abc'` simply answers `false`. |
| `GetHashCode()` | passes `_value` to `StringComparer.Ordinal` → `ArgumentNullException`. It is reached through `SameValueZeroComparer`, so such a value cannot be used as a `Map`/`Set` key, and equally not as a property key. |

All three now call `ToString()`. For a flat string `ToString()` returns `_value`, so the common path is unchanged; for a lazy subclass it is the documented materialization point. `SlicedString.EnsureCapacity` existed only to work around the base implementation and is now redundant, so it is removed.

The class also gains a doc comment stating the subclassing contract: which members a subclass carrying a `null` backing value must override, which of those are needed for correctness (`ToString`) versus only to avoid materializing, and that an overridden `GetHashCode` must agree with `StringComparer.Ordinal` over the flat text or the value stops working as a key.

### Confirmed failing before the fix

`Jint.Tests.PublicInterface/LazyHostStringTests.cs` (12 cases) was run against unpatched `main` first — 4 fail, one per failure mode above:

```
Failed CanConcatWithoutMaterializedBackingValue
  System.NullReferenceException : Object reference not set to an instance of an object.
     at Jint.Native.JsString.ConcatenatedString.Append(JsValue jsValue)
     at Jint.Native.String.StringPrototype.Concat(JsValue thisObject, JsValue[] arguments)

Failed CanBeUsedAsCollectionKey
  System.ArgumentNullException : Value cannot be null. (Parameter 'obj')
     at System.OrdinalCaseSensitiveComparer.GetHashCode(String obj)
     at Jint.Native.JsString.GetHashCode()
     at Jint.Native.SameValueZeroComparer.GetHashCode(JsValue obj)

Failed IsEqualToTheEquivalentPlainString
  Expected boolean to be True, but found False.      // host === 'abc'

Failed HasTheSameEqualityAndHashAsTheEquivalentPlainString
  Expected host.Equals(flat) to be True, but found False.

Failed!  - Failed: 4, Passed: 8, Skipped: 0, Total: 12
```

With the fix all 12 pass.

### Verification

Release build (warnings are errors): 0 errors, 1 warning — the pre-existing `MSB3277` in `Jint.Tests.CommonScripts` on `net472`, which is present on clean `main` too.

| suite | main | this branch |
| --- | --- | --- |
| `Jint.Tests` net10.0 | 4123 passed / 4 skipped | 4123 passed / 4 skipped |
| `Jint.Tests` net472 | 4059 passed / 4 skipped | 4059 passed / 4 skipped |
| `Jint.Tests.PublicInterface` (both TFMs) | 149 passed | 161 passed |
| `Jint.Tests.Test262` | 99441 passed / 157 skipped | 99441 passed / 157 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
