### PR TITLE
Share the resolved CLR member accessors through the type resolver

### DIFF
--- a/Jint.Tests/Runtime/InteropAccessorCacheSharingTests.cs
+++ b/Jint.Tests/Runtime/InteropAccessorCacheSharingTests.cs
@@ -1,0 +1,277 @@
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The resolved CLR member accessors live on the <see cref="TypeResolver"/>, so every engine configured with
+/// the same resolver resolves each member — and compiles the delegates that read it — exactly once.
+/// <para>
+/// The counting <see cref="TypeResolver.MemberFilter"/> below is the engagement probe: it is only consulted
+/// while a member is being resolved, so a zero count proves the second engine reused the first engine's work
+/// rather than merely arriving at the same answer. The rest of the file guards the other half of the
+/// bargain — that an entry is never served to an engine whose configuration would have resolved it
+/// differently, and that nothing engine-affine gets shared.
+/// </para>
+/// </summary>
+public class InteropAccessorCacheSharingTests
+{
+    #region hosts
+
+    public sealed class Host
+    {
+        public Host(int value) => Value = value;
+
+        public int Value { get; }
+
+        public string Name { get; set; } = "name";
+    }
+
+    public sealed class PrivateMemberHost
+    {
+        public int Visible => 1;
+
+        private int Hidden => 42;
+    }
+
+    public class Outer
+    {
+        public sealed class Inner
+        {
+            public int Value => 5;
+        }
+    }
+
+    public sealed class StringIndexed
+    {
+        public string this[string key] => key + "!";
+    }
+
+    private sealed class CountingResolver
+    {
+        private int _memberFilterCalls;
+
+        public TypeResolver Resolver { get; }
+
+        public CountingResolver()
+        {
+            Resolver = new TypeResolver
+            {
+                MemberFilter = _ =>
+                {
+                    _memberFilterCalls++;
+                    return true;
+                },
+            };
+        }
+
+        public int Reset()
+        {
+            var calls = _memberFilterCalls;
+            _memberFilterCalls = 0;
+            return calls;
+        }
+    }
+
+    private static Engine CreateEngine(TypeResolver resolver, object host, Action<Options>? configure = null)
+    {
+        var engine = new Engine(options =>
+        {
+            options.Interop.TypeResolver = resolver;
+            configure?.Invoke(options);
+        });
+        engine.SetValue("host", host);
+        return engine;
+    }
+
+    #endregion
+
+    #region 1. sharing
+
+    [Fact]
+    public void SecondEngineReusesTheResolutionOfTheFirst()
+    {
+        var counting = new CountingResolver();
+        var engine1 = CreateEngine(counting.Resolver, new Host(1));
+        var engine2 = CreateEngine(counting.Resolver, new Host(2));
+        counting.Reset();
+
+        engine1.Evaluate("host.Value").Should().Be(1);
+        counting.Reset().Should().BeGreaterThan(0, "the first engine has to resolve the member");
+
+        engine2.Evaluate("host.Value").Should().Be(2);
+        counting.Reset().Should().Be(0, "the resolution is shared through the resolver");
+    }
+
+    [Fact]
+    public void SharingCoversMethodsAndWrites()
+    {
+        var counting = new CountingResolver();
+        var host1 = new Host(1);
+        var host2 = new Host(2);
+        var engine1 = CreateEngine(counting.Resolver, host1);
+        var engine2 = CreateEngine(counting.Resolver, host2);
+
+        engine1.Evaluate("host.Name = 'first'; host.Name.toUpperCase()").Should().Be("FIRST");
+        counting.Reset();
+
+        engine2.Evaluate("host.Name = 'second'; host.Name.toUpperCase()").Should().Be("SECOND");
+        counting.Reset().Should().Be(0);
+
+        host1.Name.Should().Be("first");
+        host2.Name.Should().Be("second");
+    }
+
+    [Fact]
+    public void UnresolvedMembersAreSharedToo()
+    {
+        var counting = new CountingResolver();
+        var engine1 = CreateEngine(counting.Resolver, new Host(1));
+        var engine2 = CreateEngine(counting.Resolver, new Host(2));
+
+        engine1.Evaluate("typeof host.NoSuchMember").Should().Be("undefined");
+        counting.Reset();
+
+        engine2.Evaluate("typeof host.NoSuchMember").Should().Be("undefined");
+        counting.Reset().Should().Be(0);
+    }
+
+    [Fact]
+    public void ResolversOfTheirOwnDoNotShare()
+    {
+        var counting1 = new CountingResolver();
+        var counting2 = new CountingResolver();
+
+        CreateEngine(counting1.Resolver, new Host(1)).Evaluate("host.Value").Should().Be(1);
+        counting1.Reset().Should().BeGreaterThan(0);
+
+        CreateEngine(counting2.Resolver, new Host(2)).Evaluate("host.Value").Should().Be(2);
+        counting2.Reset().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void EnginesOnTheDefaultResolverStayCorrect()
+    {
+        // no explicit resolver: both engines land on TypeResolver.Default, the process-wide one
+        var engine1 = new Engine();
+        engine1.SetValue("host", new Host(11));
+        var engine2 = new Engine();
+        engine2.SetValue("host", new Host(22));
+
+        engine1.Evaluate("host.Value").Should().Be(11);
+        engine2.Evaluate("host.Value").Should().Be(22);
+        engine1.Evaluate("host.Value").Should().Be(11);
+    }
+
+    #endregion
+
+    #region 2. partitioning by interop configuration
+
+    [Fact]
+    public void BindingFlagsPartitionTheCache()
+    {
+        var resolver = new TypeResolver();
+        var restricted = CreateEngine(resolver, new PrivateMemberHost());
+        var permissive = CreateEngine(resolver, new PrivateMemberHost(), options =>
+            options.Interop.ObjectWrapperReportedPropertyBindingFlags =
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        // the restricted engine resolves first, so a shared entry would hide the member from the other one
+        restricted.Evaluate("typeof host.Hidden").Should().Be("undefined");
+        permissive.Evaluate("host.Hidden").Should().Be(42);
+
+        // ... and the other way around
+        var resolverReversed = new TypeResolver();
+        var permissiveFirst = CreateEngine(resolverReversed, new PrivateMemberHost(), options =>
+            options.Interop.ObjectWrapperReportedPropertyBindingFlags =
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        var restrictedSecond = CreateEngine(resolverReversed, new PrivateMemberHost());
+
+        permissiveFirst.Evaluate("host.Hidden").Should().Be(42);
+        restrictedSecond.Evaluate("typeof host.Hidden").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void AllowGetTypePartitionsTheCache()
+    {
+        var resolver = new TypeResolver();
+        var restricted = CreateEngine(resolver, new Host(1));
+        var permissive = CreateEngine(resolver, new Host(1), options => options.Interop.AllowGetType = true);
+
+        restricted.Evaluate("typeof host.GetType").Should().Be("undefined");
+        permissive.Evaluate("typeof host.GetType").Should().Be("function");
+        restricted.Evaluate("typeof host.GetType").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void ExtensionMethodsPartitionTheCache()
+    {
+        var resolver = new TypeResolver();
+        var without = CreateEngine(resolver, new Host(1));
+        var with = CreateEngine(resolver, new Host(1), options => options.Interop.ExtensionMethodTypes.Add(typeof(HostExtensions)));
+
+        without.Evaluate("typeof host.Doubled").Should().Be("undefined");
+        with.Evaluate("host.Doubled()").Should().Be(2);
+        without.Evaluate("typeof host.Doubled").Should().Be("undefined");
+    }
+
+    [Fact]
+    public void CustomTypeConvertersPartitionTheCache()
+    {
+        var resolver = new TypeResolver();
+        var stock = CreateEngine(resolver, new StringIndexed());
+        var custom = CreateEngine(resolver, new StringIndexed(), options => options.SetTypeConverter(engine => new WrappingTypeConverter(engine)));
+
+        stock.Evaluate("host.key").Should().Be("key!");
+        custom.Evaluate("host.key").Should().Be("key!");
+    }
+
+    #endregion
+
+    #region 3. nothing engine-affine is shared
+
+    [Fact]
+    public void NestedTypeReferencesStayWithTheirOwnEngine()
+    {
+        var resolver = new TypeResolver();
+        var engine1 = new Engine(options => options.Interop.TypeResolver = resolver);
+        engine1.SetValue("Outer", TypeReference.CreateTypeReference<Outer>(engine1));
+        var engine2 = new Engine(options => options.Interop.TypeResolver = resolver);
+        engine2.SetValue("Outer", TypeReference.CreateTypeReference<Outer>(engine2));
+
+        var inner1 = engine1.Evaluate("Outer.Inner");
+        var inner2 = engine2.Evaluate("Outer.Inner");
+
+        inner1.Should().BeOfType<TypeReference>().Which.Engine.Should().BeSameAs(engine1);
+        inner2.Should().BeOfType<TypeReference>().Which.Engine.Should().BeSameAs(engine2);
+
+        engine1.Evaluate("new Outer.Inner().Value").Should().Be(5);
+        engine2.Evaluate("new Outer.Inner().Value").Should().Be(5);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Behaves exactly like the stock converter but is not it, so the engine counts as having a
+    /// host-installed <see cref="ITypeConverter"/>.
+    /// </summary>
+    private sealed class WrappingTypeConverter : ITypeConverter
+    {
+        private readonly ITypeConverter _inner;
+
+        public WrappingTypeConverter(Engine engine) => _inner = new DefaultTypeConverter(engine);
+
+        public object? Convert(object? value, Type type, IFormatProvider formatProvider)
+            => _inner.Convert(value, type, formatProvider);
+
+        public bool TryConvert(object? value, Type type, IFormatProvider formatProvider, [NotNullWhen(true)] out object? converted)
+            => _inner.TryConvert(value, type, formatProvider, out converted);
+    }
+}
+
+internal static class HostExtensions
+{
+    public static int Doubled(this InteropAccessorCacheSharingTests.Host host) => host.Value * 2;
+}

--- a/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
+++ b/Jint.Tests/Runtime/InteropCompiledInvokerTests.cs
@@ -429,8 +429,9 @@ public class InteropCompiledInvokerTests
     // Process-wide invoker cache.
     //
     // The compiled invoker and the BCL MethodInvoker/ConstructorInvoker are cached by MethodBase in
-    // static dictionaries, shared by every Engine, because MethodDescriptor instances themselves are
-    // per-Engine (Engine._reflectionAccessors). These tests prove that sharing carries no
+    // static dictionaries, shared by every Engine, because MethodDescriptor instances themselves live
+    // on the accessors cached by a TypeResolver and so are only shared as far as the resolver is.
+    // These tests prove that sharing carries no
     // Engine-specific state - above all that one Engine's interop policy (a custom ITypeConverter or
     // registered object converters, both of which must decline the compiled lane) never leaks into
     // another Engine through the shared cache, in either order.

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -244,11 +244,11 @@ public sealed partial class Engine : IDisposable
     internal Intrinsics _originalIntrinsics = null!;
     internal Host _host = null!;
 
-    // we need to cache reflection accessors on engine level as configuration options can affect outcome.
-    // The requirement is part of the key because member resolution is filtered by it (see TypeResolver):
-    // a member that failed a readable/writable requirement must not answer for lookups carrying another one.
-    internal readonly record struct ClrPropertyDescriptorFactoriesKey(Type Type, Key PropertyName, MemberResolutionRequirement Requirement);
-    internal Dictionary<ClrPropertyDescriptorFactoriesKey, ReflectionAccessor> _reflectionAccessors = new();
+    // The resolved reflection accessors themselves live on Options.Interop.TypeResolver so that every engine
+    // sharing a resolver shares the resolution (and the delegates compiled from it). The interop configuration
+    // that steers resolution but does not live on the resolver is captured here, and partitions that cache so
+    // an entry is only ever served back to an engine that would have resolved it identically.
+    internal readonly InteropResolutionProfile _interopResolutionProfile;
 
     /// <summary>
     /// Constructs a new engine instance.
@@ -333,6 +333,16 @@ public sealed partial class Engine : IDisposable
         // Read after Options.Apply so the snapshot observes the same value JintCallStack does
         // (Apply runs the user's configuration callbacks, which can still touch Constraints).
         _maxRecursionDepth = Options.Constraints.MaxRecursionDepth;
+
+        // likewise after Apply, which is where a custom ITypeConverter gets installed
+        _interopResolutionProfile = new InteropResolutionProfile(
+            Options.Interop.AllowGetType,
+            Options.Interop.ObjectWrapperReportedFieldBindingFlags,
+            Options.Interop.ObjectWrapperReportedPropertyBindingFlags,
+            Options.Interop.ObjectWrapperReportedMethodBindingFlags,
+            _extensionMethods,
+            _typeConverterIsDefault);
+
         CallStack = new JintCallStack(_maxRecursionDepth >= 0);
         _stackGuard = new StackGuard(this);
 

--- a/Jint/Runtime/Interop/MethodDescriptor.cs
+++ b/Jint/Runtime/Interop/MethodDescriptor.cs
@@ -111,9 +111,9 @@ internal sealed class MethodDescriptor
 #if NET8_0_OR_GREATER
     // Process-wide L2 caches for the invoker machinery, keyed by the reflected member.
     //
-    // MethodDescriptor instances are per-Engine: TypeResolver.GetAccessor caches the
-    // ReflectionAccessor that owns them in Engine._reflectionAccessors. With a purely per-instance
-    // cache every new Engine therefore re-emitted an invoke stub and re-compiled the whole
+    // MethodDescriptor instances live on the ReflectionAccessor that TypeResolver.GetAccessor caches,
+    // so they are only shared as far as the resolver is. With a purely per-instance cache every Engine
+    // configured with a resolver of its own would re-emit an invoke stub and re-compile the whole
     // expression tree for every host method it called, which dominates the common
     // fresh-Engine-per-operation embedding pattern.
     //

--- a/Jint/Runtime/Interop/Reflection/CompiledMemberAccessor.cs
+++ b/Jint/Runtime/Interop/Reflection/CompiledMemberAccessor.cs
@@ -39,10 +39,10 @@ namespace Jint.Runtime.Interop.Reflection;
 /// </para>
 /// <para>
 /// The compiled delegates are cached process-wide keyed by the <see cref="MemberInfo"/>, because
-/// they are engine-independent: nothing they close over is affine to an <see cref="Engine"/>. This
-/// matters because <see cref="ReflectionAccessor"/> instances live in a per-engine cache
-/// (<c>Engine._reflectionAccessors</c>), so a per-accessor cache would recompile every member for
-/// every engine — the cost this type exists to remove. The trade-off is the same one the other
+/// they are engine-independent: nothing they close over is affine to an <see cref="Engine"/>. That
+/// keeps them shared even when <see cref="ReflectionAccessor"/> instances are not — the accessor
+/// cache lives on <see cref="TypeResolver"/>, so engines configured with resolvers of their own
+/// would otherwise recompile every member each time. The trade-off is the same one the other
 /// process-wide reflection caches in this assembly make (<see cref="TypeDescriptor"/>,
 /// <see cref="TypeReference"/>, <c>JintBinaryExpression._knownOperators</c>): the cached
 /// <see cref="MemberInfo"/> keeps its declaring assembly alive for the process lifetime.

--- a/Jint/Runtime/Interop/TypeResolver.cs
+++ b/Jint/Runtime/Interop/TypeResolver.cs
@@ -1,8 +1,9 @@
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Globalization;
 using System.Reflection;
-using System.Threading;
+using System.Runtime.InteropServices;
 using Jint.Runtime.Interop.Reflection;
 
 #pragma warning disable IL2067
@@ -15,9 +16,19 @@ namespace Jint.Runtime.Interop;
 /// <summary>
 /// Interop strategy for resolving types and members.
 /// </summary>
+/// <remarks>
+/// Holds the cache of resolved CLR member accessors, so the same instance should be shared between engines:
+/// resolving a member — and compiling the delegates that read and write it — then happens once per member
+/// rather than once per member per engine, which matters most for embedders that construct a fresh engine per
+/// operation. The cache keeps the reflected <see cref="Type"/>s alive for as long as the resolver lives, and
+/// <see cref="Default"/> lives for the process; give a resolver of your own to engines that must not outlive
+/// the types they touch.
+/// </remarks>
 public sealed class TypeResolver
 {
     public static readonly TypeResolver Default = new();
+
+    private readonly ConcurrentDictionary<AccessorCacheKey, ReflectionAccessor> _reflectionAccessors = new();
 
     /// <summary>
     /// Registers a filter that determines whether given member is wrapped to interop or returned as undefined.
@@ -78,9 +89,18 @@ public sealed class TypeResolver
         bool throwOnError = true,
         Func<ReflectionAccessor?>? accessorFactory = null)
     {
-        var key = new Engine.ClrPropertyDescriptorFactoriesKey(type, member, requirement);
+        var profile = engine._interopResolutionProfile;
+        if (!profile.IsCaptured)
+        {
+            // The engine is still running its configuration callbacks and has not captured the profile that
+            // partitions the cache yet — a host-installed ITypeConverter, for one, is only in place once they
+            // have all run. Resolve without touching the cache rather than risk mislabeling an entry.
+            return accessorFactory?.Invoke() ?? ResolvePropertyDescriptorFactory(engine, type, member, requirement, throwOnError);
+        }
 
-        var factories = engine._reflectionAccessors;
+        var key = new AccessorCacheKey(type, member, requirement, profile);
+
+        var factories = _reflectionAccessors;
         if (factories.TryGetValue(key, out var accessor))
         {
             if (throwOnError
@@ -100,14 +120,40 @@ public sealed class TypeResolver
             return accessor;
         }
 
-        // racy, we don't care, worst case we'll catch up later
-        Interlocked.CompareExchange(ref engine._reflectionAccessors,
-            new Dictionary<Engine.ClrPropertyDescriptorFactoriesKey, ReflectionAccessor>(factories)
-            {
-                [key] = accessor
-            }, factories);
+        if (IsShareable(engine, accessor))
+        {
+            // racy, we don't care: both racers resolved the same member the same way
+            factories.TryAdd(key, accessor);
+        }
 
         return accessor;
+    }
+
+    /// <summary>
+    /// Whether an accessor may enter the cache this resolver shares between engines. Everything a
+    /// <see cref="ReflectionAccessor"/> normally holds is derived from the reflected type alone — a
+    /// <see cref="PropertyInfo"/>/<see cref="FieldInfo"/> plus the delegates compiled from it, a
+    /// <see cref="MethodDescriptor"/> set, a converted indexer key — and the engine-affine parts are built
+    /// per call in <see cref="ReflectionAccessor.CreatePropertyDescriptor"/>. The two exceptions are below.
+    /// </summary>
+    private static bool IsShareable(Engine engine, ReflectionAccessor accessor)
+    {
+        // A nested type resolves to a TypeReference, which is a JsValue owned by the engine that created it:
+        // sharing it would hand one engine's object to another and pin that engine for the resolver's lifetime.
+        if (accessor is NestedTypeAccessor)
+        {
+            return false;
+        }
+
+        // An indexer accessor bakes in the index key that the engine's ITypeConverter produced from the member
+        // name. The stock converter only ever yields a plain CLR value, but a host-installed one may return
+        // anything at all, including something bound to its engine.
+        if (accessor is IndexerAccessor && !engine._typeConverterIsDefault)
+        {
+            return false;
+        }
+
+        return true;
     }
 
     private ReflectionAccessor ResolvePropertyDescriptorFactory(
@@ -611,4 +657,100 @@ public sealed class TypeResolver
             throw new NotImplementedException();
         }
     }
+}
+
+/// <summary>
+/// Key into the accessor cache a <see cref="TypeResolver"/> shares between the engines using it.
+/// </summary>
+/// <remarks>
+/// Two independent things partition this cache. <see cref="Requirement"/> is what member resolution is
+/// filtered by, so a resolution that had to skip a member for not being readable/writable must not answer a
+/// lookup carrying a different requirement. <see cref="Profile"/> is the interop configuration that steers
+/// resolution but lives on the engine's options rather than on the resolver, so an entry is only served back
+/// to an engine that would have resolved the member the same way.
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct AccessorCacheKey(
+    Type Type,
+    Key PropertyName,
+    MemberResolutionRequirement Requirement,
+    InteropResolutionProfile Profile);
+
+/// <summary>
+/// The interop configuration that steers member resolution but does not live on the
+/// <see cref="TypeResolver"/> itself, so that its accessor cache can be partitioned by it: an entry is only
+/// ever served back to an engine that would have resolved the member the same way.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nothing here is affine to an engine or a realm — the flags are values, the extension method lookup holds
+/// only <see cref="MethodInfo"/>s and is itself meant to be shared, and a host-installed
+/// <see cref="ITypeConverter"/> is reduced to "is it the stock one", never captured, because those are
+/// routinely constructed per engine.
+/// </para>
+/// <para>
+/// Hand-written rather than a positional record struct so the hash is computed once, when an engine captures
+/// its profile, instead of on every cache probe.
+/// </para>
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+internal readonly struct InteropResolutionProfile : IEquatable<InteropResolutionProfile>
+{
+    private readonly BindingFlags _fieldBindingFlags;
+    private readonly BindingFlags _propertyBindingFlags;
+    private readonly BindingFlags _methodBindingFlags;
+    private readonly ExtensionMethodCache? _extensionMethods;
+    private readonly bool _allowGetType;
+    private readonly bool _stockTypeConverter;
+    private readonly int _hashCode;
+
+    internal InteropResolutionProfile(
+        bool allowGetType,
+        BindingFlags fieldBindingFlags,
+        BindingFlags propertyBindingFlags,
+        BindingFlags methodBindingFlags,
+        ExtensionMethodCache extensionMethods,
+        bool stockTypeConverter)
+    {
+        _allowGetType = allowGetType;
+        _fieldBindingFlags = fieldBindingFlags;
+        _propertyBindingFlags = propertyBindingFlags;
+        _methodBindingFlags = methodBindingFlags;
+        _extensionMethods = extensionMethods;
+        _stockTypeConverter = stockTypeConverter;
+
+        var hashCode = allowGetType ? 1 : 0;
+        hashCode = (hashCode * 397) ^ (int) fieldBindingFlags;
+        hashCode = (hashCode * 397) ^ (int) propertyBindingFlags;
+        hashCode = (hashCode * 397) ^ (int) methodBindingFlags;
+        // ExtensionMethodCache does not override GetHashCode, this is its reference identity
+        hashCode = (hashCode * 397) ^ extensionMethods.GetHashCode();
+        _hashCode = (hashCode * 397) ^ (stockTypeConverter ? 1 : 0);
+    }
+
+    /// <summary>
+    /// Whether this is a profile an engine actually captured, as opposed to the <see langword="default"/>
+    /// an engine still inside its constructor carries. The extension method lookup is never null on a
+    /// captured one.
+    /// </summary>
+    internal bool IsCaptured => _extensionMethods is not null;
+
+    public bool Equals(InteropResolutionProfile other)
+    {
+        return _hashCode == other._hashCode
+               && _allowGetType == other._allowGetType
+               && _stockTypeConverter == other._stockTypeConverter
+               && _fieldBindingFlags == other._fieldBindingFlags
+               && _propertyBindingFlags == other._propertyBindingFlags
+               && _methodBindingFlags == other._methodBindingFlags
+               && ReferenceEquals(_extensionMethods, other._extensionMethods);
+    }
+
+    public override bool Equals(object? obj) => obj is InteropResolutionProfile other && Equals(other);
+
+    public override int GetHashCode() => _hashCode;
+
+    public static bool operator ==(InteropResolutionProfile left, InteropResolutionProfile right) => left.Equals(right);
+
+    public static bool operator !=(InteropResolutionProfile left, InteropResolutionProfile right) => !left.Equals(right);
 }


### PR DESCRIPTION
Resolved CLR member accessors live in `Engine._reflectionAccessors`, so every engine
resolves every member it touches from scratch — and, since resolution is what builds
the `MethodDescriptor` set and the compiled read/write delegates hang off the
resolved accessor, re-does that work too. For the common
fresh-engine-per-operation embedding pattern that is the whole cost, paid on every
operation, for a result that is a pure function of the reflected type and the interop
configuration.

`Options.Interop.TypeResolver` already documents itself as cache-holding state that
"should be shared between engines". Move the accessor cache there, so engines sharing
a resolver share the resolution. `TypeResolver.Default` is the process-wide default,
which is what engines constructed without an explicit resolver already share.

### The cache key merges two independently-motivated designs

This change and #2786 both concluded the old `(Type, PropertyName)` key was too
narrow, for different reasons, and **both components are necessary** — neither
subsumes the other:

- #2786 added `MemberResolutionRequirement`, because resolution is *filtered* by
  whether the caller needs a readable or a writable member. Without it a
  write-filtered resolution answered a later read, so a failed write to a getter-only
  property made every subsequent read of that member return `undefined`. That is a
  correctness fix and is preserved verbatim.
- Sharing across engines needs the interop configuration that steers resolution but
  does *not* live on the resolver, because it lives on `Options.Interop`:
  `AllowGetType`, the three `ObjectWrapperReported*BindingFlags` sets, the extension
  method cache, and whether the type converter is the stock one. Two engines
  differing in any of those would resolve the same member differently.

The reconciled key is `(Type, PropertyName, MemberResolutionRequirement, InteropResolutionProfile)`.

`InteropResolutionProfile` captures the second group. Nothing in it is affine to an
engine or a realm — the flags are values, the extension method lookup holds only
`MethodInfo`s and is itself meant to be shared (captured by reference identity), and
a host-installed `ITypeConverter` is reduced to "is it the stock one" rather than
captured, because those are routinely constructed per engine. It is hand-written
rather than a positional record struct so the hash is computed once, when an engine
captures its profile, instead of on every cache probe.

The engine captures its profile *after* `Options.Apply` runs the configuration
callbacks, since that is where a host-installed `ITypeConverter` is put in place.
Resolution while those callbacks are still running bypasses the cache entirely rather
than risk mislabeling an entry.

### Nothing engine-affine enters the shared cache

`IsShareable` keeps two accessor kinds out:

- `NestedTypeAccessor` holds a `TypeReference`, a `JsValue` owned by the engine that
  created it. Sharing it would hand one engine's object to another and pin that
  engine for the resolver's lifetime. This is the same hazard #2784 fixed for
  `TypeReference`'s own static-member cache; that guard covers `TypeReference`'s
  path, and this one covers `TypeResolver.GetAccessor`, which reaches
  `TryFindMemberAccessor`'s nested-type branch independently.
- `IndexerAccessor` bakes in the index key the engine's `ITypeConverter` produced
  from the member name. The stock converter only ever yields a plain CLR value, but a
  host-installed one may return anything, including something bound to its engine —
  so this one is only excluded when the converter is not the stock one.

Everything else a `ReflectionAccessor` holds is derived from the reflected type
alone, with the engine-affine parts built per call in
`ReflectionAccessor.CreatePropertyDescriptor` as before.

The cache keeps the reflected `Type`s alive for as long as the resolver lives, and
`Default` lives for the process — the same trade-off the other process-wide
reflection caches in the assembly already make. That is now documented on
`TypeResolver`, together with the advice to give a resolver of its own to any engine
that must not outlive the types it touches.

`InteropAccessorCacheSharingTests` proves the sharing with a counting `MemberFilter`
as the engagement probe — it is only consulted while a member is being resolved, so a
zero count on the second engine proves reuse rather than merely the same answer — and
guards the other half of the bargain: each configuration difference above partitions
the cache, and a nested type resolves to its own engine's `TypeReference`.

### Verification

Re-measured after rebasing onto current `main`. Release build clean (only the
pre-existing `MSB3277` in `Jint.Tests.CommonScripts` net472). `Jint.Tests` 4193
net10.0 / 4125 net472 (4183 / 4115 on `main` plus the 10 added here),
`Jint.Tests.PublicInterface` 256 — unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik

