### PR TITLE
Give the pooled Reference back when a reference resolver claims the read

### DIFF
--- a/Jint.Tests/Runtime/ReferenceResolverPoolingTests.cs
+++ b/Jint.Tests/Runtime/ReferenceResolverPoolingTests.cs
@@ -1,0 +1,95 @@
+using Jint.Native;
+using Jint.Pooling;
+using Jint.Runtime;
+using Jint.Runtime.Interop;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// Engine.GetValue is handed ownership of a pooled <see cref="Reference"/> and has to give it back
+/// before it returns. The exits a reference resolver takes are no exception: a claimed read that
+/// keeps the reference drains the pool by one, and once the pool is empty every further claimed read
+/// allocates a fresh instance instead of reusing one. The resolver can observe that directly — it is
+/// handed the reference itself, so a healthy pool shows up as the same few instances coming back
+/// around, while a draining pool hands out a brand new one every time.
+/// </summary>
+public class ReferenceResolverPoolingTests
+{
+    private const int Iterations = 200;
+
+    private sealed class InstanceTrackingResolver : IReferenceResolver
+    {
+        private readonly List<Reference> _distinct = new List<Reference>();
+
+        /// <summary>How many reads the resolver claimed; guards against a test that never reaches it.</summary>
+        public int Claims { get; private set; }
+
+        /// <summary>How many different <see cref="Reference"/> instances the engine handed over.</summary>
+        public int DistinctReferences => _distinct.Count;
+
+        public bool TryUnresolvableReference(Engine engine, Reference reference, out JsValue value)
+        {
+            Track(reference);
+            value = JsValue.Undefined;
+            return true;
+        }
+
+        public bool TryPropertyReference(Engine engine, Reference reference, ref JsValue value)
+        {
+            if (!value.IsNullOrUndefined())
+            {
+                return false;
+            }
+
+            Track(reference);
+            value = JsValue.Undefined;
+            return true;
+        }
+
+        public bool TryGetCallable(Engine engine, object callee, out JsValue value)
+        {
+            value = JsValue.Undefined;
+            return false;
+        }
+
+        public bool CheckCoercible(JsValue value) => true;
+
+        private void Track(Reference reference)
+        {
+            Claims++;
+            foreach (var seen in _distinct)
+            {
+                if (ReferenceEquals(seen, reference))
+                {
+                    return;
+                }
+            }
+
+            _distinct.Add(reference);
+        }
+    }
+
+    [Fact]
+    public void ClaimedNullishPropertyReadReturnsItsReferenceToThePool()
+    {
+        var resolver = new InstanceTrackingResolver();
+        var engine = new Engine(options => options.SetReferencesResolver(resolver, ReferenceResolverInterests.NullishPropertyBase));
+
+        engine.Execute($"var o = {{}}; for (var i = 0; i < {Iterations}; i++) {{ var x = o.missing.value; }}");
+
+        resolver.Claims.Should().Be(Iterations);
+        resolver.DistinctReferences.Should().BeLessThanOrEqualTo(ReferencePool.PoolSize);
+    }
+
+    [Fact]
+    public void ClaimedUnresolvableReadReturnsItsReferenceToThePool()
+    {
+        var resolver = new InstanceTrackingResolver();
+        var engine = new Engine(options => options.SetReferencesResolver(resolver, ReferenceResolverInterests.UnresolvableReference));
+
+        engine.Execute($"for (var i = 0; i < {Iterations}; i++) {{ var x = missingGlobal; }}");
+
+        resolver.Claims.Should().Be(Iterations);
+        resolver.DistinctReferences.Should().BeLessThanOrEqualTo(ReferencePool.PoolSize);
+    }
+}

--- a/Jint/Engine.cs
+++ b/Jint/Engine.cs
@@ -1071,6 +1071,15 @@ public sealed partial class Engine : IDisposable
                 reference.EvaluateAndCachePropertyKey();
                 if (_referenceResolver.TryUnresolvableReference(this, reference, out var val))
                 {
+                    // Same contract as the exits below: the caller handed over ownership of a rented
+                    // Reference, so a claimed read has to hand it back too. The resolver only inspects
+                    // the reference for the duration of the call — the declined path already recycles
+                    // this very instance a few lines down.
+                    if (returnReferenceToPool)
+                    {
+                        _referencePool.Return(reference);
+                    }
+
                     return val;
                 }
             }
@@ -1085,6 +1094,11 @@ public sealed partial class Engine : IDisposable
             reference.EvaluateAndCachePropertyKey();
             if (_referenceResolver.TryPropertyReference(this, reference, ref baseValue))
             {
+                if (returnReferenceToPool)
+                {
+                    _referencePool.Return(reference);
+                }
+
                 return baseValue;
             }
         }

--- a/Jint/Pooling/ReferencePool.cs
+++ b/Jint/Pooling/ReferencePool.cs
@@ -8,7 +8,11 @@ namespace Jint.Pooling;
 /// </summary>
 internal sealed class ReferencePool
 {
-    private const int PoolSize = 10;
+    /// <summary>
+    /// How many instances the pool can hold, and therefore the upper bound on how many distinct
+    /// <see cref="Reference" /> instances a balanced rent/return workload can ever be handed.
+    /// </summary>
+    internal const int PoolSize = 10;
     private readonly ObjectPool<Reference> _pool;
 
     public ReferencePool()


### PR DESCRIPTION
`Engine.GetValue(Reference, bool)` rents nothing itself, but it is handed ownership of the caller's pooled `Reference` through `returnReferenceToPool` and gives it back before producing the value. Two exits skipped that: when the registered `IReferenceResolver` claimed an **unresolvable** reference, and when it claimed a **property** reference, the substituted value was returned straight out and the rented `Reference` was dropped.

### Mechanism

This is **missed reuse, not retention** — the abandoned instance becomes garbage immediately, nothing holds on to it. What it costs is a pool slot per claimed read. `ReferencePool` holds ten instances (`ObjectPool`: one dedicated first slot plus a nine-element array), so after at most ten claimed reads the pool is empty. From there the balanced rent/return pairs around the read keep refilling the single free slot that the next claimed read immediately drains again, so the steady state is one fresh `Reference` allocated per claimed read.

Measured on a loop of 200 propagated nullish reads through a resolver: 200 distinct `Reference` instances handed to the resolver before, single digits after.

### Which configurations pay for it

Exactly the ones the recent interest-filter work optimises for:

* a resolver subscribed to `NullishPropertyBase` gets nullish bases routed through a *rented* `Reference` specifically so `TryPropertyReference` is offered them;
* a resolver subscribed to `UnresolvableReference` gets every read of an undeclared name routed the same way.

Both land on a claiming exit on every iteration. Engines with no resolver never enter either branch, so nothing changes for them.

### May the resolver retain the reference?

This is the question that decides whether the old code was correct — if an implementation could stash the `Reference`, returning it to the pool would be a use-after-free-shaped bug. It cannot, and nothing suggests it ever could:

* the engine **already** recycles that very instance a few lines below whenever the resolver *declines*, which is the common outcome — a resolver that stashed it would be broken today;
* the call path hands the same instance to `TryUnresolvableReference` and `TryGetCallable` and then returns it to the pool unconditionally;
* `Reference` is a mutable pooled object whose fields `Reassign` overwrites, so a detached one has no stable meaning;
* no documentation, comment or test mentions holding one past the call, and the omission dates back to the commit that introduced pooling — it wired the parameter into the two exits that existed at the bottom of the method and left the resolver exits above untouched.

### Not changed

The throw exits still abandon their reference: it is needed to build the error message, and an exceptional path is not worth the return-then-read ordering subtlety.

### Test

`ReferenceResolverPoolingTests` runs 200 claimed reads through each of the two exits and asserts the resolver was never handed more distinct `Reference` instances than the pool can hold — the resolver receives the reference itself, so instance identity is a direct read on pool health, with no allocation measurement involved. Both tests report 200 distinct instances without the fix. `PoolSize` becomes `internal` so the bound is stated in terms of the pool's actual capacity instead of a magic number.

Test262 unchanged: 99441 passed / 0 failed, same as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
