### PR TITLE
Return the rented callee Reference on every exit from a call

### DIFF
--- a/Jint.Tests/Runtime/CalleeReferencePoolingTests.cs
+++ b/Jint.Tests/Runtime/CalleeReferencePoolingTests.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// A call whose callee is not a plain <c>obj.method</c> shape rents a <see cref="Jint.Runtime.Reference"/>
+/// for the callee — it carries the this-binding and the name used in the "is not a function" messages —
+/// and hands it back once the call is dispatched. Every way of leaving the call has to do that, or the
+/// pool drains and each further call of that shape allocates a fresh instance.
+/// </summary>
+public class CalleeReferencePoolingTests
+{
+    private const int Iterations = 500;
+
+    /// <summary>
+    /// The pool holds a small, fixed number of instances, so a workload that rents and returns in
+    /// balance stops creating them almost immediately. The exact figure is not the point — the point
+    /// is that it must not scale with the number of calls made.
+    /// </summary>
+    private const int MaxCreations = 32;
+
+    [Fact]
+    public void RepeatedHostDelegateCallsReuseTheCalleeReference()
+    {
+        // Host delegates are the callees the fast-call lane serves, and calling one through a global
+        // name is the shape that rents a callee reference — so this is the combination that leaves the
+        // lane's early return responsible for the pooled instance.
+        var engine = new Engine();
+        engine.SetValue("addOne", new Func<int, int>(x => x + 1));
+
+        engine.Execute($"var s = 0; for (var i = 0; i < {Iterations}; i++) {{ s = addOne(i); }}");
+
+        engine.GetValue("s").AsNumber().Should().Be(Iterations - 1 + 1);
+        engine._referencePool.CreatedCount.Should().BeLessThanOrEqualTo(MaxCreations);
+    }
+
+    [Fact]
+    public void RepeatedShortCircuitedOptionalCallsReuseTheCalleeReference()
+    {
+        // `missing?.()` resolves the callee to undefined and short-circuits, which is another exit that
+        // leaves the rented callee reference behind.
+        var engine = new Engine();
+
+        engine.Execute($"var o = {{}}; for (var i = 0; i < {Iterations}; i++) {{ var x = o.missing?.(); }}");
+
+        engine._referencePool.CreatedCount.Should().BeLessThanOrEqualTo(MaxCreations);
+    }
+}

--- a/Jint/Pooling/ReferencePool.cs
+++ b/Jint/Pooling/ReferencePool.cs
@@ -16,8 +16,16 @@ internal sealed class ReferencePool
         _pool = new ObjectPool<Reference>(Factory, PoolSize);
     }
 
-    private static Reference Factory()
+    /// <summary>
+    /// How many instances the pool has had to create because it had none to hand out. A workload that
+    /// rents and returns in balance settles at the pool's capacity; a path that rents without returning
+    /// keeps this climbing, one per rent, which is what makes it worth asserting on in tests.
+    /// </summary>
+    internal int CreatedCount { get; private set; }
+
+    private Reference Factory()
     {
+        CreatedCount++;
         return new Reference(JsValue.Undefined, JsString.Empty, false, null);
     }
 

--- a/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
+++ b/Jint/Runtime/Interpreter/Expressions/JintCallExpression.cs
@@ -112,9 +112,17 @@ internal sealed class JintCallExpression : JintExpression
         {
             var calleeReference = _calleeExpression.Evaluate(context);
 
+            // Narrowed up front rather than after the exits below, so every one of them can hand the
+            // rented Reference back. GetValue is called with returnReferenceToPool: false because the
+            // reference is still needed for the this-binding and for the "not a function" messages, so
+            // releasing it is this method's job on every path it can leave by.
+            referenceRecord = calleeReference as Reference;
+
             // Check for generator suspension after evaluating callee
             if (suspendable is not null && suspendable.IsSuspended)
             {
+                // Resume re-evaluates the callee and rents its own reference, so this one is done with.
+                engine._referencePool.Return(referenceRecord);
                 return calleeReference as JsValue ?? JsValue.Undefined;
             }
 
@@ -127,10 +135,10 @@ internal sealed class JintCallExpression : JintExpression
 
             if (func.IsNullOrUndefined() && _expression.IsOptional())
             {
+                engine._referencePool.Return(referenceRecord);
                 return JsValue.Undefined;
             }
 
-            referenceRecord = calleeReference as Reference;
             if (ReferenceEquals(func, engine.Realm.Intrinsics.Eval)
                 && referenceRecord != null
                 && !referenceRecord.IsPropertyReference
@@ -189,6 +197,14 @@ internal sealed class JintCallExpression : JintExpression
         {
             var arg0 = _argCount >= 1 ? _arguments.GetValue(context, 0) : JsValue.Undefined;
             var arg1 = _argCount >= 2 ? _arguments.GetValue(context, 1) : JsValue.Undefined;
+
+            // Everything the reference was kept for has been read (the this-binding above; the
+            // "not a function" messages below cannot be reached from here, the callee is callable).
+            if (referenceRecord is not null)
+            {
+                engine._referencePool.Return(referenceRecord);
+            }
+
             return FastCall(engine, Unsafe.As<Function>(func), thisObject, arg0, arg1);
         }
 
@@ -205,6 +221,9 @@ internal sealed class JintCallExpression : JintExpression
             {
                 engine._jsValueArrayPool.ReturnArray(arguments);
             }
+
+            // Resume re-evaluates the callee and rents its own reference, so this one is done with.
+            engine._referencePool.Return(referenceRecord);
             return func; // Return any value, caller will check Suspended
         }
 
@@ -379,6 +398,7 @@ internal sealed class JintCallExpression : JintExpression
 
         if (argList.Length == 0)
         {
+            engine._referencePool.Return(referenceRecord);
             return JsValue.Undefined;
         }
 


### PR DESCRIPTION
Found while investigating the same omission in `Engine.GetValue` (#2816); this one is independent of that fix and needs no reference resolver to trigger.

A call whose callee is not the fast `obj.method()` shape evaluates the callee expression into a pooled `Reference`. It has to be kept for a while — it carries the this-binding and the name used in the "is not a function" messages — so `GetValue` is called with `returnReferenceToPool: false` and releasing it is the call expression's own job. Only the ordinary exit did it. Five ways of leaving the call did not:

* the **fast-call lane**, which returns straight from `FastCall`;
* an **optional call** whose callee resolved to null/undefined (`f?.()`);
* the generator/async **suspension** checks, after the callee and after the argument list;
* a direct **`eval()` with an empty argument list**.

### Impact

The fast-call lane is the one that matters. It serves host delegates, and calling one through a global name is exactly the shape that rents a callee reference — so a delegate registered by the embedder and called in a loop drops one `Reference` per call once the ten-instance pool has drained. Measured: a 500-iteration loop over `addOne(i)`, where `addOne` is a host delegate, creates **500** `Reference` instances; after the fix it settles into the pool almost immediately. A loop of short-circuiting optional calls behaves the same way.

This is **missed reuse, not retention** — the abandoned instance is garbage the moment the call returns, nothing holds it. What it costs is that a pooled allocation becomes a per-call one on a path host integrations lean on.

### Shape of the fix

`referenceRecord` is narrowed straight after the callee is evaluated, so every exit can release it uniformly instead of each one having to re-derive it. The throw exits still keep theirs: the reference is what the error message is built from, and an exceptional path is not worth the ordering subtlety.

On the fast lane the release is placed **after** the arguments are evaluated, so nothing can rent and reassign the instance while it is still being read. After that point nothing reads it at all — the this-binding was taken above, and the non-callable messages below are unreachable from the lane, which is only entered for a callee already proven to be a `Function`.

### Test

`ReferencePool` gains an internal `CreatedCount`, incremented only when the pool has nothing to hand out. That states the invariant directly: a balanced workload stops creating instances almost immediately, while a leaking one climbs by one per call. Both new tests report 500 creations for 500 calls without the fix.

Verified with the suite in Debug as well as Release, so `ObjectPool`'s `[Conditional("DEBUG")]` "freeing twice?" assertions were live. Test262 unchanged: 99441 passed / 0 failed, same as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
