### PR TITLE
Add an option to expose CLR enums to script as their name

### DIFF
--- a/Jint.Tests/Runtime/InteropEnumConversionModeTests.cs
+++ b/Jint.Tests/Runtime/InteropEnumConversionModeTests.cs
@@ -1,0 +1,178 @@
+#nullable enable
+using Jint.Native;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Exercises <see cref="Options.InteropOptions.EnumConversion"/>, the built-in replacement for the
+/// hand-written "render enums as their name" object converter that embedders otherwise have to register.
+/// The numeric default itself is pinned across every underlying-type route by
+/// <see cref="InteropEnumConversionTests"/>.
+/// </summary>
+public class InteropEnumConversionModeTests
+{
+    public enum Level
+    {
+        Zero = 0,
+        One = 1,
+        Two = 2,
+    }
+
+    [Flags]
+    public enum Access
+    {
+        None = 0,
+        Read = 1,
+        Write = 2,
+    }
+
+    public enum LongLevel : long
+    {
+        Big = 5_000_000_000L,
+    }
+
+    public sealed class Host
+    {
+        public Level Level { get; set; } = Level.One;
+        public Level? NullableLevel { get; set; }
+        public Access Access { get; set; } = Access.Read | Access.Write;
+        public LongLevel LongLevel { get; set; } = LongLevel.Big;
+        public Level Undefined { get; set; } = (Level) 42;
+        public bool Flag { get; set; } = true;
+        public int Number { get; set; } = 7;
+
+        public Level Echo(Level level) => level;
+    }
+
+    private static Engine CreateEngine(Host host, EnumConversionMode? mode = null)
+    {
+        var engine = new Engine(options =>
+        {
+            if (mode is not null)
+            {
+                options.Interop.EnumConversion = mode.Value;
+            }
+        });
+        engine.SetValue("host", host);
+        return engine;
+    }
+
+    [Fact]
+    public void DefaultsToTheNumericValue()
+    {
+        var engine = CreateEngine(new Host());
+
+        engine.Evaluate("host.Level").Should().Be(1);
+        engine.Evaluate("host.Access").Should().Be(3);
+        engine.Evaluate("host.Undefined").Should().Be(42);
+        engine.Evaluate("host.Echo(2)").Should().Be(2);
+    }
+
+    [Fact]
+    public void ExplicitNumberModeMatchesTheDefault()
+    {
+        var engine = CreateEngine(new Host(), EnumConversionMode.Number);
+
+        engine.Evaluate("host.Level").Should().Be(1);
+    }
+
+    [Fact]
+    public void StringModeExposesTheMemberName()
+    {
+        var engine = CreateEngine(new Host(), EnumConversionMode.String);
+
+        engine.Evaluate("host.Level").Should().Be("One");
+        engine.Evaluate("typeof host.Level").Should().Be("string");
+    }
+
+    [Fact]
+    public void StringModeCombinesFlagNames()
+    {
+        var engine = CreateEngine(new Host(), EnumConversionMode.String);
+
+        engine.Evaluate("host.Access").Should().Be("Read, Write");
+    }
+
+    [Fact]
+    public void StringModeFallsBackToTheNumberForANamelessValue()
+    {
+        var engine = CreateEngine(new Host(), EnumConversionMode.String);
+
+        engine.Evaluate("host.Undefined").Should().Be("42");
+    }
+
+    [Fact]
+    public void StringModeCoversWideUnderlyingTypes()
+    {
+        var engine = CreateEngine(new Host(), EnumConversionMode.String);
+
+        engine.Evaluate("host.LongLevel").Should().Be("Big");
+    }
+
+    [Fact]
+    public void StringModeCoversNullableMembers()
+    {
+        var engine = CreateEngine(new Host { NullableLevel = Level.Two }, EnumConversionMode.String);
+
+        engine.Evaluate("host.NullableLevel").Should().Be("Two");
+        engine.Evaluate("host.Level === 'One'").Should().Be(true);
+    }
+
+    [Fact]
+    public void NullNullableMemberStaysNull()
+    {
+        var engine = CreateEngine(new Host(), EnumConversionMode.String);
+
+        engine.Evaluate("host.NullableLevel").Should().Be(JsValue.Null);
+    }
+
+    [Fact]
+    public void StringModeCoversMethodReturnValues()
+    {
+        var engine = CreateEngine(new Host(), EnumConversionMode.String);
+
+        engine.Evaluate("host.Echo(2)").Should().Be("Two");
+    }
+
+    [Fact]
+    public void StringModeLeavesOtherMembersAlone()
+    {
+        var engine = CreateEngine(new Host(), EnumConversionMode.String);
+
+        engine.Evaluate("host.Flag").Should().Be(true);
+        engine.Evaluate("host.Number").Should().Be(7);
+    }
+
+    [Fact]
+    public void WritesStillAcceptBothNamesAndNumbers()
+    {
+        var host = new Host();
+        var engine = CreateEngine(host, EnumConversionMode.String);
+
+        engine.Evaluate("host.Level = 'Two'");
+        host.Level.Should().Be(Level.Two);
+
+        engine.Evaluate("host.Level = 0");
+        host.Level.Should().Be(Level.Zero);
+
+        engine.Evaluate("host.Echo('Two')").Should().Be("Two");
+    }
+
+    [Fact]
+    public void RoundTripsThroughScript()
+    {
+        var host = new Host();
+        var engine = CreateEngine(host, EnumConversionMode.String);
+
+        engine.Evaluate("host.Level = host.Echo(host.Level)");
+        host.Level.Should().Be(Level.One);
+    }
+
+    [Fact]
+    public void ModeIsPerEngine()
+    {
+        var host = new Host();
+        CreateEngine(host, EnumConversionMode.String).Evaluate("host.Level").Should().Be("One");
+        CreateEngine(host).Evaluate("host.Level").Should().Be(1);
+    }
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -154,6 +154,10 @@ public sealed partial class Engine : IDisposable
 
     // cached access
     internal readonly IObjectConverter[]? _objectConverters;
+
+    // snapshot of Options.Interop.EnumConversion, read on every CLR value crossing into script
+    internal readonly bool _enumsAsStrings;
+
     internal readonly Constraint[] _constraints;
 
     // _constraints partitioned once at construction (the set is fixed for the engine's lifetime):
@@ -280,6 +284,7 @@ public sealed partial class Engine : IDisposable
         _objectConverters = Options.Interop.ObjectConverters.Count > 0
             ? Options.Interop.ObjectConverters.ToArray()
             : null;
+        _enumsAsStrings = Options.Interop.EnumConversion == EnumConversionMode.String;
 
         _constraints = Options.Constraints.Constraints.ToArray();
         var partitionedConstraints = PartitionConstraints(_constraints);

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -438,6 +438,14 @@ public class Options
         public ValueCoercionType ValueCoercion { get; set; } = ValueCoercionType.String;
 
         /// <summary>
+        /// How CLR enum values are exposed to script code when they cross into JavaScript, defaults to
+        /// <see cref="Jint.EnumConversionMode.Number"/> (the underlying numeric value). This is the read direction;
+        /// the write direction is governed by <see cref="ValueCoercion"/> and always accepts both the member name
+        /// and the numeric value.
+        /// </summary>
+        public EnumConversionMode EnumConversion { get; set; } = EnumConversionMode.Number;
+
+        /// <summary>
         /// Strategy to create a CLR object to hold converted <see cref="ObjectInstance"/>.
         /// </summary>
         public Func<ObjectInstance, IDictionary<string, object?>>? CreateClrObject { get; set; } = _ => new ExpandoObject();
@@ -737,6 +745,24 @@ public enum ExperimentalFeature
     /// All coercion rules enabled.
     /// </summary>
     All = TaskInterop,
+}
+
+/// <summary>
+/// Strategy for exposing CLR enum values to script code, see <see cref="Options.InteropOptions.EnumConversion"/>.
+/// </summary>
+public enum EnumConversionMode
+{
+    /// <summary>
+    /// The enum's underlying numeric value is exposed. This is the default.
+    /// </summary>
+    Number,
+
+    /// <summary>
+    /// The enum member name is exposed as a string, as produced by <see cref="object.ToString"/> — a combination
+    /// of names for a matching <see cref="FlagsAttribute"/> value, and the numeric value rendered as a string for
+    /// a value that has no name. Values converted back to the CLR keep accepting both the name and the number.
+    /// </summary>
+    String,
 }
 
 /// <summary>

--- a/Jint/Runtime/Interop/DefaultObjectConverter.cs
+++ b/Jint/Runtime/Interop/DefaultObjectConverter.cs
@@ -79,6 +79,16 @@ internal static class DefaultObjectConverter
                 // runtime type.
             }
 
+            // An enum is IConvertible and reports its underlying type code, so the convertible lane just
+            // below is what turns it into a number — there is no enum-specific handling left to reach.
+            // The string form is Enum.ToString(): the member name, the comma separated names of a matching
+            // Flags combination, or the number for a nameless value.
+            if (engine._enumsAsStrings && value is Enum enumValue)
+            {
+                result = JsString.Create(enumValue.ToString());
+                return true;
+            }
+
             if (value is IConvertible convertible && TryConvertConvertible(engine, convertible, out result))
             {
                 return true;


### PR DESCRIPTION
A CLR enum crossing into script becomes its underlying number. An enum is
`IConvertible` and reports its underlying type code, so it is served by the shared
convertible lane in `DefaultObjectConverter` (see #2790, which removed the
unreachable enum-specific branch below it).

Embedders who want the *name* in script instead have no option for it, so they
register an `IObjectConverter` purely to call `Enum.ToString()`. That is a heavy way
to ask for a rendering choice: a registered converter is offered every CLR value in
the engine and, until the change alongside this one, disabled the compiled
member-read lane for every CLR member.

Add the option directly:

```csharp
options.Interop.EnumConversion = EnumConversionMode.String;
```

`EnumConversionMode.Number` is the default and is exactly today's behavior, so
nothing changes for anyone who does not opt in. `String` exposes `Enum.ToString()`:
the member name, the comma-separated names of a matching `[Flags]` combination, or
the number rendered as a string for a value with no name.

This is the read direction only. The write direction is governed by `ValueCoercion`
and keeps accepting both the member name and the numeric value, so a value read out
as `"One"` still assigns back, and `host.Level = 0` still works in string mode.

The check sits *before* the `IConvertible` branch, which is what would otherwise
claim the value, and is a single bool field read on `Engine` — snapshotted from
options at construction — on a path that already tests several `is` patterns.

`InteropEnumConversionModeTests` pins the default, both modes, flags combinations,
nameless values, wide underlying types, nullable members, a null nullable member,
method return values, non-enum members, the write direction, a round trip and
per-engine independence. It sits alongside the existing `InteropEnumConversionTests`
from #2790, which pins the numeric default across every underlying-type route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
