### PR TITLE
Stop a concatenation from growing and mutating its own receiver

### DIFF
--- a/Jint.Tests/Runtime/StringConcatReceiverTests.cs
+++ b/Jint.Tests/Runtime/StringConcatReceiverTests.cs
@@ -1,0 +1,131 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <c>String.prototype.concat</c> asks its receiver for a growable buffer before appending. A
+/// receiver that is itself the result of concatenation used to hand back <em>itself</em>, which
+/// made the append mutate a value the script can still see, and threw when the receiver had not
+/// built a buffer yet. Strings are immutable, so the receiver must never be affected.
+/// </summary>
+public class StringConcatReceiverTests
+{
+    // A compound assignment through a member reference stores the growable value back into the
+    // object/array rather than a flattened copy, so the receiver below really is that value.
+    private const string OneAppend = "var o = { p: 'a' }; o.p += 'b';";
+    private const string TwoAppends = "var o = { p: 'a' }; o.p += 'b'; o.p += 'c';";
+
+    private static Engine CreateEngine() => new();
+
+    [Fact]
+    public void ConcatOnASingleAppendReceiver()
+    {
+        // no buffer had been created yet, so asking to grow one used to dereference null
+        var engine = CreateEngine();
+
+        engine.Evaluate(OneAppend + " o.p.concat('c')").AsString().Should().Be("abc");
+    }
+
+    [Fact]
+    public void ConcatOnASingleAppendReceiverLeavesItUnchanged()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate(OneAppend + " o.p.concat('c'); o.p").AsString().Should().Be("ab");
+    }
+
+    [Fact]
+    public void ConcatOnAMultiAppendReceiver()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate(TwoAppends + " o.p.concat('d')").AsString().Should().Be("abcd");
+    }
+
+    [Fact]
+    public void ConcatDoesNotMutateAMultiAppendReceiver()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate(TwoAppends + " o.p.concat('d'); o.p").AsString().Should().Be("abc");
+    }
+
+    [Fact]
+    public void RepeatedConcatOffTheSameReceiverIsIndependent()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate(TwoAppends + " o.p.concat('1'); o.p.concat('2')").AsString().Should().Be("abc2");
+        engine.Evaluate(TwoAppends + " var a = o.p.concat('1'); var b = o.p.concat('2'); a + '|' + b + '|' + o.p")
+            .AsString().Should().Be("abc1|abc2|abc");
+    }
+
+    [Fact]
+    public void ConcatWithSeveralArguments()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate(TwoAppends + " o.p.concat('d', 'e', 'f')").AsString().Should().Be("abcdef");
+        engine.Evaluate(TwoAppends + " o.p.concat('d', 'e', 'f'); o.p").AsString().Should().Be("abc");
+        engine.Evaluate(OneAppend + " o.p.concat('c', 'd')").AsString().Should().Be("abcd");
+    }
+
+    [Fact]
+    public void ConcatWithNoArguments()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate(OneAppend + " o.p.concat()").AsString().Should().Be("ab");
+        engine.Evaluate(TwoAppends + " o.p.concat()").AsString().Should().Be("abc");
+        engine.Evaluate(TwoAppends + " o.p.concat(); o.p").AsString().Should().Be("abc");
+    }
+
+    [Fact]
+    public void ConcatOnAnAppendChainReceiver()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("var a = ['x']; for (var i = 0; i < 5; i++) { a[0] += i; } a[0].concat('!')")
+            .AsString().Should().Be("x01234!");
+        engine.Evaluate("var a = ['x']; for (var i = 0; i < 5; i++) { a[0] += i; } a[0].concat('!'); a[0]")
+            .AsString().Should().Be("x01234");
+    }
+
+    [Fact]
+    public void ConcatOnAnArrayElementReceiver()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("var a = ['a']; a[0] += 'b'; a[0] += 'c'; a[0].concat('!')").AsString().Should().Be("abc!");
+        engine.Evaluate("var a = ['a']; a[0] += 'b'; a[0] += 'c'; a[0].concat('!'); a[0]").AsString().Should().Be("abc");
+    }
+
+    [Fact]
+    public void ConcatChainedOnItsOwnResult()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate(TwoAppends + " o.p.concat('d').concat('e')").AsString().Should().Be("abcde");
+        engine.Evaluate(TwoAppends + " o.p.concat('d').concat('e'); o.p").AsString().Should().Be("abc");
+    }
+
+    [Fact]
+    public void ConcatOnAFlatReceiverIsUnaffected()
+    {
+        // control: a plain literal receiver never had either problem
+        var engine = CreateEngine();
+
+        engine.Evaluate("'ab'.concat('c')").AsString().Should().Be("abc");
+        engine.Evaluate("'ab'.concat('c', 'd')").AsString().Should().Be("abcd");
+        engine.Evaluate("'ab'.concat()").AsString().Should().Be("ab");
+        engine.Evaluate("var s = 'ab'; s.concat('c'); s").AsString().Should().Be("ab");
+    }
+
+    [Fact]
+    public void ConcatOnANonStringReceiverIsUnaffected()
+    {
+        // control: the coercion branch builds its own value and never touches the receiver
+        var engine = CreateEngine();
+
+        engine.Evaluate("String.prototype.concat.call(12, '3')").AsString().Should().Be("123");
+        engine.Evaluate("String.prototype.concat.call(true, '!')").AsString().Should().Be("true!");
+    }
+}

--- a/Jint/Native/JsString.cs
+++ b/Jint/Native/JsString.cs
@@ -501,11 +501,12 @@ public class JsString : JsValue, IEquatable<JsString>, IEquatable<string>
             return this;
         }
 
-        internal override JsString EnsureCapacity(int capacity)
-        {
-            _stringBuilder!.EnsureCapacity(capacity);
-            return this;
-        }
+        // No override of EnsureCapacity: the inherited one hands back a fresh instance seeded with
+        // this value's text. Growing this instance's buffer and returning "this" instead would let
+        // the caller append into a value that is still reachable from wherever it was read, and
+        // appending mutates in place -- so the receiver of the concatenation would change too.
+        // The buffer is also only created on the first append, so a value produced by a single
+        // concatenation has none to grow.
 
         public override int Length => _stringBuilder?.Length ?? _value?.Length ?? 0;
 


### PR DESCRIPTION
`String.prototype.concat` asks its receiver for a growable buffer and then appends into whatever it gets back:

```csharp
jsString = jsString.EnsureCapacity(0);
foreach (var argument in arguments)
{
    jsString = jsString.Append(argument);
}
```

`ConcatenatedString` overrode `EnsureCapacity` to grow its own buffer and hand back **itself**:

```csharp
internal override JsString EnsureCapacity(int capacity)
{
    _stringBuilder!.EnsureCapacity(capacity);
    return this;
}
```

Two separate things go wrong there, both fixed by dropping the override.

## 1. `concat` mutates its receiver

`Append` mutates the buffer in place, so appending into the receiver changes the receiver. Strings are immutable, so this is straightforwardly wrong:

```js
var o = { p: 'a' }; o.p += 'b'; o.p += 'c';   // o.p is 'abc', with a live buffer

o.p.concat('d');       // 'abcd'
o.p;                   // 'abcd'  -- must still be 'abc'
o.p.concat('1');       // 'abcd1' -- and o.p keeps growing
```

Two reads of the same value are not independent either:

```js
var o = { p: 'x' }; o.p += 'y'; o.p += 'z';
var a = o.p.concat('1');   // 'xyz1'
var b = o.p.concat('2');   // 'xyz12'  -- must be 'xyz2'
o.p;                       // 'xyz12'  -- must be 'xyz'
```

The growable representation is normally kept private to one binding by the interpreter's copy-on-assign step (`RequiresCloning`/`DoClone`), which is what makes in-place `Append` safe for `+=`. A method receiver is read directly and never goes through that step, so `concat` got a value that was still reachable from the object or array it was read out of.

## 2. `NullReferenceException` on a single-append receiver

The buffer is only created on the first `Append`; `JsString.Append` returns `new ConcatenatedString(string.Concat(...))` with the default `capacity: 0`, and that constructor takes the `else` branch and leaves `_stringBuilder` null. The override dereferenced it unconditionally:

```js
var o = { p: 'a' };
o.p += 'b';            // one append -- no buffer yet
o.p.concat('c');       // NullReferenceException
```

This one is worse than it looks: it surfaces as a runtime exception rather than a spec error, so it escapes a script-level `try/catch` and propagates out of `Evaluate` to the host.

## The fix

Delete the override and inherit:

```csharp
internal virtual JsString EnsureCapacity(int capacity)
{
    return new ConcatenatedString(ToString(), capacity);
}
```

That returns a fresh value seeded with the receiver's text — independent of the receiver, and with no buffer to dereference. Both symptoms go away, and the class gets smaller.

**Identity check.** There is exactly one caller of `JsString.EnsureCapacity` (`StringPrototype.Concat`) and it reassigns the result. Nothing can rely on getting `this` back regardless: the inherited implementation already returned a **new** `ConcatenatedString` for a flat receiver, so returning a new instance was always in the contract — `ConcatenatedString` was the odd one out.

**Cost.** `concat` on an already-concatenated receiver now materializes the receiver's text and starts a new buffer instead of extending the existing one. That is required for correctness — a mutable buffer cannot be shared with a value that is still reachable — and the sole caller passes `capacity: 0`, so the growth hint it was passing was doing nothing anyway.

## Relationship to #2793 and #2811

Same class, three separate holes, no overlapping lines:

- #2793 (merged) routed the **base** `GetHashCode`/`Equals(JsString)`/`EnsureCapacity` through `ToString()` so a lazily-materializing subclass works, and wrote down the subclassing contract.
- #2811 (open) fixes `ConcatenatedString.GetHashCode`, which hashed buffer identity instead of content.
- This one fixes `ConcatenatedString.EnsureCapacity`.

Based on current `main` (`23a99d5f`) rather than stacked on #2811, since the two touch different members and are independently reviewable.

## Verification

Baseline measured on the parent commit `23a99d5f`, same machine, same session.

| Suite | Baseline | With fix |
|---|---|---|
| `Jint.Tests` net10.0 | 4157 passed / 4 skipped | 4169 passed / 4 skipped |
| `Jint.Tests` net472 | 4089 passed / 4 skipped | 4101 passed / 4 skipped |
| `Jint.Tests.PublicInterface` | 256 / 256 | 256 / 256 |
| Test262 | 99441 passed / 0 failed / 157 skipped | 99441 passed / 0 failed / 157 skipped |

`+12` on each framework is exactly the new test class; nothing else moved. Release build is warning-clean apart from the pre-existing `MSB3277` in `Jint.Tests.CommonScripts` net472, which reproduces on clean `main`.

Both full Test262 runs on this machine hit known load-related flakes — one `Atomics/notify` timeout on the baseline run and the eight `language/literals/regexp/S7.8.5_*_T2.js` 30 s timeouts on the fix run. Both sets pass when re-run in isolation (104/104 and 92/92 respectively), so the conformance count is unchanged at 99441/0/157 either way.

9 of the 12 new tests fail on the parent commit; the 3 that pass are the deliberate controls (flat receiver, coerced non-string receiver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
