### PR TITLE
Add Options.AddLazyGlobal for deferred host global registration

### DIFF
--- a/Jint.Tests.PublicInterface/LazyGlobalRegistrationTests.cs
+++ b/Jint.Tests.PublicInterface/LazyGlobalRegistrationTests.cs
@@ -1,0 +1,228 @@
+#nullable enable
+
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <c>Options.AddLazyGlobal</c> installs a global whose value is produced on first read. These tests pin the
+/// three properties an embedder relies on: nothing is built until script asks for it, it is built at most
+/// once per engine, and a single <see cref="Options"/> instance can drive many engines.
+/// </summary>
+public class LazyGlobalRegistrationTests
+{
+    [Fact]
+    public void LazyGlobalIsNotMaterializedUntilRead()
+    {
+        var calls = 0;
+        var engine = new Engine(options => options.AddLazyGlobal("hostApi", e =>
+        {
+            calls++;
+            return new ClrFunction(e, "hostApi", (_, _) => "from-host");
+        }));
+
+        // constructing the engine and running unrelated script must not build it
+        engine.Evaluate("var x = 1 + 1;");
+        calls.Should().Be(0);
+
+        // ... but the property is already visible
+        engine.Evaluate("'hostApi' in globalThis").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.keys(globalThis).indexOf('hostApi') >= 0").AsBoolean().Should().BeTrue();
+        calls.Should().Be(0);
+    }
+
+    [Fact]
+    public void FactoryRunsOnFirstReadOnly()
+    {
+        var calls = 0;
+        var engine = new Engine(options => options.AddLazyGlobal("hostApi", e =>
+        {
+            calls++;
+            return new ClrFunction(e, "hostApi", (_, _) => "from-host");
+        }));
+
+        calls.Should().Be(0);
+
+        engine.Evaluate("hostApi()").AsString().Should().Be("from-host");
+        calls.Should().Be(1);
+
+        engine.Evaluate("hostApi(); hostApi(); globalThis.hostApi;");
+        calls.Should().Be(1);
+
+        // identity is stable across reads
+        engine.Evaluate("hostApi === globalThis.hostApi").AsBoolean().Should().BeTrue();
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public void TypeofDoesMaterializeButExistenceChecksDoNot()
+    {
+        var calls = 0;
+        var engine = new Engine(options => options.AddLazyGlobal("value", _ =>
+        {
+            calls++;
+            return 42;
+        }));
+
+        engine.Evaluate("'value' in globalThis").AsBoolean().Should().BeTrue();
+        engine.Evaluate("globalThis.hasOwnProperty('value')").AsBoolean().Should().BeTrue();
+        engine.Evaluate("Object.getOwnPropertyNames(globalThis).indexOf('value') >= 0").AsBoolean().Should().BeTrue();
+        calls.Should().Be(0);
+
+        engine.Evaluate("typeof value").AsString().Should().Be("number");
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public void SharedOptionsBuildOnePerEngine()
+    {
+        var calls = 0;
+        var options = new Options();
+        options.AddLazyGlobal("counter", _ =>
+        {
+            calls++;
+            return calls;
+        });
+
+        var first = new Engine(options);
+        var second = new Engine(options);
+        var third = new Engine(options);
+
+        calls.Should().Be(0);
+
+        first.Evaluate("counter").AsNumber().Should().Be(1);
+        second.Evaluate("counter").AsNumber().Should().Be(2);
+        // the third never reads it
+        calls.Should().Be(2);
+
+        // and each engine caches its own value
+        first.Evaluate("counter").AsNumber().Should().Be(1);
+        second.Evaluate("counter").AsNumber().Should().Be(2);
+        calls.Should().Be(2);
+
+        third.Evaluate("counter").AsNumber().Should().Be(3);
+        calls.Should().Be(3);
+    }
+
+    [Fact]
+    public void OverwritingBeforeFirstReadStillWinsButDoesMaterializeOnce()
+    {
+        var calls = 0;
+        var engine = new Engine(options => options.AddLazyGlobal("value", _ =>
+        {
+            calls++;
+            return "lazy";
+        }));
+
+        engine.Evaluate("value = 'replaced';");
+        engine.Evaluate("value").AsString().Should().Be("replaced");
+
+        // [[Set]] on the global object routes through [[DefineOwnProperty]], whose validation step reads
+        // the current value before replacing it - so the factory runs once and its result is discarded.
+        // The observable end state is still exactly the script's value.
+        calls.Should().Be(1);
+
+        // and it is not re-run afterwards
+        engine.Evaluate("value = 'again'; value").AsString().Should().Be("again");
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public void DeletingBeforeFirstReadSkipsTheFactory()
+    {
+        var calls = 0;
+        var engine = new Engine(options => options.AddLazyGlobal("value", _ =>
+        {
+            calls++;
+            return "lazy";
+        }));
+
+        engine.Evaluate("delete globalThis.value").AsBoolean().Should().BeTrue();
+        engine.Evaluate("'value' in globalThis").AsBoolean().Should().BeFalse();
+        engine.Evaluate("typeof value").AsString().Should().Be("undefined");
+        calls.Should().Be(0);
+    }
+
+    [Fact]
+    public void RedefiningBeforeFirstReadWins()
+    {
+        var calls = 0;
+        var engine = new Engine(options => options.AddLazyGlobal("value", _ =>
+        {
+            calls++;
+            return "lazy";
+        }));
+
+        engine.Evaluate("Object.defineProperty(globalThis, 'value', { value: 'defined', configurable: true });");
+        engine.Evaluate("value").AsString().Should().Be("defined");
+
+        // same reason as OverwritingBeforeFirstReadStillWinsButDoesMaterializeOnce: the redefinition has to
+        // compare against the current value
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public void NonEnumerableNonConfigurableFlagsAreHonoured()
+    {
+        var engine = new Engine(options => options.AddLazyGlobal(
+            "locked",
+            _ => "value",
+            PropertyFlag.None));
+
+        engine.Evaluate("Object.keys(globalThis).indexOf('locked') >= 0").AsBoolean().Should().BeFalse();
+        engine.Evaluate("'locked' in globalThis").AsBoolean().Should().BeTrue();
+        engine.Evaluate("locked").AsString().Should().Be("value");
+
+        // non-writable, non-configurable
+        engine.Evaluate("delete globalThis.locked").AsBoolean().Should().BeFalse();
+        engine.Evaluate("locked = 'other'; locked").AsString().Should().Be("value");
+    }
+
+    [Fact]
+    public void HostObjectFactoriesSeeAFullyBuiltEngine()
+    {
+        var engine = new Engine(options => options.AddLazyGlobal("api", e =>
+        {
+            // an intrinsic-touching factory would be unsafe at construction time; lazily it is fine
+            var value = e.Evaluate("({ ok: true })");
+            return value;
+        }));
+
+        engine.Evaluate("api.ok").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ManyLazyGlobalsCostNothingUntilUsed()
+    {
+        var built = 0;
+        var options = new Options();
+        for (var i = 0; i < 40; i++)
+        {
+            var name = "api" + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            options.AddLazyGlobal(name, e =>
+            {
+                built++;
+                return new ClrFunction(e, name, (_, _) => name);
+            });
+        }
+
+        var engine = new Engine(options);
+        built.Should().Be(0);
+
+        engine.Evaluate("api7()").AsString().Should().Be("api7");
+        built.Should().Be(1);
+    }
+
+    [Fact]
+    public void NullArgumentsAreRejected()
+    {
+        var options = new Options();
+        Invoking(() => options.AddLazyGlobal(null!, _ => JsValue.Undefined))
+            .Should().Throw<System.ArgumentNullException>();
+        Invoking(() => options.AddLazyGlobal("name", null!))
+            .Should().Throw<System.ArgumentNullException>();
+    }
+}

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -4,6 +4,8 @@ using System.Reflection;
 using Jint.Native;
 using Jint.Runtime;
 using Jint.Runtime.Debugger;
+using Jint.Runtime.Descriptors;
+using Jint.Runtime.Descriptors.Specialized;
 using Jint.Runtime.Interop;
 using Jint.Runtime.Modules;
 
@@ -310,6 +312,74 @@ public static class OptionsExtensions
     public static Options PreferJsPrototypeMethods(this Options options, bool prefer = true)
     {
         options.Interop.PreferJsPrototypeMethods = prefer;
+        return options;
+    }
+
+    /// <summary>
+    /// Registers a global whose value is produced the first time script reads it, instead of when the
+    /// engine is created. Hosts that install a large fixed set of globals — of which a given script
+    /// typically touches a handful — pay only for the ones actually used.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The property is installed eagerly, so existence checks and enumeration — <c>in</c>,
+    /// <c>hasOwnProperty</c>, <c>Object.keys(globalThis)</c>, <c>Object.getOwnPropertyNames</c> — see it
+    /// from the start without materializing anything. Only its value is left unresolved:
+    /// <paramref name="valueFactory"/> runs at most once per engine, on the first read of that value, and
+    /// the produced value is stored in the descriptor so subsequent reads are ordinary property reads.
+    /// <c>typeof</c> counts as a read, since it has to inspect the value to name its type.
+    /// </para>
+    /// <para>
+    /// A script that <b>deletes</b> the global before ever reading it (<c>delete globalThis.name</c>,
+    /// requires <see cref="PropertyFlag.Configurable"/>) removes the descriptor outright, and the factory
+    /// never runs. A script that <b>overwrites or redefines</b> it first does still run the factory once
+    /// and then discard the result: <c>[[Set]]</c> on the global object funnels into
+    /// <c>[[DefineOwnProperty]]</c>, whose ValidateAndApplyPropertyDescriptor step reads the current
+    /// value before replacing it. The end state is correct in every case — the script's value wins — the
+    /// laziness is simply not preserved through that particular sequence.
+    /// </para>
+    /// <para>
+    /// Registration is recorded on the <see cref="Options"/> instance and applied per engine, so a single
+    /// <see cref="Options"/> object may be shared by any number of engines: each gets its own descriptor
+    /// and its own invocation of <paramref name="valueFactory"/>, with the engine being built passed in.
+    /// The factory must not return <see langword="null"/>; <see cref="JsValue.Undefined"/> is substituted
+    /// if it does, so that a null return cannot silently turn into a factory that re-runs on every read.
+    /// </para>
+    /// </remarks>
+    /// <param name="options">Options to modify.</param>
+    /// <param name="name">The global property name.</param>
+    /// <param name="valueFactory">
+    /// Produces the value for a given engine. Invoked lazily, so it may use anything the engine exposes
+    /// after construction — unlike <see cref="UseHostFactory{T}"/> callbacks, which observe a half-built engine.
+    /// </param>
+    /// <param name="flags">
+    /// Property attributes; defaults to the configurable/enumerable/writable combination that
+    /// <see cref="Engine.SetValue(string, JsValue)"/> produces.
+    /// </param>
+    public static Options AddLazyGlobal(
+        this Options options,
+        string name,
+        Func<Engine, JsValue> valueFactory,
+        PropertyFlag flags = PropertyFlag.ConfigurableEnumerableWritable)
+    {
+        if (name is null)
+        {
+            Throw.ArgumentNullException(nameof(name));
+        }
+
+        if (valueFactory is null)
+        {
+            Throw.ArgumentNullException(nameof(valueFactory));
+        }
+
+        // Resolved once per registration, not per engine: LazyPropertyDescriptor treats a null value as
+        // "not materialized yet", so a factory returning null would silently re-run on every read.
+        Func<Engine, JsValue> resolver = engine => valueFactory(engine) ?? JsValue.Undefined;
+
+        options._configurations.Add(engine => engine.Realm.GlobalObject.SetProperty(
+            name,
+            new LazyPropertyDescriptor<Engine>(engine, resolver, flags)));
+
         return options;
     }
 


### PR DESCRIPTION
A thin embedder that installs a fixed set of host globals pays for all of them on every engine, while a given script typically reads a handful. `AddLazyGlobal` installs the property **eagerly** — so `in`, `hasOwnProperty`, `Object.keys(globalThis)` and property enumeration all see it from the start, without materializing anything — but leaves the value unresolved until the first **read**, then caches it in the descriptor.

```csharp
var options = new Options()
    .AddLazyGlobal("hostApi", engine => BuildExpensiveFacade(engine))
    .AddLazyGlobal("metrics", engine => BuildMetrics(engine));

var engine = new Engine(options);            // neither factory has run
engine.Evaluate("'hostApi' in globalThis");  // true — still neither has run
engine.Evaluate("hostApi()");                // hostApi's factory runs once, result cached
```

(`typeof value` counts as a read — it needs the value to name its type — while the existence checks above do not.)

### Shape

An extension method beside the other fluent helpers, rather than a new `GlobalOptions` sub-object on `Options`. The public surface is then **one method and no new type** (the delegate is a plain `Func<Engine, JsValue>`); `LazyPropertyDescriptor` stays internal.

The registration reuses the existing `_configurations` list, which `Options.Apply` already replays per engine — so composing with a shared `Options` instance falls out for free: each engine gets its own descriptor and its own factory invocation, with no new state on `Options`. If more global-scoped options ever appear, a sub-object can be introduced later and delegate here.

A factory returning `null` is coerced to `Undefined`, because `null` is `LazyPropertyDescriptor`'s "not materialized yet" marker and would otherwise silently turn into a factory that re-runs on every read.

Because the factory runs lazily it may use anything the engine exposes after construction — unlike `UseHostFactory<T>` callbacks, which observe a half-built engine.

### An asymmetry worth documenting (and documented on the method)

| script does this first | factory |
| --- | --- |
| `delete globalThis.name` | **never runs** — the descriptor is removed outright |
| `name = 1` (assignment) | **runs once, result discarded** |
| `Object.defineProperty(globalThis, 'name', …)` | **runs once, result discarded** |

The last two are not an oversight: `[[Set]]` on the global object funnels into `[[DefineOwnProperty]]`, whose `ValidateAndApplyPropertyDescriptor` step reads `current.[[Value]]` unconditionally before replacing it. **The end state is always correct** — the script's value wins in every case — only the laziness is lost for that particular sequence.

### Tests

`Jint.Tests.PublicInterface/LazyGlobalRegistrationTests.cs` — eager visibility vs deferred resolution, at-most-once invocation with stable identity across reads, per-engine isolation from a shared `Options`, the delete/overwrite/`defineProperty` asymmetry above, non-enumerable/non-configurable flags, factories observing a fully-built engine, and null-argument validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
