### PR TITLE
Let an object converter declare its types so unrelated members keep the fast lane

### DIFF
--- a/Jint.Tests/Runtime/InteropObjectConverterFilterTests.cs
+++ b/Jint.Tests/Runtime/InteropObjectConverterFilterTests.cs
@@ -1,0 +1,394 @@
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+using Jint.Native;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Exercises declaring the CLR types an <see cref="IObjectConverter"/> handles, which lets the engine keep
+/// the compiled member-read fast lanes for members no registered converter can ever be handed.
+/// <para>
+/// The behavioral tests below deliberately use a converter that would change the value it sees: whether the
+/// change shows up is the only black-box evidence of whether the fast lane ran, so the assertions double as
+/// documentation of the contract (declaring types is a promise — a misdeclared converter really is skipped).
+/// </para>
+/// </summary>
+public class InteropObjectConverterFilterTests
+{
+    #region hosts
+
+    public enum Level
+    {
+        Zero = 0,
+        One = 1,
+    }
+
+    public interface IMarker;
+
+    public sealed class Marked : IMarker;
+
+    public class OpenBase;
+
+    public sealed class SealedDerived : OpenBase;
+
+    public class UnrelatedOpen;
+
+    public sealed class Host
+    {
+        public bool Flag { get; set; } = true;
+        public int Number { get; set; } = 1;
+        public string Text { get; set; } = "text";
+        public Level EnumValue { get; set; } = Level.One;
+        public object? Boxed { get; set; }
+    }
+
+    private static Engine CreateEngine(Host host, Action<Options> configure)
+    {
+        var engine = new Engine(configure);
+        engine.SetValue("host", host);
+        return engine;
+    }
+
+    /// <summary>
+    /// Declaring the types a converter handles only has an observable effect where the compiled member-read
+    /// lane exists in the first place; on the other targets, and without dynamic code, every member keeps
+    /// going through the converter exactly as before.
+    /// </summary>
+    private static readonly bool _compiledReadLaneAvailable =
+#if NET8_0_OR_GREATER
+        System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeCompiled;
+#else
+        false;
+#endif
+
+    private static void ShouldRead(Engine engine, string expression, JsValue whenBypassed, JsValue whenConverted)
+    {
+        engine.Evaluate(expression).Should().Be(_compiledReadLaneAvailable ? whenBypassed : whenConverted);
+    }
+
+    /// <summary>Turns every bool it sees into its negation, and every enum into its name.</summary>
+    private sealed class MeddlingConverter : IObjectConverter
+    {
+        public bool TryConvert(Engine engine, object value, [NotNullWhen(true)] out JsValue? result)
+        {
+            if (value is bool b)
+            {
+                result = !b ? JsBoolean.True : JsBoolean.False;
+                return true;
+            }
+
+            if (value is Enum e)
+            {
+                result = JsString.Create(e.ToString());
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+    }
+
+    private sealed class NeverConverter : IObjectConverter
+    {
+        public bool TryConvert(Engine engine, object value, [NotNullWhen(true)] out JsValue? result)
+        {
+            result = null;
+            return false;
+        }
+    }
+
+    #endregion
+
+    #region 1. registration surface
+
+    [Fact]
+    public void RegistrationWithoutDeclaredTypesIsUnchanged()
+    {
+        var converter = new NeverConverter();
+        var options = new Options();
+        options.AddObjectConverter(converter);
+
+        // the overload without declared types must keep storing the converter itself
+        options.Interop.ObjectConverters.Should().ContainSingle().Which.Should().BeSameAs(converter);
+    }
+
+    [Fact]
+    public void RegistrationRequiresAtLeastOneDeclaredType()
+    {
+        var options = new Options();
+        var act = () => options.AddObjectConverter(new NeverConverter(), []);
+        act.Should().Throw<ArgumentException>().WithParameterName("handledTypes");
+    }
+
+    [Fact]
+    public void RegistrationRejectsNullDeclaredType()
+    {
+        var options = new Options();
+        var act = () => options.AddObjectConverter(new NeverConverter(), [typeof(bool), null!]);
+        act.Should().Throw<ArgumentException>().WithParameterName("handledTypes");
+    }
+
+    [Fact]
+    public void RegistrationRejectsNullConverter()
+    {
+        var options = new Options();
+        var act = () => options.AddObjectConverter(null!, typeof(bool));
+        act.Should().Throw<ArgumentNullException>().WithParameterName("objectConverter");
+    }
+
+    #endregion
+
+    #region 2. behavior of a declared converter
+
+    [Fact]
+    public void UndeclaredConverterSeesEveryMember()
+    {
+        var engine = CreateEngine(new Host(), options => options.AddObjectConverter(new MeddlingConverter()));
+
+        engine.Evaluate("host.Flag").Should().Be(false);
+        engine.Evaluate("host.EnumValue").Should().Be("One");
+    }
+
+    [Fact]
+    public void ConverterDeclaringOnlyUnrelatedTypesDoesNotSeeTheMember()
+    {
+        var engine = CreateEngine(new Host(), options => options.AddObjectConverter(new MeddlingConverter(), typeof(Guid)));
+
+        // bool cannot be a Guid, so the member never reaches the converter
+        ShouldRead(engine, "host.Flag", whenBypassed: true, whenConverted: false);
+        engine.Evaluate("host.Number").Should().Be(1);
+        engine.Evaluate("host.Text").Should().Be("text");
+    }
+
+    [Fact]
+    public void ConverterDeclaringTheMemberTypeStillSeesIt()
+    {
+        var engine = CreateEngine(new Host(), options => options.AddObjectConverter(new MeddlingConverter(), typeof(bool)));
+
+        engine.Evaluate("host.Flag").Should().Be(false);
+    }
+
+    [Fact]
+    public void DeclaringEnumLeavesOtherMembersOnTheFastLane()
+    {
+        // the case this feature exists for: a converter registered purely to render enums keeps doing so,
+        // and no longer costs every other member its fast lane
+        var engine = CreateEngine(new Host(), options => options.AddObjectConverter(new MeddlingConverter(), typeof(Enum)));
+
+        engine.Evaluate("host.EnumValue").Should().Be("One");
+        ShouldRead(engine, "host.Flag", whenBypassed: true, whenConverted: false);
+        engine.Evaluate("host.Number").Should().Be(1);
+    }
+
+    [Fact]
+    public void ObjectTypedMemberIsAlwaysOfferedToConverters()
+    {
+        var host = new Host { Boxed = true };
+        var engine = CreateEngine(host, options => options.AddObjectConverter(new MeddlingConverter(), typeof(Guid)));
+
+        // the declared type says nothing about what the member actually holds
+        engine.Evaluate("host.Boxed").Should().Be(false);
+    }
+
+    [Fact]
+    public void OneUndeclaredConverterDisablesTheNarrowing()
+    {
+        var engine = CreateEngine(new Host(), options => options
+            .AddObjectConverter(new NeverConverter(), typeof(Guid))
+            .AddObjectConverter(new MeddlingConverter()));
+
+        engine.Evaluate("host.Flag").Should().Be(false);
+    }
+
+    [Fact]
+    public void SharedAccessorsStillFollowEachEnginesOwnConverters()
+    {
+        // the accessor for Host.Flag is resolved once and reused by both engines; the converter decision is
+        // taken per read, from the reading engine, so it must not be baked into the shared accessor
+        var resolver = new TypeResolver();
+        var withConverter = new Engine(options =>
+        {
+            options.Interop.TypeResolver = resolver;
+            options.AddObjectConverter(new MeddlingConverter(), typeof(bool));
+        });
+        withConverter.SetValue("host", new Host());
+        var withoutConverter = new Engine(options => options.Interop.TypeResolver = resolver);
+        withoutConverter.SetValue("host", new Host());
+
+        withConverter.Evaluate("host.Flag").Should().Be(false);
+        withoutConverter.Evaluate("host.Flag").Should().Be(true);
+        withConverter.Evaluate("host.Flag").Should().Be(false);
+    }
+
+    [Fact]
+    public void DeclaredConverterDoesNotAffectWrites()
+    {
+        var host = new Host();
+        var engine = CreateEngine(host, options => options.AddObjectConverter(new MeddlingConverter(), typeof(Guid)));
+
+        engine.Evaluate("host.Flag = false; host.Number = 7; host.Text = 'written';");
+
+        host.Flag.Should().BeFalse();
+        host.Number.Should().Be(7);
+        host.Text.Should().Be("written");
+    }
+
+    #endregion
+
+    #region 3. assignability rules
+
+    private static ObjectConverterTypeFilter Filter(params Type[] handledTypes)
+    {
+        return ObjectConverterTypeFilter.Create([new TypedObjectConverter(new NeverConverter(), handledTypes)])!;
+    }
+
+    [Fact]
+    public void NoConvertersMeansNoFilter()
+    {
+        ObjectConverterTypeFilter.Create(null).Should().BeNull();
+        ObjectConverterTypeFilter.Create([]).Should().BeNull();
+    }
+
+    [Fact]
+    public void AnUndeclaredConverterClaimsEverything()
+    {
+        var filter = ObjectConverterTypeFilter.Create([new NeverConverter()])!;
+
+        filter.Claims(typeof(bool)).Should().BeTrue();
+        filter.Claims(typeof(string)).Should().BeTrue();
+        filter.Claims(typeof(Guid)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void DeclaredTypesFromAllConvertersAreUnioned()
+    {
+        var filter = ObjectConverterTypeFilter.Create(
+        [
+            new TypedObjectConverter(new NeverConverter(), [typeof(bool)]),
+            new TypedObjectConverter(new NeverConverter(), [typeof(string)]),
+        ])!;
+
+        filter.Claims(typeof(bool)).Should().BeTrue();
+        filter.Claims(typeof(string)).Should().BeTrue();
+        filter.Claims(typeof(int)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExactAndUnrelatedTypes()
+    {
+        var filter = Filter(typeof(string));
+
+        filter.Claims(typeof(string)).Should().BeTrue();
+        filter.Claims(typeof(int)).Should().BeFalse();
+        filter.Claims(typeof(bool)).Should().BeFalse();
+        filter.Claims(typeof(Level)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void UnknownMemberTypeIsClaimed()
+    {
+        Filter(typeof(string)).Claims(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ObjectTypedMemberIsClaimedByAnything()
+    {
+        Filter(typeof(Guid)).Claims(typeof(object)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConverterDeclaringObjectClaimsEverything()
+    {
+        var filter = Filter(typeof(object));
+
+        filter.Claims(typeof(int)).Should().BeTrue();
+        filter.Claims(typeof(string)).Should().BeTrue();
+        filter.Claims(typeof(Level)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void DeclaredEnumClaimsConcreteEnums()
+    {
+        var filter = Filter(typeof(Enum));
+
+        filter.Claims(typeof(Level)).Should().BeTrue();
+        filter.Claims(typeof(Level?)).Should().BeTrue();
+        filter.Claims(typeof(int)).Should().BeFalse();
+        filter.Claims(typeof(string)).Should().BeFalse();
+        filter.Claims(typeof(bool)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void DeclaredInterfaceClaimsImplementers()
+    {
+        var filter = Filter(typeof(IMarker));
+
+        filter.Claims(typeof(Marked)).Should().BeTrue();
+        filter.Claims(typeof(IMarker)).Should().BeTrue();
+
+        // a sealed type that does not implement it can never be one
+        filter.Claims(typeof(string)).Should().BeFalse();
+        filter.Claims(typeof(int)).Should().BeFalse();
+
+        // but a non-sealed class can have a subtype that implements it
+        filter.Claims(typeof(OpenBase)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void DeclaredBaseClassClaimsSubtypesAndSupertypes()
+    {
+        var filter = Filter(typeof(OpenBase));
+
+        filter.Claims(typeof(OpenBase)).Should().BeTrue();
+        filter.Claims(typeof(SealedDerived)).Should().BeTrue();
+
+        // a member typed as an unrelated non-sealed class: single inheritance rules out a common subtype
+        filter.Claims(typeof(UnrelatedOpen)).Should().BeFalse();
+
+        // ... unless the member is typed as an interface, which the declared class could implement
+        filter.Claims(typeof(IMarker)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void DeclaredSealedTypeIsClaimedThroughABaseTypedMember()
+    {
+        var filter = Filter(typeof(SealedDerived));
+
+        filter.Claims(typeof(OpenBase)).Should().BeTrue();
+        filter.Claims(typeof(SealedDerived)).Should().BeTrue();
+        filter.Claims(typeof(UnrelatedOpen)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NullableMembersAreClaimedThroughTheirUnderlyingType()
+    {
+        var filter = Filter(typeof(int));
+
+        filter.Claims(typeof(int?)).Should().BeTrue();
+        filter.Claims(typeof(long?)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void OpenGenericDeclarationIsTreatedAsClaimingEverything()
+    {
+        var filter = Filter(typeof(List<>));
+
+        filter.Claims(typeof(int)).Should().BeTrue();
+        filter.Claims(typeof(string)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void RepeatedQueriesAreStable()
+    {
+        var filter = Filter(typeof(Enum));
+
+        for (var i = 0; i < 3; i++)
+        {
+            filter.Claims(typeof(Level)).Should().BeTrue();
+            filter.Claims(typeof(int)).Should().BeFalse();
+        }
+    }
+
+    #endregion
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -155,6 +155,10 @@ public sealed partial class Engine : IDisposable
     // cached access
     internal readonly IObjectConverter[]? _objectConverters;
 
+    // which declared CLR member types the registered converters can claim, null when none are registered.
+    // Lets the compiled interop read lanes stay in play for members no converter can ever be handed.
+    internal readonly ObjectConverterTypeFilter? _objectConverterTypeFilter;
+
     // snapshot of Options.Interop.EnumConversion, read on every CLR value crossing into script
     internal readonly bool _enumsAsStrings;
 
@@ -284,6 +288,7 @@ public sealed partial class Engine : IDisposable
         _objectConverters = Options.Interop.ObjectConverters.Count > 0
             ? Options.Interop.ObjectConverters.ToArray()
             : null;
+        _objectConverterTypeFilter = ObjectConverterTypeFilter.Create(_objectConverters);
         _enumsAsStrings = Options.Interop.EnumConversion == EnumConversionMode.String;
 
         _constraints = BuildConstraints(Options.Constraints);

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -86,6 +86,49 @@ public static class OptionsExtensions
     }
 
     /// <summary>
+    /// Adds a <see cref="IObjectConverter"/> instance to convert CLR types to <see cref="JsValue"/>, declaring
+    /// the CLR types the converter can handle.
+    /// </summary>
+    /// <remarks>
+    /// The declaration is a promise: the converter is still offered every value, but the engine is free to keep
+    /// its compiled member-read fast lanes for members whose declared type cannot produce a value of any of the
+    /// <paramref name="handledTypes"/> — such a member never reaches the converter. Declare a base type, an
+    /// interface or <see cref="System.Enum"/> to cover a family of values, or use the overload without
+    /// <paramref name="handledTypes"/> for a converter that inspects everything.
+    /// </remarks>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="objectConverter">The converter to register.</param>
+    /// <param name="handledTypes">
+    /// The CLR types the converter handles. Values assignable to any of them (including through a declared
+    /// base type or interface) are considered convertible by this converter.
+    /// </param>
+    public static Options AddObjectConverter(this Options options, IObjectConverter objectConverter, params Type[] handledTypes)
+    {
+        if (objectConverter is null)
+        {
+            Throw.ArgumentNullException(nameof(objectConverter));
+        }
+
+        if (handledTypes is null || handledTypes.Length == 0)
+        {
+            Throw.ArgumentException(
+                "At least one handled type is required, use the overload without handled types for a converter that handles every value.",
+                nameof(handledTypes));
+        }
+
+        foreach (var handledType in handledTypes!)
+        {
+            if (handledType is null)
+            {
+                Throw.ArgumentException("Handled types cannot contain null.", nameof(handledTypes));
+            }
+        }
+
+        options.Interop.ObjectConverters.Add(new TypedObjectConverter(objectConverter!, handledTypes));
+        return options;
+    }
+
+    /// <summary>
     /// Sets maximum allowed depth of recursion.
     /// </summary>
     /// <param name="options">Options to modify</param>

--- a/Jint/Runtime/Interop/ObjectConverterTypeFilter.cs
+++ b/Jint/Runtime/Interop/ObjectConverterTypeFilter.cs
@@ -1,0 +1,182 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using Jint.Native;
+
+namespace Jint.Runtime.Interop;
+
+/// <summary>
+/// Answers "could any of this engine's registered <see cref="IObjectConverter"/>s be handed a value read
+/// from a member of this declared type?" for the interop fast lanes, which have to decline whenever the
+/// answer is yes (a converter must see every CLR value before it becomes a <see cref="JsValue"/>, and those
+/// lanes produce the <see cref="JsValue"/> themselves).
+/// <para>
+/// A converter registered without declaring the CLR types it handles can be handed anything, so a single
+/// such converter makes the filter claim every member — which is exactly the behaviour every registration
+/// had before declared types existed. Only when <b>every</b> registered converter declared its types can a
+/// member whose declared type none of them claims keep the fast lane.
+/// </para>
+/// <para>
+/// The per-type answer is memoized: the set of member types an engine touches is small and fixed, so the
+/// steady-state cost is one dictionary probe instead of the assignability walk.
+/// </para>
+/// </summary>
+internal sealed class ObjectConverterTypeFilter
+{
+    /// <summary>
+    /// Filter for a converter set containing at least one converter that did not declare its types.
+    /// </summary>
+    private static readonly ObjectConverterTypeFilter _unrestricted = new(declaredTypes: null);
+
+    /// <summary><see langword="null"/> means "claims everything", see <see cref="_unrestricted"/>.</summary>
+    private readonly Type[]? _declaredTypes;
+
+    private readonly ConcurrentDictionary<Type, bool>? _claims;
+
+    private ObjectConverterTypeFilter(Type[]? declaredTypes)
+    {
+        _declaredTypes = declaredTypes;
+        _claims = declaredTypes is not null ? new ConcurrentDictionary<Type, bool>() : null;
+    }
+
+    /// <summary>
+    /// Builds the filter for an engine's converter set, or <see langword="null"/> when no converters are
+    /// registered at all (in which case no fast lane ever has to consider them).
+    /// </summary>
+    internal static ObjectConverterTypeFilter? Create(IObjectConverter[]? converters)
+    {
+        if (converters is null || converters.Length == 0)
+        {
+            return null;
+        }
+
+        List<Type>? declaredTypes = null;
+        foreach (var converter in converters)
+        {
+            if (converter is not TypedObjectConverter typed)
+            {
+                return _unrestricted;
+            }
+
+            declaredTypes ??= new List<Type>();
+            foreach (var handledType in typed.HandledTypes)
+            {
+                if (!declaredTypes.Contains(handledType))
+                {
+                    declaredTypes.Add(handledType);
+                }
+            }
+        }
+
+        return new ObjectConverterTypeFilter(declaredTypes!.ToArray());
+    }
+
+    /// <summary>
+    /// Whether a value read from a member declared as <paramref name="memberType"/> could reach one of the
+    /// converters. Conservative: an unknown declared type is claimed.
+    /// </summary>
+    internal bool Claims(Type? memberType)
+    {
+        var declaredTypes = _declaredTypes;
+        if (declaredTypes is null || memberType is null)
+        {
+            return true;
+        }
+
+        var claims = _claims!;
+        if (claims.TryGetValue(memberType, out var result))
+        {
+            return result;
+        }
+
+        result = ComputeClaims(declaredTypes, memberType);
+        claims.TryAdd(memberType, result);
+        return result;
+    }
+
+    private static bool ComputeClaims(Type[] declaredTypes, Type memberType)
+    {
+        // a member typed as object can hold a value of any type at all
+        if (memberType == typeof(object))
+        {
+            return true;
+        }
+
+        // a boxed Nullable<T> is a boxed T, so the converter sees the underlying type
+        var underlyingType = Nullable.GetUnderlyingType(memberType);
+
+        foreach (var declaredType in declaredTypes)
+        {
+            if (Claims(declaredType, memberType)
+                || (underlyingType is not null && Claims(declaredType, underlyingType)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether some runtime type assignable to <paramref name="memberType"/> is also a
+    /// <paramref name="declaredType"/>. Errs towards <see langword="true"/> — a wrong <c>true</c> only
+    /// forgoes a fast lane, a wrong <c>false</c> would silently bypass a converter.
+    /// </summary>
+    private static bool Claims(Type declaredType, Type memberType)
+    {
+        // an open generic (typeof(List<>)) is not comparable through IsAssignableFrom at all
+        if (declaredType.ContainsGenericParameters)
+        {
+            return true;
+        }
+
+        // every value of the member's type is a declaredType (covers a member typed as a concrete enum
+        // against a converter declaring System.Enum, and an implementer against a declared interface)
+        if (declaredType.IsAssignableFrom(memberType))
+        {
+            return true;
+        }
+
+        // the member could hold a declaredType (or one of its subtypes)
+        if (memberType.IsAssignableFrom(declaredType))
+        {
+            return true;
+        }
+
+        // neither is a view of the other, so only a type deriving from both could be claimed.
+        // A value type or sealed type has no such subtype (IsSealed also covers value types).
+        if (memberType.IsSealed || declaredType.IsSealed)
+        {
+            return false;
+        }
+
+        // an interface on either side can be mixed into a subtype of the other
+        if (memberType.IsInterface || declaredType.IsInterface)
+        {
+            return true;
+        }
+
+        // two unrelated non-sealed classes: single inheritance means no type can be both
+        return false;
+    }
+}
+
+/// <summary>
+/// An <see cref="IObjectConverter"/> registered together with the CLR types it handles. The declaration is
+/// carried by this wrapper rather than by an interface member because <see cref="IObjectConverter"/> is a
+/// shipped public interface and the target frameworks include ones without default interface methods.
+/// </summary>
+internal sealed class TypedObjectConverter : IObjectConverter
+{
+    private readonly IObjectConverter _converter;
+
+    internal TypedObjectConverter(IObjectConverter converter, Type[] handledTypes)
+    {
+        _converter = converter;
+        HandledTypes = handledTypes;
+    }
+
+    internal Type[] HandledTypes { get; }
+
+    public bool TryConvert(Engine engine, object value, [NotNullWhen(true)] out JsValue? result)
+        => _converter.TryConvert(engine, value, out result);
+}

--- a/Jint/Runtime/Interop/Reflection/CompilableMemberAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/CompilableMemberAccessor.cs
@@ -53,11 +53,20 @@ internal abstract class CompilableMemberAccessor : ReflectionAccessor
     {
         value = null;
 
-        // An indexer is probed before the member itself (see GetValue), and registered object
-        // converters must see every CLR value before it becomes a JsValue - the JsValue lane
-        // produces the JsValue itself, so it cannot run in either case. These accessors never
-        // expose a ConstantValue, the third thing GetValue would consult.
-        if (HasIndexer || engine._objectConverters is not null)
+        // An indexer is probed before the member itself (see GetValue), so the lane cannot run when one
+        // is present. These accessors never expose a ConstantValue, the third thing GetValue would consult.
+        if (HasIndexer)
+        {
+            return false;
+        }
+
+        // Registered object converters must see every CLR value before it becomes a JsValue, and this lane
+        // produces the JsValue itself. Only the converters that could actually be handed a value of this
+        // member's declared type matter though: a converter that declared its handled types (see
+        // OptionsExtensions.AddObjectConverter) leaves every other member on the fast lane. A converter
+        // registered without declaring them claims everything, which is the pre-existing behaviour.
+        var converterTypeFilter = engine._objectConverterTypeFilter;
+        if (converterTypeFilter is not null && converterTypeFilter.Claims(MemberType))
         {
             return false;
         }


### PR DESCRIPTION
`CompilableMemberAccessor.TryGetJsValue` — the compiled lane that turns a CLR
member read straight into a `JsValue` — declines whenever the engine has *any*
`IObjectConverter` registered. It has to: a converter is entitled to see every CLR
value before it becomes a `JsValue`, and this lane produces the `JsValue` itself.

The consequence is all-or-nothing. An embedder that registers one converter for one
narrow purpose — rendering a single host type, say — loses the compiled read lane
for **every** CLR member in that engine, including `int`, `bool` and `string`
members the converter would have declined anyway.

Let a converter declare what it handles:

```csharp
options.AddObjectConverter(new MyConverter(), typeof(MyType));
```

A member whose declared type cannot produce a value of any declared type never
reaches that converter, so it keeps the fast lane. The existing overloads are
untouched and keep claiming everything, which is the pre-existing behavior; and one
undeclared converter in the set disables the narrowing for all of them.

The declaration is a promise, and the assignability rule set that consumes it is
deliberately conservative — a wrong "claimed" only forgoes a fast lane, a wrong
"not claimed" would silently bypass a converter:

- an `object`-typed member is always claimed; its declared type says nothing about
  what it holds
- an open generic declaration (`typeof(List<>)`) is not comparable through
  `IsAssignableFrom` at all, so it claims everything
- assignability is checked **both ways**: a member typed as a base class can hold a
  declared subtype, and a member typed as a concrete enum is claimed by a converter
  declaring `System.Enum`
- when neither type is a view of the other, only a type deriving from both could be
  claimed — impossible if either is sealed (which covers value types), possible if
  either is an interface (it can be mixed into a subtype of the other), and
  impossible for two unrelated non-sealed classes by single inheritance
- `Nullable<T>` is unwrapped, since a boxed `Nullable<T>` is a boxed `T`

The per-type answer is memoized: the set of member types an engine touches is small
and fixed, so the steady-state cost is one dictionary probe rather than the
assignability walk.

**The win is conditional.** This does nothing for an engine that registers no
converter (already on the fast lane) and nothing for one whose converter declares
nothing (unchanged). It only helps embedders who both register a converter and can
say what it is for — but for those, it restores a lane they were paying for the loss
of across their entire object graph.

`InteropObjectConverterFilterTests` covers the registration surface, the behavioral
contract, and the assignability rules case by case. The behavioral tests use a
converter that *changes* the value it sees, since whether the change shows up is the
only black-box evidence of which lane ran; they are skipped to the converted
expectation on targets without a compiled read lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
