### PR TITLE
Let host objects declare their property-access semantics

### DIFF
--- a/Jint.Benchmark/HostObjectAccessBenchmark.cs
+++ b/Jint.Benchmark/HostObjectAccessBenchmark.cs
@@ -29,19 +29,19 @@ namespace Jint.Benchmark;
 /// <list type="bullet">
 /// <item><description>
 /// <see cref="ReceiverKind"/> — <see cref="HostReceiverKind.PlainObject"/> is the script-object
-/// floor. <see cref="HostReceiverKind.LazyHost"/> is the cost an embedder pays when it declares
-/// nothing: every own-property read goes through the virtual
-/// <see cref="ObjectInstance.GetOwnProperty"/> (the fast shape/dictionary lanes in
-/// <see cref="ObjectInstance.Get(JsValue, JsValue)"/> are not reachable for a
-/// non-<c>PlainObject</c> receiver) <b>twice</b>, allocating a fresh
-/// <see cref="PropertyDescriptor"/> each time and discarding one of them. Expect the LazyHost row
-/// to be several times the PlainObject row in both time and <c>Allocated</c>, with the allocation
-/// delta ≈ (descriptor size × own-property reads) — descriptor churn is half the story, so always
-/// read the <c>Allocated</c> column next to <c>Mean</c> here.
-/// <see cref="HostReceiverKind.LazyHostOrdinary"/> is the same host declaring
-/// <see cref="PropertyAccessSemantics.Ordinary"/>, which halves the probes on an own-property hit;
-/// it still allocates the descriptor the surviving probe returns, so the gap it closes against
-/// PlainObject should be visible on <c>Mean</c> and only partial on <c>Allocated</c>.
+/// floor. <see cref="HostReceiverKind.LazyHost"/> is what an embedder pays for a custom subclass
+/// that overrides <see cref="ObjectInstance.GetOwnProperty"/> and nothing else: the engine derives
+/// <see cref="PropertyAccessSemantics.Ordinary"/> for it, so an own-property read costs one virtual
+/// probe (the fast shape/dictionary lanes in <see cref="ObjectInstance.Get(JsValue, JsValue)"/> are
+/// not reachable for a non-<c>PlainObject</c> receiver) and the fresh
+/// <see cref="PropertyDescriptor"/> that probe returns. Descriptor churn is half the story, so
+/// always read the <c>Allocated</c> column next to <c>Mean</c> here — the allocation delta against
+/// PlainObject is ≈ (descriptor size × own-property reads).
+/// <see cref="HostReceiverKind.LazyHostExotic"/> is the identical projection behind an override of
+/// <c>Get</c> that only delegates to <c>base.Get</c>. Nothing about the values changes; the engine
+/// derives <see cref="PropertyAccessSemantics.Exotic"/> from the override alone and routes every
+/// read through the full <c>Get</c> pipeline. The LazyHost → LazyHostExotic delta is therefore the
+/// price of being exotic, paid by a host that genuinely needs to observe every read.
 /// <see cref="HostReceiverKind.FixedLayout"/> is the same host records built through
 /// <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/>: a declared layout
 /// resolves to one interned hidden class, so every item in the batch shares it and reads take the
@@ -115,7 +115,7 @@ public class HostObjectAccessBenchmark
     [Params(
         HostReceiverKind.PlainObject,
         HostReceiverKind.LazyHost,
-        HostReceiverKind.LazyHostOrdinary,
+        HostReceiverKind.LazyHostExotic,
         HostReceiverKind.FixedLayout)]
     public HostReceiverKind ReceiverKind { get; set; }
 
@@ -132,7 +132,7 @@ public class HostObjectAccessBenchmark
         {
             case HostReceiverKind.PlainObject:
             case HostReceiverKind.LazyHost:
-            case HostReceiverKind.LazyHostOrdinary:
+            case HostReceiverKind.LazyHostExotic:
             case HostReceiverKind.FixedLayout:
                 break;
 
@@ -205,9 +205,7 @@ public class HostObjectAccessBenchmark
         // projected values end up in and what that representation declares about its own access.
         var fixedLayout = kind == HostReceiverKind.FixedLayout;
         var slots = fixedLayout ? new JsValue[_itemLayout.Count] : [];
-        var semantics = kind == HostReceiverKind.LazyHostOrdinary
-            ? PropertyAccessSemantics.Ordinary
-            : PropertyAccessSemantics.Unspecified;
+        var exotic = kind == HostReceiverKind.LazyHostExotic;
 
         var items = new JsValue[ItemCount];
         for (var i = 0; i < items.Length; i++)
@@ -224,7 +222,9 @@ public class HostObjectAccessBenchmark
 
             if (!fixedLayout)
             {
-                items[i] = new LazyHostObject(engine, text, numbers, semantics);
+                items[i] = exotic
+                    ? new ExoticLazyHostObject(engine, text, numbers)
+                    : new LazyHostObject(engine, text, numbers);
                 continue;
             }
 
@@ -249,16 +249,19 @@ public enum HostReceiverKind
 
     /// <summary>
     /// Custom <see cref="ObjectInstance"/> subclass projecting from a native record through the
-    /// virtual <see cref="ObjectInstance.GetOwnProperty"/>, declaring nothing. This is the default,
-    /// so it is what an embedder pays unless it opts in.
+    /// virtual <see cref="ObjectInstance.GetOwnProperty"/>, overriding nothing else and declaring
+    /// nothing. The engine derives <see cref="PropertyAccessSemantics.Ordinary"/> for it, so this is
+    /// what an embedder gets without doing anything.
     /// </summary>
     LazyHost,
 
     /// <summary>
-    /// The same host declaring <see cref="PropertyAccessSemantics.Ordinary"/>, so the engine may
-    /// resolve an own-property read from a single <see cref="ObjectInstance.GetOwnProperty"/> probe.
+    /// The same projection behind an override of <see cref="ObjectInstance.Get(JsValue, JsValue)"/>
+    /// that only delegates to the base implementation. The override alone makes the engine derive
+    /// <see cref="PropertyAccessSemantics.Exotic"/>, so this row is the cost of being exotic with
+    /// every other variable held fixed.
     /// </summary>
-    LazyHostOrdinary,
+    LazyHostExotic,
 
     /// <summary>Awaits the descriptor-free read hook. Not runnable yet.</summary>
     LazyHostValueHook,
@@ -328,9 +331,11 @@ internal sealed class UnfilteredNullPropagationResolver : IReferenceResolver
 /// </para>
 ///
 /// <para>
-/// The <c>semantics</c> argument is the only difference between the
-/// <see cref="HostReceiverKind.LazyHost"/> and <see cref="HostReceiverKind.LazyHostOrdinary"/> rows:
-/// the projection code is identical, so the delta between them is exactly what the declaration buys.
+/// It overrides <see cref="GetOwnProperty"/> and nothing else, so the engine derives
+/// <see cref="PropertyAccessSemantics.Ordinary"/> for it without the host declaring anything. The
+/// <see cref="HostReceiverKind.LazyHostExotic"/> row is <see cref="ExoticLazyHostObject"/>, which adds
+/// a pass-through <c>Get</c> override and nothing else — so the delta between the two rows is exactly
+/// what being derived exotic costs.
 /// </para>
 ///
 /// <para>
@@ -339,7 +344,7 @@ internal sealed class UnfilteredNullPropagationResolver : IReferenceResolver
 /// Jint.Tests.PublicInterface.
 /// </para>
 /// </summary>
-internal sealed class LazyHostObject : ObjectInstance
+internal class LazyHostObject : ObjectInstance
 {
     // id, kind, name, note come from the text array; amount, rate from the numbers array.
     private const int SlotId = 0;
@@ -363,9 +368,8 @@ internal sealed class LazyHostObject : ObjectInstance
     private readonly double[] _numbers;
     private readonly JsValue?[] _projected = new JsValue?[SlotCount];
 
-    public LazyHostObject(Engine engine, string[] text, double[] numbers, PropertyAccessSemantics semantics) : base(engine)
+    public LazyHostObject(Engine engine, string[] text, double[] numbers) : base(engine)
     {
-        SetPropertyAccessSemantics(semantics);
         _text = text;
         _numbers = numbers;
     }
@@ -459,6 +463,23 @@ internal sealed class LazyHostObject : ObjectInstance
         "rate" => SlotRate,
         _ => -1,
     };
+}
+
+/// <summary>
+/// The <see cref="HostReceiverKind.LazyHostExotic"/> receiver: identical projection, identical values,
+/// one added override of <see cref="ObjectInstance.Get(JsValue, JsValue)"/> that does nothing but
+/// delegate. The engine derives <see cref="PropertyAccessSemantics.Exotic"/> from the presence of that
+/// override alone, which is the point — a host does not have to behave exotically to be treated as
+/// exotic, it only has to reserve the right to. A host in this position that knows it is ordinary
+/// declares so through <c>SetPropertyAccessSemantics</c> and lands back on the LazyHost row.
+/// </summary>
+internal sealed class ExoticLazyHostObject : LazyHostObject
+{
+    public ExoticLazyHostObject(Engine engine, string[] text, double[] numbers) : base(engine, text, numbers)
+    {
+    }
+
+    public override JsValue Get(JsValue property, JsValue receiver) => base.Get(property, receiver);
 }
 
 /// <summary>

--- a/Jint.Benchmark/HostObjectAccessBenchmark.cs
+++ b/Jint.Benchmark/HostObjectAccessBenchmark.cs
@@ -29,14 +29,19 @@ namespace Jint.Benchmark;
 /// <list type="bullet">
 /// <item><description>
 /// <see cref="ReceiverKind"/> — <see cref="HostReceiverKind.PlainObject"/> is the script-object
-/// floor. <see cref="HostReceiverKind.LazyHost"/> is the cost an embedder actually pays today:
-/// every own-property read goes through the virtual <see cref="ObjectInstance.GetOwnProperty"/>
-/// (the fast shape/dictionary lanes in <see cref="ObjectInstance.Get(JsValue, JsValue)"/> are not
-/// reachable for a non-<c>PlainObject</c> receiver) and allocates a fresh
-/// <see cref="PropertyDescriptor"/> per read. Expect the LazyHost row to be several times the
-/// PlainObject row in both time and <c>Allocated</c>, with the allocation delta ≈
-/// (descriptor size × own-property reads) — descriptor churn is half the story, so always read the
-/// <c>Allocated</c> column next to <c>Mean</c> here.
+/// floor. <see cref="HostReceiverKind.LazyHost"/> is the cost an embedder pays when it declares
+/// nothing: every own-property read goes through the virtual
+/// <see cref="ObjectInstance.GetOwnProperty"/> (the fast shape/dictionary lanes in
+/// <see cref="ObjectInstance.Get(JsValue, JsValue)"/> are not reachable for a
+/// non-<c>PlainObject</c> receiver) <b>twice</b>, allocating a fresh
+/// <see cref="PropertyDescriptor"/> each time and discarding one of them. Expect the LazyHost row
+/// to be several times the PlainObject row in both time and <c>Allocated</c>, with the allocation
+/// delta ≈ (descriptor size × own-property reads) — descriptor churn is half the story, so always
+/// read the <c>Allocated</c> column next to <c>Mean</c> here.
+/// <see cref="HostReceiverKind.LazyHostOrdinary"/> is the same host declaring
+/// <see cref="PropertyAccessSemantics.Ordinary"/>, which halves the probes on an own-property hit;
+/// it still allocates the descriptor the surviving probe returns, so the gap it closes against
+/// PlainObject should be visible on <c>Mean</c> and only partial on <c>Allocated</c>.
 /// <see cref="HostReceiverKind.FixedLayout"/> is the same host records built through
 /// <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/>: a declared layout
 /// resolves to one interned hidden class, so every item in the batch shares it and reads take the
@@ -96,8 +101,8 @@ public class HostObjectAccessBenchmark
     /// builds — which is the whole point of the API: one layout resolves to one interned hidden
     /// class per engine, so the projection loop stays monomorphic across the batch instead of
     /// meeting a new shape per item. The names are <see cref="LazyHostObject"/>'s own field order,
-    /// which is also the order the <see cref="HostReceiverKind.PlainObject"/> literal uses, so all
-    /// three receivers present identical own-key order.
+    /// which is also the order the <see cref="HostReceiverKind.PlainObject"/> literal uses, so every
+    /// receiver kind presents identical own-key order.
     /// </summary>
     private static readonly JsObjectLayout _itemLayout = new(LazyHostObject.FieldNames);
 
@@ -107,7 +112,11 @@ public class HostObjectAccessBenchmark
     // Only the lanes that compile and run against today's public API are in [Params]; the members
     // awaiting a Jint feature are handled (and rejected) by GlobalSetup so that adding them here is
     // a one-line change once the feature lands.
-    [Params(HostReceiverKind.PlainObject, HostReceiverKind.LazyHost, HostReceiverKind.FixedLayout)]
+    [Params(
+        HostReceiverKind.PlainObject,
+        HostReceiverKind.LazyHost,
+        HostReceiverKind.LazyHostOrdinary,
+        HostReceiverKind.FixedLayout)]
     public HostReceiverKind ReceiverKind { get; set; }
 
     [Params(HostResolverKind.None, HostResolverKind.Unfiltered)]
@@ -123,14 +132,9 @@ public class HostObjectAccessBenchmark
         {
             case HostReceiverKind.PlainObject:
             case HostReceiverKind.LazyHost:
+            case HostReceiverKind.LazyHostOrdinary:
             case HostReceiverKind.FixedLayout:
                 break;
-
-            // TODO: enable once the host-object "ordinary access semantics" opt-in lands — the host
-            // declares a fixed set of own properties up front so reads can take the ordinary
-            // (shape/dictionary) lane instead of the virtual GetOwnProperty lane. Distinct from
-            // FixedLayout above, which gives up the custom subclass entirely; this one keeps it.
-            case HostReceiverKind.LazyHostOrdinary:
 
             // TODO: enable once the descriptor-free read hook lands — a host hook that returns the
             // JsValue directly, so a read no longer allocates a PropertyDescriptor to carry it.
@@ -196,11 +200,14 @@ public class HostObjectAccessBenchmark
                 """);
         }
 
-        // Both host lanes start from the identical native record and run it through the identical
-        // projection, so the only thing that varies between them is the object representation the
-        // projected values end up in.
+        // Every host lane starts from the identical native record and runs it through the identical
+        // projection, so the only things that vary between them are the object representation the
+        // projected values end up in and what that representation declares about its own access.
         var fixedLayout = kind == HostReceiverKind.FixedLayout;
         var slots = fixedLayout ? new JsValue[_itemLayout.Count] : [];
+        var semantics = kind == HostReceiverKind.LazyHostOrdinary
+            ? PropertyAccessSemantics.Ordinary
+            : PropertyAccessSemantics.Unspecified;
 
         var items = new JsValue[ItemCount];
         for (var i = 0; i < items.Length; i++)
@@ -217,7 +224,7 @@ public class HostObjectAccessBenchmark
 
             if (!fixedLayout)
             {
-                items[i] = new LazyHostObject(engine, text, numbers);
+                items[i] = new LazyHostObject(engine, text, numbers, semantics);
                 continue;
             }
 
@@ -242,11 +249,15 @@ public enum HostReceiverKind
 
     /// <summary>
     /// Custom <see cref="ObjectInstance"/> subclass projecting from a native record through the
-    /// virtual <see cref="ObjectInstance.GetOwnProperty"/>. This is what embedders write today.
+    /// virtual <see cref="ObjectInstance.GetOwnProperty"/>, declaring nothing. This is the default,
+    /// so it is what an embedder pays unless it opts in.
     /// </summary>
     LazyHost,
 
-    /// <summary>Awaits the host-object "ordinary access semantics" opt-in. Not runnable yet.</summary>
+    /// <summary>
+    /// The same host declaring <see cref="PropertyAccessSemantics.Ordinary"/>, so the engine may
+    /// resolve an own-property read from a single <see cref="ObjectInstance.GetOwnProperty"/> probe.
+    /// </summary>
     LazyHostOrdinary,
 
     /// <summary>Awaits the descriptor-free read hook. Not runnable yet.</summary>
@@ -308,13 +319,18 @@ internal sealed class UnfilteredNullPropagationResolver : IReferenceResolver
 /// arrives in) into JavaScript properties on demand.
 ///
 /// <para>
-/// This is deliberately the <b>today</b> baseline, written the only way the current public API
-/// allows: override the virtual <see cref="GetOwnProperty"/> and hand back a
-/// <see cref="PropertyDescriptor"/>. The projected <see cref="JsValue"/> is memoized per field
-/// (an embedder that re-projected on every read would also defeat every downstream identity cache,
-/// which would measure something else), but the descriptor itself is rebuilt on every call because
-/// the public API offers no way to avoid it. That per-read descriptor is the allocation this lane
-/// exists to size.
+/// Written the only way the public API allows: override the virtual <see cref="GetOwnProperty"/> and
+/// hand back a <see cref="PropertyDescriptor"/>. The projected <see cref="JsValue"/> is memoized per
+/// field (an embedder that re-projected on every read would also defeat every downstream identity
+/// cache, which would measure something else), but the descriptor itself is rebuilt on every call
+/// because the public API offers no way to avoid it. That per-read descriptor is the allocation this
+/// lane exists to size.
+/// </para>
+///
+/// <para>
+/// The <c>semantics</c> argument is the only difference between the
+/// <see cref="HostReceiverKind.LazyHost"/> and <see cref="HostReceiverKind.LazyHostOrdinary"/> rows:
+/// the projection code is identical, so the delta between them is exactly what the declaration buys.
 /// </para>
 ///
 /// <para>
@@ -347,8 +363,9 @@ internal sealed class LazyHostObject : ObjectInstance
     private readonly double[] _numbers;
     private readonly JsValue?[] _projected = new JsValue?[SlotCount];
 
-    public LazyHostObject(Engine engine, string[] text, double[] numbers) : base(engine)
+    public LazyHostObject(Engine engine, string[] text, double[] numbers, PropertyAccessSemantics semantics) : base(engine)
     {
+        SetPropertyAccessSemantics(semantics);
         _text = text;
         _numbers = numbers;
     }

--- a/Jint.Tests.PublicInterface/HostObjectEnumerationTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectEnumerationTests.cs
@@ -6,16 +6,18 @@ namespace Jint.Tests.PublicInterface;
 /// The read path resolves a <see cref="PropertyAccessSemantics.Ordinary"/> host object from a single
 /// own-property probe instead of routing through <c>Get</c>. These tests pin the enumeration and
 /// existence-check paths — which never took that shortcut — against the same object, so a future change to the
-/// read lane cannot desync the two.
+/// read lane cannot desync the two. Each case runs over both derived outcomes: a host that overrides only
+/// <c>GetOwnProperty</c> (derived ordinary, short lane) and one that adds a pure pass-through <c>Get</c>
+/// override (derived exotic, full pipeline). The two answer identically by construction, so any difference an
+/// assertion below can see is the engine's doing, not the host's.
 /// </summary>
 public class HostObjectEnumerationTests
 {
-    private static Engine CreateEngineWithHost(PropertyAccessSemantics semantics)
+    private static Engine CreateEngineWithHost(bool overridesGet)
     {
         var engine = new Engine();
-        var host = new ProjectedHostObject(engine, semantics)
-            .Project("alpha", 1)
-            .Project("beta", "two");
+        var host = overridesGet ? new PassThroughGetHostObject(engine) : new ProjectedHostObject(engine);
+        host.Project("alpha", 1).Project("beta", "two");
 
         engine.SetValue("host", host);
         engine.Execute("Object.prototype.inheritedOnly = 'from-prototype';");
@@ -23,11 +25,11 @@ public class HostObjectEnumerationTests
     }
 
     [Theory]
-    [InlineData(PropertyAccessSemantics.Unspecified)]
-    [InlineData(PropertyAccessSemantics.Ordinary)]
-    public void ExistenceChecksSeeExactlyTheProjectedProperties(PropertyAccessSemantics semantics)
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExistenceChecksSeeExactlyTheProjectedProperties(bool overridesGet)
     {
-        var engine = CreateEngineWithHost(semantics);
+        var engine = CreateEngineWithHost(overridesGet);
 
         engine.Evaluate("'alpha' in host").Should().Be(true);
         engine.Evaluate("'absent' in host").Should().Be(false);
@@ -43,11 +45,11 @@ public class HostObjectEnumerationTests
     }
 
     [Theory]
-    [InlineData(PropertyAccessSemantics.Unspecified)]
-    [InlineData(PropertyAccessSemantics.Ordinary)]
-    public void ReflectionOverAHostObjectMatchesItsReads(PropertyAccessSemantics semantics)
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ReflectionOverAHostObjectMatchesItsReads(bool overridesGet)
     {
-        var engine = CreateEngineWithHost(semantics);
+        var engine = CreateEngineWithHost(overridesGet);
 
         engine.Evaluate("Object.keys(host).join(',')").Should().Be("alpha,beta");
         engine.Evaluate("Object.values(host).join(',')").Should().Be("1,two");
@@ -60,11 +62,11 @@ public class HostObjectEnumerationTests
     }
 
     [Theory]
-    [InlineData(PropertyAccessSemantics.Unspecified)]
-    [InlineData(PropertyAccessSemantics.Ordinary)]
-    public void CopyingAHostObjectProducesItsProjectedValues(PropertyAccessSemantics semantics)
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CopyingAHostObjectProducesItsProjectedValues(bool overridesGet)
     {
-        var engine = CreateEngineWithHost(semantics);
+        var engine = CreateEngineWithHost(overridesGet);
 
         engine.Evaluate("JSON.stringify(Object.assign({}, host))").Should().Be("""{"alpha":1,"beta":"two"}""");
         engine.Evaluate("JSON.stringify({ ...host })").Should().Be("""{"alpha":1,"beta":"two"}""");

--- a/Jint.Tests.PublicInterface/HostObjectEnumerationTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectEnumerationTests.cs
@@ -1,0 +1,74 @@
+using Jint.Native.Object;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The read path resolves a <see cref="PropertyAccessSemantics.Ordinary"/> host object from a single
+/// own-property probe instead of routing through <c>Get</c>. These tests pin the enumeration and
+/// existence-check paths — which never took that shortcut — against the same object, so a future change to the
+/// read lane cannot desync the two.
+/// </summary>
+public class HostObjectEnumerationTests
+{
+    private static Engine CreateEngineWithHost(PropertyAccessSemantics semantics)
+    {
+        var engine = new Engine();
+        var host = new ProjectedHostObject(engine, semantics)
+            .Project("alpha", 1)
+            .Project("beta", "two");
+
+        engine.SetValue("host", host);
+        engine.Execute("Object.prototype.inheritedOnly = 'from-prototype';");
+        return engine;
+    }
+
+    [Theory]
+    [InlineData(PropertyAccessSemantics.Unspecified)]
+    [InlineData(PropertyAccessSemantics.Ordinary)]
+    public void ExistenceChecksSeeExactlyTheProjectedProperties(PropertyAccessSemantics semantics)
+    {
+        var engine = CreateEngineWithHost(semantics);
+
+        engine.Evaluate("'alpha' in host").Should().Be(true);
+        engine.Evaluate("'absent' in host").Should().Be(false);
+        engine.Evaluate("'inheritedOnly' in host").Should().Be(true);
+
+        engine.Evaluate("host.hasOwnProperty('alpha')").Should().Be(true);
+        engine.Evaluate("host.hasOwnProperty('absent')").Should().Be(false);
+        engine.Evaluate("host.hasOwnProperty('inheritedOnly')").Should().Be(false);
+
+        engine.Evaluate("host.propertyIsEnumerable('alpha')").Should().Be(true);
+        engine.Evaluate("host.propertyIsEnumerable('absent')").Should().Be(false);
+        engine.Evaluate("host.propertyIsEnumerable('inheritedOnly')").Should().Be(false);
+    }
+
+    [Theory]
+    [InlineData(PropertyAccessSemantics.Unspecified)]
+    [InlineData(PropertyAccessSemantics.Ordinary)]
+    public void ReflectionOverAHostObjectMatchesItsReads(PropertyAccessSemantics semantics)
+    {
+        var engine = CreateEngineWithHost(semantics);
+
+        engine.Evaluate("Object.keys(host).join(',')").Should().Be("alpha,beta");
+        engine.Evaluate("Object.values(host).join(',')").Should().Be("1,two");
+        engine.Evaluate("Object.entries(host).map(function (e) { return e[0] + '=' + e[1]; }).join(',')").Should().Be("alpha=1,beta=two");
+        engine.Evaluate("Object.getOwnPropertyNames(host).join(',')").Should().Be("alpha,beta");
+
+        // for-in walks the prototype chain, so it also picks the inherited name up.
+        engine.Evaluate("var seen = []; for (var k in host) { seen.push(k + ':' + host[k]); } seen.join(',');")
+            .Should().Be("alpha:1,beta:two,inheritedOnly:from-prototype");
+    }
+
+    [Theory]
+    [InlineData(PropertyAccessSemantics.Unspecified)]
+    [InlineData(PropertyAccessSemantics.Ordinary)]
+    public void CopyingAHostObjectProducesItsProjectedValues(PropertyAccessSemantics semantics)
+    {
+        var engine = CreateEngineWithHost(semantics);
+
+        engine.Evaluate("JSON.stringify(Object.assign({}, host))").Should().Be("""{"alpha":1,"beta":"two"}""");
+        engine.Evaluate("JSON.stringify({ ...host })").Should().Be("""{"alpha":1,"beta":"two"}""");
+        engine.Evaluate("JSON.stringify(host)").Should().Be("""{"alpha":1,"beta":"two"}""");
+        engine.Evaluate("JSON.stringify(host, ['beta'])").Should().Be("""{"beta":"two"}""");
+    }
+}

--- a/Jint.Tests.PublicInterface/HostObjectProbeCountTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectProbeCountTests.cs
@@ -13,39 +13,49 @@ namespace Jint.Tests.PublicInterface;
 /// writes — for one of its own properties.
 ///
 /// <para>
-/// A host receiver is neither shape-mode nor plain-object, so member reads take the non-plain
-/// lane. Without a <see cref="PropertyAccessSemantics"/> declaration the engine cannot assume the
-/// host's <c>Get</c> is the ordinary one, so it probes <c>GetOwnProperty</c> to establish whether
-/// the name is shadowed on the receiver, discards that descriptor, and then calls <c>Get</c>, which
-/// probes a second time to produce the value. Two virtual calls, two freshly built
-/// <see cref="PropertyDescriptor"/> instances, one of them thrown away — per own-property read.
+/// A host receiver is neither shape-mode nor plain-object, so member reads take the non-plain lane. What that
+/// lane may assume is decided by the object's <see cref="PropertyAccessSemantics"/>, which the engine derives
+/// from the type: a subclass that overrides <c>Get</c> is exotic, one that does not is ordinary.
 /// </para>
 ///
 /// <para>
-/// <b>What changed.</b> These counts were originally written as "today's behaviour, not desired
-/// behaviour", with a note that they should drop once a host could declare its access semantics.
-/// They have: a host that declares <see cref="PropertyAccessSemantics.Ordinary"/> resolves an
-/// own-property <i>hit</i> from a single probe, because the probe that proves the own property is
-/// not shadowed <i>is</i> the read. The <see cref="PropertyAccessSemantics.Unspecified"/> column is
-/// unchanged and stays here on purpose — it is the default, so it is what a host that declares
-/// nothing still pays. Two counts did <i>not</i> drop, and both are recorded here so the difference
-/// is not mistaken for an oversight: an own-property <i>miss</i> still ends in a <c>Get</c> that
-/// re-probes the receiver, because the probe that establishes the miss cannot also produce a value;
-/// and the base of a member call is resolved straight through <c>Get</c> rather than through the
-/// member-read lane, so it already cost one probe and the declaration does not touch it.
+/// <b>What changed.</b> These counts were originally written as "today's behaviour, not desired behaviour",
+/// with a note that they should drop once the engine could tell an ordinary host from an exotic one. It can, so
+/// there are two columns and no host is left paying the old price:
+/// </para>
+///
+/// <list type="bullet">
+/// <item><description>
+/// <b>Ordinary</b> — a host overriding only <c>GetOwnProperty</c>. An own-property <i>hit</i> costs one probe,
+/// because the probe that proves the own property is not shadowed <i>is</i> the read. It used to cost two: one
+/// to prove that, discarded, and one inside <c>Get</c> to produce the value. Nothing had to be declared for
+/// this — not overriding <c>Get</c> is already proof that <c>Get</c> is the ordinary one.
+/// </description></item>
+/// <item><description>
+/// <b>Exotic</b> — a host overriding <c>Get</c>. Every read is routed through <c>Get</c> and the engine probes
+/// nothing on its own behalf, so the count is whatever that <c>Get</c> chooses to do. The host below delegates
+/// to <c>base.Get</c>, which probes once. This column is not a regression from the old undeclared behaviour but
+/// an improvement on it: such a host used to have its <c>Get</c> bypassed entirely for any name resolving on
+/// its prototype.
+/// </description></item>
+/// </list>
+///
+/// <para>
+/// One count is worth reading twice, because it is the one that did <i>not</i> improve: an own-property
+/// <i>miss</i> costs the ordinary host two probes, the same as before. The probe that establishes the miss
+/// cannot also produce a value, so the read still ends in a <c>Get</c> that re-probes the receiver before
+/// walking to the prototype. The exotic host pays one there simply because only its <c>Get</c> probes at all.
 /// </para>
 ///
 /// <para>
-/// The counts are still assertions about behaviour rather than about desirability. The remaining
-/// cost a declaration alone cannot remove is the descriptor a hit materializes at all. Update these
-/// values deliberately when that changes — a silent change in either direction is the thing this
-/// test exists to catch.
+/// The counts are still assertions about behaviour rather than about desirability. Update them deliberately —
+/// a silent change in either direction is the thing this test exists to catch.
 /// </para>
 /// </summary>
 public class HostObjectProbeCountTests
 {
-    // A Debug build of Jint verifies an Ordinary declaration on every read by recomputing the read
-    // through Get and comparing, which costs probes of its own. Release strips the verification
+    // A Debug build of Jint verifies the ordinary semantics on every read, by recomputing the read through Get
+    // and through GetOwnProperty and comparing, which costs probes of its own. Release strips the verification
     // entirely, and Release is the configuration these numbers are about.
 #if DEBUG
     private const int OrdinaryOwnHit = 3;
@@ -55,21 +65,25 @@ public class HostObjectProbeCountTests
     private const int OrdinaryOwnMiss = 2;
 #endif
 
-    private const int UnspecifiedOwnHit = 2;
-    private const int UnspecifiedOwnMiss = 2;
+    // The exotic host's Get delegates to base.Get, which probes once whatever the outcome: on a hit the probe
+    // produces the value, on a miss it establishes the miss before the prototype walk. Nothing in the
+    // interpreter probes on its own behalf for an exotic receiver, so these are entirely the host's own doing.
+    private const int ExoticOwnHit = 1;
+    private const int ExoticOwnMiss = 1;
 
-    // The base of a member call is resolved straight through ObjectInstance.Get rather than through
-    // the member-read lane, so it costs one probe with or without a declaration — and the Debug
-    // verifier, which lives in the member-read lane, never runs for it.
+    // The base of a member call resolves straight through ObjectInstance.Get rather than through the
+    // member-read lane, so it costs one probe in both columns — and the member lane's Debug verifier never runs
+    // for it. This was already true before the derivation; it is what showed that the extra probe on the value
+    // lane was removable rather than intrinsic.
     private const int MemberCallBase = 1;
 
     [Theory]
-    [InlineData(PropertyAccessSemantics.Unspecified, UnspecifiedOwnHit)]
-    [InlineData(PropertyAccessSemantics.Ordinary, OrdinaryOwnHit)]
-    public void AnOwnPropertyReadProbesTheHostObject(PropertyAccessSemantics semantics, int expectedProbes)
+    [InlineData(false, OrdinaryOwnHit)]
+    [InlineData(true, ExoticOwnHit)]
+    public void AnOwnPropertyReadProbesTheHostObject(bool overridesGet, int expectedProbes)
     {
         var engine = new Engine();
-        var host = new ProbeCountingHostObject(engine, semantics);
+        var host = ProbeCountingHostObject.Create(engine, overridesGet);
         engine.SetValue("host", host);
 
         host.Reset();
@@ -77,76 +91,80 @@ public class HostObjectProbeCountTests
 
         value.Should().Be("value-of-prop");
 
-        // Undeclared: one probe to prove the name is not shadowed (descriptor discarded) plus one
-        // inside Get to produce the value. Declared Ordinary: the first probe is the read.
+        // Ordinary: the probe that proves the name is not shadowed is the read. Exotic: the interpreter probes
+        // nothing and the single probe is the one base.Get makes.
         host.GetOwnPropertyCallCount.Should().Be(expectedProbes);
     }
 
     [Theory]
-    [InlineData(PropertyAccessSemantics.Unspecified, 3 * UnspecifiedOwnHit)]
-    [InlineData(PropertyAccessSemantics.Ordinary, 3 * OrdinaryOwnHit)]
-    public void EachOwnPropertyReadCostsItsOwnProbes(PropertyAccessSemantics semantics, int expectedProbes)
+    [InlineData(false, 3 * OrdinaryOwnHit)]
+    [InlineData(true, 3 * ExoticOwnHit)]
+    public void EachOwnPropertyReadCostsItsOwnProbes(bool overridesGet, int expectedProbes)
     {
         var engine = new Engine();
-        var host = new ProbeCountingHostObject(engine, semantics);
+        var host = ProbeCountingHostObject.Create(engine, overridesGet);
         engine.SetValue("host", host);
 
         host.Reset();
         engine.Evaluate("host.prop; host.other; host.prop;");
 
-        // Nothing is cached across reads for a host receiver, with or without the declaration:
-        // three reads, three times the single-read cost.
+        // Nothing is cached across reads for a host receiver in either column: three reads, three times the
+        // single-read cost.
         host.GetOwnPropertyCallCount.Should().Be(expectedProbes);
     }
 
     [Theory]
-    [InlineData(PropertyAccessSemantics.Unspecified, UnspecifiedOwnMiss)]
-    [InlineData(PropertyAccessSemantics.Ordinary, OrdinaryOwnMiss)]
-    public void AMissingOwnPropertyReadIsNoCheaperThanAHit(PropertyAccessSemantics semantics, int expectedProbes)
+    [InlineData(false, OrdinaryOwnMiss)]
+    [InlineData(true, ExoticOwnMiss)]
+    public void AMissingOwnPropertyReadIsNoCheaperThanAHit(bool overridesGet, int expectedProbes)
     {
         var engine = new Engine();
-        var host = new ProbeCountingHostObject(engine, semantics);
+        var host = ProbeCountingHostObject.Create(engine, overridesGet);
         engine.SetValue("host", host);
 
         host.Reset();
         engine.Evaluate("host.notThere;").Should().BeUndefined();
 
-        // A miss is not cheaper than a hit, and the declaration does not make it so: the probe that
-        // establishes the miss cannot also produce a value, so the read still ends in a Get that
-        // re-probes the receiver before walking to the prototype.
+        // For the ordinary host a miss is not cheaper than a hit: the probe that establishes the miss cannot
+        // produce a value, so the read still ends in a Get that re-probes the receiver before walking to the
+        // prototype. This is the one count the derivation did not move.
         host.GetOwnPropertyCallCount.Should().Be(expectedProbes);
     }
 
     [Theory]
-    [InlineData(PropertyAccessSemantics.Unspecified)]
-    [InlineData(PropertyAccessSemantics.Ordinary)]
-    public void AMemberCallBaseProbesOnce(PropertyAccessSemantics semantics)
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AMemberCallBaseProbesOnce(bool overridesGet)
     {
         var engine = new Engine();
-        var host = new ProbeCountingHostObject(engine, semantics);
+        var host = ProbeCountingHostObject.Create(engine, overridesGet);
         engine.SetValue("host", host);
 
         host.Reset();
         engine.Evaluate("host.prop.toUpperCase();").Should().Be("VALUE-OF-PROP");
 
-        // Reading a host property as the base of a member call takes a different lane than reading it
-        // as a value: it goes straight through ObjectInstance.Get, so it already cost only one probe
-        // undeclared — which is the evidence that the extra probe on the value lane was removable
-        // rather than intrinsic. That lane is unaffected by the declaration, so this stays at one.
+        // Reading a host property as the base of a member call takes a different lane than reading it as a
+        // value: it goes straight through ObjectInstance.Get, so it already cost only one probe before any of
+        // this — which is the evidence that the extra probe on the value lane was removable rather than
+        // intrinsic. Neither derived outcome changes it.
         host.GetOwnPropertyCallCount.Should().Be(MemberCallBase);
     }
 }
 
 /// <summary>
-/// The minimum viable host object: it projects a couple of fields on demand and counts how often
-/// the engine asks. Written against the public surface only, exactly as an embedder must.
+/// The minimum viable host object: it projects a couple of fields on demand and counts how often the engine
+/// asks. Written against the public surface only, exactly as an embedder must. The subclass below overrides
+/// <c>Get</c> without changing what it answers, so the two differ in exactly one thing — the semantics the
+/// engine derives for them.
 /// </summary>
-file sealed class ProbeCountingHostObject : ObjectInstance
+internal class ProbeCountingHostObject : ObjectInstance
 {
-    public ProbeCountingHostObject(Engine engine, PropertyAccessSemantics semantics) : base(engine)
+    protected ProbeCountingHostObject(Engine engine) : base(engine)
     {
-        SetPropertyAccessSemantics(semantics);
     }
+
+    internal static ProbeCountingHostObject Create(Engine engine, bool overridesGet)
+        => overridesGet ? new GetOverridingProbeCountingHostObject(engine) : new ProbeCountingHostObject(engine);
 
     public int GetOwnPropertyCallCount { get; private set; }
 
@@ -156,19 +174,29 @@ file sealed class ProbeCountingHostObject : ObjectInstance
     {
         GetOwnPropertyCallCount++;
 
-        if (!property.IsString())
+        if (!TryProject(property, out var value))
         {
             return PropertyDescriptor.Undefined;
         }
 
-        var name = property.ToString();
-        if (!string.Equals(name, "prop", StringComparison.Ordinal) && !string.Equals(name, "other", StringComparison.Ordinal))
+        // A fresh descriptor per probe — all a host that only overrides GetOwnProperty can do.
+        return new PropertyDescriptor(value, writable: true, enumerable: true, configurable: true);
+    }
+
+    private static bool TryProject(JsValue property, out JsValue value)
+    {
+        if (property.IsString())
         {
-            return PropertyDescriptor.Undefined;
+            var name = property.ToString();
+            if (string.Equals(name, "prop", StringComparison.Ordinal) || string.Equals(name, "other", StringComparison.Ordinal))
+            {
+                value = new JsString("value-of-" + name);
+                return true;
+            }
         }
 
-        // A fresh descriptor per probe — the only thing the public API allows.
-        return new PropertyDescriptor(new JsString("value-of-" + name), writable: true, enumerable: true, configurable: true);
+        value = Undefined;
+        return false;
     }
 
     public override List<JsValue> GetOwnPropertyKeys(Types types = Types.String | Types.Symbol)
@@ -182,4 +210,17 @@ file sealed class ProbeCountingHostObject : ObjectInstance
 
         return keys;
     }
+}
+
+/// <summary>
+/// Identical behaviour, one difference: it overrides <c>Get</c>, so the engine derives
+/// <see cref="PropertyAccessSemantics.Exotic"/> for it and routes every read through that override.
+/// </summary>
+internal sealed class GetOverridingProbeCountingHostObject : ProbeCountingHostObject
+{
+    public GetOverridingProbeCountingHostObject(Engine engine) : base(engine)
+    {
+    }
+
+    public override JsValue Get(JsValue property, JsValue receiver) => base.Get(property, receiver);
 }

--- a/Jint.Tests.PublicInterface/HostObjectProbeCountTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectProbeCountTests.cs
@@ -14,27 +14,62 @@ namespace Jint.Tests.PublicInterface;
 ///
 /// <para>
 /// A host receiver is neither shape-mode nor plain-object, so member reads take the non-plain
-/// lane: it first probes <c>GetOwnProperty</c> to establish whether the name is shadowed on the
-/// receiver, discards that descriptor, and then calls <c>Get</c>, which probes a second time to
-/// produce the value. Two virtual calls, two freshly built <see cref="PropertyDescriptor"/>
-/// instances, one of them thrown away — per own-property read.
+/// lane. Without a <see cref="PropertyAccessSemantics"/> declaration the engine cannot assume the
+/// host's <c>Get</c> is the ordinary one, so it probes <c>GetOwnProperty</c> to establish whether
+/// the name is shadowed on the receiver, discards that descriptor, and then calls <c>Get</c>, which
+/// probes a second time to produce the value. Two virtual calls, two freshly built
+/// <see cref="PropertyDescriptor"/> instances, one of them thrown away — per own-property read.
 /// </para>
 ///
 /// <para>
-/// <b>These numbers assert today's behaviour, not desired behaviour.</b> They are expected to
-/// <b>drop</b> when the host-object ordinary-access-semantics work lands (a host that declares its
-/// own-property set up front should be readable in a single probe, and ideally without
-/// materializing a descriptor at all). When that happens, update the expected values here
-/// deliberately — a silent change in either direction is the thing this test exists to catch.
+/// <b>What changed.</b> These counts were originally written as "today's behaviour, not desired
+/// behaviour", with a note that they should drop once a host could declare its access semantics.
+/// They have: a host that declares <see cref="PropertyAccessSemantics.Ordinary"/> resolves an
+/// own-property <i>hit</i> from a single probe, because the probe that proves the own property is
+/// not shadowed <i>is</i> the read. The <see cref="PropertyAccessSemantics.Unspecified"/> column is
+/// unchanged and stays here on purpose — it is the default, so it is what a host that declares
+/// nothing still pays. Two counts did <i>not</i> drop, and both are recorded here so the difference
+/// is not mistaken for an oversight: an own-property <i>miss</i> still ends in a <c>Get</c> that
+/// re-probes the receiver, because the probe that establishes the miss cannot also produce a value;
+/// and the base of a member call is resolved straight through <c>Get</c> rather than through the
+/// member-read lane, so it already cost one probe and the declaration does not touch it.
+/// </para>
+///
+/// <para>
+/// The counts are still assertions about behaviour rather than about desirability. The remaining
+/// cost a declaration alone cannot remove is the descriptor a hit materializes at all. Update these
+/// values deliberately when that changes — a silent change in either direction is the thing this
+/// test exists to catch.
 /// </para>
 /// </summary>
 public class HostObjectProbeCountTests
 {
-    [Fact]
-    public void SimpleOwnPropertyReadProbesTheHostObjectTwice()
+    // A Debug build of Jint verifies an Ordinary declaration on every read by recomputing the read
+    // through Get and comparing, which costs probes of its own. Release strips the verification
+    // entirely, and Release is the configuration these numbers are about.
+#if DEBUG
+    private const int OrdinaryOwnHit = 3;
+    private const int OrdinaryOwnMiss = 4;
+#else
+    private const int OrdinaryOwnHit = 1;
+    private const int OrdinaryOwnMiss = 2;
+#endif
+
+    private const int UnspecifiedOwnHit = 2;
+    private const int UnspecifiedOwnMiss = 2;
+
+    // The base of a member call is resolved straight through ObjectInstance.Get rather than through
+    // the member-read lane, so it costs one probe with or without a declaration — and the Debug
+    // verifier, which lives in the member-read lane, never runs for it.
+    private const int MemberCallBase = 1;
+
+    [Theory]
+    [InlineData(PropertyAccessSemantics.Unspecified, UnspecifiedOwnHit)]
+    [InlineData(PropertyAccessSemantics.Ordinary, OrdinaryOwnHit)]
+    public void AnOwnPropertyReadProbesTheHostObject(PropertyAccessSemantics semantics, int expectedProbes)
     {
         var engine = new Engine();
-        var host = new ProbeCountingHostObject(engine);
+        var host = new ProbeCountingHostObject(engine, semantics);
         engine.SetValue("host", host);
 
         host.Reset();
@@ -42,54 +77,63 @@ public class HostObjectProbeCountTests
 
         value.Should().Be("value-of-prop");
 
-        // Today: one probe to prove the name is not shadowed (descriptor discarded) plus one inside
-        // Get to produce the value. Should become 1 — or 0 descriptors — with ordinary access semantics.
-        host.GetOwnPropertyCallCount.Should().Be(2);
+        // Undeclared: one probe to prove the name is not shadowed (descriptor discarded) plus one
+        // inside Get to produce the value. Declared Ordinary: the first probe is the read.
+        host.GetOwnPropertyCallCount.Should().Be(expectedProbes);
     }
 
-    [Fact]
-    public void EachOwnPropertyReadCostsItsOwnProbes()
+    [Theory]
+    [InlineData(PropertyAccessSemantics.Unspecified, 3 * UnspecifiedOwnHit)]
+    [InlineData(PropertyAccessSemantics.Ordinary, 3 * OrdinaryOwnHit)]
+    public void EachOwnPropertyReadCostsItsOwnProbes(PropertyAccessSemantics semantics, int expectedProbes)
     {
         var engine = new Engine();
-        var host = new ProbeCountingHostObject(engine);
+        var host = new ProbeCountingHostObject(engine, semantics);
         engine.SetValue("host", host);
 
         host.Reset();
         engine.Evaluate("host.prop; host.other; host.prop;");
 
-        // Nothing is cached across reads for a host receiver: three reads, three times the
-        // single-read cost.
-        host.GetOwnPropertyCallCount.Should().Be(6);
+        // Nothing is cached across reads for a host receiver, with or without the declaration:
+        // three reads, three times the single-read cost.
+        host.GetOwnPropertyCallCount.Should().Be(expectedProbes);
     }
 
-    [Fact]
-    public void MissingOwnPropertyReadAlsoProbesTwice()
+    [Theory]
+    [InlineData(PropertyAccessSemantics.Unspecified, UnspecifiedOwnMiss)]
+    [InlineData(PropertyAccessSemantics.Ordinary, OrdinaryOwnMiss)]
+    public void AMissingOwnPropertyReadIsNoCheaperThanAHit(PropertyAccessSemantics semantics, int expectedProbes)
     {
         var engine = new Engine();
-        var host = new ProbeCountingHostObject(engine);
+        var host = new ProbeCountingHostObject(engine, semantics);
         engine.SetValue("host", host);
 
         host.Reset();
         engine.Evaluate("host.notThere;").Should().BeUndefined();
 
-        // A miss is not cheaper than a hit: the prototype walk re-probes the receiver.
-        host.GetOwnPropertyCallCount.Should().Be(2);
+        // A miss is not cheaper than a hit, and the declaration does not make it so: the probe that
+        // establishes the miss cannot also produce a value, so the read still ends in a Get that
+        // re-probes the receiver before walking to the prototype.
+        host.GetOwnPropertyCallCount.Should().Be(expectedProbes);
     }
 
-    [Fact]
-    public void MemberCallBaseProbesOnce()
+    [Theory]
+    [InlineData(PropertyAccessSemantics.Unspecified)]
+    [InlineData(PropertyAccessSemantics.Ordinary)]
+    public void AMemberCallBaseProbesOnce(PropertyAccessSemantics semantics)
     {
         var engine = new Engine();
-        var host = new ProbeCountingHostObject(engine);
+        var host = new ProbeCountingHostObject(engine, semantics);
         engine.SetValue("host", host);
 
         host.Reset();
         engine.Evaluate("host.prop.toUpperCase();").Should().Be("VALUE-OF-PROP");
 
-        // Reading a host property as the base of a member call takes a different lane than reading
-        // it as a value, and that lane already costs only one probe — evidence that the extra probe
-        // on the value lane is removable rather than intrinsic.
-        host.GetOwnPropertyCallCount.Should().Be(1);
+        // Reading a host property as the base of a member call takes a different lane than reading it
+        // as a value: it goes straight through ObjectInstance.Get, so it already cost only one probe
+        // undeclared — which is the evidence that the extra probe on the value lane was removable
+        // rather than intrinsic. That lane is unaffected by the declaration, so this stays at one.
+        host.GetOwnPropertyCallCount.Should().Be(MemberCallBase);
     }
 }
 
@@ -99,8 +143,9 @@ public class HostObjectProbeCountTests
 /// </summary>
 file sealed class ProbeCountingHostObject : ObjectInstance
 {
-    public ProbeCountingHostObject(Engine engine) : base(engine)
+    public ProbeCountingHostObject(Engine engine, PropertyAccessSemantics semantics) : base(engine)
     {
+        SetPropertyAccessSemantics(semantics);
     }
 
     public int GetOwnPropertyCallCount { get; private set; }

--- a/Jint.Tests.PublicInterface/HostObjectSemanticsTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectSemanticsTests.cs
@@ -7,29 +7,36 @@ using Jint.Runtime.Descriptors;
 namespace Jint.Tests.PublicInterface;
 
 /// <summary>
-/// Covers <see cref="PropertyAccessSemantics"/>, the opt-in declaration an embedder's
-/// <see cref="ObjectInstance"/> subclass uses to tell the engine how its property reads behave. These live in
-/// the public-interface suite on purpose: the project references Jint without any internals access, so
-/// everything used here is genuinely reachable by a third-party host.
+/// Covers <see cref="PropertyAccessSemantics"/> — how the engine decides what an embedder's
+/// <see cref="ObjectInstance"/> subclass promises about its property reads. These live in the public-interface
+/// suite on purpose: the project references Jint without any internals access, so everything used here is
+/// genuinely reachable by a third-party host.
+///
+/// <para>
+/// The engine <b>derives</b> the answer from the type and nothing else: a subclass that overrides
+/// <c>Get</c> is <see cref="PropertyAccessSemantics.Exotic"/>, one that does not is
+/// <see cref="PropertyAccessSemantics.Ordinary"/>. Both directions are safe by construction — a type that
+/// never overrides <c>Get</c> cannot have non-ordinary <c>Get</c> semantics, and a type that does override it
+/// is the only one that can. <c>SetPropertyAccessSemantics</c> exists for the two shapes the rule cannot see,
+/// and both are covered below.
+/// </para>
 /// </summary>
 public class HostObjectSemanticsTests
 {
     // A Debug build of Jint verifies the Ordinary contract on every read by recomputing it (one probe to walk
     // the chain looking for side-effect-free descriptors, one more inside the Get it compares against).
-    // Release strips the verification, and its count is the one the two-probes-per-read guard is about.
+    // Release strips the verification, and its count is the one the probes-per-read guard is about.
 #if DEBUG
     private const int OrdinaryOwnReadProbes = 3;
 #else
     private const int OrdinaryOwnReadProbes = 1;
 #endif
 
-    private const int UnspecifiedOwnReadProbes = 2;
-
     [Fact]
     public void OrdinarySemanticsAgreeWithGetOwnPropertyForEveryReadOutcome()
     {
         var engine = new Engine();
-        var host = new ProjectedHostObject(engine, PropertyAccessSemantics.Ordinary)
+        var host = new ProjectedHostObject(engine)
             .Project("own", "own-value")
             .Project("shadowed", "from-host");
 
@@ -55,51 +62,40 @@ public class HostObjectSemanticsTests
     }
 
     [Fact]
-    public void OrdinarySemanticsResolveAnOwnReadFromASingleProbe()
+    public void AHostThatDoesNotOverrideGetResolvesAnOwnReadFromASingleProbe()
     {
         var engine = new Engine();
-        var ordinary = new ProjectedHostObject(engine, PropertyAccessSemantics.Ordinary).Project("value", 42);
-        var unspecified = new ProjectedHostObject(engine, PropertyAccessSemantics.Unspecified).Project("value", 42);
+        var host = new ProjectedHostObject(engine).Project("value", 42);
+        engine.SetValue("host", host);
 
-        engine.SetValue("ordinary", ordinary);
-        engine.SetValue("unspecified", unspecified);
+        engine.Evaluate("host.value").Should().Be(42);
 
-        // Each Evaluate compiles a fresh AST, so both reads below start from a cold inline cache.
-        engine.Evaluate("ordinary.value").Should().Be(42);
-        engine.Evaluate("unspecified.value").Should().Be(42);
-
-        // The regression guard: an object that declared ordinary [[Get]] is probed exactly once per own read.
-        // Without the declaration the engine probes once to prove the own property exists and a second time
-        // inside Get to fetch it — for a host that materializes descriptors lazily that is two virtual calls
-        // and two descriptor allocations per read, forever.
-        ordinary.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
-        unspecified.GetOwnPropertyCalls.Should().Be(UnspecifiedOwnReadProbes);
+        // The whole point of deriving rather than asking: this host declares nothing, and it still gets the
+        // single-probe lane, because not overriding Get already proves its Get is the ordinary one. Before the
+        // derivation the same type paid two probes and two descriptor allocations per read — one to prove the
+        // own property was not shadowed and one inside Get to fetch it.
+        host.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
     }
 
     [Fact]
-    public void OrdinarySemanticsResolveAMemberCallCalleeFromASingleProbe()
+    public void AHostThatDoesNotOverrideGetResolvesAMemberCallCalleeFromASingleProbe()
     {
         var engine = new Engine();
         var fn = engine.Evaluate("(function () { return 'called'; })");
-        var ordinary = new ProjectedHostObject(engine, PropertyAccessSemantics.Ordinary).Project("fn", fn);
-        var unspecified = new ProjectedHostObject(engine, PropertyAccessSemantics.Unspecified).Project("fn", fn);
-
-        engine.SetValue("ordinary", ordinary);
-        engine.SetValue("unspecified", unspecified);
+        var host = new ProjectedHostObject(engine).Project("fn", fn);
+        engine.SetValue("host", host);
 
         // The member-call callee path shares the same non-plain-receiver completion, so it inherits the lane.
-        engine.Evaluate("ordinary.fn()").Should().Be("called");
-        engine.Evaluate("unspecified.fn()").Should().Be("called");
+        engine.Evaluate("host.fn()").Should().Be("called");
 
-        ordinary.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
-        unspecified.GetOwnPropertyCalls.Should().Be(UnspecifiedOwnReadProbes);
+        host.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
     }
 
     [Fact]
     public void PrototypeMethodResolvedOffAHostReceiverStaysCorrectAcrossPrototypeMutation()
     {
         var engine = new Engine();
-        var host = new ProjectedHostObject(engine, PropertyAccessSemantics.Ordinary);
+        var host = new ProjectedHostObject(engine);
         engine.SetValue("host", host);
 
         // One member-call node read four times, so the prototype-method inline cache is warm from the second
@@ -132,52 +128,40 @@ public class HostObjectSemanticsTests
     public void AWarmPrototypeReadDoesNotReprobeTheHost()
     {
         var engine = new Engine();
-        var ordinary = new ProjectedHostObject(engine, PropertyAccessSemantics.Ordinary);
-        var unspecified = new ProjectedHostObject(engine, PropertyAccessSemantics.Unspecified);
-        engine.SetValue("ordinary", ordinary);
-        engine.SetValue("unspecified", unspecified);
+        var host = new ProjectedHostObject(engine);
+        engine.SetValue("host", host);
         engine.Execute("Object.prototype.protoMethod = function () { return 1; };");
 
-        engine.Evaluate("var total = 0; for (var i = 0; i < 10; i++) { total += ordinary.protoMethod(); } total;").Should().Be(10);
-        engine.Evaluate("var total = 0; for (var i = 0; i < 10; i++) { total += unspecified.protoMethod(); } total;").Should().Be(10);
+        engine.Evaluate("var total = 0; for (var i = 0; i < 10; i++) { total += host.protoMethod(); } total;").Should().Be(10);
 
-        // The declaration must not cost the prototype-method cache: ten reads of a prototype method through a
-        // single node probe the receiver once, exactly as they do without the declaration. That is why the
-        // ordinary lane consults that cache before it probes for an own property — doing it the other way round
-        // turns the nine cached iterations back into nine virtual probes.
-        ordinary.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
-        unspecified.GetOwnPropertyCalls.Should().Be(1);
+        // The ordinary lane must not cost the prototype-method cache: ten reads of a prototype method through a
+        // single node probe the receiver once, not ten times. That is why the lane consults that cache before it
+        // probes for an own property — doing it the other way round turns the nine cached iterations back into
+        // nine virtual probes.
+        host.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
     }
 
     [Fact]
-    public void HostGetIsBypassedWithoutADeclarationAndHonouredWithExotic()
+    public void AHostThatOverridesGetIsHonouredWithoutDeclaringAnything()
     {
-        // The correctness hole this API closes: the read path treats "does not declare exotic semantics" as
-        // "has ordinary [[Get]]" and can answer from a prototype descriptor without ever calling the host's
-        // Get. A host that computes a fallback for names it owns no descriptor for is therefore silently
-        // bypassed for any name that happens to resolve on its prototype. Declaring Exotic fixes it.
-        var undeclared = ReadOnPrototypeName(PropertyAccessSemantics.Unspecified);
-        var declared = ReadOnPrototypeName(PropertyAccessSemantics.Exotic);
+        // The correctness hole the derivation closes. The read path used to treat "carries no exotic flag" as
+        // "has ordinary [[Get]]", and a subclass defined outside Jint could not carry that flag: a host whose
+        // Get computes a value for names it owns no descriptor for was therefore silently bypassed for every
+        // name that happened to resolve on its prototype. Object.prototype alone was enough to trigger it.
+        var engine = new Engine();
+        var host = new ComputingHostObject(engine);
+        engine.SetValue("host", host);
+        engine.Execute("Object.prototype.onPrototype = 42;");
 
-        // Documents the hole: the prototype's value wins over the host's computed fallback.
-        undeclared.Should().Be(42);
-        declared.Should().Be("computed:onPrototype");
-
-        static JsValue ReadOnPrototypeName(PropertyAccessSemantics semantics)
-        {
-            var engine = new Engine();
-            var host = new ComputingHostObject(engine, semantics);
-            engine.SetValue("host", host);
-            engine.Execute("Object.prototype.onPrototype = 42;");
-            return engine.Evaluate("host.onPrototype");
-        }
+        // The host's computed value wins, because overriding Get is itself the declaration.
+        engine.Evaluate("host.onPrototype").Should().Be("computed:onPrototype");
     }
 
     [Fact]
-    public void ExoticSemanticsRouteEveryReadThroughGet()
+    public void AHostThatOverridesGetRoutesEveryReadThroughIt()
     {
         var engine = new Engine();
-        var host = new ComputingHostObject(engine, PropertyAccessSemantics.Exotic).Project("own", "own-value");
+        var host = new ComputingHostObject(engine).Project("own", "own-value");
         engine.SetValue("host", host);
 
         engine.Evaluate("host.own").Should().Be("own-value");
@@ -190,43 +174,67 @@ public class HostObjectSemanticsTests
     }
 
     [Fact]
-    public void DeclarationCanBeReplacedAndUnspecifiedClearsIt()
+    public void AGetOverrideThatIsOrdinaryCanDeclareItselfBackOntoTheShortLane()
     {
+        // Residual case one: the rule sees an override and assumes it may deviate. A host that overrides Get
+        // only to observe reads — tracing, metrics, a special case that still agrees with GetOwnProperty — says
+        // so and gets the single-probe lane back.
         var engine = new Engine();
+        var traced = new TracingHostObject(engine).Project("value", 42);
+        engine.SetValue("traced", traced);
 
+        engine.Evaluate("traced.value").Should().Be(42);
+
+        traced.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
+    }
+
+    [Fact]
+    public void AHostThatDoesNotOverrideGetCanStillDeclareItselfExotic()
+    {
+        // Residual case two: the rule sees no override and concludes Ordinary, but the host knows its
+        // GetOwnProperty is not a stable answer for the same name. Declaring Exotic routes every read through
+        // Get, which is what makes the second read observe the changed projection.
+        var engine = new Engine();
+        var host = new MutatingHostObject(engine);
+        engine.SetValue("host", host);
+
+        engine.Evaluate("var seen = []; for (var i = 0; i < 3; i++) { seen.push(host.counter); } seen.join(',');")
+            .Should().Be("1,2,3");
+    }
+
+    [Fact]
+    public void ADeclarationCanBeReplaced()
+    {
         // Last call wins, so a subclass can override what its base class declared.
+        var engine = new Engine();
         var redeclared = new RedeclaringHostObject(engine, PropertyAccessSemantics.Exotic, PropertyAccessSemantics.Ordinary);
         engine.SetValue("redeclared", redeclared);
+
         engine.Evaluate("redeclared.value").Should().Be("value");
         redeclared.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
-
-        var cleared = new RedeclaringHostObject(engine, PropertyAccessSemantics.Ordinary, PropertyAccessSemantics.Unspecified);
-        engine.SetValue("cleared", cleared);
-        engine.Evaluate("cleared.value").Should().Be("value");
-        cleared.GetOwnPropertyCalls.Should().Be(UnspecifiedOwnReadProbes);
     }
 
     [Fact]
     public void AnUnknownSemanticsValueIsRejected()
     {
         var engine = new Engine();
-        Invoking(() => new ProjectedHostObject(engine, (PropertyAccessSemantics) 99))
+        Invoking(() => new RedeclaringHostObject(engine, PropertyAccessSemantics.Ordinary, (PropertyAccessSemantics) 99))
             .Should().Throw<ArgumentOutOfRangeException>();
     }
 }
 
 /// <summary>
 /// A host object whose properties live outside the engine — no descriptor exists until one is asked for, which
-/// is the shape that pays twice for every read without a semantics declaration. Records the probe count so a
-/// test can assert how many the engine needed.
+/// is the shape that used to pay twice for every read. It overrides <see cref="GetOwnProperty"/> and nothing
+/// else, so the engine derives <see cref="PropertyAccessSemantics.Ordinary"/> for it. Records the probe count
+/// so a test can assert how many the engine needed.
 /// </summary>
 internal class ProjectedHostObject : ObjectInstance
 {
     private readonly Dictionary<string, JsValue> _fields = new Dictionary<string, JsValue>(StringComparer.Ordinal);
 
-    public ProjectedHostObject(Engine engine, PropertyAccessSemantics semantics) : base(engine)
+    public ProjectedHostObject(Engine engine) : base(engine)
     {
-        SetPropertyAccessSemantics(semantics);
     }
 
     public int GetOwnPropertyCalls { get; private set; }
@@ -288,11 +296,12 @@ internal class ProjectedHostObject : ObjectInstance
 
 /// <summary>
 /// A host object with genuinely non-ordinary reads: <see cref="Get"/> computes a value for every name it owns
-/// no descriptor for, so a read that never reaches <c>Get</c> is a read the host never sees.
+/// no descriptor for, so a read that never reaches <c>Get</c> is a read the host never sees. It declares
+/// nothing — overriding <c>Get</c> is what tells the engine so.
 /// </summary>
 internal sealed class ComputingHostObject : ProjectedHostObject
 {
-    public ComputingHostObject(Engine engine, PropertyAccessSemantics semantics) : base(engine, semantics)
+    public ComputingHostObject(Engine engine) : base(engine)
     {
     }
 
@@ -307,13 +316,72 @@ internal sealed class ComputingHostObject : ProjectedHostObject
     }
 }
 
+/// <summary>
+/// Overrides <see cref="Get"/> with a pure pass-through, so it is derived exotic while behaving exactly like
+/// the ordinary host. The control for any test that must produce the same answer under both derived outcomes.
+/// </summary>
+internal sealed class PassThroughGetHostObject : ProjectedHostObject
+{
+    public PassThroughGetHostObject(Engine engine) : base(engine)
+    {
+    }
+
+    public override JsValue Get(JsValue property, JsValue receiver) => base.Get(property, receiver);
+}
+
+/// <summary>
+/// Overrides <see cref="Get"/> without deviating from it — the shape the derivation rule is deliberately
+/// pessimistic about, and the reason <c>SetPropertyAccessSemantics</c> survives.
+/// </summary>
+internal sealed class TracingHostObject : ProjectedHostObject
+{
+    public TracingHostObject(Engine engine) : base(engine)
+    {
+        SetPropertyAccessSemantics(PropertyAccessSemantics.Ordinary);
+    }
+
+    public int GetCalls { get; private set; }
+
+    public override JsValue Get(JsValue property, JsValue receiver)
+    {
+        GetCalls++;
+        return base.Get(property, receiver);
+    }
+}
+
+/// <summary>
+/// Does not override <see cref="ObjectInstance.Get"/>, yet is not ordinary: its projection changes on every
+/// probe, so a descriptor is only ever true for the call that produced it. The other reason
+/// <c>SetPropertyAccessSemantics</c> survives.
+/// </summary>
+internal sealed class MutatingHostObject : ProjectedHostObject
+{
+    private int _counter;
+
+    public MutatingHostObject(Engine engine) : base(engine)
+    {
+        SetPropertyAccessSemantics(PropertyAccessSemantics.Exotic);
+    }
+
+    public override PropertyDescriptor GetOwnProperty(JsValue property)
+    {
+        if (property.IsString() && string.Equals(property.AsString(), "counter", StringComparison.Ordinal))
+        {
+            return new PropertyDescriptor(++_counter, writable: true, enumerable: true, configurable: true);
+        }
+
+        return base.GetOwnProperty(property);
+    }
+}
+
 /// <summary>Declares twice, mimicking a subclass overriding what its base class declared.</summary>
 internal sealed class RedeclaringHostObject : ProjectedHostObject
 {
     public RedeclaringHostObject(Engine engine, PropertyAccessSemantics first, PropertyAccessSemantics second)
-        : base(engine, first)
+        : base(engine)
     {
         Project("value", "value");
+        SetPropertyAccessSemantics(first);
         SetPropertyAccessSemantics(second);
     }
 }

--- a/Jint.Tests.PublicInterface/HostObjectSemanticsTests.cs
+++ b/Jint.Tests.PublicInterface/HostObjectSemanticsTests.cs
@@ -1,0 +1,319 @@
+using System.Collections.Generic;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// Covers <see cref="PropertyAccessSemantics"/>, the opt-in declaration an embedder's
+/// <see cref="ObjectInstance"/> subclass uses to tell the engine how its property reads behave. These live in
+/// the public-interface suite on purpose: the project references Jint without any internals access, so
+/// everything used here is genuinely reachable by a third-party host.
+/// </summary>
+public class HostObjectSemanticsTests
+{
+    // A Debug build of Jint verifies the Ordinary contract on every read by recomputing it (one probe to walk
+    // the chain looking for side-effect-free descriptors, one more inside the Get it compares against).
+    // Release strips the verification, and its count is the one the two-probes-per-read guard is about.
+#if DEBUG
+    private const int OrdinaryOwnReadProbes = 3;
+#else
+    private const int OrdinaryOwnReadProbes = 1;
+#endif
+
+    private const int UnspecifiedOwnReadProbes = 2;
+
+    [Fact]
+    public void OrdinarySemanticsAgreeWithGetOwnPropertyForEveryReadOutcome()
+    {
+        var engine = new Engine();
+        var host = new ProjectedHostObject(engine, PropertyAccessSemantics.Ordinary)
+            .Project("own", "own-value")
+            .Project("shadowed", "from-host");
+
+        engine.SetValue("host", host);
+        engine.Execute("Object.prototype.inherited = 'from-prototype'; Object.prototype.shadowed = 'from-prototype';");
+
+        // own hit
+        engine.Evaluate("host.own").Should().Be("own-value");
+        // own hit that shadows a prototype property of the same name
+        engine.Evaluate("host.shadowed").Should().Be("from-host");
+        // own miss resolved on the prototype
+        engine.Evaluate("host.inherited").Should().Be("from-prototype");
+        // absent everywhere
+        engine.Evaluate("host.absent").Should().Be(JsValue.Undefined);
+
+        // ...and the same answers when the read does not go through the interpreter's member-read path
+        host.Get("own").Should().Be("own-value");
+        host.Get("shadowed").Should().Be("from-host");
+        host.Get("inherited").Should().Be("from-prototype");
+        host.Get("absent").Should().Be(JsValue.Undefined);
+        engine.Evaluate("host['ow' + 'n']").Should().Be("own-value");
+        engine.Evaluate("host['absen' + 't']").Should().Be(JsValue.Undefined);
+    }
+
+    [Fact]
+    public void OrdinarySemanticsResolveAnOwnReadFromASingleProbe()
+    {
+        var engine = new Engine();
+        var ordinary = new ProjectedHostObject(engine, PropertyAccessSemantics.Ordinary).Project("value", 42);
+        var unspecified = new ProjectedHostObject(engine, PropertyAccessSemantics.Unspecified).Project("value", 42);
+
+        engine.SetValue("ordinary", ordinary);
+        engine.SetValue("unspecified", unspecified);
+
+        // Each Evaluate compiles a fresh AST, so both reads below start from a cold inline cache.
+        engine.Evaluate("ordinary.value").Should().Be(42);
+        engine.Evaluate("unspecified.value").Should().Be(42);
+
+        // The regression guard: an object that declared ordinary [[Get]] is probed exactly once per own read.
+        // Without the declaration the engine probes once to prove the own property exists and a second time
+        // inside Get to fetch it — for a host that materializes descriptors lazily that is two virtual calls
+        // and two descriptor allocations per read, forever.
+        ordinary.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
+        unspecified.GetOwnPropertyCalls.Should().Be(UnspecifiedOwnReadProbes);
+    }
+
+    [Fact]
+    public void OrdinarySemanticsResolveAMemberCallCalleeFromASingleProbe()
+    {
+        var engine = new Engine();
+        var fn = engine.Evaluate("(function () { return 'called'; })");
+        var ordinary = new ProjectedHostObject(engine, PropertyAccessSemantics.Ordinary).Project("fn", fn);
+        var unspecified = new ProjectedHostObject(engine, PropertyAccessSemantics.Unspecified).Project("fn", fn);
+
+        engine.SetValue("ordinary", ordinary);
+        engine.SetValue("unspecified", unspecified);
+
+        // The member-call callee path shares the same non-plain-receiver completion, so it inherits the lane.
+        engine.Evaluate("ordinary.fn()").Should().Be("called");
+        engine.Evaluate("unspecified.fn()").Should().Be("called");
+
+        ordinary.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
+        unspecified.GetOwnPropertyCalls.Should().Be(UnspecifiedOwnReadProbes);
+    }
+
+    [Fact]
+    public void PrototypeMethodResolvedOffAHostReceiverStaysCorrectAcrossPrototypeMutation()
+    {
+        var engine = new Engine();
+        var host = new ProjectedHostObject(engine, PropertyAccessSemantics.Ordinary);
+        engine.SetValue("host", host);
+
+        // One member-call node read four times, so the prototype-method inline cache is warm from the second
+        // iteration on. Every mutation must still be observed: an in-place function replacement (no version
+        // bump — the cached descriptor is live), a delete + redefine, and a swap to an accessor.
+        var result = engine.Evaluate(
+            """
+            var proto = { greet: function () { return 'v1'; } };
+            Object.setPrototypeOf(host, proto);
+
+            var seen = [];
+            for (var i = 0; i < 4; i++) {
+                seen.push(host.greet());
+                if (i === 0) {
+                    proto.greet = function () { return 'v2'; };
+                } else if (i === 1) {
+                    delete proto.greet;
+                    Object.defineProperty(proto, 'greet', { value: function () { return 'v3'; }, configurable: true, writable: true });
+                } else if (i === 2) {
+                    Object.defineProperty(proto, 'greet', { get: function () { return function () { return 'v4'; }; }, configurable: true });
+                }
+            }
+            seen.join(',');
+            """);
+
+        result.Should().Be("v1,v2,v3,v4");
+    }
+
+    [Fact]
+    public void AWarmPrototypeReadDoesNotReprobeTheHost()
+    {
+        var engine = new Engine();
+        var ordinary = new ProjectedHostObject(engine, PropertyAccessSemantics.Ordinary);
+        var unspecified = new ProjectedHostObject(engine, PropertyAccessSemantics.Unspecified);
+        engine.SetValue("ordinary", ordinary);
+        engine.SetValue("unspecified", unspecified);
+        engine.Execute("Object.prototype.protoMethod = function () { return 1; };");
+
+        engine.Evaluate("var total = 0; for (var i = 0; i < 10; i++) { total += ordinary.protoMethod(); } total;").Should().Be(10);
+        engine.Evaluate("var total = 0; for (var i = 0; i < 10; i++) { total += unspecified.protoMethod(); } total;").Should().Be(10);
+
+        // The declaration must not cost the prototype-method cache: ten reads of a prototype method through a
+        // single node probe the receiver once, exactly as they do without the declaration. That is why the
+        // ordinary lane consults that cache before it probes for an own property — doing it the other way round
+        // turns the nine cached iterations back into nine virtual probes.
+        ordinary.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
+        unspecified.GetOwnPropertyCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public void HostGetIsBypassedWithoutADeclarationAndHonouredWithExotic()
+    {
+        // The correctness hole this API closes: the read path treats "does not declare exotic semantics" as
+        // "has ordinary [[Get]]" and can answer from a prototype descriptor without ever calling the host's
+        // Get. A host that computes a fallback for names it owns no descriptor for is therefore silently
+        // bypassed for any name that happens to resolve on its prototype. Declaring Exotic fixes it.
+        var undeclared = ReadOnPrototypeName(PropertyAccessSemantics.Unspecified);
+        var declared = ReadOnPrototypeName(PropertyAccessSemantics.Exotic);
+
+        // Documents the hole: the prototype's value wins over the host's computed fallback.
+        undeclared.Should().Be(42);
+        declared.Should().Be("computed:onPrototype");
+
+        static JsValue ReadOnPrototypeName(PropertyAccessSemantics semantics)
+        {
+            var engine = new Engine();
+            var host = new ComputingHostObject(engine, semantics);
+            engine.SetValue("host", host);
+            engine.Execute("Object.prototype.onPrototype = 42;");
+            return engine.Evaluate("host.onPrototype");
+        }
+    }
+
+    [Fact]
+    public void ExoticSemanticsRouteEveryReadThroughGet()
+    {
+        var engine = new Engine();
+        var host = new ComputingHostObject(engine, PropertyAccessSemantics.Exotic).Project("own", "own-value");
+        engine.SetValue("host", host);
+
+        engine.Evaluate("host.own").Should().Be("own-value");
+        engine.Evaluate("host.other").Should().Be("computed:other");
+        engine.Evaluate("host.toString").Should().Be("computed:toString");
+
+        // A repeated read from one node must not be served from any cache either.
+        engine.Evaluate("var seen = []; for (var i = 0; i < 3; i++) { seen.push(host.toString); } seen.join('|');")
+            .Should().Be("computed:toString|computed:toString|computed:toString");
+    }
+
+    [Fact]
+    public void DeclarationCanBeReplacedAndUnspecifiedClearsIt()
+    {
+        var engine = new Engine();
+
+        // Last call wins, so a subclass can override what its base class declared.
+        var redeclared = new RedeclaringHostObject(engine, PropertyAccessSemantics.Exotic, PropertyAccessSemantics.Ordinary);
+        engine.SetValue("redeclared", redeclared);
+        engine.Evaluate("redeclared.value").Should().Be("value");
+        redeclared.GetOwnPropertyCalls.Should().Be(OrdinaryOwnReadProbes);
+
+        var cleared = new RedeclaringHostObject(engine, PropertyAccessSemantics.Ordinary, PropertyAccessSemantics.Unspecified);
+        engine.SetValue("cleared", cleared);
+        engine.Evaluate("cleared.value").Should().Be("value");
+        cleared.GetOwnPropertyCalls.Should().Be(UnspecifiedOwnReadProbes);
+    }
+
+    [Fact]
+    public void AnUnknownSemanticsValueIsRejected()
+    {
+        var engine = new Engine();
+        Invoking(() => new ProjectedHostObject(engine, (PropertyAccessSemantics) 99))
+            .Should().Throw<ArgumentOutOfRangeException>();
+    }
+}
+
+/// <summary>
+/// A host object whose properties live outside the engine — no descriptor exists until one is asked for, which
+/// is the shape that pays twice for every read without a semantics declaration. Records the probe count so a
+/// test can assert how many the engine needed.
+/// </summary>
+internal class ProjectedHostObject : ObjectInstance
+{
+    private readonly Dictionary<string, JsValue> _fields = new Dictionary<string, JsValue>(StringComparer.Ordinal);
+
+    public ProjectedHostObject(Engine engine, PropertyAccessSemantics semantics) : base(engine)
+    {
+        SetPropertyAccessSemantics(semantics);
+    }
+
+    public int GetOwnPropertyCalls { get; private set; }
+
+    /// <summary>Seeds the projected native state. Not a JavaScript-visible write.</summary>
+    public ProjectedHostObject Project(string name, JsValue value)
+    {
+        _fields[name] = value;
+        return this;
+    }
+
+    protected bool TryProject(JsValue property, out JsValue value)
+    {
+        if (property.IsString())
+        {
+            return _fields.TryGetValue(property.AsString(), out value);
+        }
+
+        value = Undefined;
+        return false;
+    }
+
+    public override PropertyDescriptor GetOwnProperty(JsValue property)
+    {
+        GetOwnPropertyCalls++;
+
+        if (TryProject(property, out var value))
+        {
+            return new PropertyDescriptor(value, writable: true, enumerable: true, configurable: true);
+        }
+
+        return PropertyDescriptor.Undefined;
+    }
+
+    public override List<JsValue> GetOwnPropertyKeys(Types types = Types.String | Types.Symbol)
+    {
+        var keys = new List<JsValue>();
+        if ((types & Types.String) != Types.Empty)
+        {
+            foreach (var name in _fields.Keys)
+            {
+                keys.Add(new JsString(name));
+            }
+        }
+
+        return keys;
+    }
+
+    public override IEnumerable<KeyValuePair<JsValue, PropertyDescriptor>> GetOwnProperties()
+    {
+        foreach (var field in _fields)
+        {
+            yield return new KeyValuePair<JsValue, PropertyDescriptor>(
+                new JsString(field.Key),
+                new PropertyDescriptor(field.Value, writable: true, enumerable: true, configurable: true));
+        }
+    }
+}
+
+/// <summary>
+/// A host object with genuinely non-ordinary reads: <see cref="Get"/> computes a value for every name it owns
+/// no descriptor for, so a read that never reaches <c>Get</c> is a read the host never sees.
+/// </summary>
+internal sealed class ComputingHostObject : ProjectedHostObject
+{
+    public ComputingHostObject(Engine engine, PropertyAccessSemantics semantics) : base(engine, semantics)
+    {
+    }
+
+    public override JsValue Get(JsValue property, JsValue receiver)
+    {
+        if (TryProject(property, out var value))
+        {
+            return value;
+        }
+
+        return new JsString("computed:" + property);
+    }
+}
+
+/// <summary>Declares twice, mimicking a subclass overriding what its base class declared.</summary>
+internal sealed class RedeclaringHostObject : ProjectedHostObject
+{
+    public RedeclaringHostObject(Engine engine, PropertyAccessSemantics first, PropertyAccessSemantics second)
+        : base(engine, first)
+    {
+        Project("value", "value");
+        SetPropertyAccessSemantics(second);
+    }
+}

--- a/Jint.Tests/Runtime/PropertyAccessSemanticsDerivationTests.cs
+++ b/Jint.Tests/Runtime/PropertyAccessSemanticsDerivationTests.cs
@@ -1,0 +1,99 @@
+#nullable enable
+
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// The engine resolves an <see cref="ObjectInstance"/> subclass's <see cref="PropertyAccessSemantics"/> by
+/// reflecting on whether the type overrides <c>Get</c>. Reflection is expensive enough that doing it per
+/// instance would cost more than the read path it buys, so it must happen once per <b>type</b>. That is
+/// invisible from the outside — a per-instance probe would produce exactly the same semantics — which is why
+/// these tests reach for the internal probe counter rather than asserting behaviour.
+/// </summary>
+public class PropertyAccessSemanticsDerivationTests
+{
+    [Fact]
+    public void TheTypeIsProbedOnceHoweverManyInstancesAreBuilt()
+    {
+        var engine = new Engine();
+
+        for (var i = 0; i < 50; i++)
+        {
+            _ = new ProbedOrdinaryHost(engine);
+        }
+
+        // Deliberately not phrased as a delta around this loop: the count is per type and for the whole process,
+        // so "exactly one" holds however many instances exist and whichever test built the first of them. A
+        // per-instance probe would put 50 here.
+        ObjectInstance.AccessSemanticsProbeCount(typeof(ProbedOrdinaryHost)).Should().Be(1);
+    }
+
+    [Fact]
+    public void EachTypeIsProbedSeparately()
+    {
+        var engine = new Engine();
+
+        _ = new ProbedExoticHost(engine);
+        _ = new ProbedExoticHost(engine);
+
+        // A subclass does not inherit its base type's cache entry — the answer depends on that type's own
+        // virtual dispatch, so it is resolved on its own the first time one is built. ProbedDerivedExoticHost is
+        // constructed nowhere else, which is what makes the "not yet" reading below meaningful.
+        ObjectInstance.AccessSemanticsProbeCount(typeof(ProbedExoticHost)).Should().Be(1);
+        ObjectInstance.AccessSemanticsProbeCount(typeof(ProbedDerivedExoticHost)).Should().Be(0);
+
+        _ = new ProbedDerivedExoticHost(engine);
+        _ = new ProbedDerivedExoticHost(engine);
+
+        ObjectInstance.AccessSemanticsProbeCount(typeof(ProbedDerivedExoticHost)).Should().Be(1);
+    }
+
+    [Fact]
+    public void OverridingGetIsWhatMakesAHostExotic()
+    {
+        // The behavioural half of the same rule: the exotic host's Get is consulted for a name that resolves on
+        // the prototype, the ordinary one's read is answered from its own descriptor without any Get of its own.
+        var engine = new Engine();
+        engine.SetValue("ordinary", new ProbedOrdinaryHost(engine));
+        engine.SetValue("exotic", new ProbedExoticHost(engine));
+        engine.Execute("Object.prototype.onPrototype = 'from-prototype';");
+
+        engine.Evaluate("ordinary.onPrototype").Should().Be("from-prototype");
+        engine.Evaluate("exotic.onPrototype").Should().Be("computed:onPrototype");
+    }
+}
+
+/// <summary>Overrides <c>GetOwnProperty</c> only, so the derivation resolves it to ordinary.</summary>
+file class ProbedOrdinaryHost : ObjectInstance
+{
+    public ProbedOrdinaryHost(Engine engine) : base(engine)
+    {
+    }
+
+    public override PropertyDescriptor GetOwnProperty(JsValue property)
+        => property.IsString() && string.Equals(property.ToString(), "own", StringComparison.Ordinal)
+            ? new PropertyDescriptor("own-value", writable: true, enumerable: true, configurable: true)
+            : PropertyDescriptor.Undefined;
+}
+
+/// <summary>Overrides <c>Get</c>, so the derivation resolves it to exotic.</summary>
+file class ProbedExoticHost : ProbedOrdinaryHost
+{
+    public ProbedExoticHost(Engine engine) : base(engine)
+    {
+    }
+
+    public override JsValue Get(JsValue property, JsValue receiver) => new JsString("computed:" + property);
+}
+
+/// <summary>Inherits the <c>Get</c> override rather than declaring its own — still exotic, probed on its own.</summary>
+file sealed class ProbedDerivedExoticHost : ProbedExoticHost
+{
+    public ProbedDerivedExoticHost(Engine engine) : base(engine)
+    {
+    }
+}

--- a/Jint/Native/Iterator/IteratorResult.cs
+++ b/Jint/Native/Iterator/IteratorResult.cs
@@ -21,9 +21,12 @@ internal sealed class IteratorResult : ObjectInstance
     private PropertyDescriptor? _valueDesc;
     private PropertyDescriptor? _doneDesc;
 
-    public IteratorResult(Engine engine, JsValue value, JsBoolean done) : base(engine)
+    // Flags go through the internal constructor rather than being derived from the type: one of these is
+    // allocated per iterator step, so it cannot afford even a cached per-instance type lookup. The value
+    // stated here is the same one the derivation would reach, since this type overrides Get.
+    public IteratorResult(Engine engine, JsValue value, JsBoolean done)
+        : base(engine, ObjectClass.Object, InternalTypes.Object | InternalTypes.ExoticGet)
     {
-        _type |= InternalTypes.ExoticGet;
         _value = value;
         _done = done;
     }

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -701,6 +701,37 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
         _symbols?.Remove((JsSymbol) key);
     }
 
+    /// <summary>
+    /// Declares how this object resolves property reads, letting the engine take shorter paths for a
+    /// host-defined subclass — or, for <see cref="PropertyAccessSemantics.Exotic"/>, forcing it to route every
+    /// read through <see cref="Get(JsValue, JsValue)"/>. See <see cref="PropertyAccessSemantics"/> for the
+    /// invariant each value promises.
+    /// </summary>
+    /// <remarks>
+    /// Must be called from the constructor, before the instance becomes reachable from script: the engine
+    /// caches reads against the declaration and does not re-check it. The last call wins — declaring
+    /// <see cref="PropertyAccessSemantics.Unspecified"/> clears a previous declaration, including one made by
+    /// a Jint base class.
+    /// </remarks>
+    protected void SetPropertyAccessSemantics(PropertyAccessSemantics semantics)
+    {
+        switch (semantics)
+        {
+            case PropertyAccessSemantics.Unspecified:
+                _type &= ~(InternalTypes.OrdinaryGet | InternalTypes.ExoticGet);
+                break;
+            case PropertyAccessSemantics.Ordinary:
+                _type = (_type & ~InternalTypes.ExoticGet) | InternalTypes.OrdinaryGet;
+                break;
+            case PropertyAccessSemantics.Exotic:
+                _type = (_type & ~InternalTypes.OrdinaryGet) | InternalTypes.ExoticGet;
+                break;
+            default:
+                Throw.ArgumentOutOfRangeException(nameof(semantics), semantics.ToString());
+                break;
+        }
+    }
+
     public override JsValue Get(JsValue property, JsValue receiver)
     {
         if ((_type & (InternalTypes.PlainObject | InternalTypes.BuiltinShapeMode)) == InternalTypes.PlainObject && _initialized && ReferenceEquals(this, receiver) && property.IsString())

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -1,5 +1,7 @@
+﻿using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Jint.Collections;
 using Jint.Native.Array;
@@ -46,8 +48,19 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     internal ObjectInstance? _prototype;
     protected readonly Engine _engine;
 
+    /// <summary>
+    /// The constructor a subclass defined outside Jint reaches. It resolves the subclass's
+    /// <see cref="PropertyAccessSemantics"/> from the type itself, so a host never has to declare anything for
+    /// the engine to read it correctly — see <see cref="DeriveAccessSemantics"/>. A subclass that disagrees
+    /// with the derived answer overrides it from its own constructor body, which runs after this one.
+    /// </summary>
     protected ObjectInstance(Engine engine) : this(engine, ObjectClass.Object)
     {
+        // GetType() in a base constructor is the most-derived runtime type, which is exactly what the
+        // derivation is about. Jint's own types that want a specific set of flags (or the hot ones, which
+        // cannot afford even a cached lookup per instance) pass them through the internal constructor and
+        // never reach this line.
+        _type |= DeriveAccessSemantics(GetType());
     }
 
     internal ObjectInstance(
@@ -702,24 +715,21 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
     }
 
     /// <summary>
-    /// Declares how this object resolves property reads, letting the engine take shorter paths for a
-    /// host-defined subclass — or, for <see cref="PropertyAccessSemantics.Exotic"/>, forcing it to route every
-    /// read through <see cref="Get(JsValue, JsValue)"/>. See <see cref="PropertyAccessSemantics"/> for the
-    /// invariant each value promises.
+    /// Overrides the <see cref="PropertyAccessSemantics"/> the engine derived for this type. Needed only for
+    /// the two shapes the derivation rule cannot see: a type that overrides
+    /// <see cref="Get(JsValue, JsValue)"/> and is nevertheless ordinary (declare
+    /// <see cref="PropertyAccessSemantics.Ordinary"/> to get the short read path back), and a type that does
+    /// not override it yet still is not ordinary (declare <see cref="PropertyAccessSemantics.Exotic"/>).
+    /// See <see cref="PropertyAccessSemantics"/> for the invariant each value promises.
     /// </summary>
     /// <remarks>
     /// Must be called from the constructor, before the instance becomes reachable from script: the engine
-    /// caches reads against the declaration and does not re-check it. The last call wins — declaring
-    /// <see cref="PropertyAccessSemantics.Unspecified"/> clears a previous declaration, including one made by
-    /// a Jint base class.
+    /// caches reads against the resolved semantics and does not re-check them. The last call wins.
     /// </remarks>
     protected void SetPropertyAccessSemantics(PropertyAccessSemantics semantics)
     {
         switch (semantics)
         {
-            case PropertyAccessSemantics.Unspecified:
-                _type &= ~(InternalTypes.OrdinaryGet | InternalTypes.ExoticGet);
-                break;
             case PropertyAccessSemantics.Ordinary:
                 _type = (_type & ~InternalTypes.ExoticGet) | InternalTypes.OrdinaryGet;
                 break;
@@ -730,6 +740,73 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                 Throw.ArgumentOutOfRangeException(nameof(semantics), semantics.ToString());
                 break;
         }
+    }
+
+    /// <summary>
+    /// The derived <see cref="PropertyAccessSemantics"/> flag for a subclass, resolved from the type once and
+    /// cached. Keyed by <see cref="Type"/> and shared process-wide because the answer depends only on the
+    /// type's own virtual dispatch, never on the engine, the realm or the instance — so a per-engine cache
+    /// would multiply the reflection without changing an answer.
+    /// <para>
+    /// Retention: the value is an enum and holds no back-reference, so an entry retains nothing but its
+    /// <see cref="Type"/> key — the same shape as the reflection caches in <c>ReflectionExtensions</c> and
+    /// <see cref="JsValue"/>. Only subclasses reaching the public constructor are ever added.
+    /// </para>
+    /// </summary>
+    private static readonly ConcurrentDictionary<Type, InternalTypes> _derivedAccessSemantics = new();
+
+    /// <summary>
+    /// How many times the reflection probe actually ran for a type — one, however many instances are built.
+    /// Exposed so a test can pin that, since the derivation is otherwise indistinguishable from probing per
+    /// instance. Written only on a cache miss.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Type, int> _accessSemanticsProbes = new();
+
+    internal static int AccessSemanticsProbeCount(Type type)
+        => _accessSemanticsProbes.TryGetValue(type, out var count) ? count : 0;
+
+    private static InternalTypes DeriveAccessSemantics(Type type)
+        => _derivedAccessSemantics.TryGetValue(type, out var semantics)
+            ? semantics
+            : DeriveAccessSemanticsUncached(type);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static InternalTypes DeriveAccessSemanticsUncached(Type type)
+        => _derivedAccessSemantics.GetOrAdd(type, static t =>
+        {
+            _accessSemanticsProbes.AddOrUpdate(t, 1, static (_, count) => count + 1);
+            return ProbeAccessSemantics(t);
+        });
+
+    /// <summary>
+    /// Decides a subclass's read semantics from the one thing that can make them deviate: whether the type
+    /// overrides <see cref="Get(JsValue, JsValue)"/>. A type that does not override it <em>has</em> the ordinary
+    /// implementation, so <see cref="PropertyAccessSemantics.Ordinary"/> is correct for it by construction —
+    /// overriding <see cref="GetOwnProperty"/> alone does not change that, because the single probe the
+    /// interpreter then does is exactly the one <c>base.Get</c> would have done. A type that overrides it may
+    /// deviate, and the engine cannot tell whether it does, so it is treated as
+    /// <see cref="PropertyAccessSemantics.Exotic"/> until the type says otherwise.
+    /// </summary>
+    /// <remarks>
+    /// Everything the probe cannot answer resolves to <see cref="InternalTypes.ExoticGet"/>: routing every read
+    /// through <c>Get</c> is always observably correct, so an inconclusive probe costs speed and never
+    /// correctness. A member hidden with <c>new</c> rather than overridden also lands there — the engine would
+    /// never dispatch to it, so the answer is merely pessimistic.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Reads a single well-known virtual member of this very type's own hierarchy, which the trimmer keeps because the engine calls it virtually. If the metadata is unavailable the probe answers ExoticGet, which is the conservative outcome and preserves observable behaviour.")]
+    private static InternalTypes ProbeAccessSemantics(Type type)
+    {
+        var get = type.GetMethod(
+            nameof(Get),
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: [typeof(JsValue), typeof(JsValue)],
+            modifiers: null);
+
+        return get is not null && get.DeclaringType == typeof(ObjectInstance)
+            ? InternalTypes.OrdinaryGet
+            : InternalTypes.ExoticGet;
     }
 
     public override JsValue Get(JsValue property, JsValue receiver)

--- a/Jint/Native/Object/PropertyAccessSemantics.cs
+++ b/Jint/Native/Object/PropertyAccessSemantics.cs
@@ -1,10 +1,15 @@
 namespace Jint.Native.Object;
 
 /// <summary>
-/// How a host-defined <see cref="ObjectInstance"/> subclass resolves property reads. Declared once from the
-/// constructor via <see cref="ObjectInstance.SetPropertyAccessSemantics"/>; the engine never infers it.
+/// How an <see cref="ObjectInstance"/> subclass resolves property reads.
 /// <para>
-/// The declaration is a promise about <see cref="ObjectInstance.Get(JsValue, JsValue)"/> and
+/// The engine <em>derives</em> this per type and never asks the host to declare it: a subclass that overrides
+/// <see cref="ObjectInstance.Get(JsValue, JsValue)"/> is <see cref="Exotic"/>, one that does not is
+/// <see cref="Ordinary"/>. <see cref="ObjectInstance.SetPropertyAccessSemantics"/> exists only to override that
+/// answer for the two shapes the rule cannot see.
+/// </para>
+/// <para>
+/// The value is a statement about <see cref="ObjectInstance.Get(JsValue, JsValue)"/> and
 /// <see cref="ObjectInstance.GetOwnProperty"/> only. It says nothing about writes, deletes or enumeration,
 /// which keep their ordinary virtual dispatch either way.
 /// </para>
@@ -12,34 +17,37 @@ namespace Jint.Native.Object;
 public enum PropertyAccessSemantics
 {
     /// <summary>
-    /// No declaration. The engine assumes nothing and resolves every read through the full
-    /// <see cref="ObjectInstance.Get(JsValue, JsValue)"/> pipeline. This is the default and preserves the
-    /// behaviour of releases that predate this API.
-    /// </summary>
-    Unspecified = 0,
-
-    /// <summary>
     /// <see cref="ObjectInstance.Get(JsValue, JsValue)"/> is exactly the ordinary one: an own property is
     /// returned as <c>UnwrapJsValue(GetOwnProperty(property), receiver)</c>, and otherwise the read continues
-    /// up the prototype chain. Declaring this lets the interpreter resolve a read from a
-    /// <em>single</em> <see cref="ObjectInstance.GetOwnProperty"/> probe instead of probing once to prove the
-    /// own property exists and a second time inside <c>Get</c> to fetch it.
+    /// up the prototype chain. The interpreter may then resolve a read from a <em>single</em>
+    /// <see cref="ObjectInstance.GetOwnProperty"/> probe instead of probing once to prove the own property
+    /// exists and a second time inside <c>Get</c> to fetch it.
     /// <para>
-    /// The invariant the host must honour: whenever <c>GetOwnProperty(property)</c> returns a descriptor other
-    /// than <see cref="Runtime.Descriptors.PropertyDescriptor.Undefined"/>,
-    /// <c>Get(property, receiver)</c> must return the value that descriptor unwraps to for that receiver.
-    /// Overriding <c>GetOwnProperty</c> alone (leaving <c>Get</c> inherited) satisfies it automatically.
-    /// Debug builds of Jint verify the invariant on every read, so running an integration suite against a
-    /// Debug build acts as a checker.
+    /// This is what a subclass that does not override <c>Get</c> derives, and it is correct for such a type by
+    /// definition — its <c>Get</c> <em>is</em> the ordinary implementation, so the single probe the interpreter
+    /// does is precisely the one <c>base.Get</c> would have done. Overriding <c>GetOwnProperty</c> alone does
+    /// not affect that.
+    /// </para>
+    /// <para>
+    /// Declaring it explicitly is only needed for a type that overrides <c>Get</c> and is nevertheless ordinary
+    /// — an override that adds tracing, or one that special-cases a name and delegates everything else to
+    /// <c>base.Get</c> while still agreeing with its own <c>GetOwnProperty</c>. Debug builds of Jint verify the
+    /// claim on every read, so running an integration suite against a Debug build acts as a checker.
     /// </para>
     /// </summary>
-    Ordinary = 1,
+    Ordinary = 0,
 
     /// <summary>
     /// <see cref="ObjectInstance.Get(JsValue, JsValue)"/> and/or <see cref="ObjectInstance.GetOwnProperty"/>
-    /// deviate from ordinary semantics — for example <c>Get</c> synthesises a value for a name that owns no
-    /// descriptor. The interpreter then never resolves a read against this object from a cached or probed
-    /// descriptor and always calls <c>Get</c>, which is required for such an object to observe every read.
+    /// deviate from ordinary semantics — for example <c>Get</c> synthesises or lazily materializes a value for
+    /// a name that owns no descriptor yet. The interpreter then never resolves a read against this object from
+    /// a cached or probed descriptor and always calls <c>Get</c>, which is what such an object needs in order
+    /// to observe every read.
+    /// <para>
+    /// This is what a subclass that overrides <c>Get</c> derives. Declaring it explicitly is only needed for a
+    /// type that does <em>not</em> override <c>Get</c> and is still not ordinary — for instance one whose
+    /// <c>GetOwnProperty</c> is not stable across calls for the same name.
+    /// </para>
     /// </summary>
-    Exotic = 2,
+    Exotic = 1,
 }

--- a/Jint/Native/Object/PropertyAccessSemantics.cs
+++ b/Jint/Native/Object/PropertyAccessSemantics.cs
@@ -1,0 +1,45 @@
+namespace Jint.Native.Object;
+
+/// <summary>
+/// How a host-defined <see cref="ObjectInstance"/> subclass resolves property reads. Declared once from the
+/// constructor via <see cref="ObjectInstance.SetPropertyAccessSemantics"/>; the engine never infers it.
+/// <para>
+/// The declaration is a promise about <see cref="ObjectInstance.Get(JsValue, JsValue)"/> and
+/// <see cref="ObjectInstance.GetOwnProperty"/> only. It says nothing about writes, deletes or enumeration,
+/// which keep their ordinary virtual dispatch either way.
+/// </para>
+/// </summary>
+public enum PropertyAccessSemantics
+{
+    /// <summary>
+    /// No declaration. The engine assumes nothing and resolves every read through the full
+    /// <see cref="ObjectInstance.Get(JsValue, JsValue)"/> pipeline. This is the default and preserves the
+    /// behaviour of releases that predate this API.
+    /// </summary>
+    Unspecified = 0,
+
+    /// <summary>
+    /// <see cref="ObjectInstance.Get(JsValue, JsValue)"/> is exactly the ordinary one: an own property is
+    /// returned as <c>UnwrapJsValue(GetOwnProperty(property), receiver)</c>, and otherwise the read continues
+    /// up the prototype chain. Declaring this lets the interpreter resolve a read from a
+    /// <em>single</em> <see cref="ObjectInstance.GetOwnProperty"/> probe instead of probing once to prove the
+    /// own property exists and a second time inside <c>Get</c> to fetch it.
+    /// <para>
+    /// The invariant the host must honour: whenever <c>GetOwnProperty(property)</c> returns a descriptor other
+    /// than <see cref="Runtime.Descriptors.PropertyDescriptor.Undefined"/>,
+    /// <c>Get(property, receiver)</c> must return the value that descriptor unwraps to for that receiver.
+    /// Overriding <c>GetOwnProperty</c> alone (leaving <c>Get</c> inherited) satisfies it automatically.
+    /// Debug builds of Jint verify the invariant on every read, so running an integration suite against a
+    /// Debug build acts as a checker.
+    /// </para>
+    /// </summary>
+    Ordinary = 1,
+
+    /// <summary>
+    /// <see cref="ObjectInstance.Get(JsValue, JsValue)"/> and/or <see cref="ObjectInstance.GetOwnProperty"/>
+    /// deviate from ordinary semantics — for example <c>Get</c> synthesises a value for a name that owns no
+    /// descriptor. The interpreter then never resolves a read against this object from a cached or probed
+    /// descriptor and always calls <c>Get</c>, which is required for such an object to observe every read.
+    /// </summary>
+    Exotic = 2,
+}

--- a/Jint/Runtime/InternalTypes.cs
+++ b/Jint/Runtime/InternalTypes.cs
@@ -65,7 +65,15 @@ internal enum InternalTypes
     // hierarchy walk — the last such walk left on the call-dispatch path, where it decides whether
     // the callee gets a call-stack frame.
     Function = 2097152,
+    // the object promises ORDINARY [[Get]] semantics even though it is not a PlainObject: Get(p, receiver)
+    // returns exactly UnwrapJsValue(GetOwnProperty(p), receiver) for an existing own property and otherwise
+    // walks the prototype chain. Declared by a host-defined subclass through
+    // ObjectInstance.SetPropertyAccessSemantics; never inferred. Unlike PlainObject (a *storage* claim, which
+    // lets the engine read _properties / the shape directly and so cannot be honoured by an object that
+    // projects properties lazily from native state) this is purely a *semantics* claim, so the interpreter
+    // may resolve a read from a single GetOwnProperty probe. Mutually exclusive with ExoticGet.
+    OrdinaryGet = 4194304,
 
     Primitive = Boolean | String | Number | Integer | BigInt | Symbol,
-    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode | Callable | Function
+    InternalFlags = ObjectEnvironmentRecord | RequiresCloning | PlainObject | Array | Module | IsHTMLDDA | ShapeMode | ShapeBuilding | ExoticGet | BuiltinShapeMode | Callable | Function | OrdinaryGet
 }

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -28,12 +28,13 @@ public class ObjectWrapper : ObjectInstance, IObjectWrapper, IEquatable<ObjectWr
         Engine engine,
         object obj,
         Type? type = null)
-        : base(engine)
-    {
         // Member access resolves against the wrapped CLR object, not ordinary own-property-then-prototype
         // lookup, so the prototype-method inline cache must skip this receiver and any object whose
-        // prototype is a wrapper. See InternalTypes.ExoticGet.
-        _type |= InternalTypes.ExoticGet;
+        // prototype is a wrapper. See InternalTypes.ExoticGet. Stated through the internal constructor rather
+        // than derived from the type: wrapping is hot enough that even a cached per-instance type lookup is
+        // not worth paying for an answer that is fixed for the whole hierarchy.
+        : base(engine, ObjectClass.Object, InternalTypes.Object | InternalTypes.ExoticGet)
+    {
         Target = obj;
         ClrType = GetClrType(obj, type);
         _typeDescriptor = TypeDescriptor.Get(ClrType);

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Jint.Native;
@@ -696,9 +697,10 @@ internal sealed class JintMemberExpression : JintExpression
     }
 
     /// <summary>
-    /// Read completion for receivers outside the shape / plain-object lanes. An <see cref="ObjectWrapper"/>
-    /// receiver first consults the wrapper member cache: on a hit (same wrapper instance, unchanged
-    /// <c>_propertiesVersion</c>) the stored descriptor is still exactly what <c>ObjectWrapper.Get</c>'s
+    /// Read completion for receivers outside the shape / plain-object lanes. A host object that declared
+    /// <see cref="PropertyAccessSemantics.Ordinary"/> resolves from a single own-property probe. Otherwise an
+    /// <see cref="ObjectWrapper"/> receiver consults the wrapper member cache: on a hit (same wrapper instance,
+    /// unchanged <c>_propertiesVersion</c>) the stored descriptor is still exactly what <c>ObjectWrapper.Get</c>'s
     /// own-property probe would return, so it unwraps directly — for a CLR property that re-invokes the CLR
     /// getter through the live <c>ReflectionDescriptor</c>, identical to the full path. Everything else —
     /// and any wrapper bail — funnels into <see cref="ReadAfterOwnMiss"/>, whose full <c>Get</c> resolves
@@ -706,6 +708,36 @@ internal sealed class JintMemberExpression : JintExpression
     /// </summary>
     private JsValue ReadFromNonPlainReceiver(ObjectInstance baseObject, JsString property)
     {
+        if ((baseObject._type & InternalTypes.OrdinaryGet) != InternalTypes.Empty)
+        {
+            // A host-defined object that promised ordinary [[Get]]. The prototype-method cache goes first: a
+            // warm hit already proved this name resolves on the prototype for this receiver, so probing the
+            // host again would undo the whole point of the cache (a member node reads one name, so a site that
+            // hits here is never an own-property site). It is one null test when it does not apply.
+            var protoHolder = _cachedProtoHolder;
+            if (protoHolder is not null && TryReadFromPrototypeCache(baseObject, protoHolder, out var cachedValue))
+            {
+                return cachedValue;
+            }
+
+            // Otherwise the probe that proves the own property exists *is* the read: the descriptor no longer
+            // has to be materialized a second time inside Get (ObjectInstance.Get's fast path needs
+            // PlainObject, which such an object cannot claim because it stores nothing in _properties). On a
+            // miss the probe also discharges ReadAfterOwnMissUncached's shadow re-check, and — unlike the
+            // ExoticGet receivers that share this method — the prototype-method cache may then be populated.
+            var ownDescriptor = baseObject.GetOwnProperty(property);
+            if (!ReferenceEquals(ownDescriptor, PropertyDescriptor.Undefined))
+            {
+                var ownValue = ObjectInstance.UnwrapJsValue(ownDescriptor, baseObject);
+                AssertOrdinaryGetAgrees(baseObject, property, ownValue);
+                return ownValue;
+            }
+
+            var inheritedValue = ReadAfterOwnMissUncached(baseObject, property, ownMissConfirmed: true);
+            AssertOrdinaryGetAgrees(baseObject, property, inheritedValue);
+            return inheritedValue;
+        }
+
         if (ReferenceEquals(baseObject, _cachedWrapper)
             && baseObject._propertiesVersion == _cachedWrapperVersion)
         {
@@ -728,6 +760,45 @@ internal sealed class JintMemberExpression : JintExpression
     }
 
     /// <summary>
+    /// Debug-only verifier for the <see cref="PropertyAccessSemantics.Ordinary"/> contract a host object
+    /// declares but Jint cannot check statically: the value the descriptor-driven lane produced must equal
+    /// what the object's own <c>Get</c> returns. Free in Release ([Conditional]), so an integration suite run
+    /// against a Debug build of Jint becomes the checker. The recomputation is skipped whenever it could be
+    /// observable — an accessor, a custom-valued descriptor, or an exotic holder anywhere on the chain — so
+    /// enabling it never changes what a script sees.
+    /// </summary>
+    [Conditional("DEBUG")]
+    private static void AssertOrdinaryGetAgrees(ObjectInstance baseObject, JsString property, JsValue value)
+    {
+#if DEBUG
+        for (var o = (ObjectInstance?) baseObject; o is not null; o = o.GetPrototypeOf())
+        {
+            if ((o._type & InternalTypes.ExoticGet) != InternalTypes.Empty)
+            {
+                return;
+            }
+
+            var descriptor = o.GetOwnProperty(property);
+            if (ReferenceEquals(descriptor, PropertyDescriptor.Undefined))
+            {
+                continue;
+            }
+
+            if ((descriptor._flags & (PropertyFlag.NonData | PropertyFlag.CustomJsValue)) != PropertyFlag.None)
+            {
+                return;
+            }
+
+            break;
+        }
+
+        Debug.Assert(
+            JsValue.SameValue(baseObject.Get(property, baseObject), value),
+            $"{baseObject.GetType()} declared PropertyAccessSemantics.Ordinary but its Get('{property}') disagrees with UnwrapJsValue(GetOwnProperty('{property}')). Declare PropertyAccessSemantics.Exotic instead, or make Get ordinary.");
+#endif
+    }
+
+    /// <summary>
     /// Resolves a member read from <paramref name="baseObject"/> after the own-property fast paths have
     /// missed: tries the prototype-method inline cache, then falls back to the full
     /// <see cref="ObjectInstance.Get(JsValue, JsValue)"/> (deeper prototype chains, exotic objects, absent).
@@ -738,8 +809,23 @@ internal sealed class JintMemberExpression : JintExpression
     private JsValue ReadAfterOwnMiss(ObjectInstance baseObject, JsString property, bool ownMissConfirmed)
     {
         var holder = _cachedProtoHolder;
-        if (holder is not null
-            && ReferenceEquals(baseObject, _cachedProtoReceiver)
+        if (holder is not null && TryReadFromPrototypeCache(baseObject, holder, out var value))
+        {
+            return value;
+        }
+
+        return ReadAfterOwnMissUncached(baseObject, property, ownMissConfirmed);
+    }
+
+    /// <summary>
+    /// The prototype-method inline cache's validity check, split out so the ordinary-semantics lane can consult
+    /// it before probing the receiver. <paramref name="holder"/> is the already-loaded <c>_cachedProtoHolder</c>,
+    /// non-null.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryReadFromPrototypeCache(ObjectInstance baseObject, ObjectInstance holder, out JsValue value)
+    {
+        if (ReferenceEquals(baseObject, _cachedProtoReceiver)
             && baseObject._propertiesVersion == _cachedProtoReceiverVersion
             // GetPrototypeOf(), not the _prototype field: a subclass may shadow the field and override
             // [[GetPrototypeOf]] (e.g. interop instances), and base Get walks via the same accessor. The
@@ -748,10 +834,12 @@ internal sealed class JintMemberExpression : JintExpression
             && ReferenceEquals(baseObject.GetPrototypeOf(), holder)
             && holder._propertiesVersion == _cachedProtoHolderVersion)
         {
-            return ObjectInstance.UnwrapJsValue(_cachedProtoDescriptor!, baseObject);
+            value = ObjectInstance.UnwrapJsValue(_cachedProtoDescriptor!, baseObject);
+            return true;
         }
 
-        return ReadAfterOwnMissUncached(baseObject, property, ownMissConfirmed);
+        value = JsValue.Undefined;
+        return false;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
An `ObjectInstance` subclass defined outside Jint can only reach the `protected ObjectInstance(Engine)` constructor, so it carries none of the internal type flags the read path keys off — neither `PlainObject` nor `ExoticGet`. Two consequences follow, one of them a live correctness hole.

### The correctness hole

`JintMemberExpression.ReadAfterOwnMissUncached` treats "lacks `InternalTypes.ExoticGet`" as "has ordinary `[[Get]]`". A host whose `Get` computes a value for names it owns no descriptor for is therefore silently bypassed for **every name that happens to resolve on its prototype**: the read is answered from the prototype's descriptor and the host's `Get` is never called. `Object.prototype` alone is enough to trigger it, and the host has no way to opt out, because the flag that would say so is internal.

```js
Object.prototype.onPrototype = 42;
host.onPrototype;   // 42 — the host's Get never runs
```

`HostObjectSemanticsTests.AHostThatOverridesGetIsHonouredWithoutDeclaringAnything` pins the fix: after this PR the host's computed value wins, and it wins without the host declaring anything, because overriding `Get` is itself the declaration.

### The cost

A read that hits an own property probes `GetOwnProperty` twice — once to prove the own property is not shadowed, discarding the descriptor, then again inside `Get`, whose fast path needs `PlainObject`. For a host that materializes descriptors lazily that is two virtual calls and two allocations per read, forever.

### The change

`PropertyAccessSemantics`, which the engine **derives per type** and never asks for:

* a subclass that **overrides `Get`** is `Exotic` — every read is routed through `Get`, which closes the correctness hole above;
* a subclass that **does not** is `Ordinary` — the read path resolves an own hit from a **single** probe.

Both directions are safe by construction. Overriding `Get` is the only way to have non-ordinary `Get` semantics, so a type that never overrides it cannot deviate; and a type that does override it is the only one that can. Overriding `GetOwnProperty` alone still lands on `Ordinary`, which is right — the single probe the interpreter then does is precisely the one `base.Get` would have done.

`protected ObjectInstance.SetPropertyAccessSemantics` survives for the two shapes the rule cannot see, and both have tests:

* a type that overrides `Get` and is nevertheless ordinary (tracing, metrics, a special case that still agrees with `GetOwnProperty`) declares `Ordinary` and gets the short lane back;
* a type that does **not** override `Get` yet still is not ordinary (a `GetOwnProperty` that is not stable across calls for the same name) declares `Exotic`.

`PropertyAccessSemantics.Unspecified` is gone; the enum is two-valued.

`OrdinaryGet` is deliberately not `PlainObject`. `PlainObject` is a *storage* claim — the engine reads `_properties` / the shape directly, bypassing virtual `GetOwnProperty` — which an object projecting lazily out of native state cannot honour. `OrdinaryGet` is only a *semantics* claim: `Get(p, receiver)` returns exactly `UnwrapJsValue(GetOwnProperty(p), receiver)` for an existing own property and otherwise walks the prototype chain.

**The lane order inside `ReadFromNonPlainReceiver` is load-bearing.** It consults the prototype-method inline cache *first* and only then probes the receiver. Putting the own probe first is a 10× regression on warm prototype reads: ten iterations of `host.protoMethod()` through one member node go from one probe to ten, because every warm hit re-probes a host it does not need to. `AWarmPrototypeReadDoesNotReprobeTheHost` is the guard.

Jint cannot verify the `Ordinary` claim cheaply at runtime, so a `[Conditional("DEBUG")]` check recomputes each such read through `Get` and compares. It is free in Release, and it turns a run of a host's own integration suite against a Debug build of Jint into a checker. It matters more under the derived model than it did under the opt-in one, since types now take the ordinary lane without a human having declared anything. The recomputation is skipped whenever it could be observable — an accessor, a custom-valued descriptor, or an exotic holder anywhere on the chain — so enabling it never changes what a script sees.

### Why not simply flip the default to `Ordinary`

Because it fails silently, and the failure is data loss rather than an exception.

There are shipping third-party hosts whose `Get` override returns a **lazily materialised** value for certain names: the backing property is not stored until first read, so `GetOwnProperty(p)` answers `Undefined` while `Get(p)` answers the parsed value. Under an `Ordinary` default the interpreter would resolve those reads from the descriptor and start returning `undefined` — no compile error, no exception. Their tests pass on the old version, they bump, and values quietly disappear. A release note does not help anyone in that position.

Deriving avoids it entirely, because overriding `Get` is exactly the signal that semantics may deviate.

This is still a behaviour change for `Get`-overriding hosts, but a **corrective** one: they move from today's state, where the prototype branch bypasses their `Get` for prototype-resident names, to `Exotic`, where it no longer does. That belongs in the release notes as a fix rather than as a break.

### Cost, and AOT

The probe is one `Type.GetMethod` per **type**, cached in a static `ConcurrentDictionary<Type, InternalTypes>` and resolved in the constructor, so nothing is added to the read path. `PropertyAccessSemanticsDerivationTests` pins it: 50 instances of a type cause one probe, and a subclass is resolved on its own rather than inheriting its base's entry. Jint's own hot types that reach the public constructor — `ObjectWrapper` (per interop wrap) and `IteratorResult` (per iterator step) — state their flags through the internal constructor instead, so neither pays even a cached lookup per instance. Their stated value is the one the derivation would have reached anyway.

Anything the probe cannot answer resolves to `Exotic`. That is what makes the trim/AOT story sound: routing every read through `Get` is always observably correct, so an environment that has stripped reflection metadata loses the optimization and never the semantics. The probe carries an `[UnconditionalSuppressMessage]` for `IL2070` so the warning does not surface in a downstream `PublishTrimmed` / `PublishAot` — Jint's own csproj already blanket-`NoWarn`s the IL2xxx family, so the Roslyn analyzer would not have flagged it either way. Under default trimming and NativeAOT the answer is correct: the trimmer must keep an override's body because the engine calls `Get` virtually, and metadata for kept members is preserved unless reflection-free mode is explicitly opted into. A host in that configuration that wants certainty declares `Exotic` explicitly.

### Probe-count guard, and the benchmark lanes

#2800 (now on `main`) added `HostObjectProbeCountTests` recording the two-probes-per-read cost with a note that the numbers should drop once this landed. They have, so this PR updates them rather than leaving the two inconsistent: exact counts per derived outcome, and the class comment records what changed. The assertions stay exact counts — a range would defeat the point of the test.

One count deliberately did **not** move, and the test records it so the difference is not mistaken for an oversight: an own-property *miss* still costs the ordinary host two probes, because the probe that establishes the miss cannot also produce a value, so the read still ends in a `Get` that re-probes the receiver. The base of a member call also still costs one, because it resolves straight through `ObjectInstance.Get` rather than through the member-read lane — which is precisely what showed the extra probe on the value lane was removable rather than intrinsic.

`HostObjectAccessBenchmark`'s receiver rows follow the model. `LazyHost` is now a host that overrides only `GetOwnProperty` and declares nothing, and `LazyHostExotic` is the identical projection behind a pass-through `Get` override — so the delta between them is the cost of being derived exotic with every other variable held fixed. Both sit alongside the `FixedLayout` row that has since landed on `main` rather than replacing it: they answer different questions, and every receiver kind now runs. No benchmark was run for this change; it does not touch the per-read mechanism the existing measurements cover, and each parameter combination was executed once through a temporary reflection driver (deleted, not part of this diff), in Release and under a Debug build where the verifier ran over the benchmark's own hosts and accepted them.

### Verification

Re-measured on current `main` (`a21cc6812`). Release build clean — exactly one warning, the pre-existing `MSB3277` in `Jint.Tests.CommonScripts` net472, confirmed on clean `main` first. `Jint.Tests` 4271 net10.0 / 4203 net472 (4268 / 4200 on `main` plus 3 added here), `Jint.Tests.PublicInterface` 312 (291 on `main` plus 21 added here), `Jint.Tests.Test262` 99441 passed / 0 failed / 157 skipped — identical to the baseline measured on clean `main` at the same commit. This PR touches the interpreter's member-read lanes, so Test262 is the run that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
