### PR TITLE
Stop the custom reference resolver from disabling the property-write fast path

### DIFF
--- a/Jint.Tests.PublicInterface/ReferenceResolverAssignmentTests.cs
+++ b/Jint.Tests.PublicInterface/ReferenceResolverAssignmentTests.cs
@@ -1,0 +1,212 @@
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <see cref="IReferenceResolver"/> has no write-side member, so installing one must not change how a
+/// property assignment behaves. These tests pin that: every case runs on an engine with a resolver and on
+/// an engine without one, and both must agree.
+/// </summary>
+public class ReferenceResolverAssignmentTests
+{
+    /// <summary>
+    /// Declines every hook, exactly like the built-in resolver, but is a distinct instance so the engine
+    /// classifies it as a custom resolver.
+    /// </summary>
+    private sealed class PassThroughResolver : IReferenceResolver
+    {
+        public bool TryUnresolvableReference(Engine engine, Reference reference, out JsValue value)
+        {
+            value = JsValue.Undefined;
+            return false;
+        }
+
+        public bool TryPropertyReference(Engine engine, Reference reference, ref JsValue value) => false;
+
+        public bool TryGetCallable(Engine engine, object callee, out JsValue value)
+        {
+            value = JsValue.Undefined;
+            return false;
+        }
+
+        public bool CheckCoercible(JsValue value) => false;
+    }
+
+    /// <summary>Substitutes a host-supplied object for any unresolvable identifier.</summary>
+    private sealed class SubstitutingResolver : IReferenceResolver
+    {
+        public JsValue Substitute { get; set; } = JsValue.Undefined;
+
+        public bool TryUnresolvableReference(Engine engine, Reference reference, out JsValue value)
+        {
+            value = Substitute;
+            return true;
+        }
+
+        public bool TryPropertyReference(Engine engine, Reference reference, ref JsValue value) => false;
+
+        public bool TryGetCallable(Engine engine, object callee, out JsValue value)
+        {
+            value = JsValue.Undefined;
+            return false;
+        }
+
+        public bool CheckCoercible(JsValue value) => true;
+    }
+
+    private sealed class Holder
+    {
+        public int Value { get; set; }
+
+        public int ReadOnly => 7;
+    }
+
+    private static Engine CreateEngine(bool withResolver) => withResolver
+        ? new Engine(options => options.SetReferencesResolver(new PassThroughResolver()))
+        : new Engine();
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SimpleAssignmentWritesAndOverwritesOwnProperties(bool withResolver)
+    {
+        var engine = CreateEngine(withResolver);
+
+        // the loop runs the same call site repeatedly so the write-side inline cache is populated and used
+        var result = engine.Evaluate("""
+            var o = { a: 1 };
+            o.a = 2;
+            o.b = 3;
+            for (var i = 0; i < 10; i++) { o.a = i; }
+            [o.a, o.b].join(',');
+            """);
+
+        result.AsString().Should().Be("9,3");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CompoundAssignmentReadsAndWritesOnce(bool withResolver)
+    {
+        var engine = CreateEngine(withResolver);
+
+        var result = engine.Evaluate("""
+            var reads = 0;
+            var o = { a: 1 };
+            o.a += 1;
+            o.a += 1;
+            var s = { x: 'a' };
+            s.x += 'b';
+            [o.a, s.x].join(',');
+            """);
+
+        result.AsString().Should().Be("3,ab");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AssignmentThroughPrototypeSetterInvokesTheSetter(bool withResolver)
+    {
+        var engine = CreateEngine(withResolver);
+
+        var result = engine.Evaluate("""
+            var seen = [];
+            var proto = {};
+            Object.defineProperty(proto, 'p', {
+                set: function (v) { seen.push(v); },
+                get: function () { return 'g'; }
+            });
+            var o = Object.create(proto);
+            o.p = 5;
+            o.p = 6;
+            [seen.join('|'), o.p, Object.getOwnPropertyNames(o).length].join(',');
+            """);
+
+        // the inherited setter runs for every write and no shadowing own property is created
+        result.AsString().Should().Be("5|6,g,0");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void StrictModeAssignmentToReadOnlyPropertyThrows(bool withResolver)
+    {
+        var engine = CreateEngine(withResolver);
+
+        engine.Execute("""
+            var o = {};
+            Object.defineProperty(o, 'r', { value: 1, writable: false });
+            """);
+
+        Invoking(() => engine.Execute("'use strict'; o.r = 2;"))
+            .Should().Throw<JavaScriptException>()
+            .Which.Message.Should().Be("Cannot assign to read only property 'r' of [object Object]");
+
+        // sloppy mode silently ignores the write
+        engine.Execute("o.r = 3;");
+        engine.Evaluate("o.r").AsNumber().Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AssignmentOnNullishBaseThrows(bool withResolver)
+    {
+        var engine = CreateEngine(withResolver);
+
+        engine.Execute("var o = { nothing: null };");
+
+        Invoking(() => engine.Execute("o.missing.x = 1;"))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("Cannot convert undefined or null to object");
+
+        Invoking(() => engine.Execute("o.nothing.x = 1;"))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("Cannot convert undefined or null to object");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AssignmentToHostObjectMemberGoesThroughTheClrSetter(bool withResolver)
+    {
+        var engine = CreateEngine(withResolver);
+        var holder = new Holder();
+        engine.SetValue("host", holder);
+
+        engine.Execute("for (var i = 0; i < 10; i++) { host.Value = i; }");
+        holder.Value.Should().Be(9);
+
+        // a getter-only CLR member refuses the write: silently in sloppy mode, with a TypeError in
+        // strict mode, and never by shadowing the member with a JS-side own property
+        engine.Execute("host.ReadOnly = 1;");
+        holder.ReadOnly.Should().Be(7);
+        engine.Evaluate("host.ReadOnly").AsNumber().Should().Be(7);
+
+        Invoking(() => engine.Execute("'use strict'; host.ReadOnly = 1;"))
+            .Should().Throw<JavaScriptException>()
+            .WithMessage("Cannot assign to read only property 'ReadOnly' of *");
+        holder.ReadOnly.Should().Be(7);
+    }
+
+    [Fact]
+    public void BaseOfAnAssignmentIsStillResolvedThroughTheResolver()
+    {
+        // The write itself never consults the resolver, but the base is read through the normal read
+        // path - so an unresolvable base must still be substituted, and the assignment must land on the
+        // substitute rather than throwing a ReferenceError.
+        var resolver = new SubstitutingResolver();
+        var engine = new Engine(options => options.SetReferencesResolver(resolver));
+
+        var target = engine.Evaluate("({})").AsObject();
+        resolver.Substitute = target;
+
+        engine.Execute("neverDeclared.assigned = 42;");
+
+        target.Get("assigned").AsNumber().Should().Be(42);
+    }
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -793,14 +793,21 @@ internal sealed class JintMemberExpression : JintExpression
     {
         var engine = context.Engine;
 
-        // Same eligibility as GetValue's primary fast path, plus the computed-read path's Suspendable==null gate:
-        // a static string-named, non-optional, non-short-circuiting, non-super property write with no custom
-        // resolver, in a context where neither operand can suspend (so no generator/async bookkeeping is needed).
+        // Same eligibility as GetValue's primary fast path, minus its custom-resolver gate, plus the
+        // computed-read path's Suspendable==null gate: a static string-named, non-optional,
+        // non-short-circuiting, non-super property write in a context where neither operand can suspend
+        // (so no generator/async bookkeeping is needed).
+        //
+        // Unlike the read path, this one needs no custom-resolver gate: IReferenceResolver has no write-side
+        // member, and none of its four methods is consulted while completing a property store —
+        // Engine.PutValue reaches the resolver on none of its branches. The base is still evaluated through
+        // the normal read path (which does consult the resolver, including for an unresolvable base), and a
+        // nullish base is not an ObjectInstance so it flows to the PutValue fallback and throws there exactly
+        // as the slow path would.
         if (_propertyExpression is not null
             || _determinedProperty is not JsString determinedProperty
             || _memberExpression.Optional
             || _objectExpressionCanShortCircuit
-            || engine._customResolver
             || _objectExpression is JintSuperExpression
             || engine.ExecutionContext.Suspendable is not null)
         {


### PR DESCRIPTION
`JintMemberExpression.TryAssignFast` copied its eligibility gate from `GetValue`'s read fast path, custom-resolver term included:

```csharp
if (_propertyExpression is not null
    || _determinedProperty is not JsString determinedProperty
    || _memberExpression.Optional
    || _objectExpressionCanShortCircuit
    || engine._customResolver          // <-- this one
    || _objectExpression is JintSuperExpression
    || engine.ExecutionContext.Suspendable is not null)
```

That term costs every embedder who installs an `IReferenceResolver` the entire in-place property store. With a resolver present, `obj.prop = rhs` rents a `Reference`, hashes the property key and goes through the full `PutValue` pipeline on every write, on every object, forever — even though the resolver has nothing to say about writes.

### Why the term is not needed on the write side

`IReferenceResolver` has no write-side member, and none of its four methods is consulted while completing a property store:

| member | only reached from |
| --- | --- |
| `TryUnresolvableReference` | `Engine.GetValue` |
| `TryPropertyReference` | `Engine.GetValue` |
| `TryGetCallable` | `JintCallExpression` |
| `CheckCoercible` | `TypeConverter.CheckObjectCoercible`, whose two call sites are both on the read path |

`Engine.PutValue` reaches the resolver on none of its branches.

What the resolver still influences is unaffected, because it happens elsewhere: the base is evaluated through the normal read path, which *does* consult the resolver — including substituting an unresolvable base — and a nullish base is not an `ObjectInstance`, so it flows to the `PutValue` fallback and throws there exactly as the slow path would.

One term removed, comment rewritten to say why the write gate differs from the read gate.

### Tests

`Jint.Tests.PublicInterface/ReferenceResolverAssignmentTests.cs` runs every case twice — on an engine with a resolver installed and on one without — and requires the two to agree: plain and repeated writes (so the write-side inline cache is populated), compound assignment, an inherited setter, strict/sloppy read-only failure, a nullish base, and writes to a wrapped host object. One further case pins that the *base* of an assignment is still resolved through the resolver, so `neverDeclared.assigned = 42` lands on the substituted object rather than raising a `ReferenceError`.

These pass before and after the change. That is the point: the change is about which lane a write takes, not about what a write does, so the tests are there to pin that the two lanes are indistinguishable.

### Verification

Release build (warnings are errors): 0 errors, 1 warning — the pre-existing `MSB3277` in `Jint.Tests.CommonScripts` on `net472`, present on clean `main` too.

| suite | main | this branch |
| --- | --- | --- |
| `Jint.Tests` net10.0 | 4123 passed / 4 skipped | 4123 passed / 4 skipped |
| `Jint.Tests` net472 | 4059 passed / 4 skipped | 4059 passed / 4 skipped |
| `Jint.Tests.PublicInterface` (both TFMs) | 149 passed | 162 passed |
| `Jint.Tests.Test262` | 99441 passed / 157 skipped | 99441 passed / 157 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
