### PR TITLE
Widen two host-bridging members to public

### DIFF
--- a/Jint.Tests.PublicInterface/HostValueBridgingTests.cs
+++ b/Jint.Tests.PublicInterface/HostValueBridgingTests.cs
@@ -1,0 +1,129 @@
+#nullable enable
+
+using System.Collections.Generic;
+using Jint.Native;
+using Jint.Native.Array;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Small public-surface gaps that host code hits when bridging values in and out of the engine. These tests
+/// would not compile if the members they exercise were still non-public.
+/// </summary>
+public class HostValueBridgingTests
+{
+    // ArrayInstance.Length is not part of the public surface; hosts read the length the same way script
+    // does. Kept as a helper so the tests below stay about TryGetValue.
+    private static uint ArrayLength(ArrayInstance array) => (uint) array.Get("length").AsNumber();
+
+    [Fact]
+    public void PropertyDescriptorCanBeConstructedFromFlagsDirectly()
+    {
+        var engine = new Engine();
+
+        var descriptor = new PropertyDescriptor(JsNumber.Create(7), PropertyFlag.ConfigurableEnumerableWritable);
+
+        descriptor.Value.AsNumber().Should().Be(7);
+        descriptor.Writable.Should().BeTrue();
+        descriptor.Enumerable.Should().BeTrue();
+        descriptor.Configurable.Should().BeTrue();
+
+        var target = engine.Evaluate("({})").AsObject();
+        target.DefineOwnProperty("answer", descriptor).Should().BeTrue();
+        engine.SetValue("target", target);
+        engine.Evaluate("target.answer").AsNumber().Should().Be(7);
+        engine.Evaluate("Object.keys(target).join(',')").AsString().Should().Be("answer");
+    }
+
+    [Fact]
+    public void PropertyDescriptorFlagsOverloadMatchesTheNullableBoolOverload()
+    {
+        var byFlags = new PropertyDescriptor(new JsString("v"), PropertyFlag.ConfigurableEnumerableWritable);
+        var byBools = new PropertyDescriptor(new JsString("v"), writable: true, enumerable: true, configurable: true);
+
+        byFlags.Writable.Should().Be(byBools.Writable);
+        byFlags.Enumerable.Should().Be(byBools.Enumerable);
+        byFlags.Configurable.Should().Be(byBools.Configurable);
+        byFlags.Value.Should().Be(byBools.Value);
+    }
+
+    [Fact]
+    public void PropertyDescriptorSupportsNonEnumerableCombinations()
+    {
+        var engine = new Engine();
+
+        var hidden = new PropertyDescriptor(JsNumber.Create(1), PropertyFlag.Configurable | PropertyFlag.Writable);
+        hidden.Enumerable.Should().BeFalse();
+
+        var target = engine.Evaluate("({})").AsObject();
+        target.DefineOwnProperty("hidden", hidden);
+        engine.SetValue("target", target);
+
+        engine.Evaluate("Object.keys(target).length").AsNumber().Should().Be(0);
+        engine.Evaluate("target.hidden").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void ArrayTryGetValueDistinguishesHolesFromStoredUndefined()
+    {
+        var engine = new Engine();
+        var array = (ArrayInstance) engine.Evaluate("[0, 1, , undefined, 4]").AsObject();
+
+        ArrayLength(array).Should().Be(5);
+
+        array.TryGetValue(0, out var zero).Should().BeTrue();
+        zero.AsNumber().Should().Be(0);
+
+        // index 2 is a hole
+        array.TryGetValue(2, out var hole).Should().BeFalse();
+        hole.IsUndefined().Should().BeTrue();
+
+        // index 3 holds a real undefined
+        array.TryGetValue(3, out var stored).Should().BeTrue();
+        stored.IsUndefined().Should().BeTrue();
+
+        array.TryGetValue(4, out var four).Should().BeTrue();
+        four.AsNumber().Should().Be(4);
+
+        // past the end
+        array.TryGetValue(5, out var beyond).Should().BeFalse();
+        beyond.IsUndefined().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ArrayTryGetValueResolvesInheritedIndices()
+    {
+        var engine = new Engine();
+        var array = (ArrayInstance) engine.Evaluate("""
+            var proto = { 1: 'from-proto' };
+            var a = [ 'own' ];
+            a.length = 3;
+            Object.setPrototypeOf(a, proto);
+            a
+            """).AsObject();
+
+        array.TryGetValue(0, out var own).Should().BeTrue();
+        own.AsString().Should().Be("own");
+
+        array.TryGetValue(1, out var inherited).Should().BeTrue();
+        inherited.AsString().Should().Be("from-proto");
+
+        array.TryGetValue(2, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ArrayTryGetValueBridgesASparseArrayInOnePass()
+    {
+        var engine = new Engine();
+        var array = (ArrayInstance) engine.Evaluate("var a = []; a[0] = 'a'; a[3] = 'd'; a").AsObject();
+
+        var bridged = new List<string?>();
+        for (uint i = 0; i < ArrayLength(array); i++)
+        {
+            bridged.Add(array.TryGetValue(i, out var value) ? value.ToString() : null);
+        }
+
+        bridged.Should().Equal("a", null, null, "d");
+    }
+}

--- a/Jint/Native/Array/ArrayInstance.cs
+++ b/Jint/Native/Array/ArrayInstance.cs
@@ -988,8 +988,20 @@ public class ArrayInstance : ObjectInstance, IEnumerable<JsValue>
         return descriptor is not null;
     }
 
+    /// <summary>
+    /// Hole-aware indexed read: returns <see langword="false"/> when <paramref name="index"/> resolves to
+    /// nothing — an array hole or an index past the end with no inherited property — and
+    /// <see langword="true"/> with the resolved value otherwise. Unlike <c>this[uint]</c>, which cannot
+    /// distinguish a hole from a stored <c>undefined</c>, this preserves that distinction, so host code
+    /// bridging a JavaScript array into a sparse-aware representation can tell the two apart in a single
+    /// pass. Getters on the array or its prototype chain are invoked, exactly as an indexed read from
+    /// script would.
+    /// </summary>
+    /// <param name="index">The array index to read.</param>
+    /// <param name="value">The resolved value, or <see cref="JsValue.Undefined"/> when the result is <see langword="false"/>.</param>
+    /// <returns>Whether the index resolved to a value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal bool TryGetValue(uint index, out JsValue value)
+    public bool TryGetValue(uint index, out JsValue value)
     {
         value = GetValue(index, unwrapFromNonDataDescriptor: true)!;
 

--- a/Jint/Runtime/Descriptors/PropertyDescriptor.cs
+++ b/Jint/Runtime/Descriptors/PropertyDescriptor.cs
@@ -23,8 +23,24 @@ public class PropertyDescriptor
         _flags = flags & ~PropertyFlag.NonData;
     }
 
+    /// <summary>
+    /// Creates a descriptor with the attribute bits given directly, instead of the three
+    /// <see cref="Nullable{T}"/> attributes the <see cref="PropertyDescriptor(JsValue?, bool?, bool?, bool?)"/>
+    /// overload has to translate into flags one branchy setter at a time. Host code that already
+    /// knows the attributes it wants — the common case when bridging host state into JavaScript —
+    /// should prefer this constructor and a ready-made combination such as
+    /// <see cref="PropertyFlag.ConfigurableEnumerableWritable"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="PropertyFlag.CustomJsValue"/> is reserved for subclasses that override
+    /// <see cref="CustomValue"/>: passing it routes <paramref name="value"/> through that virtual
+    /// setter, so on a type that does not override it the flag only adds an indirection on every
+    /// read and write. Do not pass it from ordinary host descriptors.
+    /// </remarks>
+    /// <param name="value">The property value, or <see langword="null"/> for a descriptor whose value is supplied later.</param>
+    /// <param name="flags">The property attributes.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected internal PropertyDescriptor(JsValue? value, PropertyFlag flags) : this(flags)
+    public PropertyDescriptor(JsValue? value, PropertyFlag flags) : this(flags)
     {
         if ((_flags & PropertyFlag.CustomJsValue) != PropertyFlag.None)
         {


### PR DESCRIPTION
Two members that host code has to reach for when bridging values across the boundary, but that are currently non-public.

### `PropertyDescriptor(JsValue?, PropertyFlag)` → `public`

The only descriptor constructor reachable from outside the assembly is `(JsValue?, bool?, bool?, bool?)`, which translates the three nullable attributes into flags one branchy setter at a time. A host that already knows the attributes it wants — the common case when projecting host state into JavaScript — can now pass a ready-made combination such as `PropertyFlag.ConfigurableEnumerableWritable` straight in:

```csharp
var descriptor = new PropertyDescriptor(JsNumber.Create(7), PropertyFlag.ConfigurableEnumerableWritable);
target.DefineOwnProperty("answer", descriptor);
```

Documented on the constructor: `PropertyFlag.CustomJsValue` stays reserved for subclasses that override `CustomValue`. Passing it routes the value through that virtual setter, so on a type that does not override it the flag only buys an indirection on every read and write.

### `ArrayInstance.TryGetValue(uint, out JsValue)` → `public`

It is the only indexed read that distinguishes an array *hole* from a stored `undefined` — `this[uint]` cannot — so bridging a JavaScript array into a sparse-aware host representation previously needed a second pass through script (`i in arr`). Getters on the array and its prototype chain are invoked exactly as an indexed read from script would.

Nothing else on `ArrayInstance` is widened: `_dense`, `CanUseFastAccess` and `TryGetValueFast` stay internal, and `JsArray` stays sealed.

### Noted, not addressed

While writing the tests it turned out that **`ArrayInstance` exposes no public length member at all** — `GetLength()` is `internal override`, and `Length` is not public either — so driving a hole-aware indexed read from host code means going through `array.Get("length").AsNumber()`, i.e. a `JsValue` round-trip per array. The tests do exactly that, in a helper, to keep them about `TryGetValue`. Widening a length accessor is a separate decision about `ArrayInstance`'s public surface, so it is deliberately **not** part of this PR; flagging it as a possible follow-up.

### Tests

`Jint.Tests.PublicInterface/HostValueBridgingTests.cs` — these would not compile if the members were still non-public. Covers the flags constructor against the nullable-bool overload, non-enumerable combinations, hole-vs-stored-`undefined`, inherited indices via the prototype chain, and a full sparse-array bridge in one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
