### PR TITLE
Stop re-reflecting and re-binding on every host delegate call

### DIFF
--- a/Jint.Tests.PublicInterface/HostDelegateTests.cs
+++ b/Jint.Tests.PublicInterface/HostDelegateTests.cs
@@ -1,0 +1,308 @@
+using System.Reflection;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Behaviour contract for host delegates registered through <see cref="Engine.SetValue(string, Delegate)"/>.
+/// The wrapper caches signature metadata per target method and offers an arity-specialized call lane, so
+/// these cover the arities, the params/optional shapes, return-type handling, exception propagation and
+/// cross-engine reuse that those two mechanisms must leave untouched.
+/// </summary>
+public class HostDelegateTests
+{
+    private static int Sum(params int[] values)
+    {
+        var total = 0;
+        foreach (var value in values)
+        {
+            total += value;
+        }
+        return total;
+    }
+
+    private static string Join(string separator, params object[] parts) => string.Join(separator, parts);
+
+    [Fact]
+    public void ZeroArgumentDelegate()
+    {
+        var engine = new Engine();
+        engine.SetValue("f", new Func<string>(() => "zero"));
+
+        engine.Evaluate("f()").AsString().Should().Be("zero");
+        // extra JavaScript arguments are ignored
+        engine.Evaluate("f(1, 2)").AsString().Should().Be("zero");
+    }
+
+    [Fact]
+    public void SingleArgumentDelegate()
+    {
+        var engine = new Engine();
+        engine.SetValue("f", new Func<int, int>(x => x * 2));
+
+        engine.Evaluate("f(21)").AsNumber().Should().Be(42);
+        // repeated evaluation of one call site so the call-site fast lane is engaged
+        engine.Evaluate("var total = 0; for (var i = 0; i < 10; i++) { total += f(i); } total")
+            .AsNumber().Should().Be(90);
+    }
+
+    [Fact]
+    public void TwoAndThreeArgumentDelegates()
+    {
+        var engine = new Engine();
+        engine.SetValue("two", new Func<int, int, int>((a, b) => a - b));
+        engine.SetValue("three", new Func<int, int, int, string>((a, b, c) => $"{a}/{b}/{c}"));
+
+        engine.Evaluate("two(10, 4)").AsNumber().Should().Be(6);
+        engine.Evaluate("three(1, 2, 3)").AsString().Should().Be("1/2/3");
+    }
+
+    [Fact]
+    public void OverSuppliedArgumentsAreIgnored()
+    {
+        var engine = new Engine();
+        engine.SetValue("f", new Func<int, int>(x => x + 1));
+
+        engine.Evaluate("f(1, 99, 100)").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void UnderSuppliedArgumentsGetClrDefaults()
+    {
+        var engine = new Engine();
+        engine.SetValue("num", new Func<int, int>(x => x + 1));
+        engine.SetValue("str", new Func<string, bool>(s => s is null));
+        engine.SetValue("two", new Func<int, int, string>((a, b) => $"{a}/{b}"));
+
+        // a missing value-type argument becomes default(T), a missing reference-type argument null
+        engine.Evaluate("num()").AsNumber().Should().Be(1);
+        engine.Evaluate("str()").AsBoolean().Should().BeTrue();
+        engine.Evaluate("two(7)").AsString().Should().Be("7/0");
+    }
+
+    [Fact]
+    public void OptionalClrParametersAreNotSubstituted()
+    {
+        // A delegate over a method with an optional parameter is still bound positionally: the elided
+        // argument gets default(T), not the declared default. This also pins the arity guard on the
+        // fast-call lane, which must decline when there are fewer arguments than parameters.
+        var engine = new Engine();
+        engine.SetValue("f", new Func<int, int, string>(WithOptional));
+
+        engine.Evaluate("f(1, 2)").AsString().Should().Be("1/2");
+        engine.Evaluate("f(1)").AsString().Should().Be("1/0");
+        engine.Evaluate("var r = ''; for (var i = 0; i < 5; i++) { r = f(i); } r")
+            .AsString().Should().Be("4/0");
+
+        static string WithOptional(int a, int b = 5) => $"{a}/{b}";
+    }
+
+    [Fact]
+    public void ParamsArrayDelegate()
+    {
+        var engine = new Engine();
+        engine.SetValue("sum", new Func<int[], int>(Sum));
+
+        engine.Evaluate("sum()").AsNumber().Should().Be(0);
+        engine.Evaluate("sum(1)").AsNumber().Should().Be(1);
+        engine.Evaluate("sum(1, 2, 3, 4)").AsNumber().Should().Be(10);
+    }
+
+    [Fact]
+    public void ParamsArrayDelegateWithLeadingParameter()
+    {
+        var engine = new Engine();
+        engine.SetValue("join", new Func<string, object[], string>(Join));
+
+        engine.Evaluate("join('-')").AsString().Should().Be("");
+        engine.Evaluate("join('-', 'a', 'b', 'c')").AsString().Should().Be("a-b-c");
+    }
+
+    [Fact]
+    public void ValueReferenceAndVoidReturnTypes()
+    {
+        var engine = new Engine();
+        var sideEffects = new List<int>();
+
+        engine.SetValue("valueReturn", new Func<double>(() => 1.5));
+        engine.SetValue("referenceReturn", new Func<string>(() => "text"));
+        engine.SetValue("objectReturn", new Func<object>(() => new Dictionary<string, object> { ["k"] = 1 }));
+        engine.SetValue("voidReturn", new Action<int>(sideEffects.Add));
+        engine.SetValue("voidNoArgs", new Action(() => sideEffects.Add(-1)));
+
+        engine.Evaluate("valueReturn()").AsNumber().Should().Be(1.5);
+        engine.Evaluate("referenceReturn()").AsString().Should().Be("text");
+        engine.Evaluate("objectReturn().k").AsNumber().Should().Be(1);
+
+        engine.Evaluate("voidReturn(3)").Should().Be(JsValue.Null);
+        engine.Evaluate("voidNoArgs()").Should().Be(JsValue.Null);
+        sideEffects.Should().Equal(3, -1);
+    }
+
+    [Fact]
+    public void NumericParametersOfEveryWidthBind()
+    {
+        // The numeric parameter shapes whose boxed representation does not simply follow from the
+        // JavaScript value: a wider integral type, a floating-point one, and a nullable both with and
+        // without a value.
+        var engine = new Engine();
+        engine.SetValue("asLong", new Func<long, string>(v => $"{v}"));
+        engine.SetValue("asDouble", new Func<double, double>(v => v / 2));
+        engine.SetValue("asNullable", new Func<int?, string>(v => v.HasValue ? $"{v.Value}" : "none"));
+
+        engine.Evaluate("asLong(3)").AsString().Should().Be("3");
+        engine.Evaluate("var r; for (var i = 0; i < 5; i++) { r = asLong(i); } r").AsString().Should().Be("4");
+        engine.Evaluate("asDouble(9)").AsNumber().Should().Be(4.5);
+        engine.Evaluate("asNullable(5)").AsString().Should().Be("5");
+        engine.Evaluate("asNullable(null)").AsString().Should().Be("none");
+    }
+
+    [Fact]
+    public void JsValueParametersArePassedThroughUnconverted()
+    {
+        var engine = new Engine();
+        engine.SetValue("describe", new Func<JsValue, JsValue, string>((a, b) => $"{a.Type}/{b.Type}"));
+
+        engine.Evaluate("describe('x', 1)").AsString().Should().Be("String/Number");
+        engine.Evaluate("describe(undefined, null)").AsString().Should().Be("Undefined/Null");
+    }
+
+    [Fact]
+    public void AJsValueParameterNarrowerThanItsArgumentKeepsTheBinderError()
+    {
+        // A JsValue-typed parameter takes its argument straight through unconverted, so nothing before
+        // the invocation checks that the value fits the declared parameter. The reported failure has to
+        // stay the reflection binder's, rather than becoming a cast failure surfaced as a host error.
+        var engine = new Engine();
+        engine.SetValue("f", new Func<JsString, string>(v => v.ToString()));
+
+        engine.Evaluate("f('ok')").AsString().Should().Be("ok");
+
+        Invoking(() => engine.Execute("f(1);")).Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AnOpenInstanceDelegateIsNotMisbound()
+    {
+        // The delegate type's Invoke declares the receiver as its first parameter while the target
+        // MethodInfo does not, so the wrapper's positional binding produces an argument list one short.
+        // That has never worked; what matters is that it keeps failing as a binding error instead of
+        // being read past the end by a strongly-typed invocation lane.
+        var engine = new Engine();
+        var length = (Func<string, int>) Delegate.CreateDelegate(
+            typeof(Func<string, int>),
+            typeof(string).GetProperty(nameof(string.Length))!.GetGetMethod()!);
+
+        engine.SetValue("len", length);
+
+        Invoking(() => engine.Execute("len('abcd');")).Should().Throw<TargetParameterCountException>();
+    }
+
+    [Fact]
+    public void ThrowingDelegateBubblesTheClrException()
+    {
+        var engine = new Engine();
+        engine.SetValue("boom", new Func<int, int>(_ => throw new InvalidOperationException("host failure")));
+
+        var exception = Invoking(() => engine.Execute("boom(1);"))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("host failure")
+            .Which;
+
+        // the original throw site is preserved rather than replaced by a reflection frame
+        exception.StackTrace.Should().Contain(nameof(ThrowingDelegateBubblesTheClrException));
+    }
+
+    [Fact]
+    public void ThrowingDelegateIsCatchableWhenClrExceptionsAreCaught()
+    {
+        var engine = new Engine(options => options.CatchClrExceptions());
+        engine.SetValue("boom", new Func<int>(() => throw new InvalidOperationException("host failure")));
+
+        engine.Evaluate("var m; try { boom(); } catch (e) { m = e.message; } m")
+            .AsString().Should().Be("host failure");
+    }
+
+    [Fact]
+    public void ThrowingDelegateKeepsTheJavaScriptStackTrace()
+    {
+        var engine = new Engine();
+        engine.SetValue("boom", new Action(() => throw new InvalidOperationException("host failure")));
+
+        // a JavaScript error raised from inside the host call keeps the interpreted frames around it
+        engine.SetValue("raise", new Action<Engine>(e => e.Execute("throw new Error('inner');")));
+        engine.SetValue("self", engine);
+
+        Invoking(() => engine.Execute("function outer() { boom(); } outer();"))
+            .Should().Throw<InvalidOperationException>();
+
+        var jsException = Invoking(() => engine.Execute("function outer() { raise(self); } outer();"))
+            .Should().Throw<JavaScriptException>().Which;
+
+        jsException.Message.Should().Be("inner");
+    }
+
+    [Fact]
+    public void AwaitableResultsBecomePromises()
+    {
+        var engine = new Engine();
+        engine.SetValue("later", new Func<int, Task<int>>(x => Task.FromResult(x + 1)));
+
+        var promise = engine.Evaluate("later(41)");
+        promise.UnwrapIfPromise().AsNumber().Should().Be(42);
+    }
+
+    [Fact]
+    public void TheSameDelegateInstanceWorksOnTwoEngines()
+    {
+        var shared = new Func<int, int>(x => x * 3);
+
+        var first = new Engine();
+        var second = new Engine();
+        first.SetValue("f", shared);
+        second.SetValue("f", shared);
+
+        first.Evaluate("f(2)").AsNumber().Should().Be(6);
+        second.Evaluate("f(3)").AsNumber().Should().Be(9);
+        first.Evaluate("f(4)").AsNumber().Should().Be(12);
+    }
+
+    [Fact]
+    public void CapturedStateIsPerDelegateNotPerTargetMethod()
+    {
+        // Both lambdas compile to the same MethodInfo, which is the metadata cache key - registering
+        // them on different engines must not let one wrapper observe the other's captured state.
+        static Func<int, int> Adder(int offset) => x => x + offset;
+
+        var first = new Engine();
+        var second = new Engine();
+        first.SetValue("f", Adder(1));
+        second.SetValue("f", Adder(100));
+
+        first.Evaluate("f(10)").AsNumber().Should().Be(11);
+        second.Evaluate("f(10)").AsNumber().Should().Be(110);
+    }
+
+    [Fact]
+    public void DirectInvokeAgreesWithTheInterpretedCallSite()
+    {
+        // Engine.Invoke always takes the array-based entry point while a repeated interpreted call site
+        // can take the arity-specialized one; the two must produce the same value for every shape.
+        var engine = new Engine();
+        engine.SetValue("zero", new Func<string>(() => "z"));
+        engine.SetValue("one", new Func<int, string>(a => $"{a}"));
+        engine.SetValue("two", new Func<int, string, string>((a, b) => $"{a}{b}"));
+
+        engine.Execute("""
+            function callZero() { return zero(); }
+            function callOne() { return one(5); }
+            function callTwo() { return two(5, 'x'); }
+            for (var i = 0; i < 5; i++) { callZero(); callOne(); callTwo(); }
+            """);
+
+        engine.Evaluate("callZero()").Should().Be(engine.Invoke("zero"));
+        engine.Evaluate("callOne()").Should().Be(engine.Invoke("one", 5));
+        engine.Evaluate("callTwo()").Should().Be(engine.Invoke("two", 5, "x"));
+    }
+}

--- a/Jint/Runtime/Interop/CompiledDelegateInvoker.cs
+++ b/Jint/Runtime/Interop/CompiledDelegateInvoker.cs
@@ -1,0 +1,144 @@
+#if NET8_0_OR_GREATER
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Expression = System.Linq.Expressions.Expression;
+
+// The invoker is compiled with System.Linq.Expressions and only ever binds publicly visible types
+// (guarded below), so the generated dynamic method needs no reflection-visibility relaxation.
+// IL2075/IL3050 cover the reflection + dynamic-code use, which is gated behind
+// RuntimeFeature.IsDynamicCodeCompiled before anything is built.
+#pragma warning disable IL2075
+#pragma warning disable IL3050
+
+namespace Jint.Runtime.Interop;
+
+/// <summary>
+/// Builds a strongly-typed thunk that invokes a host delegate through its own <c>Invoke</c> method
+/// instead of <see cref="Delegate.DynamicInvoke"/>, which re-binds and re-validates the whole
+/// argument list on every single call.
+/// <para>
+/// The thunk is keyed on the delegate <em>type</em> rather than on the target method, because that
+/// type alone fixes the invocation signature. Going through <c>Invoke</c> also keeps the thunk
+/// semantically identical to <see cref="Delegate.DynamicInvoke"/> for every delegate shape —
+/// multicast invocation lists, closures and open-instance delegates included — so no per-shape
+/// eligibility reasoning is needed; only types the generated code cannot reference are declined.
+/// The signature it binds is the delegate type's own, which is not always its target method's — an
+/// open-instance delegate declares the receiver as an <c>Invoke</c> parameter while the
+/// <see cref="MethodInfo"/> behind it does not — so the arity is reported back and the caller only
+/// uses the thunk for an argument list of exactly that length.
+/// </para>
+/// <para>
+/// Exceptions thrown by the host delegate propagate unwrapped (there is no reflection frame to wrap
+/// them), so the caller normalizes them to <see cref="TargetInvocationException"/> exactly as the
+/// reflection path produced them.
+/// </para>
+/// </summary>
+internal static class CompiledDelegateInvoker
+{
+    internal delegate object? Invoker(Delegate target, object?[] arguments);
+
+    /// <summary>
+    /// A built thunk together with the number of arguments it indexes out of the array it is handed.
+    /// <see cref="Invoke"/> is <see langword="null"/> for a declined delegate type, in which case
+    /// <see cref="Arity"/> is meaningless.
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    private readonly record struct CompiledInvoker(Invoker? Invoke, int Arity);
+
+    // Process-wide L2 cache; a null thunk is the "known ineligible" sentinel so a declined delegate
+    // type is never re-probed. Keyed on a Type, which pins nothing the delegate instance did not
+    // already pin, and the compiled thunk closes over no engine state — one entry serves every
+    // engine in the process. A concurrent duplicate build is benign; one thunk is discarded.
+    private static readonly ConcurrentDictionary<Type, CompiledInvoker> _cache = new();
+
+    /// <summary>
+    /// Returns the thunk for <paramref name="delegateType"/>, or <see langword="null"/> when the type
+    /// is ineligible or the runtime cannot compile the thunk to native code.
+    /// </summary>
+    /// <param name="delegateType">The concrete delegate type to build for.</param>
+    /// <param name="arity">
+    /// How many arguments the thunk reads. The caller must only hand it an argument array of exactly
+    /// that length, since the thunk indexes it positionally with no bounds reasoning of its own.
+    /// </param>
+    internal static Invoker? For(Type delegateType, out int arity)
+    {
+        var entry = _cache.GetOrAdd(delegateType, static t =>
+        {
+            // Build ONLY when the runtime will JIT the thunk. Under AOT and under an interpreted-only
+            // Expression.Compile (e.g. the Mono interpreter) an interpreted lambda is no faster than
+            // DynamicInvoke, so decline and keep the reflection path.
+            if (!RuntimeFeature.IsDynamicCodeCompiled || !TryBuild(t, out var built, out var builtArity))
+            {
+                return default;
+            }
+
+            return new CompiledInvoker(built, builtArity);
+        });
+
+        arity = entry.Arity;
+        return entry.Invoke;
+    }
+
+    private static bool TryBuild(Type delegateType, [NotNullWhen(true)] out Invoker? invoker, out int arity)
+    {
+        invoker = null;
+        arity = 0;
+
+        if (!delegateType.IsVisible || delegateType.GetMethod("Invoke") is not { } invokeMethod)
+        {
+            return false;
+        }
+
+        var returnType = invokeMethod.ReturnType;
+        if (returnType != typeof(void) && !IsBindable(returnType))
+        {
+            return false;
+        }
+
+        var parameters = invokeMethod.GetParameters();
+        foreach (var parameter in parameters)
+        {
+            // by-ref (ref / out / in) and pointer parameters cannot be fed from an object?[] element,
+            // and the reflection path is the only one that models them
+            if (!IsBindable(parameter.ParameterType))
+            {
+                return false;
+            }
+        }
+
+        var delegateParameter = Expression.Parameter(typeof(Delegate), "d");
+        var argumentsParameter = Expression.Parameter(typeof(object?[]), "args");
+
+        var arguments = new Expression[parameters.Length];
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var element = Expression.ArrayIndex(argumentsParameter, Expression.Constant(i));
+            arguments[i] = Expression.Convert(element, parameters[i].ParameterType);
+        }
+
+        Expression body = Expression.Invoke(Expression.Convert(delegateParameter, delegateType), arguments);
+        body = returnType == typeof(void)
+            ? Expression.Block(body, Expression.Constant(null, typeof(object)))
+            : Expression.Convert(body, typeof(object));
+
+        try
+        {
+            invoker = Expression.Lambda<Invoker>(body, delegateParameter, argumentsParameter).Compile();
+        }
+        catch (Exception)
+        {
+            // any shape the expression compiler refuses keeps the reflection path
+            return false;
+        }
+
+        arity = parameters.Length;
+        return invoker is not null;
+    }
+
+    private static bool IsBindable(Type type) => !type.IsByRef && !type.IsPointer && type.IsVisible;
+}
+#endif

--- a/Jint/Runtime/Interop/DelegateWrapper.cs
+++ b/Jint/Runtime/Interop/DelegateWrapper.cs
@@ -1,5 +1,7 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Jint.Extensions;
 using Jint.Native;
 using Jint.Native.Function;
@@ -16,8 +18,20 @@ namespace Jint.Runtime.Interop;
 internal sealed class DelegateWrapper : Function
 {
     private static readonly JsString _name = new JsString("delegate");
+
     private readonly Delegate _d;
-    private readonly bool _delegateContainsParamsArgument;
+
+    // Signature metadata is resolved once per target method and then read straight off the wrapper,
+    // so neither construction nor invocation re-reflects. Hosts routinely register tens of delegates
+    // per engine, and the previous shape paid GetParameters() (a defensive ParameterInfo[] clone)
+    // once per construction plus once per *call*.
+    private readonly DelegateMetadata _metadata;
+
+#if NET8_0_OR_GREATER
+    // Strongly-typed invocation lane; null when the runtime cannot compile one, in which case the
+    // reflection-based DynamicInvoke path is kept.
+    private readonly CompiledDelegateInvoker.Invoker? _invoker;
+#endif
 
     public DelegateWrapper(
         Engine engine, Delegate d)
@@ -25,87 +39,116 @@ internal sealed class DelegateWrapper : Function
     {
         _d = d;
         _prototype = engine.Realm.Intrinsics.Function.PrototypeObject;
+        _metadata = DelegateMetadata.For(d.Method);
 
-        var parameterInfos = _d.Method.GetParameters();
+#if NET8_0_OR_GREATER
+        var invoker = CompiledDelegateInvoker.For(d.GetType(), out var invokerArity);
 
-        _delegateContainsParamsArgument = false;
-        foreach (var p in parameterInfos)
-        {
-            if (Attribute.IsDefined(p, typeof(ParamArrayAttribute)))
-            {
-                _delegateContainsParamsArgument = true;
-                break;
-            }
-        }
+        // The thunk indexes the argument array positionally, so it can only serve an argument list
+        // built to the delegate type's own arity. That is not always the target method's arity: an
+        // open-instance delegate declares the receiver as an Invoke parameter while the MethodInfo
+        // behind it does not. Such a delegate cannot be bound by this wrapper at all, and keeping it
+        // on the reflection path preserves the exception it already produced.
+        _invoker = invokerArity == _metadata.Parameters.Length ? invoker : null;
+#endif
     }
 
     protected internal override JsValue Call(JsValue thisObject, JsCallArguments arguments)
     {
-        var parameterInfos = _d.Method.GetParameters();
+        return Invoke(BindArguments(arguments));
+    }
 
-#if NETFRAMEWORK
-        if (parameterInfos.Length > 0 && parameterInfos[0].ParameterType == typeof(System.Runtime.CompilerServices.Closure))
+    /// <summary>
+    /// A host delegate runs arbitrary embedder code, so the frameless lane is never available: it can
+    /// raise a JavaScript error and it can re-enter the interpreter, both of which observe the
+    /// call-stack frame through <c>error.stack</c>. Only the arity-specialized lane is offered, and
+    /// only for the shapes where an argument list of <paramref name="argumentCount"/> binds exactly
+    /// like the positional form.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CallFast"/> receives a fixed pair of argument slots and no count, so eligibility has
+    /// to be decided from <paramref name="argumentCount"/> alone. With no params array and at least as
+    /// many JavaScript arguments as the delegate has parameters, binding consumes exactly the declared
+    /// parameters and ignores the rest, which is precisely what the two slots supply. Fewer arguments
+    /// than parameters would substitute CLR defaults for the missing ones, which is observably
+    /// different from converting the <c>undefined</c> that <see cref="CallFast"/> passes, so those
+    /// arities decline.
+    /// </remarks>
+    internal override FastCallShape GetFastCallShape(int argumentCount)
+    {
+        var metadata = _metadata;
+        if (metadata.HasParamsArray
+            || metadata.Parameters.Length > 2
+            || argumentCount < metadata.Parameters.Length)
         {
-            var reducedLength = parameterInfos.Length - 1;
-            var reducedParameterInfos = new ParameterInfo[reducedLength];
-            Array.Copy(parameterInfos, 1, reducedParameterInfos, 0, reducedLength);
-            parameterInfos = reducedParameterInfos;
+            return default;
         }
-#endif
 
-        int delegateArgumentsCount = parameterInfos.Length;
-        int delegateNonParamsArgumentsCount = _delegateContainsParamsArgument ? delegateArgumentsCount - 1 : delegateArgumentsCount;
+        return new FastCallShape(Supported: true, Leaf: false, FastCallGuard.Any, FastCallGuard.Any, FastCallGuard.Any);
+    }
 
-        int jsArgumentsCount = arguments.Length;
-        int jsArgumentsWithoutParamsCount = Math.Min(jsArgumentsCount, delegateNonParamsArgumentsCount);
+    internal override JsValue CallFast(JsValue thisObject, JsValue arg0, JsValue arg1)
+    {
+        var parameterMetadata = _metadata.Parameters;
+        var count = parameterMetadata.Length;
+        if (count == 0)
+        {
+            return Invoke([]);
+        }
 
-        var clrTypeConverter = Engine.TypeConverter;
+        var converter = Engine.TypeConverter;
+        var valueCoercionType = Engine.Options.Interop.ValueCoercion;
+
+        var parameters = new object?[count];
+        for (var i = 0; i < count; i++)
+        {
+            parameters[i] = Convert(in parameterMetadata[i], i == 0 ? arg0 : arg1, converter, valueCoercionType);
+        }
+
+        return Invoke(parameters);
+    }
+
+    private object?[] BindArguments(JsCallArguments arguments)
+    {
+        var metadata = _metadata;
+        var parameterMetadata = metadata.Parameters;
+
+        var delegateArgumentsCount = parameterMetadata.Length;
+        if (delegateArgumentsCount == 0)
+        {
+            return [];
+        }
+
+        var delegateNonParamsArgumentsCount = metadata.HasParamsArray ? delegateArgumentsCount - 1 : delegateArgumentsCount;
+
+        var jsArgumentsCount = arguments.Length;
+        var jsArgumentsWithoutParamsCount = Math.Min(jsArgumentsCount, delegateNonParamsArgumentsCount);
+
+        var converter = Engine.TypeConverter;
         var valueCoercionType = Engine.Options.Interop.ValueCoercion;
         var parameters = new object?[delegateArgumentsCount];
 
         // convert non params parameter to expected types
         for (var i = 0; i < jsArgumentsWithoutParamsCount; i++)
         {
-            var parameterType = parameterInfos[i].ParameterType;
-            var value = arguments[i];
-            object? converted;
-
-            if (typeof(JsValue).IsAssignableFrom(parameterType))
-            {
-                converted = value;
-            }
-            else if (!ReflectionExtensions.TryConvertViaTypeCoercion(parameterType, valueCoercionType, value, out converted))
-            {
-                converted = clrTypeConverter.Convert(
-                    value.ToObject(),
-                    parameterType,
-                    CultureInfo.InvariantCulture);
-            }
-
-            parameters[i] = converted;
+            parameters[i] = Convert(in parameterMetadata[i], arguments[i], converter, valueCoercionType);
         }
 
         // assign null to parameters not provided
         for (var i = jsArgumentsWithoutParamsCount; i < delegateNonParamsArgumentsCount; i++)
         {
-            if (parameterInfos[i].ParameterType.IsValueType)
-            {
-                parameters[i] = Activator.CreateInstance(parameterInfos[i].ParameterType);
-            }
-            else
-            {
-                parameters[i] = null;
-            }
+            var parameter = parameterMetadata[i];
+            parameters[i] = parameter.IsValueType ? Activator.CreateInstance(parameter.ParameterType) : null;
         }
 
         // assign params to array and converts each object to expected type
-        if (_delegateContainsParamsArgument)
+        if (metadata.HasParamsArray)
         {
-            int paramsArgumentIndex = delegateArgumentsCount - 1;
-            int paramsCount = Math.Max(0, jsArgumentsCount - delegateNonParamsArgumentsCount);
+            var paramsArgumentIndex = delegateArgumentsCount - 1;
+            var paramsCount = Math.Max(0, jsArgumentsCount - delegateNonParamsArgumentsCount);
 
-            var paramsParameterType = parameterInfos[paramsArgumentIndex].ParameterType.GetElementType();
-            var paramsParameter = Array.CreateInstance(paramsParameterType!, paramsCount);
+            var paramsParameterType = metadata.ParamsElementType!;
+            var paramsParameter = Array.CreateInstance(paramsParameterType, paramsCount);
 
             for (var i = paramsArgumentIndex; i < jsArgumentsCount; i++)
             {
@@ -113,15 +156,15 @@ internal sealed class DelegateWrapper : Function
                 var value = arguments[i];
                 object? converted;
 
-                if (paramsParameterType == typeof(JsValue))
+                if (metadata.ParamsElementIsJsValue)
                 {
                     converted = value;
                 }
                 else if (!ReflectionExtensions.TryConvertViaTypeCoercion(paramsParameterType, valueCoercionType, value, out converted))
                 {
-                    converted = Engine.TypeConverter.Convert(
+                    converted = converter.Convert(
                         value.ToObject(),
-                        paramsParameterType!,
+                        paramsParameterType,
                         CultureInfo.InvariantCulture);
                 }
 
@@ -131,25 +174,69 @@ internal sealed class DelegateWrapper : Function
             parameters[paramsArgumentIndex] = paramsParameter;
         }
 
+        return parameters;
+    }
+
+    private static object? Convert(
+        in ParameterMetadata parameter,
+        JsValue value,
+        ITypeConverter converter,
+        ValueCoercionType valueCoercionType)
+    {
+        if (parameter.IsJsValue)
+        {
+            return value;
+        }
+
+        var parameterType = parameter.ParameterType;
+        if (ReflectionExtensions.TryConvertViaTypeCoercion(parameterType, valueCoercionType, value, out var converted))
+        {
+            return converted;
+        }
+
+        return converter.Convert(value.ToObject(), parameterType, CultureInfo.InvariantCulture);
+    }
+
+    private JsValue Invoke(object?[] parameters)
+    {
+        object? result;
+#if NET8_0_OR_GREATER
+        // The compiled thunk emits an unbox/castclass per argument, which - unlike the reflection
+        // binder - coerces nothing, so it may only run for an exactly-typed argument list.
+        var invoker = _invoker;
+        var viaCompiledLane = invoker is not null && _metadata.CanBind(parameters);
+#endif
         try
         {
-            var result = _d.DynamicInvoke(parameters);
-            // an awaitable result must reach promise conversion before a constraint can throw,
-            // so that the in-flight Task gets a continuation attached and is never left unobserved
-            var returnValue = IsAwaitable(result)
-                ? ConvertAwaitableToPromise(Engine, result!)
-                : FromObject(Engine, result);
-            Engine.CheckAmortizedConstraintsAtHostBoundary();
-            return returnValue;
+#if NET8_0_OR_GREATER
+            result = viaCompiledLane ? invoker!(_d, parameters) : _d.DynamicInvoke(parameters);
+#else
+            result = _d.DynamicInvoke(parameters);
+#endif
         }
+#if NET8_0_OR_GREATER
+        // The compiled lane calls the delegate directly, so a host exception arrives unwrapped; the
+        // DynamicInvoke lane keeps its historical filter so only target exceptions (which it wraps)
+        // are intercepted and a binder failure still surfaces as-is.
+        catch (Exception exception) when (viaCompiledLane || exception is TargetInvocationException)
+#else
         catch (TargetInvocationException exception)
+#endif
         {
-            // a throwing host call never reaches the post-invoke check above; re-check here so a
+            // a throwing host call never reaches the post-invoke check below; re-check here so a
             // loop of throwing host calls cannot stretch the detection window either
             Engine.CheckAmortizedConstraintsAtHostBoundary();
-            Throw.MeaningfulException(Engine, exception);
+            Throw.MeaningfulException(Engine, exception as TargetInvocationException ?? new TargetInvocationException(exception));
             throw;
         }
+
+        // an awaitable result must reach promise conversion before a constraint can throw,
+        // so that the in-flight Task gets a continuation attached and is never left unobserved
+        var returnValue = IsAwaitable(result)
+            ? ConvertAwaitableToPromise(Engine, result!)
+            : FromObject(Engine, result);
+        Engine.CheckAmortizedConstraintsAtHostBoundary();
+        return returnValue;
     }
 
     private static bool IsAwaitable(object? obj)
@@ -180,5 +267,136 @@ internal sealed class DelegateWrapper : Function
         return false;
 #endif
     }
+}
 
+/// <summary>
+/// One parameter of a wrapped delegate, with the per-call reflection questions
+/// (<c>typeof(JsValue).IsAssignableFrom(...)</c>, <c>IsValueType</c>, the boxed representation of a
+/// <see cref="Nullable{T}"/>) answered up front.
+/// </summary>
+/// <param name="ParameterType">The declared parameter type.</param>
+/// <param name="BoxedType">
+/// The runtime type an argument for this parameter is boxed as — <c>T</c> rather than
+/// <c>Nullable&lt;T&gt;</c>, since a nullable never survives boxing.
+/// </param>
+/// <param name="IsJsValue">Whether the parameter takes a <see cref="JsValue"/> straight through.</param>
+/// <param name="IsValueType">Whether the parameter is a value type, which an argument must match exactly.</param>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct ParameterMetadata(Type ParameterType, Type BoxedType, bool IsJsValue, bool IsValueType);
+
+/// <summary>
+/// Signature metadata for a wrapped delegate's target method: everything <see cref="DelegateWrapper"/>
+/// needs in order to bind JavaScript arguments, resolved once instead of on every construction and
+/// every call.
+/// </summary>
+internal sealed class DelegateMetadata
+{
+    // Keyed on the target MethodInfo rather than on the Delegate instance: a capturing lambda produces
+    // a brand new Delegate for every registration but always reports the same compiler-generated
+    // MethodInfo, so an instance-keyed cache would never hit. Everything stored here derives purely
+    // from that MethodInfo and holds no engine state, which is what makes one process-wide cache sound
+    // across engines. The trade-off matches the other reflection caches in this namespace: an entry
+    // pins the MethodInfo, and therefore its declaring assembly, for the process lifetime. A concurrent
+    // duplicate build is benign — both produce equivalent metadata and one is discarded.
+    private static readonly ConcurrentDictionary<MethodInfo, DelegateMetadata> _cache = new();
+
+    internal static DelegateMetadata For(MethodInfo method)
+        => _cache.GetOrAdd(method, static m => new DelegateMetadata(m));
+
+    private DelegateMetadata(MethodInfo method)
+    {
+        var parameterInfos = method.GetParameters();
+
+#if NETFRAMEWORK
+        if (parameterInfos.Length > 0 && parameterInfos[0].ParameterType == typeof(System.Runtime.CompilerServices.Closure))
+        {
+            var reducedLength = parameterInfos.Length - 1;
+            var reducedParameterInfos = new ParameterInfo[reducedLength];
+            Array.Copy(parameterInfos, 1, reducedParameterInfos, 0, reducedLength);
+            parameterInfos = reducedParameterInfos;
+        }
+#endif
+
+        ParameterMetadata[] parameters = parameterInfos.Length == 0 ? [] : new ParameterMetadata[parameterInfos.Length];
+        var hasParamsArray = false;
+        for (var i = 0; i < parameterInfos.Length; i++)
+        {
+            var parameterInfo = parameterInfos[i];
+            var parameterType = parameterInfo.ParameterType;
+            parameters[i] = new ParameterMetadata(
+                parameterType,
+                BoxedType: Nullable.GetUnderlyingType(parameterType) ?? parameterType,
+                IsJsValue: typeof(JsValue).IsAssignableFrom(parameterType),
+                IsValueType: parameterType.IsValueType);
+
+            hasParamsArray |= Attribute.IsDefined(parameterInfo, typeof(ParamArrayAttribute));
+        }
+
+        Parameters = parameters;
+        HasParamsArray = hasParamsArray;
+
+        if (hasParamsArray)
+        {
+            ParamsElementType = parameterInfos[parameterInfos.Length - 1].ParameterType.GetElementType();
+            ParamsElementIsJsValue = ParamsElementType == typeof(JsValue);
+        }
+    }
+
+    internal ParameterMetadata[] Parameters { get; }
+
+    internal bool HasParamsArray { get; }
+
+    /// <summary>Element type of the trailing params array; only meaningful when <see cref="HasParamsArray"/>.</summary>
+    internal Type? ParamsElementType { get; }
+
+    internal bool ParamsElementIsJsValue { get; }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Whether <paramref name="parameters"/> may be handed to a strongly-typed invoker, whose emitted
+    /// unbox/castclass per argument is stricter than the reflection binder: the binder accepts any box
+    /// it knows how to coerce to the parameter type, the emitted unbox demands the exact type.
+    /// </summary>
+    /// <remarks>
+    /// Everything the built-in conversion path produces satisfies that — it boxes as the declared
+    /// member type — but two things reach here that it does not control: the path ends in an
+    /// <see cref="ITypeConverter"/> a host may replace with one that returns whatever it likes, and a
+    /// <see cref="JsValue"/>-typed parameter takes its argument straight through unconverted, so a
+    /// parameter narrower than <see cref="JsValue"/> can be handed a value it does not accept. Both
+    /// keep the reflection path, whose <see cref="ArgumentException"/> is the outcome they already
+    /// produced; taking the compiled lane would instead surface a cast failure as a host error.
+    /// </remarks>
+    internal bool CanBind(object?[] parameters)
+    {
+        var parameterMetadata = Parameters;
+        for (var i = 0; i < parameterMetadata.Length; i++)
+        {
+            var parameter = parameterMetadata[i];
+            var value = parameters[i];
+
+            if (value is null)
+            {
+                // a castclass accepts null and so does a Nullable<T> conversion; a plain unbox does not
+                if (parameter.IsValueType && ReferenceEquals(parameter.BoxedType, parameter.ParameterType))
+                {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (ReferenceEquals(value.GetType(), parameter.BoxedType))
+            {
+                continue;
+            }
+
+            if (parameter.IsValueType || !parameter.ParameterType.IsInstanceOfType(value))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+#endif
 }


### PR DESCRIPTION
`DelegateWrapper` resolved its target method's signature with `Method.GetParameters()` in the constructor — and then did it again inside `Call`. Every single invocation of a host delegate paid a defensive `ParameterInfo[]` clone plus a per-parameter attribute lookup before any argument was converted. It then invoked through `Delegate.DynamicInvoke`, which re-binds and re-validates the whole argument list on every call.

Three changes, in increasing order of what they buy:

**1. Signature metadata is resolved once.** Parameter types, whether each is a `JsValue` passthrough or a value type, the boxed representation of a `Nullable<T>`, the params array and its element type — all resolved into a `DelegateMetadata` cached in a `ConcurrentDictionary` keyed on the target `MethodInfo`. The key is the *method*, not the `Delegate`: a capturing lambda produces a brand new `Delegate` for every registration but always reports the same compiler-generated `MethodInfo`, so an instance-keyed cache would never hit. Everything cached derives purely from that `MethodInfo` and holds no engine state, which is what makes one process-wide cache sound across engines. The second `GetParameters()` is gone.

**2. The wrapper implements the fast-call mechanism from #2783** — `Supported: true, Leaf: false`. A host delegate runs arbitrary embedder code, so it can raise a JavaScript error and re-enter the interpreter, both of which observe the call-stack frame through `error.stack`; the frameless lane is therefore never offered. The arity guard declines a params array, more than two parameters, and any call site passing fewer arguments than the delegate declares — those substitute CLR defaults for the missing ones rather than converting the `undefined` the fast lane would hand over.

**3. On net8.0+, invocation goes through a compiled thunk instead of `DynamicInvoke`.** Built per delegate *type* (that type alone fixes the invocation signature) and only when `RuntimeFeature.IsDynamicCodeCompiled` says it will actually be JITted — under AOT or an interpreted-only `Expression.Compile` an interpreted lambda is no faster than `DynamicInvoke`, so it declines. Going through the delegate's own `Invoke` keeps the thunk semantically identical to `DynamicInvoke` for every delegate shape, including multicast invocation lists and closures. By-ref, pointer and non-visible types decline and keep the reflection path, as does a delegate whose `Invoke` arity differs from its target method's (an open-instance delegate), which this wrapper cannot bind positionally in the first place.

Because the compiled lane calls the delegate directly, a host exception arrives unwrapped rather than inside a `TargetInvocationException`, so the catch filter covers both shapes and normalizes before reporting. The CLR exception, its message and its original stack trace reach the host exactly as before.

### `CanBind` and #2785

The compiled thunk emits an `unbox`/`castclass` per argument, which demands the exact type where the reflection binder would coerce, so `CanBind` gates the lane. Re-checked against #2785, which fixed `TryConvertViaTypeCoercion` to box a coerced integer as the *declared* member type instead of always as `int` — that mis-typed box was the original reason `CanBind` had to exist.

With #2785 merged, that case no longer declines. Instrumenting `CanBind` and sweeping the parameter shapes a host actually registers shows only two declines left, and neither is a numeric one:

| shape | verdict | why |
| --- | --- | --- |
| `long`, `int`, `short`, `uint`, `float`, `double`, `decimal`, `bool`, `enum`, `DateTime` | accepted | the conversion path boxes as the declared type |
| `int?` with a value / with `null` | accepted | boxes as `int` / stays `null`, both of which `unbox.any` to `int?` |
| under-supplied value type and reference type | accepted | `Activator.CreateInstance(T)` / `null` |
| `params T[]`, with and without a leading parameter | accepted | `Array.CreateInstance` gives exactly `T[]` |
| `object`, `IList<int>`, `string`, `JsValue` | accepted | assignable |
| **`JsString` parameter handed a `JsNumber`** | **declined** | a `JsValue` parameter takes its argument through unconverted, so nothing before the invocation checks it fits |
| **custom `ITypeConverter` returning a `string` for a `TimeSpan` parameter** | **declined** | the conversion path ends in an interface a host may replace |

So `CanBind` stays, but its job has changed: it is no longer defending against Jint's own coercion, it is defending against the two inputs the conversion path does not control. `long`-typed parameters — the motivating case — now take the compiled lane. Both remaining declines keep the reflection binder's `ArgumentException`, which is the outcome they already produced; without the gate they would surface a cast failure as a host error instead. Both are pinned by new tests.

The doc comments and the test comment that described the widening case have been rewritten accordingly.

### Tests

`Jint.Tests.PublicInterface/HostDelegateTests.cs` (20 cases): arities 0–3, over- and under-supplied arguments, optional CLR parameters, params arrays with and without a leading parameter, value/reference/void returns, numeric widths and nullables, `JsValue` passthrough, exception propagation (including that the original throw site survives, and `CatchClrExceptions`), awaitable results becoming promises, one delegate instance shared by two engines, two lambdas sharing a `MethodInfo` but not their captured state, and `Engine.Invoke` agreeing with a repeated interpreted call site. Plus the two `CanBind` cases and the open-instance delegate above.

### Verification

Release build (warnings are errors): 0 errors, 1 warning — the pre-existing `MSB3277` in `Jint.Tests.CommonScripts` on `net472`, present on clean `main` too.

| suite | main | this branch |
| --- | --- | --- |
| `Jint.Tests` net10.0 | 4123 passed / 4 skipped | 4123 passed / 4 skipped |
| `Jint.Tests` net472 | 4059 passed / 4 skipped | 4059 passed / 4 skipped |
| `Jint.Tests.PublicInterface` (both TFMs) | 149 passed | 169 passed |
| `Jint.Tests.Test262` | 99441 passed / 157 skipped | 99441 passed / 157 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
