### PR TITLE
Compare set values the same way everywhere a set is stored or copied

### DIFF
--- a/Jint.Tests/Runtime/SetSameValueZeroTests.cs
+++ b/Jint.Tests/Runtime/SetSameValueZeroTests.cs
@@ -1,0 +1,132 @@
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A <c>Set</c> compares its values with SameValueZero, which — unlike <c>===</c> — treats
+/// <c>NaN</c> as equal to itself. The backing structure keeps both a lookup structure and an
+/// ordering list, and both of them, plus every set derived from an existing one, have to use that
+/// same rule. Where they disagree the two halves drift apart: a value can be missing from lookups
+/// while iteration still yields it.
+/// </summary>
+public class SetSameValueZeroTests
+{
+    private static Engine CreateEngine() => new();
+
+    [Fact]
+    public void DeleteRemovesNaN()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("new Set([NaN]).delete(NaN)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("var s = new Set([NaN]); s.delete(NaN); s.size").AsNumber().Should().Be(0);
+        engine.Evaluate("var s = new Set([NaN]); s.delete(NaN); s.has(NaN)").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void DeleteLeavesNoStragglerBehindForNaN()
+    {
+        // the ordering list and the lookup structure must agree afterwards
+        var engine = CreateEngine();
+
+        engine.Evaluate("var s = new Set([NaN]); s.delete(NaN); [...s].length").AsNumber().Should().Be(0);
+        engine.Evaluate("var s = new Set([NaN]); s.delete(NaN); var n = 0; s.forEach(function () { n++; }); n")
+            .AsNumber().Should().Be(0);
+        engine.Evaluate("var s = new Set([NaN]); s.delete(NaN); Array.from(s.values()).length").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void ReAddingNaNAfterDeleteDoesNotDuplicate()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("var s = new Set([NaN]); s.delete(NaN); s.add(NaN); s.size").AsNumber().Should().Be(1);
+        engine.Evaluate("var s = new Set([NaN]); s.delete(NaN); s.add(NaN); [...s].length").AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void DeleteRemovesNaNAmongOtherValues()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("var s = new Set([1, NaN, 2]); s.delete(NaN); s.size").AsNumber().Should().Be(2);
+        engine.Evaluate("var s = new Set([1, NaN, 2]); s.delete(NaN); [...s].join(',')").AsString().Should().Be("1,2");
+    }
+
+    [Fact]
+    public void ADerivedSetKeepsNaNSemantics()
+    {
+        // a set produced from another one must not fall back to default equality
+        var engine = CreateEngine();
+
+        engine.Evaluate("new Set([NaN, 1]).difference(new Set([1])).has(NaN)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new Set([NaN, 1]).symmetricDifference(new Set([1])).has(NaN)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new Set([NaN, 1]).intersection(new Set([NaN])).has(NaN)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new Set([NaN, 1]).union(new Set([NaN])).has(NaN)").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ADerivedSetDoesNotDuplicateNaN()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("var d = new Set([NaN, 1]).difference(new Set([1])); d.add(NaN); d.size")
+            .AsNumber().Should().Be(1);
+        engine.Evaluate("var d = new Set([NaN, 1]).symmetricDifference(new Set([1])); d.add(NaN); d.size")
+            .AsNumber().Should().Be(1);
+    }
+
+    [Fact]
+    public void ADerivedSetCanDeleteNaN()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("new Set([NaN, 1]).difference(new Set([1])).delete(NaN)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("var d = new Set([NaN, 1]).difference(new Set([1])); d.delete(NaN); d.size")
+            .AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void SubsetAndDisjointChecksHandleNaN()
+    {
+        var engine = CreateEngine();
+
+        engine.Evaluate("new Set([NaN]).isSubsetOf(new Set([NaN, 1]))").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new Set([NaN, 1]).isSupersetOf(new Set([NaN]))").AsBoolean().Should().BeTrue();
+        engine.Evaluate("new Set([NaN]).isDisjointFrom(new Set([NaN]))").AsBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void NegativeZeroIsNormalized()
+    {
+        // the other SameValueZero special case, which already worked; guards the same code path
+        var engine = CreateEngine();
+
+        engine.Evaluate("new Set([-0]).delete(0)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("var s = new Set([-0]); s.delete(0); s.size").AsNumber().Should().Be(0);
+        engine.Evaluate("new Set([-0, 0]).size").AsNumber().Should().Be(1);
+        engine.Evaluate("Object.is([...new Set([-0])][0], 0)").AsBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void OrdinaryValuesAreUnaffected()
+    {
+        // control
+        var engine = CreateEngine();
+
+        engine.Evaluate("var s = new Set([1, 2]); s.delete(1); s.size").AsNumber().Should().Be(1);
+        engine.Evaluate("var s = new Set([1, 2]); s.delete(3)").AsBoolean().Should().BeFalse();
+        engine.Evaluate("var s = new Set(['a', 'b']); s.delete('a'); [...s].join(',')").AsString().Should().Be("b");
+        engine.Evaluate("new Set([1, 2]).difference(new Set([2])).has(1)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("var o = {}; var s = new Set([o]); s.delete(o); s.size").AsNumber().Should().Be(0);
+    }
+
+    [Fact]
+    public void MapAlreadyHandledNaN()
+    {
+        // Map uses a different backing structure and was never affected; pinned for contrast
+        var engine = CreateEngine();
+
+        engine.Evaluate("new Map([[NaN, 'v']]).delete(NaN)").AsBoolean().Should().BeTrue();
+        engine.Evaluate("var m = new Map([[NaN, 'v']]); m.delete(NaN); m.size").AsNumber().Should().Be(0);
+        engine.Evaluate("new Map([[NaN, 'v']]).get(NaN)").AsString().Should().Be("v");
+    }
+}

--- a/Jint/Runtime/OrderedSet.cs
+++ b/Jint/Runtime/OrderedSet.cs
@@ -10,7 +10,9 @@ internal sealed class OrderedSet<T> : IEnumerable<T>
     public OrderedSet(HashSet<T> values)
     {
         _list = new List<T>(values);
-        _set = new HashSet<T>(values);
+        // carry the source comparer over: the copy has to keep answering equality the same way,
+        // otherwise a derived set silently falls back to default equality
+        _set = new HashSet<T>(values, values.Comparer);
     }
 
     public OrderedSet(IEqualityComparer<T> comparer)
@@ -60,8 +62,25 @@ internal sealed class OrderedSet<T> : IEnumerable<T>
 
     public bool Remove(T item)
     {
-        _set.Remove(item);
-        return _list.Remove(item);
+        if (!_set.Remove(item))
+        {
+            return false;
+        }
+
+        // List.Remove would compare with the default comparer, which can disagree with the set's
+        // one and leave the ordering list holding a value the set no longer has
+        var comparer = _set.Comparer;
+        var list = _list;
+        for (var i = 0; i < list.Count; i++)
+        {
+            if (comparer.Equals(list[i], item))
+            {
+                list.RemoveAt(i);
+                break;
+            }
+        }
+
+        return true;
     }
 
     public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();


### PR DESCRIPTION
A `Set` compares its values with SameValueZero, which — unlike `===` — treats `NaN` as equal to itself. `OrderedSet` keeps a `HashSet` for lookups alongside a `List` for iteration order, and two places compared with `EqualityComparer<T>.Default` instead of the set's own comparer. The two comparers agree on everything except `NaN`, which is exactly where the two halves drift apart.

## 1. `delete(NaN)` leaves the value behind

```csharp
public bool Remove(T item)
{
    _set.Remove(item);
    return _list.Remove(item);   // default comparer
}
```

`List<T>.Remove` uses `EqualityComparer<JsValue>.Default`, which resolves to `JsValue.Equals(JsValue)` → `JsNumber.Equals`, and that returns `false` outright when either side is `NaN` (correct for `===`, wrong for a Set). So the lookup structure drops the value while the ordering list keeps it:

```js
var s = new Set([NaN]);

s.delete(NaN);   // false  -- spec requires true
s.size;          // 1      -- must be 0
s.has(NaN);      // false  -- the set and its ordering list now disagree
[...s];          // [NaN]  -- iteration still yields the deleted value
s.forEach(...)   // still visits it
```

And because the two halves disagree, re-adding compounds it:

```js
var s = new Set([NaN]);
s.delete(NaN);
s.add(NaN);
s.size;          // 2 -- two NaN entries
```

## 2. A derived set loses SameValueZero entirely

```csharp
public OrderedSet(HashSet<T> values)
{
    _list = new List<T>(values);
    _set = new HashSet<T>(values);   // comparer dropped
}
```

`new HashSet<T>(IEnumerable<T>)` uses the default comparer, so every set built through this constructor — the `difference`, `intersection` and `symmetricDifference` results — came back comparing with default equality even though the source had been carefully populated through `SameValueZeroComparer`:

```js
var d = new Set([NaN, 1]).difference(new Set([1]));
d.has(NaN);      // false -- must be true
d.delete(NaN);   // false -- must be true
d.add(NaN);
d.size;          // 2     -- must be 1, NaN is already in there

new Set([NaN, 1]).symmetricDifference(new Set([1])).has(NaN);   // false
```

`union` was unaffected — it goes through `Clone()`, which does carry the comparer over.

## The fix

Carry the comparer when copying, and search the ordering list with the set's comparer, returning the lookup structure's answer as the authoritative one:

```csharp
_set = new HashSet<T>(values, values.Comparer);
```

```csharp
public bool Remove(T item)
{
    if (!_set.Remove(item))
    {
        return false;
    }

    var comparer = _set.Comparer;
    var list = _list;
    for (var i = 0; i < list.Count; i++)
    {
        if (comparer.Equals(list[i], item))
        {
            list.RemoveAt(i);
            break;
        }
    }

    return true;
}
```

The scan replaces `List<T>.Remove`, which was already doing the same linear scan — just with the wrong comparer — so removal keeps the cost it had.

Ordinary values are unaffected: the two comparers only ever disagree on `NaN`. `-0`/`+0` already worked, because the value is normalized to `+0` before it is stored; there is a test pinning that path too. `Map` was never affected — it uses `JintOrderedDictionary`, which threads the comparer through consistently — and a test pins that for contrast.

## Verification

Baseline measured on the parent commit `285cc7fd`, same machine, same session.

| Suite | Baseline | With fix |
|---|---|---|
| `Jint.Tests` net10.0 | 4183 passed / 4 skipped | 4194 passed / 4 skipped |
| `Jint.Tests` net472 | 4115 passed / 4 skipped | 4126 passed / 4 skipped |
| `Jint.Tests.PublicInterface` | 256 / 256 | 256 / 256 |
| Test262 | 99441 passed / 0 failed / 157 skipped | 99441 passed / 0 failed / 157 skipped |

`+11` on each framework is exactly the new test class; nothing else moved. Both Test262 runs were clean with zero failures. Release build is warning-clean apart from the pre-existing `MSB3277` in `Jint.Tests.CommonScripts` net472, which reproduces on clean `main`.

7 of the 11 new tests fail on the parent commit; the 4 that pass are the controls (`-0` normalization, ordinary values, `Map`, and the subset/disjoint checks, which take a different path).

Test262 does not move, which is worth flagging given the area: the conformance suite covers `Set.prototype.delete` and covers `NaN` in a set, but does not appear to combine them on a set whose deletion is then observed through `size` or iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
