### PR TITLE
Stop execution constraints from disarming the tight-loop lane

### DIFF
--- a/Jint.Tests/Runtime/StatementLimitThrowPointTests.cs
+++ b/Jint.Tests/Runtime/StatementLimitThrowPointTests.cs
@@ -1,0 +1,220 @@
+using System.Collections.Generic;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A <see cref="Jint.Constraints.MaxStatementsConstraint"/> no longer disarms the interpreter's tight-loop
+/// lanes: the lanes charge the counter themselves. These tests pin that the charge cadence — and therefore
+/// the exact statement at which the limit throws — is identical with the lane armed and disarmed. The lane
+/// is disarmed by registering one extra (non-amortizable) constraint, which pushes the exact partition past
+/// the single-statement-counter shape the inline lane requires.
+/// </summary>
+public class StatementLimitThrowPointTests
+{
+    private sealed class InertConstraint : Constraint
+    {
+        public override void Check()
+        {
+        }
+
+        public override void Reset()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Observes external state only, so it is safe to amortize and must not disarm the tight lane.
+    /// </summary>
+    private sealed class AmortizableTripwire : Constraint
+    {
+        public bool Armed;
+        public int Checks;
+
+        public override bool IsAmortizable => true;
+
+        public override void Check()
+        {
+            Checks++;
+            if (Armed)
+            {
+                throw new TripwireException();
+            }
+        }
+
+        public override void Reset()
+        {
+        }
+    }
+
+    private sealed class TripwireException : System.Exception
+    {
+    }
+
+    private static string Run(string body, int maxStatements, bool disarmTightLane)
+    {
+        var sink = new List<string>();
+        var engine = new Engine(options =>
+        {
+            options.MaxStatements(maxStatements);
+            if (disarmTightLane)
+            {
+                options.Constraint(new InertConstraint());
+            }
+        });
+        engine.SetValue("log", new System.Action<string>(sink.Add));
+
+        var outcome = "ok";
+        try
+        {
+            engine.Evaluate("(function () {" + body + "})()");
+        }
+        catch (StatementsCountOverflowException)
+        {
+            outcome = "limit";
+        }
+
+        return outcome + "|" + string.Join(",", sink);
+    }
+
+    public static TheoryData<string> LoopShapes() =>
+    [
+        // for: block with several statements (routes through JintStatementList, which charges for the block)
+        "for (var i = 0; i < 4; i++) { log('a' + i); log('b' + i); }",
+        // for: single-statement block (routes through the block's single-statement lane, no block charge)
+        "for (var i = 0; i < 4; i++) { log('a' + i); }",
+        // for: bare statement body
+        "for (var i = 0; i < 4; i++) log('a' + i);",
+        // for: empty block (still a statement list, so still charged per iteration)
+        "var n = 0; for (var i = 0; i < 4; i++) { } log('n' + n);",
+        // for: empty statement body
+        "for (var i = 0; i < 4; i++) ; log('done');",
+        // for: if/else chain
+        "for (var i = 0; i < 6; i++) { if (i % 2 == 0) log('e' + i); else log('o' + i); }",
+        // for: if with a nested block branch (the branch block charges too)
+        "for (var i = 0; i < 6; i++) { if (i % 2 == 0) { log('e' + i); log('x' + i); } }",
+        // for: var declarations mixed in
+        "for (var i = 0; i < 4; i++) { var v = i * 2; log('v' + v); }",
+        // for: let body (per-iteration environment / flattening)
+        "for (let i = 0; i < 4; i++) { let v = i * 2; log('v' + v); }",
+        // while
+        "var i = 0; while (i < 4) { log('w' + i); i++; }",
+        "var i = 0; while (i < 4) { i++; }  log('i' + i);",
+        "var i = 0; while (i < 4) i++; log('i' + i);",
+        // do-while
+        "var i = 0; do { log('d' + i); i++; } while (i < 4);",
+        "var i = 0; do i++; while (i < 4); log('i' + i);",
+        // nested loops
+        "for (var i = 0; i < 3; i++) { for (var j = 0; j < 3; j++) { log(i + '' + j); } }",
+    ];
+
+    [Theory]
+    [MemberData(nameof(LoopShapes))]
+    public void ThrowPointIsIdenticalWithAndWithoutTheTightLane(string body)
+    {
+        // sweep the whole interesting range: every limit between "throws on the first statement" and
+        // "runs to completion" must place the throw at exactly the same statement in both lanes
+        for (var maxStatements = 1; maxStatements <= 80; maxStatements++)
+        {
+            var armed = Run(body, maxStatements, disarmTightLane: false);
+            var disarmed = Run(body, maxStatements, disarmTightLane: true);
+
+            armed.Should().Be(disarmed, $"max statements {maxStatements} for `{body}`");
+        }
+    }
+
+    [Fact]
+    public void StatementLimitStillTripsInsideTightLoops()
+    {
+        var engine = new Engine(options => options.MaxStatements(50));
+
+        Invoking(() => engine.Evaluate("(function () { var x = 0; for (var i = 0; i < 100000; i++) { x += 1; } })()"))
+            .Should().ThrowExactly<StatementsCountOverflowException>();
+    }
+
+    [Fact]
+    public void StatementLimitCountsAcrossEvaluationsAsBefore()
+    {
+        var engine = new Engine(options => options.MaxStatements(20));
+
+        engine.Evaluate("var a = 1;");
+        Invoking(() => engine.Evaluate("(function () { for (var i = 0; i < 100; i++) { a++; } })()"))
+            .Should().ThrowExactly<StatementsCountOverflowException>();
+
+        engine.Constraints.Reset();
+        engine.Evaluate("var b = 2;");
+        engine.Evaluate("b").AsNumber().Should().Be(2);
+    }
+
+    [Fact]
+    public void UnlimitedStatementConstraintDoesNotThrow()
+    {
+        // MaxStatements <= 0 means unlimited; the inline charge must reproduce that short-circuit
+        var engine = new Engine(options => options.MaxStatements(0));
+
+        engine.Evaluate("(function () { var x = 0; for (var i = 0; i < 10000; i++) { x += 1; } return x; })()")
+            .AsNumber().Should().Be(10000);
+    }
+
+    [Fact]
+    public void AmortizableUserConstraintKeepsTheTightLaneAndTheStatementLimitExact()
+    {
+        var tripwire = new AmortizableTripwire();
+        var engine = new Engine(options =>
+        {
+            options.MaxStatements(40);
+            options.Constraint(tripwire);
+        });
+
+        // the amortizable constraint joins the amortized partition, so the exact partition is still
+        // just the statement counter and the inline lane stays available: the throw point must match
+        // an engine configured with the statement limit alone
+        var sink = new List<string>();
+        engine.SetValue("log", new System.Action<string>(sink.Add));
+
+        Invoking(() => engine.Evaluate("(function () { for (var i = 0; i < 100; i++) { log('x' + i); } })()"))
+            .Should().ThrowExactly<StatementsCountOverflowException>();
+
+        var expected = Run("for (var i = 0; i < 100; i++) { log('x' + i); }", 40, disarmTightLane: false);
+        ("limit|" + string.Join(",", sink)).Should().Be(expected);
+    }
+
+    [Fact]
+    public void AmortizableUserConstraintIsStillCheckedInsideATightLoop()
+    {
+        var tripwire = new AmortizableTripwire();
+        var engine = new Engine(options => options.Constraint(tripwire));
+
+        // no exact constraints at all: the tight lane runs, and the amortized cadence must still reach
+        // the constraint often enough to interrupt an otherwise unbounded loop
+        tripwire.Armed = true;
+        Invoking(() => engine.Evaluate("(function () { var x = 0; for (var i = 0; i < 1000000; i++) { x += 1; } return x; })()"))
+            .Should().ThrowExactly<TripwireException>();
+
+        tripwire.Checks.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void NonAmortizableUserConstraintKeepsPerStatementCadence()
+    {
+        var counting = new CountingConstraint();
+        var engine = new Engine(options => options.Constraint(counting));
+
+        engine.Evaluate("(function () { var x = 0; for (var i = 0; i < 10; i++) { x += 1; } return x; })()");
+
+        // default IsAmortizable is false, so the constraint stays exact and sees every statement
+        counting.Checks.Should().BeGreaterThan(10);
+    }
+
+    private sealed class CountingConstraint : Constraint
+    {
+        public int Checks;
+
+        public override void Check() => Checks++;
+
+        // deliberately not clearing Checks: the engine resets constraints before every evaluation
+        public override void Reset()
+        {
+        }
+    }
+}

--- a/Jint/Constraints/CancellationConstraint.cs
+++ b/Jint/Constraints/CancellationConstraint.cs
@@ -19,6 +19,13 @@ public sealed class CancellationConstraint : Constraint
     /// </summary>
     internal CancellationToken Token => _cancellationToken;
 
+    /// <summary>
+    /// A cancellation token is external state that <see cref="Check"/> only reads and never consumes, and
+    /// it never un-cancels, so checking less often bounds how late cancellation is noticed rather than
+    /// changing whether it is.
+    /// </summary>
+    public override bool IsAmortizable => true;
+
     public override void Check()
     {
         if (_cancellationToken.IsCancellationRequested)

--- a/Jint/Constraints/MaxStatementsConstraint.cs
+++ b/Jint/Constraints/MaxStatementsConstraint.cs
@@ -16,6 +16,12 @@ public sealed class MaxStatementsConstraint : Constraint
     /// </summary>
     public int MaxStatements { get; set; }
 
+    /// <summary>
+    /// Never amortizable: this constraint counts its own invocations, so the call frequency <em>is</em>
+    /// what it measures. Skipping calls would not merely delay detection, it would change the count.
+    /// </summary>
+    public override bool IsAmortizable => false;
+
     public override void Check()
     {
         if (MaxStatements > 0 && ++_statementsCount > MaxStatements)

--- a/Jint/Constraints/MemoryLimitConstraint.cs
+++ b/Jint/Constraints/MemoryLimitConstraint.cs
@@ -27,6 +27,15 @@ public sealed class MemoryLimitConstraint : Constraint
         _memoryLimit = memoryLimit;
     }
 
+    /// <summary>
+    /// Never amortizable: unlike a clock, allocation between two checks is irreversible and unbounded per
+    /// statement — a single iteration can allocate arbitrarily much (exponential string growth, say) — so
+    /// checking less often would let the process overshoot the configured cap, potentially to a real
+    /// <see cref="OutOfMemoryException"/>, instead of merely noticing it late. Staying exact is what keeps
+    /// the limit usable as a hard-ish bound when sandboxing untrusted code.
+    /// </summary>
+    public override bool IsAmortizable => false;
+
     public override void Check()
     {
         if (_memoryLimit <= 0)

--- a/Jint/Constraints/TimeConstraint.cs
+++ b/Jint/Constraints/TimeConstraint.cs
@@ -33,6 +33,12 @@ internal sealed class TimeConstraint : Constraint
         _timeoutTicks = ticks >= long.MaxValue / 2.0 ? long.MaxValue / 2 : (long) ticks;
     }
 
+    /// <summary>
+    /// A deadline is external state that <see cref="Check"/> only reads, and a clock only advances, so
+    /// checking less often bounds how late the timeout is noticed rather than changing what is measured.
+    /// </summary>
+    public override bool IsAmortizable => true;
+
     public override void Check()
     {
         var deadline = _deadline;

--- a/Jint/Engine.Constraints.cs
+++ b/Jint/Engine.Constraints.cs
@@ -8,7 +8,10 @@ public partial class Engine
     public ConstraintOperations Constraints { get; }
 
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-    private readonly record struct ConstraintPartition(Constraint[] Exact, Constraint[] Amortized);
+    private readonly record struct ConstraintPartition(
+        Constraint[] Exact,
+        Constraint[] Amortized,
+        MaxStatementsConstraint? InlineStatementCounter);
 
     /// <summary>
     /// Materializes the constraint set for this engine.
@@ -56,40 +59,38 @@ public partial class Engine
     }
 
     /// <summary>
-    /// Splits the registered constraints by required check frequency. The built-in time and
-    /// cancellation constraints only observe external state that a check reads without consuming
-    /// (a timer, a token), so checking them every N statements is semantically equivalent to
-    /// checking per statement — only the detection latency is bounded instead of immediate (the
-    /// same reasoning bulk built-ins apply via <see cref="ConstraintCheckInterval"/>). Everything
-    /// else stays exact:
-    /// <list type="bullet">
-    /// <item><see cref="MaxStatementsConstraint"/> counts statements, so its call frequency IS its
-    /// semantics.</item>
-    /// <item><see cref="MemoryLimitConstraint"/> reads an allocation counter, but unlike a clock
-    /// that only advances, allocation between checks is irreversible and unbounded per statement
-    /// (a single iteration can allocate arbitrarily much, e.g. exponential string growth), so
-    /// amortizing it would let the process overshoot the configured cap — potentially to a real
-    /// OutOfMemoryException — before the next check. Keeping it exact preserves the memory bound
-    /// as a hard-ish guarantee for sandboxing untrusted code (matching pre-tight-lane behavior).</item>
-    /// <item>User-derived constraints may depend on being called once per statement — silently
-    /// amortizing them would be a breaking behavior change.</item>
-    /// </list>
+    /// Splits the registered constraints by required check frequency, which each constraint declares for
+    /// itself through <see cref="Constraint.IsAmortizable"/>. An amortizable constraint only observes
+    /// external state that a check reads without consuming, so checking it every N statements is
+    /// semantically equivalent to checking per statement — only the detection latency is bounded instead
+    /// of immediate (the same reasoning bulk built-ins apply via <see cref="ConstraintCheckInterval"/>).
+    /// Everything else stays exact, which is the default and therefore what a user-derived constraint gets
+    /// unless it opts in. See <see cref="Constraint.IsAmortizable"/> for when opting in is sound, and each
+    /// built-in constraint for why it answers the way it does.
+    /// <para>
+    /// <see cref="MaxStatementsConstraint"/> additionally gets a dedicated lane: when it is the
+    /// <em>only</em> exact constraint it is also reported as
+    /// <see cref="ConstraintPartition.InlineStatementCounter"/>, so the interpreter can charge it directly
+    /// (a devirtualized call on a sealed type) at exactly the same points <see cref="RunPerStatementChecks"/>
+    /// would, and the tight-loop lanes — which cannot run the exact list — stay armed.
+    /// </para>
+    /// <para>
     /// Interop call sites additionally re-check on return from user CLR code — see
     /// <see cref="CheckAmortizedConstraintsAtHostBoundary"/> for that mechanism's rationale.
+    /// </para>
     /// </summary>
     private static ConstraintPartition PartitionConstraints(Constraint[] constraints)
     {
         if (constraints.Length == 0)
         {
-            return new ConstraintPartition([], []);
+            return new ConstraintPartition([], [], null);
         }
 
         var exact = new List<Constraint>(constraints.Length);
         var amortized = new List<Constraint>(constraints.Length);
         foreach (var constraint in constraints)
         {
-            // Both types are sealed, so the check cannot match a user-derived subclass.
-            if (constraint is TimeConstraint or CancellationConstraint)
+            if (constraint.IsAmortizable)
             {
                 amortized.Add(constraint);
             }
@@ -99,7 +100,12 @@ public partial class Engine
             }
         }
 
-        return new ConstraintPartition(exact.ToArray(), amortized.ToArray());
+        // A lone statement counter is the one exact constraint the interpreter can charge itself, so
+        // report it separately and let the per-statement path skip the exact-list walk entirely.
+        // MaxStatementsConstraint is sealed, hence the exact type match.
+        var inlineStatementCounter = exact.Count == 1 ? exact[0] as MaxStatementsConstraint : null;
+
+        return new ConstraintPartition(exact.ToArray(), amortized.ToArray(), inlineStatementCounter);
     }
 
     public class ConstraintOperations

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -166,6 +166,15 @@ public sealed partial class Engine : IDisposable
     internal readonly Constraint[] _exactConstraints;
     internal readonly Constraint[] _amortizedConstraints;
 
+    /// <summary>
+    /// Set when the exact partition consists of nothing but a <see cref="MaxStatementsConstraint"/>. That
+    /// single constraint is one the interpreter can charge itself — a devirtualized call on a sealed type
+    /// rather than a walk over <see cref="_exactConstraints"/> — which lets the tight-loop lanes stay armed
+    /// while still hitting the counter once per executed statement, at exactly the points
+    /// <see cref="RunPerStatementChecks"/> would have.
+    /// </summary>
+    internal readonly MaxStatementsConstraint? _inlineStatementCounter;
+
     internal readonly bool _isDebugMode;
     internal readonly bool _isStrict;
 
@@ -306,6 +315,7 @@ public sealed partial class Engine : IDisposable
         var partitionedConstraints = PartitionConstraints(_constraints);
         _exactConstraints = partitionedConstraints.Exact;
         _amortizedConstraints = partitionedConstraints.Amortized;
+        _inlineStatementCounter = partitionedConstraints.InlineStatementCounter;
         _referenceResolver = Options.ReferenceResolver;
         var resolverInterests = ReferenceEquals(_referenceResolver, DefaultReferenceResolver.Instance)
             ? ReferenceResolverInterests.None

--- a/Jint/IConstraint.cs
+++ b/Jint/IConstraint.cs
@@ -14,4 +14,32 @@ public abstract class Constraint
     /// Called before script is run. Useful when you use an engine object for multiple executions.
     /// </summary>
     public abstract void Reset();
+
+    /// <summary>
+    /// Whether the engine may check this constraint every N statements instead of before every single one.
+    /// This is the sole input to that classification, so a constraint decides its own check cadence here.
+    /// Defaults to <see langword="false"/>, which is how every user-derived constraint behaved before this
+    /// property existed; the built-in constraints each override it and say why.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Amortization is sound only when <see cref="Check"/> <b>observes external state without consuming
+    /// it</b> — a wall clock, a <see cref="System.Threading.CancellationToken"/>, a flag another thread
+    /// sets. For such a constraint, checking less often changes nothing but detection latency, which stays
+    /// bounded (the engine also re-checks whenever control returns from host code, so a single long CLR
+    /// call cannot stretch it).
+    /// </para>
+    /// <para>
+    /// It is <b>not</b> sound when the call frequency is itself the semantics. A constraint that counts its
+    /// own invocations (a statement budget) must stay exact, because skipping calls changes what it
+    /// measures. Neither is it sound for a budget over a quantity that can grow without bound between two
+    /// checks — an allocation cap, for instance, can be blown arbitrarily far past its limit inside one
+    /// statement, so the built-in memory-limit constraint deliberately stays exact.
+    /// </para>
+    /// <para>
+    /// Returning <see langword="true"/> also keeps the interpreter's tight-loop lanes armed, since those
+    /// lanes drive amortized constraints at their own bounded cadence but cannot run exact ones.
+    /// </para>
+    /// </remarks>
+    public virtual bool IsAmortizable => false;
 }

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Jint.Constraints;
 using Jint.Native.Generator;
 
 namespace Jint.Runtime.Interpreter;
@@ -20,13 +21,21 @@ internal sealed class EvaluationContext
 
     private readonly bool _shouldRunPerStatementChecks;
     private readonly bool _hasAmortizedConstraints;
+    private readonly MaxStatementsConstraint? _statementCounter;
     private int _amortizedConstraintCountdown;
 
     public EvaluationContext(Engine engine)
     {
         Engine = engine;
         OperatorOverloadingAllowed = engine.Options.Interop.AllowOperatorOverloading;
-        _shouldRunPerStatementChecks = engine._exactConstraints.Length > 0 || engine._isDebugMode;
+
+        // A lone statement counter does not have to disarm the statement fast paths: it is charged
+        // inline instead (see ChargeStatement), once per executed statement, at the same points
+        // RunPerStatementChecks would have reached. Debug mode still forces the generic path, because
+        // the debugger's step hook rides along in RunPerStatementChecks.
+        _statementCounter = engine._isDebugMode ? null : engine._inlineStatementCounter;
+        _shouldRunPerStatementChecks = (engine._exactConstraints.Length > 0 || engine._isDebugMode)
+                                       && _statementCounter is null;
         _hasAmortizedConstraints = engine._amortizedConstraints.Length > 0;
         _amortizedConstraintCountdown = AmortizedConstraintCheckInterval;
     }
@@ -38,6 +47,7 @@ internal sealed class EvaluationContext
         OperatorOverloadingAllowed = false;
         _shouldRunPerStatementChecks = false;
         _hasAmortizedConstraints = false;
+        _statementCounter = null;
     }
 
     public readonly Engine Engine;
@@ -47,7 +57,8 @@ internal sealed class EvaluationContext
     /// Frozen per context (exact constraints or debug mode at creation); statement fast paths
     /// that skip <see cref="RunBeforeExecuteStatementChecks"/> must be gated on this AND keep
     /// amortized constraints live by driving <see cref="RunAmortizedConstraintChecks"/> at a
-    /// bounded cadence (e.g. once per loop iteration).
+    /// bounded cadence (e.g. once per loop iteration), AND charge <see cref="ChargeStatement"/>
+    /// once per statement they execute.
     /// </summary>
     internal bool ShouldRunPerStatementChecks => _shouldRunPerStatementChecks;
 
@@ -99,8 +110,30 @@ internal sealed class EvaluationContext
         {
             Engine.RunPerStatementChecks(statement);
         }
+        else
+        {
+            // Mutually exclusive by construction: _statementCounter is only set when the exact list
+            // collapsed to that one constraint, which is precisely when _shouldRunPerStatementChecks
+            // is false. Charging in both branches would double-count.
+            ChargeStatement();
+        }
 
         RunAmortizedConstraintChecks();
+    }
+
+    /// <summary>
+    /// Charges one executed statement against the inline statement counter, if there is one. Statement
+    /// fast paths that bypass <see cref="RunBeforeExecuteStatementChecks"/> must call this exactly where
+    /// the generic path would have run the check — once per non-block statement, plus once for a block
+    /// whose contents run through a <see cref="JintStatementList"/> — so the statement at which
+    /// <see cref="MaxStatementsConstraint"/> throws is the same with the fast path armed or disarmed.
+    /// <see cref="MaxStatementsConstraint"/> is sealed, so this is a devirtualized, inlineable call, and a
+    /// null field is a predictable branch when no counter is configured.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void ChargeStatement()
+    {
+        _statementCounter?.Check();
     }
 
     /// <summary>

--- a/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintBlockStatement.cs
@@ -343,9 +343,15 @@ internal sealed class JintBlockStatement : JintStatement<NestedBlockStatement>
     {
         if (_singleStatement is not null)
         {
+            // ExecuteSingle runs the statement directly, so only that statement is charged — matched here
+            // by its own ExecuteDiscarded.
             _singleStatement.ExecuteDiscarded(context);
             return;
         }
+
+        // The list form runs through JintStatementList.Execute, which charges once for the block itself
+        // before charging each contained statement; reproduce that first charge here.
+        context.ChargeStatement();
 
         var list = _statementList!;
         var count = list.Count;

--- a/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintDoWhileStatement.cs
@@ -137,9 +137,18 @@ internal sealed class JintDoWhileStatement : JintStatement<DoWhileStatement>
         var list = _tightBodyList;
         var engine = context.Engine;
 
+        // See JintForStatement.TightForBody: a non-single body costs the generic lane one extra
+        // statement-counter charge per iteration (the block, or the bare EmptyStatement body).
+        var chargeBodyEnvelope = single is null;
+
         do
         {
             context.RunAmortizedConstraintChecks();
+
+            if (chargeBodyEnvelope)
+            {
+                context.ChargeStatement();
+            }
 
             if (single is not null)
             {

--- a/Jint/Runtime/Interpreter/Statements/JintEmptyStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintEmptyStatement.cs
@@ -15,5 +15,6 @@ internal sealed class JintEmptyStatement : JintStatement<EmptyStatement>
 
     internal override void ExecuteDiscarded(EvaluationContext context)
     {
+        context.ChargeStatement();
     }
 }

--- a/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintExpressionStatement.cs
@@ -48,6 +48,8 @@ internal sealed class JintExpressionStatement : JintStatement<ExpressionStatemen
     /// </summary>
     internal override void ExecuteDiscarded(EvaluationContext context)
     {
+        context.ChargeStatement();
+
         if (_expressionCanDiscard)
         {
             _expression.EvaluateAndDiscard(context);

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -719,9 +719,21 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         var engine = context.Engine;
         var resetBodySlotsPerIteration = flattenActive && !_flattenedBodySlotsInitBeforeUse;
 
+        // The generic lane charges the statement counter once more per iteration than the per-statement
+        // charges below account for, whenever the body is not a single statement: a block body whose
+        // contents run through JintStatementList charges for the block, and an EmptyStatement body (which
+        // leaves both references null) charges for the empty statement. Both are exactly the `single is
+        // null` shape.
+        var chargeBodyEnvelope = single is null;
+
         while (test.GetBooleanValue(context))
         {
             context.RunAmortizedConstraintChecks();
+
+            if (chargeBodyEnvelope)
+            {
+                context.ChargeStatement();
+            }
 
             if (resetBodySlotsPerIteration)
             {

--- a/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintIfStatement.cs
@@ -84,6 +84,8 @@ internal sealed class JintIfStatement : JintStatement<IfStatement>
     /// </summary>
     internal override void ExecuteDiscarded(EvaluationContext context)
     {
+        context.ChargeStatement();
+
         if (_test.GetBooleanValue(context))
         {
             if (context.Engine._error is not null)

--- a/Jint/Runtime/Interpreter/Statements/JintStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintStatement.cs
@@ -48,6 +48,11 @@ internal abstract class JintStatement
     /// predicate (no break/continue/return/labels, so only Normal completions can occur). Deferred
     /// errors surface via <see cref="Engine._error"/>, which the caller polls after each statement.
     /// The base implementation falls back to the full <see cref="Execute"/> ceremony.
+    /// <para>
+    /// Overrides must call <see cref="EvaluationContext.ChargeStatement"/> first: it stands in for the
+    /// statement-counting constraint that <see cref="Execute"/> would have charged here, and its cadence
+    /// decides where a statement limit throws.
+    /// </para>
     /// </summary>
     internal virtual void ExecuteDiscarded(EvaluationContext context)
     {

--- a/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintVariableDeclaration.cs
@@ -97,6 +97,7 @@ internal sealed class JintVariableDeclaration : JintStatement<VariableDeclaratio
     /// </summary>
     internal override void ExecuteDiscarded(EvaluationContext context)
     {
+        context.ChargeStatement();
         context.LastSyntaxElement = _statement;
         ExecuteInternal(context);
     }

--- a/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintWhileStatement.cs
@@ -143,9 +143,18 @@ internal sealed class JintWhileStatement : JintStatement<WhileStatement>
         var list = _tightBodyList;
         var engine = context.Engine;
 
+        // See JintForStatement.TightForBody: a non-single body costs the generic lane one extra
+        // statement-counter charge per iteration (the block, or the bare EmptyStatement body).
+        var chargeBodyEnvelope = single is null;
+
         while (test.GetBooleanValue(context))
         {
             context.RunAmortizedConstraintChecks();
+
+            if (chargeBodyEnvelope)
+            {
+                context.ChargeStatement();
+            }
 
             if (single is not null)
             {


### PR DESCRIPTION
`EvaluationContext` derives `_shouldRunPerStatementChecks` from *"any exact constraint exists"*, and the `for`/`while`/`do-while` tight body lanes are gated on its negation. `PartitionConstraints` only amortizes the sealed `TimeConstraint` and `CancellationConstraint`, so that gate bites twice: a host that sets `MaxStatements` loses the tight lane, and so does a host with **any** user-derived `Constraint` at all — including one that merely watches a clock.

Two independent-but-related changes, both about the same gate.

### 1. A lone `MaxStatementsConstraint` no longer disarms anything

When the exact partition is *solely* that constraint (it is `sealed`, so this is an exact type test) and debug mode is off, `PartitionConstraints` reports it separately as `ConstraintPartition.InlineStatementCounter`, `_shouldRunPerStatementChecks` stays `false`, and the interpreter charges the counter itself through `EvaluationContext.ChargeStatement()` — a devirtualized, inlineable call on a sealed type instead of a walk over the exact array, and a predictable null-check branch when no counter is configured. Debug mode still forces the generic path, because the debugger's step hook rides along in `RunPerStatementChecks`.

**Cadence is the entire risk here.** The charge is placed exactly where the generic path runs the check, so the statement at which the limit throws is unchanged:

- once per non-block statement — each `ExecuteDiscarded` override;
- once for a block whose contents run through `JintStatementList`;
- once for a bare `EmptyStatement` loop body.

The last two are the `single is null` shape in the tight lanes, which is why those lanes charge one body envelope per iteration.

The differential test is the argument: **15 loop shapes × every statement limit from 1 to 80**, asserting that the recorded side-effect sequence *and* the throw/no-throw outcome are identical with the lane armed and with it disarmed by an extra inert constraint.

Writing that test surfaced a **pre-existing gap**: for a bare `EmptyStatement` body (`for (;;);`) the tight lane charged the counter **nothing at all**, while the generic path charges one statement per iteration. That is fixed here as part of getting the cadence to match.

### 2. `public virtual bool Constraint.IsAmortizable => false`

A user-derived constraint that only *observes* external state — a clock, a cancellation token, a flag another thread sets — can now join the amortized partition and stop forcing per-statement checks. The default preserves today's behaviour for every existing subclass.

The property documents when opting in is sound, and when it is not:

- **Not** for a constraint that counts its own invocations — the call frequency *is* the semantics.
- **Not** for a budget over a quantity that can grow without bound between two checks. An allocation cap can be blown arbitrarily far past its limit inside a single statement, which is exactly why the built-in `MemoryLimitConstraint` deliberately stays exact.

### Relationship to #2795

This was written while #2795 ("Give every engine its own constraint instances so Options can be shared") was still open, so it was deliberately built to **compose** rather than stack: #2795 changes *how `Engine` builds* `_constraints`, while this changes *how that array is partitioned*, and `PartitionConstraints(Constraint[])` stays a pure function of the array it is handed.

#2795 has since merged, so this branch simply sits on top of it: `BuildConstraints` is not touched, and factory-produced constraint instances reach `PartitionConstraints` exactly like directly-registered ones and are classified identically. The differential test registers its extra inert constraint through `Options.Constraint(Constraint)`, the instance overload #2795 kept for the single-engine case.

### Verification

Full Test262 run, plus `Jint.Tests` and `Jint.Tests.PublicInterface`, all unchanged against the `main` baseline. Test262 matters most here since this touches the statement-execution lanes.

---

### Review follow-up: one classification mechanism instead of two

The first version classified with two rules for one decision:

```csharp
// The two built-in types are sealed, so the check cannot match a user-derived subclass; those
// join only by opting in explicitly.
if (constraint is TimeConstraint or CancellationConstraint || constraint.IsAmortizable)
```

The comment existed only to argue that the dual mechanism was safe — a sign the mechanism was the problem. Now that `Constraint.IsAmortizable` exists, the built-ins declare themselves and the partition reads only the property:

```csharp
if (constraint.IsAmortizable)
```

`TimeConstraint` and `CancellationConstraint` now override it to `true`, each with a one-line reason.

**`MaxStatementsConstraint` and `MemoryLimitConstraint` also get explicit `=> false` overrides.** Mechanically redundant — they already inherit `false` — but the *reasoning* is the non-obvious part, and it was living in a bullet list in `Engine.Constraints.cs`, far from the types it describes. Two considerations decided it:

- With only two of four built-ins declaring, a reader cannot tell "deliberately exact" from "nobody got round to it" — a bad ambiguity for a classification that decides whether a sandbox's memory cap is a hard bound.
- The reasons are per-type facts, not partition facts: a statement counter's call frequency *is* its semantics; allocation between two memory checks is irreversible and unbounded, so amortizing would let the process overshoot the cap rather than merely notice it late.

The long comment on `PartitionConstraints` shrinks to a pointer at `Constraint.IsAmortizable` and the individual types, keeping only what is genuinely about the partition (the inline-statement-counter lane and the host-boundary re-check).

**Behaviour is unchanged**, by construction:

| constraint | before | after |
| --- | --- | --- |
| `TimeConstraint` (internal sealed) | amortized, via type test | amortized, via `=> true` |
| `CancellationConstraint` (public sealed) | amortized, via type test | amortized, via `=> true` |
| `MaxStatementsConstraint` | exact | exact, now explicitly |
| `MemoryLimitConstraint` | exact | exact, now explicitly |
| user-derived | `IsAmortizable`, default `false` | unchanged |

All four built-ins are `sealed`, so no subclass can reach a different answer than the old type test did. The 15-loop-shapes × statement-limits-1–80 differential test is the guard and passes unchanged, alongside a full Test262 run.

**One publicly observable consequence, and it is a correction:** `CancellationConstraint` is `public sealed`, so an embedder holding one from `engine.Constraints.Find<CancellationConstraint>()` now reads `IsAmortizable == true` where the inherited default said `false`. The engine has amortized this constraint all along; the inherited `false` simply contradicted what the engine actually did. Same for `TimeConstraint`, which is `internal` and therefore not observable at all.

**Deliberately untouched:** `exact[0] as MaxStatementsConstraint` in the inline-counter line stays a type test. That is not classification — it identifies a concrete sealed type so the interpreter can call `Check()` devirtualized — and a property could not express it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
