### PR TITLE
Let a reference resolver declare which situations it wants to be consulted for

### DIFF
--- a/Jint.Tests.PublicInterface/ReferenceResolverInterestsTests.cs
+++ b/Jint.Tests.PublicInterface/ReferenceResolverInterestsTests.cs
@@ -1,0 +1,350 @@
+#nullable enable
+
+using System.Collections.Generic;
+using Jint.Native;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <see cref="ReferenceResolverInterests"/> is a subscription filter: the engine simply does not call the
+/// resolver for situations it did not subscribe to, and keeps the interpreter fast paths those situations
+/// would otherwise disable. These tests pin, per flag, both which callbacks fire and what the script sees.
+/// </summary>
+public class ReferenceResolverInterestsTests
+{
+    private static bool IsNullish(JsValue value) => value.IsNull() || value.IsUndefined();
+
+    /// <summary>
+    /// Counts every callback and records the kind of base each property reference had, so a test can assert
+    /// "not consulted" as directly as "consulted". Behaviour-wise it is the classic null-propagation helper:
+    /// a null/undefined base yields <c>undefined</c> instead of throwing.
+    /// </summary>
+    private sealed class CountingResolver : IReferenceResolver
+    {
+        public int UnresolvableCalls;
+        public int CallableCalls;
+        public int CoercibleCalls;
+        public readonly List<string> PropertyBases = new();
+
+        public int PropertyCalls => PropertyBases.Count;
+
+        public void Reset()
+        {
+            UnresolvableCalls = 0;
+            CallableCalls = 0;
+            CoercibleCalls = 0;
+            PropertyBases.Clear();
+        }
+
+        public bool TryUnresolvableReference(Engine engine, Reference reference, out JsValue value)
+        {
+            UnresolvableCalls++;
+            value = JsValue.Undefined;
+            return true;
+        }
+
+        public bool TryPropertyReference(Engine engine, Reference reference, ref JsValue value)
+        {
+            var baseValue = reference.Base;
+            PropertyBases.Add(Describe(baseValue));
+
+            if (IsNullish(baseValue))
+            {
+                value = JsValue.Undefined;
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool TryGetCallable(Engine engine, object callee, out JsValue value)
+        {
+            CallableCalls++;
+            value = new ClrFunction(engine, "substitute", (_, _) => "substituted");
+            return true;
+        }
+
+        public bool CheckCoercible(JsValue value)
+        {
+            CoercibleCalls++;
+            return true;
+        }
+
+        private static string Describe(JsValue value)
+        {
+            if (IsNullish(value))
+            {
+                return "nullish";
+            }
+
+            return value.IsObject() ? "object" : "primitive";
+        }
+    }
+
+    private static (Engine Engine, CountingResolver Resolver) CreateEngine(ReferenceResolverInterests? interests)
+    {
+        var resolver = new CountingResolver();
+        var engine = new Engine(options =>
+        {
+            if (interests is null)
+            {
+                options.SetReferencesResolver(resolver);
+            }
+            else
+            {
+                options.SetReferencesResolver(resolver, interests.Value);
+            }
+        });
+
+        engine.Evaluate("var obj = { x: 1, s: 'text', arr: [10, 20, 30], m: function () { return 'm'; }, notCallable: 7 };");
+        resolver.Reset();
+        return (engine, resolver);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // The interest-free overload keeps the pre-filter behaviour exactly.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void InterestFreeOverloadGetsEveryInterest()
+    {
+        var options = new Options();
+        options.SetReferencesResolver(new CountingResolver(), ReferenceResolverInterests.NullishPropertyBase);
+        options.ReferenceResolverInterests.Should().Be(ReferenceResolverInterests.NullishPropertyBase);
+
+        // re-registering through the interest-free overload must not silently inherit the narrow set
+        options.SetReferencesResolver(new CountingResolver());
+        options.ReferenceResolverInterests.Should().Be(ReferenceResolverInterests.All);
+    }
+
+    [Fact]
+    public void UnfilteredResolverBehavesAsBefore()
+    {
+        var (engine, resolver) = CreateEngine(interests: null);
+
+        // null propagation through a chain of missing properties
+        engine.Evaluate("obj.missing.deeper.deepest").IsUndefined().Should().BeTrue();
+        // unresolvable identifiers resolve to undefined instead of throwing
+        engine.Evaluate("typeof neverDeclared").AsString().Should().Be("undefined");
+        engine.Evaluate("neverDeclared").IsUndefined().Should().BeTrue();
+        // a non-callable callee is substituted
+        engine.Evaluate("obj.notCallable()").AsString().Should().Be("substituted");
+
+        resolver.PropertyBases.Should().Contain("object");
+        resolver.PropertyBases.Should().Contain("nullish");
+        resolver.UnresolvableCalls.Should().BeGreaterThan(0);
+        resolver.CallableCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public void NoneMeansTheResolverIsNeverConsulted()
+    {
+        var (engine, resolver) = CreateEngine(ReferenceResolverInterests.None);
+
+        engine.Evaluate("obj.x").AsNumber().Should().Be(1);
+        Invoking(() => engine.Evaluate("obj.missing.deeper")).Should().Throw<JavaScriptException>();
+        Invoking(() => engine.Evaluate("neverDeclared")).Should().Throw<JavaScriptException>();
+        Invoking(() => engine.Evaluate("obj.notCallable()")).Should().Throw<JavaScriptException>();
+
+        resolver.PropertyCalls.Should().Be(0);
+        resolver.UnresolvableCalls.Should().Be(0);
+        resolver.CallableCalls.Should().Be(0);
+        resolver.CoercibleCalls.Should().Be(0);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // NullishPropertyBase only: the documented "not consulted for object bases" case.
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void NullishOnlyResolverIsNotConsultedForObjectBases()
+    {
+        var (engine, resolver) = CreateEngine(ReferenceResolverInterests.NullishPropertyBase);
+
+        // plain member read, repeated so the inline caches engage
+        engine.Evaluate("var total = 0; for (var i = 0; i < 20; i++) { total += obj.x; } total").AsNumber().Should().Be(20);
+        // computed index read off a dense array
+        engine.Evaluate("obj.arr[1]").AsNumber().Should().Be(20);
+        // member call
+        engine.Evaluate("obj.m()").AsString().Should().Be("m");
+        // member write, then read back
+        engine.Evaluate("obj.written = 5; obj.written").AsNumber().Should().Be(5);
+        // string primitive base
+        engine.Evaluate("obj.s.length").AsNumber().Should().Be(4);
+
+        resolver.PropertyCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public void NullishOnlyResolverStillHandlesNullishBases()
+    {
+        var (engine, resolver) = CreateEngine(ReferenceResolverInterests.NullishPropertyBase);
+
+        engine.Evaluate("obj.missing.deeper").IsUndefined().Should().BeTrue();
+        engine.Evaluate("obj.missing.deeper.deepest").IsUndefined().Should().BeTrue();
+
+        resolver.PropertyBases.Should().OnlyContain(kind => kind == "nullish");
+        resolver.CoercibleCalls.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void NullishOnlyResolverHandlesNullishBasesInComputedReads()
+    {
+        var (engine, resolver) = CreateEngine(ReferenceResolverInterests.NullishPropertyBase);
+
+        engine.Evaluate("var i = 0; obj.missing[i]").IsUndefined().Should().BeTrue();
+
+        resolver.PropertyBases.Should().OnlyContain(kind => kind == "nullish");
+    }
+
+    [Fact]
+    public void NullishOnlyResolverDoesNotAnswerUnresolvableOrCallee()
+    {
+        var (engine, resolver) = CreateEngine(ReferenceResolverInterests.NullishPropertyBase);
+
+        Invoking(() => engine.Evaluate("neverDeclared")).Should().Throw<JavaScriptException>();
+        Invoking(() => engine.Evaluate("obj.notCallable()")).Should().Throw<JavaScriptException>();
+
+        resolver.UnresolvableCalls.Should().Be(0);
+        resolver.CallableCalls.Should().Be(0);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // ObjectPropertyBase / PrimitivePropertyBase
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ObjectBaseOnlyResolverSeesObjectBasesAndNotNullishOrPrimitiveOnes()
+    {
+        var (engine, resolver) = CreateEngine(ReferenceResolverInterests.ObjectPropertyBase);
+
+        engine.Evaluate("obj.x").AsNumber().Should().Be(1);
+        resolver.PropertyBases.Should().OnlyContain(kind => kind == "object");
+
+        resolver.Reset();
+        engine.Evaluate("obj.s.length").AsNumber().Should().Be(4);
+        // the `obj.s` half has an object base; the `.length` half has a primitive one and is skipped
+        resolver.PropertyBases.Should().OnlyContain(kind => kind == "object");
+
+        resolver.Reset();
+        Invoking(() => engine.Evaluate("obj.missing.deeper")).Should().Throw<JavaScriptException>();
+        resolver.PropertyBases.Should().NotContain("nullish");
+        resolver.CoercibleCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public void PrimitiveBaseOnlyResolverSeesPrimitiveBasesOnly()
+    {
+        var (engine, resolver) = CreateEngine(ReferenceResolverInterests.PrimitivePropertyBase);
+
+        engine.Evaluate("obj.x").AsNumber().Should().Be(1);
+        resolver.PropertyCalls.Should().Be(0);
+
+        engine.Evaluate("obj.s.length").AsNumber().Should().Be(4);
+        resolver.PropertyBases.Should().OnlyContain(kind => kind == "primitive");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // UnresolvableReference / NonCallableCallee
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void UnresolvableOnlyResolverAnswersMissingIdentifiersOnly()
+    {
+        var (engine, resolver) = CreateEngine(ReferenceResolverInterests.UnresolvableReference);
+
+        engine.Evaluate("neverDeclared").IsUndefined().Should().BeTrue();
+        resolver.UnresolvableCalls.Should().BeGreaterThan(0);
+
+        resolver.Reset();
+        engine.Evaluate("obj.x").AsNumber().Should().Be(1);
+        Invoking(() => engine.Evaluate("obj.missing.deeper")).Should().Throw<JavaScriptException>();
+        resolver.PropertyCalls.Should().Be(0);
+        resolver.CoercibleCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public void UnresolvableOnlyResolverAnswersCallsToMissingIdentifiers()
+    {
+        var (engine, resolver) = CreateEngine(ReferenceResolverInterests.UnresolvableReference);
+
+        // the callee itself is unresolvable: the resolver supplies the this-binding, and the substituted
+        // value is not callable, so the call still fails - but the resolver was consulted
+        Invoking(() => engine.Evaluate("neverDeclared()")).Should().Throw<JavaScriptException>();
+        resolver.UnresolvableCalls.Should().BeGreaterThan(0);
+        resolver.CallableCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public void CalleeOnlyResolverSubstitutesNonCallableCallees()
+    {
+        var (engine, resolver) = CreateEngine(ReferenceResolverInterests.NonCallableCallee);
+
+        engine.Evaluate("obj.notCallable()").AsString().Should().Be("substituted");
+        resolver.CallableCalls.Should().Be(1);
+        resolver.PropertyCalls.Should().Be(0);
+
+        // and a real method still dispatches normally, without consulting anything
+        resolver.Reset();
+        engine.Evaluate("obj.m()").AsString().Should().Be("m");
+        resolver.CallableCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public void CalleeInterestDoesNotDisableTheMemberCallFastPath()
+    {
+        var (engine, resolver) = CreateEngine(ReferenceResolverInterests.NonCallableCallee);
+
+        engine.Evaluate("var out = ''; for (var i = 0; i < 20; i++) { out = obj.m(); } out").AsString().Should().Be("m");
+        resolver.PropertyCalls.Should().Be(0);
+        resolver.CallableCalls.Should().Be(0);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Optional chaining short-circuits before any resolver involvement, under every filter.
+    // ---------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(ReferenceResolverInterests.None)]
+    [InlineData(ReferenceResolverInterests.NullishPropertyBase)]
+    [InlineData(ReferenceResolverInterests.ObjectPropertyBase)]
+    [InlineData(ReferenceResolverInterests.All)]
+    public void OptionalChainingShortCircuitsRegardlessOfInterests(ReferenceResolverInterests interests)
+    {
+        var (engine, _) = CreateEngine(interests);
+
+        engine.Evaluate("obj.missing?.deeper").IsUndefined().Should().BeTrue();
+        engine.Evaluate("obj?.x").AsNumber().Should().Be(1);
+        engine.Evaluate("obj.missing?.[0]").IsUndefined().Should().BeTrue();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Values stay correct under every filter — the filter must never change what a read produces for
+    // situations outside it.
+    // ---------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(ReferenceResolverInterests.None)]
+    [InlineData(ReferenceResolverInterests.NullishPropertyBase)]
+    [InlineData(ReferenceResolverInterests.ObjectPropertyBase)]
+    [InlineData(ReferenceResolverInterests.PrimitivePropertyBase)]
+    [InlineData(ReferenceResolverInterests.UnresolvableReference)]
+    [InlineData(ReferenceResolverInterests.NonCallableCallee)]
+    [InlineData(ReferenceResolverInterests.All)]
+    public void OrdinaryReadsProduceTheSameValuesUnderEveryFilter(ReferenceResolverInterests interests)
+    {
+        var (engine, _) = CreateEngine(interests);
+
+        engine.Evaluate("obj.x").AsNumber().Should().Be(1);
+        engine.Evaluate("obj.arr[2]").AsNumber().Should().Be(30);
+        engine.Evaluate("obj.arr.length").AsNumber().Should().Be(3);
+        engine.Evaluate("obj.s.length").AsNumber().Should().Be(4);
+        engine.Evaluate("obj.s.toUpperCase()").AsString().Should().Be("TEXT");
+        engine.Evaluate("obj.m()").AsString().Should().Be("m");
+        engine.Evaluate("obj.assigned = 42; obj.assigned").AsNumber().Should().Be(42);
+        engine.Evaluate("var sum = 0; for (var i = 0; i < obj.arr.length; i++) { sum += obj.arr[i]; } sum")
+            .AsNumber().Should().Be(60);
+    }
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -169,7 +169,23 @@ public sealed partial class Engine : IDisposable
     internal readonly bool _isDebugMode;
     internal readonly bool _isStrict;
 
+    // Whether the reference resolver is consulted at all, plus the per-situation subscription flags
+    // derived from Options.ReferenceResolverInterests. Splitting them is what lets a resolver that only
+    // cares about, say, null/undefined bases keep the member-read, indexed-read and member-call fast
+    // lanes armed instead of forcing every property reference through Reference + TryPropertyReference.
     internal readonly bool _customResolver;
+    internal readonly bool _resolverWatchesObjectBase;
+    internal readonly bool _resolverWatchesPrimitiveBase;
+
+    /// <summary>
+    /// <c>ObjectPropertyBase | PrimitivePropertyBase</c>: the gate for the read/call fast paths, which
+    /// resolve a member without renting a <see cref="Reference"/> and therefore cannot offer a non-nullish
+    /// base to <see cref="IReferenceResolver.TryPropertyReference"/>.
+    /// </summary>
+    internal readonly bool _resolverWatchesValueBase;
+    internal readonly bool _resolverWatchesNullishBase;
+    internal readonly bool _resolverWatchesUnresolvable;
+    internal readonly bool _resolverWatchesCallee;
     internal readonly IReferenceResolver _referenceResolver;
 
     // Snapshot of Options.Constraints.MaxRecursionDepth. Every call expression compares the pushed
@@ -291,7 +307,16 @@ public sealed partial class Engine : IDisposable
         _exactConstraints = partitionedConstraints.Exact;
         _amortizedConstraints = partitionedConstraints.Amortized;
         _referenceResolver = Options.ReferenceResolver;
-        _customResolver = !ReferenceEquals(_referenceResolver, DefaultReferenceResolver.Instance);
+        var resolverInterests = ReferenceEquals(_referenceResolver, DefaultReferenceResolver.Instance)
+            ? ReferenceResolverInterests.None
+            : Options.ReferenceResolverInterests;
+        _customResolver = resolverInterests != ReferenceResolverInterests.None;
+        _resolverWatchesObjectBase = (resolverInterests & ReferenceResolverInterests.ObjectPropertyBase) != ReferenceResolverInterests.None;
+        _resolverWatchesPrimitiveBase = (resolverInterests & ReferenceResolverInterests.PrimitivePropertyBase) != ReferenceResolverInterests.None;
+        _resolverWatchesValueBase = _resolverWatchesObjectBase || _resolverWatchesPrimitiveBase;
+        _resolverWatchesNullishBase = (resolverInterests & ReferenceResolverInterests.NullishPropertyBase) != ReferenceResolverInterests.None;
+        _resolverWatchesUnresolvable = (resolverInterests & ReferenceResolverInterests.UnresolvableReference) != ReferenceResolverInterests.None;
+        _resolverWatchesCallee = (resolverInterests & ReferenceResolverInterests.NonCallableCallee) != ReferenceResolverInterests.None;
 
         _referencePool = new ReferencePool();
         _argumentsInstancePool = new ArgumentsInstancePool(this);
@@ -1016,7 +1041,7 @@ public sealed partial class Engine : IDisposable
 
         if (reference.IsUnresolvableReference)
         {
-            if (_customResolver)
+            if (_resolverWatchesUnresolvable)
             {
                 reference.EvaluateAndCachePropertyKey();
                 if (_referenceResolver.TryUnresolvableReference(this, reference, out var val))
@@ -1028,7 +1053,9 @@ public sealed partial class Engine : IDisposable
             Throw.ReferenceError(Realm, reference);
         }
 
-        if ((baseValue._type & InternalTypes.ObjectEnvironmentRecord) == InternalTypes.Empty && _customResolver)
+        if (_customResolver
+            && (baseValue._type & InternalTypes.ObjectEnvironmentRecord) == InternalTypes.Empty
+            && ResolverWatchesBase(baseValue))
         {
             reference.EvaluateAndCachePropertyKey();
             if (_referenceResolver.TryPropertyReference(this, reference, ref baseValue))
@@ -1059,7 +1086,14 @@ public sealed partial class Engine : IDisposable
                     return baseObj.PrivateGet((PrivateName) reference.ReferencedName);
                 }
 
-                reference.EvaluateAndCachePropertyKey();
+                // An object-base-watching resolver already evaluated the key above (the branch's guard is
+                // exactly this branch's precondition), so the key is cached and this call would be pure
+                // overhead; everything else still needs it.
+                if (!_resolverWatchesObjectBase)
+                {
+                    reference.EvaluateAndCachePropertyKey();
+                }
+
                 var v = baseObj.Get(reference.ReferencedName, reference.ThisValue);
                 return v;
             }
@@ -1106,6 +1140,22 @@ public sealed partial class Engine : IDisposable
         }
 
         return bindingValue;
+    }
+
+    /// <summary>
+    /// Whether the registered reference resolver subscribed to property references with this kind of base.
+    /// The base's kind is only known once it has been evaluated, so this is the runtime half of the
+    /// build-time <see cref="_resolverWatchesValueBase"/> gate.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool ResolverWatchesBase(JsValue baseValue)
+    {
+        if (baseValue.IsNullOrUndefined())
+        {
+            return _resolverWatchesNullishBase;
+        }
+
+        return baseValue.IsObject() ? _resolverWatchesObjectBase : _resolverWatchesPrimitiveBase;
     }
 
     private void ThrowPropertyNotFound(JsValue property, JsValue baseValue)

--- a/Jint/Options.Extensions.cs
+++ b/Jint/Options.Extensions.cs
@@ -339,9 +339,25 @@ public static class OptionsExtensions
         return options;
     }
 
+    /// <summary>
+    /// Registers a reference resolver that is consulted in every situation
+    /// (<see cref="ReferenceResolverInterests.All"/>).
+    /// </summary>
     public static Options SetReferencesResolver(this Options options, IReferenceResolver resolver)
     {
+        return SetReferencesResolver(options, resolver, ReferenceResolverInterests.All);
+    }
+
+    /// <summary>
+    /// Registers a reference resolver together with the situations it wants to be consulted for. The engine
+    /// does not call the resolver for anything outside <paramref name="interests"/>, and keeps the
+    /// interpreter fast paths those situations would otherwise disable — see
+    /// <see cref="ReferenceResolverInterests"/>.
+    /// </summary>
+    public static Options SetReferencesResolver(this Options options, IReferenceResolver resolver, ReferenceResolverInterests interests)
+    {
         options.ReferenceResolver = resolver;
+        options.ReferenceResolverInterests = interests;
         return options;
     }
 

--- a/Jint/Options.cs
+++ b/Jint/Options.cs
@@ -121,6 +121,20 @@ public class Options
     public IReferenceResolver ReferenceResolver { get; set; } = DefaultReferenceResolver.Instance;
 
     /// <summary>
+    /// The situations <see cref="ReferenceResolver"/> is consulted for. Defaults to
+    /// <see cref="ReferenceResolverInterests.All"/>, which is how every resolver behaved before this filter
+    /// existed. Narrowing it keeps interpreter fast paths armed for the situations the resolver opts out of;
+    /// see <see cref="ReferenceResolverInterests"/> for what each flag costs. Ignored while
+    /// <see cref="ReferenceResolver"/> is the built-in default.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="OptionsExtensions.SetReferencesResolver(Options, IReferenceResolver)"/> resets this to
+    /// <see cref="ReferenceResolverInterests.All"/>, so registering a second resolver through the
+    /// interest-free overload never silently inherits a narrower set from the first.
+    /// </remarks>
+    public ReferenceResolverInterests ReferenceResolverInterests { get; set; } = ReferenceResolverInterests.All;
+
+    /// <summary>
     /// Whether calling 'eval' with custom code and function constructors taking function code as string is allowed.
     /// Defaults to true.
     /// </summary>

--- a/Jint/Runtime/Interop/IReferenceResolver.cs
+++ b/Jint/Runtime/Interop/IReferenceResolver.cs
@@ -51,3 +51,72 @@ public interface IReferenceResolver
     /// <returns>Whether to accept the value.</returns>
     bool CheckCoercible(JsValue value);
 }
+
+/// <summary>
+/// The situations in which an <see cref="IReferenceResolver"/> wants to be consulted, declared when the
+/// resolver is registered via
+/// <see cref="OptionsExtensions.SetReferencesResolver(Options, IReferenceResolver, ReferenceResolverInterests)"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a <b>subscription filter, not a promise</b>. Every situation the resolver does not subscribe to
+/// is one the engine simply does not call it for, so there is no contract a host can violate by narrowing:
+/// the engine behaves exactly as if no resolver were registered for those situations.
+/// </para>
+/// <para>
+/// Narrowing matters because the mere presence of a resolver disables several interpreter fast paths — the
+/// member-read inline caches, the dense-array indexed-read lane and the member-call callee lane all have to
+/// route through a <see cref="Reference"/> so the resolver gets its chance. Declaring only what is actually
+/// used keeps those lanes armed. A resolver registered through
+/// <see cref="OptionsExtensions.SetReferencesResolver(Options, IReferenceResolver)"/> gets <see cref="All"/>,
+/// which behaves exactly as before this filter existed.
+/// </para>
+/// </remarks>
+[Flags]
+public enum ReferenceResolverInterests
+{
+    /// <summary>
+    /// The resolver is never consulted. Equivalent to registering no resolver at all.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Property references whose base is <c>null</c> or <c>undefined</c> — the null-propagation use case
+    /// (<c>a.b.c</c> yielding <see cref="JsValue.Undefined"/> instead of throwing). Enables both
+    /// <see cref="IReferenceResolver.CheckCoercible"/> and <see cref="IReferenceResolver.TryPropertyReference"/>
+    /// for those references.
+    /// </summary>
+    NullishPropertyBase = 1 << 0,
+
+    /// <summary>
+    /// Property references whose base is an object. This is the costliest interest to subscribe to: it
+    /// disables the non-computed member-read caches, the dense-array indexed-read lane and the member-call
+    /// callee lane, because every property read has to be offered to
+    /// <see cref="IReferenceResolver.TryPropertyReference"/> first.
+    /// </summary>
+    ObjectPropertyBase = 1 << 1,
+
+    /// <summary>
+    /// Property references whose base is a primitive other than <c>null</c>/<c>undefined</c> — a string,
+    /// number, boolean, symbol or BigInt. Shares the read-lane cost with <see cref="ObjectPropertyBase"/>,
+    /// since the base's type is only known once the base has been evaluated.
+    /// </summary>
+    PrimitivePropertyBase = 1 << 2,
+
+    /// <summary>
+    /// Unresolvable references — reads of names that resolve to no binding — routed through
+    /// <see cref="IReferenceResolver.TryUnresolvableReference"/> instead of throwing a <c>ReferenceError</c>.
+    /// </summary>
+    UnresolvableReference = 1 << 3,
+
+    /// <summary>
+    /// Call expressions whose resolved callee is not callable, routed through
+    /// <see cref="IReferenceResolver.TryGetCallable"/> instead of throwing a <c>TypeError</c>.
+    /// </summary>
+    NonCallableCallee = 1 << 4,
+
+    /// <summary>
+    /// Every situation. The default for resolvers registered without an explicit interest set.
+    /// </summary>
+    All = NullishPropertyBase | ObjectPropertyBase | PrimitivePropertyBase | UnresolvableReference | NonCallableCallee,
+}

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -82,9 +82,13 @@ internal sealed class JintCallExpression : JintExpression
         JsValue? fastFunc = null;
         var fastThis = JsValue.Undefined;
         var member = _calleeMember;
+        // Only a resolver watching object/primitive property bases has to disarm this: GetCalleeForCall
+        // returns Undefined for a null/undefined receiver and for a non-callable result, and both of those
+        // fall through to the Reference path where CheckCoercible / TryUnresolvableReference / TryGetCallable
+        // still run.
         if (member is not null
             && member.IsFastCallEligible
-            && !engine._customResolver)
+            && !engine._resolverWatchesValueBase)
         {
             fastFunc = member.GetCalleeForCall(context, out fastThis);
             if (suspendable is not null && suspendable.IsSuspended)
@@ -151,7 +155,8 @@ internal sealed class JintCallExpression : JintExpression
                     // since the unresolvable reference base is a sentinel (not undefined), also
                     // consult the resolver for unresolvable references so a call to an undefined
                     // name is routed through it instead of casting the sentinel to an Environment
-                    if ((baseValue.IsNullOrUndefined() || referenceRecord.IsUnresolvableReference)
+                    if (engine._resolverWatchesUnresolvable
+                        && (baseValue.IsNullOrUndefined() || referenceRecord.IsUnresolvableReference)
                         && engine._referenceResolver.TryUnresolvableReference(engine, referenceRecord, out var value))
                     {
                         thisObject = value;
@@ -203,7 +208,8 @@ internal sealed class JintCallExpression : JintExpression
             return func; // Return any value, caller will check Suspended
         }
 
-        if (!func.IsObject() && !engine._referenceResolver.TryGetCallable(engine, reference, out func))
+        if (!func.IsObject()
+            && (!engine._resolverWatchesCallee || !engine._referenceResolver.TryGetCallable(engine, reference, out func)))
         {
             ThrowMemberIsNotFunction(referenceRecord, reference, engine);
         }

--- a/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintMemberExpression.cs
@@ -369,7 +369,7 @@ internal sealed class JintMemberExpression : JintExpression
             && _determinedProperty is JsString determinedProperty
             && !_memberExpression.Optional
             && !_objectExpressionCanShortCircuit
-            && !engine._customResolver
+            && !engine._resolverWatchesValueBase
             && _objectExpression is not JintSuperExpression)
         {
             var baseValue = _objectExpression.GetValue(context);
@@ -380,6 +380,16 @@ internal sealed class JintMemberExpression : JintExpression
 
             if (baseValue.IsNullOrUndefined())
             {
+                if (engine._resolverWatchesNullishBase)
+                {
+                    // A resolver subscribed to null/undefined bases can substitute a value for this read
+                    // (the null-propagation use case), and only Engine.GetValue's TryPropertyReference lane
+                    // offers it that chance. Complete through a Reference rented from the already-resolved
+                    // base — the base is not re-evaluated, so nothing observable happens twice.
+                    var nullishBaseReference = engine._referencePool.Rent(baseValue, determinedProperty, engine.ExecutionContext.Strict, thisValue: null);
+                    return CompleteReadFromReference(context, engine, nullishBaseReference);
+                }
+
                 TypeConverter.CheckObjectCoercible(engine, baseValue, _memberExpression.Property, determinedProperty.ToString());
             }
 
@@ -465,8 +475,12 @@ internal sealed class JintMemberExpression : JintExpression
         // the index once, then read the dense slot directly. A miss rents a Reference from the
         // already-resolved operands — no re-evaluation — and completes through the normal path. The
         // Suspendable==null gate means neither operand can suspend, so no suspend bookkeeping is needed.
+        // The dense-array hit below only fires for an object (JsArray) base; every other outcome —
+        // including a null/undefined base — completes through the rented Reference, which still reaches
+        // CheckCoercible and TryPropertyReference. So only a resolver watching non-nullish bases has to
+        // disarm this lane.
         if (_computedReadEligible
-            && !engine._customResolver
+            && !engine._resolverWatchesValueBase
             && engine.ExecutionContext.Suspendable is null)
         {
             var baseValue = _objectExpression.GetValue(context);

--- a/Jint/Runtime/TypeConverter.cs
+++ b/Jint/Runtime/TypeConverter.cs
@@ -1081,7 +1081,9 @@ public static class TypeConverter
         Node sourceNode,
         string? referenceName)
     {
-        if (!engine._referenceResolver.CheckCoercible(o))
+        // Only a resolver that subscribed to null/undefined bases gets a say here; otherwise the
+        // interface call is skipped entirely and the read throws as it would with no resolver at all.
+        if (!engine._resolverWatchesNullishBase || !engine._referenceResolver.CheckCoercible(o))
         {
             ThrowMemberNullOrUndefinedError(engine, o, sourceNode, referenceName);
         }


### PR DESCRIPTION
The mere *presence* of a custom `IReferenceResolver` collapses into a single `Engine._customResolver` bool, and that bool disables:

- every non-computed member-read inline cache (shape slot, plain-object descriptor, `ObjectWrapper` member, `s.length`),
- the dense-array computed-read lane,
- the member-call callee lane,

and makes `Engine.GetValue` run `EvaluateAndCachePropertyKey()` plus a **virtual** `TryPropertyReference` on *every single property reference*.

A resolver that only implements null-propagation — the documented motivating use case, which only ever cares about `null`/`undefined` bases — pays all of it.

### The change

A new `[Flags] ReferenceResolverInterests` enum (`NullishPropertyBase`, `ObjectPropertyBase`, `PrimitivePropertyBase`, `UnresolvableReference`, `NonCallableCallee`, `All`) carried on `Options`, plus an overload:

```csharp
options.SetReferencesResolver(new NullPropagationReferenceResolver(),
    ReferenceResolverInterests.NullishPropertyBase);
```

Carried on `Options` rather than on a second interface, which keeps net462/netstandard2.0 free of default interface methods and puts **no burden on existing resolvers**. The interest-free overload sets `All`, so an existing registration behaves byte-identically to today; it also *resets* the property, so registering a second resolver through it never silently inherits a narrower set from the first.

**This is a subscription filter, not a promise.** Declaring only `NullishPropertyBase` means the engine does not call the resolver for object bases at all — so there is no contract for a host to violate by narrowing. For every unsubscribed situation the engine behaves exactly as if no resolver were registered.

### How the gating is placed

`Engine` derives the flags once at construction. `_customResolver` becomes "interests != None"; `_resolverWatchesValueBase` (`Object|Primitive`) gates the read/call fast paths.

The primary member-read lane is two-level: it is *entered* whenever the resolver does not watch value bases, and bails out to the rented-`Reference` path **from inside** when the base turns out to be nullish and the resolver does watch those — so `CheckCoercible` and `TryPropertyReference` still run, from an already-resolved base (nothing observable happens twice). The computed-index lane and `JintCallExpression` needed only the entry gate: their nullish and non-callable outcomes already fall through to the `Reference` path. `TypeConverter.CheckObjectCoercible` and `JintCallExpression`'s `TryUnresolvableReference` / `TryGetCallable` are gated on their own flags, so the interface call disappears entirely for resolvers that did not subscribe.

### A suggested "free fix" that turned out to be unsafe

An obvious-looking cleanup here is to hoist the `reference.EvaluateAndCachePropertyKey()` calls out of their branches and do it once up front. **That is not safe.** `GetValue` reads `var property = reference.ReferencedName;` *before* those calls, and the string lane below deliberately uses that un-keyed value — it tests `property._type & (String | Integer)` to reach `TryHandleStringValue`. Evaluating the key first turns `"abc"[1]`'s property from a `JsNumber` into the `JsString` `"1"`, losing the `Integer` flag and the fast path with it.

So the duplicate is removed by **gating** rather than hoisting.

With an object-base-watching resolver the key was evaluated twice per read (once for `TryPropertyReference`, once before `baseObj.Get`); the second call is now gated on `!_resolverWatchesObjectBase` — that branch's guard is exactly the first call's precondition, so the key is already cached and the un-keyed `property` local above is untouched.

### Tests

`Jint.Tests.PublicInterface/ReferenceResolverInterestsTests.cs` — each flag exercised in isolation (subscribed ⇒ consulted, unsubscribed ⇒ not consulted **and** the engine falls back to its no-resolver behaviour), `All` equivalence with the interest-free overload, `None`, optional-chaining short-circuit under every filter, and a theory asserting that ordinary reads — including `obj.s.length`, dense-array indexing and member calls — produce identical values under all seven filters.

Test262 is the load-bearing suite for this one: full run, no change against the baseline.

### Relationship to #2797

#2797 removed the `_customResolver` term from the **write** fast path (`TryAssignFast`) outright, on the grounds that `IReferenceResolver` has no write-side member at all. This PR is the read/call-side counterpart: those lanes genuinely *can* reach the resolver, so they are filtered by declared interest rather than removed. This branch is cut from `main` with #2797 already in it, and the two touch disjoint gates in `JintMemberExpression`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
