### PR TITLE
Let a host see which representation an object actually got

### DIFF
--- a/Jint.Tests.PublicInterface/ObjectRepresentationTests.cs
+++ b/Jint.Tests.PublicInterface/ObjectRepresentationTests.cs
@@ -1,0 +1,356 @@
+#nullable enable
+
+using System.Collections.Generic;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime.Descriptors;
+
+namespace Jint.Tests.PublicInterface;
+
+/// <summary>
+/// <see cref="Engine.AdvancedOperations.GetObjectRepresentation"/> is the only way a host can tell whether
+/// the object factories actually shaped an object or quietly fell back to the dictionary representation.
+/// These tests live outside the Jint assembly on purpose: the point of the API is that an integrator with
+/// nothing but the public surface can write exactly these assertions.
+/// </summary>
+public class ObjectRepresentationTests
+{
+    private static readonly JsObjectLayout Layout = new("id", "name", "active");
+
+    private static JsObject CreateSample(Engine engine) => JsObject.Create(
+        engine,
+        Layout,
+        [JsNumber.Create(1), new JsString("sample"), JsBoolean.True]);
+
+    private static KeyValuePair<string, JsValue>[] SampleEntries() =>
+    [
+        new("id", JsNumber.Create(1)),
+        new("name", new JsString("sample")),
+        new("active", JsBoolean.True)
+    ];
+
+    /// <summary>A host object that answers its own properties instead of using Jint's storage.</summary>
+    private sealed class HostRecord : ObjectInstance
+    {
+        public HostRecord(Engine engine) : base(engine)
+        {
+        }
+
+        public override PropertyDescriptor GetOwnProperty(JsValue property)
+        {
+            return property is JsString name && string.Equals(name.ToString(), "answer", System.StringComparison.Ordinal)
+                ? new PropertyDescriptor(JsNumber.Create(42), writable: false, enumerable: true, configurable: false)
+                : PropertyDescriptor.Undefined;
+        }
+    }
+
+    private sealed class HostPoint
+    {
+        public int X { get; set; }
+    }
+
+    // ---- reachability ----
+
+    [Fact]
+    public void TheDiagnosticIsReachableFromOutsideTheJintAssembly()
+    {
+        // This project has no InternalsVisibleTo, so the call below compiling at all is the guarantee. The
+        // reflection assertions catch the accident of the surface being narrowed to internal + IVT later.
+        var engine = new Engine();
+        engine.Advanced.GetObjectRepresentation(CreateSample(engine)).Should().Be(ObjectRepresentation.HiddenClass);
+
+        typeof(ObjectRepresentation).IsPublic.Should().BeTrue();
+        typeof(Engine.AdvancedOperations).GetMethod(nameof(Engine.AdvancedOperations.GetObjectRepresentation))
+            .Should().NotBeNull();
+    }
+
+    [Fact]
+    public void NullIsRejected()
+    {
+        var engine = new Engine();
+        Invoking(() => engine.Advanced.GetObjectRepresentation(null!)).Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AnObjectFromAnotherEngineIsRejected()
+    {
+        // Hidden classes are interned per engine and the fallback thresholds are per-engine counters, so
+        // asking one engine about another's object is a mistake worth failing on rather than answering.
+        var engine = new Engine();
+        var other = new Engine();
+
+        Invoking(() => engine.Advanced.GetObjectRepresentation(CreateSample(other)))
+            .Should().Throw<ArgumentException>().WithMessage("*different engine*");
+    }
+
+    // ---- what the factories produce ----
+
+    [Fact]
+    public void AnObjectBuiltFromALayoutIsShaped()
+    {
+        var engine = new Engine();
+        engine.Advanced.GetObjectRepresentation(CreateSample(engine)).Should().Be(ObjectRepresentation.HiddenClass);
+
+        // An empty layout still resolves to a (property-less) hidden class.
+        var empty = JsObject.Create(engine, new JsObjectLayout(), []);
+        engine.Advanced.GetObjectRepresentation(empty).Should().Be(ObjectRepresentation.HiddenClass);
+
+        // Wider than the in-object slot capacity, so the values spill — still shaped.
+        var wide = JsObject.Create(engine, new JsObjectLayout("a", "b", "c", "d", "e", "f", "g"),
+        [
+            JsNumber.Create(1), JsNumber.Create(2), JsNumber.Create(3), JsNumber.Create(4),
+            JsNumber.Create(5), JsNumber.Create(6), JsNumber.Create(7)
+        ]);
+        engine.Advanced.GetObjectRepresentation(wide).Should().Be(ObjectRepresentation.HiddenClass);
+    }
+
+    [Fact]
+    public void AnObjectBuiltFromEntriesIsShaped()
+    {
+        var engine = new Engine();
+        var fromSpan = JsObject.CreateFromEntries(engine, SampleEntries());
+        engine.Advanced.GetObjectRepresentation(fromSpan).Should().Be(ObjectRepresentation.HiddenClass);
+
+        var fromEnumerable = JsObject.CreateFromEntries(engine, (IEnumerable<KeyValuePair<string, JsValue>>) SampleEntries());
+        engine.Advanced.GetObjectRepresentation(fromEnumerable).Should().Be(ObjectRepresentation.HiddenClass);
+    }
+
+    [Fact]
+    public void AnEmptyEntrySetStaysInTheDictionaryRepresentation()
+    {
+        // Shaping starts on the first entry, so an object that never got one was never shaped. This is a
+        // real difference from the empty-layout case above, and exactly the kind of thing the diagnostic
+        // exists to make visible.
+        var engine = new Engine();
+        var empty = JsObject.CreateFromEntries(engine, System.Array.Empty<KeyValuePair<string, JsValue>>());
+
+        engine.Advanced.GetObjectRepresentation(empty).Should().Be(ObjectRepresentation.Dictionary);
+    }
+
+    [Fact]
+    public void AnOrdinaryObjectLiteralIsShapedAndAnEmptyOneIsNot()
+    {
+        var engine = new Engine();
+
+        var literal = engine.Evaluate("({ id: 1, name: 'sample', active: true })").AsObject();
+        engine.Advanced.GetObjectRepresentation(literal).Should().Be(ObjectRepresentation.HiddenClass);
+
+        var empty = engine.Evaluate("({})").AsObject();
+        engine.Advanced.GetObjectRepresentation(empty).Should().Be(ObjectRepresentation.Dictionary);
+    }
+
+    // ---- fallback triggers ----
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("7")]
+    [InlineData("2nd")]
+    public void AnIntegerIndexLikeEntryKeyFallsBackToTheDictionaryRepresentation(string name)
+    {
+        var engine = new Engine();
+
+        // as the first key: never shaped at all
+        var leading = JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>(name, JsNumber.Create(1)),
+            new KeyValuePair<string, JsValue>("other", JsNumber.Create(2))
+        ]);
+        engine.Advanced.GetObjectRepresentation(leading).Should().Be(ObjectRepresentation.Dictionary);
+
+        // and part way through: shaped, then dropped mid-build
+        var trailing = JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("other", JsNumber.Create(2)),
+            new KeyValuePair<string, JsValue>(name, JsNumber.Create(1))
+        ]);
+        engine.Advanced.GetObjectRepresentation(trailing).Should().Be(ObjectRepresentation.Dictionary);
+    }
+
+    [Fact]
+    public void TooManyEntriesFallBackToTheDictionaryRepresentation()
+    {
+        var engine = new Engine();
+        var entries = new KeyValuePair<string, JsValue>[80];
+        for (var i = 0; i < entries.Length; i++)
+        {
+            entries[i] = new KeyValuePair<string, JsValue>("k" + i, JsNumber.Create(i));
+        }
+
+        engine.Advanced.GetObjectRepresentation(JsObject.CreateFromEntries(engine, entries))
+            .Should().Be(ObjectRepresentation.Dictionary);
+    }
+
+    [Fact]
+    public void VaryingKeySetsEventuallyStopBeingShaped()
+    {
+        // The first object of a brand-new key set is shaped; after enough *different* key sets have branched
+        // off the same point, later ones are not. Nothing about the failing call differs from the succeeding
+        // one — the trigger is the engine's accumulated state, which is precisely why a host cannot predict
+        // this at the call site and needs to be able to observe it instead.
+        var engine = new Engine();
+
+        JsObject Build(int i) => JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("k" + i, JsNumber.Create(i)),
+            new KeyValuePair<string, JsValue>("shared", JsNumber.Create(i))
+        ]);
+
+        engine.Advanced.GetObjectRepresentation(Build(0)).Should().Be(ObjectRepresentation.HiddenClass);
+
+        var fellBackAt = -1;
+        for (var i = 1; i < 500 && fellBackAt < 0; i++)
+        {
+            if (engine.Advanced.GetObjectRepresentation(Build(i)) == ObjectRepresentation.Dictionary)
+            {
+                fellBackAt = i;
+            }
+        }
+
+        fellBackAt.Should().BeGreaterThan(0, "an unbounded variety of key sets must stop interning layouts");
+
+        // The objects are still completely correct, whichever representation they landed in.
+        engine.SetValue("o", Build(fellBackAt));
+        engine.Evaluate("Object.keys(o).join()").Should().Be("k" + fellBackAt + ",shared");
+        engine.Evaluate("o.shared").Should().Be(fellBackAt);
+    }
+
+    [Fact]
+    public void TheEnginesLayoutBudgetIsCumulativeAndEventuallyRunsOut()
+    {
+        // Same layout, same call, different answer depending only on how many *other* layouts this engine
+        // has interned before — the second reason a host cannot know the representation by construction.
+        var engine = new Engine();
+        var values = new JsValue[64];
+        for (var i = 0; i < values.Length; i++)
+        {
+            values[i] = JsNumber.Create(i);
+        }
+
+        JsObjectLayout WideLayout(string prefix)
+        {
+            var names = new string[64];
+            for (var i = 0; i < names.Length; i++)
+            {
+                names[i] = prefix + i;
+            }
+
+            return new JsObjectLayout(names);
+        }
+
+        var first = WideLayout("first_");
+        engine.Advanced.GetObjectRepresentation(JsObject.Create(engine, first, values))
+            .Should().Be(ObjectRepresentation.HiddenClass);
+
+        var exhaustedAt = -1;
+        for (var iteration = 0; iteration < 1000 && exhaustedAt < 0; iteration++)
+        {
+            var layout = WideLayout("burn" + iteration + "_");
+            if (engine.Advanced.GetObjectRepresentation(JsObject.Create(engine, layout, values)) == ObjectRepresentation.Dictionary)
+            {
+                exhaustedAt = iteration;
+            }
+        }
+
+        exhaustedAt.Should().BeGreaterThan(0, "the per-engine layout budget is finite");
+
+        // An already-resolved layout keeps its hidden class: the budget only gates layouts new to the engine.
+        engine.Advanced.GetObjectRepresentation(JsObject.Create(engine, first, values))
+            .Should().Be(ObjectRepresentation.HiddenClass);
+
+        // A different engine starts over with a full budget, from the very layout that just failed.
+        var fresh = new Engine();
+        fresh.Advanced.GetObjectRepresentation(JsObject.Create(fresh, WideLayout("burn" + exhaustedAt + "_"), values))
+            .Should().Be(ObjectRepresentation.HiddenClass);
+    }
+
+    // ---- deopt after construction ----
+
+    [Theory]
+    [InlineData("o.extra = 1;")]
+    [InlineData("delete o.name;")]
+    [InlineData("Object.freeze(o);")]
+    [InlineData("Object.seal(o);")]
+    [InlineData("Object.defineProperty(o, 'g', { get: function () { return 1; } });")]
+    [InlineData("Object.defineProperty(o, 'name', { value: 2, writable: false });")]
+    public void MutationsAShapeCannotExpressDropTheObjectToTheDictionaryRepresentation(string script)
+    {
+        var engine = new Engine();
+        var obj = CreateSample(engine);
+        engine.SetValue("o", obj);
+
+        engine.Advanced.GetObjectRepresentation(obj).Should().Be(ObjectRepresentation.HiddenClass);
+        engine.Execute(script);
+        engine.Advanced.GetObjectRepresentation(obj).Should().Be(ObjectRepresentation.Dictionary);
+
+        // ...and the object still behaves exactly as it did.
+        engine.Evaluate("o.id").Should().Be(1);
+    }
+
+    [Fact]
+    public void MutationsAShapeCanExpressKeepTheObjectShaped()
+    {
+        var engine = new Engine();
+        var obj = CreateSample(engine);
+        engine.SetValue("o", obj);
+
+        // Overwriting a value in place, adding a symbol key (which lives outside the layout), preventing
+        // extensions (which changes no property descriptor) and swapping the prototype all leave the layout
+        // intact — so a host asserting "still shaped" is not asserting "never touched".
+        engine.Execute("o.name = 'changed'; o[Symbol('s')] = 1;");
+        engine.Advanced.GetObjectRepresentation(obj).Should().Be(ObjectRepresentation.HiddenClass);
+
+        engine.Execute("Object.setPrototypeOf(o, { inherited: 1 });");
+        engine.Advanced.GetObjectRepresentation(obj).Should().Be(ObjectRepresentation.HiddenClass);
+
+        engine.Execute("Object.preventExtensions(o);");
+        engine.Advanced.GetObjectRepresentation(obj).Should().Be(ObjectRepresentation.HiddenClass);
+
+        engine.Evaluate("o.name + ',' + o.inherited").Should().Be("changed,1");
+    }
+
+    // ---- the other representations ----
+
+    [Fact]
+    public void ABuiltinUsesItsSharedLayout()
+    {
+        var engine = new Engine();
+
+        // Built-ins populate lazily, so touch them first; the diagnostic deliberately does not do this
+        // itself, because a diagnostic that initializes what it inspects changes what it is measuring.
+        engine.Execute("Math.abs(1); JSON.stringify(1);");
+
+        engine.Advanced.GetObjectRepresentation(engine.Evaluate("Math").AsObject())
+            .Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+        engine.Advanced.GetObjectRepresentation(engine.Evaluate("JSON").AsObject())
+            .Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+    }
+
+    [Fact]
+    public void SpecializedObjectTypesReportThemselvesAsSuch()
+    {
+        var engine = new Engine();
+        engine.SetValue("host", new HostPoint { X = 1 });
+
+        var array = engine.Evaluate("[1, 2, 3]").AsObject();
+        engine.Advanced.GetObjectRepresentation(array).Should().Be(ObjectRepresentation.Specialized);
+
+        var wrapper = engine.Evaluate("host").AsObject();
+        engine.Advanced.GetObjectRepresentation(wrapper).Should().Be(ObjectRepresentation.Specialized);
+
+        var proxy = engine.Evaluate("new Proxy({}, {})").AsObject();
+        engine.Advanced.GetObjectRepresentation(proxy).Should().Be(ObjectRepresentation.Specialized);
+    }
+
+    [Fact]
+    public void AHostDefinedObjectSubclassIsNotReportedAsADictionary()
+    {
+        // A subclass that answers its own properties stores nothing in Jint's dictionary, so calling it a
+        // dictionary object would be wrong.
+        var engine = new Engine();
+        var host = new HostRecord(engine);
+        engine.SetValue("host", host);
+
+        engine.Evaluate("host.answer").Should().Be(42);
+        engine.Advanced.GetObjectRepresentation(host).Should().Be(ObjectRepresentation.Specialized);
+    }
+}

--- a/Jint.Tests/Runtime/ObjectRepresentationTests.cs
+++ b/Jint.Tests/Runtime/ObjectRepresentationTests.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime;
+
+namespace Jint.Tests.Runtime;
+
+/// <summary>
+/// <see cref="Engine.AdvancedOperations.GetObjectRepresentation"/> is a diagnostic, so its whole value is
+/// that it cannot disagree with reality. These tests cross-check every answer it gives against the internal
+/// state it claims to describe; the behavior a host can actually observe is covered in
+/// Jint.Tests.PublicInterface/ObjectRepresentationTests.cs.
+/// </summary>
+public class ObjectRepresentationTests
+{
+    private static readonly JsObjectLayout Layout = new("id", "name", "active");
+
+    private static JsObject CreateSample(Engine engine) => JsObject.Create(
+        engine,
+        Layout,
+        [JsNumber.Create(1), JsString.Create("sample"), JsBoolean.True]);
+
+    [Fact]
+    public void ShapedAndDeoptedObjectsAgreeWithTheShapeFlag()
+    {
+        var engine = new Engine();
+        var obj = CreateSample(engine);
+        engine.SetValue("o", obj);
+
+        (obj._type & InternalTypes.ShapeMode).Should().NotBe(InternalTypes.Empty);
+        engine.Advanced.GetObjectRepresentation(obj).Should().Be(ObjectRepresentation.HiddenClass);
+
+        engine.Execute("o.extra = 1;");
+
+        (obj._type & InternalTypes.ShapeMode).Should().Be(InternalTypes.Empty);
+        obj._properties.Should().NotBeNull();
+        engine.Advanced.GetObjectRepresentation(obj).Should().Be(ObjectRepresentation.Dictionary);
+    }
+
+    [Fact]
+    public void BuiltinsAgreeWithTheBuiltinShapeFlag()
+    {
+        var engine = new Engine();
+        engine.Execute("Math.abs(1);");
+
+        var math = engine.Evaluate("Math").AsObject();
+        (math._type & InternalTypes.BuiltinShapeMode).Should().NotBe(InternalTypes.Empty);
+        engine.Advanced.GetObjectRepresentation(math).Should().Be(ObjectRepresentation.SharedBuiltinLayout);
+    }
+
+    [Fact]
+    public void EachFallbackTriggerAgreesWithTheShapeFlag()
+    {
+        var engine = new Engine();
+
+        // integer-index-like key
+        var indexLike = JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("a", JsNumber.Create(1)),
+            new KeyValuePair<string, JsValue>("0", JsNumber.Create(2))
+        ]);
+        (indexLike._type & InternalTypes.ShapeMode).Should().Be(InternalTypes.Empty);
+        engine.Advanced.GetObjectRepresentation(indexLike).Should().Be(ObjectRepresentation.Dictionary);
+
+        // more properties than a hidden class can describe
+        var entries = new KeyValuePair<string, JsValue>[Shape.MaxShapeProperties + 1];
+        for (var i = 0; i < entries.Length; i++)
+        {
+            entries[i] = new KeyValuePair<string, JsValue>("k" + i, JsNumber.Create(i));
+        }
+
+        var tooWide = JsObject.CreateFromEntries(engine, entries);
+        (tooWide._type & InternalTypes.ShapeMode).Should().Be(InternalTypes.Empty);
+        engine.Advanced.GetObjectRepresentation(tooWide).Should().Be(ObjectRepresentation.Dictionary);
+    }
+
+    [Fact]
+    public void TheFanoutGuardIsReportedExactlyWhereItTrips()
+    {
+        // Only the first MaxFanout distinct first-keys can branch off the empty root shape; the very next
+        // object is refused and finishes as a dictionary. The diagnostic must flip at exactly that boundary.
+        var engine = new Engine();
+
+        JsObject Build(int i) => JsObject.CreateFromEntries(engine,
+        [
+            new KeyValuePair<string, JsValue>("k" + i, JsNumber.Create(i)),
+            new KeyValuePair<string, JsValue>("shared", JsNumber.Create(i))
+        ]);
+
+        var shaped = 0;
+        for (var i = 0; i < Shape.MaxFanout * 2; i++)
+        {
+            var representation = engine.Advanced.GetObjectRepresentation(Build(i));
+            var expected = i < Shape.MaxFanout
+                ? ObjectRepresentation.HiddenClass
+                : ObjectRepresentation.Dictionary;
+
+            representation.Should().Be(expected, "object {0} of an ever-widening fan-out", i);
+            if (representation == ObjectRepresentation.HiddenClass)
+            {
+                shaped++;
+            }
+        }
+
+        shaped.Should().Be(Shape.MaxFanout);
+    }
+
+    [Fact]
+    public void TheHostLayoutBudgetIsReportedExactlyWhereItRunsOut()
+    {
+        var engine = new Engine();
+
+        const int Width = 64; // the widest layout a hidden class can describe: fewest iterations to spend the budget
+        var values = new JsValue[Width];
+        for (var i = 0; i < Width; i++)
+        {
+            values[i] = JsNumber.Create(i);
+        }
+
+        JsObjectLayout WideLayout(string prefix)
+        {
+            var names = new string[Width];
+            for (var i = 0; i < Width; i++)
+            {
+                names[i] = prefix + i;
+            }
+
+            return new JsObjectLayout(names);
+        }
+
+        var layouts = new List<JsObjectLayout>();
+        for (var iteration = 0; iteration < Engine.HostShapeTransitionBudget / Width; iteration++)
+        {
+            var layout = WideLayout("L" + iteration + "_");
+            layouts.Add(layout);
+            engine.Advanced.GetObjectRepresentation(JsObject.Create(engine, layout, values))
+                .Should().Be(ObjectRepresentation.HiddenClass);
+        }
+
+        // Budget spent: a layout the engine has not seen before can no longer be interned.
+        engine.Advanced.GetObjectRepresentation(JsObject.Create(engine, WideLayout("overflow_"), values))
+            .Should().Be(ObjectRepresentation.Dictionary);
+
+        // An already-resolved layout still hits its memo, which never consults the budget.
+        engine.Advanced.GetObjectRepresentation(JsObject.Create(engine, layouts[0], values))
+            .Should().Be(ObjectRepresentation.HiddenClass);
+    }
+}

--- a/Jint/Engine.Advanced.cs
+++ b/Jint/Engine.Advanced.cs
@@ -123,6 +123,72 @@ public partial class Engine
         }
 
         /// <summary>
+        /// Reports which internal representation <paramref name="value"/> is currently using for its own
+        /// string-keyed properties.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>This is a diagnostic, and it is not part of Jint's compatibility contract.</b>
+        /// <see cref="ObjectRepresentation"/> names an internal implementation detail: which representation
+        /// any given object ends up in may change in any release, and the enum may gain members. Neither is
+        /// a breaking change, and neither will be treated as one.
+        /// </para>
+        /// <para>
+        /// Use it in diagnostics, assertions and regression tests; do not branch on it in production code.
+        /// The representations are indistinguishable from script — they differ only in speed and allocation,
+        /// never in behavior — so a host that takes different code paths per representation is depending on
+        /// something Jint is free to change underneath it.
+        /// </para>
+        /// <para>
+        /// The motivating case: <see cref="JsObject.Create"/> and <see cref="JsObject.CreateFromEntries(Engine, IEnumerable{KeyValuePair{string, JsValue}})"/>
+        /// fall back to the dictionary representation silently and correctly when they cannot shape an
+        /// object, and two of the triggers are not knowable at the call site (they depend on what the engine
+        /// has already built). Without this method a host cannot write a test proving its objects are still
+        /// being shaped, and a later change could deoptimize them unnoticed.
+        /// </para>
+        /// <para>
+        /// This method observes without perturbing: it does not force a lazily initialized built-in to
+        /// populate its properties, so such an object reports its settled representation only once something
+        /// has touched it.
+        /// </para>
+        /// </remarks>
+        /// <param name="value">The object to inspect. It must belong to this engine.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="value"/> belongs to a different engine.</exception>
+        public ObjectRepresentation GetObjectRepresentation(ObjectInstance value)
+        {
+            if (value is null)
+            {
+                Throw.ArgumentNullException(nameof(value));
+            }
+
+            if (!ReferenceEquals(value.Engine, _engine))
+            {
+                // Hidden classes are interned per engine and the fallback thresholds are per-engine counters,
+                // so a representation question is only meaningful about the engine that built the object.
+                // Rejecting a foreign object turns the mixed-up-engine mistake — easy to make in exactly the
+                // multi-engine tests this API is written for — into a failure instead of a misleading pass.
+                Throw.ArgumentException("The object belongs to a different engine.", nameof(value));
+            }
+
+            if ((value._type & InternalTypes.ShapeMode) != InternalTypes.Empty)
+            {
+                return ObjectRepresentation.HiddenClass;
+            }
+
+            if ((value._type & InternalTypes.BuiltinShapeMode) != InternalTypes.Empty)
+            {
+                return ObjectRepresentation.SharedBuiltinLayout;
+            }
+
+            // JsObject is the only type that can be in the hidden-class representation, and it is sealed, so
+            // a JsObject that is not shaped is in the ordinary property-dictionary representation and nothing
+            // else. Any other subclass may resolve own properties itself, which neither of those two names
+            // would describe honestly.
+            return value is JsObject ? ObjectRepresentation.Dictionary : ObjectRepresentation.Specialized;
+        }
+
+        /// <summary>
         /// Event raised when a promise is rejected without a handler (operation = Reject),
         /// or when a handler is added to a previously unhandled rejected promise (operation = Handle).
         /// This implements the HostPromiseRejectionTracker abstract operation from the TC39 spec.
@@ -137,6 +203,57 @@ public partial class Engine
             PromiseRejectionTracker?.Invoke(_engine, new PromiseRejectionTrackerEventArgs(promise, operation));
         }
     }
+}
+
+/// <summary>
+/// The internal representation an object uses for its own string-keyed properties, as reported by
+/// <see cref="Engine.AdvancedOperations.GetObjectRepresentation"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>These values describe an internal representation and are not part of Jint's compatibility
+/// contract.</b> Which representation a given object ends up in may change in any release, and this enum
+/// may gain members. Neither is a breaking change, and neither will be treated as one.
+/// </para>
+/// <para>
+/// The representations are indistinguishable from script; they differ only in speed and allocation. This
+/// enum therefore exists for diagnostics and tests — so that host code can assert an optimization it asked
+/// for actually happened — and host code must not branch on it in production.
+/// </para>
+/// </remarks>
+public enum ObjectRepresentation
+{
+    /// <summary>
+    /// A plain object whose own string-keyed properties are stored as individual descriptors in a
+    /// per-object property dictionary. This is the ordinary representation, and the one
+    /// <see cref="HiddenClass"/> degrades to whenever it meets something it cannot express. The dictionary
+    /// is allocated lazily, so a plain object with no properties yet is already in this representation.
+    /// </summary>
+    Dictionary = 0,
+
+    /// <summary>
+    /// A plain object whose own string-keyed properties are described by a hidden class shared with every
+    /// other object of the same layout, leaving only the values stored per object. This is what
+    /// <see cref="Jint.Native.JsObject.Create"/> and <c>JsObject.CreateFromEntries</c> aim for, and what an
+    /// ordinary object literal reaches.
+    /// </summary>
+    HiddenClass = 1,
+
+    /// <summary>
+    /// A built-in whose own string-keyed properties come from a layout shared by every instance of its
+    /// type, with the values resolved per realm. Built-ins install this lazily on first use, and a built-in
+    /// mutated in a way the shared layout cannot express stops using it.
+    /// </summary>
+    SharedBuiltinLayout = 2,
+
+    /// <summary>
+    /// The object is not a plain object: it is an instance of a specialized object type — an array, a typed
+    /// array, a proxy, a CLR object wrapper, a built-in, or a host-defined
+    /// <see cref="Jint.Native.Object.ObjectInstance"/> subclass. Where such a type keeps its own properties
+    /// is that type's business — it may resolve them itself, use the ordinary property dictionary, or both —
+    /// so none of the other members would describe it honestly.
+    /// </summary>
+    Specialized = 3,
 }
 
 /// <summary>


### PR DESCRIPTION
Adds a small diagnostic so a host can tell which internal representation an object ended up in.

```csharp
ObjectRepresentation representation = engine.Advanced.GetObjectRepresentation(obj);
// Dictionary | HiddenClass | SharedBuiltinLayout | Specialized
```

## Why

`JsObject.Create` and `JsObject.CreateFromEntries` build objects straight into the hidden-class representation, and fall back to the dictionary representation whenever they cannot. The fallback is correct and completely invisible from script — which is precisely the problem. A host that adopted those factories for their performance has no way to write a regression test proving it still gets what it asked for, so a later refactor can silently deoptimize it.

## Why a host cannot just avoid the fallback by construction

Two of the four fallback triggers are locally knowable, and the layout API already rejects them up front: `JsObjectLayout`'s constructor throws for an integer-index-like name and for more than `Shape.MaxShapeProperties` names. A host can check both against its own data.

The other two are **not** knowable at the call site, because they are properties of the engine's accumulated state rather than of the call:

**1. The transition fan-out guard is about other objects.** `TryShapeAdd` refuses when the shape it is growing already has `Shape.MaxFanout` distinct child transitions. That shape node is interned and shared: the same per-prototype transition tree is grown by object literals, spread, `Object.fromEntries`, constructor `this.x =`, JSON parsing and host `CreateFromEntries` alike. So whether a given `CreateFromEntries` call shapes depends on how many *other* key sets — including ones created by script the host does not control — have already branched off the same node. `TheFanoutGuardIsReportedExactlyWhereItTrips` pins the boundary: with an ever-widening set of first keys, objects 0..63 are shaped and object 64 onwards are not, from a call site that never changes.

(This guard applies to the entries path only. Resolving a `JsObjectLayout` walks `Shape.Add` directly, as object literals do, so it does not pass through `TryShapeAdd`.)

**2. The host layout budget is cumulative and per engine.** `Engine._hostShapeTransitions` counts every newly interned transition host construction causes over the engine's whole lifetime, and is never reset. Once `Engine.HostShapeTransitionBudget` is spent, both factories keep working and simply return dictionary-mode objects. The same `JsObject.Create(engine, layout, values)` therefore answers differently depending only on what that engine did earlier — and because both factories share the counter, entries-path usage drains the budget available to the layout path. For `JsObject.Create` this is in fact the *only* reachable trigger, since the layout constructor has already excluded the other two. `TheHostLayoutBudgetIsReportedExactlyWhereItRunsOut` pins it: 256 fresh 64-wide layouts exhaust the budget exactly, the next new layout falls back, and a previously resolved layout still hits its memo.

Neither is a bug — both bound shared, engine-lifetime state that an adversarial or merely varied key set would otherwise grow without limit. They just cannot be predicted from the call site, so observation is the only option.

## This API is explicitly non-contractual

The XML documentation states, and this description repeats, that:

- the values name an **internal representation** that may change in any release, and the enum **may gain members**;
- it exists for **diagnostics and tests**; host code must not branch on it in production;
- a change in an object's representation is **not** a breaking change and will not be treated as one.

That is the substance of the change. An additive diagnostic that omits it turns an implementation detail into a compatibility contract, which is the one real risk here.

The member names describe what a representation *is*, never how good it is. Nothing is called `Fast` or `Optimal`: such a name silently changes meaning the moment a third representation exists, and host assertions written against it would quietly start meaning something else without ever failing.

## Design notes

- **Parameter type is `ObjectInstance`, not `JsObject`.** `JsObject` is sealed, so it could only ever answer a binary question, and a host holding the result of `engine.Evaluate(...).AsObject()` would have to cast. `ObjectInstance` matches what `Engine.Advanced.CreateProxy` already takes.
- **`Specialized` exists because "dictionary" would be a lie.** An object that is not a plain object — an array, a proxy, a CLR wrapper, a host-defined `ObjectInstance` subclass — may resolve its own properties instead of, or in addition to, the property dictionary. The type test is exact: `JsObject` is the only type that can be in the hidden-class representation and it is sealed, so an unshaped `JsObject` is in the dictionary representation and nothing else.
- **`SharedBuiltinLayout` gets its own member** because it is a genuinely distinct, flag-distinguishable representation; folding built-ins into either of the other two would misreport them.
- **The method does not perturb what it observes.** It deliberately does not force a lazily initialized built-in to populate itself, so such an object reports its settled representation only once something has touched it. The tests touch built-ins explicitly, which documents the caveat in executable form.
- **It rejects an object from another engine.** Hidden classes are interned per engine and both thresholds above are per-engine counters, so the question is only meaningful about the engine that built the object; failing turns the mixed-up-engine mistake into an error rather than a misleading pass.

## Possible follow-up (not included)

A host may also want to know whether two objects **share** one interned layout — shaped-but-not-shared still costs the inline cache, and an enum cannot express a relation. That is deliberately left out; it can be added as a separate predicate if an integrator asks for it.

## Tests

- `Jint.Tests.PublicInterface/ObjectRepresentationTests.cs` — the reachability home, since that project has no `InternalsVisibleTo`, so these are exactly the assertions a third-party integrator can write. Covers both factories, an object literal, every fallback trigger, post-construction deopt (add, delete, freeze, seal, accessor, non-writable redefine), the mutations that *keep* an object shaped (in-place write, symbol key, prototype swap, `preventExtensions`), built-ins, arrays/proxies/CLR wrappers, a host-defined subclass, and both argument rejections.
- `Jint.Tests/Runtime/ObjectRepresentationTests.cs` — cross-checks every answer against the internal flags it claims to describe, and pins both non-local thresholds at their exact boundary.

One incidental finding, now pinned: `Object.preventExtensions` does **not** deopt a shaped object, because it changes no property descriptor — unlike `freeze` and `seal`.

Verified against `main` (`0836361`): build clean apart from the pre-existing `MSB3277` in `Jint.Tests.CommonScripts` net472; `Jint.Tests` 4275 passing on net10.0 and 4207 on net472 (+5 each); `Jint.Tests.PublicInterface` 314 passing on both target frameworks (+23); Test262 unchanged at 99441 passing, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
