### PR TITLE
Enable the three benchmark lanes whose features have since shipped

### DIFF
--- a/Jint.Benchmark/FreshEngineGlobalsBenchmark.cs
+++ b/Jint.Benchmark/FreshEngineGlobalsBenchmark.cs
@@ -30,9 +30,25 @@ namespace Jint.Benchmark;
 /// reflects over the delegate's <c>Invoke</c> signature; <see cref="GlobalKind.ClrFunction"/> is
 /// the hand-written escape hatch that skips that. The gap between the two rows is the price of the
 /// convenient API, and it is only visible with a fresh engine per operation — on a reused engine
-/// it is amortized to nothing.
+/// it is amortized to nothing. <see cref="GlobalKind.Lazy"/> registers the very same
+/// <see cref="ClrFunction"/> bodies through <see cref="OptionsExtensions.AddLazyGlobal"/>, so the
+/// Lazy-vs-ClrFunction gap is exactly what deferring the value construction buys or costs — the
+/// function objects being built are identical, only <i>when</i> and <i>whether</i> differs.
 /// </description></item>
 /// </list>
+///
+/// <para><b>Keeping the lazy row honest</b></para>
+/// <para>
+/// A lazy global is only cheaper if its factory never runs, so a workload that reads every
+/// registered global would measure the eager cost plus an indirection and the row would say
+/// nothing. The script here calls <c>fn0</c> and nothing else, so exactly <b>one</b> of the
+/// <see cref="GlobalCount"/> registered globals is ever materialized. The
+/// <see cref="GlobalCount"/> axis then spans both ends of the honesty question on its own:
+/// at <c>GlobalCount=1</c> the single global is read, which is the worst case where laziness is
+/// pure overhead and the row must not win; at <c>GlobalCount=40</c> one of forty is read, which is
+/// the case the API exists for. A Lazy row that beats <c>ClrFunction</c> at <c>GlobalCount=1</c>
+/// would mean the comparison had drifted, not that laziness got faster.
+/// </para>
 ///
 /// <para>
 /// The delegates are built by a factory <b>per engine</b> and several of them are capturing
@@ -41,6 +57,11 @@ namespace Jint.Benchmark;
 /// for any cache keyed on something coarser than the delegate instance (a <c>MethodInfo</c>, say):
 /// a fresh closure instance still shares its <c>MethodInfo</c>, a fresh lambda body does not.
 /// Reusing one cached delegate array across operations would measure a different, easier problem.
+/// The Lazy row is the one place this cannot apply, and deliberately so: registration lives on
+/// <see cref="Options"/>, which the engine replays per construction, so the factory delegates are
+/// created once and the per-engine work is the descriptor installation the API actually charges.
+/// Re-registering per operation would grow the shared <see cref="Options"/> without bound and
+/// measure a leak rather than a feature.
 /// </para>
 /// </summary>
 [MemoryDiagnoser]
@@ -59,26 +80,34 @@ public class FreshEngineGlobalsBenchmark
     [Params(1, 10, 40)]
     public int GlobalCount { get; set; }
 
-    // GlobalKind.Lazy is intentionally absent from [Params] — see GlobalSetup.
-    [Params(GlobalKind.Delegate, GlobalKind.ClrFunction)]
+    [Params(GlobalKind.Delegate, GlobalKind.ClrFunction, GlobalKind.Lazy)]
     public GlobalKind Kind { get; set; }
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        if (Kind == GlobalKind.Lazy)
-        {
-            // TODO: enable once lazy global registration lands — the embedder hands over a name and
-            // a factory, and the engine only builds the function object if the script reads the
-            // name. That turns the per-global slope measured here into a per-*used*-global slope.
-            throw new NotSupportedException($"{Kind} awaits a Jint feature that does not exist yet; see the TODO in {nameof(GlobalSetup)}.");
-        }
-
         // One Options instance shared by every constructed engine: an embedder configures interop
         // policy once at start-up and only the globals differ per engine.
         _sharedOptions = new Options();
 
+        if (Kind == GlobalKind.Lazy)
+        {
+            // Lazy globals are declared on the options rather than on the engine, and the engine
+            // replays that declaration as it is constructed — so this loop runs once for the whole
+            // benchmark and every operation still gets its own descriptors and its own (at most one
+            // per engine) factory invocation. The factory produces the same ClrFunction the eager
+            // ClrFunction row hands over directly, so the two rows differ only in when it is built.
+            for (var i = 0; i < GlobalCount; i++)
+            {
+                var name = _names[i];
+                var index = i;
+                _sharedOptions.AddLazyGlobal(name, engine => CreateClrFunction(engine, name, index));
+            }
+        }
+
         // One statement, and it calls into the host so global resolution is on the measured path.
+        // It reads fn0 only: that single read is what keeps the Lazy row a per-*used*-global cost
+        // instead of a restatement of the eager one. See "Keeping the lazy row honest" above.
         _script = Engine.PrepareScript("fn0(1) + fn0(2);");
 
         // Prove the lane before it is measured.
@@ -97,6 +126,12 @@ public class FreshEngineGlobalsBenchmark
 
     private void RegisterGlobals(Engine engine)
     {
+        if (Kind == GlobalKind.Lazy)
+        {
+            // Already installed: constructing the engine replayed the options' registrations.
+            return;
+        }
+
         var count = GlobalCount;
         for (var i = 0; i < count; i++)
         {
@@ -170,6 +205,11 @@ public enum GlobalKind
     /// <summary>A hand-written <see cref="ClrFunction"/> — no delegate signature reflection.</summary>
     ClrFunction,
 
-    /// <summary>Awaits lazy global registration. Not runnable yet.</summary>
+    /// <summary>
+    /// The same <see cref="ClrFunction"/> bodies, declared through
+    /// <see cref="OptionsExtensions.AddLazyGlobal"/>: the property is installed on every engine but
+    /// its value is only built if the script reads it. Turns the per-global registration slope into
+    /// a per-<i>used</i>-global one.
+    /// </summary>
     Lazy,
 }

--- a/Jint.Benchmark/HostObjectAccessBenchmark.cs
+++ b/Jint.Benchmark/HostObjectAccessBenchmark.cs
@@ -37,6 +37,15 @@ namespace Jint.Benchmark;
 /// PlainObject row in both time and <c>Allocated</c>, with the allocation delta ≈
 /// (descriptor size × own-property reads) — descriptor churn is half the story, so always read the
 /// <c>Allocated</c> column next to <c>Mean</c> here.
+/// <see cref="HostReceiverKind.FixedLayout"/> is the same host records built through
+/// <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/>: a declared layout
+/// resolves to one interned hidden class, so every item in the batch shares it and reads take the
+/// ordinary shape-keyed lane. The LazyHost → FixedLayout delta is therefore the whole cost of the
+/// custom-subclass representation — the virtual <see cref="ObjectInstance.GetOwnProperty"/> call
+/// <i>and</i> the per-read <see cref="PropertyDescriptor"/>, which the shaped form removes
+/// together. Its useful control is <see cref="HostReceiverKind.PlainObject"/>: the two build the
+/// same key order into the same representation, so FixedLayout landing on the PlainObject row is
+/// the expected result and any gap is host-side projection cost, not access cost.
 /// </description></item>
 /// <item><description>
 /// <see cref="ResolverKind"/> — installing any <see cref="IReferenceResolver"/> sets
@@ -82,13 +91,23 @@ public class HostObjectAccessBenchmark
         }
         """;
 
+    /// <summary>
+    /// Declared once and shared by every item the <see cref="HostReceiverKind.FixedLayout"/> lane
+    /// builds — which is the whole point of the API: one layout resolves to one interned hidden
+    /// class per engine, so the projection loop stays monomorphic across the batch instead of
+    /// meeting a new shape per item. The names are <see cref="LazyHostObject"/>'s own field order,
+    /// which is also the order the <see cref="HostReceiverKind.PlainObject"/> literal uses, so all
+    /// three receivers present identical own-key order.
+    /// </summary>
+    private static readonly JsObjectLayout _itemLayout = new(LazyHostObject.FieldNames);
+
     private Engine _engine = null!;
     private Prepared<Script> _projection;
 
     // Only the lanes that compile and run against today's public API are in [Params]; the members
     // awaiting a Jint feature are handled (and rejected) by GlobalSetup so that adding them here is
     // a one-line change once the feature lands.
-    [Params(HostReceiverKind.PlainObject, HostReceiverKind.LazyHost)]
+    [Params(HostReceiverKind.PlainObject, HostReceiverKind.LazyHost, HostReceiverKind.FixedLayout)]
     public HostReceiverKind ReceiverKind { get; set; }
 
     [Params(HostResolverKind.None, HostResolverKind.Unfiltered)]
@@ -104,20 +123,18 @@ public class HostObjectAccessBenchmark
         {
             case HostReceiverKind.PlainObject:
             case HostReceiverKind.LazyHost:
+            case HostReceiverKind.FixedLayout:
                 break;
 
             // TODO: enable once the host-object "ordinary access semantics" opt-in lands — the host
             // declares a fixed set of own properties up front so reads can take the ordinary
-            // (shape/dictionary) lane instead of the virtual GetOwnProperty lane.
+            // (shape/dictionary) lane instead of the virtual GetOwnProperty lane. Distinct from
+            // FixedLayout above, which gives up the custom subclass entirely; this one keeps it.
             case HostReceiverKind.LazyHostOrdinary:
 
             // TODO: enable once the descriptor-free read hook lands — a host hook that returns the
             // JsValue directly, so a read no longer allocates a PropertyDescriptor to carry it.
             case HostReceiverKind.LazyHostValueHook:
-
-            // TODO: enable once the fixed-layout object factory lands — the host declares the layout
-            // once and the engine allocates a flat slot array per instance.
-            case HostReceiverKind.FixedLayout:
                 throw new NotSupportedException($"{ReceiverKind} awaits a Jint feature that does not exist yet; see the TODO in {nameof(GlobalSetup)}.");
 
             default:
@@ -179,6 +196,12 @@ public class HostObjectAccessBenchmark
                 """);
         }
 
+        // Both host lanes start from the identical native record and run it through the identical
+        // projection, so the only thing that varies between them is the object representation the
+        // projected values end up in.
+        var fixedLayout = kind == HostReceiverKind.FixedLayout;
+        var slots = fixedLayout ? new JsValue[_itemLayout.Count] : [];
+
         var items = new JsValue[ItemCount];
         for (var i = 0; i < items.Length; i++)
         {
@@ -191,7 +214,20 @@ public class HostObjectAccessBenchmark
                 "note for record " + index,
             };
             var numbers = new double[] { i + 1, 1.5 };
-            items[i] = new LazyHostObject(engine, text, numbers);
+
+            if (!fixedLayout)
+            {
+                items[i] = new LazyHostObject(engine, text, numbers);
+                continue;
+            }
+
+            for (var slot = 0; slot < slots.Length; slot++)
+            {
+                slots[slot] = LazyHostObject.ProjectSlot(slot, text, numbers);
+            }
+
+            // Create copies the values into the object's own slots, so one buffer serves the batch.
+            items[i] = JsObject.Create(engine, _itemLayout, slots);
         }
 
         return new JsArray(engine, items);
@@ -216,7 +252,11 @@ public enum HostReceiverKind
     /// <summary>Awaits the descriptor-free read hook. Not runnable yet.</summary>
     LazyHostValueHook,
 
-    /// <summary>Awaits the fixed-layout object factory. Not runnable yet.</summary>
+    /// <summary>
+    /// The same native records, projected once into ordinary objects built straight into the hidden
+    /// class through <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/>.
+    /// No custom subclass, so reads take the shape-keyed lane and allocate no descriptor.
+    /// </summary>
     FixedLayout,
 }
 
@@ -294,15 +334,14 @@ internal sealed class LazyHostObject : ObjectInstance
     private const int SlotRate = 5;
     private const int SlotCount = 6;
 
-    private static readonly JsValue[] _keys =
-    [
-        new JsString("id"),
-        new JsString("kind"),
-        new JsString("name"),
-        new JsString("note"),
-        new JsString("amount"),
-        new JsString("rate"),
-    ];
+    /// <summary>
+    /// Own-property names in slot order — the single source of truth for this record's shape, shared
+    /// with the <see cref="HostReceiverKind.FixedLayout"/> lane's <see cref="JsObjectLayout"/> so the
+    /// two receivers cannot drift apart in key set or key order.
+    /// </summary>
+    internal static readonly string[] FieldNames = ["id", "kind", "name", "note", "amount", "rate"];
+
+    private static readonly JsValue[] _keys = Array.ConvertAll(FieldNames, static name => (JsValue) new JsString(name));
 
     private readonly string[] _text;
     private readonly double[] _numbers;
@@ -371,19 +410,27 @@ internal sealed class LazyHostObject : ObjectInstance
             return projected;
         }
 
-        projected = slot switch
-        {
-            SlotAmount => JsNumber.Create(_numbers[0]),
-            SlotRate => JsNumber.Create(_numbers[1]),
-            // The one field the script calls a string method on is handed over unmaterialized, so
-            // the String.prototype receiver inline cache is on the measured path.
-            SlotName => LazyHostString.FromUtf8(_text[SlotName]),
-            _ => new JsString(_text[slot]),
-        };
-
+        projected = ProjectSlot(slot, _text, _numbers);
         _projected[slot] = projected;
         return projected;
     }
+
+    /// <summary>
+    /// The one place a native record field becomes a <see cref="JsValue"/>. Static and shared with
+    /// the <see cref="HostReceiverKind.FixedLayout"/> lane, which builds its objects eagerly from
+    /// the same records — so the two host receivers hand the script value-for-value identical
+    /// properties and the only difference left between them is the representation carrying those
+    /// values.
+    /// </summary>
+    internal static JsValue ProjectSlot(int slot, string[] text, double[] numbers) => slot switch
+    {
+        SlotAmount => JsNumber.Create(numbers[0]),
+        SlotRate => JsNumber.Create(numbers[1]),
+        // The one field the script calls a string method on is handed over unmaterialized, so
+        // the String.prototype receiver inline cache is on the measured path.
+        SlotName => LazyHostString.FromUtf8(text[SlotName]),
+        _ => new JsString(text[slot]),
+    };
 
     private static int SlotOf(string name) => name switch
     {
@@ -409,15 +456,15 @@ internal sealed class LazyHostObject : ObjectInstance
 /// </para>
 ///
 /// <para>
-/// <b>Hazard:</b> the base class stores its flat value in an internal field that a subclass cannot
-/// populate, and a handful of base members read that field directly instead of going through
-/// <see cref="ToString"/>. Everything reachable through the public surface is overridden below,
-/// but <c>JsString.EnsureCapacity</c> is <c>internal virtual</c> and so <b>not overridable by an
-/// embedder</b> — it dereferences the null backing value, so <c>String.prototype.concat</c> on an
-/// instance of this class currently throws a <see cref="NullReferenceException"/>. The projection
-/// workload deliberately avoids <c>concat</c>; drop this note (and feel free to add a concat lane)
-/// once the base class routes <c>EnsureCapacity</c> through <c>ToString()</c> the way
-/// <c>JsString.SlicedString</c> does.
+/// The overrides below are exactly the ones the base class's subclassing contract asks of a value
+/// carrying a null backing field: <see cref="ToString"/> for correctness, the rest to keep reads
+/// from materializing. Nothing here needs to work around the base class any more — the members
+/// that used to read the backing field directly now route through <see cref="ToString"/> — so a
+/// concatenation lane over this receiver would be sound. It is deliberately not added: the
+/// projection script is shared by every parameter combination so that the columns are the only
+/// thing that varies, and string concatenation is a string-representation question rather than a
+/// host-object-access one. The lazy string is already on the measured path through
+/// <c>it.name.toUpperCase()</c>.
 /// </para>
 /// </summary>
 internal sealed class LazyHostString : JsString

--- a/Jint.Tests.PublicInterface/FixedLayoutObjectTests.cs
+++ b/Jint.Tests.PublicInterface/FixedLayoutObjectTests.cs
@@ -1,0 +1,573 @@
+using System.Collections.Generic;
+using Jint.Native;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// The host-facing object factories: <see cref="JsObjectLayout"/> + <see cref="JsObject.Create"/> for a
+/// fixed, known layout, and <see cref="JsObject.CreateFromEntries(Engine, System.ReadOnlySpan{KeyValuePair{string, JsValue}})"/>
+/// for a runtime key set. Everything asserted here is observable through the public API only; the
+/// hidden-class interning these build on is pinned separately (Jint.Tests, which can see internals).
+/// </summary>
+public class FixedLayoutObjectTests
+{
+    private static readonly JsObjectLayout Layout = new("id", "name", "active");
+
+    private static JsObject CreateSample(Engine engine) => JsObject.Create(
+        engine,
+        Layout,
+        [JsNumber.Create(1), new JsString("jint"), JsBoolean.True]);
+
+    private static Engine EngineWithSample(out JsObject obj)
+    {
+        var engine = new Engine();
+        obj = CreateSample(engine);
+        engine.SetValue("o", obj);
+        return engine;
+    }
+
+    // ---- layout validation ----
+
+    [Fact]
+    public void LayoutRejectsNullNameCollection()
+    {
+        Invoking(() => new JsObjectLayout((string[]) null)).Should().Throw<ArgumentNullException>();
+        Invoking(() => new JsObjectLayout((IReadOnlyList<string>) null)).Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void LayoutRejectsDuplicateNames()
+    {
+        Invoking(() => new JsObjectLayout("a", "b", "a"))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("*Duplicate property name 'a' at index 2*");
+    }
+
+    [Fact]
+    public void LayoutRejectsNullOrEmptyNames()
+    {
+        Invoking(() => new JsObjectLayout("a", null)).Should().Throw<ArgumentException>().WithMessage("*index 1*");
+        Invoking(() => new JsObjectLayout("a", "")).Should().Throw<ArgumentException>().WithMessage("*index 1*");
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("42")]
+    [InlineData("1x")]
+    [InlineData("0abc")]
+    public void LayoutRejectsIntegerIndexLikeNames(string name)
+    {
+        // Such a key must enumerate in ascending numeric order ahead of the string keys, which a fixed
+        // insertion-ordered layout cannot express.
+        Invoking(() => new JsObjectLayout("a", name))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("*starts with a digit*");
+    }
+
+    [Fact]
+    public void LayoutAcceptsUpToSixtyFourNamesAndRejectsMore()
+    {
+        var sixtyFour = new string[64];
+        for (var i = 0; i < sixtyFour.Length; i++)
+        {
+            sixtyFour[i] = "p" + i;
+        }
+
+        var layout = new JsObjectLayout(sixtyFour);
+        layout.Count.Should().Be(64);
+
+        var sixtyFive = new string[65];
+        for (var i = 0; i < sixtyFive.Length; i++)
+        {
+            sixtyFive[i] = "p" + i;
+        }
+
+        Invoking(() => new JsObjectLayout(sixtyFive))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("*at most 64 properties*");
+    }
+
+    [Fact]
+    public void LayoutExposesCountAndIndexOf()
+    {
+        Layout.Count.Should().Be(3);
+        Layout.IndexOf("id").Should().Be(0);
+        Layout.IndexOf("name").Should().Be(1);
+        Layout.IndexOf("active").Should().Be(2);
+        Layout.IndexOf("missing").Should().Be(-1);
+        Layout.IndexOf(null).Should().Be(-1);
+    }
+
+    [Fact]
+    public void WideLayoutIndexOfUsesTheIndexedPath()
+    {
+        // Past the linear-scan cutover IndexOf switches to a built index; the answers must not change.
+        var names = new string[40];
+        for (var i = 0; i < names.Length; i++)
+        {
+            names[i] = "field" + i;
+        }
+
+        var layout = new JsObjectLayout(names);
+        for (var i = 0; i < names.Length; i++)
+        {
+            layout.IndexOf(names[i]).Should().Be(i);
+        }
+
+        layout.IndexOf("field40").Should().Be(-1);
+    }
+
+    [Fact]
+    public void CreateRejectsArityMismatchAndNullArguments()
+    {
+        var engine = new Engine();
+
+        Invoking(() => JsObject.Create(engine, Layout, [JsNumber.Create(1)]))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("*describes 3 properties but 1 values*");
+
+        Invoking(() => JsObject.Create(engine, Layout, []))
+            .Should().Throw<ArgumentException>();
+
+        Invoking(() => JsObject.Create(null, Layout, [])).Should().Throw<ArgumentNullException>();
+        Invoking(() => JsObject.Create(engine, null, [])).Should().Throw<ArgumentNullException>();
+    }
+
+    // ---- shape of the produced object ----
+
+    [Fact]
+    public void CreatedObjectReadsWritesAndReportsPresenceLikeALiteral()
+    {
+        var engine = EngineWithSample(out _);
+
+        engine.Evaluate("o.id").Should().Be(1);
+        engine.Evaluate("o.name").Should().Be("jint");
+        engine.Evaluate("o.active").Should().Be(true);
+        engine.Evaluate("o.missing").Should().BeUndefined();
+
+        engine.Evaluate("'name' in o").Should().Be(true);
+        engine.Evaluate("'missing' in o").Should().Be(false);
+        engine.Evaluate("Object.prototype.hasOwnProperty.call(o, 'active')").Should().Be(true);
+        engine.Evaluate("Object.getPrototypeOf(o) === Object.prototype").Should().Be(true);
+
+        // Values are writable in place, without changing the layout.
+        engine.Evaluate("o.name = 'changed'; o.name").Should().Be("changed");
+        engine.Evaluate("Object.keys(o).join()").Should().Be("id,name,active");
+
+        var descriptor = engine.Evaluate("""
+            (function () {
+                var d = Object.getOwnPropertyDescriptor(o, 'id');
+                return [d.value, d.writable, d.enumerable, d.configurable].join();
+            })()
+            """);
+        descriptor.Should().Be("1,true,true,true");
+    }
+
+    [Fact]
+    public void CreatedObjectOwnKeyOrderMatchesAnEquivalentLiteral()
+    {
+        var engine = EngineWithSample(out _);
+        engine.Execute("var literal = { id: 1, name: 'jint', active: true };");
+
+        engine.Evaluate("Object.keys(o).join()").Should().Be("id,name,active");
+        engine.Evaluate("Object.keys(o).join() === Object.keys(literal).join()").Should().Be(true);
+
+        engine.Evaluate("(function () { var r = []; for (var k in o) r.push(k); return r.join(); })()")
+            .Should().Be("id,name,active");
+
+        engine.Evaluate("JSON.stringify(o)").Should().Be("""{"id":1,"name":"jint","active":true}""");
+        engine.Evaluate("JSON.stringify(o) === JSON.stringify(literal)").Should().Be(true);
+
+        engine.Evaluate("Object.keys({ ...o }).join()").Should().Be("id,name,active");
+        engine.Evaluate("JSON.stringify(Object.entries(o))").Should().Be("""[["id",1],["name","jint"],["active",true]]""");
+    }
+
+    [Fact]
+    public void EmptyLayoutCreatesAnEmptyObject()
+    {
+        var engine = new Engine();
+        var empty = new JsObjectLayout();
+        empty.Count.Should().Be(0);
+
+        engine.SetValue("o", JsObject.Create(engine, empty, []));
+        engine.Evaluate("Object.keys(o).length").Should().Be(0);
+        engine.Evaluate("JSON.stringify(o)").Should().Be("{}");
+        engine.Evaluate("o.x = 1; o.x").Should().Be(1);
+    }
+
+    [Fact]
+    public void LayoutWiderThanTheInlineSlotCapacityKeepsOrderAndValues()
+    {
+        var engine = new Engine();
+        var layout = new JsObjectLayout("a", "b", "c", "d", "e", "f", "g");
+        engine.SetValue("o", JsObject.Create(engine, layout,
+        [
+            JsNumber.Create(1), JsNumber.Create(2), JsNumber.Create(3), JsNumber.Create(4),
+            JsNumber.Create(5), JsNumber.Create(6), JsNumber.Create(7)
+        ]));
+
+        engine.Evaluate("Object.keys(o).join()").Should().Be("a,b,c,d,e,f,g");
+        engine.Evaluate("Object.values(o).join()").Should().Be("1,2,3,4,5,6,7");
+        engine.Evaluate("o.g = 70; o.a = 10; o.a + ',' + o.g").Should().Be("10,70");
+    }
+
+    [Fact]
+    public void NullValuesBecomeUndefined()
+    {
+        var engine = new Engine();
+        var layout = new JsObjectLayout("a", "b");
+        engine.SetValue("o", JsObject.Create(engine, layout, [null, JsValue.Null]));
+
+        engine.Evaluate("o.a === undefined").Should().Be(true);
+        engine.Evaluate("o.b === null").Should().Be(true);
+        engine.Evaluate("Object.keys(o).join()").Should().Be("a,b");
+    }
+
+    // ---- degradation: every trigger must leave a correct ordinary object behind ----
+
+    [Fact]
+    public void AddingAPropertyKeepsEverythingCorrect()
+    {
+        var engine = EngineWithSample(out _);
+
+        engine.Evaluate("o.extra = 'x'; Object.keys(o).join()").Should().Be("id,name,active,extra");
+        engine.Evaluate("JSON.stringify(o)").Should().Be("""{"id":1,"name":"jint","active":true,"extra":"x"}""");
+        engine.Evaluate("o.id + '|' + o.extra").Should().Be("1|x");
+    }
+
+    [Fact]
+    public void DeletingAPropertyKeepsEverythingCorrect()
+    {
+        var engine = EngineWithSample(out _);
+
+        engine.Evaluate("delete o.name").Should().Be(true);
+        engine.Evaluate("Object.keys(o).join()").Should().Be("id,active");
+        engine.Evaluate("'name' in o").Should().Be(false);
+        engine.Evaluate("o.name").Should().BeUndefined();
+        engine.Evaluate("o.id + ',' + o.active").Should().Be("1,true");
+
+        // still an ordinary object afterwards
+        engine.Evaluate("o.name = 're-added'; Object.keys(o).join()").Should().Be("id,active,name");
+    }
+
+    [Fact]
+    public void FreezingKeepsEverythingCorrect()
+    {
+        var engine = EngineWithSample(out _);
+
+        engine.Evaluate("Object.freeze(o); Object.isFrozen(o)").Should().Be(true);
+        engine.Evaluate("o.name = 'nope'; o.name").Should().Be("jint");
+        engine.Evaluate("o.brandNew = 1; 'brandNew' in o").Should().Be(false);
+        engine.Evaluate("delete o.id; 'id' in o").Should().Be(true);
+        engine.Evaluate("Object.keys(o).join()").Should().Be("id,name,active");
+
+        var descriptor = engine.Evaluate("""
+            (function () {
+                var d = Object.getOwnPropertyDescriptor(o, 'id');
+                return [d.writable, d.configurable].join();
+            })()
+            """);
+        descriptor.Should().Be("false,false");
+
+        engine.Evaluate("(function () { 'use strict'; try { o.name = 'x'; return 'no-throw'; } catch (e) { return e instanceof TypeError ? 'TypeError' : 'other'; } })()")
+            .Should().Be("TypeError");
+    }
+
+    [Fact]
+    public void SealingKeepsEverythingCorrect()
+    {
+        var engine = EngineWithSample(out _);
+
+        engine.Evaluate("Object.seal(o); Object.isSealed(o)").Should().Be(true);
+        engine.Evaluate("Object.isFrozen(o)").Should().Be(false);
+        engine.Evaluate("o.name = 'still writable'; o.name").Should().Be("still writable");
+        engine.Evaluate("o.brandNew = 1; 'brandNew' in o").Should().Be(false);
+        engine.Evaluate("delete o.id; 'id' in o").Should().Be(true);
+        engine.Evaluate("Object.keys(o).join()").Should().Be("id,name,active");
+    }
+
+    [Fact]
+    public void DefiningAnAccessorKeepsEverythingCorrect()
+    {
+        var engine = EngineWithSample(out _);
+
+        engine.Evaluate("""
+            Object.defineProperty(o, 'label', {
+                get: function () { return this.name + '#' + this.id; },
+                enumerable: true,
+                configurable: true
+            });
+            """);
+
+        engine.Evaluate("o.label").Should().Be("jint#1");
+        engine.Evaluate("Object.keys(o).join()").Should().Be("id,name,active,label");
+        engine.Evaluate("typeof Object.getOwnPropertyDescriptor(o, 'label').get").Should().Be("function");
+        engine.Evaluate("o.id = 7; o.label").Should().Be("jint#7");
+
+        // redefining an existing layout property as an accessor works too
+        engine.Evaluate("Object.defineProperty(o, 'name', { get: function () { return 'computed'; }, enumerable: true, configurable: true }); o.name")
+            .Should().Be("computed");
+        engine.Evaluate("Object.keys(o).join()").Should().Be("id,name,active,label");
+    }
+
+    [Fact]
+    public void DefiningANonEnumerablePropertyKeepsEverythingCorrect()
+    {
+        var engine = EngineWithSample(out _);
+
+        engine.Evaluate("Object.defineProperty(o, 'hidden', { value: 42, enumerable: false, writable: false, configurable: false });");
+        engine.Evaluate("o.hidden").Should().Be(42);
+        engine.Evaluate("Object.keys(o).join()").Should().Be("id,name,active");
+        engine.Evaluate("Object.getOwnPropertyNames(o).join()").Should().Be("id,name,active,hidden");
+        engine.Evaluate("JSON.stringify(o)").Should().Be("""{"id":1,"name":"jint","active":true}""");
+    }
+
+    [Fact]
+    public void SettingThePrototypeKeepsEverythingCorrect()
+    {
+        var engine = EngineWithSample(out _);
+        engine.Execute("var proto = { inherited: 'yes', name: 'shadowed' };");
+
+        engine.Evaluate("Object.setPrototypeOf(o, proto); Object.getPrototypeOf(o) === proto").Should().Be(true);
+        engine.Evaluate("o.inherited").Should().Be("yes");
+        engine.Evaluate("o.name").Should().Be("jint");
+        engine.Evaluate("Object.keys(o).join()").Should().Be("id,name,active");
+        engine.Evaluate("(function () { var r = []; for (var k in o) r.push(k); return r.join(); })()")
+            .Should().Be("id,name,active,inherited");
+
+        engine.Evaluate("Object.setPrototypeOf(o, null); o.inherited === undefined").Should().Be(true);
+        engine.Evaluate("Object.keys(o).join()").Should().Be("id,name,active");
+    }
+
+    [Fact]
+    public void SymbolKeysCoexistWithTheLayout()
+    {
+        var engine = EngineWithSample(out _);
+
+        engine.Evaluate("var s = Symbol('s'); o[s] = 'sym'; o[s]").Should().Be("sym");
+        engine.Evaluate("Object.keys(o).join()").Should().Be("id,name,active");
+        engine.Evaluate("Object.getOwnPropertySymbols(o).length").Should().Be(1);
+    }
+
+    // ---- cross engine ----
+
+    [Fact]
+    public void TheSameLayoutWorksAcrossEnginesWithoutLeakingState()
+    {
+        var first = new Engine();
+        var second = new Engine();
+
+        first.SetValue("o", JsObject.Create(first, Layout, [JsNumber.Create(1), new JsString("first"), JsBoolean.True]));
+        second.SetValue("o", JsObject.Create(second, Layout, [JsNumber.Create(2), new JsString("second"), JsBoolean.False]));
+
+        first.Evaluate("JSON.stringify(o)").Should().Be("""{"id":1,"name":"first","active":true}""");
+        second.Evaluate("JSON.stringify(o)").Should().Be("""{"id":2,"name":"second","active":false}""");
+
+        // Mutating (and deopting) one engine's object must not disturb the other's, nor the shared layout.
+        first.Evaluate("delete o.name; o.extra = true;");
+        first.Evaluate("Object.keys(o).join()").Should().Be("id,active,extra");
+        second.Evaluate("Object.keys(o).join()").Should().Be("id,name,active");
+
+        var third = new Engine();
+        third.SetValue("o", JsObject.Create(third, Layout, [JsNumber.Create(3), new JsString("third"), JsBoolean.True]));
+        third.Evaluate("Object.keys(o).join()").Should().Be("id,name,active");
+        Layout.Count.Should().Be(3);
+    }
+
+    [Fact]
+    public void ManyObjectsFromOneLayoutBehaveIdentically()
+    {
+        var engine = new Engine();
+        var array = engine.Intrinsics.Array.Construct(0);
+        for (var i = 0; i < 500; i++)
+        {
+            array.Push(JsObject.Create(engine, Layout, [JsNumber.Create(i), new JsString("n" + i), JsBoolean.True]));
+        }
+
+        engine.SetValue("items", array);
+        engine.Evaluate("(function () { var s = 0; for (var i = 0; i < items.length; i++) s += items[i].id; return s; })()")
+            .Should().Be(124750);
+        engine.Evaluate("items[499].name").Should().Be("n499");
+        engine.Evaluate("Object.keys(items[250]).join()").Should().Be("id,name,active");
+    }
+
+    // ---- CreateFromEntries ----
+
+    [Fact]
+    public void CreateFromEntriesKeepsInsertionOrder()
+    {
+        var engine = new Engine();
+        engine.SetValue("o", JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("zebra", JsNumber.Create(1)),
+            new KeyValuePair<string, JsValue>("apple", new JsString("a")),
+            new KeyValuePair<string, JsValue>("mango", JsBoolean.False)
+        ]));
+
+        engine.Evaluate("Object.keys(o).join()").Should().Be("zebra,apple,mango");
+        engine.Evaluate("JSON.stringify(o)").Should().Be("""{"zebra":1,"apple":"a","mango":false}""");
+        engine.Evaluate("(function () { var r = []; for (var k in o) r.push(k); return r.join(); })()")
+            .Should().Be("zebra,apple,mango");
+        engine.Evaluate("Object.keys({ ...o }).join()").Should().Be("zebra,apple,mango");
+    }
+
+    [Fact]
+    public void CreateFromEntriesAcceptsAnArrayAndAnEnumerable()
+    {
+        var engine = new Engine();
+
+        var array = new[]
+        {
+            new KeyValuePair<string, JsValue>("a", JsNumber.Create(1)),
+            new KeyValuePair<string, JsValue>("b", JsNumber.Create(2))
+        };
+        engine.SetValue("fromArray", JsObject.CreateFromEntries(engine, array));
+
+        var list = new List<KeyValuePair<string, JsValue>>(array);
+        engine.SetValue("fromList", JsObject.CreateFromEntries(engine, list));
+
+        var dictionary = new Dictionary<string, JsValue>(StringComparer.Ordinal)
+        {
+            ["a"] = JsNumber.Create(1),
+            ["b"] = JsNumber.Create(2)
+        };
+        engine.SetValue("fromDictionary", JsObject.CreateFromEntries(engine, dictionary));
+
+        engine.Evaluate("JSON.stringify(fromArray)").Should().Be("""{"a":1,"b":2}""");
+        engine.Evaluate("JSON.stringify(fromList)").Should().Be("""{"a":1,"b":2}""");
+        engine.Evaluate("Object.keys(fromDictionary).sort().join()").Should().Be("a,b");
+        engine.Evaluate("fromDictionary.a + fromDictionary.b").Should().Be(3);
+    }
+
+    [Fact]
+    public void CreateFromEntriesRejectsNullArguments()
+    {
+        var engine = new Engine();
+
+        Invoking(() => JsObject.CreateFromEntries(null, System.Array.Empty<KeyValuePair<string, JsValue>>()))
+            .Should().Throw<ArgumentNullException>();
+        Invoking(() => JsObject.CreateFromEntries(engine, (IEnumerable<KeyValuePair<string, JsValue>>) null))
+            .Should().Throw<ArgumentNullException>();
+        Invoking(() => JsObject.CreateFromEntries(engine, new[] { new KeyValuePair<string, JsValue>(null, JsValue.Null) }))
+            .Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void CreateFromEntriesEmptyProducesAnOrdinaryEmptyObject()
+    {
+        var engine = new Engine();
+        engine.SetValue("o", JsObject.CreateFromEntries(engine, System.Array.Empty<KeyValuePair<string, JsValue>>()));
+
+        engine.Evaluate("Object.keys(o).length").Should().Be(0);
+        engine.Evaluate("o.x = 1; JSON.stringify(o)").Should().Be("""{"x":1}""");
+    }
+
+    [Fact]
+    public void CreateFromEntriesDuplicateKeyKeepsFirstPositionAndLastValue()
+    {
+        var engine = new Engine();
+        engine.SetValue("o", JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("a", JsNumber.Create(1)),
+            new KeyValuePair<string, JsValue>("b", JsNumber.Create(2)),
+            new KeyValuePair<string, JsValue>("a", JsNumber.Create(3))
+        ]));
+
+        engine.Evaluate("JSON.stringify(o)").Should().Be("""{"a":3,"b":2}""");
+    }
+
+    [Fact]
+    public void CreateFromEntriesWithIntegerLikeKeysUsesSpecOrder()
+    {
+        var engine = new Engine();
+        engine.SetValue("o", JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("b", JsNumber.Create(1)),
+            new KeyValuePair<string, JsValue>("5", JsNumber.Create(2)),
+            new KeyValuePair<string, JsValue>("a", JsNumber.Create(3)),
+            new KeyValuePair<string, JsValue>("0", JsNumber.Create(4))
+        ]));
+
+        // Integer indices ascending first, then the string keys in insertion order.
+        engine.Evaluate("Object.keys(o).join()").Should().Be("0,5,b,a");
+        engine.Evaluate("o[0] + ',' + o[5] + ',' + o.a + ',' + o.b").Should().Be("4,2,3,1");
+
+        // Leading integer-like key: never shaped at all, same result.
+        engine.SetValue("p", JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("0", JsNumber.Create(1)),
+            new KeyValuePair<string, JsValue>("z", JsNumber.Create(2))
+        ]));
+        engine.Evaluate("Object.keys(p).join()").Should().Be("0,z");
+    }
+
+    [Fact]
+    public void CreateFromEntriesPastTheHiddenClassPropertyLimitKeepsEveryEntry()
+    {
+        var engine = new Engine();
+        var entries = new KeyValuePair<string, JsValue>[80];
+        for (var i = 0; i < entries.Length; i++)
+        {
+            entries[i] = new KeyValuePair<string, JsValue>("k" + i, JsNumber.Create(i));
+        }
+
+        engine.SetValue("o", JsObject.CreateFromEntries(engine, entries));
+        engine.Evaluate("""
+            (function () {
+                var keys = Object.keys(o);
+                if (keys.length !== 80) return false;
+                for (var i = 0; i < 80; i++) {
+                    if (keys[i] !== ('k' + i) || o['k' + i] !== i) return false;
+                }
+                return true;
+            })()
+            """).Should().Be(true);
+    }
+
+    [Fact]
+    public void CreateFromEntriesResultDegradesCorrectly()
+    {
+        var engine = new Engine();
+        engine.SetValue("o", JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("a", JsNumber.Create(1)),
+            new KeyValuePair<string, JsValue>("b", JsNumber.Create(2))
+        ]));
+
+        engine.Evaluate("o.c = 3; delete o.a; Object.defineProperty(o, 'd', { get: function () { return 4; }, enumerable: true });");
+        engine.Evaluate("Object.keys(o).join()").Should().Be("b,c,d");
+        engine.Evaluate("o.b + o.c + o.d").Should().Be(9);
+        engine.Evaluate("Object.freeze(o); Object.isFrozen(o)").Should().Be(true);
+    }
+
+    [Fact]
+    public void CreateFromEntriesWithVaryingKeySetsStaysCorrect()
+    {
+        // A host feeding wildly varying key sets must keep getting correct objects; the engine bounds how
+        // much hidden-class state that can intern and silently degrades the representation, never the
+        // behavior.
+        var engine = new Engine();
+        var array = engine.Intrinsics.Array.Construct(0);
+        for (var i = 0; i < 2000; i++)
+        {
+            array.Push(JsObject.CreateFromEntries(engine,
+            [
+                new KeyValuePair<string, JsValue>("f" + i, JsNumber.Create(i)),
+                new KeyValuePair<string, JsValue>("g" + (i * 7), JsNumber.Create(i)),
+                new KeyValuePair<string, JsValue>("shared", JsNumber.Create(i))
+            ]));
+        }
+
+        engine.SetValue("items", array);
+        engine.Evaluate("""
+            (function () {
+                for (var i = 0; i < items.length; i++) {
+                    var o = items[i];
+                    if (Object.keys(o).join() !== ['f' + i, 'g' + (i * 7), 'shared'].join()) return false;
+                    if (o['f' + i] !== i || o.shared !== i) return false;
+                }
+                return true;
+            })()
+            """).Should().Be(true);
+    }
+}

--- a/Jint.Tests/Runtime/HostObjectFactoryShapeTests.cs
+++ b/Jint.Tests/Runtime/HostObjectFactoryShapeTests.cs
@@ -1,0 +1,277 @@
+using System.Collections.Generic;
+using Jint.Native;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Pins the hidden-class behavior of the host-facing object factories (<see cref="JsObject.Create"/> and
+/// <see cref="JsObject.CreateFromEntries(Engine, System.ReadOnlySpan{KeyValuePair{string, JsValue}})"/>).
+/// Interning — separately constructed objects of the same layout referencing the very same
+/// <see cref="Jint.Native.Object.Shape"/> — is what keeps a script's <c>o.x</c> call site monomorphic
+/// across a whole batch, and it is not observable through the public API, so it is asserted here where
+/// internals are visible. The publicly observable behavior lives in
+/// Jint.Tests.PublicInterface/FixedLayoutObjectTests.cs.
+/// </summary>
+public class HostObjectFactoryShapeTests
+{
+    private static readonly JsObjectLayout Layout = new("id", "name", "active");
+
+    private static JsObject Sample(Engine engine, int id) => JsObject.Create(
+        engine,
+        Layout,
+        [JsNumber.Create(id), JsString.Create("n" + id), JsBoolean.True]);
+
+    [Fact]
+    public void CreatedObjectIsInShapeMode()
+    {
+        var engine = new Engine();
+        var obj = Sample(engine, 1);
+
+        (obj._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
+        obj.ShapeOf.SlotCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void EveryObjectBuiltFromOneLayoutSharesOneShape()
+    {
+        var engine = new Engine();
+        var first = Sample(engine, 1);
+        var shape = first.ShapeOf;
+
+        for (var i = 2; i <= 200; i++)
+        {
+            var next = Sample(engine, i);
+            next.Should().NotBeSameAs(first);
+            // Same instance, not merely an equal layout: this is what makes the member inline cache hit
+            // across separately-constructed objects.
+            next.ShapeOf.Should().BeSameAs(shape);
+        }
+    }
+
+    [Fact]
+    public void LayoutShapeIsTheSameShapeAnEquivalentObjectLiteralBuilds()
+    {
+        var engine = new Engine();
+        var created = Sample(engine, 1);
+
+        var literal = engine.Evaluate("({ id: 1, name: 'n1', active: true })").Should().BeOfType<JsObject>().Which;
+        literal.ShapeOf.Should().BeSameAs(created.ShapeOf);
+
+        // ...and the same one the entries factory reaches for the same key sequence.
+        var fromEntries = JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("id", JsNumber.Create(1)),
+            new KeyValuePair<string, JsValue>("name", JsString.Create("n1")),
+            new KeyValuePair<string, JsValue>("active", JsBoolean.True)
+        ]);
+        fromEntries.ShapeOf.Should().BeSameAs(created.ShapeOf);
+
+        // ...and the one Object.fromEntries / spread reach, since all of them grow the same per-prototype
+        // transition tree.
+        var spread = engine.Evaluate("({ ...{ id: 1, name: 'n1', active: true } })").Should().BeOfType<JsObject>().Which;
+        spread.ShapeOf.Should().BeSameAs(created.ShapeOf);
+    }
+
+    [Fact]
+    public void RepeatedEntryKeySequencesShareOneShape()
+    {
+        var engine = new Engine();
+
+        JsObject Build(int i) => JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("first", JsNumber.Create(i)),
+            new KeyValuePair<string, JsValue>("second", JsString.Create("s")),
+            new KeyValuePair<string, JsValue>("third", JsBoolean.False),
+            new KeyValuePair<string, JsValue>("fourth", JsNumber.Create(i)),
+            new KeyValuePair<string, JsValue>("fifth", JsNumber.Create(i))
+        ]);
+
+        var first = Build(0);
+        (first._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
+
+        for (var i = 1; i < 50; i++)
+        {
+            Build(i).ShapeOf.Should().BeSameAs(first.ShapeOf);
+        }
+
+        // A different key sequence must land on a different shape (the tree branches, it does not merge).
+        var other = JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("second", JsNumber.Create(1)),
+            new KeyValuePair<string, JsValue>("first", JsNumber.Create(1))
+        ]);
+        other.ShapeOf.Should().NotBeSameAs(first.ShapeOf);
+    }
+
+    [Fact]
+    public void TheSameLayoutResolvesToADifferentShapePerEngine()
+    {
+        var first = new Engine();
+        var second = new Engine();
+
+        var a = Sample(first, 1);
+        var b = Sample(second, 1);
+
+        // Empty root shapes are interned per (engine, prototype) and the transition tree hangs off that
+        // root, so one process-shared layout cannot carry a single Shape.
+        a.ShapeOf.Should().NotBeSameAs(b.ShapeOf);
+        a.ShapeOf.SlotCount.Should().Be(3);
+        b.ShapeOf.SlotCount.Should().Be(3);
+
+        // Within each engine the memo still holds.
+        Sample(first, 2).ShapeOf.Should().BeSameAs(a.ShapeOf);
+        Sample(second, 2).ShapeOf.Should().BeSameAs(b.ShapeOf);
+    }
+
+    [Fact]
+    public void DifferentLayoutInstancesWithTheSameNamesShareOneShape()
+    {
+        var engine = new Engine();
+        var equivalent = new JsObjectLayout("id", "name", "active");
+
+        var a = Sample(engine, 1);
+        var b = JsObject.Create(engine, equivalent, [JsNumber.Create(2), JsString.Create("n2"), JsBoolean.False]);
+
+        // The memo is per layout instance, but the transitions it walks are interned per prototype, so a
+        // host that (wastefully) rebuilds an equal layout still lands on the same hidden class.
+        b.ShapeOf.Should().BeSameAs(a.ShapeOf);
+    }
+
+    [Theory]
+    [InlineData("o.extra = 1;")]
+    [InlineData("delete o.name;")]
+    [InlineData("Object.freeze(o);")]
+    [InlineData("Object.seal(o);")]
+    [InlineData("Object.defineProperty(o, 'g', { get: function () { return 1; } });")]
+    [InlineData("Object.defineProperty(o, 'name', { value: 2, writable: false });")]
+    public void DeoptTriggersLeaveAnOrdinaryDictionaryObject(string script)
+    {
+        var engine = new Engine();
+        var obj = Sample(engine, 1);
+        engine.SetValue("o", obj);
+
+        (obj._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
+        engine.Execute(script);
+
+        (obj._type & InternalTypes.ShapeMode).Should().Be(InternalTypes.Empty);
+        obj._properties.Should().NotBeNull();
+        engine.Evaluate("o.id").Should().Be(1);
+    }
+
+    [Fact]
+    public void SettingThePrototypeKeepsTheLayoutValid()
+    {
+        // Unlike the other mutations, a prototype change does NOT deopt: a Shape maps names to slots and
+        // never encodes the prototype, and the member inline cache only serves own-slot reads, so the
+        // object stays shaped and correct. The shape it keeps is rooted at the previous prototype, which
+        // costs nothing but a missed sharing opportunity with objects built under the new one.
+        var engine = new Engine();
+        var obj = Sample(engine, 1);
+        engine.SetValue("o", obj);
+        engine.Execute("var proto = { inherited: 'yes' }; Object.setPrototypeOf(o, proto);");
+
+        engine.Evaluate("o.id").Should().Be(1);
+        engine.Evaluate("o.inherited").Should().Be("yes");
+        engine.Evaluate("Object.keys(o).join()").Should().Be("id,name,active");
+    }
+
+    [Fact]
+    public void IntegerLikeEntryKeyDropsTheObjectToDictionaryMode()
+    {
+        var engine = new Engine();
+        var obj = JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("a", JsNumber.Create(1)),
+            new KeyValuePair<string, JsValue>("0", JsNumber.Create(2))
+        ]);
+
+        (obj._type & InternalTypes.ShapeMode).Should().Be(InternalTypes.Empty);
+        engine.SetValue("o", obj);
+        engine.Evaluate("Object.keys(o).join()").Should().Be("0,a");
+    }
+
+    [Fact]
+    public void WildlyVaryingEntryKeySetsStopInterningAndFallBackToDictionaries()
+    {
+        // The fan-out guard bounds how many distinct continuations one shape may sprout: once the empty
+        // root has MaxFanout children, an object whose very first key is new is refused immediately and
+        // finishes as a dictionary. That is what keeps an adversarial key set from growing the
+        // per-prototype transition tree without bound.
+        var engine = new Engine();
+        var shapedCount = 0;
+        for (var i = 0; i < 500; i++)
+        {
+            var obj = JsObject.CreateFromEntries(engine,
+            [
+                new KeyValuePair<string, JsValue>("k" + i, JsNumber.Create(i)),
+                new KeyValuePair<string, JsValue>("shared", JsNumber.Create(i))
+            ]);
+
+            if ((obj._type & InternalTypes.ShapeMode) != InternalTypes.Empty)
+            {
+                shapedCount++;
+            }
+
+            engine.SetValue("o", obj);
+            engine.Evaluate("Object.keys(o).join()").Should().Be("k" + i + ",shared");
+            engine.Evaluate("o.shared").Should().Be(i);
+        }
+
+        // Only the first MaxFanout distinct first-keys can be interned under the root.
+        shapedCount.Should().Be(64);
+    }
+
+    [Fact]
+    public void ExhaustingTheHostTransitionBudgetFallsBackToDictionaryObjects()
+    {
+        var engine = new Engine();
+
+        // 64 properties is the widest layout a hidden class can describe, so this burns the engine's
+        // whole host budget in the fewest possible iterations.
+        const int Width = 64;
+        var layouts = new List<JsObjectLayout>();
+        var values = new JsValue[Width];
+        for (var i = 0; i < Width; i++)
+        {
+            values[i] = JsNumber.Create(i);
+        }
+
+        var iterations = Engine.HostShapeTransitionBudget / Width;
+        for (var iteration = 0; iteration < iterations; iteration++)
+        {
+            var names = new string[Width];
+            for (var i = 0; i < Width; i++)
+            {
+                names[i] = "L" + iteration + "_" + i;
+            }
+
+            var layout = new JsObjectLayout(names);
+            layouts.Add(layout);
+            var obj = JsObject.Create(engine, layout, values);
+            (obj._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
+        }
+
+        // Budget spent: a brand-new layout now produces a correct, ordinary dictionary-mode object.
+        var overflowNames = new string[Width];
+        for (var i = 0; i < Width; i++)
+        {
+            overflowNames[i] = "overflow_" + i;
+        }
+
+        var overflow = JsObject.Create(engine, new JsObjectLayout(overflowNames), values);
+        (overflow._type & InternalTypes.ShapeMode).Should().Be(InternalTypes.Empty);
+        engine.SetValue("o", overflow);
+        engine.Evaluate("Object.keys(o).length").Should().Be(Width);
+        engine.Evaluate("o.overflow_0 + ',' + o.overflow_63").Should().Be("0,63");
+
+        // Layouts already resolved keep their interned shape — the memo hit never consults the budget.
+        var reused = JsObject.Create(engine, layouts[0], values);
+        (reused._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
+
+        // A different engine has its own budget.
+        var fresh = new Engine();
+        var freshObj = JsObject.Create(fresh, new JsObjectLayout(overflowNames), values);
+        (freshObj._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
+    }
+}

--- a/Jint/Engine.Shapes.cs
+++ b/Jint/Engine.Shapes.cs
@@ -1,20 +1,132 @@
 using System.Runtime.CompilerServices;
+using Jint.Native;
 using Jint.Native.Object;
 
 namespace Jint;
 
 public partial class Engine
 {
-    // Empty root shapes, keyed by prototype, so all plain objects with the same prototype share one
-    // transition tree (and therefore share Shape instances for identical layouts). Keyed weakly so a
-    // prototype's shapes are released with it; the table is only consulted on a cold path (an
-    // object-literal site building its shape for the first time, or for a new prototype), because the
-    // resulting leaf shape is cached on the AST node.
-    private ConditionalWeakTable<ObjectInstance, Shape>? _emptyShapes;
+    // Per-prototype hidden-class state, keyed weakly so a prototype's shapes are released with it. The
+    // table is only consulted on a cold path (an object-literal site building its shape for the first
+    // time, a new prototype, or a host layout that has not been resolved against this engine yet),
+    // because the resulting leaf shape is cached on the AST node / in the per-prototype layout memo.
+    private ConditionalWeakTable<ObjectInstance, ShapeRoot>? _shapeRoots;
 
-    internal Shape GetEmptyShape(ObjectInstance prototype)
+    // Bounds how many NEW transition nodes host-driven object construction (JsObject.Create /
+    // JsObject.CreateFromEntries) may intern over this engine's lifetime. A transition tree is pinned by
+    // its prototype, which for Object.prototype means the engine's lifetime, so a host that feeds
+    // wildly varying key sets — document field names, user-defined columns — must not be able to grow
+    // it without bound. Reused transitions (the whole point: identically laid-out items share a shape)
+    // cost nothing, so only genuinely new layouts consume the budget. Once exhausted, host construction
+    // keeps working but produces ordinary dictionary-mode objects.
+    //
+    // Note this is the ONLY bound on the layout path: JsObjectLayout caps a single layout at
+    // Shape.MaxShapeProperties, but resolving a layout walks Shape.Add directly (as object literals do)
+    // and therefore does not go through TryShapeAdd's MaxFanout guard.
+    internal const int HostShapeTransitionBudget = 16 * 1024;
+    private int _hostShapeTransitions;
+
+    internal Shape GetEmptyShape(ObjectInstance prototype) => GetShapeRoot(prototype).Empty;
+
+    private ShapeRoot GetShapeRoot(ObjectInstance prototype)
     {
-        _emptyShapes ??= new ConditionalWeakTable<ObjectInstance, Shape>();
-        return _emptyShapes.GetValue(prototype, static _ => new Shape());
+        _shapeRoots ??= new ConditionalWeakTable<ObjectInstance, ShapeRoot>();
+        return _shapeRoots.GetValue(prototype, static _ => new ShapeRoot());
+    }
+
+    /// <summary>
+    /// True while host-driven construction may still intern new hidden-class transitions; see
+    /// <see cref="HostShapeTransitionBudget"/>. Callers that grow a shape incrementally check this once
+    /// per object and then charge each newly interned transition with
+    /// <see cref="ChargeHostShapeTransition"/>; an object already under construction is allowed to
+    /// finish shaped (the overshoot is bounded by <see cref="Shape.MaxShapeProperties"/>).
+    /// </summary>
+    internal bool HostShapeBudgetAvailable => _hostShapeTransitions < HostShapeTransitionBudget;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void ChargeHostShapeTransition() => _hostShapeTransitions++;
+
+    /// <summary>
+    /// Resolves a host-declared <see cref="JsObjectLayout"/> to the interned leaf <see cref="Shape"/> for
+    /// <paramref name="prototype"/> in this engine, memoizing the result so every later call with the same
+    /// layout is a single weak-table probe. Returns <c>null</c> when the layout is not memoized yet and the
+    /// engine's host transition budget cannot cover it, in which case the caller builds an ordinary
+    /// dictionary-mode object instead.
+    /// <para>
+    /// Resolution is necessarily per engine: the empty root shape is interned per (engine, prototype) and
+    /// the whole transition tree hangs off it, so one process-shared layout maps to a different
+    /// <see cref="Shape"/> in every engine that uses it.
+    /// </para>
+    /// </summary>
+    internal Shape? TryGetLayoutShape(ObjectInstance prototype, JsObjectLayout layout)
+    {
+        var root = GetShapeRoot(prototype);
+        if (root.TryGetLayoutShape(layout, out var memoized))
+        {
+            return memoized;
+        }
+
+        var count = layout.Count;
+        if (_hostShapeTransitions + count > HostShapeTransitionBudget)
+        {
+            return null;
+        }
+
+        // Conservatively charge the whole layout rather than only the transitions the build actually
+        // interns: a layout that shares a prefix with an existing one is over-charged, which only makes
+        // the bound stricter, and it keeps the memo miss a single pass.
+        _hostShapeTransitions += count;
+        return root.GetOrBuildLayoutShape(layout);
+    }
+
+    /// <summary>
+    /// The hidden-class state anchored to one prototype: its empty root shape (from which the whole
+    /// transition tree grows) plus the memo of host layouts already resolved against that root.
+    /// <para>
+    /// Lifetime: this object is the value of a <see cref="ConditionalWeakTable{TKey,TValue}"/> keyed by the
+    /// prototype, so a dropped prototype takes its root, its transition tree and its layout memo with it.
+    /// The memo is itself weakly keyed by <see cref="JsObjectLayout"/>, so a dropped layout releases its
+    /// entry; and a <see cref="Shape"/> references only its parent chain and its key strings — never a
+    /// prototype, an engine or a layout — so a memo entry pins nothing beyond the layout it describes.
+    /// </para>
+    /// </summary>
+    private sealed class ShapeRoot
+    {
+        internal readonly Shape Empty = new Shape();
+
+        private ConditionalWeakTable<JsObjectLayout, Shape>? _layoutShapes;
+        private ConditionalWeakTable<JsObjectLayout, Shape>.CreateValueCallback? _build;
+
+        internal bool TryGetLayoutShape(JsObjectLayout layout, out Shape? shape)
+        {
+            var table = _layoutShapes;
+            if (table is null)
+            {
+                shape = null;
+                return false;
+            }
+
+            return table.TryGetValue(layout, out shape);
+        }
+
+        internal Shape GetOrBuildLayoutShape(JsObjectLayout layout)
+        {
+            var table = _layoutShapes ??= new ConditionalWeakTable<JsObjectLayout, Shape>();
+            // Memoize the callback so the common (hit) path allocates nothing and the miss path allocates
+            // one delegate per prototype rather than one per call.
+            return table.GetValue(layout, _build ??= BuildLayoutShape);
+        }
+
+        private Shape BuildLayoutShape(JsObjectLayout layout)
+        {
+            var shape = Empty;
+            var keys = layout.Keys;
+            for (var i = 0; i < keys.Length; i++)
+            {
+                shape = shape.Add(in keys[i]);
+            }
+
+            return shape;
+        }
     }
 }

--- a/Jint/Native/JsObject.Create.cs
+++ b/Jint/Native/JsObject.Create.cs
@@ -1,0 +1,234 @@
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Native;
+
+/// <summary>
+/// Host-facing factories that build plain objects straight into the hidden-class (shape) representation.
+/// </summary>
+public sealed partial class JsObject
+{
+    /// <summary>
+    /// Creates an object with <paramref name="layout"/>'s properties, in layout order, taking their values
+    /// from <paramref name="values"/> by slot. The result is a completely ordinary object whose prototype is
+    /// the engine's <c>Object.prototype</c> and whose properties are configurable, enumerable and writable —
+    /// indistinguishable from the equivalent object literal, including own-key order.
+    /// <para>
+    /// Unlike populating a fresh <see cref="JsObject"/> through
+    /// <see cref="ObjectInstance.FastSetDataProperty(string, JsValue)"/> — which stores raw descriptors and
+    /// therefore builds a property dictionary — this resolves the layout to an interned hidden class once per
+    /// (engine, layout) and then only fills value slots. Every object created from the same layout in the
+    /// same engine shares that hidden class, so a script reading the same property across a batch of such
+    /// objects keeps a monomorphic inline cache.
+    /// </para>
+    /// <para>
+    /// Anything the representation cannot express falls back automatically and correctly: adding or deleting
+    /// a property, defining an accessor or a non-default attribute, freezing or sealing all convert the
+    /// object to the ordinary dictionary representation, exactly as they do for an object literal.
+    /// </para>
+    /// </summary>
+    /// <param name="engine">The engine the object belongs to.</param>
+    /// <param name="layout">The property layout; see <see cref="JsObjectLayout"/>.</param>
+    /// <param name="values">
+    /// One value per layout property, in layout order. A <c>null</c> entry is stored as
+    /// <see cref="JsValue.Undefined"/>.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="engine"/> or <paramref name="layout"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="values"/> does not have exactly <see cref="JsObjectLayout.Count"/> entries.</exception>
+    public static JsObject Create(Engine engine, JsObjectLayout layout, ReadOnlySpan<JsValue> values)
+    {
+        if (engine is null)
+        {
+            Throw.ArgumentNullException(nameof(engine));
+        }
+
+        if (layout is null)
+        {
+            Throw.ArgumentNullException(nameof(layout));
+        }
+
+        var keys = layout.Keys;
+        if (values.Length != keys.Length)
+        {
+            Throw.ArgumentException(
+                $"The layout describes {keys.Length} properties but {values.Length} values were given.",
+                nameof(values));
+        }
+
+        var obj = new JsObject(engine);
+
+        // The JsObject constructor already anchored the object to the active realm's Object.prototype;
+        // resolve the layout against that exact prototype, because shapes are interned per prototype.
+        var shape = obj._prototype is { } proto ? engine.TryGetLayoutShape(proto, layout) : null;
+        if (shape is null)
+        {
+            // No prototype (only reachable while the realm is still being built) or the engine's host
+            // transition budget is spent: build the same object in the ordinary dictionary representation.
+            for (var i = 0; i < keys.Length; i++)
+            {
+                obj.FastSetDataProperty(keys[i].Name, values[i] ?? Undefined);
+            }
+
+            return obj;
+        }
+
+        // Install the interned layout and fill the slots. A layout within the in-object slot capacity makes
+        // the object itself the only allocation.
+        obj.InitShape(shape);
+        for (var i = 0; i < values.Length; i++)
+        {
+            obj.SetSlot(i, values[i] ?? Undefined);
+        }
+
+        return obj;
+    }
+
+    /// <summary>
+    /// Creates an object from a sequence of name/value entries, in the order given, for host data whose key
+    /// set is only known at runtime. Later entries with a name already present overwrite the earlier value
+    /// in place, keeping the first occurrence's position — the same rule an object literal and
+    /// <c>Object.fromEntries</c> follow.
+    /// <para>
+    /// Entries are added through the incremental hidden-class path, so repeated calls presenting the same
+    /// key sequence produce objects that share one interned hidden class — which is what keeps a script
+    /// reading those objects monomorphic. Key sets too varied for that (see the remarks) degrade to the
+    /// ordinary dictionary representation, never to incorrect behavior.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// The object falls back to the dictionary representation — mid-build, preserving everything added so
+    /// far — when an entry name starts with a digit (integer-index-like keys must enumerate in ascending
+    /// numeric order ahead of the string keys), when it would exceed the number of properties a hidden class
+    /// can describe, or when the layout it is growing has already sprouted too many distinct continuations
+    /// (the object-used-as-a-hash-map pattern). Each engine also bounds how many new layouts host code may
+    /// intern over its lifetime; past that, this method keeps working and simply returns dictionary-mode
+    /// objects.
+    /// </remarks>
+    /// <param name="engine">The engine the object belongs to.</param>
+    /// <param name="entries">The property names and values, in the order they should appear.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="engine"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">An entry name is <c>null</c>.</exception>
+    public static JsObject CreateFromEntries(Engine engine, ReadOnlySpan<KeyValuePair<string, JsValue>> entries)
+    {
+        if (engine is null)
+        {
+            Throw.ArgumentNullException(nameof(engine));
+        }
+
+        var obj = new JsObject(engine);
+        var state = new EntryBuildState();
+        for (var i = 0; i < entries.Length; i++)
+        {
+            AddEntry(obj, engine, entries[i].Key, entries[i].Value, ref state);
+        }
+
+        return obj;
+    }
+
+    /// <summary>
+    /// Enumerable overload of
+    /// <see cref="CreateFromEntries(Engine, ReadOnlySpan{KeyValuePair{string, JsValue}})"/>, for hosts whose
+    /// data already lives in a <see cref="Dictionary{TKey,TValue}"/> or another sequence that cannot be
+    /// viewed as a span — materializing one just to call this API would cost the very allocation the shaped
+    /// representation saves. Enumeration order is the source's order, and it is walked exactly once.
+    /// </summary>
+    /// <param name="engine">The engine the object belongs to.</param>
+    /// <param name="entries">The property names and values, in the order they should appear.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="engine"/> or <paramref name="entries"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">An entry name is <c>null</c>.</exception>
+    public static JsObject CreateFromEntries(Engine engine, IEnumerable<KeyValuePair<string, JsValue>> entries)
+    {
+        if (engine is null)
+        {
+            Throw.ArgumentNullException(nameof(engine));
+        }
+
+        if (entries is null)
+        {
+            Throw.ArgumentNullException(nameof(entries));
+        }
+
+        var obj = new JsObject(engine);
+        var state = new EntryBuildState();
+        foreach (var entry in entries)
+        {
+            AddEntry(obj, engine, entry.Key, entry.Value, ref state);
+        }
+
+        return obj;
+    }
+
+    /// <summary>
+    /// The per-object locals both <c>CreateFromEntries</c> overloads carry through
+    /// <see cref="AddEntry"/>: whether the object is still growing a hidden class, and whether the next
+    /// entry is the first one (shaping starts lazily so an empty entry set stays a bare property-less
+    /// object).
+    /// </summary>
+    private struct EntryBuildState
+    {
+        internal bool Shaped;
+        internal bool Started;
+    }
+
+    /// <summary>
+    /// Adds one host entry, routing through the hidden-class machinery so identically-keyed items share an
+    /// interned layout, and dropping the object to the dictionary representation — preserving insertion
+    /// order — the moment a key or a growth guard says the layout cannot continue.
+    /// </summary>
+    private static void AddEntry(JsObject obj, Engine engine, string? name, JsValue? value, ref EntryBuildState state)
+    {
+        if (name is null)
+        {
+            Throw.ArgumentException("Entry property names must not be null.", "entries");
+        }
+
+        var v = value ?? Undefined;
+        var integerIndexLike = Shape.IsIntegerIndexLikeKey(name);
+
+        if (!state.Started)
+        {
+            state.Started = true;
+            // Start shaping lazily on the first entry, and only when that entry can actually live in a
+            // shape — an object whose first key is integer-index-like would deopt immediately.
+            if (!integerIndexLike && engine.HostShapeBudgetAvailable && obj._prototype is { } proto)
+            {
+                obj.StartShapeBuilding(engine.GetEmptyShape(proto));
+                state.Shaped = true;
+            }
+        }
+
+        if (state.Shaped)
+        {
+            if (!integerIndexLike)
+            {
+                Key key = name;
+                if (obj.ShapeOf.TryGetSlot(in key, out var slot))
+                {
+                    // Duplicate name: last value wins at the first occurrence's position, matching the
+                    // dictionary representation's replace-in-place.
+                    obj.SetSlot(slot, v);
+                    return;
+                }
+
+                if (obj.TryShapeAdd(in key, v, out var created))
+                {
+                    if (created)
+                    {
+                        // Only newly interned transitions consume the engine's budget; the repeated-layout
+                        // case — the one this API exists for — costs nothing.
+                        engine.ChargeHostShapeTransition();
+                    }
+
+                    return;
+                }
+            }
+
+            // Integer-index-like key, or a growth guard (own-property count / transition fan-out) refused
+            // the add: finish this object as a dictionary, keeping everything added so far.
+            obj.ConvertToDictionaryMode();
+            state.Shaped = false;
+        }
+
+        obj.FastSetDataProperty(name, v);
+    }
+}

--- a/Jint/Native/JsObject.cs
+++ b/Jint/Native/JsObject.cs
@@ -7,7 +7,7 @@ namespace Jint.Native;
 /// <summary>
 /// Dynamically constructed JavaScript object instance.
 /// </summary>
-public sealed class JsObject : ObjectInstance
+public sealed partial class JsObject : ObjectInstance
 {
     // Hidden-class shape storage lives here (not on base ObjectInstance) so only plain objects — the
     // population that benefits from shapes — carry these fields; JsDate/JsArray/TypedArray/wrappers/

--- a/Jint/Native/JsObjectLayout.cs
+++ b/Jint/Native/JsObjectLayout.cs
@@ -1,0 +1,175 @@
+using System.Runtime.CompilerServices;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Native;
+
+/// <summary>
+/// An immutable description of a fixed own-property layout — a set of property names in a fixed order —
+/// that host code can hand to <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/>
+/// to build objects directly in Jint's hidden-class representation.
+/// <para>
+/// Intended for the common embedding pattern where every item of a batch carries the <em>same</em>
+/// properties: declare the layout once (it is engine-agnostic and safe to share across engines and
+/// threads — typically a <c>static readonly</c> field), then create one object per item.
+/// Every object built from the same layout in the same engine shares one hidden class, so a script
+/// reading <c>item.name</c> in a loop over the batch keeps a monomorphic inline cache and no
+/// per-property descriptor or property dictionary is allocated. Contrast with populating a fresh
+/// <see cref="JsObject"/> through
+/// <see cref="ObjectInstance.FastSetDataProperty(string, JsValue)"/>, which stores raw descriptors and
+/// therefore forces the dictionary representation.
+/// </para>
+/// <para>
+/// The property names are validated once, here, so object creation itself has nothing left to check.
+/// </para>
+/// </summary>
+/// <example>
+/// <code>
+/// private static readonly JsObjectLayout PointLayout = new("x", "y", "label");
+///
+/// JsObject ToJs(Engine engine, Point p) => JsObject.Create(
+///     engine,
+///     PointLayout,
+///     [JsNumber.Create(p.X), JsNumber.Create(p.Y), new JsString(p.Label)]);
+/// </code>
+/// </example>
+public sealed class JsObjectLayout
+{
+    // Below this count IndexOf walks the keys (a precomputed-hash compare plus an ordinal compare per
+    // step), which beats a dictionary probe for the small layouts this type targets. Mirrors Shape.
+    private const int LinearScanLimit = 16;
+
+    // Property names in slot (= insertion) order, pre-hashed so resolving the layout to a Shape is a
+    // straight walk of interned transitions with no re-hashing.
+    private readonly Key[] _keys;
+
+    // Lazily built for wide layouts only.
+    private Dictionary<Key, int>? _index;
+
+    /// <summary>
+    /// Creates a layout for the given property names, in the order the properties should appear in the
+    /// created objects' own-key order.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="propertyNames"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">
+    /// A name is <c>null</c> or empty, two names are equal, a name starts with a digit (such a key must be
+    /// enumerated in ascending numeric order ahead of the string keys, which a fixed layout cannot
+    /// express), or there are more names than a hidden class can describe.
+    /// </exception>
+    public JsObjectLayout(params string[] propertyNames) : this((IReadOnlyList<string>) propertyNames)
+    {
+    }
+
+    /// <summary>
+    /// Creates a layout for the given property names, in the order the properties should appear in the
+    /// created objects' own-key order.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="propertyNames"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">
+    /// A name is <c>null</c> or empty, two names are equal, a name starts with a digit (such a key must be
+    /// enumerated in ascending numeric order ahead of the string keys, which a fixed layout cannot
+    /// express), or there are more names than a hidden class can describe.
+    /// </exception>
+    public JsObjectLayout(IReadOnlyList<string> propertyNames)
+    {
+        if (propertyNames is null)
+        {
+            Throw.ArgumentNullException(nameof(propertyNames));
+        }
+
+        var count = propertyNames.Count;
+        if (count > Shape.MaxShapeProperties)
+        {
+            Throw.ArgumentException(
+                $"A layout can describe at most {Shape.MaxShapeProperties} properties, but {count} property names were given.",
+                nameof(propertyNames));
+        }
+
+        var keys = count > 0 ? new Key[count] : System.Array.Empty<Key>();
+        for (var i = 0; i < count; i++)
+        {
+            var name = propertyNames[i];
+            if (string.IsNullOrEmpty(name))
+            {
+                Throw.ArgumentException(
+                    $"Property name at index {i} is null or empty; layout property names must be non-empty strings.",
+                    nameof(propertyNames));
+            }
+
+            if (Shape.IsIntegerIndexLikeKey(name))
+            {
+                Throw.ArgumentException(
+                    $"Property name '{name}' at index {i} starts with a digit. Integer-index-like keys must be enumerated in ascending numeric order before the string keys, which a fixed layout cannot express; build such objects with JsObject.CreateFromEntries instead.",
+                    nameof(propertyNames));
+            }
+
+            Key key = name;
+            for (var j = 0; j < i; j++)
+            {
+                if (keys[j] == key)
+                {
+                    Throw.ArgumentException(
+                        $"Duplicate property name '{name}' at index {i}; layout property names must be distinct.",
+                        nameof(propertyNames));
+                }
+            }
+
+            keys[i] = key;
+        }
+
+        _keys = keys;
+    }
+
+    /// <summary>The number of properties this layout describes.</summary>
+    public int Count => _keys.Length;
+
+    /// <summary>
+    /// The slot of <paramref name="name"/> in this layout — the index its value occupies in the
+    /// <c>values</c> span passed to
+    /// <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/> — or <c>-1</c> when the
+    /// layout does not describe that property.
+    /// </summary>
+    public int IndexOf(string name)
+    {
+        if (name is null)
+        {
+            return -1;
+        }
+
+        Key key = name;
+        var keys = _keys;
+        if (keys.Length < LinearScanLimit)
+        {
+            for (var i = 0; i < keys.Length; i++)
+            {
+                if (keys[i] == key)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        return (_index ??= BuildIndex()).TryGetValue(key, out var index) ? index : -1;
+    }
+
+    /// <summary>Property names in slot order, pre-hashed. Must be treated as read-only.</summary>
+    internal Key[] Keys
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _keys;
+    }
+
+    private Dictionary<Key, int> BuildIndex()
+    {
+        var keys = _keys;
+        var index = new Dictionary<Key, int>(keys.Length);
+        for (var i = 0; i < keys.Length; i++)
+        {
+            index[keys[i]] = i;
+        }
+
+        return index;
+    }
+}

--- a/Jint/Native/Json/JsonParser.cs
+++ b/Jint/Native/Json/JsonParser.cs
@@ -963,7 +963,7 @@ public sealed class JsonParser
         // integer indices first (https://tc39.es/ecma262/#sec-ordinaryownpropertykeys), which the
         // slot (= insertion) order cannot express. Same conservative digit-leading classifier as the
         // other shape guards.
-        var digitLeading = name.Length > 0 && char.IsDigit(name[0]);
+        var digitLeading = Shape.IsIntegerIndexLikeKey(name);
 
         if (first)
         {

--- a/Jint/Native/Object/ObjectInstance.Fast.cs
+++ b/Jint/Native/Object/ObjectInstance.Fast.cs
@@ -9,6 +9,13 @@ namespace Jint.Native.Object;
 /// created object, or installing members on a host-provided global — and are not a general substitute for
 /// <see cref="ObjectInstance.Set(JsValue,JsValue,JsValue)"/> or
 /// <see cref="ObjectInstance.DefineOwnProperty"/>. See the individual members for what is skipped.
+/// <para>
+/// For building a <em>new</em> plain object out of host data, prefer
+/// <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/> or
+/// <see cref="JsObject.CreateFromEntries(Engine, ReadOnlySpan{KeyValuePair{string, JsValue}})"/> over
+/// populating a fresh <see cref="JsObject"/> through these helpers: those build directly into the
+/// hidden-class representation instead of deoptimizing out of it.
+/// </para>
 /// </summary>
 public partial class ObjectInstance
 {
@@ -95,6 +102,16 @@ public partial class ObjectInstance
     /// writes. Prefer this for setup-time writes only; for steady-state mutation of an existing property use
     /// <see cref="ObjectInstance.Set(JsValue,JsValue,JsValue)"/>, which stores through the existing
     /// descriptor and leaves the receiver's layout intact.
+    /// </para>
+    /// <para>
+    /// Despite the name, a loop of these calls is <em>not</em> the fastest way to project host data into a
+    /// new object, precisely because of that deopt: each object gets a descriptor per property and a
+    /// property dictionary, and the script reading a batch of them never keeps a monomorphic inline cache.
+    /// Use <see cref="JsObject.Create(Engine, JsObjectLayout, ReadOnlySpan{JsValue})"/> when the property
+    /// names are known up front, or
+    /// <see cref="JsObject.CreateFromEntries(Engine, ReadOnlySpan{KeyValuePair{string, JsValue}})"/> when
+    /// they are only known at runtime; both build straight into the shaped representation, so objects
+    /// sharing a layout share one hidden class.
     /// </para>
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jint/Native/Object/ObjectInstance.cs
+++ b/Jint/Native/Object/ObjectInstance.cs
@@ -2115,7 +2115,7 @@ public partial class ObjectInstance : JsValue, IEquatable<ObjectInstance>
                 // build-then-deopt and intern junk "0"→"1"→… chains under the shared per-prototype root;
                 // they take the dictionary fallback below instead.
                 if ((_type & InternalTypes.ShapeBuilding) != InternalTypes.Empty
-                    && (key.Name.Length == 0 || !char.IsDigit(key.Name[0]))
+                    && !Shape.IsIntegerIndexLikeKey(key.Name)
                     && jo.TryShapeAdd(in key, v))
                 {
                     return true;

--- a/Jint/Native/Object/Shape.cs
+++ b/Jint/Native/Object/Shape.cs
@@ -68,6 +68,18 @@ internal sealed class Shape
     // be numerically sorted through the dictionary path.
     private JsValue[]? _orderedKeyStrings;
 
+    /// <summary>
+    /// The single conservative classifier every shape entry point uses to keep integer-index-like keys
+    /// out of shapes. Own-key order places integer indices first, in ascending numeric order
+    /// (https://tc39.es/ecma262/#sec-ordinaryownpropertykeys), which slot (= insertion) order cannot
+    /// express — so such a key would guarantee a build-then-deopt and would intern junk transition
+    /// chains under the shared per-prototype root. Digit-leading is deliberately broader than
+    /// "is a canonical array index" ("1x" is rejected too): it is a single char test on a hot path, and
+    /// over-rejecting only costs the dictionary representation.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool IsIntegerIndexLikeKey(string name) => name.Length > 0 && char.IsDigit(name[0]);
+
     /// <summary>Creates an empty root shape. There is one root per prototype, interned by the engine's
     /// empty-shape table, so all objects sharing a prototype build their layouts from the same tree.</summary>
     internal Shape()
@@ -210,7 +222,7 @@ internal sealed class Shape
         for (var i = 0; i < keys.Length; i++)
         {
             var name = keys[i].Name;
-            if (name.Length > 0 && char.IsDigit(name[0]))
+            if (IsIntegerIndexLikeKey(name))
             {
                 // integer-index-like key: order needs the numeric sort; leave the memo unbuilt.
                 strings = null;

--- a/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintObjectExpression.cs
@@ -186,7 +186,7 @@ internal sealed class JintObjectExpression : JintExpression
 
                 // A digit-leading key (an array index or an index-like string) would deopt the shape
                 // on first enumeration; keep such literals on the dictionary build instead.
-                if (name.Length > 0 && char.IsDigit(name[0]))
+                if (Shape.IsIntegerIndexLikeKey(name))
                 {
                     _fastKeysShapeable = false;
                 }


### PR DESCRIPTION
> **Stacked on #2810 — merge that one first.** The `FixedLayout` row below is built on the
> fixed-layout object factory that #2810 introduces, so this branch carries #2810's commit
> (rebased onto current `main`, which it was 8 commits behind). Once #2810 merges, that commit
> drops out of this diff on the next rebase and only the two benchmark files remain.

Three TODOs in the host-embedding benchmarks described work that has since landed, and each one
kept a parameter member out of its `[Params]` set by having `GlobalSetup` throw for it. All three
are now live; two TODOs remain, for features that genuinely do not exist yet.

### 1. `FreshEngineGlobalsBenchmark` — `GlobalKind.Lazy`

Registers the same `ClrFunction` bodies the eager `ClrFunction` row hands over directly, through
the lazy-global registration API, so the two rows differ only in *when* — and *whether* — the
function object is built. The benchmark now compares all three registration styles of N globals on
a fresh engine.

**Keeping the comparison honest.** A lazy global is only cheaper if its factory never runs, so a
workload reading every registered global would measure the eager cost plus an indirection and the
row would say nothing. The existing script already avoids that: it calls `fn0` and nothing else, so
exactly one of the `GlobalCount` registered globals is ever materialized. The `GlobalCount` axis
then spans both ends of the question by itself — at `GlobalCount=1` the single global *is* read,
the worst case where laziness is pure overhead and the row must not win; at `GlobalCount=40` one of
forty is read, the case the API exists for. The script was deliberately left unchanged (touching it
would move the two existing rows' baselines), and the invariant is now stated in the type's docs so
a later edit cannot quietly invalidate the row.

Registration for that row lives on the options rather than on the engine, which is what the API
charges for: the engine replays the declaration per construction, so every operation still gets its
own descriptors and its own single factory invocation, while the factory delegates are created
once. Re-registering per operation would grow the shared options without bound and measure a leak
instead of a feature.

### 2. `HostObjectAccessBenchmark` — `HostReceiverKind.FixedLayout`

Builds the batch through the layout factory, so one declared layout resolves to one interned hidden
class and every item shares it — the projection loop stays monomorphic and reads land on the
shape-keyed inline cache instead of the virtual `GetOwnProperty` lane. The `LazyHost` → `FixedLayout`
delta is then the whole cost of the custom-subclass representation, the virtual call *and* the
per-read descriptor together.

Both host rows start from the identical native record and run it through the identical projection —
now a shared static helper so they cannot drift apart — leaving the object representation as the
only difference between them. The layout is driven by the custom subclass's own field order, which
is also the plain-object literal's order, so all three receivers present identical own-key order
and the plain-object row is a true control.

### 3. `HostObjectAccessBenchmark` — stale hazard note removed

The note warned that concatenating a host string with an unmaterialized backing value throws, and
said to drop it once the base class routed its buffer-growing member through `ToString()`. #2793
did exactly that, and #2812 then deleted the concatenation subclass's override outright — so the
hazard is gone twice over.

Verified rather than assumed: concatenation was exercised on that host string against current
`main` before the note was deleted, along with the receiver-immutability, strict-equality and
hashing cases the same fixes covered.

**The projection script is deliberately not widened to include concatenation.** It is shared by
every parameter combination so that the columns stay the only thing that varies, and string
concatenation is a string-representation question rather than a host-object-access one — the lazy
string is already on the measured path through `it.name.toUpperCase()`. The note is replaced by a
statement of the subclassing contract the class actually satisfies, so the omission reads as a
scope decision rather than an oversight.

### Verification

No measurements were taken — that is a separate serial phase. Correctness only:

- Each newly enabled row was executed exactly once outside BenchmarkDotNet, via a temporary
  in-assembly driver that was deleted before committing (it is not in this diff). All 9
  `FreshEngineGlobals` combinations and all 12 `HostObjectAccess` combinations run clean.
- The lazy-globals honesty invariant is asserted directly: 40 registered, existence checks and
  enumeration see all 40 while materializing none, and the script's single read produces exactly
  one factory invocation — two per two engines off one shared options instance.
- All three receivers project the same total, and the layout-built object was confirmed to be in
  shape mode sharing one interned hidden class with both a second layout-built object and the
  equivalent object literal — the factory silently falls back to the dictionary representation when
  it cannot shape, and that fallback is invisible to script.
- `dotnet build -c Release` on the solution: succeeds, with only the pre-existing `MSB3277`
  (`System.Memory` version conflict in the `net472` test lane), confirmed identical on clean `main`.
- `--list flat` still enumerates the whole suite (515 lanes) with both benchmarks present.
- Because this branch carries #2810 rebased onto a newer `main`, `Jint.Tests` (4247 net10.0 /
  4179 net472) and `Jint.Tests.PublicInterface` (291 / 291) were run too: all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
