### PR TITLE
Add benchmark lanes for the host-object and interop shapes integrators run

### DIFF
--- a/Jint.Benchmark/ConstrainedExecutionBenchmark.cs
+++ b/Jint.Benchmark/ConstrainedExecutionBenchmark.cs
@@ -4,20 +4,55 @@ using Jint.Native;
 namespace Jint.Benchmark;
 
 /// <summary>
-/// Per-statement constraint check overhead: a registered timeout (the most common embedder
-/// safety net) used to force a virtual Check() call before every executed statement and
-/// disarm the tight for-body lane. The amortized-constraint partition reduces that to a
-/// countdown decrement per statement and keeps the lane armed, so the TimeoutEnabled=true
-/// row should track the unconstrained row closely.
+/// Per-statement constraint check overhead. A registered constraint used to force a virtual
+/// Check() call before every executed statement and disarm the tight for-body lane; the
+/// amortized-constraint partition removed that for the constraints it can legally apply to.
+/// Which constraint you register therefore decides what you pay:
+///
+/// <list type="bullet">
+/// <item><description>
+/// <see cref="TimeoutEnabled"/> — a timeout only observes a clock, which a check reads without
+/// consuming, so it is <b>amortized</b>: a countdown decrement per statement, and the tight lane
+/// stays armed. The <c>TimeoutEnabled=true</c> row should track the unconstrained row closely.
+/// </description></item>
+/// <item><description>
+/// <see cref="StatementLimitEnabled"/> — a statement limit is an <b>exact</b> constraint: its call
+/// frequency <i>is</i> its semantics (it counts the calls), so it cannot be amortized without
+/// changing what it means. It forces the per-statement check path and therefore disarms the tight
+/// body lane in <c>for</c>, <c>while</c> and <c>do-while</c>. Expect the
+/// <c>StatementLimitEnabled=true</c> rows to be visibly slower than the unconstrained row —
+/// that gap, not the timeout gap, is what an embedder pays for a runaway-script guard today.
+/// </description></item>
+/// </list>
+///
+/// Both flags are independent, so the four rows also show whether the two costs compose or
+/// overlap (the exact constraint already forces the per-statement path, so adding a timeout on top
+/// of it should cost far less than adding it to the unconstrained row).
 /// </summary>
 [MemoryDiagnoser]
 public class ConstrainedExecutionBenchmark
 {
+    /// <summary>
+    /// Comfortably above the ~2M statements one evaluation executes, so the lane measures the cost
+    /// of <i>having</i> an exact constraint registered rather than the cost of tripping it.
+    /// Constraints are reset per top-level evaluation, so the budget applies per operation.
+    /// <para>
+    /// Not <see cref="int.MaxValue"/>: that spelling of "effectively unlimited" registers no
+    /// constraint at all (see <see cref="ConstraintsOptionsExtensions.MaxStatements"/>), so the
+    /// <c>StatementLimitEnabled=true</c> rows would have measured the unconstrained engine and
+    /// reported a zero gap.
+    /// </para>
+    /// </summary>
+    private const int StatementBudget = 100_000_000;
+
     private Engine _engine = null!;
     private Prepared<Script> _functionLocalLoop;
 
     [Params(false, true)]
     public bool TimeoutEnabled { get; set; }
+
+    [Params(false, true)]
+    public bool StatementLimitEnabled { get; set; }
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -33,9 +68,21 @@ public class ConstrainedExecutionBenchmark
             f();
             """);
 
-        _engine = TimeoutEnabled
-            ? new Engine(options => options.TimeoutInterval(TimeSpan.FromSeconds(30)))
-            : new Engine();
+        var timeoutEnabled = TimeoutEnabled;
+        var statementLimitEnabled = StatementLimitEnabled;
+        _engine = new Engine(options =>
+        {
+            if (timeoutEnabled)
+            {
+                options.TimeoutInterval(TimeSpan.FromSeconds(30));
+            }
+
+            if (statementLimitEnabled)
+            {
+                options.MaxStatements(StatementBudget);
+            }
+        });
+
         _engine.Evaluate(_functionLocalLoop);
     }
 

--- a/Jint.Benchmark/FreshEngineGlobalsBenchmark.cs
+++ b/Jint.Benchmark/FreshEngineGlobalsBenchmark.cs
@@ -1,0 +1,175 @@
+#nullable enable
+
+using System.Globalization;
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The cost profile of a thin embedder: a <b>fresh engine per execution</b>, a globals table wired
+/// up from scratch on it, and a tiny prepared script on top. Nothing else in this suite covers
+/// that combination — <see cref="EngineConstructionBenchmark"/> builds a fresh engine with no
+/// globals at all, and <see cref="InteropBenchmark"/> reuses one engine with a handful of globals
+/// registered once — so registration cost has never been on a measured path even though it is
+/// most of what a per-request embedding does before any script runs.
+///
+/// <para><b>What each parameter proves</b></para>
+/// <list type="bullet">
+/// <item><description>
+/// <see cref="GlobalCount"/> — 1 / 10 / 40 spans "one entry point" to "a full host API surface".
+/// The per-global slope is the number that matters: subtract the <c>GlobalCount=1</c> row from the
+/// <c>GlobalCount=40</c> row and divide by 39. A flat slope means registration is free; a steep
+/// one means every added host global taxes every execution. Read <c>Allocated</c> alongside
+/// <c>Mean</c> — a per-global allocation slope is a per-request GC cost.
+/// </description></item>
+/// <item><description>
+/// <see cref="Kind"/> — <see cref="GlobalKind.Delegate"/> goes through the delegate wrapper, which
+/// reflects over the delegate's <c>Invoke</c> signature; <see cref="GlobalKind.ClrFunction"/> is
+/// the hand-written escape hatch that skips that. The gap between the two rows is the price of the
+/// convenient API, and it is only visible with a fresh engine per operation — on a reused engine
+/// it is amortized to nothing.
+/// </description></item>
+/// </list>
+///
+/// <para>
+/// The delegates are built by a factory <b>per engine</b> and several of them are capturing
+/// closures, so every operation hands the engine a fresh delegate instance. That is what an
+/// embedder that builds its host API per request actually does, and it is the case that matters
+/// for any cache keyed on something coarser than the delegate instance (a <c>MethodInfo</c>, say):
+/// a fresh closure instance still shares its <c>MethodInfo</c>, a fresh lambda body does not.
+/// Reusing one cached delegate array across operations would measure a different, easier problem.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+public class FreshEngineGlobalsBenchmark
+{
+    /// <summary>Longest matrix entry; names are precomputed so name formatting is not in the measurement.</summary>
+    private const int MaxGlobals = 40;
+
+    private static readonly string[] _names = BuildNames();
+
+    private readonly double[] _sink = new double[1];
+
+    private Options _sharedOptions = null!;
+    private Prepared<Script> _script;
+
+    [Params(1, 10, 40)]
+    public int GlobalCount { get; set; }
+
+    // GlobalKind.Lazy is intentionally absent from [Params] — see GlobalSetup.
+    [Params(GlobalKind.Delegate, GlobalKind.ClrFunction)]
+    public GlobalKind Kind { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        if (Kind == GlobalKind.Lazy)
+        {
+            // TODO: enable once lazy global registration lands — the embedder hands over a name and
+            // a factory, and the engine only builds the function object if the script reads the
+            // name. That turns the per-global slope measured here into a per-*used*-global slope.
+            throw new NotSupportedException($"{Kind} awaits a Jint feature that does not exist yet; see the TODO in {nameof(GlobalSetup)}.");
+        }
+
+        // One Options instance shared by every constructed engine: an embedder configures interop
+        // policy once at start-up and only the globals differ per engine.
+        _sharedOptions = new Options();
+
+        // One statement, and it calls into the host so global resolution is on the measured path.
+        _script = Engine.PrepareScript("fn0(1) + fn0(2);");
+
+        // Prove the lane before it is measured.
+        RunOnce();
+    }
+
+    [Benchmark]
+    public JsValue FreshEngineWithGlobals() => RunOnce();
+
+    private JsValue RunOnce()
+    {
+        var engine = new Engine(_sharedOptions);
+        RegisterGlobals(engine);
+        return engine.Evaluate(_script);
+    }
+
+    private void RegisterGlobals(Engine engine)
+    {
+        var count = GlobalCount;
+        for (var i = 0; i < count; i++)
+        {
+            var name = _names[i];
+            if (Kind == GlobalKind.Delegate)
+            {
+                engine.SetValue(name, CreateDelegate(i));
+            }
+            else
+            {
+                engine.SetValue(name, CreateClrFunction(engine, name, i));
+            }
+        }
+    }
+
+    /// <summary>
+    /// A mix of arities and return shapes, most of them capturing closures — the realistic output of
+    /// a per-engine host API factory rather than a table of cached static lambdas.
+    /// </summary>
+    private Delegate CreateDelegate(int index)
+    {
+        var salt = index + 1;
+        var sink = _sink;
+        return (index % 5) switch
+        {
+            0 => new Func<double, double>(x => x * salt),
+            1 => new Func<double, double, double>((x, y) => x + y + salt),
+            2 => new Func<string, string>(s => s + salt.ToString(CultureInfo.InvariantCulture)),
+            3 => new Func<double>(() => salt),
+            _ => new Action<double>(x => sink[0] += x + salt),
+        };
+    }
+
+    /// <summary>The same host API expressed the manual way, bypassing delegate signature reflection.</summary>
+    private ClrFunction CreateClrFunction(Engine engine, string name, int index)
+    {
+        var salt = index + 1;
+        var sink = _sink;
+        return (index % 5) switch
+        {
+            0 => new ClrFunction(engine, name, (_, args) => JsNumber.Create(args.At(0).AsNumber() * salt), length: 1),
+            1 => new ClrFunction(engine, name, (_, args) => JsNumber.Create(args.At(0).AsNumber() + args.At(1).AsNumber() + salt), length: 2),
+            2 => new ClrFunction(engine, name, (_, args) => new JsString(args.At(0).ToString() + salt.ToString(CultureInfo.InvariantCulture)), length: 1),
+            3 => new ClrFunction(engine, name, (_, _) => JsNumber.Create(salt)),
+            _ => new ClrFunction(engine, name, (_, args) =>
+            {
+                sink[0] += args.At(0).AsNumber() + salt;
+                return JsValue.Undefined;
+            }, length: 1),
+        };
+    }
+
+    private static string[] BuildNames()
+    {
+        var names = new string[MaxGlobals];
+        for (var i = 0; i < names.Length; i++)
+        {
+            names[i] = "fn" + i.ToString(CultureInfo.InvariantCulture);
+        }
+
+        return names;
+    }
+}
+
+/// <summary>How a host function is handed to a fresh engine.</summary>
+public enum GlobalKind
+{
+    /// <summary>A CLR delegate — the convenient API, wrapped by the engine.</summary>
+    Delegate,
+
+    /// <summary>A hand-written <see cref="ClrFunction"/> — no delegate signature reflection.</summary>
+    ClrFunction,
+
+    /// <summary>Awaits lazy global registration. Not runnable yet.</summary>
+    Lazy,
+}

--- a/Jint.Benchmark/HostObjectAccessBenchmark.cs
+++ b/Jint.Benchmark/HostObjectAccessBenchmark.cs
@@ -1,0 +1,479 @@
+#nullable enable
+
+using System.Globalization;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// The embedding shape that no other benchmark in this suite covers: a script projecting over
+/// <b>host-supplied objects</b> — a custom <see cref="ObjectInstance"/> subclass that materializes
+/// its properties on demand from a native record — instead of over plain script objects, with the
+/// two engine-wide switches embedders routinely flip on top of it (a reference resolver and an
+/// execution constraint).
+///
+/// <para>
+/// The workload is a single projection loop that touches every read shape a data-shaping script
+/// uses: member read (<c>it.kind</c>), member call (<c>it.name.toUpperCase()</c>), computed index
+/// (<c>items[i]</c>), member write (into a fresh literal) and object-literal construction. It is
+/// deliberately one script for all lanes so the parameter columns are the only thing that varies.
+/// </para>
+///
+/// <para><b>What each parameter proves</b></para>
+/// <list type="bullet">
+/// <item><description>
+/// <see cref="ReceiverKind"/> — <see cref="HostReceiverKind.PlainObject"/> is the script-object
+/// floor. <see cref="HostReceiverKind.LazyHost"/> is the cost an embedder actually pays today:
+/// every own-property read goes through the virtual <see cref="ObjectInstance.GetOwnProperty"/>
+/// (the fast shape/dictionary lanes in <see cref="ObjectInstance.Get(JsValue, JsValue)"/> are not
+/// reachable for a non-<c>PlainObject</c> receiver) and allocates a fresh
+/// <see cref="PropertyDescriptor"/> per read. Expect the LazyHost row to be several times the
+/// PlainObject row in both time and <c>Allocated</c>, with the allocation delta ≈
+/// (descriptor size × own-property reads) — descriptor churn is half the story, so always read the
+/// <c>Allocated</c> column next to <c>Mean</c> here.
+/// </description></item>
+/// <item><description>
+/// <see cref="ResolverKind"/> — installing any <see cref="IReferenceResolver"/> sets
+/// <c>Engine._customResolver</c>, which turns off the member-expression inline caches and the
+/// call fast path engine-wide (see <c>JintMemberExpression</c> / <c>JintCallExpression</c>).
+/// The <see cref="HostResolverKind.Unfiltered"/> row sizes that global de-optimization; it is
+/// paid on every member read in the script, not only on the null-propagating ones the resolver
+/// exists for.
+/// </description></item>
+/// <item><description>
+/// <see cref="StatementLimit"/> — a statement limit is an <i>exact</i> constraint, so unlike a
+/// timeout it cannot be amortized: it forces per-statement checks and disarms the tight-body loop
+/// lane. Expect a visible regression on the <c>true</c> rows. See
+/// <see cref="ConstrainedExecutionBenchmark"/> for the same effect measured in isolation.
+/// </description></item>
+/// </list>
+/// </summary>
+[MemoryDiagnoser]
+public class HostObjectAccessBenchmark
+{
+    private const int ItemCount = 200;
+
+    /// <summary>
+    /// Large enough that the loop never trips it — the lane measures the cost of <i>having</i> an
+    /// exact constraint registered, not the cost of hitting its limit. Deliberately not
+    /// <see cref="int.MaxValue"/>, which registers no constraint at all (see
+    /// <see cref="ConstraintsOptionsExtensions.MaxStatements"/>) and would have made the
+    /// <c>StatementLimit=true</c> rows a second copy of the unconstrained ones.
+    /// </summary>
+    private const int StatementBudget = 100_000_000;
+
+    private const string ProjectionSource = """
+        function project(items) {
+          var total = 0, out = [];
+          for (var i = 0; i < items.length; i++) {
+            var it = items[i];
+            if (it.kind === 'a' && it.amount > 0) {
+              total += it.amount * it.rate;
+              out.push({ id: it.id, name: it.name.toUpperCase(), total: total });
+            }
+          }
+          return total;
+        }
+        """;
+
+    private Engine _engine = null!;
+    private Prepared<Script> _projection;
+
+    // Only the lanes that compile and run against today's public API are in [Params]; the members
+    // awaiting a Jint feature are handled (and rejected) by GlobalSetup so that adding them here is
+    // a one-line change once the feature lands.
+    [Params(HostReceiverKind.PlainObject, HostReceiverKind.LazyHost)]
+    public HostReceiverKind ReceiverKind { get; set; }
+
+    [Params(HostResolverKind.None, HostResolverKind.Unfiltered)]
+    public HostResolverKind ResolverKind { get; set; }
+
+    [Params(false, true)]
+    public bool StatementLimit { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        switch (ReceiverKind)
+        {
+            case HostReceiverKind.PlainObject:
+            case HostReceiverKind.LazyHost:
+                break;
+
+            // TODO: enable once the host-object "ordinary access semantics" opt-in lands — the host
+            // declares a fixed set of own properties up front so reads can take the ordinary
+            // (shape/dictionary) lane instead of the virtual GetOwnProperty lane.
+            case HostReceiverKind.LazyHostOrdinary:
+
+            // TODO: enable once the descriptor-free read hook lands — a host hook that returns the
+            // JsValue directly, so a read no longer allocates a PropertyDescriptor to carry it.
+            case HostReceiverKind.LazyHostValueHook:
+
+            // TODO: enable once the fixed-layout object factory lands — the host declares the layout
+            // once and the engine allocates a flat slot array per instance.
+            case HostReceiverKind.FixedLayout:
+                throw new NotSupportedException($"{ReceiverKind} awaits a Jint feature that does not exist yet; see the TODO in {nameof(GlobalSetup)}.");
+
+            default:
+                throw new NotSupportedException(ReceiverKind.ToString());
+        }
+
+        if (ResolverKind == HostResolverKind.NullishOnly)
+        {
+            // TODO: enable once the resolver interest filter lands — a resolver that declares it only
+            // cares about null/undefined bases, so the engine can keep its member inline caches armed
+            // instead of de-optimizing every member read engine-wide.
+            throw new NotSupportedException($"{ResolverKind} awaits a Jint feature that does not exist yet; see the TODO in {nameof(GlobalSetup)}.");
+        }
+
+        var options = new Options();
+        if (ResolverKind == HostResolverKind.Unfiltered)
+        {
+            options.SetReferencesResolver(new UnfilteredNullPropagationResolver());
+        }
+
+        if (StatementLimit)
+        {
+            options.MaxStatements(StatementBudget);
+        }
+
+        _engine = new Engine(options);
+        _engine.Execute(ProjectionSource);
+        _engine.SetValue("items", BuildItems(_engine, ReceiverKind));
+
+        _projection = Engine.PrepareScript("project(items);");
+        _engine.Evaluate(_projection);
+    }
+
+    [Benchmark]
+    public JsValue Projection() => _engine.Evaluate(_projection);
+
+    private static JsValue BuildItems(Engine engine, HostReceiverKind kind)
+    {
+        if (kind == HostReceiverKind.PlainObject)
+        {
+            // Built from script so the baseline objects get the ordinary representation an object
+            // literal produces (hidden-class shape, ordinary access lane) rather than a hand-built
+            // one that might not match what real script data looks like.
+            return engine.Evaluate($$"""
+                (function () {
+                  var a = [];
+                  for (var i = 0; i < {{ItemCount}}; i++) {
+                    a.push({
+                      id: 'id-' + i,
+                      kind: (i % 2 === 0) ? 'a' : 'b',
+                      name: 'record name ' + i,
+                      note: 'note for record ' + i,
+                      amount: i + 1,
+                      rate: 1.5
+                    });
+                  }
+                  return a;
+                })()
+                """);
+        }
+
+        var items = new JsValue[ItemCount];
+        for (var i = 0; i < items.Length; i++)
+        {
+            var index = i.ToString(CultureInfo.InvariantCulture);
+            var text = new[]
+            {
+                "id-" + index,
+                i % 2 == 0 ? "a" : "b",
+                "record name " + index,
+                "note for record " + index,
+            };
+            var numbers = new double[] { i + 1, 1.5 };
+            items[i] = new LazyHostObject(engine, text, numbers);
+        }
+
+        return new JsArray(engine, items);
+    }
+}
+
+/// <summary>Receiver shapes the projection loop reads from.</summary>
+public enum HostReceiverKind
+{
+    /// <summary>Plain script object — the floor every host shape is measured against.</summary>
+    PlainObject,
+
+    /// <summary>
+    /// Custom <see cref="ObjectInstance"/> subclass projecting from a native record through the
+    /// virtual <see cref="ObjectInstance.GetOwnProperty"/>. This is what embedders write today.
+    /// </summary>
+    LazyHost,
+
+    /// <summary>Awaits the host-object "ordinary access semantics" opt-in. Not runnable yet.</summary>
+    LazyHostOrdinary,
+
+    /// <summary>Awaits the descriptor-free read hook. Not runnable yet.</summary>
+    LazyHostValueHook,
+
+    /// <summary>Awaits the fixed-layout object factory. Not runnable yet.</summary>
+    FixedLayout,
+}
+
+/// <summary>Reference-resolver configurations layered on top of the receiver.</summary>
+public enum HostResolverKind
+{
+    /// <summary>Engine default resolver — member inline caches stay armed.</summary>
+    None,
+
+    /// <summary>
+    /// A null-propagating resolver of the kind embedders install so that <c>a.b.c</c> over missing
+    /// data yields undefined instead of throwing. It carries no interest filter, so the engine
+    /// de-optimizes every member read.
+    /// </summary>
+    Unfiltered,
+
+    /// <summary>Awaits the resolver interest filter. Not runnable yet.</summary>
+    NullishOnly,
+}
+
+/// <summary>
+/// The null-propagating resolver shape embedders install verbatim: any nullish property base
+/// resolves to undefined rather than throwing, and calling through a nullish base yields a no-op
+/// function. Deliberately unfiltered — that is the point of the lane.
+/// </summary>
+internal sealed class UnfilteredNullPropagationResolver : IReferenceResolver
+{
+    public bool TryUnresolvableReference(Engine engine, Reference reference, out JsValue value)
+    {
+        value = reference.Base;
+        return true;
+    }
+
+    public bool TryPropertyReference(Engine engine, Reference reference, ref JsValue value)
+        => value.IsNull() || value.IsUndefined();
+
+    public bool TryGetCallable(Engine engine, object callee, out JsValue value)
+    {
+        value = new ClrFunction(engine, "anonymous", static (thisObj, _) => thisObj);
+        return true;
+    }
+
+    public bool CheckCoercible(JsValue value) => true;
+}
+
+/// <summary>
+/// A host object that projects a small native record (a <see cref="string"/> array plus a
+/// <see cref="double"/> array — the shape a column store, a document field set or a decoded row
+/// arrives in) into JavaScript properties on demand.
+///
+/// <para>
+/// This is deliberately the <b>today</b> baseline, written the only way the current public API
+/// allows: override the virtual <see cref="GetOwnProperty"/> and hand back a
+/// <see cref="PropertyDescriptor"/>. The projected <see cref="JsValue"/> is memoized per field
+/// (an embedder that re-projected on every read would also defeat every downstream identity cache,
+/// which would measure something else), but the descriptor itself is rebuilt on every call because
+/// the public API offers no way to avoid it. That per-read descriptor is the allocation this lane
+/// exists to size.
+/// </para>
+///
+/// <para>
+/// <see cref="GetOwnPropertyCallCount"/> is the regression guard for the "more than one virtual
+/// GetOwnProperty call per own-property read" finding — see the probe-count test in
+/// Jint.Tests.PublicInterface.
+/// </para>
+/// </summary>
+internal sealed class LazyHostObject : ObjectInstance
+{
+    // id, kind, name, note come from the text array; amount, rate from the numbers array.
+    private const int SlotId = 0;
+    private const int SlotKind = 1;
+    private const int SlotName = 2;
+    private const int SlotNote = 3;
+    private const int SlotAmount = 4;
+    private const int SlotRate = 5;
+    private const int SlotCount = 6;
+
+    private static readonly JsValue[] _keys =
+    [
+        new JsString("id"),
+        new JsString("kind"),
+        new JsString("name"),
+        new JsString("note"),
+        new JsString("amount"),
+        new JsString("rate"),
+    ];
+
+    private readonly string[] _text;
+    private readonly double[] _numbers;
+    private readonly JsValue?[] _projected = new JsValue?[SlotCount];
+
+    public LazyHostObject(Engine engine, string[] text, double[] numbers) : base(engine)
+    {
+        _text = text;
+        _numbers = numbers;
+    }
+
+    /// <summary>
+    /// How many times the engine asked this instance for an own property. Exposed so a test can
+    /// pin today's probes-per-read ratio.
+    /// </summary>
+    public int GetOwnPropertyCallCount { get; private set; }
+
+    public void ResetGetOwnPropertyCallCount() => GetOwnPropertyCallCount = 0;
+
+    public override PropertyDescriptor GetOwnProperty(JsValue property)
+    {
+        GetOwnPropertyCallCount++;
+
+        if (!property.IsString())
+        {
+            return PropertyDescriptor.Undefined;
+        }
+
+        var slot = SlotOf(property.ToString());
+        if (slot < 0)
+        {
+            return PropertyDescriptor.Undefined;
+        }
+
+        // Fresh descriptor per call: the public PropertyDescriptor surface has no reusable
+        // data-descriptor form an embedder can hand back, so this allocation is unavoidable today.
+        return new PropertyDescriptor(Project(slot), writable: true, enumerable: true, configurable: true);
+    }
+
+    public override List<JsValue> GetOwnPropertyKeys(Types types = Types.String | Types.Symbol)
+    {
+        var keys = new List<JsValue>(SlotCount);
+        if ((types & Types.String) != Types.Empty)
+        {
+            keys.AddRange(_keys);
+        }
+
+        return keys;
+    }
+
+    public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
+    {
+        for (var slot = 0; slot < SlotCount; slot++)
+        {
+            yield return new KeyValuePair<JsValue, PropertyDescriptor>(
+                _keys[slot],
+                new PropertyDescriptor(Project(slot), writable: true, enumerable: true, configurable: true));
+        }
+    }
+
+    private JsValue Project(int slot)
+    {
+        var projected = _projected[slot];
+        if (projected is not null)
+        {
+            return projected;
+        }
+
+        projected = slot switch
+        {
+            SlotAmount => JsNumber.Create(_numbers[0]),
+            SlotRate => JsNumber.Create(_numbers[1]),
+            // The one field the script calls a string method on is handed over unmaterialized, so
+            // the String.prototype receiver inline cache is on the measured path.
+            SlotName => LazyHostString.FromUtf8(_text[SlotName]),
+            _ => new JsString(_text[slot]),
+        };
+
+        _projected[slot] = projected;
+        return projected;
+    }
+
+    private static int SlotOf(string name) => name switch
+    {
+        "id" => SlotId,
+        "kind" => SlotKind,
+        "name" => SlotName,
+        "note" => SlotNote,
+        "amount" => SlotAmount,
+        "rate" => SlotRate,
+        _ => -1,
+    };
+}
+
+/// <summary>
+/// A string whose characters live in a host-owned encoded buffer and are only decoded when the
+/// engine genuinely needs a flat <see cref="string"/> — the shape a host uses when most projected
+/// strings are compared or discarded rather than read.
+///
+/// <para>
+/// <b>Public surface only.</b> Jint grants this project <c>InternalsVisibleTo</c>, but this class
+/// restricts itself to members an embedder in an unrelated assembly could also override —
+/// otherwise the lane would measure a host object no embedder can actually build.
+/// </para>
+///
+/// <para>
+/// <b>Hazard:</b> the base class stores its flat value in an internal field that a subclass cannot
+/// populate, and a handful of base members read that field directly instead of going through
+/// <see cref="ToString"/>. Everything reachable through the public surface is overridden below,
+/// but <c>JsString.EnsureCapacity</c> is <c>internal virtual</c> and so <b>not overridable by an
+/// embedder</b> — it dereferences the null backing value, so <c>String.prototype.concat</c> on an
+/// instance of this class currently throws a <see cref="NullReferenceException"/>. The projection
+/// workload deliberately avoids <c>concat</c>; drop this note (and feel free to add a concat lane)
+/// once the base class routes <c>EnsureCapacity</c> through <c>ToString()</c> the way
+/// <c>JsString.SlicedString</c> does.
+/// </para>
+/// </summary>
+internal sealed class LazyHostString : JsString
+{
+    private readonly byte[] _utf8;
+    private readonly int _length;
+    private string? _materialized;
+
+    private LazyHostString(byte[] utf8, int length) : base(null!)
+    {
+        _utf8 = utf8;
+        _length = length;
+    }
+
+    public static LazyHostString FromUtf8(string value) => new(Encoding.UTF8.GetBytes(value), value.Length);
+
+    /// <summary>How many times the engine forced a decode. A read-mostly host wants this at zero.</summary>
+    public int MaterializeCount { get; private set; }
+
+    public override string ToString()
+    {
+        if (_materialized is null)
+        {
+            MaterializeCount++;
+            _materialized = Encoding.UTF8.GetString(_utf8);
+        }
+
+        return _materialized;
+    }
+
+    public override int Length => _length;
+
+    public override char this[int index] => ToString()[index];
+
+    public override bool Equals(string? other)
+        => other is not null && _length == other.Length && string.Equals(ToString(), other, StringComparison.Ordinal);
+
+    public override bool Equals(JsString? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        // Length is answered without decoding, so a mismatched compare stays materialization-free.
+        return _length == other.Length && string.Equals(ToString(), other.ToString(), StringComparison.Ordinal);
+    }
+
+    // IsLooselyEqual is deliberately not overridden: the base implementation routes a JsString
+    // comparand through the virtual Equals(JsString) overridden above and everything else through
+    // ToString(), so it never touches the null backing field.
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(ToString());
+}

--- a/Jint.Benchmark/InteropNestedDictionaryBenchmark.cs
+++ b/Jint.Benchmark/InteropNestedDictionaryBenchmark.cs
@@ -1,0 +1,127 @@
+#nullable enable
+
+using System.Globalization;
+using System.Text.Json.Nodes;
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Walking a chain of string keys down an untyped host document — <c>o.a.b.c.d</c> — which is how
+/// an embedder that passes JSON-shaped data (a deserialized payload, a document, a config tree)
+/// exposes it. No existing benchmark measures a <b>chain</b>: <see cref="InteropBenchmark"/> reads
+/// one level off a dictionary, and <see cref="InteropLambdaBenchmark"/> reads one level then
+/// iterates an array.
+///
+/// <para>
+/// Depth is the whole point. Every level is an independent wrapper lookup, and none of them is a
+/// property on a declared type, so nothing along the chain can use the compiled member accessor:
+/// <list type="bullet">
+/// <item><description>
+/// <see cref="NestedSourceKind.Dictionary"/> routes each level through
+/// <c>TypeDescriptor.TryGetDictionaryValue</c>, which invokes the dictionary's <c>TryGetValue</c>
+/// via <c>MethodInfo.Invoke</c> with a freshly boxed <c>object[]</c> parameter array — per level,
+/// per read.
+/// </description></item>
+/// <item><description>
+/// <see cref="NestedSourceKind.JsonObject"/> routes each level through the string-indexer accessor
+/// that Jint special-cases for <c>System.Text.Json.Nodes.JsonNode</c>, then converts the resulting
+/// node. Same shape from the script's point of view, different machinery underneath — worth having
+/// both rows so an improvement to one is not mistaken for an improvement to the other.
+/// </description></item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Expected shape: <c>Mean</c> and <c>Allocated</c> should both rise roughly linearly with
+/// <see cref="Depth"/>. Compare the <c>Depth=4</c> row against four times the <c>Depth=1</c> row —
+/// anything super-linear means an intermediate wrapper is being rebuilt rather than reused, and the
+/// per-level allocation slope is the boxed-argument churn.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+public class InteropNestedDictionaryBenchmark
+{
+    private const int Iterations = 1_000;
+    private const int MaxDepth = 4;
+
+    private Engine _engine = null!;
+    private Prepared<Script> _script;
+
+    [Params(NestedSourceKind.Dictionary, NestedSourceKind.JsonObject)]
+    public NestedSourceKind Source { get; set; }
+
+    [Params(1, 2, 4)]
+    public int Depth { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _engine = new Engine();
+
+        // e.g. Depth 4 -> "o.a.b.c.d"
+        var chain = "o";
+        for (var level = 0; level < Depth; level++)
+        {
+            chain += "." + KeyAt(level);
+        }
+
+        _engine.Execute($$"""
+            function walk(o, n) {
+              var acc = 0;
+              for (var i = 0; i < n; i++) {
+                acc += {{chain}};
+              }
+              return acc;
+            }
+            """);
+
+        _engine.SetValue("doc", BuildDocument(Source, Depth));
+        _script = Engine.PrepareScript($"walk(doc, {Iterations});");
+        _engine.Evaluate(_script);
+    }
+
+    [Benchmark]
+    public JsValue WalkChain() => _engine.Evaluate(_script);
+
+    internal static object BuildDocument(NestedSourceKind kind, int depth)
+    {
+        if (kind == NestedSourceKind.JsonObject)
+        {
+            JsonNode leaf = JsonValue.Create(1.5);
+            for (var level = depth - 1; level >= 0; level--)
+            {
+                leaf = new JsonObject { [KeyAt(level)] = leaf };
+            }
+
+            return leaf;
+        }
+
+        object node = 1.5d;
+        for (var level = depth - 1; level >= 0; level--)
+        {
+            node = new Dictionary<string, object>(StringComparer.Ordinal) { [KeyAt(level)] = node };
+        }
+
+        return node;
+    }
+
+    private static string KeyAt(int level)
+    {
+        // a, b, c, d ... then k0, k1 ... if the matrix ever grows past MaxDepth.
+        return level < MaxDepth
+            ? ((char) ('a' + level)).ToString()
+            : "k" + level.ToString(CultureInfo.InvariantCulture);
+    }
+}
+
+/// <summary>Untyped host document shapes an embedder passes across the boundary.</summary>
+public enum NestedSourceKind
+{
+    /// <summary>A string-keyed generic dictionary tree.</summary>
+    Dictionary,
+
+    /// <summary>A <see cref="JsonObject"/> tree.</summary>
+    JsonObject,
+}

--- a/Jint.Benchmark/InteropObjectConverterBenchmark.cs
+++ b/Jint.Benchmark/InteropObjectConverterBenchmark.cs
@@ -1,0 +1,101 @@
+#nullable enable
+
+using BenchmarkDotNet.Attributes;
+using Jint.Native;
+using Jint.Runtime.Interop;
+
+namespace Jint.Benchmark;
+
+/// <summary>
+/// Sizes an engine-wide de-optimization that has no other coverage: registering a single
+/// <see cref="IObjectConverter"/> makes <c>Engine._objectConverters</c> non-null, and the compiled
+/// member-accessor lane bails out whenever that field is set
+/// (<c>Runtime/Interop/Reflection/CompilableMemberAccessor.cs</c>). It has to — a registered
+/// converter is entitled to see every CLR value before it becomes a <see cref="JsValue"/>, and the
+/// compiled lane produces the <see cref="JsValue"/> itself — but the consequence is that
+/// <b>one</b> converter, however narrow, sends <b>every</b> CLR property read on <b>every</b>
+/// wrapped object in the engine back through reflection.
+///
+/// <para>
+/// The converter installed here deliberately converts nothing: it returns <c>false</c> for every
+/// value, so both rows produce identical results and the delta is purely the cost of the
+/// converter's <i>presence</i>. Embedders routinely register exactly one narrow converter (for a
+/// single host type) without knowing it prices in every other read.
+/// </para>
+///
+/// <para>
+/// Expected shape: <c>ObjectConverterRegistered=true</c> slower than <c>false</c> on both time and
+/// <c>Allocated</c>, with the gap proportional to the number of CLR member reads in the loop.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+public class InteropObjectConverterBenchmark
+{
+    private const int Iterations = 1_000;
+
+    private const string Source = """
+        function readAll(o, n) {
+          var acc = 0;
+          for (var i = 0; i < n; i++) {
+            acc += o.Amount + o.Rate + o.Count;
+            if (o.Name.length > 0) { acc += 1; }
+          }
+          return acc;
+        }
+        """;
+
+    private Engine _engine = null!;
+    private Prepared<Script> _script;
+
+    [Params(false, true)]
+    public bool ObjectConverterRegistered { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        var converterRegistered = ObjectConverterRegistered;
+        _engine = new Engine(options =>
+        {
+            if (converterRegistered)
+            {
+                options.AddObjectConverter(new NeverConvertingObjectConverter());
+            }
+        });
+
+        _engine.Execute(Source);
+        _engine.SetValue("record", new HostRecord { Name = "record name", Amount = 12.5, Rate = 1.5, Count = 3 });
+
+        _script = Engine.PrepareScript($"readAll(record, {Iterations});");
+        _engine.Evaluate(_script);
+    }
+
+    [Benchmark]
+    public JsValue ReadClrProperties() => _engine.Evaluate(_script);
+
+    /// <summary>A plain host POCO — the shape most embedders hand across the boundary.</summary>
+    public sealed class HostRecord
+    {
+        public string Name { get; set; } = "";
+        public double Amount { get; set; }
+        public double Rate { get; set; }
+        public int Count { get; set; }
+    }
+
+    /// <summary>
+    /// Converts nothing, so the two rows are behaviourally identical and the measurement isolates
+    /// the cost of a converter merely being registered.
+    /// </summary>
+    private sealed class NeverConvertingObjectConverter : IObjectConverter
+    {
+        // The interface annotates result with [NotNullWhen(true)]. That attribute cannot be spelled
+        // in this project — YantraJS.Core (referenced for the engine-comparison lanes) ships its own
+        // System.Diagnostics.CodeAnalysis.NotNullWhenAttribute, so the name is ambiguous — so the
+        // parameter is declared non-nullable instead, which is a strictly stronger promise and
+        // satisfies the annotation without needing it.
+        public bool TryConvert(Engine engine, object value, out JsValue result)
+        {
+            result = JsValue.Undefined;
+            return false;
+        }
+    }
+}

--- a/Jint.Tests.PublicInterface/HostObjectProbeCountTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectProbeCountTests.cs
@@ -1,0 +1,140 @@
+#nullable enable
+
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Regression guard for how many times the engine asks a <b>host object</b> — a custom
+/// <see cref="ObjectInstance"/> subclass, the shape every embedder that projects native data
+/// writes — for one of its own properties.
+///
+/// <para>
+/// A host receiver is neither shape-mode nor plain-object, so member reads take the non-plain
+/// lane: it first probes <c>GetOwnProperty</c> to establish whether the name is shadowed on the
+/// receiver, discards that descriptor, and then calls <c>Get</c>, which probes a second time to
+/// produce the value. Two virtual calls, two freshly built <see cref="PropertyDescriptor"/>
+/// instances, one of them thrown away — per own-property read.
+/// </para>
+///
+/// <para>
+/// <b>These numbers assert today's behaviour, not desired behaviour.</b> They are expected to
+/// <b>drop</b> when the host-object ordinary-access-semantics work lands (a host that declares its
+/// own-property set up front should be readable in a single probe, and ideally without
+/// materializing a descriptor at all). When that happens, update the expected values here
+/// deliberately — a silent change in either direction is the thing this test exists to catch.
+/// </para>
+/// </summary>
+public class HostObjectProbeCountTests
+{
+    [Fact]
+    public void SimpleOwnPropertyReadProbesTheHostObjectTwice()
+    {
+        var engine = new Engine();
+        var host = new ProbeCountingHostObject(engine);
+        engine.SetValue("host", host);
+
+        host.Reset();
+        var value = engine.Evaluate("host.prop;");
+
+        value.Should().Be("value-of-prop");
+
+        // Today: one probe to prove the name is not shadowed (descriptor discarded) plus one inside
+        // Get to produce the value. Should become 1 — or 0 descriptors — with ordinary access semantics.
+        host.GetOwnPropertyCallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void EachOwnPropertyReadCostsItsOwnProbes()
+    {
+        var engine = new Engine();
+        var host = new ProbeCountingHostObject(engine);
+        engine.SetValue("host", host);
+
+        host.Reset();
+        engine.Evaluate("host.prop; host.other; host.prop;");
+
+        // Nothing is cached across reads for a host receiver: three reads, three times the
+        // single-read cost.
+        host.GetOwnPropertyCallCount.Should().Be(6);
+    }
+
+    [Fact]
+    public void MissingOwnPropertyReadAlsoProbesTwice()
+    {
+        var engine = new Engine();
+        var host = new ProbeCountingHostObject(engine);
+        engine.SetValue("host", host);
+
+        host.Reset();
+        engine.Evaluate("host.notThere;").Should().BeUndefined();
+
+        // A miss is not cheaper than a hit: the prototype walk re-probes the receiver.
+        host.GetOwnPropertyCallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void MemberCallBaseProbesOnce()
+    {
+        var engine = new Engine();
+        var host = new ProbeCountingHostObject(engine);
+        engine.SetValue("host", host);
+
+        host.Reset();
+        engine.Evaluate("host.prop.toUpperCase();").Should().Be("VALUE-OF-PROP");
+
+        // Reading a host property as the base of a member call takes a different lane than reading
+        // it as a value, and that lane already costs only one probe — evidence that the extra probe
+        // on the value lane is removable rather than intrinsic.
+        host.GetOwnPropertyCallCount.Should().Be(1);
+    }
+}
+
+/// <summary>
+/// The minimum viable host object: it projects a couple of fields on demand and counts how often
+/// the engine asks. Written against the public surface only, exactly as an embedder must.
+/// </summary>
+file sealed class ProbeCountingHostObject : ObjectInstance
+{
+    public ProbeCountingHostObject(Engine engine) : base(engine)
+    {
+    }
+
+    public int GetOwnPropertyCallCount { get; private set; }
+
+    public void Reset() => GetOwnPropertyCallCount = 0;
+
+    public override PropertyDescriptor GetOwnProperty(JsValue property)
+    {
+        GetOwnPropertyCallCount++;
+
+        if (!property.IsString())
+        {
+            return PropertyDescriptor.Undefined;
+        }
+
+        var name = property.ToString();
+        if (!string.Equals(name, "prop", StringComparison.Ordinal) && !string.Equals(name, "other", StringComparison.Ordinal))
+        {
+            return PropertyDescriptor.Undefined;
+        }
+
+        // A fresh descriptor per probe — the only thing the public API allows.
+        return new PropertyDescriptor(new JsString("value-of-" + name), writable: true, enumerable: true, configurable: true);
+    }
+
+    public override List<JsValue> GetOwnPropertyKeys(Types types = Types.String | Types.Symbol)
+    {
+        var keys = new List<JsValue>(2);
+        if ((types & Types.String) != Types.Empty)
+        {
+            keys.Add(new JsString("prop"));
+            keys.Add(new JsString("other"));
+        }
+
+        return keys;
+    }
+}


### PR DESCRIPTION
Nothing in the benchmark suite measured the shapes an integrator actually runs: a script projecting over host-supplied objects, a fresh engine with a globals table wired up per execution, an interop de-optimization that one narrow registration turns on engine-wide, and a key-chain walk down an untyped host document. Four new lanes, one new parameter on an existing lane, and one test that records today's per-read cost of a host object so a change to it cannot be silent.

**`HostObjectAccessBenchmark`** — one projection loop (member read, member call, computed index, member write, object-literal construction) run over three independent switches. `ReceiverKind` contrasts a plain script object against a custom `ObjectInstance` subclass that materializes its properties on demand, which is the shape an integrator writes and the only one whose reads cannot reach the shape/dictionary lanes in `ObjectInstance.Get`; read `Allocated` next to `Mean`, because a per-read `PropertyDescriptor` is half the story. `ResolverKind` sizes the engine-wide de-optimization that installing any `IReferenceResolver` causes — it is paid on every member read in the script, not only the null-propagating ones the resolver exists for. `StatementLimit` layers an exact constraint on top.

**`FreshEngineGlobalsBenchmark`** — a fresh engine per operation with 1 / 10 / 40 host globals registered on it, as a delegate (reflected over its `Invoke` signature) or as a hand-written `ClrFunction`. `EngineConstructionBenchmark` builds a fresh engine with no globals and `InteropBenchmark` reuses one engine with globals registered once, so registration cost has never been on a measured path even though it is most of what a per-request embedding does before any script runs. The per-global slope is the number that matters. The delegates are built per engine and several capture, so every operation hands the engine a fresh instance — reusing one cached array would measure a different, easier problem.

**`InteropObjectConverterBenchmark`** — registering a single `IObjectConverter` makes `Engine._objectConverters` non-null, and the compiled member-accessor lane must bail out whenever it is set, because a registered converter is entitled to see every CLR value before it becomes a `JsValue`. The consequence is that one narrow converter sends every CLR property read on every wrapped object in the engine back through reflection. The converter installed here converts nothing, so both rows are behaviourally identical and the delta is purely the cost of its presence.

**`InteropNestedDictionaryBenchmark`** — `o.a.b.c.d` over an untyped host document, both as a string-keyed dictionary tree and as a `JsonObject` tree. No existing benchmark measures a *chain*: `InteropBenchmark` reads one level off a dictionary and `InteropLambdaBenchmark` reads one level then iterates. Depth is the point — no level is a property on a declared type, so none of them can use the compiled member accessor, and the two sources reach that conclusion through different machinery, so an improvement to one is not mistaken for an improvement to the other.

**`ConstrainedExecutionBenchmark.StatementLimitEnabled`** — the existing lane only varied a timeout, which is amortizable because a check reads a clock without consuming it. A statement limit is exact: its call frequency *is* its semantics, so it forces the per-statement check path and disarms the tight body lane in `for` / `while` / `do-while`. That gap, not the timeout gap, is what an integrator pays for a runaway-script guard today, and the four rows also show whether the two costs compose or overlap.

**`HostObjectProbeCountTests`** — the benchmark above is built on the claim that a host object is asked for the same own property twice per read. This pins that claim as an exact number rather than leaving it to a doc comment, and it belongs in the public-interface suite because the host it counts is written against the public surface only. The counts assert today's behaviour, not desired behaviour, and the class says so.

### Three things worth recording

Each one nearly produced a benchmark that measured the wrong thing.

* **`Jint.Benchmark/Directory.Build.props` is deliberately empty**, which stops the root props — warnings-as-errors and nullable reference types among them — from reaching this project. New files opt in themselves with `#nullable enable`; without it the host types here compile with no null analysis at all.
* **Jint grants `Jint.Benchmark` `InternalsVisibleTo`**, so a host type written here can quietly reach members no third-party integrator can. `LazyHostObject` and `LazyHostString` restrict themselves to the public surface on purpose — otherwise the lane would model a host nobody can actually write. `LazyHostString` documents where that bites: `JsString.EnsureCapacity` is `internal virtual`, so it is not overridable from outside the assembly, and it dereferences the backing field a subclass cannot populate — `String.prototype.concat` on such a string throws. The workload avoids `concat` deliberately, and the note says to drop it once the base class routes that call through `ToString()` the way `JsString.SlicedString` does.
* **`options.MaxStatements(int.MaxValue)` registers nothing at all** (#2789 documents why: the constraint counts statements in an `int`, so the comparison can never be true). Both statement-limit lanes use `100_000_000` for that reason and say so at the constant. Spelling "effectively unlimited" the obvious way would have made every `StatementLimit=true` row a second copy of the unconstrained row and reported a bogus zero gap.

### Verification

No benchmark was run. Each of the 26 parameter combinations across the five benchmark types was executed exactly once through a temporary reflection driver — set the `[Params]` properties, invoke `[GlobalSetup]`, invoke the `[Benchmark]` method — which reported the expected result for every combination (`15000`, `3`, `18000`, `1500`, `2000000` respectively). The driver was deleted afterwards and is not part of this diff.

Release build clean (the only warning is the pre-existing `MSB3277` in `Jint.Tests.CommonScripts` net472, present on `main`). `Jint.Tests` 4123 net10.0 / 4059 net472, `Jint.Tests.PublicInterface` 153 (149 on `main` plus the four new probe-count tests), `Jint.Tests.Test262` 99441 passed / 0 failed / 157 skipped — all identical to `main` apart from the four added tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
