### PR TITLE
Give every engine its own constraint instances so Options can be shared

### DIFF
--- a/Jint.Tests.PublicInterface/SharedOptionsConstraintIsolationTests.cs
+++ b/Jint.Tests.PublicInterface/SharedOptionsConstraintIsolationTests.cs
@@ -1,0 +1,208 @@
+using Jint.Constraints;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Building many engines from a single <see cref="Options"/> instance is a supported pattern, so the
+/// per-execution state a constraint carries (statement counter, deadline) must belong to one engine
+/// only. These tests pin that isolation for the built-in constraints.
+/// </summary>
+public class SharedOptionsConstraintIsolationTests
+{
+    private const int EngineCount = 8;
+
+    private const string LoopScript = """
+        var total = 0;
+        for (var i = 0; i < 2000; i++) {
+            total += i;
+        }
+        total;
+        """;
+
+    private const double LoopScriptResult = 1999 * 2000 / 2d;
+
+    [Fact]
+    public async Task EachEngineGetsItsOwnStatementBudgetWhenRunConcurrently()
+    {
+        // A budget just above what one run needs: a shared counter would blow it well before all
+        // engines finished, an isolated one leaves every engine comfortably inside its own budget.
+        var options = new Options().MaxStatements(MeasureStatements(LoopScript) + 10);
+        var engines = new Engine[EngineCount];
+        for (var i = 0; i < engines.Length; i++)
+        {
+            engines[i] = new Engine(options);
+        }
+
+        using var start = new ManualResetEventSlim(false);
+        var tasks = new Task<double>[engines.Length];
+        for (var i = 0; i < engines.Length; i++)
+        {
+            var engine = engines[i];
+            tasks[i] = Task.Run(() =>
+            {
+                start.Wait();
+                return engine.Evaluate(LoopScript).AsNumber();
+            });
+        }
+
+        start.Set();
+
+        var results = await Task.WhenAll(tasks);
+
+        results.Should().OnlyContain(x => x == LoopScriptResult);
+    }
+
+    [Fact]
+    public void EachEngineGetsItsOwnStatementConstraintInstance()
+    {
+        var options = new Options().MaxStatements(100_000);
+        var first = new Engine(options);
+        var second = new Engine(options);
+
+        var firstConstraint = first.Constraints.Find<MaxStatementsConstraint>();
+        var secondConstraint = second.Constraints.Find<MaxStatementsConstraint>();
+
+        firstConstraint.Should().NotBeNull();
+        secondConstraint.Should().NotBeNull();
+        firstConstraint.Should().NotBeSameAs(secondConstraint);
+    }
+
+    [Fact]
+    public void FindReturnsALiveConstraintThatOnlyAffectsItsOwnEngine()
+    {
+        var options = new Options().MaxStatements(100_000);
+        var restricted = new Engine(options);
+        var unrestricted = new Engine(options);
+
+        // an embedder is allowed to retune the limit after the engine exists
+        restricted.Constraints.Find<MaxStatementsConstraint>().MaxStatements = 5;
+
+        unrestricted.Constraints.Find<MaxStatementsConstraint>().MaxStatements.Should().Be(100_000);
+
+        Invoking(() => restricted.Evaluate(LoopScript)).Should().Throw<StatementsCountOverflowException>();
+        unrestricted.Evaluate(LoopScript).AsNumber().Should().Be(LoopScriptResult);
+    }
+
+    [Fact]
+    public void EachEngineGetsItsOwnTimeoutDeadline()
+    {
+        var options = new Options().TimeoutInterval(TimeSpan.FromMilliseconds(100));
+        var engine = new Engine(options);
+        var other = new Engine(options);
+
+        // Runs past the timeout and then starts an execution on the sibling engine. A shared
+        // deadline would be re-armed by the sibling's run and this engine would sail past its own
+        // timeout; an isolated deadline has already expired by the time control comes back.
+        engine.SetValue("runOnOtherEngine", new Action(() =>
+        {
+            Thread.Sleep(TimeSpan.FromMilliseconds(250));
+            other.Evaluate("1 + 1");
+        }));
+
+        var script = """
+            runOnOtherEngine();
+            var total = 0;
+            for (var i = 0; i < 20000; i++) {
+                total += i;
+            }
+            total;
+            """;
+
+        Invoking(() => engine.Evaluate(script)).Should().Throw<TimeoutException>();
+    }
+
+    [Fact]
+    public void ConstraintInstanceRegistrationStillWorks()
+    {
+        // the instance overload stays supported for the single-engine case
+        var constraint = new CountingConstraint();
+        var engine = new Engine(new Options().Constraint(constraint));
+
+        engine.Evaluate(LoopScript).AsNumber().Should().Be(LoopScriptResult);
+
+        constraint.HighWaterMark.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void ConstraintFactoryRegistrationProducesOneInstancePerEngine()
+    {
+        var created = new List<CountingConstraint>();
+        var options = new Options().Constraint(() =>
+        {
+            var constraint = new CountingConstraint();
+            lock (created)
+            {
+                created.Add(constraint);
+            }
+            return constraint;
+        });
+
+        _ = new Engine(options);
+        _ = new Engine(options);
+        _ = new Engine(options);
+
+        created.Should().HaveCount(3);
+        created.Distinct().Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void WithoutConstraintRemovesFactoryRegistrations()
+    {
+        var options = new Options()
+            .MaxStatements(5)
+            .WithoutConstraint(x => x is MaxStatementsConstraint);
+
+        var engine = new Engine(options);
+
+        engine.Constraints.Find<MaxStatementsConstraint>().Should().BeNull();
+        engine.Evaluate(LoopScript).AsNumber().Should().Be(LoopScriptResult);
+    }
+
+    [Fact]
+    public void ReconfiguringAConstraintReplacesTheEarlierRegistration()
+    {
+        // MaxStatements clears any previous registration before adding its own
+        var options = new Options().MaxStatements(5).MaxStatements(100_000);
+
+        var engine = new Engine(options);
+
+        engine.Constraints.Find<MaxStatementsConstraint>().MaxStatements.Should().Be(100_000);
+        engine.Evaluate(LoopScript).AsNumber().Should().Be(LoopScriptResult);
+    }
+
+    /// <summary>
+    /// Counts how many statement checks a script performs. A user-derived constraint is checked at
+    /// exactly the same points as <see cref="MaxStatementsConstraint"/>, so the high water mark is the
+    /// statement budget the script needs.
+    /// </summary>
+    private static int MeasureStatements(string script)
+    {
+        var constraint = new CountingConstraint();
+        var engine = new Engine(new Options().Constraint(constraint));
+        engine.Evaluate(script);
+        return constraint.HighWaterMark;
+    }
+
+    private sealed class CountingConstraint : Constraint
+    {
+        private int _count;
+
+        /// <summary>
+        /// The highest count reached within a single execution. Tracked separately because the engine
+        /// resets constraints both before and after every execution.
+        /// </summary>
+        public int HighWaterMark { get; private set; }
+
+        public override void Check()
+        {
+            _count++;
+            if (_count > HighWaterMark)
+            {
+                HighWaterMark = _count;
+            }
+        }
+
+        public override void Reset() => _count = 0;
+    }
+}

--- a/Jint.Tests/Runtime/ConstraintRegistrationTests.cs
+++ b/Jint.Tests/Runtime/ConstraintRegistrationTests.cs
@@ -11,11 +11,17 @@ namespace Jint.Tests.Runtime;
 /// </summary>
 public class ConstraintRegistrationTests
 {
-    private static List<Constraint> Register(Action<Options> configure)
+    /// <summary>
+    /// The constraints an engine built from these options actually ends up with. Asking the engine
+    /// rather than the options is what makes this independent of <em>how</em> a helper registered its
+    /// constraint: the built-in helpers register a factory so that each engine gets its own instance,
+    /// while a directly registered instance is shared, and both arrive here the same way.
+    /// </summary>
+    private static IReadOnlyList<Constraint> Register(Action<Options> configure)
     {
         var options = new Options();
         configure(options);
-        return options.Constraints.Constraints;
+        return new Engine(options)._constraints;
     }
 
     private static int CountOf<T>(Action<Options> configure) where T : Constraint

--- a/Jint/Constraints/ConstraintsOptionsExtensions.cs
+++ b/Jint/Constraints/ConstraintsOptionsExtensions.cs
@@ -22,6 +22,12 @@ namespace Jint;
 /// an engine against itself.
 /// </para>
 /// </summary>
+/// <remarks>
+/// Every method here registers a <i>factory</i> rather than a constraint instance, so each engine
+/// built from the options gets its own constraint and its own per-execution state (statement
+/// counter, deadline). That is what keeps a single <see cref="Options"/> instance safe to reuse for
+/// many engines, including engines running concurrently.
+/// </remarks>
 public static class ConstraintsOptionsExtensions
 {
     /// <summary>
@@ -43,7 +49,7 @@ public static class ConstraintsOptionsExtensions
 
         if (maxStatements > 0 && maxStatements < int.MaxValue)
         {
-            options.Constraint(new MaxStatementsConstraint(maxStatements));
+            options.Constraint(() => new MaxStatementsConstraint(maxStatements));
         }
         return options;
     }
@@ -66,7 +72,7 @@ public static class ConstraintsOptionsExtensions
 
         if (memoryLimit > 0 && memoryLimit < long.MaxValue)
         {
-            options.Constraint(new MemoryLimitConstraint(memoryLimit));
+            options.Constraint(() => new MemoryLimitConstraint(memoryLimit));
         }
         return options;
     }
@@ -89,7 +95,7 @@ public static class ConstraintsOptionsExtensions
 
         if (timeoutInterval > TimeSpan.Zero && timeoutInterval < TimeSpan.MaxValue)
         {
-            options.Constraint(new TimeConstraint(timeoutInterval));
+            options.Constraint(() => new TimeConstraint(timeoutInterval));
         }
         return options;
     }
@@ -110,7 +116,7 @@ public static class ConstraintsOptionsExtensions
 
         if (cancellationToken != default)
         {
-            options.Constraint(new CancellationConstraint(cancellationToken));
+            options.Constraint(() => new CancellationConstraint(cancellationToken));
         }
         return options;
     }

--- a/Jint/Engine.Constraints.cs
+++ b/Jint/Engine.Constraints.cs
@@ -1,4 +1,5 @@
 using Jint.Constraints;
+using Jint.Runtime;
 
 namespace Jint;
 
@@ -8,6 +9,51 @@ public partial class Engine
 
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
     private readonly record struct ConstraintPartition(Constraint[] Exact, Constraint[] Amortized);
+
+    /// <summary>
+    /// Materializes the constraint set for this engine.
+    /// </summary>
+    /// <remarks>
+    /// Constraints hold per-execution state — a statement counter, a deadline, an observed token — and
+    /// <see cref="ResetConstraints"/> rewinds that state at the start of every execution. Sharing one
+    /// <see cref="Options"/> instance across engines is a supported (and recommended) pattern, so the
+    /// engine cannot simply take a reference to whatever the options hold: two engines would then share
+    /// one budget and one engine's reset would rewind another engine's in-flight execution. Factory
+    /// registrations therefore produce a fresh instance per engine here. Instances registered directly
+    /// through <see cref="OptionsExtensions.Constraint(Options, Constraint)"/> are used as given — that
+    /// overload is documented as single-engine-only, and nothing can be cloned out of an arbitrary
+    /// user-derived <see cref="Constraint"/>.
+    /// </remarks>
+    private static Constraint[] BuildConstraints(Options.ConstraintOptions options)
+    {
+        var factories = options.ConstraintFactories;
+        var instances = options.Constraints;
+
+        if (factories.Count == 0)
+        {
+            return instances.Count == 0 ? [] : instances.ToArray();
+        }
+
+        var constraints = new Constraint[factories.Count + instances.Count];
+        var index = 0;
+        foreach (var factory in factories)
+        {
+            var constraint = factory();
+            if (constraint is null)
+            {
+                Throw.InvalidOperationException("A registered constraint factory returned null.");
+            }
+
+            constraints[index++] = constraint;
+        }
+
+        foreach (var instance in instances)
+        {
+            constraints[index++] = instance;
+        }
+
+        return constraints;
+    }
 
     /// <summary>
     /// Splits the registered constraints by required check frequency. The built-in time and

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -281,7 +281,7 @@ public sealed partial class Engine : IDisposable
             ? Options.Interop.ObjectConverters.ToArray()
             : null;
 
-        _constraints = Options.Constraints.Constraints.ToArray();
+        _constraints = BuildConstraints(Options.Constraints);
         var partitionedConstraints = PartitionConstraints(_constraints);
         _exactConstraints = partitionedConstraints.Exact;
         _amortizedConstraints = partitionedConstraints.Amortized;

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -254,6 +254,15 @@ public static class OptionsExtensions
         return options;
     }
 
+    /// <summary>
+    /// Registers a single constraint instance.
+    /// </summary>
+    /// <remarks>
+    /// The instance is shared by every engine built from these options. Constraints normally carry
+    /// per-execution state, so this overload is only safe for options that build exactly one engine.
+    /// Use <see cref="Constraint(Options, Func{Constraint})"/> when the same options are reused for
+    /// several engines.
+    /// </remarks>
     public static Options Constraint(this Options options, Constraint constraint)
     {
         if (constraint != null)
@@ -264,9 +273,50 @@ public static class OptionsExtensions
         return options;
     }
 
+    /// <summary>
+    /// Registers a factory that produces a constraint. Each engine built from these options invokes the
+    /// factory exactly once while constructing, so no per-execution constraint state is ever shared
+    /// between engines — which makes it safe to build many engines, including concurrently running ones,
+    /// from a single <see cref="Options"/> instance.
+    /// </summary>
+    /// <param name="options">The engine options.</param>
+    /// <param name="constraintFactory">
+    /// Produces a fresh, unconfigured constraint instance on every invocation. It must not hand out the
+    /// same instance twice, otherwise the isolation this overload exists for is lost, and it must have no
+    /// side effect beyond creating the constraint: <see cref="WithoutConstraint"/> invokes it once more to
+    /// classify the registration.
+    /// </param>
+    /// <returns>The options instance for fluent configuration.</returns>
+    public static Options Constraint(this Options options, Func<Constraint> constraintFactory)
+    {
+        if (constraintFactory != null)
+        {
+            options.Constraints.ConstraintFactories.Add(constraintFactory);
+        }
+
+        return options;
+    }
+
+    /// <summary>
+    /// Removes every registered constraint matching <paramref name="predicate"/>.
+    /// </summary>
+    /// <remarks>
+    /// A factory registration has no instance to test against, so the predicate is evaluated against a
+    /// throw-away probe obtained from the factory — which is why a factory must not do anything beyond
+    /// creating the constraint. Because a factory is required to return a fresh, unconfigured instance,
+    /// the classification predicates this method is used with (<c>x =&gt; x is SomeConstraint</c>) select
+    /// exactly the same registrations they would have selected before the registration became
+    /// factory-based, which is what keeps the "replace the constraint of this kind" behaviour of
+    /// <see cref="ConstraintsOptionsExtensions"/> intact.
+    /// </remarks>
     public static Options WithoutConstraint(this Options options, Predicate<Constraint> predicate)
     {
         options.Constraints.Constraints.RemoveAll(predicate);
+        options.Constraints.ConstraintFactories.RemoveAll(factory =>
+        {
+            var probe = factory();
+            return probe is not null && predicate(probe);
+        });
         return options;
     }
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -531,9 +531,24 @@ public class Options
     public class ConstraintOptions
     {
         /// <summary>
-        /// Registered constraints.
+        /// Registered constraint instances.
         /// </summary>
+        /// <remarks>
+        /// Every engine built from these options observes these exact instances. Constraints normally
+        /// carry per-execution state (a statement counter, a deadline), so a shared instance is only
+        /// safe when a single engine is built from the options and it is never used concurrently.
+        /// To share one <see cref="Options"/> across several engines, register a factory instead
+        /// (<see cref="OptionsExtensions.Constraint(Options, Func{Constraint})"/>) so each engine gets
+        /// its own instance; the built-in constraint extension methods already do that.
+        /// </remarks>
         public List<Constraint> Constraints { get; } = new();
+
+        /// <summary>
+        /// Registered constraint factories. Each engine built from these options invokes every factory
+        /// exactly once while constructing, so the constraints — and the per-execution state they carry —
+        /// belong to that engine alone.
+        /// </summary>
+        internal List<Func<Constraint>> ConstraintFactories { get; } = new();
 
         /// <summary>
         /// Maximum recursion depth allowed, defaults to -1 (no checks).


### PR DESCRIPTION
Reusing one `Options` instance for many engines is a supported (and recommended) pattern — it is how a host avoids re-running the whole option pipeline per engine. But `Engine` copied the registered constraint **instances**:

```csharp
_constraints = Options.Constraints.Constraints.ToArray();
```

and constraints carry mutable per-execution state: `MaxStatementsConstraint._statementsCount`, `TimeConstraint._deadline`, `MemoryLimitConstraint._initialMemoryUsage` / `_initialThreadId`. So a host that shares an `Options` and calls any constraint helper ends up with one counter and one deadline shared by every engine built from it:

- **the statement budget is consumed collectively** — engines running concurrently blow a per-run budget that each of them individually stays well inside, and `ResetConstraints` on one engine rewinds another engine's in-flight count;
- **a sibling engine's execution re-arms the shared deadline**, so an engine that has already overrun its own timeout sails past it;
- **`Engine.Constraints.Find<T>()` hands back the shared instance**, so retuning `MaxStatements` on one engine silently retunes every other engine built from the same options.

### The fix

`Options.ConstraintOptions` gains an internal factory list, and `OptionsExtensions` a public `Constraint(this Options, Func<Constraint>)` overload beside the existing instance one. The built-in helpers (`MaxStatements`, `LimitMemory`, `TimeoutInterval`, `CancellationToken`) register factories, and `Engine` invokes each factory once while constructing, so its constraints — and the state they carry — belong to it alone.

The instance overload stays and behaves exactly as before. Nothing can be safely cloned out of an arbitrary user-derived `Constraint`, so it is documented as single-engine-only rather than silently changed; hosts with their own stateful constraint now have the factory overload to reach for.

`ConstraintRegistrationTests` (added in #2788 / #2789) counted registrations by reading `options.Constraints.Constraints`, which is now only half the picture, so it asks the engine for the constraint set it materialized instead. That is what every one of those assertions is really about, and it no longer depends on which of the two registration lists a helper used.

`WithoutConstraint` filters both lists. A factory registration has no instance to test a `Predicate<Constraint>` against, so it is classified by probing the factory for a throw-away instance. Since a factory is required to return a fresh, unconfigured constraint, the `x is SomeConstraint` predicates the helpers use select exactly the registrations they selected before — which is what keeps their "replace the constraint of this kind" behaviour intact, including `TimeoutInterval`'s removal of the previous timeout added in #2788.

### Confirmed failing before the fix

`Jint.Tests.PublicInterface/SharedOptionsConstraintIsolationTests.cs` has 8 cases; 7 of them compile against the unpatched API (the eighth exercises the new factory overload). Run against unpatched `main`, 4 of those 7 fail — one per failure mode above:

```
Failed EachEngineGetsItsOwnStatementBudgetWhenRunConcurrently
  Jint.Runtime.StatementsCountOverflowException : The maximum number of statements executed have been reached.

Failed EachEngineGetsItsOwnStatementConstraintInstance
  Did not expect firstConstraint to refer to Jint.Constraints.MaxStatementsConstraint

Failed FindReturnsALiveConstraintThatOnlyAffectsItsOwnEngine
  Expected unrestricted.Constraints.Find<MaxStatementsConstraint>().MaxStatements to be 100000,
  but found 5 (difference of -99995).

Failed EachEngineGetsItsOwnTimeoutDeadline
  Expected a <System.TimeoutException> to be thrown, but no exception was thrown.

Failed!  - Failed: 4, Passed: 3, Skipped: 0, Total: 7
```

With the fix all 8 pass.

### Verification

Release build (warnings are errors): 0 errors, 1 warning — the pre-existing `MSB3277` in `Jint.Tests.CommonScripts` on `net472`, present on clean `main` too.

| suite | main | this branch |
| --- | --- | --- |
| `Jint.Tests` net10.0 | 4123 passed / 4 skipped | 4123 passed / 4 skipped |
| `Jint.Tests` net472 | 4059 passed / 4 skipped | 4059 passed / 4 skipped |
| `Jint.Tests.PublicInterface` (both TFMs) | 149 passed | 157 passed |
| `Jint.Tests.Test262` | 99441 passed / 157 skipped | 99441 passed / 157 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
