### PR TITLE
Hash a concatenated string by its content, not by its buffer identity

### DIFF
--- a/Jint.Tests/Runtime/StringRepresentationKeyTests.cs
+++ b/Jint.Tests/Runtime/StringRepresentationKeyTests.cs
@@ -1,0 +1,198 @@
+using Jint.Native;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <see cref="JsString"/> has more than one internal representation: a flat value, a lazily
+/// materialized view over a larger string, and a growable buffer built up by repeated concatenation.
+/// All of them must be usable interchangeably as a key, which means each one has to hash its
+/// <em>content</em> — the same hash a plain <see cref="JsString"/> with those characters produces.
+/// Hashing anything else (buffer identity, for instance) breaks the equals/hash-code contract:
+/// two values compare equal but land in different buckets, so a lookup misses.
+/// </summary>
+public class StringRepresentationKeyTests
+{
+    /// <summary>
+    /// Builds "abc" as a growable-buffer string and leaves it where a built-in can read it back
+    /// without the interpreter's copy-on-assign step flattening it first. Two appends are needed:
+    /// the first produces a buffer-free value, the second grows the buffer.
+    /// </summary>
+    private const string ConcatenatedInArray = "var a = ['a']; a[0] += 'b'; a[0] += 'c';";
+
+    private static Engine CreateEngine() => new();
+
+    [Fact]
+    public void ConcatenatedStringIsBuiltUpWithALiveBuffer()
+    {
+        // guards the premise of every other test here: if the interpreter ever starts flattening
+        // this shape, these tests would silently stop covering the growable-buffer representation
+        var engine = CreateEngine();
+
+        var value = engine.Evaluate(ConcatenatedInArray + " a[0]");
+
+        value.Should().BeOfType<JsString.ConcatenatedString>();
+        value.ToString().Should().Be("abc");
+    }
+
+    [Fact]
+    public void ConcatenatedStringHashesLikeTheEquivalentFlatString()
+    {
+        var engine = CreateEngine();
+
+        var concatenated = engine.Evaluate(ConcatenatedInArray + " a[0]");
+
+        concatenated.Equals(new JsString("abc")).Should().BeTrue();
+        concatenated.GetHashCode().Should().Be(new JsString("abc").GetHashCode());
+    }
+
+    [Fact]
+    public void StringConcatResultHashesLikeTheEquivalentFlatString()
+    {
+        var engine = CreateEngine();
+
+        var concatenated = engine.Evaluate("'a'.concat('b', 'c')");
+
+        concatenated.Should().BeOfType<JsString.ConcatenatedString>();
+        concatenated.Equals(new JsString("abc")).Should().BeTrue();
+        concatenated.GetHashCode().Should().Be(new JsString("abc").GetHashCode());
+    }
+
+    [Fact]
+    public void ConcatenatedStringHashesLikeTheFlatStringAfterMaterializing()
+    {
+        // asking for the flat text caches it, but the growable buffer is still around; the hash
+        // must not depend on which of the two the value happens to be carrying
+        var engine = CreateEngine();
+
+        var concatenated = engine.Evaluate(ConcatenatedInArray + " String(a[0]); a[0]");
+
+        concatenated.ToString().Should().Be("abc");
+        concatenated.GetHashCode().Should().Be(new JsString("abc").GetHashCode());
+    }
+
+    [Fact]
+    public void ConcatenatedStringWorksAsAHostDictionaryKey()
+    {
+        // a host that keys its own dictionary by JsValue relies on the same contract
+        var engine = CreateEngine();
+        var concatenated = engine.Evaluate(ConcatenatedInArray + " a[0]");
+
+        var set = new HashSet<JsValue> { concatenated };
+
+        set.Contains(new JsString("abc")).Should().BeTrue();
+        set.Add(new JsString("abc")).Should().BeFalse("an equal string must not create a second entry");
+    }
+
+    [Fact]
+    public void ConcatenatedStringIsFoundInASetByALiteral()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate(ConcatenatedInArray + " new Set(a).has('abc')").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConcatenatedStringIsFoundInAMapByALiteral()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate(ConcatenatedInArray + " new Map(new Set(a).entries()).get('abc')")
+            .AsString().Should().Be("abc");
+    }
+
+    [Fact]
+    public void ConcatenatedStringDoesNotCreateADuplicateSetEntry()
+    {
+        var engine = CreateEngine();
+
+        // the array holds the growable-buffer "abc" and a plain literal "abc"
+        engine.Evaluate("var a = ['a', 'abc']; a[0] += 'b'; a[0] += 'c'; new Set(a).size")
+            .AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void ALiteralSetFindsAConcatenatedString()
+    {
+        // the other direction: the stored keys are flat and the probed value is concatenated
+        var engine = CreateEngine();
+
+        engine.Evaluate(ConcatenatedInArray + " new Set(['abc']).intersection(new Set(a)).size")
+            .AsNumber().Should().Be(1);
+        engine.Evaluate(ConcatenatedInArray + " new Set(a).intersection(new Set(['abc'])).size")
+            .AsNumber().Should().Be(1);
+        engine.Evaluate(ConcatenatedInArray + " new Set(a).isSubsetOf(new Set(['abc']))")
+            .AsBoolean().Should().BeTrue();
+        engine.Evaluate(ConcatenatedInArray + " new Set(['abc']).union(new Set(a)).size")
+            .AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void AppendChainIsFoundInASetByALiteral()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("var a = ['x']; for (var i = 0; i < 5; i++) { a[0] += i; } new Set(a).has('x01234')")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConcatenatedObjectPropertyIsFoundInASetByALiteral()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("var o = { p: 'a' }; o.p += 'b'; o.p += 'c'; new Set(Object.values(o)).has('abc')")
+            .AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConcatenatedStringRemovedFromASetByALiteral()
+    {
+        // removal happened to work already (the ordering list compares by content), but it left the
+        // lookup structure holding a stale entry; assert the observable end state either way
+        var engine = CreateEngine();
+
+        engine.Evaluate(ConcatenatedInArray + " var s = new Set(a); s.delete('abc'); s.size")
+            .AsNumber().Should().Be(0);
+        engine.Evaluate(ConcatenatedInArray + " var s = new Set(a); s.delete('abc'); s.has('abc')")
+            .AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ConcatenatedStringWorksAsAPropertyKey()
+    {
+        // property keys are converted to a flat .NET string before they are hashed, so they were
+        // never affected; pinned here to bound the blast radius of the representation choice
+        var engine = CreateEngine();
+
+        engine.Evaluate(ConcatenatedInArray + " var o = {}; o[a[0]] = 7; o.abc").AsNumber().Should().Be(7);
+        engine.Evaluate(ConcatenatedInArray + " var o = { abc: 7 }; o[a[0]]").AsNumber().Should().Be(7);
+        engine.Evaluate(ConcatenatedInArray + " var o = { abc: 7 }; a[0] in o").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConcatenatedStringComparesEqualToTheEquivalentLiteral()
+    {
+        // equality was always content based -- that is precisely why an identity hash is a contract
+        // violation rather than merely an unusual choice
+        var engine = CreateEngine();
+
+        engine.Evaluate(ConcatenatedInArray + " a[0] === 'abc'").AsBoolean().Should().BeTrue();
+        engine.Evaluate(ConcatenatedInArray + " 'abc' === a[0]").AsBoolean().Should().BeTrue();
+        engine.Evaluate(ConcatenatedInArray + " a.includes('abc')").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void SlicedStringIsUsableAsACollectionKey()
+    {
+        // the sibling lazily materialized representation already hashes its content; regression guard
+        var engine = CreateEngine();
+        const string Source = "var big = 'abcde'; while (big.length < 2000) { big = big + big; } big = big.substring(0, 2000);";
+
+        engine.Evaluate(Source + " new Set([big.substring(0, 1500), big.substring(0, 1500)]).size")
+            .AsNumber().Should().Be(1);
+        engine.Evaluate(Source + " var flat = big.split('').slice(0, 1500).join(''); new Set([big.substring(0, 1500), flat]).size")
+            .AsNumber().Should().Be(1);
+        engine.Evaluate(Source + " var flat = big.split('').slice(0, 1500).join(''); new Map([[big.substring(0, 1500), 1]]).get(flat)")
+            .AsNumber().Should().Be(1);
+    }
+}

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -565,7 +565,12 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
             return string.Equals(ToString(), other.ToString(), StringComparison.Ordinal);
         }
 
-        public override int GetHashCode() => _stringBuilder?.GetHashCode() ?? StringComparer.Ordinal.GetHashCode(_value);
+        // Hash the content, exactly like the flat base implementation: StringBuilder does not
+        // override GetHashCode, so hashing the buffer would hash its identity and an equal value
+        // would land in a different bucket than the flat string Equals says it matches.
+        // Materializing is unavoidable for a content hash, and Equals already materializes, so no
+        // previously allocation-free path becomes allocating.
+        public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(ToString());
 
         internal override JsValue DoClone()
         {


### PR DESCRIPTION
A string built up by repeated concatenation carries a growable buffer, and `ConcatenatedString.GetHashCode` returned that buffer's hash whenever the buffer was live:

```csharp
public override int GetHashCode() => _stringBuilder?.GetHashCode() ?? StringComparer.Ordinal.GetHashCode(_value);
```

`StringBuilder` does not override `GetHashCode`, so that is `object.GetHashCode` — reference identity. A concatenated `"abc"` therefore hashed differently from a flat `"abc"`, while `Equals` compared by content on both sides. That is a straight equals/hash-code contract violation: two values report equal but land in different buckets, so every hash-based lookup that mixes the two representations silently misses.

## Reproduction

The interpreter copies a string value on assignment and when building call arguments, which flattens the concatenated representation and hides the problem in the obvious shapes. It does *not* copy when a compound assignment writes back through a member reference, so the growable-buffer value stays in the array/object — and built-ins read it back out directly:

```js
var a = ['a'];
a[0] += 'b';                  // first append: no buffer yet
a[0] += 'c';                  // second append: buffer is now live

new Set(a).has('abc');        // false  -- expected true
```

Deduplication misses for the same reason:

```js
var b = ['a', 'abc'];
b[0] += 'b'; b[0] += 'c';

new Set(b).size;              // 2  -- expected 1, the two values are ===
```

It reaches `Map` and the set-operation methods too:

```js
var a = ['a']; a[0] += 'b'; a[0] += 'c';

new Map(new Set(a).entries()).get('abc');            // undefined -- expected 'abc'
new Set(['abc']).intersection(new Set(a)).size;      // 0  -- expected 1
new Set(a).isSubsetOf(new Set(['abc']));             // false -- expected true
new Set(['abc']).union(new Set(a)).size;             // 2  -- expected 1
```

An object property is affected identically, via any built-in that reads the value back:

```js
var o = { p: 'a' }; o.p += 'b'; o.p += 'c';
new Set(Object.values(o)).has('abc');                // false -- expected true
```

And at the API surface, where the contract actually lives — `JsString` and `JsValue.GetHashCode` are public, so a host keying its own dictionary by `JsValue` hits it directly:

```csharp
var concatenated = engine.Evaluate("var a = ['a']; a[0] += 'b'; a[0] += 'c'; a[0]");

concatenated.Equals(new JsString("abc"));                          // true
concatenated.GetHashCode() == new JsString("abc").GetHashCode();   // false
```

## Blast radius

**Affected:** anything hashing a `JsValue` — `Map` and `Set` (`JintOrderedDictionary` / `OrderedSet` via `SameValueZeroComparer`, whose `GetHashCode` is just `obj.GetHashCode()`), the set-operation methods, `Map.groupBy`/`Object.groupBy`'s internal grouping dictionary, and any host-side `Dictionary<JsValue, …>` / `HashSet<JsValue>`.

**Not affected — confirmed and pinned by tests:**

- **Property keys.** They are converted to a flat `string` and hashed through `Key`/`Hash.GetFNVHashCode(string)`, never through `JsValue.GetHashCode`. `o[concatenated] = 7; o.abc` was always correct.
- **Equality.** `Equals(string)`, `Equals(JsString)` and the `JsValue`/`object` overloads that forward to them all compare by content, materializing where needed. `===`, `==` and `Array.prototype.includes` (`SameValueZero`, no hashing) were always correct. Equality being right is exactly what makes the identity hash a contract violation rather than merely an unusual choice.
- **The sibling lazily materialized representation** (`SlicedString`) already hashed its content — via `AsSpan()`/`ToString()` with `StringComparer.Ordinal` — and is interchangeable with a flat string in a `Map`/`Set` today. That it got this right is what makes the concatenated one look like an oversight rather than a deliberate trade.

## The fix and its cost

```csharp
public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(ToString());
```

This matches the flat base implementation exactly.

Hashing now forces the buffer to be materialized. That is unavoidable — a content hash has to see the content — and it is **not a new cost on any previously allocation-free path**: `Equals` already materializes on these same values (both the `Equals(JsString)` fallback and the mixed flat/concatenated comparison call `ToString()`), and anything that hashes a value goes on to compare it. `ToString()` caches into `_value` and clears the dirty flag, so repeated hashing of the same value materializes once.

I deliberately did **not** null `_stringBuilder` once `ToString()` has materialized `_value`, even though it would let subsequent operations take the flat path. It is not behaviour-preserving: `EnsureCapacity` does `_stringBuilder!.EnsureCapacity(capacity)` and would throw once the field were null, and `Append` would allocate a fresh exactly-sized buffer instead of reusing the grown one, turning amortized appends into a copy per materialization. That is a separate change with its own trade-offs, not something to bundle into a correctness fix.

## Relationship to #2793

Complementary, no overlap. #2793 routed the **base** `JsString.GetHashCode`/`Equals(JsString)`/`EnsureCapacity` through `ToString()` so a lazily-materializing subclass works, and documented the subclassing contract — including, explicitly, that *"an overridden `GetHashCode()` must produce the same hash as the equivalent flat string, otherwise the value cannot be used interchangeably as a property key or collection key."* It did not touch `ConcatenatedString.GetHashCode`, which is the one in-tree subclass that violated exactly that rule. This branch is rebased on top of #2793 and the diff is a single hunk.

## Verification

Baseline measured on clean `main` at 387f29bf, same machine, same session.

| Suite | Baseline | With fix |
|---|---|---|
| `Jint.Tests` net10.0 | 4136 passed / 4 skipped | 4151 passed / 4 skipped |
| `Jint.Tests` net472 | 4072 passed / 4 skipped | 4087 passed / 4 skipped |
| `Jint.Tests.PublicInterface` | 203 / 203 | 203 / 203 |
| Test262 | 99441 passed / 0 failed / 157 skipped | 99441 passed / 0 failed / 157 skipped |

`+15` on each `Jint.Tests` framework is exactly the new test class; nothing else moved. Release build is warning-clean apart from the pre-existing `MSB3277` in `Jint.Tests.CommonScripts` net472, which reproduces on clean `main`.

Test262 is unchanged. Worth saying why, since `Map`/`Set` is the affected area: the conformance suite builds its keys through paths where the interpreter's copy-on-assign already flattens the value, so no conformance test exercised a mixed-representation lookup. That is also why this survived unnoticed.

The 10 new tests that reproduce the bug all fail on the parent commit with hash mismatches (`Expected concatenated.GetHashCode() to be -420569591, but found 17398045`) and pass with the fix. The remaining 5 pin the bounds — property keys, equality, and `SlicedString` — and pass either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
