### PR TITLE
Correct three comments that contradict current behaviour

### DIFF
--- a/Jint/Runtime/InternalTypes.cs
+++ b/Jint/Runtime/InternalTypes.cs
@@ -42,9 +42,12 @@ internal enum InternalTypes
     // brand-new property grows the shape via a transition. Plain shaped objects (object literals) lack this
     // flag and deopt to a dictionary when they gain a key, since they aren't a reused allocation site.
     ShapeBuilding = 131072,
-    // the object overrides [[Get]] / [[GetOwnProperty]] with non-ordinary semantics (Proxy, TypedArray
-    // integer-index access, IteratorResult). The prototype-method inline cache skips such receivers and
-    // prototypes so it never bypasses their custom property resolution.
+    // the object's [[Get]] / [[GetOwnProperty]] may deviate from ordinary semantics (Proxy, TypedArray
+    // integer-index access, IteratorResult). Set explicitly by those built-ins, and otherwise derived for
+    // a host subclass that overrides Get — conservatively, since the engine cannot tell whether such an
+    // override actually deviates; a subclass that knows it does not declares OrdinaryGet through
+    // ObjectInstance.SetPropertyAccessSemantics. The prototype-method inline cache skips such receivers
+    // and prototypes so it never bypasses their custom property resolution.
     ExoticGet = 262144,
     // a built-in whose string-keyed own properties live in a shared BuiltinShape + a per-realm descriptor
     // array reached via IBuiltinShaped, not _properties. Set when the shape is installed, cleared on deopt
@@ -67,8 +70,10 @@ internal enum InternalTypes
     Function = 2097152,
     // the object promises ORDINARY [[Get]] semantics even though it is not a PlainObject: Get(p, receiver)
     // returns exactly UnwrapJsValue(GetOwnProperty(p), receiver) for an existing own property and otherwise
-    // walks the prototype chain. Declared by a host-defined subclass through
-    // ObjectInstance.SetPropertyAccessSemantics; never inferred. Unlike PlainObject (a *storage* claim, which
+    // walks the prototype chain. Derived in the public ObjectInstance(Engine) constructor from whether the
+    // runtime type overrides Get(JsValue, JsValue) — a subclass that does not gets this flag, one that does
+    // gets ExoticGet instead; the probe is cached per Type. ObjectInstance.SetPropertyAccessSemantics stays
+    // as the escape hatch for the two shapes that rule cannot see. Unlike PlainObject (a *storage* claim, which
     // lets the engine read _properties / the shape directly and so cannot be honoured by an object that
     // projects properties lazily from native state) this is purely a *semantics* claim, so the interpreter
     // may resolve a read from a single GetOwnProperty probe. Mutually exclusive with ExoticGet.

--- a/Jint/Runtime/Interpreter/EvaluationContext.cs
+++ b/Jint/Runtime/Interpreter/EvaluationContext.cs
@@ -12,10 +12,12 @@ internal sealed class EvaluationContext
     /// <summary>
     /// How many statements may execute between checks of the amortized constraints (see
     /// Engine.Constraints.cs for the partition rationale). Small enough that timeout /
-    /// cancellation / memory-limit detection latency stays far below anything observable at
-    /// the granularity those constraints operate on, large enough that the per-statement cost
-    /// collapses to a countdown decrement and branch. Statements that call user CLR code
-    /// re-check on return instead — see <see cref="Engine.CheckAmortizedConstraintsAtHostBoundary"/>.
+    /// cancellation detection latency stays far below anything observable at the granularity
+    /// those constraints operate on, large enough that the per-statement cost collapses to a
+    /// countdown decrement and branch. Nothing whose budget a single statement can blow past is
+    /// checked at this cadence; see <see cref="Constraint.IsAmortizable"/>. Statements that call
+    /// user CLR code re-check on return instead — see
+    /// <see cref="Engine.CheckAmortizedConstraintsAtHostBoundary"/>.
     /// </summary>
     internal const int AmortizedConstraintCheckInterval = 64;
 

--- a/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
+++ b/Jint/Runtime/Interpreter/Statements/JintForStatement.cs
@@ -559,9 +559,10 @@ internal sealed class JintForStatement : JintStatement<ForStatement>
         // Tight loop: with an expression-statements-only body, a non-suspendable frame, no
         // per-statement (exact) constraint/debug checks, dead completion values and no fresh
         // per-iteration environment, nothing per iteration remains observable but test, body
-        // expressions and update. Amortized constraints (timeout, cancellation, memory limit)
-        // do not disarm the lane: TightForBody drives the shared amortized countdown once per
-        // iteration, keeping their detection latency bounded.
+        // expressions and update. Amortized constraints (timeout, cancellation) do not disarm
+        // the lane: TightForBody drives the shared amortized countdown once per iteration,
+        // keeping their detection latency bounded. Exact constraints do disarm it, and the
+        // memory limit is exact — registering one sends the loop down the generic path below.
         // The DebugMode probe is live (same coarseness as the debugHandler hoisting below).
         if (_tightBodyEligible
             && !skipTestOnce


### PR DESCRIPTION
Three comments describe behaviour the code no longer has. Comments only — no behaviour change, and the diff is five hunks.

**`InternalTypes.OrdinaryGet`** said the flag is declared by a host-defined subclass through `ObjectInstance.SetPropertyAccessSemantics` and is "never inferred". The public `ObjectInstance(Engine)` constructor now derives it from the runtime type — a subclass that does not override `Get(JsValue, JsValue)` gets `OrdinaryGet`, one that does gets `ExoticGet`, probe cached per `Type`. The comment now says how the value is arrived at, and notes that the setter remains as the escape hatch for the shapes the rule cannot see.

The neighbouring **`ExoticGet`** comment had drifted from the same change: it claimed the object *does* deviate from ordinary `[[Get]]`/`[[GetOwnProperty]]`, when it is now also the conservative derived answer for any subclass that overrides `Get`, deviating or not. Reworded to "may deviate", with where the flag comes from in each case.

**`JintForStatement.ForBodyEvaluation`** listed the memory limit among the amortized constraints that do not disarm the tight-body lane. `MemoryLimitConstraint.IsAmortizable` is `false`, so it lands in the exact list, `ShouldRunPerStatementChecks` goes true and the gate sends the loop down the generic path. The comment now says that.

**`EvaluationContext.AmortizedConstraintCheckInterval`** had the same stale claim from the other side — it listed memory-limit detection latency among the things the interval bounds, when that constraint never runs at this cadence. Dropped, with a pointer to `Constraint.IsAmortizable`, which already explains why a budget one statement can blow past has to stay exact.

Verified with `dotnet build --configuration Release` (warnings are errors); `git diff` touches comment lines only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
