### PR TITLE
Document what the Fast* property setters actually skip

### DIFF
--- a/Jint/Native/Object/ObjectInstance.Fast.cs
+++ b/Jint/Native/Object/ObjectInstance.Fast.cs
@@ -4,16 +4,38 @@ using Jint.Runtime.Descriptors;
 namespace Jint.Native.Object;
 
 /// <summary>
-/// Fast access helpers which violate JavaScript specification, but helpful when accessed
-/// against ObjectInstance and prototype chain is intact.
+/// Raw own-property write helpers that bypass the ECMAScript <c>[[Set]]</c> / <c>[[DefineOwnProperty]]</c>
+/// pipeline. They are intended for building up an object the host fully controls — populating a freshly
+/// created object, or installing members on a host-provided global — and are not a general substitute for
+/// <see cref="ObjectInstance.Set(JsValue,JsValue,JsValue)"/> or
+/// <see cref="ObjectInstance.DefineOwnProperty"/>. See the individual members for what is skipped.
 /// </summary>
 public partial class ObjectInstance
 {
     /// <summary>
-    /// Creates data property without checking prototype, property existence and overwrites any data already present.
+    /// Stores <paramref name="value"/> as an own property named <paramref name="name"/> on this object,
+    /// replacing any own property of that name.
     /// </summary>
     /// <remarks>
-    /// Does not conform to JavaScript specification prototype etc. handling etc.
+    /// <para>
+    /// The write always lands as an <em>own</em> property on the receiver and therefore <em>shadows</em>
+    /// anything of that name inherited from the prototype chain. If the member is — or later becomes —
+    /// prototype-resident, this silently creates a shadow rather than updating the inherited member, and a
+    /// data descriptor can end up shadowing an inherited accessor. (<c>Error.prototype.stack</c> is a
+    /// concrete example of a member that lives on the prototype as an accessor.)
+    /// </para>
+    /// <para>
+    /// No inherited setter is invoked, and no <c>[[DefineOwnProperty]]</c> validation runs — extensibility,
+    /// the configurable/writable flags of an existing property, and the data/accessor compatibility rules
+    /// are all ignored, and no <c>TypeError</c> can be raised. That is what "fast" means here.
+    /// </para>
+    /// <para>
+    /// Storing a raw <see cref="PropertyDescriptor"/> is a dictionary-mode operation, so a shape-mode
+    /// receiver is deoptimized and permanently forfeits the shape inline cache used for property reads and
+    /// writes. Prefer this for setup-time writes only; for steady-state mutation of an existing property use
+    /// <see cref="ObjectInstance.Set(JsValue,JsValue,JsValue)"/>, which stores through the existing
+    /// descriptor and leaves the receiver's layout intact.
+    /// </para>
     /// </remarks>
     public void FastSetProperty(string name, PropertyDescriptor value)
     {
@@ -21,10 +43,29 @@ public partial class ObjectInstance
     }
 
     /// <summary>
-    /// Creates data property without checking prototype, property existence and overwrites any data already present.
+    /// Stores <paramref name="value"/> as an own property keyed by <paramref name="property"/> on this
+    /// object, replacing any own property of that name.
     /// </summary>
     /// <remarks>
-    /// Does not conform to JavaScript specification prototype etc. handling etc.
+    /// <para>
+    /// The write always lands as an <em>own</em> property on the receiver and therefore <em>shadows</em>
+    /// anything of that name inherited from the prototype chain. If the member is — or later becomes —
+    /// prototype-resident, this silently creates a shadow rather than updating the inherited member, and a
+    /// data descriptor can end up shadowing an inherited accessor. (<c>Error.prototype.stack</c> is a
+    /// concrete example of a member that lives on the prototype as an accessor.)
+    /// </para>
+    /// <para>
+    /// No inherited setter is invoked, and no <c>[[DefineOwnProperty]]</c> validation runs — extensibility,
+    /// the configurable/writable flags of an existing property, and the data/accessor compatibility rules
+    /// are all ignored, and no <c>TypeError</c> can be raised. That is what "fast" means here.
+    /// </para>
+    /// <para>
+    /// Storing a raw <see cref="PropertyDescriptor"/> under a string key is a dictionary-mode operation, so a
+    /// shape-mode receiver is deoptimized and permanently forfeits the shape inline cache used for property
+    /// reads and writes. Prefer this for setup-time writes only; for steady-state mutation of an existing
+    /// property use <see cref="ObjectInstance.Set(JsValue,JsValue,JsValue)"/>, which stores through the
+    /// existing descriptor and leaves the receiver's layout intact.
+    /// </para>
     /// </remarks>
     public void FastSetProperty(JsValue property, PropertyDescriptor value)
     {
@@ -32,10 +73,29 @@ public partial class ObjectInstance
     }
 
     /// <summary>
-    /// Creates data property (configurable, enumerable, writable) without checking prototype, property existence and overwrites any data already present.
+    /// Stores <paramref name="value"/> as a configurable, enumerable, writable own data property named
+    /// <paramref name="name"/> on this object, replacing any own property of that name.
     /// </summary>
     /// <remarks>
-    /// Does not conform to JavaScript specification prototype etc. handling etc.
+    /// <para>
+    /// The write always lands as an <em>own</em> property on the receiver and therefore <em>shadows</em>
+    /// anything of that name inherited from the prototype chain. If the member is — or later becomes —
+    /// prototype-resident, this silently creates a shadow rather than updating the inherited member, and
+    /// the data property written here can end up shadowing an inherited accessor. (<c>Error.prototype.stack</c>
+    /// is a concrete example of a member that lives on the prototype as an accessor.)
+    /// </para>
+    /// <para>
+    /// No inherited setter is invoked, and no <c>[[DefineOwnProperty]]</c> validation runs — extensibility,
+    /// the configurable/writable flags of an existing property, and the data/accessor compatibility rules
+    /// are all ignored, and no <c>TypeError</c> can be raised. That is what "fast" means here.
+    /// </para>
+    /// <para>
+    /// It stores a raw <see cref="PropertyDescriptor"/>, which is a dictionary-mode operation, so a shape-mode
+    /// receiver is deoptimized and permanently forfeits the shape inline cache used for property reads and
+    /// writes. Prefer this for setup-time writes only; for steady-state mutation of an existing property use
+    /// <see cref="ObjectInstance.Set(JsValue,JsValue,JsValue)"/>, which stores through the existing
+    /// descriptor and leaves the receiver's layout intact.
+    /// </para>
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void FastSetDataProperty(string name, JsValue value)


### PR DESCRIPTION
The `Fast*` property setters carried this as their entire contract:

```
/// Creates data property without checking prototype, property existence and overwrites any data already present.
/// Does not conform to JavaScript specification prototype etc. handling etc.
```

That is not enough to decide whether they are safe for a given write, and getting it wrong is silent — the script reads back what it wrote while the intended target never changed. This spells out the three consequences instead.

- **The write always lands as an own property**, so it *shadows* anything of that name inherited from the prototype chain rather than updating it — including shadowing an inherited accessor with a data property. `Error.prototype.stack` is a concrete member this happens to.
- **No inherited setter runs and no `[[DefineOwnProperty]]` validation runs**: extensibility, an existing property's configurable/writable flags, and the data/accessor compatibility rules are all ignored, and no `TypeError` can be raised. That is what "fast" means here.
- **Storing a raw `PropertyDescriptor` is a dictionary-mode operation**, so a shape-mode receiver is deoptimized and permanently loses the shape inline cache used for property reads and writes. These are setup-time helpers; steady-state mutation of an existing property belongs on `Set`, which stores through the existing descriptor and leaves the layout intact.

The class-level summary now says what the group is *for* — building up an object the host fully controls, such as a freshly created object or a host-provided global — rather than only what it violates.

Documentation only; no behaviour change.

### Verification

Release build (warnings are errors): 0 errors, 1 warning — the pre-existing `MSB3277` in `Jint.Tests.CommonScripts` on `net472`, present on clean `main` too. `Jint.Tests` 4123 (net10.0) / 4059 (net472), `Jint.Tests.PublicInterface` 149, `Jint.Tests.Test262` 99441 passed / 157 skipped — all identical to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
